### PR TITLE
Fix advisory-images command

### DIFF
--- a/elliott/elliottlib/errata.py
+++ b/elliott/elliottlib/errata.py
@@ -661,18 +661,19 @@ def get_advisory_images(image_advisory_id, raw=False):
     if raw:
         return '\n'.join(cdn_docker_file_list.keys())
 
-    pattern = re.compile(r'^redhat-openshift(\d)-')
+    def _get_image_name(nvr, repo):
+        name = next(iter(repo['docker']['target']['external_repos'].keys()), None)
+        if not name:
+            raise ValueError(f"Couldn't get repo name for {nvr}. Please open a ticket for CLOUDWF to set up the CDN repo.")
+        return name
 
-    def _get_image_name(repo):
-        return pattern.sub(r'openshift\1/', list(repo['docker']['target']['repos'].keys())[0])
-
-    def _get_nvr(component):
+    def _get_vr(component):
         parts = component.split('-')
         return '{}-{}'.format(parts[-2], parts[-1])
 
     image_list = [
-        '{}:{}'.format(_get_image_name(repo), _get_nvr(key))
-        for key, repo in sorted(cdn_docker_file_list.items())
+        '{}:{}'.format(_get_image_name(nvr, repo), _get_vr(nvr))
+        for nvr, repo in sorted(cdn_docker_file_list.items())
     ]
 
     return '#########\n{}\n#########'.format('\n'.join(image_list))

--- a/elliott/tests/test_errata.py
+++ b/elliott/tests/test_errata.py
@@ -152,6 +152,9 @@ class TestAdvisoryImages(unittest.TestCase):
                         'redhat-openshift3-ose-kube-rbac-proxy': {
                             'tags': ['latest', 'v3.11', 'v3.11.154', 'v3.11.154-1']
                         }
+                    },
+                    'external_repos': {
+                        "openshift3/ose-kube-rbac-proxy": {}
                     }
                 }
             }
@@ -163,6 +166,9 @@ class TestAdvisoryImages(unittest.TestCase):
                         'redhat-openshift3-jenkins-subordinate-base-rhel7': {
                             'tags': ['v3.11', 'v3.11.154', 'v3.11.154-1']
                         }
+                    },
+                    'external_repos': {
+                        "openshift3/jenkins-subordinate-base-rhel7": {}
                     }
                 }
             }
@@ -174,6 +180,9 @@ class TestAdvisoryImages(unittest.TestCase):
                         'redhat-openshift3-ose-pod': {
                             'tags': ['latest', 'v3.11', 'v3.11.154', 'v3.11.154-1']
                         }
+                    },
+                    'external_repos': {
+                        "openshift3/ose-pod": {}
                     }
                 }
             }


### PR DESCRIPTION
Got an error when running this command in promote-assembly job:

```
  File "/mnt/workspace/jenkins/working/cd-builds_build_promote-assembly/art-tools/elliott/elliottlib/errata.py", line 667, in _get_image_name
    return pattern.sub(r'openshift\1/', list(repo['docker']['target']['repos'].keys())[0])
IndexError: list index out of range
```

By looking at this issue, it seems to me that Errata Tool has changed its response message format of the API.