### PR TITLE
bashlex uses POSIX-1834 standard

### DIFF
--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1966,7 +1966,7 @@ class ImageDistGitRepo(DistGitRepo):
                 df_lines.extend([
                     '',
                     '# RHEL version in final image must match the one in ART\'s config',
-                    f'RUN source /etc/os-release && [[ "$PLATFORM_ID" == platform:el{el_version} ]]'
+                    f'RUN source /etc/os-release && [ "$PLATFORM_ID" == platform:el{el_version} ]'
                 ])
 
             df_content = "\n".join(df_lines)


### PR DESCRIPTION
see https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/51685/consoleFull

```
>>> import bashlex


>>> bashlex.parse('[ -f abc ] && echo yes')
[ListNode(parts=[CommandNode(parts=[WordNode(parts=[] pos=(0, 1) word='['), WordNode(parts=[] pos=(2, 4) word='-f'), WordNode(parts=[] pos=(5, 8)
 word='abc'), WordNode(parts=[] pos=(9, 10) word=']')] pos=(0, 10)), OperatorNode(op='&&' pos=(11, 13)), CommandNode(parts=[WordNode(parts=[] pos
=(14, 18) word='echo'), WordNode(parts=[] pos=(19, 22) word='yes')] pos=(14, 22))] pos=(0, 22))]


>>> bashlex.parse('[[ -f abc ]] && echo yes')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jdelft/.local/lib/python3.11/site-packages/bashlex/parser.py", line 601, in parse
    parts = [p.parse()]
             ^^^^^^^^^
  File "/home/jdelft/.local/lib/python3.11/site-packages/bashlex/parser.py", line 682, in parse
    tree = theparser.parse(lexer=self.tok, context=self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jdelft/.local/lib/python3.11/site-packages/bashlex/yacc.py", line 277, in parse
    return self.parseopt_notrack(input,lexer,debug,tracking,tokenfunc,context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jdelft/.local/lib/python3.11/site-packages/bashlex/yacc.py", line 1079, in parseopt_notrack
    tok = self.errorfunc(errtoken)
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jdelft/.local/lib/python3.11/site-packages/bashlex/parser.py", line 538, in p_error
    raise errors.ParsingError('unexpected token %r' % p.value,
bashlex.errors.ParsingError: unexpected token '-f' (position 3)
```