### PR TITLE
Fix resolve dockerfile name

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -22,7 +22,7 @@ from artcommonlib.pushd import Dir
 from doozerlib.cli import cli, pass_runtime
 from doozerlib import constants, util
 from doozerlib.image import ImageMetadata
-from doozerlib.util import get_docker_config_json, what_is_in_master, extract_version_fields, resolve_dockerfile_name
+from doozerlib.util import get_docker_config_json, what_is_in_master, extract_version_fields
 from artcommonlib.util import convert_remote_git_to_https, split_git_url, remove_prefix, convert_remote_git_to_ssh
 from pyartcd import jenkins
 
@@ -1032,7 +1032,7 @@ def images_streams_prs(runtime, github_access_token, bug, interstitial, ignore_c
             exectools.cmd_assert('git fetch --all', retries=3)
 
             df_path = Dir.getpath()
-            dockerfile_name = resolve_dockerfile_name(image_meta.config, image_meta.config.content.source.dockerfile, logger)
+            dockerfile_name = image_meta.resolve_dockerfile_name()
 
             df_path = df_path.joinpath(dockerfile_name).resolve()
             ci_operator_config_path = Dir.getpath().joinpath('.ci-operator.yaml').resolve()  # https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -40,7 +40,7 @@ from doozerlib.rpm_utils import parse_nvr
 from doozerlib.source_modifications import SourceModifierFactory
 from artcommonlib.util import convert_remote_git_to_https, isolate_rhel_major_from_distgit_branch, deep_merge
 from doozerlib.comment_on_pr import CommentOnPr
-from doozerlib.util import extract_version_fields, resolve_dockerfile_name
+from doozerlib.util import extract_version_fields
 
 # doozer used to be part of OIT
 OIT_COMMENT_PREFIX = '#oit##'
@@ -1671,7 +1671,7 @@ class ImageDistGitRepo(DistGitRepo):
 
         Return either an integer representing the RHEL major version, or None if something went wrong.
         """
-        df_name = resolve_dockerfile_name(self.config, self.source_path(), self.logger)
+        df_name = self.metadata.resolve_dockerfile_name()
         subdir = self.config.content.source.path
         if not subdir:
             subdir = '.'
@@ -2502,7 +2502,7 @@ class ImageDistGitRepo(DistGitRepo):
 
             self.env_vars_from_source.update(self.metadata.extract_kube_env_vars())
 
-        dockerfile_name = resolve_dockerfile_name(self.config, self.source_path(), self.logger)
+        dockerfile_name = self.metadata.resolve_dockerfile_name()
 
         # The path to the source Dockerfile we are reconciling against.
         source_dockerfile_path = os.path.join(self.source_path(), dockerfile_name)

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -673,6 +673,21 @@ class Metadata(object):
         """
         return self._component_name
 
+    def resolve_dockerfile_name(self) -> str:
+        """
+        :return: Upstream Dockerfile name
+        If content.source.dockerfile is not specified, use content.source.dockerfile_fallback
+        If content.source.dockerfile_fallback is not specified, use "Dockerfile"
+        """
+        dockerfile_name = "Dockerfile"
+        if self.config.content.source.dockerfile is not Missing:
+            # Be aware that this attribute sometimes contains path elements
+            dockerfile_name = self.config.content.source.dockerfile
+        elif self.config.content.source.dockerfile_fallback is not Missing:
+            dockerfile_name = self.config.content.source.dockerfile_fallback
+            self.logger.info(f"source.dockerfile not found, using source.dockerfile_fallback {dockerfile_name}")
+        return dockerfile_name
+
     def needs_rebuild(self):
         if self.config.targets:
             # If this meta has multiple build targets, check currency of each

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -595,28 +595,3 @@ def oc_image_info__caching(pull_spec: str, go_arch: str = 'amd64') -> Dict:
     if you expect the image to change during the course of doozer's execution.
     """
     return oc_image_info(pull_spec, go_arch)
-
-
-def resolve_dockerfile_name(config, source_path, logger):
-    """
-    Resolve the Dockerfile name of upstream. If file specified in content.source.dockerfile doesn't exist,
-    try looking at the one specified in content.source.dockerfile_fallback as well.
-    """
-    if config.content.source.dockerfile is not Missing:
-        # Be aware that this attribute sometimes contains path elements too.
-        dockerfile_name = config.content.source.dockerfile
-
-        source_dockerfile_path = os.path.join(source_path, dockerfile_name)
-
-        if not os.path.isfile(source_dockerfile_path):
-            dockerfile_name_fallback = config.content.source.dockerfile_fallback
-            if dockerfile_name_fallback is not Missing:
-                logger.info(
-                    f"Could not find source dockerfile at {dockerfile_name}, using fallback {dockerfile_name_fallback}")
-                return dockerfile_name_fallback
-            raise DoozerFatalError(
-                f"Fallback dockerfile {dockerfile_name_fallback} is Missing and source dockerfile {source_dockerfile_path} doesn't exist")
-        else:
-            return dockerfile_name
-    else:
-        return "Dockerfile"


### PR DESCRIPTION
Right now images:streams prs open breaks because of this.
We don't need the absolute path of Dockerfile but just the filename, 
so we do not need to pass in source_path.