### PR TITLE
ART-5994 Automate golang update SOP

### DIFF
--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -4,8 +4,7 @@ from pyartcd.cli import cli
 from pyartcd.pipelines import (
     build_microshift, check_bugs, gen_assembly, prepare_release, promote, rebuild, report_rhcos,
     review_cvp, tarball_sources, build_sync, build_rhcos, ocp4_scan, images_health, operator_sdk_sync,
-    olm_bundle, ocp4, scan_for_kernel_bugs, tag_rpms, advisory_drop, cleanup_locks, brew_scan_osh,
-    scan_fips, sigstore_sign
+    olm_bundle, ocp4, scan_for_kernel_bugs, tag_rpms, advisory_drop, cleanup_locks, brew_scan_osh, scan_fips, sigstore_sign, update_golang, rebuild_golang_rpms
 )
 
 

--- a/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py
+++ b/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py
@@ -1,0 +1,284 @@
+import click
+import koji
+import datetime
+import logging
+import os
+from typing import List
+from ghapi.all import GhApi
+from specfile import Specfile
+
+from artcommonlib.constants import BREW_HUB
+from artcommonlib.release_util import split_el_suffix_in_release
+from pyartcd import exectools
+from pyartcd import constants
+from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.runtime import Runtime
+from doozerlib.rpm_utils import parse_nvr
+from elliottlib import util as elliottutil
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class RebuildGolangRPMsPipeline:
+    def __init__(self, runtime: Runtime, ocp_version: str, go_nvrs: List[str], art_jira: str):
+        self.runtime = runtime
+        self.ocp_version = ocp_version
+        self.go_nvrs = go_nvrs
+        self.art_jira = art_jira
+        self.koji_session = koji.ClientSession(BREW_HUB)
+
+    async def run(self):
+        # validate that the ocp version allows given rhel versions
+        # TODO: we can deduce this from streams.yml keys that are defined for the group
+        # for now we will hardcode this mapping
+        ocp_el_map = {
+            '4.10': {7, 8},
+            '4.11': {7, 8},
+            '4.12': {8, 9},
+            '4.13': {8, 9},
+            '4.14': {8, 9},
+            '4.15': {8, 9},
+            '4.16': {8, 9},
+        }
+        if self.ocp_version not in ocp_el_map:
+            raise click.BadParameter(f'OCP version is not supported right now: {self.ocp_version}')
+
+        supported_els = ocp_el_map[self.ocp_version]
+        if len(self.go_nvrs) > len(supported_els):
+            raise click.BadParameter(f'There should be max 1 nvr for each supported rhel version: {supported_els}')
+
+        # extract & validate rhel versions and golang versions from nvrs
+        el_nvr_map = dict()  # {8: 'golang-1.16.7-1.el8', 9: 'golang-1.16.7-1.el9'}
+        go_version = None
+        for nvr in self.go_nvrs:
+            parsed_nvr = parse_nvr(nvr)
+            name = parsed_nvr['name']
+            if not (name == 'golang' or name.startswith('go-toolset')):
+                raise ValueError(f'Only golang/go-toolset nvrs are supported, found: {name}')
+            if go_version and go_version != parsed_nvr['version']:
+                raise ValueError(f'All nvrs should have the same golang version, found: {go_version} and'
+                                 f' {parsed_nvr["version"]}')
+            go_version = parsed_nvr['version']
+
+            _, el_version = split_el_suffix_in_release(parsed_nvr['release'])
+            # el_version is either None or something like "el8"
+            if not el_version:
+                raise ValueError(f'Cannot detect an el version in NVR {nvr}')
+            el_version = int(el_version[2:])
+            if el_version not in supported_els:
+                raise ValueError(f'Unsupported RHEL version detected for nvr {nvr}, supported versions are:'
+                                 f' {supported_els}')
+            if el_version in el_nvr_map:
+                raise ValueError(f'Cannot have two nvrs for the same rhel version: {nvr},'
+                                 f' {el_nvr_map[el_version]}')
+            el_nvr_map[el_version] = nvr
+
+        _LOGGER.info(f'Golang version detected: {go_version}')
+        _LOGGER.info(f'NVRs by rhel version: {el_nvr_map}')
+
+        # For rpms - first make sure builds are tagged and available
+        _LOGGER.info('Checking if golang builds are tagged and available in rpm buildroots')
+        error_msg = ""
+        for el_v, nvr in el_nvr_map.items():
+            if await self.is_latest_and_available(el_v, nvr):
+                _LOGGER.info(f"{nvr} is tagged and available in buildroot")
+            else:
+                msg = f"{nvr} is not tagged and available in buildroot. "
+                error_msg += msg
+                _LOGGER.error(msg)
+
+        if error_msg:
+            raise ValueError(error_msg)
+
+        # Check which rpms need to be rebuilt
+        _LOGGER.info('Checking if rpms need to be rebuilt')
+        _LOGGER.info('Will ignore microshift rpm since it is special and rebuilds for payload image')
+
+        # fetch art_built_rpms
+        art_built_rpms = self.get_art_built_rpms()
+
+        non_art_rpms_for_rebuild = dict()
+        art_rpms_for_rebuild = set()
+        for el_v, nvr in el_nvr_map.items():
+            _LOGGER.info(f'Fetching all rhel{el_v} rpms in our candidate tag')
+            rpms = [parse_nvr(n) for n in self.get_rpms(el_v) if 'microshift' not in n]
+            _LOGGER.info('Determining golang rpms and their build versions')
+            go_nvr_map = elliottutil.get_golang_rpm_nvrs(
+                [(n['name'], n['version'], n['release']) for n in rpms],
+                _LOGGER
+            )
+            for go_v, nvrs in go_nvr_map.items():
+                nvr_s = [f'{n[0]}-{n[1]}-{n[2]}' for n in nvrs]
+                if go_v in nvr:
+                    _LOGGER.info(f'Builds on latest go version {go_v}: {nvr_s}')
+                    continue
+                _LOGGER.info(f'Builds on previous go version {go_v}: {nvr_s}')
+                art_rpms_for_rebuild.update([n[0] for n in nvrs if n[0] in art_built_rpms])
+                if el_v not in non_art_rpms_for_rebuild:
+                    non_art_rpms_for_rebuild[el_v] = []
+                non_art_rpms_for_rebuild[el_v].extend([n[0] for n in nvrs if n[0] not in art_built_rpms])
+
+            if non_art_rpms_for_rebuild.get(el_v):
+                _LOGGER.info(f'These non-ART rhel{el_v} rpms are on previous golang versions, they need to be '
+                             f'rebuilt: {sorted(non_art_rpms_for_rebuild[el_v])}')
+
+        if art_rpms_for_rebuild:
+            _LOGGER.info(f'These ART rpms are on previous golang versions, they need to be rebuilt: {sorted(art_rpms_for_rebuild)}')
+            self.rebuild_art_rpms(art_rpms_for_rebuild)
+
+        if not non_art_rpms_for_rebuild:
+            _LOGGER.info('All non-ART rpms are using given golang builds!')
+            return
+
+        _LOGGER.info('Building non-ART rpms...')
+
+        _, author, _ = await exectools.cmd_gather_async('git config user.name')
+        _, email, _ = await exectools.cmd_gather_async('git config user.email')
+        author = author.strip()
+        email = email.strip()
+        if not email.endswith('@redhat.com'):
+            raise ValueError(f'git config user.email {email} does not end with @redhat.com')
+        if email == "noreply@redhat.com":
+            email = "aos-team-art@redhat.com"
+        _LOGGER.info(f"Will use author={author} email={email} for bump commit message")
+
+        for el_v, rpms in non_art_rpms_for_rebuild.items():
+            for rpm in rpms:
+                try:
+                    await self.bump_and_rebuild_rpm(rpm, el_v, author, email)
+                except Exception as err:
+                    _LOGGER.error(f'Error bumping and rebuilding {rpm}: {err}')
+                    continue
+
+    def get_art_built_rpms(self):
+        github_token = os.environ.get('GITHUB_TOKEN')
+        if not github_token:
+            raise ValueError("GITHUB_TOKEN environment variable is required to fetch build data repo contents")
+        api = GhApi(owner='openshift-eng', repo='ocp-build-data', token=github_token)
+        branch = f'openshift-{self.ocp_version}'
+        content = api.repos.get_content(path='rpms', ref=branch)
+        return [c['name'].rstrip('.yml') for c in content if c['name'].endswith('.yml')]
+
+    def rebuild_art_rpms(self, rpms):
+        _LOGGER.info(f"Trigger job at {constants.JENKINS_UI_URL}/job/aos-cd-builds/job/build%252Focp4/build "
+                     f"with params BUILD_VERSION={self.ocp_version} ASSEMBLY=stream "
+                     f"PIN_BUILDS=True BUILD_IMAGES=none BUILD_RPMS=only RPM_LIST={','.join(rpms)}")
+        # jenkins.start_ocp4(
+        #     build_version=self.ocp_version,
+        #     assembly='stream',
+        #     rpm_list=rpms,
+        #     dry_run=self.runtime.dry_run
+        # )
+
+    async def bump_and_rebuild_rpm(self, rpm, el_v, author, email):
+        branch = f'rhaos-{self.ocp_version}-rhel-{el_v}'
+        # check if dir exists
+        if not os.path.isdir(rpm):
+            cmd = f'rhpkg clone --branch {branch} rpms/{rpm}'
+            await exectools.cmd_assert_async(cmd)
+        else:
+            await exectools.cmd_assert_async('git reset --hard', cwd=rpm)
+            await exectools.cmd_assert_async('git fetch --all', cwd=rpm)
+        await exectools.cmd_assert_async(f'git checkout {branch}', cwd=rpm)
+        await exectools.cmd_assert_async('git reset --hard @{upstream}', cwd=rpm)
+
+        # get last commit message on this branch
+        bump_msg = f'Bump and rebuild with latest golang, resolves {self.art_jira}'
+        rc, commit_message, _ = await exectools.cmd_gather_async('git log -1 --format=%s', cwd=rpm)
+        if rc != 0:
+            raise ValueError(f'Cannot get last commit message for {rpm}')
+        if bump_msg in commit_message:
+            _LOGGER.info(f'{rpm}/{branch} - Bump commit exists on branch, build in queue? skipping')
+            return
+
+        # get all .spec files
+        specs = [f for f in os.listdir(rpm) if f.endswith('.spec')]
+        if len(specs) != 1:
+            raise ValueError(f'Expected to find only 1 .spec file in {rpm}, found: {specs}')
+
+        spec = Specfile(os.path.join(rpm, specs[0]))
+
+        _LOGGER.info(f'{rpm}/{branch} - Bumping release in specfile')
+
+        # Increment second digit of the Release segment e.g.
+        # 42.rhaos4_8.el8 -> 42.1.rhaos4_8.el8
+        # 6.3.rhaos4_8.el8 -> 6.4.rhaos4_8.el8
+        _LOGGER.info(f'{rpm}/{branch} - Current release in specfile: {spec.release}')
+        k = spec.release.split('.')
+        digits = []
+        non_digit_marker = None
+        for p in k:
+            if p.isdigit():
+                digits.append(p)
+            else:
+                non_digit_marker = spec.release.index(p)
+                break
+        if len(digits) < 1:
+            raise ValueError("unexpected release in specfile")
+        elif len(digits) < 2:
+            digits.append(0)
+        rel = f'{digits[0]}.{int(digits[1])+1}'
+        if non_digit_marker:
+            rel += f'.{spec.release[non_digit_marker:]}'
+        spec.release = rel
+        _LOGGER.info(f'{rpm}/{branch} - New release in specfile: {spec.release}')
+
+        _LOGGER.info(f'{rpm}/{branch} - Adding changelog entry in specfile')
+        spec.add_changelog_entry(
+            bump_msg,
+            author=author,
+            email=email,
+            timestamp=datetime.date.today(),
+        )
+
+        if self.runtime.dry_run:
+            _LOGGER.info(f"{rpm}/{branch} - Dry run, would've committed changes and triggered build")
+            return
+
+        spec.save()
+        cmd = f'git commit -am "{bump_msg}"'
+        await exectools.cmd_assert_async(cmd, cwd=rpm)
+        cmd = 'git push'
+        await exectools.cmd_assert_async(cmd, cwd=rpm)
+        cmd = 'rhpkg build --nowait'
+        await exectools.cmd_assert_async(cmd, cwd=rpm)
+
+    def get_rpms(self, el_v):
+        # get all the go rpms from the candidate tag
+        tag = f'rhaos-{self.ocp_version}-rhel-{el_v}-candidate'
+        latest_builds = [b['nvr'] for b in self.koji_session.listTagged(tag, latest=True)]
+        rpms = [b for b in latest_builds if not ('-container' in b or b.startswith('rhcos-'))]
+        return rpms
+
+    def is_latest_build(self, el_v: int, nvr: str) -> bool:
+        build_tag = f'rhaos-{self.ocp_version}-rhel-{el_v}-build'
+        _LOGGER.info(f'Checking build root {build_tag}')
+        parsed_nvr = parse_nvr(nvr)
+        latest_build = self.koji_session.getLatestBuilds(build_tag, package=parsed_nvr['name'])
+        if not latest_build:  # if this happens, investigate
+            raise ValueError(f'Cannot find latest {parsed_nvr["name"]} build in {build_tag}. Please investigate.')
+        if nvr == latest_build[0]['nvr']:
+            return True
+        return False
+
+    async def is_latest_and_available(self, el_v: int, nvr: str) -> bool:
+        if not self.is_latest_build(el_v, nvr):
+            return False
+
+        # If regen repo has been run this would take a few seconds
+        # sadly --timeout cannot be less than 1 minute, so we wait for 1 minute
+        build_tag = f'rhaos-{self.ocp_version}-rhel-{el_v}-build'
+        _LOGGER.info(f'Checking build root {build_tag}')
+        cmd = f'brew wait-repo {build_tag} --build {nvr} --timeout=1'
+        rc, _, _ = await exectools.cmd_gather_async(cmd)
+        return rc == 0
+
+
+@cli.command('rebuild-golang-rpms')
+@click.option('--ocp-version', required=True, help='OCP version to rebuild golang rpms for')
+@click.option('--art-jira', required=True, help='Related ART Jira ticket e.g. ART-1234')
+@click.argument('go_nvrs', metavar='GO_NVRS...', nargs=-1, required=True)
+@pass_runtime
+@click_coroutine
+async def rebuild_golang_rpms(runtime: Runtime, ocp_version: str, go_nvrs: List[str], art_jira: str):
+    await RebuildGolangRPMsPipeline(runtime, ocp_version, go_nvrs, art_jira).run()

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -139,7 +139,7 @@ class UpdateGolangPipeline:
 
         need_update = False
         if len(builder_nvrs) == len(el_nvr_map):  # existing builders found for all rhel versions
