### PR TITLE
increase timeout for microshift build

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -257,7 +257,7 @@ class BuildMicroShiftPipeline:
         await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars)
 
     # Advisory can have several pending checks, so retry it a few times
-    @retry(reraise=True, stop=stop_after_attempt(5), wait=wait_fixed(1200))
+    @retry(reraise=True, stop=stop_after_attempt(10), wait=wait_fixed(1800))
     async def _change_advisory_status(self):
         """ move advisory status to QE
         """


### PR DESCRIPTION
Malware scanning takes a random amount of time to complete, sometimes it finishes quickly, other times it may take a couple of hours