### PR TITLE
Move duplicated functions to artcommon

### DIFF
--- a/artcommon/artcommonlib/arch_util.py
+++ b/artcommon/artcommonlib/arch_util.py
@@ -1,0 +1,43 @@
+BREW_ARCHES = ["x86_64", "s390x", "ppc64le", "aarch64", "multi"]
+BREW_ARCH_SUFFIXES = ["", "-s390x", "-ppc64le", "-aarch64", "-multi"]
+GO_ARCHES = ["amd64", "s390x", "ppc64le", "arm64", "multi"]
+GO_ARCH_SUFFIXES = ["", "-s390x", "-ppc64le", "-arm64", "-multi"]
+
+
+def go_arch_for_brew_arch(brew_arch: str) -> str:
+    if brew_arch in GO_ARCHES:
+        return brew_arch  # allow to already be a go arch, just keep same
+    if brew_arch in BREW_ARCHES:
+        return GO_ARCHES[BREW_ARCHES.index(brew_arch)]
+    raise Exception(f"no such brew arch '{brew_arch}' - cannot translate to golang arch")
+
+
+def go_suffix_for_arch(arch: str, is_private: bool = False) -> str:
+    """
+    Imagestreams and namespaces for the release controller indicate
+    a CPU architecture and whether the release is part of the private release controller.
+    using [-<arch>][-priv] as a suffix. This method calculates that suffix
+    based on what arch and privacy you are trying to reach.
+    :param arch: The CPU architecture
+    :param is_private: True if you are looking for a private release controller
+    :return: A suffix to use when address release controller imagestreams/namespaces.
+             x86 arch is never included in the suffix (i.e. '' is used).
+    """
+    arch = go_arch_for_brew_arch(arch)  # translate either incoming arch style
+    suffix = GO_ARCH_SUFFIXES[GO_ARCHES.index(arch)]
+    if is_private:
+        suffix += '-priv'
+    return suffix
+
+
+def brew_arch_for_go_arch(go_arch: str) -> str:
+    if go_arch in BREW_ARCHES:
+        return go_arch  # allow to already be a brew arch, just keep same
+    if go_arch in GO_ARCHES:
+        return BREW_ARCHES[GO_ARCHES.index(go_arch)]
+    raise Exception(f"no such golang arch '{go_arch}' - cannot translate to brew arch")
+
+
+def brew_suffix_for_arch(arch: str) -> str:
+    arch = brew_arch_for_go_arch(arch)  # translate either incoming arch style
+    return BREW_ARCH_SUFFIXES[BREW_ARCHES.index(arch)]

--- a/artcommon/tests/test_arch_util.py
+++ b/artcommon/tests/test_arch_util.py
@@ -1,0 +1,15 @@
+import unittest
+
+from artcommonlib import arch_util
+
+
+class TestArchUtil(unittest.TestCase):
+    def test_brew_arch_suffixes(self):
+        expectations = {
+            "x86_64": "",
+            "amd64": "",
+            "aarch64": "-aarch64",
+            "arm64": "-aarch64"
+        }
+        for arch, suffix in expectations.items():
+            self.assertEqual(arch_util.brew_suffix_for_arch(arch), suffix)

--- a/artcommon/tests/test_arch_util.py
+++ b/artcommon/tests/test_arch_util.py
@@ -31,3 +31,17 @@ class TestArchUtil(unittest.TestCase):
 
         with self.assertRaises(Exception):
             self.assertEqual(arch_util.brew_arch_for_go_arch('wrong'), 'bogus')
+
+    def test_go_arch_suffixes(self):
+        expectations = {
+            "x86_64": "",
+            "amd64": "",
+            "aarch64": "-arm64",
+            "arm64": "-arm64"
+        }
+
+        for arch, suffix in expectations.items():
+            self.assertEqual(arch_util.go_suffix_for_arch(arch), suffix)
+
+        for arch, suffix in expectations.items():
+            self.assertEqual(arch_util.go_suffix_for_arch(arch, is_private=True), f'{suffix}-priv')

--- a/artcommon/tests/test_arch_util.py
+++ b/artcommon/tests/test_arch_util.py
@@ -45,3 +45,21 @@ class TestArchUtil(unittest.TestCase):
 
         for arch, suffix in expectations.items():
             self.assertEqual(arch_util.go_suffix_for_arch(arch, is_private=True), f'{suffix}-priv')
+
+    def test_go_arch_for_brew_arch(self):
+        expectations = {
+            "amd64": "x86_64",
+            "s390x": "s390x",
+            "ppc64le": "ppc64le",
+            "arm64": "aarch64",
+            "multi": "multi"
+        }
+
+        for go_arch, brew_arch in expectations.items():
+            self.assertEqual(arch_util.go_arch_for_brew_arch(brew_arch), go_arch)
+
+        for go_arch in expectations.keys():
+            self.assertEqual(arch_util.go_arch_for_brew_arch(go_arch), go_arch)
+
+        with self.assertRaises(Exception):
+            self.assertEqual(arch_util.go_arch_for_brew_arch('wrong'), 'bogus')

--- a/artcommon/tests/test_arch_util.py
+++ b/artcommon/tests/test_arch_util.py
@@ -13,3 +13,21 @@ class TestArchUtil(unittest.TestCase):
         }
         for arch, suffix in expectations.items():
             self.assertEqual(arch_util.brew_suffix_for_arch(arch), suffix)
