### PR TITLE
ART-9793 Handle the new 'signing' phase

### DIFF
--- a/artcommon/artcommonlib/release_util.py
+++ b/artcommon/artcommonlib/release_util.py
@@ -1,4 +1,5 @@
 import re
+from enum import Enum
 from typing import Optional, Tuple
 
 
@@ -49,3 +50,38 @@ def isolate_el_version_in_release(release: str) -> Optional[int]:
     if el_suffix:
         return int(el_suffix[2:])
     return None
+
+
+class SoftwareLifecyclePhase(Enum):
+    PRE_RELEASE = 0
+    SIGNING = 1
+    RELEASE = 2
+    EOL = 100
+
+    @classmethod
+    def from_name(cls, phase_name):
+        try:
+            return cls[phase_name.upper().replace('-', '_')]
+        except KeyError:
+            raise ValueError(f'{phase_name} is not a valid phase name')
+
+    def __lt__(self, other):
+        if isinstance(other, SoftwareLifecyclePhase):
+            return self.value < other.value
+        return self.value < other
+
+    def __gt__(self, other):
+        if isinstance(other, SoftwareLifecyclePhase):
+            return self.value > other.value
+        return self.value > other
+
+    def __le__(self, other):
+        return not self > other
+
+    def __ge__(self, other):
+        return not self < other
+
+    def __eq__(self, other):
+        if isinstance(other, SoftwareLifecyclePhase):
+            return self.value == other.value
+        return self.value == other

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -4,6 +4,7 @@ import yaml
 
 from artcommonlib import util, build_util, release_util
 from artcommonlib.model import Model, MissingModel
+from artcommonlib.release_util import SoftwareLifecyclePhase
 from artcommonlib.util import deep_merge, isolate_major_minor_in_group
 
 
@@ -176,3 +177,52 @@ alternative_upstream:
         major, minor = isolate_major_minor_in_group('openshift-invalid.16')
         self.assertEqual(major, None)
         self.assertEqual(minor, None)
+
+
+class TestSoftwareLifecyclePhase(unittest.TestCase):
+    def test_from_name_valid(self):
+        self.assertEqual(SoftwareLifecyclePhase.from_name('eol'), SoftwareLifecyclePhase.EOL)
+        self.assertEqual(SoftwareLifecyclePhase.from_name('pre-release'), SoftwareLifecyclePhase.PRE_RELEASE)
+        self.assertEqual(SoftwareLifecyclePhase.from_name('signing'), SoftwareLifecyclePhase.SIGNING)
+        self.assertEqual(SoftwareLifecyclePhase.from_name('release'), SoftwareLifecyclePhase.RELEASE)
+
+    def test_from_name_invalid(self):
+        with self.assertRaises(ValueError):
+            SoftwareLifecyclePhase.from_name('invalid')
+
+    def test_lt(self):
+        self.assertTrue(SoftwareLifecyclePhase.PRE_RELEASE < SoftwareLifecyclePhase.SIGNING)
+        self.assertTrue(SoftwareLifecyclePhase.SIGNING < SoftwareLifecyclePhase.RELEASE)
+        self.assertTrue(SoftwareLifecyclePhase.RELEASE < SoftwareLifecyclePhase.EOL)
+        self.assertTrue(SoftwareLifecyclePhase.EOL < 101)
+        self.assertTrue(SoftwareLifecyclePhase.PRE_RELEASE < 1)
+
+    def test_gt(self):
+        self.assertTrue(SoftwareLifecyclePhase.RELEASE > SoftwareLifecyclePhase.SIGNING)
+        self.assertTrue(SoftwareLifecyclePhase.SIGNING > SoftwareLifecyclePhase.PRE_RELEASE)
+        self.assertTrue(SoftwareLifecyclePhase.EOL > SoftwareLifecyclePhase.RELEASE)
+        self.assertTrue(SoftwareLifecyclePhase.RELEASE > 1)
+        self.assertTrue(SoftwareLifecyclePhase.SIGNING > 0)
+
+    def test_le(self):
+        self.assertTrue(SoftwareLifecyclePhase.EOL <= SoftwareLifecyclePhase.EOL)
+        self.assertTrue(SoftwareLifecyclePhase.PRE_RELEASE <= SoftwareLifecyclePhase.SIGNING)
+        self.assertTrue(SoftwareLifecyclePhase.SIGNING <= SoftwareLifecyclePhase.RELEASE)
+        self.assertTrue(SoftwareLifecyclePhase.EOL <= 100)
+        self.assertTrue(SoftwareLifecyclePhase.PRE_RELEASE <= 0)
+
+    def test_ge(self):
+        self.assertTrue(SoftwareLifecyclePhase.RELEASE >= SoftwareLifecyclePhase.RELEASE)
+        self.assertTrue(SoftwareLifecyclePhase.SIGNING >= SoftwareLifecyclePhase.PRE_RELEASE)
+        self.assertTrue(SoftwareLifecyclePhase.EOL >= SoftwareLifecyclePhase.PRE_RELEASE)
+        self.assertTrue(SoftwareLifecyclePhase.RELEASE >= 2)
+        self.assertTrue(SoftwareLifecyclePhase.SIGNING >= 1)
+
+    def test_eq(self):
+        self.assertEqual(SoftwareLifecyclePhase.RELEASE, 2)
+        self.assertEqual(SoftwareLifecyclePhase.RELEASE, SoftwareLifecyclePhase.RELEASE)
+        self.assertNotEqual(SoftwareLifecyclePhase.RELEASE, SoftwareLifecyclePhase.PRE_RELEASE)
+        self.assertEqual(SoftwareLifecyclePhase.SIGNING, 1)
+        self.assertEqual(SoftwareLifecyclePhase.PRE_RELEASE, 0)
+        self.assertEqual(SoftwareLifecyclePhase.EOL.value, 100)
+        self.assertNotEqual(SoftwareLifecyclePhase.EOL.value, 101)

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -10,6 +10,7 @@ from opentelemetry import trace
 from artcommonlib import rhcos, redis
 from artcommonlib.arch_util import go_suffix_for_arch
 from artcommonlib.exectools import limit_concurrency
