### PR TITLE
ART-8684 Verify payload detects extra and shipped nvrs

### DIFF
--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -204,19 +204,17 @@ written out to summary_results.json.
     runtime.initialize()
     rhcos_images = {c['name'] for c in rhcos.get_container_configs(runtime)}
 
+    runtime.logger.info("Fetching nvrs from advisory..")
+    all_advisory_nvrs: List[tuple] = elliottlib.errata.get_all_advisory_nvrs(advisory)
+    # filter out rhcos nvrs since they are special and not auto-stitched and fetched by util.get_nvrs_from_payload
+    all_advisory_nvrs = [n for n in all_advisory_nvrs if "rhcos-" not in n[0]]
+    all_advisory_nvrs = set(all_advisory_nvrs)
+    runtime.logger.info(f"Found {len(all_advisory_nvrs)} nvrs in advisory")
+
     runtime.logger.info("Fetching nvrs from payload..")
     all_payload_nvrs = await util.get_nvrs_from_payload(payload, rhcos_images, runtime.logger)
     all_payload_nvrs = set(all_payload_nvrs)
     runtime.logger.info(f"Found {len(all_payload_nvrs)} nvrs in payload")
-
-    runtime.logger.info("Fetching nvrs from advisory..")
-    all_advisory_nvrs = elliottlib.errata.get_all_advisory_nvrs(advisory)
-
-    # filter out rhcos nvrs since they are special and not auto-stitched and fetched by util.get_nvrs_from_payload
-    all_advisory_nvrs = [n for n in all_advisory_nvrs if "rhcos-" not in n[0]]
-
-    all_advisory_nvrs = set(all_advisory_nvrs)
-    runtime.logger.info(f"Found {len(all_advisory_nvrs)} nvrs in advisory")
 
     missing_in_advisory = all_payload_nvrs - all_advisory_nvrs
     extra_in_advisory = all_advisory_nvrs - all_payload_nvrs

--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -226,7 +226,7 @@ written out to summary_results.json.
     in_shipped_advisory = set()
     attached_but_shipped_or_pending = set()
 
-    runtime.logger.info(f"Checking if any payload nvrs that are attached have been shipped...")
+    runtime.logger.info("Checking if any payload nvrs that are attached have been shipped...")
     for nvr_tuple in all_payload_nvrs & all_advisory_nvrs:
         nvr = "-".join(nvr_tuple)
         build = elliottlib.errata.get_brew_build(nvr)

--- a/elliott/elliottlib/cli/find_bugs_golang_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_golang_cli.py
@@ -262,8 +262,7 @@ class FindBugsGolangCli:
         if not self.go_nvr_map:
             self._logger.info(f"Fetching go build nvrs for {self.pullspec}...")
             rhcos_images = {c['name'] for c in get_container_configs(self._runtime)}
