### PR TITLE
set custom cert for konflux

### DIFF
--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -28,4 +28,4 @@ default_db_params = {
 # TODO: once brew outage is resolved, change to 6 hours again (currently set to 100)
 BREW_BUILD_TIMEOUT = 100 * 60 * 60  # how long we wait before canceling a task
 
-KONFLUX_CUSTOM_CERT = "/tmp/Current-IT-Root-CAs.pem"
+KONFLUX_REPO_CERT_PATH = "/tmp/Current-IT-Root-CAs.pem"

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -28,4 +28,10 @@ default_db_params = {
 # TODO: once brew outage is resolved, change to 6 hours again (currently set to 100)
 BREW_BUILD_TIMEOUT = 100 * 60 * 60  # how long we wait before canceling a task
 
-KONFLUX_REPO_CERT_PATH = "/tmp/Current-IT-Root-CAs.pem"
+# In Brew, 'ADD tls-ca-bundle.pem /tmp/tls-ca-bundle.pem' is injected during build and 'sslcacert=/tmp/tls-ca-bundle.pem'
+# is specified for CA cert, so that 'sslverify=true' can be used in yum repos.
+# To achieve the same in Konflux, we need to 'ADD tls-ca-bundle.pem /tmp/tls-ca-bundle.pem' in every Dockerfile stage
+# and set 'sslcacert=/tmp/Current-IT-Root-CAs.pem'
+KONFLUX_REPO_CA_BUNDLE_TMP_PATH = "/tmp"
+KONFLUX_REPO_CA_BUNDLE_FILENAME = "Current-IT-Root-CAs.pem"
+KONFLUX_REPO_CA_BUNDLE_HOST = "https://certs.corp.redhat.com/certs"

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -27,3 +27,5 @@ default_db_params = {
 
 # TODO: once brew outage is resolved, change to 6 hours again (currently set to 100)
 BREW_BUILD_TIMEOUT = 100 * 60 * 60  # how long we wait before canceling a task
+
+KONFLUX_CUSTOM_CERT = "/tmp/Current-IT-Root-CAs.pem"

--- a/doozer/doozerlib/k_distgit.py
+++ b/doozer/doozerlib/k_distgit.py
@@ -4,6 +4,7 @@ from dockerfile_parse import DockerfileParser
 from artcommonlib import assertion, logutil, build_util, exectools
 from artcommonlib.pushd import Dir
 from doozerlib.distgit import ImageDistGitRepo
+from doozerlib import util
 
 
 class KonfluxImageDistGitRepo(ImageDistGitRepo):
@@ -74,7 +75,8 @@ class KonfluxImageDistGitRepo(ImageDistGitRepo):
             "\n# Start Konflux-specific steps",
             "RUN mkdir -p /tmp/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/yum_temp/",
             "COPY .oit/signed.repo /etc/yum.repos.d/",
-            "# End Konflux-specific steps\n",
+            "ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp",
+            "# End Konflux-specific steps\n\n",
             at_start=True,
             all_stages=True,
         )
@@ -83,7 +85,7 @@ class KonfluxImageDistGitRepo(ImageDistGitRepo):
         dfp.add_lines(
             "\n# Start Konflux-specific steps",
             "RUN cp /tmp/yum_temp/* /etc/yum.repos.d/",
-            "# End Konflux-specific steps\n"
+            "# End Konflux-specific steps\n\n"
         )
         return version, release
 
@@ -101,3 +103,25 @@ class KonfluxImageDistGitRepo(ImageDistGitRepo):
         self.logger.info("Image rebase for %s completed. Stop waiting." % image_name)
         if terminate_event.is_set():
             raise KeyboardInterrupt()
+
+    def _generate_repo_conf(self):
+        """
+        Generates a repo file in .oit/repo.conf
+        """
+
+        self.logger.debug("Generating repo file for Dockerfile {}".format(self.metadata.distgit_key))
+
+        # Make our metadata directory if it does not exist
+        util.mkdirs(self.dg_path.joinpath('.oit'))
+
+        repos = self.runtime.repos
+        enabled_repos = self.config.get('enabled_repos', [])
+        non_shipping_repos = self.config.get('non_shipping_repos', [])
+
+        for t in repos.repotypes:
+            with self.dg_path.joinpath('.oit', f'{t}.repo').open('w', encoding="utf-8") as rc:
+                content = repos.repo_file(t, enabled_repos=enabled_repos, konflux=True)
+                rc.write(content)
+
+        with self.dg_path.joinpath('content_sets.yml').open('w', encoding="utf-8") as rc:
+            rc.write(repos.content_sets(enabled_repos=enabled_repos, non_shipping_repos=non_shipping_repos))

--- a/doozer/doozerlib/k_distgit.py
+++ b/doozer/doozerlib/k_distgit.py
@@ -1,10 +1,12 @@
 import os
 import pathlib
+
 from dockerfile_parse import DockerfileParser
 from artcommonlib import assertion, logutil, build_util, exectools
 from artcommonlib.pushd import Dir
 from doozerlib.distgit import ImageDistGitRepo
 from doozerlib import util
+from doozerlib.constants import KONFLUX_REPO_CA_BUNDLE_HOST, KONFLUX_REPO_CA_BUNDLE_FILENAME, KONFLUX_REPO_CA_BUNDLE_TMP_PATH
 
 
 class KonfluxImageDistGitRepo(ImageDistGitRepo):
@@ -75,7 +77,7 @@ class KonfluxImageDistGitRepo(ImageDistGitRepo):
             "\n# Start Konflux-specific steps",
             "RUN mkdir -p /tmp/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/yum_temp/",
             "COPY .oit/signed.repo /etc/yum.repos.d/",
-            "ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp",
+            f"ADD {KONFLUX_REPO_CA_BUNDLE_HOST}/{KONFLUX_REPO_CA_BUNDLE_FILENAME} {KONFLUX_REPO_CA_BUNDLE_TMP_PATH}",
             "# End Konflux-specific steps\n\n",
             at_start=True,
             all_stages=True,

--- a/doozer/doozerlib/repos.py
+++ b/doozer/doozerlib/repos.py
@@ -12,7 +12,7 @@ import yaml
 
 from artcommonlib.model import Missing, Model
 from doozerlib.repodata import Repodata, RepodataLoader
-from doozerlib.constants import KONFLUX_CUSTOM_CERT
+from doozerlib.constants import KONFLUX_REPO_CERT_PATH
 
 
 DEFAULT_REPOTYPES = ['unsigned', 'signed']
@@ -193,7 +193,7 @@ class Repo(object):
             result += 'gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release\n'
 
         if konflux:
-            result += f'sslcacert = {KONFLUX_CUSTOM_CERT}\n'
+            result += f'sslcacert = {KONFLUX_REPO_CERT_PATH}\n'
 
         result += '\n'
 

--- a/doozer/doozerlib/repos.py
+++ b/doozer/doozerlib/repos.py
@@ -12,7 +12,7 @@ import yaml
 
 from artcommonlib.model import Missing, Model
 from doozerlib.repodata import Repodata, RepodataLoader
-from doozerlib.constants import KONFLUX_REPO_CERT_PATH
+from doozerlib.constants import KONFLUX_REPO_CA_BUNDLE_TMP_PATH, KONFLUX_REPO_CA_BUNDLE_FILENAME
 
 
 DEFAULT_REPOTYPES = ['unsigned', 'signed']
@@ -193,7 +193,7 @@ class Repo(object):
             result += 'gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release\n'
 
         if konflux:
-            result += f'sslcacert = {KONFLUX_REPO_CERT_PATH}\n'
+            result += f'sslcacert = {KONFLUX_REPO_CA_BUNDLE_TMP_PATH}/{KONFLUX_REPO_CA_BUNDLE_FILENAME}\n'
 
         result += '\n'
 

--- a/doozer/doozerlib/repos.py
+++ b/doozer/doozerlib/repos.py
@@ -12,6 +12,7 @@ import yaml
 
 from artcommonlib.model import Missing, Model
 from doozerlib.repodata import Repodata, RepodataLoader
+from doozerlib.constants import KONFLUX_CUSTOM_CERT
 
 
 DEFAULT_REPOTYPES = ['unsigned', 'signed']
@@ -125,7 +126,7 @@ class Repo(object):
         else:
             return self._data.content_set[arch]
 
-    def conf_section(self, repotype, arch=ARCH_X86_64, enabled=None, section_name=None):
+    def conf_section(self, repotype, arch=ARCH_X86_64, enabled=None, section_name=None, konflux=False):
         """
         Returns a str that represents a yum repo configuration section corresponding
         to this repo in group.yml.
@@ -134,6 +135,7 @@ class Repo(object):
         :param arch: The architecture this section if being generated for (e.g. ppc64le or x86_64).
         :param enabled: If True|False, explicitly set 'enabled = 1|0' in section. If None, inherit group.yml setting.
         :param section_name: The section name to use if not the repo name in group.yml.
+        :param konflux: If True, set custom cert path for Konflux
         :return: Returns a string representing a repo section in a yum configuration file. e.g.
             [rhel-7-server-ansible-2.4-rpms]
             gpgcheck = 0
@@ -189,6 +191,9 @@ class Repo(object):
         if self._data.conf.get('gpgkey', None) is None and self._data.conf.get('extra_options', {}).get('gpgkey', None) is None:
             # This key will bed used only if gpgcheck=1
             result += 'gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release\n'
+
+        if konflux:
+            result += f'sslcacert = {KONFLUX_CUSTOM_CERT}\n'
 
         result += '\n'
 
@@ -280,7 +285,7 @@ class Repos(object):
         """Mainly for debugging to dump a dict representation of the collection"""
         return str(self._repos)
 
-    def repo_file(self, repo_type, enabled_repos=[], empty_repos=[], arch=None):
+    def repo_file(self, repo_type, enabled_repos=[], empty_repos=[], arch=None, konflux=False):
         """
         Returns a str defining a list of repo configuration secions for a yum configuration file.
         :param repo_type: Whether to prefer signed or unsigned repos.
@@ -305,12 +310,12 @@ class Repos(object):
             if arch:  # Generating a single arch?
                 # Just use the configured name for the set. This behavior needs to be preserved to
                 # prevent changing mirrored repos by reposync.
-                result += r.conf_section(repo_type, enabled=enabled, arch=arch, section_name=r.name)
+                result += r.conf_section(repo_type, enabled=enabled, arch=arch, section_name=r.name, konflux=konflux)
             else:
                 # When generating a repo file for multi-arch builds, we need all arches in the same repo file.
                 for iarch in r.arches:
                     section_name = '{}-{}'.format(r.name, iarch)
-                    result += r.conf_section(repo_type, enabled=enabled, arch=iarch, section_name=section_name)
+                    result += r.conf_section(repo_type, enabled=enabled, arch=iarch, section_name=section_name, konflux=konflux)
 
         for er in empty_repos:
             result += EMPTY_REPO.format(er)


### PR DESCRIPTION
Needed to access ocp-artifacts with `sslverify`. Setting `sslcacert` in `.repo` files ([docs](https://dnf.readthedocs.io/en/latest/conf_ref.html)).

Brew does this under the hood with `ADD tls-ca-bundle.pem /tmp/tls-ca-bundle.pem`. Example log [here](https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/packages/ose-installer-container/v4.16.0/202405281506.p0.gd61ee0a.assembly.stream.el9/data/logs/x86_64.log)