### PR TITLE
Only keep fail counters > 0

### DIFF
--- a/pyartcd/pyartcd/redis.py
+++ b/pyartcd/pyartcd/redis.py
@@ -82,4 +82,6 @@ async def delete_key(conn: aioredis.commands.Redis, key: str) -> int:
     """
 
     logger.debug('Deleting key %s', key)
-    return await conn.delete(key)
+    res = await conn.delete(key)
+    logger.debug('Key %s %s', key, 'deleted' if res else 'not found')
+    return res


### PR DESCRIPTION
Currently, we store build-sync fail counters on Redis even when the count is 0. To improve data observability, this PR proposes to keep only those > 0, so that it will be evident at a first glance what versions have been failing to sync.