### PR TITLE
[ART-7730] Trigger SAST scans for builds in candidate tags

### DIFF
--- a/doozer/doozerlib/cli/__main__.py
+++ b/doozer/doozerlib/cli/__main__.py
@@ -42,6 +42,7 @@ from doozerlib.cli.config_plashet import config_plashet
 from doozerlib.cli.release_calc_upgrade_tests import release_calc_upgrade_tests
 from doozerlib.cli.inspect_stream import inspect_stream
 from doozerlib.cli.config_tag_rpms import config_tag_rpms
+from doozerlib.cli.scan_osh import scan_osh
 
 from doozerlib import coverity
 from doozerlib.exceptions import DoozerFatalError

--- a/doozer/doozerlib/cli/scan_osh.py
+++ b/doozer/doozerlib/cli/scan_osh.py
@@ -1,0 +1,180 @@
+import click
+import koji
+import asyncio
+from doozerlib.cli import cli, click_coroutine, pass_runtime
+from doozerlib.runtime import Runtime
+from doozerlib.exectools import fire_and_forget, cmd_gather_async, limit_concurrency
+from doozerlib.util import cprint
+from typing import Optional
+
+
+class ScanOshCli:
+    def __init__(self, runtime: Runtime, last_brew_event: int, dry_run: bool, nvrs: Optional[list],
+                 check_triggered: Optional[bool], all_builds: Optional[bool]):
+        self.runtime = runtime
+        self.last_brew_event = last_brew_event
+        self.dry_run = dry_run
+        self.brew_tags = []
+        self.specific_nvrs = nvrs
+        self.check_triggered = check_triggered
+        self.all_builds = all_builds
+        self.error_nvrs = []
+
+        # Initialize runtime and brewhub session
+        self.runtime.initialize(clone_distgits=False)
+        self.koji_session = koji.ClientSession(self.runtime.group_config.urls.brewhub)
+
+    @staticmethod
+    async def get_untriggered_nvrs(nvrs):
+        """
+        So we might have already triggered a scan for the same NVR. If this flag is enabled, we want to check
+        if it has and not re-trigger it again.
+        But please note that this will take a lot of time since it has to run for all 200+ packages.
+        """
+
+        @limit_concurrency(16)
+        async def run_get_untriggered_nvrs(nvr):
+            rc, _, _ = await cmd_gather_async(f"osh-cli find-tasks --nvr {nvr}")
+
+            return None if rc == 0 else nvr
+
+        tasks = []
+        for nvr in nvrs:
+            tasks.append(run_get_untriggered_nvrs(nvr))
+
+        nvrs = await asyncio.gather(*tasks)
+
+        untriggered_nvrs = [nvr for nvr in nvrs if nvr]
+
+        return untriggered_nvrs
+
+    def get_tagged_latest(self, tag):
+        """
+        Returns the latest RPMs and builds tagged in to the candidate tag received as input
+        """
+        latest_tagged = self.koji_session.listTagged(tag=tag, latest=True)
+        if latest_tagged:
+            return latest_tagged
+        else:
+            return []
+
+    def get_tagged_all(self, tag):
+        """
+        Returns all the RPMs and builds that are currently in the candidate tag received as input
+        """
+        latest_tagged = self.koji_session.listTagged(tag=tag, latest=False)
+        if latest_tagged:
+            return latest_tagged
+        else:
+            return []
+
+    def trigger_scans(self, nvrs: list):
+        cmd_template = "osh-cli mock-build --config={config} --brew-build {nvr} --nowait"
+        for nvr in nvrs:
+            # Skip rhcos for now
+            if nvr.startswith("rhcos"):
+                self.runtime.logger.warning(f"Skipping RHCOS builds. Scan is not triggered for {nvr}")
+                continue
+
+            if "container" in nvr:
+                cmd = cmd_template.format(config="cspodman", nvr=nvr)
+
+            else:
+                if "el7" in nvr:
+                    rhel_version = 7
+                elif "el8" in nvr:
+                    rhel_version = 8
+                elif "el9" in nvr or nvr.startswith("rhcos"):
+                    rhel_version = 9
+                else:
+                    self.runtime.logger.error("Invalid RHEL version")
+                    return
+
+                cmd = cmd_template.format(config=f"rhel-{rhel_version}-x86_64", nvr=nvr)
+
+            message = f"Ran command: {cmd}"
+
+            if not self.dry_run:
+                fire_and_forget(self.runtime.cwd, cmd)
+            else:
+                message = "[DRY RUN] " + message
+
+            self.runtime.logger.info(message)
+
+        self.runtime.logger.info(f"Total number of build scans kicked off: {len(nvrs)}")
+
+    async def run(self):
+        if not self.specific_nvrs:
+            tags = self.runtime.get_errata_config()["brew_tag_product_version_mapping"].keys()
+            for tag in tags:
+                major, minor = self.runtime.get_major_minor_fields()
+                self.brew_tags.append(tag.format(MAJOR=major, MINOR=minor))
+
+            builds = []
+
+            if self.last_brew_event or self.all_builds:
+                for tag in self.brew_tags:
+                    builds += self.get_tagged_all(tag=tag)
+
+                if self.last_brew_event:
+                    builds = [build for build in builds if build["create_event"] > self.last_brew_event]
+            else:
+                # If no --since field is specified, find all the builds that have been tagged into our candidate tags
+                for tag in self.brew_tags:
+                    builds += self.get_tagged_latest(tag=tag)
+
+            # Sort the builds based on the event ID by descending order so that latest is always on top
+            # Note: create_event is the event on which the build was tagged in the tag and not the build creation time
+            builds = sorted(builds, key=lambda x: x["create_event"], reverse=True)
+
+            nvrs = [build["nvr"] for build in builds]
+            nvr_brew_mapping = [(build["nvr"], build["create_event"]) for build in builds]
+
+            # To store the final list of NVRs that we will kick off scans for
+            nvrs_for_scans = []
+
+            if nvr_brew_mapping:
+                self.runtime.logger.info(f"NVRs to trigger scans for {nvr_brew_mapping}")
+
+            if builds:
+                latest_event_id = nvr_brew_mapping[0][1]
+
+                nvrs_for_scans = nvrs
+
+                # Return back the latest brew event ID
+                cprint(latest_event_id)
+            else:
+                self.runtime.logger.warning(
+                    f"No new NVRs have been found since last brew event: {self.last_brew_event}")
+                return None
+
+        else:
+            self.runtime.logger.info(f"Triggering scans for this particular list of NVRs: {self.specific_nvrs}")
+
+            nvrs_for_scans = self.specific_nvrs
+
+        if self.check_triggered:
+            nvrs_for_scans = await self.get_untriggered_nvrs(nvrs_for_scans)
+
+        self.trigger_scans(nvrs_for_scans)
+
+
+@cli.command("images:scan-osh", help="Trigger scans for builds with brew event IDs greater than the value specified")
+@click.option("--since", required=False, help="Builds after this brew event. If empty, latest builds will retrieved")
+@click.option("--dry-run", default=False, is_flag=True,
+              help="Do not trigger anything, but only print build operations.")
+@click.option("--nvrs", required=False,
+              help="Comma separated list to trigger scans specifically. Will not check candidate tags")
+@click.option("--check-triggered", required=False, is_flag=True, default=False,
+              help="Triggers scans for NVRs only after checking if they haven't already")
+@click.option("--all-builds", required=False, is_flag=True, default=False, help="Check all builds in candidate tags")
+@pass_runtime
+@click_coroutine
+async def scan_osh(runtime: Runtime, since: str, dry_run: bool, nvrs: str, check_triggered: bool, all_builds: bool):
+    cli_pipeline = ScanOshCli(runtime=runtime,
+                              last_brew_event=int(since) if since else None,
+                              dry_run=dry_run,
+                              nvrs=nvrs.split(",") if nvrs else None,
+                              check_triggered=check_triggered,
+                              all_builds=all_builds)
+    await cli_pipeline.run()

