### PR TITLE
Populate all non-modular rpms

### DIFF
--- a/doozer/doozerlib/repodata.py
+++ b/doozer/doozerlib/repodata.py
@@ -252,7 +252,7 @@ class OutdatedRPMFinder:
         return candidate_modular_rpms
 
     @staticmethod
-    def _find_candidate_non_modular_rpms(all_non_modular_rpms, candidate_modular_rpms, logger):
+    def _find_candidate_non_modular_rpms(all_non_modular_rpms):
         """ Finds all candidate non-modular rpms.
         For each non-modular rpm, if there is another candidate modular rpm with the same package name,
         the non-modular rpm will be exempt.
@@ -262,10 +262,6 @@ class OutdatedRPMFinder:
             rpm = Rpm.from_nevra(nevra)
             _, candidate = candidate_non_modular_rpms.get(rpm.name, (None, None))
             if not candidate or rpm.compare(candidate) > 0:
-                if rpm.name in candidate_modular_rpms:
-                    modular_repo, modular_rpm = candidate_modular_rpms[rpm.name]
-                    logger.debug("Non-modular RPM %s from %s is shadowed by modular RPM %s from %s", nevra, repo, modular_rpm.nevra, modular_repo)
-                    continue  # This non-modular rpm is shadowed by a modular rpm
                 candidate_non_modular_rpms[rpm.name] = (repo, rpm)
         return candidate_non_modular_rpms
 
@@ -325,8 +321,8 @@ class OutdatedRPMFinder:
                     continue  # It is a modular rpm
                 all_non_modular_rpms[rpm.nevra] = repodata.name
 
-        # Populate candidate_non_modulear_rpms, which will hold all visible non-modular rpms that are latest among all configured repos
-        candidate_non_modulear_rpms = self._find_candidate_non_modular_rpms(all_non_modular_rpms, candidate_modular_rpms, logger)
+        # fetch all visible non-modular rpms that are latest among all configured repos
+        candidate_non_modular_rpms = self._find_candidate_non_modular_rpms(all_non_modular_rpms)
 
         # Compare archive rpms to all candidate rpms
         results: List[Tuple[str, str, str]] = []
@@ -336,9 +332,9 @@ class OutdatedRPMFinder:
             if archive_rpm.nevra in all_modular_rpms:  # Archive rpm is a modular rpm
                 repo, candidate_rpm = candidate_modular_rpms.get(name, (None, None))
             else:  # Archive rpm is a non-modular rpm
-                repo, candidate_rpm = candidate_non_modulear_rpms.get(name, (None, None))
+                repo, candidate_rpm = candidate_non_modular_rpms.get(name, (None, None))
             if not repo or not candidate_rpm:
-                continue  # Archive rpm rpm is not available in any configured repos
+                continue  # Archive rpm is not available in any configured repos
             if archive_rpm.compare(candidate_rpm) < 0:  # Archive rpm is older than candidate rpm
                 results.append((archive_rpm.nevra, candidate_rpm.nevra, repo))
         return results


### PR DESCRIPTION
Recently when preparing [4.12.54](https://github.com/openshift-eng/ocp-build-data/pull/4570/files) we saw a case where a 4.12 image (ose-agent-installer-node-agent) 
contained non-latest rpms. This was being flagged by [build-sync](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/255/consoleFull) 

```
ose-agent-installer-node-agent:
  - code: CONFLICTING_INHERITED_DEPENDENCY
    msg: Expected image to contain assembly override dependencies NVR runc-1.1.6-5.2.rhaos4.12.el8
      but found runc-1.1.6-5.1.rhaos4.12.el8 installed
    permitted: false
  - code: CONFLICTING_INHERITED_DEPENDENCY
    msg: Expected image to contain assembly override dependencies NVR containernetworking-plugins-1.4.0-1.1.rhaos4.12.el8
      but found containernetworking-plugins-1.4.0-1.rhaos4.12.el8 installed
    permitted: false
  - code: CONFLICTING_INHERITED_DEPENDENCY
    msg: Expected image to contain assembly override dependencies NVR podman-4.4.1-2.1.rhaos4.12.el8
      but found podman-4.4.1-2.rhaos4.12.el8 installed
    permitted: false
```

These rpms had been updated in repos for a while. So I checked ocp4_scan and noticed that the image
was not being detected by scan-sources to have outdated rpms and that's why was not being rebuilt.

After debugging I found this block of code which ultimately was ignoring non-modular rpms (from our plashet repo)
in favor of modular rpms (appstream repo) - which was leading to the installed (archive) rpm being not found 
related to any enabled repo.

I think we can remove it since we are giving preference to modular rpms in the func already, and only 
when it's not found in modular rpms, do we look for it in non-modular rpms.

## Test
Using brew event (taken from https://github.com/openshift-eng/ocp-build-data/pull/4570/files) we can constrain it to the build that the above build-sync complained about having non-latest rpms installed.

Without this change, no reason is found to rebuild. 

And with this change:

```
$ doozer --brew-event 57152859 --assembly=stream --group openshift-4.12 
--images ose-agent-installer-node-agent config:scan-sources
...
Getting RPMs contained in ose-agent-installer-node-agent-container-v4.12.0-202403241038.p0.ga61cd6e.assembly.stream.el8
...
IMAGES:
  ose-agent-installer-node-agent is changed (reason: 
Outdated RPM podman-3:4.4.1-2.rhaos4.12.el8.x86_64 installed in 
ose-agent-installer-node-agent-container-v4.12.0-202403241038.p0.ga61cd6e.assembly.stream.el8 (x86_64) when 
podman-3:4.4.1-2.1.rhaos4.12.el8.x86_64 was available in repo rhel-8-server-ose-rpms-embargoed-x86_64;

Outdated RPM containernetworking-plugins-1:1.4.0-1.rhaos4.12.el8.x86_64 installed in 
ose-agent-installer-node-agent-container-v4.12.0-202403241038.p0.ga61cd6e.assembly.stream.el8 (x86_64) when 
containernetworking-plugins-1:1.4.0-1.1.rhaos4.12.el8.x86_64 was available in repo rhel-8-server-ose-rpms-embargoed-x86_64;

Outdated RPM runc-3:1.1.6-5.1.rhaos4.12.el8.x86_64 installed in 
ose-agent-installer-node-agent-container-v4.12.0-202403241038.p0.ga61cd6e.assembly.stream.el8 (x86_64) when 
runc-3:1.1.6-5.2.rhaos4.12.el8.x86_64 was available in repo rhel-8-server-ose-rpms-embargoed-x86_64;

Outdated RPM podman-catatonit-3:4.4.1-2.rhaos4.12.el8.x86_64 installed in ose-agent-installer-node-agent-container-v4.12.0-202403241038.p0.ga61cd6e.assembly.stream.el8 (x86_64) when 
podman-catatonit-3:4.4.1-2.1.rhaos4.12.el8.x86_64 was available in repo rhel-8-server-ose-rpms-embargoed-x86_64;

```