+
+    def test_brew_arch_for_go_arch(self):
+        expectations = {
+            "x86_64": "amd64",
+            "s390x": "s390x",
+            "ppc64le": "ppc64le",
+            "aarch64": "arm64",
+            "multi": "multi"
+        }
+
+        for brew_arch, go_arch in expectations.items():
+            self.assertEqual(arch_util.brew_arch_for_go_arch(go_arch), brew_arch)
+
+        for brew_arch in expectations.keys():
+            self.assertEqual(arch_util.brew_arch_for_go_arch(brew_arch), brew_arch)
+
+        with self.assertRaises(Exception):
+            self.assertEqual(arch_util.brew_arch_for_go_arch('wrong'), 'bogus')

--- a/doozer/doozerlib/assembly_inspector.py
+++ b/doozer/doozerlib/assembly_inspector.py
@@ -1,4 +1,6 @@
 from typing import Any, List, Dict, Optional, cast
+
+from artcommonlib.arch_util import brew_arch_for_go_arch
 from doozerlib.plashet import PlashetBuilder
 
 from koji import ClientSession
@@ -484,7 +486,7 @@ class AssemblyInspector:
                  in the app.ci imagestream for ART's release/arch (e.g. ocp-s390x:is/4.7-art-latest-s390x).
         """
         runtime = self.runtime
-        brew_arch = util.brew_arch_for_go_arch(arch)
+        brew_arch = brew_arch_for_go_arch(arch)
         build_id = None
         runtime.logger.info(f"Getting latest RHCOS source for {brew_arch}...")
 

--- a/doozer/doozerlib/cli/gen_assembly_helper.py
+++ b/doozer/doozerlib/cli/gen_assembly_helper.py
@@ -1,9 +1,9 @@
 import click
 import yaml
 
-from doozerlib import util
+from artcommonlib.arch_util import brew_arch_for_go_arch
 from doozerlib.cli import cli
-from doozerlib.rhcos import RHCOSBuildFinder, RHCOSBuildInspector
+from doozerlib.rhcos import RHCOSBuildFinder
 from artcommonlib.rhcos import get_container_configs, get_container_pullspec
 
 
@@ -19,7 +19,7 @@ def gen_assembly_rhcos(runtime, build_id):
     runtime.initialize(clone_distgits=False)
     rhcos_info = {}
     for arch in runtime.group_config.arches:
-        brew_arch = util.brew_arch_for_go_arch(arch)
+        brew_arch = brew_arch_for_go_arch(arch)
         runtime.logger.info(f"Getting RHCOS pullspecs for build {build_id}-{brew_arch}...")
         for container_conf in get_container_configs(runtime):
             version = runtime.get_minor_version()

--- a/doozer/doozerlib/cli/get_nightlies.py
+++ b/doozer/doozerlib/cli/get_nightlies.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Sequence, Set, Tuple
 import aiohttp
 import click
 
-from artcommonlib.arch_util import brew_arch_for_go_arch, go_suffix_for_arch
+from artcommonlib.arch_util import brew_arch_for_go_arch, go_suffix_for_arch, go_arch_for_brew_arch
 from doozerlib import constants, exectools, logutil, util
 from doozerlib.cli import cli, click_coroutine
 from doozerlib.model import Model
@@ -238,7 +238,7 @@ def rc_api_url(tag: str, arch: str) -> str:
     @param arch  architecture we are interested in (e.g. "s390x")
     @return e.g. "https://s390x.ocp.releases.ci.openshift.org/api/v1/releasestream/4.9.0-0.nightly-s390x"
     """
-    arch = util.go_arch_for_brew_arch(arch)
+    arch = go_arch_for_brew_arch(arch)
     arch_suffix = go_suffix_for_arch(arch)
     return f"{constants.RC_BASE_URL.format(arch=arch)}/api/v1/releasestream/{tag}{arch_suffix}"
 

--- a/doozer/doozerlib/cli/get_nightlies.py
+++ b/doozer/doozerlib/cli/get_nightlies.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Sequence, Set, Tuple
 import aiohttp
 import click
 
-from artcommonlib.arch_util import brew_arch_for_go_arch
+from artcommonlib.arch_util import brew_arch_for_go_arch, go_suffix_for_arch
 from doozerlib import constants, exectools, logutil, util
 from doozerlib.cli import cli, click_coroutine
 from doozerlib.model import Model
