### PR TITLE
Set target_version value as string

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -738,7 +738,7 @@ Jira mapping: https://github.com/openshift-eng/ocp-build-data/blob/main/product.
             'project': {'key': project},
             'issuetype': {'name': 'Bug'},
             'versions': [{'name': release_version}],  # Affects Version/s
-            'customfield_12323140': [{'name': Model(runtime.gitdata.load_data(key='bug').data).jira_config.target_release[-1]}],  # customfield_12323140 is Target Version in jira
+            'customfield_12323140': [{'name': str(Model(runtime.gitdata.load_data(key='bug').data).jira_config.target_release[-1])}],  # customfield_12323140 is Target Version in jira
             'components': [{'name': component}],
             'summary': summary,
             'description': description


### PR DESCRIPTION
Fixes error `response text = {"errorMessages":[],"errors":{"customfield_12323140":"expected 'name' property to be a string"}}`