### PR TITLE
[fips-pipeline] [ART-8272] Migrate scan to cluster

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline-task.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline-task.yaml
@@ -10,9 +10,6 @@ spec:
     - description: 'Space separated NVRs'
       name: nvrs
       type: string
-    - description: 'DOOZER_DATA_PATH value'
-      name: doozer_path
-      type: string
   steps:
     - image: image-registry.openshift-image-registry.svc:5000/art-cd/art-cd:base
       name: run-script
@@ -45,8 +42,6 @@ spec:
             secretKeyRef:
               name: art-bot-config
               key: slack-api-token
-        - name: DOOZER_DATA_PATH
-          value: $(params.doozer_path)
   volumes:
     - name: art-bot-docker-config
       secret:

--- a/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline.yaml
@@ -10,9 +10,6 @@ spec:
     - description: 'Space separated NVRs'
       name: nvrs
       type: string
-    - description: 'DOOZER_DATA_PATH value'
-      name: doozer_path
-      type: string
   tasks:
     - name: run-script
       params:
@@ -20,8 +17,6 @@ spec:
           value: $(params.version)
         - name: nvrs
           value: $(params.nvrs)
-        - name: doozer_path
-          value: $(params.doozer_path)
       taskRef:
         kind: Task
         name: fips-pipeline-task

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -4,7 +4,7 @@ from pyartcd.cli import cli
 from pyartcd.pipelines import (
     build_microshift, check_bugs, gen_assembly, prepare_release, promote, rebuild, report_rhcos,
     review_cvp, tarball_sources, build_sync, build_rhcos, ocp4_scan, images_health, operator_sdk_sync,
-    olm_bundle, ocp4, scan_for_kernel_bugs, tag_rpms, advisory_drop, cleanup_locks, brew_scan_osh, sigstore_sign, update_golang, rebuild_golang_rpms
+    olm_bundle, ocp4, scan_for_kernel_bugs, tag_rpms, advisory_drop, cleanup_locks, brew_scan_osh, sigstore_sign, update_golang, rebuild_golang_rpms, scan_fips
 )
 
 

--- a/pyartcd/pyartcd/pipelines/scan_fips.py
+++ b/pyartcd/pyartcd/pipelines/scan_fips.py
@@ -1,0 +1,68 @@
+"""
+For this command to work, https://github.com/openshift/check-payload binary has to exist in PATH and run as root
+This job is deployed on ART cluster
+"""
+import json
+import click
+from typing import Optional
+from pyartcd.runtime import Runtime
+from pyartcd.cli import cli, pass_runtime, click_coroutine
+from pyartcd import exectools
+
+
+class ScanFips:
+    def __init__(self, runtime: Runtime, version: str, nvrs: Optional[list]):
+        self.runtime = runtime
+        self.version = version
+        self.nvrs = nvrs
+
+        # Setup slack client
+        self.slack_client = self.runtime.new_slack_client()
+        self.slack_client.bind_channel(f"openshift-{self.version}")
+
+    async def run(self):
+        cmd = [
+            "doozer",
+            "--group",
+            f"openshift-{self.version}",
+            "--data-path",
+            "https://github.com/openshift-eng/ocp-build-data",
+            "images:scan-fips",
+            "--nvrs",
+            f"{','.join(self.nvrs)}"
+        ]
+
+        _, result, _ = await exectools.cmd_gather_async(cmd, stderr=True)
+
+        result_json = json.loads(result)
+
+        self.runtime.logger.info(f"Result: {result_json}")
+
+        if result_json:
+            # alert release artists
+            if not self.runtime.dry_run:
+                message = ":warning: FIPS scan has failed for some builds. Please verify."
+                slack_response = await self.slack_client.say(message=message)
+                slack_thread = slack_response["message"]["ts"]
+
+                await self.slack_client.say(
+                    message=result,
+                    thread_ts=slack_thread,
+                )
+            else:
+                self.runtime.logger.info("[DRY RUN] Would have messaged slack")
+        else:
+            self.runtime.logger.info("No issues")
+
+
+@cli.command("scan-fips", help="Trigger FIPS check for specified NVRs")
+@click.option("--version", required=True, help="openshift version eg: 4.15")
+@click.option("--nvrs", required=False, help="Comma separated list to trigger scans for")
+@pass_runtime
+@click_coroutine
+async def scan_osh(runtime: Runtime, version: str, nvrs: str):
+    pipeline = ScanFips(runtime=runtime,
+                        version=version,
+                        nvrs=nvrs.split(",") if nvrs else None
+                        )
+    await pipeline.run()


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-8272

The scan will clone payload images locally. This caused buildvm storage to be used up completely. Setting up scan on the cluster since pod storage is transient and independent. No need to clean images now, since the pod will be deleted after the run.

ocp4 test run [successful](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/ashwin-aos-cd-jobs/job/build%252Focp4/52/)
cluster pipeline [successful](https://console-openshift-console.apps.artc2023.pc3z.p1.openshiftapps.com/k8s/ns/art-cd/tekton.dev~v1~PipelineRun/fips-pipeline-run-tx62m)

Needs https://github.com/openshift-eng/aos-cd-jobs/pull/4139