### PR TITLE
[artcluster] setup webhooks to trigger art-cd build auto

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/image/base.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/image/base.yaml
@@ -24,3 +24,7 @@ spec:
   runPolicy: Serial
   triggers:
     - type: ConfigChange
+    - type: Generic
+      generic:
+        secretReference:
+          name: build-config-webhook-secret


### PR DESCRIPTION
So that art-cd build config will automatically trigger new builds when we push to art-tools