### PR TITLE
support bug close status with Obsolete

### DIFF
--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -409,7 +409,7 @@ class BugValidator:
                     self._complain(message)
                 if blocker.status in ['CLOSED', 'Closed'] and \
                     blocker.resolution not in ['CURRENTRELEASE', 'NEXTRELEASE', 'ERRATA', 'DUPLICATE', 'NOTABUG', 'WONTFIX',
-                                               'Done', 'Fixed', 'Done-Errata',
+                                               'Done', 'Fixed', 'Done-Errata', 'Obsolete',
                                                'Current Release', 'Errata', 'Next Release',
                                                "Won't Do", "Won't Fix",
                                                'Duplicate', 'Duplicate Issue',


### PR DESCRIPTION
OCPBUGS-26416 status was closed with Obsolete, we should not block this with invalid status