### PR TITLE
Set default value for release_schedules

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -111,7 +111,7 @@ def get_assembly_release_date(assembly, group):
     """
     assembly_release_date = None
     release_schedules = requests.get(f'{RELEASE_SCHEDULES}/{group}.z/?fields=all_ga_tasks', headers={'Accept': 'application/json'})
-    for release in release_schedules.json().get('all_ga_tasks', []):
+    for release in release_schedules.json()['all_ga_tasks']:
         if assembly in release['name']:
             # convert date format for advisory usage, 2024-02-13 -> 2024-Feb-13
             assembly_release_date = datetime.strptime(release['date_start'], "%Y-%m-%d").strftime("%Y-%b-%d")
@@ -129,7 +129,7 @@ def get_inflight(assembly, group):
         raise ValueError(f'Assembly release date not found for {assembly}')
     major, minor = get_ocp_version_from_group(group)
     release_schedules = requests.get(f'{RELEASE_SCHEDULES}/openshift-{major}.{minor-1}.z/?fields=all_ga_tasks', headers={'Accept': 'application/json'})
-    for release in release_schedules.json().get('all_ga_tasks', []):
+    for release in release_schedules.json()['all_ga_tasks']:
         is_future = is_future_release_date(release['date_start'])
         if is_future:
             days_diff = abs((datetime.strptime(assembly_release_date, "%Y-%b-%d") - datetime.strptime(release['date_start'], "%Y-%m-%d")).days)

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -111,7 +111,7 @@ def get_assembly_release_date(assembly, group):
     """
     assembly_release_date = None
     release_schedules = requests.get(f'{RELEASE_SCHEDULES}/{group}.z/?fields=all_ga_tasks', headers={'Accept': 'application/json'})
-    for release in release_schedules.json()['all_ga_tasks']:
+    for release in release_schedules.json().get('all_ga_tasks', []):
         if assembly in release['name']:
             # convert date format for advisory usage, 2024-02-13 -> 2024-Feb-13
             assembly_release_date = datetime.strptime(release['date_start'], "%Y-%m-%d").strftime("%Y-%b-%d")
@@ -129,7 +129,7 @@ def get_inflight(assembly, group):
         raise ValueError(f'Assembly release date not found for {assembly}')
     major, minor = get_ocp_version_from_group(group)
     release_schedules = requests.get(f'{RELEASE_SCHEDULES}/openshift-{major}.{minor-1}.z/?fields=all_ga_tasks', headers={'Accept': 'application/json'})
-    for release in release_schedules.json()['all_ga_tasks']:
+    for release in release_schedules.json().get('all_ga_tasks', []):
         is_future = is_future_release_date(release['date_start'])
         if is_future:
             days_diff = abs((datetime.strptime(assembly_release_date, "%Y-%b-%d") - datetime.strptime(release['date_start'], "%Y-%m-%d")).days)

--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -43,7 +43,7 @@ class GenAssemblyPipeline:
         self.auto_trigger_build_sync = auto_trigger_build_sync
         self.custom = custom
         self.arches = arches
-        self.in_flight = in_flight if in_flight else get_inflight(assembly, group)
+        self.in_flight = None if in_flight.lower() == "none" else get_inflight(assembly, group)
         self.previous_list = previous_list
         self.auto_previous = auto_previous
         self.pre_ga_mode = pre_ga_mode


### PR DESCRIPTION
```
  File "/mnt/workspace/jenkins/working/aos-cd-builds_build_gen-assembly/art-tools/artcommon/artcommonlib/util.py", line 127, in get_inflight
    assembly_release_date = get_assembly_release_date(assembly, group)
  File "/mnt/workspace/jenkins/working/aos-cd-builds_build_gen-assembly/art-tools/artcommon/artcommonlib/util.py", line 114, in get_assembly_release_date
    for release in release_schedules.json()['all_ga_tasks']:
KeyError: 'all_ga_tasks
```

For jenkins [job](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fgen-assembly/806/console)