### PR TITLE
Tag rpms spam on a schedule

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -1,4 +1,4 @@
-from typing import OrderedDict, Optional
+from typing import OrderedDict, Optional, Tuple
 from datetime import datetime
 from artcommonlib.constants import RELEASE_SCHEDULES
 import requests
@@ -194,3 +194,16 @@ def deep_merge(dict1, dict2):
             merged[key] = value
 
     return merged
+
+
+def isolate_major_minor_in_group(group_name: str) -> Tuple[Optional[int], Optional[int]]:
+    """
+    Given a group name, determines whether it contains an OCP {major}.{minor} version.
+    If it does, it returns the version value as (int, int).
+    If it is not found, (None, None) is returned.
+    """
+
+    match = re.fullmatch(r"openshift-(\d+).(\d+)", group_name)
+    if not match:
+        return None, None
+    return int(match[1]), int(match[2])

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -4,7 +4,7 @@ import yaml
 
 from artcommonlib import util, build_util, release_util
 from artcommonlib.model import Model, MissingModel
-from artcommonlib.util import deep_merge
+from artcommonlib.util import deep_merge, isolate_major_minor_in_group
 
 
 class TestUtil(unittest.TestCase):
@@ -159,3 +159,20 @@ alternative_upstream:
         self.assertEqual(merged_config.content.source.git.branch.target, 'release-4.16')
         self.assertEqual(merged_config.get('from').get('builder'), [{'stream': 'golang'}, {'stream': 'rhel-9-golang'}])
         self.assertEqual(merged_config.get('from').get('member'), 'openshift-enterprise-base')
+
+    def test_isolate_major_minor_in_group(self):
+        major, minor = isolate_major_minor_in_group('openshift-4.16')
+        self.assertEqual(major, 4)
+        self.assertEqual(minor, 16)
+
+        major, minor = isolate_major_minor_in_group('invalid-4.16')
+        self.assertEqual(major, None)
+        self.assertEqual(minor, None)
+
+        major, minor = isolate_major_minor_in_group('openshift-4.invalid')
+        self.assertEqual(major, None)
+        self.assertEqual(minor, None)
+
+        major, minor = isolate_major_minor_in_group('openshift-invalid.16')
+        self.assertEqual(major, None)
+        self.assertEqual(minor, None)

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -24,6 +24,7 @@ from artcommonlib.arch_util import brew_arch_for_go_arch, go_arch_for_brew_arch,
 from artcommonlib.assembly import AssemblyTypes
 from artcommonlib.format_util import red_print
 from artcommonlib.model import Model, Missing
+from artcommonlib.util import isolate_major_minor_in_group
 
 try:
     from reprlib import repr
@@ -527,18 +528,6 @@ async def find_manifest_list_sha(pull_spec):
     if 'listDigest' not in image_data:
         raise ValueError('Specified image is not a manifest-list.')
     return image_data['listDigest']
