### PR TITLE
wip ART-9922 verify-attached-bugs structured output

### DIFF
--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 import traceback
 import logging

--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 import traceback
 import logging

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -408,7 +408,7 @@ def categorize_bugs_by_type(bugs: List[Bug], advisory_id_map: Dict[str, int],
     if issues:
         if not permissive:
             logger.error("Found these issues with bugs:")
-            yaml.dump([i.to_dict() for i in issues], indent=2, sort_keys=False, width=float("inf"))
+            yaml.dump([i.to_dict() for i in issues], sys.stderr, indent=2, sort_keys=False, width=float("inf"))
             raise ElliottFatalError("Found issues with bugs which need to be fixed.")
     return bugs_by_type, issues
 

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -398,7 +398,7 @@ def categorize_bugs_by_type(bugs: List[Bug], advisory_id_map: Dict[str, int],
                     still_not_found_with_component = [(b.id, b.whiteboard_component) for b in still_not_found]
                     message = ('No attached builds found in advisories for tracker bugs (bug, package): '
                                f'{stringify(still_not_found_with_component)}. Either attach builds or explicitly include/exclude '
-                               f'the bug ids in the assembly definition')
+                               'the bug ids in the assembly definition')
                     issue = VerifyIssue(
                         code=VerifyIssueCode.TRACKER_BUGS_NO_BUILDS,
                         message=message

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -408,7 +408,7 @@ def categorize_bugs_by_type(bugs: List[Bug], advisory_id_map: Dict[str, int],
     if issues:
         if not permissive:
             logger.error("Found these issues with bugs:")
-            yaml.dump([i.to_dict() for i in issues], indent=2, sort_keys=False)
+            yaml.dump([i.to_dict() for i in issues], indent=2, sort_keys=False, width=float("inf"))
             raise ElliottFatalError("Found issues with bugs which need to be fixed.")
     return bugs_by_type, issues
 

--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -116,7 +116,10 @@ async def verify_attached_bugs(runtime: Runtime, verify_bug_status: bool, adviso
         if verify_flaws:
             await validator.verify_attached_flaws(advisory_bug_map)
     except Exception as e:
-        validator._complain(f"Error validating attached bugs: {e}")
+        validator._complain(VerifyIssue(
+            code=VerifyIssueCode.VALIDATION_ERROR,
+            message=f"Error validating attached bugs: {type(e)}: {e}"
+        ))
     finally:
         await validator.close()
         validator.report()
@@ -163,7 +166,10 @@ async def verify_bugs(runtime, verify_bug_status, output, no_verify_blocking_bug
     try:
         validator.validate(ocp_bugs, verify_bug_status, no_verify_blocking_bugs)
     except Exception as e:
-        validator._complain(f"Error validating bugs: {e}")
+        validator._complain(VerifyIssue(
+            code=VerifyIssueCode.VALIDATION_ERROR,
+            message=f"Error validating bugs: {type(e)}: {e}"
+        ))
     finally:
         await validator.close()
         validator.report()
@@ -187,7 +193,7 @@ class BugValidator:
             self.problems = [p.to_dict() for p in self.problems]
             if self.output == 'text':
                 print("Found the following problems, please investigate")
-                print(yaml.dump(self.problems, indent=2, sort_keys=False))
+                print(yaml.dump(self.problems, indent=2, sort_keys=False, width=float("inf")))
             elif self.output == 'json':
                 print(json.dumps(self.problems, indent=2, sort_keys=False))
             elif self.output == 'slack':
@@ -413,7 +419,7 @@ class BugValidator:
         except ValueError as e:
             issues.append(VerifyIssue(
                 code=VerifyIssueCode.VALIDATION_ERROR,
-                message=f"Error validating cve exclusions on advisory {advisory_id}: {e}"
+                message=f"Error validating cve exclusions on advisory {advisory_id}: {type(e)}: {e}"
             ))
 
         # Validate `CVE Names` field of the advisory

--- a/elliott/elliottlib/verify_issue.py
+++ b/elliott/elliottlib/verify_issue.py
@@ -1,0 +1,75 @@
+from enum import Enum
+from typing import Iterable
+
+
+def stringify(i, sort=True):
+    """
+    Convert iterable containing strings to a string without single quotes
+    This is useful when dumping data to JSON/YAML for humans to read
+    Bad for serialization
+    """
+    if not isinstance(i, Iterable):
+        return str(i)
+    # sort it so it's deterministic unless told not to
+    i = sorted(i) if sort else i
+    return str(i).replace("'", "")
+
+
+class VerifyIssueCode(Enum):
+    def __str__(self):
+        return self.value
+
+    # Bug validations
+
+    INVALID_TARGET_RELEASE = "invalid_target_release"
+    INVALID_TRACKER_BUGS = "invalid_tracker_bugs"
+    INVALID_BUG_STATUS = "invalid_bug_status"
+
+    BUGS_MULTIPLE_ADVISORIES = "bugs_multiple_advisories"
+
+    PARENT_BUG_WRONG_STATUS = "parent_bug_wrong_status"
+    PARENT_BUG_NOT_SHIPPING = "parent_bug_not_shipping"
+
+    # Advisory validations
+
+    WRONG_ADVISORY_TYPE = "wrong_advisory_type"
+
+    MISSING_FLAW_BUGS = "missing_flaw_bugs"
+    EXTRA_FLAW_BUGS = "extra_flaw_bugs"
+
+    EXTRA_CVE_EXCLUSIONS = "extra_cve_exclusions"
+    MISSING_CVE_EXCLUSIONS = "missing_cve_exclusions"
+
+    EXTRA_CVE_NAMES_IN_ADVISORY = "extra_cve_names_in_advisory"
+    MISSING_CVE_NAMES_IN_ADVISORY = "missing_cve_names_in_advisory"
+
+    MISSING_BUGS_IN_ADVISORY = "missing_bugs_in_advisory"
+    EXTRA_BUGS_IN_ADVISORY = "extra_bugs_in_advisory"
+
+    TRACKER_BUGS_NO_BUILDS = "tracker_bugs_no_builds"
+
+    # Other
+
+    VALIDATION_ERROR = "validation_error"
+
+
+class VerifyIssue:
+    def __init__(self, code: VerifyIssueCode, message: str):
+        """
+        :param code: The code of the issue.
+        :param message: The description of the issue with all the necessary details.
+        """
+        self.code = code
+        self.message = message
+
+    def __str__(self):
+        return self.message
+
+    def __repr__(self):
+        return self.message
+
+    def to_dict(self):
+        return {
+            "code": self.code.value,
+            "message": self.message,
+        }

--- a/elliott/tests/test_verify_attached_bugs_cli.py
+++ b/elliott/tests/test_verify_attached_bugs_cli.py
@@ -136,10 +136,11 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
         flexmock(BugValidator).should_receive("verify_bugs_advisory_type")
 
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'verify-attached-bugs', str(advisory_id)])
-        # if result.exit_code != 0:
-        #     exc_type, exc_value, exc_traceback = result.exc_info
-        #     t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
-        #     self.fail(t)
+        import traceback
+        if result.exit_code != 0:
+            exc_type, exc_value, exc_traceback = result.exc_info
+            t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
+            self.fail(t)
         self.assertEqual(result.exit_code, 1)
         self.assertIn('Regression possible: ON_QA bug OCPBUGS-2 is a backport of bug OCPBUGS-3 which has status '
                       'MODIFIED', result.output)


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-9922

Goal of this PR is to turn all bug/advisory validations we have peppered 
in our commands into a code so it's structured, and then we can do nice things on top of it, 
like permits and suggesting/applying remediations based on the validation code.

Splitting changes over PRs to make this easier to review
- https://github.com/openshift-eng/art-tools/pull/703
- https://github.com/openshift-eng/art-tools/pull/702

