### PR TITLE
Dont try to read stdin by default

### DIFF
--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -39,9 +39,8 @@ pass_runtime = click.make_pass_decorator(Runtime)
 @use_default_advisory_option
 @click.option(
     "--builds-file", "-f", "builds_file",
-    help="File to read builds from, omit to read from STDIN.",
+    help="File to read builds from, `-` to read from STDIN.",
     type=click.File("rt"),
-    default=sys.stdin,
 )
 @click.option(
     '--build', '-b', 'builds',
@@ -121,6 +120,8 @@ PRESENT advisory. Here are some examples:
         raise click.BadParameter('Use only one of --build or --builds-file.')
 
     if builds_file:
+        if builds_file == "-":
+            builds_file = sys.stdin
         builds = [line.strip() for line in builds_file.readlines()]
 
     runtime.initialize(mode='images' if kind == 'image' else 'rpms')

--- a/elliott/elliottlib/cli/remove_builds_cli.py
+++ b/elliott/elliottlib/cli/remove_builds_cli.py
@@ -28,9 +28,8 @@ LOGGER = logutil.get_logger(__name__)
               help="Don't change anything")
 @click.option(
     "--builds-file", "-f", "builds_file",
-    help="File to read builds from, omit to read from STDIN.",
+    help="File to read builds from, `-` to read from STDIN.",
     type=click.File("rt"),
-    default=sys.stdin,
 )
 @click.pass_obj
 def remove_builds_cli(runtime: Runtime, builds, advisory_id, default_advisory_type, clean, noop, builds_file):
@@ -58,6 +57,8 @@ def remove_builds_cli(runtime: Runtime, builds, advisory_id, default_advisory_ty
         raise click.BadParameter("Use only one of --build or --builds-file")
 
     if builds_file:
+        if builds_file == "-":
+            builds_file = sys.stdin
         builds = [line.strip() for line in builds_file.readlines()]
 
     if bool(clean) == bool(builds):


### PR DESCRIPTION
This changes the stdin invocation to 
```
echo sriov-network-operator-metadata-container-v4.16.0.202404221110.p0.g3b79f5e.assembly.stream.el9-7 | 
./elliott --assembly ec.6 -g openshift-4.16 find-builds -k image -f -
```

to better adjust for other cli options we have