-            nvr_map = await get_nvrs_from_payload(self.pullspec, rhcos_images)
-            nvrs = [(n, vr_tuple[0], vr_tuple[1]) for n, vr_tuple in nvr_map.items()]
+            nvrs = await get_nvrs_from_payload(self.pullspec, rhcos_images)
             self.go_nvr_map = get_golang_container_nvrs(nvrs, self._logger)
 
         if fixed_in_nvr:

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -273,7 +273,7 @@ def get_assembly_bug_ids(runtime, bug_tracker_type):
 
 
 def categorize_bugs_by_type(bugs: List[Bug], advisory_id_map: Dict[str, int],
-                            permitted_bug_ids, operator_bundle_advisory: str = "metadata",
+                            permitted_bug_ids=None, operator_bundle_advisory: str = "metadata",
                             permissive=False, major_version: int = 4):
     issues = []
 

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -343,8 +343,8 @@ def categorize_bugs_by_type(bugs: List[Bug], advisory_id_map: Dict[str, int],
         advisory = advisory_id_map.get(kind)
         if not advisory:
             continue
-        attached_builds = errata.get_advisory_nvrs(advisory)
-        packages = list(attached_builds.keys())
+        attached_builds = errata.get_all_advisory_nvrs(advisory)
+        packages = set(b[0] for b in attached_builds)
         exception_packages = []
         if kind == 'image':
             # golang builder is a special tracker component

--- a/elliott/elliottlib/cli/get_golang_versions_cli.py
+++ b/elliott/elliottlib/cli/get_golang_versions_cli.py
@@ -140,8 +140,7 @@ def print_advisory_golang(advisory_id, components, output, report):
 
 
 async def print_release_golang(pullspec, rhcos_images, components, output, report):
-    nvr_map = await util.get_nvrs_from_payload(pullspec, rhcos_images, _LOGGER)
-    nvrs = [(n, vr_tuple[0], vr_tuple[1]) for n, vr_tuple in nvr_map.items()]
+    nvrs = await util.get_nvrs_from_payload(pullspec, rhcos_images, _LOGGER)
     _LOGGER.debug(f'{len(nvrs)} builds found in {pullspec}')
     if not nvrs:
         _LOGGER.debug('No golang builds found. exiting')

--- a/elliott/elliottlib/errata.py
+++ b/elliott/elliottlib/errata.py
@@ -592,7 +592,7 @@ def get_advisory_builds(advisory, session=None):
     return advisory_builds
 
 
-def get_all_advisory_nvrs(advisory):
+def get_all_advisory_nvrs(advisory) -> List[tuple]:
     """
     :return: list of tuples (name, version, release)
     """

--- a/elliott/elliottlib/errata.py
+++ b/elliott/elliottlib/errata.py
@@ -592,32 +592,6 @@ def get_advisory_builds(advisory, session=None):
     return advisory_builds
 
 
-def get_advisory_nvrs(advisory):
-    """
-    :return: dict, with keys as package names and values as strs in the form: '{version}-{release}'
-    """
-    try:
-        builds = get_builds(advisory)
-    except exceptions.ErrataToolError as ex:
-        raise exceptions.ElliottFatalError(getattr(ex, 'message', repr(ex)))
-
-    all_advisory_nvrs = {}
-    # Results come back with top level keys which are brew tags
-    for tag in builds.keys():
-        # Each top level has a key 'builds' which is a list of dicts
-        for build in builds[tag]['builds']:
-            # Each dict has a top level key which might be the actual
-            # 'nvr' but I don't have enough data to know for sure
-            # yet. Also I don't know when there might be more than one
-            # key in the build dict. We'll loop over it to be sure.
-            for name in build.keys():
-                n, v, r = name.rsplit('-', 2)
-                version_release = "{}-{}".format(v, r)
-                all_advisory_nvrs[n] = version_release
-
-    return all_advisory_nvrs
-
-
 def get_all_advisory_nvrs(advisory):
     """
     :return: list of tuples (name, version, release)

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -508,7 +508,7 @@ async def get_nvrs_from_payload(pullspec, rhcos_images, logger=None):
         if logger:
             logger.info(msg)
 
-    all_payload_nvrs = {}
+    all_payload_nvrs = []
     log("Fetching release info...")
     release_export_cmd = f'oc adm release info {pullspec} -o json'
 
@@ -549,5 +549,5 @@ async def get_nvrs_from_payload(pullspec, rhcos_images, logger=None):
         component = labels['com.redhat.component']
         v = labels['version']
         r = labels['release']
-        all_payload_nvrs[component] = (v, r)
+        all_payload_nvrs.append((component, v, r))
     return all_payload_nvrs

--- a/elliott/tests/test_find_bugs_sweep_cli.py
+++ b/elliott/tests/test_find_bugs_sweep_cli.py
@@ -281,15 +281,15 @@ class TestCategorizeBugsByType(unittest.TestCase):
             flexmock(id='OCPBUGS-4', is_tracker_bug=lambda: False, is_invalid_tracker_bug=lambda: False, component='MicroShift'),
         ]
         builds_map = {
-            'image': {bugs[2].whiteboard_component: None},
-            'rpm': {bugs[1].whiteboard_component: None},
-            'extras': {bugs[0].whiteboard_component: None},
-            'microshift': dict(),
+            'image': [(bugs[2].whiteboard_component, 'version', 'release')],
+            'rpm': [(bugs[1].whiteboard_component, 'version', 'release')],
+            'extras': [(bugs[0].whiteboard_component, 'version', 'release')],
+            'microshift': [],
         }
 
         flexmock(sweep_cli).should_receive("extras_bugs").and_return({bugs[3]})
         for kind in advisory_id_map.keys():
-            flexmock(errata).should_receive("get_advisory_nvrs").with_args(advisory_id_map[kind]).and_return(
+            flexmock(errata).should_receive("get_all_advisory_nvrs").with_args(advisory_id_map[kind]).and_return(
                 builds_map[kind])
         expected = {
             'rpm': {bugs[1].id},
@@ -299,7 +299,8 @@ class TestCategorizeBugsByType(unittest.TestCase):
             'microshift': {bugs[4].id},
         }
 
-        queried, issues = categorize_bugs_by_type(bugs, advisory_id_map, 4, operator_bundle_advisory="metadata")
+        queried, issues = categorize_bugs_by_type(bugs, advisory_id_map, major_version=4,
+                                                  operator_bundle_advisory="metadata")
         self.assertEqual(issues, [])
         for adv in queried:
             actual = set()
@@ -312,7 +313,7 @@ class TestCategorizeBugsByType(unittest.TestCase):
         advisory_id_map = {'image': 1, 'rpm': 2, 'extras': 3, 'microshift': 4}
         flexmock(sweep_cli).should_receive("extras_bugs").and_return({bugs[0]})
         with self.assertRaisesRegex(ElliottFatalError, 'look like CVE trackers'):
-            categorize_bugs_by_type(bugs, advisory_id_map, 4, operator_bundle_advisory="metadata")
+            categorize_bugs_by_type(bugs, advisory_id_map, major_version=4, operator_bundle_advisory="metadata")
 
 
 class TestGenAssemblyBugIDs(unittest.TestCase):

--- a/elliott/tests/test_get_golang_versions_cli.py
+++ b/elliott/tests/test_get_golang_versions_cli.py
@@ -59,7 +59,7 @@ class TestGetGolangVersionsCli(unittest.IsolatedAsyncioTestCase):
     def test_get_golang_versions_release(self, mock_get_nvrs_from_payload: AsyncMock):
         runner = CliRunner()
         flexmock(Runtime).should_receive("initialize").and_return(None)
-        payload_nvrs = {'ose-cli-container': ('3.0.1', '6.el8')}
+        payload_nvrs = [('ose-cli-container', '3.0.1', '6.el8')]
         go_map = {'1.15': {('ose-cli-container', '3.0.1', '6.el8')}}
 
         logger = get_golang_versions_cli._LOGGER

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -595,13 +595,13 @@ class PrepareReleasePipeline:
         _LOGGER.info("Running command: %s", cmd)
         subprocess.run(cmd, check=True, universal_newlines=True, cwd=self.working_dir)
         # elliott verify-payload always writes results to $cwd/"summary_results.json".
-        # move it to a different location to avoid overwritting the result.
+        # move it to a different location to avoid overwriting the result.
         results_path = self.working_dir / "summary_results.json"
         new_path = self.working_dir / f"verify-payload-results-{pullspec.split(':')[-1]}.json"
         shutil.move(results_path, new_path)
         with open(new_path, "r") as f:
             results = json.load(f)
-            if results.get("missing_in_advisory") or results.get("payload_advisory_mismatch"):
+            if results.get("missing_in_advisory") or results.get("extra_in_advisory") or results.get("attached_but_shipped_or_pending"):
                 raise ValueError(f"""Failed to verify payload for nightly {pullspec}.
 Please fix advisories and nightlies to match each other, manually verify them with `elliott verify-payload`,
 update JIRA accordingly, then notify QE and multi-arch QE for testing.""")


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/ART-8684

Test 
```
./elliott --group=openshift-4.15 --assembly rc.6 verify-payload registry.ci.openshift.org/ocp/release:4.15.0-0.nightly-2024-02-07-062935 123983
2024-02-13 21:58:51,328 INFO Cloning config data from https://github.com/openshift-eng/ocp-build-data.git
2024-02-13 21:58:52,558 INFO Using branch from group.yml: rhaos-4.15-rhel-8
2024-02-13 21:58:52,559 INFO Constraining brew event to assembly basis for rc.6: 56190631
2024-02-13 21:58:52,559 INFO Fetching nvrs from payload..
2024-02-13 21:58:52,559 INFO Fetching release info...
2024-02-13 21:58:53,932 INFO Looping over payload images...
2024-02-13 21:58:53,932 INFO 191 images to check
2024-02-13 21:58:53,932 INFO Querying image infos...
2024-02-13 21:58:58,344 INFO Skipping rhcos image machine-os-content
2024-02-13 21:58:58,355 INFO Skipping rhcos image rhel-coreos
2024-02-13 21:58:58,356 INFO Skipping rhcos image rhel-coreos-extensions
2024-02-13 21:58:58,359 INFO Found 188 nvrs in payload
2024-02-13 21:58:58,359 INFO Fetching nvrs from advisory..
2024-02-13 21:59:12,293 INFO Found 181 nvrs in advisory
2024-02-13 21:59:12,294 INFO Extra in advisory 0
2024-02-13 21:59:12,294 INFO Checking if any payload nvrs that are attached have been shipped...
2024-02-13 22:01:36,876 INFO Checking if 7 missing images are shipped...
2024-02-13 22:01:42,637 INFO Missing in advisory 0
Summary results:
{
    "missing_in_advisory": [],
    "extra_in_advisory": [],
    "in_pending_advisory": [
        "ironic-rhcos-downloader-container-v4.15.0-202402021808.p0.gbcbcd95.assembly.stream"
    ],
    "in_shipped_advisory": [
        "csi-livenessprobe-container-v4.15.0-202401290854.p0.g240bb8c.assembly.stream",
        "csi-node-driver-registrar-container-v4.15.0-202401290854.p0.g9005584.assembly.stream",
        "csi-provisioner-container-v4.15.0-202401290854.p0.gce5a1a3.assembly.stream",
        "kube-rbac-proxy-container-v4.15.0-202401290854.p0.ge8e8c84.assembly.stream",
        "ose-csi-external-resizer-container-v4.15.0-202401290854.p0.g3b4236d.assembly.stream",
        "ose-csi-external-snapshotter-container-v4.15.0-202401261531.p0.g090cd57.assembly.stream"
    ],
    "attached_but_shipped_or_pending": []
}
Wrote out summary results: summary_results.json

```

