### PR TITLE
ART-9555 deprecate kernel ship-ok tag check for assembly

### DIFF
--- a/doozer/doozerlib/assembly_inspector.py
+++ b/doozer/doozerlib/assembly_inspector.py
@@ -105,17 +105,6 @@ class AssemblyInspector:
                 if rpm_delivery_config.stop_ship_tag and rpm_delivery_config.stop_ship_tag in tag_names:
                     issues.append(AssemblyIssue(f'{component_description} has {rpm_build["nvr"]}, which has been tagged into the stop-ship tag: {rpm_delivery_config.stop_ship_tag}', component=component, code=AssemblyIssueCode.IMPERMISSIBLE))
                     continue
-                # Check if the rpm has an explicit "ship-ok" tag
-                if rpm_delivery_config.ship_ok_tag and rpm_delivery_config.ship_ok_tag not in tag_names:
-                    # If the rpm is not tagged into the integration tag, it might be obtained from a released repo
-                    if rpm_delivery_config.integration_tag and rpm_delivery_config.integration_tag not in tag_names:
-                        release_tag = next(filter(lambda tag: tag.endswith("-released"), tag_names), None)
-                        if release_tag:
-                            self.runtime.logger.warning(f"Permit {rpm_build['nvr']} because it was already released through {release_tag}.")
-                            continue
-                    # For non-stream releases, MISSING_SHIP_OK_TAG issue will be reported if the rpm doesn't have a "ship-ok" tag
-                    if self.assembly_type is not AssemblyTypes.STREAM:
-                        issues.append(AssemblyIssue(f'{component_description} has {rpm_build["nvr"]}, which is missing the ship-ok tag: {rpm_delivery_config.ship_ok_tag}', component=component, code=AssemblyIssueCode.MISSING_SHIP_OK_TAG))
         return issues
 
     def check_installed_rpms_in_image(self, dg_key: str, build_inspector: BrewBuildImageInspector):

--- a/doozer/tests/test_assembly_inspector.py
+++ b/doozer/tests/test_assembly_inspector.py
@@ -36,19 +36,6 @@ class TestAssemblyInspector(IsolatedAsyncioTestCase):
         issues = ai._check_installed_packages_for_rpm_delivery("foo", "foo-1.2.3-1", rpm_packages)
         self.assertEqual(issues, [])
 
-        # Test a standard release with a package not tagged into my-ship-ok-tag
-        brew_session.listTags.return_value = [
-            {"name": "tag-a"},
-            {"name": "my-integration-tag"},
-        ]
-        issues = ai._check_installed_packages_for_rpm_delivery("foo", "foo-1.2.3-1", rpm_packages)
-        self.assertEqual(len(issues), 1)
-
-        # Test a stream "release" with a package not tagged into my-ship-ok-tag
-        ai.assembly_type = AssemblyTypes.STREAM
-        issues = ai._check_installed_packages_for_rpm_delivery("foo", "foo-1.2.3-1", rpm_packages)
-        self.assertEqual(len(issues), 0)
-
         # Test a stream "release" with a package not tagged into my-stop-ship-tag
         brew_session.listTags.return_value = [
             {"name": "tag-a"},


### PR DESCRIPTION
early-kernel-ship-ok tag is not required to check now