### PR TITLE
olm-bundle: clone distgits when needed do not prevent cloning

### DIFF
--- a/doozer/doozerlib/cli/olm_bundle.py
+++ b/doozer/doozerlib/cli/olm_bundle.py
@@ -229,7 +229,13 @@ def rebase_and_build_olm_bundle(runtime: Runtime, operator_nvrs: Tuple[str, ...]
         elasticsearch-operator-container-v4.2.30-202004240858 \
         cluster-logging-operator-container-v4.2.30-202004240858
     """
-    runtime.initialize(clone_distgits=False)
+
+    runtime.initialize(config_only=True)
+
+    if runtime.group_config.canonical_builders_from_upstream:
+        runtime.initialize(clone_distgits=True)
+    else:
+        runtime.initialize(clone_distgits=False)
 
     if not operator_nvrs:
         # If this verb is run without operator NVRs, query Brew for all operator builds


### PR DESCRIPTION
Re-revert https://github.com/openshift-eng/art-tools/pull/459, but do not prevent cloning

Tested with:
```
doozer --assembly=stream --group=openshift-4.14 olm-bundle:rebase-and-build -- sriov-network-operator-container-v4.14.0-202403112340.p0.g7a362a5.assembly.stream.el8
```