### PR TITLE
Merging doozer, pyartcd requirements.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 venv:
 	python3.8 -m venv venv
 	./venv/bin/pip install --upgrade pip
-	./venv/bin/pip install -e artcommon/ doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
+	./venv/bin/pip install -e artcommon/ -e elliott/ -e ocp-build-data-validator/
 	./venv/bin/pip install -r doozer/requirements-dev.txt -r pyartcd/requirements-dev.txt -r ocp-build-data-validator/requirements-dev.txt
 	cd elliott && ../venv/bin/pip install '.[tests]'
 	# source venv/bin/activate
@@ -23,7 +23,7 @@ test: lint unit
 default-python-venv:
 	python3 -m venv venv
 	./venv/bin/pip install --upgrade pip
-	./venv/bin/pip install -e artcommon/ doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
+	./venv/bin/pip install -e artcommon/ -e elliott/ -e ocp-build-data-validator/
 	./venv/bin/pip install -r doozer/requirements-dev.txt -r pyartcd/requirements-dev.txt -r ocp-build-data-validator/requirements-dev.txt
 	cd elliott && ../venv/bin/pip install '.[tests]'
 	# source venv/bin/activate

--- a/artcommon/requirements.txt
+++ b/artcommon/requirements.txt
@@ -1,0 +1,39 @@
+aiofiles
+aiohttp[speedups] >= 3.6
+aiohttp >= 3.9.4  # not directly required, pinned by Snyk to avoid a vulnerability
+aiohttp_retry
+aioredlock >= 0.7.3
+bashlex
+click >= 8.1.3
+contextvars
+cryptography
+defusedxml
+dockerfile-parse >= 0.0.13
+errata-tool ~= 1.31.0
+future
+ghapi
+jenkinsapi >= 0.3.13  # https://github.com/pycontribs/jenkinsapi/issues/833
+jira >= 3.4.1  # https://github.com/pycontribs/jira/issues/1486
+koji
+mysql-connector-python >= 8.0.21
+opentelemetry-exporter-otlp-proto-grpc
+opentelemetry-sdk
+openshift-client ~= 2.0.1
+pip_system_certs
+PyGitHub == 1.59.1
+pydantic ~= 1.10.7
+pygit2 >= 1.11.1  # https://github.com/libgit2/pygit2/issues/1176
+pyyaml >= 5.1
+python-dateutil >= 2.8.1
+redis >= 5.0.1
+requests >= 2.32.0  # not directly required, pinned by Snyk to avoid a vulnerability
+requests_kerberos
+ruamel.yaml
+semver ~= 3.0.1
+setuptools >= 65.5.1
+slack_sdk >= 3.13.0
+specfile
+stomp.py ~= 8.1.0
+tenacity
+tomli ~= 2.0.1
+wrapt

--- a/artcommon/setup.py
+++ b/artcommon/setup.py
@@ -4,6 +4,9 @@ import sys
 if sys.version_info < (3, 8):
     sys.exit('Sorry, Python < 3.8 is not supported.')
 
+with open('./requirements.txt') as f:
+    INSTALL_REQUIRES = f.read().splitlines()
+
 setup(
     name="artcommon",
     author="AOS ART Team",
@@ -13,6 +16,7 @@ setup(
     license="Apache License, Version 2.0",
     packages=find_packages(exclude=["tests", "tests.*"]),
     dependency_links=[],
+    install_requires=INSTALL_REQUIRES,
     python_requires='>=3.8',
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/doozer/requirements.txt
+++ b/doozer/requirements.txt
@@ -1,3 +1,5 @@
+# Merged to artcommon/requirements.txt
+# Please add new dependencies there
 aiofiles
 bashlex
 click >= 8.1.3

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-pip3 install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/
+pip3 install -e artcommon/ -e elliott/

--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -1,3 +1,5 @@
+# Merged to artcommon/requirements.txt
+# Please add new dependencies there
 Jinja2
 aiofiles
 aiohttp[speedups] >= 3.6


### PR DESCRIPTION
Now that we use art-tools as a whole, merging dependencies to `artcommon/requirements.txt` for better dependency management.

Merging doozer and pyartcd, as first pass