### PR TITLE
ART-9503 Handle multiple plashet host locations

### DIFF
--- a/pyartcd/pyartcd/constants.py
+++ b/pyartcd/pyartcd/constants.py
@@ -1,5 +1,14 @@
-PLASHET_REMOTE_URL = "https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/RHOCP/plashets"
-PLASHET_REMOTE_HOST = "ocp-artifacts"
+PLASHET_REMOTES = [
+    {
+        'url': 'https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/RHOCP/plashets',
+        'host': 'ocp-artifacts'
+    },
+    {
+        'url': 'https://ocp-artifacts-art--runtime-int.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/pub/RHOCP/plashets',
+        'host': 'new-ocp-artifacts'
+    }
+]
+
 PLASHET_REMOTE_BASE_DIR = "/mnt/data/pub/RHOCP/plashets"
 
 SPMM_UTILS_REMOTE_HOST = "exd-ocp-buildvm-bot-prod@spmm-util"

--- a/pyartcd/tests/pipelines/test_rebuild.py
+++ b/pyartcd/tests/pipelines/test_rebuild.py
@@ -13,7 +13,8 @@ class TestRebuildPipeline(IsolatedAsyncioTestCase):
     def test_ocp_build_data_url(self, cmd_gather_async: Mock):
         runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, dry_run=False)
         fork_url = 'https://fork.com/ocp-build-data-fork.git'
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RHCOS, dg_key=None, ocp_build_data_url=fork_url)
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.RHCOS, dg_key=None, ocp_build_data_url=fork_url)
         actual = pipeline._doozer_env_vars["DOOZER_DATA_PATH"]
         expected = fork_url
         self.assertEqual(actual, expected)
@@ -24,12 +25,13 @@ class TestRebuildPipeline(IsolatedAsyncioTestCase):
     @patch("pyartcd.exectools.cmd_assert_async")
     async def test_build_plashet_from_tags(self, cmd_assert_async: AsyncMock, rmtree: Mock, path_exists: Mock, path_mkdir: Mock):
         runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RHCOS, dg_key=None, ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.RHCOS, dg_key=None, ocp_build_data_url='')
         tag_pvs = [("fake-tag-candidate", "FAKE-PRODUCT-VERSION")]
         embargoed_tags = ["fake-tag-embargoed"]
         actual = await pipeline._build_plashet_from_tags("plashet1234", "plashet1234", 8, ["x86_64", "s390x"], tag_pvs, embargoed_tags, 12345)
         expected_local_dir = runtime.working_dir / "plashets/el8/art0001/plashet1234"
-        expected_remote_url = constants.PLASHET_REMOTE_URL + "/4.9-el8/art0001/plashet1234"
+        expected_remote_url = constants.PLASHET_REMOTES[0]['url'] + "/4.9-el8/art0001/plashet1234"
         self.assertEqual(actual, ("plashet1234", expected_local_dir, expected_remote_url))
         path_exists.assert_called_once_with()
         rmtree.assert_called_once_with(expected_local_dir)
@@ -41,10 +43,11 @@ class TestRebuildPipeline(IsolatedAsyncioTestCase):
     @patch("pyartcd.exectools.cmd_assert_async")
     async def test_build_plashet_for_assembly_rhcos(self, cmd_assert_async: AsyncMock, rmtree: Mock, path_exists: Mock, path_mkdir: Mock):
         runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RHCOS, dg_key=None, ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.RHCOS, dg_key=None, ocp_build_data_url='')
         actual = await pipeline._build_plashet_for_assembly("plashet1234", "plashet1234", 8, ["x86_64", "s390x"], 12345)
         expected_local_dir = runtime.working_dir / "plashets/el8/art0001/plashet1234"
-        expected_remote_url = constants.PLASHET_REMOTE_URL + "/4.9-el8/art0001/plashet1234"
+        expected_remote_url = constants.PLASHET_REMOTES[0]['url'] + "/4.9-el8/art0001/plashet1234"
         self.assertEqual(actual, ("plashet1234", expected_local_dir, expected_remote_url))
         path_exists.assert_called_once_with()
         rmtree.assert_called_once_with(expected_local_dir)
@@ -56,10 +59,11 @@ class TestRebuildPipeline(IsolatedAsyncioTestCase):
     @patch("pyartcd.exectools.cmd_assert_async")
     async def test_build_plashet_for_assembly_image(self, cmd_assert_async: AsyncMock, rmtree: Mock, path_exists: Mock, path_mkdir: Mock):
         runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.IMAGE, dg_key="foo", ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.IMAGE, dg_key="foo", ocp_build_data_url='')
         actual = await pipeline._build_plashet_for_assembly("plashet1234", "plashet1234", 8, ["x86_64", "s390x"], 12345)
         expected_local_dir = runtime.working_dir / "plashets/el8/art0001/plashet1234"
