### PR TITLE
[build-sync] Mark viable=false as partial success

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -2,7 +2,7 @@ import asyncio
 import glob
 import json
 import os
-
+import sys
 import click
 import yaml
 
@@ -16,8 +16,10 @@ from doozerlib.util import go_suffix_for_arch
 
 GEN_PAYLOAD_ARTIFACTS_OUT_DIR = 'gen-payload-artifacts'
 
+
 class ViableFalseError(Exception):
     pass
+
 
 class BuildSyncPipeline:
     def __init__(self, runtime: Runtime, version: str, assembly: str, publish: bool, data_path: str,


### PR DESCRIPTION
Having an exit code different than 1 will enable us to mark job as Unstable
in cases where assembly is not viable, but pipeline did not crash with unexpected failure.