### PR TITLE
doozer gen-payload: Assert that latest is latest

### DIFF
--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -442,11 +442,15 @@ class Metadata(object):
             if assembly is None:
                 assembly = self.runtime.assembly
 
-            list_builds_kwargs = {'completeBefore': None}  # extra kwargs that will be passed to koji_api.listBuilds invocations
-            if complete_before_event is not None and complete_before_event >= 0:
-                # listBuilds accepts timestamps, not brew events, so convert brew event into seconds since the epoch
-                complete_before_ts = koji_api.getEvent(complete_before_event)['ts']
-                list_builds_kwargs['completeBefore'] = complete_before_ts
+            list_builds_kwargs = {}  # extra kwargs that will be passed to koji_api.listBuilds invocations
+            if complete_before_event is not None:
+                if complete_before_event < 0:
+                    # By setting the parameter to None, it tells the koji wrapper to not bound the brew event.
+                    list_builds_kwargs['completeBefore'] = None
+                else:
+                    # listBuilds accepts timestamps, not brew events, so convert brew event into seconds since the epoch
+                    complete_before_ts = koji_api.getEvent(complete_before_event)['ts']
+                    list_builds_kwargs['completeBefore'] = complete_before_ts
 
             def default_return():
                 msg = f"No builds detected for using prefix: '{pattern_prefix}', extra_pattern: '{extra_pattern}', assembly: '{assembly}', build_state: '{build_state.name}', el_target: '{el_target}'"


### PR DESCRIPTION
Follow up to https://github.com/openshift-eng/art-tools/pull/562

See slack thread: https://redhat-internal.slack.com/archives/GDBRP5YJH/p1713954580446079

https://issues.redhat.com/browse/RHELBLD-15024

Brew api is returning us outdated builds, this is to verify it in assembly_inspector which gets called via gen-payload when we create nightlies (which only runs for --stream without a brew event passed in)

Brew call - `listBuilds(completeBefore=brew_event_timestamp)`

## Test
```
$ doozer --assembly=stream --group=openshift-4.17 -i ose-installer-artifacts release:gen-payload --output-dir=gen-payload-artifacts
...
ValueError: 
Latest build ose-installer-artifacts-container-v4.17.0-202404251943.p0.g388a35c.assembly.stream.el8 
is not the true latest build ose-installer-artifacts-container-v4.17.0-202404260414.p0.g59cc24d.assembly.stream.el8 
for image ose-installer-artifacts.
Brew event: 57677105 timestamp: 1714153567.77471 2024-04-26 17:46:07.774710 UTC. 
True latest build completion ts: 1714140511.85667 2024-04-26 14:08:31.856669
```