### PR TITLE
[scan-osh] trigger only for scheduled job

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -29,7 +29,6 @@ class Jobs(Enum):
     OLM_BUNDLE = 'aos-cd-builds/build%2Folm_bundle'
     SYNC_FOR_CI = 'scheduled-builds/sync-for-ci'
     MICROSHIFT_SYNC = 'aos-cd-builds/build%2Fmicroshift_sync'
-    SCAN_OSH = 'aos-cd-builds/build%2Fscan-osh'
     CINCINNATI_PRS = 'aos-cd-builds/build%2Fcincinnati-prs'
 
 
@@ -395,24 +394,6 @@ def update_description(description: str, append: bool = True):
         description = build.get_description() + description
 
     set_build_description(build, description)
-
-
-def start_scan_osh(nvrs: list, version: str, check_triggered: bool, create_jira_tickets: bool, email: Optional[str] = "", **kwargs):
-    params = {
-        "NVRS": ",".join(nvrs),
-        "BUILD_VERSION": version,
-        "CREATE_JIRA_TICKETS": create_jira_tickets,
-        "CHECK_TRIGGERED": check_triggered
-    }
-
-    if email:
-        params["EMAIL"] = email
-
-    return start_build(
-        job=Jobs.SCAN_OSH,
-        params=params,
-        **kwargs
-    )
 
 
 def is_api_reachable() -> bool:

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -842,15 +842,6 @@ class Ocp4Pipeline:
 
         jenkins.update_description(f'<hr />Build results:<br/><br/>{timing_report}<br/>')
 
-    def _trigger_osh_scans(self):
-        if self.assembly == 'stream':
-            # Trigger scans only for stream assemblies
-            try:
-                jenkins.start_scan_osh(nvrs=self.success_nvrs, version=self.version.stream, create_jira_tickets=True,
-                                       check_triggered=True)
-            except Exception as e:
-                self.runtime.logger.error(f"Failed to trigger scan-osh job: {e}")
-
     async def run(self):
         await self._initialize()
 
@@ -903,9 +894,6 @@ class Ocp4Pipeline:
 
         # All good
         self._report_success()
-
-        if self.success_nvrs:  # Trigger osh scans for successfully built images and RPMs
-            self._trigger_osh_scans()
 
 
 @cli.command("ocp4",

--- a/pyartcd/tests/pipelines/test_ocp4.py
+++ b/pyartcd/tests/pipelines/test_ocp4.py
@@ -543,7 +543,6 @@ class TestBuilds(unittest.IsolatedAsyncioTestCase):
     @patch("shutil.rmtree")
     @patch("builtins.open")
     @patch("pyartcd.jenkins.update_title")
-    @patch("pyartcd.jenkins.start_scan_osh")
     @patch("pyartcd.jenkins.update_description")
     @patch("pyartcd.util.default_release_suffix", return_value="2100123111.p?")
     @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "rhaos-4.13-rhel-8", ""))


### PR DESCRIPTION
We had been triggering the job after ocp4 since our initial requirement was to scan images that we were building. Since the requirement had evolved to scan everything in our candidate tags, a scheduled job was setup for that purpose. 

During the scheduled job, all the brew builds since the previous run will be collected and the workflow executed.