### PR TITLE
Move cincinnati PR creation to promote.py

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -30,6 +30,7 @@ class Jobs(Enum):
     SYNC_FOR_CI = 'scheduled-builds/sync-for-ci'
     MICROSHIFT_SYNC = 'aos-cd-builds/build%2Fmicroshift_sync'
     SCAN_OSH = 'aos-cd-builds/build%2Fscan-osh'
+    CINCINNATI_PRS = 'aos-cd-builds/build%2Fcincinnati-prs'
 
 
 def init_jenkins():
@@ -276,6 +277,19 @@ def start_build_sync(build_version: str, assembly: str, doozer_data_path: Option
         job=Jobs.BUILD_SYNC,
         params=params,
         **kwargs
+    )
+
+
+def start_build_cincinnati_prs(from_releases: list, release_name: str, advisory_id: int,
+                               candidate_pr_note: str, **kwargs) -> Optional[str]:
+    return start_build(
+        job=Jobs.CINCINNATI_PRS,
+        params={
+            'FROM_RELEASE_TAG': ','.join(from_releases),
+            'RELEASE_NAME': release_name,
+            'ADVISORY_NUM': advisory_id,
+            'CANDIDATE_PR_NOTE': candidate_pr_note,
+        }, **kwargs
     )
 
 

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -280,8 +280,8 @@ def start_build_sync(build_version: str, assembly: str, doozer_data_path: Option
     )
 
 
-def start_build_cincinnati_prs(from_releases: list, release_name: str, advisory_id: int,
-                               candidate_pr_note: str, **kwargs) -> Optional[str]:
+def start_cincinnati_prs(from_releases: list, release_name: str, advisory_id: int,
+                         candidate_pr_note: str, skip_ota_notification, **kwargs) -> Optional[str]:
     return start_build(
         job=Jobs.CINCINNATI_PRS,
         params={
@@ -289,6 +289,7 @@ def start_build_cincinnati_prs(from_releases: list, release_name: str, advisory_
             'RELEASE_NAME': release_name,
             'ADVISORY_NUM': advisory_id,
             'CANDIDATE_PR_NOTE': candidate_pr_note,
+            'SKIP_OTA_SLACK_NOTIFICATION': skip_ota_notification
         }, **kwargs
     )
 

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -289,7 +289,8 @@ def start_cincinnati_prs(from_releases: list, release_name: str, advisory_id: in
             'RELEASE_NAME': release_name,
             'ADVISORY_NUM': advisory_id,
             'CANDIDATE_PR_NOTE': candidate_pr_note,
-            'SKIP_OTA_SLACK_NOTIFICATION': skip_ota_notification
+            'SKIP_OTA_SLACK_NOTIFICATION': skip_ota_notification,
+            'GITHUB_ORG': 'openshift',
         }, **kwargs
     )
 

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -52,6 +52,7 @@ class PromotePipeline:
                  skip_build_microshift: bool = False,
                  skip_signing: bool = False,
                  skip_cincinnati_prs: bool = False,
+                 skip_ota_notification: bool = False,
                  permit_overwrite: bool = False,
                  no_multi: bool = False, multi_only: bool = False,
                  skip_mirror_binaries: bool = False,
@@ -68,6 +69,7 @@ class PromotePipeline:
         self.skip_mirror_binaries = skip_mirror_binaries
         self.skip_signing = skip_signing
         self.skip_cincinnati_prs = skip_cincinnati_prs
+        self.skip_ota_notification = skip_ota_notification
         self.permit_overwrite = permit_overwrite
 
         if multi_only and no_multi:
@@ -1473,11 +1475,12 @@ class PromotePipeline:
         if "advisory" in release_info and release_info["advisory"]:
             advisory_id = release_info["advisory"]
 
-        jenkins.start_build_cincinnati_prs(
+        jenkins.start_cincinnati_prs(
             from_releases,
             release_info["name"],
             advisory_id,
             candidate_pr_note,
+            self.skip_ota_notification
         )
 
 
@@ -1498,6 +1501,8 @@ class PromotePipeline:
               help="Do not sign artifacts")
 @click.option("--skip-cincinnati-prs", is_flag=True,
               help="Do not create Cincinnati PRs")
+@click.option("--skip-ota-notification", is_flag=True,
+                help="Do not send OTA notification on slack")
 @click.option("--permit-overwrite", is_flag=True,
               help="DANGER! Allows the pipeline to overwrite an existing payload.")
 @click.option("--no-multi", is_flag=True, help="Do not promote a multi-arch/heterogeneous payload.")
@@ -1514,6 +1519,7 @@ async def promote(runtime: Runtime, group: str, assembly: str,
                   skip_build_microshift: bool,
                   skip_signing: bool,
                   skip_cincinnati_prs: bool,
+                  skip_ota_notification: bool,
                   permit_overwrite: bool, no_multi: bool, multi_only: bool,
                   skip_mirror_binaries: bool,
                   use_multi_hack: bool,
@@ -1524,6 +1530,7 @@ async def promote(runtime: Runtime, group: str, assembly: str,
                                skip_build_microshift,
                                skip_signing,
                                skip_cincinnati_prs,
+                               skip_ota_notification,
                                permit_overwrite, no_multi, multi_only,
                                skip_mirror_binaries,
                                use_multi_hack,

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1451,7 +1451,7 @@ class PromotePipeline:
     def create_cincinnati_prs(self, assembly_type, release_info):
         """ Create Cincinnati PRs for the release.
         """
-        if assembly_type == "custom":
+        if assembly_type == assembly.AssemblyTypes.CUSTOM:
             self._logger.info("Skipping PR creation for custom assembly")
             return
 
@@ -1502,7 +1502,7 @@ class PromotePipeline:
 @click.option("--skip-cincinnati-prs", is_flag=True,
               help="Do not create Cincinnati PRs")
 @click.option("--skip-ota-notification", is_flag=True,
-                help="Do not send OTA notification on slack")
+              help="Do not send OTA notification on slack")
 @click.option("--permit-overwrite", is_flag=True,
               help="DANGER! Allows the pipeline to overwrite an existing payload.")
 @click.option("--no-multi", is_flag=True, help="Do not promote a multi-arch/heterogeneous payload.")


### PR DESCRIPTION
ec.0 promote job [failed](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fpromote-assembly/857/) on readJSON jenkins pipeline step flaking for perfectly valid json, rerunning it did the job - but [missing](https://redhat-internal.slack.com/archives/CJARLA942/p1696352245035539) cincinnati PRs can cause unecessary delays. The remaining steps outside of pyartcd promote.py are sending release message on umb, create cincinnati PRs, validating rhsas - I would like to move the cincinnati step inside pyartcd, so all important steps are done before the possibility of flaking on json

Should go with https://github.com/openshift-eng/aos-cd-jobs/pull/3983
Requesting /lgtm 