### PR TITLE
Move duplicated functions to artcommon

### DIFF
--- a/artcommon/artcommonlib/build_util.py
+++ b/artcommon/artcommonlib/build_util.py
@@ -1,0 +1,45 @@
+from typing import List, Optional, Iterable, Dict
+
+from artcommonlib.release_util import isolate_assembly_in_release
+
+
+def find_latest_build(builds: List[Dict], assembly: Optional[str]) -> Optional[Dict]:
+    """ Find the latest build specific to the assembly in a list of builds belonging to the same component and brew tag
+    :param builds: a list of build dicts sorted by tagging event in descending order
+    :param assembly: the name of assembly; None if assemblies support is disabled
+    :return: a brew build dict or None
+    """
+
+    if not assembly:  # if assembly is not enabled, choose the true latest tagged
+        chosen_build = builds[0] if builds else None
+    else:  # assembly is enabled
+        # find the newest build containing ".assembly.<assembly-name>" in its RELEASE field
+        chosen_build = next((build for build in builds if isolate_assembly_in_release(build["release"]) == assembly),
+                            None)
+        if not chosen_build and assembly != "stream":
+            # If no such build, fall back to the newest build containing ".assembly.stream"
+            chosen_build = next(
+                (build for build in builds if isolate_assembly_in_release(build["release"]) == "stream"), None)
+        if not chosen_build:
+            # If none of the builds have .assembly.stream in the RELEASE field,
+            # fall back to the latest build without .assembly in the RELEASE field
+            chosen_build = next((build for build in builds if isolate_assembly_in_release(build["release"]) is None),
+                                None)
+    return chosen_build
+
+
+def find_latest_builds(brew_builds: Iterable[Dict], assembly: Optional[str]) -> Iterable[Dict]:
+    """ Find latest builds specific to the assembly in a list of brew builds.
+    :param brew_builds: a list of build dicts sorted by tagging event in descending order
+    :param assembly: the name of assembly; None if assemblies support is disabled
+    :return: an iterator of latest brew build dicts
+    """
+    # group builds by component name
+    grouped_builds = {}  # key is component_name, value is a list of Brew build dicts
+    for build in brew_builds:
+        grouped_builds.setdefault(build["name"], []).append(build)
+
+    for builds in grouped_builds.values():  # builds are ordered from newest tagged to oldest tagged
+        chosen_build = find_latest_build(builds, assembly)
+        if chosen_build:
+            yield chosen_build

--- a/artcommon/artcommonlib/release_util.py
+++ b/artcommon/artcommonlib/release_util.py
@@ -1,0 +1,51 @@
+import re
+from typing import Optional, Tuple
+
+
+def split_el_suffix_in_release(release: str) -> Tuple[str, Optional[str]]:
+    """
+    Given a release field, this will method will split out any
+    .el### or +el### suffix and return (prefix, el_suffix) where el_suffix
+    is None if there .el### is not detected.
+    """
+
+    el_suffix_match = re.match(r'(.*)[.+](el\d+)(?:.*|$)', release)
+    if el_suffix_match:
+        prefix = el_suffix_match.group(1)
+        el_suffix = el_suffix_match.group(2)
+        return prefix, el_suffix
+    else:
+        return release, None
+
+
+def isolate_assembly_in_release(release: str) -> Optional[str]:
+    """
+    Given a release field, determines whether is contains
+    an assembly name. If it does, it returns the assembly
+    name. If it is not found, None is returned.
+    """
+    assembly_prefix = '.assembly.'
+    asm_pos = release.rfind(assembly_prefix)
+    if asm_pos == -1:
+        return None
+
+    # Our rpm release fields will usually have ".el?" after ".assembly.name"
+    # But some of our base images can have ".el?" before ".assembly.name"
+    # If ".el?" appears after assembly name, then strip it off
+    el_pos = release.rfind('.el')
+    if el_pos > asm_pos:
+        release, _ = split_el_suffix_in_release(release)
+
+    return release[asm_pos + len(assembly_prefix):]
+
+
+def isolate_el_version_in_release(release: str) -> Optional[int]:
+    """
+    Given a release field, determines whether is contains
+    a RHEL version. If it does, it returns the version value as an int.
+    If it is not found, None is returned.
+    """
+    _, el_suffix = split_el_suffix_in_release(release)
+    if el_suffix:
+        return int(el_suffix[2:])
+    return None

