### PR TITLE
Don't set publish date if batch is provided

### DIFF
--- a/elliott/elliottlib/cli/create_cli.py
+++ b/elliott/elliottlib/cli/create_cli.py
@@ -120,7 +120,7 @@ advisory.
             advisory_id = advisory_info["id"]
             green_prefix("Created new advisory: ")
             print_advisory(advisory_id, advisory_name, boilerplate['synopsis'], package_owner, assigned_to,
-                           et_data['quality_responsibility_name'], date or batch_id)
+                           et_data['quality_responsibility_name'], date, batch_id)
 
             if with_placeholder:
                 click.echo("Creating and attaching placeholder bug...")
@@ -145,18 +145,20 @@ advisory.
         else:
             green_prefix("Would have created advisory: ")
             click.echo("")
-            print_advisory(0, "(unassigned)", boilerplate['synopsis'], package_owner, assigned_to, et_data['quality_responsibility_name'], release_date, batch_id)
+            print_advisory(0, "(unassigned)", boilerplate['synopsis'], package_owner, assigned_to,
+                           et_data['quality_responsibility_name'], date, batch_id)
     finally:
         await errata_api.close()
 
 
-def print_advisory(advisory_id: int, errata_name: str, synopsis: str, package_owner: str, assigned_to: str, qe_group: str, release_date: datetime, batch_id: Optional[int] = None):
+def print_advisory(advisory_id: int, errata_name: str, synopsis: str, package_owner: str, assigned_to: str, qe_group: str,
+                   release_date: Optional[datetime], batch_id: Optional[int] = None):
     click.echo(f"""{errata_name}: {synopsis}
   package owner: {package_owner}  qe: {assigned_to} qe_group: {qe_group}
   url:   https://errata.devel.redhat.com/advisory/{advisory_id}
   state: NEW_FILES
   created:     None
-  ship target: {release_date.strftime(YMD)}
+  ship target: {release_date}
   batch_id:    {batch_id}
   ship date:   None
   age:         0 days

--- a/elliott/elliottlib/cli/create_cli.py
+++ b/elliott/elliottlib/cli/create_cli.py
@@ -86,8 +86,8 @@ advisory.
 
     et_data = runtime.get_errata_config()
 
-    if date and batch_id:
-        raise click.BadParameter("Cannot specify both --date and --batch-id")
+    if sum(map(bool, [date, batch_id])) != 1:
+        raise click.BadParameter("Need either --date or --batch-id")
 
     if "boilerplates" not in et_data:
         raise ValueError("`boilerplates` is required in erratatool.yml")

--- a/elliott/elliottlib/cli/create_cli.py
+++ b/elliott/elliottlib/cli/create_cli.py
@@ -23,7 +23,7 @@ LOGGER = logutil.get_logger(__name__)
               help="Type of Advisory to create.")
 @click.option("--art-advisory-key", required=True,
               help="Boilerplate for the advisory. This will be looked up from erratatool.yml")
-@click.option("--date", required=True,
+@click.option("--date",
               callback=validate_release_date,
               help="Release date for the advisory. Format: YYYY-Mon-DD.")
 @click.option('--assigned-to', metavar="EMAIL_ADDR", required=True,
@@ -88,8 +88,13 @@ advisory.
 
     et_data = runtime.get_errata_config()
 
-    # User entered a valid value for --date, set the release date
-    release_date = datetime.strptime(date, YMD)
+    if date and batch_id:
+        raise click.BadParameter("Cannot specify both --date and --batch-id")
+
+    release_date = None
+    if date:
+        # User entered a valid value for --date, set the release date
+        release_date = datetime.strptime(date, YMD).strftime(YMD)
 
     if "boilerplates" not in et_data:
         raise ValueError("`boilerplates` is required in erratatool.yml")
@@ -114,7 +119,7 @@ advisory.
                 advisory_package_owner_email=package_owner,
                 advisory_manager_email=manager,
                 advisory_assigned_to_email=assigned_to,
-                advisory_publish_date_override=release_date.strftime(YMD),
+                advisory_publish_date_override=release_date,
                 batch_id=batch_id
             )
             advisory_info = next(iter(created_advisory["errata"].values()))

--- a/elliott/elliottlib/errata_async.py
+++ b/elliott/elliottlib/errata_async.py
@@ -286,6 +286,8 @@ class AsyncErrataAPI:
             if batch_name:
                 data["batch"]["name"] = batch_name
         else:
+            if not advisory_publish_date_override:
+                raise ValueError("Either batch or advisory_publish_date_override must be provided")
             data["advisory"]["publish_date_override"] = advisory_publish_date_override
         return cast(Dict, await self._make_request(aiohttp.hdrs.METH_POST, path, json=data))
 

--- a/elliott/elliottlib/errata_async.py
+++ b/elliott/elliottlib/errata_async.py
@@ -248,7 +248,7 @@ class AsyncErrataAPI:
         :param advisory_topic: Topic
         :param advisory_description: Description
         :param advisory_solution: Solution
-        :param advisory_publish_date_override: Publish date override in "YYYY-MM-DD" format
+        :param advisory_publish_date_override: Publish date override in "YYYY-MM-DD" format. This will only be set if batch is not provided
         :param advisory_text_only: Whether the advisory is text only
         :param advisory_quality_responsibility_name: Quality responsibility name
         :param advisory_security_impact: Security impact
@@ -277,14 +277,16 @@ class AsyncErrataAPI:
                 "manager_email": advisory_manager_email,
                 "assigned_to_email": advisory_assigned_to_email,
                 "text_only": 1 if advisory_text_only else 0,
-                "publish_date_override": advisory_publish_date_override,
             },
             "batch": {},
         }
-        if batch_id:
-            data["batch"]["id"] = batch_id
-        if batch_name:
-            data["batch"]["name"] = batch_name
+        if batch_id or batch_name:
+            if batch_id:
+                data["batch"]["id"] = batch_id
+            if batch_name:
+                data["batch"]["name"] = batch_name
+        else:
+            data["advisory"]["publish_date_override"] = advisory_publish_date_override
         return cast(Dict, await self._make_request(aiohttp.hdrs.METH_POST, path, json=data))
 
     async def request_liveid(self, advisory_id: int):

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -462,10 +462,11 @@ class PrepareReleasePipeline:
             f"--assigned-to={self.runtime.config['advisory']['assigned_to']}",
             f"--manager={self.runtime.config['advisory']['manager']}",
             f"--package-owner={self.package_owner}",
-            f"--date={release_date}",
         ]
         if batch_id:
             create_cmd.append(f"--batch-id={batch_id}")
+        else:
+            create_cmd.append(f"--date={release_date}")
         if not self.dry_run:
             create_cmd.append("--yes")
         _LOGGER.info("Running command: %s", create_cmd)


### PR DESCRIPTION
This is to resolve the issue of advisory publish date field being set and stuck in the past,
when we update the associated batch publish date to something else. In such a case errata-tool library 
cannot perform operations on it

```
ElliottFatalError("Error finding or attaching bugs: [ErrataException('Erratum 136272: publish_date_override: cannot be
 set before 2024-Jul-24 which is determined by batch date of the advisory or ship_date of release\\n')]. See logs for 
more information.")
```

[slack_ref](https://redhat-internal.slack.com/archives/C06625LHXQS/p1721412549172059?thread_ts=1721411461.605679&cid=C06625LHXQS)