### PR TITLE
ART-8684 Automatically remove invalid builds

### DIFF
--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -218,15 +218,18 @@ PRESENT advisory. Here are some examples:
 
             # In ET, new nvr replaces already attached nvr for a (package, el_version) in a product version.
             # so filter out nvrs that would be replaced by canonical nvrs
+            valid_package_els = {}
+            for n in canonical_nvrs:
+                parsed_n = parse_nvr(n)
+                n_el = isolate_el_version_in_release(parsed_n['release'])
+                valid_package_els[(parsed_n['name'], n_el)] = True
+
             temp = []
             for n in nvrs_to_remove:
                 parsed_n = parse_nvr(n)
                 n_el = isolate_el_version_in_release(parsed_n['release'])
-                for n2 in canonical_nvrs:
-                    parsed_n2 = parse_nvr(n2)
-                    n2_el = isolate_el_version_in_release(parsed_n2['release'])
-                    if parsed_n['name'] == parsed_n2['name'] and n_el == n2_el:
-                        temp.append(n)
+                if (parsed_n['name'], n_el) in valid_package_els:
+                    temp.append(n)
 
             nvrs_to_remove = nvrs_to_remove - set(temp)
             if nvrs_to_remove:

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -218,11 +218,11 @@ PRESENT advisory. Here are some examples:
 
             # In ET, new nvr replaces already attached nvr for a (package, el_version) in a product version.
             # so filter out nvrs that would be replaced by canonical nvrs
-            valid_package_els = {}
+            valid_package_els = set()
             for n in canonical_nvrs:
                 parsed_n = parse_nvr(n)
                 n_el = isolate_el_version_in_release(parsed_n['release'])
-                valid_package_els[(parsed_n['name'], n_el)] = True
+                valid_package_els.add((parsed_n['name'], n_el))
 
             temp = []
             for n in nvrs_to_remove:

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -68,12 +68,16 @@ pass_runtime = click.make_pass_decorator(Runtime)
 @click.option(
     '--member-only', is_flag=True,
     help='(For rpms) Only sweep member rpms')
+@click.option('--clean', is_flag=True,
+              help='Remove builds from advisory that were not found in build sweep. Cannot be used with -b or -f')
+@click.option('--dry-run', '--noop', is_flag=True,
+              help='Do not attach/remove builds from advisory, only show what would be done')
 @click_coroutine
 @pass_runtime
 # # # NOTE: if you change the method signature, be aware that verify_attached_operators_cli.py # # #
 # # # invokes find_builds_cli so please avoid breaking it.                                     # # #
 async def find_builds_cli(runtime: Runtime, advisory_id, default_advisory_type, builds_file, builds, kind, as_json,
-                          no_cdn_repos, payload, non_payload, include_shipped, member_only: bool):
+                          no_cdn_repos, payload, non_payload, include_shipped, member_only: bool, clean: bool, dry_run: bool):
     """Automatically or manually find or attach viable rpm or image builds
 to ADVISORY. Default behavior searches Brew for viable builds in the
 given group. Provide builds manually by giving one or more --build
@@ -118,6 +122,11 @@ PRESENT advisory. Here are some examples:
         raise click.BadParameter('Use only one of --payload or --non-payload.')
     if builds and builds_file:
         raise click.BadParameter('Use only one of --build or --builds-file.')
+    if clean:
+        if not (advisory_id or default_advisory_type):
+            raise click.BadParameter('Cannot use --clean without --attach or --use-default-advisory.')
+        if builds or builds_file:
+            raise click.BadParameter('Cannot use --clean with --build or --builds-file.')
 
     if builds_file:
         if builds_file == "-":
@@ -155,7 +164,7 @@ PRESENT advisory. Here are some examples:
             nvrps = await _fetch_builds_by_kind_rpm(runtime, tag_pv_map, brew_session, include_shipped, member_only)
 
     LOGGER.info('Fetching info for builds from Errata')
-    builds = parallel_results_with_progress(
+    builds: List[brew.Build] = parallel_results_with_progress(
         nvrps,
         lambda nvrp: errata.get_brew_build(f'{nvrp[0]}-{nvrp[1]}-{nvrp[2]}',
                                            nvrp[3], session=requests.Session())
@@ -189,23 +198,50 @@ PRESENT advisory. Here are some examples:
 
     try:
         erratum = errata.Advisory(errata_id=advisory_id)
-        erratum.ensure_state('NEW_FILES')
-        erratum.attach_builds(builds, kind)
+        if dry_run:
+            yellow_print("[dry-run] Would've moved advisory to NEW_FILES state")
+        else:
+            erratum.ensure_state('NEW_FILES')
+
+        # store nvrs that are already attached to the advisory
+        advisory_build_nvrs = []
+        for build_list in erratum.errata_builds.values():  # one per product version
+            advisory_build_nvrs.extend(build_list)
+
+        if dry_run:
+            yellow_print(f"[dry-run] Would've attached {len(builds)} builds to advisory {advisory_id}")
+        else:
+            erratum.attach_builds(builds, kind)
+
+        if clean:
+            nvrs_to_remove = set(advisory_build_nvrs) - set([b.nvr for b in builds])
+            if nvrs_to_remove:
+                LOGGER.info(f"Removing builds from advisory that were not found in build sweep: {len(nvrs_to_remove)}")
+                if dry_run:
+                    yellow_print(f"[dry-run] Would've removed {len(nvrs_to_remove)} builds from advisory {advisory_id}")
+                else:
+                    erratum.remove_builds(nvrs_to_remove)
+
         cdn_repos = et_data.get('cdn_repos')
         if kind == 'image':
-            ensure_rhcos_file_meta(advisory_id)
+            if dry_run:
+                yellow_print("[dry-run] Would've modified RHCOS file metadata")
+            else:
+                ensure_rhcos_file_meta(advisory_id)
             if cdn_repos and not no_cdn_repos:
                 cdn_repos = set(cdn_repos)
                 available_repos = set([i['repo']['name'] for i in erratum.metadataCdnRepos()])
                 not_available_repos = cdn_repos - available_repos
                 repos_to_enable = cdn_repos & available_repos
                 if repos_to_enable:
-                    erratum.set_cdn_repos(repos_to_enable)
+                    if dry_run:
+                        yellow_print(f"[dry-run] Would've enabled CDN repos: {repos_to_enable}")
+                    else:
+                        erratum.set_cdn_repos(repos_to_enable)
                 if not_available_repos:
                     raise ValueError("These cdn repos defined in erratatool.yml are not available for the advisory "
                                      f"{advisory_id}: {not_available_repos}. Please remove these or request them to "
                                      "be created.")
-                erratum.set_cdn_repos(cdn_repos)
     except ErrataException as e:
         red_print(f'Cannot change advisory {advisory_id}: {e}')
         exit(1)
@@ -469,11 +505,12 @@ async def _fetch_builds_by_kind_rpm(runtime: Runtime, tag_pv_map: Dict[str, str]
     return nvrps
 
 
-def _filter_out_attached_builds(build_objects: brew.Build, include_shipped: bool = False):
+def _filter_out_attached_builds(build_objects: List[brew.Build], include_shipped: bool = False) \
+                                -> (List[brew.Build], Dict[int, Set[str]]):
     """
     Filter out builds that are already attached to an ART advisory
     """
-    unattached_builds = []
+    unattached_builds: List[brew.Build] = []
     errata_version_cache = {}  # avoid reloading the same errata for multiple builds
     attached_to_advisories: Dict[int, Set[str]] = dict()
     for b in build_objects:

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -241,7 +241,7 @@ PRESENT advisory. Here are some examples:
                     yellow_print(f"[dry-run] Would've removed {len(nvrs_to_remove)} builds from advisory {advisory_id}")
                 else:
                     erratum.ensure_state('NEW_FILES')
-                    erratum.remove_builds(nvrs_to_remove)
+                    erratum.remove_builds(list(nvrs_to_remove))
 
         cdn_repos = et_data.get('cdn_repos')
         if kind == 'image':

--- a/elliott/elliottlib/errata.py
+++ b/elliott/elliottlib/errata.py
@@ -381,7 +381,7 @@ def get_brew_builds(errata_id, session=None):
             msg=res.text))
 
 
-def get_brew_build(nvr, product_version='', session=None):
+def get_brew_build(nvr, product_version='', session=None) -> brew.Build:
     """5.2.2.1. GET /api/v1/build/{id_or_nvr}
 
     Get Brew build details.

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -581,8 +581,10 @@ class PrepareReleasePipeline:
         if impetus == "microshift":
             # By default, elliott sweeps every tagged rpm. We need `--member-only` to only sweep those listed in `--rpms`.
             cmd.append("--member-only")
