### PR TITLE
Fix rhcos validator

### DIFF
--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -180,6 +180,9 @@
       "description": "RHCOS needs special config as it is a special build",
       "type": "object",
       "properties": {
+        "allow_missing_brew_rpms": {
+          "type": "boolean"
+        },
         "payload_tags": {
           "type": "array",
           "items": {

--- a/ocp-build-data-validator/validator/json_schemas/rhcos.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/rhcos.schema.json
@@ -90,22 +90,5 @@
     },
     "dependencies-": {}
   },
-  "anyOf": [
-    {
-      "required": [
-        "machine-os-content"
-      ]
-    },
-    {
-      "required": [
-        "machine-os-content!"
-      ]
-    },
-    {
-      "required": [
-        "machine-os-content?"
-      ]
-    }
-  ],
   "additionalProperties": false
 }


### PR DESCRIPTION
4.16+ do not have `machine-os-content` anymore, make that property optional. Also, permit `allow_missing_brew_rpms` in group.yml.