### PR TITLE
ART-8688 Enable mass rebuild queue

### DIFF
--- a/artcommon/artcommonlib/redis.py
+++ b/artcommon/artcommonlib/redis.py
@@ -57,6 +57,16 @@ def handle_connection_sync(func):
 
 
 @handle_connection
+async def call(conn: redis.asyncio.client.Redis, func_name: str, *args, **kwargs):
+    """
+    Call any redis client function with opening and closing of connection auto handled
+    call('zadd', name, mapping) -> redis_connection.zadd(name, mapping)
+    """
+    func = getattr(conn, func_name)
+    return await func(*args, **kwargs)
+
+
+@handle_connection
 async def get_value(conn: redis.asyncio.client.Redis, key: str):
     """
     Returns value for a given key
@@ -101,7 +111,7 @@ def set_value_sync(conn: redis.client.Redis, key: str, value):
 @handle_connection
 async def get_keys(conn: redis.asyncio.client.Redis, pattern: str):
     """
-    Returns a list of keys (string) matching pattern (e.g. "*.count")
+    Returns a list of keys (string) matching pattern (e.g. "count*")
     """
 
     keys = await conn.keys(pattern)

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -872,10 +872,11 @@ class Ocp4Pipeline:
             if self.mass_rebuild:
                 await self._slack_client.say(
                     f':loading-correct: Enqueuing mass rebuild for {self.version.stream} :loading-correct:')
-                await locks.run_with_lock(
+                await locks.run_with_mass_rebuild_lock(
                     coro=self._rebase_and_build_images(),
                     lock=Lock.MASS_REBUILD,
                     lock_name=Lock.MASS_REBUILD.value,
+                    ocp_version=self.version.stream,
                     lock_id=self.lock_identifier
                 )
             else:


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-8688

Summary
- Store a `mass-rebuld-queue` in redis to store versions in queue. Pop it based on priority and then acquire mass rebuild  lock.
- Move to official redis client async implementation (we were using https://github.com/deepsentinel/aioredis which was a fork of https://github.com/aio-libs-abandoned/aioredis-py which moved in the official redis client). This is mainly because calling commands with params is different between these 2 and we are better off relying on official client lib.
- TODO: implement an initial wait time when lock isn't acquired

Test build
https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Focp4/33/console