### PR TITLE
Do not attempt to move microshift advisory to QE

### DIFF
--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -353,7 +353,7 @@ def categorize_bugs_by_type(bugs: List[Bug], advisory_id_map: Dict[str, int],
 
         for bug in tracker_bugs:
             package_name = bug.whiteboard_component
-            if package_name == "microshift" and len(packages) == 0:
+            if kind == "microshift" and package_name == "microshift" and len(packages) == 0:
                 # microshift is special since it has a separate advisory, and it's build is attached
                 # after payload is promoted. So do not pre-emptively complain
                 logger.info(f"skip attach microshift bug {bug.id} to {advisory} because this advisory has no builds attached")

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -379,6 +379,9 @@ class PrepareReleasePipeline:
 
         # Move advisories to QE
         for impetus, advisory in advisories.items():
+            # microshift advisory is special, and it will not be ready at this time
+            if impetus == 'microshift':
+                continue
             if impetus == 'metadata' and (self.advance_release or self.pre_release):
                 # We don't need to move emtpy metadata advisory if it's an advance release
                 _LOGGER.info("Not moving metadata advisory to QE since prerelease/advance release detected")


### PR DESCRIPTION
We try to move microshift advisory to QE in prep and promote,
at which time it doesn't have any builds and always fails,
which leads to noisy logs and complains. So skip that.