### PR TITLE
build-sync: fix runtime initialization

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -122,7 +122,7 @@ read and propagate/expose this annotation in its display of the release image.
     # Initialize group config: we need this to determine the canonical builders behavior
     runtime.initialize(config_only=True)
 
-    if runtime.group_config.canonical_builders:
+    if runtime.group_config.canonical_builders_from_upstream:
         runtime.initialize(mode="both", clone_distgits=True, clone_source=False, prevent_cloning=False)
     else:
         runtime.initialize(mode="both", clone_distgits=False, clone_source=False, prevent_cloning=True)


### PR DESCRIPTION
After the introduction of `.el<version>` suffixes in Brew builds, we are getting empty builds lists after [filtering them out](https://github.com/openshift-eng/art-tools/blob/main/doozer/doozerlib/metadata.py#L485).

When doing so, `branch_el_target()` reads from the image metadata, which must be updated to use the `alternative_upstream` stanza when using canonical builders. This el target must match the one indicated by the build suffix. If we don't consider the alternative_upstream config, we'll get el9 branches (read from the image main config) for .el8 builds, and we'll filter these builds out thus not finding any.

Unfortunately, to do so we need to clone distgits and do the upstream intended rhel version check. 