### PR TITLE
ART-7628 Store Jenkins build path as lock value

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -61,6 +61,14 @@ def get_build_url():
 
 
 def get_build_path():
+    """
+    Examples:
+    - https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/46870/ =>
+        job/aos-cd-builds/job/build%252Focp4/46870
+    - https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/46870 =>
+        job/aos-cd-builds/job/build%252Focp4/46870
+    """
+
     url = get_build_url()
     return '/'.join(url.split('/')[3:]) if url else None
 

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -477,9 +477,14 @@ class PromotePipeline:
 
         lock = Lock.SIGNING
         lock_name = lock.value.format(signing_env=self.signing_env)
+        lock_identifier = jenkins.get_build_path()
+        if not lock_identifier:
+            self._logger.warning('Env var BUILD_URL has not been defined: '
+                                 'a random identifier will be used for the locks')
+
         lock_manager = locks.LockManager.from_lock(lock)
 
-        async with await lock_manager.lock(lock_name):
+        async with await lock_manager.lock(resource=lock_name, lock_identifier=lock_identifier):
             async with AsyncSignatory(uri, cert_file, key_file, sig_keyname=sig_keyname) as signatory:
                 tasks = []
                 json_digests = []


### PR DESCRIPTION
Provide all lock-using jobs with the capability of tracking Jenkins builds:
- ocp4_scan
- rebuild
- olm_bundle
- promote