@@ -239,7 +239,7 @@ def rc_api_url(tag: str, arch: str) -> str:
     @return e.g. "https://s390x.ocp.releases.ci.openshift.org/api/v1/releasestream/4.9.0-0.nightly-s390x"
     """
     arch = util.go_arch_for_brew_arch(arch)
-    arch_suffix = util.go_suffix_for_arch(arch)
+    arch_suffix = go_suffix_for_arch(arch)
     return f"{constants.RC_BASE_URL.format(arch=arch)}/api/v1/releasestream/{tag}{arch_suffix}"
 
 

--- a/doozer/doozerlib/cli/get_nightlies.py
+++ b/doozer/doozerlib/cli/get_nightlies.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Sequence, Set, Tuple
 import aiohttp
 import click
 
+from artcommonlib.arch_util import brew_arch_for_go_arch
 from doozerlib import constants, exectools, logutil, util
 from doozerlib.cli import cli, click_coroutine
 from doozerlib.model import Model
@@ -146,7 +147,7 @@ def determine_arch_list(runtime: Runtime, exclude_arches: Set[str]) -> Set[str]:
     #     available_arches.add("multi")
 
     try:
-        exclude_arches = set(util.brew_arch_for_go_arch(arch) for arch in exclude_arches)
+        exclude_arches = set(brew_arch_for_go_arch(arch) for arch in exclude_arches)
     except Exception as ex:
         raise ValueError(f"invalid --exclude-arch: {ex}")
 

--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -8,6 +8,7 @@ import sys
 from typing import Dict, List, Optional, Set, Tuple
 import yaml
 
+from artcommonlib.arch_util import go_suffix_for_arch
 from doozerlib import util
 from doozerlib.assembly import AssemblyTypes
 from doozerlib.cli import cli, pass_runtime, click_coroutine
@@ -189,7 +190,7 @@ class GenAssemblyCli:
             if major_minor != self.runtime.get_minor_version():
                 self._exit_with_error(f'Specified nightly {nightly_name} does not match group major.minor')
             self.reference_releases_by_arch[brew_cpu_arch] = nightly_name
-            rc_suffix = util.go_suffix_for_arch(brew_cpu_arch, priv)
+            rc_suffix = go_suffix_for_arch(brew_cpu_arch, priv)
             nightly_pullspec = f'registry.ci.openshift.org/ocp{rc_suffix}/release{rc_suffix}:{nightly_name}'
             if brew_cpu_arch in self.release_pullspecs:
                 raise ValueError(

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock
 
 import aiofiles
 import click
+
+from artcommonlib.arch_util import brew_arch_for_go_arch
 from doozerlib import rpm_utils
 import yaml
 from artcommonlib import rhcos
@@ -27,7 +29,7 @@ from doozerlib.image import ImageMetadata, BrewBuildImageInspector, ArchiveImage
 from doozerlib.assembly_inspector import AssemblyInspector
 from doozerlib.runtime import Runtime
 from doozerlib.telemetry import start_as_current_span_async
-from doozerlib.util import red_print, go_suffix_for_arch, brew_arch_for_go_arch, isolate_nightly_name_components, \
+from doozerlib.util import red_print, go_suffix_for_arch, isolate_nightly_name_components, \
     go_arch_for_brew_arch
 from artcommonlib.util import convert_remote_git_to_https
 from doozerlib.assembly import AssemblyTypes, assembly_basis, AssemblyIssue, AssemblyIssueCode

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock
 import aiofiles
 import click
 
-from artcommonlib.arch_util import brew_arch_for_go_arch, go_suffix_for_arch
+from artcommonlib.arch_util import brew_arch_for_go_arch, go_suffix_for_arch, go_arch_for_brew_arch
 from doozerlib import rpm_utils
 import yaml
 from artcommonlib import rhcos
@@ -29,7 +29,7 @@ from doozerlib.image import ImageMetadata, BrewBuildImageInspector, ArchiveImage
 from doozerlib.assembly_inspector import AssemblyInspector
 from doozerlib.runtime import Runtime
 from doozerlib.telemetry import start_as_current_span_async
-from doozerlib.util import red_print, isolate_nightly_name_components, go_arch_for_brew_arch
+from doozerlib.util import red_print, isolate_nightly_name_components
 from artcommonlib.util import convert_remote_git_to_https
 from doozerlib.assembly import AssemblyTypes, assembly_basis, AssemblyIssue, AssemblyIssueCode
 from doozerlib import exectools

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -12,13 +12,13 @@ from unittest.mock import MagicMock
 import aiofiles
 import click
 
-from artcommonlib.arch_util import brew_arch_for_go_arch
+from artcommonlib.arch_util import brew_arch_for_go_arch, go_suffix_for_arch
 from doozerlib import rpm_utils
 import yaml
 from artcommonlib import rhcos
 from artcommonlib.rhcos import RhcosMissingContainerException
 import openshift as oc
-from opentelemetry import metrics, trace
+from opentelemetry import trace
 
 
 from doozerlib.rpm_utils import parse_nvr
@@ -29,8 +29,7 @@ from doozerlib.image import ImageMetadata, BrewBuildImageInspector, ArchiveImage
 from doozerlib.assembly_inspector import AssemblyInspector
 from doozerlib.runtime import Runtime
 from doozerlib.telemetry import start_as_current_span_async
-from doozerlib.util import red_print, go_suffix_for_arch, isolate_nightly_name_components, \
-    go_arch_for_brew_arch
+from doozerlib.util import red_print, isolate_nightly_name_components, go_arch_for_brew_arch
 from artcommonlib.util import convert_remote_git_to_https
 from doozerlib.assembly import AssemblyTypes, assembly_basis, AssemblyIssue, AssemblyIssueCode
 from doozerlib import exectools

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -8,6 +8,7 @@ from typing import (Any, Awaitable, Dict, List, Optional, Set, Tuple, Union,
 from copy import deepcopy
 
 import doozerlib
+from artcommonlib.arch_util import brew_arch_for_go_arch
 from doozerlib import brew, coverity, exectools
 from doozerlib.constants import BREWWEB_URL
 from doozerlib.distgit import pull_image
@@ -16,8 +17,7 @@ from doozerlib.model import Missing, Model
 from doozerlib.pushd import Dir
 from doozerlib.repodata import OutdatedRPMFinder, Repodata
 from doozerlib.rpm_utils import parse_nvr, to_nevra
-from doozerlib.util import (brew_arch_for_go_arch, go_arch_for_brew_arch,
-                            isolate_el_version_in_release)
+from doozerlib.util import (go_arch_for_brew_arch, isolate_el_version_in_release)
 
 
 class ImageMetadata(Metadata):

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -8,7 +8,7 @@ from typing import (Any, Awaitable, Dict, List, Optional, Set, Tuple, Union,
 from copy import deepcopy
 
 import doozerlib
-from artcommonlib.arch_util import brew_arch_for_go_arch
+from artcommonlib.arch_util import brew_arch_for_go_arch, go_arch_for_brew_arch
 from doozerlib import brew, coverity, exectools
 from doozerlib.constants import BREWWEB_URL
 from doozerlib.distgit import pull_image
@@ -17,7 +17,7 @@ from doozerlib.model import Missing, Model
 from doozerlib.pushd import Dir
 from doozerlib.repodata import OutdatedRPMFinder, Repodata
 from doozerlib.rpm_utils import parse_nvr, to_nevra
-from doozerlib.util import (go_arch_for_brew_arch, isolate_el_version_in_release)
+from doozerlib.util import isolate_el_version_in_release
 
 
 class ImageMetadata(Metadata):

--- a/doozer/doozerlib/rhcos.py
+++ b/doozer/doozerlib/rhcos.py
@@ -8,11 +8,12 @@ from urllib.error import URLError
 import koji
 from tenacity import retry, stop_after_attempt, wait_fixed
 
+from artcommonlib.arch_util import brew_suffix_for_arch
 from doozerlib import brew, exectools, logutil
-from doozerlib.model import ListModel, Model
+from doozerlib.model import Model
 from doozerlib.repodata import OutdatedRPMFinder, Repodata
 from doozerlib.runtime import Runtime
-from doozerlib.util import brew_suffix_for_arch, isolate_el_version_in_release
+from doozerlib.util import isolate_el_version_in_release
 from artcommonlib import rhcos
 from artcommonlib.constants import RHCOS_RELEASES_BASE_URL
 

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -486,24 +486,6 @@ def go_arch_for_brew_arch(brew_arch: str) -> str:
     raise Exception(f"no such brew arch '{brew_arch}' - cannot translate to golang arch")
 
 
-def go_suffix_for_arch(arch: str, is_private: bool = False) -> str:
-    """
-    Imagestreams and namespaces for the release controller indicate
-    a CPU architecture and whether the release is part of the private release controller.
-    using [-<arch>][-priv] as a suffix. This method calculates that suffix
-    based on what arch and privacy you are trying to reach.
-    :param arch: The CPU architecture
-    :param is_private: True if you are looking for a private release controller
-    :return: A suffix to use when address release controller imagestreams/namespaces.
-             x86 arch is never included in the suffix (i.e. '' is used).
-    """
-    arch = go_arch_for_brew_arch(arch)  # translate either incoming arch style
-    suffix = go_arch_suffixes[go_arches.index(arch)]
-    if is_private:
-        suffix += '-priv'
-    return suffix
-
-
 def find_latest_build(builds: List[Dict], assembly: Optional[str]) -> Optional[Dict]:
     """ Find the latest build specific to the assembly in a list of builds belonging to the same component and brew tag
     :param builds: a list of build dicts sorted by tagging event in descending order

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -19,6 +19,7 @@ import click
 import semver
 import yaml
 
