### PR TITLE
latest_build_list(): log the search pattern when no builds are found

### DIFF
--- a/elliott/elliottlib/metadata.py
+++ b/elliott/elliottlib/metadata.py
@@ -281,6 +281,7 @@ class Metadata(object):
                 # Include * after pattern_suffix to tolerate other release components that might be introduced later.
                 # Also include a .el<version> suffix to match the new build pattern
                 rhel_pattern = f'{pattern_prefix}{extra_pattern}{pattern_suffix}.{el_suffix}*'
+                assert 'None' not in rhel_pattern
                 builds = koji_api.listBuilds(packageID=package_id,
                                              state=None if build_state is None else build_state.value,
                                              pattern=rhel_pattern,
@@ -290,12 +291,17 @@ class Metadata(object):
                 # If no builds were found, the component might still be following the old pattern,
                 # where a .el suffix was not included in the NVR
                 if not builds:
+                    self.logger.warning('No builds found using pattern %s', rhel_pattern)
+
                     legacy_pattern = f'{pattern_prefix}{extra_pattern}{pattern_suffix}*{rpm_suffix}'
+                    assert 'None' not in legacy_pattern
                     builds = koji_api.listBuilds(packageID=package_id,
                                                  state=None if build_state is None else build_state.value,
                                                  pattern=legacy_pattern,
                                                  queryOpts={'limit': 1, 'order': '-creation_event_id'},
                                                  **list_builds_kwargs)
+                    if not builds:
+                        self.logger.warning('No builds found using pattern %s', legacy_pattern)
 
                 # Ensure the suffix ends the string OR at least terminated by a '.' .
                 # This latter check ensures that 'assembly.how' doesn't match a build from


### PR DESCRIPTION
Currently we only get a single warning that goes like this:
```
No builds detected for using prefix: 'openshift-base-nodejs-container-v4.16.', extra_pattern: '*', assembly: 'test', build_state: 'COMPLETE', el_target: 'None'
```
This is the final message of an iterative process that attempts to find builds by progressively broadening the search pattern. It would be useful to see what queries are being attempted. Since it's happened in the past that `None` made it as a string into the search pattern, let us also assert that this is never happening. Crash otherwise (so we notice and fix).