### PR TITLE
find-builds: Report on all found builds

### DIFF
--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -151,28 +151,26 @@ PRESENT advisory. Here are some examples:
         lambda nvrp: errata.get_brew_build(f'{nvrp[0]}-{nvrp[1]}-{nvrp[2]}',
                                            nvrp[3], session=requests.Session())
     )
-    previous = len(unshipped_builds)
-    unshipped_builds, attached_to_advisories = _filter_out_attached_builds(unshipped_builds, include_shipped)
-    if len(unshipped_builds) != previous:
-        click.echo(f'Filtered out {previous - len(unshipped_builds)} build(s) since they are already attached to '
-                   f'these ART advisories: {attached_to_advisories}')
+
+    # if we want to attach found builds to an advisory -> filter out already attached builds
+    # if we want to report on found builds -> do not filter out
+    if advisory_id:
+        previous = len(unshipped_builds)
+        unshipped_builds, attached_to_advisories = _filter_out_attached_builds(unshipped_builds, include_shipped)
+        if len(unshipped_builds) != previous:
+            click.echo(f'Filtered out {previous - len(unshipped_builds)} build(s) since they are already attached to '
+                       f'these ART advisories: {attached_to_advisories}')
 
     _json_dump(as_json, unshipped_builds, kind, tag_pv_map)
 
     if not unshipped_builds:
-        green_print('No builds needed to be attached.')
+        green_print('No unshipped builds found. To include shipped builds, use --include-shipped')
         return
 
     if not advisory_id:
-        click.echo('The following {n} builds '.format(n=len(unshipped_builds)), nl=False)
-        click.secho('may be attached', bold=True, nl=False)
-        click.echo(' to an advisory:')
+        click.echo(f'Found {len(unshipped_builds)} builds: ')
         for b in sorted(unshipped_builds):
             click.echo(' ' + b.nvr)
-        return
-
-    if not unshipped_builds:
-        # Do not change advisory state unless strictly necessary
         return
 
     try:


### PR DESCRIPTION
When reporting on found builds for an assembly, do not filter out builds that are attached to an advisory

```
$ elliott --assembly 4.15.5 -g openshift-4.15 find-builds -k rpm
...
Found 9 builds: 
 conmon-2.1.7-10.rhaos4.15.el9
 cri-o-1.28.4-5.rhaos4.15.git159b3c8.el8
 cri-o-1.28.4-5.rhaos4.15.git159b3c8.el9
 fuse-overlayfs-1.10-2.rhaos4.15.el8
 libslirp-4.4.0-4.rhaos4.15.el8
 openshift-4.15.0-202403180038.p0.gf1b5f6c.assembly.stream.el8
 openshift-4.15.0-202403180038.p0.gf1b5f6c.assembly.stream.el9
 slirp4netns-1.1.8-2.rhaos4.15.el8
 toolbox-0.1.0-2.rhaos4.15.el8

```