### PR TITLE
[ART-7954] Ignore image config change on noop commit message

### DIFF
--- a/doozer/doozerlib/cli/scan_sources.py
+++ b/doozer/doozerlib/cli/scan_sources.py
@@ -199,10 +199,10 @@ class ConfigScanSources:
                 self.runtime.logger.info('%s config_digest %s is differing from %s',
                                          image_meta.distgit_key, prev_digest, current_digest)
                 # fetch latest commit message on branch
-                with Dir(self.runtime.data_path):
+                with Dir(self.runtime.data_dir):
                     rc, commit_message, _ = exectools.cmd_gather('git log -1 --format=%s', strip=True)
                     if rc != 0:
-                        raise IOError(f'Unable to retrieve commit message from {self.runtime.data_path}')
+                        raise IOError(f'Unable to retrieve commit message from {self.runtime.data_dir}')
 
                 if commit_message.lower().startswith('scan-sources:noop'):
                     self.runtime.logger.info('Ignoring digest change since commit message indicates noop')


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-7954

Tested with https://github.com/openshift-eng/ocp-build-data/pull/3643

```
./doozer --assembly=stream --group 'openshift-4.15'@4.15-update-build-data-org --data-path https://github.com/locriandev/ocp-build-data --images openshift-base-nodejs config:scan-sources

2023-10-18 10:02:54,087 INFO openshift-base-nodejs config_digest sha256:5fa2beca671ca46d957547e08ad3cfba1b0b512c57994757c8d82896a4956963 is differing from sha256:734bb25abfe89ce7f032a202d62f21725288e8b69ed809f3f643d62a9b7a2878
2023-10-18 10:02:54,090 INFO $22: ['git', 'log', '-1', '--format=%s'] - [cwd=/tmp/oit-or_of314.tmp/ocp-build-data]: Executing:cmd_gather
2023-10-18 10:02:54,092 INFO Time elapsed (hh:mm:ss.ms) 0:00:00.002366 in exectools.py:167 from scan_sources.py:203:rc, commit_message, _ = exectools.cmd_gather('git log -1 --format=%s', strip=True) : $22: ['git', 'log', '-1', '--format=%s'] - [cwd=/tmp/oit-or_of314.tmp/ocp-build-data]: Executed:cmd_gather
2023-10-18 10:02:54,092 INFO Ignoring digest change since commit message indicates noop
```