-
-
-def isolate_major_minor_in_group(group_name: str) -> Tuple[int, int]:
-    """
-    Given a group name, determines whether is contains
-    a OCP major.minor version. If it does, it returns the version value as (int, int).
-    If it is not found, (None, None) is returned.
-    """
-    match = re.fullmatch(r"openshift-(\d+).(\d+)", group_name)
-    if not match:
-        return None, None
-    return int(match[1]), int(match[2])
 
 
 def get_release_name(assembly_type: artcommonlib.assembly.AssemblyTypes, group_name: str, assembly_name: str,

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -14,7 +14,7 @@ import click
 
 from artcommonlib.arch_util import brew_arch_for_go_arch
 from artcommonlib.assembly import AssemblyTypes
-from artcommonlib.util import get_ocp_version_from_group
+from artcommonlib.util import get_ocp_version_from_group, isolate_major_minor_in_group
 from doozerlib.util import isolate_nightly_name_components
 from ghapi.all import GhApi
 from ruamel.yaml import YAML
@@ -26,9 +26,7 @@ from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.git import GitRepository
 from pyartcd.record import parse_record_log
 from pyartcd.runtime import Runtime
-from pyartcd.util import (get_assembly_basis, get_assembly_type,
-                          isolate_el_version_in_release, load_group_config,
-                          load_releases_config)
+from pyartcd.util import (get_assembly_type, isolate_el_version_in_release, load_group_config, load_releases_config)
 
 yaml = YAML(typ="rt")
 yaml.default_flow_style = False
@@ -74,7 +72,7 @@ class BuildMicroShiftPipeline:
         await oc.registry_login(self.runtime)
 
         assembly_type = AssemblyTypes.STREAM
-        major, minor = util.isolate_major_minor_in_group(self.group)
+        major, minor = isolate_major_minor_in_group(self.group)
 
         try:
             group_config = await load_group_config(self.group, self.assembly, env=self._doozer_env_vars)

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -6,7 +6,6 @@ import re
 import click
 import yaml
 from opentelemetry import trace
-from tenacity import retry, stop_after_attempt, wait_fixed
 
 from artcommonlib import rhcos, redis
 from artcommonlib.arch_util import go_suffix_for_arch

--- a/pyartcd/pyartcd/pipelines/operator_sdk_sync.py
+++ b/pyartcd/pyartcd/pipelines/operator_sdk_sync.py
@@ -9,6 +9,7 @@ from errata_tool import Erratum
 
 from artcommonlib.arch_util import brew_arch_for_go_arch
 from artcommonlib.constants import BREW_DOWNLOAD_URL, BREW_HUB
+from artcommonlib.util import isolate_major_minor_in_group
 from pyartcd import constants, util, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.runtime import Runtime
@@ -89,7 +90,7 @@ class OperatorSDKPipeline:
         self.exec_cmd(cmd)
         if arch == 'amd64' or arch == 'arm64':
             tarballFilename = f"{self.sdk}-{sdkVersion}-darwin-{rarch}.tar.gz"
-            major, minor = util.isolate_major_minor_in_group(self.group)
+            major, minor = isolate_major_minor_in_group(self.group)
             share_path = "mac_arm64" if arch == 'arm64' and (major, minor) >= (4, 12) else "mac"
             cmd = f"oc image extract {constants.OPERATOR_URL}@{shasum} --path /usr/share/{self.sdk}/{share_path}/{self.sdk}:./{rarch}/ --confirm" + \
                   f" && chmod +x ./{rarch}/{self.sdk} && tar -c --preserve-order -z -v --file ./{rarch}/{tarballFilename} ./{rarch}/{self.sdk}" + \

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Optional, Tuple, Union, Iterable
+from typing import Dict, Optional, Union, Iterable
 
 import yaml
 
@@ -47,18 +47,6 @@ def isolate_el_version_in_branch(branch_name: str) -> Optional[int]:
         return int(match.group(1))
 
     return None
-
-
-def isolate_major_minor_in_group(group_name: str) -> Tuple[int, int]:
-    """
-    Given a group name, determines whether is contains
-    a OCP major.minor version. If it does, it returns the version value as (int, int).
-    If it is not found, (None, None) is returned.
-    """
-    match = re.fullmatch(r"openshift-(\d+).(\d+)", group_name)
-    if not match:
-        return None, None
-    return int(match[1]), int(match[2])
 
 
 def is_greenwave_all_pass_on_advisory(advisory_id: int) -> bool:


### PR DESCRIPTION
Instead of sending a Slack notification every time `tag-rpms` fails for any reason, catch any `ChildProcessError` exception thrown by Doozer (meaning something went wrong when tagging/untagging packages) and send a notification every 5 failures. Use a fail counter to handle this periodicity, just like `build-sync` does.

Needs https://github.com/openshift-eng/aos-cd-jobs/pull/4097 to merge along