### PR TITLE
[ART-10300] remove failed build's dependents from bundle build list

### DIFF
--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1022,6 +1022,7 @@ class ImageDistGitRepo(DistGitRepo):
         owners = list(self.config.owners) if self.config.owners and self.config.owners is not Missing else []
         action = "build"
         release = self.org_release if self.org_release is not None else '?'
+        dependents = list(self.config.dependents) if self.config.dependents is not Missing else []
         record = {
             "dir": self.distgit_dir,
             "dockerfile": "%s/Dockerfile" % self.distgit_dir,
@@ -1036,6 +1037,7 @@ class ImageDistGitRepo(DistGitRepo):
             "status": -1,
             "push_status": -1,
             "has_olm_bundle": 1 if self.config['update-csv'] is not Missing else 0,
+            "dependents": ",".join(dependents),
             # Status defaults to failure until explicitly set by success. This handles raised exceptions.
         }
 

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -784,11 +784,10 @@ class Ocp4Pipeline:
         for record in records:
             # If failed build has dependents, remove it operator bundle from list because olm_bundle job won't succeed
             if record['status'] != '0' and record.get('nvrs', None) and record.get('dependents', None):
-                distgit_nvrs = record['dependents'].split(', ')
-                for dep in distgit_nvrs:
+                for dep in record['dependents'].split(','):
                     for record in records:
                         if record['distgit'] == dep and record.get('nvrs', None):
-                            operator_nvrs.remove(record['nvrs'].split(', ')[0])
+                            operator_nvrs.remove(record['nvrs'].split(',')[0])
 
         await util.sync_images(
             version=self.version.stream,

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -781,6 +781,14 @@ class Ocp4Pipeline:
         for record in records:
             if record['has_olm_bundle'] == '1' and record['status'] == '0' and record.get('nvrs', None):
                 operator_nvrs.append(record['nvrs'].split(',')[0])
+        for record in records:
+            # If failed build has dependents, remove it operator bundle from list because olm_bundle job won't succeed
+            if record['status'] != '0' and record.get('nvrs', None) and record.get('dependents', None):
+                distgit_nvrs = record['dependents'].split(', ')
+                for dep in distgit_nvrs:
+                    for record in records:
+                        if record['distgit'] == dep and record.get('nvrs', None):
+                            operator_nvrs.remove(record['nvrs'].split(', ')[0])
 
         await util.sync_images(
             version=self.version.stream,

--- a/pyartcd/tests/pipelines/test_ocp4.py
+++ b/pyartcd/tests/pipelines/test_ocp4.py
@@ -858,11 +858,11 @@ class TestSyncImages(unittest.IsolatedAsyncioTestCase):
     @patch("builtins.open")
     @patch("pyartcd.record.parse_record_log", return_value={
         'build': [
-            {'has_olm_bundle': '1', 'status': '0', 'nvrs': 'nvr1,nvr2'},
-            {'has_olm_bundle': '0', 'status': '0', 'nvrs': 'nvr3'},
-            {'has_olm_bundle': '1', 'status': '1', 'nvrs': 'nvr4'},
-            {'has_olm_bundle': '1', 'status': '0', 'nvrs': ''},
-            {'has_olm_bundle': '1', 'status': '0', 'nvrs': 'nvr5'},
+            {'has_olm_bundle': '1', 'status': '0', 'dependents': '', 'distgit': 'nvr', 'nvrs': 'nvr1,nvr2'},
+            {'has_olm_bundle': '0', 'status': '0', 'dependents': '', 'distgit': 'nvr', 'nvrs': 'nvr3'},
+            {'has_olm_bundle': '1', 'status': '1', 'dependents': '', 'distgit': 'nvr', 'nvrs': 'nvr4'},
+            {'has_olm_bundle': '1', 'status': '0', 'dependents': '', 'distgit': 'nvr', 'nvrs': ''},
+            {'has_olm_bundle': '1', 'status': '0', 'dependents': '', 'distgit': 'nvr', 'nvrs': 'nvr5'},
         ]
     })
     @patch("pyartcd.util.sync_images")
@@ -902,11 +902,11 @@ class TestSyncImages(unittest.IsolatedAsyncioTestCase):
     @patch("builtins.open")
     @patch("pyartcd.record.parse_record_log", return_value={
         'build': [
-            {'has_olm_bundle': '1', 'status': '0', 'nvrs': 'nvr1,nvr2'},
-            {'has_olm_bundle': '0', 'status': '0', 'nvrs': 'nvr3'},
-            {'has_olm_bundle': '1', 'status': '1', 'nvrs': 'nvr4'},
-            {'has_olm_bundle': '1', 'status': '0', 'nvrs': ''},
-            {'has_olm_bundle': '1', 'status': '0', 'nvrs': 'nvr5'},
+            {'has_olm_bundle': '1', 'status': '0', 'dependents': '', 'distgit': 'nvr', 'nvrs': 'nvr1,nvr2'},
+            {'has_olm_bundle': '0', 'status': '0', 'dependents': '', 'distgit': 'nvr', 'nvrs': 'nvr3'},
+            {'has_olm_bundle': '1', 'status': '1', 'dependents': '', 'distgit': 'nvr', 'nvrs': 'nvr4'},
+            {'has_olm_bundle': '1', 'status': '0', 'dependents': '', 'distgit': 'nvr', 'nvrs': ''},
+            {'has_olm_bundle': '1', 'status': '0', 'dependents': '', 'distgit': 'nvr', 'nvrs': 'nvr5'},
         ]
     })
     @patch("pyartcd.jenkins.start_olm_bundle")


### PR DESCRIPTION
ref: [ART-10300](https://issues.redhat.com/browse/ART-10300)
This pr is to fix the issue when ocp4 job success build openshift-kubernetes-nmstate-operator but failed to build nmstate-console-plugin we should not trigger olm_bundle job for openshift-kubernetes-nmstate-operator because its referenced image failed to build.


Add image's dependents metadata into build record.
When generate the list of builds for olm_bumdle job, check if there are failed build exist in record, if true then don't trigger related olm_bundle build by removing its operator from build list to avoid build errors.