### PR TITLE
Fix sync-ci-images

### DIFF
--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -249,7 +249,11 @@ def what_is_in_master() -> str:
     content = exectools.urlopen_assert(ci_config_url).read()
     ci_config = yaml.safe_load(content)
     # Look for something like: https://github.com/openshift/release/blob/251cb12e913dcde7be7a2b36a211650ed91c45c4/ci-operator/config/openshift/images/openshift-images-master.yaml#L64
-    target_release = ci_config.get('promotion', {}).get('name', None)
+    promotion_to = ci_config.get('promotion', {}).get('to', [])
+    if promotion_to:
+        target_release = promotion_to[0].get('name', None)
+    else:
+        target_release = None
     if not target_release:
         red_print(content)
         raise IOError('Unable to find which openshift release resides in master')


### PR DESCRIPTION
The [job](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/scheduled-builds/job/sync-ci-images/) is currently broken because
```
  File "/mnt/workspace/jenkins/working/scheduled-builds/sync-ci-images/art-tools/doozer/doozerlib/util.py", line 255, in what_is_in_master
    raise IOError('Unable to find which openshift release resides in master')
OSError: Unable to find which openshift release resides in master
```
https://raw.githubusercontent.com/openshift/release/master/ci-operator/config/openshift/images/openshift-images-master.yaml response appears to have changed:
```
promotion:
  to:
  - name: "4.16"
    namespace: ocp
```