### PR TITLE
Fix CVE mapping for RHCOS

### DIFF
--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -151,7 +151,8 @@ def _update_advisory(runtime, advisory, flaw_bugs, bug_tracker, noop):
 
 
 async def associate_builds_with_cves(errata_api: AsyncErrataAPI, advisory: Erratum, flaw_bugs: Iterable[Bug], attached_tracker_bugs: List[Bug], tracker_flaws: Dict[int, Iterable], dry_run: bool):
-    attached_builds = [b for pv in advisory.errata_builds.values() for b in pv]
+    # `Erratum.errata_builds` doesn't include RHCOS builds. Use AsyncErrataAPI instead.
+    attached_builds = await errata_api.get_builds_flattened(advisory.errata_id)
     cve_components_mapping: Dict[str, Set[str]] = {}
     for tracker in attached_tracker_bugs:
         component_name = tracker.whiteboard_component

--- a/elliott/tests/test_attach_cve_flaws_cli.py
+++ b/elliott/tests/test_attach_cve_flaws_cli.py
@@ -78,6 +78,10 @@ class TestAttachCVEFlawsCLI(unittest.IsolatedAsyncioTestCase):
                 }
             }
         )
+        errata_api.get_builds_flattened.return_value = [
+            "a-1.0.0-1.el8", "b-1.0.0-1.el8", "c-1.0.0-1.el8", "d-1.0.0-1.el8",
+            "a-1.0.0-1.el7", "e-1.0.0-1.el7", "f-1.0.0-1.el7"
+        ]
         tracker_flaws = {
             1: [101, 103],
             2: [101, 103],


### PR DESCRIPTION
`elliott attach-cve-flaws` failed to create CVE mapping exclusion for RHCOS builds (https://redhat-internal.slack.com/archives/C03JYDGPX8F/p1695894086384359?thread_ts=1695893433.497649&cid=C03JYDGPX8F).

The problem is that `Erratum.errata_builds` doesn't include RHCOS builds. This PR changes to another API get attached builds.