### PR TITLE
[sast pipeline] update test build filtering logic

### DIFF
--- a/doozer/doozerlib/cli/scan_osh.py
+++ b/doozer/doozerlib/cli/scan_osh.py
@@ -682,7 +682,7 @@ class ScanOshCli:
                 continue
 
             # Exclude all test builds
-            if build["nvr"].endswith(".test"):
+            if "assembly.test" in build["nvr"]:
                 self.runtime.logger.debug(f"Skipping test build: {build['nvr']}")
                 continue
 
@@ -760,7 +760,7 @@ class ScanOshCli:
             package_name = build["package_name"]
 
             # Exclude all test builds
-            if nvr.endswith(".test"):
+            if "assembly.test" in nvr:
                 self.runtime.logger.debug(f"Skipping test build: {nvr}")
                 continue
 


### PR DESCRIPTION
Since we started added `.el8` at the end, test build NVRs look like `assembly.test.el*`. Updating logic so that its excluded correctly.