### PR TITLE
Allow pipeline user to trigger tekton pipelines

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/cluster-role-binding.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: triggers-pipeline-eventlistener-binding
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: art-cd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-eventlistener-roles


### PR DESCRIPTION
Should fix `Error: failed to list PipelineResources from namespace art-cd: pipelineresources.tekton.dev is forbidden: User "system:serviceaccount:art-cd:pipeline" cannot list resource "pipelineresources" in API group "tekton.dev" in the namespace "art-cd"
`