### PR TITLE
Improve log handling

### DIFF
--- a/artcommon/artcommonlib/logutil.py
+++ b/artcommon/artcommonlib/logutil.py
@@ -1,9 +1,78 @@
 import logging
+import re
 
 
 class EntityLoggingAdapter(logging.LoggerAdapter):
     def process(self, msg, kwargs):
         return '[%s] %s' % (self.extra['entity'], msg), kwargs
+
+
+class RedactingFilter(logging.Filter):
+    """ A filter to remove sensitive information like passwords, tokens, and keys from logs
+    https://docs.python.org/3/library/logging.html#filter-objects
+    """
+
+    PATTERNS = {
+        'requests_gssapi.gssapi_': [
+            (re.compile(r'Authorization header:(.+)', re.IGNORECASE), 'Authorization header: <redacted>'),
+        ]
+    }
+
+    def filter(self, record: logging.LogRecord):
+        if record.name in self.PATTERNS.keys():
+            self._redact(record)
+        return True
+
+    def _redact(self, record: logging.LogRecord):
+        msg = isinstance(record.msg, str) and record.msg or str(record.msg)
+        patterns = self.PATTERNS[record.name]
+        for pattern, replacement in patterns:
+            m = pattern.search(msg)
+            if m:
+                record.msg = pattern.sub(replacement, msg)
+                break
+
+
+def setup_logging(log_level: int, debug_log_path: str):
+    """
+    Setup logging with common configurations for art-tools.
+
+    This function:
+    - configure the root logger to log messages with levels of DEBUG and higher to the specified debug.log file
+    - configure the root logger to log messages to the console with the specified log level
+    - configure the root logger to redact sensitive information from logs using RedactingFilter
+    - configure the log level for some third-party libraries to avoid leaking sensitive information
+
+    :param log_level: The log level to use for console logging
+    :param debug_log_path: The path to the debug log file
+
+    :return: The root logger
+    """
+    # set up the root logger to log messages with levels of DEBUG and higher to debug.log
+    logging.basicConfig(level=logging.DEBUG,
+                        format='%(asctime)s %(name)-12s %(levelname)s (%(thread)d) %(message)s',
+                        filename=debug_log_path,
+                        force=True)
+
+    root_logger = logging.getLogger()
+
+    # define a Handler which writes $log_level messages or higher to the sys.stderr
+    console = logging.StreamHandler()
+    console.setLevel(log_level)
+    formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)s %(message)s')
+    console.setFormatter(formatter)
+
+    # add the handler to the root logger
+    root_logger.addHandler(console)
+
+    # add a RedactingFilter to redact sensitive information from logs
+    redacting_filter = RedactingFilter()
+    for handler in root_logger.handlers:
+        handler.addFilter(redacting_filter)
+
+    # configure the log level for some third-party libraries
+    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 
 def get_logger(module_name=None):

--- a/doozer/tests/test_runtime.py
+++ b/doozer/tests/test_runtime.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import unittest
 from flexmock import flexmock
+import logging
 
 from artcommonlib import logutil, exectools
 from artcommonlib.model import Model
@@ -10,11 +11,11 @@ from doozerlib import runtime
 def stub_runtime():
     rt = runtime.Runtime(
         latest_parent_version=False,
-        logger=logutil.get_logger(__name__),
         stage=False,
         branch='test-branch',
         rhpkg_config="",
     )
+    rt._logger = logging.getLogger(__name__)
     rt.group_config = Model()
     return rt
 


### PR DESCRIPTION
This PR improves log handling logic in following items:
- New helper function `setup_logging` is added to `artcommonlib` to set up logging for doozer and elliott in a common way.
- Logging level provided by command line and formatter strings are configured to the root logger, so that they are proprogated to child loggers obtained through `logging.getLogger`.
- No need to pass `runtime.logger` everywhere to log with configured options.  `logging.getLogger(__name__)` is able to obtain a logger from a different module without coupling Runtime.
- RedactingFilter is added to remove sensitive information like passwords, tokens, and keys from logs.