### PR TITLE
[fips] update Makefile to support default python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,11 @@ unit:
 	./venv/bin/python -m pytest --verbose --color=yes ocp-build-data-validator/tests/
 
 test: lint unit
+
+default-python-venv:
+	python3 -m venv venv
+	./venv/bin/pip install --upgrade pip
+	./venv/bin/pip install -e artcommon/ doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
+	./venv/bin/pip install -r doozer/requirements-dev.txt -r pyartcd/requirements-dev.txt -r ocp-build-data-validator/requirements-dev.txt
+	cd elliott && ../venv/bin/pip install '.[tests]'
+	# source venv/bin/activate

--- a/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline-task.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline-task.yaml
@@ -22,10 +22,12 @@ spec:
         touch /root/.config/artcd.toml
 
         kinit -kt /tmp/keytab/keytab ocp-build/buildvm.openshift.eng.bos.redhat.com@IPA.REDHAT.COM
-        
-        python3 -m venv venv && source venv/bin/activate && pip install	--upgrade pip && pip install -e artcommon/ doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/ && cd elliott && pip install '.[tests]' && cd ..
 
-        artcd -vv --dry-run scan-fips --version $(params.version) --nvrs $(params.nvrs) 
+        make default-python-venv
+
+        source venv/bin/activate
+
+        artcd -vv --dry-run scan-fips --version $(params.version) --nvrs $(params.nvrs)
 
       securityContext:
         runAsGroup: 0


### PR DESCRIPTION
Openshift is automatically delimiting if the line length is tool long. Adding commands to the makefile for now

Successful [run](https://console-openshift-console.apps.artc2023.pc3z.p1.openshiftapps.com/k8s/ns/art-cd/tekton.dev~v1~PipelineRun/fips-pipeline-3wab09/logs)