### PR TITLE
Include disabled rpms flag for rpms:print

### DIFF
--- a/doozer/doozerlib/cli/rpms.py
+++ b/doozer/doozerlib/cli/rpms.py
@@ -5,15 +5,16 @@ from doozerlib.cli import cli, pass_runtime
 
 @cli.command("rpms:print", short_help="Print data for each rpm metadata")
 @click.option("--short", default=False, is_flag=True, help="Suppress all output other than the data itself")
+@click.option("--include-disabled", default=False, is_flag=True, help="Include disabled RPMs")
 @click.option("--output", "-o", default=None, help="Write data to FILE instead of STDOUT")
 @click.argument("pattern", default="{build}", nargs=1)
 @pass_runtime
-def rpms_print(runtime, short, output, pattern):
+def rpms_print(runtime, short, include_disabled, output, pattern):
     # If user omitted braces, add them.
     if "{" not in pattern:
         pattern = "{%s}" % pattern.strip()
 
-    runtime.initialize(mode="rpms", clone_distgits=False)
+    runtime.initialize(mode="rpms", disabled=include_disabled, clone_distgits=False)
     rpms = list(runtime.rpm_metas())
 
     if short:


### PR DESCRIPTION
Follows https://github.com/openshift-eng/art-tools/pull/209

Since microshift is disabled, it won't show up in this command, without specifying the disabled flag. We need this option so that our SAST pipeline can see which all RPMs are managed by us.

_Requesting /lgtm and /approve_