### PR TITLE
mass-rebuilds: only for streams.<stream>.image attribute

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -477,7 +477,7 @@ class ImageMetadata(Metadata):
         if from_stream:
             referred_streams.add(from_stream)
         if referred_streams:
-            message["streams"] = {stream: streams[stream] for stream in referred_streams}
+            message["streams"] = {stream: streams[stream].get('image') for stream in referred_streams}
 
         # Avoid non serializable objects. Known to occur for PosixPath objects in content.source.modifications.
         default = lambda o: f"<<non-serializable: {type(o).__qualname__}>>"


### PR DESCRIPTION
If one introduces or changes an attribute in the stream definition in streams.yml, this will result in a new config_digest for all consuming images, which results in mass rebuilds. In the context of product rebuilds, we are only interested if the key `image` of the streams entry changes. This commit makes that happen.