### PR TITLE
Allow multiple comments on pr

### DIFF
--- a/doozer/doozerlib/comment_on_pr.py
+++ b/doozer/doozerlib/comment_on_pr.py
@@ -39,7 +39,7 @@ class CommentOnPr:
         """
         issue_comments = self.list_comments()
         for issue_comment in issue_comments:
-            if f"Distgit: {self.distgit_name}" in issue_comment["body"]:
+            if  "[ART PR BUILD NOTIFIER]" in issue_comment["body"] and f"Distgit: {self.distgit_name}" in issue_comment["body"]:
                 return True
         return False
 

--- a/doozer/doozerlib/comment_on_pr.py
+++ b/doozer/doozerlib/comment_on_pr.py
@@ -39,7 +39,7 @@ class CommentOnPr:
         """
         issue_comments = self.list_comments()
         for issue_comment in issue_comments:
-            if  "[ART PR BUILD NOTIFIER]" in issue_comment["body"] and f"Distgit: {self.distgit_name}" in issue_comment["body"]:
+            if "[ART PR BUILD NOTIFIER]" in issue_comment["body"] and f"Distgit: {self.distgit_name}" in issue_comment["body"]:
                 return True
         return False
 

--- a/doozer/doozerlib/comment_on_pr.py
+++ b/doozer/doozerlib/comment_on_pr.py
@@ -39,23 +39,23 @@ class CommentOnPr:
         """
         issue_comments = self.list_comments()
         for issue_comment in issue_comments:
-            if "[ART PR BUILD NOTIFIER]" in issue_comment["body"]:
+            if f"Distgit: {self.distgit_name}" in issue_comment["body"]:
                 return True
         return False
 
     def post_comment(self):
         """
-        Post the comment in the PR if the comment doesn't exist already
+        Post the comment in the PR
         """
         # https://docs.github.com/rest/reference/issues#create-an-issue-comment
 
         # Message to be posted to the comment
         comment = "**[ART PR BUILD NOTIFIER]**\n\n" + \
+                  f"Distgit: {self.distgit_name}\n" + \
                   "This PR has been included in build " + \
                   f"[{self.nvr}]({BREWWEB_URL}/buildinfo" + \
-                  f"?buildID={self.build_id}) " + \
-                  f"for distgit *{self.distgit_name}*. \n All builds following this will " + \
-                  "include this PR."
+                  f"?buildID={self.build_id}).\n" + \
+                  "All builds following this will include this PR."
 
         self.gh_client.issues.create_comment(issue_number=self.pr["number"], body=comment)
 
@@ -113,6 +113,6 @@ class CommentOnPr:
                 LOGGER.warning("Skipped PR build notifier reporting on old PR %s", self.pr["html_url"])
                 return
 
-        # Check if comment doesn't already exist. Then post comment
+        # Check if comment doesn't already exist already. Then post comment
         if not self.check_if_comment_exist():
             self.post_comment()

--- a/doozer/tests/test_comment_on_pr.py
+++ b/doozer/tests/test_comment_on_pr.py
@@ -11,9 +11,9 @@ class TestCommentOnPr(unittest.TestCase):
         self.nvr = "nvr"
         self.build_id = "build_id"
         self.distgit_name = "distgit_name"
-        self.comment = '**[ART PR BUILD NOTIFIER]**\n\nThis PR has been included in build ' \
-                       '[nvr](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=build_id) for ' \
-                       'distgit *distgit_name*. \n All builds following this will include this PR.'
+        self.comment = '**[ART PR BUILD NOTIFIER]**\n\nDistgit: distgit_name\nThis PR has been included in build ' \
+                       '[nvr](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=build_id).\n' \
+                       'All builds following this will include this PR.'
 
     def test_list_comments(self):
         pr_no = 1
@@ -29,7 +29,7 @@ class TestCommentOnPr(unittest.TestCase):
     @patch.object(CommentOnPr, "list_comments")
     def test_check_if_comment_exist(self, mock_list_comments):
         api_mock = MagicMock()
-        api_mock.issues.list_comments.return_value = [{"body": "[ART PR BUILD NOTIFIER]"}]
+        api_mock.issues.list_comments.return_value = [{"body": "[ART PR BUILD NOTIFIER]\n\nDistgit: distgit_name"}]
         mock_list_comments.return_value = api_mock.issues.list_comments()
         comment_on_pr = CommentOnPr(self.distgit_dir, self.nvr, self.build_id, self.distgit_name)
         result = comment_on_pr.check_if_comment_exist()


### PR DESCRIPTION
When one github repository builds more than one image, allow every build to post a comment on pr. Fix misleading comments

An example on how the notifier looks like can be found [here](https://github.com/lgarciaaco/ovn-kubernetes/pull/9)