### PR TITLE
fix operator_sdk_sync job

### DIFF
--- a/pyartcd/pyartcd/pipelines/operator_sdk_sync.py
+++ b/pyartcd/pyartcd/pipelines/operator_sdk_sync.py
@@ -85,7 +85,7 @@ class OperatorSDKPipeline:
 
         cmd = f"rm -rf ./{rarch} && mkdir ./{rarch}" + \
               f" && oc image extract {constants.OPERATOR_URL}@{shasum} --path /usr/local/bin/{self.sdk}:./{rarch}/ --confirm" + \
-              f" && chmod +x ./{rarch}/{self.sdk} && tar -c --preserve-order -z -v --file ./{rarch}/{tarballFilename} ./{rarch}/{self.sdk}" + \
+              f" && chmod +x ./{rarch}/{self.sdk} && tar -c -z -v --file ./{rarch}/{tarballFilename} ./{rarch}/{self.sdk}" + \
               f" && ln -s {tarballFilename} ./{rarch}/{self.sdk}-linux-{rarch}.tar.gz && rm -f ./{rarch}/{self.sdk}"
         self.exec_cmd(cmd)
         if arch == 'amd64' or arch == 'arm64':
@@ -93,7 +93,7 @@ class OperatorSDKPipeline:
             major, minor = isolate_major_minor_in_group(self.group)
             share_path = "mac_arm64" if arch == 'arm64' and (major, minor) >= (4, 12) else "mac"
             cmd = f"oc image extract {constants.OPERATOR_URL}@{shasum} --path /usr/share/{self.sdk}/{share_path}/{self.sdk}:./{rarch}/ --confirm" + \
-                  f" && chmod +x ./{rarch}/{self.sdk} && tar -c --preserve-order -z -v --file ./{rarch}/{tarballFilename} ./{rarch}/{self.sdk}" + \
+                  f" && chmod +x ./{rarch}/{self.sdk} && tar -c -z -v --file ./{rarch}/{tarballFilename} ./{rarch}/{self.sdk}" + \
                   f" && ln -s {tarballFilename} ./{rarch}/{self.sdk}-darwin-{rarch}.tar.gz && rm -f ./{rarch}/{self.sdk}"
             self.exec_cmd(cmd)
         self._sync_mirror(rarch)


### PR DESCRIPTION
in new version of tar --preserve-order is not supported, instead

> In -c, -r, or -u mode, each specified file or directory is added to the archive in the order specified on the command line.  By default, the contents of each directory are also archived.