### PR TITLE
WIP First fix speedup

### DIFF
--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -72,6 +72,10 @@ class Bug:
     def whiteboard_component(self):
         raise NotImplementedError
 
+    @property
+    def keywords(self):
+        raise NotImplementedError
+
     def all_advisory_ids(self):
         raise NotImplementedError
 
@@ -158,6 +162,10 @@ class BugzillaBug(Bug):
         return self.bug.id
 
     @property
+    def keywords(self):
+        return self.bug.keywords
+
+    @property
     def product(self):
         return self.bug.product
 
@@ -223,7 +231,7 @@ class BugzillaBug(Bug):
 
 class JIRABug(Bug):
     def __getattr__(self, attr):
-        if attr in self.__dict__:
+        if attr in dir(self):
             return getattr(self, attr)
         return getattr(self.bug.fields, attr)
 


### PR DESCRIPTION
At GA time, we determine which flaw bugs are first fixes and only attach those to advisories.
But this analysis is quite heavy, each flaw bug can take upto half a minute or more and there
are 50+ flaw bugs to analyze at GA time. So this can mean 30+ minutes to determine first fixes.

This means the commands `attach-cve-flaws` and `verify-attached-bugs --verify-flaws` both are
essentially blocked on this, they cannot proceed with the other things that they do before this
analysis completes.

In addition to that http requests can fail/timeout, which can cause the command to fail and be
brittle. So in this proposal, we can capture the list of cves that are determined to be first fixes in
the first proper run (30+ mins) and then in subsequent runs we can provide the command with 
this list to speedup. Essentially a cache. We can think about capturing this in assembly definition 
or redis. One more todo is to look at the http requests we are making and caching them and see 
if there is a significant speedup due to duplicate requests.