### PR TITLE
ART-8476 doozer images:rebase assert RHEL version equivalence in Dockerfiles

### DIFF
--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1630,7 +1630,6 @@ class ImageDistGitRepo(DistGitRepo):
         mapped_images = []
 
         original_parents = dfp.parent_images
-        count = 0
         for i, image in enumerate(parent_images):
             # Does this image inherit from an image defined in a different group member distgit?
             if image.member is not Missing:
@@ -1650,8 +1649,6 @@ class ImageDistGitRepo(DistGitRepo):
 
             else:
                 raise IOError("Image in 'from' for [%s] is missing its definition." % image.name)
-
-            count += 1
 
         # Write rebased from directives
         dfp.parent_images = mapped_images

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1412,6 +1412,7 @@ class ImageDistGitRepo(DistGitRepo):
                 build = koji_api.getBuild(build_nvr, strict=True)
 
             # Get the pullspec for the upstream equivalent
+            # registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.20.10-202310161945.el8.gdc4b478
             upstream_equivalent_pullspec = build['extra']['image']['index']['pull'][1]
 
             # Verify whether the image exists

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1846,7 +1846,7 @@ class ImageDistGitRepo(DistGitRepo):
 
             # ART-8476 assert rhel version equivalence
             if self.should_match_upstream:
-                el_version = util.isolate_el_version_in_brew_tag(self.branch)
+                el_version = util.isolate_el_version_in_brew_tag(self.config.distgit.branch)
                 df_lines.extend([
                     '',
                     '# RHEL version in final image must match the one in ART\'s config',

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1427,9 +1427,7 @@ class ImageDistGitRepo(DistGitRepo):
             out, _ = exectools.cmd_assert(cmd, retries=3)
 
             # It does. Use this to rebase FROM directive
-            mapped_image_data = json.loads(out)
-            mapped_image_data_labels = mapped_image_data['config']['config']['Labels']
-            mapped_image = f'{labels["name"]}:{mapped_image_data_labels["version"]}-{mapped_image_data_labels["release"]}'
+            mapped_image = f'{labels["name"]}:{labels["version"]}-{labels["release"]}'
 
             dfp.add_lines_at(0,
                              f"# Rebased {original_parent} with {mapped_image} to follow upstream config")

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1394,7 +1394,13 @@ class ImageDistGitRepo(DistGitRepo):
                 if changed:
                     dfp.add_lines_at(entry, "RUN " + new_value, replace=True)
 
-    def _resolve_parent(self, original_parent, dfp):
+    def _resolve_parent(self, original_parent: str, dfp: DockerfileParser) -> Optional[str]:
+        """
+        Resolve the upstream image (CI) to its equivalent image downstream (brew).
+        :param original_parent: The upstream image e.g.
+        registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15
+        :param dfp: DockerfileParser object for the image
+        """
         try:
             self.logger.debug('Retrieving image info for image %s', original_parent)
             cmd = f'oc image info {original_parent} -o json'


### PR DESCRIPTION
This PRs introduces 2 changes during images rebase:

1. Also rebase base images (rhel) as well as golang builders

2. If we're trying to match upstream config during rebase, add an extra layer to the Dockerfile to make sure that upstream RHEL version matches the one we have configured locally. Break the build otherwise.

This will let developers use their preferred builder versions before feature freeze, but will enforce that there is agreement upon an image RHEL version
