### PR TITLE
Remove go.real symlink

### DIFF
--- a/doozer/doozerlib/go.real
+++ b/doozer/doozerlib/go.real
@@ -1,1 +1,0 @@
-/usr/bin/go


### PR DESCRIPTION
This symlink prevents ArgoCD from working with art-tools repo.