--- a/doozer/doozerlib/cli/config_plashet.py
+++ b/doozer/doozerlib/cli/config_plashet.py
@@ -5,13 +5,15 @@ import os
 import ssl
 import sys
 import time
-import xmlrpc.client as xmlrpclib
 from types import SimpleNamespace
 from typing import Dict, List, Optional, Tuple
 
 import click
 import requests
 import yaml
+
+from artcommonlib.build_util import find_latest_builds
+from artcommonlib.release_util import isolate_el_version_in_release
 from doozerlib.rpm_utils import compare_nvr, parse_nvr
 from requests_kerberos import HTTPKerberosAuth
 
@@ -20,8 +22,7 @@ from doozerlib.exceptions import DoozerFatalError
 from doozerlib.plashet import PlashetBuilder
 from doozerlib.runtime import Runtime
 from doozerlib.brew import get_builds_tags
-from doozerlib.util import (find_latest_builds, isolate_el_version_in_brew_tag,
-                            mkdirs, strip_epoch, to_nvre, isolate_el_version_in_release)
+from doozerlib.util import (isolate_el_version_in_brew_tag, mkdirs, strip_epoch, to_nvre)
 from elliottlib import errata
 
 ERRATA_API_URL = "https://errata.engineering.redhat.com/api/v1/"

--- a/doozer/doozerlib/cli/config_tag_rpms.py
+++ b/doozer/doozerlib/cli/config_tag_rpms.py
@@ -5,6 +5,7 @@ from typing import Dict, Iterable, List, Optional, Set, Tuple, Union, cast
 import click
 import koji
 
+from artcommonlib.release_util import split_el_suffix_in_release
 from doozerlib import brew, exectools
 from doozerlib.assembly import AssemblyTypes
 from doozerlib.cli import cli, click_coroutine, pass_runtime
@@ -12,7 +13,6 @@ from doozerlib.constants import BREWWEB_URL
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.rpm_delivery import RPMDeliveries
 from doozerlib.runtime import Runtime
-from doozerlib.util import split_el_suffix_in_release
 
 
 class TagRPMsCli:

--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Optional, Set, Tuple
 import yaml
 
 from artcommonlib.arch_util import go_suffix_for_arch
+from artcommonlib.release_util import isolate_el_version_in_release
 from doozerlib import util
 from doozerlib.assembly import AssemblyTypes
 from doozerlib.cli import cli, pass_runtime, click_coroutine
@@ -421,7 +422,7 @@ class GenAssemblyCli:
                 rpm_build_nvr = ref_releases_rpm_build['nvr']
 
                 # If so, what RHEL version is this build for?
