### PR TITLE
[ART-9795] Konflux rebase and build

### DIFF
--- a/doozer/doozerlib/cli/__main__.py
+++ b/doozer/doozerlib/cli/__main__.py
@@ -28,7 +28,6 @@ from doozerlib.cli.inspect_stream import inspect_stream
 from doozerlib.cli.config_tag_rpms import config_tag_rpms
 from doozerlib.cli.scan_osh import scan_osh
 from doozerlib.cli.scan_fips import scan_fips
-from doozerlib.cli.konflux import konflux
 from doozerlib.cli.gen_assembly_helper import gen_assembly_rhcos
 from doozerlib.cli.rpms import rpms_print, rpms_rebase_and_build, rpms_rebase, rpms_build, rpms_clone, rpms_clone_sources
 from doozerlib.cli.olm_bundle import list_olm_operators, olm_bundles_print, rebase_and_build_olm_bundle

--- a/doozer/doozerlib/cli/__main__.py
+++ b/doozer/doozerlib/cli/__main__.py
@@ -28,6 +28,7 @@ from doozerlib.cli.inspect_stream import inspect_stream
 from doozerlib.cli.config_tag_rpms import config_tag_rpms
 from doozerlib.cli.scan_osh import scan_osh
 from doozerlib.cli.scan_fips import scan_fips
+from doozerlib.cli.konflux import konflux
 from doozerlib.cli.gen_assembly_helper import gen_assembly_rhcos
 from doozerlib.cli.rpms import rpms_print, rpms_rebase_and_build, rpms_rebase, rpms_build, rpms_clone, rpms_clone_sources
 from doozerlib.cli.olm_bundle import list_olm_operators, olm_bundles_print, rebase_and_build_olm_bundle

