### PR TITLE
[fips-tekton] fix, keep dry run for now

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline-task.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline-task.yaml
@@ -26,11 +26,12 @@ spec:
 
         kinit -kt /tmp/keytab/keytab ocp-build/buildvm.openshift.eng.bos.redhat.com@IPA.REDHAT.COM
 
-        artcd -vv scan-fips --version $(params.version) --nvrs $(params.nvrs) 
+        artcd -vv --dry-run scan-fips --version $(params.version) --nvrs $(params.nvrs) 
 
       securityContext:
         runAsGroup: 0
         runAsUser: 0
+        privileged: true
       volumeMounts:
         - mountPath: /root/.config/art-bot
           name: art-bot-docker-config


### PR DESCRIPTION
`privileged: true` required for `check-payload`