### PR TITLE
ocp-build-data-validator: Print json path with message

### DIFF
--- a/ocp-build-data-validator/validator/schema/image_schema.py
+++ b/ocp-build-data-validator/validator/schema/image_schema.py
@@ -25,4 +25,4 @@ def validate(file, data):
         # TODO: Check if the base images referenced in `from` field exist
     except ValidationError:
         errors = validator.iter_errors(data)
-        return '\n'.join([str(e.message) for e in errors])
+        return '\n'.join([f"{e.json_path}: {e.message}" for e in errors])

--- a/ocp-build-data-validator/validator/schema/releases_schema.py
+++ b/ocp-build-data-validator/validator/schema/releases_schema.py
@@ -54,4 +54,4 @@ def validate(_, data):
         validator.validate(demerged_data)
     except ValidationError:
         errors = validator.iter_errors(demerged_data)
-        return '\n'.join([str(e.message) for e in errors])
+        return '\n'.join([f"{e.json_path}: {e.message}" for e in errors])


### PR DESCRIPTION
Tweak to print offending json path with message

```
Validating 1 file(s)...
Schema mismatch: ../../ocp-build-data/releases.yml
Returned error: $.releases.4.15.26.assembly.members.images[4]: 'why' is a required property
$.releases.4.15.26.assembly.members.images[5]: 'why' is a required property
$.releases.4.15.26.assembly.permits[0]: Additional properties are not allowed ('why' was unexpected)
```