### PR TITLE
compression log for build_sync

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -235,14 +235,15 @@ class BuildSyncPipeline:
 
         # Create tar archive
         self.logger.info('Creating backup archives')
-        cmd = ['tar', 'zcvf', 'app.ci-backup.tgz']
-        cmd.extend(glob.glob('*.backup.yaml'))
+        await exectools.cmd_assert_async("lzma -9 " + " ".join(glob.glob('*.backup.yaml')))
+        cmd = ['tar', 'cvf', 'app.ci-backup.tgz', '--lzma']
+        cmd.extend(glob.glob('*.backup.yaml.lzma'))
         await exectools.cmd_assert_async(cmd)
 
         # Remove *.yaml
         self.logger.debug('Removing yaml files')
         cmd = ['rm']
-        cmd.extend(glob.glob('*.backup.yaml'))
+        cmd.extend(glob.glob('*.backup.yaml.lzma'))
         await exectools.cmd_assert_async(cmd)
 
     @limit_concurrency(500)


### PR DESCRIPTION
compression app.ci backup from ~60mb to ~10mb
app.ci-backup.tar.gz in previous job:  https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/1672/artifact/
after compress: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/1690/artifact/