### PR TITLE
Delete locks if associated build cannot be found

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -408,3 +408,12 @@ def start_scan_osh(nvrs: list, version: str, email: Optional[str] = "", **kwargs
         params=params,
         **kwargs
     )
+
+
+def is_api_reachable() -> bool:
+    """
+    Returns True if Jenkins API is reachable, False otherwise
+    """
+
+    endpoint = f'{constants.JENKINS_SERVER_URL}/api/json'
+    return requests.get(endpoint).status_code == 200

--- a/pyartcd/pyartcd/pipelines/cleanup_locks.py
+++ b/pyartcd/pyartcd/pipelines/cleanup_locks.py
@@ -34,7 +34,13 @@ async def cleanup_locks(runtime: Runtime):
                     runtime.logger.info('Build %s is still running: won\'t delete lock %s', build_path, lock_name)
 
             except ValueError:
-                runtime.logger.warning('Could not get build from lock %s with id %s: skipping', lock_name, build_path)
+                if jenkins.is_api_reachable():
+                    # Make sure Jenkins API are responding
+                    # Assume the build is not found because it was manually deleted, and clean up the orphan lock
+                    runtime.logger.warning('Could not get build from lock %s with id %s: deleting',
+                                           lock_name, build_path)
+                    lock: Lock = await lock_manager.get_lock(resource=lock_name, lock_identifier=build_path)
+                    await lock_manager.unlock(lock)
 
     finally:
         await lock_manager.destroy()


### PR DESCRIPTION
In case a build has been aborted (thus leaving an orphan lock in Redis), and then manually removed by a user, the clean up procedure will complain that the build associated to a lock cannot be found in Jenkins. Currently, it will display a warning and skip that lock.

This leads to locks that are never clean up. This PR proposes to delete those locks for which associated builds cannot be found. The only side effect I am seeing is that if we run `pyartcd` locally, we'll be creating locks with random IDs. These will be garbage collected by the cleanup procedure. It seems reasonable to me, as we shouldn't be creating those locks outside of a Jenkins context, and we might forgot to clean them up.