### PR TITLE
Skip when no nvrs to scan

### DIFF
--- a/doozer/doozerlib/cli/scan_osh.py
+++ b/doozer/doozerlib/cli/scan_osh.py
@@ -512,6 +512,10 @@ class ScanOshCli:
             self.runtime.logger.info(f"Triggering scans for this particular list of NVRs: {self.specific_nvrs}")
             nvrs_for_scans = self.specific_nvrs
 
+        if not nvrs_for_scans:
+            self.runtime.logger.info("No new builds to scan")
+            return
+
         if self.check_triggered:
             nvrs_for_scans = await self.get_untriggered_nvrs(nvrs_for_scans)
 


### PR DESCRIPTION
Fixes issue in [job](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fscan-osh/13773/console), where `nvrs_for_scans` is an empty list