### PR TITLE
Verify blocking bugs are attached to an advisory

### DIFF
--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -402,19 +402,25 @@ class JIRABug(Bug):
         return ('Placeholder' in self.summary) and (self.component == 'Release') and ('Automation' in self.keywords)
 
     def _get_blocks(self):
-        # link "blocks"
         blocks = []
         for link in self.bug.fields.issuelinks:
+            # link "blocks"
             if link.type.name == "Blocks" and hasattr(link, "outwardIssue"):
                 blocks.append(link.outwardIssue.key)
+            # link "is depended on by"
+            if link.type.name == "Depend" and hasattr(link, "inwardIssue"):
+                blocks.append(link.inwardIssue.key)
         return blocks
 
     def _get_depends(self):
-        # link "is blocked by"
         depends = []
         for link in self.bug.fields.issuelinks:
+            # link "is blocked by"
             if link.type.name == "Blocks" and hasattr(link, "inwardIssue"):
                 depends.append(link.inwardIssue.key)
+            # link "depends on"
+            if link.type.name == "Depend" and hasattr(link, "outwardIssue"):
+                depends.append(link.outwardIssue.key)
         return depends
 
     @staticmethod


### PR DESCRIPTION
Discover cases when a 4.14 bug that is attached to an advisory, has a 4.15 parent bug which is not attached to any advisory.

```
$ elliott --assembly 4.14.21 -g openshift-4.14 verify-attached-bugs
...
Regression possible: Verified bug OCPBUGS-21217 is a backport of bug OCPBUGS-22034 which is on Verified but not attached to any advisory
```
