### PR TITLE
[promote] Make sure image advisory exists for candidate-type assemblies

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -198,7 +198,7 @@ class PromotePipeline:
             image_advisory = impetus_advisories.get("image", 0)
             errata_url = ""
 
-            if assembly_type == assembly.AssemblyTypes.STANDARD:
+            if assembly_type in [assembly.AssemblyTypes.STANDARD, assembly.AssemblyTypes.CANDIDATE]:
                 if image_advisory <= 0:
                     err = VerificationError(f"No associated image advisory for {self.assembly} is defined.")
                     justification = self._reraise_if_not_permitted(err, "NO_ERRATA", permits)


### PR DESCRIPTION
Recently we had a case where rc promotion jumped the gun and went in parallel with prepare-rel, and 
4.14.0-rc.0 didn't get image advisory embedded in it's metadata, and a bunch
of unexpected things happened which confused us ([slack thread](https://redhat-internal.slack.com/archives/C04L1FPFHNH/p1694072265386539))

We have a check in place which complains if this happens, 
make it apply for candidate assemblies as well.