### PR TITLE
use Release Controller API get payload info

### DIFF
--- a/pyartcd/pyartcd/constants.py
+++ b/pyartcd/pyartcd/constants.py
@@ -17,6 +17,12 @@ NIGHTLY_PAYLOAD_REPOS = {
     "ppc64le": "registry.ci.openshift.org/ocp-ppc64le/release-ppc64le",
     "aarch64": "registry.ci.openshift.org/ocp-arm64/release-arm64",
 }
+RELEASE_CONTROLLER_ENDPOINT = {
+    "x86_64": "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream",
+    "aarch64": "https://arm64.ocp.releases.ci.openshift.org/api/v1/releasestream",
+    "s390x": "https://s390x.ocp.releases.ci.openshift.org/api/v1/releasestream",
+    "ppc64le": "https://ppc64le.ocp.releases.ci.openshift.org/api/v1/releasestream",
+}
 
 # Maps the name of a release component tag to the filename element to include
 # when creating artifacts on mirror.openshift.com.


### PR DESCRIPTION
The most usage of the parse_release_payloads function is to get payload digest from release, we currently trigger oc cli to parse result. This PR is to get the digest from the Release Controller which is simpler and more direct and don't need to consider authentication issues.

test job: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fbuild-microshift/639/