### PR TITLE
[ART-8241] Add pipeline for quay backup

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/art-cd-image/base.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/art-cd-image/base.yaml
@@ -1,0 +1,26 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  labels:
+    build: art-cd
+  name: art-cd-base
+spec:
+  source:
+    dockerfile: art-cluster/apps/art-cd-image/Containerfile.base
+    git:
+      ref: master
+      uri: https://github.com/openshift-eng/aos-cd-jobs
+    type: Git
+  strategy:
+    dockerStrategy:
+      dockerfilePath: art-cluster/apps/art-cd-image/Containerfile.base
+    type: Docker
+  output:
+    to:
+      kind: ImageStreamTag
+      name: art-cd:base
+  successfulBuildsHistoryLimit: 10
+  failedBuildsHistoryLimit: 5
+  runPolicy: Serial
+  triggers:
+    - type: ConfigChange

--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/image/base.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/image/base.yaml
@@ -6,14 +6,14 @@ metadata:
   name: art-cd-base
 spec:
   source:
-    dockerfile: art-cluster/apps/art-cd-image/Containerfile.base
+    dockerfile: art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
     git:
       ref: master
-      uri: https://github.com/openshift-eng/aos-cd-jobs
+      uri: https://github.com/openshift-eng/art-tools
     type: Git
   strategy:
     dockerStrategy:
-      dockerfilePath: art-cluster/apps/art-cd-image/Containerfile.base
+      dockerfilePath: art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
     type: Docker
   output:
     to:

--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/secrets/art_quay_dev.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/secrets/art_quay_dev.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: art-publish-ci-dockerconfigjson
+spec:
+  data:
+    - remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: art/prod/openshift-release-dev+art_quay_dev@quay.io-dockerconfigjson-plaintext
+      secretKey: config.json
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: main-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: synced-art-publish-ci-dockerconfigjson
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: Opaque

--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/secrets/aws-doomsday-bucket-readonly.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/secrets/aws-doomsday-bucket-readonly.yaml
@@ -1,0 +1,28 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-doomsday-creds-readonly
+spec:
+  data:
+    - remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: art/aws-doomsday-bucket-readonly/config
+      secretKey: config
+    - remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: art/aws-doomsday-bucket-readonly/credentials
+      secretKey: credentials
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: main-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: synced-aws-doomsday-readonly
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: Opaque

--- a/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline-task.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline-task.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: doomsday-script-task
+spec:
+  params:
+    - description: 'OCP major version, eg: 4.15'
+      name: major
+      type: string
+    - description: 'Full version, eg: 4.15.5'
+      name: version
+      type: string
+  steps:
+    - env:
+        - name: DOCKER_CONFIG
+          value: /tmp/.docker
+      image: default-route-openshift-image-registry.apps.artc2023.pc3z.p1.openshiftapps.com/art-cd/art-cd:base
+      name: run-script
+      resources: {}
+      script: |
+        #!/usr/bin/env bash
+
+        set -e
+
+        mkdir -p workspace 
+        cd workspace
+
+        arches=(x86_64 s390x ppc64le aarch64 multi)
+
+        for arch in "${arches[@]}"; do
+            path=$(params.major)/$(params.version)/$arch
+            command="oc adm release mirror quay.io/openshift-release-dev/ocp-release:$(params.version)-$arch --keep-manifest-list --to-dir=$path"
+            echo "Running command: $command"
+            $command
+            sleep 5
+
+            awscommand="aws s3 sync $path s3://ocp-doomsday-registry/release-image/$path"
+            echo Running aws command: $awscommand
+            $awscommand
+            sleep 5
+
+
+            echo "Cleaning dir: $(params.major)/$(params.version)"
+            rm -rf $path
+        done
+      securityContext:
+        runAsGroup: 0
+        runAsUser: 0
+      volumeMounts:
+        - mountPath: /tmp/.docker
+          name: synced-art-publish-ci-dockerconfigjson
+        - mountPath: /root/.aws
+          name: synced-aws-doomsday-readonly
+  volumes:
+    - name: synced-art-publish-ci-dockerconfigjson
+      secret:
+        secretName: synced-art-publish-ci-dockerconfigjson
+    - name: synced-aws-doomsday-readonly
+      secret:
+        secretName: synced-aws-doomsday-readonly

--- a/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline.yaml
@@ -1,0 +1,22 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: doomsday-pipeline
+spec:
+  params:
+    - description: 'OCP major version, eg: 4.15'
+      name: major
+      type: string
+    - description: 'Full version, eg: 4.15.5'
+      name: version
+      type: string
+  tasks:
+    - name: run-script
+      params:
+        - name: major
+          value: $(params.major)
+        - name: version
+          value: $(params.version)
+      taskRef:
+        kind: Task
+        name: doomsday-script-task

