### PR TITLE
[ART-6149] Fix comment on PR feature

### DIFF
--- a/doozer/doozerlib/comment_on_pr.py
+++ b/doozer/doozerlib/comment_on_pr.py
@@ -1,12 +1,17 @@
+import os
 from ghapi.all import GhApi
 from doozerlib.pushd import Dir
 from dockerfile_parse import DockerfileParser
+from doozerlib.constants import BREWWEB_URL, GITHUB_TOKEN
 
 
 class CommentOnPr:
-    def __init__(self, distgit_dir: str, token: str):
+    def __init__(self, distgit_dir: str, nvr: str, build_id: str, distgit_name: str):
         self.distgit_dir = distgit_dir
-        self.token = token
+        self.nvr = nvr
+        self.build_id = build_id
+        self.distgit_name = distgit_name
+        self.token = os.getenv(GITHUB_TOKEN)
         self.owner = None
         self.repo = None
         self.commit = None
@@ -21,25 +26,31 @@ class CommentOnPr:
         # https://docs.github.com/rest/reference/issues#list-issue-comments
         return self.gh_client.issues.list_comments(issue_number=self.pr_no, per_page=100)
 
-    def check_if_comment_exist(self, comment):
+    def check_if_comment_exist(self):
         """
         Check if the same comment already exists in the PR
         """
         issue_comments = self.list_comments()
         for issue_comment in issue_comments:
-            if issue_comment["body"] == comment:
+            if "[ART PR BUILD NOTIFIER]" in issue_comment["body"]:
                 return True
         return False
 
-    def post_comment(self, comment):
+    def post_comment(self):
         """
         Post the comment in the PR if the comment doesn't exist already
         """
         # https://docs.github.com/rest/reference/issues#create-an-issue-comment
-        if not self.check_if_comment_exist(comment):
-            self.gh_client.issues.create_comment(issue_number=self.pr_no, body=comment)
-            return True
-        return False
+
+        # Message to be posted to the comment
+        comment = "**[ART PR BUILD NOTIFIER]**\n\n" + \
+                  "This PR has been included in build " + \
+                  f"[{self.nvr}]({BREWWEB_URL}/buildinfo" + \
+                  f"?buildID={self.build_id}) " + \
+                  f"for distgit *{self.distgit_name}*. \n All builds following this will " + \
+                  "include this PR."
+
+        self.gh_client.issues.create_comment(issue_number=self.pr_no, body=comment)
 
     def set_pr_from_commit(self):
         """
@@ -77,3 +88,12 @@ class CommentOnPr:
         Set the gh client after the get_source_details function is run
         """
         self.gh_client = GhApi(owner=self.owner, repo=self.repo, token=self.token)
+
+    def run(self):
+        self.set_repo_details()
+        self.set_github_client()
+        self.set_pr_from_commit()
+
+        # Check if comment doesn't already exist. Then post comment
+        if not self.check_if_comment_exist():
+            self.post_comment()

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -29,7 +29,6 @@ import doozerlib
 from doozerlib import assertion, constants, exectools, logutil, state, util
 from doozerlib.assembly import AssemblyTypes
 from doozerlib.brew import get_build_objects, watch_task, BuildStates
-from doozerlib.constants import BREWWEB_URL
 from doozerlib.dblib import Record
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.model import ListModel, Missing, Model
@@ -41,7 +40,6 @@ from doozerlib.source_modifications import SourceModifierFactory
 from doozerlib.util import yellow_print
 from artcommonlib.util import convert_remote_git_to_https
 from doozerlib.comment_on_pr import CommentOnPr
-from string import Template
 
 # doozer used to be part of OIT
 OIT_COMMENT_PREFIX = '#oit##'