--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -810,6 +810,7 @@ def k_images_build_image(runtime, repo_type, repo, push_to_defaults, push_to, sc
 
     print(results)
 
+
 @cli.command("images:build", short_help="Build images for the group.")
 @click.option("--repo-type", metavar="REPO_TYPE", envvar="OIT_IMAGES_REPO_TYPE",
               default='',

--- a/doozer/doozerlib/cli/konflux.py
+++ b/doozer/doozerlib/cli/konflux.py
@@ -1,0 +1,161 @@
+import click
+import os
+import yaml
+import jinja2
+import string
+
+from artcommonlib.exectools import cmd_assert, cmd_gather
+from doozerlib.cli import cli, pass_runtime, click_coroutine
+from doozerlib.runtime import Runtime
+
+GITHUB_TOKEN_SECRET_NAME = "github-access-token-ash"  # Secret name for GH token for openshift-priv
+QUAY_REGISTRY_REPO_URL = "quay.io/rh_ee_asdas/konflux-test"
+QUAY_REGISTRY_SECRET_NAME = "component-1"
+KONFLUX_ROOT_WORKING_DIR = "/tmp/crap/konflux"
+
+
+class Konflux:
+    def __init__(self, runtime: Runtime, distgit_name: str, namespace: str):
+        self.runtime = runtime
+
+        self.runtime.initialize(clone_distgits=False)
+        self.namespace = namespace
+
+        # An application resource name must start with a lower case alphabetical character,
+        # be under 63 characters, and can only consist of lower case alphanumeric characters or ‘-’
+        # Hence renaming openshift-4.16 to openshift-4-16 for example
+        self.major_minor = runtime.group.split("-")[-1].replace(".", "-")
+        self.application_name = runtime.group.replace(".", "-")  # Name of the Konflux application
+
+        self.distgit_name = distgit_name
+        self.image_meta = runtime.image_map[distgit_name]
+        self.component_name = f"ocp-{self.major_minor}-{distgit_name}"  # Name of the Konflux component
+        self.konflux_working_dir = f"{KONFLUX_ROOT_WORKING_DIR}/{distgit_name}"
+        self.output_registry = f"{QUAY_REGISTRY_REPO_URL}:{self.component_name}"
+
+        # https://github.com/openshift/coredns -> https://github.com/openshift-priv/coredns
+        self.github_url = self.image_meta.config["content"]["source"]["git"]["web"].replace("openshift", "openshift-priv")
+
+    @staticmethod
+    def verify_secret(secret_name: str):
+        command = f"oc get secret {secret_name}"
+        cmd_assert(command)
+
+    def initialize(self):
+        command = f"oc project {self.namespace}"
+        cmd_assert(command)
+
+        # All secret names should be unique in the namespace
+        # Check if secret for openshift-priv access is present
+        self.verify_secret(QUAY_REGISTRY_SECRET_NAME)
+
+        # Check if secret for quay registry access is present
+        self.verify_secret(GITHUB_TOKEN_SECRET_NAME)
+
+    @staticmethod
+    def generate_file(file_path: str, data: dict, output_path: str):
+        # Load the YAML template
+        with open(file_path, "r") as file:
+            template_content = file.read()
+
+        # Create a Jinja2 template from the file content
+        template = jinja2.Template(template_content)
+
+        # Render the template with data
+        rendered_content = template.render(data)
+
+        # Load the rendered content as YAML
+        yaml_data = yaml.safe_load(rendered_content)
+
+        output_directory = os.path.dirname(output_path)
+        if not os.path.exists(output_directory):
+            os.makedirs(output_directory)
+
+        # Dump the YAML data to a file
+        with open(output_path, 'w') as file:
+            yaml.safe_dump(yaml_data, file)
+
+    def get_resource_uid(self, resource_name, name):
+        command = f"oc get {resource_name} {name} -o yaml"
+        self.runtime.logger.info(f"Running command: {command}")
+        out, _ = cmd_assert(command)
+        return yaml.safe_load(out)["metadata"]["uid"]
+
+    def apply_generated_file(self, data, file_path, output_path, mode="apply"):
+        """
+        Apply the generated files to the cluster
+        """
+        self.generate_file(file_path=file_path, data=data, output_path=output_path)
+        command = f"oc {mode} -f {output_path}"
+        self.runtime.logger.info(f"Running command: {command}")
+        cmd_assert(command)
+
+    def generate_files(self):
+        data = {
+            "application": {
+                "name": self.application_name
+            },
+            "namespace": self.namespace,
+
+        }
+        self.apply_generated_file(data, "doozer/static/konflux/application.yaml",
+                                  f"{self.konflux_working_dir}/application.yaml")
+
+        application_uid = self.get_resource_uid(resource_name="Application", name=self.application_name)
+        data = {
+            "registry_details": string.Template("""'{"image":"$registry_url","visibility":"$registry_visibility","secret":"$registry_secret"}'""").substitute(registry_url=QUAY_REGISTRY_REPO_URL, registry_visibility="private", registry_secret=QUAY_REGISTRY_SECRET_NAME),
+            "namespace": self.namespace,
+            "application": {
+                "name": self.application_name,
+                "uid": application_uid
+            },
+            "component": {
+                "name": self.component_name
+            },
+            "git": {
+                "token_name": GITHUB_TOKEN_SECRET_NAME,
+                "context": "./",
+                "url": self.github_url,
+                "branch": f"art-<{self.runtime.group}>-assembly-<test>-dgk-<{self.distgit_name}>",
+                "dockerfile_path": "Dockerfile"
+            }
+        }
+        self.apply_generated_file(data, "doozer/static/konflux/component.yaml", f"{self.konflux_working_dir}/component.yaml")
+
+        component_uid = self.get_resource_uid(resource_name="Component", name=self.component_name)
+        data = {
+            "namespace": self.namespace,
+            "application": {
+                "name": self.application_name
+            },
+            "component": {
+                "name": self.component_name,
+                "uid": component_uid
+            },
+            "git": {
+                "token_name": GITHUB_TOKEN_SECRET_NAME,
+                "context": ".",
+                "url": self.github_url,
+                "branch": f"art-<{self.runtime.group}>-assembly-<test>-dgk-<{self.distgit_name}>",
+                "dockerfile_path": "Dockerfile"
+            },
+            "konflux": {
+                "bundle_sha": "quay.io/redhat-appstudio-tekton-catalog/pipeline-docker-build:13ecd03ec9f7de811f837a5460c41105231c911a"
+            },
+            "output_registry_url": self.output_registry
+        }
+
+        self.apply_generated_file(data, "doozer/static/konflux/pipeline_run.yaml", f"{self.konflux_working_dir}/pipeline_run.yaml", mode="create")
+        self.runtime.logger.info(f"Will push to registry {self.output_registry} on success")
+
+    def run(self):
+        self.initialize()
+        self.generate_files()
+
+
+@cli.command("k:ocp4", help="Konflux pipeline")
+@click.option("--namespace", required=True, help="OCP namespace where konflux is deployed to")
+@pass_runtime
+def konflux(runtime: Runtime, namespace: str):
+    pipeline = Konflux(runtime=runtime, distgit_name="coredns", namespace=namespace)
+    pipeline.run()

--- a/doozer/doozerlib/k_distgit.py
+++ b/doozer/doozerlib/k_distgit.py
@@ -158,5 +158,13 @@ class KonfluxImageDistGitRepo(ImageDistGitRepo):
             # Regardless of success, allow other images depending on this one to progress or fail.
             self.build_lock.release()
 
-    def _konflux_watch_build(self):
-        pass
+    # def _konflux_watch_build(self):
+    #     terminate_event = threading.Event()
+    #     try:
+    #         error = await exectools.to_thread(
+    #             watch_task, session, log_f, task_id, terminate_event
+    #         )
+    #     except (asyncio.CancelledError, KeyboardInterrupt):
+    #         terminate_event.set()
+    #         raise
+    #     return error

--- a/doozer/doozerlib/k_distgit.py
+++ b/doozer/doozerlib/k_distgit.py
@@ -123,15 +123,16 @@ class KonfluxImageDistGitRepo(ImageDistGitRepo):
                 if 'member' in builder:
                     self._set_wait_for(builder['member'], terminate_event)
 
-
-
             if self.runtime.assembly and isolate_assembly_in_release(release) != self.runtime.assembly:
                 # Assemblies should follow its naming convention
                 raise ValueError(f"Image {self.name} is not rebased with assembly '{self.runtime.assembly}'.")
 
             konflux_builder = KonfluxBuilder(runtime=self.runtime, distgit_name=self.name, namespace="asdas-tenant")
             try:
-                task_id, task_url, build_info = asyncio.run(konflux_builder.build())
+                status = asyncio.run(konflux_builder.build())
+
+                if not status:
+                    raise Exception("Error in konflux builder")
 
             except Exception:
                 raise
@@ -139,7 +140,6 @@ class KonfluxImageDistGitRepo(ImageDistGitRepo):
             self.build_status = True
         except (Exception, KeyboardInterrupt):
             tb = traceback.format_exc()
-            record["message"] = "Exception occurred:\n{}".format(tb)
             self.logger.info("Exception occurred during build:\n{}".format(tb))
             # This is designed to fall through to finally. Since this method is designed to be
             # threaded, we should not throw an exception; instead return False.

--- a/doozer/doozerlib/konflux_builder.py
+++ b/doozer/doozerlib/konflux_builder.py
@@ -5,7 +5,6 @@ import string
 import traceback
 
 from artcommonlib import exectools
-from doozerlib.runtime import Runtime
 
 GITHUB_TOKEN_SECRET_NAME = "github-access-token-ash"  # Secret name for GH token for openshift-priv
 QUAY_REGISTRY_REPO_URL = "quay.io/rh_ee_asdas/konflux-test"
@@ -14,9 +13,9 @@ KONFLUX_ROOT_WORKING_DIR = "/tmp/crap/konflux"
 
 
 class KonfluxBuilder:
-    def __init__(self, runtime: Runtime, distgit_name: str, namespace: str):
+    def __init__(self, runtime, distgit_name: str, namespace: str, dry_run):
         self.runtime = runtime
-
+        self.dry_run = dry_run
         self.runtime.initialize(clone_distgits=False)
         self.namespace = namespace
 
@@ -99,7 +98,7 @@ class KonfluxBuilder:
             "namespace": self.namespace,
 
         }
-        self.apply_generated_file(data, "doozer/static/konflux/application.yaml",
+        self.apply_generated_file(data, "/home/asdas/PycharmProjects/art-tools/doozer/static/konflux/application.yaml",
                                   f"{self.konflux_working_dir}/application.yaml")
 
         application_uid = self.get_resource_uid(resource_name="Application", name=self.application_name)
@@ -121,7 +120,7 @@ class KonfluxBuilder:
                 "dockerfile_path": "Dockerfile"
             }
         }
