### PR TITLE
Log cgit url error

### DIFF
--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -381,7 +381,7 @@ class Metadata(object):
                 3, lambda: urllib.request.urlopen(url),
                 check_f=lambda req: req.code == 200)
         except Exception as e:
-            raise IOError(f"Failed to fetch {url}: {e}")
+            raise IOError(f"Failed to fetch {url}: {e}. Does branch {branch} exist?")
         return req.read()
 
     def get_latest_build(self, default: Optional[Any] = -1, assembly: Optional[str] = None, extra_pattern: str = '*',

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -376,9 +376,12 @@ class Metadata(object):
         :return: the content of the file
         """
         url = self.cgit_file_url(filename, commit_hash=commit_hash, branch=branch)
-        req = exectools.retry(
-            3, lambda: urllib.request.urlopen(url),
-            check_f=lambda req: req.code == 200)
+        try:
+            req = exectools.retry(
+                3, lambda: urllib.request.urlopen(url),
+                check_f=lambda req: req.code == 200)
+        except Exception as e:
+            raise IOError(f"Failed to fetch {url}: {e}")
         return req.read()
 
     def get_latest_build(self, default: Optional[Any] = -1, assembly: Optional[str] = None, extra_pattern: str = '*',


### PR DESCRIPTION
We can get this error when a distgit branch doesn't exist, log it so we know
which image/rpm has the issue

Test run https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4_scan/528137/console