### PR TITLE
ART-9251: olm_bundle: Fix operand name resolution

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -18,9 +18,7 @@ class ImageMetadata(Metadata):
 
     def __init__(self, runtime: "doozerlib.Runtime", data_obj: Dict, commitish: Optional[str] = None, clone_source: Optional[bool] = False, prevent_cloning: Optional[bool] = False):
         super(ImageMetadata, self).__init__('image', runtime, data_obj, commitish, prevent_cloning=prevent_cloning)
-        self.image_name = self.config.name
         self.required = self.config.get('required', False)
-        self.image_name_short = self.image_name.split('/')[-1]
         self.parent = None
         self.children = []  # list of ImageMetadata which use this image as a parent.
         self.dependencies: Set[str] = set()
@@ -33,6 +31,14 @@ class ImageMetadata(Metadata):
             self.children.append(dependent)
         if clone_source:
             runtime.resolve_source(self)
+
+    @property
+    def image_name(self):
+        return self.config.name
+
+    @property
+    def image_name_short(self):
+        return self.config.name.split('/')[-1]
 
     def get_assembly_rpm_package_dependencies(self, el_ver: int) -> Tuple[Dict[str, str], Dict[str, str]]:
         """

--- a/elliott/elliottlib/imagecfg.py
+++ b/elliott/elliottlib/imagecfg.py
@@ -8,8 +8,14 @@ class ImageMetadata(Metadata):
 
     def __init__(self, runtime, data_obj):
         super(ImageMetadata, self).__init__('image', runtime, data_obj)
-        self.image_name = self.config.name
-        self.image_name_short = self.image_name.split('/')[-1]
+
+    @property
+    def image_name(self):
+        return self.config.name
+
+    @property
+    def image_name_short(self):
+        return self.image_name.split('/')[-1]
 
     @property
     def base_only(self):


### PR DESCRIPTION
Alternative upstream section may override image name (e.g. https://github.com/openshift-eng/ocp-build-data/blob/f82bb057fef0f20ab67f34b3270742b9191b6e84/images/nmstate-console-plugin.yml#L54).

Currently when alternative upstream is effective, the image_name and image_name_short fields of ImageMetadata object don't respect the alternative upstream override.

The root cause of this issue is that the `ImageMetadata.name` and `ImageMetadata.name_in_short` are not updated after an alternative upstream config is applied. This PR fixes this issue by changing those two fields to properties to make sure their values are always up to date.