### PR TITLE
Add experimental distributed tracing with OpenTelemetry

### DIFF
--- a/doozer/doozerlib/assembly.py
+++ b/doozer/doozerlib/assembly.py
@@ -93,6 +93,13 @@ class AssemblyIssue:
     def __repr__(self):
         return self.msg
 
+    def to_dict(self):
+        return {
+            "code": self.code.value,
+            "component": self.component,
+            "msg": self.msg
+        }
+
 
 def merger(a, b):
     """

--- a/doozer/doozerlib/cli/__init__.py
+++ b/doozer/doozerlib/cli/__init__.py
@@ -8,6 +8,7 @@ import click
 from doozerlib import dotconfig, __version__
 from doozerlib.cli import cli_opts
 from doozerlib.runtime import Runtime
+from doozerlib.telemetry import initialize_telemetry
 from doozerlib.util import yellow_print
 
 CTX_GLOBAL = None
@@ -38,6 +39,8 @@ def print_version(ctx, param, value):
 @click.group(context_settings=context_settings)
 @click.option('--version', is_flag=True, callback=print_version,
               expose_value=False, is_eager=True)
+@click.option('--enable-telemetry', is_flag=True,
+              help="[Experimental] Enable OpenTelemetry support")
 @click.option("--data-path", metavar='PATH', default=None,
               help="Git repo or directory containing groups metadata")
 @click.option("--working-dir", metavar='PATH', default=None,
@@ -104,6 +107,10 @@ def print_version(ctx, param, value):
 def cli(ctx, **kwargs):
     global CTX_GLOBAL
     kwargs['global_opts'] = None  # can only be set in settings.yaml, add manually
+
+    # Initialize telemetry if needed
+    if kwargs['enable_telemetry'] or os.environ.get("TELEMETRY_ENABLED") == "1":
+        initialize_telemetry()
 
     # This section mostly for containerizing doozer
     # It allows the user to simply place settings.yaml into their working dir

--- a/doozer/doozerlib/telemetry.py
+++ b/doozer/doozerlib/telemetry.py
@@ -1,0 +1,94 @@
+import os
+import sys
+from functools import wraps
+from typing import Any, Awaitable, Callable, Optional, Sequence
+
+from opentelemetry import context, metrics, trace
+from opentelemetry.context import Context
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import (ConsoleMetricExporter,
+                                              PeriodicExportingMetricReader)
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (BatchSpanProcessor,
+                                            ConsoleSpanExporter, SpanExporter)
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.semconv.resource import ResourceAttributes
+from opentelemetry.trace.propagation.tracecontext import \
+    TraceContextTextMapPropagator
+from opentelemetry.util.types import Attributes
+
+from doozerlib import __version__
+
+
+def new_tracker_provider(resource: Resource, exporter: SpanExporter):
+    """ Creates and initialize a TracerProvider for Doozer.
+    Currently we only export traces to stderr for development purpose.
+    """
+    processor = BatchSpanProcessor(exporter)
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(processor)
+    return provider
+
+
+def initialize_telemetry():
+    # Initialize resource attributes;
+    # Additional attributes can be specified in OTEL_RESOURCE_ATTRIBUTES env var
+    resource = Resource.create(attributes={
+        ResourceAttributes.SERVICE_NAME: "doozer",
+        ResourceAttributes.SERVICE_VERSION: __version__,
+    })
+
+    otel_exporter_otlp_endpoint = os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT')
+    otel_exporter_otlp_headers = os.environ.get('OTEL_EXPORTER_OTLP_HEADERS')
+    if otel_exporter_otlp_endpoint:
+        exporter = OTLPSpanExporter(endpoint=otel_exporter_otlp_endpoint, headers=otel_exporter_otlp_headers)
+    else:
+        # OTEL_EXPORTER_OTLP_ENDPOINT is not defined; export to stderr
+        exporter = ConsoleSpanExporter(service_name="doozer", out=sys.stderr)
+
+    tp = new_tracker_provider(resource, exporter)
+    trace.set_tracer_provider(tp)
+    # TRACEPARENT env var is used to propagate trace context
+    traceparent = os.environ.get('TRACEPARENT')
+    if traceparent:
+        carrier = {'traceparent': traceparent}
+        ctx = TraceContextTextMapPropagator().extract(carrier=carrier)
+        context.attach(ctx)
+        print(f"Use TRACEPARENT {traceparent} for telemetry", file=sys.stderr)
+
+
+def start_as_current_span_async(
+    tracer: trace.Tracer,
+    name: str,
+    context: Optional[Context] = None,
+    kind: trace.SpanKind = trace.SpanKind.INTERNAL,
+    attributes: Attributes = None,
+    links: Optional[Sequence[trace.Link]] = None,
+    start_time: Optional[int] = None,
+    record_exception: bool = True,
+    set_status_on_exception: bool = True,
+    end_on_exit: bool = True,
+):
+    """ A decorator like tracer.start_as_current_span, but works for async functions
+    """
+
+    def decorator(function: Callable[..., Awaitable[Any]]):
+        @wraps(function)
+        async def wrapper(*args, **kwargs):
+            with tracer.start_as_current_span(
+                name=name,
+                context=context,
+                kind=kind,
+                attributes=attributes,
+                links=links,
+                start_time=start_time,
+                record_exception=record_exception,
+                set_status_on_exception=set_status_on_exception,
+                end_on_exit=end_on_exit,
+            ):
+                return await function(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/doozer/requirements.txt
+++ b/doozer/requirements.txt
@@ -5,6 +5,8 @@ dockerfile-parse >= 0.0.13
 defusedxml
 future
 koji
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-grpc
 pip_system_certs
 PyGitHub == 1.59.1
 pyyaml >= 5.1

--- a/pyartcd/pyartcd/cli.py
+++ b/pyartcd/pyartcd/cli.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import sys
+import os
 from functools import update_wrapper
 from pathlib import Path
 from typing import Optional
@@ -9,6 +10,7 @@ import click
 
 from pyartcd import __version__
 from pyartcd.runtime import Runtime
+from pyartcd.telemetry import initialize_telemetry
 
 pass_runtime = click.make_pass_decorator(Runtime)
 
@@ -38,6 +40,8 @@ def print_version(ctx, param, value):
 @click.option('--version', is_flag=True, callback=print_version,
               expose_value=False, is_eager=True,
               help="Print version information and quit")
+@click.option('--enable-telemetry', is_flag=True,
+              help="[Experimental] Enable OpenTelemetry support")
 @click.option("--config", "-c", metavar='PATH',
               help="Configuration file ('~/.config/artcd.toml' by default)")
 @click.option("--working-dir", "-C", metavar='PATH', default=None,
@@ -47,8 +51,11 @@ def print_version(ctx, param, value):
 @click.option("--verbosity", "-v", count=True,
               help="[MULTIPLE] increase output verbosity")
 @click.pass_context
-def cli(ctx: click.Context, config: Optional[str], working_dir: Optional[str], dry_run: bool, verbosity: int):
-
+def cli(ctx: click.Context, config: Optional[str], working_dir: Optional[str], dry_run: bool, verbosity: int,
+        enable_telemetry: bool):
+    # Initialize telemetry if needed
+    if enable_telemetry or os.environ.get("TELEMETRY_ENABLED") == "1":
+        initialize_telemetry()
     config_filename = config or Path("~/.config/artcd.toml").expanduser()
     working_dir = working_dir or Path.cwd()
     # configure logging

--- a/pyartcd/pyartcd/exectools.py
+++ b/pyartcd/pyartcd/exectools.py
@@ -4,8 +4,14 @@ import functools
 import logging
 import shlex
 from typing import List, Tuple, Union
+from opentelemetry import trace
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+from pyartcd.telemetry import start_as_current_span_async
+
 
 logger = logging.getLogger(__name__)
+TRACER = trace.get_tracer(__name__)
 
 
 async def to_thread(func, *args, **kwargs):
@@ -46,6 +52,7 @@ def limit_concurrency(limit=5):
     return executor
 
 
+@start_as_current_span_async(TRACER, "cmd_gather_async")
 async def cmd_gather_async(cmd: Union[List[str], str], check: bool = True, **kwargs) -> Tuple[int, str, str]:
     """ Runs a command asynchronously and returns rc,stdout,stderr as a tuple
     :param cmd <string|list>: A shell command
