### PR TITLE
[ART-9923] support dockerfile_fallback field

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -22,7 +22,7 @@ from artcommonlib.pushd import Dir
 from doozerlib.cli import cli, pass_runtime
 from doozerlib import constants, util
 from doozerlib.image import ImageMetadata
-from doozerlib.util import get_docker_config_json, what_is_in_master, extract_version_fields
+from doozerlib.util import get_docker_config_json, what_is_in_master, extract_version_fields, resolve_dockerfile_name
 from artcommonlib.util import convert_remote_git_to_https, split_git_url, remove_prefix, convert_remote_git_to_ssh
 from pyartcd import jenkins
 
@@ -1031,16 +1031,8 @@ def images_streams_prs(runtime, github_access_token, bug, interstitial, ignore_c
             exectools.cmd_assert(f'git remote add fork {convert_remote_git_to_ssh(fork_repo.git_url)}')
             exectools.cmd_assert('git fetch --all', retries=3)
 
-            # The path to the Dockerfile in the target branch
-            if image_meta.config.content.source.dockerfile is not Missing:
-                # Be aware that this attribute sometimes contains path elements too.
-                dockerfile_name = image_meta.config.content.source.dockerfile
-            else:
-                dockerfile_name = "Dockerfile"
-
             df_path = Dir.getpath()
-            if image_meta.config.content.source.path:
-                dockerfile_name = os.path.join(image_meta.config.content.source.path, dockerfile_name)
+            dockerfile_name = resolve_dockerfile_name(image_meta.config, image_meta.config.content.source.dockerfile, logger)
 
             df_path = df_path.joinpath(dockerfile_name).resolve()
             ci_operator_config_path = Dir.getpath().joinpath('.ci-operator.yaml').resolve()  # https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -40,7 +40,7 @@ from doozerlib.rpm_utils import parse_nvr
 from doozerlib.source_modifications import SourceModifierFactory
 from artcommonlib.util import convert_remote_git_to_https, isolate_rhel_major_from_distgit_branch, deep_merge
 from doozerlib.comment_on_pr import CommentOnPr
-from doozerlib.util import extract_version_fields
+from doozerlib.util import extract_version_fields, resolve_dockerfile_name
 
 # doozer used to be part of OIT
 OIT_COMMENT_PREFIX = '#oit##'
@@ -1671,9 +1671,7 @@ class ImageDistGitRepo(DistGitRepo):
 
         Return either an integer representing the RHEL major version, or None if something went wrong.
         """
-        df_name = self.config.content.source.dockerfile
-        if not df_name:
-            df_name = 'Dockerfile'
+        df_name = resolve_dockerfile_name(self.config, self.source_path(), self.logger)
         subdir = self.config.content.source.path
         if not subdir:
             subdir = '.'
@@ -2504,13 +2502,7 @@ class ImageDistGitRepo(DistGitRepo):
 
             self.env_vars_from_source.update(self.metadata.extract_kube_env_vars())
 
-        # See if the config is telling us a file other than "Dockerfile" defines the
-        # distgit image content.
-        if self.config.content.source.dockerfile is not Missing:
-            # Be aware that this attribute sometimes contains path elements too.
-            dockerfile_name = self.config.content.source.dockerfile
-        else:
-            dockerfile_name = "Dockerfile"
+        dockerfile_name = resolve_dockerfile_name(self.config, self.source_path(), self.logger)
 
         # The path to the source Dockerfile we are reconciling against.
         source_dockerfile_path = os.path.join(self.source_path(), dockerfile_name)

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -32,6 +32,7 @@ except ImportError:
     pass
 
 from doozerlib import constants
+from doozerlib.exceptions import DoozerFatalError
 from functools import lru_cache
 
 DICT_EMPTY = object()
@@ -594,3 +595,28 @@ def oc_image_info__caching(pull_spec: str, go_arch: str = 'amd64') -> Dict:
     if you expect the image to change during the course of doozer's execution.
     """
     return oc_image_info(pull_spec, go_arch)
+
+
+def resolve_dockerfile_name(config, source_path, logger):
+    """
+    Resolve the Dockerfile name of upstream. If file specified in content.source.dockerfile doesn't exist,
+    try looking at the one specified in content.source.dockerfile_fallback as well.
+    """
+    if config.content.source.dockerfile is not Missing:
+        # Be aware that this attribute sometimes contains path elements too.
+        dockerfile_name = config.content.source.dockerfile
+
+        source_dockerfile_path = os.path.join(source_path, dockerfile_name)
+
+        if not os.path.isfile(source_dockerfile_path):
+            dockerfile_name_fallback = config.content.source.dockerfile_fallback
+            if dockerfile_name_fallback is not Missing:
+                logger.info(
+                    f"Could not find source dockerfile at {dockerfile_name}, using fallback {dockerfile_name_fallback}")
+                return dockerfile_name_fallback
+            raise DoozerFatalError(
+                f"Fallback dockerfile {dockerfile_name_fallback} is Missing and source dockerfile {source_dockerfile_path} doesn't exist")
+        else:
+            return dockerfile_name
+    else:
+        return "Dockerfile"


### PR DESCRIPTION
Alongside https://github.com/openshift-eng/ocp-build-data/pull/5002

Upstream Dockerfiles are sometimes incorrectly named as `.rhel7` or `.rhel8` when their actual contents are rhel9. Added a new `dockerfile_fallback` field in ocp-build-data, so that we can raise upstream PRs without the need for coordinating the PR merge with ocp-build-data

Changes in this PR:
- Refactor the logic to find the dockerfile name to `resolve_dockerfile_name` in doozer `utils.py`
- Use that function in rebase and upstream pr logic so that we consistently give back the same name