### PR TITLE
[fips-scan] rotate keytab

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/secrets/exd-ocp-buildvm-bot-prod-keytab.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/secrets/exd-ocp-buildvm-bot-prod-keytab.yaml
@@ -1,0 +1,29 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: exd-ocp-buildvm-bot-prod-keytab
+spec:
+  data:
+    - remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: art/prod/exd-ocp-buildvm-bot-prod-keytab-principal
+        property: principal
+      secretKey: principal
+    - remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: art/prod/exd-ocp-buildvm-bot-prod-keytab
+      secretKey: keytab
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: main-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: synced-exd-ocp-buildvm-bot-prod-keytab
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: Opaque

--- a/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline-task.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline-task.yaml
@@ -21,12 +21,12 @@ spec:
 
         touch /root/.config/artcd.toml
 
-        kinit -kt /tmp/keytab/keytab ocp-build/buildvm.openshift.eng.bos.redhat.com@IPA.REDHAT.COM
+        kinit -kt /tmp/keytab/keytab exd-ocp-buildvm-bot-prod@IPA.REDHAT.COM
         
         pip install stomp.py==8.1.0
         pip install setuptools==65.5.1
 
-        artcd -vv scan-fips --version $(params.version) --nvrs $(params.nvrs)
+        artcd -vv --dry-run scan-fips --version $(params.version) --nvrs $(params.nvrs)
 
       securityContext:
         runAsGroup: 0
@@ -38,7 +38,7 @@ spec:
         - mountPath: /root/.config/doozer
           name: doozer-config
         - mountPath: /tmp/keytab
-          name: art-bot-keytab
+          name: synced-exd-ocp-buildvm-bot-prod-keytab
       env:
         - name: SLACK_BOT_TOKEN
           valueFrom:
@@ -52,6 +52,6 @@ spec:
     - name: doozer-config
       secret:
         secretName: doozer-config
-    - name: art-bot-keytab
+    - name: synced-exd-ocp-buildvm-bot-prod-keytab
       secret:
-        secretName: art-bot-keytab
+        secretName: synced-exd-ocp-buildvm-bot-prod-keytab


### PR DESCRIPTION
- Updating keytab to be pulled from AWS
- Setting `--dry-run` until we turn the scans back on