### PR TITLE
Regression alerts only if next version is GA

### DIFF
--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+import yaml
 from typing import Any, Dict, Iterable, List, Set, Tuple
 import click
 from errata_tool import Erratum
@@ -180,7 +181,15 @@ class BugValidator:
                  is_attached: bool = False):
         non_flaw_bugs = self.filter_bugs_by_release(non_flaw_bugs, complain=True)
         self._find_invalid_trackers(non_flaw_bugs)
-        if not no_verify_blocking_bugs:
+
+        # Make sure the next version is GA before regression check
+        major, minor = self.runtime.get_major_minor()
+        next_version_branch = f"openshift-{major}.{minor + 1}"
+        out = self.runtime.get_file_from_gitdata(next_version_branch, 'group.yml')
+        next_group_config = yaml.safe_load(out)
+        next_is_ga = next_group_config['software_lifecycle']['phase'] == 'release'
+
+        if not no_verify_blocking_bugs and next_is_ga:
             blocking_bugs_for = self._get_blocking_bugs_for(non_flaw_bugs)
             self._verify_blocking_bugs(blocking_bugs_for, is_attached=is_attached)
 

--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -184,12 +184,13 @@ class BugValidator:
 
         # Make sure the next version is GA before regression check
         major, minor = self.runtime.get_major_minor()
-        next_version_branch = f"openshift-{major}.{minor + 1}"
-        out = self.runtime.get_file_from_gitdata(next_version_branch, 'group.yml')
-        next_group_config = yaml.safe_load(out)
-        next_is_ga = next_group_config['software_lifecycle']['phase'] == 'release'
+        version = f"{major}.{minor + 1}"
+        next_is_ga = self.runtime.is_version_in_lifecycle_phase("release", version)
+        if not next_is_ga:
+            no_verify_blocking_bugs = True
+            logger.info(f"Skipping regression check because {version} is not GA")
 
-        if not no_verify_blocking_bugs and next_is_ga:
+        if not no_verify_blocking_bugs:
             blocking_bugs_for = self._get_blocking_bugs_for(non_flaw_bugs)
             self._verify_blocking_bugs(blocking_bugs_for, is_attached=is_attached)
 

--- a/elliott/elliottlib/runtime.py
+++ b/elliott/elliottlib/runtime.py
@@ -445,7 +445,23 @@ class Runtime(GroupRuntime):
     def get_errata_config(self, **kwargs):
         return self.gitdata.load_data(key='erratatool', **kwargs).data
 
-    def get_file_from_gitdata(self, branch, filename):
+    def is_version_in_lifecycle_phase(self, phase: str, version: str = None) -> bool:
+        """
+        Determine if the version is in the specified lifecycle phase.
+        :param phase: The lifecycle phase to check.
+        :param version: The version to check. If ommitted the runtime's group version is used. e.g. "4.16"
+        :return: True if the version is in the specified phase, False otherwise.
+        """
+        major, minor = self.get_major_minor()
+        if version and version != f"{major}.{minor}":
+            out = self.get_file_from_branch(f"openshift-{version}", 'group.yml')
+            next_group_config = yaml.safe_load(out)
+            actual_phase = next_group_config.get('software_lifecycle', {}).get('phase', None)
+        else:
+            actual_phase = self.group_config.software_lifecycle.phase
+        return actual_phase == phase
+
+    def get_file_from_branch(self, branch, filename):
         if branch == self.branch:
             raise ValueError("Do not use this method to access files from the current branch")
 

--- a/elliott/tests/test_verify_attached_bugs_cli.py
+++ b/elliott/tests/test_verify_attached_bugs_cli.py
@@ -30,8 +30,7 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
         flexmock(Runtime).should_receive("initialize")
         flexmock(Runtime).should_receive("get_errata_config").and_return({})
         flexmock(Runtime).should_receive("get_major_minor").and_return((4, 6))
-        next_version_config = {'software_lifecycle': {'phase': 'pre-release'}}
-        flexmock(Runtime).should_receive("get_file_from_gitdata").and_return(yaml.dump(next_version_config))
+        flexmock(Runtime).should_receive("is_version_in_lifecycle_phase").and_return(False)
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         client = flexmock()
         flexmock(client).should_receive("fields").and_return([])
@@ -59,8 +58,7 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
         flexmock(Runtime).should_receive("initialize")
         flexmock(Runtime).should_receive("get_errata_config").and_return({})
         flexmock(Runtime).should_receive("get_major_minor").and_return((4, 6))
-        next_version_config = {'software_lifecycle': {'phase': 'release'}}
-        flexmock(Runtime).should_receive("get_file_from_gitdata").and_return(yaml.dump(next_version_config))
+        flexmock(Runtime).should_receive("is_version_in_lifecycle_phase").and_return(True)
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         client = flexmock()
         flexmock(client).should_receive("fields").and_return([])
@@ -102,8 +100,7 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
         flexmock(Runtime).should_receive("initialize")
         flexmock(Runtime).should_receive("get_errata_config").and_return({})
         flexmock(Runtime).should_receive("get_major_minor").and_return((4, 6))
