### PR TITLE
Do not reinit group_commitish

### DIFF
--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -104,6 +104,7 @@ class Runtime(GroupRuntime):
         self.logger = None
         self.data_path = None
         self.data_dir = None
+        self.group_commitish = None
         self.latest_parent_version = False
         self.rhpkg_config = None
         self._koji_client_session = None
@@ -382,7 +383,7 @@ class Runtime(GroupRuntime):
 
         if '@' in self.group:
             self.group, self.group_commitish = self.group.split('@', 1)
-        else:
+        elif self.group_commitish is None:
             self.group_commitish = self.group
 
         if group_only:


### PR DESCRIPTION
This was leading to 2 different branches being checked out when running a command,
which inits runtime twice. It was because we overwrite the values that are passed to us, 
and the second time we init those are not available to us.

Double init'ng runtime looks to be an anti-pattern that we should get rid of, for now this 
should suffice.

Test:

doozer --assembly=4.13.39 --data-path=https://github.com/mbiarnes/ocp-build-data --working-dir . --group=openshift-4.13@prep-assembly-definition-4.13 release:gen-payload

Before:
INFO On commit: af871f15b5f638ac3ade385b8051eb5ebd6596b8 (prep-assembly-definition-4.13)
INFO On commit: 3620494c9c8910decf208453e72de95ba00f2cd6 (openshift-4.13)

After
INFO On commit: af871f15b5f638ac3ade385b8051eb5ebd6596b8 (prep-assembly-definition-4.13)
INFO On commit: af871f15b5f638ac3ade385b8051eb5ebd6596b8 (prep-assembly-definition-4.13)