-        self.apply_generated_file(data, "doozer/static/konflux/component.yaml", f"{self.konflux_working_dir}/component.yaml")
+        self.apply_generated_file(data, "/home/asdas/PycharmProjects/art-tools/doozer/static/konflux/component.yaml", f"{self.konflux_working_dir}/component.yaml")
 
         component_uid = self.get_resource_uid(resource_name="Component", name=self.component_name)
         data = {
@@ -146,12 +145,12 @@ class KonfluxBuilder:
             "output_registry_url": self.output_registry
         }
 
-        self.apply_generated_file(data, "doozer/static/konflux/pipeline_run.yaml", f"{self.konflux_working_dir}/pipeline_run.yaml", mode="create")
+        self.apply_generated_file(data, "/home/asdas/PycharmProjects/art-tools/doozer/static/konflux/pipeline_run.yaml", f"{self.konflux_working_dir}/pipeline_run.yaml", mode="create")
         self.runtime.logger.info(f"Will push to registry {self.output_registry} on success")
 
         return ""  # Return pipeline run id
 
-    async def build(self, image, retries: int = 3):
+    async def build(self, image, retries: int = 1):
         dg = image.distgit_repo()
         logger = dg.logger
         for attempt in range(retries):

--- a/doozer/doozerlib/konflux_builder.py
+++ b/doozer/doozerlib/konflux_builder.py
@@ -1,11 +1,9 @@
-import click
 import os
 import yaml
 import jinja2
 import string
 
 from artcommonlib.exectools import cmd_assert, cmd_gather
