### PR TITLE
Add pipeline list role for art-cd

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/pipeline-list-role.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/pipeline-list-role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: art-cd
+  name: pipeline-list-role
+rules:
+- apiGroups: ["tekton.dev"]
+  resources: ["pipelineresources"]
+  verbs: ["list"]

--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/pipeline-list-rolebinding.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/pipeline-list-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pipeline-list-rolebinding
+  namespace: art-cd
+subjects:
+- kind: ServiceAccount
+  name: pipeline
+  namespace: art-cd
+roleRef:
+  kind: Role
+  name: pipeline-list-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
To fix error `Error: failed to list PipelineResources from namespace art-cd: pipelineresources.tekton.dev is forbidden: User "system:serviceaccount:art-cd:pipeline" cannot list resource "pipelineresources" in API group "tekton.dev" in the namespace "art-cd"`