+from artcommonlib.arch_util import brew_arch_for_go_arch
 from doozerlib.model import Missing, Model
 
 try:
@@ -483,14 +484,6 @@ def go_arch_for_brew_arch(brew_arch: str) -> str:
     if brew_arch in brew_arches:
         return go_arches[brew_arches.index(brew_arch)]
     raise Exception(f"no such brew arch '{brew_arch}' - cannot translate to golang arch")
-
-
-def brew_arch_for_go_arch(go_arch: str) -> str:
-    if go_arch in brew_arches:
-        return go_arch  # allow to already be a brew arch, just keep same
-    if go_arch in go_arches:
-        return brew_arches[go_arches.index(go_arch)]
-    raise Exception(f"no such golang arch '{go_arch}' - cannot translate to brew arch")
 
 
 def go_suffix_for_arch(arch: str, is_private: bool = False) -> str:

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -19,7 +19,7 @@ import click
 import semver
 import yaml
 
-from artcommonlib.arch_util import brew_arch_for_go_arch
+from artcommonlib.arch_util import brew_arch_for_go_arch, go_arch_for_brew_arch, GO_ARCHES
 from doozerlib.model import Missing, Model
 
 try:
@@ -365,7 +365,7 @@ def isolate_nightly_name_components(nightly_name: str) -> (str, str, bool):
     is_private = ('priv' in components)
     pos = components.index('nightly')
     possible_arch = components[pos + 1]
-    if possible_arch not in go_arches:
+    if possible_arch not in GO_ARCHES:
         go_arch = 'x86_64'  # for historical reasons, amd64 is not included in the release name
     else:
         go_arch = possible_arch
@@ -469,21 +469,6 @@ def total_size(o, handlers=None, verbose=False):
         return s
 
     return sizeof(o)
-
-
-# some of our systems refer to golang's architecture nomenclature; translate between that and brew arches
-brew_arches = ["x86_64", "s390x", "ppc64le", "aarch64", "multi"]
-brew_arch_suffixes = ["", "-s390x", "-ppc64le", "-aarch64", "-multi"]
-go_arches = ["amd64", "s390x", "ppc64le", "arm64", "multi"]
-go_arch_suffixes = ["", "-s390x", "-ppc64le", "-arm64", "-multi"]
-
-
-def go_arch_for_brew_arch(brew_arch: str) -> str:
-    if brew_arch in go_arches:
-        return brew_arch  # allow to already be a go arch, just keep same
-    if brew_arch in brew_arches:
-        return go_arches[brew_arches.index(brew_arch)]
-    raise Exception(f"no such brew arch '{brew_arch}' - cannot translate to golang arch")
 
 
 def find_latest_build(builds: List[Dict], assembly: Optional[str]) -> Optional[Dict]:

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -511,11 +511,6 @@ def go_suffix_for_arch(arch: str, is_private: bool = False) -> str:
     return suffix
 
 
