### PR TITLE
[verify-attached-operators] gather-dependencies Don't fail on move state error

### DIFF
--- a/elliott/elliottlib/cli/common.py
+++ b/elliott/elliottlib/cli/common.py
@@ -125,4 +125,7 @@ def move_builds(attached_builds, kind, from_advisory, to_advisory):
     to_erratum.ensure_state('NEW_FILES')
     to_erratum.attach_builds(attached_builds, kind)
     if old_state != 'NEW_FILES':
-        to_erratum.ensure_state(old_state)
+        try:
+            to_erratum.ensure_state(old_state)
+        except errata.ErrataException as ex:
+            yellow_print(f"Unable to move advisory {to_advisory} to {old_state}: {ex}. Please move it manually.")

--- a/elliott/elliottlib/cli/verify_attached_operators_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_operators_cli.py
@@ -330,11 +330,9 @@ def _handle_missing_builds(
         for adv in missing:
             missing_nvrs = builds_by_advisory[adv]
             if adv:
-                print(f"  {missing_nvrs} --from {adv}\n")
                 attached_builds = [b for b in errata.get_brew_builds(adv) if b.nvr in missing_nvrs]
                 move_builds(attached_builds, "image", adv, target)
             else:
-                print(f"  {missing_nvrs} --attach {target}\n")
                 # attaching builds from scratch is complicated; call out to existing cli
                 ctx.invoke(find_builds_cli, advisory=target, default_advisory_type=None,
                            builds=missing_nvrs, kind="image", from_diff=None, as_json=False,
@@ -342,14 +340,7 @@ def _handle_missing_builds(
                            non_payload=False, include_shipped=False, member_only=False)
         return True, True
     else:
-        print("To manually attach builds not already in the specified advisories:")
-        for adv in missing:
-            if adv:
-                builds_args = ",".join(b for b in builds_by_advisory[adv])
-                print(f"  elliott move-builds -k image --only {builds_args} --from {adv} --to <target_advisory>\n")
-            else:
-                builds_args = " ".join(f"-b {b}" for b in builds_by_advisory[adv])
-                print(f"  elliott find-builds -k image {builds_args} --attach <target_advisory>\n")
+        print("To automatically attach/move builds not already in the specified advisory, run with --gather-dependencies")
         return True, False
 
 


### PR DESCRIPTION
When we move builds, there are usually checks running on an advisory
which block it from moving to QE, so don't fail on that.

Also update print statements for the new `--gather-dependencies` flag.