### PR TITLE
ART-7624 Send qe email during promote rather than prepare

### DIFF
--- a/pyartcd/config.example.toml
+++ b/pyartcd/config.example.toml
@@ -12,8 +12,8 @@ smtp_server = "smtp.corp.redhat.com"
 from = "aos-art-automation@redhat.com"
 reply_to = "aos-team-art@redhat.com"
 cc = []
-prepare_release_notification_recipients_ocp4=["multi-arch-zstream-testing@redhat.com", "aos-qe@redhat.com"]
-prepare_release_notification_recipients_ocp3=["wzheng@redhat.com", "gpei@redhat.com", "aos-qe@redhat.com", "mp-entitlement-qe@redhat.com", "openshift-lp-test@redhat.com", "pprakash@redhat.com"]
+qe_notification_recipients_ocp4=["multi-arch-zstream-testing@redhat.com", "aos-qe@redhat.com"]
+qe_notification_recipients_ocp3=["wzheng@redhat.com", "gpei@redhat.com", "aos-qe@redhat.com", "mp-entitlement-qe@redhat.com", "openshift-lp-test@redhat.com", "pprakash@redhat.com"]
 promote_image_list_recipients = ["openshift-ccs@redhat.com"]
 
 [jira]

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -4,34 +4,33 @@ import os
 import re
 import shutil
 import subprocess
-from io import StringIO
-from pathlib import Path
-from subprocess import PIPE, CalledProcessError
-from typing import Dict, Iterable, List, Optional, Tuple
-
 import aiofiles
 import click
 import jinja2
 import semver
+from io import StringIO
+from pathlib import Path
+from subprocess import PIPE, CalledProcessError
+from typing import Dict, List, Optional, Tuple
+from jira.resources import Issue
+from ruamel.yaml import YAML
+from tenacity import retry, stop_after_attempt, wait_fixed
+
 from doozerlib.assembly import AssemblyTypes
-from doozerlib.util import go_suffix_for_arch
 from elliottlib.assembly import assembly_group_config
 from elliottlib.errata import set_blocking_advisory, get_blocking_advisories
 from elliottlib.model import Model
-from jira.resources import Issue
-from pyartcd import exectools, constants
+from pyartcd import exectools
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.jira import JIRAClient
 from pyartcd.slack import SlackClient
-from pyartcd.mail import MailService
 from pyartcd.record import parse_record_log
 from pyartcd.runtime import Runtime
 from pyartcd.util import (get_assembly_basis, get_assembly_type,
                           get_release_name_for_assembly,
                           is_greenwave_all_pass_on_advisory,
                           nightlies_with_pullspecs)
-from ruamel.yaml import YAML
-from tenacity import retry, stop_after_attempt, wait_fixed
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -95,7 +94,6 @@ class PrepareReleasePipeline:
         self.elliott_working_dir = self.working_dir / "elliott-working"
         self.doozer_working_dir = self.working_dir / "doozer-working"
         self._jira_client = JIRAClient.from_url(self.runtime.config["jira"]["url"], token_auth=jira_token)
-        self.mail = MailService.from_config(self.runtime.config)
         # sets environment variables for Elliott and Doozer
         self._ocp_build_data_url = self.runtime.config.get("build_config", {}).get("ocp_build_data_url")
         self._doozer_env_vars = os.environ.copy()

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -129,7 +129,7 @@ class PrepareReleasePipeline:
             raise ValueError(f"Assembly {self.assembly} is not explicitly defined in releases.yml for group {self.group_name}.")
         group_config = assembly_group_config(Model(releases_config), self.assembly, Model(group_config)).primitive()
         nightlies = get_assembly_basis(releases_config, self.assembly).get("reference_releases", {}).values()
