### PR TITLE
Update golang script tweaks

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -328,26 +328,30 @@ class UpdateGolangPipeline:
         el_instructions = ''
         for el_v, nvr in el_nvr_map.items():
             nvr_list_string += f'- RHEL{el_v}: {nvr}\n'
-            el_instructions += f'\nFor rhel{el_v}:\n'
+            el_instructions += f'For rhel{el_v}:\n'
             if el_v == 8:
                 module_tag = self.get_module_tag(nvr, el_v)
                 if not module_tag:
                     raise click.BadParameter(f'Cannot find module tag for {nvr}')
+                commit_link = "https://gitlab.cee.redhat.com/rcm/rcm-ansible/-/commit/e838f59751cebe86347e6a82252dec0a1593c735"
                 el_instructions += (f'- Update inheritance for each `rhaos-{self.ocp_version}-rhel-{el_v}-override` '
-                                    f'tag to include the module tag `{module_tag}`\n')
+                                    f'tag to include the module tag `{module_tag}`. This is usually done via a '
+                                    f'commit in rcm-ansible repo ({commit_link}). Please do not '
+                                    'directly tag the module build in the override tag.\n')
             elif el_v in (7, 9):
                 el_instructions += f'- `brew tag rhaos-{self.ocp_version}-rhel-{el_v}-override {nvr}`\n'
             el_instructions += f'- Run `brew regen-repo` for `rhaos-{self.ocp_version}-rhel-{el_v}-build`\n'
 
-        template = f'''OpenShift requests that buildroots for version {self.ocp_version} provide a new
+        template = f'''OpenShift requests that buildroots for version {self.ocp_version} provide a new \
 golang compiler version {go_version} , reference: {self.art_jira}
 
 The new NVRs are:
 {nvr_list_string}
 {el_instructions}
 '''
-
-        _LOGGER.info(f'Please create https://issues.redhat.com/browse/CWFCONF Jira ticket with the following content:\n{template}')
+        title = f'Request Golang {go_version} for OCP {self.ocp_version}'
+        _LOGGER.info('Please create https://issues.redhat.com/browse/CWFCONF Jira ticket with \n'
+                     f'title: {title}\ncontent:\n{template}')
 
 
 @cli.command('update-golang')


### PR DESCRIPTION
Should go with https://github.com/openshift-eng/aos-cd-jobs/pull/4164

Several improvements for update-golang script
- Detect if running in jenkins env - don't try to do jenkins operations if not
- Add `--confirm` for confirming rebase and build, this is so when we run locally we don't accidently build. Jobs should have it enabled by default https://github.com/openshift-eng/aos-cd-jobs/pull/4164 
- Check streams.yml after building missing builders and notify of updates.
- Update jira ticket instructions to be precise and only apply for rhel8
- Remove ticket instructions for non-module builds and instead print out tagging instructions
- Add check if module build is directly tagged in override tag and untag instructions

Test:
```
./artcd -v --config config.example.toml update-golang --ocp-version=4.16 
--art-jira=ART-9118 golang-1.22.2-1.module+el8.10.0+21789+dd446cb3 --create-tagging-ticket
...
ValueError: golang-1.21.9-1.module+el8.10.0+21671+b35c3b78 is tagged in rhaos-4.16-rhel-8-override, 
please make sure it is available via module inheritance 
(brew list-tagged rhaos-4.16-rhel-8-override golang --inherit). 
If not, use --create-tagging-ticket. Once it is available, untag it from the override tag 
(brew untag-build rhaos-4.16-rhel-8-override golang-1.21.9-1.module+el8.10.0+21671+b35c3b78)
```