### PR TITLE
log severity change

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -707,7 +707,7 @@ class GenPayloadCli:
                 self.logger.warning("Permitting issues only because --emergency-ignore-issues was specified")
                 self.payload_permitted = True
             else:
-                self.logger.warning("Assembly is not permitted. Will not apply changes to imagestreams.")
+                self.logger.error("Assembly is not permitted. Will not apply changes to imagestreams.")
                 self.apply = False
                 self.apply_multi_arch = False
 


### PR DESCRIPTION
when in build-sync logs, after scanning all images and doing checks the output is
permitted: false and so viable: false the job will fail and it is  misleading to have a warning here.
**WARNING Assembly is not permitted. Will not apply changes to imagestreams.**
