### PR TITLE
Set default lock timeout to a BIG value

### DIFF
--- a/pyartcd/tests/test_locks.py
+++ b/pyartcd/tests/test_locks.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from unittest.mock import patch
 
-from pyartcd.locks import LockManager, LOCK_POLICY, Lock
+from pyartcd.locks import LockManager, LOCK_POLICY, Lock, DEFAULT_LOCK_TIMEOUT
 
 
 class TestLocks(TestCase):
@@ -10,7 +10,7 @@ class TestLocks(TestCase):
         lock_policy: dict = LOCK_POLICY[lock]
         self.assertEqual(lock_policy['retry_count'], 36000)
         self.assertEqual(lock_policy['retry_delay_min'], 0.1)
-        self.assertEqual(lock_policy['lock_timeout'], 60 * 60 * 24)
+        self.assertEqual(lock_policy['lock_timeout'], DEFAULT_LOCK_TIMEOUT)
 
     def test_lock_name(self):
         lock: Lock = Lock.BUILD


### PR DESCRIPTION
In our current locks when lock timeout is reached they silently expire, no exception is raised. This is an expected pattern in redis, the lib we use implements https://redis.io/docs/manual/patterns/distributed-locks/ and sets keys with an expiration time.

But it's unexpected for us. We've had a pattern of using BIG job-wide locks, since we started using locks in jenkins. From what I remember there was no expiry time in jenkins locks, so as long as the `lock() {do something}` ran, it kept the lock active.

We're in the middle of these 2 approaches, and bad things can happen without us noticing. 
Therefore set lock timeouts to a BIG value, effectively not relying on them (until we change our lock use pattern)