### PR TITLE
find-bugs:sweep - Skip attaching bugs if advisory is not present

### DIFF
--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -248,6 +248,10 @@ async def find_and_attach_bugs(runtime: Runtime, advisory_id, default_advisory_t
     for advisory_type in sorted(advisory_types_to_attach):
         kind_bugs = bugs_by_type.get(advisory_type)
         if kind_bugs:
+            if advisory_type not in advisory_ids:
+                logger.warning(f"Bugs were found for {advisory_type} but not attached because {advisory_type} advisory "
+                               "does not exist")
+                continue
             bug_tracker.attach_bugs([b.id for b in kind_bugs], advisory_id=advisory_ids[advisory_type], noop=noop,
                                     verbose=runtime.debug)
     return bugs


### PR DESCRIPTION
Tested with https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release/30/console