### PR TITLE
Fix rhcos version in promote

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -419,7 +419,7 @@ class PromotePipeline:
             rhcos_name = get_primary_container_name(self.group_runtime)
             rhcos = next((t for t in release_info.get("references", {}).get("spec", {}).get("tags", []) if t["name"] == rhcos_name), None)
             if rhcos:
-                rhcos_version = rhcos["annotations"]["io.openshift.build.versions"].split("=")[1]  # machine-os=48.84.202112162302-0 => 48.84.202112162302-0
+                rhcos_version = rhcos["annotations"]["version"]  # 415.92.202310161140-0
                 data["content"][arch]["rhcos_version"] = rhcos_version
         # sync rhcos srpms
         await self.sync_rhcos_srpms(assembly_type, data)
@@ -1002,7 +1002,7 @@ class PromotePipeline:
                             "tags": [
                                 {
                                     "name": get_primary_container_name(self.group_runtime),
-                                    "annotations": {"io.openshift.build.versions": "machine-os=00.00.212301010000-0"}
+                                    "annotations": {"version": "00.00.212301010000-0"}
                                 }
                             ]
                         }

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -273,6 +273,8 @@ class PromotePipeline:
             reference_releases = util.get_assembly_basis(releases_config, self.assembly).get("reference_releases", {})
             tag_stable = assembly_type in [assembly.AssemblyTypes.STANDARD, assembly.AssemblyTypes.CANDIDATE, assembly.AssemblyTypes.PREVIEW]
             release_infos = await self.promote(assembly_type, release_name, arches, previous_list, metadata, reference_releases, tag_stable)
+            self._logger.info('Release info for %s: %s', release_name, json.dumps(release_infos, indent=4))
+
             pullspecs = {arch: release_info["image"] for arch, release_info in release_infos.items()}
             pullspecs_repr = ", ".join(f"{arch}: {pullspecs[arch]}" for arch in sorted(pullspecs.keys()))
             self._logger.info("All release images for %s have been promoted. Pullspecs: %s", release_name, pullspecs_repr)

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -202,7 +202,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
                 "tags": [
                     {
                         "name": "machine-os-content",
-                        "annotations": {"io.openshift.build.versions": "machine-os=00.00.212301010000-0"}
+                        "annotations": {"version": "00.00.212301010000-0"}
                     }
                 ]
             }
@@ -413,7 +413,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
                 "tags": [
                     {
                         "name": "machine-os-content",
-                        "annotations": {"io.openshift.build.versions": "machine-os=00.00.212301010000-0"}
+                        "annotations": {"version": "00.00.212301010000-0"}
                     }
                 ]
             },
@@ -512,7 +512,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
                 "tags": [
                     {
                         "name": "machine-os-content",
-                        "annotations": {"io.openshift.build.versions": "machine-os=00.00.212301010000-0"}
+                        "annotations": {"version": "00.00.212301010000-0"}
                     }
                 ]
             }


### PR DESCRIPTION
For 4.15, due to machine-os-content having disappeared from the payload, promote job is failing on 
```
rhcos_version = rhcos["annotations"]["io.openshift.build.versions"].split("=")[1]  # machine-os=48.84.202112162302-0 => 48.84.202112162302-0
KeyError: 'io.openshift.build.versions'
```

The `version` label is always found and can be used as an alternative, as it appears in all versions since 4.6:
```
versions=(
  "4.14.2"
  "4.13.22"
  "4.12.43"
  "4.11.53"
  "4.10.67"
  "4.9.59"
  "4.8.57"
  "4.7.60"
  "4.6.62"
)

for version in ${versions[@]}; do
  echo $version;
  oc image info -o json $(oc adm release info --image-for machine-os-content ${version}) | jq -r '.config.config.Labels.version';
  echo "------------------------";
done
```