### PR TITLE
report nothing when list of inconsistencies is empty

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -1687,6 +1687,10 @@ class PayloadGenerator:
         exclude_assembly_issues = [AssemblyIssueCode.OUTDATED_RPMS_IN_STREAM_BUILD]
 
         msgs = sorted([i.msg for i in inconsistencies if i.code not in exclude_assembly_issues])
+
+        if not msgs:
+            return {}
+
         if len(msgs) > 5:
             # an exhaustive list of the problems may be too large; that goes in the state file.
             msgs[5:] = ["(...and more)"]


### PR DESCRIPTION
in case the inconsistencies are only about  AssemblyIssueCode.OUTDATED_RPMS_IN_STREAM_BUILD the msgs will be empty