### PR TITLE
bug sweep: look more precise at cutoff event

### DIFF
--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -782,7 +782,7 @@ class JIRABugTracker(BugTracker):
         val = ','.join(f'"{s}"' for s in desired_statuses)
         query = f"issue in ({','.join([b.id for b in bugs])}) " \
                 f"and status was in ({val}) " \
-                f'before("{dt}")'
+                f'on("{dt}")'
         return self._search(query, verbose=verbose)
 
     async def filter_attached_bugs(self, bugs: Iterable):


### PR DESCRIPTION
OCPBUGS-21035 got ON_QA in October, got back to Assigned, got fixed again. The logic for establishing if this was fixed at the cutoff time is short circuited, as the question "was it ON_QA or higher before cutoff time?" is Yes.

This changes the query to ask for the status at the cutoff time.

The `WAS` operator is explained here: https://support.atlassian.com/jira-software-cloud/docs/jql-operators/