### PR TITLE
[scan-osh] update regex for microshift nightly

### DIFF
--- a/doozer/doozerlib/cli/scan_osh.py
+++ b/doozer/doozerlib/cli/scan_osh.py
@@ -227,7 +227,7 @@ class ScanOshCli:
         if match:
             task_id = match.group("task_id")
 
-        pattern = r"\*Build record\*: \[(?P<nvr>[a-z0-9.-]+)\|.+"
+        pattern = r"\*Build record\*: \[(?P<nvr>[a-z0-9~._-]+)\|.+"
         match = re.search(pattern=pattern, string=description)
         nvr = None
         if match:
@@ -583,6 +583,9 @@ class ScanOshCli:
             if kind == BuildType.RPM:
                 # Get the build in the currently "open" ticket
                 _, build_nvr_on_ticket = self.get_scan_details_from_ticket(description=issue.fields.description)
+
+                assert build_nvr_on_ticket is not None
+
                 build_on_ticket = self.koji_session.getBuild(build_nvr_on_ticket)
 
                 if int(build_on_ticket["build_id"]) > int(build["build_id"]):


### PR DESCRIPTION
The characters `~` and `_` need to be included since microshift nightly NVR contains it. Eg: `microshift-4.16.0~0.nightly_2024_01_05_154400-202401052128.p0.g0467b5a.assembly.microshift.el9`