### PR TITLE
ART-7731 use actual advisroy type for release

### DIFF
--- a/elliott/elliottlib/cli/create_cli.py
+++ b/elliott/elliottlib/cli/create_cli.py
@@ -24,6 +24,9 @@ LOGGER = elliottlib.logutil.getLogger(__name__)
               type=click.Choice(elliottlib.constants.errata_valid_impetus),
               default='standard',
               help="Impetus for the advisory creation. 'standard' by default")
+@click.option("--art-advisory-key",
+              type=click.Choice(['rpm', 'microshift', 'metadata', 'image', 'extras']),
+              help="Class of the advisory. Should be one of [rpm, microshift, metadata, image, extras].")
 @click.option("--date", required=True,
               callback=validate_release_date,
               help="Release date for the advisory. Format: YYYY-Mon-DD.")
@@ -49,7 +52,7 @@ LOGGER = elliottlib.logutil.getLogger(__name__)
               help="Bug IDs for attaching to the advisory on creation. Required for creating a security advisory.")
 @click.pass_obj
 @click.pass_context
-def create_cli(ctx, runtime, errata_type, kind, impetus, date, assigned_to, manager, package_owner, with_liveid, yes, bugs):
+def create_cli(ctx, runtime, errata_type, kind, impetus, art_advisory_key, date, assigned_to, manager, package_owner, with_liveid, yes, bugs):
     """Create a new advisory. The kind of advisory must be specified with
 '--kind'. Valid choices are 'rpm' and 'image'.
 
@@ -112,7 +115,7 @@ advisory.
             et_data,
             errata_type=errata_type,
             kind=kind,
-            boilerplate_name=(impetus if impetus != "standard" else kind),
+            boilerplate_name=(art_advisory_key if art_advisory_key else kind),
             release_date=release_date.strftime(YMD),
             assigned_to=assigned_to,
             manager=manager,

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -149,9 +149,9 @@ class PrepareReleasePipeline:
             for ad in advisories:
                 if advisories[ad] < 0:
                     if ad == "microshift":
-                        advisories[ad] = self.create_advisory("RHEA" if is_ga else "RHBA", "rpm", ad)
+                        advisories[ad] = self.create_advisory("RHEA" if is_ga else "RHBA", "rpm", ad, ad)
                     else:
-                        advisories[ad] = self.create_advisory("RHEA" if is_ga else "RHBA", "rpm" if ad == "rpm" else "image", "ga" if is_ga else "standard")
+                        advisories[ad] = self.create_advisory("RHEA" if is_ga else "RHBA", "rpm" if ad == "rpm" else "image", "ga" if is_ga else "standard", ad)
 
         await self.set_advisory_dependencies(advisories)
 
@@ -289,8 +289,8 @@ class PrepareReleasePipeline:
         if match and int(match[1]) != 0:
             _LOGGER.info(f"{int(match[1])} Blocker Bugs found! Make sure to resolve these blocker bugs before proceeding to promote the release.")
 
-    def create_advisory(self, type: str, kind: str, impetus: str) -> int:
-        _LOGGER.info("Creating advisory with type %s, kind %s, and impetus %s...", type, kind, impetus)
+    def create_advisory(self, type: str, kind: str, impetus: str, art_advisory_key: str) -> int:
+        _LOGGER.info("Creating advisory with type %s, kind %s, and impetus %s art_advisory_key %s ...", type, kind, impetus, art_advisory_key)
         create_cmd = [
             "elliott",
             f"--working-dir={self.elliott_working_dir}",
@@ -300,6 +300,7 @@ class PrepareReleasePipeline:
             f"--type={type}",
             f"--kind={kind}",
             f"--impetus={impetus}",
+            f"--art-advisory-key={art_advisory_key}",
             f"--assigned-to={self.runtime.config['advisory']['assigned_to']}",
             f"--manager={self.runtime.config['advisory']['manager']}",
             f"--package-owner={self.package_owner}",


### PR DESCRIPTION
**boilerplate_name** in the create advisory function need to be one of the type ['rpm', 'microshift', 'metadata', 'image', 'extras'] with match the key in errata template
**impetus** is used for advisory metadata info need to be one of [standard, cve, ga, test]
**kind** is used for advisory class that need to be one of [rpm, image]