### PR TITLE
[ART-7926] [scan-osh] Update  OCPBUGS workflow

### DIFF
--- a/doozer/doozerlib/cli/scan_osh.py
+++ b/doozer/doozerlib/cli/scan_osh.py
@@ -14,7 +14,6 @@ from doozerlib.rpmcfg import RPMMetadata
 from typing import Optional
 from jira import JIRA, Issue
 from tenacity import retry, stop_after_attempt, wait_fixed
-from doozerlib.rpm_utils import parse_nvr
 
 SCAN_RESULTS_URL_TEMPLATE = "https://cov01.lab.eng.brq2.redhat.com/osh/task/{task_id}/log/{nvr}/scan-results-imp.js"
 
@@ -24,13 +23,15 @@ One or more software security scan issues have been detected for the package *{p
 *Important scan results*: [html|https://cov01.lab.eng.brq2.redhat.com/osh/task/{scan_id}/log/{nvr}/scan-results-imp.html] / [json|https://cov01.lab.eng.brq2.redhat.com/osh/task/{scan_id}/log/{nvr}/scan-results-imp.js] (Check 'defects')
 *All scan results*: https://cov01.lab.eng.brq2.redhat.com/osh/task/{scan_id}
 *Build record*: [{nvr}|https://brewweb.engineering.redhat.com/brew/buildinfo?buildID={brew_build_id}]
-*Upstream commit*: [{upstream_git_commit}|{upstream_repo_url}/commit/{upstream_git_commit}]
+*Upstream commit*: {upstream_commit}
 
 Once these issues are addressed, the Bug can be closed. But a new one will be opened if new issues are found in the next build.
 
 For information on triaging these issues and dispositioning this ticket, please review the [policy document for SAST Scanning Jira Tickets|https://docs.google.com/document/d/1GsT3tvw5qf3sOSAkTSVWnMIO6vzIuirhsVhhsbK_qf0].
 
 For other questions please reach out to @release-artists in #forum-ocp-art.
+
+_(Ticket title and description are maintained by the bot. Please do not modify)_
 """
 
 
@@ -39,9 +40,15 @@ class BuildType(Enum):
     RPM = 2
 
 
+class JiraStatus(Enum):
+    OPEN = 1
+    CLOSED = 2
+
+
 class ScanOshCli:
     def __init__(self, runtime: Runtime, last_brew_event: int, dry_run: bool, check_triggered: Optional[bool],
-                 all_builds: Optional[bool], create_jira_tickets: Optional[bool], skip_diff_check: Optional[bool]):
+                 all_builds: Optional[bool], create_jira_tickets: Optional[bool]):
+        self.tag_rhel_mapping = {}
         self.runtime = runtime
         self.last_brew_event = last_brew_event
         self.dry_run = dry_run
@@ -52,7 +59,6 @@ class ScanOshCli:
         self.error_nvrs = []
         self.version = self.runtime.group.split("-")[-1]
         self.jira_project = "OCPBUGS"
-        self.skip_diff_check = skip_diff_check
         self.brew_distgit_mapping = self.get_brew_distgit_mapping()
         self.brew_distgit_mapping_rpms = self.get_brew_distgit_mapping(kind=BuildType.RPM)
         self.jira_target_version = self.get_target_version()
@@ -64,6 +70,54 @@ class ScanOshCli:
         # Initialize JIRA client
         self.jira_client: JIRA = self.runtime.build_jira_client()
 
+    # Static functions
+    @staticmethod
+    def is_jira_workflow_component_disabled(meta):
+        """
+        Check if the OCPBUGS workflow is enabled in ocp-build-data image meta config
+        """
+        flag = meta.config.external_scanners.sast_scanning.jira_integration.enabled
+
+        # Disable only if specifically defined in config
+        return flag in [False, "False", "false", "no"]
+
+    def is_jira_workflow_group_enabled(self):
+        """
+        Check if JIRA workflow is disabled for this particular OCP version in group.yml
+        """
+        flag = self.runtime.group_config.external_scanners.sast_scanning.jira_integration.enabled
+        return flag in [True, "True", "true", "yes"]
+
+    @staticmethod
+    async def get_untriggered_nvrs(nvrs):
+        """
+        So we might have already triggered a scan for the same NVR. If this flag is enabled, we want to check
+        if it has and not re-trigger it again.
+        But please note that this will take a lot of time since it has to run for all 200+ packages.
+        """
+
+        @limit_concurrency(16)
+        async def run_get_untriggered_nvrs(nvr):
+            rc, _, _ = await cmd_gather_async(f"osh-cli find-tasks --nvr {nvr}")
+
+            return None if rc == 0 else nvr
+
+        tasks = []
+        for nvr in nvrs:
+            tasks.append(run_get_untriggered_nvrs(nvr))
+
+        nvrs = await asyncio.gather(*tasks)
+
+        untriggered_nvrs = [nvr for nvr in nvrs if nvr]
+
+        return untriggered_nvrs
+
+    # Retry
+    @retry(reraise=True, stop=stop_after_attempt(10), wait=wait_fixed(3))
+    def search_issues(self, query):
+        return self.jira_client.search_issues(query)
+
+    # Get functions
     def get_target_version(self):
         """
         Non GA versions have target version set to .0, while the others with .z
@@ -100,95 +154,44 @@ class ScanOshCli:
 
         return dict_data
 
-    def get_scan_info(self, brew_package_name: str):
+    def get_scan_info(self, nvr: str):
         """
         Find the last successful scan for a particular package and retrieve its ID
         """
         # Eg: osh-cli find-tasks --regex ose-network-tools-container-v4.15
         # Needs to be updated once https://issues.redhat.com/browse/OSH-376 is completed
-        cmd = f"osh-cli find-tasks --regex {brew_package_name}"
+        cmd = f"osh-cli find-tasks --nvr {nvr} --latest"
 
         _, result, _ = cmd_gather(cmd)
 
-        finished_tasks = result.strip().split("\n")
+        tasks = result.strip().split("\n")
 
-        successful_scan_task_id = None
-        successful_scan_nvr = None
-        previous_scan_nvr = None
-        task_id = None
+        if tasks == ['']:
+            # Skip components that have no scans
+            return None, None
 
-        # Some components do not have any successful scans, so lets time out and go to the next one if so
-        failed_counter = 0
-        failed_counter_limit = 20
-        for index, task_id in enumerate(finished_tasks):
-            if failed_counter >= failed_counter_limit:
-                self.runtime.logger.error(f"Reached failed scan limit, skipping component: {brew_package_name}")
-                return None, None, None, None
-            cmd = f"osh-cli task-info {task_id}"
-            self.runtime.logger.info(f"Running: {cmd}")
+        # This will always be a list with len 1, since we're using --latest flag
+        task_id = tasks[0]
 
-            _, result, _ = cmd_gather(cmd)
+        cmd = f"osh-cli task-info {task_id}"
+        self.runtime.logger.info(f"[osh-cli] Running: {cmd}")
 
-            if "state_label = CLOSED" in result:
-                # Reset counter since we found a successful scan
-                failed_counter = 0
-                if not successful_scan_task_id:
-                    # Found the first successful scan.
-                    successful_scan_task_id = task_id
-                    successful_scan_nvr = yaml.safe_load(result.replace(" =", ":"))["label"]
+        _, result, _ = cmd_gather(cmd)
+        result_parsed_yml = yaml.safe_load(result.replace(" =", ":"))
 
-                    # Need to find the previous successful scan as well
-                    continue
+        return task_id, result_parsed_yml["state_label"]
 
-                # Found the latest and previous successful scan
-                previous_scan_nvr = yaml.safe_load(result.replace(" =", ":"))["label"]  # returns NVR
-
-                if previous_scan_nvr == successful_scan_nvr:
-                    # Sometimes we have two scans with the same NVR
-                    continue
-
-                # task_id here would be the one of the previous successful scan
-                return successful_scan_task_id, successful_scan_nvr, task_id, previous_scan_nvr
-
-            failed_counter += 1
-
-        # If there is no successful scans
-        return successful_scan_task_id, successful_scan_nvr, task_id, previous_scan_nvr
-
-    def check_if_scan_issues_exist(self, task_id: str, nvr: str) -> bool:
-        """
-        ProdSec only wants us to check the scan-results-imp.js file of a scan and see if scan issues are reported.
-        """
-
-        url = f"{SCAN_RESULTS_URL_TEMPLATE.format(task_id=task_id, nvr=nvr)}?format=raw"
-        self.runtime.logger.info(f"Checking OSH Scan for issues: {url}")
-
-        try:
-            response = requests.get(url)
-            if len(response.json()["defects"]) > 0:
-                return True
-        except Exception:
-            self.runtime.logger.warning(f"Don't see scan-results-imp.js for {nvr}")
-
-        return False
-
-    def get_distgit_name_from_brew_nvr(self, nvr: str, kind: BuildType) -> str:
+    def get_distgit_name_from_brew(self, kind: BuildType, brew_package_name: str) -> str:
         """
             Returns the distgit name from the brew nvr
 
-            :param nvr: Full NVR eg: openshift-enterprise-pod-container-v4.14.0-202310031045.p0.g9ef6de6.assembly.stream
-            :param kind: Either IMAGE or RPM
+            :param kind: Metadata kind
+            :param brew_package_name: Name of the brew package
             """
-        brew_package_name = self.koji_session.getBuild(buildInfo=nvr, strict=True)["package_name"]
-
         if kind == BuildType.IMAGE:
             return self.brew_distgit_mapping.get(brew_package_name)
 
         return self.brew_distgit_mapping_rpms.get(brew_package_name)
-
-    @retry(reraise=True, stop=stop_after_attempt(10), wait=wait_fixed(3))
-    def search_issues(self, query):
-        return self.jira_client.search_issues(query)
 
     def get_scan_defects(self, scan_id, scan_nvr):
         url = f"{SCAN_RESULTS_URL_TEMPLATE.format(task_id=scan_id, nvr=scan_nvr)}?format=raw"
@@ -197,36 +200,6 @@ class ScanOshCli:
         scan_response = requests.get(url)
 
         return scan_response.json()["defects"]
-
-    def is_latest_scan_different_from_previous(self, latest_scan_id, latest_scan_nvr, previous_scan_id,
-                                               previous_scan_nvr):
-        # If this is the first scan, then there won't be a previous one
-        # Or there is no previous successful scan
-        if not previous_scan_id:
-            return True
-
-        latest_scan_defects = self.get_scan_defects(scan_id=latest_scan_id, scan_nvr=latest_scan_nvr)
-        previous_scan_defects = self.get_scan_defects(scan_id=previous_scan_id, scan_nvr=previous_scan_nvr)
-
-        for defect in latest_scan_defects:
-            if defect not in previous_scan_defects:
-                self.runtime.logger.info("Detected that the scan of the latest build has new issues, "
-                                         "compared to the previous one")
-                return True
-
-        return False
-
-    def has_latest_scan_resolved_all_issues(self, latest_scan_id, latest_scan_nvr, previous_scan_id, previous_scan_nvr):
-        """
-        Check if the latest scan has resolved all issues from the previous scan
-        """
-        latest_scan_defects = self.get_scan_defects(scan_id=latest_scan_id, scan_nvr=latest_scan_nvr)
-        previous_scan_defects = self.get_scan_defects(scan_id=previous_scan_id, scan_nvr=previous_scan_nvr)
-
-        if not latest_scan_defects and previous_scan_defects:
-            # If the previous scan results are not empty but the latest scan results are empty
-            return True
-        return False
 
     def get_upstream_git_commit(self, nvr: str):
         # Get "ead7616" from sriov-network-operator-container-v4.15.0-202311171551.p0.gead7616.assembly.stream
@@ -242,280 +215,53 @@ class ScanOshCli:
         else:
             self.runtime.logger.error("Regex match not found")
 
-    def create_update_ocpbugs_ticket(self, packages: dict):
-        """
-        Check if an OCPBUGS ticket already exists for a particular package. If it doesn't create one and update
-        the contents to point to the latest scan results
-        """
-        for brew_package_name in packages:
-            data = packages[brew_package_name]
-
-            # Check if ticket exits
-            summary = f"{self.version} SAST scan issues for {brew_package_name}"
-
-            # Find if there is already a "OPEN" ticket for this component.
-            # A ticket is said to be "OPEN" if status <= 'Assigned'.
-            # If we detect a net-new security issue, we should open a new ticket instead of updating the one
-            # that is in the process of being fixed.
-            query = f"project={self.jira_project} AND ( summary ~ '{summary}' ) AND " \
-                    "status in ('New', 'Assigned')"
-            # Can use open_issues.pop().raw['fields'] to see all the fields for the JIRA issue, to test
-            # also jira title search is fuzzy, so we need to check if an issue is really the one we want
-            open_issues = [i for i in self.search_issues(query) if i.fields.summary == summary]
-            self.runtime.logger.info(f"Issues found with query '{query}': {open_issues}")
-
-            # Check if this is the first time that we are raising the ticket for this component
-            query = f"project={self.jira_project} AND ( summary ~ '{summary}' ) AND " \
-                    "status not in ('New', 'Assigned')"
-            closed_issues = [i for i in self.search_issues(query) if i.fields.summary == summary]
-            previous_ticket_id = None
-            if not closed_issues and not open_issues:
-                # There are no tickets for this component, raise a ticket
-                self.skip_diff_check = True
-            else:
-                self.runtime.logger.info(f"Closed Issues: {closed_issues}")
-                try:
-                    previous_ticket_id = closed_issues.pop()  # Returned in LIFO (last-in, first-out) order.
-                except IndexError:
-                    # If it's an empty list, pop will fail
-                    # previous_ticket_id is already set to None, so no action needed
-                    pass
-
-            upstream_git_commit = self.get_upstream_git_commit(nvr=data["latest_coverity_scan_nvr"])
-
-            description = MESSAGE.format(package_name=brew_package_name,
-                                         scan_id=data["latest_coverity_scan"],
-                                         nvr=data["latest_coverity_scan_nvr"],
-                                         brew_build_id=data["brew_build_id"],
-                                         upstream_repo_url=data["upstream_repo_url"],
-                                         upstream_git_commit=upstream_git_commit)
-
-            fields = {
-                "project": {"key": f"{self.jira_project}"},
-                "issuetype": {"name": "Bug"},
-                "versions": [{"name": self.jira_target_version}],  # Affects Version/s
-                "components": [{"name": data["jira_potential_component"]}],
-                "security": {"id": "11697"},  # Restrict to Red Hat Employee
-                "summary": summary,
-                "description": description
-            }
-
-            if len(open_issues) == 0:
-                # No tickets exist in ('New', 'Assigned') so we could consider opening a new one
-                # Do not reraise a ticket if the diff has not changed, but we would still need to update the ticket
-                # with the new build and scan
-                if not self.skip_diff_check and not self.is_latest_scan_different_from_previous(
-                        latest_scan_id=data["latest_coverity_scan"],
-                        latest_scan_nvr=data["latest_coverity_scan_nvr"],
-                        previous_scan_id=data["previous_scan_id"],
-                        previous_scan_nvr=data["previous_scan_nvr"]):
-                    self.runtime.logger.info(f"No new defects found for package {data['package_name']}")
-                    continue
-
-                # Report the latest and previous scan on the ticket as a comment
-                comment = f"This ticket was raised because ART automation found new issues in the " \
-                          f"[latest completed scan|{SCAN_RESULTS_URL_TEMPLATE.format(task_id=data['latest_coverity_scan'], nvr=data['latest_coverity_scan_nvr'])}], " \
-                          f"when compared to the [the previous one|{SCAN_RESULTS_URL_TEMPLATE.format(task_id=data['previous_scan_id'], nvr=data['previous_scan_nvr'])}]"
-
-                # Create a new JIRA ticket
-                if self.dry_run:
-                    self.runtime.logger.info(f"[DRY RUN]: Would have created a new bug in {self.jira_project} "
-                                             f"JIRA project with fields {fields}")
-                    self.runtime.logger.info(f"Would have commented: {comment}")
-                    continue
-
-                issue: Issue = self.jira_client.create_issue(
-                    fields
-                )
-
-                self.runtime.logger.info(f"Created a new issue {issue.key}")
-
-                # Create a "Relates to" link to the previously closed ticket, if it exists
-                if previous_ticket_id:
-                    self.jira_client.create_issue_link(
-                        type="Related",
-                        inwardIssue=previous_ticket_id.key,
-                        outwardIssue=issue.key,
-                    )
-
-                    self.runtime.logger.info(f"Linked {previous_ticket_id.key} to {issue.key}")
-
-                if not self.skip_diff_check:
-                    # https://jira.readthedocs.io/examples.html#comments
-                    self.jira_client.add_comment(issue.key, comment)
-
-            elif len(open_issues) == 1:
-                issue = open_issues.pop()
-
-                if self.has_latest_scan_resolved_all_issues(
-                        latest_scan_id=data["latest_coverity_scan"],
-                        latest_scan_nvr=data["latest_coverity_scan_nvr"],
-                        previous_scan_id=data["previous_scan_id"],
-                        previous_scan_nvr=data["previous_scan_nvr"]):
-                    if not self.dry_run:
-                        self.jira_client.transition_issue(issue.key, "Closed")
-                        self.runtime.logger.info(f"Closed issue {issue.key}")
-                    else:
-                        self.runtime.logger.info(f"[DRY RUN]: Would have closed ticket {issue.key}")
-
-                else:
-                    # Update existing JIRA ticket if there is a change
-                    self.runtime.logger.info(f"A {self.jira_project} ticket already exists: {issue.key}")
-
-                    if not self.dry_run:
-                        # Keep notify as False since this description will constantly be updated everytime there's a
-                        # new build
-                        issue.update(
-                            fields={"description": fields["description"]},
-                            notify=False)
-                        self.runtime.logger.info(f"The fields of {issue.key} has been updated to {fields}")
-                    else:
-                        self.runtime.logger.info(f"[DRY RUN]: Would have updated {issue.key} with new description: "
-                                                 f"{fields['description']}")
-
-            else:
-                self.runtime.logger.error(f"More than one JIRA ticket exists: {open_issues}")
-
-    def get_packages_with_scan_issues(self, mapping: dict):
-        """
-        Check the latest scan of a particular package for a version (which we already found) and check if
-        scan issues exist. Collect those and return back.
-
-        :param mapping: Eg: {'ose-network-tools-container': {'package_name_with_version': 'ose-network-tools-container-v4.15.0-',
-                                                           'nvr': 'ose-network-tools-container-v4.15.0-202310170244.p0.gdf85e45.assembly.stream',
-                                                           'package_name': 'ose-network-tools-container',
-                                                           'latest_coverity_scan': '337873'}
-        }
-        """
-
-        nvrs_with_scan_issues = {}
-
-        # Check if scan issues detected for a NVR
-        for brew_package_name, data in mapping.items():
-            if not data["latest_coverity_scan"]:
-                self.runtime.logger.info(f"No successful scan found for package {brew_package_name}")
-                continue
-
-            if self.check_if_scan_issues_exist(task_id=data["latest_coverity_scan"],
-                                               nvr=data["latest_coverity_scan_nvr"]):
-                nvrs_with_scan_issues[brew_package_name] = data
-
-            else:
-                self.runtime.logger.info(f"No scan issues found for NVR: {data['latest_coverity_scan_nvr']}")
-
-        return nvrs_with_scan_issues
-
     @staticmethod
-    def is_sast_jira_disabled(meta):
+    def get_scan_id_from_ticket(description):
+        pattern = r"\*All scan results\*: https://cov01.lab.eng.brq2.redhat.com/osh/task/(?P<task_id>[0-9]+)"
+        match = re.search(pattern=pattern, string=description)
+        task_id = None
+        if match:
+            task_id = match.group("task_id")
+
+        pattern = r"\*Build record\*: \[?P<nvr>(.+)\|.+"
+        match = re.search(pattern=pattern, string=description)
+        nvr = None
+        if match:
+            nvr = match.group("nvr")
+
+        return task_id, nvr
+
+    def get_jira_issues(self, summary, status):
+        if status == JiraStatus.OPEN:
+            condition = "in"
+        else:
+            condition = "not in"
+
+        query = f"project={self.jira_project} AND ( summary ~ '{summary}' ) AND " \
+                f"status {condition} ('New', 'Assigned')"
+        return [i for i in self.search_issues(query) if i.fields.summary == summary]
+
+    def get_non_art_upstream_repo_and_jira_component(self, brew_info):
         """
-        Check if the OCPBUGS workflow is enabled in ocp-build-data image meta config
+        Get upstream repo URL for images or RPMs not built by ART
         """
-        flag = meta.config.get("external_scanners", {}).get("sast_scanning", {}).get("jira_integration", {}).get("enabled")
+        distgit_url = brew_info["source"]
+        upstream_repo_url = distgit_url
 
-        # Disable only if specifically defined in config
-        return flag in [False, "False", "false", "no"]
+        if distgit_url.startswith("git:"):
+            distgit_url = distgit_url.replace("git:", "git+https:")
+            upstream_repo_url = distgit_url.split("git+")[1]
 
-    async def ocp_bugs_workflow_run(self, brew_components: dict):
-        # List of brew components to check
-        brew_package_names = []
+            # Find JIRA component
+        product_config = self.runtime.get_product_config()
+        component_mapping = product_config.bug_mapping.components
+        component_entry = component_mapping[brew_info["package_name"]]
+        potential_component = component_entry.issue_component
 
-        # We only care about the value
-        for build in brew_components.values():
-            nvr = build["nvr"]
-            brew_info = build["brew_info"]
+        if not potential_component:
+            potential_component = "Unknown"
 
-            kind: BuildType = BuildType.IMAGE if "container" in nvr else BuildType.RPM
-
-            self.runtime.logger.info(f"[OCPBUGS] Checking build: {nvr} for kind {kind.name}")
-
-            distgit_name = self.get_distgit_name_from_brew_nvr(nvr=nvr, kind=kind)
-            if not distgit_name:
-                self.runtime.logger.warning(f"Looks like we are not building: {nvr}")
-
-                # Go to the next NVR
-                continue
-
-            meta = None
-            # Metadata can be that of images or RPMs.
-            if kind == BuildType.IMAGE:
-                meta: ImageMetadata = self.runtime.image_map.get(distgit_name)
-            elif kind == BuildType.RPM:
-                meta: RPMMetadata = self.runtime.rpm_map.get(distgit_name)
-
-            # If there is no metadata for the component, the ART might not be building it
-            if not meta:
-                self.runtime.logger.error(f"Looks like ART is not building image/rpm with distgit name: {distgit_name}")
-                continue
-            if self.is_sast_jira_disabled(meta):
-                self.runtime.logger.info(f"Skipping OCPBUGS creation for distgit {distgit_name} "
-                                         f"since disabled in image metadata")
-                continue
-
-            # Upstream repo URL from image config
-            upstream_repo_url = meta.config.get("content", {}).get("source", {}).get("git", {}).get("web")
-
-            # Returns project and component name
-            _, potential_component = meta.get_jira_info()
-
-            nvr = parse_nvr(brew_info["nvr"])
-
-            # Get ose-network-tools-container-v4.15.0 from ose-network-tools-container-v4.15.0-202310170244.p0.gdf85e45.assembly.stream
-            pkg_name_w_version = f"{nvr['name']}-v{self.version}.0"
-
-            # For RPMS, the nvr doesn't have a 'v' in them
-            # Egs: microshift-4.15.0~0.nightly_2023_11_20_004519-202311200428.p0.ged001ce.assembly.microshift.el9 or
-            # openshift-ansible-4.10.0-202310200811.p0.g72c7be6.assembly.stream.el7
-            if kind == BuildType.RPM:
-                pkg_name_w_version = pkg_name_w_version.replace("v", "")
-
-            self.runtime.logger.info(f"Package name with version: {pkg_name_w_version}")
-
-            brew_package_names.append({
-                "package_name_with_version": pkg_name_w_version,
-                "nvr": brew_info["nvr"],
-                "brew_build_id": brew_info["id"],
-                "package_name": brew_info["package_name"],
-                "jira_potential_component": potential_component,
-                "upstream_repo_url": upstream_repo_url
-            })
-
-        # Get latest scan results
-        brew_coverity_mapping = {}
-
-        for package in brew_package_names:
-            package["latest_coverity_scan"], package["latest_coverity_scan_nvr"], package["previous_scan_id"], \
-                package["previous_scan_nvr"] = self.get_scan_info(package["package_name_with_version"])
-            brew_coverity_mapping[package["package_name"]] = package
-
-        # Collect packages that have scan issues detected
-        packages_with_scan_issues = self.get_packages_with_scan_issues(brew_coverity_mapping)
-
-        # Create or update OCPBUGS ticket
-        self.create_update_ocpbugs_ticket(packages_with_scan_issues)
-
-    @staticmethod
-    async def get_untriggered_nvrs(nvrs):
-        """
-        So we might have already triggered a scan for the same NVR. If this flag is enabled, we want to check
-        if it has and not re-trigger it again.
-        But please note that this will take a lot of time since it has to run for all 200+ packages.
-        """
-
-        @limit_concurrency(16)
-        async def run_get_untriggered_nvrs(nvr):
-            rc, _, _ = await cmd_gather_async(f"osh-cli find-tasks --nvr {nvr}")
-
-            return None if rc == 0 else nvr
-
-        tasks = []
-        for nvr in nvrs:
-            tasks.append(run_get_untriggered_nvrs(nvr))
-
-        nvrs = await asyncio.gather(*tasks)
-
-        untriggered_nvrs = [nvr for nvr in nvrs if nvr]
-
-        return untriggered_nvrs
+        return upstream_repo_url, potential_component
 
     def get_tagged_latest(self, tag):
         """
@@ -536,6 +282,56 @@ class ScanOshCli:
             return latest_tagged
         else:
             return []
+
+    def get_commit_text(self, upstream_repo_url, nvr):
+        if "github.com" in upstream_repo_url:
+            # ART built components will have the GitHub URL which are almost all images and a handful of RPMs
+            upstream_github_commit = self.get_upstream_git_commit(nvr=nvr)
+            jira_commit_text = f"[{upstream_github_commit}|{upstream_repo_url}/commit/{upstream_github_commit}]"
+        else:
+            # non-ART components will have distgit URLs
+            distgit_url = upstream_repo_url
+            distgit_commit = distgit_url.split("#")[-1]
+
+            jira_commit_text = f"[{distgit_commit}|{distgit_url}]"
+
+        return jira_commit_text
+
+    # Other util functions
+    def does_scan_issues_exist(self, task_id: str, nvr: str) -> bool:
+        """
+        ProdSec only wants us to check the scan-results-imp.js file of a scan and see if scan issues are reported.
+        """
+
+        url = f"{SCAN_RESULTS_URL_TEMPLATE.format(task_id=task_id, nvr=nvr)}?format=raw"
+        self.runtime.logger.info(f"Checking OSH Scan for issues: {url}")
+
+        try:
+            response = requests.get(url)
+            if len(response.json()["defects"]) > 0:
+                return True
+        except Exception:
+            self.runtime.logger.warning(f"Don't see scan-results-imp.js for {nvr}")
+
+        return False
+
+    def is_latest_scan_different_from_previous(self, latest_scan_id, latest_scan_nvr, previous_scan_id,
+                                               previous_scan_nvr):
+        # If this is the first scan, then there won't be a previous one
+        # Or there is no previous successful scan
+        if not previous_scan_id:
+            return True
+
+        latest_scan_defects = self.get_scan_defects(scan_id=latest_scan_id, scan_nvr=latest_scan_nvr)
+        previous_scan_defects = self.get_scan_defects(scan_id=previous_scan_id, scan_nvr=previous_scan_nvr)
+
+        for defect in latest_scan_defects:
+            if defect not in previous_scan_defects:
+                self.runtime.logger.info("Detected that the scan of the latest build has new issues, "
+                                         "compared to the previous one")
+                return True
+
+        return False
 
     def generate_commands(self, nvrs) -> Optional[list]:
         """
@@ -563,6 +359,253 @@ class ScanOshCli:
 
         return cmds
 
+    # Main workflow functions
+    def categorize_components(self, components):
+        components_with_issues = []
+        components_without_issues = []
+
+        for component in components:
+            build = component["build"]
+            task_id = component["osh_task_id"]
+            nvr = build["nvr"]
+
+            # Check if the scan result has any issues reported.
+            if self.does_scan_issues_exist(task_id=task_id, nvr=nvr):
+                components_with_issues.append(component)
+            else:
+                components_without_issues.append(component)
+
+        return components_with_issues, components_without_issues
+
+    @limit_concurrency(16)
+    async def get_latest_task_ids(self, nvr, package_name):
+        # There is a bug in the osh-cli that sometimes, tasks are not in the order of created time
+        # But task IDs are generated based on that order, so sorting in descending order and get the latest task for
+        # a particular NVR
+        cmd = f"osh-cli find-tasks --nvr {nvr} --latest"
+
+        _, result, _ = await cmd_gather_async(cmd)
+        tasks = result.strip().split("\n")
+
+        # This will always be a list with len 1, since we're using --latest flag
+        return (package_name, None) if tasks == [''] else (package_name, tasks[0])
+
+    @limit_concurrency(16)
+    async def get_osh_task_state(self, task_id, package_name):
+        cmd = f"osh-cli task-info {task_id}"
+
+        _, result, _ = await cmd_gather_async(cmd)
+        result_parsed_yml = yaml.safe_load(result.replace(" =", ":"))
+
+        return package_name, result_parsed_yml["state_label"]
+
+    async def process_tasks_osh(self, components):
+        components_with_closed_scans = []
+        nvrs_to_retrigger_scans = []
+
+        tasks = []
+        for component in components.values():
+            build = component["build"]
+            nvr = build["nvr"]
+            package_name = build["package_name"]
+
+            tasks.append(self.get_latest_task_ids(nvr, package_name))
+        result = await asyncio.gather(*tasks)
+
+        components_with_task_ids = {}
+        for package_name, task_id in result:
+            component = components[package_name]
+            if not task_id:
+                nvr = component["build"]["nvr"]
+                # Does not have a valid scan
+                nvrs_to_retrigger_scans.append(nvr)
+                continue
+
+            component["osh_task_id"] = task_id
+
+            components_with_task_ids[package_name] = component
+
+        tasks = []
+        for component in components_with_task_ids.values():
+            build = component["build"]
+            task_id = component["osh_task_id"]
+            package_name = build["package_name"]
+
+            tasks.append(self.get_osh_task_state(task_id=task_id, package_name=package_name))
+        result = await asyncio.gather(*tasks)
+
+        for package_name, state in result:
+            if state == "OPEN":
+                # Scan is running. Let's check again on the next run
+                continue
+
+            if state == "FAILED":
+                # Skip for now, verify with OSH if it's an issue or not
+                self.runtime.logger.error(f"Looks like scan has failed for package: {package_name}")
+                continue
+
+            components_with_closed_scans.append(components[package_name])
+
+        return components_with_closed_scans, nvrs_to_retrigger_scans
+
+    def create_update_jira_ticket(self, components):
+        for component in components:
+            build = component["build"]
+            metadata = component["metadata"]
+            task_id = component["osh_task_id"]
+            summary = component["jira_search_summary"]
+            nvr = build["nvr"]
+
+            if metadata:
+                # ART is building this component
+                # Upstream repo URL from image config
+                upstream_repo_url = metadata.config.content.source.git.web
+
+                # Returns project and component name
+                _, potential_component = metadata.get_jira_info()
+            else:
+                # ART is NOT building this component
+                # If no GitHub url, mention the distgit URL instead
+                upstream_repo_url, potential_component = self.get_non_art_upstream_repo_and_jira_component(build)
+
+            jira_commit_text = self.get_commit_text(upstream_repo_url, nvr)
+
+            description = MESSAGE.format(package_name=build["package_name"],
+                                         scan_id=task_id,
+                                         nvr=nvr,
+                                         brew_build_id=build["id"],
+                                         upstream_commit=jira_commit_text)
+
+            fields = {
+                "project": {"key": f"{self.jira_project}"},
+                "issuetype": {"name": "Bug"},
+                "versions": [{"name": self.jira_target_version}],  # Affects Version/s
+                "components": [{"name": potential_component}],
+                "security": {"id": "11697"},  # Restrict to Red Hat Employee
+                "summary": summary,
+                "description": description
+            }
+
+            # Get the latest OPEN tickets (if any) for the component
+            # Find if there is already a "OPEN" ticket for this component.
+            # A ticket is said to be "OPEN" if status <= 'Assigned'.
+            # If we detect a net-new security issue, we should open a new ticket instead of updating the one
+            # that is in the process of being fixed.
+            open_issues = self.get_jira_issues(summary, JiraStatus.OPEN)
+
+            if len(open_issues) == 0:
+                # Check if there are any closed tickets
+
+                closed_issues = self.get_jira_issues(summary, JiraStatus.CLOSED)
+
+                if len(closed_issues) == 0:
+                    # This is the first time we are raising a ticket for this component
+                    # Create a new JIRA ticket
+                    if not self.dry_run:
+                        _: Issue = self.jira_client.create_issue(fields)
+                    else:
+                        self.runtime.logger.info(f"[DRY RUN]: Would have created a new bug in {self.jira_project} "
+                                                 f"JIRA project with fields {fields}")
+                        continue
+
+                # There are closed issues.
+                try:
+                    previous_ticket = closed_issues.pop()  # Returned in LIFO (last-in, first-out) order.
+                except IndexError:
+                    # If it's an empty list, pop will fail
+                    self.runtime.logger.error("Previous ticket retrival failed.")
+                    continue
+
+                # Check if the current NVR is in the ticket description
+                if nvr in previous_ticket.fields.description:
+                    # Looks like it's the same NVR
+                    continue
+
+                # Not the same NVR
+                # Pass the description from the previous NVR to be processed
+                previous_task_id, previous_nvr = self.get_scan_id_from_ticket(
+                    description=previous_ticket.fields.description)
+
+                # We should always be able to retrieve the scan ID from the ticket
+                assert previous_task_id is not None
+                assert previous_nvr is not None
+
+                if previous_task_id == task_id:
+                    # It's the same task
+                    continue
+
+                # Check the diff
+                if not self.is_latest_scan_different_from_previous(latest_scan_id=task_id,
+                                                                   latest_scan_nvr=nvr,
+                                                                   previous_scan_id=previous_task_id,
+                                                                   previous_scan_nvr=previous_nvr):
+                    # No diff
+                    continue
+
+                # There is a diff
+                # Since it's different, raise a ticket and link the old ticket to the new one
+                if not self.dry_run:
+                    issue: Issue = self.jira_client.create_issue(fields)
+                    self.runtime.logger.info(f"Created new issue: {issue.key}")
+
+                    # Create a "Relates to" link to the previously closed ticket, if it exists
+                    self.jira_client.create_issue_link(
+                        type="Related",
+                        inwardIssue=previous_ticket.key,
+                        outwardIssue=issue.key,
+                    )
+
+                    self.runtime.logger.info(f"Linked {previous_ticket.key} to {issue.key}")
+                else:
+                    self.runtime.logger.info(f"[DRY RUN]: Would have created a new bug in {self.jira_project} "
+                                             f"JIRA project with fields {fields}")
+                    if previous_ticket:
+                        self.runtime.logger.info(f"Would have linked {previous_ticket.key} to the issue")
+                    continue
+
+            elif len(open_issues) == 1:
+                issue = open_issues.pop()
+                self.runtime.logger.info(f"A {self.jira_project} ticket already exists: {issue.key}")
+
+                # Check if the current NVR is in the ticket description
+                if nvr in issue.fields.description:
+                    # Looks like it's the same NVR
+                    continue
+
+                if not self.dry_run:
+                    # Keep notify as False since this description will constantly be updated everytime there's a
+                    # new build
+                    issue.update(fields={"description": fields["description"]}, notify=False)
+                    self.runtime.logger.info(f"The fields of {issue.key} has been updated to {fields}")
+                else:
+                    self.runtime.logger.info(f"[DRY RUN]: Would have updated {issue.key} with new description: "
+                                             f"{fields['description']}")
+
+            else:
+                self.runtime.logger.error(f"More than one JIRA ticket exists: {open_issues}")
+
+    async def ocp_bugs_workflow(self, components: dict):
+        # Get components that has successful scans. If no scans, retrigger
+        components_with_closed_scans, nvrs_to_retrigger_scans = await self.process_tasks_osh(components)
+
+        # Trigger scans for ones that do not exist
+        self.trigger_scans(nvrs_to_retrigger_scans)
+
+        components_with_issues, components_without_issues = self.categorize_components(components_with_closed_scans)
+        for component in components_without_issues:
+            summary = component["jira_search_summary"]
+
+            open_issues = self.get_jira_issues(summary, status=JiraStatus.OPEN)
+            # Close open issues, if they exist
+            for open_issue in open_issues:
+                if not self.dry_run:
+                    self.jira_client.transition_issue(open_issue.key, "Closed")
+                    self.runtime.logger.info(f"Closed issue {open_issue.key}")
+                else:
+                    self.runtime.logger.info(f"Would have closed issue: {open_issue.key}")
+
+        self.create_update_jira_ticket(components_with_issues)
+
     def trigger_scans(self, nvrs: list):
         cmds = self.generate_commands(nvrs=nvrs)
 
@@ -583,11 +626,6 @@ class ScanOshCli:
         Collect all the builds since the previous run. If this is the first run, get all the builds in the candidate
         tags
         """
-        tags = self.runtime.get_errata_config()["brew_tag_product_version_mapping"].keys()
-        for tag in tags:
-            major, minor = self.runtime.get_major_minor_fields()
-            self.brew_tags.append(tag.format(MAJOR=major, MINOR=minor))
-
         builds = []
 
         if self.last_brew_event or self.all_builds:
@@ -612,15 +650,17 @@ class ScanOshCli:
         for build in builds:
             # Skip rhcos for now
             if build["nvr"].startswith("rhcos"):
-                self.runtime.logger.warning(f"Skipping RHCOS builds. Scan is not triggered for {build['nvr']}")
+                self.runtime.logger.debug(f"Skipping RHCOS builds. Scan is not triggered for {build['nvr']}")
+                continue
+
+            # Exclude all test builds
+            if build["nvr"].endswith(".test"):
+                self.runtime.logger.debug(f"Skipping test build: {build['nvr']}")
                 continue
 
             nvrs.append(build["nvr"])
 
         nvr_brew_mapping = [(build["nvr"], build["create_event"]) for build in builds]
-
-        # To store the final list of NVRs that we will kick off scans for
-        nvrs_for_scans = []
 
         if nvr_brew_mapping:
             self.runtime.logger.info(f"NVRs to trigger scans for {nvr_brew_mapping}")
@@ -639,15 +679,15 @@ class ScanOshCli:
 
         return nvrs_for_scans
 
-    async def run(self):
+    async def trigger_scans_workflow(self):
+        """
+        Trigger scans incrementally by looking at the brew event
+        """
         nvrs_for_scans = self.brew_candidate_workflow()
 
         if not nvrs_for_scans:
             self.runtime.logger.info("No new builds to scan")
             return
-
-        # For raising JIRA tickets, we ideally need to check them even if they are already scanned
-        all_nvrs = nvrs_for_scans
 
         if self.check_triggered:
             nvrs_for_scans = await self.get_untriggered_nvrs(nvrs_for_scans)
@@ -655,36 +695,126 @@ class ScanOshCli:
         # Trigger the scans
         self.trigger_scans(nvrs_for_scans)
 
-        # Check if the OCP version is enabled for raising Jira tickets
-        if self.runtime.group_config.external_scanners.sast_scanning.jira_integration.enabled not in [True, "True", "true", "yes"]:
-            self.runtime.logger.info(f"Skipping OCPBUGS creation workflow since not enabled in group.yml for "
-                                     f"{self.version}")
-            return
+    async def process_data_for_ocpbugs_workflow(self):
+        # Get all builds from candidate tags
+        build_package_mapping = {}
 
-        if self.create_jira_tickets:
-            brew_components = {}
-            for nvr in all_nvrs:
-                if nvr.endswith(".test"):
-                    # Exclude all test builds
-                    self.runtime.logger.info(f"Skipping test build: {nvr}")
-                    continue
+        for tag in self.brew_tags:
+            # Get all the latest builds from the candidate tags
+            builds = self.get_tagged_latest(tag=tag)
+            self.runtime.logger.info(f"Retrieved all latest builds from tag {tag}")
 
-                if "bundle-container" in nvr or "metadata-container" in nvr:
-                    # Exclude all bundle builds
-                    self.runtime.logger.info(f"Skipping bundle build: {nvr}")
-                    continue
-
-                brew_info = self.koji_session.getBuild(nvr)
-                package_name = brew_info["package_name"]
-
-                # More than one build of a component can be present after the previous run,
-                # so lets get just the latest build. The nvrs are ordered from earliest to newest
-                brew_components[package_name] = {
-                    "nvr": nvr,
-                    "brew_info": brew_info
+            for build in builds:
+                build_package_mapping[build["package_name"]] = {
+                    "build": build,
+                    "tag": tag
                 }
 
-            await self.ocp_bugs_workflow_run(brew_components)
+        # Get the list of excluded package names from group.yml
+        excluded_components = self.runtime.group_config.external_scanners.sast_scanning.jira_integration.exclude_components
+        self.runtime.logger.info(f"Retrieved components that have been excluded, from group.yml: {excluded_components}")
+
+        # Components that are not excluded
+        components_under_consideration = {}
+        for component in build_package_mapping.values():
+            tag = component["tag"]
+            build = component["build"]
+            nvr = build["nvr"]
+            package_name = build["package_name"]
+
+            # Exclude all test builds
+            if nvr.endswith(".test"):
+                self.runtime.logger.debug(f"Skipping test build: {nvr}")
+                continue
+
+            # Exclude RHCOS builds
+            if nvr.startswith("rhcos"):
+                self.runtime.logger.debug(f"Skipping rhcos build: {nvr}")
+                continue
+
+            # Exclude all bundle builds
+            if "bundle-container" in nvr or "metadata-container" in nvr:
+                self.runtime.logger.debug(f"Skipping bundle build: {nvr}")
+                continue
+
+            # Exclude components in the "excluded list" in group.yml
+            if package_name in excluded_components:
+                self.runtime.logger.debug(f"Skipping build: {nvr} (since it's in excluded components)")
+                continue
+
+            kind: BuildType = BuildType.IMAGE if "container" in nvr and nvr.endswith(".stream") else BuildType.RPM
+            component["kind"] = kind
+
+            distgit_name = self.get_distgit_name_from_brew(kind=kind, brew_package_name=build["package_name"])
+            metadata = None
+            # Either ART is building this component or not
+            if distgit_name:
+                # ART is building this component
+                # Metadata can be that of images or RPMs.
+                if kind == BuildType.IMAGE:
+                    metadata: ImageMetadata = self.runtime.image_map.get(distgit_name)
+                elif kind == BuildType.RPM:
+                    metadata: RPMMetadata = self.runtime.rpm_map.get(distgit_name)
+
+                # To make sure that the image metadata is correctly loaded at runtime.
+                # For ART managed components, this should always work
+                # Choosing to assert, instead of assuming
+                assert metadata is not None
+
+                # Exclude components that are disabled in component metadata yml
+                if self.is_jira_workflow_component_disabled(metadata):
+                    self.runtime.logger.info(f"Skipping OCPBUGS creation for distgit {distgit_name} "
+                                             f"since disabled in component metadata")
+                    continue
+
+            if kind == BuildType.IMAGE:
+                jira_search_summary = f"{self.version} SAST scan issues for {build['package_name']}"
+            else:
+                rhel_version = self.tag_rhel_mapping[tag]
+                jira_search_summary = f"{rhel_version} SAST scan issues for {build['package_name']}"
+
+            component["metadata"] = metadata
+            component["jira_search_summary"] = jira_search_summary
+
+            components_under_consideration[package_name] = component
+
+        await self.ocp_bugs_workflow(components_under_consideration)
+
+    async def run(self):
+        # Setup brew tags
+        tags = self.runtime.get_errata_config()["brew_tag_product_version_mapping"].keys()
+        for tag in tags:
+            major, minor = self.runtime.get_major_minor_fields()
+            self.brew_tags.append(tag.format(MAJOR=major, MINOR=minor))
+        self.runtime.logger.info(f"Retrieved candidate tags: {self.brew_tags}")
+
+        # Trigger scans workflow
+        await self.trigger_scans_workflow()
+
+        # JIRA integration workflow
+
+        # Create rhel mapping
+        for tag in self.brew_tags:
+            pattern = r"rhaos-\d.\d+(-ironic){0,1}-(?P<rhel_version>rhel-\d+)-candidate"
+            match = re.search(pattern=pattern, string=tag)
+            rhel_version = None
+            if match:
+                rhel_version = match.group("rhel_version")
+
+            assert rhel_version is not None
+
+            self.tag_rhel_mapping[tag] = rhel_version
+        self.runtime.logger.info(f"Created RHEL-brew-tag mapping: {self.tag_rhel_mapping}")
+
+        if not self.create_jira_tickets:
+            return
+
+        # Check if the OCP version is enabled for raising Jira tickets
+        if not self.is_jira_workflow_group_enabled():
+            self.runtime.logger.info(f"Skipping OCPBUGS creation workflow since not enabled in group.yml for {self.version}")
+            return
+
+        await self.process_data_for_ocpbugs_workflow()
 
 
 @cli.command("images:scan-osh", help="Trigger scans for builds with brew event IDs greater than the value specified")
@@ -696,17 +826,14 @@ class ScanOshCli:
 @click.option("--all-builds", required=False, is_flag=True, default=False, help="Check all builds in candidate tags")
 @click.option("--create-jira-tickets", required=False, is_flag=True, default=False,
               help="Create OCPBUGS ticket for a package if scan issues exist")
-@click.option("--skip-diff-check", required=False, is_flag=True, default=False,
-              help="Used along with --create-jira-tickets. Skip checking the diff between current and previous scan")
 @pass_runtime
 @click_coroutine
 async def scan_osh(runtime: Runtime, since: str, dry_run: bool, check_triggered: bool, all_builds: bool,
-                   create_jira_tickets: bool, skip_diff_check: bool):
+                   create_jira_tickets: bool):
     cli_pipeline = ScanOshCli(runtime=runtime,
                               last_brew_event=int(since) if since else None,
                               dry_run=dry_run,
                               check_triggered=check_triggered,
                               all_builds=all_builds,
-                              create_jira_tickets=create_jira_tickets,
-                              skip_diff_check=skip_diff_check)
+                              create_jira_tickets=create_jira_tickets)
     await cli_pipeline.run()


### PR DESCRIPTION
For RPMs, we need to raise one ticket per rhel version, not ocp version. Hence updating the workflow to reflect that, while including optimizations. This will be a periodic scan set to run every hour.

How the new workflow will look like:
- Retrieve all builds from brew candidate tags, from [erratatool.yml](https://github.com/openshift-eng/ocp-build-data/blob/e2ec932f1594e3f5be49ab6d1b9003218c6f81ce/erratatool.yml#L8)
- Get all the latest builds from those tags
- If scan issues exist for those NVRs, raise a ticket (if there isn't already one)
- RPM tickets will be raised with title having rhel version as the prefix, while images will OCP version as the prefix.


Note:
Since this new workflow will immediatelly open tickets for a version, since all latest builds are checked (in the previous workflow, we were raising tickets for new builds only) need to deactivate for versions < 4.15 temporarily so that we can phase it out: 
https://github.com/openshift-eng/ocp-build-data/pull/4043