### PR TITLE
[konflux] fix Dockerfile step, sslcacert only for ocp-artifacts

### DIFF
--- a/doozer/doozerlib/k_distgit.py
+++ b/doozer/doozerlib/k_distgit.py
@@ -75,7 +75,7 @@ class KonfluxImageDistGitRepo(ImageDistGitRepo):
         # Populating the repo file needs to happen after every FROM before the original Dockerfile can invoke yum/dnf.
         dfp.add_lines(
             "\n# Start Konflux-specific steps",
-            "RUN mkdir -p /tmp/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/yum_temp/",
+            "RUN mkdir -p /tmp/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/yum_temp/ || true",
             "COPY .oit/signed.repo /etc/yum.repos.d/",
             f"ADD {KONFLUX_REPO_CA_BUNDLE_HOST}/{KONFLUX_REPO_CA_BUNDLE_FILENAME} {KONFLUX_REPO_CA_BUNDLE_TMP_PATH}",
             "# End Konflux-specific steps\n\n",
@@ -86,7 +86,7 @@ class KonfluxImageDistGitRepo(ImageDistGitRepo):
         # Put back original yum config
         dfp.add_lines(
             "\n# Start Konflux-specific steps",
-            "RUN cp /tmp/yum_temp/* /etc/yum.repos.d/",
+            "RUN cp /tmp/yum_temp/* /etc/yum.repos.d/ || true",
             "# End Konflux-specific steps\n\n"
         )
         return version, release

--- a/doozer/doozerlib/repos.py
+++ b/doozer/doozerlib/repos.py
@@ -192,7 +192,7 @@ class Repo(object):
             # This key will bed used only if gpgcheck=1
             result += 'gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release\n'
 
-        if konflux:
+        if 'ocp-artifacts' in self.baseurl(repotype, arch) and konflux:
             result += f'sslcacert = {KONFLUX_REPO_CA_BUNDLE_TMP_PATH}/{KONFLUX_REPO_CA_BUNDLE_FILENAME}\n'
 
         result += '\n'


### PR DESCRIPTION
Changes in this PR:
- In some images, `/etc/yum.repos.d/` exists, but it is empty
- `sslcacert` only for ocp-artifacts