### PR TITLE
[ART-7462] set alignment bug's depends

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -748,6 +748,10 @@ Jira mapping: https://github.com/openshift-eng/ocp-build-data/blob/main/product.
             issue = jira_client.create_issue(
                 fields
             )
+            # check depend issues and set depend to a higher version issue if ture
+            depend_issues = search_issues(f"project={project} AND summary ~ 'Update {major}.{minor+1} {image_meta.name} image to be consistent with ART'")
+            if depend_issues:
+                jira_client.create_issue_link("Depend", issue.key, depend_issues[0].key)
             new_issues[distgit_key] = issue
             print(f'A JIRA issue has been opened for {pr.html_url}: {issue.key}')
             connect_issue_with_pr(pr, issue.key)


### PR DESCRIPTION
re: [ART-7462](https://issues.redhat.com/browse/ART-7462)
accoring to https://github.com/openshift/cluster-update-keys/pull/47#issuecomment-1664730578
after creating an alignment bug CI will check if it has a bug to depend on if it's not non-GA version
we need to check if a similar bug in higher version exist and try to link it