+from artcommonlib.release_util import SoftwareLifecyclePhase
 from artcommonlib.util import split_git_url
 from pyartcd.cli import cli, pass_runtime, click_coroutine
 from pyartcd.oc import registry_login
@@ -440,7 +441,8 @@ class BuildSyncPipeline:
 
         if fail_count % forum_release_notify_frequency == 0:
             # For GA releases, let forum-ocp-release know why no new builds
-            if self.group_runtime.group_config['software_lifecycle']['phase'] == 'release':
+            phase = SoftwareLifecyclePhase.from_name(self.group_runtime.group_config['software_lifecycle']['phase'])
+            if phase == SoftwareLifecyclePhase.RELEASE:
                 slack_client.bind('#forum-ocp-release').say(msg)
 
 

--- a/pyartcd/pyartcd/pipelines/check_bugs.py
+++ b/pyartcd/pyartcd/pipelines/check_bugs.py
@@ -25,6 +25,8 @@ class CheckBugsPipeline:
         # Load group config
         self.group_config = await util.load_group_config(
             group=f'openshift-{self.version}', assembly='stream', doozer_data_path=self.data_path)
+
+        # Check bugs only for GA releases
         if self.group_config['software_lifecycle']['phase'] != 'release':
             return None
 
@@ -85,10 +87,6 @@ class CheckBugsPipeline:
         return '.'.join([major, str(int(minor) + 1)])
 
     async def _find_regressions(self):
-        # Do nothing for EOL releases
-        if self.group_config['software_lifecycle']['phase'] == 'eol':
-            return
-
         # Check pre-release
         next_minor = self.get_next_minor(self.version)
         if not await self._is_version_in_release_state(next_minor):

--- a/pyartcd/pyartcd/pipelines/check_bugs.py
+++ b/pyartcd/pyartcd/pipelines/check_bugs.py
@@ -4,15 +4,17 @@ import click
 
 from pyartcd import exectools, util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.constants import OCP_BUILD_DATA_URL
 from pyartcd.runtime import Runtime
 
 BASE_URL = 'https://api.openshift.com/api/upgrades_info/v1/graph?arch=amd64&channel=fast'
 
 
 class CheckBugsPipeline:
-    def __init__(self, runtime: Runtime, version: str) -> None:
+    def __init__(self, runtime: Runtime, version: str, data_path: str) -> None:
         self.runtime = runtime
         self.version = version
+        self.data_path = data_path
         self.group_config = None
         self.logger = runtime.logger
         self.issues = []
@@ -21,7 +23,8 @@ class CheckBugsPipeline:
 
     async def run(self):
         # Load group config
-        self.group_config = await util.load_group_config(group=f'openshift-{self.version}', assembly='stream')
+        self.group_config = await util.load_group_config(
+            group=f'openshift-{self.version}', assembly='stream', doozer_data_path=self.data_path)
         if self.group_config['software_lifecycle']['phase'] != 'release':
             return None
 
@@ -62,16 +65,16 @@ class CheckBugsPipeline:
         self.logger.info('Command returned: %s', out)
         self.issues.extend(out)
 
-    async def _is_build_permitted(self, version: str) -> bool:
+    async def _is_version_in_release_state(self, version: str) -> bool:
         """
-        Only include 'release' state group, exclude 'eol' and 'pre-release'
+        Returns True if the provided version is in "release" state
         """
 
         group_config = await util.load_group_config(group=f'openshift-{version}', assembly='stream')
         phase = group_config['software_lifecycle']['phase']
 
         if phase != 'release':
-            self.logger.info('Release %s is in state "%s"', version, phase)
+            self.logger.info('%s is in state "%s"', version, phase)
             return False
 
         return True
@@ -88,7 +91,7 @@ class CheckBugsPipeline:
 
         # Check pre-release
         next_minor = self.get_next_minor(self.version)
-        if not await self._is_build_permitted(next_minor):
+        if not await self._is_version_in_release_state(next_minor):
             self.logger.info('Skipping regression checks for %s as %s is not in "release" state',
                              self.version, next_minor)
             return
@@ -135,10 +138,12 @@ async def slack_report(results, slack_client):
               help='Slack channel to be notified for failures')
 @click.option('--version', 'versions', required=True, multiple=True,
               help='OCP version to check for blockers e.g. 4.7')
+@click.option("--data-path", required=False, default=OCP_BUILD_DATA_URL,
+              help="ocp-build-data fork to use (e.g. assembly definition in your own fork)")
 @pass_runtime
 @click_coroutine
-async def check_bugs(runtime: Runtime, slack_channel: str, versions: list):
-    tasks = [CheckBugsPipeline(runtime, version=version).run() for version in versions]
+async def check_bugs(runtime: Runtime, slack_channel: str, versions: list, data_path: str):
+    tasks = [CheckBugsPipeline(runtime, version=version, data_path=data_path).run() for version in versions]
     results = await asyncio.gather(*tasks)
 
     if any(results):

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -14,6 +14,7 @@ import artcommonlib
 from artcommonlib.arch_util import go_suffix_for_arch
 from artcommonlib.assembly import assembly_type
 from artcommonlib.model import Model
+from artcommonlib.release_util import SoftwareLifecyclePhase
 from doozerlib import util as doozerutil
 from errata_tool import ErrataConnector
 
@@ -646,7 +647,8 @@ async def get_signing_mode(group: str = None, assembly: str = None, group_config
         assert assembly, 'Assembly must be specified in order to load group config'
         group_config = await load_group_config(group=group, assembly=assembly)
 
-    return 'unsigned' if group_config['software_lifecycle']['phase'] == 'pre-release' else 'signed'
+    phase = SoftwareLifecyclePhase.from_name(group_config['software_lifecycle']['phase'])
+    return 'signed' if phase >= SoftwareLifecyclePhase.SIGNING else 'unsigned'
 
 
 def nightlies_with_pullspecs(nightly_tags: Iterable[str]) -> Dict[str, str]:


### PR DESCRIPTION
Currently, we need to move the release state to `release` in order to start signing artifacts. This is the side effects of triggering bugs checks for a release, that might not be GA yet.

The proposal is to add a new `signing` state, so that we can start signing artifacts, while still preventing bugs checks for that release.

This PR suggests a more structured approach to release states, so that we can compare values and assert, for example, that `'release' > 'pre-release'` and the like.