### PR TITLE
Re-apply Runtime refactoring with fixes for cloning public upstream repo

### DIFF
--- a/artcommon/artcommonlib/git_helper.py
+++ b/artcommon/artcommonlib/git_helper.py
@@ -1,0 +1,65 @@
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from artcommonlib import exectools
+from artcommonlib import util as art_util
+from artcommonlib.lock import get_named_semaphore
+
+LOGGER = logging.getLogger(__name__)
+
+
+def git_clone(remote_url: str, target_dir: str, gitargs=[], set_env={}, timeout=0,
+              git_cache_dir: Optional[str] = None):
+
+    if git_cache_dir:
+        Path(git_cache_dir).mkdir(parents=True, exist_ok=True)
+        normalized_url = art_util.convert_remote_git_to_https(remote_url)
+        # Strip special chars out of normalized url to create a human friendly, but unique filename
+        file_friendly_url = normalized_url.split('//')[-1].replace('/', '_')
+        repo_dir = os.path.join(git_cache_dir, file_friendly_url)
+        LOGGER.info(f'Cache for {remote_url} going to {repo_dir}')
+
+        if not os.path.exists(repo_dir):
+            LOGGER.info(f'Initializing cache directory for git remote: {remote_url}')
+
+            # If the cache directory for this repo does not exist yet, we will create one.
+            # But we must do so carefully to minimize races with any other doozer instance
+            # running on the machine.
+            with get_named_semaphore(repo_dir, is_dir=True):  # also make sure we cooperate with other threads in this process.
+                tmp_repo_dir = tempfile.mkdtemp(dir=git_cache_dir)
+                exectools.cmd_assert(f'git init --bare {tmp_repo_dir}')
+                with exectools.Dir(tmp_repo_dir):
+                    exectools.cmd_assert(f'git remote add origin {remote_url}')
+
+                try:
+                    os.rename(tmp_repo_dir, repo_dir)
+                except:
+                    # There are two categories of failure
+                    # 1. Another doozer instance already created the directory, in which case we are good to go.
+                    # 2. Something unexpected is preventing the rename.
+                    if not os.path.exists(repo_dir):
+                        # Not sure why the rename failed. Raise to user.
+                        raise
+
+        # If we get here, we have a bare repo with a remote set
+        # Pull content to update the cache. This should be safe for multiple doozer instances to perform.
+        LOGGER.info(f'Updating cache directory for git remote: {remote_url}')
+        # Fire and forget this fetch -- just used to keep cache as fresh as possible
+        exectools.fire_and_forget(repo_dir, 'git fetch --all')
+        gitargs.extend(['--dissociate', '--reference-if-able', repo_dir])
+
+    gitargs.append('--recurse-submodules')
+
+    LOGGER.info(f'Cloning to: {target_dir}')
+
+    # Perform the clone (including --reference args if cache_dir was set)
+    cmd = []
+    if timeout:
+        cmd.extend(['timeout', f'{timeout}'])
+    cmd.extend(['git', 'clone', remote_url])
+    cmd.extend(gitargs)
+    cmd.append(target_dir)
+    exectools.cmd_assert(cmd, retries=3, on_retry=["rm", "-rf", target_dir], set_env=set_env)

--- a/artcommon/artcommonlib/lock.py
+++ b/artcommon/artcommonlib/lock.py
@@ -1,0 +1,30 @@
+from multiprocessing import Semaphore
+from pathlib import Path
+
+# See get_named_semaphore. The empty string key serves as a lock for the data structure.
+_NAMED_SEMAPHORES = {'': Semaphore(1)}
+
+
+def get_named_semaphore(lock_name: str, is_dir=False, count=1):
+    """
+    Returns a semaphore (which can be used as a context manager). The first time a lock_name
+    is received, a new semaphore will be established. Subsequent uses of that lock_name will
+    receive the same semaphore.
+    :param lock_name: A unique name for resource threads are contending over. If using a directory name
+                        as a lock_name, provide an absolute path.
+    :param is_dir: The lock_name is a directory (method will ignore things like trailing slashes)
+    :param count: The number of times the lock can be claimed. Default=1, which is a full mutex.
+    :return: A semaphore associated with the lock_name.
+    """
+    if is_dir:
+        p = '_dir::' + str(Path(str(lock_name)).absolute())  # normalize (e.g. strip trailing /)
+    else:
+        p = lock_name
+    global _NAMED_SEMAPHORES
+    with _NAMED_SEMAPHORES['']:
+        if p in _NAMED_SEMAPHORES:
+            return _NAMED_SEMAPHORES[p]
+        else:
+            new_semaphore = Semaphore(count)
+            _NAMED_SEMAPHORES[p] = new_semaphore
+            return new_semaphore

--- a/doozer/doozerlib/assembly_inspector.py
+++ b/doozer/doozerlib/assembly_inspector.py
@@ -16,6 +16,7 @@ from doozerlib.brew_info import BrewBuildImageInspector
 from doozerlib.rpmcfg import RPMMetadata
 from doozerlib.rhcos import RHCOSBuildInspector, RHCOSBuildFinder
 from artcommonlib.rhcos import get_container_configs, RhcosMissingContainerException
+from doozerlib.source_resolver import SourceResolver
 
 
 class AssemblyInspector:
@@ -378,7 +379,7 @@ class AssemblyInspector:
         content_git_url = image_meta.config.content.source.git.url
         if content_git_url:
             # Make sure things are in https form so we can compare
-            content_git_url, _ = self.runtime.get_public_upstream(artutil.convert_remote_git_to_https(content_git_url))
+            content_git_url, _ = SourceResolver.get_public_upstream(content_git_url, self.group_config.public_upstreams)
             build_git_url = artutil.convert_remote_git_to_https(build_inspector.get_source_git_url())
             if content_git_url != build_git_url:
                 # Impermissible as artist can just fix upstream git source in assembly definition

--- a/doozer/doozerlib/assembly_inspector.py
+++ b/doozer/doozerlib/assembly_inspector.py
@@ -379,7 +379,7 @@ class AssemblyInspector:
         content_git_url = image_meta.config.content.source.git.url
         if content_git_url:
             # Make sure things are in https form so we can compare
-            content_git_url, _ = SourceResolver.get_public_upstream(content_git_url, self.group_config.public_upstreams)
+            content_git_url, _ = SourceResolver.get_public_upstream(content_git_url, self.runtime.group_config.public_upstreams)
             build_git_url = artutil.convert_remote_git_to_https(build_inspector.get_source_git_url())
             if content_git_url != build_git_url:
                 # Impermissible as artist can just fix upstream git source in assembly definition

--- a/doozer/doozerlib/assembly_inspector.py
+++ b/doozer/doozerlib/assembly_inspector.py
@@ -379,7 +379,7 @@ class AssemblyInspector:
         content_git_url = image_meta.config.content.source.git.url
         if content_git_url:
             # Make sure things are in https form so we can compare
-            content_git_url, _ = SourceResolver.get_public_upstream(content_git_url, self.runtime.group_config.public_upstreams)
+            content_git_url, _, _ = SourceResolver.get_public_upstream(content_git_url, self.runtime.group_config.public_upstreams)
             build_git_url = artutil.convert_remote_git_to_https(build_inspector.get_source_git_url())
             if content_git_url != build_git_url:
                 # Impermissible as artist can just fix upstream git source in assembly definition

--- a/doozer/doozerlib/cli/__init__.py
+++ b/doozer/doozerlib/cli/__init__.py
@@ -234,3 +234,30 @@ def validate_rpm_version(ctx, param, version: str):
     if pre_release:
         result += f"~{pre_release}"
     return result
+
+
+class RemoteRequired(click.Option):
+    """
+    Option wrapper class for items that aren't needed for local
+    builds. Automatically handles them being required for remote
+    but ignored when building local.
+    When specified, options are assumed to be required for remote.
+    There is no need to include `required=True` in the click.Option init.
+    """
+    def __init__(self, *args, **kwargs):
+        kwargs['help'] = (
+            kwargs.get('help', '') + '\nNOTE: This argument is ignored with the global option --local'
+        ).strip()
+        super(RemoteRequired, self).__init__(*args, **kwargs)
+
+    def handle_parse_result(self, ctx, opts, args):
+        if not ctx.obj.local and not (self.name in opts):
+            self.required = True
+
+        return super(RemoteRequired, self).handle_parse_result(
+            ctx, opts, args)
+
+
+option_commit_message = click.option("--message", "-m", cls=RemoteRequired, metavar='MSG', help="Commit message for dist-git.")
+option_push = click.option('--push/--no-push', default=False, is_flag=True,
+                           help='Pushes to distgit after local changes (--no-push by default).')