-from doozerlib.cli import cli, pass_runtime, click_coroutine
 from doozerlib.runtime import Runtime
 
 GITHUB_TOKEN_SECRET_NAME = "github-access-token-ash"  # Secret name for GH token for openshift-priv
@@ -14,7 +12,7 @@ QUAY_REGISTRY_SECRET_NAME = "component-1"
 KONFLUX_ROOT_WORKING_DIR = "/tmp/crap/konflux"
 
 
-class Konflux:
+class KonfluxBuilder:
     def __init__(self, runtime: Runtime, distgit_name: str, namespace: str):
         self.runtime = runtime
 
@@ -148,14 +146,11 @@ class Konflux:
         self.apply_generated_file(data, "doozer/static/konflux/pipeline_run.yaml", f"{self.konflux_working_dir}/pipeline_run.yaml", mode="create")
         self.runtime.logger.info(f"Will push to registry {self.output_registry} on success")
 
-    def run(self):
+    def build(self):
+        pass
+
+    def _start_build(self):
         self.initialize()
         self.generate_files()
 
 
-@cli.command("k:ocp4", help="Konflux pipeline")
-@click.option("--namespace", required=True, help="OCP namespace where konflux is deployed to")
-@pass_runtime
-def konflux(runtime: Runtime, namespace: str):
-    pipeline = Konflux(runtime=runtime, distgit_name="coredns", namespace=namespace)
-    pipeline.run()

--- a/doozer/doozerlib/konflux_builder.py
+++ b/doozer/doozerlib/konflux_builder.py
@@ -32,7 +32,8 @@ class KonfluxBuilder:
         self.output_registry = f"{QUAY_REGISTRY_REPO_URL}:{self.component_name}"
 
         # https://github.com/openshift/coredns -> https://github.com/openshift-priv/coredns
