### PR TITLE
ART-8041 Use git ls-remote instead of GitHub API

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4_scan.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan.py
@@ -104,7 +104,9 @@ class Ocp4ScanPipeline:
         # Run doozer scan-sources
         cmd = f'doozer --data-path={self.data_path} --assembly stream --working-dir={self._doozer_working} ' \
               f'--group=openshift-{self.version} ' \
-              f'config:scan-sources --yaml --ci-kubeconfig {os.environ["KUBECONFIG"]}'
+              f'config:scan-sources --yaml --ci-kubeconfig {os.environ["KUBECONFIG"]} --rebase-priv'
+        if self.runtime.dry_run:
+            cmd += ' --dry-run'
         _, out, _ = await exectools.cmd_gather_async(cmd, stderr=None)
 
         self.logger.info('scan-sources output for openshift-%s:\n%s', self.version, out)


### PR DESCRIPTION
Changes in this PR:
-  `_do_shas_match()` updated to use `git ls-remote` to compare commit SHAs on private/public upstrams without calling GitHub API
- if `ocp4-scan` is built with `DRY_RUN` set to True, pass the `--dry-run` option to `doozer config:scan-sources`; this will not perform the rebase, only print what it would have done
- re-enable the currently disabled rebase procedure, by adding the `--rebase-priv` flag to doozer

Test run: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4_scan/553872/console