### PR TITLE
[ART-9920] add new cve type field

### DIFF
--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -87,6 +87,9 @@ class Bug:
     def is_ocp_bug(self):
         raise NotImplementedError
 
+    def is_vnlnerability_cve(self):
+        raise NotImplementedError
+
     @property
     def component(self):
         raise NotImplementedError
@@ -217,6 +220,9 @@ class BugzillaBug(Bug):
     def is_ocp_bug(self):
         return self.product == constants.BUGZILLA_PRODUCT_OCP
 
+    def is_vnlnerability_cve(self):
+        return False
+
     def creation_time_parsed(self):
         return datetime.strptime(str(self.bug.creation_time), '%Y%m%dT%H:%M:%S').replace(tzinfo=timezone.utc)
 
@@ -259,6 +265,8 @@ class JIRABug(Bug):
             return None
 
     def is_tracker_bug(self):
+        if self.is_vnlnerability_cve():
+            return True
         has_keywords = set(constants.TRACKER_BUG_KEYWORDS).issubset(set(self.keywords))
         has_whiteboard_component = bool(self.whiteboard_component)
         has_linked_flaw = bool(self.corresponding_flaw_bug_ids)
@@ -357,6 +365,17 @@ class JIRABug(Bug):
         return self.bug.fields.project.key
 
     @property
+    def cve_id(self):
+        if self.is_vnlnerability_cve():
+            return getattr(self.bug.fields, JIRABugTracker.field_cve_id)
+        if not (self.is_tracker_bug() or self.is_flaw_bug()):
+            return None
+        cve_id = re.search(r'CVE-\d+-\d+', self.summary)
+        if cve_id:
+            return cve_id.group()
+        return None
+
+    @property
     def alias(self):
         # TODO: See usage. this can be correct or incorrect based in usage.
         return self.bug.fields.labels
@@ -373,6 +392,8 @@ class JIRABug(Bug):
 
         :returns: a string if a value is found, otherwise None
         """
+        if self.is_vnlnerability_cve():
+            return getattr(self.bug.fields, JIRABugTracker.field_cve_upstream_component)
         markers = [r'^art:pscomponent:\s*(\S+)', r'^pscomponent:\s*(\S+)']
         for label in self.bug.fields.labels:
             for marker in markers:
@@ -416,6 +437,9 @@ class JIRABug(Bug):
 
     def is_ocp_bug(self):
         return self.bug.fields.project.key == "OCPBUGS" and not self.is_placeholder_bug()
+
+    def is_vnlnerability_cve(self):
+        return self.bug.fields.issuetype.name == "Vulnerability"
 
     def is_placeholder_bug(self):
         return ('Placeholder' in self.summary) and (self.component == 'Release') and ('Automation' in self.keywords)
@@ -620,6 +644,9 @@ class JIRABugTracker(BugTracker):
     field_release_blocker = 'customfield_12319743'  # "Release Blocker"
     field_blocked_reason = 'customfield_12316544'  # "Blocked Reason"
     field_severity = 'customfield_12316142'  # "Severity"
+    field_cve_id = 'customfield_12324749'  # "CVE ID"
+    field_cve_upstream_component = 'customfield_12324751'  # "Upstream Affected Component"
+    field_cve_is_embargo = 'customfield_12324750'  # "Embargo Status"
 
     @staticmethod
     def get_config(runtime) -> Dict:

--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -386,7 +386,7 @@ class JIRABug(Bug):
 
         :returns: a string if a value is found, otherwise None
         """
-        if self.is_vnlnerability_cve():
+        if self.is_type_vulnerability():
             return getattr(self.bug.fields, JIRABugTracker.field_cve_component)
         markers = [r'^art:pscomponent:\s*(\S+)', r'^pscomponent:\s*(\S+)']
         for label in self.bug.fields.labels:

