### PR TITLE
[ART-7995] pyartcd.promote: call sigstore signing

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -13,7 +13,7 @@ import hashlib
 import shutil
 from collections import OrderedDict
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Union
+from typing import Dict, Iterable, List, Optional, Union, Set
 from urllib.parse import quote
 from ruamel.yaml import YAML
 from semver import VersionInfo
@@ -28,7 +28,7 @@ from artcommonlib.exectools import to_thread, manifest_tool
 from artcommonlib.rhcos import get_primary_container_name
 from artcommonlib.util import isolate_major_minor_in_group
 from pyartcd.locks import Lock
-from pyartcd.signatory import AsyncSignatory
+from pyartcd.signatory import AsyncSignatory, SigstoreSignatory
 from pyartcd.util import nightlies_with_pullspecs
 from pyartcd import constants, exectools, locks, util, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
@@ -63,6 +63,7 @@ class PromotePipeline:
                  skip_image_list: bool = False,
                  skip_build_microshift: bool = False,
                  skip_signing: bool = False,
+                 skip_sigstore: bool = False,
                  skip_cincinnati_prs: bool = False,
                  skip_ota_notification: bool = False,
                  permit_overwrite: bool = False,
@@ -80,6 +81,7 @@ class PromotePipeline:
         self.skip_build_microshift = skip_build_microshift
         self.skip_mirror_binaries = skip_mirror_binaries
         self.skip_signing = skip_signing
+        self.skip_sigstore = skip_sigstore
         self.skip_cincinnati_prs = skip_cincinnati_prs
         self.skip_ota_notification = skip_ota_notification
         self.permit_overwrite = permit_overwrite
@@ -92,6 +94,8 @@ class PromotePipeline:
         self._multi_enabled = False
         if not self.skip_signing and not signing_env:
             raise ValueError("--signing-env is required unless --skip-signing is set")
+        if not self.skip_sigstore and not signing_env:
+            raise ValueError("--signing-env is required unless --skip-sigstore is set")
         self.signing_env = signing_env
 
         self._logger = self.runtime.logger
@@ -121,6 +125,8 @@ class PromotePipeline:
             required_vars += ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]
         if not self.skip_signing:
             required_vars += ["SIGNING_CERT", "SIGNING_KEY", "REDIS_SERVER_PASSWORD", "REDIS_HOST", "REDIS_PORT"]
+        if not self.skip_sigstore:
+            required_vars += ["KMS_CRED_FILE", "KMS_KEY_ID"]
         if not self.skip_build_microshift:
             required_vars += ["JENKINS_SERVICE_ACCOUNT", "JENKINS_SERVICE_ACCOUNT_TOKEN"]
 
@@ -398,6 +404,8 @@ class PromotePipeline:
                         lock_name=lock.value.format(signing_env=self.signing_env),
                         lock_id=lock_identifier
                     )
+                if not self.skip_sigstore:
+                    await self.sigstore_sign(release_name, release_infos)
 
         except Exception as err:
             self._logger.exception(err)
@@ -725,6 +733,36 @@ class PromotePipeline:
         # Publish the clients to our S3 bucket.
         await util.mirror_to_s3(f"{base_to_mirror_dir}/{build_arch}", f"s3://art-srv-enterprise/pub/openshift-v4/{build_arch}", dry_run=self.runtime.dry_run)
         return f"{build_arch}/clients/{client_type}/{release_name}/sha256sum.txt"
+
+    async def sigstore_sign(self, release_name: str, release_infos: Dict):
+        """ Signs release and component images with sigstore/cosign which publishes to quay
+        """
+        CONCURRENCY_LIMIT = 100  # we run out of processes without a limit
+        signatory = SigstoreSignatory(
+            logger=self._logger,
+            dry_run=self.runtime.dry_run,
+            signing_creds=os.environ.get("KMS_CRED_FILE", "dummy-file"),
+            signing_key_id=os.environ.get("KMS_KEY_ID", "dummy-key"),
+            concurrency_limit=CONCURRENCY_LIMIT,
+            sign_release=False,  # until OTA-1267 is complete
+            sign_components=True,
+            verify_release=False,  # not needed when we're supplying the shasum pullspecs
+        )
+        # recursively discover all the pullspecs that need to be signed.
+        images: List[str] = [
+            # for paranoia, refer to release image pullspecs with shasums
+            signatory.redigest_pullspec(info["image"], info["digest"])
+            for info in release_infos.values()
+        ]
+        need_signing: Set[str] = set()
+        errors: Dict[str, str] = {}  # pullspec -> exception
+        need_signing, errors = await signatory.discover_pullspecs(images, release_name)
+
+        if errors:
+            # this should be impossible given we just created the pullspecs
+            raise IOError(f"Not all pullspecs examined were viable: {errors}")
+        if errors := await signatory.sign_pullspecs(need_signing):
+            raise IOError(f"Not all signings succeeded, check errors: {errors}")
 
     def publish_baremetal_installer_binary(self, release_pullspec: str, client_mirror_dir: str, build_arch: str):
         _, baremetal_installer_pullspec = get_release_image_pullspec(release_pullspec, 'baremetal-installer')