-        expected_remote_url = constants.PLASHET_REMOTE_URL + "/4.9-el8/art0001/plashet1234"
+        expected_remote_url = constants.PLASHET_REMOTES[0]['url'] + "/4.9-el8/art0001/plashet1234"
         self.assertEqual(actual, ("plashet1234", expected_local_dir, expected_remote_url))
         path_exists.assert_called_once_with()
         rmtree.assert_called_once_with(expected_local_dir)
@@ -68,7 +72,8 @@ class TestRebuildPipeline(IsolatedAsyncioTestCase):
     @patch("pyartcd.exectools.cmd_assert_async")
     async def test_copy_plashet_out_to_remote(self, cmd_assert_async: AsyncMock):
         runtime = MagicMock(dry_run=False)
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RHCOS, dg_key=None, ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.RHCOS, dg_key=None, ocp_build_data_url='')
         local_plashet_dir = "/path/to/local/plashets/el8/plashet1234"
         await pipeline._copy_plashet_out_to_remote(8, local_plashet_dir, "building")
         cmd_assert_async.assert_any_await(
@@ -77,9 +82,9 @@ class TestRebuildPipeline(IsolatedAsyncioTestCase):
         cmd_assert_async.assert_any_await(
             ["rsync", "-av", "--links", "--progress", "-h", "--no-g", "--omit-dir-times", "--chmod=Dug=rwX,ugo+r",
              "--perms", "--", "/path/to/local/plashets/el8/plashet1234",
-             f"{constants.PLASHET_REMOTE_HOST}:{constants.PLASHET_REMOTE_BASE_DIR}/4.9-el8/art0001"])
+             f"{constants.PLASHET_REMOTES[0]['host']}:{constants.PLASHET_REMOTE_BASE_DIR}/4.9-el8/art0001"])
         cmd_assert_async.assert_any_await(
-            ["ssh", constants.PLASHET_REMOTE_HOST, "--", "ln", "-sfn", "--",
+            ["ssh", constants.PLASHET_REMOTES[0]['host'], "--", "ln", "-sfn", "--",
              "plashet1234", f"{constants.PLASHET_REMOTE_BASE_DIR}/4.9-el8/art0001/building"])
 
     @patch("pyartcd.pipelines.rebuild.RebuildPipeline._build_plashet_for_assembly")
@@ -90,7 +95,8 @@ class TestRebuildPipeline(IsolatedAsyncioTestCase):
             "arches": ["x86_64", "s390x"],
             "signing_advisory": 12345,
         }
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RHCOS, dg_key=None, ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.RHCOS, dg_key=None, ocp_build_data_url='')
         _build_plashet_from_tags.return_value = PlashetBuildResult("plashet1", Path("/path/to/local/dir1"), "https://example.com/dir1")
         _build_plashet_for_assembly.return_value = PlashetBuildResult("plashet2", Path("/path/to/local/dir2"), "https://example.com/dir2")
         actual = await pipeline._build_plashets("202107160000", 8, group_config, None)
@@ -106,7 +112,8 @@ class TestRebuildPipeline(IsolatedAsyncioTestCase):
             "arches": ["x86_64", "s390x"],
             "signing_advisory": 12345,
         }
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.IMAGE, dg_key="foo", ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.IMAGE, dg_key="foo", ocp_build_data_url='')
         _build_plashet_from_tags.return_value = PlashetBuildResult("plashet1", Path("/path/to/local/dir1"), "https://example.com/dir1")
         _build_plashet_for_assembly.return_value = PlashetBuildResult("plashet2", Path("/path/to/local/dir2"), "https://example.com/dir2")
         image_config = {"enabled_repos": ["rhel-8-server-ose-rpms-embargoed", "rhel-8-server-ironic-rpms"]}