@@ -1078,20 +1076,11 @@ class ImageDistGitRepo(DistGitRepo):
                         if comment_on_pr:
                             try:
                                 comment_on_pr_obj = CommentOnPr(distgit_dir=self.distgit_dir,
-                                                                token=os.getenv(constants.GITHUB_TOKEN))
-                                comment_on_pr_obj.set_repo_details()
-                                comment_on_pr_obj.set_github_client()
-                                comment_on_pr_obj.set_pr_from_commit()
-                                # Message to be posted to the comment
-                                message = Template("**[ART PR BUILD NOTIFIER]**\n\n"
-                                                   "This PR has been included in build "
-                                                   f"[$nvr]({BREWWEB_URL}/buildinfo"
-                                                   "?buildID=$build_id) "
-                                                   "for distgit *$distgit_name*. \n All builds following this will "
-                                                   "include this PR.")
-                                comment_on_pr_obj.post_comment(message.substitute(nvr=build_info["nvr"],
-                                                                                  build_id=build_info["id"],
-                                                                                  distgit_name=self.metadata.name))
+                                                                nvr=build_info["nvr"],
+                                                                build_id=build_info["id"],
+                                                                distgit_name=self.metadata.name
+                                                                )
+                                comment_on_pr_obj.run()
                             except Exception as e:
                                 self.logger.error(f"Error commenting on PR for build task id {task_id} for distgit"
                                                   f"{self.metadata.name}: {e}")

--- a/doozer/tests/test_comment_on_pr.py
+++ b/doozer/tests/test_comment_on_pr.py
@@ -8,13 +8,18 @@ class TestCommentOnPr(unittest.TestCase):
         self.distgit_dir = "distgit_dir"
         self.token = "token"
         self.commit = "commit_sha"
-        self.comment = "comment"
+        self.nvr = "nvr"
+        self.build_id = "build_id"
+        self.distgit_name = "distgit_name"
+        self.comment = '**[ART PR BUILD NOTIFIER]**\n\nThis PR has been included in build ' \
+                       '[nvr](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=build_id) for ' \
+                       'distgit *distgit_name*. \n All builds following this will include this PR.'
 
     def test_list_comments(self):
         pr_no = 1
         api_mock = MagicMock()
         api_mock.issues.list_comments.return_value = [{"body": "test comment"}]
-        comment_on_pr = CommentOnPr(self.distgit_dir, self.token)
+        comment_on_pr = CommentOnPr(self.distgit_dir, self.nvr, self.build_id, self.distgit_name)
         comment_on_pr.pr_no = pr_no
         comment_on_pr.gh_client = api_mock
         result = comment_on_pr.list_comments()
@@ -24,10 +29,10 @@ class TestCommentOnPr(unittest.TestCase):
     @patch.object(CommentOnPr, "list_comments")
     def test_check_if_comment_exist(self, mock_list_comments):
         api_mock = MagicMock()
-        api_mock.issues.list_comments.return_value = [{"body": self.comment}]
+        api_mock.issues.list_comments.return_value = [{"body": "[ART PR BUILD NOTIFIER]"}]
         mock_list_comments.return_value = api_mock.issues.list_comments()
-        comment_on_pr = CommentOnPr(self.distgit_dir, self.token)
-        result = comment_on_pr.check_if_comment_exist(self.comment)
+        comment_on_pr = CommentOnPr(self.distgit_dir, self.nvr, self.build_id, self.distgit_name)
+        result = comment_on_pr.check_if_comment_exist()
         self.assertTrue(result)
 
     @patch.object(CommentOnPr, "list_comments")
@@ -35,8 +40,8 @@ class TestCommentOnPr(unittest.TestCase):
         api_mock = MagicMock()
         api_mock.issues.list_comments.return_value = [{"body": "test comment"}]
         mock_list_comments.return_value = api_mock.issues.list_comments()
-        comment_on_pr = CommentOnPr(self.distgit_dir, self.token)
-        result = comment_on_pr.check_if_comment_exist(self.comment)
+        comment_on_pr = CommentOnPr(self.distgit_dir, self.nvr, self.build_id, self.distgit_name)
+        result = comment_on_pr.check_if_comment_exist()
         self.assertFalse(result)
 
     @patch.object(CommentOnPr, "check_if_comment_exist")
