### PR TITLE
[ART-7318][ART-5526] introduce doozer operator_index_mode for pre-releases

### DIFF
--- a/doozer/.devcontainer/dev.Dockerfile
+++ b/doozer/.devcontainer/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:37
+FROM registry.fedoraproject.org/fedora:38
 LABEL name="doozer-dev" \
   description="Doozer development container image" \
   maintainer="OpenShift Automated Release Tooling (ART) Team <aos-team-art@redhat.com>"


### PR DESCRIPTION
Introduce logic to label bundles differently depending on the group release mode, which can make bundles available either to future releases or in pre-release indexes.

[This hack run](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/lmeyer/job/lmeyer-dev/job/dev-build%252Folm_bundle/38/console) against [this config](https://github.com/openshift-eng/ocp-build-data/pull/3424/files) produced [local-storage-operator-metadata-container-v4.14.0.202308281027.p0.g089e32e.assembly.stream-2](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2655730) which I added to a [test advisory](https://errata.devel.redhat.com/advisory/119637) along with dependencies so we can really exercise this new capability.