--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -263,6 +263,9 @@ class Runtime(object):
 
         return assembly_group_config(self.get_releases_config(), self.assembly, tmp_config)
 
+    def get_errata_config(self, **kwargs):
+        return self.gitdata.load_data(key='erratatool', **kwargs).data
+
     def _get_replace_vars(self, group_config: Model):
         replace_vars = group_config.vars or Model()
         # If assembly mode is enabled, `runtime_assembly` will become the assembly name.

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -4,7 +4,7 @@ from pyartcd.cli import cli
 from pyartcd.pipelines import (
     build_microshift, check_bugs, gen_assembly, prepare_release, promote, rebuild, report_rhcos,
     review_cvp, tarball_sources, build_sync, build_rhcos, ocp4_scan, images_health, operator_sdk_sync,
-    olm_bundle, ocp4, scan_for_kernel_bugs, tag_rpms, advisory_drop, cleanup_locks
+    olm_bundle, ocp4, scan_for_kernel_bugs, tag_rpms, advisory_drop, cleanup_locks, brew_scan_osh
 )
 
 

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -378,9 +378,10 @@ def update_description(description: str, append: bool = True):
     set_build_description(build, description)
 
 
-def start_scan_osh(nvrs: list, email: Optional[str] = "", **kwargs):
+def start_scan_osh(nvrs: list, version: str, email: Optional[str] = "", **kwargs):
     params = {
-        "NVRS": ",".join(nvrs)
+        "NVRS": ",".join(nvrs),
+        "BUILD_VERSION": version
     }
 
     if email:

--- a/pyartcd/pyartcd/pipelines/brew_scan_osh.py
+++ b/pyartcd/pyartcd/pipelines/brew_scan_osh.py
@@ -1,0 +1,102 @@
+"""
+This job scans the candidate tags for a particular version, and triggers scans for builds that are tagged into it.
+"""
+import click
+from typing import Optional
+from pyartcd import exectools, redis
+from pyartcd.runtime import Runtime
+from pyartcd.cli import cli, pass_runtime, click_coroutine
+
+
+class OshScan:
+    def __init__(self, runtime: Runtime, version: str, check_triggered: Optional[bool], email: Optional[str],
+                 nvrs: Optional[list], all_builds: Optional[bool]):
+        self.runtime = runtime
+        self.email = email
+        self.version = version
+        self.major, self.minor = self.version.split(".")
+        self.check_triggered = check_triggered
+        self.specific_nvrs = nvrs
+        self.all_builds = all_builds
+
+        self.redis_key = f"appdata:sast-scan:{self.version}"
+
+    async def store_brew_event(self, brew_event_id: str):
+        await redis.set_value(self.redis_key, brew_event_id)
+
+    async def retrieve_brew_event(self):
+        last_brew_event = await redis.get_value(self.redis_key)
+
+        # Remove trailing \n
+        if last_brew_event:
+            last_brew_event = last_brew_event.strip()
+
+        return last_brew_event
+
+    async def run(self):
+        cmd = [
+            "doozer",
+            "--group",
+            f"openshift-{self.version}",
+            "images:scan-osh",
+        ]
+
+        last_brew_event = await self.retrieve_brew_event()
+
+        self.runtime.logger.info(f"Found last brew event from REDIS: {last_brew_event}")
+
+        if self.runtime.dry_run:
+            cmd.append("--dry-run")
+
+        if self.check_triggered:
+            cmd.append("--check-triggered")
+
+        if self.specific_nvrs or self.all_builds:
+            if self.specific_nvrs:
+                cmd += [
+                    "--nvrs",
+                    f"{','.join(self.specific_nvrs)}"
+                ]
+
+            if self.all_builds:
+                cmd.append("--all-builds")
+        else:
+            # So if we give the specific list of nvrs, we don't need to pass the last brew event
+            if last_brew_event:
+                cmd += [
+                    "--since",
+                    f"{last_brew_event}"
+                ]
+
+        _, brew_event, _ = await exectools.cmd_gather_async(cmd, stderr=True)
+        if not brew_event and not self.specific_nvrs:
+            self.runtime.logger.warning(f"No new builds found for candidate tags in {self.version}")
+            return
+
+        if not self.specific_nvrs and not self.all_builds:
+            # We do not need to write to Redis if we're manually triggering scans for specific builds
+            if not self.runtime.dry_run:
+                # Write the latest brew event back to the file
+                if last_brew_event != brew_event:
+                    # No need to set if it's the same value
+                    await self.store_brew_event(brew_event)
+            else:
+                self.runtime.logger.info("[DRY RUN] Would have written to Redis")
+
+
+@cli.command("scan-osh")
+@click.option("--version", required=True, help="openshift version eg: 4.15")
+@click.option("--email", required=False, help="Additional email to which the results of the scan should be sent out to")
+@click.option("--nvrs", required=False, help="Comma separated list to trigger scans specifically. Will not check candidate tags")
+@click.option("--check-triggered", required=False, is_flag=True, default=False, help="Triggers scans for NVRs only after checking if they haven't already")
+@click.option("--all-builds", required=False, is_flag=True, default=False, help="Check all builds in candidate tags")
+@pass_runtime
+@click_coroutine
+async def scan_osh(runtime: Runtime, version: str, email: str, nvrs: str, check_triggered: bool, all_builds: bool):
+    pipeline = OshScan(runtime=runtime,
+                       email=email,
+                       version=version,
+                       nvrs=nvrs.split(",") if nvrs else None,
+                       check_triggered=check_triggered,
+                       all_builds=all_builds)
+    await pipeline.run()

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -834,7 +834,7 @@ class Ocp4Pipeline:
 
     def _trigger_osh_scans(self):
         try:
-            jenkins.start_scan_osh(nvrs=self.success_nvrs)
+            jenkins.start_scan_osh(nvrs=self.success_nvrs, version=self.version.stream)
         except Exception as e:
             self.runtime.logger.error(f"Failed to trigger scan-osh job: {e}")
 


### PR DESCRIPTION
Find all the builds tagged into our candidate tags, get the last brew event ID from the saved file `event.json` in workspace. Run scans for all of the builds with brew event after the last run. If there is no last run, get all the latest builds and run the scans.

Successful test [run](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/ashwin-aos-cd-jobs/job/build%252Fscan-osh-new/19/console).