### PR TITLE
Adjust elliott rhcos to new image label

### DIFF
--- a/elliott/elliottlib/rhcos.py
+++ b/elliott/elliottlib/rhcos.py
@@ -6,7 +6,8 @@ from artcommonlib import exectools
 from artcommonlib.arch_util import brew_suffix_for_arch
 from artcommonlib.format_util import red_print
 from elliottlib import constants
-from artcommonlib.rhcos import get_primary_container_name
+from artcommonlib.rhcos import (get_primary_container_name,
+                                get_build_id_from_rhcos_pullspec)
 
 
 def release_url(runtime, version, arch="x86_64", private=False):
@@ -85,13 +86,12 @@ def _build_meta(runtime, build_id, version, arch="x86_64", private=False, meta_t
 
 
 def get_build_from_payload(runtime, payload_pullspec):
+    out, _ = exectools.cmd_assert(["oc", "image", "info", "-o", "json", payload_pullspec])
+    arch = json.loads(out)["config"]["architecture"]
     rhcos_tag = get_primary_container_name(runtime)
     out, _ = exectools.cmd_assert(["oc", "adm", "release", "info", "--image-for", rhcos_tag, "--", payload_pullspec])
     rhcos_pullspec = out.split('\n')[0]
-    out, _ = exectools.cmd_assert(["oc", "image", "info", "-o", "json", rhcos_pullspec])
-    image_info = json.loads(out)
-    build_id = image_info["config"]["config"]["Labels"]["version"]
-    arch = image_info["config"]["architecture"]
+    build_id = get_build_id_from_rhcos_pullspec(rhcos_pullspec)
     return build_id, arch
 
 


### PR DESCRIPTION
Using previous work done from https://github.com/openshift-eng/art-tools/pull/464 

Test:
(This was failing before)

elliott --quiet -g openshift-4.16 rhcos -r 4.16.0-0.nightly-2024-04-24-091844 -p kernel