### PR TITLE
ART-8114 gen-assembly configures prerelease advisories

### DIFF
--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -30,7 +30,8 @@ class GenAssemblyPipeline:
     def __init__(self, runtime: Runtime, group: str, assembly: str, data_path: str,
                  nightlies: Tuple[str, ...], allow_pending: bool, allow_rejected: bool, allow_inconsistency: bool,
                  custom: bool, arches: Tuple[str, ...], in_flight: Optional[str], previous_list: Tuple[str, ...],
-                 auto_previous: bool, auto_trigger_build_sync: bool, logger: Optional[logging.Logger] = None):
+                 auto_previous: bool, auto_trigger_build_sync: bool, prerelease: bool = False,
+                 logger: Optional[logging.Logger] = None):
         self.runtime = runtime
         self.group = group
         self.assembly = assembly
@@ -45,6 +46,7 @@ class GenAssemblyPipeline:
         self.in_flight = in_flight
         self.previous_list = previous_list
         self.auto_previous = auto_previous
+        self.prerelease = prerelease
         self._logger = logger or runtime.logger
         self._slack_client = self.runtime.new_slack_client()
         self._working_dir = self.runtime.working_dir.absolute()
@@ -145,6 +147,8 @@ class GenAssemblyPipeline:
             cmd.append(f"--nightly={nightly}")
         if self.custom:
             cmd.append("--custom")
+        if self.prerelease:
+            cmd.append("--prerelease")
         else:
             if self.in_flight:
                 cmd.append(f"--in-flight={self.in_flight}")
@@ -245,6 +249,8 @@ class GenAssemblyPipeline:
               help="Allow matching nightlies built from matching commits but with inconsistent RPMs")
 @click.option("--custom", is_flag=True,
               help="Custom assemblies are not for official release. They can, for example, not have all required arches for the group.")
+@click.option("--prerelease", is_flag=True,
+              help="Prepare the assembly for a prerelease operator advisory")
 @click.option('--auto-trigger-build-sync', is_flag=True,
               help='Will trigger build-sync automatically after PR creation')
 @click.option("--arch", "arches", metavar="TAG", multiple=True,
@@ -255,12 +261,12 @@ class GenAssemblyPipeline:
 @pass_runtime
 @click_coroutine
 async def gen_assembly(runtime: Runtime, data_path: str, group: str, assembly: str, nightlies: Tuple[str, ...],
-                       allow_pending: bool, allow_rejected: bool, allow_inconsistency: bool, custom: bool,
+                       allow_pending: bool, allow_rejected: bool, allow_inconsistency: bool, custom: bool, prerelease: bool,
                        auto_trigger_build_sync: bool, arches: Tuple[str, ...], in_flight: Optional[str],
                        previous_list: Tuple[str, ...], auto_previous: bool):
     pipeline = GenAssemblyPipeline(runtime=runtime, group=group, assembly=assembly, data_path=data_path,
                                    nightlies=nightlies, allow_pending=allow_pending, allow_rejected=allow_rejected,
                                    allow_inconsistency=allow_inconsistency, arches=arches, custom=custom,
                                    auto_trigger_build_sync=auto_trigger_build_sync,
-                                   in_flight=in_flight, previous_list=previous_list, auto_previous=auto_previous)
+                                   in_flight=in_flight, previous_list=previous_list, auto_previous=auto_previous, prerelease=prerelease)
     await pipeline.run()


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-8114
Design doc: https://docs.google.com/document/d/1S_ivD8Sh85LuZKnClqvoRvIhn4hNJQA76jpfUaFZjUA/edit

## Summary
- Add `--prerelease` flag to gen-assembly, to indicate a candidate assembly is a prerelease 
  - https://github.com/openshift-eng/aos-cd-jobs/pull/4069
- ECs are always prerelease
- Inherit advisories and release jira from last EC in RC.0
- Do not inherit prerelease advisory
- Configure operator index mode to prerelease when indicated.

Prepare release will use these appropriately: https://github.com/openshift-eng/art-tools/pull/263

## Test
```
$ doozer --assembly stream --group openshift-4.15 --arches x86_64 release:gen-assembly --name rc.1 from-releases --nightly 4.15.0-0.nightly-2023-12-19-033450 --prerelease
...
      group:
        advisories:
          extras: 123982
          image: 123983
          metadata: 123984
          microshift: 123985
          prerelease: -1
          rpm: 123986
        operator_index_mode: pre-release
        release_jira: ART-8258
```

