### PR TITLE
Fix a bug in image embargo detection

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -500,3 +500,7 @@ class ImageMetadata(Metadata):
         """ Returns derived brew target name from the distgit branch name
         """
         return f"{self.branch()}-containers-candidate"
+
+    @property
+    def image_build_method(self):
+        return self.config.image_build_method or self.runtime.group_config.default_image_build_method or "osbs2"

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -127,6 +127,9 @@ class Metadata(object):
         self.raw_config = Model(data_obj.data)  # Config straight from ocp-build-data
         assert (self.raw_config.name is not Missing)
 
+        self.private_fix: Optional[bool] = None
+        """ True if the source contains embargoed (private) CVE fixes. Defaulting to None means this should be auto-determined. """
+
         self.config = assembly_metadata_config(runtime.get_releases_config(), runtime.assembly, meta_type, self.distgit_key, self.raw_config)
         self.namespace, self._component_name = Metadata.extract_component_info(meta_type, self.name, self.config)
 

--- a/doozer/doozerlib/rpmcfg.py
+++ b/doozer/doozerlib/rpmcfg.py
@@ -34,8 +34,6 @@ class RPMMetadata(Metadata):
         self.tag = None
         self.build_status = False
         self.pre_init_sha = None
-        # This will be set to True if the source contains embargoed (private) CVE fixes. Defaulting to None means this should be auto-determined.
-        self.private_fix = None
 
         # If populated, extra variables that will added as os_git_vars
         self.extra_os_git_vars = {}

--- a/doozer/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/doozer/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -80,6 +80,7 @@ class TestImageDistGit(TestDistgit):
                             config=flexmock(distgit=flexmock(branch=distgit.Missing),
                                             image_build_method=distgit.Missing,
                                             get=lambda *_: {}),
+                            image_build_method="default-method",
                             name="_irrelevant_",
                             logger="_irrelevant_")
 
@@ -95,6 +96,7 @@ class TestImageDistGit(TestDistgit):
                                             image_build_method=distgit.Missing,
                                             get=get),
                             name="_irrelevant_",
+                            image_build_method="osbs2",
                             logger="_irrelevant_")
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -105,6 +107,7 @@ class TestImageDistGit(TestDistgit):
                                             image_build_method=distgit.Missing,
                                             get=get),
                             name="_irrelevant_",
+                            image_build_method="osbs2",
                             logger="_irrelevant_")
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -115,6 +118,7 @@ class TestImageDistGit(TestDistgit):
                                             image_build_method="imagebuilder",
                                             get=get),
                             name="_irrelevant_",
+                            image_build_method="imagebuilder",
                             logger="_irrelevant_")
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -127,6 +131,7 @@ class TestImageDistGit(TestDistgit):
                                             image_build_method="config-method",
                                             get=lambda _, d: d),
                             name="_irrelevant_",
+                            image_build_method="config-method",
                             logger="_irrelevant_")
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)


### PR DESCRIPTION
In function `_mapped_image_from_member`, the embargo state (private_fix flag) is set to its parent member's state. This is wrong.

The assumption is that when one of the parent images has an embargo, the child image is considered embargoed as well.

Also moving private_fix and image_build_method fields from ImageDistGitRepo class to Metadata.