### PR TITLE
Revert "[tekton] Update tekton pipeline api version"

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: doomsday-pipeline


### PR DESCRIPTION
Reverts openshift-eng/art-tools#377

Not required, since the problem was with `tkn` client on build vm. It was an old version.