### PR TITLE
[ART-9186] Konflux rebase

### DIFF
--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -392,7 +392,7 @@ def images_rebase(runtime: Runtime, version: Optional[str], release: Optional[st
 @option_commit_message
 @option_push
 @pass_runtime
-def k_images_rebase(runtime: Runtime, version: Optional[str], release: Optional[str], embargoed: bool, repo_type: str, force_yum_updates: bool, message: str, push: bool, skip_config_check: bool, dry_run: bool):
+def k_images_rebase(runtime: Runtime, embargoed: bool, repo_type: str, force_yum_updates: bool, message: str, push: bool, skip_config_check: bool, dry_run: bool, version: Optional[str], release: Optional[str]):
     """
     Reusing most of the code from 'images_rebase' for now, since we might need to change once we discuss with the Konflux team
     """
@@ -422,6 +422,7 @@ def k_images_rebase(runtime: Runtime, version: Optional[str], release: Optional[
         )
 
     metas = runtime.ordered_image_metas()
+
     lstate['total'] = len(metas)
 
     def dgr_rebase(image_meta, terminate_event):

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1789,9 +1789,6 @@ class ImageDistGitRepo(DistGitRepo):
             else:
                 raise IOError("Image in 'from' for [%s] is missing its definition." % image.name)
 
-        if self.is_konflux:
-            mapped_images = [image.replace(constants.REGISTRY_PROXY_BASE_URL, constants.BREW_REGISTRY_BASE_URL) for image in mapped_images]
-
         # Write rebased from directives
         dfp.parent_images = mapped_images
 

--- a/doozer/doozerlib/k_distgit.py
+++ b/doozer/doozerlib/k_distgit.py
@@ -110,6 +110,6 @@ class KonfluxImageDistGitRepo(ImageDistGitRepo):
         # If the parent we are going to build is embargoed, this image should also be embargoed
         self.private_fix = from_image_distgit.private_fix
 
-        # Tag format <distgit_name>_<distgit_branch>_<version>
+        # Tag format <distgit_name>_<distgit_branch>_<uuid_tag>
         # Eg: quay.io/rh_ee_asdas/konflux-test:openshift-base-rhel9_rhaos-4.17-rhel-9_v4.17.0.20240606.094143
         return f"{KONFLUX_QUAY_REGISTRY}:{from_image_metadata.distgit_key}_{self.config.distgit.branch}_{self.uuid_tag}"

--- a/doozer/doozerlib/k_distgit.py
+++ b/doozer/doozerlib/k_distgit.py
@@ -110,6 +110,6 @@ class KonfluxImageDistGitRepo(ImageDistGitRepo):
         # If the parent we are going to build is embargoed, this image should also be embargoed
         self.private_fix = from_image_distgit.private_fix
 
-        # Tag format <name>_<version>
-        # Eg: quay.io/rh_ee_asdas/konflux-test:openshift-enterprise-base-rhel9_v4.17.0.20240605.220838
-        return f"{KONFLUX_QUAY_REGISTRY}:{from_image_metadata.image_name_short}_{self.uuid_tag}"
+        # Tag format <distgit_name>_<distgit_branch>_<version>
+        # Eg: quay.io/rh_ee_asdas/konflux-test:openshift-base-rhel9_rhaos-4.17-rhel-9_v4.17.0.20240606.094143
+        return f"{KONFLUX_QUAY_REGISTRY}:{from_image_metadata.distgit_key}_{self.config.distgit.branch}_{self.uuid_tag}"


### PR DESCRIPTION
Changes in this PR:
- Use quay.io registry urls in `FROM` since Konflux builds from an to Quay. Use `quay.io/rh_ee_asdas/konflux-test` for testing, for now and then switch to team registry.