@@ -1586,7 +1624,9 @@ class PromotePipeline:
 @click.option("--skip-build-microshift", is_flag=True,
               help="Do not build microshift rpm")
 @click.option("--skip-signing", is_flag=True,
-              help="Do not sign artifacts")
+              help="Do not sign artifacts (legacy signing)")
+@click.option("--skip-sigstore", is_flag=True,
+              help="Do not sign using the newer sigstore method.")
 @click.option("--skip-cincinnati-prs", is_flag=True,
               help="Do not create Cincinnati PRs")
 @click.option("--skip-ota-notification", is_flag=True,
@@ -1606,6 +1646,7 @@ async def promote(runtime: Runtime, group: str, assembly: str,
                   skip_image_list: bool,
                   skip_build_microshift: bool,
                   skip_signing: bool,
+                  skip_sigstore: bool,
                   skip_cincinnati_prs: bool,
                   skip_ota_notification: bool,
                   permit_overwrite: bool, no_multi: bool, multi_only: bool,
@@ -1614,7 +1655,7 @@ async def promote(runtime: Runtime, group: str, assembly: str,
                   signing_env: Optional[str]):
     pipeline = await PromotePipeline.create(
         runtime, group, assembly, skip_blocker_bug_check, skip_attached_bug_check, skip_image_list,
-        skip_build_microshift, skip_signing, skip_cincinnati_prs, skip_ota_notification,
+        skip_build_microshift, skip_signing, skip_sigstore, skip_cincinnati_prs, skip_ota_notification,
         permit_overwrite, no_multi, multi_only, skip_mirror_binaries, use_multi_hack, signing_env
     )
     await pipeline.run()

--- a/pyartcd/pyartcd/signatory.py
+++ b/pyartcd/pyartcd/signatory.py
@@ -248,7 +248,7 @@ class SigstoreSignatory:
         self.verify_release = verify_release  # require a legacy signature on release images
 
     @staticmethod
-    def _redigest_pullspec(pullspec, digest):
+    def redigest_pullspec(pullspec, digest):
         """ form the pullspec for a digest in the same repo as an existing pullspec """
         if len(halves := pullspec.split("@sha256:")) == 2:  # assume that was a digest at the end
             return f"{halves[0]}@{digest}"
@@ -312,7 +312,7 @@ class SigstoreSignatory:
             # the list, only the final image to be downloaded. we do however need to examine each
             # manifest to see if that might be a release image.
             for manifest in img_info:
-                need_examining.add(self._redigest_pullspec(manifest["name"], manifest["digest"]))
+                need_examining.add(self.redigest_pullspec(manifest["name"], manifest["digest"]))
         elif (this_rn := img_info["config"]["config"]["Labels"].get("io.openshift.release")):
             # release image; get references and examine those
             self._logger.info("%s is a release image with name %s", pullspec, this_rn)

--- a/pyartcd/pyartcd/slack.py
+++ b/pyartcd/pyartcd/slack.py
@@ -59,7 +59,7 @@ class SlackClient:
             })
         if self.dry_run:
             _LOGGER.warning("[DRY RUN] Would have sent slack message to %s: %s %s", self.channel, message, attachments)
-            return {"message": {"ts": "fake"}}
+            return {"ts": "fake"}
         response = await self._client.chat_postMessage(channel=self.channel, text=message, thread_ts=thread_ts,
                                                        username=self.as_user, link_names=True, attachments=attachments,
                                                        icon_emoji=self.icon_emoji, reply_broadcast=False)


### PR DESCRIPTION
uses the same signatory code from sigstore-sign to sign a release.
for now it will only sign component images, not release images due to OTA-1267.

Must merge with https://github.com/openshift-eng/aos-cd-jobs/pull/4146 - either alone breaks promotion