-        next_version_config = {'software_lifecycle': {'phase': 'release'}}
-        flexmock(Runtime).should_receive("get_file_from_gitdata").and_return(yaml.dump(next_version_config))
+        flexmock(Runtime).should_receive("is_version_in_lifecycle_phase").and_return(True)
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'project': 'OCPBUGS', 'target_release': [
             '4.6.z']})
         client = flexmock()

--- a/elliott/tests/test_verify_attached_bugs_cli.py
+++ b/elliott/tests/test_verify_attached_bugs_cli.py
@@ -1,3 +1,5 @@
+import yaml
+
 from click.testing import CliRunner
 from errata_tool import Erratum
 from unittest.mock import patch
@@ -23,10 +25,42 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
         validator = BugValidator(runtime, True)
         self.assertEqual(validator.target_releases, ['4.9.z'])
 
+    def test_verify_bugs_skip_blocking_bugs_for_prerelease(self):
+        runner = CliRunner()
+        flexmock(Runtime).should_receive("initialize")
+        flexmock(Runtime).should_receive("get_errata_config").and_return({})
+        flexmock(Runtime).should_receive("get_major_minor").and_return((4, 6))
+        next_version_config = {'software_lifecycle': {'phase': 'pre-release'}}
+        flexmock(Runtime).should_receive("get_file_from_gitdata").and_return(yaml.dump(next_version_config))
+        flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
+        client = flexmock()
+        flexmock(client).should_receive("fields").and_return([])
+        flexmock(JIRABugTracker).should_receive("login").and_return(client)
+        flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
+        flexmock(BugzillaBugTracker).should_receive("login")
+
+        bugs = [
+            flexmock(id="OCPBUGS-1", target_release=['4.6.z'], depends_on=['OCPBUGS-4'],
+                     status='ON_QA', is_ocp_bug=lambda: True, is_tracker_bug=lambda: False,
+                     is_invalid_tracker_bug=lambda: False),
+            flexmock(id="OCPBUGS-2", target_release=['4.6.z'], depends_on=['OCPBUGS-3'],
+                     status='ON_QA', is_ocp_bug=lambda: True, is_tracker_bug=lambda: False,
+                     is_invalid_tracker_bug=lambda: False)
+        ]
+
+        flexmock(JIRABugTracker).should_receive("search").and_return(bugs)
+        flexmock(BugzillaBugTracker).should_receive("search").and_return([])
+
+        result = runner.invoke(cli, ['-g', 'openshift-4.6', '--assembly=4.6.6', 'verify-bugs'])
+        self.assertEqual(result.exit_code, 0)
+
     def test_verify_bugs_with_sweep_cli(self):
         runner = CliRunner()
         flexmock(Runtime).should_receive("initialize")
         flexmock(Runtime).should_receive("get_errata_config").and_return({})
+        flexmock(Runtime).should_receive("get_major_minor").and_return((4, 6))
+        next_version_config = {'software_lifecycle': {'phase': 'release'}}
+        flexmock(Runtime).should_receive("get_file_from_gitdata").and_return(yaml.dump(next_version_config))
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         client = flexmock()
         flexmock(client).should_receive("fields").and_return([])
@@ -67,6 +101,9 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
         runner = CliRunner()
         flexmock(Runtime).should_receive("initialize")
         flexmock(Runtime).should_receive("get_errata_config").and_return({})
+        flexmock(Runtime).should_receive("get_major_minor").and_return((4, 6))
+        next_version_config = {'software_lifecycle': {'phase': 'release'}}
+        flexmock(Runtime).should_receive("get_file_from_gitdata").and_return(yaml.dump(next_version_config))
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'project': 'OCPBUGS', 'target_release': [
             '4.6.z']})
         client = flexmock()

--- a/pyartcd/pyartcd/pipelines/check_bugs.py
+++ b/pyartcd/pyartcd/pipelines/check_bugs.py
@@ -67,34 +67,7 @@ class CheckBugsPipeline:
         self.logger.info('Command returned: %s', out)
         self.issues.extend(out)
 
-    async def _is_version_in_release_state(self, version: str) -> bool:
-        """
-        Returns True if the provided version is in "release" state
-        """
-
-        group_config = await util.load_group_config(group=f'openshift-{version}', assembly='stream')
-        phase = group_config['software_lifecycle']['phase']
-
-        if phase != 'release':
-            self.logger.info('%s is in state "%s"', version, phase)
-            return False
-
-        return True
-
-    @staticmethod
-    def get_next_minor(version: str) -> str:
-        major, minor = version.split('.')[:2]
-        return '.'.join([major, str(int(minor) + 1)])
-
     async def _find_regressions(self):
-        # Check pre-release
-        next_minor = self.get_next_minor(self.version)
-        if not await self._is_version_in_release_state(next_minor):
-            self.logger.info('Skipping regression checks for %s as %s is not in "release" state',
-                             self.version, next_minor)
-            return
-
-        # Next minor is GA: going to check for regressions
         self.logger.info(f'Checking possible regressions for Openshift {self.version}')
 
         # Verify bugs


### PR DESCRIPTION
Make sure next version is GA for doing regression checks
Relies on `software_lifecycle`  config in group.yml

Test: elliott --assembly 4.15.12 -g openshift-4.15 verify-attached-bugs