### PR TITLE
Use : separator for lock names

### DIFF
--- a/pyartcd/pyartcd/locks.py
+++ b/pyartcd/pyartcd/locks.py
@@ -8,12 +8,12 @@ from pyartcd import redis
 
 # Defines the pipeline locks managed by Redis
 class Lock(enum.Enum):
-    OLM_BUNDLE = 'olm-bundle-lock-{version}'
-    MIRRORING_RPMS = 'mirroring-rpms-{version}'
-    COMPOSE = 'compose-lock-{version}'
-    BUILD = 'build-lock-{version}'
-    MASS_REBUILD = 'mass-rebuild-serializer'
-    SIGNING = 'signing-lock-{signing_env}'
+    OLM_BUNDLE = 'lock:olm-bundle-{version}'
+    MIRRORING_RPMS = 'lock:mirroring-rpms:{version}'
+    COMPOSE = 'lock:compose:{version}'
+    BUILD = 'lock:build:{version}'
+    MASS_REBUILD = 'lock:mass-rebuild-serializer'
+    SIGNING = 'lock:signing:{signing_env}'
 
 
 # This constant defines for each lock type:
@@ -127,9 +127,9 @@ class LockManager(Aioredlock):
         """
 
         if version:
-            pattern = f'*-lock-{version}'
+            pattern = f'lock:*:{version}'
         else:
-            pattern = '*-lock-*'
+            pattern = 'lock:*'
 
         self.logger.info('Retrieving locks matching pattern "%s"', pattern)
         return await redis.get_keys(pattern)

--- a/pyartcd/tests/test_locks.py
+++ b/pyartcd/tests/test_locks.py
@@ -15,7 +15,7 @@ class TestLocks(TestCase):
     def test_lock_name(self):
         lock: Lock = Lock.BUILD
         lock_name = lock.value.format(version='4.14')
-        self.assertEqual(lock_name, 'build-lock-4.14')
+        self.assertEqual(lock_name, 'lock:build:4.14')
 
     @patch("pyartcd.redis.redis_url", return_value='fake_url')
     @patch("aioredlock.algorithm.Aioredlock.__attrs_post_init__")


### PR DESCRIPTION
Using `:` as a separator in Redis keys allows for a better visualization in the UI.

![image](https://github.com/openshift-eng/art-tools/assets/39080928/922b6240-be2e-4d97-8624-a192768ce729)

Tested with:

```
import asyncio

from pyartcd import redis
from pyartcd.locks import LockManager


async def main():
    lock_manager = LockManager([redis.redis_url()])

    locks = await lock_manager.get_locks()
    for lock in locks:
        print(f'{lock} - {await lock_manager.get_lock_id(lock)}')

    print('-----------------------------------------')

    locks = await lock_manager.get_locks('4.5')
    for lock in locks:
        print(f'{lock} - {await lock_manager.get_lock_id(lock)}')


if __name__ == '__main__':
    asyncio.new_event_loop().run_until_complete(main())
```
