### PR TITLE
Validate cdn repos

### DIFF
--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -182,6 +182,12 @@ PRESENT advisory. Here are some examples:
         if kind == 'image':
             ensure_rhcos_file_meta(advisory_id)
             if cdn_repos and not no_cdn_repos:
+                cdn_repos = set(cdn_repos)
+                available_repos = set([i['repo']['name'] for i in erratum.metadataCdnRepos()])
+                not_available_repos = cdn_repos - available_repos
+                if not_available_repos:
+                    raise ValueError("These cdn repos defined in erratatool.yml are not available for the advisory "
+                                     f"{advisory_id}: {not_available_repos}")
                 erratum.set_cdn_repos(cdn_repos)
     except ErrataException as e:
         red_print(f'Cannot change advisory {advisory_id}: {e}')

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -190,7 +190,8 @@ PRESENT advisory. Here are some examples:
                     erratum.set_cdn_repos(repos_to_enable)
                 if not_available_repos:
                     raise ValueError("These cdn repos defined in erratatool.yml are not available for the advisory "
-                                     f"{advisory_id}: {not_available_repos}")
+                                     f"{advisory_id}: {not_available_repos}. Please remove these or request them to "
+                                     "be created.")
                 erratum.set_cdn_repos(cdn_repos)
     except ErrataException as e:
         red_print(f'Cannot change advisory {advisory_id}: {e}')

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -185,6 +185,9 @@ PRESENT advisory. Here are some examples:
                 cdn_repos = set(cdn_repos)
                 available_repos = set([i['repo']['name'] for i in erratum.metadataCdnRepos()])
                 not_available_repos = cdn_repos - available_repos
+                repos_to_enable = cdn_repos & available_repos
+                if repos_to_enable:
+                    erratum.set_cdn_repos(repos_to_enable)
                 if not_available_repos:
                     raise ValueError("These cdn repos defined in erratatool.yml are not available for the advisory "
                                      f"{advisory_id}: {not_available_repos}")


### PR DESCRIPTION
As part of `find-builds --attach` when we try make API request to ErrataTool to enable cdn repos, 
it can fail with `requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://errata.devel.redhat.com/api/v1/erratum/125775/metadata_cdn_repos`
This happens when we ask it to operate on cdn repos that do not exist. Reason is 
because we have a misconfig in our erratatool.yml file / or we haven't created them yet.
So enable what can be enabled and then complain.

see: [107](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release/107/consoleFull)
https://errata.devel.redhat.com/api/v1/erratum/125775/metadata_cdn_repos