### PR TITLE
Set prerelease label in bundle build always

### DIFF
--- a/doozer/doozerlib/olm/bundle.py
+++ b/doozer/doozerlib/olm/bundle.py
@@ -553,9 +553,8 @@ class OLMBundle(object):
         labels = {
             'com.redhat.delivery.operator.bundle': 'true',
             'com.redhat.openshift.versions': versions.format(**self.runtime.group_config.vars),
+            'com.redhat.prerelease': str(self.operator_index_mode == 'pre-release'),
         }
-        if self.operator_index_mode == 'pre-release':
-            labels['com.redhat.prerelease'] = 'true'
         return labels
 
     @property

--- a/doozer/doozerlib/olm/bundle.py
+++ b/doozer/doozerlib/olm/bundle.py
@@ -553,7 +553,7 @@ class OLMBundle(object):
         labels = {
             'com.redhat.delivery.operator.bundle': 'true',
             'com.redhat.openshift.versions': versions.format(**self.runtime.group_config.vars),
-            'com.redhat.prerelease': str(self.operator_index_mode == 'pre-release'),
+            'com.redhat.prerelease': str(self.operator_index_mode == 'pre-release').lower(),
         }
         return labels
 


### PR DESCRIPTION
Follow up to https://github.com/openshift-eng/art-tools/pull/608
When trying to match labels, we missed the case when a label would be present in 
found image that we do not want or want it to be false. To get around this always set prerelease label to 
whatever state it is in (true/false)