### PR TITLE
fix --import-mode=PreserveOriginal command

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1427,10 +1427,10 @@ class PromotePipeline:
         cmd = [
             "oc",
             "tag",
+            "--import-mode=PreserveOriginal",
             "--",
             image_pullspec,
-            image_stream_tag,
-            "--import-mode=PreserveOriginal"
+            image_stream_tag
         ]
         if self.runtime.dry_run:
             self._logger.warning("[DRY RUN] Would have run %s", cmd)


### PR DESCRIPTION
Since `--` is present in the command, the option has to be before that

Error
```error: "--import-mode=PreserveOriginal" must be of the form <stream_name>:<tag>
2024-06-20 20:03:30,340 pyartcd:ERROR Error promoting release images: Process ['oc', 'tag', '--', 'quay.io/openshift-release-dev/ocp-release:4.15.19-aarch64', 'ocp-arm64/release-arm64:4.15.19', '--import-mode=PreserveOriginal'] exited with code 1.
```