### PR TITLE
Fail on image mirroring timeout

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -758,11 +758,8 @@ class GenPayloadCli:
 
         if self.apply or self.apply_multi_arch:
             self.logger.info(f"Mirroring images from {str(src_dest_path)}")
-            try:
-                await asyncio.wait_for(exectools.cmd_assert_async(
-                    f"oc image mirror --keep-manifest-list --filename={str(src_dest_path)}", retries=3), timeout=1800)
-            except asyncio.TimeoutError:
-                pass
+            await asyncio.wait_for(exectools.cmd_assert_async(
+                f"oc image mirror --keep-manifest-list --filename={str(src_dest_path)}", retries=3), timeout=1800)
 
     async def generate_specific_payload_imagestreams(self, arch: str, private_mode: bool,
                                                      payload_entries: Dict[str, PayloadEntry],


### PR DESCRIPTION
I traced the lifecycle of an image that the release controller failed to import. The job shows no error mirroring, but the mirroring operation lasts exactly 30 seconds.
If an exception is swallowed, neither the release controller nor heterogeneous payloads stand a chance, so do not proceed.