### PR TITLE
Fix target_release key fetch

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -19,11 +19,11 @@ from dockerfile_parse import DockerfileParser
 from doozerlib.model import Model, Missing
 from doozerlib.pushd import Dir
 from doozerlib.cli import cli, pass_runtime
-from doozerlib import brew, state, exectools, constants
+from doozerlib import exectools, constants
 from doozerlib.image import ImageMetadata
 from doozerlib.util import get_docker_config_json, convert_remote_git_to_ssh, \
     split_git_url, remove_prefix, green_print, \
-    yellow_print, red_print, convert_remote_git_to_https, \
+    yellow_print, \
     what_is_in_master, extract_version_fields, convert_remote_git_to_https
 
 
@@ -738,7 +738,7 @@ Jira mapping: https://github.com/openshift-eng/ocp-build-data/blob/main/product.
             'project': {'key': project},
             'issuetype': {'name': 'Bug'},
             'versions': [{'name': release_version}],  # Affects Version/s
-            'customfield_12323140': [{'name': Model(runtime.gitdata.load_data(key='bug').data).jira_config.target_release[-1]}],  # customfield_12323140 is Target Version in jira
+            'customfield_12323140': [{'name': Model(runtime.gitdata.load_data(key='bug').data).target_release[-1]}],  # customfield_12323140 is Target Version in jira
             'components': [{'name': component}],
             'summary': summary,
             'description': description


### PR DESCRIPTION
This is failing the sync-for-ci job
target_release is not under jira_config (https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.14/bug.yml)