### PR TITLE
Train Doozer to auto-create missing distgit branches

### DIFF
--- a/doozer/doozerlib/exectools.py
+++ b/doozer/doozerlib/exectools.py
@@ -94,7 +94,7 @@ def cmd_assert(cmd, realtime=False, retries=1, pollrate=60, on_retry=None,
     :param timeout: Kill the process if it does not terminate after timeout seconds.
     :return: (stdout,stderr) if exit code is zero
     """
-
+    result, stdout, stderr = -1, '', ''
     for try_num in range(0, retries):
         if try_num > 0:
             logger.debug(
@@ -112,10 +112,9 @@ def cmd_assert(cmd, realtime=False, retries=1, pollrate=60, on_retry=None,
 
     logger.debug("cmd_assert: Final result = {} in {} tries.".format(result, try_num))
 
-    assertion.success(
-        result,
-        "Error running [{}] {}: {} See debug log for more details.".
-        format(pushd.Dir.getcwd(), cmd, stderr))
+    if result != SUCCESS:
+        msg = f"Process {cmd} exited with code {result}:\ncwd={pushd.Dir.getcwd()}\nstdout>>{stdout}<<\nstderr>>{stderr}<<\n"
+        raise ChildProcessError(msg, (result, stdout, stderr))
 
     return stdout, stderr
 

--- a/doozer/tests/test_distgit/test_generic_distgit.py
+++ b/doozer/tests/test_distgit/test_generic_distgit.py
@@ -87,9 +87,9 @@ class TestGenericDistGit(TestDistgit):
 
         expected_cmd = ['git', '-C', 'my-root-dir/my-namespace/my-distgit-key', 'rev-parse', 'HEAD']
         (flexmock(distgit.exectools)
-         .should_receive("cmd_assert")
+         .should_receive("cmd_gather")
          .with_args(expected_cmd, strip=True)
-         .and_return("abcdefg", "")
+         .and_return(0, "abcdefg", "")
          .once())
 
         distgit.DistGitRepo(metadata, autoclone=False).clone("my-root-dir", "my-branch")
@@ -154,9 +154,9 @@ class TestGenericDistGit(TestDistgit):
 
         expected_cmd = ['git', '-C', 'my-root-dir/my-namespace/my-distgit-key', 'rev-parse', 'HEAD']
         (flexmock(distgit.exectools)
-         .should_receive("cmd_assert")
+         .should_receive("cmd_gather")
          .with_args(expected_cmd, strip=True)
-         .and_return("abcdefg", "")
+         .and_return(0, "abcdefg", "")
          .once())
 
         metadata = flexmock(config=MockConfig(content="_irrelevant_"),
@@ -197,9 +197,9 @@ class TestGenericDistGit(TestDistgit):
 
         expected_cmd = ['git', '-C', 'my-root-dir/my-namespace/my-distgit-key', 'rev-parse', 'HEAD']
         (flexmock(distgit.exectools)
-         .should_receive("cmd_assert")
+         .should_receive("cmd_gather")
          .with_args(expected_cmd, strip=True)
-         .and_return("abcdefg", "")
+         .and_return(0, "abcdefg", "")
          .once())
 
         expected_warning = ("Warning: images:rebase was skipped and "
@@ -252,9 +252,9 @@ class TestGenericDistGit(TestDistgit):
 
         expected_cmd = ['git', '-C', 'my-root-dir/my-namespace/my-distgit-key', 'rev-parse', 'HEAD']
         (flexmock(distgit.exectools)
-         .should_receive("cmd_assert")
+         .should_receive("cmd_gather")
          .with_args(expected_cmd, strip=True)
-         .and_return("abcdefg", "")
+         .and_return(0, "abcdefg", "")
          .once())
 
         metadata = flexmock(config=MockConfig(content="_irrelevant_"),


### PR DESCRIPTION
Updates gen-payload and images:rebase commands to auto-create missing distgit branches.
This is a bit hacky and doesn't work for rpms.