### PR TITLE
Use new target version field

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -761,7 +761,7 @@ Jira mapping: https://github.com/openshift-eng/ocp-build-data/blob/main/product.
             'project': {'key': project},
             'issuetype': {'name': 'Bug'},
             'versions': [{'name': release_version}],  # Affects Version/s
-            'customfield_12323140': [{'name': Model(runtime.gitdata.load_data(key='bug').data).target_release[-1]}],  # customfield_12323140 is Target Version in jira
+            'customfield_12319940': [{'name': Model(runtime.gitdata.load_data(key='bug').data).target_release[-1]}],  # customfield_12319940 is Target Version in jira
             'components': [{'name': component}],
             'summary': summary,
             'description': description

--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -578,7 +578,7 @@ class JIRABugTracker(BugTracker):
 
     # Prefer to query by user visible Field Name. Context: https://issues.redhat.com/browse/ART-7053
     FIELD_BLOCKED_BY_BZ = 'customfield_12322152'  # "Blocked by Bugzilla Bug"
-    FIELD_TARGET_VERSION = 'customfield_12323140'  # "Target Version"
+    FIELD_TARGET_VERSION = 'customfield_12319940'  # "Target Version"
     FIELD_RELEASE_BLOCKER = 'customfield_12319743'  # "Release Blocker"
     FIELD_BLOCKED_REASON = 'customfield_12316544'  # "Blocked Reason"
     FIELD_SEVERITY = 'customfield_12316142'  # "Severity"


### PR DESCRIPTION
Jira admins changed the current field to "Target Version - old"
this is the new "Target Version"
https://issues.redhat.com/rest/api/2/field