### PR TITLE
Honor canonical builders from upstream in gen-assembly

### DIFF
--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -69,8 +69,13 @@ async def gen_assembly_from_releases(ctx, runtime: Runtime, nightlies: Tuple[str
                                      auto_previous: bool, graph_url: Optional[str], graph_content_stable: Optional[str],
                                      graph_content_candidate: Optional[str], suggestions_url: Optional[str],
                                      output_file: Optional[str]):
+    # Initialize group config: we need this to determine the canonical builders behavior
+    runtime.initialize(config_only=True)
 
-    runtime.initialize(mode='both', clone_distgits=False, clone_source=False, prevent_cloning=True)
+    if runtime.group_config.canonical_builders_from_upstream:
+        runtime.initialize(mode="both", clone_distgits=True, clone_source=False, prevent_cloning=False)
+    else:
+        runtime.initialize(mode='both', clone_distgits=False, clone_source=False, prevent_cloning=True)
 
     assembly_def = await GenAssemblyCli(
         runtime=runtime,


### PR DESCRIPTION
Same as https://github.com/openshift-eng/art-tools/pull/395, for `release:gen-assembly`