-        self.github_url = self.image_meta.config["content"]["source"]["git"]["web"].replace("openshift", "openshift-priv")
+        repo = self.image_meta.config["content"]["source"]["git"]["web"]
+        self.github_url = repo.replace("openshift", "openshift-priv") if "/openshift/" in repo else repo
 
         self.initialize()
 

--- a/doozer/static/konflux/application.yaml
+++ b/doozer/static/konflux/application.yaml
@@ -1,0 +1,7 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Application
+metadata:
+  name: {{ application.name }}
+  namespace: {{ namespace }}
+spec:
+  displayName: {{ application.name }}

--- a/doozer/static/konflux/component.yaml
+++ b/doozer/static/konflux/component.yaml
@@ -1,0 +1,22 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    image.redhat.com/image: {{ registry_details }}
+  namespace: {{ namespace }}
+  ownerReferences:
+    - apiVersion: appstudio.redhat.com/v1alpha1
+      kind: Application
+      name: {{ application.name }}
+      uid: {{ application.uid }}
+  name: {{ component.name }}
+spec:
+  application: {{ application.name }}
+  componentName: {{ component.name }}
+  secret: {{ git.token_name }}
+  source:
+    git:
+      context: {{ git.context }}
+      dockerfileUrl: {{ git.dockerfile_path }}
+      revision: {{ git.branch }}
+      url: {{ git.url }}

--- a/doozer/static/konflux/pipeline_run.yaml
+++ b/doozer/static/konflux/pipeline_run.yaml
@@ -1,0 +1,59 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: {{ component.name }}-
+  namespace: {{ namespace }}
+  labels:
+    appstudio.openshift.io/application: {{ application.name }}
+    appstudio.openshift.io/component: {{ component.name }}
+    pipelines.appstudio.openshift.io/type: build
+    pipelines.openshift.io/runtime: generic
+    pipelines.openshift.io/strategy: docker
+    pipelines.openshift.io/used-by: build-cloud
+  ownerReferences:
+    - apiVersion: appstudio.redhat.com/v1alpha1
+      kind: Component
+      name: {{ component.name }}
+      uid: {{ component.uid }}
+spec:
+  params:
+    - name: dockerfile
+      value: Dockerfile
+    - name: git-url
+      value: {{ git.url }}
+    - name: output-image
+      value: {{ output_registry_url }}
+    - name: path-context
+      value: {{ git.context }}
+    - name: revision
+      value: {{ git.branch }}
+    - name: skip-checks
+      value: {{ skip_checks }}
+  pipelineRef:
+    params:
+      - name: name
+        value: docker-build
+      - name: bundle
+        value: {{ konflux.bundle_sha }}
+      - name: kind
+        value: pipeline
+    resolver: bundles
+  taskRunTemplate:
+    serviceAccountName: appstudio-pipeline
+  timeouts:
+    pipeline: 1h0m0s
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        metadata:
+          creationTimestamp: null
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+        status: {}
+    - name: git-auth
+      secret:
+        secretName: {{ git.token_name }}

--- a/pyartcd/pyartcd/pipelines/k_ocp4.py
+++ b/pyartcd/pyartcd/pipelines/k_ocp4.py
@@ -47,6 +47,7 @@ class KonfluxPipeline:
             f"--images={','.join(self.image_list)}", "k:images:rebase", f"--version=v{self.version.stream}",
             f"--release='{self.version.release}'",
             f"--message='Updating Dockerfile version and release v{self.version.stream}-{self.version.release}'",
+            "--skip-config-check"
         ])
 
         if self.runtime.dry_run:

--- a/pyartcd/pyartcd/pipelines/k_ocp4.py
+++ b/pyartcd/pyartcd/pipelines/k_ocp4.py
@@ -93,7 +93,7 @@ class KonfluxPipeline:
         await self._rebase(images=parents_children)
 
 
-@cli.command("k_ocp4", help=" Konflux pipeline")
+@cli.command("k:ocp4", help=" Konflux pipeline")
 @click.option("--image-list", required=True, default="",
               help="Comma/space-separated list to include/exclude per BUILD_IMAGES "
                    "(e.g. logging-kibana5,openshift-jenkins-2)")

