### PR TITLE
[fips] Error out if there is an issue

### DIFF
--- a/pyartcd/pyartcd/pipelines/scan_fips.py
+++ b/pyartcd/pyartcd/pipelines/scan_fips.py
@@ -55,6 +55,7 @@ class ScanFips:
 
                 # Exit as error so that we see in the PipelineRun
                 self.runtime.logger.error("FIPS issues were found")
+                sys.exit(1)
             else:
                 self.runtime.logger.info("[DRY RUN] Would have messaged slack")
         else:


### PR DESCRIPTION
`sys.exit(1)` if there is a FIPS issue, so that the pipeline turns red, on the cluster