### PR TITLE
Fix rhel pattern when None

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -174,7 +174,7 @@ class ImageMetadata(Metadata):
     def pull_url(self):
         # Don't trust what is the Dockerfile for version & release. This field may not even be present.
         # Query brew to find the most recently built release for this component version.
-        _, version, release = self.get_latest_build_info()
+        _, version, release = self.get_latest_build_info(el_target=self.branch_el_target())
 
         # we need to pull images from proxy if 'brew_image_namespace' is enabled:
         # https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/pulling_pre_quay_switch_over_osbs_built_container_images_using_the_osbs_registry_proxy

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -461,7 +461,7 @@ class Metadata(object):
             def latest_build_list(pattern_suffix):
                 # Include * after pattern_suffix to tolerate other release components that might be introduced later.
                 # Also include a .el<version> suffix to match the new build pattern
-                rhel_pattern = f'{pattern_prefix}{extra_pattern}{pattern_suffix}.el{el_target}*'
+                rhel_pattern = f'{pattern_prefix}{extra_pattern}{pattern_suffix}.el{el_target or ""}*'
                 builds = koji_api.listBuilds(packageID=package_id,
                                              state=None if build_state is None else build_state.value,
                                              pattern=rhel_pattern,

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -461,7 +461,7 @@ class Metadata(object):
             def latest_build_list(pattern_suffix):
                 # Include * after pattern_suffix to tolerate other release components that might be introduced later.
                 # Also include a .el<version> suffix to match the new build pattern
-                rhel_pattern = f'{pattern_prefix}{extra_pattern}{pattern_suffix}.el{el_target or ""}*'
+                rhel_pattern = f'{pattern_prefix}{extra_pattern}{pattern_suffix}.{f"el{el_target}" if el_target else ""}*'
                 builds = koji_api.listBuilds(packageID=package_id,
                                              state=None if build_state is None else build_state.value,
                                              pattern=rhel_pattern,


### PR DESCRIPTION
Fix for https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/scheduled-builds/job/sync-ci-images/94192/
`OSError: No builds detected for using prefix: 'ci-openshift-golang-builder-latest-container-v4.16.', extra_pattern: '*', assembly: 'stream', build_state: 'COMPLETE', el_target: 'None'`

Test
`doozer --assembly stream --group openshift-4.16  images:streams gen-buildconfigs -o test.yml`