### PR TITLE
[scan-osh] skip comment if skip_diff_check is enabled

### DIFF
--- a/doozer/doozerlib/cli/scan_osh.py
+++ b/doozer/doozerlib/cli/scan_osh.py
@@ -342,8 +342,9 @@ class ScanOshCli:
 
                     self.runtime.logger.info(f"Linked {previous_ticket_id.key} to {issue.key}")
 
-                # https://jira.readthedocs.io/examples.html#comments
-                self.jira_client.add_comment(issue.key, comment)
+                if not self.skip_diff_check:
+                    # https://jira.readthedocs.io/examples.html#comments
+                    self.jira_client.add_comment(issue.key, comment)
 
             elif len(open_issues) == 1:
                 issue = open_issues.pop()


### PR DESCRIPTION
If its the first time we are creating a ticket for a component, we don't need to comment on the ticket like [this](https://issues.redhat.com/browse/OCPBUGS-24468?focusedId=23591413&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-23591413).