### PR TITLE
[artc-fips] remove dry-run, message to art-cluster-monitoring

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline-task.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline-task.yaml
@@ -27,7 +27,7 @@ spec:
 
         source venv/bin/activate
 
-        artcd -vv --dry-run scan-fips --version $(params.version) --nvrs $(params.nvrs)
+        artcd -vv scan-fips --version $(params.version) --nvrs $(params.nvrs)
 
       securityContext:
         runAsGroup: 0

--- a/pyartcd/pyartcd/pipelines/scan_fips.py
+++ b/pyartcd/pyartcd/pipelines/scan_fips.py
@@ -18,7 +18,7 @@ class ScanFips:
 
         # Setup slack client
         self.slack_client = self.runtime.new_slack_client()
-        self.slack_client.bind_channel(f"openshift-{self.version}")
+        self.slack_client.bind_channel(f"#art-cluster-monitoring")
 
     async def run(self):
         cmd = [


### PR DESCRIPTION
Changes in this PR:
- Remove `--dry-run`
- Message to `art-cluster-monitoring` for now, till where are confident the pipeline is not reporting false positives