### PR TITLE
[ART-8416] Add support for checking external packages

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -644,18 +644,8 @@ class GenPayloadCli:
 
         # record issues found in assembly list and per payload entry
         rhcos_build = cast(RHCOSBuildInspector, payload_entry.rhcos_build)
-        self.assembly_issues.extend(assembly_inspector.check_rhcos_issues(rhcos_build))
+        self.assembly_issues.extend(await assembly_inspector.check_rhcos_issues(rhcos_build))
         payload_entry.issues.extend(ai for ai in self.assembly_issues if ai.component == "rhcos")
-
-        if self.runtime.assembly_type is AssemblyTypes.STREAM:
-            # For stream alone, we want to verify that the very latest RPMs are installed.
-            for installed_nvr, newest_nvr, repo in await rhcos_build.find_non_latest_rpms():
-                self.assembly_issues.append(AssemblyIssue(
-                    f"Found outdated RPM ({installed_nvr}) "
-                    f"installed in {payload_entry.rhcos_build} ({rhcos_build.brew_arch})"
-                    f" when {newest_nvr} is available in repo {repo}",
-                    component="rhcos", code=AssemblyIssueCode.OUTDATED_RPMS_IN_STREAM_BUILD
-                ))
 
     def detect_rhcos_inconsistent_rpms(self, targeted_rhcos_builds: Dict[bool, List[RHCOSBuildInspector]]):
         """

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -245,7 +245,7 @@ class TestGenPayloadCli(IsolatedAsyncioTestCase):
     async def test_detect_rhcos_issues(self):
         gpcli = rgp_cli.GenPayloadCli(runtime=MagicMock(assembly_type=AssemblyTypes.STREAM))
         rhcos_issue = Mock(AssemblyIssue, component='rhcos')
-        ai = flexmock(Mock(AssemblyInspector), check_rhcos_issues=[rhcos_issue])
+        ai = flexmock(Mock(AssemblyInspector), check_rhcos_issues=AsyncMock(return_value=[rhcos_issue]))
         rhcos_build = flexmock(
             Mock(rhcos.RHCOSBuildInspector, brew_arch="x86_64"),
             find_non_latest_rpms=AsyncMock(return_value=[("installed", "newest", "repo_name")]))
@@ -254,7 +254,6 @@ class TestGenPayloadCli(IsolatedAsyncioTestCase):
 
         await gpcli.detect_rhcos_issues(rhcos_entry, ai)
         self.assertEqual(gpcli.assembly_issues[0], rhcos_entry.issues[0])
-        self.assertEqual(gpcli.assembly_issues[1].code, AssemblyIssueCode.OUTDATED_RPMS_IN_STREAM_BUILD)
 
         # make the if statement false
         gpcli = rgp_cli.GenPayloadCli(runtime=MagicMock(assembly="standard"))


### PR DESCRIPTION
Enhance `doozer release:gen-payload` command to check external rpms
installed in RHCOS and group images.
    
Use following config to enable external package check for RHCOS and
group images.
    
```yaml
check_external_packages:
  - name: cri-o
    tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
    condition: match
  - name: containernetworking-plugins
    tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
    condition: match
  - name: NetworkManager
    tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
    condition: greater_equal
```
