### PR TITLE
Update validator

### DIFF
--- a/ocp-build-data-validator/validator/json_schemas/image_content.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_content.base.schema.json
@@ -21,7 +21,6 @@
         "ci_alignment": {
           "type": "object",
           "properties": {
-            "enabled-": {},
             "final_user": {
               "description": "Parameter for the transform Dockerfile to set this user when complete",
               "oneOf": [

--- a/ocp-build-data-validator/validator/json_schemas/image_content.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_content.base.schema.json
@@ -21,16 +21,6 @@
         "ci_alignment": {
           "type": "object",
           "properties": {
-            "enabled": {
-              "description": "Whether to enable CI alignment. Default value: true",
-              "type": "boolean"
-            },
-            "enabled?": {
-              "$ref": "#/properties/source/properties/ci_alignment/properties/enabled"
-            },
-            "enabled!": {
-              "$ref": "#/properties/source/properties/ci_alignment/properties/enabled"
-            },
             "enabled-": {},
             "final_user": {
               "description": "Parameter for the transform Dockerfile to set this user when complete",


### PR DESCRIPTION
Current schema allows `ci_alignment.enabled` property, which is misleading as setting it to False will not prevent CI alignment PRs to be created.

Follows https://github.com/openshift-eng/ocp-build-data/pull/4356