@@ -62,25 +69,40 @@ async def cmd_gather_async(cmd: Union[List[str], str], check: bool = True, **kwa
     # Remove any empty tokens from the command list
     cmd_list = [token for token in cmd_list if token]
 
+    span = trace.get_current_span()
+    span.set_attribute("pyartcd.param.cmd", cmd_list)
+
     logger.info("Executing:cmd_gather_async %s", cmd_list)
     # capture stdout and stderr if they are not set in kwargs
     if "stdout" not in kwargs:
         kwargs["stdout"] = asyncio.subprocess.PIPE
     if "stderr" not in kwargs:
         kwargs["stderr"] = asyncio.subprocess.PIPE
+
+    # Propagate trace context to subprocess
+    env = kwargs.get("env", {})
+    carrier = {}
+    TraceContextTextMapPropagator().inject(carrier)
+    if "traceparent" in carrier:
+        env["TRACEPARENT"] = carrier["traceparent"]
+        kwargs["env"] = env
+
     proc = await asyncio.subprocess.create_subprocess_exec(cmd_list[0], *cmd_list[1:], **kwargs)
     stdout, stderr = await proc.communicate()
     stdout = stdout.decode() if stdout else ""
     stderr = stderr.decode() if stderr else ""
+    span.set_attribute("pyartcd.result.exit_code", proc.returncode)
     if proc.returncode != 0:
         msg = f"Process {cmd_list!r} exited with code {proc.returncode}.\nstdout>>{stdout}<<\nstderr>>{stderr}<<\n"
         if check:
             raise ChildProcessError(msg)
         else:
             logger.warning(msg)
+    span.set_status(trace.StatusCode.OK)
     return proc.returncode, stdout, stderr
 
 
+@start_as_current_span_async(TRACER, "cmd_assert_async")
 async def cmd_assert_async(cmd: Union[List[str], str], check: bool = True, **kwargs) -> int:
     """ Runs a command and optionally raises an exception if the return code of the command indicates failure.
     :param cmd <string|list>: A shell command
@@ -96,13 +118,27 @@ async def cmd_assert_async(cmd: Union[List[str], str], check: bool = True, **kwa
     # Remove any empty tokens from the command list
     cmd_list = [token for token in cmd_list if token]
 
+    span = trace.get_current_span()
+    span.set_attribute("pyartcd.param.cmd", cmd_list)
+
+    # Propagate trace context to subprocess
+    env = kwargs.get("env", {})
+    carrier = {}
+    TraceContextTextMapPropagator().inject(carrier)
+    if "traceparent" in carrier:
+        env["TRACEPARENT"] = carrier["traceparent"]
+        logger.warning("Pass TRACEPARENT %s", env["TRACEPARENT"])
+        kwargs["env"] = env
+
     logger.info("Executing:cmd_assert_async %s", cmd_list)
     proc = await asyncio.subprocess.create_subprocess_exec(cmd_list[0], *cmd_list[1:], **kwargs)
     returncode = await proc.wait()
+    span.set_attribute("pyartcd.result.exit_code", returncode)
     if returncode != 0:
         msg = f"Process {cmd_list!r} exited with code {returncode}."
         if check:
             raise ChildProcessError(msg)
         else:
             logger.warning(msg)
-    return proc.returncode
+    span.set_status(trace.StatusCode.OK)
+    return returncode

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -5,15 +5,19 @@ import os
 
 import click
 import yaml
+from opentelemetry import trace
 
 from pyartcd.cli import cli, pass_runtime, click_coroutine
 from pyartcd.oc import registry_login
 from pyartcd.redis import RedisError
 from pyartcd.runtime import Runtime
 from pyartcd import exectools, constants, redis, util
+from pyartcd.telemetry import start_as_current_span_async
 from pyartcd.util import branch_arches
 from doozerlib.util import go_suffix_for_arch
 
+
+TRACER = trace.get_tracer(__name__)
 GEN_PAYLOAD_ARTIFACTS_OUT_DIR = 'gen-payload-artifacts'
 
 
@@ -256,7 +260,7 @@ class BuildSyncPipeline:
             cmd.extend([f'--exclude-arch {arch}' for arch in self.exclude_arches])
         if self.runtime.dry_run:
             cmd.extend(['--skip-gc-tagging', '--moist-run'])
-        await exectools.cmd_assert_async(cmd)
+        await exectools.cmd_assert_async(cmd, env=os.environ.copy())
 
         # Populate CI imagestreams
         await self._populate_ci_imagestreams()
@@ -375,6 +379,7 @@ class BuildSyncPipeline:
                    "heterogeneous release payload by setting this to true")
 @pass_runtime
 @click_coroutine
+@start_as_current_span_async(TRACER, "build-sync")
 async def build_sync(runtime: Runtime, version: str, assembly: str, publish: bool, data_path: str,
                      emergency_ignore_issues: bool, retrigger_current_nightly: bool, data_gitref: str,
                      debug: bool, images: str, exclude_arches: str, skip_multiarch_payload: bool):
@@ -392,10 +397,16 @@ async def build_sync(runtime: Runtime, version: str, assembly: str, publish: boo
         exclude_arches=exclude_arches,
         skip_multiarch_payload=skip_multiarch_payload
     )
-
+    span = trace.get_current_span()
+    span.set_attributes({
+        "pyartcd.param.dry_run": runtime.dry_run,
+        "pyartcd.param.version": version,
+        "pyartcd.param.assembly": assembly,
+    })
     try:
         await pipeline.run()
         await pipeline.handle_success()
+        span.set_status(trace.StatusCode.OK)
 
     except (RuntimeError, ChildProcessError):
         # Only for 'stream' assembly, track failure to enable future notifications

--- a/pyartcd/pyartcd/telemetry.py
+++ b/pyartcd/pyartcd/telemetry.py
@@ -1,0 +1,94 @@
+import os
+import sys
+from functools import wraps
+from typing import Any, Awaitable, Callable, Optional, Sequence
+
+from opentelemetry import context, metrics, trace
+from opentelemetry.context import Context
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import (ConsoleMetricExporter,
+                                              PeriodicExportingMetricReader)
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (BatchSpanProcessor,
+                                            ConsoleSpanExporter, SpanExporter)
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.semconv.resource import ResourceAttributes
+from opentelemetry.trace.propagation.tracecontext import \
+    TraceContextTextMapPropagator
+from opentelemetry.util.types import Attributes
+
+from pyartcd import __version__
+
+
+def new_tracker_provider(resource: Resource, exporter: SpanExporter):
+    """ Creates and initialize a TracerProvider for Doozer.
+    Currently we only export traces to stderr for development purpose.
+    """
+    processor = BatchSpanProcessor(exporter)
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(processor)
+    return provider
+
+
+def initialize_telemetry():
+    # Initialize resource attributes;
+    # Additional attributes can be specified in OTEL_RESOURCE_ATTRIBUTES env var
+    resource = Resource.create(attributes={
+        ResourceAttributes.SERVICE_NAME: "pyartcd",
+        ResourceAttributes.SERVICE_VERSION: __version__,
+    })
+
+    otel_exporter_otlp_endpoint = os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT')
+    otel_exporter_otlp_headers = os.environ.get('OTEL_EXPORTER_OTLP_HEADERS')
+    if otel_exporter_otlp_endpoint:
+        exporter = OTLPSpanExporter(endpoint=otel_exporter_otlp_endpoint, headers=otel_exporter_otlp_headers)
+    else:
+        # OTEL_EXPORTER_OTLP_ENDPOINT is not defined; export to stderr
+        exporter = ConsoleSpanExporter(service_name="doozer", out=sys.stderr)
+
+    tp = new_tracker_provider(resource, exporter)
+    trace.set_tracer_provider(tp)
+    # TRACEPARENT env var is used to propagate trace context
+    traceparent = os.environ.get('TRACEPARENT')
+    if traceparent:
+        carrier = {'traceparent': traceparent}
+        ctx = TraceContextTextMapPropagator().extract(carrier=carrier)
+        context.attach(ctx)
+        print(f"Use TRACEPARENT {traceparent} for telemetry", file=sys.stderr)
+
+
+def start_as_current_span_async(
+    tracer: trace.Tracer,
+    name: str,
+    context: Optional[Context] = None,
+    kind: trace.SpanKind = trace.SpanKind.INTERNAL,
+    attributes: Attributes = None,
+    links: Optional[Sequence[trace.Link]] = None,
+    start_time: Optional[int] = None,
+    record_exception: bool = True,
+    set_status_on_exception: bool = True,
+    end_on_exit: bool = True,
+):
+    """ A decorator like tracer.start_as_current_span, but works for async functions
+    """
+
+    def decorator(function: Callable[..., Awaitable[Any]]):
+        @wraps(function)
+        async def wrapper(*args, **kwargs):
+            with tracer.start_as_current_span(
+                name=name,
+                context=context,
+                kind=kind,
+                attributes=attributes,
+                links=links,
+                start_time=start_time,
+                record_exception=record_exception,
+                set_status_on_exception=set_status_on_exception,
+                end_on_exit=end_on_exit,
+            ):
+                return await function(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -11,6 +11,8 @@ ghapi
 jenkinsapi >= 0.3.13  # https://github.com/pycontribs/jenkinsapi/issues/833
 jira >= 3.4.1  # https://github.com/pycontribs/jira/issues/1486
 openshift-client
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-grpc
 pygit2 == 1.10.1 # https://github.com/libgit2/pygit2/issues/1176
 rh-doozer
 rh-elliott


### PR DESCRIPTION
- pyartcd: Add tracing for build-sync pipeline job.
- doozer: Add tracing for releases:gen-payload command.

This can be enabled by setting env var `TELEMETRY_ENABLED=1`.

Inter-process trace context is propagated through env var `TRACEPARENT`.

Currently traces are printed to stderr. In the future production traces
should be forwarded to a collector.

Requires https://github.com/openshift-eng/art-tools/pull/99 to include pyartcd/elliott/doozer versions in traces.