-                el_ver = util.isolate_el_version_in_release(ref_releases_rpm_build['release'])
+                el_ver = isolate_el_version_in_release(ref_releases_rpm_build['release'])
                 if not el_ver:
                     self._exit_with_error(f'Unable to isolate el? version in {rpm_build_nvr}')
 

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -27,6 +27,7 @@ from tenacity import (before_sleep_log, retry, retry_if_not_result,
 
 import doozerlib
 from artcommonlib import assertion
+from artcommonlib.release_util import isolate_assembly_in_release
 from doozerlib import constants, exectools, logutil, state, util
 from doozerlib.assembly import AssemblyTypes
 from doozerlib.brew import BuildStates
@@ -1024,7 +1025,7 @@ class ImageDistGitRepo(DistGitRepo):
                 if 'member' in builder:
                     self._set_wait_for(builder['member'], terminate_event)
 
-            if self.runtime.assembly and util.isolate_assembly_in_release(release) != self.runtime.assembly:
+            if self.runtime.assembly and isolate_assembly_in_release(release) != self.runtime.assembly:
                 # Assemblies should follow its naming convention
                 raise ValueError(f"Image {self.name} is not rebased with assembly '{self.runtime.assembly}'.")
 

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 
 import doozerlib
 from artcommonlib.arch_util import brew_arch_for_go_arch, go_arch_for_brew_arch
+from artcommonlib.release_util import isolate_el_version_in_release
 from doozerlib import brew, coverity, exectools
 from doozerlib.constants import BREWWEB_URL
 from doozerlib.distgit import pull_image
@@ -17,7 +18,6 @@ from doozerlib.model import Missing, Model
 from doozerlib.pushd import Dir
 from doozerlib.repodata import OutdatedRPMFinder, Repodata
 from doozerlib.rpm_utils import parse_nvr, to_nevra
-from doozerlib.util import isolate_el_version_in_release
 
 
 class ImageMetadata(Metadata):

--- a/doozer/doozerlib/olm/bundle.py
+++ b/doozer/doozerlib/olm/bundle.py
@@ -13,7 +13,8 @@ import yaml
 from dockerfile_parse import DockerfileParser
 from koji import ClientSession
 
-from doozerlib import brew, exectools, pushd, util
+from artcommonlib.build_util import find_latest_build
+from doozerlib import brew, exectools, pushd
 from doozerlib.runtime import Runtime
 
 
@@ -78,7 +79,7 @@ class OLMBundle(object):
             return build
         builds = list(map(lambda build: _apply_hack(build), builds))
 
-        latest_build = util.find_latest_build(builds, self.runtime.assembly)
+        latest_build = find_latest_build(builds, self.runtime.assembly)
 
         # revert the hack
         latest_build["release"] = latest_build["_release"]

--- a/doozer/doozerlib/plashet.py
+++ b/doozer/doozerlib/plashet.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from logging import Logger
 from typing import Dict, Iterable, List, Optional, Union
 
+from artcommonlib.build_util import find_latest_builds
 from doozerlib.rpm_utils import parse_nvr
 from koji import ClientSession
 
@@ -11,7 +12,7 @@ from doozerlib.brew import get_build_objects, list_archives_by_builds
 from doozerlib.image import ImageMetadata
 from doozerlib.model import Model
 from doozerlib.rpmcfg import RPMMetadata
-from doozerlib.util import find_latest_builds, strip_epoch, to_nvre
+from doozerlib.util import strip_epoch, to_nvre
 
 
 class PlashetBuilder:

--- a/doozer/doozerlib/rhcos.py
+++ b/doozer/doozerlib/rhcos.py
@@ -9,11 +9,11 @@ import koji
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from artcommonlib.arch_util import brew_suffix_for_arch
+from artcommonlib.release_util import isolate_el_version_in_release
 from doozerlib import brew, exectools, logutil
 from doozerlib.model import Model
 from doozerlib.repodata import OutdatedRPMFinder, Repodata
 from doozerlib.runtime import Runtime
-from doozerlib.util import isolate_el_version_in_release
 from artcommonlib import rhcos
 from artcommonlib.constants import RHCOS_RELEASES_BASE_URL
 

--- a/doozer/doozerlib/rpm_builder.py
+++ b/doozer/doozerlib/rpm_builder.py
@@ -11,13 +11,14 @@ from typing import Dict, List, Optional
 import aiofiles
 import aiofiles.os
 
+from artcommonlib.release_util import isolate_assembly_in_release
 from doozerlib import brew, exectools
 from doozerlib.constants import BREWWEB_URL
 from doozerlib.distgit import RPMDistGitRepo
 from doozerlib.model import Missing
 from doozerlib.rpmcfg import RPMMetadata
 from doozerlib.runtime import Runtime
-from doozerlib.util import is_in_directory, isolate_assembly_in_release
+from doozerlib.util import is_in_directory
 
 
 class RPMBuilder:

--- a/doozer/tests/test_util.py
+++ b/doozer/tests/test_util.py
@@ -6,42 +6,6 @@ from doozerlib.model import Model
 
 
 class TestUtil(unittest.TestCase):
-
-    def test_isolate_assembly_in_release(self):
-        test_cases = [
-            ('1.2.3-y.p.p1', None),
-            ('1.2.3-y.p.p1.assembly', None),
-            ('1.2.3-y.p.p1.assembly.x', 'x'),
-            ('1.2.3-y.p.p1.assembly.xyz', 'xyz'),
-            ('1.2.3-y.p.p1.assembly.xyz.el7', 'xyz'),
-            ('1.2.3-y.p.p1.assembly.4.9.99.el7', '4.9.99'),
-            ('1.2.3-y.p.p1.assembly.4.9.el700.hi', '4.9'),
-            ('1.2.3-y.p.p1.assembly.art12398.el10', 'art12398'),
-            ('1.2.3-y.p.p1.assembly.art12398.el10', 'art12398'),
-            ('1.2.3-y.el9.p1.assembly.test', 'test')
-        ]
-
-        for t in test_cases:
-            actual = util.isolate_assembly_in_release(t[0])
-            expected = t[1]
-            self.assertEqual(actual, expected)
-
-    def test_isolate_el_version_in_release(self):
-        test_cases = [
-            ('container-selinux-2.167.0-1.module+el8.5.0+12397+bf23b712:2', 8),
-            ('ansible-runner-http-1.0.0-2.el8ar', 8),
-            ('1.2.3-y.p.p1.assembly.4.9.99.el7', 7),
-            ('1.2.3-y.p.p1.assembly.4.9.el7', 7),
-            ('1.2.3-y.p.p1.assembly.art12398.el199', 199),
-            ('1.2.3-y.p.p1.assembly.art12398', None),
-            ('1.2.3-y.p.p1.assembly.4.7.e.8', None)
-        ]
-
-        for t in test_cases:
-            actual = util.isolate_el_version_in_release(t[0])
-            expected = t[1]
-            self.assertEqual(actual, expected)
-
     def test_isolate_nightly_name_components(self):
         self.assertEqual(util.isolate_nightly_name_components('4.1.0-0.nightly-2019-11-08-213727'), ('4.1', 'x86_64', False))
         self.assertEqual(util.isolate_nightly_name_components('4.1.0-0.nightly-priv-2019-11-08-213727'), ('4.1', 'x86_64', True))
@@ -71,33 +35,6 @@ class TestUtil(unittest.TestCase):
             go_arch_for_brew_arch("bogus")
         with self.assertRaises(Exception):
             brew_arch_for_go_arch("bogus")
-
-    def test_find_latest_builds(self):
-        builds = [
-            {"id": 13, "name": "a-container", "version": "v1.2.3", "release": "3.assembly.stream", "tag_name": "tag1"},
-            {"id": 12, "name": "a-container", "version": "v1.2.3", "release": "2.assembly.hotfix_a", "tag_name": "tag1"},
-            {"id": 11, "name": "a-container", "version": "v1.2.3", "release": "1.assembly.hotfix_a", "tag_name": "tag1"},
-            {"id": 23, "name": "b-container", "version": "v1.2.3", "release": "3.assembly.test", "tag_name": "tag1"},
-            {"id": 22, "name": "b-container", "version": "v1.2.3", "release": "2.assembly.hotfix_b", "tag_name": "tag1"},
-            {"id": 21, "name": "b-container", "version": "v1.2.3", "release": "1.assembly.stream", "tag_name": "tag1"},
-            {"id": 33, "name": "c-container", "version": "v1.2.3", "release": "3", "tag_name": "tag1"},
-            {"id": 32, "name": "c-container", "version": "v1.2.3", "release": "2.assembly.hotfix_b", "tag_name": "tag1"},
-            {"id": 31, "name": "c-container", "version": "v1.2.3", "release": "1", "tag_name": "tag1"},
-        ]
-        actual = util.find_latest_builds(builds, "stream")
-        self.assertEqual([13, 21, 33], [b["id"] for b in actual])
-
-        actual = util.find_latest_builds(builds, "hotfix_a")
-        self.assertEqual([12, 21, 33], [b["id"] for b in actual])
-
-        actual = util.find_latest_builds(builds, "hotfix_b")
-        self.assertEqual([13, 22, 32], [b["id"] for b in actual])
-
-        actual = util.find_latest_builds(builds, "test")
-        self.assertEqual([13, 23, 33], [b["id"] for b in actual])
-
-        actual = util.find_latest_builds(builds, None)
-        self.assertEqual([13, 23, 33], [b["id"] for b in actual])
 
     def test_isolate_timestamp_in_release(self):
         actual = util.isolate_timestamp_in_release("foo-4.7.0-202107021813.p0.g01c9f3f.el8")

--- a/elliott/elliottlib/build_finder.py
+++ b/elliott/elliottlib/build_finder.py
@@ -1,3 +1,4 @@
+from artcommonlib.build_util import find_latest_builds
 from elliottlib.imagecfg import ImageMetadata
 import logging
 from logging import Logger
@@ -9,7 +10,7 @@ from elliottlib.assembly import assembly_metadata_config, assembly_rhcos_config
 from elliottlib.brew import get_build_objects
 from elliottlib.model import Model
 from elliottlib.rpmcfg import RPMMetadata
-from elliottlib.util import find_latest_builds, parse_nvr, strip_epoch, to_nvre
+from elliottlib.util import parse_nvr, strip_epoch, to_nvre
 
 
 class BuildFinder:

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -258,50 +258,6 @@ def get_golang_version_from_build_log(log):
     return go_version
 
 
-def split_el_suffix_in_release(release: str) -> Tuple[str, Optional[str]]:
-    """
-    Given a release field, this will method will split out any
-    .el### suffix and return (prefix, el_suffix) where el_suffix
-    is None if there .el### is not detected.
-    """
-
-    el_suffix_match = re.match(r'(.*)\.(el\d+)(?:\.+|$)', release)
-    if el_suffix_match:
-        prefix = el_suffix_match.group(1)
-        el_suffix = el_suffix_match.group(2)
-        return prefix, el_suffix
-    else:
-        return release, None
-
-
-def isolate_assembly_in_release(release: str) -> str:
-    """
-    Given a release field, determines whether is contains
-    an assembly name. If it does, it returns the assembly
-    name. If it is not found, None is returned.
-    """
-    # Because RPM release fields will have .el? as their suffix, we cannot
-    # assume that endswith(.assembly.<name>). Strip off .el?
-    prefix, _ = split_el_suffix_in_release(release)
-    asm_pos = prefix.rfind('.assembly.')
-    if asm_pos == -1:
-        return None
-
-    return prefix[asm_pos + len('.assembly.'):]
-
-
-def isolate_el_version_in_release(release: str) -> Optional[int]:
-    """
-    Given a release field, determines whether is contains
-    a RHEL version. If it does, it returns the version value as an int.
-    If it is not found, None is returned.
-    """
-    _, el_suffix = split_el_suffix_in_release(release)
-    if el_suffix:
-        return int(el_suffix[2:])
-    return None
-
-
 def isolate_el_version_in_brew_tag(tag: str) -> Optional[int]:
     """
     Given a brew tag (target) name, determines whether is contains
@@ -310,44 +266,6 @@ def isolate_el_version_in_brew_tag(tag: str) -> Optional[int]:
     """
     el_version_match = re.search(r"rhel-(\d+)", tag)
     return int(el_version_match[1]) if el_version_match else None
-
-
-def find_latest_build(builds: List[Dict], assembly: Optional[str]) -> Optional[Dict]:
-    """ Find the latest build specific to the assembly in a list of builds belonging to the same component and brew tag
-    :param brew_builds: a list of build dicts sorted by tagging event in descending order
-    :param assembly: the name of assembly; None if assemblies support is disabled
-    :return: a brew build dict or None
-    """
-    chosen_build = None
-    if not assembly:  # if assembly is not enabled, choose the true latest tagged
-        chosen_build = builds[0] if builds else None
-    else:  # assembly is enabled
-        # find the newest build containing ".assembly.<assembly-name>" in its RELEASE field
-        chosen_build = next((build for build in builds if isolate_assembly_in_release(build["release"]) == assembly), None)
-        if not chosen_build and assembly != "stream":
-            # If no such build, fall back to the newest build containing ".assembly.stream"
-            chosen_build = next((build for build in builds if isolate_assembly_in_release(build["release"]) == "stream"), None)
-        if not chosen_build:
-            # If none of the builds have .assembly.stream in the RELEASE field, fall back to the latest build without .assembly in the RELEASE field
-            chosen_build = next((build for build in builds if isolate_assembly_in_release(build["release"]) is None), None)
-    return chosen_build
-
-
-def find_latest_builds(brew_builds: Iterable[Dict], assembly: Optional[str]) -> Iterable[Dict]:
-    """ Find latest builds specific to the assembly in a list of brew builds.
-    :param brew_builds: a list of build dicts sorted by tagging event in descending order
-    :param assembly: the name of assembly; None if assemblies support is disabled
-    :return: an iterator of latest brew build dicts
-    """
-    # group builds by component name
-    grouped_builds = {}  # key is component_name, value is a list of Brew build dicts
-    for build in brew_builds:
-        grouped_builds.setdefault(build["name"], []).append(build)
-
-    for builds in grouped_builds.values():  # builds are ordered from newest tagged to oldest tagged
-        chosen_build = find_latest_build(builds, assembly)
-        if chosen_build:
-            yield chosen_build
 
 
 def split_nvr_epoch(nvre):

--- a/elliott/tests/test_util.py
+++ b/elliott/tests/test_util.py
@@ -6,51 +6,6 @@ from elliottlib import brew
 
 
 class TestUtil(unittest.TestCase):
-    def test_isolate_assembly_in_release(self):
-        self.assertEqual(util.isolate_assembly_in_release('1.2.3-y.p.p1'), None)
-        self.assertEqual(util.isolate_assembly_in_release('1.2.3-y.p.p1.assembly'), None)
-        self.assertEqual(util.isolate_assembly_in_release('1.2.3-y.p.p1.assembly.x'), 'x')
-        self.assertEqual(util.isolate_assembly_in_release('1.2.3-y.p.p1.assembly.xyz'), 'xyz')
-        self.assertEqual(util.isolate_assembly_in_release('1.2.3-y.p.p1.assembly.xyz.el7'), 'xyz')
-        self.assertEqual(util.isolate_assembly_in_release('1.2.3-y.p.p1.assembly.4.9.99.el7'), '4.9.99')
-        self.assertEqual(util.isolate_assembly_in_release('1.2.3-y.p.p1.assembly.4.9.el700.hi'), '4.9')
-        self.assertEqual(util.isolate_assembly_in_release('1.2.3-y.p.p1.assembly.art12398.el10'), 'art12398')
-        self.assertEqual(util.isolate_assembly_in_release('1.2.3-y.p.p1.assembly.art12398.el10'), 'art12398')
-
-    def test_isolate_el_version_in_release(self):
-        self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.4.9.99.el7'), 7)
-        self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.4.9.el7'), 7)
-        self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.art12398.el199'), 199)
-        self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.art12398'), None)
-        self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.4.7.e.8'), None)
-
-    def test_find_latest_builds(self):
-        builds = [
-            {"id": 13, "name": "a-container", "version": "v1.2.3", "release": "3.assembly.stream", "tag_name": "tag1"},
-            {"id": 12, "name": "a-container", "version": "v1.2.3", "release": "2.assembly.hotfix_a", "tag_name": "tag1"},
-            {"id": 11, "name": "a-container", "version": "v1.2.3", "release": "1.assembly.hotfix_a", "tag_name": "tag1"},
-            {"id": 23, "name": "b-container", "version": "v1.2.3", "release": "3.assembly.test", "tag_name": "tag1"},
-            {"id": 22, "name": "b-container", "version": "v1.2.3", "release": "2.assembly.hotfix_b", "tag_name": "tag1"},
-            {"id": 21, "name": "b-container", "version": "v1.2.3", "release": "1.assembly.stream", "tag_name": "tag1"},
-            {"id": 33, "name": "c-container", "version": "v1.2.3", "release": "3", "tag_name": "tag1"},
-            {"id": 32, "name": "c-container", "version": "v1.2.3", "release": "2.assembly.hotfix_b", "tag_name": "tag1"},
-            {"id": 31, "name": "c-container", "version": "v1.2.3", "release": "1", "tag_name": "tag1"},
-        ]
-        actual = util.find_latest_builds(builds, "stream")
-        self.assertEqual([13, 21, 33], [b["id"] for b in actual])
-
-        actual = util.find_latest_builds(builds, "hotfix_a")
-        self.assertEqual([12, 21, 33], [b["id"] for b in actual])
-
-        actual = util.find_latest_builds(builds, "hotfix_b")
-        self.assertEqual([13, 22, 32], [b["id"] for b in actual])
-
-        actual = util.find_latest_builds(builds, "test")
-        self.assertEqual([13, 23, 33], [b["id"] for b in actual])
-
-        actual = util.find_latest_builds(builds, None)
-        self.assertEqual([13, 23, 33], [b["id"] for b in actual])
-
     def test_isolate_timestamp_in_release(self):
         actual = util.isolate_timestamp_in_release("foo-4.7.0-202107021813.p0.g01c9f3f.el8")
         expected = "202107021813"


### PR DESCRIPTION
Moved duplicated functions from elliott/doozer into artcommon:

- find_latest_build
- find_latest_builds
- split_el_suffix_in_release
- isolate_assembly_in_release
- isolate_el_version_in_release