--- a/doozer/doozerlib/cli/images_okd.py
+++ b/doozer/doozerlib/cli/images_okd.py
@@ -670,7 +670,7 @@ def images_okd_prs(runtime, github_access_token, ignore_missing_images, okd_vers
             logger.info(f'Skipping non-OKD image: {image_meta.distgit_key}')
             continue
 
-        public_repo_url, public_branch = SourceResolver.get_public_upstream(source_repo_url, runtime.group_config.public_upstreams)
+        public_repo_url, public_branch, _ = SourceResolver.get_public_upstream(source_repo_url, runtime.group_config.public_upstreams)
         if not public_branch:
             public_branch = source_repo_branch
 

--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -963,7 +963,7 @@ def images_streams_prs(runtime, github_access_token, bug, interstitial, ignore_c
             logger.info('Skipping PR check since there is no configured github source URL')
             continue
 
-        public_repo_url, public_branch = SourceResolver.get_public_upstream(source_repo_url, runtime.group_config.public_upstreams)
+        public_repo_url, public_branch, _ = SourceResolver.get_public_upstream(source_repo_url, runtime.group_config.public_upstreams)
         if not public_branch:
             public_branch = source_repo_branch
 

--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -5,7 +5,6 @@ import yaml
 import json
 import hashlib
 import time
-from pathlib import Path
 import random
 import re
 from typing import Dict, Set
@@ -21,8 +20,10 @@ from artcommonlib.model import Missing, Model
 from artcommonlib.pushd import Dir
 from doozerlib.cli import cli, pass_runtime
 from doozerlib import constants, util
+from artcommonlib.git_helper import git_clone
 from doozerlib.image import ImageMetadata
 from doozerlib.util import get_docker_config_json, what_is_in_master, extract_version_fields
+from doozerlib.source_resolver import SourceResolver
 from artcommonlib.util import convert_remote_git_to_https, split_git_url, remove_prefix, convert_remote_git_to_ssh
 from pyartcd import jenkins
 
@@ -962,7 +963,7 @@ def images_streams_prs(runtime, github_access_token, bug, interstitial, ignore_c
             logger.info('Skipping PR check since there is no configured github source URL')
             continue
 
-        public_repo_url, public_branch = runtime.get_public_upstream(source_repo_url)
+        public_repo_url, public_branch = SourceResolver.get_public_upstream(source_repo_url, runtime.group_config.public_upstreams)
         if not public_branch:
             public_branch = source_repo_branch
 
@@ -1024,7 +1025,7 @@ def images_streams_prs(runtime, github_access_token, bug, interstitial, ignore_c
         public_repo_url = convert_remote_git_to_ssh(public_repo_url)
         clone_dir = os.path.join(runtime.working_dir, 'clones', dgk)
         # Clone the private url to make the best possible use of our doozer_cache
-        runtime.git_clone(source_repo_url, clone_dir)
+        git_clone(source_repo_url, clone_dir, git_cache_dir=runtime.git_cache_dir)
 
         with Dir(clone_dir):
             exectools.cmd_assert(f'git remote add public {public_repo_url}')

--- a/doozer/doozerlib/cli/olm_bundle.py
+++ b/doozer/doozerlib/cli/olm_bundle.py
@@ -189,7 +189,7 @@ def rebase_and_build_olm_bundle(runtime: Runtime, operator_nvrs: Tuple[str, ...]
             runtime.logger.error('Error during rebase or build for: {}'.format(operator_nvr))
             record['message'] = str(err)
         finally:
-            runtime.add_record("build_olm_bundle", **record)
+            runtime.record_logger.add_record("build_olm_bundle", **record)
             return record
 
     olm_bundles = [OLMBundle(runtime, op, dry_run=dry_run) for op in operator_builds]

--- a/doozer/doozerlib/cli/rpms.py
+++ b/doozer/doozerlib/cli/rpms.py
@@ -213,7 +213,6 @@ async def _rebase_rpm(runtime: Runtime, builder: RPMBuilder, rpm: RPMMetadata, v
         record["release"] = rpm.release
         record["specfile"] = rpm.specfile
         record["private_fix"] = rpm.private_fix
-        record["source_head"] = rpm.source_head
         record["source_commit"] = rpm.pre_init_sha or ""
         record["dg_branch"] = rpm.distgit_repo().branch
         record["status"] = 0
@@ -224,7 +223,7 @@ async def _rebase_rpm(runtime: Runtime, builder: RPMBuilder, rpm: RPMMetadata, v
         record["message"] = "Exception occurred:\n{}".format(tb)
         logger.error("Exception occurred when rebasing %s:\n%s", rpm.distgit_key, tb)
     finally:
-        runtime.add_record(action, **record)
+        runtime.record_logger.add_record(action, **record)
     return record["status"]
 
 
@@ -301,5 +300,5 @@ async def _build_rpm(runtime: Runtime, builder: RPMBuilder, rpm: RPMMetadata):
             record["task_urls"] = task_urls
             record["task_id"] = task_ids[0]
             record["task_url"] = task_urls[0]
-        runtime.add_record(action, **record)
+        runtime.record_logger.add_record(action, **record)
     return record["status"]

--- a/doozer/doozerlib/cli/scan_sources.py
+++ b/doozer/doozerlib/cli/scan_sources.py
@@ -186,7 +186,14 @@ class ConfigScanSources:
                                             metadata.meta_type, metadata.name)
                 continue
 
-            public_url, public_branch_name = public_upstream
+            public_url, public_branch_name, has_public_upstream = public_upstream
+
+            # If no public upstream exists, skip the rebase
+            if not has_public_upstream:
+                self.runtime.logger.warning('%s %s does not have a public upstream: skipping openshift-priv rebase',
+                                            metadata.meta_type, metadata.name)
+                continue
+
             priv_url = artcommonlib.util.convert_remote_git_to_https(metadata.config.content.source.git.url)
             priv_branch_name = metadata.config.content.source.git.branch.target
 

--- a/doozer/doozerlib/cli/scan_sources.py
+++ b/doozer/doozerlib/cli/scan_sources.py
@@ -220,7 +220,7 @@ class ConfigScanSources:
                 continue
 
             # If they don't, clone source repo
-            path = self.runtime.source_resolver.resolve_source(metadata)
+            path = self.runtime.source_resolver.resolve_source(metadata).source_path
 
             # SHAs might differ because of previous rebase; let's check the actual content across upstreams
             if self._is_pub_ancestor_of_priv(path, public_branch_name, priv_branch_name, priv_repo_name):

--- a/doozer/doozerlib/cli/scan_sources.py
+++ b/doozer/doozerlib/cli/scan_sources.py
@@ -17,6 +17,7 @@ from doozerlib.cli import release_gen_payload as rgp
 from doozerlib.image import ImageMetadata
 from doozerlib.metadata import RebuildHint, RebuildHintCode, Metadata
 from doozerlib.runtime import Runtime
+from doozerlib.source_resolver import SourceResolver
 
 
 class ConfigScanSources:
@@ -168,9 +169,8 @@ class ConfigScanSources:
 
     def rebase_into_priv(self):
         self.runtime.logger.info('Rebasing public upstream contents into openshift-priv')
-
         upstream_mappings = exectools.parallel_exec(
-            lambda meta, _: (meta, self.runtime.get_public_upstream(meta.config.content.source.git.url)),
+            lambda meta, _: (meta, SourceResolver.get_public_upstream(meta.config.content.source.git.url, self.runtime.group_config.public_upstreams)),
             self.all_metas,
             n_threads=20,
         ).get()
@@ -220,7 +220,7 @@ class ConfigScanSources:
                 continue
 
             # If they don't, clone source repo
-            path = self.runtime.resolve_source(metadata)
+            path = self.runtime.source_resolver.resolve_source(metadata)
 
             # SHAs might differ because of previous rebase; let's check the actual content across upstreams
             if self._is_pub_ancestor_of_priv(path, public_branch_name, priv_branch_name, priv_repo_name):

--- a/doozer/doozerlib/coverity.py
+++ b/doozer/doozerlib/coverity.py
@@ -612,22 +612,22 @@ def records_results(cc: CoverityContext, stage_number, waived_cov_path_root=None
         diff_count = len(diff_json.get('issues', []))
         all_count = len(all_json.get('issues', []))
         host_stage_waived_flag_path = cc.get_stage_results_waive_path(stage_number)
-        cc.image.runtime.add_record('covscan',
-                                    distgit=cc.image.qualified_name,
-                                    distgit_key=cc.image.distgit_key,
-                                    commit_results_path=str(dest_result_path),
-                                    all_results_js_path=str(dest_all_js_path),
-                                    all_results_html_path=str(dest_all_results_html_path),
-                                    diff_results_js_path=str(dest_diff_js_path),
-                                    diff_results_html_path=str(dest_diff_results_html_path),
-                                    diff_count=str(diff_count),
-                                    all_count=str(all_count),
-                                    stage_number=str(stage_number),
-                                    waive_path=str(host_stage_waived_flag_path),
-                                    waived=str(host_stage_waived_flag_path.exists()).lower(),
-                                    owners=owners,
-                                    image=cc.image.config.name,
-                                    commit_hash=cc.dg_commit_hash)
+        cc.image.runtime.record_logger.add_record('covscan',
+                                                  distgit=cc.image.qualified_name,
+                                                  distgit_key=cc.image.distgit_key,
+                                                  commit_results_path=str(dest_result_path),
+                                                  all_results_js_path=str(dest_all_js_path),
+                                                  all_results_html_path=str(dest_all_results_html_path),
+                                                  diff_results_js_path=str(dest_diff_js_path),
+                                                  diff_results_html_path=str(dest_diff_results_html_path),
+                                                  diff_count=str(diff_count),
+                                                  all_count=str(all_count),
+                                                  stage_number=str(stage_number),
+                                                  waive_path=str(host_stage_waived_flag_path),
+                                                  waived=str(host_stage_waived_flag_path.exists()).lower(),
+                                                  owners=owners,
+                                                  image=cc.image.config.name,
+                                                  commit_hash=cc.dg_commit_hash)
 
     if write_only:
         if dest_all_js_path.exists():

--- a/doozer/doozerlib/dblib.py
+++ b/doozer/doozerlib/dblib.py
@@ -9,6 +9,8 @@ from doozerlib import constants
 import functools
 import datetime
 
+from artcommonlib.lock import get_named_semaphore
+
 try:
     import mysql.connector as mysql_connector
 except:
@@ -489,7 +491,7 @@ class Record(object):
 
     def __exit__(self, *args):
         try:
-            with self.db.runtime.get_named_semaphore('dblib::mysql'):
+            with get_named_semaphore('dblib::mysql'):
 
                 attr_payload = {}
 

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -2497,7 +2497,7 @@ class ImageDistGitRepo(DistGitRepo):
 
             out, _ = exectools.cmd_assert(["git", "remote", "get-url", "origin"], strip=True)
             self.actual_source_url = out  # This may differ from the URL we report to the public
-            self.public_facing_source_url, _ = SourceResolver.get_public_upstream(out, self.runtime.group_config.public_upstreams)  # Point to public upstream if there are private components to the URL
+            self.public_facing_source_url, _, _ = SourceResolver.get_public_upstream(out, self.runtime.group_config.public_upstreams)  # Point to public upstream if there are private components to the URL
             # If private_fix has not already been set (e.g. by --embargoed), determine if the source contains private fixes by checking if the private org branch commit exists in the public org
             if self.private_fix is None:
                 if self.metadata.public_upstream_branch and not SourceResolver.is_branch_commit_hash(self.metadata.public_upstream_branch):

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -35,12 +35,15 @@ from doozerlib.brew import BuildStates
 from doozerlib.dblib import Record
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.brew_info import BrewBuildImageInspector
+from artcommonlib.git_helper import git_clone
+from artcommonlib.lock import get_named_semaphore
 from doozerlib.osbs2_builder import OSBS2Builder, OSBS2BuildError
 from doozerlib.rpm_utils import parse_nvr
 from doozerlib.source_modifications import SourceModifierFactory
 from artcommonlib.util import convert_remote_git_to_https, isolate_rhel_major_from_distgit_branch, deep_merge
 from doozerlib.comment_on_pr import CommentOnPr
 from doozerlib.util import extract_version_fields
+from doozerlib.source_resolver import SourceResolver
 
 # doozer used to be part of OIT
 OIT_COMMENT_PREFIX = '#oit##'
@@ -219,8 +222,9 @@ class DistGitRepo(object):
                             gitargs.extend(["--depth", str(rhpkg_clone_depth)])
 
                         try:
-                            self.runtime.git_clone(self.metadata.distgit_remote_url(), self.distgit_dir, gitargs=gitargs,
-                                                   set_env=constants.GIT_NO_PROMPTS, timeout=timeout)
+                            git_clone(self.metadata.distgit_remote_url(), self.distgit_dir, gitargs=gitargs,
+                                      set_env=constants.GIT_NO_PROMPTS, timeout=timeout,
+                                      git_cache_dir=self.runtime.git_cache_dir)
                         except ChildProcessError as err:
                             # Create branch on demand
                             if len(err.args) > 1 and self.has_source() and re.fullmatch(r'rhaos-\d+\.\d+-rhel-\d+', distgit_branch):
@@ -283,8 +287,7 @@ class DistGitRepo(object):
         """
         Check whether this dist-git repo has source content
         """
-        return "git" in self.config.content.source or \
-               "alias" in self.config.content.source
+        return self.metadata.has_source()
 
     def source_path(self):
         """
@@ -292,7 +295,7 @@ class DistGitRepo(object):
                 the source.path subdirectory if the metadata includes one.
         """
 
-        source_root = self.runtime.resolve_source(self.metadata)
+        source_root = self.runtime.source_resolver.resolve_source(self.metadata).source_path
         sub_path = self.config.content.source.path
 
         path = source_root
@@ -380,7 +383,7 @@ class DistGitRepo(object):
                 # be pushed. If every distgit within a release is being pushed at the same
                 # time, a single push invocation can take hours to complete -- making the
                 # timeout value counterproductive. Limit to 5 simultaneous pushes.
-                with self.runtime.get_named_semaphore('rhpkg::push', count=5):
+                with get_named_semaphore('rhpkg::push', count=5):
                     timeout = str(self.runtime.global_opts['rhpkg_push_timeout'])
                     exectools.cmd_assert(f"timeout {timeout} git push --set-upstream origin {self.branch}", retries=3)
                     # Many builds require a tag associated with a commit to be a semver
@@ -476,7 +479,7 @@ class ImageDistGitRepo(DistGitRepo):
         if self._canonical_builders_enabled():
             # If the image is distgit-only, this logic does not apply
             if self.has_source():
-                source_path = self.runtime.resolve_source(self.metadata)
+                source_path = self.runtime.source_resolver.resolve_source(self.metadata).source_path
                 self.art_intended_el_version = self._determine_art_rhel_version()
                 self.upstream_intended_el_version = self._determine_upstream_rhel_version(source_path)
             # To match upstream, we need to be able to infer upstream intended RHEL version
@@ -951,7 +954,7 @@ class ImageDistGitRepo(DistGitRepo):
                     raise
 
                 finally:
-                    self.runtime.add_record(action, **record)
+                    self.runtime.record_logger.add_record(action, **record)
 
             return (self.metadata.distgit_key, True)
 
@@ -1163,7 +1166,7 @@ class ImageDistGitRepo(DistGitRepo):
 
         record['push_status'] = '0' if self.push_status else '-1'
 
-        self.runtime.add_record(action, **record)
+        self.runtime.record_logger.add_record(action, **record)
         lstate = self.runtime.state[self.runtime.command]
         if not (self.build_status and self.push_status):
             state.record_image_fail(lstate, self.metadata, 'Build failure', self.runtime.logger)
@@ -2494,10 +2497,10 @@ class ImageDistGitRepo(DistGitRepo):
 
             out, _ = exectools.cmd_assert(["git", "remote", "get-url", "origin"], strip=True)
             self.actual_source_url = out  # This may differ from the URL we report to the public
-            self.public_facing_source_url, _ = self.runtime.get_public_upstream(out)  # Point to public upstream if there are private components to the URL
+            self.public_facing_source_url, _ = SourceResolver.get_public_upstream(out, self.runtime.group_config.public_upstreams)  # Point to public upstream if there are private components to the URL
             # If private_fix has not already been set (e.g. by --embargoed), determine if the source contains private fixes by checking if the private org branch commit exists in the public org
             if self.private_fix is None:
-                if self.metadata.public_upstream_branch and not self.runtime.is_branch_commit_hash(self.metadata.public_upstream_branch):
+                if self.metadata.public_upstream_branch and not SourceResolver.is_branch_commit_hash(self.metadata.public_upstream_branch):
                     self.private_fix = not util.is_commit_in_public_upstream(self.source_full_sha, self.metadata.public_upstream_branch, source_dir)
                 else:
                     self.private_fix = False
@@ -2612,16 +2615,16 @@ class ImageDistGitRepo(DistGitRepo):
             else:
                 source_dockerfile_subpath = "{}/{}".format(sub_path, dockerfile_name)
             # there ought to be a better way to determine the source alias that was registered:
-            source_root = self.runtime.resolve_source(self.metadata)
+            source_root = self.runtime.source_resolver.resolve_source(self.metadata).source_path
             source_alias = self.config.content.source.get('alias', os.path.basename(source_root))
 
-            self.runtime.add_record("dockerfile_notify",
-                                    distgit=self.metadata.qualified_name,
-                                    image=self.config.name,
-                                    owners=','.join(owners),
-                                    source_alias=source_alias,
-                                    source_dockerfile_subpath=source_dockerfile_subpath,
-                                    dockerfile=str(dg_path.joinpath('Dockerfile')))
+            self.runtime.record_logger.add_record("dockerfile_notify",
+                                                  distgit=self.metadata.qualified_name,
+                                                  image=self.config.name,
+                                                  owners=','.join(owners),
+                                                  source_alias=source_alias,
+                                                  source_dockerfile_subpath=source_dockerfile_subpath,
+                                                  dockerfile=str(dg_path.joinpath('Dockerfile')))
 
     def _run_modifications(self):
         """

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -30,7 +30,7 @@ class ImageMetadata(Metadata):
             dependent.dependencies.add(self.distgit_key)
             self.children.append(dependent)
         if clone_source:
-            runtime.resolve_source(self)
+            runtime.source_resolver.resolve_source(self)
 
     @property
     def image_name(self):

--- a/doozer/doozerlib/k_distgit.py
+++ b/doozer/doozerlib/k_distgit.py
@@ -6,6 +6,8 @@ from artcommonlib import assertion, logutil, build_util, exectools
 from artcommonlib.pushd import Dir
 from doozerlib.distgit import ImageDistGitRepo
 from doozerlib.constants import KONFLUX_REPO_CA_BUNDLE_HOST, KONFLUX_REPO_CA_BUNDLE_FILENAME, KONFLUX_REPO_CA_BUNDLE_TMP_PATH
+from artcommonlib.git_helper import git_clone
+from artcommonlib.lock import get_named_semaphore
 
 
 class KonfluxImageDistGitRepo(ImageDistGitRepo):
@@ -38,7 +40,7 @@ class KonfluxImageDistGitRepo(ImageDistGitRepo):
         url = self.metadata.config.content.source.git.url
 
         git_args = ["--no-single-branch", "--branch", branch]
-        self.runtime.git_clone(url, self.distgit_dir, gitargs=git_args)
+        git_clone(url, self.distgit_dir, gitargs=git_args, git_cache_dir=self.runtime.git_cache_dir)
 
     def push(self):
         """
@@ -57,7 +59,7 @@ class KonfluxImageDistGitRepo(ImageDistGitRepo):
             # be pushed. If every repo within a release is being pushed at the same
             # time, a single push invocation can take hours to complete -- making the
             # timeout value counterproductive. Limit to 5 simultaneous pushes.
-            with self.runtime.get_named_semaphore('k_distgit::push', count=5):
+            with get_named_semaphore('k_distgit::push', count=5):
                 exectools.cmd_assert(f"git checkout -b {self.upstream_branch}")
                 exectools.cmd_assert(f"git push --set-upstream origin {self.upstream_branch} -f", retries=3)
 

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -10,7 +10,7 @@ import urllib.parse
 import dateutil.parser
 import requests
 from enum import Enum
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union, cast
 from defusedxml import ElementTree
 from dockerfile_parse import DockerfileParser
 from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
@@ -25,6 +25,7 @@ from artcommonlib.model import Missing, Model
 from doozerlib.brew import BuildStates
 from doozerlib.distgit import DistGitRepo, ImageDistGitRepo, RPMDistGitRepo
 from doozerlib.k_distgit import KonfluxImageDistGitRepo
+from doozerlib.source_resolver import SourceResolver
 from doozerlib.util import (isolate_el_version_in_brew_tag,
                             isolate_git_commit_in_release)
 
@@ -666,6 +667,13 @@ class Metadata(object):
         """
         return self._component_name
 
+    def has_source(self):
+        """
+        Check whether this component has source content
+        """
+        return "git" in self.config.content.source or \
+               "alias" in self.config.content.source
+
     def needs_rebuild(self):
         if self.config.targets:
             # If this meta has multiple build targets, check currency of each
@@ -753,18 +761,13 @@ class Metadata(object):
         # Otherwise, we have source. In the case of git source, check the upstream with ls-remote.
         # In the case of alias (only legacy stuff afaik), check the cloned repo directory.
 
+        use_source_fallback_branch = cast(str, self.runtime.group_config.use_source_fallback_branch or "yes")
         if "git" in self.config.content.source:
-            remote_branch = self.runtime.detect_remote_source_branch(self.config.content.source.git)[0]
-            out, _ = exectools.cmd_assert(["git", "ls-remote", self.config.content.source.git.url, remote_branch], strip=True, retries=5, on_retry='sleep 5')
-            # Example output "296ac244f3e7fd2d937316639892f90f158718b0	refs/heads/openshift-4.8"
-            upstream_commit_hash = out.split()[0]
+            _, upstream_commit_hash = SourceResolver.detect_remote_source_branch(self.config.content.source.git, self.runtime.stage, use_source_fallback_branch)
         elif self.config.content.source.alias and self.runtime.group_config.sources and self.config.content.source.alias in self.runtime.group_config.sources:
             # This is a new style alias with url information in group config
             source_details = self.runtime.group_config.sources[self.config.content.source.alias]
-            remote_branch = self.runtime.detect_remote_source_branch(source_details)[0]
-            out, _ = exectools.cmd_assert(["git", "ls-remote", source_details.url, remote_branch], strip=True, retries=5, on_retry='sleep 5')
-            # Example output "296ac244f3e7fd2d937316639892f90f158718b0	refs/heads/openshift-4.8"
-            upstream_commit_hash = out.split()[0]
+            _, upstream_commit_hash = SourceResolver.detect_remote_source_branch(source_details, self.runtime.stage, use_source_fallback_branch)
         else:
             # If it is not git, we will need to punt to the rest of doozer to get the upstream source for us.
             with Dir(dgr.source_path()):
@@ -859,10 +862,9 @@ class Metadata(object):
                 May be empty if there is no kube information in the source dir.
         """
         envs = dict()
-        upstream_source_path: pathlib.Path = pathlib.Path(self.runtime.resolve_source(self))
-        if not upstream_source_path:
-            # distgit only. Return empty.
+        if not self.has_source():  # distgit only. Return empty.
             return envs
+        upstream_source_path: pathlib.Path = pathlib.Path(self.runtime.source_resolver.resolve_source(self).source_path)
 
         with Dir(upstream_source_path):
             out, _ = exectools.cmd_assert(["git", "rev-parse", "HEAD"])

--- a/doozer/doozerlib/record_logger.py
+++ b/doozer/doozerlib/record_logger.py
@@ -1,0 +1,42 @@
+
+import threading
+
+
+class RecordLogger:
+    """ A class to log records of actions taken by Doozer that need to be communicated to outside systems.
+    This class usually writes record.log file in the working directory
+    """
+    def __init__(self, path: str) -> None:
+        self._record_log = open(path, "a", encoding='utf-8')
+        self._log_lock = threading.Lock()
+
+    def close(self):
+        self._record_log.close()
+
+    def add_record(self, record_type: str, **kwargs):
+        """
+        Records an action taken by oit that needs to be communicated to outside
+        systems. For example, the update a Dockerfile which needs to be
+        reviewed by an owner. Each record is encoded on a single line in the
+        record.log. Records cannot contain line feeds -- if you need to
+        communicate multi-line data, create a record with a path to a file in
+        the working directory.
+
+        :param record_type: The type of record to create.
+        :param kwargs: key/value pairs
+
+        A record line is designed to be easily parsed and formatted as:
+        record_type|key1=value1|key2=value2|...|
+        """
+        record = "%s|" % record_type
+        for k, v in kwargs.items():
+            assert ("\n" not in str(k))
+            # Make sure the values have no linefeeds as this would interfere with simple parsing.
+            v = str(v).replace("\n", " ;;; ").replace("\r", "")
+            record += "%s=%s|" % (k, v)
+        # Multiple image build processes could be calling us with action simultaneously, so
+        # synchronize output to the file.
+        with self._log_lock:
+            # Add the record to the file
+            self._record_log.write("%s\n" % record)
+            self._record_log.flush()

--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -70,12 +70,6 @@ def remove_tmp_working_dir(runtime):
         click.echo("Temporary working directory preserved by operation: %s" % runtime.working_dir)
 
 
-# A named tuple for caching the result of Runtime._resolve_source.
-SourceResolution = namedtuple('SourceResolution', [
-    'source_path', 'url', 'branch', 'public_upstream_url', 'public_upstream_branch'
-])
-
-
 class Runtime(GroupRuntime):
     # Use any time it is necessary to synchronize feedback from multiple threads.
     mutex = RLock()

--- a/doozer/doozerlib/source_resolver.py
+++ b/doozer/doozerlib/source_resolver.py
@@ -1,0 +1,402 @@
+import logging
+import os
+import shutil
+import urllib.parse
+from dataclasses import dataclass
+from multiprocessing import Lock
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, cast
+
+from artcommonlib import assertion, exectools
+from artcommonlib import util as art_util
+from artcommonlib.git_helper import git_clone
+from artcommonlib.lock import get_named_semaphore
+from artcommonlib.model import ListModel, Missing, Model
+
+from doozerlib import constants
+from doozerlib.record_logger import RecordLogger
+
+if TYPE_CHECKING:
+    from doozerlib.metadata import Metadata
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class SourceResolution:
+    """ A dataclass for caching the result of SourceResolver.resolve_source."""
+    source_path: str
+    """ The local path to the source code repository. """
+    url: str
+    """ The URL (usually HTTPS or SSH) of the source code repository. """
+    branch: str
+    """ The branch name (or commit hash) of the source code repository. """
+    https_url: str
+    """ The HTTPS URL (instead of SSH) of the source code repository. """
+    commit_hash: str
+    """ The commit hash of the source code repository. """
+    public_upstream_url: Optional[str]
+    """ The public upstream URL of the source code repository. """
+    public_upstream_branch: Optional[str]
+    """ The public upstream branch name of the source code repository. """
+
+
+class SourceResolver:
+    """ A class for resolving source code repositories.
+    """
+
+    def __init__(self, sources_base_dir: str, cache_dir: Optional[str], group_config: Model,
+                 local=False, upcycle=False, stage=False,
+                 record_logger: Optional[RecordLogger] = None, state_holder: Optional[Dict[str, Any]] = None) -> None:
+        """ Initialize a new SourceResolver instance.
+        :param sources_base_dir: The base directory where source code repositories will be cloned.
+        :param cache_dir: The base directory where source code repositories will be cached.
+        :param group_config: The group configuration.
+        :param local: If True, the source code repositories will be resolved locally.
+        :param upcycle: If True, the source code repositories will be refreshed.
+        :param stage: If True, the stage branch will be used instead of the target branch.
+        :param record_logger: The record logger to use for logging source resolutions.
+        :param state_holder: The state holder dict to use for storing source resolutions.
+        """
+        self.sources_base_dir = Path(sources_base_dir)
+        self.local = local
+        # Map of source code repo aliases (e.g. "ose") to named tuples representing the source resolution cache.
+        # See registry_repo.
+        self.source_resolutions: Dict[str, SourceResolution] = {}
+        self.upcycle = upcycle
+        self.stage = stage
+        self.cache_dir = cache_dir
+        self._group_config = group_config
+        self._record_logger = record_logger
+        self._state_holder = state_holder
+
+    def resolve_source(self, meta: 'Metadata') -> SourceResolution:
+        """ Resolve the source code repository for the specified metadata.
+        :param meta: The metadata to resolve the source code repository for.
+        :return: A SourceResolution instance containing the information of the resolved source code repository.
+        """
+        LOGGER.debug("Resolving source for {}".format(meta.qualified_key))
+        source = cast(Optional[Model], meta.config.content.source)
+        if not source:
+            raise ValueError(f"No source defined in metadata config for {meta.qualified_key}")
+
+        source_details = None
+        # This allows passing `--source <distgit_key> path` to
+        # override any source to something local without it
+        # having been configured for an alias
+        if self.local and meta.distgit_key in self.source_resolutions:
+            alias = meta.distgit_key
+        elif 'git' in source:
+            git_url = urllib.parse.urlparse(art_util.convert_remote_git_to_https(source.git.url))
+            name = os.path.splitext(os.path.basename(git_url.path))[0]
+            alias = f'{meta.namespace}_{meta.name}_{name}'
+            source_details = dict(source.git)
+        elif 'alias' in source:
+            alias = str(source.alias)
+        else:
+            raise ValueError(f"No source url or alias defined for {meta.qualified_key}")
+
+        LOGGER.debug("Resolving local source directory for alias {}".format(alias))
+        if alias in self.source_resolutions:
+            r = self.source_resolutions[alias]
+            path = r.source_path
+            meta.public_upstream_url = r.public_upstream_url
+            meta.public_upstream_branch = r.public_upstream_branch
+            LOGGER.debug("returning previously resolved path for alias {}: {}".format(alias, path))
+            return self.source_resolutions[alias]
+
+        # Where the source will land, check early so we know if old or new style
+        if not source_details:  # old style alias was given
+            if self._group_config.sources is Missing or alias not in self._group_config.sources:
+                raise IOError("Source alias not found in specified sources or in the current group: %s" % alias)
+            source_details = dict(self._group_config.sources[alias])
+            source_dir = os.path.join(self.sources_base_dir, f"global_{alias}")
+        else:
+            source_dir = os.path.join(self.sources_base_dir, alias)
+
+        LOGGER.debug("checking for source directory in source_dir: {}".format(source_dir))
+
+        with get_named_semaphore(source_dir, is_dir=True):
+            if alias in self.source_resolutions:  # we checked before, but check again inside the lock
+                r = self.source_resolutions[alias]
+                path = r.source_path
+                meta.public_upstream_url = r.public_upstream_url
+                meta.public_upstream_branch = r.public_upstream_branch
+                LOGGER.debug("returning previously resolved path for alias {}: {}".format(alias, path))
+                return self.source_resolutions[alias]
+
+            # If this source has already been extracted for this working directory
+            if os.path.isdir(source_dir):
+                if not self.upcycle:
+                    # Store so that the next attempt to resolve the source hits the map
+                    r = self.source_resolutions[alias]
+                    path = r.source_path
+                    meta.public_upstream_url = r.public_upstream_url
+                    meta.public_upstream_branch = r.public_upstream_branch
+                    LOGGER.info("Source '{}' already exists in (skipping clone): {}".format(alias, source_dir))
+                    return self.source_resolutions[alias]
+                if self.local:
+                    raise IOError("--upcycle mode doesn't work with --local.")
+                LOGGER.info("Refreshing source for '{}' due to --upcycle: {}".format(alias, source_dir))
+                shutil.rmtree(source_dir)
+
+            if meta.prevent_cloning:
+                raise IOError(f'Attempt to clone upstream {meta.distgit_key} after cloning disabled; a regression has been introduced.')
+
+            use_source_fallback_branch = cast(str, self._group_config.use_source_fallback_branch or "yes")
+            clone_branch, _ = self.detect_remote_source_branch(source_details, self.stage, use_source_fallback_branch)
+
+            url = str(source_details["url"])
+            if self._group_config.public_upstreams:
+                meta.public_upstream_url, meta.public_upstream_branch = self.get_public_upstream(url, self._group_config.public_upstreams)
+
+            LOGGER.info("Attempting to checkout source '%s' branch %s in: %s" % (url, clone_branch, source_dir))
+            try:
+                # clone all branches as we must sometimes reference master /OWNERS for maintainer information
+                if self.is_branch_commit_hash(branch=clone_branch):
+                    gitargs = []
+                else:
+                    gitargs = ['--branch', clone_branch]
+
+                git_clone(url, source_dir, gitargs=gitargs, set_env=constants.GIT_NO_PROMPTS, git_cache_dir=self.cache_dir)
+
+                if self.is_branch_commit_hash(branch=clone_branch):
+                    with exectools.Dir(source_dir):
+                        exectools.cmd_assert(f'git checkout {clone_branch}')
+
+                # fetch public upstream source
+                if meta.public_upstream_url and meta.public_upstream_branch:
+                    self.setup_and_fetch_public_upstream_source(meta.public_upstream_url, meta.public_upstream_branch, source_dir)
+
+            except IOError as e:
+                LOGGER.info("Unable to checkout branch {}: {}".format(clone_branch, str(e)))
+                shutil.rmtree(source_dir)
+                raise IOError("Error checking out target branch of source '%s' in %s: %s" % (alias, source_dir, str(e)))
+
+            if meta.commitish:
+                # With the alias registered, check out the commit we want
+                LOGGER.info(f"Determining if commit-ish {meta.commitish} exists")
+                cmd = ["git", "-C", source_dir, "branch", "--contains", meta.commitish]
+                exectools.cmd_assert(cmd)
+                LOGGER.info(f"Checking out commit-ish {meta.commitish}")
+                exectools.cmd_assert(["git", "-C", source_dir, "checkout", meta.commitish])
+
+            # Store so that the next attempt to resolve the source hits the map
+            self.register_source_alias(alias, source_dir)
+
+            return self.source_resolutions[alias]
+
+    @staticmethod
+    def detect_remote_source_branch(source_details: Dict[str, Any],
+                                    stage: bool,
+                                    use_source_fallback_branch: str = "yes") -> Tuple[str, str]:
+        """ Find a configured source branch that exists, or raise DoozerFatalError.
+
+        :param source_details: The source details from the metadata config.
+        :param stage: If True, the stage branch will be used instead of the target branch.
+        :param use_source_fallback_branch: The fallback strategy to use. Must be one of "yes", "always", or "never".
+        :returns: Returns branch name and git hash
+        """
+        if use_source_fallback_branch not in ["yes", "always", "never"]:
+            raise ValueError(f"Invalid value for use_source_fallback_branch: {use_source_fallback_branch}")
+
+        git_url = source_details["url"]
+        branches = source_details["branch"]
+
+        stage_branch = branches.get("stage", None) if stage else None
+        if stage_branch:
+            LOGGER.info('Normal branch overridden by --stage option, using "{}"'.format(stage_branch))
+            result = SourceResolver._get_remote_branch_ref(git_url, stage_branch)
+            if result:
+                return stage_branch, result
+            raise IOError('--stage option specified and no stage branch named "{}" exists for {}'.format(stage_branch, git_url))
+
+        branch = branches["target"]  # This is a misnomer as it can also be a git commit hash an not just a branch name.
+        fallback_branch = branches.get("fallback", None)
+        if use_source_fallback_branch == "always" and fallback_branch:
+            # only use the fallback (unless none is given)
+            branch, fallback_branch = fallback_branch, None
+        elif use_source_fallback_branch == "never":
+            # ignore the fallback
+            fallback_branch = None
+
+        if SourceResolver.is_branch_commit_hash(branch):
+            return branch, branch
+
+        result = SourceResolver._get_remote_branch_ref(git_url, branch)
+        if result:
+            return branch, result
+
+        if not fallback_branch:
+            raise IOError('Requested target branch {} does not exist and no fallback provided'.format(branch))
+
+        LOGGER.info('Target branch does not exist in {}, checking fallback branch {}'.format(git_url, fallback_branch))
+        result = SourceResolver._get_remote_branch_ref(git_url, fallback_branch)
+        if result:
+            return fallback_branch, result
+        raise IOError('Requested fallback branch {} does not exist'.format(branch))
+
+    @staticmethod
+    def is_branch_commit_hash(branch):
+        """
+        When building custom assemblies, it is sometimes useful to
+        pin upstream sources to specific git commits. This cannot
+        be done with standard assemblies which should be built from
+        branches.
+        :param branch: A branch name in rpm or image metadata.
+        :returns: Returns True if the specified branch name is actually a commit hash for a custom assembly.
+        """
+        if len(branch) >= 7:  # The hash must be sufficiently unique
+            try:
+                int(branch, 16)   # A hash must be a valid hex number
+                return True
+            except ValueError:
+                pass
+        return False
+
+    @staticmethod
+    def _get_remote_branch_ref(git_url, branch):
+        """
+        Detect whether a single branch exists on a remote repo; returns git hash if found
+        :param git_url: The URL to the git repo to check.
+        :param branch: The name of the branch. If the name is not a branch and appears to be a commit
+                hash, the hash will be returned without modification.
+        """
+        LOGGER.info('Checking if target branch {} exists in {}'.format(branch, git_url))
+
+        try:
+            out, _ = exectools.cmd_assert('git ls-remote --heads {} {}'.format(git_url, branch), retries=3)
+        except Exception as err:
+            # We don't expect and exception if the branch does not exist; just an empty string
+            LOGGER.error('Error attempting to find target branch {} hash: {}'.format(branch, err))
+            return None
+        result = out.strip()  # any result means the branch is found; e.g. "7e66b10fbcd6bb4988275ffad0a69f563695901f	refs/heads/some_branch")
+        if not result and SourceResolver.is_branch_commit_hash(branch):
+            return branch  # It is valid hex; just return it
+
+        return result.split()[0] if result else None
+
+    def register_source_alias(self, alias: str, path: str):
+        LOGGER.info("Registering source alias %s: %s" % (alias, path))
+        path = os.path.abspath(path)
+        assertion.isdir(path, "Error registering source alias %s" % alias)
+        with exectools.Dir(path):
+            url = None
+            origin_url = "?"
+            rc1, out_origin, err_origin = exectools.cmd_gather(
+                ["git", "config", "--get", "remote.origin.url"])
+            if rc1 == 0:
+                url = out_origin.strip()
+                # Usually something like "git@github.com:openshift/origin.git"
+                # But we want an https hyperlink like http://github.com/openshift/origin
+                if url.startswith("git@"):
+                    origin_url = art_util.convert_remote_git_to_https(url)
+                else:
+                    origin_url = url
+            else:
+                LOGGER.error("Failed acquiring origin url for source alias %s: %s" % (alias, err_origin))
+
+            branch = None
+            rc2, out_branch, err_branch = exectools.cmd_gather(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"])
+            if rc2 == 0:
+                branch = out_branch.strip()
+            else:
+                LOGGER.error("Failed acquiring origin branch for source alias %s: %s" % (alias, err_branch))
+
+            if not url or not branch:
+                raise IOError(f"Couldn't detect source URL or branch for local source {path}. Is it a valid Git repo?")
+
+            out, _ = exectools.cmd_assert(["git", "rev-parse", "HEAD"])
+            commit_hash = out.strip()
+
+            public_upstream_url = None
+            public_upstream_branch = None
+            if branch != 'HEAD' and self._group_config.public_upstreams:
+                # If branch == HEAD, our source is a detached HEAD.
+                public_upstream_url, public_upstream_branch = self.get_public_upstream(url, self._group_config.public_upstreams)
+                if public_upstream_url and not public_upstream_branch:
+                    public_upstream_branch = branch
+
+            resolution = SourceResolution(
+                source_path=path,
+                url=url,
+                branch=branch,
+                https_url=origin_url,
+                commit_hash=commit_hash,
+                public_upstream_url=public_upstream_url,
+                public_upstream_branch=public_upstream_branch,
+            )
+            self.source_resolutions[alias] = resolution
+            if self._record_logger:
+                self._record_logger.add_record("source_alias", alias=alias, origin_url=origin_url, branch=branch or '?', path=path)
+            if self._state_holder is not None:
+                self._state_holder[alias] = {
+                    'url': origin_url,
+                    'branch': branch or '?',
+                    'path': path
+                }
+            return resolution
+
+    @staticmethod
+    def get_public_upstream(remote_git: str, public_upstreams: ListModel) -> Tuple[str, Optional[str]]:
+        """
+        Some upstream repo are private in order to allow CVE workflows. While we
+        may want to build from a private upstream, we don't necessarily want to confuse
+        end-users by referencing it in our public facing image labels / etc.
+        In group.yaml, you can specify a mapping in "public_upstreams". It
+        represents private_url_prefix => public_url_prefix. Remote URLs passed to this
+        method which contain one of the private url prefixes will be translated
+        into a new string with the public prefix in its place. If there is not
+        applicable mapping, the incoming url will still be normalized into https.
+        :param remote_git: The URL to analyze for private repo patterns.
+        :param public_upstreams: The public upstream configuration from group.yaml.
+        :return: tuple (url, branch)
+            - url: An https normalized remote address with private repo information replaced. If there is no
+                   applicable private repo replacement, remote_git will be returned (normalized to https).
+            - branch: Optional public branch name if the public upstream source use a different branch name from the private upstream.
+        """
+        remote_https = art_util.convert_remote_git_to_https(remote_git)
+
+        if public_upstreams:
+
+            # We prefer the longest match in the mapping, so iterate through the entire
+            # map and keep track of the longest matching private remote.
+            target_priv_prefix = None
+            target_pub_prefix = None
+            target_pub_branch = None
+            for upstream in public_upstreams:
+                priv = upstream["private"]
+                pub = upstream["public"]
+                # priv can be a full repo, or an organization (e.g. git@github.com:openshift)
+                # It will be treated as a prefix to be replaced
+                https_priv_prefix = art_util.convert_remote_git_to_https(priv)  # Normalize whatever is specified in group.yaml
+                https_pub_prefix = art_util.convert_remote_git_to_https(pub)
+                if remote_https.startswith(f'{https_priv_prefix}/') or remote_https == https_priv_prefix:
+                    # If we have not set the prefix yet, or if it is longer than the current contender
+                    if not target_priv_prefix or len(https_priv_prefix) > len(target_pub_prefix):
+                        target_priv_prefix = https_priv_prefix
+                        target_pub_prefix = https_pub_prefix
+                        target_pub_branch = upstream.get("public_branch")
+
+            if target_priv_prefix:
+                return f'{target_pub_prefix}{remote_https[len(target_priv_prefix):]}', target_pub_branch
+
+        return remote_https, None
+
+    @staticmethod
+    def setup_and_fetch_public_upstream_source(public_source_url: str, public_upstream_branch: str, source_dir: str):
+        """
+        Fetch public upstream source for specified Git repository. Set up public_upstream remote if needed.
+
+        :param public_source_url: HTTPS Git URL of the public upstream source
+        :param public_upstream_branch: Git branch of the public upstream source
+        :param source_dir: Path to the local Git repository
+        """
+        out, _ = exectools.cmd_assert(["git", "-C", source_dir, "remote"])
+        if 'public_upstream' not in out.strip().split():
+            exectools.cmd_assert(["git", "-C", source_dir, "remote", "add", "--", "public_upstream", public_source_url])
+        else:
+            exectools.cmd_assert(["git", "-C", source_dir, "remote", "set-url", "--", "public_upstream", public_source_url])
+        exectools.cmd_assert(["git", "-C", source_dir, "fetch", "--", "public_upstream", public_upstream_branch], retries=3,
+                             set_env=constants.GIT_NO_PROMPTS)

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -50,23 +50,6 @@ def dict_get(dct, path, default=DICT_EMPTY):
     return dct
 
 
-def setup_and_fetch_public_upstream_source(public_source_url: str, public_upstream_branch: str, source_dir: str):
-    """
-    Fetch public upstream source for specified Git repository. Set up public_upstream remote if needed.
-
-    :param public_source_url: HTTPS Git URL of the public upstream source
-    :param public_upstream_branch: Git branch of the public upstream source
-    :param source_dir: Path to the local Git repository
-    """
-    out, err = exectools.cmd_assert(["git", "-C", source_dir, "remote"])
-    if 'public_upstream' not in out.strip().split():
-        exectools.cmd_assert(["git", "-C", source_dir, "remote", "add", "--", "public_upstream", public_source_url])
-    else:
-        exectools.cmd_assert(["git", "-C", source_dir, "remote", "set-url", "--", "public_upstream", public_source_url])
-    exectools.cmd_assert(["git", "-C", source_dir, "fetch", "--", "public_upstream", public_upstream_branch], retries=3,
-                         set_env=constants.GIT_NO_PROMPTS)
-
-
 def is_commit_in_public_upstream(revision: str, public_upstream_branch: str, source_dir: str):
     """
     Determine if the public upstream branch includes the specified commit.

--- a/doozer/requirements.txt
+++ b/doozer/requirements.txt
@@ -5,6 +5,8 @@ dockerfile-parse >= 0.0.13
 defusedxml
 future
 koji
+kubernetes-asyncio ~= 28.0
+openshift ~= 0.13.2
 opentelemetry-sdk
 opentelemetry-exporter-otlp-proto-grpc
 pip_system_certs
@@ -13,7 +15,7 @@ pyyaml >= 5.1
 requests
 requests_kerberos
 semver
-tenacity ~= 8.3.0  # https://github.com/jd/tenacity/issues/471
+tenacity ~= 8.4, != 8.4.0  # https://github.com/jd/tenacity/issues/471
 wrapt
 mysql-connector-python >= 8.0.21
 pydantic ~= 1.10.7

--- a/doozer/tests/test_distgit/support.py
+++ b/doozer/tests/test_distgit/support.py
@@ -56,9 +56,6 @@ class MockRuntime(object):
         self.cache_dir = None
         self.assembly_type = AssemblyTypes.STANDARD
 
-    def detect_remote_source_branch(self, _):
-        pass
-
 
 class MockMetadata(object):
 

--- a/doozer/tests/test_distgit/test_generic_distgit.py
+++ b/doozer/tests/test_distgit/test_generic_distgit.py
@@ -388,8 +388,8 @@ class TestGenericDistGit(TestDistgit):
         # preventing tests from interacting with the real filesystem
         flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
         flexmock(distgit.os.path).should_receive("isdir").and_return(True)
-
-        metadata = flexmock(runtime=self.mock_runtime(resolve_source=lambda *_: "source-root",
+        source_resolver = flexmock(resolve_source=flexmock(source_path="source-root"))
+        metadata = flexmock(runtime=self.mock_runtime(source_resolver=source_resolver,
                                                       branch="_irrelevant_"),
                             config=flexmock(content=flexmock(source=flexmock(path="sub-path")),
                                             distgit=flexmock(branch="_irrelevant_")),
@@ -405,7 +405,8 @@ class TestGenericDistGit(TestDistgit):
         flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
         flexmock(distgit.os.path).should_receive("isdir").and_return(True)
 
-        metadata = flexmock(runtime=self.mock_runtime(resolve_source=lambda *_: "source-root",
+        source_resolver = flexmock(resolve_source=flexmock(source_path="source-root"))
+        metadata = flexmock(runtime=self.mock_runtime(source_resolver=source_resolver,
                                                       branch="_irrelevant_"),
                             config=flexmock(content=flexmock(source=flexmock(path=distgit.Missing)),
                                             distgit=flexmock(branch="_irrelevant_")),

--- a/doozer/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/doozer/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -194,8 +194,7 @@ class TestImageDistGit(TestDistgit):
             .with_args("timeout 999 git push --tags", retries=3)\
             .ordered()
 
-        metadata = flexmock(runtime=self.mock_runtime(global_opts={"rhpkg_push_timeout": 999},
-                                                      get_named_semaphore=lambda *_, **__: Lock()),
+        metadata = flexmock(runtime=self.mock_runtime(global_opts={"rhpkg_push_timeout": 999}),
                             config=flexmock(distgit=flexmock(branch="_irrelevant_")),
                             name="_irrelevant_",
                             logger=flexmock(info=lambda *_: None))
@@ -216,8 +215,7 @@ class TestImageDistGit(TestDistgit):
         # pretending cmd_assert raised an IOError
         flexmock(distgit.exectools).should_receive("cmd_assert").and_raise(IOError("io-error"))
 
-        metadata = flexmock(runtime=self.mock_runtime(global_opts={"rhpkg_push_timeout": "_irrelevant_"},
-                                                      get_named_semaphore=lambda *_, **__: Lock()),
+        metadata = flexmock(runtime=self.mock_runtime(global_opts={"rhpkg_push_timeout": "_irrelevant_"}),
                             config=flexmock(distgit=flexmock(branch="_irrelevant_")),
                             name="_irrelevant_",
                             logger=flexmock(info=lambda *_: None))

--- a/doozer/tests/test_distgit/test_image_distgit/test_push_image.py
+++ b/doozer/tests/test_distgit/test_image_distgit/test_push_image.py
@@ -2,7 +2,7 @@ import errno
 import os
 import io
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from flexmock import flexmock
 
@@ -25,6 +25,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
             command="some-command",
             add_record=lambda *_, **__: None,
             assembly_type=AssemblyTypes.STANDARD,
+            record_logger=Mock()
         )
 
     @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)

--- a/doozer/tests/test_metadata.py
+++ b/doozer/tests/test_metadata.py
@@ -419,6 +419,7 @@ class TestMetadata(TestCase):
             return self._list_builds(builds, packageID=packageID, state=state, pattern=pattern, queryOpts=queryOpts)
 
         runtime.downstream_commitish_overrides = {}
+        runtime.group_config.use_source_fallback_branch = None
         koji_mock.listBuilds.side_effect = list_builds
         ls_remote_commit = '296ac244f3e7fd2d937316639892f90f158718b0'
 

--- a/doozer/tests/test_runtime.py
+++ b/doozer/tests/test_runtime.py
@@ -20,57 +20,5 @@ def stub_runtime():
     return rt
 
 
-class RuntimeTestCase(unittest.TestCase):
-    def test_get_remote_branch_ref(self):
-        rt = stub_runtime()
-        flexmock(exectools).should_receive("cmd_assert").once().and_return("spam", "")
-        res = rt._get_remote_branch_ref("giturl", "branch")
-        self.assertEqual(res, "spam")
-
-        flexmock(exectools).should_receive("cmd_assert").once().and_return("", "")
-        self.assertIsNone(rt._get_remote_branch_ref("giturl", "branch"))
-
-        flexmock(exectools).should_receive("cmd_assert").once().and_raise(Exception("whatever"))
-        self.assertIsNone(rt._get_remote_branch_ref("giturl", "branch"))
-
-    def test_detect_remote_source_branch(self):
-        rt = stub_runtime()
-        source_details = dict(
-            url='some_git_repo',
-            branch=dict(
-                target='main_branch',
-                fallback='fallback_branch',
-                stage='stage_branch',
-            ),
-        )
-
-        # got a hit on the first branch
-        flexmock(rt).should_receive("_get_remote_branch_ref").once().and_return("spam")
-        self.assertEqual(("main_branch", "spam"), rt.detect_remote_source_branch(source_details))
-
-        # got a hit on the fallback branch
-        (flexmock(rt).
-            should_receive("_get_remote_branch_ref").
-            and_return(None).
-            and_return("eggs"))
-        self.assertEqual(("fallback_branch", "eggs"), rt.detect_remote_source_branch(source_details))
-
-        # no target or fallback branch
-        flexmock(rt).should_receive("_get_remote_branch_ref").and_return(None)
-        with self.assertRaises(runtime.DoozerFatalError):
-            rt.detect_remote_source_branch(source_details)
-
-        # request stage branch, get it
-        rt.stage = True
-        flexmock(rt).should_receive("_get_remote_branch_ref").once().and_return("spam")
-        self.assertEqual(("stage_branch", "spam"), rt.detect_remote_source_branch(source_details))
-
-        # request stage branch, not there
-        rt.stage = True
-        flexmock(rt).should_receive("_get_remote_branch_ref").once().and_return(None)
-        with self.assertRaises(runtime.DoozerFatalError):
-            rt.detect_remote_source_branch(source_details)
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/doozer/tests/test_source_resolver.py
+++ b/doozer/tests/test_source_resolver.py
@@ -1,0 +1,64 @@
+
+from unittest import TestCase
+from flexmock import flexmock
+from artcommonlib import exectools
+from artcommonlib.model import Model
+from doozerlib.source_resolver import SourceResolver
+
+
+class SourceResolverTestCase(TestCase):
+    @staticmethod
+    def create_source_resolver():
+        return SourceResolver(
+            sources_base_dir="/path/to/sources",
+            cache_dir="/path/to/cache",
+            group_config=Model()
+        )
+
+    def test_get_remote_branch_ref(self):
+        sr = self.create_source_resolver()
+        flexmock(exectools).should_receive("cmd_assert").once().and_return("spam", "")
+        res = sr._get_remote_branch_ref("giturl", "branch")
+        self.assertEqual(res, "spam")
+
+        flexmock(exectools).should_receive("cmd_assert").once().and_return("", "")
+        self.assertIsNone(sr._get_remote_branch_ref("giturl", "branch"))
+
+        flexmock(exectools).should_receive("cmd_assert").once().and_raise(Exception("whatever"))
+        self.assertIsNone(sr._get_remote_branch_ref("giturl", "branch"))
+
+    def test_detect_remote_source_branch(self):
+        sr = self.create_source_resolver()
+        source_details = dict(
+            url='some_git_repo',
+            branch=dict(
+                target='main_branch',
+                fallback='fallback_branch',
+                stage='stage_branch',
+            ),
+        )
+
+        # got a hit on the first branch
+        flexmock(SourceResolver).should_receive("_get_remote_branch_ref").once().and_return("spam")
+        self.assertEqual(("main_branch", "spam"), sr.detect_remote_source_branch(source_details, stage=False))
+
+        # got a hit on the fallback branch
+        (flexmock(SourceResolver).
+            should_receive("_get_remote_branch_ref").
+            and_return(None).
+            and_return("eggs"))
+        self.assertEqual(("fallback_branch", "eggs"), sr.detect_remote_source_branch(source_details, stage=False))
+
+        # no target or fallback branch
+        flexmock(SourceResolver).should_receive("_get_remote_branch_ref").and_return(None)
+        with self.assertRaises(IOError):
+            sr.detect_remote_source_branch(source_details, stage=False)
+
+        # request stage branch, get it
+        flexmock(SourceResolver).should_receive("_get_remote_branch_ref").once().and_return("spam")
+        self.assertEqual(("stage_branch", "spam"), sr.detect_remote_source_branch(source_details, stage=True))
+
+        # request stage branch, not there
+        flexmock(SourceResolver).should_receive("_get_remote_branch_ref").once().and_return(None)
+        with self.assertRaises(IOError):
+            sr.detect_remote_source_branch(source_details, stage=True)

--- a/elliott/elliottlib/runtime.py
+++ b/elliott/elliottlib/runtime.py
@@ -369,49 +369,6 @@ class Runtime(GroupRuntime):
         except gitdata.GitDataException as ex:
             raise ElliottFatalError(ex)
 
-    def get_public_upstream(self, remote_git: str) -> Tuple[str, Optional[str]]:
-        """
-        Some upstream repo are private in order to allow CVE workflows. While we
-        may want to build from a private upstream, we don't necessarily want to confuse
-        end-users by referencing it in our public facing image labels / etc.
-        In group.yaml, you can specify a mapping in "public_upstreams". It
-        represents private_url_prefix => public_url_prefix. Remote URLs passed to this
-        method which contain one of the private url prefixes will be translated
-        into a new string with the public prefix in its place. If there is not
-        applicable mapping, the incoming url will still be normalized into https.
-        :param remote_git: The URL to analyze for private repo patterns.
-        :return: tuple (url, branch)
-            - url: An https normalized remote address with private repo information replaced.
-            - branch: Optional public branch name if the public upstream source use a different branch name from the private upstream.
-        """
-        remote_https = util.convert_remote_git_to_https(remote_git)
-
-        if self.group_config.public_upstreams:
-
-            # We prefer the longest match in the mapping, so iterate through the entire
-            # map and keep track of the longest matching private remote.
-            target_priv_prefix = None
-            target_pub_prefix = None
-            target_pub_branch = None
-            for upstream in self.group_config.public_upstreams:
-                priv = upstream["private"]
-                pub = upstream["public"]
-                # priv can be a full repo, or an organization (e.g. git@github.com:openshift)
-                # It will be treated as a prefix to be replaced
-                https_priv_prefix = util.convert_remote_git_to_https(priv)  # Normalize whatever is specified in group.yaml
-                https_pub_prefix = util.convert_remote_git_to_https(pub)
-                if remote_https.startswith(f'{https_priv_prefix}/') or remote_https == https_priv_prefix:
-                    # If we have not set the prefix yet, or if it is longer than the current contender
-                    if not target_priv_prefix or len(https_priv_prefix) > len(target_pub_prefix):
-                        target_priv_prefix = https_priv_prefix
-                        target_pub_prefix = https_pub_prefix
-                        target_pub_branch = upstream.get("public_branch")
-
-            if target_priv_prefix:
-                return (f'{target_pub_prefix}{remote_https[len(target_priv_prefix):]}', target_pub_branch)
-
-        return (remote_https, None)
-
     def get_releases_config(self):
         if self.releases_config is not None:
             return self.releases_config

--- a/elliott/pyproject.toml
+++ b/elliott/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "requests",
     "requests-gssapi ~= 1.2.3",
     "ruamel.yaml",
-    "tenacity ~= 8.3.0",  # https://github.com/jd/tenacity/issues/471
+    "tenacity ~= 8.4, != 8.4.0",  # https://github.com/jd/tenacity/issues/471
     "jira >= 3.4.1",  # https://github.com/pycontribs/jira/issues/1486
     "prettytable"
 ]

--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -21,7 +21,7 @@ ruamel.yaml
 semver ~= 3.0.1
 slack_sdk >= 3.13.0
 stomp.py ~= 8.1.0
-tenacity ~= 8.3.0  # https://github.com/jd/tenacity/issues/471
+tenacity ~= 8.4, != 8.4.0 # https://github.com/jd/tenacity/issues/471
 tomli ~= 2.0.1
 specfile
 aiohttp>=3.9.4 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
The 4th commit in this PR fixes an issue that the public upstream repo is not cloned if `get_public_upstream` returns a None public branch.