### PR TITLE
Fix olm bundle invocations

### DIFF
--- a/doozer/doozerlib/cli/__main__.py
+++ b/doozer/doozerlib/cli/__main__.py
@@ -29,7 +29,7 @@ from doozerlib.cli.scan_osh import scan_osh
 from doozerlib.cli.scan_fips import scan_fips
 from doozerlib.cli.gen_assembly_helper import gen_assembly_rhcos
 from doozerlib.cli.rpms import rpms_print, rpms_rebase_and_build, rpms_rebase, rpms_build, rpms_clone, rpms_clone_sources
-from doozerlib.cli.olm_bundle import list_olm_operators, olm_bundles_print, rebase_olm_bundle, build_olm_bundle, rebase_and_build_olm_bundle
+from doozerlib.cli.olm_bundle import list_olm_operators, olm_bundles_print, rebase_and_build_olm_bundle
 from doozerlib.cli.config import config_commit, config_push, config_get, config_read_group, config_read_releases, \
     config_read_assemblies, config_mode, config_print, config_gencsv, config_rhcos_src, config_update_required
 from doozerlib.cli.images import images_clone, images_list, images_push_distgit, images_covscan, images_rebase, \

--- a/doozer/doozerlib/olm/bundle.py
+++ b/doozer/doozerlib/olm/bundle.py
@@ -155,7 +155,7 @@ class OLMBundle(object):
 
     def does_bundle_branch_exist(self):
         try:
-            self.clone_bundle(retries=None)
+            self.clone_bundle(retries=1)
             return True, ''
         except Exception as err:
             if len(err.args) > 1:
@@ -180,7 +180,7 @@ class OLMBundle(object):
         dg_dir.parent.mkdir(parents=True, exist_ok=True)
         exectools.cmd_assert('rhpkg {} clone --depth 1 --branch {} {} {}'.format(
             self.rhpkg_opts, self.branch, self.bundle_repo_name, self.bundle_clone_path
-        ), retries=3)
+        ), retries=retries)
 
     def clean_bundle_contents(self):
         """Delete all files currently present in the bundle repository


### PR DESCRIPTION
Follow up to https://github.com/openshift-eng/art-tools/pull/582/files
This also deprecates `olm-bundle:build` and `olm-bundle:rebase` commands.
We don't use these anywhere in the pipeline since we always want to build and
rebase as a single operation. Supporting these now takes extra effort (with refactoring)
so remove them.