### PR TITLE
[ART-9330] [ART-8971] new embargo process

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -626,11 +626,10 @@ class GenPayloadCli:
                 public_entries[k] = v
 
             entries_for_arch[arch] = entries
+            self.assembly_issues.extend(payload_issues)
 
-            self.assembly_issues.extend(public_payload_issues)
-
-            # Always make sure that embargoed builds do not flow to public image stream
-            # If releasing after embargo lift, this can be permitted using 'EMBARGOED_CONTENT' code
+            # Report issues for any embargoed content being made public.
+            # If releasing after embargo lift, these can be permitted using 'EMBARGOED_CONTENT' code
             embargo_issues = PayloadGenerator.embargo_issues_for_payload(public_entries, arch)
             self.assembly_issues.extend(embargo_issues)
 

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -607,22 +607,25 @@ class GenPayloadCli:
                 continue
             # No adjustment for private or public; the assembly's canonical payload content is the same.
 
-            # entries: Dict[str, PayloadEntry]  # Key of this dict is release payload tag name
-            # issues: List[AssemblyIssue]
+            # public_entries: Dict[str, PayloadEntry]  # Key of this dict is release payload tag name
+            # public_payload_issues: List[AssemblyIssue]
             public_entries, public_payload_issues = PayloadGenerator.find_payload_entries(assembly_inspector, arch, self.full_component_repo(repo_type=RepositoryType.PUBLIC))
 
+            entries: Dict[str, PayloadEntry] = dict()
             for k, v in public_entries.items():
                 if not v.build_inspector:
                     # Its RHCOS, since it doesn't have a build inspector. Put it in for now, but change once RHCOS
                     # supports private nightlies
-                    entries_for_arch[k] = v
+                    entries[k] = v
                     continue
 
                 if v.build_inspector.is_under_embargo() and self.runtime.assembly_type == AssemblyTypes.STREAM:
                     # It's an embargoed build. Filter it out if its stream
                     continue
 
-                entries_for_arch[k] = v
+                entries[k] = v
+
+            entries_for_arch[arch] = entries
 
             self.assembly_issues.extend(public_payload_issues)
 

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -799,6 +799,9 @@ class GenPayloadCli:
             False: dict()
         }
 
+        # Ensure that all payload images have been mirrored before updating
+        # the imagestream. Otherwise, the imagestream will fail to import the
+        # image.
         tasks = []
         for arch, payload_entries in self.private_payload_entries_for_arch.items():
             tasks.append(self.mirror_payload_content(arch, payload_entries, True))

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -810,8 +810,7 @@ class GenPayloadCli:
         await asyncio.sleep(120)
 
         # Updating public and private image streams
-        for private_mode, payload_entries_for_each_arch_iter in [(False, self.payload_entries_for_arch),
-                                                            (True, self.private_payload_entries_for_arch)]:
+        for private_mode, payload_entries_for_each_arch_iter in [(False, self.payload_entries_for_arch), (True, self.private_payload_entries_for_arch)]:
             tasks = []
             for arch, payload_entries in payload_entries_for_each_arch_iter.items():
                 self.logger.info(f"Building payload files for architecture: {arch}; private: {private_mode}")

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -797,7 +797,6 @@ class GenPayloadCli:
             False: dict()
         }
 
-        # filtered_payload_entries_for_arch includes embargoed content when self.embargo_permit_ack is set
         tasks = []
         for arch, payload_entries in self.private_payload_entries_for_arch.items():
             tasks.append(self.mirror_payload_content(arch, payload_entries, True))

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -609,21 +609,21 @@ class GenPayloadCli:
 
             # public_entries: Dict[str, PayloadEntry]  # Key of this dict is release payload tag name
             # public_payload_issues: List[AssemblyIssue]
-            public_entries, public_payload_issues = PayloadGenerator.find_payload_entries(assembly_inspector, arch, self.full_component_repo(repo_type=RepositoryType.PUBLIC))
+            entries, payload_issues = PayloadGenerator.find_payload_entries(assembly_inspector, arch, self.full_component_repo(repo_type=RepositoryType.PUBLIC))
 
-            entries: Dict[str, PayloadEntry] = dict()
-            for k, v in public_entries.items():
+            public_entries: Dict[str, PayloadEntry] = dict()
+            for k, v in entries.items():
                 if not v.build_inspector:
                     # Its RHCOS, since it doesn't have a build inspector. Put it in for now, but change once RHCOS
                     # supports private nightlies
