### PR TITLE
Do not post traceback to slack

### DIFF
--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -103,7 +103,7 @@ class GenAssemblyPipeline:
         except Exception as err:
             error_message = f"Error generating assembly definition: {err}\n {traceback.format_exc()}"
             self._logger.error(error_message)
-            await self._slack_client.say(error_message, slack_thread)
+            await self._slack_client.say(f"Error generating assembly definition for {self.assembly}", slack_thread)
             raise
 
     async def _get_nightlies(self):

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -581,7 +581,7 @@ class Ocp4Pipeline:
             self.runtime.logger.error(error_msg)
             self.runtime.logger.error(traceback.format_exc())
             self._slack_client.bind_channel(f'openshift-{self.version.stream}')
-            await self._slack_client.say(error_msg)
+            await self._slack_client.say("Failed building compose")
             raise
 
         if self.assembly == 'stream':
@@ -799,7 +799,8 @@ class Ocp4Pipeline:
             self.runtime.logger.error(error_msg)
             self.runtime.logger.error(traceback.format_exc())
             self._slack_client.bind_channel(f'openshift-{self.version.stream}')
-            await self._slack_client.say(error_msg)
+            await self._slack_client.say(f"Failed syncing {self.rpm_mirror.local_plashet_path} repo to "
+                                         f"art-srv-enterprise S3")
             raise
 
     async def _sweep(self):

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -401,8 +401,7 @@ class PromotePipeline:
 
         except Exception as err:
             self._logger.exception(err)
-            error_message = f"Error promoting release {release_name}: {err}\n {traceback.format_exc()}"
-            message = f"Promoting release {release_name} failed with: {error_message}"
+            message = f"Promoting release {release_name} failed"
             await self._slack_client.say_in_thread(message)
             raise
 

--- a/pyartcd/pyartcd/pipelines/scan_for_kernel_bugs.py
+++ b/pyartcd/pyartcd/pipelines/scan_for_kernel_bugs.py
@@ -40,7 +40,7 @@ class ScanForKernelBugsPipeline:
         except Exception as err:
             error_message = f"Error scanning for kernel bugs: {err}\n {traceback.format_exc()}"
             logger.error(error_message)
-            await slack_client.say(f":warning: {error_message}")
+            await slack_client.say(":warning: Error scanning for kernel bugs")
             raise
 
     async def _clone_kernel_bugs(self):

--- a/pyartcd/pyartcd/pipelines/tag_rpms.py
+++ b/pyartcd/pyartcd/pipelines/tag_rpms.py
@@ -72,7 +72,7 @@ class TagRPMsPipeline:
         except Exception as err:
             error_message = f"Error running tag-rpms: {err}\n {traceback.format_exc()}"
             self.logger.error(error_message)
-            await self.slack_client.say(f":warning: {error_message}")
+            await self.slack_client.say(":warning: Error running tag-rpms")
             raise
 
     async def tag_rpms(self):


### PR DESCRIPTION
Due to our jira instance being quite volatile we've been getting a lot of jira related job failures,
each of these job failures posts a lengthy traceback in slack which doesn't help.
Even otherwise traceback.format_exc from pyartcd aren't helpful and do not get to the actual error, so remove them