--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
@@ -1,0 +1,41 @@
+FROM registry.access.redhat.com/ubi9/ubi:latest
+
+# Set metadata
+LABEL name="openshift-art/artcd-base" \
+  maintainer="OpenShift Team Automated Release Tooling <aos-team-art@redhat.com>"
+
+# Trust Red Hat IT Root CA certificates and add repos
+RUN curl -fLo /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem \
+ && curl -fLo /etc/pki/ca-trust/source/anchors/2015-IT-Root-CA.pem https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem \
+ && update-ca-trust extract
+
+# Copy repository configurations for software installations
+COPY art-cluster/data/projects/art-cd/image/files/etc/yum.repos.d /etc/yum.repos.d/
+
+# Install necessary packages and Python libraries
+RUN dnf -y install python3 python3-pip python3-wheel python3-devel gcc krb5-devel wget tar gzip git krb5-workstation \
+    brewkoji rhpkg \
+    && python3 -m pip install --upgrade setuptools pip \
+    && dnf clean all
+
+# Set ARG for OC_VERSION
+ARG OC_VERSION=latest
+
+# Install oc client
+RUN wget -O "openshift-client-linux-${OC_VERSION}.tar.gz" "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz" \
+  && tar -C /usr/local/bin -xzvf "openshift-client-linux-$OC_VERSION.tar.gz" oc kubectl
+
+RUN wget -O "awscliv2.zip" "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" \
+  && unzip awscliv2.zip &&  ./aws/install
+
+# Set workspace
+WORKDIR /home/dev
+
+# Clone art-tools into a specific directory and run the install script
+RUN git clone https://github.com/openshift-eng/art-tools.git art-tools \
+    && cd art-tools \
+    && ./install.sh
+
+# Create a non-root user and set as current
+RUN useradd -m -d /home/dev -u 1000 dev
+USER 1000

--- a/art-cluster/pipelines/data/project/art-cd/image/files/etc/yum.repos.d/pulp.repo
+++ b/art-cluster/pipelines/data/project/art-cd/image/files/etc/yum.repos.d/pulp.repo
@@ -1,0 +1,13 @@
+[pulp-dist-baseos]
+name = Dist repo - BaseOS
+baseurl = http://rhsm-pulp.corp.redhat.com/content/dist/rhel$releasever/$releasever/$basearch/baseos/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[pulp-dist-appstream]
+name = Dist repo - AppStream
+baseurl = http://rhsm-pulp.corp.redhat.com/content/dist/rhel$releasever/$releasever/$basearch/appstream/os/
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1

--- a/art-cluster/pipelines/data/project/art-cd/image/files/etc/yum.repos.d/rcm-tools.repo
+++ b/art-cluster/pipelines/data/project/art-cd/image/files/etc/yum.repos.d/rcm-tools.repo
@@ -1,0 +1,27 @@
+[rcm-tools-rhel-$releasever-baseos-rpms]
+name=RCM Tools for Red Hat Enterprise Linux $releasever BaseOS (RPMs)
+baseurl=http://download.devel.redhat.com/rel-eng/RCMTOOLS/latest-RCMTOOLS-2-RHEL-$releasever/compose/BaseOS/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=http://download.devel.redhat.com/rel-eng/RCMTOOLS/RPM-GPG-KEY-rcminternal
+
+[rcm-tools-rhel-$releasever-baseos-source-rpms]
+name=RCM Tools for Red Hat Enterprise Linux $releasever BaseOS (Source RPMs)
+baseurl=http://download.devel.redhat.com/rel-eng/RCMTOOLS/latest-RCMTOOLS-2-RHEL-$releasever/compose/BaseOS/source/tree/
+enabled=0
+gpgcheck=1
+gpgkey=http://download.devel.redhat.com/rel-eng/RCMTOOLS/RPM-GPG-KEY-rcminternal
+
+[rcm-tools-rhel-$releasever-server-optional-rpms]
+name=RCM Tools for Red Hat Enterprise Linux $releasever BaseOS - Optional (RPMs)
+baseurl=http://download.devel.redhat.com/rel-eng/RCMTOOLS/latest-RCMTOOLS-2-RHEL-$releasever/compose/BaseOS-optional/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=http://download.devel.redhat.com/rel-eng/RCMTOOLS/RPM-GPG-KEY-rcminternal
+
+[rcm-tools-rhel-$releasever-server-optional-source-rpms]
+name=RCM Tools for Red Hat Enterprise Linux $releasever BaseOS - Optional (Source RPMs)
+baseurl=http://download.devel.redhat.com/rel-eng/RCMTOOLS/latest-RCMTOOLS-2-RHEL-$releasever/compose/BaseOS-optional/source/tree/
+enabled=0
+gpgcheck=1
+gpgkey=http://download.devel.redhat.com/rel-eng/RCMTOOLS/RPM-GPG-KEY-rcminternal


### PR DESCRIPTION
For https://issues.redhat.com/browse/ART-8241

New in this PR:
- Setting art-tools as the home for our all our pipeline config, except ones that need to be kept secret, which shall remain in art-config
- New directory structure for our future pipelines
- Base image config for our future pipelines (migrating from` aos-cd-jobs/tekton-pipelines`)
- Tekton pipeline for quay backup as mentioned in the ticket including their argocd config