### PR TITLE
[scan-osh] Skip component if can't file imp file

### DIFF
--- a/doozer/doozerlib/cli/scan_osh.py
+++ b/doozer/doozerlib/cli/scan_osh.py
@@ -148,8 +148,11 @@ class ScanOshCli:
         self.runtime.logger.info(f"Checking OSH Scan for issues: {url}")
         response = requests.get(url)
 
-        if len(response.json()["defects"]) > 0:
-            return True
+        try:
+            if len(response.json()["defects"]) > 0:
+                return True
+        except Exception:
+            self.runtime.logger.warning(f"Don't see scan-results-imp.js for {nvr}")
 
         return False
 
@@ -363,13 +366,9 @@ class ScanOshCli:
                 self.runtime.logger.info(f"No successful scan found for package {brew_package_name}")
                 continue
 
-            try:
-                if self.check_if_scan_issues_exist(task_id=data["latest_coverity_scan"],
-                                                   nvr=data["latest_coverity_scan_nvr"]):
-                    nvrs_with_scan_issues[brew_package_name] = data
-            except Exception:
-                self.runtime.logger.warning(f"Don't see scan-results-imp.js. Skipping {brew_package_name}")
-                continue
+            if self.check_if_scan_issues_exist(task_id=data["latest_coverity_scan"],
+                                               nvr=data["latest_coverity_scan_nvr"]):
+                nvrs_with_scan_issues[brew_package_name] = data
 
             else:
                 self.runtime.logger.info(f"No scan issues found for NVR: {data['latest_coverity_scan_nvr']}")

--- a/doozer/doozerlib/cli/scan_osh.py
+++ b/doozer/doozerlib/cli/scan_osh.py
@@ -363,9 +363,13 @@ class ScanOshCli:
                 self.runtime.logger.info(f"No successful scan found for package {brew_package_name}")
                 continue
 
-            if self.check_if_scan_issues_exist(task_id=data["latest_coverity_scan"],
-                                               nvr=data["latest_coverity_scan_nvr"]):
-                nvrs_with_scan_issues[brew_package_name] = data
+            try:
+                if self.check_if_scan_issues_exist(task_id=data["latest_coverity_scan"],
+                                                   nvr=data["latest_coverity_scan_nvr"]):
+                    nvrs_with_scan_issues[brew_package_name] = data
+            except Exception:
+                self.runtime.logger.warning(f"Don't see scan-results-imp.js. Skipping {brew_package_name}")
+                continue
 
             else:
                 self.runtime.logger.info(f"No scan issues found for NVR: {data['latest_coverity_scan_nvr']}")

--- a/doozer/doozerlib/cli/scan_osh.py
+++ b/doozer/doozerlib/cli/scan_osh.py
@@ -146,9 +146,9 @@ class ScanOshCli:
 
         url = SCAN_RESULTS_URL_TEMPLATE.format(task_id=task_id, nvr=nvr)
         self.runtime.logger.info(f"Checking OSH Scan for issues: {url}")
-        response = requests.get(url)
 
         try:
+            response = requests.get(url)
             if len(response.json()["defects"]) > 0:
                 return True
         except Exception:


### PR DESCRIPTION
Due to an upstream bug, sometimes we don't have the scan-imp file. Lets skip that component now.