### PR TITLE
ART-9934: Clean up FIPS installer archive paths

### DIFF
--- a/pyartcd/pyartcd/oc.py
+++ b/pyartcd/pyartcd/oc.py
@@ -116,7 +116,7 @@ def extract_release_client_tools(release_pullspec: str, path_arg: str, single_ar
     common_oc_wrapper("extract_tools", "adm", args, True, False)
 
 
-def extract_baremetal_installer(release_pullspec: str, path: str, arch: str) -> (int, str):
+def extract_baremetal_installer(release_pullspec: str, path: str, arch: str, cmd: str = 'openshift-baremetal-install') -> (int, str):
     """
     Extract baremetal-installer binary to specified location
     :param release_pullspec: e.g. quay.io/openshift-release-dev/ocp-release:4.14.0-ec.2-x86_64
@@ -125,7 +125,7 @@ def extract_baremetal_installer(release_pullspec: str, path: str, arch: str) -> 
     """
 
     # oc adm release extract --command=openshift-baremetal-install -n=ocp --to <path> <pullspec>
-    args = ['release', 'extract', '--command=openshift-baremetal-install', '-n=ocp', '--from',
+    args = ['release', 'extract', f'--command={cmd}', '-n=ocp', '--from',
             release_pullspec, '--command-os', f'linux/{arch}', f'--to={path}']
     return common_oc_wrapper(
         cmd_result_name='extract_baremetal',

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -791,7 +791,7 @@ class PromotePipeline:
         # Create tarball
         archive_name = f'openshift-install-{rhel_version}-{go_arch}.tar.gz'
         with tarfile.open(f'{client_mirror_dir}/{archive_name}', 'w:gz') as tar:
-            tar.add(f'{client_mirror_dir}/{binary_name}')
+            tar.add(f'{client_mirror_dir}/{binary_name}', f'{binary_name}')
         self._logger.info('Created tarball %s at %s', archive_name, client_mirror_dir)
 
         # Write shasum to sha256sum.txt

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -775,20 +775,20 @@ class PromotePipeline:
         self._logger.info('baremetal-installer pullspec: %s', baremetal_installer_pullspec)
 
         # Check rhel version (used for archive naming)
-        # With future releases (probably 4.15) this will eventually need to switch to rhel9
         major, minor = isolate_major_minor_in_group(self.group)
         if major == 4 and minor < 16:
             rhel_version = 'rhel8'
+            binary_name = 'openshift-baremetal-install'
         else:
             rhel_version = 'rhel9'
+            binary_name = 'openshift-install-fips'
 
         # oc adm release extract --command=openshift-baremetal-install -n=ocp <release-pullspec>
         self._logger.info('Extracting baremetal-install')
         go_arch = go_arch_for_brew_arch(build_arch)
-        extract_baremetal_installer(release_pullspec, client_mirror_dir, go_arch)
+        extract_baremetal_installer(release_pullspec, client_mirror_dir, go_arch, binary_name)
 
         # Create tarball
-        binary_name = 'openshift-baremetal-install'
         archive_name = f'openshift-install-{rhel_version}-{go_arch}.tar.gz'
         with tarfile.open(f'{client_mirror_dir}/{archive_name}', 'w:gz') as tar:
             tar.add(f'{client_mirror_dir}/{binary_name}')


### PR DESCRIPTION
Currently the `openshift-install-rhel9-amd64.tar.gz` archive contains the file `artcd_working/to_mirror/openshift-v4/x86_64/clients/ocp/4.16.0-rc.4/openshift-baremetal-install`. Change this to the desired value, which is `openshift-install-fips`.