### PR TITLE
Include rhcos build_id & image nvr in assembly issue

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -1405,7 +1405,8 @@ class PayloadGenerator:
 
             # check that each specified package in the member is consistent with the RHCOS build
             for pkg in consistent_pkgs:
-                issues.append(PayloadGenerator.validate_pkg_consistency_req(payload_tag, pkg, bbii, rhcos_rpm_vrs))
+                issues.append(PayloadGenerator.validate_pkg_consistency_req(payload_tag, pkg, bbii, rhcos_rpm_vrs,
+                                                                            str(primary_rhcos_build)))
 
         return [issue for issue in issues if issue]
 
@@ -1413,10 +1414,12 @@ class PayloadGenerator:
     def validate_pkg_consistency_req(
             payload_tag: str, pkg: str,
             bbii: BrewBuildImageInspector,
-            rhcos_rpm_vrs: Dict[str, str]) -> Optional[AssemblyIssue]:
+            rhcos_rpm_vrs: Dict[str, str],
+            rhcos_build_id: str) -> Optional[AssemblyIssue]:
         """check that the specified package in the member is consistent with the RHCOS build"""
         logger = bbii.runtime.logger
-        logger.debug(f"Checking consistency of {pkg} for {payload_tag} against RHCOS")
+        payload_tag_nvr: str = bbii.get_nvr()
+        logger.debug(f"Checking consistency of {pkg} for {payload_tag_nvr} against {rhcos_build_id}")
         member_nvrs: Dict[str, Dict] = bbii.get_all_installed_package_build_dicts()  # by name
         try:
             build = member_nvrs[pkg]
@@ -1432,16 +1435,16 @@ class PayloadGenerator:
 
         # find package RPM names in the RHCOS build and check that they have the same version
         required_vr = "-".join([build["version"], build["release"]])
-        logger.debug(f"{payload_tag} {pkg} has RPMs {rpm_names} at version {required_vr}")
+        logger.debug(f"{payload_tag_nvr} {pkg} has RPMs {rpm_names} at version {required_vr}")
         for name in rpm_names:
             vr = rhcos_rpm_vrs.get(name)
             if vr:
                 logger.debug(f"RHCOS RPM {name} version is {vr}")
             if vr and vr != required_vr:
                 return AssemblyIssue(
-                    f"RHCOS and '{payload_tag}' should both use the same build of "
-                    f"package '{pkg}', but RHCOS has installed {name}-{vr} and "
-                    f"'{payload_tag}' has installed from {build['nvr']}",
+                    f"RHCOS and '{payload_tag}' should use the same build of "
+                    f"package '{pkg}', but {rhcos_build_id} has {name}-{vr} and "
+                    f"{payload_tag_nvr} has {build['nvr']}",
                     payload_tag, AssemblyIssueCode.FAILED_CONSISTENCY_REQUIREMENT)
                 # no need to check other RPMs from this package build, one is enough
 


### PR DESCRIPTION
## Summary
When debugging assembly issues it's important to know the rhcos build_id and nvr,
so we are sure about which rhcos & nvr has the inconsistency

## Test
- `./doozer --group openshift-4.11 inspect:stream FAILED_CONSISTENCY_REQUIREMENT`

## Output
```
Assembly does not permit: 
[RHCOS and 'driver-toolkit' should use the same build of package 'kernel', but RHCOSBuild:x86_64:411.86.202308300701-0 has kernel-modules-4.18.0-372.70.1.el8_6 and driver-toolkit-container-v4.11.0-202308310342.p0.g28589b0.assembly.stream has kernel-4.18.0-372.71.1.el8_6, 
RHCOS and 'driver-toolkit' should use the same build of package 'kernel-rt', but RHCOSBuild:x86_64:411.86.202308300701-0 has kernel-rt-devel-4.18.0-372.70.1.rt7.228.el8_6 and driver-toolkit-container-v4.11.0-202308310342.p0.g28589b0.assembly.stream has kernel-rt-4.18.0-372.71.1.rt7.230.el8_6, 
RHCOS and 'driver-toolkit' should use the same build of package 'kernel', but RHCOSBuild:ppc64le:411.86.202308300701-0 has kernel-modules-4.18.0-372.70.1.el8_6 and driver-toolkit-container-v4.11.0-202308310342.p0.g28589b0.assembly.stream has kernel-4.18.0-372.71.1.el8_6, 
RHCOS and 'driver-toolkit' should use the same build of package 'kernel', but RHCOSBuild:s390x:411.86.202308300701-0 has kernel-modules-4.18.0-372.70.1.el8_6 and driver-toolkit-container-v4.11.0-202308310342.p0.g28589b0.assembly.stream has kernel-4.18.0-372.71.1.el8_6, 
RHCOS and 'driver-toolkit' should use the same build of package 'kernel', but RHCOSBuild:aarch64:411.86.202308300701-0 has kernel-modules-4.18.0-372.70.1.el8_6 and driver-toolkit-container-v4.11.0-202308310342.p0.g28589b0.assembly.stream has kernel-4.18.0-372.71.1.el8_6]

```