### PR TITLE
Close placeholder bug when dropping an advisory

### DIFF
--- a/pyartcd/pyartcd/pipelines/advisory_drop.py
+++ b/pyartcd/pyartcd/pipelines/advisory_drop.py
@@ -21,6 +21,7 @@ async def advisory_drop(runtime: Runtime, group: str, advisory: str, comment: st
         '--advisory', advisory,
         '--auto',
         '--comment', comment,
+        '--close-placeholder',
         '--from', 'RELEASE_PENDING',
         '--to', 'VERIFIED',
     ]


### PR DESCRIPTION
This reverts https://github.com/openshift-eng/aos-cd-jobs/pull/3924

Requires https://github.com/openshift-eng/art-tools/pull/202