### PR TITLE
Handle EOL release phase

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -667,10 +667,10 @@ class Ocp4Pipeline:
     async def _build_images(self):
         self.runtime.logger.info('Building images')
 
-        # If any arch is GA, use signed for everything. See _build_compose() for details.
-        group_config = await util.load_group_config(
-            group=f'openshift-{self.version.stream}', assembly=self.assembly)
-        signing_mode = 'signed' if group_config['software_lifecycle']['phase'] == 'release' else 'unsigned'
+        signing_mode = await util.get_signing_mode(
+            group=f'openshift-{self.version.stream}',
+            assembly=self.assembly
+        )
 
         # Doozer command
         cmd = self._doozer_base_command.copy()

--- a/pyartcd/pyartcd/plashets.py
+++ b/pyartcd/pyartcd/plashets.py
@@ -163,7 +163,7 @@ async def build_plashets(stream: str, release: str, assembly: str = 'stream',
     logger.info("Building plashet repos: %s", ", ".join(plashet_config.keys()))
 
     # Check release state
-    signing_mode = 'signed' if group_config['software_lifecycle']['phase'] == 'release' else 'unsigned'
+    signing_mode = await util.get_signing_mode(group_config=group_config)
 
     # Create plashet repos on ocp-artifacts
     # We can't safely run doozer config:plashet from-tags in parallel as this moment.

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -630,3 +630,18 @@ async def mirror_to_google_cloud(source: Union[str, Path], dest: str, dry_run=Fa
         logger.warning("[DRY RUN] Would have run %s", cmd)
         return
     await exectools.cmd_assert_async(cmd, env=os.environ.copy(), stdout=sys.stderr)
+
+
+async def get_signing_mode(group: str = None, assembly: str = None, group_config: dict = None) -> str:
+    """
+    If any arch is GA, use signed mode for everything
+    This also includes EOL ones, that might be triggered manually
+    Versions that are still in pre-release state will not be signed
+    """
+
+    if not group_config:
+        assert group, 'Group must be specified in order to load group config'
+        assert assembly, 'Assembly must be specified in order to load group config'
+        group_config = await load_group_config(group=group, assembly=assembly)
+
+    return 'unsigned' if group_config['software_lifecycle']['phase'] == 'pre-release' else 'signed'


### PR DESCRIPTION
This PR will account for changes in `group.yaml`, where we can set the release phase for a specific group to be `eol`