### PR TITLE
Add importPolicy PreserveOriginal for image tags

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -991,7 +991,7 @@ class GenPayloadCli:
         The release payload images referenced in the multi-release payload manifest list are
         themselves somewhat standard release payloads (i.e. they are based on CVO images for their
         arch) BUT, each component image they reference is a manifest list. For example, the `cli`
-        image in the s390x release payload will point to a a manifest list composed of cli image
+        image in the s390x release payload will point to a manifest list composed of cli image
         manifests for each architecture.
 
         So the top-level release payload pullspec is a manifest list, referencing release payload
@@ -1308,6 +1308,9 @@ class GenPayloadCli:
                 },
                 "referencePolicy": {
                     "type": "Source"
+                },
+                "importPolicy": {
+                    "importMode": "PreserveOriginal"
                 },
                 "name": multi_release_istag,
                 "annotations": dict(**{
@@ -1655,6 +1658,9 @@ class PayloadGenerator:
             "from": {
                 "kind": "DockerImage",
                 "name": payload_entry.dest_pullspec,
+            },
+            "importPolicy": {
+                "importMode": "PreserveOriginal"
             }
         }
 

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -533,6 +533,7 @@ spec:
                 "annotations": {},
                 "from": dict(kind="DockerImage", name="quay.io/org/repo@sha256:abcdef"),
                 "name": "spam",
+                "importPolicy": {"importMode": "PreserveOriginal"},
             }
         )
         gpcli.create_multi_manifest_list.assert_not_awaited()
@@ -547,6 +548,7 @@ spec:
                 "annotations": {},
                 "from": dict(kind="DockerImage", name="new-manifest-list-pullspec"),
                 "name": "spam",
+                "importPolicy": {"importMode": "PreserveOriginal"},
             }
         )
         gpcli.create_multi_manifest_list.assert_awaited_once_with("spam", arch_to_payload_entry, "ocp")


### PR DESCRIPTION
Multi nightlies on release controller aren't preserving the original manifest list, just the x86 component.