### PR TITLE
[operator and bundle builds] Complain if image references not found

### DIFF
--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -2201,7 +2201,7 @@ class ImageDistGitRepo(DistGitRepo):
                 self.runtime.logger.error(e)
                 raise
 
-        if len(image_refs) != found_image_refs:
+        if len(image_refs) != len(found_image_refs):
             message = (f"Mismatch between number of found image references in {csv_file} and image-references file. "
                        f"Found {len(found_image_refs)}: {sorted(found_image_refs)}, "
                        f"Expected {len(image_refs)}: {sorted([i['name'] for i in image_refs])}. "

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -2153,6 +2153,9 @@ class ImageDistGitRepo(DistGitRepo):
         registry = csv_config['registry'].rstrip("/")
         image_map = csv_config.get('image-map', {})
 
+        # Record image references found
+        found_image_refs = set()
+
         for ref in image_refs:
             try:
                 name = ref['name']
@@ -2187,14 +2190,24 @@ class ImageDistGitRepo(DistGitRepo):
 
                 with io.open(csv_file, 'r+', encoding="utf-8") as f:
                     content = f.read()
-                    content = content.replace(spec + '\n', replace + '\n')
-                    content = content.replace(spec + '\"', replace + '\"')
-                    f.seek(0)
-                    f.truncate()
-                    f.write(content)
+                    if content.count(spec):
+                        content = content.replace(spec + '\n', replace + '\n')
+                        content = content.replace(spec + '\"', replace + '\"')
+                        f.seek(0)
+                        f.truncate()
+                        f.write(content)
+                        found_image_refs.add(name)
             except Exception as e:
                 self.runtime.logger.error(e)
                 raise
+
+        if len(image_refs) != found_image_refs:
+            message = (f"Mismatch between number of found image references in {csv_file} and image-references file. "
+                       f"Found {len(found_image_refs)}: {sorted(found_image_refs)}, "
+                       f"Expected {len(image_refs)}: {sorted([i['name'] for i in image_refs])}. "
+                       "Operator metadata is invalid, please investigate.")
+            self.runtime.logger.error(message)
+            raise DoozerFatalError(message)
 
         if version.startswith('v'):
             version = version[1:]  # strip off leading v

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -2206,8 +2206,7 @@ class ImageDistGitRepo(DistGitRepo):
                        f"Found {len(found_image_refs)}: {sorted(found_image_refs)}, "
                        f"Expected {len(image_refs)}: {sorted([i['name'] for i in image_refs])}. "
                        "Operator metadata is invalid, please investigate.")
-            self.runtime.logger.error(message)
-            raise DoozerFatalError(message)
+            self.runtime.logger.warning(message)
 
         if version.startswith('v'):
             version = version[1:]  # strip off leading v

--- a/doozer/doozerlib/olm/bundle.py
+++ b/doozer/doozerlib/olm/bundle.py
@@ -379,12 +379,12 @@ class OLMBundle(object):
                 match.group(1).replace('openshift/', 'openshift4/'),
                 sha
             )
-            key = re.search(r'([^\/]+)\/(.+)', match.group(1)).group(2)
+            key = re.search(r'([^/]+)/(.+)', match.group(1)).group(2)
             self.runtime.logger.info(f"Replacing {self.operator_csv_config['registry']}/{source_image} with {image}")
             found_images[key] = image
             return image
 
-        pattern = fr'{self.operator_csv_config['registry']}\/([^:]+):([^\'"\\\s]+)'
+        pattern = rf'{self.operator_csv_config['registry']}\/([^:]+):([^\'"\\\s]+)'
         new_contents = re.sub(
             pattern,
             collect_replaced_image,

--- a/doozer/doozerlib/olm/bundle.py
+++ b/doozer/doozerlib/olm/bundle.py
@@ -384,7 +384,7 @@ class OLMBundle(object):
             found_images[key] = image
             return image
 
-        pattern = rf'{self.operator_csv_config['registry']}\/([^:]+):([^\'"\\\s]+)'
+        pattern = r'{}\/([^:]+):([^\'"\\\s]+)'.format(self.operator_csv_config['registry'])
         new_contents = re.sub(
             pattern,
             collect_replaced_image,

--- a/doozer/doozerlib/olm/bundle.py
+++ b/doozer/doozerlib/olm/bundle.py
@@ -248,8 +248,7 @@ class OLMBundle(object):
                        f"Found {len(self.found_image_references)}: {sorted(self.found_image_references.keys())}, "
                        f"Expected {len(self.image_references)}: {sorted(self.image_references.keys())}. "
                        "Operator build metadata is invalid, please investigate.")
-            self.runtime.logger.error(message)
-            raise ValueError(message)
+            self.runtime.logger.warning(message)
 
     def generate_bundle_annotations(self):
         """Create an annotations YAML file for the bundle, using info extracted from operator's


### PR DESCRIPTION
We should not build operators with invalid metadata references. This causes 
a bunch of problems down the line, when they fail csv validation or other issues 
when installing the image where references were not found and replaced correctly.

This was recently seen in 4.17 where we built bundle nvr for operator nvr with invalid refs 
[ose-metallb-operator-bundle-container-v4.17.0.202407130042.p0.g3fe67bc.assembly.stream.el9-2](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3181361) and it was 
understandably failing cvp test after it was attached advisory. We want to save time and effort by failing 
earlier and working to resolve this kind of issue earlier.

## Test

Rebasing metallb operator with the problematic commit

```
$ ./doozer -g openshift-4.17 --assembly test --ignore-missing-base --images ose-metallb-operator 
--lock-upstream ose-metallb-operator 3fe67bc7130b3c431c8593ccf2b756af57b44ace images:rebase 
-m "testing" --version=v4.17 --release="20240724.p?"
...
doozerlib.exceptions.DoozerFatalError: Mismatch between number of found image references in 
/tmp/oit-h9r8yt6u.tmp/distgits/containers/ose-metallb-operator/manifests/stable/metallb-
operator.clusterserviceversion.yaml and image-references file. 
Found 1: ['kube-rbac-proxy'], 
Expected 4: ['kube-rbac-proxy', 'metallb-frr-rhel9', 'metallb-rhel9', 'metallb-rhel9-operator']. 
Operator metadata is invalid, please investigate.

```

Rebasing a currently problematic operator

```
$ ./doozer -g openshift-4.16 --assembly test --ignore-missing-base --images 
cluster-nfd-operator images:rebase -m "testing" --version=v4.16 --release="20240724.p?"
...
doozerlib.exceptions.DoozerFatalError: Mismatch between number of found image references in 
/home/sid/Projects/art/distgits/containers/cluster-nfd-operator/manifests/stable/manifests/nfd.clusterserviceversion.yaml and image-references file. 
Found 2: ['cluster-nfd-operator', 'node-feature-discovery'], 
Expected 3: ['cluster-nfd-operator', 'kube-rbac-proxy', 'node-feature-discovery']. 
Operator metadata is invalid, please investigate.

```

This finds a legit issue (correct me if i'm wrong) of a valid reference being replaced in a PR merged 4 months ago.
In which case we know about it and contact image owners

https://github.com/openshift/cluster-nfd-operator/commit/08ea3c60d835c5dd222a8588aa4ffb8fd0d48791#diff-59356dca073f089f92ccb6f5650fad26af3bd8173c90f0161efa3a4a48231300R647
