### PR TITLE
Update metadata.config after merging alternative_upstream

### DIFF
--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1726,7 +1726,8 @@ class ImageDistGitRepo(DistGitRepo):
         self.should_match_upstream = True
         # Distgit branch must be changed to track the alternative one
         self.branch = self.config.distgit.branch
-        # Also update builds targets
+        # Also update metadata config
+        self.metadata.config = self.config
         self.metadata.targets = self.metadata.determine_targets()
 
     def _rebase_from_directives(self, dfp):


### PR DESCRIPTION
Brew build targets are not `alternative_upstream` aware. This should fix it:
https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/51955/console