### PR TITLE
elliott find-bugs:golang enhancements

### DIFF
--- a/elliott/elliottlib/build_finder.py
+++ b/elliott/elliottlib/build_finder.py
@@ -55,15 +55,15 @@ class BuildFinder:
         """
         if not assembly:
             # Assemblies are disabled. We need the true latest tagged builds in the brew tag
-            self._logger.info("Finding latest builds in Brew tag %s...", tag)
+            self._logger.debug("Finding latest builds in Brew tag %s...", tag)
             builds = self._koji_api.listTagged(tag, latest=True, inherit=inherit, event=event, type=build_type)
         else:
             # Assemblies are enabled. We need all tagged builds in the brew tag then find the latest ones for the assembly.
-            self._logger.info("Finding builds specific to assembly %s in Brew tag %s...", assembly, tag)
+            self._logger.debug("Finding builds specific to assembly %s in Brew tag %s...", assembly, tag)
             tagged_builds = self._koji_api.listTagged(tag, latest=False, inherit=inherit, event=event, type=build_type)
             builds = find_latest_builds(tagged_builds, assembly)
         component_builds = {build["name"]: build for build in builds}
-        self._logger.info("Found %s builds.", len(component_builds))
+        self._logger.debug("Found %s builds.", len(component_builds))
         for build in component_builds.values():  # Save to cache
             self._cache_build(build)
         return component_builds

--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -90,6 +90,16 @@ class Bug:
     def product(self):
         raise NotImplementedError
 
+    @property
+    def cve_id(self):
+        if not (self.is_tracker_bug() or self.is_flaw_bug()):
+            return None
+        cve_id = re.search(r'CVE-\d+-\d+', self.summary)
+        if cve_id:
+            return cve_id.group()
+        return None
+
+
     @staticmethod
     def get_target_release(bugs: List[Bug]) -> str:
         """
@@ -208,6 +218,11 @@ class BugzillaBug(Bug):
 
 
 class JIRABug(Bug):
+    def __getattr__(self, attr):
+        if attr in self.__dict__:
+            return getattr(self, attr)
+        return getattr(self.bug.fields, attr)
+
     def __init__(self, bug_obj: Issue):
         super().__init__(bug_obj)
 

--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -99,7 +99,6 @@ class Bug:
             return cve_id.group()
         return None
 
-
     @staticmethod
     def get_target_release(bugs: List[Bug]) -> str:
         """

--- a/elliott/elliottlib/cli/find_bugs_golang_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_golang_cli.py
@@ -409,7 +409,7 @@ class FindBugsGolangCli:
               is_flag=True,
               default=False,
               help="If a tracker bug is fixed then comment with analysis and move to ON_QA")
-@click.option('--art-jira', required=True, help='Related ART Jira ticket for reference e.g. ART-1234')
+@click.option('--art-jira', help='Related ART Jira ticket for reference e.g. ART-1234')
 @click.option("--dry-run", "--noop",
               is_flag=True,
               default=False,

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -384,8 +384,6 @@ async def _fetch_builds_by_kind_rpm(runtime: Runtime, tag_pv_map: Dict[str, str]
         if any(nvr for dep in rhcos_config.dependencies.rpms for _, nvr in dep.items()):
             raise ElliottFatalError(f"Assembly {runtime.assembly} is not appliable for build sweep because it contains RHCOS specific dependencies for a custom release.")
 
-    green_prefix('Generating list of rpms: ')
-    click.echo('Hold on a moment, fetching Brew builds')
     builds: List[Dict] = []
 
     if member_only:  # Sweep only member rpms
@@ -430,18 +428,17 @@ async def _fetch_builds_by_kind_rpm(runtime: Runtime, tag_pv_map: Dict[str, str]
     not_attachable_nvrs = [b["nvr"] for b in builds if "tag_name" not in b]
 
     if not_attachable_nvrs:
-        yellow_print(f"The following NVRs will not be swept because they don't have allowed tags {list(tag_pv_map.keys())}:")
-        for nvr in not_attachable_nvrs:
-            yellow_print(f"\t{nvr}")
+        LOGGER.info(f"The following NVRs will not be swept because they don't have allowed tags"
+                    f" {list(tag_pv_map.keys())}: {not_attachable_nvrs}")
 
     shipped = set()
     if include_shipped:
-        click.echo("Do not filter out shipped builds, all builds will be attached")
+        LOGGER.debug("Do not filter out shipped builds, all builds will be attached")
     else:
-        click.echo("Filtering out shipped builds...")
+        LOGGER.debug("Filtering out shipped builds...")
         shipped = _find_shipped_builds([b["id"] for b in qualified_builds], brew_session)
     unshipped = [b for b in qualified_builds if b["id"] not in shipped]
-    click.echo(f'Found {len(shipped)+len(unshipped)} builds, of which {len(unshipped)} are new.')
+    LOGGER.info(f'Found {len(shipped)+len(unshipped)} builds, of which {len(unshipped)} are new.')
     nvrps = _gen_nvrp_tuples(unshipped, tag_pv_map)
     nvrps = sorted(set(nvrps))  # remove duplicates
     return nvrps

--- a/elliott/pyproject.toml
+++ b/elliott/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "ruamel.yaml",
     "tenacity",
     "jira >= 3.4.1",  # https://github.com/pycontribs/jira/issues/1486
+    "prettytable"
 ]
 
 [project.scripts]


### PR DESCRIPTION
Bunch of fixes and enhancements for `elliott find-bugs:golang`
- Support `cve_id` as a property of our `Bug` class. This will appear for trackers and flaw bugs.
- The command right now finds bugs and start analyzing immediately. Instead 
    - report on trackers and CVEs by default ([prettytable](https://pypi.org/project/prettytable/) makes the report look very nice and readable)
    - `--analyze` flag to do analysis on found bugs
- Do not analyze bugs that don't appear to be golang compiler bugs (like golang lib bugs). Report / warn about them and exit
- Better jira comment when `--fixed-in-nvr` is passed
- Require `--art-jira` when updating tracker
- Remove noisy prints, move logs info -> debug