-def brew_suffix_for_arch(arch: str) -> str:
-    arch = brew_arch_for_go_arch(arch)  # translate either incoming arch style
-    return brew_arch_suffixes[brew_arches.index(arch)]
-
-
 def find_latest_build(builds: List[Dict], assembly: Optional[str]) -> Optional[Dict]:
     """ Find the latest build specific to the assembly in a list of builds belonging to the same component and brew tag
     :param builds: a list of build dicts sorted by tagging event in descending order

--- a/doozer/tests/test_util.py
+++ b/doozer/tests/test_util.py
@@ -1,6 +1,6 @@
 import unittest
 
-from artcommonlib.arch_util import brew_arch_for_go_arch
+from artcommonlib.arch_util import brew_arch_for_go_arch, go_arch_for_brew_arch
 from doozerlib import util
 from doozerlib.model import Model
 
@@ -68,7 +68,7 @@ class TestUtil(unittest.TestCase):
 
     def test_bogus_arch_xlate(self):
         with self.assertRaises(Exception):
-            util.go_arch_for_brew_arch("bogus")
+            go_arch_for_brew_arch("bogus")
         with self.assertRaises(Exception):
             brew_arch_for_go_arch("bogus")
 

--- a/doozer/tests/test_util.py
+++ b/doozer/tests/test_util.py
@@ -75,16 +75,6 @@ class TestUtil(unittest.TestCase):
         for arch, suffix in expectations.items():
             self.assertEqual(util.go_suffix_for_arch(arch), suffix)
 
-    def test_brew_arch_suffixes(self):
-        expectations = {
-            "x86_64": "",
-            "amd64": "",
-            "aarch64": "-aarch64",
-            "arm64": "-aarch64"
-        }
-        for arch, suffix in expectations.items():
-            self.assertEqual(util.brew_suffix_for_arch(arch), suffix)
-
     def test_bogus_arch_xlate(self):
         with self.assertRaises(Exception):
             util.go_arch_for_brew_arch("bogus")

--- a/doozer/tests/test_util.py
+++ b/doozer/tests/test_util.py
@@ -1,5 +1,6 @@
 import unittest
 
+from artcommonlib.arch_util import brew_arch_for_go_arch
 from doozerlib import util
 from doozerlib.model import Model
 
@@ -79,7 +80,7 @@ class TestUtil(unittest.TestCase):
         with self.assertRaises(Exception):
             util.go_arch_for_brew_arch("bogus")
         with self.assertRaises(Exception):
-            util.brew_arch_for_go_arch("bogus")
+            brew_arch_for_go_arch("bogus")
 
     def test_find_latest_builds(self):
         builds = [

--- a/doozer/tests/test_util.py
+++ b/doozer/tests/test_util.py
@@ -66,16 +66,6 @@ class TestUtil(unittest.TestCase):
         self.assertRaises(IOError, util.extract_version_fields, 'v1.2', 3)
         self.assertRaises(IOError, util.extract_version_fields, '1.2', 3)
 
-    def test_go_arch_suffixes(self):
-        expectations = {
-            "x86_64": "",
-            "amd64": "",
-            "aarch64": "-arm64",
-            "arm64": "-arm64"
-        }
-        for arch, suffix in expectations.items():
-            self.assertEqual(util.go_suffix_for_arch(arch), suffix)
-
     def test_bogus_arch_xlate(self):
         with self.assertRaises(Exception):
             util.go_arch_for_brew_arch("bogus")

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -9,6 +9,7 @@ import koji
 import requests
 from errata_tool import ErrataException
 
+from artcommonlib.arch_util import BREW_ARCHES
 from artcommonlib.rhcos import get_container_configs
 from elliottlib import Runtime, brew, errata, logutil
 from elliottlib import exectools
@@ -19,7 +20,7 @@ from elliottlib.cli.common import (cli, find_default_advisory,
 from elliottlib.exceptions import ElliottFatalError
 from elliottlib.imagecfg import ImageMetadata
 from elliottlib.cli.rhcos_cli import get_build_id_from_rhcos_pullspec
-from elliottlib.util import (ensure_erratatool_auth, brew_arches,
+from elliottlib.util import (ensure_erratatool_auth,
                              get_release_version, green_prefix, green_print,
                              isolate_el_version_in_brew_tag,
                              parallel_results_with_progress, pbar_header, progress_func,
@@ -279,7 +280,7 @@ def ensure_rhcos_file_meta(advisory_id):
         if f['title'] or 'rhcos' not in f['file']['path']:
             continue
 
-        arch = next((a for a in brew_arches if a in f['file']['path']), None)
+        arch = next((a for a in BREW_ARCHES if a in f['file']['path']), None)
         if not arch:
             raise ValueError(f'Unable to determine arch from rhcos file path: {f["file"]["path"]}. Please investigate.')
 

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -9,11 +9,10 @@ import koji
 import requests
 from errata_tool import ErrataException
 
-import elliottlib
-from elliottlib import Runtime, brew, constants, errata, logutil
+from artcommonlib.rhcos import get_container_configs
+from elliottlib import Runtime, brew, errata, logutil
 from elliottlib import exectools
 from elliottlib.assembly import assembly_metadata_config, assembly_rhcos_config
-from elliottlib.rhcos import get_container_configs
 from elliottlib.build_finder import BuildFinder
 from elliottlib.cli.common import (cli, find_default_advisory,
                                    use_default_advisory_option, click_coroutine)

--- a/elliott/elliottlib/cli/find_unconsumed_rpms.py
+++ b/elliott/elliottlib/cli/find_unconsumed_rpms.py
@@ -1,8 +1,9 @@
-
 import asyncio
 from typing import Dict, List, Optional
 import click
-from elliottlib import brew, exectools, rhcos, util
+
+from artcommonlib.arch_util import brew_arch_for_go_arch
+from elliottlib import brew, exectools, rhcos
 from elliottlib.assembly import assembly_rhcos_config, AssemblyTypes, assembly_type
 from elliottlib.build_finder import BuildFinder
 
@@ -63,7 +64,7 @@ class FindUnconsumedRpms:
                 assembly_rhcos_arch_pullspec = rhcos_config[container_conf.name].images[brew_arch]
                 if assembly_rhcos_arch_pullspec:
                     rhcos_build_id, arch = rhcos.get_build_from_pullspec(assembly_rhcos_arch_pullspec)
-                    if util.brew_arch_for_go_arch(arch) != brew_arch:
+                    if brew_arch_for_go_arch(arch) != brew_arch:
                         raise ValueError(f"Pullspec {assembly_rhcos_arch_pullspec} is not {brew_arch}")
                     rhcos_build_ids[brew_arch] = rhcos_build_id
                     continue

--- a/elliott/elliottlib/cli/rhcos_cli.py
+++ b/elliott/elliottlib/cli/rhcos_cli.py
@@ -1,7 +1,7 @@
 import click
 import json
 
-from artcommonlib.arch_util import brew_arch_for_go_arch
+from artcommonlib.arch_util import brew_arch_for_go_arch, go_suffix_for_arch
 from elliottlib.cli.common import cli
 from elliottlib import rhcos, util, exectools
 from artcommonlib.rhcos import get_primary_container_name
@@ -105,7 +105,7 @@ def get_pullspec(release, arch):
 
 
 def get_nightly_pullspec(release, arch):
-    suffix = util.go_suffix_for_arch(arch)
+    suffix = go_suffix_for_arch(arch)
     return f'registry.ci.openshift.org/ocp{suffix}/release{suffix}:{release}'
 
 

--- a/elliott/elliottlib/cli/rhcos_cli.py
+++ b/elliott/elliottlib/cli/rhcos_cli.py
@@ -1,5 +1,7 @@
 import click
 import json
+
+from artcommonlib.arch_util import brew_arch_for_go_arch
 from elliottlib.cli.common import cli
 from elliottlib import rhcos, util, exectools
 from artcommonlib.rhcos import get_primary_container_name
@@ -138,7 +140,7 @@ def _via_build_id(runtime, build_id, arch, version, packages, go, logger):
     if not build_id:
         Exception('Cannot find build_id')
 
-    arch = util.brew_arch_for_go_arch(arch)
+    arch = brew_arch_for_go_arch(arch)
     util.green_print(f'Build: {build_id} Arch: {arch}')
     nvrs = rhcos.get_rpm_nvrs(runtime, build_id, version, arch)
     if not nvrs:

--- a/elliott/elliottlib/cli/rhcos_cli.py
+++ b/elliott/elliottlib/cli/rhcos_cli.py
@@ -1,7 +1,7 @@
 import click
 import json
 
-from artcommonlib.arch_util import brew_arch_for_go_arch, go_suffix_for_arch
+from artcommonlib.arch_util import brew_arch_for_go_arch, go_suffix_for_arch, BREW_ARCHES, GO_ARCHES
 from elliottlib.cli.common import cli
 from elliottlib import rhcos, util, exectools
 from artcommonlib.rhcos import get_primary_container_name
@@ -12,7 +12,7 @@ from artcommonlib.rhcos import get_primary_container_name
               help='Show details for this OCP release. Can be a full pullspec or a named release ex: 4.8.4')
 @click.option('--arch', 'arch',
               default='x86_64',
-              type=click.Choice(util.brew_arches + ['all']),
+              type=click.Choice(BREW_ARCHES + ['all']),
               help='Specify architecture. Default is x86_64. "all" to get all arches. aarch64 only works for 4.8+')
 @click.option('--packages', '-p', 'packages',
               help='Show details for only these package names (comma-separated)')
@@ -65,7 +65,7 @@ def rhcos_cli(runtime, release, packages, arch, go):
     runtime.initialize()
     major, minor = runtime.get_major_minor()
     if nightly:
-        for a in util.go_arches:
+        for a in GO_ARCHES:
             if a in release:
                 arch = a
                 break
@@ -74,7 +74,7 @@ def rhcos_cli(runtime, release, packages, arch, go):
     logger = runtime.logger
 
     if arch == 'all':
-        target_arches = util.brew_arches
+        target_arches = BREW_ARCHES
         if major == 4 and minor < 9:
             target_arches.remove("aarch64")
     else:

--- a/elliott/elliottlib/cvp.py
+++ b/elliott/elliottlib/cvp.py
@@ -12,10 +12,11 @@ from aiohttp.client_exceptions import (ClientResponseError,
 from tenacity import (before_sleep_log, retry, retry_if_exception_type,
                       stop_after_attempt, wait_exponential)
 
+from artcommonlib.arch_util import brew_arch_for_go_arch
 from elliottlib.exectools import limit_concurrency
 from elliottlib.imagecfg import ImageMetadata
 from elliottlib.resultsdb import ResultsDBAPI
-from elliottlib.util import all_same, brew_arch_for_go_arch, parse_nvr
+from elliottlib.util import all_same, parse_nvr
 
 
 class CVPInspector:

--- a/elliott/elliottlib/rhcos.py
+++ b/elliott/elliottlib/rhcos.py
@@ -1,9 +1,10 @@
 import json
 from tenacity import retry, stop_after_attempt, wait_fixed
 from urllib import request
-from elliottlib.model import ListModel
+
+from artcommonlib.arch_util import brew_suffix_for_arch
 from elliottlib import util, exectools, constants
-from artcommonlib.rhcos import get_container_configs, get_primary_container_name
+from artcommonlib.rhcos import get_primary_container_name
 
 
 def release_url(runtime, version, arch="x86_64", private=False):
@@ -28,7 +29,7 @@ def release_url(runtime, version, arch="x86_64", private=False):
     if bucket_url:
         return bucket_url
 
-    bucket_suffix = util.brew_suffix_for_arch(arch)
+    bucket_suffix = brew_suffix_for_arch(arch)
     return f"{constants.RHCOS_RELEASES_BASE_URL}/rhcos-{version}{bucket_suffix}"
 
 

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -587,21 +587,6 @@ def pretty_print_nvrs_go(go_nvr_map):
             print(pretty_nvr)
 
 
-# some of our systems refer to golang's architecture nomenclature; translate between that and brew arches
-brew_arches = ["x86_64", "s390x", "ppc64le", "aarch64"]
-brew_arch_suffixes = ["", "-s390x", "-ppc64le", "-aarch64"]
-go_arches = ["amd64", "s390x", "ppc64le", "arm64"]
-go_arch_suffixes = ["", "-s390x", "-ppc64le", "-arm64"]
-
-
-def go_arch_for_brew_arch(brew_arch: str) -> str:
-    if brew_arch in go_arches:
-        return brew_arch   # allow to already be a go arch, just keep same
-    if brew_arch in brew_arches:
-        return go_arches[brew_arches.index(brew_arch)]
-    raise Exception(f"no such brew arch '{brew_arch}' - cannot translate to golang arch")
-
-
 def chunk(a_sequence: Sequence[Any], chunk_size: int) -> List[Any]:
     for i in range(0, len(a_sequence), chunk_size):
         yield a_sequence[i:i + chunk_size]

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -602,14 +602,6 @@ def go_arch_for_brew_arch(brew_arch: str) -> str:
     raise Exception(f"no such brew arch '{brew_arch}' - cannot translate to golang arch")
 
 
-def brew_arch_for_go_arch(go_arch: str) -> str:
-    if go_arch in brew_arches:
-        return go_arch  # allow to already be a brew arch, just keep same
-    if go_arch in go_arches:
-        return brew_arches[go_arches.index(go_arch)]
-    raise Exception(f"no such golang arch '{go_arch}' - cannot translate to brew arch")
-
-
 # imagestreams and such often began without consideration for multi-arch and then
 # added a suffix everywhere to accommodate arches (but kept the legacy location for x86).
 def go_suffix_for_arch(arch: str) -> str:

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -617,11 +617,6 @@ def go_suffix_for_arch(arch: str) -> str:
     return go_arch_suffixes[go_arches.index(arch)]
 
 
-def brew_suffix_for_arch(arch: str) -> str:
-    arch = brew_arch_for_go_arch(arch)  # translate either incoming arch style
-    return brew_arch_suffixes[brew_arches.index(arch)]
-
-
 def chunk(a_sequence: Sequence[Any], chunk_size: int) -> List[Any]:
     for i in range(0, len(a_sequence), chunk_size):
         yield a_sequence[i:i + chunk_size]

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -602,13 +602,6 @@ def go_arch_for_brew_arch(brew_arch: str) -> str:
     raise Exception(f"no such brew arch '{brew_arch}' - cannot translate to golang arch")
 
 
-# imagestreams and such often began without consideration for multi-arch and then
-# added a suffix everywhere to accommodate arches (but kept the legacy location for x86).
-def go_suffix_for_arch(arch: str) -> str:
-    arch = go_arch_for_brew_arch(arch)  # translate either incoming arch style
-    return go_arch_suffixes[go_arches.index(arch)]
-
-
 def chunk(a_sequence: Sequence[Any], chunk_size: int) -> List[Any]:
     for i in range(0, len(a_sequence), chunk_size):
         yield a_sequence[i:i + chunk_size]

--- a/elliott/tests/test_find_builds_cli.py
+++ b/elliott/tests/test_find_builds_cli.py
@@ -1,10 +1,11 @@
 import unittest
-from elliottlib.cli.find_builds_cli import _filter_out_attached_builds, _find_shipped_builds
-from elliottlib.brew import Build
-from elliottlib import errata as erratalib
-from flexmock import flexmock
-import json
 from unittest import mock
+
+from flexmock import flexmock
+
+from elliottlib import errata as erratalib
+from elliottlib.brew import Build
+from elliottlib.cli.find_builds_cli import _filter_out_attached_builds, _find_shipped_builds
 
 
 class TestFindBuildsCli(unittest.TestCase):

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -11,9 +11,10 @@ from tempfile import TemporaryDirectory
 from typing import Dict, Iterable, List, Optional, Tuple, cast
 
 import click
+
+from artcommonlib.arch_util import brew_arch_for_go_arch
 from doozerlib.assembly import AssemblyTypes
-from doozerlib.util import (brew_arch_for_go_arch,
-                            isolate_nightly_name_components)
+from doozerlib.util import isolate_nightly_name_components
 from ghapi.all import GhApi
 from ruamel.yaml import YAML
 from semver import VersionInfo

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -9,6 +9,7 @@ from opentelemetry import trace
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from artcommonlib import rhcos
+from artcommonlib.arch_util import go_suffix_for_arch
 from artcommonlib.util import split_git_url
 from pyartcd.cli import cli, pass_runtime, click_coroutine
 from pyartcd.oc import registry_login
@@ -18,7 +19,6 @@ from pyartcd import exectools, constants, redis, locks
 from pyartcd.telemetry import start_as_current_span_async
 from pyartcd.util import branch_arches
 from pyartcd.jenkins import get_build_url
-from doozerlib.util import go_suffix_for_arch
 from ghapi.all import GhApi
 
 

--- a/pyartcd/pyartcd/pipelines/operator_sdk_sync.py
+++ b/pyartcd/pyartcd/pipelines/operator_sdk_sync.py
@@ -6,11 +6,12 @@ import yaml
 import click
 import koji
 from errata_tool import Erratum
+
+from artcommonlib.arch_util import brew_arch_for_go_arch
 from artcommonlib.constants import BREW_DOWNLOAD_URL, BREW_HUB
 from pyartcd import constants, util, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.runtime import Runtime
-from doozerlib.util import brew_arch_for_go_arch
 
 
 class OperatorSDKPipeline:

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -21,10 +21,10 @@ from tenacity import (RetryCallState, RetryError, retry,
                       retry_if_exception_type, retry_if_result,
                       stop_after_attempt, wait_fixed)
 
-from artcommonlib.arch_util import brew_suffix_for_arch, brew_arch_for_go_arch, go_suffix_for_arch
+from artcommonlib.arch_util import brew_suffix_for_arch, brew_arch_for_go_arch, \
+                                   go_suffix_for_arch, go_arch_for_brew_arch
 from artcommonlib.rhcos import get_primary_container_name
 from doozerlib import assembly
-from doozerlib.util import go_arch_for_brew_arch
 from pyartcd.locks import Lock
 from pyartcd.signatory import AsyncSignatory
 from pyartcd.util import nightlies_with_pullspecs

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -21,10 +21,10 @@ from tenacity import (RetryCallState, RetryError, retry,
                       retry_if_exception_type, retry_if_result,
                       stop_after_attempt, wait_fixed)
 
+from artcommonlib.arch_util import brew_suffix_for_arch
 from artcommonlib.rhcos import get_primary_container_name
 from doozerlib import assembly
-from doozerlib.util import (brew_arch_for_go_arch, brew_suffix_for_arch,
-                            go_arch_for_brew_arch, go_suffix_for_arch)
+from doozerlib.util import (brew_arch_for_go_arch, go_arch_for_brew_arch, go_suffix_for_arch)
 from pyartcd.locks import Lock
 from pyartcd.signatory import AsyncSignatory
 from pyartcd.util import nightlies_with_pullspecs

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -22,7 +22,7 @@ from tenacity import (RetryCallState, RetryError, retry,
                       stop_after_attempt, wait_fixed)
 
 from artcommonlib.arch_util import brew_suffix_for_arch, brew_arch_for_go_arch, \
-                                   go_suffix_for_arch, go_arch_for_brew_arch
+    go_suffix_for_arch, go_arch_for_brew_arch
 from artcommonlib.rhcos import get_primary_container_name
 from doozerlib import assembly
 from pyartcd.locks import Lock

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -21,10 +21,10 @@ from tenacity import (RetryCallState, RetryError, retry,
                       retry_if_exception_type, retry_if_result,
                       stop_after_attempt, wait_fixed)
 
-from artcommonlib.arch_util import brew_suffix_for_arch, brew_arch_for_go_arch
+from artcommonlib.arch_util import brew_suffix_for_arch, brew_arch_for_go_arch, go_suffix_for_arch
 from artcommonlib.rhcos import get_primary_container_name
 from doozerlib import assembly
-from doozerlib.util import (go_arch_for_brew_arch, go_suffix_for_arch)
+from doozerlib.util import go_arch_for_brew_arch
 from pyartcd.locks import Lock
 from pyartcd.signatory import AsyncSignatory
 from pyartcd.util import nightlies_with_pullspecs

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -21,10 +21,10 @@ from tenacity import (RetryCallState, RetryError, retry,
                       retry_if_exception_type, retry_if_result,
                       stop_after_attempt, wait_fixed)
 
-from artcommonlib.arch_util import brew_suffix_for_arch
+from artcommonlib.arch_util import brew_suffix_for_arch, brew_arch_for_go_arch
 from artcommonlib.rhcos import get_primary_container_name
 from doozerlib import assembly
-from doozerlib.util import (brew_arch_for_go_arch, go_arch_for_brew_arch, go_suffix_for_arch)
+from doozerlib.util import (go_arch_for_brew_arch, go_suffix_for_arch)
 from pyartcd.locks import Lock
 from pyartcd.signatory import AsyncSignatory
 from pyartcd.util import nightlies_with_pullspecs

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Dict, Optional, Tuple, Union, Iterable
 
 import yaml
+
+from artcommonlib.arch_util import go_suffix_for_arch
 from doozerlib import assembly, model
 from doozerlib import util as doozerutil
 from errata_tool import ErrataConnector
@@ -668,7 +670,7 @@ def nightlies_with_pullspecs(nightly_tags: Iterable[str]) -> Dict[str, str]:
             arch = "x86_64"
         if ":" not in nightly:
             # prepend pullspec URL to nightly name
-            arch_suffix = doozerutil.go_suffix_for_arch(arch)
+            arch_suffix = go_suffix_for_arch(arch)
             nightly = f"registry.ci.openshift.org/ocp{arch_suffix}/release{arch_suffix}:{nightly}"
         arch_nightlies[arch] = nightly
     return arch_nightlies


### PR DESCRIPTION
Move these functions from doozer/elliott into artcommon as they're duplicated:
- go_arch_for_brew_arch
- go_suffix_for_arch
- brew_arch_for_go_arch
- brew_suffix_for_arch

Also move arch names/suffixes to artcommon. Improve unit tests