### PR TITLE
Select existing bundle image for assembly if delivery labels match

### DIFF
--- a/doozer/doozerlib/cli/olm_bundle.py
+++ b/doozer/doozerlib/cli/olm_bundle.py
@@ -83,7 +83,7 @@ def olm_bundles_print(runtime: Runtime, skip_missing, pattern: Optional[str]):
             s = s.replace('{nvr}', nvr)
             olm_bundle.get_operator_buildinfo(nvr=nvr)  # Populate the object for the operator we are interested in.
             s = s.replace('{bundle_component}', olm_bundle.bundle_brew_component)
-            bundle_image_name = olm_bundle.get_bundle_image_name()
+            bundle_image_name = olm_bundle.bundle_image_name
 
             if '{paired_' in s:
                 # Paired bundle values must correspond exactly to the latest operator NVR.

--- a/doozer/tests/test_olm_bundle.py
+++ b/doozer/tests/test_olm_bundle.py
@@ -15,7 +15,7 @@ class TestOLMBundle(unittest.TestCase):
             'source': f'https://pkgs.devel.redhat.com/git/containers/{name}'
                       '#d37b219bb1227aed06e32a995f74595f845bb981'
         }, brew_session=MagicMock()))
-        self.assertEqual(olm.get_bundle_image_name(), 'openshift/ose-foo-operator-bundle')
+        self.assertEqual(olm.bundle_image_name, 'openshift/ose-foo-operator-bundle')
 
     def test_get_bundle_image_name_with_ose_prefix(self):
         name = 'ose-foo-operator'
@@ -24,4 +24,4 @@ class TestOLMBundle(unittest.TestCase):
             'source': f'https://pkgs.devel.redhat.com/git/containers/{name}'
                       '#d37b219bb1227aed06e32a995f74595f845bb981'
         }, brew_session=MagicMock()))
-        self.assertEqual(olm.get_bundle_image_name(), 'openshift/ose-foo-operator-bundle')
+        self.assertEqual(olm.bundle_image_name, 'openshift/ose-foo-operator-bundle')


### PR DESCRIPTION
When preparing prerelease assembly like ECs, we set `operator_index_mode: pre-release` 
in assembly definition. This gets used by olm-bundle:rebase-and-build to set the appropriate 
labels on the bundle image. These are different for ECs and normal stream builds that we do.
So we cannot reuse normal stream builds that we build everyday via olm_bundle job for ECs,
or any assembly that has something different for `operator_index_mode` config than what's in
group.yml for the group. 

To get around this we opted to force rebuild bundle images for prerelease everytime, (except
when advisory was already populated which then we skipped). But this isn't perfect. We've been
seeing the bundle rebase and build command failures where it would fail if distgit branch doesn't
exist or if a rebase/build fails. This leads those builds to get lost and leading us and pipeline to 
force build them multiple times. This build time is significant so it costs us time and attention.

Instead we can try to match labels that we expect bundle image to have and make sure latest
build has those. This would mean when we run this command in quick successions, even with
failures, existing builds would be found and reused.

Note that we are not matching all labels but only delivery_labels which can change for assembly.

## Test
```
./doozer --group=openshift-4.16 --assembly ec.6 olm-bundle:rebase-and-build --dry-run
```