-            _LOGGER.info(f"Checking if existing builder images are being used in streams.yml")
+            _LOGGER.info("Checking if existing builder images are being used in streams.yml")
 
             owner, repo = 'openshift-eng', 'ocp-build-data'
             branch, filename = f'openshift-{self.ocp_version}', 'streams.yml'

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -1,0 +1,314 @@
+import click
+import koji
+import logging
+import re
+import os
+import yaml
+import base64
+from typing import List
+from ghapi.all import GhApi
+
+from artcommonlib.constants import BREW_HUB
+from artcommonlib.format_util import green_print, yellow_print, red_print
+from artcommonlib.release_util import split_el_suffix_in_release
+from pyartcd import exectools
+from pyartcd import constants
+from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.runtime import Runtime
+from doozerlib.rpm_utils import parse_nvr
+from doozerlib.brew import BuildStates
+from elliottlib.constants import GOLANG_BUILDER_CVE_COMPONENT
+from elliottlib import util as elliottutil
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class UpdateGolangPipeline:
+    def __init__(self, runtime: Runtime, ocp_version: str, create_ticket: bool, go_nvrs: List[str],
+                 permit_missing_qe_tag: bool, art_jira: str):
+        self.runtime = runtime
+        self.ocp_version = ocp_version
+        self.create_ticket = create_ticket
+        self.go_nvrs = go_nvrs
+        self.art_jira = art_jira
+        self.permit_missing_qe_tag = permit_missing_qe_tag
+        self.koji_session = koji.ClientSession(BREW_HUB)
+
+        self.github_token = os.environ.get('GITHUB_TOKEN')
+        if not self.github_token:
+            raise ValueError("GITHUB_TOKEN environment variable is required to fetch build data repo contents")
+
+    async def run(self):
+        # validate that the ocp version allows given rhel versions
+        # TODO: we can deduce this from streams.yml keys that are defined for the group
+        # for now we will hardcode this mapping
+        ocp_el_map = {
+            '4.10': {7, 8},
+            '4.11': {7, 8},
+            '4.12': {8, 9},
+            '4.13': {8, 9},
+            '4.14': {8, 9},
+            '4.15': {8, 9},
+            '4.16': {8, 9},
+        }
+        if self.ocp_version not in ocp_el_map:
+            raise click.BadParameter(f'OCP version is not supported right now: {self.ocp_version}')
+
+        supported_els = ocp_el_map[self.ocp_version]
+        if len(self.go_nvrs) > len(supported_els):
+            raise click.BadParameter(f'There should be max 1 nvr for each supported rhel version: {supported_els}')
+
+        # extract & validate rhel versions and golang versions from nvrs
+        el_nvr_map = dict()  # {8: 'golang-1.16.7-1.el8', 9: 'golang-1.16.7-1.el9'}
+        go_version = None
+        for nvr in self.go_nvrs:
+            parsed_nvr = parse_nvr(nvr)
+            name = parsed_nvr['name']
+            if not (name == 'golang' or name.startswith('go-toolset')):
+                raise ValueError(f'Only golang/go-toolset nvrs are supported, found: {name}')
+            if go_version and go_version != parsed_nvr['version']:
+                raise ValueError(f'All nvrs should have the same golang version, found: {go_version} and'
+                                 f' {parsed_nvr["version"]}')
+            go_version = parsed_nvr['version']
+
+            _, el_version = split_el_suffix_in_release(parsed_nvr['release'])
+            # el_version is either None or something like "el8"
+            if not el_version:
+                raise ValueError(f'Cannot detect an el version in NVR {nvr}')
+            el_version = int(el_version[2:])
+            if el_version not in supported_els:
+                raise ValueError(f'Unsupported RHEL version detected for nvr {nvr}, supported versions are:'
+                                 f' {supported_els}')
+            if el_version in el_nvr_map:
+                raise ValueError(f'Cannot have two nvrs for the same rhel version: {nvr},'
+                                 f' {el_nvr_map[el_version]}')
+            el_nvr_map[el_version] = nvr
+
+        _LOGGER.info(f'Golang version detected: {go_version}')
+        _LOGGER.info(f'NVRs by rhel version: {el_nvr_map}')
+
+        # if requested, create ticket for tagging request
+        if self.create_ticket:
+            _LOGGER.info('Making sure that builds are not already tagged & have necessary qe tags')
+            for el_v, nvr in el_nvr_map.items():
+                if self.is_latest_build(el_v, nvr):
+                    raise ValueError(f'{nvr} is already the latest build, run '
+                                     'only with nvrs that are not latest or run without --create-tagging-ticket')
+                # check if all the necessary tags exist
+                if not self.has_necessary_tags(nvr):
+                    if self.permit_missing_qe_tag:
+                        _LOGGER.warning(f'{nvr} does not have the necessary qe tags, but --permit-missing-qe-tag was used')
+                        continue
+                    raise ValueError(f'{nvr} does not have the necessary qe tags. Use --permit-missing-qe-tag to ignore this')
+
+            _LOGGER.info('Creating Jira ticket to tag golang builds in buildroots')
+            self.create_jira_ticket(el_nvr_map, go_version)
+            return
+
+        for el_v, nvr in el_nvr_map.items():
+            if not await self.is_latest_and_available(el_v, nvr):
+                raise ValueError(f'{nvr} is not the latest build in buildroot, tag yourself or get them tagged via'
+                                 '--create-tagging-ticket')
+        _LOGGER.info('All builds are tagged and available!')
+
+        # Make a sanity check if a builder nvr exists for this version and if it's already pinned
+        component = GOLANG_BUILDER_CVE_COMPONENT
+        _LOGGER.info(f"Checking if {component} builds exist for given golang builds")
+        package_info = self.koji_session.getPackage(component)
+        if not package_info:
+            raise IOError(f'No brew package is defined for {component}')
+        package_id = package_info['id']
+        builder_nvrs = {}
+        for el_v, go_nvr in el_nvr_map.items():
+            pattern = f"{component}-v{go_version}-*el{el_v}*"
+            builds = self.koji_session.listBuilds(packageID=package_id,
+                                                  state=BuildStates.COMPLETE.value,  # complete
+                                                  pattern=pattern,
+                                                  queryOpts={'limit': 1, 'order': '-creation_event_id'})
+            if builds:
+                build = builds[0]
+                go_nvr_map = elliottutil.get_golang_container_nvrs(
+                    [(build['name'], build['version'], build['release'])],
+                    _LOGGER
+                )  # {'1.20.12-2.el9_3': {('openshift-golang-builder-container', 'v1.20.12',
+                # '202403212137.el9.g144a3f8.el9')}}
+                builder_go_vr = list(go_nvr_map.keys())[0]
+                if builder_go_vr in go_nvr:
+                    _LOGGER.info(f"Found existing builder image: {build['nvr']} built with {go_nvr}")
+                    builder_nvrs[el_v] = build['nvr']
+
+        need_update = False
+        if len(builder_nvrs) == len(el_nvr_map):  # existing builders found for all rhel versions
+            _LOGGER.info(f"Checking if existing builder images are being used in streams.yml")
+
+            owner, repo = 'openshift-eng', 'ocp-build-data'
+            branch, filename = f'openshift-{self.ocp_version}', 'streams.yml'
+
+            api = GhApi(owner=owner, repo=repo, token=self.github_token)
+            blob = api.repos.get_content(filename, ref=branch)
+            group_config = yaml.safe_load(base64.b64decode(blob['content']))
+            major_go, minor_go, _ = go_version.split('.')
+            for stream_name, info in group_config.items():
+                if 'golang' not in stream_name:
+                    continue
+                image_nvr_like = info['image']
+                if 'golang-builder' not in image_nvr_like:
+                    continue
+                name, vr = image_nvr_like.split(':')
+                nvr = f"{name.replace('/', '-')}-container-{vr}"
+                pattern = f"{component}-v{major_go}.{minor_go}"
+                if not nvr.startswith(pattern):
+                    continue
+
+                _, el_version = split_el_suffix_in_release(vr)
+                el_version = int(el_version[2:])
+                if nvr == builder_nvrs[el_version]:
+                    _LOGGER.info(f'stream:{stream_name} has the desired builder nvr:{nvr}')
+                else:
+                    yellow_print(f'update stream:{stream_name}:image to {builder_nvrs[el_version]}')
+                    need_update = True
+
+            if not need_update:
+                green_print("Builders don't need update since nvr are built and pinned in streams.yml")
+            else:
+                red_print("Please update streams.yml")
+        else:
+            missing_in = el_nvr_map.keys() - builder_nvrs.keys()
+            # Make sure builder branches are updated for building
+            _LOGGER.info(f"Builder images are missing for rhel versions: {missing_in}. "
+                         "Verifying builder branches are updated for building")
+            for el_v in missing_in:
+                self.verify_golang_builder_repo(el_v, go_version)
+                _LOGGER.info(
+                    f"Please trigger job at {constants.JENKINS_UI_URL}/job/aos-cd-builds"
+                    "/job/build%252Fgolang-builder/ "
+                    f"with params GOLANG_VERSION={go_version} RHEL_VERSION={el_v}")
+
+    def verify_golang_builder_repo(self, el_v, go_version):
+        # read group.yml from the branch rhel-{el_v}-golang-{go_v} using ghapi
+        owner, repo = 'openshift-eng', 'ocp-build-data'
+        major_go, minor_go, patch_go = go_version.split('.')
+        go_v = f"{major_go}.{minor_go}"
+        branch, filename = f'rhel-{el_v}-golang-{go_v}', 'group.yml'
+
+        api = GhApi(owner=owner, repo=repo, token=self.github_token)
+        blob = api.repos.get_content(filename, ref=branch)
+        group_config = yaml.safe_load(base64.b64decode(blob['content']))
+        content_repo_url = self.get_content_repo_url(el_v)
+
+        golang_repo = f'rhel-{el_v}-golang-rpms'
+        if golang_repo not in group_config['repos']:
+            raise ValueError(f"Did not find {golang_repo} defined at "
+                             f"https://github.com/{owner}/{repo}/blob/{branch}/{filename}. If it's with a different "
+                             "name please correct it.")
+
+        expected = {arch: f'{content_repo_url}/{arch}/'
+                    for arch in group_config['repos'][golang_repo]['conf']['baseurl'].keys()}
+
+        major, minor = group_config['vars']['MAJOR'], group_config['vars']['MINOR']
+        actual = {arch: val.format(MAJOR=major, MINOR=minor)
+                  for arch, val in group_config['repos'][golang_repo]['conf']['baseurl'].items()}
+
+        if expected != actual:
+            raise ValueError(f"Did not find repo {golang_repo} to have the expected urls. \nexpected="
+                             f"{expected}\nactual={actual}")
+
+        _LOGGER.info(f"Builder branch {branch} has the expected content set urls")
+
+        # # create a new branch rhel-{el_v}-golang-{go_v}-update using ghapi
+        # branch = f'rhel-{el_v}-golang-{go_v}-update'
+        # title = f'Update golang rpms for {nvr}'
+        # body = f'Update golang rpms for {nvr} by updating group.yml'
+        # api.repos.create_branch(branch, 'rhel-{el_v}-golang-{go_v}')
+        #
+        # # create a pull request with the updated group.yml using ghapi
+        # branch = f'rhel-{el_v}-golang-{go_v}-update'
+        # title = f'Rebuild golang rpms for {nvr}'
+        # body = f'Rebuild golang rpms for {nvr} by updating group.yml'
+        # api.repos.create_pull(title=title, body=body, head=branch, base=branch)
+
+    def get_content_repo_url(self, el_v):
+        url = 'https://download-node-02.eng.bos.redhat.com/brewroot/repos/{repo}/latest'
+        return url.format(repo=f'rhaos-{self.ocp_version}-rhel-{el_v}-build')
+
+    def has_necessary_tags(self, nvr: str) -> bool:
+        tag_regex = r'^RH[EBS]A-.*(pending|released)$'
+        tags = [t['name'] for t in self.koji_session.listTags(build=nvr)]
+        if any(re.match(tag_regex, t) for t in tags):
+            return True
+        _LOGGER.info(f'NVR {nvr} does not have any tags matching {tag_regex}')
+        return False
+
+    def is_latest_build(self, el_v: int, nvr: str) -> bool:
+        build_tag = f'rhaos-{self.ocp_version}-rhel-{el_v}-build'
+        _LOGGER.info(f'Checking build root {build_tag} for latest build')
+        parsed_nvr = parse_nvr(nvr)
+        latest_build = self.koji_session.getLatestBuilds(build_tag, package=parsed_nvr['name'])
+        if not latest_build:  # if this happens, investigate
+            raise ValueError(f'Cannot find latest {parsed_nvr["name"]} build in {build_tag}. Please investigate.')
+        if nvr == latest_build[0]['nvr']:
+            return True
+        return False
+
+    async def is_latest_and_available(self, el_v: int, nvr: str) -> bool:
+        if not self.is_latest_build(el_v, nvr):
+            return False
+
+        # If regen repo has been run this would take a few seconds
+        # sadly --timeout cannot be less than 1 minute, so we wait for 1 minute
+        build_tag = f'rhaos-{self.ocp_version}-rhel-{el_v}-build'
+        _LOGGER.info(f'Checking build root {build_tag} if latest build is available')
+        cmd = f'brew wait-repo {build_tag} --build {nvr} --timeout=1'
+        rc, _, _ = await exectools.cmd_gather_async(cmd)
+        return rc == 0
+
+    def get_module_tag(self, nvr, el_v) -> str:
+        tags = [t['name'] for t in self.koji_session.listTags(build=nvr)]
+        prefix = f'module-go-toolset-rhel{el_v}-'
+        return next((t for t in tags if t.startswith(prefix) and not t.endswith('-build')), None)
+
+    def create_jira_ticket(self, el_nvr_map, go_version):
+        # project = 'CWFCONF'
+        # labels = ['releng']
+        # components = ['BLD', 'cat-brew', 'prod-RHOSE']
+        # due_date = (datetime.datetime.today() + datetime.timedelta(days=3)).strftime('%Y/%m/%d')
+
+        nvr_list_string = ''
+        el_instructions = ''
+        for el_v, nvr in el_nvr_map.items():
+            nvr_list_string += f'- RHEL{el_v}: {nvr}\n'
+            el_instructions += f'\nFor rhel{el_v}:\n'
+            if el_v == 8:
+                module_tag = self.get_module_tag(nvr, el_v)
+                if not module_tag:
+                    raise click.BadParameter(f'Cannot find module tag for {nvr}')
+                el_instructions += (f'- Update inheritance for each `rhaos-{self.ocp_version}-rhel-{el_v}-override` '
+                                    f'tag to include the module tag `{module_tag}`\n')
+            elif el_v in (7, 9):
+                el_instructions += f'- `brew tag rhaos-{self.ocp_version}-rhel-{el_v}-override {nvr}`\n'
+            el_instructions += f'- Run `brew regen-repo` for `rhaos-{self.ocp_version}-rhel-{el_v}-build`\n'
+
+        template = f'''OpenShift requests that buildroots for version {self.ocp_version} provide a new
+golang compiler version {go_version} , reference: {self.art_jira}
+
+The new NVRs are:
+{nvr_list_string}
+{el_instructions}
+'''
+
+        _LOGGER.info(f'Please create https://issues.redhat.com/browse/CWFCONF Jira ticket with the following content:\n{template}')
+
+
+@cli.command('update-golang')
+@click.option('--ocp-version', required=True, help='OCP version to update golang for')
+@click.option('--create-tagging-ticket', 'create_ticket', is_flag=True, default=False,
+              help='Create CWFCONF Jira ticket for tagging request')
+@click.option('--permit-missing-qe-tag', is_flag=True, default=False,
+              help='Permit missing qe tags on builds')
+@click.option('--art-jira', required=True, help='Related ART Jira ticket e.g. ART-1234')
+@click.argument('go_nvrs', metavar='GO_NVRS...', nargs=-1, required=True)
+@pass_runtime
+@click_coroutine
+async def update_golang(runtime: Runtime, ocp_version: str, create_ticket: bool, go_nvrs: List[str],
+                        permit_missing_qe_tag: bool, art_jira: str):
+    await UpdateGolangPipeline(runtime, ocp_version, create_ticket, go_nvrs, permit_missing_qe_tag, art_jira).run()

