### PR TITLE
scan-sources pattern match for exempted packages

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -408,16 +408,16 @@ class ImageMetadata(Metadata):
 
             # Populate all rpms contained in the image build
             arch_rpms: Dict[str, List[Dict]] = {}  # arch => list of rpm dicts to check for updates in configured repos
-            exempted_packages = self.config.scan_sources.exempted_packages or []
-            exempted_packages = set(exempted_packages)
             for arch, archive_inspector in arch_archives.items():
                 arch_rpms[arch] = []
                 # Example results of listing RPMs in an given imageID:
                 # https://gist.github.com/jupierce/a8798858104dcf6dfa4bd1d6dd99d2d8
                 rpm_entries = archive_inspector.get_installed_rpm_dicts()
                 for rpm_entry in rpm_entries:
-                    if rpm_entry["name"] in exempted_packages:
-                        self.logger.warning("Package %s is exempted from package change detection", to_nevra(rpm_entry))
+                    is_exempt, pattern = self.is_rpm_exempt(rpm_entry["name"])
+                    if is_exempt:
+                        self.logger.warning("%s is exempt from rpm change detection by '%s'",
+                                            to_nevra(rpm_entry), pattern)
                         continue
 
                     build_id = rpm_entry['build_id']

--- a/doozer/doozerlib/repodata.py
+++ b/doozer/doozerlib/repodata.py
@@ -245,19 +245,19 @@ class OutdatedRPMFinder:
     def _find_candidate_non_modular_rpms(all_non_modular_rpms, candidate_modular_rpms, logger):
         """ Finds all candidate non-modular rpms.
         For each non-modular rpm, if there is another candidate modular rpm with the same package name,
-        the non-modular rpm will be exempted.
+        the non-modular rpm will be exempt.
         """
-        candidate_non_modulear_rpms: Dict[str, Tuple[str, Rpm]] = {}  # package_name => (repo_name, rpm)
+        candidate_non_modular_rpms: Dict[str, Tuple[str, Rpm]] = {}  # package_name => (repo_name, rpm)
         for nevra, repo in all_non_modular_rpms.items():
             rpm = Rpm.from_nevra(nevra)
-            _, candidate = candidate_non_modulear_rpms.get(rpm.name, (None, None))
+            _, candidate = candidate_non_modular_rpms.get(rpm.name, (None, None))
             if not candidate or rpm.compare(candidate) > 0:
                 if rpm.name in candidate_modular_rpms:
                     modular_repo, modular_rpm = candidate_modular_rpms[rpm.name]
                     logger.debug("Non-modular RPM %s from %s is shadowed by modular RPM %s from %s", nevra, repo, modular_rpm.nevra, modular_repo)
                     continue  # This non-modular rpm is shadowed by a modular rpm
-                candidate_non_modulear_rpms[rpm.name] = (repo, rpm)
-        return candidate_non_modulear_rpms
+                candidate_non_modular_rpms[rpm.name] = (repo, rpm)
+        return candidate_non_modular_rpms
 
     def find_non_latest_rpms(self, rpms_to_check: List[Dict], repodatas: List[Repodata], logger: Optional[Logger] = None) -> List[Tuple[str, str, str]]:
         """

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -13,7 +13,7 @@ import openshift as oc
 from doozerlib.assembly import AssemblyIssueCode, AssemblyTypes, AssemblyIssue
 from doozerlib.assembly_inspector import AssemblyInspector
 from doozerlib.cli import release_gen_payload as rgp_cli
-from doozerlib.image import BrewBuildImageInspector
+from doozerlib.image import BrewBuildImageInspector, ImageMetadata
 from doozerlib.model import Model
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib import rhcos
@@ -187,6 +187,7 @@ class TestGenPayloadCli(IsolatedAsyncioTestCase):
     async def test_detect_non_latest_rpms(self):
         gpcli = rgp_cli.GenPayloadCli()
         bbii = AsyncMock(BrewBuildImageInspector)
+        bbii.get_image_meta.return_value = Mock(ImageMetadata, is_rpm_exempt=Mock(return_value=(False, None)))
         bbii.find_non_latest_rpms.return_value = {"x86_64": [("foo-0:1.2.0-1.el9.x86_64", "foo-0:1.2.1-1.el9.x86_64", "repo_name")], "s390x": []}
         ai = flexmock(Mock(AssemblyInspector), get_group_release_images=dict(spam=bbii))
         await gpcli.detect_non_latest_rpms(ai)


### PR DESCRIPTION
- Introduce new config "exempt_rpms" intended to replace "exempted_packages". Right now both of them will be effective.
- Accept glob pattern matching 

After we have moved over all ocp-build-data branches from exempted_packages to exempt_rpms, 
I'll make a PR to remove the exempted_packages config from here