### PR TITLE
invalidate cloudfront cache during promote

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -775,6 +775,9 @@ class PromotePipeline:
 
         # Publish the clients to our S3 bucket.
         await util.mirror_to_s3(f"{base_to_mirror_dir}/{build_arch}", f"s3://art-srv-enterprise/pub/openshift-v4/{build_arch}", dry_run=self.runtime.dry_run)
+
+        await util.invalidate_cloudfront_cache("/pub/openshift-v4/clients/ocp-dev-preview/latest/*")
+
         return f"{build_arch}/clients/{client_type}/{release_name}/sha256sum.txt"
 
     async def sigstore_sign(self, release_name: str, release_infos: Dict):

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -608,6 +608,15 @@ The following logs are just the container build portion of the OSBS build:
         )
 
 
+async def invalidate_cloudfront_cache(invalidation_path):
+    """
+    Invalidate s3 Cloudfront cache
+    """
+    cmd = f"aws cloudfront create-invalidation --distribution-id E3RAW1IMLSZJW3 --paths {invalidation_path}"
+
+    await exectools.cmd_assert_async(cmd, env=os.environ.copy(), stdout=sys.stderr)
+
+
 async def mirror_to_s3(source: Union[str, Path], dest: str, exclude: Optional[str] = None, include: Optional[str] = None, dry_run=False):
     """
     Copy to AWS S3


### PR DESCRIPTION
Since /latest is a symlink, cloudfront does not instantly update when we update the clients. Need to manually invalidate