@@ -44,28 +49,15 @@ class TestCommentOnPr(unittest.TestCase):
         pr_no = 1
         api_mock = MagicMock()
         mock_check_if_comment_exist.return_value = False
-        comment_on_pr = CommentOnPr(self.distgit_dir, self.token)
+        comment_on_pr = CommentOnPr(self.distgit_dir, self.nvr, self.build_id, self.distgit_name)
         comment_on_pr.pr_no = pr_no
         comment_on_pr.gh_client = api_mock
-        result = comment_on_pr.post_comment(self.comment)
+        _ = comment_on_pr.post_comment()
         api_mock.issues.create_comment.assert_called_once_with(issue_number=pr_no, body=self.comment)
-        self.assertTrue(result)
-
-    @patch.object(CommentOnPr, "check_if_comment_exist")
-    def test_post_comment_when_comment_already_exists(self, mock_check_if_comment_exist):
-        pr_no = 1
-        api_mock = MagicMock()
-        mock_check_if_comment_exist.return_value = True
-        comment_on_pr = CommentOnPr(self.distgit_dir, self.token)
-        comment_on_pr.pr_no = pr_no
-        comment_on_pr.gh_client = api_mock
-        result = comment_on_pr.post_comment(self.comment)
-        api_mock.issues.create_comment.assert_not_called()
-        self.assertFalse(result)
 
     def test_get_pr_from_commit(self):
         api_mock = MagicMock()
-        comment_on_pr = CommentOnPr(self.distgit_dir, self.token)
+        comment_on_pr = CommentOnPr(self.distgit_dir, self.nvr, self.build_id, self.distgit_name)
         comment_on_pr.gh_client = api_mock
         api_mock.repos.list_pull_requests_associated_with_commit.return_value = [{"html_url": "test_url", "number": 1}]
         comment_on_pr.set_pr_from_commit()
@@ -74,7 +66,7 @@ class TestCommentOnPr(unittest.TestCase):
 
     def test_multiple_prs_for_merge_commit(self):
         api_mock = MagicMock()
-        comment_on_pr = CommentOnPr(self.distgit_dir, self.token)
+        comment_on_pr = CommentOnPr(self.distgit_dir, self.nvr, self.build_id, self.distgit_name)
         comment_on_pr.gh_client = api_mock
         api_mock.repos.list_pull_requests_associated_with_commit.return_value = [{"html_url": "test_url", "number": 1},
                                                                                  {"html_url": "test_url_2",
@@ -83,7 +75,7 @@ class TestCommentOnPr(unittest.TestCase):
             comment_on_pr.set_pr_from_commit()
 
     def test_set_github_client(self):
-        comment_on_pr = CommentOnPr(self.distgit_dir, self.token)
+        comment_on_pr = CommentOnPr(self.distgit_dir, self.nvr, self.build_id, self.distgit_name)
         comment_on_pr.owner = "owner"
         comment_on_pr.repo = "repo"
         comment_on_pr.token = "token"
@@ -92,7 +84,7 @@ class TestCommentOnPr(unittest.TestCase):
 
     @patch('doozerlib.comment_on_pr.DockerfileParser')
     def test_get_source_details(self, mock_parser):
-        comment_on_pr = CommentOnPr(self.distgit_dir, self.token)
+        comment_on_pr = CommentOnPr(self.distgit_dir, self.nvr, self.build_id, self.distgit_name)
         # Mocking the labels dictionary of the DockerfileParser object
         mock_parser.return_value.labels = {
             "io.openshift.build.commit.url": "https://github.com/openshift/origin/commit/660e0c785a2c9b1fd5fad33cbcffd77a6d84ccb5"

--- a/pyartcd/pyartcd/pipelines/ocp4_scan.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan.py
@@ -64,6 +64,7 @@ class Ocp4ScanPipeline:
                 assembly='stream',
                 rpm_list=self.changes.get('rpms', []),
                 image_list=self.changes.get('images', []),
+                comment_on_pr=True
             )
 
         elif self.rhcos_inconsistent:

--- a/pyartcd/tests/pipelines/test_ocp4.py
+++ b/pyartcd/tests/pipelines/test_ocp4.py
@@ -30,7 +30,8 @@ class TestInitialBuildPlan(unittest.IsolatedAsyncioTestCase):
             build_images='all',
             image_list='',
             skip_plashets=False,
-            mail_list_failure=''
+            mail_list_failure='',
+            comment_on_pr=False
         )
 
     @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
@@ -134,7 +135,8 @@ class TestPlannedBuilds(unittest.IsolatedAsyncioTestCase):
             build_images='all',
             image_list='',
             skip_plashets=False,
-            mail_list_failure=''
+            mail_list_failure='',
+            comment_on_pr=False
         )
 
     @patch("pyartcd.jenkins.update_description")
