### PR TITLE
Fix rebase with a deep_merge() function

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -4,6 +4,8 @@ from artcommonlib.constants import RELEASE_SCHEDULES
 import requests
 import re
 
+from artcommonlib.model import Model
+
 
 def remove_prefix(s: str, prefix: str) -> str:
     if s.startswith(prefix):
@@ -170,3 +172,24 @@ def get_ocp_version_from_group(group):
     if not match:
         raise ValueError(f"Invalid group name: {group}")
     return int(match[1]), int(match[2])
+
+
+def deep_merge(dict1, dict2):
+    """
+    Recursively merge two dictionaries.
+
+    Returns:
+    A new dictionary with merged values.
+    """
+
+    merged = dict1.copy()
+
+    for key, value in dict2.items():
+        if isinstance(merged.get(key), dict) and isinstance(value, dict):
+            # If both values are dictionaries, merge them recursively
+            merged[key] = deep_merge(merged[key], value)
+        else:
+            # Otherwise, simply update the value
+            merged[key] = value
+
+    return merged


### PR DESCRIPTION
`util.merge_objects()` is failing when we try and merge configs during rebase, by throwing this Exception:
```
AttributeError: 'dict' object has no attribute 'move_to_end'
```

This could be solved by casting the object into an OrderedDict, still it has problems when overriding existing keys: it will not preseve tested leaves. More details in [this thread](https://redhat-internal.slack.com/archives/GDBRP5YJH/p1706796879603389?thread_ts=1706774096.594939&cid=GDBRP5YJH)