### PR TITLE
WIP: sweep earlier

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -904,6 +904,9 @@ class Ocp4Pipeline:
         else:
             self.runtime.logger.warning('Skipping plashets creation as SKIP_PLASHETS was set to True')
 
+        # Find MODIFIED bugs for the target-releases, and set them to ON_QA
+        await self._sweep()
+
         # Rebase and build images
         if self.build_plan.build_images:
             if self.mass_rebuild:
@@ -920,9 +923,6 @@ class Ocp4Pipeline:
 
         # Mirror RPMs
         await self._mirror_rpms()
-
-        # Find MODIFIED bugs for the target-releases, and set them to ON_QA
-        await self._sweep()
 
         # All good
         self._report_success()


### PR DESCRIPTION
This change (naively, wrongly) wants to move the moment of setting bugs to QE right before the image rebase starts.

In the case of a long-running ocp4 job (let's say: Mass rebuild), the time delta of rebase and when we look for bugs that are on MODIFIED, becomes rather large. This means that bugs are set to ON_QA before the commit is built.

This change proposes to do the bug transition before rebasing to distgit.

This would not be necessary if https://issues.redhat.com/browse/ART-6566 were implemented.