### PR TITLE
elliott - remove builds cli

### DIFF
--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -61,6 +61,7 @@ from elliottlib.cli.find_bugs_kernel_cli import find_bugs_kernel_cli
 from elliottlib.cli.find_bugs_kernel_clones_cli import find_bugs_kernel_clones_cli
 from elliottlib.cli.move_builds_cli import move_builds_cli
 from elliottlib.cli.find_bugs_golang_cli import find_bugs_golang_cli
+from elliottlib.cli.remove_builds_cli import remove_builds_cli
 
 # 3rd party
 import click
@@ -424,6 +425,7 @@ cli.add_command(find_bugs_kernel_cli)
 cli.add_command(find_bugs_kernel_clones_cli)
 cli.add_command(move_builds_cli)
 cli.add_command(find_bugs_golang_cli)
+cli.add_command(remove_builds_cli)
 
 # -----------------------------------------------------------------------------
 # CLI Entry point

--- a/elliott/elliottlib/cli/remove_builds_cli.py
+++ b/elliott/elliottlib/cli/remove_builds_cli.py
@@ -1,0 +1,85 @@
+import click
+from errata_tool import ErrataException
+from elliottlib import Runtime, brew, errata, logutil
+from elliottlib.cli.common import (cli, find_default_advisory,
+                                   use_default_advisory_option)
+from elliottlib.util import ensure_erratatool_auth
+
+
+LOGGER = logutil.getLogger(__name__)
+
+
+@cli.command('remove-builds', short_help='Remove builds from ADVISORY')
+@click.argument('builds', metavar='<NVR_OR_ID>', nargs=-1, required=False, default=None)
+@click.option('--advisory', '-a', 'advisory_id',
+              type=int, metavar='ADVISORY',
+              help='Remove found builds from ADVISORY')
+@use_default_advisory_option
+@click.option("--all", "clean",
+              required=False,
+              default=False, is_flag=True,
+              help="Remove all builds attached to the Advisory")
+@click.option("--noop", "--dry-run",
+              is_flag=True,
+              default=False,
+              help="Don't change anything")
+@click.pass_obj
+def remove_builds_cli(runtime: Runtime, builds, advisory_id, default_advisory_type, clean, noop):
+    """Remove builds (image or rpm) from ADVISORY.
+
+    Remove builds that are attached to an advisory:
+
+\b
+    $ elliott --group openshift-4.14 remove-builds
+    openshift-enterprise-deployer-container-v4.14.0-202401121302.p0.g286cfa5.assembly.stream
+    ose-installer-container-v4.14.0-202401121302.p0.ga57f47f.assembly.stream --advisory 1234123
+
+    Remove build from default rpm advisory
+
+\b
+    $ elliott --group openshift-4.14 --assembly 4.14.9 remove-builds fmt-10.2.1-1.el9 --use-default-advisory rpm
+
+    Remove all builds from default image advisory
+
+\b
+    $ elliott --group openshift-4.14 --assembly 4.14.9 remove-builds --all --use-default-advisory image
+
+"""
+    if bool(clean) == bool(builds):
+        raise click.BadParameter("Specify either <NVRs> or --all param")
+    if bool(advisory_id) == bool(default_advisory_type):
+        raise click.BadParameter("Specify either --advisory <ADVISORY_ID> or --use-default-advisory")
+
+    runtime.initialize()
+    if default_advisory_type is not None:
+        advisory_id = find_default_advisory(runtime, default_advisory_type)
+
+    ensure_erratatool_auth()
+
+    builds_to_remove = []
+    advisory_builds = errata.get_brew_builds(advisory_id)
+
+    if builds:
+        builds_to_remove = [b.nvr for b in advisory_builds if b.nvr in builds]
+    elif clean:
+        builds_to_remove = [b.nvr for b in advisory_builds]
+
+    LOGGER.info(f"Found {len(builds_to_remove)} build(s) attached to advisory")
+    if not builds_to_remove:
+        return
+    if len(builds_to_remove) < 10:
+        LOGGER.info(builds_to_remove)
+
+    LOGGER.info(f"Removing build(s) from advisory {advisory_id} ..")
+
+    if noop:
+        LOGGER.info("[NOOP] Would've removed build(s) from advisory")
+        return
+
+    try:
+        erratum = errata.Advisory(errata_id=advisory_id)
+        erratum.ensure_state('NEW_FILES')
+        erratum.remove_builds(builds_to_remove)
+    except ErrataException as e:
+        LOGGER.error(f"Cannot change advisory {advisory_id}: {e}")
+        exit(1)

--- a/elliott/elliottlib/cli/verify_attached_operators_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_operators_cli.py
@@ -336,7 +336,7 @@ def _handle_missing_builds(
                 # attaching builds from scratch is complicated; call out to existing cli
                 ctx.invoke(find_builds_cli, advisory_id=target, default_advisory_type=None,
                            builds=missing_nvrs, kind="image", as_json=False,
-                           remove=False, clean=False, no_cdn_repos=True, payload=False,
+                           no_cdn_repos=True, payload=False,
                            non_payload=False, include_shipped=False, member_only=False)
         return True, True
     else:


### PR DESCRIPTION
## Summary
- Extract out removing builds flags from `find-builds` into `remove-builds`
- Deprecate remove flags from `find-builds`
- This follows our pattern of `attach-bugs`, `remove-bugs` and `find-bugs` being separate; reducing code paths in build sweep and cleaning it up overall, which helps in discovering and fixing issues faster
- I did not discover this flag being used in any of our pipeline code.

## Test
- `./elliott -g openshift-4.14 --assembly 4.14.9 remove-builds --all --use-default-advisory image --noop`
- NVR that is not attached to advisory - `./elliott -g openshift-4.14 --assembly 4.14.9 remove-builds openshift-enterprise-deployer-container-v4.14.0-202401121302.p0.g286cfa5.assembly.stream --use-default-advisory image --noop`
- NVR that is attached to advisory - `./elliott -g openshift-4.14 --assembly 4.14.9 remove-builds ose-tools-container-v4.14.0-202401100833.p0.g286cfa5.assembly.stream --use-default-advisory image --noop`
- find builds works as usual - `./elliott --group=openshift-4.14 --assembly 4.14.9 find-builds --kind=rpm`