--- a/elliott/tests/test_bzutil.py
+++ b/elliott/tests/test_bzutil.py
@@ -142,7 +142,7 @@ class TestJIRABug(unittest.TestCase):
     def test_is_tracker_bug(self):
         bug = flexmock(
             key='OCPBUGS1',
-            fields=flexmock(labels=constants.TRACKER_BUG_KEYWORDS + ['somethingelse', 'pscomponent:my-image', 'flaw:bz#123']))
+            fields=flexmock(labels=constants.TRACKER_BUG_KEYWORDS + ['somethingelse', 'pscomponent:my-image', 'flaw:bz#123'], issuetype=flexmock(name='Bug')))
         expected = True
         actual = JIRABug(bug).is_tracker_bug()
         self.assertEqual(expected, actual)
@@ -150,7 +150,7 @@ class TestJIRABug(unittest.TestCase):
     def test_is_tracker_bug_missing_keywords(self):
         bug = flexmock(
             key='OCPBUGS1',
-            fields=flexmock(labels=['somethingelse', 'pscomponent:my-image', 'flaw:bz#123']))
+            fields=flexmock(labels=['somethingelse', 'pscomponent:my-image', 'flaw:bz#123'], issuetype=flexmock(name='Bug')))
         expected = False
         actual = JIRABug(bug).is_tracker_bug()
         self.assertEqual(expected, actual)
@@ -158,7 +158,7 @@ class TestJIRABug(unittest.TestCase):
     def test_is_tracker_bug_missing_pscomponent(self):
         bug = flexmock(
             key='OCPBUGS1',
-            fields=flexmock(labels=constants.TRACKER_BUG_KEYWORDS + ['somethingelse', 'flaw:bz#123']))
+            fields=flexmock(labels=constants.TRACKER_BUG_KEYWORDS + ['somethingelse', 'flaw:bz#123'], issuetype=flexmock(name='Bug')))
         expected = False
         actual = JIRABug(bug).is_tracker_bug()
         self.assertEqual(expected, actual)
@@ -166,7 +166,7 @@ class TestJIRABug(unittest.TestCase):
     def test_is_tracker_bug_missing_flaw(self):
         bug = flexmock(
             key='OCPBUGS1',
-            fields=flexmock(labels=constants.TRACKER_BUG_KEYWORDS + ['somethingelse', 'pscomponent:my-image']))
+            fields=flexmock(labels=constants.TRACKER_BUG_KEYWORDS + ['somethingelse', 'pscomponent:my-image'], issuetype=flexmock(name='Bug')))
         expected = False
         actual = JIRABug(bug).is_tracker_bug()
         self.assertEqual(expected, actual)
@@ -199,14 +199,14 @@ class TestJIRABug(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_whiteboard_component(self):
-        bug = JIRABug(flexmock(key=1, fields=flexmock(labels=["foo"])))
+        bug = JIRABug(flexmock(key=1, fields=flexmock(labels=["foo"], issuetype=flexmock(name='Bug'))))
         self.assertIsNone(bug.whiteboard_component)
 
-        bug = JIRABug(flexmock(key=1, fields=flexmock(labels=["pscomponent: "])))
+        bug = JIRABug(flexmock(key=1, fields=flexmock(labels=["pscomponent: "], issuetype=flexmock(name='Bug'))))
         self.assertIsNone(bug.whiteboard_component)
 
         for expected in ["something", "openvswitch2.15", "trailing_blank 	"]:
-            bug = JIRABug(flexmock(key=1, fields=flexmock(labels=[f"pscomponent: {expected}"])))
+            bug = JIRABug(flexmock(key=1, fields=flexmock(labels=[f"pscomponent: {expected}"], issuetype=flexmock(name='Bug'))))
             actual = bug.whiteboard_component
             self.assertEqual(actual, expected.strip())
 


### PR DESCRIPTION
ref [ART-9920](https://issues.redhat.com/browse/ART-9920)
Prodsec will start creating new format of CVE bug with type `Vulnerability`, and `Vulnerability` type of bug has some useful customfield that we can use to simplify our check

the example bug has these fields is [OCPBUGS-36952](https://issues.redhat.com/browse/OCPBUGS-36952)

* customfield_12324749 --> `CVE ID` field, we can use this field to get cve id, no need to do string match
* customfield_12324751 --> `Upstream Affected Component` field, we can use this field to get pscomponent
* customfield_12324750 --> `Embargo Status` field, we can use this field as flag to check embargo status