### PR TITLE
[gen-assembly] Allow limiting arches for all assembly types

### DIFF
--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -83,7 +83,7 @@ class GenAssemblyPipeline:
         slack_thread = slack_response["message"]["ts"]
         try:
             if self.arches and not self.custom:
-                raise ValueError("Customizing arches can only be used with custom assemblies.")
+                self._logger.warning("Customizing arches for non-custom assembly, proceed with caution")
 
             if self.custom and (self.auto_previous or self.previous_list or self.in_flight):
                 raise ValueError("Specifying previous list for a custom release is not allowed.")


### PR DESCRIPTION
When creating a candidate or standard release, there can be a case when we do not have
a matching set of nightlies for all arches - we've been seeing this issue when
creating 4.14 Release candidates ([job](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fgen-assembly/673/)) - this is due to x64 Release Controller running behind due
to pending nightlies, from other arch RCs.

In this case we still want to use x64 nightly as the basis for the RC, and then let the other arch
builds be selected accordingly by the brew event, and manually fit in RHCOS images. If anything
is inconsistent, build-sync will warn/complain, so allowing this gets us to the next step

requesting /lgtm and /approve
