### PR TITLE
[fips-scan] Refactor exit

### DIFF
--- a/pyartcd/pyartcd/pipelines/scan_fips.py
+++ b/pyartcd/pyartcd/pipelines/scan_fips.py
@@ -55,9 +55,10 @@ class ScanFips:
 
                 # Exit as error so that we see in the PipelineRun
                 self.runtime.logger.error("FIPS issues were found")
-                sys.exit(1)
+
             else:
                 self.runtime.logger.info("[DRY RUN] Would have messaged slack")
+            sys.exit(1)
         else:
             self.runtime.logger.info("No issues")
 


### PR DESCRIPTION
Exit with `1` even for dry-run