### PR TITLE
ART-8426 Support showing go version for payload

### DIFF
--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -12,14 +12,13 @@ web service.
 # stdlib
 from multiprocessing import cpu_count
 from multiprocessing.dummy import Pool as ThreadPool
-import asyncio
 import datetime
 import json
 import sys
 from typing import Dict, List
 
 # ours
-from elliottlib import exectools
+from elliottlib import util
 from elliottlib import Runtime
 from elliottlib import rhcos
 import elliottlib.constants
@@ -207,57 +206,7 @@ written out to summary_results.json.
 
     click.echo("Found {} builds".format(len(all_advisory_nvrs)))
 
-    all_payload_nvrs = {}
-    click.echo("Fetching release info")
-    release_export_cmd = 'oc adm release info {} -o json'.format(payload)
-
-    rc, stdout, stderr = exectools.cmd_gather(release_export_cmd)
-    if rc != 0:
-        # Probably no point in continuing.. can't contact brew?
-        print("Unable to run oc release info: out={}  ; err={}".format(stdout, stderr))
-        exit(1)
-    else:
-        click.echo("Got release info")
-
-    payload_json = json.loads(stdout)
-
-    green_prefix("Looping over payload images: ")
-    click.echo("{} images to check".format(len(payload_json['references']['spec']['tags'])))
-    cmds = [['oc', 'image', 'info', '-o', 'json', tag['from']['name']] for tag in payload_json['references']['spec']['tags']]
-
-    green_prefix("Querying image infos...")
-    cmd_results = await asyncio.gather(*[exectools.cmd_gather_async(cmd) for cmd in cmds])
-
-    for image, cmd, cmd_result in zip(payload_json['references']['spec']['tags'], cmds, cmd_results):
-        click.echo("----")
-        image_name = image['name']
-        rc, stdout, stderr = cmd_result
-        if rc != 0:
-            # Probably no point in continuing.. can't contact brew?
-            red_prefix("Unable to run oc image info: ")
-            red_print(f"cmd={cmd!r}, out={stdout}  ; err={stderr}")
-            exit(1)
-
-        image_info = json.loads(stdout)
-        labels = image_info['config']['config']['Labels']
-
-        # The machine-os-content image doesn't follow the standard
-        # pattern. We need to skip that image when we find it, it is
-        # not attached to advisories.
-        if image_name in rhcos_images:
-            yellow_prefix(f"Skipping rhcos image {image_name}: ")
-            click.echo("Not required for checks")
-            continue
-
-        if not labels or any(i not in labels for i in ['version', 'release', 'com.redhat.component']):
-            red_print(f"For image {image_name} expected labels don't exist")
-            exit(1)
-        component = labels['com.redhat.component']
-        click.echo(f"Payload name: {image_name}")
-        click.echo(f"Brew name: {component}")
-        v = labels['version']
-        r = labels['release']
-        all_payload_nvrs[component] = f"{v}-{r}"
+    all_payload_nvrs = await util.get_nvrs_from_payload(payload, rhcos_images, runtime.logger)
 
     missing_in_errata = {}
     payload_doesnt_match_errata = {}
@@ -273,7 +222,8 @@ written out to summary_results.json.
     green_prefix("Analyzing data: ")
     click.echo("{} images to consider from payload".format(len(all_payload_nvrs)))
 
-    for image, vr in all_payload_nvrs.items():
+    for image, vr_tuple in all_payload_nvrs.items():
+        vr = f"{vr_tuple[0]}-{vr_tuple[1]}"
         imagevr = f"{image}-{vr}"
         yellow_prefix("Cross-checking from payload: ")
         click.echo(imagevr)

--- a/elliott/elliottlib/cli/get_golang_versions_cli.py
+++ b/elliott/elliottlib/cli/get_golang_versions_cli.py
@@ -1,14 +1,17 @@
 import click
-
-from elliottlib import errata, logutil, util
+import json
+from elliottlib import util, errata, logutil, rhcos
 from elliottlib.cli.common import (cli, find_default_advisory,
                                    use_default_advisory_option)
+from elliottlib.cli.common import click_coroutine
 from elliottlib.rpm_utils import parse_nvr
 
 _LOGGER = logutil.getLogger(__name__)
 
 
 @cli.command("go", short_help="Get version of Go for advisory builds")
