### PR TITLE
[ART-8912] Skip ocp-build-data for pr in build feature

### DIFF
--- a/doozer/doozerlib/comment_on_pr.py
+++ b/doozer/doozerlib/comment_on_pr.py
@@ -97,6 +97,11 @@ class CommentOnPr:
 
     def run(self):
         self.set_repo_details()
+
+        if self.repo == "ocp-build-data":
+            LOGGER.warning("Skipping commenting on PRs in ocp-build-data")
+            return
+
         self.set_github_client()
         self.set_pr_from_commit()
 


### PR DESCRIPTION
Since PR in build feature was intended for upstream repos, skipping ocp-build-data, for comments like this [one](https://github.com/openshift-eng/ocp-build-data/pull/4386#issuecomment-1941647714).