--- a/pyartcd/pyartcd/pipelines/k_ocp4.py
+++ b/pyartcd/pyartcd/pipelines/k_ocp4.py
@@ -1,8 +1,10 @@
 import json
 import click
 import os
+import yaml
+from artcommonlib import exectools
+from artcommonlib.util import TreeAnalyzer
 from pyartcd import constants
-from pyartcd import exectools
 from pyartcd import util
 from pyartcd.cli import cli, pass_runtime, click_coroutine
 from pyartcd.runtime import Runtime
@@ -10,9 +12,9 @@ from pyartcd.runtime import Runtime
 
 class Version:
     def __init__(self):
-        self.stream = ''  # "X.Y" e.g. "4.0"
-        self.branch = ''  # e.g. "rhaos-4.0-rhel-7"
-        self.release = ''  # e.g. "201901011200.?"
+        self.stream = ""  # "X.Y" e.g. "4.0"
+        self.branch = ""  # e.g. "rhaos-4.0-rhel-7"
+        self.release = ""  # e.g. "201901011200.?"
         self.major = 0  # X in X.Y, e.g. 4
         self.minor = 0  # Y in X.Y, e.g. 0
 
@@ -23,51 +25,84 @@ class Version:
 class KonfluxPipeline:
     def __init__(self, runtime, assembly, data_path, image_list, version, data_gitref):
         self.runtime = runtime
-        self.image_list = image_list
-        self._doozer_working = os.path.abspath(f'{self.runtime.working_dir / "doozer_working"}')
+        self.image_list = image_list.split(",")
+        self._doozer_working = os.path.abspath(f"{self.runtime.working_dir / 'doozer_working'}")
         self.version = Version()
         self.version.stream = version
         self.version.release = util.default_release_suffix()
 
-        group_param = f'--group=openshift-{version}'
+        group_param = f"--group=openshift-{version}"
         if data_gitref:
-            group_param += f'@{data_gitref}'
+            group_param += f"@{data_gitref}"
 
         self._doozer_base_command = [
-            'doozer',
-            f'--assembly={assembly}',
-            f'--working-dir={self._doozer_working}',
-            f'--data-path={data_path}',
+            "doozer",
+            f"--assembly={assembly}",
+            f"--working-dir={self._doozer_working}",
+            f"--data-path={data_path}",
             group_param
         ]
 
-    async def rebase(self):
+        self.tree_analyzer = TreeAnalyzer(self._get_tree())
+
+    async def _rebase(self, images):
         cmd = self._doozer_base_command.copy()
         cmd.extend([
-            '--latest-parent-version', f'--images={self.image_list}', 'k:images:rebase',
-            f'--version=v{self.version.stream}', f'--release={self.version.release}', '--push',
+            "--latest-parent-version", "k:images:rebase", f"--images={','.join(images)}",
+            f"--version=v{self.version.stream}", f"--release='{self.version.release}'",
             f"--message='Updating Dockerfile version and release v{self.version.stream}-{self.version.release}'",
         ])
 
         if self.runtime.dry_run:
-            cmd.append('--dry-run')
+            cmd.append("--dry-run")
 
         await exectools.cmd_assert_async(cmd)
 
+    def _get_tree(self):
+        """
+        Get the parent-tree graph from ocp-build-data, of all images
+        """
+        cmd = self._doozer_base_command.copy()
+        cmd.extend([
+            "images:show-tree",
+            "--yml"
+        ])
+        out, _ = exectools.cmd_assert(cmd)
+        self.runtime.logger.info("images:show-tree output:\n%s", out)
+        return yaml.safe_load(out)
+
+    def _get_parents_children(self, images):
+        """
+        Get the list of parents and children of a node, including the node as well.
+        """
+        unique_images = set()
+
+        for image in images:
+            unique_images.add(image)
+            parents, children = self.tree_analyzer.get_parents_and_children(image)
+            for node in parents + children:
+                unique_images.add(node)
+
+        return unique_images
+
     async def run(self):