+@click.option("--release", "-r",
+              help="Release/nightly pullspec to inspect builds for")
 @click.option('--advisory', '-a', 'advisory_id', type=int,
               help="The advisory ID to fetch builds from")
 @use_default_advisory_option
@@ -16,55 +19,75 @@ _LOGGER = logutil.getLogger(__name__)
               help="Brew nvrs to show go version for. Comma separated")
 @click.option('--components', '-c',
               help="Only show go versions for these components (rpms/images) in advisory. Comma separated")
+@click.option('-o', '--output',
+              type=click.Choice(['json', 'text']),
+              default='text', help='Output format')
+@click.option('--report', '-R', 'report', is_flag=True, default=False)
 @click.pass_obj
-def get_golang_versions_cli(runtime, advisory_id, default_advisory_type, nvrs, components):
+@click_coroutine
+async def get_golang_versions_cli(runtime, release, advisory_id, default_advisory_type, nvrs, components, output,
+                                  report):
     """
-    Prints the Go version used to build a component to stdout.
+    Get the Go version for brew builds specified via nvrs / advisory / release
 
     Usage:
 
 \b
     $ elliott go -a 76557
 
-    List go version for brew builds in the given advisory
+    List go version for all golang builds in the given advisory
 
 \b
     $ elliott go -a 79683 -c ironic-container,ose-ovirt-csi-driver-container
 
-    List go version for brew builds in the given advisory
+    List go version for the given brew components in the advisory
 
 \b
-    $ elliott -g openshift-4.8 go --use-default-advisory image -c grafana-container,ose-installer-container
+    $ elliott -g openshift-4.12 --assembly 4.12.13 go --use-default-advisory image
 
-    List go version for brew builds for given component names attached to the default advisory for a group
+    Use default advisory for a group/assembly
 
 \b
     $ elliott go -n podman-3.0.1-6.el8,podman-1.9.3-3.rhaos4.6.el8
 
-    List go version for given brew builds
-"""
-    count_options = sum(map(bool, [advisory_id, nvrs, default_advisory_type]))
-    if count_options > 1:
-        raise click.BadParameter("Use only one of --advisory, --nvrs, --use-default-advisory")
+    List go version for given brew nvrs
 
