### PR TITLE
Make sure brewroot dir exists

### DIFF
--- a/doozer/doozerlib/cli/config.py
+++ b/doozer/doozerlib/cli/config.py
@@ -444,6 +444,10 @@ def config_rhcos_src(runtime: Runtime, version, output, brew_root, arch):
         out_base_dir_path = output_path.joinpath(package_name, build_obj['version'], build_obj['release'])
         out_base_dir_path.mkdir(parents=True, exist_ok=True)
         out_src_dir = out_base_dir_path.joinpath('src')
+        if not src_dir_path.exists():
+            runtime.logger.warning(f'Failed to find RPM brewroot directory {str(src_dir_path.absolute())}')
+            continue
+
         if out_src_dir.exists():
             if out_src_dir.is_symlink():
                 runtime.logger.info(f'Output directory already contains a symlink for {package_nvr}. Skipping.')


### PR DESCRIPTION
To fix https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fpromote-assembly/998/console

doozer is expecting http://download-node-02.eng.bos.redhat.com/brewroot/packages/libgcrypt/1.10.0/10.el9_0/ to be alive but looking at http://download-node-02.eng.bos.redhat.com/brewroot/packages/libgcrypt/1.10.0/ the naming convention is little different, so skip it in that case

Test run
https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fpromote-assembly/1002/console

2024-02-07 20:36:03,843 WARNING Failed to find RPM brewroot directory /mnt/redhat/brewroot/packages/libgcrypt/1.10.0/10.el9/src