### PR TITLE
ART-7628 Store Jenkins build path as lock identifier

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -5,6 +5,7 @@ import time
 from enum import Enum
 from typing import Optional
 
+import requests
 from jenkinsapi.jenkins import Jenkins
 from jenkinsapi.job import Job
 from jenkinsapi.queue import QueueItem
@@ -136,6 +137,21 @@ def set_build_description(build: Build, description: str):
         data="",
         valid=[200]
     )
+
+
+def is_build_running(build_path: str) -> bool:
+    init_jenkins()
+
+    response = requests.get(f'{constants.JENKINS_SERVER_URL}/{build_path}/api/json')
+    if response.status_code != 200:
+        logger.error('Could not fetch data for build %s', build_path)
+        raise ValueError
+
+    build_data = response.json()
+    logger.info('Build %s %s in progress',
+                f'{constants.JENKINS_UI_URL}/{build_path}',
+                'is' if build_data['inProgress'] else 'is not')
+    return build_data['inProgress']
 
 
 @check_env_vars

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -70,6 +70,12 @@ def get_build_id() -> str:
 
 
 def get_build_id_from_url(build_url: str) -> int:
+    """
+    Examples:
+    - https://buildvm.hosts.prod.psi.bos.redhat.com:8443/job/aos-cd-builds/job/build%252Focp4/46870/ => 46870
+    - https://buildvm.hosts.prod.psi.bos.redhat.com:8443/job/aos-cd-builds/job/build%252Focp4/46870 => 46870
+    """
+
     return int(list(filter(None, build_url.split('/')))[-1])
 
 
@@ -140,6 +146,17 @@ def set_build_description(build: Build, description: str):
 
 
 def is_build_running(build_path: str) -> bool:
+    """
+    Fetches build data using API endpoint {JENKINS_SERVER_URL}/{BUILD_PATH}/api/json
+    E.g. https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/46902/api/json
+
+    The resulting JSON has a field called "inProgress" that is true if the build is still ongoing
+
+    Build paths examples are:
+    - job/aos-cd-builds/job/build%252Focp4/46902
+    - job/hack/job/dpaolell/job/ocp4/238/
+    """
+
     init_jenkins()
 
     response = requests.get(f'{constants.JENKINS_SERVER_URL}/{build_path}/api/json')

--- a/pyartcd/pyartcd/locks.py
+++ b/pyartcd/pyartcd/locks.py
@@ -128,9 +128,8 @@ class LockManager(Aioredlock):
 
         if version:
             pattern = f'*-lock-{version}'
-            self.logger.info('Retrieving active locks for OCP %s', version)
         else:
             pattern = '*-lock-*'
-            self.logger.info('Retrieving all active locks')
 
+        self.logger.info('Retrieving locks matching pattern "%s"', pattern)
         return await redis.get_keys(pattern)

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -404,7 +404,7 @@ class BuildMicroShiftPipeline:
         yaml.dump(releases_yaml, releases_yaml_path)
         # Create a PR
         title = f"Pin microshift build for {self.group} {self.assembly}"
-        body = f"Created by job run {self.runtime.get_job_run_url()}"
+        body = f"Created by job run {jenkins.get_build_url()}"
         match = re.search(r"github\.com[:/](.+)/(.+)(?:.git)?", ocp_build_data_repo_push_url)
         if not match:
             raise ValueError(f"Couldn't create a pull request: {ocp_build_data_repo_push_url} is not a valid github repo")

--- a/pyartcd/pyartcd/pipelines/cleanup_locks.py
+++ b/pyartcd/pyartcd/pipelines/cleanup_locks.py
@@ -25,7 +25,7 @@ async def cleanup_locks(runtime: Runtime):
                     runtime.logger.warning('Deleting lock %s that was created by %s that\'s not currently running',
                                            lock_name,
                                            build_url.replace(constants.JENKINS_SERVER_URL, constants.JENKINS_UI_URL))
-                    lock = Lock(lock_manager=lock_manager, resource=lock_name, id=build_path)
+                    lock = lock_manager.get_lock(resource=lock_name, lock_identifier=build_path)
                     await lock_manager.unlock(lock)
 
                 else:

--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -8,7 +8,7 @@ from typing import Iterable, Optional, OrderedDict, Tuple
 
 import click
 from ghapi.all import GhApi
-from pyartcd import exectools, constants
+from pyartcd import exectools, constants, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.git import GitRepository
 from pyartcd.runtime import Runtime
@@ -183,7 +183,7 @@ class GenAssemblyPipeline:
         yaml.dump(releases_yaml, releases_yaml_path)
         # Create a PR
         title = f"Add assembly {self.assembly}"
