### PR TITLE
scan-sources: Always search images by el_target

### DIFF
--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -479,15 +479,14 @@ class Metadata(object):
 
             def latest_build_list(pattern_suffix):
                 # Include * after pattern_suffix to tolerate other release components that might be introduced later
-                # we do not want "**" in the pattern so do some additional checks
+                # we do not want "**" in the pattern so check first
                 main_pattern = f"{pattern_prefix}{extra_pattern}{pattern_suffix}"
-                if not main_pattern.endswith("*"):
-                    main_pattern = f"{main_pattern}*"
+                if main_pattern[-1] != "*":
+                    main_pattern += "*"
 
                 # include a .el<version> suffix to match the new build pattern
                 el_suffix = f'.el{el_ver}*' if el_ver else ''
                 pattern = f'{main_pattern}{el_suffix}'
-                self.logger.info(f'Searching latest build for pattern={pattern}, state={build_state.name}')
                 builds = koji_api.listBuilds(packageID=package_id,
                                              state=None if build_state is None else build_state.value,
                                              pattern=pattern,

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -481,7 +481,7 @@ class Metadata(object):
                 # Include * after pattern_suffix to tolerate other release components that might be introduced later
                 # we do not want "**" in the pattern so check first
                 main_pattern = f"{pattern_prefix}{extra_pattern}{pattern_suffix}"
-                if main_pattern[-1] != "*":
+                if not main_pattern.endswith("*"):
                     main_pattern += "*"
 
                 # include a .el<version> suffix to match the new build pattern

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -477,16 +477,15 @@ class Metadata(object):
                     return default
                 raise IOError(msg)
 
-            def latest_build_list(pattern_suffix):
-                # Include * after pattern_suffix to tolerate other release components that might be introduced later
-                # we do not want "**" in the pattern so check first
-                main_pattern = f"{pattern_prefix}{extra_pattern}{pattern_suffix}"
-                if not main_pattern.endswith("*"):
-                    main_pattern += "*"
+            def latest_build_list(assembly_suffix):
+                # we always add el_suffix to a nvr when we trigger a build
+                # if el_ver is None, we will try and match any el version
+                el_suffix = f'.el{el_ver if el_ver else "*"}'
 
-                # include a .el<version> suffix to match the new build pattern
-                el_suffix = f'.el{el_ver}*' if el_ver else ''
-                pattern = f'{main_pattern}{el_suffix}'
+                # we will not tolerate new naming components in pattern by default
+                # so this pattern will need update as new nvr naming components are added
+                pattern = f"{pattern_prefix}{extra_pattern}{assembly_suffix}{el_suffix}"
+
                 builds = koji_api.listBuilds(packageID=package_id,
                                              state=None if build_state is None else build_state.value,
                                              pattern=pattern,
@@ -496,7 +495,7 @@ class Metadata(object):
                 # Ensure the suffix ends the string OR at least terminated by a '.' .
                 # This latter check ensures that 'assembly.how' doesn't match a build from
                 # "assembly.howdy'.
-                refined = [b for b in builds if b['nvr'].endswith(pattern_suffix) or f'{pattern_suffix}.' in b['nvr']]
+                refined = [b for b in builds if b['nvr'].endswith(assembly_suffix) or f'{assembly_suffix}.' in b['nvr']]
 
                 if refined and build_state == BuildStates.COMPLETE:
                     # A final sanity check to see if the build is tagged with something we

--- a/doozer/tests/test_metadata.py
+++ b/doozer/tests/test_metadata.py
@@ -270,8 +270,8 @@ class TestMetadata(TestCase):
             self.build_record(now - datetime.timedelta(hours=1), assembly='stream', el_target=8, is_rpm=True)
         ]
         self.assertEqual(meta.get_latest_build(default=None), builds[1])  # Latest is el7 by one hour
-        self.assertEqual(meta.get_latest_build(default=None, el_target=7), builds[1])
-        self.assertEqual(meta.get_latest_build(default=None, el_target=8), builds[2])
+        self.assertEqual(meta.get_latest_build(default=None, el_target='7'), builds[1])
+        self.assertEqual(meta.get_latest_build(default=None, el_target='8'), builds[2])
 
     def test_needs_rebuild_disgit_only(self):
         runtime = self.runtime

--- a/doozer/tests/test_metadata.py
+++ b/doozer/tests/test_metadata.py
@@ -190,13 +190,13 @@ class TestMetadata(TestCase):
         self.assertEqual(meta.get_latest_build(default=None), builds[3])
 
         # Make sure that just matching the prefix of an assembly is not sufficient.
-        # builds = [
-        #     self.build_record(now - datetime.timedelta(hours=5), assembly='stream'),
-        #     self.build_record(now - datetime.timedelta(hours=5), assembly=runtime.assembly),
-        #     self.build_record(now, assembly='not_ours'),
-        #     self.build_record(now, assembly=f'{runtime.assembly}b')
-        # ]
-        # self.assertEqual(meta.get_latest_build(default=None), builds[1])
+        builds = [
+            self.build_record(now - datetime.timedelta(hours=5), assembly='stream'),
+            self.build_record(now - datetime.timedelta(hours=5), assembly=runtime.assembly),
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now, assembly=f'{runtime.assembly}b')
+        ]
+        self.assertEqual(meta.get_latest_build(default=None), builds[1])
 
         # el7 should not match.
         builds = [

--- a/elliott/elliottlib/metadata.py
+++ b/elliott/elliottlib/metadata.py
@@ -268,7 +268,7 @@ class Metadata(object):
                 # Include * after pattern_suffix to tolerate other release components that might be introduced later
                 # we do not want "**" in the pattern so check first
                 main_pattern = f"{pattern_prefix}{extra_pattern}{pattern_suffix}"
-                if main_pattern[-1] != "*":
+                if not main_pattern.endswith("*"):
                     main_pattern += "*"
 
                 # include a .el<version> suffix to match the new build pattern

--- a/elliott/elliottlib/metadata.py
+++ b/elliott/elliottlib/metadata.py
@@ -232,6 +232,8 @@ class Metadata(object):
                     el_ver = isolate_el_version_in_brew_tag(el_target)
                 if not el_ver:
                     raise ValueError(f'Unable to determine rhel version from specified el_target: {el_target}')
+            elif self.meta_type == 'image':
+                el_ver = self.branch_el_target()
 
             if self.meta_type == 'image':
                 ver_prefix = 'v'  # openshift-enterprise-console-container-v4.7.0-202106032231.p0.git.d9f4379
@@ -263,11 +265,15 @@ class Metadata(object):
                 raise IOError(msg)
 
             def latest_build_list(pattern_suffix):
-                # Include * after pattern_suffix to tolerate other release components that might be introduced later.
-                # Also include a .el<version> suffix to match the new build pattern
+                # Include * after pattern_suffix to tolerate other release components that might be introduced later
+                # we do not want "**" in the pattern so check first
+                main_pattern = f"{pattern_prefix}{extra_pattern}{pattern_suffix}"
+                if main_pattern[-1] != "*":
+                    main_pattern += "*"
 
+                # include a .el<version> suffix to match the new build pattern
                 el_suffix = f'.el{el_ver}*' if el_ver else ''
-                pattern = f'{pattern_prefix}{extra_pattern}{pattern_suffix}*{el_suffix}'
+                pattern = f'{main_pattern}{el_suffix}'
                 builds = koji_api.listBuilds(packageID=package_id,
                                              state=None if build_state is None else build_state.value,
                                              pattern=pattern,
@@ -278,24 +284,6 @@ class Metadata(object):
                 # This latter check ensures that 'assembly.how' doesn't match a build from
                 # "assembly.howdy'.
                 refined = [b for b in builds if b['nvr'].endswith(pattern_suffix) or f'{pattern_suffix}.' in b['nvr']]
-
-                # .el? was added to images well after assemblies were established. It allows us to build multiple
-                # images out of the same distgit if they differ in RHEL version. Because this was added late, not
-                # all image NVRs will possess .el? . Nonetheless, we want to filter down the list to the desired el
-                # version, if they do.
-                if self.meta_type == 'image':
-                    image_el_ver = f'.el{self.branch_el_target()}'
-                    # Ensure the suffix ends the string OR at least terminated by a '.' .
-                    el_refined = [b for b in refined if
-                                  b['nvr'].endswith(image_el_ver) or f'{image_el_ver}.' in b['nvr']]
-                    if el_refined:
-                        # if there were any images which had .el?, prefer them over the non-qualified.
-                        refined = el_refined
-                    else:
-                        # Everything was eliminated when elX was included. So at least filter out those which possess elY
-                        # where X != Y
-                        el_pattern = re.compile(r'.*\.el\d+.*')
-                        refined = [b for b in refined if not el_pattern.match(b['nvr'])]
 
                 if refined and build_state == BuildStates.COMPLETE:
                     # A final sanity check to see if the build is tagged with something we

--- a/elliott/tests/test_metadata.py
+++ b/elliott/tests/test_metadata.py
@@ -171,13 +171,13 @@ class TestMetadata(unittest.TestCase):
         self.assertEqual(meta.get_latest_build(default=None), builds[3])
 
         # Make sure that just matching the prefix of an assembly is not sufficient.
-        # builds = [
-        #     self.build_record(now - datetime.timedelta(hours=5), assembly='stream'),
-        #     self.build_record(now - datetime.timedelta(hours=5), assembly=runtime.assembly),
-        #     self.build_record(now, assembly='not_ours'),
-        #     self.build_record(now, assembly=f'{runtime.assembly}b')
-        # ]
-        # self.assertEqual(meta.get_latest_build(default=None), builds[1])
+        builds = [
+            self.build_record(now - datetime.timedelta(hours=5), assembly='stream'),
+            self.build_record(now - datetime.timedelta(hours=5), assembly=runtime.assembly),
+            self.build_record(now, assembly='not_ours'),
+            self.build_record(now, assembly=f'{runtime.assembly}b')
+        ]
+        self.assertEqual(meta.get_latest_build(default=None), builds[1])
 
         # el7 should not match.
         builds = [


### PR DESCRIPTION
This fixes the issue of not properly finding builds for ci golang builder images (because they share brew package for el8 and el9 builds happening in parallel). It was happening because we were only fetching latest build (for any el version), since https://github.com/openshift-eng/art-tools/pull/402  and then filtering out builds that did not match `branch_el_target` later, which resulted in no builds.

This would result in both images (el8 and el9) fetching builds by the same pattern (not including el version) and 
one would randomly get it's latest and other one would not.

Now since all our nvrs include ".el" suffix in them (it's been a while since we introduced them), use it by default. 

Before:
```
./doozer --assembly=stream --working-dir ../../ --group openshift-4.16 \
                                                         --images=ci-openshift-golang-builder-latest.rhel9 \
                                                         --rpms=openshift config:scan-sources

ci-openshift-golang-builder-latest.rhel9 is changed (reason: Component ci-openshift-golang-builder-latest-container
 has no latest build for assembly stream and target None)
```

^ if `ci-openshift-golang-builder-latest.rhel9` doesn't give that result, try `ci-openshift-golang-builder-latest.rhel8`

After:
```
Running a change assessment on ci-openshift-golang-builder-latest-container-
v4.16.0-202407172305.p0.g2ed769e.assembly.stream.el9 built at event 59120310
```
