### PR TITLE
add art-attention to microshift already pinned message

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -121,7 +121,7 @@ class BuildMicroShiftPipeline:
             if assembly_type is not AssemblyTypes.STREAM and not self.force:
                 pinned_nvrs = util.get_rpm_if_pinned_directly(releases_config, self.assembly, 'microshift')
                 if pinned_nvrs:
-                    message = (f"For assembly {self.assembly} builds are already pinned: {pinned_nvrs}. Use FORCE to "
+                    message = (f"@release-artists For assembly {self.assembly} builds are already pinned: {pinned_nvrs}. Use FORCE to "
                                "rebuild.")
                     self._logger.info(message)
                     await self.slack_client.say_in_thread(message=message, reaction="art-attention")

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -124,7 +124,7 @@ class BuildMicroShiftPipeline:
                     message = (f"For assembly {self.assembly} builds are already pinned: {pinned_nvrs}. Use FORCE to "
                                "rebuild.")
                     self._logger.info(message)
-                    await self.slack_client.say_in_thread(message)
+                    await self.slack_client.say_in_thread(message=message, reaction="art-attention")
                     nvrs = list(pinned_nvrs.values())
                 else:
                     nvrs = await self._find_builds()


### PR DESCRIPTION
Since [message](https://redhat-internal.slack.com/archives/C05FEGT8SH2/p1711216738161449?thread_ts=1711216737.986789&cid=C05FEGT8SH2) is easy to miss