### PR TITLE
distgit: Push to origin

### DIFF
--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -384,8 +384,7 @@ class DistGitRepo(object):
                 # timeout value counterproductive. Limit to 5 simultaneous pushes.
                 with self.runtime.get_named_semaphore('rhpkg::push', count=5):
                     timeout = str(self.runtime.global_opts['rhpkg_push_timeout'])
-                    exectools.cmd_assert("timeout {} rhpkg push".format(timeout), retries=3)
-                    # rhpkg will create but not push tags :(
+                    exectools.cmd_assert(f"timeout {timeout} git push --set-upstream origin {self.branch}", retries=3)
                     # Many builds require a tag associated with a commit to be a semver
                     # and they will only fail at runtime when parsing that tag
                     # if it is not a valid semver. This means we must have a valid

--- a/doozer/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/doozer/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -176,7 +176,7 @@ class TestImageDistGit(TestDistgit):
 
         flexmock(distgit.exectools)\
             .should_receive("cmd_assert")\
-            .with_args("timeout 999 rhpkg push", retries=3)\
+            .with_args("timeout 999 git push --set-upstream origin _irrelevant_", retries=3)\
             .ordered()
 
         flexmock(distgit.exectools)\


### PR DESCRIPTION
In the current code, we get when building on a new branch:
```
fatal: The current branch rhaos-4.13-rhel-9 has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin rhaos-4.13-rhel-9
```

We cannot configure `git` to do `push.autoSetupRemote`, as our git is too old. So move away from rhpkg to push, and use git directly.