### PR TITLE
Only alert when advisory cannot move from new_files to qe

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -267,6 +267,7 @@ class BuildMicroShiftPipeline:
             "--assembly", self.assembly,
             "change-state",
             "-s", "QE",
+            "--from", "NEW_FILES",
             "--use-default-advisory", "microshift"
         ]
         await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars)

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -396,7 +396,7 @@ class PrepareReleasePipeline:
                 _LOGGER.info("Not moving metadata advisory to QE since prerelease/advance release detected")
                 continue
             try:
-                self.change_advisory_state(advisory, "QE")
+                self.change_advisory_state_qe(advisory)
             except Exception as ex:
                 _LOGGER.warning(f"Unable to move {impetus} advisory {advisory} to QE: {ex}")
                 await self._slack_client.say_in_thread(f"Unable to move {impetus} advisory {advisory} to QE. Details in log.")
@@ -657,17 +657,16 @@ class PrepareReleasePipeline:
         _LOGGER.info("Running command: %s", cmd)
         await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars, cwd=self.working_dir)
 
-    def change_advisory_state(self, advisory: int, state: str):
+    def change_advisory_state_qe(self, advisory: int):
         cmd = [
             "elliott",
             f"--working-dir={self.elliott_working_dir}",
             f"--group={self.group_name}",
             "--assembly", self.assembly,
             "change-state",
-            "-s",
-            state,
-            "-a",
-            str(advisory),
+            "-s", "QE",
+            "--from", "NEW_FILES",
+            "-a", str(advisory),
         ]
         if self.dry_run:
             cmd.append("--dry-run")

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -213,7 +213,7 @@ class PromotePipeline:
                         continue
                     logger.info("Moving advisory %s to QE...", advisory)
                     tasks_with_args.append(
-                        {"args": (impetus, advisory), "task": self.change_advisory_state(advisory, "QE")})
+                        {"args": (impetus, advisory), "task": self.change_advisory_state_qe(advisory)})
 
                 results = await asyncio.gather(*[t["task"] for t in tasks_with_args], return_exceptions=True)
                 for i in range(len(results)):
@@ -928,14 +928,13 @@ class PromotePipeline:
         if log_shasum:
             util.log_file_content(f"{path_to_dir}/sha256sum.txt")  # print sha256sum.txt
 
-    async def change_advisory_state(self, advisory: int, state: str):
+    async def change_advisory_state_qe(self, advisory: int):
         cmd = [
             "elliott",
             "change-state",
-            "-s",
-            state,
-            "-a",
-            str(advisory),
+            "-s", "QE",
+            "--from", "NEW_FILES",
+            "-a", str(advisory),
         ]
         if self.runtime.dry_run:
             cmd.append("--dry-run")

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -354,7 +354,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         pipeline = await PromotePipeline.create(runtime, group="openshift-4.10", assembly="4.10.99",
                                                 signing_env="prod", skip_sigstore=True)
         pipeline.check_blocker_bugs = AsyncMock()
-        pipeline.change_advisory_state = AsyncMock()
+        pipeline.change_advisory_state_qe = AsyncMock()
         pipeline.get_advisory_info = AsyncMock(return_value={
             "id": 2,
             "errata_id": 2,
@@ -394,7 +394,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         pipeline = await PromotePipeline.create(runtime, group="openshift-4.10", assembly="4.10.99",
                                                 signing_env="prod", skip_sigstore=True)
         pipeline.check_blocker_bugs = AsyncMock()
-        pipeline.change_advisory_state = AsyncMock()
+        pipeline.change_advisory_state_qe = AsyncMock()
         pipeline.get_advisory_info = AsyncMock(return_value={
             "id": 2,
             "errata_id": 2222,
@@ -468,7 +468,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             runtime, group="openshift-4.10", assembly="4.10.99",
             skip_mirror_binaries=True, signing_env="prod", skip_sigstore=True)
         pipeline.check_blocker_bugs = AsyncMock()
-        pipeline.change_advisory_state = AsyncMock()
+        pipeline.change_advisory_state_qe = AsyncMock()
         pipeline.get_advisory_info = AsyncMock(return_value={
             "id": 2,
             "errata_id": 2222,
@@ -487,7 +487,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         load_releases_config.assert_awaited_once_with(group='openshift-4.10', data_path='https://example.com/ocp-build-data.git')
         pipeline.check_blocker_bugs.assert_awaited_once_with()
         for advisory in [1, 2, 3, 4]:
-            pipeline.change_advisory_state.assert_any_await(advisory, "QE")
+            pipeline.change_advisory_state_qe.assert_any_await(advisory)
         pipeline.get_advisory_info.assert_awaited_once_with(2)
         pipeline.verify_attached_bugs.assert_awaited_once_with([1, 2, 3, 4], no_verify_blocking_bugs=False,
                                                                verify_flaws=True)


### PR DESCRIPTION
We try and move advisories to QE and alert in slack if we fail. But 
sometimes we run prep/promote jobs when advisories in REL_PREP, or 
even SHIPPED_LIVE to do something else. In those cases we don't want to 
error and be alerted when we cannot move advisory from those advanced
states to QE. So introduce a `--from` flag in elliott change-state which indicates 
that we should not operate if advisory is not in that state. Then we use 
`--from NEW_FILES` in our promote and prep pipelines.