@@ -346,7 +348,8 @@ class TestInitialize(unittest.IsolatedAsyncioTestCase):
             build_images='all',
             image_list='',
             skip_plashets=False,
-            mail_list_failure=''
+            mail_list_failure='',
+            comment_on_pr=False
         )
 
     def setUp(self) -> None:
@@ -487,7 +490,8 @@ class TestBuilds(unittest.IsolatedAsyncioTestCase):
             build_images='all',
             image_list='',
             skip_plashets=False,
-            mail_list_failure=''
+            mail_list_failure='',
+            comment_on_pr=False
         )
         pipeline._doozer_working = 'doozer_working'
         pipeline.build_plan.active_image_count = 5
@@ -684,7 +688,8 @@ class TestBuildCompose(unittest.IsolatedAsyncioTestCase):
             build_images='all',
             image_list='',
             skip_plashets=False,
-            mail_list_failure=''
+            mail_list_failure='',
+            comment_on_pr=False
         )
 
     @patch("pyartcd.util.get_freeze_automation", return_value="False")
@@ -805,7 +810,8 @@ class TestUpdateDistgit(unittest.IsolatedAsyncioTestCase):
             build_images='all',
             image_list='',
             skip_plashets=False,
-            mail_list_failure=''
+            mail_list_failure='',
+            comment_on_pr=False
         )
 
         pipeline.version.release = '2099010109.p?'
@@ -874,7 +880,8 @@ class TestSyncImages(unittest.IsolatedAsyncioTestCase):
             build_images='all',
             image_list='',
             skip_plashets=False,
-            mail_list_failure=''
+            mail_list_failure='',
+            comment_on_pr=False
         )
 
         # No images
@@ -918,7 +925,8 @@ class TestSyncImages(unittest.IsolatedAsyncioTestCase):
             build_images='all',
             image_list='',
             skip_plashets=False,
-            mail_list_failure=''
+            mail_list_failure='',
+            comment_on_pr=False
         )
 
         # No images
@@ -969,7 +977,8 @@ class TestMirrorRpms(unittest.IsolatedAsyncioTestCase):
             build_images='all',
             image_list='',
             skip_plashets=False,
-            mail_list_failure=''
+            mail_list_failure='',
+            comment_on_pr=False
         )
 
         # Mock lock manager
@@ -1023,7 +1032,8 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
             build_images='all',
             image_list='',
             skip_plashets=False,
-            mail_list_failure=''
+            mail_list_failure='',
+            comment_on_pr=False
         )
 
     def test_include_exclude(self):


### PR DESCRIPTION
The comment on PR feature aims to comment on the PR that kicked off an ocp4 build for images. The feature was disabled because multiple messages were being posted on the same PR ([example](https://github.com/openshift/network-tools/pull/75)). But it was because I was checking whether the entire message was there. For new messages, the NVR will change. This issue is now fixed by checking if there is any comment with `[ART PR BUILD NOTIFIER]`