### PR TITLE
promote: Fix invalid json

### DIFF
--- a/pyartcd/pyartcd/s3.py
+++ b/pyartcd/pyartcd/s3.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from typing import Optional
 from pyartcd import exectools
 from tenacity import retry, stop_after_attempt, wait_fixed
@@ -57,4 +58,4 @@ async def sync_dir_to_s3_mirror(local_dir: str, s3_path: str, exclude: Optional[
         wait=wait_fixed(30),  # wait for 30 seconds between retries
         stop=(stop_after_attempt(3)),  # max 3 attempts
         reraise=True
-    )(exectools.cmd_assert_async)(base_cmd, env=env)
+    )(exectools.cmd_assert_async)(base_cmd, env=env, stdout=sys.stderr)


### PR DESCRIPTION
promote can fail while reading the json that artcd produces. The json includes logs from aws s3 interactions. This ensures that stdout of the aws gets redirected to stderr.