### PR TITLE
Add delivery to validator image config schema

### DIFF
--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -1119,7 +1119,8 @@
         ],
         "additionalProperties": false
       }
-    }
+    },
+    "delivery": {}
   },
   "additionalProperties": false
 }


### PR DESCRIPTION
Adds delivery property to image config schema used by ocp-build-data-validator.