### PR TITLE
ART-9441 keep / dir if upstream remove it

### DIFF
--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1983,6 +1983,10 @@ class ImageDistGitRepo(DistGitRepo):
                 if in_mod_block:
                     continue
 
+                # ART-9441 keep / dir for following cmd
+                if "rm -rf --no-preserve-root /" in line:
+                    continue
+
                 # remove any old instances of empty.repo mods that aren't in mod block
                 if 'empty.repo' not in line:
                     if line.endswith('\n'):


### PR DESCRIPTION
In [ART-9441](https://issues.redhat.com//browse/ART-9441) upstream removed / in the last layer. This is a workaround to keep the last layer not empty to run source cmd