### PR TITLE
Dont run commands with same working-dir concurrently

### DIFF
--- a/pyartcd/pyartcd/pipelines/check_bugs.py
+++ b/pyartcd/pyartcd/pipelines/check_bugs.py
@@ -31,7 +31,9 @@ class CheckBugsPipeline:
             return None
 
         # Find issues
-        await asyncio.gather(*[self._find_blockers(), self._find_regressions()])
+        # Note: don't run them concurrently since their working dir is the same and they can conflict
+        await self._find_blockers()
+        await self._find_regressions()
 
         # Return report
         if not self.issues:


### PR DESCRIPTION
Fix issues with running commands with same working-dir 
concurrently

https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fcheck-bugs/103/console