### PR TITLE
Make jenkins test environment independent

### DIFF
--- a/pyartcd/tests/test_jenkins.py
+++ b/pyartcd/tests/test_jenkins.py
@@ -69,6 +69,8 @@ class TestJenkinsStartBuild(unittest.TestCase):
 
     def test_get_build_url_and_path(self):
         # No BUILD_URL env var defined
+        if os.environ.get('BUILD_URL'):
+            del os.environ['BUILD_URL']
         self.assertEqual(jenkins.get_build_url(), None)
         self.assertEqual(jenkins.get_build_path(), None)
 


### PR DESCRIPTION
pyartcd unit tests are currently failing on
```
Traceback (most recent call last):
  File "/home/dpaolell/develop/github.com/openshift/art-tools/pyartcd/tests/test_jenkins.py", line 72, in test_get_build_url_and_path
    self.assertEqual(jenkins.get_build_url(), None)
AssertionError: 'build-url' != None
```