### PR TITLE
only check bug for active release

### DIFF
--- a/pyartcd/pyartcd/pipelines/check_bugs.py
+++ b/pyartcd/pyartcd/pipelines/check_bugs.py
@@ -22,6 +22,8 @@ class CheckBugsPipeline:
     async def run(self):
         # Load group config
         self.group_config = await util.load_group_config(group=f'openshift-{self.version}', assembly='stream')
+        if self.group_config['software_lifecycle']['phase'] != 'release':
+            return None
 
         # Find issues
         await asyncio.gather(*[self._find_blockers(), self._find_regressions()])


### PR DESCRIPTION
test job: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fcheck-bugs/35/console
in the test job it param has "--version 4.17 --version 4.16 --version 4.15 --version 4.14 --version 4.13 --version 4.12 --version 4.11 --version 4.7 --version 3.11" which is the list of choice we could build, but for check bugs job we only need check active release