--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -23,3 +23,4 @@ slack_sdk >= 3.13.0
 stomp.py ~= 8.1.0
 tenacity
 tomli ~= 2.0.1
+specfile


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-5994
Automate https://art-docs.engineering.redhat.com/sop/update-golang/ 

## Summary
These commands are intended to be part of a job that release-artists can run, multiple times and depending on the state of things the pipeline decides to wait or take action & also run manually if needed.

The happy path would be:
- Someone/we create an ART ticket with qe approved golang builds.
- A release artist runs `update-golang --create-ticket` which
    - validates golang nvrs
    - checks if builds are already tagged and available in buildroot, if they are - complains.
    - creates cwfconf ticket description, which release artist takes and creates a ticket with
- After/before the cwfconf ticket resolves, when we run `update-golang` - it 
    - checks if golang-builder-container exists for the given golang version, if not 
        - makes sure builds are tagged and available in buildroot
        - verifies relevant golang branch is updated with expected repo
        - instructs to start golang-builder branch
- Once golang-builder job builds nvrs, we run script again, which 
    - detects nvrs exist
    - checks if nvrs are pinned in streams.yml, if not creates a PR to pin those nvrs
- After this, release-artist runs `rebuild-golang-rpms` which
    - fetches art built golang rpms and detects if they are outdated. 
    - gives instructions on how to rebuild them via ocp4 job
    - fetches non-art build golang rpms, detects if they are outdated
    - Bumps and rebuilds them.
