### PR TITLE
Use art automation address for art image build fail emails

### DIFF
--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -597,9 +597,9 @@ The following logs are just the container build portion of the OSBS build:
 
         # Send email to owners of failed image builds
         # If art is the only owner of image (example for our ci golang builder images) send instead to our default automation email
-        owner = failure['owners']
+        owner = (failure['owners']
                 if (failure['owners'] and failure['owners'] != ["aos-team-art@redhat.com"])
-                else default_owner
+                else default_owner)
         mail_client.send_mail(
             to=['aos-art-automation+failed-ocp-build@redhat.com', owner],
             subject=f'Failed OCP build of {failure["image"]}:{failure["version"]}',

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -595,9 +595,13 @@ The following logs are just the container build portion of the OSBS build:
                             f'{failure["message"]}\n' \
                             f'{container_log}'
 
+        # Send email to owners of failed image builds
+        # If art is the only owner of image (example for our ci golang builder images) send instead to our default automation email
+        owner = failure['owners']
+                if (failure['owners'] and failure['owners'] != ["aos-team-art@redhat.com"])
+                else default_owner
         mail_client.send_mail(
-            to=['aos-art-automation+failed-ocp-build@redhat.com',
-                failure['owners'] if failure['owners'] else default_owner],
+            to=['aos-art-automation+failed-ocp-build@redhat.com', owner],
             subject=f'Failed OCP build of {failure["image"]}:{failure["version"]}',
             content=explanation_body
         )

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -598,8 +598,8 @@ The following logs are just the container build portion of the OSBS build:
         # Send email to owners of failed image builds
         # If art is the only owner of image (example for our ci golang builder images) send instead to our default automation email
         owner = (failure['owners']
-                if (failure['owners'] and failure['owners'] != ["aos-team-art@redhat.com"])
-                else default_owner)
+                 if (failure['owners'] and failure['owners'] != ["aos-team-art@redhat.com"])
+                 else default_owner)
         mail_client.send_mail(
             to=['aos-art-automation+failed-ocp-build@redhat.com', owner],
             subject=f'Failed OCP build of {failure["image"]}:{failure["version"]}',


### PR DESCRIPTION
Right now we're getting emails for build failures of images that we own (ci golang builders)
on our team address. Reroute these to art automation address.