### PR TITLE
[ART-8256] Add Art-Dash Link to Health:Images Reports

### DIFF
--- a/doozer/tests/test_images_health.py
+++ b/doozer/tests/test_images_health.py
@@ -1,7 +1,13 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 from doozerlib.cli import images_health
+
+
+class MockRuntime:
+    def __init__(self):
+        self.group_config = Mock()
+        self.group_config.name = 'testgroup'
 
 
 def add_record(image, state, task_id=123, build_url='link', time=1617641142670, name='name'):
@@ -13,7 +19,8 @@ def add_record(image, state, task_id=123, build_url='link', time=1617641142670, 
 
 def get_concerns(image):
     '''Interface for the real get_concerns function, with inconsequential options filled in'''
-    return images_health.get_concerns(image, {}, 5, 'slack')
+    mock_runtime = MockRuntime()
+    return images_health.get_concerns(image, mock_runtime, 5, 'slack')
 
 
 data = {}


### PR DESCRIPTION
This commit integrates Art-Dash links into the health:images reports. The goal is to enhance accessibility and traceability of the reports by providing direct links to Art-Dash for detailed build histories. This streamlines the process for analyzing build concerns and improves overall efficiency.

Key Changes:
- `generate_art_dash_history_link` to create Art-Dash URLs based on build records.
- Updated `images_health` to incorporate these Art-Dash links.
- Modified YAML output in `images_health` to handle URLs correctly and prevent YAML dump from adding unwanted quotes.

This enhancement is part of ongoing efforts to improve our build monitoring tools, simplifying the workflow for developers and release managers. A regex post-processing step has been added to ensure clarity and readability of the reports, maintaining user-friendly YAML formatting despite complex URL strings.