### PR TITLE
Fix altconfig getter

### DIFF
--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1647,7 +1647,7 @@ class ImageDistGitRepo(DistGitRepo):
 
         if self.should_match_upstream:
             # Check if there is an alternative configuration matching upstream RHEL version
-            alt_configs = self.config.get('alternative_upstream', None)
+            alt_configs = self.config.get('alternative_upstream', [])
             matched = False
             for alt_config in alt_configs:
                 if alt_config['when'] == self.upstream_intended_el_version:


### PR DESCRIPTION
```
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Focp4/art-tools/doozer/doozerlib/distgit.py", line 1652, in _update_image_config
    for alt_config in alt_configs:
TypeError: 'NoneType' object is not iterable
2023-12-18 20:06:22,615 ERROR [containers/ironic-rhcos-downloader] 'NoneType' object is not iterable
```