-        body = f"Created by job run {self.runtime.get_job_run_url()}"
+        body = f"Created by job run {jenkins.get_build_url()}"
         match = re.search(r"github\.com[:/](.+)/(.+)(?:.git)?", ocp_build_data_repo_push_url)
         if not match:
             raise ValueError(f"Couldn't create a pull request: {ocp_build_data_repo_push_url} is not a valid github repo")

--- a/pyartcd/pyartcd/pipelines/operator_sdk_sync.py
+++ b/pyartcd/pyartcd/pipelines/operator_sdk_sync.py
@@ -5,7 +5,7 @@ import requests
 import click
 import koji
 from errata_tool import Erratum
-from pyartcd import constants, util
+from pyartcd import constants, util, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.runtime import Runtime
 from doozerlib.util import brew_arch_for_go_arch
@@ -45,7 +45,7 @@ class OperatorSDKPipeline:
                 'openshift-enterprise-operator-sdk-container')]
             if not sdk_build:
                 self._logger.info("No SDK build to ship, update subtask 8 then close ...")
-                self._jira_client.complete_subtask(self.parent_jira_key, 7, f"No SDK build to ship, operator_sdk_sync job: {self.runtime.get_job_run_url()}")
+                self._jira_client.complete_subtask(self.parent_jira_key, 7, f"No SDK build to ship, operator_sdk_sync job: {jenkins.get_build_url()}")
                 return
             build = koji.ClientSession(constants.BREW_SERVER).getBuild(sdk_build[0])
         elif self.nvr:
@@ -58,7 +58,7 @@ class OperatorSDKPipeline:
         for arch in self.arches.split(','):
             self._extract_binaries(arch, sdkVersion, build['extra']['image']['index']['pull'][0])
         if self.assembly:
-            self._jira_client.complete_subtask(self.parent_jira_key, 7, f"operator_sdk_sync job: {self.runtime.get_job_run_url()}")
+            self._jira_client.complete_subtask(self.parent_jira_key, 7, f"operator_sdk_sync job: {jenkins.get_build_url()}")
 
     def _get_sdkversion(self, build):
         build_log_res = requests.get(f"{constants.BREW_DOWNLOAD_SERVER}/packages/{build['name']}/{build['version']}/{build['release']}/data/logs/x86_64.log")

--- a/pyartcd/pyartcd/pipelines/review_cvp.py
+++ b/pyartcd/pyartcd/pipelines/review_cvp.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 import click
 from ghapi.all import GhApi
-from pyartcd import exectools
+from pyartcd import exectools, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.git import GitRepository
 from pyartcd.runtime import Runtime
@@ -74,7 +74,7 @@ class ReviewCVPPipeline:
                 warnings.extend(await self._resolve_content_set_failures(build_data_path, failed_optional))
 
                 title = f"Automated CVP content_set_check fix for {self.group}"
-                body = f"Created by build {self.runtime.get_job_run_url()}"
+                body = f"Created by build {jenkins.get_build_url()}"
                 pushed = await build_data.commit_push(f"{title}\n{body}")
                 if pushed:
                     match = re.search(r"github\.com[:/](.+)/(.+)(?:.git)?", ocp_build_data_repo_push_url)
@@ -100,7 +100,7 @@ class ReviewCVPPipeline:
                 self._logger.info(messages[-1])
 
         messages.append("")
