### PR TITLE
[tekton] [ART-9550] doomsday pipeline, increase timeout to 4hrs

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1560,7 +1560,8 @@ class PromotePipeline:
         cmd = f"tkn pipeline start {pipeline_name} " \
               f"--kubeconfig {os.environ['ART_CLUSTER_ART_CD_PIPELINE_KUBECONFIG']} " \
               f"--param major={self.group.split('-')[-1]} " \
-              f"--param version={self.assembly}"
+              f"--param version={self.assembly} " \
+              "--pipeline-timeout 4h"
 
         env = os.environ.copy()
         rc, _, _ = await exectools.cmd_gather_async(cmd, env=env)


### PR DESCRIPTION
Ref https://issues.redhat.com/browse/ART-9550

Pipeline run has a defualt cutoff time of `1h`. Sometimes, the mirroring takes more time that that and hence will fail ([example](https://console-openshift-console.apps.artc2023.pc3z.p1.openshiftapps.com/k8s/ns/art-cd/tekton.dev~v1~PipelineRun/doomsday-pipeline-run-6rmp4)). Increasing to `4h` taking into account of retries