### PR TITLE
Fix package version prints

### DIFF
--- a/.github/workflows/doozer-unit-tests.yaml
+++ b/.github/workflows/doozer-unit-tests.yaml
@@ -8,15 +8,20 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    container: fedora:37
+    container: fedora:38
     steps:
-      - uses: actions/checkout@v3
+      - name: Install git
+        run: dnf install -y git
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          set-safe-directory: ${{ env.GITHUB_WORKSPACE }}
+      - name: Install packages
+        run: dnf install -y gcc krb5-devel
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
           python-version: '3.8'
-      - name: Install packages
-        run: cd doozer && dnf install -y gcc krb5-devel
       - name: Create venv and install dependencies
         run: cd doozer && make venv
       - name: Run tests

--- a/.github/workflows/elliott-unit-tests.yaml
+++ b/.github/workflows/elliott-unit-tests.yaml
@@ -8,17 +8,20 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    container: fedora:37
+    container: fedora:38
     steps:
-      - uses: actions/checkout@v3
+      - name: Install git
+        run: dnf install -y git
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: '0'
+          fetch-depth: 0
+          set-safe-directory: ${{ env.GITHUB_WORKSPACE }}
+      - name: Install packages
+        run: dnf install -y gcc krb5-devel
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
           python-version: '3.8'
-      - name: Install packages
-        run: cd elliott && dnf install -y gcc krb5-devel
       - name: Create venv and install dependencies
         run: cd elliott && make venv
       - name: Run tests

--- a/.github/workflows/pyartcd-unit-tests.yaml
+++ b/.github/workflows/pyartcd-unit-tests.yaml
@@ -8,15 +8,20 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    container: fedora:37
+    container: fedora:38
     steps:
-      - uses: actions/checkout@v3
+      - name: Install git
+        run: dnf install -y git
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          set-safe-directory: ${{ env.GITHUB_WORKSPACE }}
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
           python-version: '3.8'
       - name: Install packages
-        run: cd pyartcd && dnf install -y gcc krb5-devel
+        run: dnf install -y gcc krb5-devel
       - name: Create venv and install dependencies
         run: cd pyartcd && make venv
       - name: Run tests

--- a/doozer/doozerlib/__init__.py
+++ b/doozer/doozerlib/__init__.py
@@ -1,15 +1,16 @@
-import os
 import sys
+from importlib.metadata import PackageNotFoundError, version
+from typing import cast
+
 if sys.version_info < (3, 8):
     sys.exit('Sorry, Python < 3.8 is not supported.')
 
 from doozerlib.runtime import Runtime
 
+__version__ = "0.0.0"
 
-def version():
-    try:
-        from ._version import version
-    except ImportError:
-        from setuptools_scm import get_version
-        version = get_version()
-    return version
+try:
+    __version__ = cast(str, version("rh-doozer"))
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/doozer/doozerlib/cli/__init__.py
+++ b/doozer/doozerlib/cli/__init__.py
@@ -5,7 +5,7 @@ from functools import update_wrapper
 
 import click
 
-from doozerlib import dotconfig, version
+from doozerlib import dotconfig, __version__
 from doozerlib.cli import cli_opts
 from doozerlib.runtime import Runtime
 from doozerlib.util import yellow_print
