### PR TITLE
Don't set publish date if batch is provided

### DIFF
--- a/elliott/elliottlib/cli/create_cli.py
+++ b/elliott/elliottlib/cli/create_cli.py
@@ -149,7 +149,7 @@ advisory.
         await errata_api.close()
 
 
-def print_advisory(advisory_id: int, errata_name: str, synopsis: str, package_owner: str, assigned_to: str, qe_group: str, release_date: Optional[datetime], batch_id: Optional[int] = None):
+def print_advisory(advisory_id: int, errata_name: str, synopsis: str, package_owner: str, assigned_to: str, qe_group: str, release_date: Optional[str], batch_id: Optional[int] = None):
     click.echo(f"""{errata_name}: {synopsis}
   package owner: {package_owner}  qe: {assigned_to} qe_group: {qe_group}
   url:   https://errata.devel.redhat.com/advisory/{advisory_id}

--- a/elliott/elliottlib/cli/create_cli.py
+++ b/elliott/elliottlib/cli/create_cli.py
@@ -119,8 +119,7 @@ advisory.
             advisory_name = advisory_info["fulladvisory"].rsplit("-", 1)[0]
             advisory_id = advisory_info["id"]
             green_prefix("Created new advisory: ")
-            print_advisory(advisory_id, advisory_name, boilerplate['synopsis'], package_owner, assigned_to,
-                           et_data['quality_responsibility_name'], date, batch_id)
+            print_advisory(advisory_id, advisory_name, boilerplate['synopsis'], package_owner, assigned_to, et_data['quality_responsibility_name'], date, batch_id)
 
             if with_placeholder:
                 click.echo("Creating and attaching placeholder bug...")
@@ -145,14 +144,12 @@ advisory.
         else:
             green_prefix("Would have created advisory: ")
             click.echo("")
-            print_advisory(0, "(unassigned)", boilerplate['synopsis'], package_owner, assigned_to,
-                           et_data['quality_responsibility_name'], date, batch_id)
+            print_advisory(0, "(unassigned)", boilerplate['synopsis'], package_owner, assigned_to, et_data['quality_responsibility_name'], date, batch_id)
     finally:
         await errata_api.close()
 
 
-def print_advisory(advisory_id: int, errata_name: str, synopsis: str, package_owner: str, assigned_to: str, qe_group: str,
-                   release_date: Optional[datetime], batch_id: Optional[int] = None):
+def print_advisory(advisory_id: int, errata_name: str, synopsis: str, package_owner: str, assigned_to: str, qe_group: str, release_date: Optional[datetime], batch_id: Optional[int] = None):
     click.echo(f"""{errata_name}: {synopsis}
   package owner: {package_owner}  qe: {assigned_to} qe_group: {qe_group}
   url:   https://errata.devel.redhat.com/advisory/{advisory_id}

--- a/elliott/elliottlib/errata_async.py
+++ b/elliott/elliottlib/errata_async.py
@@ -297,6 +297,7 @@ class AsyncErrataAPI:
         if not batch_id and not batch_name:
             advisory_info = next(iter(advisory["errata"].values()))
             advisory_id = advisory_info["id"]
+            _LOGGER.info(f"Clearing batch association for advisory {advisory_id}")
             # clearing batch requires special permissions, so don't raise exception if it fails
             try:
                 await self.change_batch_for_advisory(advisory_id)

--- a/elliott/elliottlib/errata_async.py
+++ b/elliott/elliottlib/errata_async.py
@@ -248,7 +248,7 @@ class AsyncErrataAPI:
         :param advisory_topic: Topic
         :param advisory_description: Description
         :param advisory_solution: Solution
-        :param advisory_publish_date_override: Publish date override in "YYYY-MM-DD" format
+        :param advisory_publish_date_override: Publish date override in "YYYY-MM-DD" format. This will only be set if batch is not provided
         :param advisory_text_only: Whether the advisory is text only
         :param advisory_quality_responsibility_name: Quality responsibility name
         :param advisory_security_impact: Security impact
@@ -277,14 +277,18 @@ class AsyncErrataAPI:
                 "manager_email": advisory_manager_email,
                 "assigned_to_email": advisory_assigned_to_email,
                 "text_only": 1 if advisory_text_only else 0,
-                "publish_date_override": advisory_publish_date_override,
             },
             "batch": {},
         }
-        if batch_id:
-            data["batch"]["id"] = batch_id
-        if batch_name:
-            data["batch"]["name"] = batch_name
+        if batch_id or batch_name:
+            if batch_id:
+                data["batch"]["id"] = batch_id
+            if batch_name:
+                data["batch"]["name"] = batch_name
+        else:
+            if not advisory_publish_date_override:
+                raise ValueError("Either batch or advisory_publish_date_override must be provided")
+            data["advisory"]["publish_date_override"] = advisory_publish_date_override
         return cast(Dict, await self._make_request(aiohttp.hdrs.METH_POST, path, json=data))
 
     async def request_liveid(self, advisory_id: int):

--- a/elliott/elliottlib/errata_async.py
+++ b/elliott/elliottlib/errata_async.py
@@ -297,7 +297,11 @@ class AsyncErrataAPI:
         if not batch_id and not batch_name:
             advisory_info = next(iter(advisory["errata"].values()))
             advisory_id = advisory_info["id"]
-            await self.change_batch_for_advisory(advisory_id)
+            # clearing batch requires special permissions, so don't raise exception if it fails
+            try:
+                await self.change_batch_for_advisory(advisory_id)
+            except Exception as e:
+                _LOGGER.warning(f"Failed to clear batch association for advisory {advisory_id}: {e}")
 
         return advisory
 

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -46,6 +46,8 @@ def ensure_erratatool_auth():
 
 def validate_release_date(ctx, param, value):
     """Ensures dates are provided in the correct format"""
+    if value is None:
+        return None
     try:
         release_date = datetime.datetime.strptime(value, YMD)
         if release_date == default_release_date:

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -471,10 +471,11 @@ class PrepareReleasePipeline:
             f"--assigned-to={self.runtime.config['advisory']['assigned_to']}",
             f"--manager={self.runtime.config['advisory']['manager']}",
             f"--package-owner={self.package_owner}",
-            f"--date={release_date}",
         ]
         if batch_id:
             create_cmd.append(f"--batch-id={batch_id}")
+        else:
+            create_cmd.append(f"--date={release_date}")
         if not self.dry_run:
             create_cmd.append("--yes")
         _LOGGER.info("Running command: %s", create_cmd)

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -206,7 +206,7 @@ class PrepareReleasePipeline:
                                                               art_advisory_key=ad,
                                                               release_date=release_date)
                         await self._slack_client.say_in_thread(
-                            f"Advance advisory created with release date {one_week_before_text}")
+                            f"{ad} advisory created with release date {release_date}")
                         continue
                     advisories[ad] = self.create_advisory(advisory_type=advisory_type,
                                                           art_advisory_key=ad,


### PR DESCRIPTION
Reverts openshift-eng/art-tools#795
Original PR https://github.com/openshift-eng/art-tools/pull/792

Original PR failed for https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release/226/console , so includes the fix.

It also 
- sets the Prerelease advisory date to +3 days from prep.
- tries to clear batch when creating advisory to remove automatic ErrataTool batch association 