-        if not self.dry_run:
-            cmd.append(f"--attach={advisory}")
+        cmd.append(f"--attach={advisory}")
+        cmd.append("--clean")
+        if self.dry_run:
+            cmd.append("--dry-run")
         _LOGGER.info("Running command: %s", cmd)
         await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars, cwd=self.working_dir)
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-8684

Introduce `--clean` and `--dry-run` flags to `elliott find-builds`
`--clean` removes all builds in advisory that were not found as part of build sweep.

```
$ elliott -g openshift-4.16 --assembly rc.4 find-builds -k image --non-payload 
--use-default-advisory extras --clean --dry-run
...
Default advisory detected: 125774
Found 48 builds, of which 11 are new.
2024-06-13 11:20:47,741 INFO 11 builds are already attached to given advisory
2024-06-13 11:20:47,741 INFO Fetching advisory
No eligible builds found. To include shipped builds, use --include-shipped
2024-06-13 11:20:53,543 INFO Removing builds from advisory that were not found in build sweep: 6
 openshift-enterprise-egress-router-container-v4.16.0-202405041048.p0.ga26ca1f.assembly.stream.el8
 openshift-enterprise-helm-operator-container-v4.16.0-202405110441.p0.gf727897.assembly.stream.el8
 openshift-enterprise-operator-sdk-container-v4.16.0-202404292211.p0.g1234572.assembly.stream.el8
 ose-csi-driver-shared-resource-mustgather-container-v4.16.0-202404302047.p0.gcf116d9.assembly.stream.el8
 ose-egress-http-proxy-container-v4.16.0-202404292211.p0.g95de81f.assembly.stream.el8
 ptp-operator-must-gather-container-v4.16.0-202404302047.p0.g8ce2061.assembly.stream.el8
[dry-run] Would've moved advisory to NEW_FILES state
[dry-run] Would've removed 6 builds from advisory 125774
[dry-run] Would've ensured RHCOS file metadata is set
[dry-run] Would've enabled CDN repos: {'rhocp-4_DOT_16-for-rhel-9-x86_64-rpms', 'rhocp-4_DOT_16-for-rhel-9-aarch64-rpms', 'rhocp-4_DOT_16-for-rhel-9-s390x-rpms', 'rhocp-4_DOT_16-for-rhel-9-ppc64le-rpms'}
```