### PR TITLE
[fips scan] [ART-10376] periodically scan all latest builds

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline-task.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline-task.yaml
@@ -26,7 +26,7 @@ spec:
         pip install stomp.py==8.1.0
         pip install setuptools==70.0.0
 
-        artcd -vv --dry-run scan-fips --version $(params.version) --nvrs $(params.nvrs)
+        artcd -vv --dry-run scan-fips --all-images
 
       securityContext:
         runAsGroup: 0

--- a/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline-task.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline-task.yaml
@@ -4,9 +4,10 @@ metadata:
   name: fips-pipeline-task
 spec:
   params:
-    - description: 'OCP major version, eg: 4.15'
-      name: version
+    - description: 'Doozer data path i.e. ocp build data url'
+      name: data_path
       type: string
+      default: 'https://github.com/openshift-eng/ocp-build-data'
     - description: 'Space separated NVRs'
       name: nvrs
       type: string
@@ -26,7 +27,7 @@ spec:
         pip install stomp.py==8.1.0
         pip install setuptools==70.0.0
 
-        artcd -vv --dry-run scan-fips --all-images
+        artcd -vv --dry-run scan-fips --data-path $(params.data_path) --all-images
 
       securityContext:
         runAsGroup: 0

--- a/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline.yaml
@@ -4,17 +4,18 @@ metadata:
   name: fips-pipeline
 spec:
   params:
-    - description: 'OCP major version, eg: 4.15'
-      name: version
+    - description: 'Doozer data path i.e. ocp build data url'
+      name: data_path
       type: string
+      default: 'https://github.com/openshift-eng/ocp-build-data'
     - description: 'Space separated NVRs'
       name: nvrs
       type: string
   tasks:
     - name: run-script
       params:
-        - name: version
-          value: $(params.version)
+        - name: data_path
+          value: $(params.data_path)
         - name: nvrs
           value: $(params.nvrs)
       taskRef:

--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -10,3 +10,5 @@ GIT_NO_PROMPTS = {
     "GIT_SSH_COMMAND": "ssh -oBatchMode=yes",
     "GIT_TERMINAL_PROMPT": "0",
 }
+
+ACTIVE_OCP_VERSIONS = [4.12, 4.13, 4.14, 4.15, 4.16, 4.17]

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -935,27 +935,6 @@ class Ocp4Pipeline:
             version_queue_name=queue
         )
 
-    async def _trigger_fips_pipeline(self):
-        """
-        Check if the successfully built images are FIPS client. This function will trigger a pipeline on ART cluster
-
-        :param version: Eg. 4.15
-        :param doozer_path: Eg. https://github.com/openshift-eng/ocp-build-data
-        :param nvrs: Eg. NVRs of successful builds
-        """
-        pipeline_name = "fips-pipeline"
-        cmd = f"tkn pipeline start {pipeline_name} " \
-              f"--kubeconfig {os.environ['ART_CLUSTER_ART_CD_PIPELINE_KUBECONFIG']} " \
-              f"--param version={self.version.stream} " \
-              f"--param nvrs={','.join(self.success_nvrs)} "
-
-        rc, _, _ = await exectools.cmd_gather_async(cmd)
-
-        if rc == 0:
-            self.runtime.logger.info("Successfully triggered FIPS pipline on cluster")
-        else:
-            self.runtime.logger.error("Error while triggering FIPS pipline on cluster")
-
     async def run(self):
         await self._initialize()
 
@@ -1003,12 +982,6 @@ class Ocp4Pipeline:
 
         # All good
         self._report_success()
-
-        # Run FIPS scan on successfully built images
-        if self.assembly != 'test' and self.success_nvrs:
-            # Skip scanning test builds
-            # Also skip if there are no successful builds
-            await self._trigger_fips_pipeline()
 
 
 @cli.command("ocp4",


### PR DESCRIPTION
- Add the `--all-images` flag to the doozer `images:scan-fips` command
- Update artcd to to run for all active ocp4 versions
- Remove trigger from ocp4

Follow up PR will be raised after this has been deployed on cluster, to setup the scheduled job, which in turn will trigger the pipeline. Right now, these changes are only add the "scan all latest images" part and remove the code from ocp4 which calls the pipeline after every successful run.