### PR TITLE
Fix elliott find-builds

### DIFF
--- a/doozer/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/doozer/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -610,8 +610,8 @@ COPY --from=builder /some/path/a /some/path/b
         self.assertEqual(actual["remote_sources"][0]["remote_source"]["pkg_managers"], ["gomod"])
         self.assertEqual(actual["remote_sources"][0]["remote_source"]["flags"], ["gomod-vendor-check"])
 
-    @patch('doozerlib.distgit.datetime')
-    @patch('doozerlib.distgit.ReleaseSchedule')
+    @patch('artcommonlib.build_util.datetime')
+    @patch('artcommonlib.build_util.ReleaseSchedule')
     def test_canonical_builders_enabled(self, release_schedule, mock_datetime):
         # canonical_builders_from_upstream not defined
         self.img_dg.config.canonical_builders_from_upstream = Missing

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -330,7 +330,10 @@ async def _fetch_builds_by_kind_image(runtime: Runtime, tag_pv_map: Dict[str, st
         'Generating list of images: ',
         f'Hold on a moment, fetching Brew builds for {len(image_metas)} components...')
 
-    brew_latest_builds: List[Dict] = await asyncio.gather(*[exectools.to_thread(progress_func, image.get_latest_build) for image in image_metas])
+    tasks = [exectools.to_thread(
+        progress_func,
+        functools.partial(image.get_latest_build, el_target=image.branch_el_target())) for image in image_metas]
+    brew_latest_builds: List[Dict] = list(await asyncio.gather(*tasks))
 
     _ensure_accepted_tags(brew_latest_builds, brew_session, tag_pv_map)
     shipped = set()

--- a/elliott/elliottlib/metadata.py
+++ b/elliott/elliottlib/metadata.py
@@ -4,6 +4,7 @@ from builtins import object
 from typing import Any, Optional, Tuple, Union, List
 
 import yaml
+from artcommonlib import build_util
 
 from artcommonlib import logutil
 from artcommonlib.assembly import assembly_basis_event, assembly_metadata_config
@@ -257,9 +258,26 @@ class Metadata(object):
                 raise IOError(msg)
 
             def latest_build_list(pattern_suffix):
+                nonlocal el_target
+
+                if self.meta_type == 'image':
+                    # For pre-releases, if canonical builders are enabled and alternative_upstream config is defined,
+                    # consider rhel 8 as the normal build target. Even if this is an approximation, it is very realistic
+                    # that the alternative config is downgrading the image to rhelX-1 while upstream aligns to ART's
+                    # desires, and with this assumption we'll avoid attaching outdated builds to the advisories
+                    if self.config.canonical_builders_from_upstream is not Missing:
+                        canonical_builders_from_upstream = self.config.canonical_builders_from_upstream
+                    else:
+                        canonical_builders_from_upstream = self.runtime.group_config.canonical_builders_from_upstream
+
+                    if build_util.canonical_builders_enabled(canonical_builders_from_upstream, self.runtime) and \
+                            self.config.alternative_upstream is not Missing:
+                        el_target = self.branch_el_target() - 1
+                el_suffix = f'.el{el_target}' if el_target else ''
+
                 # Include * after pattern_suffix to tolerate other release components that might be introduced later.
                 # Also include a .el<version> suffix to match the new build pattern
-                rhel_pattern = f'{pattern_prefix}{extra_pattern}{pattern_suffix}.el{el_target}*'
+                rhel_pattern = f'{pattern_prefix}{extra_pattern}{pattern_suffix}.{el_suffix}*'
                 builds = koji_api.listBuilds(packageID=package_id,
                                              state=None if build_state is None else build_state.value,
                                              pattern=rhel_pattern,
@@ -277,7 +295,7 @@ class Metadata(object):
                                                  **list_builds_kwargs)
 
                 # Ensure the suffix ends the string OR at least terminated by a '.' .
-                # This latter check ensures that 'assembly.how' doesn't not match a build from
+                # This latter check ensures that 'assembly.how' doesn't match a build from
                 # "assembly.howdy'.
                 refined = [b for b in builds if b['nvr'].endswith(pattern_suffix) or f'{pattern_suffix}.' in b['nvr']]
 
@@ -286,15 +304,15 @@ class Metadata(object):
                 # all image NVRs will possess .el? . Nonetheless, we want to filter down the list to the desired el
                 # version, if they do.
                 if self.meta_type == 'image':
-                    image_el_ver = f'.el{self.branch_el_target()}'
+                    image_el_ver = f'.el{el_target}'
                     # Ensure the suffix ends the string OR at least terminated by a '.' .
                     el_refined = [b for b in refined if b['nvr'].endswith(image_el_ver) or f'{image_el_ver}.' in b['nvr']]
                     if el_refined:
                         # if there were any images which had .el?, prefer them over the non-qualified.
                         refined = el_refined
                     else:
-                        # Everything was eliminated when elX was required (where X is our target).
-                        # So at least filter out those which possess elY where X != Y
+                        # Everything was eliminated when elX was included. So at least filter out those which possess elY
+                        # where X != Y
                         el_pattern = re.compile(r'.*\.el\d+.*')
                         refined = [b for b in refined if not el_pattern.match(b['nvr'])]
 


### PR DESCRIPTION
For pre-releases, canonical builders will be enabled and `alternative_upstream` configs will be defined for many components. This feature requires distgits to be cloned (discussion [here](https://redhat-internal.slack.com/archives/C06625LHXQS/p1708975115881139?thread_ts=1708610009.547359&cid=C06625LHXQS)) in order to take the alternative_upstream into consideration, but Elliott knows nothing about them and it is not trivial to teach him.

As an alternative, we can hack `find-builds` like this: if canonical builders are enabled and `alternative_upstream` is defined for an image, it most likely means that upstream is behind ART's main config with respect to the rhel target. Therefore, when looking for builds, Elliott can consider a downgraded (-1) rhel target to find, for example, `.el8` builds instead of the el9 it normally would.

Tested with:
```
$ elliott --group=openshift-4.16 --assembly=stream --rpms=openshift-clients find-builds --kind=rpm --member-only
openshift-clients-4.16.0-202402272209.p0.g91ba77a.assembly.stream.el8
openshift-clients-4.16.0-202402272209.p0.g91ba77a.assembly.stream.el9

$ elliott --group=openshift-4.16 --assembly=stream --images=azure-file-csi-driver-operator find-builds --kind=image --payload
ose-azure-file-csi-driver-operator-container-v4.16.0-202402281710.p0.g74590de.assembly.stream.el9

$ elliott --group=openshift-4.16 --assembly=stream --images=csi-livenessprobe find-builds --kind=image --payload
csi-livenessprobe-container-v4.16.0-202403010139.p0.ga5a99fc.assembly.stream.el8
```