### PR TITLE
Notify about mass rebuilds when they actually start/complete

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -5,7 +5,6 @@ import traceback
 
 import click
 import yaml
-from aioredlock import LockError
 
 from pyartcd import locks, util, plashets, exectools, constants, \
     jenkins, record as record_util, oc
@@ -711,11 +710,18 @@ class Ocp4Pipeline:
         if not self.build_plan.build_images:
             return  # to facilitate testing
 
+        if self.mass_rebuild:
+            await self._slack_client.say(
+                f':construction: Starting image builds for {self.version} mass rebuild :construction:')
+
         # In case of mass rebuilds, rebase and build should happend within the same lock scope
         # Otherwise we might rebase, then get blocked on the mass rebuild lock
         # As a consequence, we might be building outdated stuff
         await self._rebase_images()
         await self._build_images()
+
+        if self.mass_rebuild:
+            await self._slack_client.say(f'::done_it_is: Mass rebuild for {self.version} complete :done_it_is:')
 
     async def _sync_images(self):
         if not self.build_plan.build_images:
@@ -866,7 +872,8 @@ class Ocp4Pipeline:
         # Rebase and build images
         if self.build_plan.build_images:
             if self.mass_rebuild:
-                await self._slack_client.say(f':construction: Mass rebuild for {self.version} :construction:')
+                await self._slack_client.say(
+                    f':loading-correct: Enqueuing mass rebuild for {self.version} :loading-correct:')
                 await locks.run_with_lock(
                     coro=self._rebase_and_build_images(),
                     lock=Lock.MASS_REBUILD,


### PR DESCRIPTION
Notifying about a mass rebuild before acquiring the lock can be misleading. This PR proposes to be a little more verbose (acceptable in case of mass rebuilds, that do not happen every day) and make it clear:
- when a version wants to mass rebuild (acquiring the lock)
- when the mass rebuild has actually started (lock acquired)
- when the mass rebuild has terminated (lock released)

Follows https://github.com/openshift-eng/art-tools/pull/94