### PR TITLE
Use multiple search patterns when looking for builds

### DIFF
--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -459,16 +459,24 @@ class Metadata(object):
                 raise IOError(msg)
 
             def latest_build_list(pattern_suffix):
-                # Include * after pattern_suffix to tolerate:
-                # 1. Matching an unspecified RPM suffix (e.g. .el7).
-                # 2. Other release components that might be introduced later.
-                # Matching a higher number of builds to avoid getting only the wrong .el<version> one,
-                # which will be then filtered out
+                # Include * after pattern_suffix to tolerate other release components that might be introduced later.
+                # Also include a .el<version> suffix to match the new build pattern
+                rhel_pattern = f'{pattern_prefix}{extra_pattern}{pattern_suffix}.el{el_target}*'
                 builds = koji_api.listBuilds(packageID=package_id,
                                              state=None if build_state is None else build_state.value,
-                                             pattern=f'{pattern_prefix}{extra_pattern}{pattern_suffix}*{rpm_suffix}',
-                                             queryOpts={'limit': 10, 'order': '-creation_event_id'},
+                                             pattern=rhel_pattern,
+                                             queryOpts={'limit': 1, 'order': '-creation_event_id'},
                                              **list_builds_kwargs)
+
+                # If no builds were found, the component might still be following the old pattern,
+                # where a .el suffix was not included in the NVR
+                if not builds:
+                    legacy_pattern = f'{pattern_prefix}{extra_pattern}{pattern_suffix}*{rpm_suffix}'
+                    builds = koji_api.listBuilds(packageID=package_id,
+                                                 state=None if build_state is None else build_state.value,
+                                                 pattern=legacy_pattern,
+                                                 queryOpts={'limit': 1, 'order': '-creation_event_id'},
+                                                 **list_builds_kwargs)
 
                 # Ensure the suffix ends the string OR at least terminated by a '.' .
                 # This latter check ensures that 'assembly.how' doesn't match a build from

--- a/elliott/elliottlib/metadata.py
+++ b/elliott/elliottlib/metadata.py
@@ -258,16 +258,24 @@ class Metadata(object):
                 raise IOError(msg)
 
             def latest_build_list(pattern_suffix):
-                # Include * after pattern_suffix to tolerate:
-                # 1. Matching an unspecified RPM suffix (e.g. .el7).
-                # 2. Other release components that might be introduced later.
-                # Matching a higher number of builds to avoid getting only the wrong .el<version> one,
-                # which will be then filtered out
+                # Include * after pattern_suffix to tolerate other release components that might be introduced later.
+                # Also include a .el<version> suffix to match the new build pattern
+                rhel_pattern = f'{pattern_prefix}{extra_pattern}{pattern_suffix}.el{el_target}*'
                 builds = koji_api.listBuilds(packageID=package_id,
                                              state=None if build_state is None else build_state.value,
-                                             pattern=f'{pattern_prefix}{extra_pattern}{pattern_suffix}*{rpm_suffix}',
-                                             queryOpts={'limit': 10, 'order': '-creation_event_id'},
+                                             pattern=rhel_pattern,
+                                             queryOpts={'limit': 1, 'order': '-creation_event_id'},
                                              **list_builds_kwargs)
+
+                # If no builds were found, the component might still be following the old pattern,
+                # where a .el suffix was not included in the NVR
+                if not builds:
+                    legacy_pattern = f'{pattern_prefix}{extra_pattern}{pattern_suffix}*{rpm_suffix}'
+                    builds = koji_api.listBuilds(packageID=package_id,
+                                                 state=None if build_state is None else build_state.value,
+                                                 pattern=legacy_pattern,
+                                                 queryOpts={'limit': 1, 'order': '-creation_event_id'},
+                                                 **list_builds_kwargs)
 
                 # Ensure the suffix ends the string OR at least terminated by a '.' .
                 # This latter check ensures that 'assembly.how' doesn't not match a build from


### PR DESCRIPTION
Fixes https://github.com/openshift-eng/art-tools/pull/402. Using `branch_el_target()` go compose the search pattern lead to an error, as this is drawn from group.yml and can differ from the actual rhel target we're interested in. So for example in 4.14 it was always finding el8 builds for `openshift-clients`, that in turn has both rhel 8 and 9 build targets.