### PR TITLE
[ART-7926] [scan-osh] Enable OCPBUGS pipeline for ART managed RPMs

### DIFF
--- a/doozer/doozerlib/cli/scan_osh.py
+++ b/doozer/doozerlib/cli/scan_osh.py
@@ -408,9 +408,8 @@ class ScanOshCli:
         Check if the OCPBUGS workflow is enabled in ocp-build-data config
         """
         flag = meta.config.get("external_scanners", {}).get("sast_scanning", {}).get("jira_integration", {}).get("enabled")
-        if flag in [True, "True", "true", "yes"]:
-            return True
-        return False
+
+        return flag in [True, "True", "true", "yes"]
 
     async def ocp_bugs_workflow_run(self, brew_components: dict):
         # List of brew components to check


### PR DESCRIPTION
Alongside https://github.com/openshift-eng/ocp-build-data/pull/3973

Till now only scan results of images were being checked. This PR starts looking at RPMs that ART is managing.

Test ticket that got raised: https://issues.redhat.com/browse/ART-8415

