### PR TITLE
Pass reposync enabled repos to invocation

### DIFF
--- a/doozer/doozerlib/cli/__main__.py
+++ b/doozer/doozerlib/cli/__main__.py
@@ -223,6 +223,7 @@ def beta_reposync(runtime, output, cachedir, arch, repo_type, names, dry_run):
     """
     runtime.initialize(clone_distgits=False)
     repos = runtime.repos
+    enabled_repos = [repo for repo in repos.values() if repo.is_reposync_enabled()]
 
     yum_conf = """
 [main]
@@ -239,7 +240,7 @@ installonly_limit=3
 
     optional_fails = []
 
-    repos_content = repos.repo_file(repo_type, enabled_repos=None, arch=arch)
+    repos_content = repos.repo_file(repo_type, enabled_repos=enabled_repos, arch=arch)
     content = "{}\n\n{}".format(yum_conf, repos_content)
 
     if dry_run:


### PR DESCRIPTION
Fix `sync-for-ci`. 
Test run: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fsync-for-ci/224781/console