### PR TITLE
allow EMBARGOED_CONTENT in standard permits

### DIFF
--- a/artcommon/artcommonlib/assembly.py
+++ b/artcommon/artcommonlib/assembly.py
@@ -234,7 +234,6 @@ def assembly_permits(releases_config: Model, assembly: typing.Optional[str]) -> 
     """
     defined_permits = assembly_config_struct(releases_config, assembly, 'permits', [])
 
-    non_embargo_permits = []
     # Do some basic validation here to fail fast
     if assembly_type(releases_config, assembly) == AssemblyTypes.STANDARD:
         if any(permit.code != AssemblyIssueCode.EMBARGOED_CONTENT.name for permit in defined_permits):

--- a/artcommon/artcommonlib/assembly.py
+++ b/artcommon/artcommonlib/assembly.py
@@ -237,11 +237,7 @@ def assembly_permits(releases_config: Model, assembly: typing.Optional[str]) -> 
     non_embargo_permits = []
     # Do some basic validation here to fail fast
     if assembly_type(releases_config, assembly) == AssemblyTypes.STANDARD:
-        for permit in defined_permits:
-            if permit.code != AssemblyIssueCode.EMBARGOED_CONTENT.name:
-                non_embargo_permits.append(permit)
-
-        if non_embargo_permits:
+        if any(permit.code != AssemblyIssueCode.EMBARGOED_CONTENT.name for permit in defined_permits):
             raise ValueError(f'STANDARD assemblies like {assembly} only allow {AssemblyIssueCode.EMBARGOED_CONTENT.name} in "permits"')
 
     for permit in defined_permits:


### PR DESCRIPTION
Permits are usually not allowed in standard assemblies. But after embargo lift, we would like to explicitly add the permit so that we make consciously publish private builds to public image streams.