### PR TITLE
Fix newly created advisory ID being set to 0

### DIFF
--- a/elliott/elliottlib/cli/create_cli.py
+++ b/elliott/elliottlib/cli/create_cli.py
@@ -121,7 +121,7 @@ advisory.
             advisory_name = advisory_info["fulladvisory"].rsplit("-", 1)[0]
             advisory_id = advisory_info["id"]
             green_prefix("Created new advisory: ")
-            print_advisory(advisory_name, boilerplate['synopsis'], package_owner, assigned_to, et_data['quality_responsibility_name'], release_date, batch_id)
+            print_advisory(advisory_id, advisory_name, boilerplate['synopsis'], package_owner, assigned_to, et_data['quality_responsibility_name'], release_date, batch_id)
 
             if with_placeholder:
                 click.echo("Creating and attaching placeholder bug...")
@@ -146,15 +146,15 @@ advisory.
         else:
             green_prefix("Would have created advisory: ")
             click.echo("")
-            print_advisory("(unassigned)", boilerplate['synopsis'], package_owner, assigned_to, et_data['quality_responsibility_name'], release_date, batch_id)
+            print_advisory(0, "(unassigned)", boilerplate['synopsis'], package_owner, assigned_to, et_data['quality_responsibility_name'], release_date, batch_id)
     finally:
         await errata_api.close()
 
 
-def print_advisory(errata_name: str, synopsis: str, package_owner: str, assigned_to: str, qe_group: str, release_date: datetime, batch_id: Optional[int] = None):
+def print_advisory(advisory_id: int, errata_name: str, synopsis: str, package_owner: str, assigned_to: str, qe_group: str, release_date: datetime, batch_id: Optional[int] = None):
     click.echo(f"""{errata_name}: {synopsis}
   package owner: {package_owner}  qe: {assigned_to} qe_group: {qe_group}
-  url:   https://errata.devel.redhat.com/advisory/0
+  url:   https://errata.devel.redhat.com/advisory/{advisory_id}
   state: NEW_FILES
   created:     None
   ship target: {release_date.strftime(YMD)}


### PR DESCRIPTION
There is an issue in
https://github.com/openshift-eng/art-tools/pull/697, where `elliott create` command doesn't print newly created advisory ID to stdout. This breaks prepare-release job and causes 0 populated to releases.yml (e.g. https://github.com/openshift-eng/ocp-build-data/commit/52a2b2f8c5920cb734a30eb824862d657aa529f7)