### PR TITLE
Store job failures in redis

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -35,7 +35,7 @@ class BuildSyncPipeline:
         self.skip_multiarch_payload = skip_multiarch_payload
         self.logger = runtime.logger
         self.working_dir = self.runtime.working_dir
-        self.fail_count_name = f'count:build-sync-failure:{assembly}:{version}'
+        self.fail_count_name = f'count:failure:build-sync:{assembly}:{version}'
 
     async def run(self):
         # Make sure we're logged into the OC registry

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -400,7 +400,7 @@ async def build_sync(runtime: Runtime, version: str, assembly: str, publish: boo
         if assembly == 'stream':
             await pipeline.handle_failure()
 
-        # Re-reise the exception to make the job as failed
+        # Re-raise the exception to make the job as failed
         raise
 
     except RedisError as e:

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -841,7 +841,7 @@ class Ocp4Pipeline:
                 content=f'Check Jenkins console for details: {jenkins.current_build_url}/console'
             )
 
-    async def handle_success(self):
+    def _report_success(self):
         # Update description with build metrics
         if self.runtime.dry_run or (not self.build_plan.build_rpms and not self.build_plan.build_images):
             record_log = {}  # Nothing was actually built
@@ -892,6 +892,7 @@ class Ocp4Pipeline:
 
         await self._mirror_rpms()
         await self._sweep()
+        self._report_success()
 
         if self.success_nvrs:  # Trigger osh scans for successfully built images and RPMs
             self._trigger_osh_scans()

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -956,7 +956,7 @@ async def ocp4(runtime: Runtime, version: str, assembly: str, data_path: str, da
     )
 
     lock_manager = None
-    fail_count_name = f'count:ocp4-failure:{assembly}:{version}'
+    fail_count_name = f'count:failure:ocp4:{assembly}:{version}'
 
     try:
         if ignore_locks:

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -579,10 +579,6 @@ class Ocp4Pipeline:
             await self._slack_client.say(error_msg)
             raise
 
-        except LockError as e:
-            self.runtime.logger.error('Failed acquiring lock %s: %s', lock_name, e)
-            raise
-
         finally:
             await lock_manager.destroy()
 
@@ -735,10 +731,6 @@ class Ocp4Pipeline:
                     await self._rebase_images()
                     await self._build_images()
 
-            except LockError as e:
-                self.runtime.logger.error('Failed acquiring lock %s: %s', lock_name, e)
-                raise
-
             finally:
                 await lock_manager.destroy()
 
@@ -814,10 +806,6 @@ class Ocp4Pipeline:
             self.runtime.logger.error(traceback.format_exc())
             self._slack_client.bind_channel(f'openshift-{self.version.stream}')
             await self._slack_client.say(error_msg)
-            raise
-
-        except LockError as e:
-            self.runtime.logger.error('Failed acquiring lock %s: %s', lock_name, e)
             raise
 
         finally:
