### PR TITLE
Support for reactions, :art-attention: for microshift-sync

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -176,7 +176,7 @@ class BuildMicroShiftPipeline:
                     self._logger.warning("Failed to trigger microshift_sync job: %s", err)
                     message = "@release-artists Please start <https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888" \
                               "/job/aos-cd-builds/job/build%252Fmicroshift_sync|microshift sync> manually."
-                    await self.slack_client.say_in_thread(message)
+                    await self.slack_client.say_in_thread(message, reaction=":art-attention:")
 
             # Check if microshift advisory is defined in assembly
             if 'microshift' not in advisories:

--- a/pyartcd/pyartcd/slack.py
+++ b/pyartcd/pyartcd/slack.py
@@ -50,7 +50,7 @@ class SlackClient:
         else:
             return await self.say(message, reaction, self._thread_ts)
 
-    async def say(self, message: str, reaction:  Optional[str] = None, thread_ts: Optional[str] = None):
+    async def say(self, message: str, reaction: Optional[str] = None, thread_ts: Optional[str] = None):
         attachments = []
         if self.build_url:
             attachments.append({


### PR DESCRIPTION
Changes in this PR:
- Add support for reactions in slack message
- Add `:art-attention:` for Microshift sync, until we can automatically trigger it from microshift build