### PR TITLE
[prerelease] remove operator index mode group.yml

### DIFF
--- a/doozer/doozerlib/olm/bundle.py
+++ b/doozer/doozerlib/olm/bundle.py
@@ -570,7 +570,9 @@ class OLMBundle(object):
 
     @property
     def redhat_delivery_tags(self):
-        versions = 'v{MAJOR}.{MINOR}' if self.operator_index_mode == 'ga-plus' else '=v{MAJOR}.{MINOR}'
+        # If enabling ga-plus in the future for stage push of the non-pre-release bundles
+        # versions = 'v{MAJOR}.{MINOR}' if self.operator_index_mode == 'ga-plus' else '=v{MAJOR}.{MINOR}'
+        versions = '=v{MAJOR}.{MINOR}'
 
         labels = {
             'com.redhat.delivery.operator.bundle': 'true',


### PR DESCRIPTION
Remove `operator_index_mode` from `group.yml`. We directly specify the field in assembly config during gen assembly.

Alongside https://github.com/openshift-eng/art-tools/pull/296