### PR TITLE
ART-3506 Do not limit rebase into -priv to one component

### DIFF
--- a/doozer/doozerlib/cli/scan_sources.py
+++ b/doozer/doozerlib/cli/scan_sources.py
@@ -39,10 +39,6 @@ class ConfigScanSources:
         self.oldest_image_event_ts = None
         self.newest_image_event_ts = 0
 
-        # TODO temp hack to apply rebase into -priv to only one component; when a random component is rebased,
-        # the rebase procedure will exit. This will let us inspect the results while minimizing risks
-        self.rebased = False
-
     def run(self):
         with self.runtime.shared_koji_client_session() as koji_api:
             self.runtime.logger.info(f'scan-sources coordinate: brew_event: '
@@ -109,9 +105,6 @@ class ConfigScanSources:
                 cmd=['git', 'push', 'origin', priv_branch_name],
                 retries=3)
             self.runtime.logger.info('Successfully reconciled %s with public upstream', metadata.name)
-
-            # TODO remove once we're confident it all works fine
-            self.rebased = True
 
         except ChildProcessError:
             # Failed pushing to openshift-priv
@@ -181,10 +174,6 @@ class ConfigScanSources:
             if not metadata.enabled:
                 self.runtime.logger.warning('%s is disabled: skipping rebase', metadata.name)
                 continue
-
-            # TODO remove once we're confident it all works fine
-            if self.rebased:
-                return
 
             if metadata.config.content is Missing:
                 self.runtime.logger.warning('%s %s is a distgit-only component: skipping openshift-priv rebase',


### PR DESCRIPTION
For safety reasons, we only rebase one component at the time at each ocp4-scan run. This was intended to avoid disasters when deploying a dangerous feature for the first time.

Rebase has now been running for a while, and Splunk can be used to monitor its actions:
- [this search](https://rhcorporate.splunkcloud.com/en-US/app/rh_openshift_art/search?q=search%20host%3Dbuildvm*%20index%3Djenkins_console%20%7C%20search%20%22Fast-forwarded%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-30d%40d&latest=now&display.page.search.tab=events&display.general.type=events&sid=1699348347.1350805_7AF866D2-E4C8-447C-A52A-318F2E6F81AF) shows the fast-forward operations into openshift-priv
- [this one](https://rhcorporate.splunkcloud.com/en-US/app/rh_openshift_art/search?q=search%20host%3Dbuildvm*%20index%3Djenkins_console%20%7C%20search%20%22will%20need%20manual%20reconciliation%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-30d%40d&latest=now&display.page.search.tab=events&display.general.type=events&sid=1699348869.1351328_7AF866D2-E4C8-447C-A52A-318F2E6F81AF) shows the places in need for a manual reconciliation (due to force pushes to public upstream)

Time has probably come to let the rebase into openshift-priv flow freely, so we can also experiment the last use case that's never happened yet: the one where we merge public into priv when the latter is ahead of the former