### PR TITLE
gen-assembly rhcos helper

### DIFF
--- a/doozer/doozerlib/cli/__main__.py
+++ b/doozer/doozerlib/cli/__main__.py
@@ -43,6 +43,7 @@ from doozerlib.cli.release_calc_upgrade_tests import release_calc_upgrade_tests
 from doozerlib.cli.inspect_stream import inspect_stream
 from doozerlib.cli.config_tag_rpms import config_tag_rpms
 from doozerlib.cli.scan_osh import scan_osh
+from doozerlib.cli.gen_assembly_helper import gen_assembly_rhcos
 
 from doozerlib import coverity
 from doozerlib.exceptions import DoozerFatalError

--- a/doozer/doozerlib/cli/gen_assembly_helper.py
+++ b/doozer/doozerlib/cli/gen_assembly_helper.py
@@ -6,10 +6,15 @@ from doozerlib.cli import cli
 from doozerlib.rhcos import RHCOSBuildFinder, RHCOSBuildInspector, get_container_configs, get_container_pullspec
 
 
-@cli.command("gen-assembly:rhcos", short_help="Generate assembly config for rhcos by given build_id")
+@cli.command("gen-assembly:rhcos", short_help="Generate assembly config for rhcos by given build_id eg. 414.92.202309222337-0")
 @click.argument("build_id", required=True)
 @click.pass_obj
 def gen_assembly_rhcos(runtime, build_id):
+    """
+    Generate assembly config for rhcos by given build_id
+
+    $ doozer -g openshift-4.14 gen-assembly:rhcos 414.92.202309222337-0
+    """
     runtime.initialize(clone_distgits=False)
     rhcos_info = {}
     for arch in runtime.group_config.arches:

--- a/doozer/doozerlib/cli/gen_assembly_helper.py
+++ b/doozer/doozerlib/cli/gen_assembly_helper.py
@@ -1,0 +1,27 @@
+import click
+import yaml
+
+from doozerlib import util
+from doozerlib.cli import cli
+from doozerlib.rhcos import RHCOSBuildFinder, RHCOSBuildInspector, get_container_configs, get_container_pullspec
+
+@cli.command("gen-assembly:rhcos", short_help="Generate assembly config for rhcos by given build_id")
+@click.argument("build_id", required=True)
+@click.pass_obj
+def gen_assembly_rhcos(runtime, build_id):
+    runtime.initialize(clone_distgits=False)
+    rhcos_info = {}
+    for arch in runtime.group_config.arches:
+        brew_arch = util.brew_arch_for_go_arch(arch)
+        runtime.logger.info(f"Getting RHCOS pullspecs for build {build_id}-{brew_arch}...")
+        for container_conf in get_container_configs(runtime):
+            version = runtime.get_minor_version()
+            finder = RHCOSBuildFinder(runtime, version, brew_arch, False)
+            if container_conf.name not in rhcos_info:
+                rhcos_info[container_conf.name] = {"images": {}}
+            rhcos_info[container_conf.name]["images"][arch] = get_container_pullspec(
+                finder.rhcos_build_meta(build_id),
+                container_conf or finder.get_primary_container_conf()
+            )
+
+    print(yaml.dump({'rhcos': rhcos_info}))

--- a/doozer/doozerlib/cli/gen_assembly_helper.py
+++ b/doozer/doozerlib/cli/gen_assembly_helper.py
@@ -5,6 +5,7 @@ from doozerlib import util
 from doozerlib.cli import cli
 from doozerlib.rhcos import RHCOSBuildFinder, RHCOSBuildInspector, get_container_configs, get_container_pullspec
 
+
 @cli.command("gen-assembly:rhcos", short_help="Generate assembly config for rhcos by given build_id")
 @click.argument("build_id", required=True)
 @click.pass_obj


### PR DESCRIPTION
Sometimes we need to manually hack in a particular rhcos build in an assembly,
or find pullspecs for some arches which were excluded when running gen-assembly,
 this helps with that.

```
$ ./doozer --group openshift-4.14 gen-assembly:rhcos 414.92.202309222337-0
...
rhcos:
  machine-os-content:
    images:
      aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1d3f7859caf06708720482372bfaf36571fe0a8565093cebac21a5feb4dc97d0
      ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cbc8861b311be4bc900f4b53179995317eb4c2f1ce25814ceff7b2be30ebc3ff
      s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a5d0b8cd2ba52feb9076f7f1f269f8c8b3aed546e5dfd92ca13e13e1405125c8
      x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:74ea50e311c11a3aa4257397f9fd2ac1208ec22dc62b4c5a6a615fdd471623f7
  rhel-coreos:
    images:
      aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:958d92aa6c45faae2e67bf5c28ac726c196f8de482b7fad22e7b813f3bab1cfb
      ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0845fa305ea00e429a8b8c2696fa4188542e2e5faad12dff9dc6266bc6d4f31c
      s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8828143da8eb205474889c49caa95423079dc6691d2fa25153ea029c6f30d3a0
      x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:03a75520e8231d0d4da44ec2536776652591848f7bdc58ad3c4ac66247d87380
  rhel-coreos-extensions:
    images:
      aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e7992fa52c42a5e275d357e41bbf81d3197d573863f356e3361863bcf12fc18e
      ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3a4f1577ac9f5265677c0649fc2e40fd286b5c800f8a9de327c1cf254adfba49
      s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9bf1da53a5926050ceee2eb1472e7e048585705eb5731ab61cef80505b618826
      x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dc790bbc0bf9bbdfa6ca19dc4fe4476b2c2d7c05a198e10165d4b603c4ed55fd
```

requesting /lgtm and /approve