### PR TITLE
ART-8115 Modify prepare-release job for prereleases

### DIFF
--- a/elliott/elliottlib/errata.py
+++ b/elliott/elliottlib/errata.py
@@ -235,9 +235,14 @@ def new_erratum(et_data, errata_type, boilerplate_name, release_date=None, creat
 
     boilerplate = et_data['boilerplates'][boilerplate_name]
 
+    if 'release' in boilerplate:
+        release = boilerplate['release']
+    else:
+        release = et_data['release']
+
     e = Advisory(
         product=et_data['product'],
-        release=et_data['release'],
+        release=release,
         errata_type=errata_type,
         synopsis=boilerplate['synopsis'],
         topic=boilerplate['topic'],

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -49,8 +49,8 @@ class BuildMicroShiftPipeline:
         self.force = force
         self._logger = logger or runtime.logger
         self._working_dir = self.runtime.working_dir.absolute()
-        self.slack_client = None
-        self.slack_thread = None
+        self.slack_client = runtime.new_slack_client()
+        self.slack_client.bind_channel(group)
 
         # determines OCP version
         match = re.fullmatch(r"openshift-(\d+).(\d+)", group)
@@ -114,7 +114,7 @@ class BuildMicroShiftPipeline:
 
             # Start slack thread for named assemblies
             if assembly_type is not AssemblyTypes.STREAM:
-                await self.slack_say(f":construction: Microshift prep for assembly {self.assembly} :construction:")
+                await self.slack_client.say_in_thread(f":construction: Microshift prep for assembly {self.assembly} :construction:")
 
             # For named assemblies, check if builds are pinned or already exist
             nvrs = []
@@ -127,7 +127,7 @@ class BuildMicroShiftPipeline:
                     message = (f"For assembly {self.assembly} builds are already pinned: {pinned_nvrs}. Use FORCE to "
                                "rebuild.")
                     self._logger.info(message)
-                    await self.slack_say(message)
+                    await self.slack_client.say_in_thread(message)
                     nvrs = list(pinned_nvrs.values())
                 else:
                     nvrs = await self._find_builds()
@@ -154,7 +154,7 @@ class BuildMicroShiftPipeline:
                     return
 
                 message = f"microshift for assembly {self.assembly} has been successfully built."
-                await self.slack_say(message)
+                await self.slack_client.say_in_thread(message)
 
             # Check if we need create a PR to pin eligible builds
             diff = set(nvrs) - set(pinned_nvrs.values())
@@ -164,7 +164,7 @@ class BuildMicroShiftPipeline:
 
                 message = (f"PR to pin microshift build to the {self.assembly} assembly has been merged:"
                            f" {pr.html_url}")
-                await self.slack_say(message)
+                await self.slack_client.say_in_thread(message)
 
             if assembly_type in [AssemblyTypes.PREVIEW, AssemblyTypes.CANDIDATE]:
                 version = f'{major}.{minor}'
@@ -172,12 +172,12 @@ class BuildMicroShiftPipeline:
                     jenkins.start_microshift_sync(version=version, assembly=self.assembly)
                     message = f"microshift_sync for version {version} and assembly {self.assembly} has been triggered\n" \
                               f"This will publish the microshift build to mirror"
-                    await self.slack_say(message)
+                    await self.slack_client.say_in_thread(message)
                 except Exception as err:
                     self._logger.warning("Failed to trigger microshift_sync job: %s", err)
                     message = "@release-artists Please start <https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888" \
                               "/job/aos-cd-builds/job/build%252Fmicroshift_sync|microshift sync> manually."
-                    await self.slack_say(message)
+                    await self.slack_client.say_in_thread(message)
 
             # Check if microshift advisory is defined in assembly
             if 'microshift' not in advisories:
@@ -187,32 +187,21 @@ class BuildMicroShiftPipeline:
             microshift_advisory_id = advisories['microshift']
 
             # prepare microshift advisory
-            await self.slack_say(f"Start preparing microshift advisory for assembly {self.assembly}..")
+            await self.slack_client.say_in_thread(f"Start preparing microshift advisory for assembly {self.assembly}..")
             await self._attach_builds()
             await self._sweep_bugs()
             await self._attach_cve_flaws()
             await self._change_advisory_status()
             await self._verify_microshift_bugs(microshift_advisory_id)
-            await self.slack_say("Completed preparing microshift advisory.")
+            await self.slack_client.say_in_thread("Completed preparing microshift advisory.")
         except Exception as err:
             slack_message = f"Encountered error: {err}"
             error_message = slack_message + f"\n {traceback.format_exc()}"
             self._logger.error(error_message)
             if assembly_type != AssemblyTypes.STREAM:
                 slack_message += "\n@release-artists"
-            await self.slack_say(slack_message)
+            await self.slack_client.say_in_thread(slack_message)
             raise
-
-    async def slack_say(self, message: str):
-        if not self.slack_client:
-            self.slack_client = self.runtime.new_slack_client()
-            self.slack_client.bind_channel(self.group)
-
-        if not self.slack_thread:
-            slack_response = await self.slack_client.say(message)
-            self.slack_thread = slack_response["message"]["ts"]
-        else:
-            await self.slack_client.say(message, self.slack_thread)
 
     async def _attach_builds(self):
         """ attach the microshift builds to advisory

--- a/pyartcd/pyartcd/slack.py
+++ b/pyartcd/pyartcd/slack.py
@@ -21,6 +21,7 @@ class SlackClient:
         self.dry_run = dry_run
         self.as_user = "art-release-bot"
         self.icon_emoji = ":robot_face:"
+        self._thread_ts = None
         self._client = AsyncWebClient(token=token)
 
     def bind_channel(self, channel_or_release: Optional[str]):
@@ -40,6 +41,14 @@ class SlackClient:
             self.channel = f"#art-release-{match[1]}-{match[2]}"
         else:
             raise ValueError(f"Invalid channel_or_release value: {channel_or_release}")
+
+    async def say_in_thread(self, message: str):
+        if not self._thread_ts:
+            response = await self.say(message)
+            self._thread_ts = response.data["ts"]
+            return self._thread_ts
+        else:
+            return await self.say(message, self._thread_ts)
 
     async def say(self, message: str, thread_ts: Optional[str] = None):
         attachments = []


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-8115

Summary
- Add and use `--permissive` mode to `elliott find-bugs:sweep` to avoid erroring out on invalid bugs when we prep ECs and RCs.
- Build and attach bundle builds to prerelease advisories
- Skip attach-cve-flaws when we're prepping a prerelease assembly
- Gather dependencies from other advisories when prepping prerelease advisory
- Use `rhose async auto` release for preGA advisories - with https://github.com/openshift-eng/ocp-build-data/pull/4101
- Bring all prep-release slack messages in a single thread
