### PR TITLE
Get missing bundle branches first

### DIFF
--- a/doozer/doozerlib/cli/olm_bundle.py
+++ b/doozer/doozerlib/cli/olm_bundle.py
@@ -231,20 +231,13 @@ def rebase_and_build_olm_bundle(runtime: Runtime, operator_nvrs: Tuple[str, ...]
     """
 
     runtime.initialize(config_only=True)
+    clone_distgits = bool(runtime.group_config.canonical_builders_from_upstream)
+    runtime.initialize(clone_distgits=clone_distgits)
 
-    operator_metas = []
-    clone_distgits = False
     if not operator_nvrs:
         # If this verb is run without operator NVRs, query Brew for all operator builds
         operator_metas = [meta for meta in runtime.ordered_image_metas() if
                           meta.enabled and meta.config['update-csv'] is not Missing]
-        runtime.images = [o.image_name for o in operator_metas]
-        # Check if canonical_builders_from_upstream is set in group_config
-        clone_distgits = bool(runtime.group_config.canonical_builders_from_upstream)
-
-    runtime.initialize(clone_distgits=clone_distgits)
-
-    if not operator_nvrs:
         results = exectools.parallel_exec(lambda meta, _: meta.get_latest_build(), operator_metas)
         operator_builds = results.get()
     else:

--- a/doozer/doozerlib/cli/olm_bundle.py
+++ b/doozer/doozerlib/cli/olm_bundle.py
@@ -231,6 +231,11 @@ def rebase_and_build_olm_bundle(runtime: Runtime, operator_nvrs: Tuple[str, ...]
     """
 
     runtime.initialize(config_only=True)
+    if not operator_nvrs:
+        # If this verb is run without operator NVRs, query Brew for all operator builds
+        operator_metas = [meta for meta in runtime.ordered_image_metas() if
+                          meta.enabled and meta.config['update-csv'] is not Missing]
+        runtime.images = [o.image_name for o in operator_metas]
 
     if runtime.group_config.canonical_builders_from_upstream:
         runtime.initialize(clone_distgits=True)
@@ -246,7 +251,7 @@ def rebase_and_build_olm_bundle(runtime: Runtime, operator_nvrs: Tuple[str, ...]
     else:
         operator_builds = list(operator_nvrs)
 
-    def rebase_and_build(operator):
+    def rebase_and_build(olm_bundle: OLMBundle):
         record = {
             'status': -1,
             "task_id": "",
@@ -255,13 +260,12 @@ def rebase_and_build_olm_bundle(runtime: Runtime, operator_nvrs: Tuple[str, ...]
             "bundle_nvr": "",
             "message": "Unknown failure",
         }
+        operator_nvr = olm_bundle.operator_nvr
         try:
-            olm_bundle = OLMBundle(runtime, dry_run)
-            operator_nvr = operator if isinstance(operator, str) else operator["nvr"]
             record['operator_nvr'] = operator_nvr
             if not force:
                 runtime.logger.info("%s - Finding most recent bundle build", operator_nvr)
-                bundle_nvr = olm_bundle.find_bundle_for(operator)
+                bundle_nvr = olm_bundle.find_bundle_image()
                 if bundle_nvr:
                     runtime.logger.info("%s - Found bundle build %s", operator_nvr, bundle_nvr)
                     record['status'] = 0
@@ -270,7 +274,7 @@ def rebase_and_build_olm_bundle(runtime: Runtime, operator_nvrs: Tuple[str, ...]
                     return record
                 runtime.logger.info("%s - No bundle build found", operator_nvr)
             runtime.logger.info("%s - Rebasing bundle distgit repo", operator_nvr)
-            olm_bundle.rebase(operator)
+            olm_bundle.rebase()
             runtime.logger.info("%s - Building bundle distgit repo", operator_nvr)
             task_id, task_url, bundle_nvr = olm_bundle.build()
             record['status'] = 0
@@ -280,13 +284,21 @@ def rebase_and_build_olm_bundle(runtime: Runtime, operator_nvrs: Tuple[str, ...]
             record['bundle_nvr'] = bundle_nvr
         except Exception as err:
             traceback.print_exc()
-            runtime.logger.error('Error during rebase or build for: {}'.format(operator))
+            runtime.logger.error('Error during rebase or build for: {}'.format(operator_nvr))
             record['message'] = str(err)
         finally:
             runtime.add_record("build_olm_bundle", **record)
             return record
 
-    results = exectools.parallel_exec(lambda operator, _: rebase_and_build(operator), operator_builds).get()
+    olm_bundles = [OLMBundle(runtime, op, dry_run=dry_run) for op in operator_builds]
+    get_branches_results = exectools.parallel_exec(lambda bundle, _: bundle.does_bundle_branch_exist(),
+                                                   olm_bundles).get()
+    if not all([result[0] for result in get_branches_results]):
+        runtime.logger.error('One or more bundle branches do not exist: '
+                             f'{[result[1] for result in get_branches_results if not result[0]]}. Please create them first.')
+        sys.exit(1)
+
+    results = exectools.parallel_exec(lambda bundle, _: rebase_and_build(bundle), olm_bundles).get()
 
     for record in results:
         if record['status'] == 0:

--- a/doozer/doozerlib/olm/bundle.py
+++ b/doozer/doozerlib/olm/bundle.py
@@ -184,7 +184,7 @@ class OLMBundle(object):
 
     def does_bundle_branch_exist(self):
         try:
-            self.clone_bundle()
+            self.clone_bundle(retries=None)
             return True, ''
         except Exception as err:
             if len(err.args) > 1:
@@ -194,7 +194,7 @@ class OLMBundle(object):
                     return False, f'{self.bundle_repo_name}/{self.branch}'
             raise
 
-    def clone_bundle(self):
+    def clone_bundle(self, retries: int = 3):
         """Clone corresponding bundle distgit repository of given operator NVR
         """
         dg_dir = Path(self.bundle_clone_path)
@@ -209,7 +209,7 @@ class OLMBundle(object):
         dg_dir.parent.mkdir(parents=True, exist_ok=True)
         exectools.cmd_assert('rhpkg {} clone --depth 1 --branch {} {} {}'.format(
             self.rhpkg_opts, self.branch, self.bundle_repo_name, self.bundle_clone_path
-        ))
+        ), retries=retries)
 
     def clean_bundle_contents(self):
         """Delete all files currently present in the bundle repository

--- a/doozer/doozerlib/olm/bundle.py
+++ b/doozer/doozerlib/olm/bundle.py
@@ -29,30 +29,46 @@ class OLMBundle(object):
     independently built, due to their tight coupling to corresponding operators
     """
 
-    def __init__(self, runtime: Runtime, dry_run: bool, brew_session: Optional[ClientSession] = None):
+    def __init__(self, runtime: Runtime,
+                 operator_nvr_or_dict: Union[str, dict],
+                 dry_run: Optional[bool] = False,
+                 brew_session: Optional[ClientSession] = None):
         self.runtime = runtime
         self.dry_run = dry_run
         self.brew_session = brew_session or runtime.build_retrying_koji_client()
-        self.operator_nvr: Optional[str] = None
         self.operator_dict: Optional[dict] = None
-        self.operator_repo_name: Optional[str] = None
-        self.operator_build_commit: Optional[str] = None
 
-    def find_bundle_for(self, operator_build: Union[str, dict]) -> str:
-        """Check if a bundle already exists for a given `operator_build`.
+        if operator_nvr_or_dict:
+            if isinstance(operator_nvr_or_dict, dict):
+                self.operator_dict = operator_nvr_or_dict
+            else:
+                print(f"operator_nvr_or_dict: {operator_nvr_or_dict}")
+                build = brew.get_build_objects([operator_nvr_or_dict], self.brew_session)[0]
+                if not build:
+                    raise IOError(f"Build {self.operator_nvr} doesn't exist in Brew.")
+                self.operator_dict = build
 
-        :param operator_build: Operator build dict or NVR (format: my-operator-container-v4.2.30-202004200449)
+    @property
+    def operator_nvr(self):
+        return self.operator_dict['nvr']
+
+    @property
+    def operator_repo_name(self):
+        source_url = urlparse(self.operator_dict['source'])
+        # /git/containers/ose-cluster-kube-descheduler-operator => containers/ose-cluster-kube-descheduler-operator
+        return f"containers/{source_url.path.rstrip('/').rsplit('/')[-1]}"
+
+    @property
+    def operator_build_commit(self):
+        source_url = urlparse(self.operator_dict['source'])
+        return source_url.fragment
+
+    def find_bundle_image(self) -> str:
+        """Check if a bundle already exists for the nvr that was used to init the OLMBundle object
+
         :return: NVR of latest found bundle build, or None if there is no bundle build nvr
-                        corresponding to the last operator build's nvr.
+                        corresponding to the nvr used to init the OLMBundle object
         """
-        if isinstance(operator_build, str):
-            self.operator_nvr = operator_build
-        else:
-            self.operator_nvr = operator_build["nvr"]
-            self.operator_dict = operator_build
-
-        self.get_operator_buildinfo()
-
         prefix = f"{self.bundle_brew_component}-{self.operator_dict['version']}.{self.operator_dict['release']}-"
         bundle_package_id = self.brew_session.getPackageID(self.bundle_brew_component, strict=True)
         builds = self.brew_session.listBuilds(packageID=bundle_package_id, pattern=prefix + "*", state=brew.BuildStates.COMPLETE.value,
@@ -86,20 +102,13 @@ class OLMBundle(object):
         del latest_build["_release"]
         return latest_build
 
-    def rebase(self, operator_build: Union[str, dict]):
+    def rebase(self):
         """Update bundle distgit contents with manifests from given operator NVR
         Perform image SHA replacement on manifests before commit & push
         Annotations and Dockerfile labels are re-generated with info from operator's package YAML
 
-        :param operator_build: Operator build dict or NVR (format: my-operator-container-v4.2.30-202004200449)
         :return bool True if rebase succeeds, False if there was nothing new to commit
         """
-        if isinstance(operator_build, str):
-            self.operator_nvr = operator_build
-        else:
-            self.operator_nvr = operator_build["nvr"]
-            self.operator_dict = operator_build
-        self.get_operator_buildinfo()
         self.clone_operator()
         self.checkout_operator_to_build_commit()
         self.clone_bundle()
@@ -112,16 +121,12 @@ class OLMBundle(object):
         self.create_container_yaml()
         return self.commit_and_push_bundle(commit_msg="Update bundle manifests")
 
-    def build(self, operator_name=None) -> Tuple[Optional[int], Optional[int], Optional[str]]:
+    def build(self) -> Tuple[Optional[int], Optional[int], Optional[str]]:
         """Trigger a brew build of operator's bundle
 
-        :param operator_name: Operator name (as in ocp-build-data file name, not brew component)
         :return: (task_id, task_url, nvr) if build succeeds, (task_id, task_url, None) if container-build task is created but build fails,
                  or (None, None, None) if unable to create a container-build task.
         """
-        if operator_name:
-            self.operator_repo_name = 'containers/{}'.format(operator_name)
-
         self.clone_bundle()
         task_id, task_url = self.trigger_bundle_container_build()
         if task_id:
@@ -153,23 +158,6 @@ class OLMBundle(object):
         prefix = '' if self.bundle_name.startswith('ose-') else 'ose-'
         return 'openshift/{}{}'.format(prefix, self.bundle_name)
 
-    def get_operator_buildinfo(self, nvr=None):
-        """Get operator distgit repository name and commit hash used to build given operator NVR
-        :param nvr: If specified, used to set self.operator_nvr.
-        """
-        if nvr:
-            self.operator_nvr = nvr
-
-        if not self.operator_dict or self.operator_dict["nvr"] != self.operator_nvr:
-            self.operator_dict = brew.get_build_objects([self.operator_nvr], self.brew_session)[0]
-            if not self.operator_dict:
-                raise IOError(f"Build {self.operator_nvr} doesn't exist in Brew.")
-
-        # source_url looks like "https://pkgs.devel.redhat.com/git/containers/foo#deadbeef"
-        source_url = urlparse(self.operator_dict['source'])
-        self.operator_repo_name = f"containers/{source_url.path.rstrip('/').rsplit('/')[-1]}"  # /git/containers/ose-cluster-kube-descheduler-operator => containers/ose-cluster-kube-descheduler-operator
-        self.operator_build_commit = source_url.fragment
-
     def clone_operator(self):
         """Clone operator distgit repository to doozer working dir
         """
@@ -194,6 +182,18 @@ class OLMBundle(object):
         with pushd.Dir(self.operator_clone_path):
             exectools.cmd_assert('git checkout {}'.format(self.operator_build_commit))
 
+    def does_bundle_branch_exist(self):
+        try:
+            self.clone_bundle()
+            return True, ''
+        except Exception as err:
+            if len(err.args) > 1:
+                _, _, clone_error = err.args[1]
+                if f"Could not find remote branch {self.branch} to clone" in clone_error:
+                    self.runtime.logger.warning("Could not find remote branch %s to clone, skipping bundle clone", self.branch)
+                    return False, f'{self.bundle_repo_name}/{self.branch}'
+            raise
+
     def clone_bundle(self):
         """Clone corresponding bundle distgit repository of given operator NVR
         """
@@ -209,7 +209,7 @@ class OLMBundle(object):
         dg_dir.parent.mkdir(parents=True, exist_ok=True)
         exectools.cmd_assert('rhpkg {} clone --depth 1 --branch {} {} {}'.format(
             self.rhpkg_opts, self.branch, self.bundle_repo_name, self.bundle_clone_path
-        ), retries=3)
+        ))
 
     def clean_bundle_contents(self):
         """Delete all files currently present in the bundle repository

--- a/doozer/tests/test_olm_bundle.py
+++ b/doozer/tests/test_olm_bundle.py
@@ -9,9 +9,19 @@ from doozerlib.olm.bundle import OLMBundle
 class TestOLMBundle(unittest.TestCase):
 
     def test_get_bundle_image_name_no_ose_prefix(self):
-        obj = flexmock(OLMBundle(None, dry_run=False, brew_session=MagicMock()), bundle_name='foo')
-        self.assertEqual(obj.get_bundle_image_name(), 'openshift/ose-foo')
+        name = 'foo-operator'
+        olm = flexmock(OLMBundle(runtime=None, operator_nvr_or_dict={
+            'nvr': f'{name}-1.0.0-1',
+            'source': f'https://pkgs.devel.redhat.com/git/containers/{name}'
+                      '#d37b219bb1227aed06e32a995f74595f845bb981'
+        }, brew_session=MagicMock()))
+        self.assertEqual(olm.get_bundle_image_name(), 'openshift/ose-foo-operator-bundle')
 
     def test_get_bundle_image_name_with_ose_prefix(self):
-        obj = flexmock(OLMBundle(None, dry_run=False, brew_session=MagicMock()), bundle_name='ose-foo')
-        self.assertEqual(obj.get_bundle_image_name(), 'openshift/ose-foo')
+        name = 'ose-foo-operator'
+        olm = flexmock(OLMBundle(runtime=None, operator_nvr_or_dict={
+            'nvr': f'{name}-1.0.0-1',
+            'source': f'https://pkgs.devel.redhat.com/git/containers/{name}'
+                      '#d37b219bb1227aed06e32a995f74595f845bb981'
+        }, brew_session=MagicMock()))
+        self.assertEqual(olm.get_bundle_image_name(), 'openshift/ose-foo-operator-bundle')


### PR DESCRIPTION


If distgit branch doesn't exist, fail fast
```
./doozer --group=openshift-4.16 --assembly ec.6 olm-bundle:rebase-and-build --dry-run

ERROR One or more bundle branches do not exist: ['containers/ose-smb-csi-driver-operator-bundle/rhaos-4.16-rhel-8', 'containers/dpu-operator-bundle/rhaos-4.16-rhel-8']
```