### PR TITLE
prepare-release: Explicitly add newly created advisory to batch

### DIFF
--- a/elliott/tests/test_errata_async.py
+++ b/elliott/tests/test_errata_async.py
@@ -35,7 +35,6 @@ class TestAsyncErrataAPI(IsolatedAsyncioTestCase):
         actual = await api._make_request("GET", "/api/path", headers=headers, parse_json=False)
         expected_headers = {**api._headers, **headers, **{"Authorization": 'Negotiate abcdef'}}
         request.assert_called_once_with("GET", "https://errata.example.com/api/path", headers=expected_headers)
-        fake_response.raise_for_status.assert_called_once_with()
         fake_response.read.assert_awaited_once_with()
         actual = await api._make_request("GET", "/api/path", parse_json=False)
         self.assertEqual(actual, b"daedbeef")

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -197,7 +197,8 @@ class PrepareReleasePipeline:
                         continue
                     advisories[ad] = self.create_advisory(advisory_type=advisory_type,
                                                           art_advisory_key=ad,
-                                                          release_date=self.release_date)
+                                                          release_date=self.release_date,
+                                                          batch_id=batch["id"] if batch else 0)
             await self._slack_client.say_in_thread(f"Regular advisories created with release date {self.release_date}")
 
         jira_issue_key = group_config.get("release_jira")
@@ -444,7 +445,7 @@ class PrepareReleasePipeline:
         if match and int(match[1]) != 0:
             _LOGGER.info(f"{int(match[1])} Blocker Bugs found! Make sure to resolve these blocker bugs before proceeding to promote the release.")
 
-    def create_advisory(self, advisory_type: str, art_advisory_key: str, release_date: str) -> int:
+    def create_advisory(self, advisory_type: str, art_advisory_key: str, release_date: str, batch_id: int = 0) -> int:
         _LOGGER.info("Creating advisory with type %s art_advisory_key %s ...", advisory_type, art_advisory_key)
         create_cmd = [
             "elliott",
@@ -459,6 +460,8 @@ class PrepareReleasePipeline:
             f"--package-owner={self.package_owner}",
             f"--date={release_date}",
         ]
+        if batch_id:
+            create_cmd.append(f"--batch-id={batch_id}")
         if not self.dry_run:
             create_cmd.append("--yes")
         _LOGGER.info("Running command: %s", create_cmd)


### PR DESCRIPTION
Due to an issue in Errata Tool, if batch is enabled for an ET Release,
newly created advisories will be implicitly added to an open batch.

This has caused chaos because our ET release (RHOSE ASYNC - AUTO) is
shared among multiple teams (ART, CPaaS, etc) and advisories for
different OCP releases are prepared in parallel.

I would like to propose a new CLI option `--batch-id` for the `elliott
create` command, so that we can explicitly specify the batch ID when
creating an advisory. To achieve this, raw Errata REST API is used since
the errata_tool library doesn't expose that field.

Also updated prepare_release job to use the new CLI option.