### PR TITLE
Revert "Ignore okd config changes for triggering production builds"

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -453,8 +453,7 @@ class ImageMetadata(Metadata):
                 return False
 
     def calculate_config_digest(self, group_config, streams):
-        ignore_keys = ["owners", "scan_sources",
-                       "content.source.ci_alignment", "content.source.okd_alignment"
+        ignore_keys = ["owners", "scan_sources", "content.source.ci_alignment",
                        "content.source.git", "external_scanners"]  # list of keys that shouldn't be involved in config digest calculation
         image_config: Dict[str, Any] = deepcopy(self.config.primitive())
         group_config: Dict[str, Any] = group_config.primitive()


### PR DESCRIPTION
Reverts openshift-eng/art-tools#686

This removes a field from existing configuration, and thus triggers rebuilds. Mass rebuilds in 4.16 and 4.17 are unwanted at the moment, hence the revert. 