### PR TITLE
Make compose lock assembly aware

### DIFF
--- a/pyartcd/pyartcd/locks.py
+++ b/pyartcd/pyartcd/locks.py
@@ -11,7 +11,7 @@ from pyartcd import redis
 class Lock(enum.Enum):
     OLM_BUNDLE = 'lock:olm-bundle-{version}'
     MIRRORING_RPMS = 'lock:mirroring-rpms:{version}'
-    COMPOSE = 'lock:compose:{version}'
+    PLASHET = 'lock:compose:{assembly}:{version}'
     BUILD = 'lock:build:{version}'
     MASS_REBUILD = 'lock:mass-rebuild-serializer'
     SIGNING = 'lock:signing:{signing_env}'
@@ -35,7 +35,7 @@ LOCK_POLICY = {
         'lock_timeout': 60 * 60 * 3,  # 3 hours
     },
     # compose: give up after 1 hour
-    Lock.COMPOSE: {
+    Lock.PLASHET: {
         'retry_count': 36000,
         'retry_delay_min': 0.1,
         'lock_timeout': 60 * 60 * 6,  # 6 hours

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -851,12 +851,15 @@ class Ocp4Pipeline:
         # Rebase and build RPMs
         await self._rebase_and_build_rpms()
         if not self.skip_plashets:
+            lock = Lock.PLASHET
+            lock_name = lock.value.format(assembly=self.assembly, version=self.version.stream)
             await locks.run_with_lock(
                 coro=self._build_compose(),
-                lock=Lock.COMPOSE,
-                lock_name=Lock.COMPOSE.value.format(version=self.version.stream),
+                lock=lock,
+                lock_name=lock_name,
                 lock_id=self.lock_identifier
             )
+
         else:
             self.runtime.logger.warning('Skipping plashets creation as SKIP_PLASHETS was set to True')
 

--- a/pyartcd/tests/test_locks.py
+++ b/pyartcd/tests/test_locks.py
@@ -20,9 +20,10 @@ class TestLocks(TestCase):
     @patch("pyartcd.redis.redis_url", return_value='fake_url')
     @patch("aioredlock.algorithm.Aioredlock.__attrs_post_init__")
     def test_lock_manager(self, *_):
-        lock: Lock = Lock.COMPOSE
+        lock: Lock = Lock.PLASHET
+        policy = LOCK_POLICY[lock]
         lm = LockManager.from_lock(lock)
-        self.assertEqual(lm.retry_count, LOCK_POLICY[Lock.COMPOSE]['retry_count'])
-        self.assertEqual(lm.retry_delay_min, LOCK_POLICY[Lock.COMPOSE]['retry_delay_min'])
-        self.assertEqual(lm.internal_lock_timeout, LOCK_POLICY[Lock.COMPOSE]['lock_timeout'])
+        self.assertEqual(lm.retry_count, policy['retry_count'])
+        self.assertEqual(lm.retry_delay_min, policy['retry_delay_min'])
+        self.assertEqual(lm.internal_lock_timeout, policy['lock_timeout'])
         self.assertEqual(lm.redis_connections, ['fake_url'])


### PR DESCRIPTION
When running a build in `test` assembly, compose lock may not be acquired if there's another compose build ongoing for the same version. This leads to undesired waits and longer testing times. Making this lock assembly aware will let us build plashets for `test` assembly without uselessly blocking on resource acquisition

Seeking for lgtm, approve labels