-        await self.rebase()
+        # Get all the parents and children that we need. Combine them so that there are no duplicates.
+        # This will be the new set of images to rebase
+        parents_children = self._get_parents_children(self.image_list)
+
+        await self._rebase(images=parents_children)
 
 
 @cli.command("k_ocp4", help=" Konflux pipeline")
-@click.option('--image-list', required=True, default='',
-              help='Comma/space-separated list to include/exclude per BUILD_IMAGES '
-                   '(e.g. logging-kibana5,openshift-jenkins-2)')
-@click.option('--assembly', required=True, help='The name of an assembly to rebase & build for')
-@click.option('--data-path', required=False, default=constants.OCP_BUILD_DATA_URL,
-              help='ocp-build-data fork to use (e.g. assembly definition in your own fork)')
-@click.option('--version', required=True, help='OCP version to scan, e.g. 4.14')
-@click.option('--data-gitref', required=False, default='',
-              help='Doozer data path git [branch / tag / sha] to use')
+@click.option("--image-list", required=True, default="",
+              help="Comma/space-separated list to include/exclude per BUILD_IMAGES "
+                   "(e.g. logging-kibana5,openshift-jenkins-2)")
+@click.option("--assembly", required=True, help="The name of an assembly to rebase & build for")
+@click.option("--data-path", required=False, default=constants.OCP_BUILD_DATA_URL,
+              help="ocp-build-data fork to use (e.g. assembly definition in your own fork)")
+@click.option("--version", required=True, help="OCP version to scan, e.g. 4.14")
+@click.option("--data-gitref", required=False, default="",
+              help="Doozer data path git [branch / tag / sha] to use")
 @pass_runtime
 @click_coroutine
 async def ocp4(runtime: Runtime, assembly, data_path, image_list, version, data_gitref):

--- a/pyartcd/pyartcd/pipelines/k_ocp4.py
+++ b/pyartcd/pyartcd/pipelines/k_ocp4.py
@@ -45,7 +45,7 @@ class KonfluxPipeline:
         cmd = self._doozer_base_command.copy()
         cmd.extend([
             f"--images={','.join(self.image_list)}", "k:images:rebase", f"--version=v{self.version.stream}",
-            f"--release='{self.version.release}'",
+            f"--release={self.version.release}",
             f"--message='Updating Dockerfile version and release v{self.version.stream}-{self.version.release}'",
             "--skip-config-check"
         ])
@@ -53,16 +53,20 @@ class KonfluxPipeline:
         if self.runtime.dry_run:
             cmd.append("--dry-run")
 
-        await exectools.cmd_assert_async(cmd)
+        rc, _, _ = await exectools.cmd_gather_async(cmd)
+
+        assert rc == 0
 
     async def _build(self):
         cmd = self._doozer_base_command.copy()
         cmd.extend([
-            f"--images={','.join(self.image_list)}", "k:images:build",
+            f"--images={','.join(self.image_list)}", "k:images:build", "--namespace=asdas-tenant"
         ])
 
         try:
-            await exectools.cmd_assert_async(cmd)
+            rc, _, _ = await exectools.cmd_gather_async(cmd)
+
+            assert rc == 0
 
         except ChildProcessError:
             raise

--- a/pyartcd/pyartcd/pipelines/k_ocp4.py
+++ b/pyartcd/pyartcd/pipelines/k_ocp4.py
@@ -55,8 +55,21 @@ class KonfluxPipeline:
 
         await exectools.cmd_assert_async(cmd)
 
+    async def _build(self):
+        cmd = self._doozer_base_command.copy()
+        cmd.extend([
+            f"--images={','.join(self.image_list)}", "k:images:build",
+        ])
+
+        try:
+            await exectools.cmd_assert_async(cmd)
+
+        except ChildProcessError:
+            raise
+
     async def run(self):
         await self._rebase()
+        await self._build()
 
 
 @cli.command("k:ocp4", help=" Konflux pipeline")


### PR DESCRIPTION
Changes in this PR:
- Use quay.io registry urls in `FROM` since Konflux builds from an to Quay. Use `quay.io/rh_ee_asdas/konflux-test` for testing, for now and then switch to team registry.