### PR TITLE
gen-assembly: notify when non-latest green amd64 nightly is selected

### DIFF
--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import re
@@ -6,17 +7,18 @@ from collections import namedtuple
 from io import StringIO
 from typing import Iterable, Optional, OrderedDict, Tuple
 
+import aiohttp
 import click
 from ghapi.all import GhApi
+from ruamel.yaml import YAML
 
-from artcommonlib.util import split_git_url, merge_objects, get_inflight
+from artcommonlib.util import split_git_url, merge_objects, get_inflight, isolate_major_minor_in_group
+from doozerlib.cli.get_nightlies import rc_api_url
 from pyartcd import exectools, constants, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.git import GitRepository
-from pyartcd.runtime import Runtime
-from ruamel.yaml import YAML
-
 from pyartcd.jenkins import start_build_sync
+from pyartcd.runtime import Runtime
 
 yaml = YAML(typ="rt")
 yaml.default_flow_style = False
@@ -85,8 +87,9 @@ class GenAssemblyPipeline:
             if self.custom and (self.auto_previous or self.previous_list or self.in_flight):
                 raise ValueError("Specifying previous list for a custom release is not allowed.")
 
-            self._logger.info("Getting nightlies from Release Controllers...")
-            candidate_nightlies = await self._get_nightlies()
+            candidate_nightlies, latest_nightly = await asyncio.gather(
+                *[self._get_nightlies(), self._get_latest_accepted_nightly()])
+
             self._logger.info("Generating assembly definition...")
             assembly_definition = await self._gen_assembly_from_releases(candidate_nightlies)
             out = StringIO()
@@ -97,7 +100,11 @@ class GenAssemblyPipeline:
             pr = await self._create_or_update_pull_request(assembly_definition)
 
             # Sends a slack message
-            message = f"Hi @release-artists , please review assembly definition for {self.assembly}: {pr.html_url}\n\nthe inflight release is {self.in_flight}"
+            message = (f"Hi @release-artists, please review assembly definition for {self.assembly}: {pr.html_url}\n\n"
+                       f"The inflight release is {self.in_flight}")
+            if latest_nightly not in candidate_nightlies:
+                message += '\n\n:warning: note that `gen-assembly` did not select the latest accepted amd64 nightly'
+
             await self._slack_client.say(message, slack_thread)
 
         except Exception as err:
@@ -106,11 +113,35 @@ class GenAssemblyPipeline:
             await self._slack_client.say(f"Error generating assembly definition for {self.assembly}", slack_thread)
             raise
 
+    async def _get_latest_accepted_nightly(self):
+        self._logger.info('Retrieving most recent accepted amd64 nightly...')
+
+        major, minor = isolate_major_minor_in_group(self.group)
+        tag_base = f'{major}.{minor}.0-0.nightly'
+        rc_endpoint = f"{rc_api_url(tag_base, 'amd64')}/tags"
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(rc_endpoint) as response:
+                if response.status != 200:
+                    self._logger.warning('Failed retrieving latest accepted nighly from %s', rc_endpoint)
+                    return None
+
+                tags = (await response.json()).get('tags', [])
+                accepted_nightlies = list(filter(lambda tag: tag['phase'] == 'Accepted', tags))
+
+                if accepted_nightlies:
+                    return accepted_nightlies[0]['name']
+                else:
+                    self._logger.warning('No accepted nightly found')
+                    return None
+
     async def _get_nightlies(self):
         """
         Get nightlies from Release Controllers
         :return: NVRs
         """
+
+        self._logger.info("Getting nightlies from Release Controllers...")
 
         cmd = [
             "doozer",


### PR DESCRIPTION
Depending on timing logics, it may happen that latest amd64 nightly does not have an equivalent set across all arches. In this case, release-artists might want to investigate and see if this is acceptable, or if a manual intervention is required to capture latest nightly changes.