### PR TITLE
Do not fetch the release date for custom assemblies

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -1,10 +1,10 @@
 from typing import OrderedDict, Optional, Tuple
 from datetime import datetime
-from artcommonlib.constants import RELEASE_SCHEDULES
-import requests
 import re
 
-from artcommonlib.model import Model
+import requests
+
+from artcommonlib.constants import RELEASE_SCHEDULES
 
 
 def remove_prefix(s: str, prefix: str) -> str:
@@ -111,12 +111,17 @@ def get_assembly_release_date(assembly, group):
     """
     assembly_release_date = None
     release_schedules = requests.get(f'{RELEASE_SCHEDULES}/{group}.z/?fields=all_ga_tasks', headers={'Accept': 'application/json'})
-    for release in release_schedules.json()['all_ga_tasks']:
-        if assembly in release['name']:
-            # convert date format for advisory usage, 2024-02-13 -> 2024-Feb-13
-            assembly_release_date = datetime.strptime(release['date_start'], "%Y-%m-%d").strftime("%Y-%b-%d")
-            break
-    return assembly_release_date
+
+    try:
+        for release in release_schedules.json()['all_ga_tasks']:
+            if assembly in release['name']:
+                # convert date format for advisory usage, 2024-02-13 -> 2024-Feb-13
+                assembly_release_date = datetime.strptime(release['date_start'], "%Y-%m-%d").strftime("%Y-%b-%d")
+                break
+        return assembly_release_date
+
+    except KeyError:
+        return None
 
 
 def get_inflight(assembly, group):

--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -43,7 +43,13 @@ class GenAssemblyPipeline:
         self.auto_trigger_build_sync = auto_trigger_build_sync
         self.custom = custom
         self.arches = arches
-        self.in_flight = in_flight if in_flight else get_inflight(assembly, group)
+        if in_flight:
+            self.in_flight = in_flight
+        elif not custom:
+            self.in_flight = get_inflight(assembly, group)
+        else:
+            self.in_flight = None
+
         self.previous_list = previous_list
         self.auto_previous = auto_previous
         self.pre_ga_mode = pre_ga_mode


### PR DESCRIPTION
If `gen-assembly` is run with `IN_FLIGHT_PREV = none` and a custom assembly (e.g. `art1234`), pyartcd will try to infer the inflight prev from the release schedule, and fail to do so. It is now throwing an exception, which prevents us from running gen-assembly with custom assemblies.

The proposed fix is to skip fetching the release date for custom assemblies, where IN_FLIGHT_PREV and PREVIOUS shall be None

[Test run ](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgen-assembly/13/console) (broke because `koji.GenericError: No such build: 'ubi8-container-416.94.202403121338-0-1136'`)