### PR TITLE
for ec and rc use current date to get in flight release

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -131,7 +131,7 @@ def get_inflight(assembly, group):
     """
     inflight_release = None
     if 'ec' in assembly or 'rc' in assembly:
-        return None
+        raise ValueError(f'You are preparing {assembly} and get no input from in-flight, currently auto get inflight for non GA release is not supported, please input an in-flight value.')
     assembly_release_date = get_assembly_release_date(assembly, group)
     if not assembly_release_date:
         raise ValueError(f'Assembly release date not found for {assembly}')

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -130,6 +130,8 @@ def get_inflight(assembly, group):
     Get inflight release name from current assembly release
     """
     inflight_release = None
+    if 'ec' in assembly or 'rc' in assembly:
+        return None
     assembly_release_date = get_assembly_release_date(assembly, group)
     if not assembly_release_date:
         raise ValueError(f'Assembly release date not found for {assembly}')

--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -45,7 +45,7 @@ class GenAssemblyPipeline:
         self.arches = arches
         if in_flight:
             self.in_flight = in_flight
-        elif not custom and not pre_ga_mode:
+        elif not custom:
             self.in_flight = get_inflight(assembly, group)
         else:
             self.in_flight = None


### PR DESCRIPTION
fix issue like https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgen-assembly/63/consoleFull
don't break when assembly is ec or rc, when release not found in pp use current date as default value.