### PR TITLE
Advisory id should be passed as string

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -192,8 +192,8 @@ class BuildMicroShiftPipeline:
             await self._attach_builds()
             await self._sweep_bugs()
             await self._attach_cve_flaws()
-            await self._verify_microshift_bugs(microshift_advisory_id)
             await self._change_advisory_status()
+            await self._verify_microshift_bugs(microshift_advisory_id)
             await self.slack_say("Completed preparing microshift advisory.")
         except Exception as err:
             slack_message = f"Encountered error: {err}"
@@ -263,7 +263,7 @@ class BuildMicroShiftPipeline:
             "--assembly", self.assembly,
             "verify-attached-bugs",
             "--verify-flaws",
-            advisory_id
+            str(advisory_id)
         ]
         await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars)
 


### PR DESCRIPTION
Resolves error encountered at https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fbuild-microshift/707/consoleFull

Also move advisory to qe before running verify