### PR TITLE
ART-7731 not update solution for doc

### DIFF
--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -189,7 +189,7 @@ def get_updated_advisory_rhsa(logger, cve_boilerplate: dict, advisory: Erratum, 
             security_reviewer=cve_boilerplate['security_reviewer'],
             synopsis=cve_boilerplate['synopsis'],
             topic=cve_boilerplate['topic'].format(IMPACT="Low"),
-            solution=cve_boilerplate['solution'],
+            # solution=cve_boilerplate['solution'],
             security_impact='Low',
         )
 

--- a/elliott/tests/test_attach_cve_flaws_cli.py
+++ b/elliott/tests/test_attach_cve_flaws_cli.py
@@ -41,7 +41,6 @@ class TestAttachCVEFlawsCLI(unittest.IsolatedAsyncioTestCase):
             security_reviewer=boilerplate['security_reviewer'],
             synopsis=boilerplate['synopsis'],
             topic=boilerplate['topic'].format(IMPACT="Low"),
-            solution=boilerplate['solution'],
             security_impact='Low',
         )
 


### PR DESCRIPTION
re: [ART-7731](https://issues.redhat.com/browse/ART-7731)
doc only want update solution for image advisory, our default value of image advisory already have SHA text included, so no need to update solution section when converting RHBA to RHSA