-        self.candidate_nightlies = self.parse_nighties(nightlies)
+        self.candidate_nightlies = nightlies_with_pullspecs(nightlies)
 
         if release_config and assembly_type != AssemblyTypes.STANDARD:
             _LOGGER.warning("No need to check Blocker Bugs for assembly %s", self.assembly)

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -28,7 +28,8 @@ from pyartcd.record import parse_record_log
 from pyartcd.runtime import Runtime
 from pyartcd.util import (get_assembly_basis, get_assembly_type,
                           get_release_name_for_assembly,
-                          is_greenwave_all_pass_on_advisory)
+                          is_greenwave_all_pass_on_advisory,
+                          nightlies_with_pullspecs)
 from ruamel.yaml import YAML
 from tenacity import retry, stop_after_attempt, wait_fixed
 
@@ -72,7 +73,7 @@ class PrepareReleasePipeline:
                 raise ValueError("No nightly needed for OCP3 releases")
             if self.release_version[0] >= 4 and not nightlies:
                 raise ValueError("You need to specify at least one nightly.")
-            self.candidate_nightlies = self.parse_nighties(nightlies)
+            self.candidate_nightlies = nightlies_with_pullspecs(nightlies)
         else:
             if name:
                 raise ValueError("Release name cannot be set for a non-stream assembly.")
@@ -194,7 +195,7 @@ class PrepareReleasePipeline:
                 _LOGGER.warning("[DRY RUN ]Would have updated Jira ticket status")
 
         _LOGGER.info("Updating ocp-build-data...")
-        build_data_changed = await self.update_build_data(advisories, jira_issue_key)
+        await self.update_build_data(advisories, jira_issue_key)
 
         _LOGGER.info("Sweep builds into the the advisories...")
         for impetus, advisory in advisories.items():
@@ -223,14 +224,6 @@ class PrepareReleasePipeline:
             _LOGGER.info("Verify the swept builds match the nightlies...")
             for _, payload in self.candidate_nightlies.items():
                 self.verify_payload(payload, advisories["image"])
-
-        if build_data_changed or self.candidate_nightlies:
-            _LOGGER.info("Sending a notification to QE and multi-arch QE...")
-            if self.dry_run:
-                jira_issue_link = "https://jira.example.com/browse/FOO-1"
-            else:
-                jira_issue_link = jira_issue.permalink()
-            self.send_notification_email(advisories, jira_issue_link)
 
         # Move advisories to QE
         self._slack_client.bind_channel(self.release_name)
@@ -273,25 +266,6 @@ class PrepareReleasePipeline:
         yaml.preserve_quotes = True
         yaml.width = 4096
         return yaml.load(content)
-
-    @classmethod
-    def parse_nighties(cls, nighty_tags: Iterable[str]) -> Dict[str, str]:
-        arch_nightlies = {}
-        for nightly in nighty_tags:
-            if "s390x" in nightly:
-                arch = "s390x"
-            elif "ppc64le" in nightly:
-                arch = "ppc64le"
-            elif "arm64" in nightly:
-                arch = "aarch64"
-            else:
-                arch = "x86_64"
-            if ":" not in nightly:
-                # prepend pullspec URL to nightly name
-                arch_suffix = go_suffix_for_arch(arch)
-                nightly = f"registry.ci.openshift.org/ocp{arch_suffix}/release{arch_suffix}:{nightly}"
-            arch_nightlies[arch] = nightly
-        return arch_nightlies
 
     def check_blockers(self):
         # Note: --assembly option should always be "stream". We are checking blocker bugs for this release branch regardless of the sweep cutoff timestamp.
