### PR TITLE
fix sha256sum not signed in retrigger job

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -346,6 +346,14 @@ class PromotePipeline:
                 if not self.skip_mirror_binaries:
                     message_digests = await self.extract_and_publish_clients(client_type, release_infos)
                 if not self.skip_signing:
+                    if not message_digests:
+                        # if job retriggered due to UMB server issue, then sha256sum.txt may not get signed
+                        for arch, release_info in release_infos.items():
+                            if arch == "multi":
+                                message_digest = f"multi/clients/{client_type}/{release_name}/sha256sum.txt"
+                            else:
+                                message_digest = f"{arch}/clients/{client_type}/{release_name}/sha256sum.txt"
+                            message_digests.append(message_digest)
                     await self.sign_artifacts(release_name, client_type, release_infos, message_digests)
 
         except Exception as err:


### PR DESCRIPTION
if promote job failed with signing step due to UMB server broken but the sync to mirror step complete then if we retrigger the job with skip mirroring artifacts then the sha256sum.txt is not signed, add a check to get it not skiped
ref: https://redhat-internal.slack.com/archives/C02CJ4FNYSV/p1695370596029039?thread_ts=1693545269.704049&cid=C02CJ4FNYSV