### PR TITLE
Pin PyGithub

### DIFF
--- a/doozer/requirements.txt
+++ b/doozer/requirements.txt
@@ -6,7 +6,7 @@ defusedxml
 future
 koji
 pip_system_certs
-PyGitHub >= 1.46
+PyGitHub == 1.59.1
 pyyaml >= 5.1
 requests
 requests_kerberos


### PR DESCRIPTION
PyGithub 2.1 is currently raising this error:
```
File "/usr/local/lib/python3.9/site-packages/github/GithubRetry.py", line 74, in __init__
kwargs["allowed_methods"] = kwargs.get("allowed_methods", Retry.DEFAULT_ALLOWED_METHODS.union({"GET", "POST"}))
AttributeError: type object 'Retry' has no attribute 'DEFAULT_ALLOWED_METHODS'
```
Pinning a specific version that proved to be working in a local environment.

Context: https://redhat-internal.slack.com/archives/GDBRP5YJH/p1696419743125039?thread_ts=1696419695.085749&cid=GDBRP5YJH