- Then `elliott --assembly stream -g <group> find-bugs:golang` is run to detect newly built golang rpms in our tags and move found open golang trackers to on_qa

Using https://github.com/packit/specfile to modify specfile

## Todos
- [X] Validate given golang nvrs
- [X] Validate they are tagged and available in buildroots
- [X] If not available, help create CWFCONF ticket from template
- Build rpms
    - [X] Check which rpms need to be rebuilt in our tags
    - [x] Filter out art built rpms
    - [x] Trigger builds for non art built rpms
    - [x] Trigger builds for art built rpms
- Build the builder containers
    - [ ] Updating the builder branch

## Try it out
```
$ python3 artcd -v --config config.example.toml update-golang --ocp-version 4.15 golang-1.20.12-1.el9_3 golang-1.20.12-2.module+el8.9.0+21033+5795bdf6 --art-jira ART-8631 --permit-missing-qe-tag

2024-02-08 11:24:34,677 pyartcd.pipelines.update_golang:INFO Golang version detected: 1.20.12
2024-02-08 11:24:34,677 pyartcd.pipelines.update_golang:INFO NVRs by rhel version: {9: 'golang-1.20.12-1.el9_3', 8: 'golang-1.20.12-2.module+el8.9.0+21033+5795bdf6'}
2024-02-08 11:24:34,677 pyartcd.pipelines.update_golang:INFO Not creating Jira ticket, run with --create-tagging-ticket to create one if one does not exist
2024-02-08 11:24:34,677 pyartcd.pipelines.update_golang:INFO Checking if any builder image builds exist for 1.20.12 in brew
2024-02-08 11:24:35,528 pyartcd.pipelines.update_golang:INFO Found builder nvrs for this version {9: 'openshift-golang-builder-container-v1.20.12-202401111603.el9.g0bebe58', 8: 'openshift-golang-builder-container-v1.20.12-202401111802.el8.g17c0aac'}. Checking if they are being used in streams.yml
2024-02-08 11:24:35,922 pyartcd.pipelines.update_golang:INFO stream:golang has the desired builder nvr:openshift-golang-builder-container-v1.20.12-202401111802.el8.g17c0aac
2024-02-08 11:24:35,922 pyartcd.pipelines.update_golang:INFO stream:ibm-rhel-8-golang-1.20 has the desired builder nvr:openshift-golang-builder-container-v1.20.12-202401111802.el8.g17c0aac
2024-02-08 11:24:35,923 pyartcd.pipelines.update_golang:INFO stream:rhel-9-golang has the desired builder nvr:openshift-golang-builder-container-v1.20.12-202401111603.el9.g0bebe58
2024-02-08 11:24:35,923 pyartcd.pipelines.update_golang:INFO stream:ibm-rhel-9-golang-1.20 has the desired builder nvr:openshift-golang-builder-container-v1.20.12-202401111603.el9.g0bebe58
Builders don't need update since nvr are built and pinned in streams.yml
```