@@ -119,7 +126,8 @@ class TestRebuildPipeline(IsolatedAsyncioTestCase):
     @patch("pathlib.Path.read_text")
     def test_generate_repo_file_for_image(self, read_text: Mock):
         runtime = MagicMock(dry_run=False)
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.IMAGE, dg_key="foo", ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.IMAGE, dg_key="foo", ocp_build_data_url='')
         plashets = [
             PlashetBuildResult("rhel-8-server-ose", "fake-basis", "https://example.com/plashets/4.9-el8/art0001/fake-basis"),
             PlashetBuildResult("plashet-rebuild-basis2", "fake-basis2", "https://example.com/plashets/4.9-el8/art0001/fake-basis2"),
@@ -183,7 +191,8 @@ priority = 1
 
     def test_generate_repo_file_for_rhcos(self):
         runtime = MagicMock(dry_run=False)
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RHCOS, dg_key=None, ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.RHCOS, dg_key=None, ocp_build_data_url='')
         out_file = StringIO()
         plashets = [
             PlashetBuildResult("plashet-rebuild-basis", "fake-basis", "https://example.com/plashets/4.9-el8/art0001/fake-basis"),
@@ -212,7 +221,8 @@ priority = 1
     @patch("pyartcd.exectools.cmd_gather_async")
     async def test_get_meta_config(self, cmd_gather_async: Mock):
         runtime = MagicMock(dry_run=False)
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.IMAGE, dg_key="foo", ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.IMAGE, dg_key="foo", ocp_build_data_url='')
         cmd_gather_async.return_value = (0, """
 images:
   foo:
@@ -224,7 +234,8 @@ images:
     @patch("pyartcd.exectools.cmd_assert_async")
     async def test_rebase_image(self, cmd_assert_async: Mock):
         runtime = MagicMock(dry_run=False)
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.IMAGE, dg_key="foo", ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.IMAGE, dg_key="foo", ocp_build_data_url='')
         await pipeline._rebase_image("202107160000.p?")
 
         runtime.dry_run = True
@@ -235,7 +246,8 @@ images:
     @patch("pyartcd.exectools.cmd_assert_async")
     async def test_build_image(self, cmd_assert_async: Mock, open: Mock):
         runtime = MagicMock(dry_run=False, working_dir=Path("/path/to/working"))
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.IMAGE, dg_key="foo", ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.IMAGE, dg_key="foo", ocp_build_data_url='')
         repo_url = "http://example.com/plashets/4.9-el8/art0001/art0001-image-foo-overrides/rebuild.repo"
         open.return_value.__enter__.return_value = StringIO("build|nvrs=foo-container-v1.2.3-1.p0.assembly.art0001|")
         nvrs = await pipeline._build_image(repo_url)
@@ -251,7 +263,8 @@ images:
     @patch("pyartcd.exectools.cmd_assert_async")
     async def test_rebase_and_build_rpm(self, cmd_assert_async: Mock, open: Mock):
         runtime = MagicMock(dry_run=False, working_dir=Path("/path/to/working"))
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RPM, dg_key="foo", ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.RPM, dg_key="foo", ocp_build_data_url='')
         release = "202107160000.p?"
         open.return_value.__enter__.return_value = StringIO("build_rpm|nvrs=foo-v1.2.3-202107160000.p0.assembly.art0001.el8,foo-v1.2.3-202107160000.p0.assembly.art0001.el7|")
         nvrs = await pipeline._rebase_and_build_rpm(release)
@@ -265,7 +278,8 @@ images:
 
     def test_generate_example_schema_rpm(self):
         runtime = MagicMock(dry_run=False)
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RPM, dg_key="foo", ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.RPM, dg_key="foo", ocp_build_data_url='')
         actual = pipeline._generate_example_schema(["foo-v1.2.3-1.el8", "foo-v1.2.3-1.el7"])
         expected = {
             "releases": {
@@ -290,7 +304,8 @@ images:
 
     def test_generate_example_schema_image(self):
         runtime = MagicMock(dry_run=False)
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.IMAGE, dg_key="foo", ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.IMAGE, dg_key="foo", ocp_build_data_url='')
         actual = pipeline._generate_example_schema(["foo-container-v1.2.3-1"])
         expected = {
             "releases": {
@@ -330,7 +345,8 @@ images:
                 }
             }
         }
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RPM, dg_key="foo", ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.RPM, dg_key="foo", ocp_build_data_url='')
         _rebase_and_build_rpm.return_value = ["foo-v1.2.3-1.el8", "foo-v1.2.3-1.el7"]
         _generate_example_schema.return_value = {"some_key": "some_value"}
         await pipeline.run()
@@ -355,7 +371,8 @@ images:
         mock_datetime.utcnow.return_value = datetime(2021, 7, 16, 0, 0, 0, 0, tzinfo=timezone.utc)
         timestamp = mock_datetime.utcnow.return_value.strftime("%Y%m%d%H%M")
         runtime = MagicMock(dry_run=False)
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.IMAGE, dg_key="foo", ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.IMAGE, dg_key="foo", ocp_build_data_url='')
         group_config = load_group_config.return_value = {
             "arches": ["x86_64", "s390x"],
             "signing_advisory": 12345,
@@ -402,7 +419,8 @@ images:
         mock_datetime.utcnow.return_value = datetime(2021, 7, 16, 0, 0, 0, 0, tzinfo=timezone.utc)
         timestamp = mock_datetime.utcnow.return_value.strftime("%Y%m%d%H%M")
         runtime = MagicMock(dry_run=False)
-        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RHCOS, dg_key=None, ocp_build_data_url='')
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
+                                   type=RebuildType.RHCOS, dg_key=None, ocp_build_data_url='')
         group_config = load_group_config.return_value = {
             "arches": ["x86_64", "s390x"],
             "signing_advisory": 12345,


### PR DESCRIPTION
`ocp-artifacts` is being migrated to a new place. To make this transition smoother, the plan is to:
- start producing plashets on both (old and new one) hosts
- let the world know we're migrating
- after a reasonable time, give a final notice and decommission the old host

This PR tackles the first point. This [ocp4 build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/3575/console) rebuilt 4.7 plashets, after having wiped them out manually on current ocp-artifacts VM. The result is  visible on both indexes:
- https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/RHOCP/plashets/4.7/
- https://ocp-artifacts-art--runtime-int.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/pub/RHOCP/plashets/4.7/