### PR TITLE
set aws output and clear mirror cache

### DIFF
--- a/doozer/doozerlib/cli/olm_bundle.py
+++ b/doozer/doozerlib/cli/olm_bundle.py
@@ -141,8 +141,6 @@ def rebase_and_build_olm_bundle(runtime: Runtime, operator_nvrs: Tuple[str, ...]
     """
 
     runtime.initialize(config_only=True)
-    clone_distgits = bool(runtime.group_config.canonical_builders_from_upstream)
-    runtime.initialize(clone_distgits=clone_distgits)
 
     if not operator_nvrs:
         # If this verb is run without operator NVRs, query Brew for all operator builds

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -526,6 +526,8 @@ class PromotePipeline:
             else:
                 message_digest = await self.publish_client(base_to_mirror_dir, pullspec, release_name, arch, client_type)
             message_digests.append(message_digest)
+        # clear mirror cache
+        shutil.rmtree(base_to_mirror_dir, ignore_errors=True)
         return message_digests
 
     async def sign_artifacts(self, release_name: str, client_type: str, release_infos: Dict, message_digests: List[str]):

--- a/pyartcd/pyartcd/s3.py
+++ b/pyartcd/pyartcd/s3.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from typing import Optional
 from pyartcd import exectools
 from tenacity import retry, stop_after_attempt, wait_fixed
@@ -57,4 +58,4 @@ async def sync_dir_to_s3_mirror(local_dir: str, s3_path: str, exclude: Optional[
         wait=wait_fixed(30),  # wait for 30 seconds between retries
         stop=(stop_after_attempt(3)),  # max 3 attempts
         reraise=True
-    )(exectools.cmd_assert_async)(base_cmd, env=env)
+    )(exectools.cmd_assert_async)(base_cmd, stdout=sys.stderr, env=env)


### PR DESCRIPTION
for aws cli in the promote job, it output will affect the script output for json parser in jenkins job
for mirror cache, the promote job will store the mirror cache around ~20GB in workspace, clear it after mirror to s3 complete
for olm bundle init, we don't need to full clone all repos when build only a few bundles