```
$ python3 artcd -v --config config.example.toml rebuild-golang-rpms --ocp-version 4.15 golang-1.20.12-1.el9_3 golang-1.20.12-2.module+el8.9.0+21033+5795bdf6 --art-jira ART-8631

2024-02-08 11:44:46,725 pyartcd.pipelines.rebuild_golang_rpms:INFO Golang version detected: 1.20.12
2024-02-08 11:44:46,725 pyartcd.pipelines.rebuild_golang_rpms:INFO NVRs by rhel version: {9: 'golang-1.20.12-1.el9_3', 8: 'golang-1.20.12-2.module+el8.9.0+21033+5795bdf6'}
2024-02-08 11:44:46,725 pyartcd.pipelines.rebuild_golang_rpms:INFO Checking if golang builds are tagged and available in rpm buildroots
2024-02-08 11:44:46,725 pyartcd.pipelines.rebuild_golang_rpms:INFO Checking build root rhaos-4.15-rhel-9-build
2024-02-08 11:44:47,708 pyartcd.pipelines.rebuild_golang_rpms:INFO Checking build root rhaos-4.15-rhel-9-build
2024-02-08 11:44:47,733 pyartcd.exectools:INFO Executing:cmd_gather_async ['brew', 'wait-repo', 'rhaos-4.15-rhel-9-build', '--build', 'golang-1.20.12-1.el9_3', '--timeout=1']
2024-02-08 11:44:50,191 pyartcd.pipelines.rebuild_golang_rpms:INFO golang-1.20.12-1.el9_3 is tagged and available in buildroot
2024-02-08 11:44:50,191 pyartcd.pipelines.rebuild_golang_rpms:INFO Checking build root rhaos-4.15-rhel-8-build
2024-02-08 11:44:53,045 pyartcd.pipelines.rebuild_golang_rpms:INFO Checking build root rhaos-4.15-rhel-8-build
2024-02-08 11:44:53,046 pyartcd.exectools:INFO Executing:cmd_gather_async ['brew', 'wait-repo', 'rhaos-4.15-rhel-8-build', '--build', 'golang-1.20.12-2.module+el8.9.0+21033+5795bdf6', '--timeout=1']
2024-02-08 11:45:00,789 pyartcd.pipelines.rebuild_golang_rpms:INFO golang-1.20.12-2.module+el8.9.0+21033+5795bdf6 is tagged and available in buildroot
2024-02-08 11:45:00,790 pyartcd.pipelines.rebuild_golang_rpms:INFO Checking if rpms need to be rebuilt
2024-02-08 11:45:00,790 pyartcd.pipelines.rebuild_golang_rpms:INFO Will ignore microshift rpm since it is special and rebuilds for payload image
2024-02-08 11:45:01,071 pyartcd.pipelines.rebuild_golang_rpms:INFO Fetching all rhel9 rpms in our candidate tag
2024-02-08 11:45:02,367 pyartcd.pipelines.rebuild_golang_rpms:INFO Determining golang rpms and their build versions
2024-02-08 11:45:29,773 pyartcd.pipelines.rebuild_golang_rpms:INFO Builds on latest go version 1.20.12-1.el9_3: ['cri-o-1.28.3-8.rhaos4.15.gitc31d8d0.el9', 'openshift-4.15.0-202402061038.p0.gf1618d5.assembly.stream.el9', 'buildah-1.29.1-20.2.rhaos4.15.el9', 'ignition-2.14.0-6.2.rhaos4.13.el9', 'skopeo-1.11.2-21.1.rhaos4.15.el9', 'conmon-2.1.7-1.2.rhaos4.14.el9', 'cri-tools-1.28.0-3.el9', 'openshift-clients-4.15.0-202402070507.p0.g48dcf59.assembly.stream.el9', 'podman-4.4.1-20.rhaos4.15.el9', 'runc-1.1.12-1.rhaos4.15.el9', 'ose-aws-ecr-image-credential-provider-4.15.0-202401231232.p0.gba252ab.assembly.stream.el9']
2024-02-08 11:45:29,773 pyartcd.pipelines.rebuild_golang_rpms:INFO Fetching all rhel8 rpms in our candidate tag
2024-02-08 11:45:31,008 pyartcd.pipelines.rebuild_golang_rpms:INFO Determining golang rpms and their build versions
2024-02-08 11:45:47,066 pyartcd.pipelines.rebuild_golang_rpms:INFO Builds on latest go version 1.20.12-2.module+el8.9.0+21033+5795bdf6: ['butane-0.19.0-1.2.rhaos4.15.el8', 'skopeo-1.11.2-21.1.rhaos4.15.el8', 'cri-o-1.28.3-8.rhaos4.15.gitc31d8d0.el8', 'openshift-clients-4.15.0-202402070507.p0.g48dcf59.assembly.stream.el8', 'buildah-1.29.1-20.2.rhaos4.15.el8', 'cri-tools-1.28.0-3.el8', 'ose-aws-ecr-image-credential-provider-4.15.0-202401231232.p0.gba252ab.assembly.stream.el8', 'runc-1.1.12-1.rhaos4.15.el8', 'golang-github-prometheus-promu-0.15.0-15.2.gitd5383c5.el8', 'podman-4.4.1-20.rhaos4.15.el8', 'openshift-4.15.0-202402061038.p0.gf1618d5.assembly.stream.el8', 'containernetworking-plugins-1.4.0-1.1.rhaos4.15.el8']
2024-02-08 11:45:47,066 pyartcd.pipelines.rebuild_golang_rpms:INFO All non-ART rpms are using given golang builds!

```