@@ -976,10 +964,6 @@ async def ocp4(runtime: Runtime, version: str, assembly: str, data_path: str, da
         try:
             async with await lock_manager.lock(resource=lock_name, lock_identifier=lock_identifier):
                 await pipeline.run()
-
-        except LockError as e:
-            runtime.logger.error('Failed acquiring lock %s: %s', lock_name, e)
-            raise
 
         finally:
             await lock_manager.destroy()

--- a/pyartcd/pyartcd/pipelines/ocp4_scan.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan.py
@@ -146,7 +146,7 @@ async def ocp4_scan(runtime: Runtime, version: str):
         runtime.logger.warning('Env var BUILD_URL has not been defined: a random identifier will be used for the locks')
 
     pipeline = Ocp4ScanPipeline(runtime, version)
-    fail_count_name = f'count:ocp4-scan-failure:stream:{version}'
+    fail_count_name = f'count:failure:ocp4-scan:stream:{version}'
 
     try:
         # Skip the build if already locked

--- a/pyartcd/pyartcd/pipelines/ocp4_scan.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan.py
@@ -153,8 +153,5 @@ async def ocp4_scan(runtime: Runtime, version: str):
             async with await lock_manager.lock(resource=lock_name, lock_identifier=lock_identifier):
                 await Ocp4ScanPipeline(runtime, version).run()
 
-    except LockError as e:
-        runtime.logger.error('Failed acquiring lock %s: %s', lock_name, e)
-        raise
     finally:
         await lock_manager.destroy()

--- a/pyartcd/pyartcd/pipelines/olm_bundle.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle.py
@@ -95,9 +95,5 @@ async def olm_bundle(runtime: Runtime, version: str, assembly: str, data_path: s
                                    f'buildvm job: {os.environ["BUILD_URL"]}')
             raise
 
-    except LockError as e:
-        runtime.logger.error('Failed acquiring lock %s: %s', lock_name, e)
-        raise
-
     finally:
         await lock_manager.destroy()

--- a/pyartcd/pyartcd/pipelines/rebuild.py
+++ b/pyartcd/pyartcd/pipelines/rebuild.py
@@ -613,6 +613,5 @@ async def rebuild(runtime: Runtime, ocp_build_data_url: str, version: str, assem
             async with await lock_manager.lock(resource=lock_name, lock_identifier=lock_identifier):
                 await pipeline.run()
 
-        except LockError as e:
-            runtime.logger.error('Failed acquiring lock %s: %s', lock_name, e)
-            raise
+        finally:
+            await lock_manager.destroy()

--- a/pyartcd/pyartcd/redis.py
+++ b/pyartcd/pyartcd/redis.py
@@ -101,9 +101,9 @@ async def clear_counter(counter: str):
         logger.info('Counter %s can\'t be deleted as it does not exist')
 
 
-async def increment_counter(counter: str):
+async def increment_counter(counter: str) -> int:
     """
-    Increment by 1 a counter on Redis
+    Increment by 1 a counter on Redis. Returns the new counter value
     """
 
     # Get current count
@@ -115,3 +115,5 @@ async def increment_counter(counter: str):
     new_count = int(current_count) + 1
     await set_value(counter, new_count)
     logger.info('Count %s set to %s', counter, new_count)
+
+    return new_count

--- a/pyartcd/pyartcd/redis.py
+++ b/pyartcd/pyartcd/redis.py
@@ -85,3 +85,33 @@ async def delete_key(conn: aioredis.commands.Redis, key: str) -> int:
     res = await conn.delete(key)
     logger.debug('Key %s %s', key, 'deleted' if res else 'not found')
     return res
+
+
+async def clear_counter(counter: str):
+    """
+    Clear counter from Redis
+    """
+
+    res = await delete_key(counter)
+
+    if res:
+        logger.info('Counter "%s" deleted', counter)
+
+    else:
+        logger.info('Counter %s can\'t be deleted as it does not exist')
+
+
+async def increment_counter(counter: str):
+    """
+    Increment by 1 a counter on Redis
+    """
+
+    # Get current count
+    current_count = await get_value(counter)
+    if current_count is None:  # does not yet exist in Redis
+        current_count = 0
+
+    # Increment counter
+    new_count = int(current_count) + 1
+    await set_value(counter, new_count)
+    logger.info('Count %s set to %s', counter, new_count)

--- a/pyartcd/tests/test_jenkins.py
+++ b/pyartcd/tests/test_jenkins.py
@@ -69,6 +69,8 @@ class TestJenkinsStartBuild(unittest.TestCase):
 
     def test_get_build_url_and_path(self):
         # No BUILD_URL env var defined
+        if os.environ.get('BUILD_URL'):
+            del os.environ['BUILD_URL']
         self.assertEqual(jenkins.get_build_url(), None)
         self.assertEqual(jenkins.get_build_path(), None)
 


### PR DESCRIPTION
Jobs affected by this change are:
- ocp4
- ocp4-scan
- olm_bundle

Ideas in this PR:
- track in Redis failures for the jobs we're mostly interested in, as we already do for `build-sync`. Keeping them organized will let us implement scheduled checks and notifications as needed.

- as an example, `olm-bundle` [spams slack](https://redhat-internal.slack.com/archives/C04L1FPFHNH/p1694077550422039) as soon as a run fails; that could be improved, setting a threshold for each group, and starting to spam when that threshold is exceeded; we could also spam only for `stream`, and start pinging @release-artists without being too noisy.

- this would simplify manual checks/messages like [this one](https://redhat-internal.slack.com/archives/GDBRP5YJH/p1695302687889259)

- changing the fail count format to include a `failure` field will let us "count" anything else in the future, while keeping data organized in a hierarchical fashion