-                    entries[k] = v
+                    public_entries[k] = v
                     continue
 
                 if v.build_inspector.is_under_embargo() and self.runtime.assembly_type == AssemblyTypes.STREAM:
                     # It's an embargoed build. Filter it out if its stream
                     continue
 
-                entries[k] = v
+                public_entries[k] = v
 
             entries_for_arch[arch] = entries
 

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -761,25 +761,42 @@ class GenPayloadCli:
             False: dict()
         }
 
+        # Filter out embargoed builds to mirror to public quay
+        filtered_payload_entries_for_arch = {}
+        for arch, payload_entries in self.payload_entries_for_arch.items():
+            filtered_payload_entries = {}
+            for payload_tag_name, payload_entry in payload_entries.items():
+                if payload_entry.rhcos_build is None and payload_entry.build_inspector.is_under_embargo():
+                    # We do not want embargoed builds to get leaked to public quay
+                    # RHCOS builds are considered non-embargoed for now
+                    continue
+                filtered_payload_entries[payload_tag_name] = payload_entry
+
+            if filtered_payload_entries:
+                # Sync if there are any builds for this arch, otherwise omit the arch entirely
+                filtered_payload_entries_for_arch[arch] = filtered_payload_entries
+
         # Ensure that all payload images have been mirrored before updating
         # the imagestream. Otherwise, the imagestream will fail to import the
         # image.
         tasks = []
         for arch, payload_entries in self.private_payload_entries_for_arch.items():
             tasks.append(self.mirror_payload_content(arch, payload_entries, True))
-        for arch, payload_entries in self.payload_entries_for_arch.items():
+        for arch, payload_entries in filtered_payload_entries_for_arch.items():
             tasks.append(self.mirror_payload_content(arch, payload_entries))
         await asyncio.gather(*tasks)
 
         await asyncio.sleep(120)
 
-        # Update the imagestreams being monitored by the release controller.
-        tasks = []
-        for arch, payload_entries in self.payload_entries_for_arch.items():
-            for private_mode in self.privacy_modes:
+        # Updating public and private image streams
+        for private_mode, payload_entries_for_each_arch in [(False, filtered_payload_entries_for_arch),
+                                                            (True, self.private_payload_entries_for_arch)]:
+            tasks = []
+            for arch, payload_entries in payload_entries_for_each_arch.items():
                 self.logger.info(f"Building payload files for architecture: {arch}; private: {private_mode}")
-                tasks.append(self.generate_specific_payload_imagestreams(arch, private_mode, payload_entries, multi_specs))
-        await asyncio.gather(*tasks)
+                tasks.append(self.generate_specific_payload_imagestreams(
+                    arch, private_mode, payload_entries, multi_specs))
+            await asyncio.gather(*tasks)
 
         if self.apply_multi_arch:
             if self.runtime.group_config.multi_arch.enabled:

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -273,7 +273,7 @@ class TestGenPayloadCli(IsolatedAsyncioTestCase):
         self.assertEqual(gpcli.assembly_issues[0].code, AssemblyIssueCode.INCONSISTENT_RHCOS_RPMS)
 
     def test_summarize_issue_permits(self):
-        gpcli = rgp_cli.GenPayloadCli()
+        gpcli = rgp_cli.GenPayloadCli(runtime=MagicMock(assembly_type=AssemblyTypes.STREAM))
         gpcli.assembly_issues = [
             Mock(AssemblyIssue, code=AssemblyIssueCode.INCONSISTENT_RHCOS_RPMS, component="spam", msg=""),
             Mock(AssemblyIssue, code=AssemblyIssueCode.CONFLICTING_GROUP_RPM_INSTALLED, component="eggs", msg=""),
@@ -285,7 +285,7 @@ class TestGenPayloadCli(IsolatedAsyncioTestCase):
         self.assertFalse(report["eggs"][0]["permitted"])
 
     def test_assess_assembly_viability(self):
-        gpcli = rgp_cli.GenPayloadCli(apply=True, apply_multi_arch=True)
+        gpcli = rgp_cli.GenPayloadCli(apply=True, apply_multi_arch=True, runtime=MagicMock(assembly_type=AssemblyTypes.STREAM))
 
         gpcli.payload_permitted, gpcli.emergency_ignore_issues = True, False
         gpcli.assess_assembly_viability()

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -315,8 +315,8 @@ class TestGenPayloadCli(IsolatedAsyncioTestCase):
         gpcli.sync_heterogeneous_payloads = AsyncMock()
 
         await gpcli.sync_payloads()
-        self.assertEqual(gpcli.mirror_payload_content.await_count, 0)
-        self.assertEqual(gpcli.generate_specific_payload_imagestreams.await_count, 0)
+        self.assertEqual(gpcli.mirror_payload_content.await_count, 1)
+        self.assertEqual(gpcli.generate_specific_payload_imagestreams.await_count, 1)
         gpcli.sync_heterogeneous_payloads.assert_awaited_once()
 
     @patch("aiofiles.open")

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -218,9 +218,11 @@ class TestGenPayloadCli(IsolatedAsyncioTestCase):
             runtime=MagicMock(arches=["ppc64le", "s390x"]),
         )
         pg_eissuesfp_mock.return_value = ["embargo_issues"]
