### PR TITLE
attach-cve-flaws: Permit explicitly included bugs

### DIFF
--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -341,16 +341,17 @@ def categorize_bugs_by_type(bugs: List[Bug], advisory_id_map: Dict[str, int],
         logger.warning('No attached builds found in advisories for tracker bugs (bug, package):'
                        f' {not_found_with_component}.')
 
+        not_permitted = not_found
         if permitted_bug_ids:
             logger.warning('The following bugs will be attached because they are '
                            f'explicitly included in the assembly config: {permitted_bug_ids}')
-            not_found = not_found - set(permitted_bug_ids)
+            not_permitted = {b for b in not_found if b.id not in permitted_bug_ids}
 
-        if not_found:
-            not_found_with_component = [(b.id, b.whiteboard_component) for b in not_found]
+        if not_permitted:
+            not_permitted_with_component = [(b.id, b.whiteboard_component) for b in not_found]
             message = ('No attached builds found in advisories for tracker bugs (bug, package): '
-                       f'{not_found_with_component}. Either attach builds or explicitly include/exclude the bug ids '
-                       'in the assembly definition')
+                       f'{not_permitted_with_component}. Either attach builds or explicitly include/exclude the bug '
+                       f'ids in the assembly definition')
             logger.error(message)
             raise ValueError(message)
 

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -608,10 +608,9 @@ update JIRA accordingly, then notify QE and multi-arch QE for testing.""")
             _LOGGER.warning("Release JIRA %s has different number of subtasks from the template ticket %s. Subtasks will not be updated.", issue.key, template_issue.key)
             return
         for subtask, template_subtask in zip(subtasks, template_subtasks):
-            fields = {
-                "summary": template_subtask.fields.summary,
-                "description": template_subtask.fields.description,
-            }
+            fields = {"summary": template_subtask.fields.summary}
+            if template_subtask.fields.description:
+                fields["description"] = template_subtask.fields.description
             if "template" in template_subtask.fields.labels:
                 fields = self._render_jira_template(fields, template_vars)
             if not self.dry_run:


### PR DESCRIPTION
This allows us to permit bugs that may have component-build mismatch due to some
reason, but are still valid to ship. This mismatch can be due to rpm components being
mentioned in image bugs or base image bugs whose builds we don't ship but still we
would want to ship the bugs

I also discovered that we can fail with a not obvious error when a subtask does not have any description 
set which is the reason for [327b8d3](https://github.com/openshift-eng/art-tools/pull/71/commits/327b8d3911a04fb48001694cec7fb958f091f650)

See https://github.com/openshift-eng/ocp-build-data/pull/3549
Test run: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fprepare-release/858/console