-        messages.append(f"""Check <{self.runtime.get_job_run_url()}/consoleFull|build logs> and <{self.runtime.get_job_run_url()}/artifact/artcd_working/cvp-test-results.yaml/*view*/|cvp-test-results.yaml> for detailed CVP test results.""")
+        messages.append(f"""Check <{jenkins.get_build_url()}/consoleFull|build logs> and <{jenkins.get_build_url()}/artifact/artcd_working/cvp-test-results.yaml/*view*/|cvp-test-results.yaml> for detailed CVP test results.""")
         self._logger.info(messages[-1])
 
         messages.append("""For more information about content_set_check, see https://docs.engineering.redhat.com/x/a05iEQ.

--- a/pyartcd/pyartcd/runtime.py
+++ b/pyartcd/pyartcd/runtime.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional
 
 import tomli
 
+from pyartcd import jenkins
 from pyartcd.jira import JIRAClient
 from pyartcd.mail import MailService
 from pyartcd.slack import SlackClient
@@ -50,21 +51,9 @@ class Runtime:
             if not token and not self.dry_run:
                 raise ValueError("SLACK_BOT_TOKEN environment variable is not set")
         return SlackClient(token, dry_run=self.dry_run,
-                           job_name=self.get_job_name(),
-                           job_run_url=self.get_job_run_url(),
-                           job_run_name=self.get_job_run_name())
+                           job_name=jenkins.get_job_name(),
+                           build_url=jenkins.get_build_url(),
+                           build_id=jenkins.get_build_id())
 
     def new_mail_client(self):
         return MailService.from_config(self.config)
-
-    def get_job_name(self):
-        return os.environ.get("JOB_NAME")
-
-    def get_job_run_name(self):
-        return os.environ.get("BUILD_ID")
-
-    def get_job_run_url(self):
-        url = os.environ.get("BUILD_URL")
-        if not url:
-            return None
-        return f"{url.rstrip('/')}"

--- a/pyartcd/pyartcd/slack.py
+++ b/pyartcd/pyartcd/slack.py
@@ -12,12 +12,12 @@ class SlackClient:
     """
     DEFAULT_CHANNEL = "#art-release"
 
-    def __init__(self, token: str, job_name: Optional[str], job_run_name: Optional[str], job_run_url: Optional[str], dry_run: bool = False) -> None:
+    def __init__(self, token: str, job_name: Optional[str], build_id: Optional[str], build_url: Optional[str], dry_run: bool = False) -> None:
         self.token = token
         self.channel = self.DEFAULT_CHANNEL
         self.job_name = job_name
-        self.job_run_name = job_run_name
-        self.job_run_url = job_run_url
+        self.build_id = build_id
+        self.build_url = build_url
         self.dry_run = dry_run
         self.as_user = "art-release-bot"
         self.icon_emoji = ":robot_face:"
@@ -43,9 +43,9 @@ class SlackClient:
 
     async def say(self, message: str, thread_ts: Optional[str] = None):
         attachments = []
-        if self.job_run_url:
+        if self.build_url:
             attachments.append({
-                "title": f"Job: {self.job_name} <{self.job_run_url}/consoleFull|{self.job_run_name}>",
+                "title": f"Job: {self.job_name} <{self.build_url}/consoleFull|{self.build_id}>",
                 "color": "#439FE0",
             })
         if self.dry_run:
@@ -68,9 +68,9 @@ class SlackClient:
 
     async def post_image(self, message: str, file: str):
         attachments = []
-        if self.job_run_url:
+        if self.build_url:
             attachments.append({
-                "title": f"Job: {self.job_name} <{self.job_run_url}|{self.job_run_name}>",
+                "title": f"Job: {self.job_name} <{self.build_url}|{self.build_id}>",
                 "color": "#439FE0",
             })
         if self.dry_run:

--- a/pyartcd/tests/test_jenkins.py
+++ b/pyartcd/tests/test_jenkins.py
@@ -66,3 +66,27 @@ class TestJenkinsStartBuild(unittest.TestCase):
         mock_job.invoke.assert_called_once_with(build_params=params)
         mock_queue_item.poll.assert_called_once()
         mock_build.assert_called_once_with(url=triggered_url, buildno=1, job=mock_job)
+
+    def test_get_build_url_and_path(self):
+        # No BUILD_URL env var defined
+        self.assertEqual(jenkins.get_build_url(), None)
+        self.assertEqual(jenkins.get_build_path(), None)
+
+        # Trailing slash will be removed
+        os.environ['BUILD_URL'] = 'https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/' \
+                                  'job/aos-cd-builds/job/build%252Focp4/46870/'
+        self.assertEqual(jenkins.get_build_url(), 'https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/'
+                                                  'job/aos-cd-builds/job/build%252Focp4/46870')
+
+        # Build path
+        build_path = jenkins.get_build_path()
+        self.assertEqual(build_path, 'job/aos-cd-builds/job/build%252Focp4/46870')
+
+    def test_get_build_id_from_url(self):
+        build_url = 'https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/' \
+                    'job/aos-cd-builds/job/build%252Focp4/46870/'
+        self.assertEqual(jenkins.get_build_id_from_url(build_url), 46870)
+
+        build_url = 'https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/' \
+                    'job/aos-cd-builds/job/build%252Focp4/46870'
+        self.assertEqual(jenkins.get_build_id_from_url(build_url), 46870)


### PR DESCRIPTION
Must go with https://github.com/openshift-eng/aos-cd-jobs/pull/3959

The actual change is represented by setting identifiers for all locks created by `ocp4` equal to the Jenkins build path.
The build path is the build URL minus the host name; so given a build URL as https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/46870/, all locks created within that run will be identified as `job/aos-cd-builds/job/build%252Focp4/46870`.

This identifier will be then used by a scheduled lock cleanup procedure, which will release all the locks who are identified by a build that's no longer running.

A [test ocp4 build](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/ocp4/238/) created `build-lock-4.10` with value `job/hack/job/dpaolell/job/ocp4/238`

The cleanup procedure was then run by a [hack space run](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/cleanup-locks/39/console), that correctly deleted only that lock, while keeping everything else intact. More details about testing in https://github.com/openshift-eng/aos-cd-jobs/pull/3959