@@ -699,29 +673,6 @@ update JIRA accordingly, then notify QE and multi-arch QE for testing.""")
             cmd.append(f"{advisory}")
         _LOGGER.info("Running command: %s", cmd)
         await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars, cwd=self.working_dir)
-
-    @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(10))
-    def send_notification_email(self, advisories: Dict[str, int], jira_link: str):
-        subject = f"OCP {self.release_name} advisories and nightlies"
-        content = f"This is the current set of advisories for {self.release_name}:\n"
-        for impetus, advisory in advisories.items():
-            content += (
-                f"- {impetus}: https://errata.devel.redhat.com/advisory/{advisory}\n"
-            )
-        if 'microshift' in advisories.keys():
-            content += "\n Note: Microshift advisory is not populated with build until after the release has been promoted on Release Controller. It will take a few hours for it to be ready and on QE."
-        if self.candidate_nightlies:
-            content += "\nNightlies:\n"
-            for arch, pullspec in self.candidate_nightlies.items():
-                content += f"- {arch}: {pullspec}\n"
-        elif self.assembly != "stream":
-            content += "\nThis release is NOT directly based on existing nightlies.\n"
-            content += f"Its definition is provided by the assembly found under key '{self.assembly}' in " \
-                       f"{constants.OCP_BUILD_DATA_URL}/blob/{self.group_name}/releases.yml\n"
-        content += f"\nJIRA ticket: {jira_link}\n"
-        content += "\nThanks.\n"
-        email_dir = self.working_dir / "email"
-        self.mail.send_mail(self.runtime.config["email"][f"prepare_release_notification_recipients_ocp{self.release_version[0]}"], subject, content, archive_dir=email_dir, dry_run=self.dry_run)
 
 
 @cli.command("prepare-release")

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -5,25 +5,27 @@ import os
 import re
 import sys
 import traceback
-from collections import OrderedDict
-from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Union
-from urllib.parse import quote
-
+import requests
 import aiohttp
 import click
 import tarfile
 import hashlib
 import shutil
-import urllib.parse
+from collections import OrderedDict
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Union
+from urllib.parse import quote
+from ruamel.yaml import YAML
+from semver import VersionInfo
+from tenacity import (RetryCallState, RetryError, retry,
+                      retry_if_exception_type, retry_if_result,
+                      stop_after_attempt, wait_fixed)
 
-from pyartcd.locks import Lock
-from pyartcd.signatory import AsyncSignatory
-import requests
-# from pyartcd.cincinnati import CincinnatiAPI
 from doozerlib import assembly
 from doozerlib.util import (brew_arch_for_go_arch, brew_suffix_for_arch,
                             go_arch_for_brew_arch, go_suffix_for_arch)
+from pyartcd.locks import Lock
+from pyartcd.signatory import AsyncSignatory
 from pyartcd.util import nightlies_with_pullspecs
 from pyartcd import constants, exectools, locks, util, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
@@ -34,11 +36,7 @@ from pyartcd.s3 import sync_dir_to_s3_mirror
 from pyartcd.oc import get_release_image_info, get_release_image_pullspec, extract_release_binary, \
     extract_release_client_tools, get_release_image_info_from_pullspec, extract_baremetal_installer
 from pyartcd.runtime import Runtime
-from ruamel.yaml import YAML
-from semver import VersionInfo
-from tenacity import (RetryCallState, RetryError, retry,
-                      retry_if_exception_type, retry_if_result,
-                      stop_after_attempt, wait_fixed)
+
 
 yaml = YAML(typ="safe")
 yaml.default_flow_style = False

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1435,7 +1435,7 @@ class PromotePipeline:
         email_dir = self._working_dir.absolute() / "email"
         mail = MailService.from_config(self.runtime.config)
         mail.send_mail(
-            self.runtime.config["email"][f"prepare_release_notification_recipients_ocp{release_version[0]}"],
+            self.runtime.config["email"][f"qe_notification_recipients_ocp{release_version[0]}"],
             subject, content, archive_dir=email_dir, dry_run=self.dry_run)
 
 

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -318,14 +318,14 @@ class PromotePipeline:
                     self._logger.info("Advisory image list sent.")
 
                 # update jira promote task status
-                release_jira = group_config.get("release_jira")
-                if release_jira and not self.dry_run:
-                    self._logger.info("Updating promote release subtask")
-                    parent_jira = self._jira_client.get_issue(release_jira)
+                self._logger.info("Updating promote release subtask")
+                jira_issue_key = group_config.get("release_jira")
+                if jira_issue_key and not self.dry_run:
+                    parent_jira = self._jira_client.get_issue(jira_issue_key)
                     title = "[Wed] Promote the tested nightly"
                     subtask = next((s.key for s in parent_jira.fields.subtasks if title in s.fields.summary), None)
                     if not subtask:
-                        raise ValueError("Promote release subtask not found in release_jira: %s", release_jira)
+                        raise ValueError("Promote release subtask not found in release_jira: %s", jira_issue_key)
 
                     if subtask.fields.status.name != "Closed":
                         self._jira_client.add_comment(

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -323,7 +323,7 @@ class PromotePipeline:
                 if jira_issue_key and not self.dry_run:
                     parent_jira = self._jira_client.get_issue(jira_issue_key)
                     title = "[Wed] Promote the tested nightly"
-                    subtask = next((s.key for s in parent_jira.fields.subtasks if title in s.fields.summary), None)
+                    subtask = next((s for s in parent_jira.fields.subtasks if title in s.fields.summary), None)
                     if not subtask:
                         raise ValueError("Promote release subtask not found in release_jira: %s", jira_issue_key)
 
@@ -1393,7 +1393,7 @@ class PromotePipeline:
         self._logger.info("Checking notify QE release subtask")
         parent_jira = self._jira_client.get_issue(jira_issue_key)
         title = "Notify QE of release advisories"
-        subtask = next((s.key for s in parent_jira.fields.subtasks if title in s.fields.summary), None)
+        subtask = next((s for s in parent_jira.fields.subtasks if title in s.fields.summary), None)
         if not subtask:
             raise ValueError("Notify QE release subtask not found in release_jira: %s", jira_issue_key)
 

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -322,7 +322,7 @@ class PromotePipeline:
                 self._logger.info("Updating promote release subtask")
                 if release_jira and not self.runtime.dry_run:
                     parent_jira = self._jira_client.get_issue(release_jira)
-                    title = "[Wed] Promote the tested nightly"
+                    title = "Promote the tested nightly"
                     subtask = next((s for s in parent_jira.fields.subtasks if title in s.fields.summary), None)
                     if not subtask:
                         raise ValueError("Promote release subtask not found in release_jira: %s", release_jira)

--- a/pyartcd/tests/test_util.py
+++ b/pyartcd/tests/test_util.py
@@ -18,6 +18,18 @@ class TestUtil(IsolatedAsyncioTestCase):
         self.assertEqual(util.isolate_el_version_in_branch('rhaos-4.9-rhel-777'), 777)
         self.assertEqual(util.isolate_el_version_in_branch('rhaos-4.9'), None)
 
+    def test_nightlies_with_pullspecs(self):
+        nightly_tags = ['4.14.0-0.nightly-arm64-2023-09-15-082316', '4.14.0-0.nightly-ppc64le-2023-09-15-125921',
+                        '4.14.0-0.nightly-s390x-2023-09-15-114441', '4.14.0-0.nightly-2023-09-15-055234']
+
+        expected = {
+            'aarch64': 'registry.ci.openshift.org/ocp-arm64/release-arm64:4.14.0-0.nightly-arm64-2023-09-15-082316',
+            'ppc64le': 'registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.14.0-0.nightly-ppc64le-2023-09-15-125921',
+            's390x': 'registry.ci.openshift.org/ocp-s390x/release-s390x:4.14.0-0.nightly-s390x-2023-09-15-114441',
+            'x86_64': 'registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2023-09-15-055234'
+        }
+        self.assertEqual(util.nightlies_with_pullspecs(nightly_tags), expected)
+
     @patch("tempfile.mkdtemp")
     @patch("shutil.rmtree")
     @patch("pyartcd.exectools.cmd_gather_async")


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-7674

## Summary
- No longer send qe email on prepare, no updates when advisories / release-jira is updated (which is a rare case)
- Instead send qe email once as part of promote
- Create new subtask on release-jira for this, mark task closed when completed, so that if promote runs again, we don't send repeated emails.
- Select subtasks based on title rather than fixed number which can be brittle/wrong

release ticket template: https://issues.redhat.com/browse/ART-4223

Should go with https://github.com/openshift-eng/aos-cd-jobs/pull/3950

Test run: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Fpromote-assembly/19/console
