### PR TITLE
Doozer: set completeBefore appropriately when searching for builds

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -32,6 +32,9 @@ class ImageMetadata(Metadata):
         if clone_source:
             runtime.resolve_source(self)
 
+    def __str__(self):
+        return self.name
+
     @property
     def image_name(self):
         return self.config.name

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -442,15 +442,11 @@ class Metadata(object):
             if assembly is None:
                 assembly = self.runtime.assembly
 
-            list_builds_kwargs = {}  # extra kwargs that will be passed to koji_api.listBuilds invocations
-            if complete_before_event is not None:
-                if complete_before_event < 0:
-                    # By setting the parameter to None, it tells the koji wrapper to not bound the brew event.
-                    list_builds_kwargs['completeBefore'] = None
-                else:
-                    # listBuilds accepts timestamps, not brew events, so convert brew event into seconds since the epoch
-                    complete_before_ts = koji_api.getEvent(complete_before_event)['ts']
-                    list_builds_kwargs['completeBefore'] = complete_before_ts
+            list_builds_kwargs = {'completeBefore': None}  # extra kwargs that will be passed to koji_api.listBuilds invocations
+            if complete_before_event is not None and complete_before_event >= 0:
+                # listBuilds accepts timestamps, not brew events, so convert brew event into seconds since the epoch
+                complete_before_ts = koji_api.getEvent(complete_before_event)['ts']
+                list_builds_kwargs['completeBefore'] = complete_before_ts
 
             def default_return():
                 msg = f"No builds detected for using prefix: '{pattern_prefix}', extra_pattern: '{extra_pattern}', assembly: '{assembly}', build_state: '{build_state.name}', el_target: '{el_target}'"


### PR DESCRIPTION
When `complete_before_event` is not set, we are not passing the `completeBefore` keyword argument to the Koji wrapper. As a consequence, a timestamp is getting auto assigned as follows:
```
            elif method_name == 'listBuilds':
                if 'completeBefore' not in kwargs and 'createdBefore' not in kwargs:
                    kwargs = kwargs or {}
                    kwargs['completeBefore'] = self.___before_timestamp
```
This has been acting as a filter to our build search, preventing us from picking up the latest news in some cases