### PR TITLE
Pin tenacity 8.3

### DIFF
--- a/doozer/requirements.txt
+++ b/doozer/requirements.txt
@@ -13,7 +13,7 @@ pyyaml >= 5.1
 requests
 requests_kerberos
 semver
-tenacity
+tenacity ~= 8.3.0  # https://github.com/jd/tenacity/issues/471
 wrapt
 mysql-connector-python >= 8.0.21
 pydantic ~= 1.10.7

--- a/elliott/pyproject.toml
+++ b/elliott/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "requests",
     "requests-gssapi ~= 1.2.3",
     "ruamel.yaml",
-    "tenacity",
+    "tenacity ~= 8.3.0",  # https://github.com/jd/tenacity/issues/471
     "jira >= 3.4.1",  # https://github.com/pycontribs/jira/issues/1486
     "prettytable"
 ]

--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -21,7 +21,7 @@ ruamel.yaml
 semver ~= 3.0.1
 slack_sdk >= 3.13.0
 stomp.py ~= 8.1.0
-tenacity
+tenacity ~= 8.3.0  # https://github.com/jd/tenacity/issues/471
 tomli ~= 2.0.1
 specfile
 aiohttp>=3.9.4 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
8.4.0 is broken:

```
  File "/mnt/jenkins-workspace/aos-cd-builds_build_ocp4_scan/art-venv/lib64/python3.9/site-packages/tenacity/__init__.py", line 653, in <module>
    from tenacity.asyncio import AsyncRetrying  # noqa:E402,I100
ModuleNotFoundError: No module named 'tenacity.asyncio'
```