-    if default_advisory_type:
+\b
+    $ elliott go -r registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2023-04-24-145153
+
+    List go version for given release pullspec
+"""
+    count_options = sum(map(bool, [advisory_id, nvrs, default_advisory_type, release]))
+    if count_options > 1:
+        raise click.BadParameter("Use only one of --release, --advisory, --nvrs, --use-default-advisory")
+
+    advisory_id, rhcos_images = None, None
+    if default_advisory_type or release:
         runtime.initialize()
-        advisory_id = find_default_advisory(runtime, default_advisory_type)
+        if default_advisory_type:
+            advisory_id = find_default_advisory(runtime, default_advisory_type)
+        elif release:
+            rhcos_images = {c['name'] for c in rhcos.get_container_configs(runtime)}
     else:
         runtime.initialize(no_group=True)
 
-    if advisory_id:
-        if components:
-            components = [c.strip() for c in components.split(',')]
-        return get_advisory_golang(advisory_id, components)
+    if components:
+        components = [c.strip() for c in components.split(',')]
+        if release and not all(c.endswith('-container') for c in components):
+            raise click.BadParameter('components for payload should end with -container')
+
+    if release:
+        return await print_release_golang(release, rhcos_images, components, output, report)
+    elif advisory_id:
+        return print_advisory_golang(advisory_id, components, output, report)
     elif nvrs:
         nvrs = [n.strip() for n in nvrs.split(',')]
-        return get_nvrs_golang(nvrs)
+        return print_nvrs_golang(nvrs, output, report)
     else:
         util.red_print('The input value is not valid.')
 
 
-def get_nvrs_golang(nvrs):
+def print_nvrs_golang(nvrs, output, report):
     container_nvrs, rpm_nvrs = [], []
     for n in nvrs:
         parsed_nvr = parse_nvr(n)
@@ -74,22 +97,27 @@ def get_nvrs_golang(nvrs):
         else:
             rpm_nvrs.append(nvr_tuple)
 
+    go_nvr_map = {}
     if rpm_nvrs:
-        go_nvr_map = util.get_golang_rpm_nvrs(rpm_nvrs, _LOGGER)
-        util.pretty_print_nvrs_go(go_nvr_map)
-    elif container_nvrs:
-        go_nvr_map = util.get_golang_container_nvrs(container_nvrs, _LOGGER)
-        util.pretty_print_nvrs_go(go_nvr_map)
-    else:
-        util.green_print('There is no builds related to golang.')
+        go_nvr_map.update(util.get_golang_rpm_nvrs(rpm_nvrs, _LOGGER))
+    if container_nvrs:
+        go_nvr_map.update(util.get_golang_container_nvrs(container_nvrs, _LOGGER))
+
+    if not go_nvr_map:
+        util.green_print('No golang builds detected')
+
+    if output == 'json':
+        util.pretty_print_nvrs_go_json(go_nvr_map, report)
+    elif output == 'text':
+        util.pretty_print_nvrs_go(go_nvr_map, report)
 
 
-def get_advisory_golang(advisory_id, components):
+def print_advisory_golang(advisory_id, components, output, report):
     nvrs = errata.get_all_advisory_nvrs(advisory_id)
     _LOGGER.debug(f'{len(nvrs)} builds found in advisory')
     if not nvrs:
-        _LOGGER.debug('No builds found. exiting')
-        util.green_print('there is no builds related to golang')
+        _LOGGER.debug('No golang builds found. exiting')
+        util.green_print(f'No golang builds found in advisory {advisory_id}')
         return
     if components:
         if 'openshift' in components:
@@ -103,4 +131,25 @@ def get_advisory_golang(advisory_id, components):
     else:
         go_nvr_map = util.get_golang_rpm_nvrs(nvrs, _LOGGER)
 
-    util.pretty_print_nvrs_go(go_nvr_map)
+    if output == 'json':
+        util.pretty_print_nvrs_go_json(go_nvr_map, report)
+    elif output == 'text':
+        util.pretty_print_nvrs_go(go_nvr_map, report)
+
+
+async def print_release_golang(pullspec, rhcos_images, components, output, report):
+    nvr_map = await util.get_nvrs_from_payload(pullspec, rhcos_images, _LOGGER)
+    nvrs = [(n, vr_tuple[0], vr_tuple[1]) for n, vr_tuple in nvr_map.items()]
+    _LOGGER.debug(f'{len(nvrs)} builds found in {pullspec}')
+    if not nvrs:
+        _LOGGER.debug('No golang builds found. exiting')
+        util.green_print(f'No golang builds found in release {pullspec}')
+        return
+    if components:
+        nvrs = [p for p in nvrs if p[0] in components]
+
+    go_nvr_map = util.get_golang_container_nvrs(nvrs, _LOGGER)
+    if output == 'json':
+        util.pretty_print_nvrs_go_json(go_nvr_map, report)
+    elif output == 'text':
+        util.pretty_print_nvrs_go(go_nvr_map, report)


### PR DESCRIPTION
To support https://issues.redhat.com/browse/ART-8426

Reviving https://github.com/openshift-eng/elliott/pull/543 

Since we're supporting different go versions in a payload with canonical_builders_from_upstream config option,
it's useful to get builder info for all images in a payload to compare.

I extracted out code from verify-payload to get nvrs from payload, so it could be used here as well.

## Test

```
$ ./elliott -g openshift-4.16 go -r registry.ci.openshift.org/ocp/release:4.16.0-0.nightly-2023-12-19-195550 --report -o json
...
[
    {
        "builder_nvr": "openshift-golang-builder-container-v1.20.10-202310161945.el9.gbbb66ea",
        "building_count": 65
    },
    {
        "builder_nvr": "openshift-golang-builder-container-v1.21.3-202311211941.el9.g7b42730",
        "building_count": 55
    },
    {
        "builder_nvr": "openshift-golang-builder-container-v1.20.10-202310161945.el8.gdc4b478",
        "building_count": 33
    },
    {
        "builder_nvr": "openshift-golang-builder-container-v1.21.3-202311221709.el8.gf79bf9c",
        "building_count": 22
    },
    {
        "builder_nvr": "openshift-golang-builder-container-v1.19.13-202310161903.el9.g0f9bb4c",
        "building_count": 1
    },
    {
        "builder_nvr": "openshift-golang-builder-container-v1.19.13-202310161907.el8.g0d095f7",
        "building_count": 1
    }
]

```

elliott -g openshift-4.12 --assembly 4.12.14 verify-payload quay.io/openshift-release-dev/ocp-release:4.12.14-x86_64 113026

