### PR TITLE
rpm fips wrapper: Explicitly allow no CGO for GOOS=windows

### DIFF
--- a/doozer/doozerlib/rpm_builder_go_wrapper.sh
+++ b/doozer/doozerlib/rpm_builder_go_wrapper.sh
@@ -30,7 +30,7 @@ if [[ "${CGO_ENABLED}" == "0" ]]; then
     echoerr "non-compliant RPM attempted to use CGO_ENABLED=${CGO_ENABLED}"
 fi
 
-if [[ "${GOOS}" == "darwin" ]]; then
+if [[ "${GOOS}" == darwin || "${GOOS}" == windows ]]; then
     echoerr "permitting CGO_ENABLED=${CGO_ENABLED} because of GOOS=${GOOS}"
 else
     export CGO_ENABLED="1"

--- a/doozer/doozerlib/rpm_builder_go_wrapper.sh
+++ b/doozer/doozerlib/rpm_builder_go_wrapper.sh
@@ -34,8 +34,8 @@ if [[ "${GOOS}" == darwin || "${GOOS}" == windows ]]; then
     echoerr "permitting CGO_ENABLED=${CGO_ENABLED} because of GOOS=${GOOS}"
 else
     export CGO_ENABLED="1"
-    echoerr "forcing CGO_ENABLED=${CGO_ENABLED}"
 fi
+echoerr "GOOS is $GOOS, CGO_ENABLED is ${CGO_ENABLED}"
 
 HAS_TAGS=0
 if cat <<< "$@" | grep "\-tags" > /dev/null; then
@@ -147,4 +147,12 @@ echo 1>&2
 
 echoerr "Invoking actual go binary"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) # Get the directory in which this script is executing
+
+echo -n "$LOG_PREFIX} go environment variable" 1>&2
+{ "${SCRIPT_DIR}/go.real" env | grep -e CGO_ENABLED -e GOEXPERIMENT -e GOOS -e GOARCH -e GOAMD64; } 1>&2
+
+echoerr "FORCE_FOD_MODE=$FORCE_FOD_MODE"
+echoerr "FORCE_OPENSSL=$FORCE_OPENSSL"
+echoerr "FORCE_DYNAMIC=$FORCE_DYNAMIC"
+
 ${SCRIPT_DIR}/go.real "${ARGS[@]}"


### PR DESCRIPTION
Seems like golang changed between 1.21 and 1.22, where `GOOS=windows` stopped to do the right thing by disabling CGO. This surfaced with builds of openshift-clients in 4.17 after updating the rhel9 build root to go-1.22.

This change helps the compiler in the build root to not try CGO when the target is windows.

Successful build with this change: https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3070403
Fixes https://issues.redhat.com/browse/OCPBUGS-32516