### PR TITLE
Use .el<version> suffix to find Brew builds

### DIFF
--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -462,10 +462,12 @@ class Metadata(object):
                 # Include * after pattern_suffix to tolerate:
                 # 1. Matching an unspecified RPM suffix (e.g. .el7).
                 # 2. Other release components that might be introduced later.
+                # Matching a higher number of builds to avoid getting only the wrong .el<version> one,
+                # which will be then filtered out
                 builds = koji_api.listBuilds(packageID=package_id,
                                              state=None if build_state is None else build_state.value,
                                              pattern=f'{pattern_prefix}{extra_pattern}{pattern_suffix}*{rpm_suffix}',
-                                             queryOpts={'limit': 1, 'order': '-creation_event_id'},
+                                             queryOpts={'limit': 10, 'order': '-creation_event_id'},
                                              **list_builds_kwargs)
 
                 # Ensure the suffix ends the string OR at least terminated by a '.' .

--- a/elliott/elliottlib/metadata.py
+++ b/elliott/elliottlib/metadata.py
@@ -261,10 +261,12 @@ class Metadata(object):
                 # Include * after pattern_suffix to tolerate:
                 # 1. Matching an unspecified RPM suffix (e.g. .el7).
                 # 2. Other release components that might be introduced later.
+                # Matching a higher number of builds to avoid getting only the wrong .el<version> one,
+                # which will be then filtered out
                 builds = koji_api.listBuilds(packageID=package_id,
                                              state=None if build_state is None else build_state.value,
                                              pattern=f'{pattern_prefix}{extra_pattern}{pattern_suffix}*{rpm_suffix}',
-                                             queryOpts={'limit': 1, 'order': '-creation_event_id'},
+                                             queryOpts={'limit': 10, 'order': '-creation_event_id'},
                                              **list_builds_kwargs)
 
                 # Ensure the suffix ends the string OR at least terminated by a '.' .


### PR DESCRIPTION
Follows changes in https://github.com/openshift-eng/art-tools/pull/361

Fixes error like
```
OSError: No builds detected for using prefix: 'ci-openshift-golang-builder-latest-container-v4.16.', extra_pattern: '*', assembly: 'stream', build_state: 'COMPLETE', el_target: 'None'
```
that is caused by, for example, `.el8` build being the latest one, and we're looking for el9 builds. We'll filter out the build because of [this check](https://github.com/openshift-eng/art-tools/blob/main/doozer/doozerlib/metadata.py#L483)