### PR TITLE
Fix release bumps for non ART RPMs

### DIFF
--- a/pyartcd/tests/test_rebuild_golang_rpms.py
+++ b/pyartcd/tests/test_rebuild_golang_rpms.py
@@ -1,0 +1,39 @@
+import unittest
+from unittest import TestCase
+from unittest.mock import MagicMock
+from pyartcd.pipelines.rebuild_golang_rpms import RebuildGolangRPMsPipeline
+
+
+class TestBumpRpms(TestCase):
+
+    def setUp(self):
+        runtime = MagicMock()
+        self.pipeline = RebuildGolangRPMsPipeline(runtime, ocp_version="4.17", go_nvrs=["go1.16"], art_jira="JIRA-123")
+
+    def test_bump_up_case_1(self):
+        fake_releases = "42.rhaos4.17.abcd"
+        actual_r = self.pipeline.bump_release(fake_releases)
+        expected_r = "43.rhaos4.17.abcd"
+        self.assertEqual(actual_r, expected_r)
+
+    def test_bump_up_case_2(self):
+        fake_release = "42.1.rhaos4.17.abcd"
+        actual_r = self.pipeline.bump_release(fake_release)
+        expected_r = "43.rhaos4.17.abcd"
+        self.assertEqual(actual_r, expected_r)
+
+    def test_bump_up_case_3(self):
+        fake_releases = "rhaos4.17.abcd"
+        actual_r = self.pipeline.bump_release(fake_releases)
+        expected_r = "1.rhaos4.17.abcd"
+        self.assertEqual(actual_r, expected_r)
+
+    def test_bump_up_case_4(self):
+        fake_releases = "42.1"
+        actual_r = self.pipeline.bump_release(fake_releases)
+        expected_r = "43"
+        self.assertEqual(actual_r, expected_r)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pyartcd/tests/test_rebuild_golang_rpms.py
+++ b/pyartcd/tests/test_rebuild_golang_rpms.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 from pyartcd.pipelines.rebuild_golang_rpms import RebuildGolangRPMsPipeline
 
 
-class TestBumpRpms(TestCase):
+class TestBumpRelease(TestCase):
 
     def setUp(self):
         runtime = MagicMock()


### PR DESCRIPTION
tested locally with 

`artcd -v --working-dir=$HOME/tmp/art-tools --config=$HOME/Development/git/OpenShift/aos-cd-jobs/config/artcd.toml --dry-run rebuild-golang-rpms --ocp-version=4.17 --art-jira=[ART-9118](https://issues.redhat.com//browse/ART-9118) golang-1.22.2-1.module+el8.10.0+21789+dd446cb3`

and get

```
2024-06-14 12:42:27,488 pyartcd.pipelines.rebuild_golang_rpms:INFO cri-o/rhaos-4.17-rhel-8 - Current release in specfile: 2.rhaos4.17.git%{shortcommit0}
2024-06-14 12:42:27,590 pyartcd.pipelines.rebuild_golang_rpms:INFO cri-o/rhaos-4.17-rhel-8 - New release in specfile: 3.rhaos4.17.git%{shortcommit0}
```

have still to look if this works also for other RPMs since they could have different release field.