### PR TITLE
verify-bugs: Report consistently

### DIFF
--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -1,6 +1,5 @@
 import asyncio
 import re
-import yaml
 import json
 from typing import Any, Dict, Iterable, List, Set, Tuple
 import click
@@ -177,7 +176,8 @@ class BugValidator:
         if self.problems:
             if self.output == 'text':
                 print("Found the following problems, please investigate")
-                print(yaml.dump(self.problems, indent=2, sort_keys=False))
+                for problem in self.problems:
+                    print(problem)
             elif self.output == 'json':
                 print(json.dumps(self.problems, indent=2, sort_keys=False))
             elif self.output == 'slack':

--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -1,5 +1,7 @@
 import asyncio
 import re
+import yaml
+import json
 from typing import Any, Dict, Iterable, List, Set, Tuple
 import click
 
@@ -173,10 +175,14 @@ class BugValidator:
 
     def report(self):
         if self.problems:
-            if self.output != 'slack':
+            if self.output == 'text':
                 print("Found the following problems, please investigate")
-                for p in self.problems:
-                    print(p)
+                print(yaml.dump(self.problems, indent=2, sort_keys=False))
+            elif self.output == 'json':
+                print(json.dumps(self.problems, indent=2, sort_keys=False))
+            elif self.output == 'slack':
+                for problem in self.problems:
+                    print(problem)
             exit(1)
 
     def validate(self, non_flaw_bugs: List[Bug], verify_bug_status: bool, no_verify_blocking_bugs: bool,
@@ -485,5 +491,4 @@ class BugValidator:
                 self._complain(f"Bug <{bug.weburl}|{bug.id}> is an invalid tracker bug. Please fix")
 
     def _complain(self, problem: str):
-        red_print(problem)
         self.problems.append(problem)

--- a/elliott/tests/test_verify_attached_bugs_cli.py
+++ b/elliott/tests/test_verify_attached_bugs_cli.py
@@ -142,7 +142,7 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
 
     @patch('elliottlib.cli.verify_attached_bugs_cli.assembly_issues_config')
     @patch('elliottlib.cli.verify_attached_bugs_cli.BugValidator.verify_bugs_multiple_advisories')
-    @patch('elliottlib.cli.verify_attached_bugs_cli.AsyncErrataAPI')
+    @patch('elliottlib.errata_async.AsyncErrataAPI._generate_auth_header')
     def test_verify_attached_bugs_cli_fail_on_type(self, *_):
         runner = CliRunner()
         flexmock(Runtime).should_receive("initialize")


### PR DESCRIPTION
Wrap validate methods in try-except and have exceptions go to the report at the end.
This is so that even if we break, we always report on previously completed validations.
Move reporting to `report()` in BugValidator class

Test:
`./elliott -g openshift-4.16 --assembly stream verify-bugs --output slack`