### PR TITLE
use branch in image config

### DIFF
--- a/doozer/doozerlib/olm/bundle.py
+++ b/doozer/doozerlib/olm/bundle.py
@@ -610,12 +610,12 @@ class OLMBundle(object):
 
     @property
     def target(self):
-        target_match = re.match(r'.*-rhel-(\d+)(?:-|$)', str(self.branch()))
+        target_match = re.match(r'.*-rhel-(\d+)(?:-|$)', self.branch)
         if target_match:
             el_target = int(target_match.group(1))
             return self.runtime.get_default_candidate_brew_tag(el_target=el_target) or '{}-candidate'.format(self.branch)
         else:
-            raise IOError(f'Unable to determine rhel version from branch: {self.branch()}')
+            raise IOError(f'Unable to determine rhel version from branch: {self.branch}')
 
     @property
     def valid_subscription_label(self):

--- a/doozer/doozerlib/olm/bundle.py
+++ b/doozer/doozerlib/olm/bundle.py
@@ -610,7 +610,12 @@ class OLMBundle(object):
 
     @property
     def target(self):
-        return self.runtime.get_default_candidate_brew_tag() or '{}-candidate'.format(self.branch)
+        target_match = re.match(r'.*-rhel-(\d+)(?:-|$)', str(self.branch()))
+        if target_match:
+            el_target = int(target_match.group(1))
+            return self.runtime.get_default_candidate_brew_tag(el_target=el_target) or '{}-candidate'.format(self.branch)
+        else:
+            raise IOError(f'Unable to determine rhel version from branch: {self.branch()}')
 
     @property
     def valid_subscription_label(self):

--- a/doozer/doozerlib/olm/bundle.py
+++ b/doozer/doozerlib/olm/bundle.py
@@ -536,6 +536,9 @@ class OLMBundle(object):
 
     @property
     def branch(self):
+        config = self.runtime.image_map[self.operator_name].config
+        if 'distgit' in config and 'branch' in config['distgit']:
+            return config['distgit']['branch']
         return self.runtime.group_config.branch.format(**self.runtime.group_config.vars)
 
     @property


### PR DESCRIPTION
When building the bundle, the current branch and target rely on the global configuration, but some images have been migrated to RHEL 9 while the global configuration remains set to RHEL 8. To ensure consistency and accuracy in the build process, it is imperative to honor the specific configuration of each image. Therefore, this pull request aims to optimize build system to correctly identify and apply the specific configuration for each image instead of solely relying on the global configuration.

test job: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Folm_bundle/271/console