### PR TITLE
Use canonical builders when rhel versions match

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -151,6 +151,17 @@ def isolate_rhel_major_from_version(version: str) -> Optional[int]:
     return None
 
 
+def isolate_rhel_major_from_distgit_branch(branch: str) -> Optional[int]:
+    """
+    E.g. 'rhaos-4.16-rhel-9' => 9
+    """
+
+    match = re.fullmatch(r"^rhaos-\d+\.\d+-rhel-(\d+)", branch)
+    if match:
+        return int(match[1])
+    return None
+
+
 def get_ocp_version_from_group(group):
     """
     Extract ocp version from group value openshift-4.15 --> 4, 15

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -105,3 +105,9 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(8, util.isolate_rhel_major_from_version('8.6'))
         self.assertEqual(10, util.isolate_rhel_major_from_version('10.1'))
         self.assertEqual(None, util.isolate_rhel_major_from_version('invalid'))
+
+    def test_isolate_rhel_major_from_distgit_branch(self):
+        self.assertEqual(9, util.isolate_rhel_major_from_distgit_branch('rhaos-4.16-rhel-9'))
+        self.assertEqual(8, util.isolate_rhel_major_from_distgit_branch('rhaos-4.16-rhel-8'))
+        self.assertEqual(10, util.isolate_rhel_major_from_distgit_branch('rhaos-4.16-rhel-10'))
+        self.assertEqual(None, util.isolate_rhel_major_from_distgit_branch('invalid'))

--- a/doozer/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/doozer/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -618,7 +618,7 @@ COPY --from=builder /some/path/a /some/path/b
         get_value.return_value = '9'
         with patch('builtins.open', new_callable=mock_open) as mocked_open:
             mocked_open.return_value = io.StringIO('FROM bogus')
-            self.assertEqual('9', self.img_dg._determine_upstream_rhel_version('source-path'))
+            self.assertEqual(9, self.img_dg._determine_upstream_rhel_version('source-path'))
 
         # Not in Redis yet: parsing os-release
         get_value.return_value = None
@@ -686,7 +686,7 @@ COPY --from=builder /some/path/a /some/path/b
              'alternative_upstream': [{'when': 'el7', 'distgit': {'branch': 'rhaos-4.16-rhel-8'}}]})
         self.img_dg.upstream_intended_el_version = 8  # also valid as an integer
         self.img_dg._update_image_config()
-        self.assertFalse(self.img_dg.should_match_upstream)
+        self.assertTrue(self.img_dg.should_match_upstream)
         self.assertEqual(self.img_dg.config['distgit']['branch'], 'rhaos-4.16-rhel-9')
 
 


### PR DESCRIPTION
If there is no matching "when" clause but ART and upstream rhel versions match, apply canonical builders