@@ -26,7 +26,7 @@ or else they would die.
 def print_version(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
-    click.echo('Doozer v{}'.format(version()))
+    click.echo('Doozer v{}'.format(__version__))
     click.echo('Python v{}'.format(sys.version))
     click.echo(VERSION_QUOTE)
     ctx.exit()

--- a/doozer/setup.py
+++ b/doozer/setup.py
@@ -12,10 +12,13 @@ setup(
     name="rh-doozer",
     author="AOS ART Team",
     author_email="aos-team-art@redhat.com",
-    setup_requires=[],
+    setup_requires=['setuptools>=65.5.1', 'setuptools_scm'],
+    use_scm_version={
+        "root": ".."
+    },
     description="CLI tool for managing and automating Red Hat software releases",
     long_description=open('README.md').read(),
-    url="https://github.com/openshift-eng/doozer",
+    url="https://github.com/openshift-eng/art-tools/tree/main/doozer",
     license="Apache License, Version 2.0",
     packages=find_packages(exclude=["tests", "tests.*", "functional_tests", "functional_tests.*", "tests_functional", "tests_functional.*"]),
     include_package_data=True,
@@ -31,9 +34,11 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Environment :: Console",
         "Operating System :: POSIX",
         "License :: OSI Approved :: Apache Software License",

--- a/elliott/elliottlib/__init__.py
+++ b/elliott/elliottlib/__init__.py
@@ -1,16 +1,16 @@
-import os
 import sys
+from importlib.metadata import PackageNotFoundError, version
+from typing import cast
 
 if sys.version_info < (3, 8):
     sys.exit('Sorry, Python < 3.8 is no longer supported.')
 
 from elliottlib.runtime import Runtime
 
+__version__ = "0.0.0"
 
-def version():
-    try:
-        from ._version import version
-    except ImportError:
-        from setuptools_scm import get_version
-        version = get_version()
-    return version
+try:
+    __version__ = cast(str, version("rh-elliott"))
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/elliott/elliottlib/cli/common.py
+++ b/elliott/elliottlib/cli/common.py
@@ -4,7 +4,7 @@ from functools import update_wrapper
 
 import click
 
-from elliottlib import Runtime, constants, dotconfig, version, errata
+from elliottlib import Runtime, constants, dotconfig, __version__, errata
 from elliottlib.cli import cli_opts
 from elliottlib.util import green_prefix, red_prefix, yellow_print
 
@@ -12,8 +12,8 @@ from elliottlib.util import green_prefix, red_prefix, yellow_print
 def print_version(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
-    click.echo('Elliott v{}'.format(version()))
-    click.echo("Python v{}".format(sys.version))
+    click.echo(f'Elliott v{__version__}')
+    click.echo(f'Python v{sys.version}')
     ctx.exit()
 
 

--- a/elliott/pyproject.toml
+++ b/elliott/pyproject.toml
@@ -1,11 +1,13 @@
 [build-system]
-requires = [
-    "setuptools>=65.5.1",  # not directly required, pinned by Snyk to avoid a vulnerability
-]
+requires = ["setuptools>=65.5.1", "setuptools_scm[toml]>=8.0"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["elliottlib", "elliottlib.cli"]
+[tool.setuptools.packages.find]
+include = ["elliottlib*"]
+namespaces = false
+
+[tool.setuptools_scm]
+root = ".."
 
 [project]
 dynamic = ["version"]
@@ -25,7 +27,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -63,8 +64,8 @@ dependencies = [
 elliott = "elliottlib.cli.__main__:main"
 
 [project.urls]
-homepage = "https://github.com/openshift-eng/elliott"
-repository = "https://github.com/openshift-eng/elliott.git"
+homepage = "https://github.com/openshift-eng/art-tools/tree/main/elliott"
+repository = "https://github.com/openshift-eng/art-tools.git"
 
 [project.optional-dependencies]
 tests = [

--- a/pyartcd/pyartcd/__init__.py
+++ b/pyartcd/pyartcd/__init__.py
@@ -1,4 +1,19 @@
 import os
+import sys
 import typing
+from importlib.metadata import PackageNotFoundError, version
+from typing import cast
 
 StrOrBytesPath = typing.Union[str, bytes, os.PathLike]
+
+if sys.version_info < (3, 8):
+    sys.exit('Sorry, Python < 3.8 is not supported.')
+
+__version__ = "0.0.0"
+
+
+try:
+    __version__ = cast(str, version("pyartcd"))
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/pyartcd/pyartcd/cli.py
+++ b/pyartcd/pyartcd/cli.py
@@ -1,11 +1,13 @@
 import asyncio
-from functools import update_wrapper
 import logging
+import sys
+from functools import update_wrapper
 from pathlib import Path
 from typing import Optional
 
 import click
 
+from pyartcd import __version__
 from pyartcd.runtime import Runtime
 
 pass_runtime = click.make_pass_decorator(Runtime)
@@ -21,10 +23,21 @@ def click_coroutine(f):
     return update_wrapper(wrapper, f)
 
 
+def print_version(ctx, param, value):
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo('artcd v{}'.format(__version__))
+    click.echo('Python v{}'.format(sys.version))
+    ctx.exit()
+
+
 # ============================================================================
 # GLOBAL OPTIONS: parameters for all commands
 # ============================================================================
 @click.group(context_settings=dict(help_option_names=['-h', '--help']))
+@click.option('--version', is_flag=True, callback=print_version,
+              expose_value=False, is_eager=True,
+              help="Print version information and quit")
 @click.option("--config", "-c", metavar='PATH',
               help="Configuration file ('~/.config/artcd.toml' by default)")
 @click.option("--working-dir", "-C", metavar='PATH', default=None,
@@ -35,6 +48,7 @@ def click_coroutine(f):
               help="[MULTIPLE] increase output verbosity")
 @click.pass_context
 def cli(ctx: click.Context, config: Optional[str], working_dir: Optional[str], dry_run: bool, verbosity: int):
+
     config_filename = config or Path("~/.config/artcd.toml").expanduser()
     working_dir = working_dir or Path.cwd()
     # configure logging

--- a/pyartcd/setup.py
+++ b/pyartcd/setup.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
 import sys
-if sys.version_info < (3, 6):
-    sys.exit('Sorry, Python < 3.6 is not supported.')
+if sys.version_info < (3, 8):
+    sys.exit('Sorry, Python < 3.8 is not supported.')
 
 with open('./requirements.txt') as f:
     INSTALL_REQUIRES = f.read().splitlines()
@@ -11,9 +11,12 @@ setup(
     name="pyartcd",
     author="AOS ART Team",
     author_email="aos-team-art@redhat.com",
-    version="0.0.1-dev",
+    setup_requires=['setuptools>=65.5.1', 'setuptools_scm'],
+    use_scm_version={
+        "root": ".."
+    },
     description="Python based pipeline library for managing and automating Red Hat OpenShift Container Platform releases",
-    url="https://github.com/openshift-eng/aos-cd-jobs/",
+    url="https://github.com/openshift-eng/art-tools/tree/main/pyartcd",
     license="Apache License, Version 2.0",
     packages=find_packages(exclude=["tests", "tests.*"]),
     include_package_data=True,
@@ -25,14 +28,15 @@ setup(
     },
     test_suite='tests',
     dependency_links=[],
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Environment :: Console",
         "Operating System :: POSIX",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
- Add `artcd --version`.
- Fix `elliott --version` and `doozer --version` commands
- Provide `elliottlib.__version__`, `doozerlib.__version__`, and `pyartcd.__version__` to get versions in program.
