### PR TITLE
[scan-osh] after ocp4, do not trigger duplicate scans

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -397,11 +397,12 @@ def update_description(description: str, append: bool = True):
     set_build_description(build, description)
 
 
-def start_scan_osh(nvrs: list, version: str, create_jira_tickets: bool, email: Optional[str] = "", **kwargs):
+def start_scan_osh(nvrs: list, version: str, check_triggered: bool, create_jira_tickets: bool, email: Optional[str] = "", **kwargs):
     params = {
         "NVRS": ",".join(nvrs),
         "BUILD_VERSION": version,
-        "CREATE_JIRA_TICKETS": create_jira_tickets
+        "CREATE_JIRA_TICKETS": create_jira_tickets,
+        "CHECK_TRIGGERED": check_triggered
     }
 
     if email:

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -846,7 +846,8 @@ class Ocp4Pipeline:
         if self.assembly == 'stream':
             # Trigger scans only for stream assemblies
             try:
-                jenkins.start_scan_osh(nvrs=self.success_nvrs, version=self.version.stream, create_jira_tickets=True)
+                jenkins.start_scan_osh(nvrs=self.success_nvrs, version=self.version.stream, create_jira_tickets=True,
+                                       check_triggered=True)
             except Exception as e:
                 self.runtime.logger.error(f"Failed to trigger scan-osh job: {e}")
 


### PR DESCRIPTION
The scheduled variant of SAST scan only triggers if there isn't already one. But the ocp4 job does not. This PR aims to fix that.