-        pg_findpe_mock.return_value = ("entries", ["issues"])
+
+        test_payload_entry = rgp_cli.PayloadEntry(image_meta=Mock(distgit_key="spam"), issues=[], dest_pullspec="dummy")
+        pg_findpe_mock.return_value = (dict(tag1=test_payload_entry), ["issues"])
         e4a = gpcli.generate_payload_entries(Mock(AssemblyInspector))
-        self.assertEqual(e4a, (dict(ppc64le="entries"), dict(ppc64le="entries")))
+        self.assertEqual(e4a, (dict(ppc64le=dict(tag1=test_payload_entry)), dict(ppc64le=dict(tag1=test_payload_entry))))
         self.assertEqual(gpcli.assembly_issues, ["issues", "embargo_issues"])
 
     async def test_detect_extend_payload_entry_issues(self):

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -211,15 +211,17 @@ class TestGenPayloadCli(IsolatedAsyncioTestCase):
         self.assertEqual(gpcli.assembly_issues, ["stuff"])
 
     @patch("doozerlib.cli.release_gen_payload.PayloadGenerator.find_payload_entries")
-    def test_generate_payload_entries(self, pg_fpe_mock):
+    @patch("doozerlib.cli.release_gen_payload.PayloadGenerator.embargo_issues_for_payload")
+    def test_generate_payload_entries(self, pg_eissuesfp_mock, pg_findpe_mock):
         gpcli = rgp_cli.GenPayloadCli(
             exclude_arch=["s390x"],
             runtime=MagicMock(arches=["ppc64le", "s390x"]),
         )
-        pg_fpe_mock.return_value = ("entries", ["issues"])
+        pg_eissuesfp_mock.return_value = ["embargo_issues"]
+        pg_findpe_mock.return_value = ("entries", ["issues"])
         e4a = gpcli.generate_payload_entries(Mock(AssemblyInspector))
         self.assertEqual(e4a, (dict(ppc64le="entries"), dict(ppc64le="entries")))
-        self.assertEqual(gpcli.assembly_issues, ["issues"])
+        self.assertEqual(gpcli.assembly_issues, ["issues", "embargo_issues"])
 
     async def test_detect_extend_payload_entry_issues(self):
         runtime = MagicMock(group_config=Model())


### PR DESCRIPTION
Ref https://issues.redhat.com/browse/ART-8080

The goal of this PR is to setup a new flow so that we can create embargoed nightlies (visible in the private release controller), so that QE and other stakeholders can test the payload well in advance of the embargo being lifted. Currently, we only start building after the embargo is lifted, and we immediately pin the build(s) in the payload and promote. Having the private builds earlier in the private release controller will let us follow the usual pattern of release, but with public nightlies. The flow can be summarized as follow:

- For STREAM:
    - Only public builds are synced to public image streams (thereby to public nightlies), but both public and private builds are synced to private nightlies. Since we rebase from openshift to openshift-priv before building from the latter, we make sure that the private builds always contain the latest public content.
  
- For non-STREAM:
    - A two key approach is adopted.
    - A parameter in build_sync has to be enabled as well. This param will set `--embargo-permit-ack`. (key 1)
    - If a private build is seen, it will fail viability, with code `EMBARGOED_CONTENT`. We need to permit this in the assembly definition (key 2)
     - Both the above condition has to be satisfied. Due to the nature of embargoes, the accidental release of embargoed content, before lift, is severe. Hence this level of gating is proposed.
     - gen-assembly can be run with private nightlies as params, instead of public nightlies.