### PR TITLE
verify-attached-bugs: Use raw advisory fetch to be fast and less error prone

### DIFF
--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -1,9 +1,7 @@
 import asyncio
 import re
-import yaml
 from typing import Any, Dict, Iterable, List, Set, Tuple
 import click
-from errata_tool import Erratum
 
 from artcommonlib import logutil
 from artcommonlib.assembly import assembly_issues_config
@@ -14,6 +12,7 @@ from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
 from elliottlib.runtime import Runtime
 from elliottlib.util import minor_version_tuple
 from elliottlib.bzutil import Bug
+from elliottlib.errata import get_bug_ids
 from elliottlib.cli.attach_cve_flaws_cli import get_flaws
 from elliottlib.cli.find_bugs_sweep_cli import FindBugsSweep, categorize_bugs_by_type
 
@@ -341,17 +340,20 @@ class BugValidator:
         :return: a dict with advisory id as key and set of bug objects as value
         """
         logger.info(f"Retrieving bugs for advisories: {advisory_ids}")
-        advisories = [Erratum(errata_id=advisory_id) for advisory_id in advisory_ids]
 
-        attached_bug_map = {advisory_id: set() for advisory_id in advisory_ids}
+        # {12345: {'bugzilla' -> [..], 'jira' -> [..]} .. }
+        advisory_bug_id_map: Dict[int, Dict] = {advisory_id: get_bug_ids(advisory_id) for advisory_id in advisory_ids}
+
+        # we do this to gather bug ids from all advisories of a bug type
+        # and fetch them in one go to avoid multiple requests
+        attached_bug_map: Dict[int, Set[Bug]] = {advisory_id: set() for advisory_id in advisory_ids}
         for bug_tracker_type in ['jira', 'bugzilla']:
             bug_tracker = self.runtime.get_bug_tracker(bug_tracker_type)
-            advisory_bug_id_map = {advisory.errata_id: bug_tracker.advisory_bug_ids(advisory)
-                                   for advisory in advisories}
-            bug_map = bug_tracker.get_bugs_map([bug_id for bug_list in advisory_bug_id_map.values()
-                                                for bug_id in bug_list])
+            all_bug_ids = {bug_id for bug_dict in advisory_bug_id_map.values() for bug_id in bug_dict[bug_tracker_type]}
+            bug_map: Dict[Bug] = bug_tracker.get_bugs_map(all_bug_ids)
             for advisory_id in advisory_ids:
-                set_of_bugs = {bug_map[bid] for bid in advisory_bug_id_map[advisory_id] if bid in bug_map}
+                set_of_bugs: Set[Bug] = {bug_map[bid] for bid in advisory_bug_id_map[advisory_id][bug_tracker_type]
+                                         if bid in bug_map}
                 attached_bug_map[advisory_id] = attached_bug_map[advisory_id] | set_of_bugs
         return attached_bug_map
 

--- a/elliott/elliottlib/errata.py
+++ b/elliott/elliottlib/errata.py
@@ -180,11 +180,16 @@ def get_jira_issue(jira_issue_id):
     return ErrataConnector()._get(f"/jira_issues/{jira_issue_id}.json")
 
 
-def get_bug_ids(advisory_id):
+def get_bug_ids(advisory_id) -> dict:
     """
     Retrieve just the bug IDs from an advisory without wasting time processing it, loading builds, etc.
+    :param advisory_id: The advisory ID
+    :return: A dict with keys 'bugzilla' and 'jira' containing lists of bug IDs
     """
-    return [bug['bug']['id'] for bug in get_raw_erratum(advisory_id)['bugs']['bugs']]
+    raw_erratum = get_raw_erratum(advisory_id)
+    bugzilla_ids = [bug['bug']['id'] for bug in raw_erratum['bugs']['bugs']]
+    jira_ids = raw_erratum['jira_issues']['idsfixed']
+    return {'bugzilla': bugzilla_ids, 'jira': jira_ids}
 
 
 def get_erratum_content_type(advisory_id: str):


### PR DESCRIPTION
Using Erratum(..) from errata_tool to initialize advisory is very slow and error prone for big GA advisories, 
It makes an http call for each build attached to the advisory (and more things) which 
we do not need and we hit timeout error in ET often which crashes us.
So instead use raw erratum api to fetch bugs for these advisories

## Test
`./elliott --assembly rc.4 -g openshift-4.16 verify-attached-bugs --verify-bug-status --skip-multiple-advisories-check
`