### PR TITLE
Init elliott debug.log

### DIFF
--- a/elliott/elliottlib/runtime.py
+++ b/elliott/elliottlib/runtime.py
@@ -153,6 +153,8 @@ class Runtime(GroupRuntime):
             if not os.path.isdir(self.working_dir):
                 os.makedirs(self.working_dir)
 
+        self.debug_log_path = os.path.join(self.working_dir, 'debug.log')
+
         if not self._logger:
             self.initialize_logging()
 


### PR DESCRIPTION
Follow up to https://github.com/openshift-eng/art-tools/pull/725
Without a valid debug.log path, we log debug messages to console.
So init this as how we do it for doozer.