### PR TITLE
Fix microshift-sync link in slack

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -175,9 +175,8 @@ class BuildMicroShiftPipeline:
                     await self.slack_say(message)
                 except Exception as err:
                     self._logger.warning("Failed to trigger microshift_sync job: %s", err)
-                    message = "@release-artists Please start <microshift sync | " \
-                              "https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888" \
-                              "/job/aos-cd-builds/job/build%252Fmicroshift_sync> manually."
+                    message = "@release-artists Please start <https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888" \
+                              "/job/aos-cd-builds/job/build%252Fmicroshift_sync|microshift sync> manually."
                     await self.slack_say(message)
 
             # Check if microshift advisory is defined in assembly


### PR DESCRIPTION
Fix messages like this: https://redhat-internal.slack.com/archives/C05FEGT8SH2/p1700026353265139?thread_ts=1700026352.836499&cid=C05FEGT8SH2