### PR TITLE
Tweak verify bugs for advance advisory

### DIFF
--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -18,7 +18,6 @@ from jira import JIRA, Issue
 from errata_tool import Erratum
 from errata_tool.jira_issue import JiraIssue as ErrataJira
 from errata_tool.bug import Bug as ErrataBug
-from bugzilla.bug import Bug
 from koji import ClientSession
 from tenacity import retry, stop_after_attempt, wait_fixed
 
@@ -47,6 +46,12 @@ def get_jira_bz_bug_ids(bug_ids):
 class Bug:
     def __init__(self, bug_obj):
         self.bug = bug_obj
+
+    def __str__(self):
+        return str(self.id)
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}:{self.id}'
 
     @property
     def id(self):
@@ -100,7 +105,7 @@ class Bug:
         return None
 
     @staticmethod
-    def get_target_release(bugs: List[Bug]) -> str:
+    def get_target_release(bugs: List) -> str:
         """
         Pass in a list of bugs and get their target release version back.
         Raises exception if they have different target release versions set.

--- a/elliott/elliottlib/errata.py
+++ b/elliott/elliottlib/errata.py
@@ -22,10 +22,7 @@ from elliottlib.util import chunk
 from elliottlib import bzutil
 from requests_gssapi import HTTPSPNEGOAuth
 from errata_tool import Erratum, ErrataException, ErrataConnector
-from typing import List, Optional
-
-
-import xmlrpc.client
+from typing import List
 
 logger = logutil.get_logger(__name__)
 
@@ -870,3 +867,10 @@ def push_cdn_stage(advisory_id):
         # if advisory has push dependencies then it will return 400, this is expected
         return None
     return response.json()
+
+
+def is_advisory_editable(advisory_id: int) -> bool:
+    erratum = get_raw_erratum(advisory_id)['errata']
+    advisory_type_key = list(erratum.keys())[0]
+    status = erratum[advisory_type_key]['status']
+    return status in {"NEW_FILES", "QE"}


### PR DESCRIPTION
Right now verify-attached-bugs considers advance advisory if there are bugs
attached to it, but that is not always true and it is not correct logic. So correct that

Test:
`elliott --assembly rc.4 -g openshift-4.16 verify-attached-bugs --verify-bug-status --skip-multiple-advisories-check`