### PR TITLE
Enable promote with upgrades_next edges

### DIFF
--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -151,6 +151,16 @@
       "$ref": "#/properties/upgrades"
     },
     "upgrades-": {},
+    "upgrades_next": {
+      "type": "string"
+    },
+    "upgrades_next!": {
+      "$ref": "#/properties/upgrades_next"
+    },
+    "upgrades_next?": {
+      "$ref": "#/properties/upgrades_next"
+    },
+    "upgrades_next-": {},
     "check_golang_versions": {
       "type": "boolean"
     },

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1278,7 +1278,9 @@ class PromotePipeline:
                 # Add task to build arch-specific heterogeneous payload
                 metadata = metadata.copy() if metadata else {}
                 metadata['release.openshift.io/architecture'] = 'multi'
-                build_tasks.append(self.build_release_image(release_name, brew_arch, previous_list, metadata, arch_payload_dest, arch_payload_source, None, keep_manifest_list=True))
+                build_tasks.append(self.build_release_image(release_name, brew_arch, previous_list, next_list,
+                                                            metadata, arch_payload_dest, arch_payload_source,
+                                                            None, keep_manifest_list=True))
 
             # Build and push all arch-specific heterogeneous payloads
             self._logger.info("Building arch-specific heterogeneous payloads for %s...", include_arches)

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1057,7 +1057,7 @@ class PromotePipeline:
         :param release_name: Release name. e.g. 4.11.0-rc.6
         :param arches: List of architecture names. e.g. ["x86_64", "s390x"]. Don't use "multi" in this parameter.
         :param previous_list: upgrade edges that are used in `oc adm release new --previous`
-        :param next_list: (Optional) upgrade edges that are used in `oc adm release new --next`
+        :param next_list: upgrade edges that are used in `oc adm release new --next`
         :param metadata: Payload metadata
         :param reference_releases: A dict of reference release payloads to promote. Keys are architecture names, values are payload pullspecs
         :param tag_stable: Whether to tag the promoted payload to "4-stable[-$arch]" release stream.
@@ -1096,7 +1096,7 @@ class PromotePipeline:
         :param release_name: Release name. e.g. 4.11.0-rc.6
         :param arches: List of architecture names. e.g. ["x86_64", "s390x"].
         :param previous_list: upgrade edges that are used in `oc adm release new --previous`
-        :param next_list: (Optional) upgrade edges that are used in `oc adm release new --next`
+        :param next_list: upgrade edges that are used in `oc adm release new --next`
         :param metadata: Payload metadata
         :param reference_releases: A dict of reference release payloads to promote. Keys are architecture names, values are payload pullspecs
         :param tag_stable: Whether to tag the promoted payload to "4-stable[-$arch]" release stream.

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -189,6 +189,13 @@ class PromotePipeline:
                 raise ValueError("Previous list (`upgrades` field in group config) has an invalid semver.")
 
             # Get next list
+            # We do not in our normal process require populating "next" edges
+            # In normal flow, each release's "next" edges are the following release's "previous" edges
+            # But in case we miss adding an edge in "previous" list, we can add it in a "next" list
+            # Example: 4.13.a and 4.14.b are shipping together in a week. 4.14.b has 4.13.a in its "previous" list.
+            # Due to new requirements we re-promote 4.13 which becomes 4.13.(a+1)
+            # 4.14.b does not have 4.13.(a+1) in its "previous" list.
+            # So we need to add 4.14.b in 4.13.(a+1)'s "next" list
             upgrades_next_str: Optional[str] = group_config.get("upgrades_next")
             next_list = list(map(lambda s: s.strip(), upgrades_next_str.split(","))) if upgrades_next_str else []
             # Ensure all versions in next list are valid semvers.

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1050,7 +1050,8 @@ class PromotePipeline:
         :param assembly_type: Assembly type
         :param release_name: Release name. e.g. 4.11.0-rc.6
         :param arches: List of architecture names. e.g. ["x86_64", "s390x"]. Don't use "multi" in this parameter.
-        :param previous_list: Previous list.
+        :param previous_list: upgrade edges that are used in `oc adm release new --previous`
+        :param next_list: upgrade edges that are used in `oc adm release new --next`
         :param metadata: Payload metadata
         :param reference_releases: A dict of reference release payloads to promote. Keys are architecture names, values are payload pullspecs
         :param tag_stable: Whether to tag the promoted payload to "4-stable[-$arch]" release stream.
@@ -1058,7 +1059,9 @@ class PromotePipeline:
         """
         tasks = OrderedDict()
         if not self.no_multi and self._multi_enabled:
-            tasks["heterogeneous"] = self._promote_heterogeneous_payload(assembly_type, release_name, arches, previous_list, metadata, tag_stable)
+            tasks["heterogeneous"] = self._promote_heterogeneous_payload(assembly_type, release_name, arches,
+                                                                         previous_list, next_list,
+                                                                         metadata, tag_stable)
         else:
             self._logger.warning("Multi/heterogeneous payload is disabled.")
         if not self.multi_only:
@@ -1200,7 +1203,9 @@ class PromotePipeline:
         self._logger.info("Release image %s has been tagged into %s.", dest_image_pullspec, namespace_image_stream_tag)
         return dest_image_info
 
-    async def _promote_heterogeneous_payload(self, assembly_type: AssemblyTypes, release_name: str, include_arches: List[str], previous_list: List[str], metadata: Optional[Dict], tag_stable: bool):
+    async def _promote_heterogeneous_payload(self, assembly_type: AssemblyTypes, release_name: str,
+                                             include_arches: List[str], previous_list: List[str], next_list: List[str],
+                                             metadata: Optional[Dict], tag_stable: bool):
         """ Promote heterogeneous payload.
         The heterogeneous payload itself is a manifest list, which include references to arch-specific heterogeneous payloads.
         :param assembly_type: Assembly type

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -440,6 +440,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
     })
     @patch("pyartcd.pipelines.promote.util.load_group_config", return_value=Model({
         "upgrades": "4.10.98,4.9.99",
+        "upgrades_next": "4.11.45",
         "advisories": {"rpm": 1, "image": 2, "extras": 3, "metadata": 4},
         "description": "whatever",
         "arches": ["x86_64", "s390x", "ppc64le", "aarch64"],
@@ -493,13 +494,13 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
                                                                verify_flaws=True)
         get_release_image_info.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", raise_if_not_found=ANY)
         get_release_image_info.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-s390x", raise_if_not_found=ANY)
-        build_release_image.assert_any_await("4.10.99", "x86_64", ["4.10.98", "4.9.99"], [],
+        build_release_image.assert_any_await("4.10.99", "x86_64", ["4.10.98", "4.9.99"], ["4.11.45"],
                                              {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", "registry.ci.openshift.org/ocp/release:nightly-x86_64", None, keep_manifest_list=False)
-        build_release_image.assert_any_await("4.10.99", "s390x", ["4.10.98", "4.9.99"], [],
+        build_release_image.assert_any_await("4.10.99", "s390x", ["4.10.98", "4.9.99"], ["4.11.45"],
                                              {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-s390x", "registry.ci.openshift.org/ocp-s390x/release-s390x:nightly-s390x", None, keep_manifest_list=False)
-        build_release_image.assert_any_await("4.10.99", "ppc64le", ["4.10.98", "4.9.99"], [],
+        build_release_image.assert_any_await("4.10.99", "ppc64le", ["4.10.98", "4.9.99"], ["4.11.45"],
                                              {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-ppc64le", "registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:nightly-ppc64le", None, keep_manifest_list=False)
-        build_release_image.assert_any_await("4.10.99", "aarch64", ["4.10.98", "4.9.99"], [],
+        build_release_image.assert_any_await("4.10.99", "aarch64", ["4.10.98", "4.9.99"], ["4.11.45"],
                                              {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64", "registry.ci.openshift.org/ocp-arm64/release-arm64:nightly-aarch64", None, keep_manifest_list=False)
         pipeline._slack_client.bind_channel.assert_called_once_with("4.10.99")
         pipeline.get_image_stream_tag.assert_any_await("ocp", "release:4.10.99")

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -253,11 +253,11 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         get_release_image_info.assert_any_await(
             "quay.io/openshift-release-dev/ocp-release:4.10.99-assembly.art0001-s390x", raise_if_not_found=ANY)
         build_release_image.assert_any_await(
-            "4.10.99-assembly.art0001", "x86_64", [], {},
+            "4.10.99-assembly.art0001", "x86_64", [], [], {},
             "quay.io/openshift-release-dev/ocp-release:4.10.99-assembly.art0001-x86_64", None,
             '4.10-art-assembly-art0001', keep_manifest_list=False)
         build_release_image.assert_any_await(
-            "4.10.99-assembly.art0001", "s390x", [], {},
+            "4.10.99-assembly.art0001", "s390x", [], [], {},
             "quay.io/openshift-release-dev/ocp-release:4.10.99-assembly.art0001-s390x", None,
             '4.10-art-assembly-art0001-s390x', keep_manifest_list=False)
         pipeline._slack_client.bind_channel.assert_called_once_with("4.10.99-assembly.art0001")
@@ -493,10 +493,14 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
                                                                verify_flaws=True)
         get_release_image_info.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", raise_if_not_found=ANY)
         get_release_image_info.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-s390x", raise_if_not_found=ANY)
-        build_release_image.assert_any_await("4.10.99", "x86_64", ["4.10.98", "4.9.99"], {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", "registry.ci.openshift.org/ocp/release:nightly-x86_64", None, keep_manifest_list=False)
-        build_release_image.assert_any_await("4.10.99", "s390x", ["4.10.98", "4.9.99"], {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-s390x", "registry.ci.openshift.org/ocp-s390x/release-s390x:nightly-s390x", None, keep_manifest_list=False)
-        build_release_image.assert_any_await("4.10.99", "ppc64le", ["4.10.98", "4.9.99"], {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-ppc64le", "registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:nightly-ppc64le", None, keep_manifest_list=False)
-        build_release_image.assert_any_await("4.10.99", "aarch64", ["4.10.98", "4.9.99"], {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64", "registry.ci.openshift.org/ocp-arm64/release-arm64:nightly-aarch64", None, keep_manifest_list=False)
+        build_release_image.assert_any_await("4.10.99", "x86_64", ["4.10.98", "4.9.99"], [],
+                                             {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", "registry.ci.openshift.org/ocp/release:nightly-x86_64", None, keep_manifest_list=False)
+        build_release_image.assert_any_await("4.10.99", "s390x", ["4.10.98", "4.9.99"], [],
+                                             {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-s390x", "registry.ci.openshift.org/ocp-s390x/release-s390x:nightly-s390x", None, keep_manifest_list=False)
+        build_release_image.assert_any_await("4.10.99", "ppc64le", ["4.10.98", "4.9.99"], [],
+                                             {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-ppc64le", "registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:nightly-ppc64le", None, keep_manifest_list=False)
+        build_release_image.assert_any_await("4.10.99", "aarch64", ["4.10.98", "4.9.99"], [],
+                                             {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64", "registry.ci.openshift.org/ocp-arm64/release-arm64:nightly-aarch64", None, keep_manifest_list=False)
         pipeline._slack_client.bind_channel.assert_called_once_with("4.10.99")
         pipeline.get_image_stream_tag.assert_any_await("ocp", "release:4.10.99")
         pipeline.tag_release.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", "ocp/release:4.10.99")
@@ -557,13 +561,15 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             release_name="4.10.99",
             arch="x86_64",
             previous_list=previous_list,
+            next_list=[],
             metadata=metadata,
             reference_release=reference_release,
             tag_stable=True,
             assembly_type=AssemblyTypes.CUSTOM
         )
         get_release_image_info.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64")
-        build_release_image.assert_awaited_once_with("4.10.99", "x86_64", previous_list, metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", f'registry.ci.openshift.org/ocp/release:{reference_release}', None, keep_manifest_list=False)
+        build_release_image.assert_awaited_once_with("4.10.99", "x86_64", previous_list, [],
+                                                     metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", f'registry.ci.openshift.org/ocp/release:{reference_release}', None, keep_manifest_list=False)
         get_image_stream_tag.assert_awaited_once_with("ocp", "release:4.10.99")
         tag_release.assert_awaited_once_with("quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", "ocp/release:4.10.99")
         self.assertEqual(actual["image"], "quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64")
@@ -578,13 +584,15 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             release_name="4.10.99",
             arch="aarch64",
             previous_list=previous_list,
+            next_list=[],
             metadata=metadata,
             reference_release=reference_release,
             tag_stable=True,
             assembly_type=AssemblyTypes.CUSTOM
         )
         get_release_image_info.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64")
-        build_release_image.assert_awaited_once_with("4.10.99", "aarch64", previous_list, metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64", f'registry.ci.openshift.org/ocp-arm64/release-arm64:{reference_release}', None, keep_manifest_list=False)
+        build_release_image.assert_awaited_once_with("4.10.99", "aarch64", previous_list, [],
+                                                     metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64", f'registry.ci.openshift.org/ocp-arm64/release-arm64:{reference_release}', None, keep_manifest_list=False)
         get_image_stream_tag.assert_awaited_once_with("ocp-arm64", "release-arm64:4.10.99")
         tag_release.assert_awaited_once_with("quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64", "ocp-arm64/release-arm64:4.10.99")
         self.assertEqual(actual["image"], "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64")
@@ -605,13 +613,15 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
                 release_name="4.10.99",
                 arch="aarch64",
                 previous_list=previous_list,
+                next_list=[],
                 metadata=metadata,
                 reference_release=reference_release,
                 tag_stable=True,
                 assembly_type=AssemblyTypes.CUSTOM
             )
         get_release_image_info.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64")
-        build_release_image.assert_awaited_once_with("4.10.99", "aarch64", previous_list, metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64", f'registry.ci.openshift.org/ocp-arm64/release-arm64:{reference_release}', None, keep_manifest_list=False)
+        build_release_image.assert_awaited_once_with("4.10.99", "aarch64", previous_list, [],
+                                                     metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64", f'registry.ci.openshift.org/ocp-arm64/release-arm64:{reference_release}', None, keep_manifest_list=False)
         get_image_stream_tag.assert_awaited_once_with("ocp-arm64", "release-arm64:4.10.99")
         tag_release.assert_not_awaited()
 
@@ -637,7 +647,8 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         # test x86_64
         reference_release = "registry.ci.openshift.org/ocp/release:whatever-x86_64"
         dest_pullspec = "example.com/foo/release:4.10.99-x86_64"
-        await pipeline.build_release_image("4.10.99", "x86_64", previous_list, metadata, dest_pullspec, reference_release, None, keep_manifest_list=False)
+        await pipeline.build_release_image("4.10.99", "x86_64", previous_list, [],
+                                           metadata, dest_pullspec, reference_release, None, keep_manifest_list=False)
         expected_cmd = ["oc", "adm", "release", "new", "-n", "ocp", "--name=4.10.99", "--to-image=example.com/foo/release:4.10.99-x86_64", f"--from-release={reference_release}", "--previous=4.10.98,4.10.97,4.9.99", "--metadata", "{\"description\": \"whatever\", \"url\": \"https://access.redhat.com/errata/RHBA-2099:2222\"}"]
         cmd_assert_async.assert_awaited_once_with(expected_cmd, env=ANY, stdout=ANY)
 
@@ -645,7 +656,8 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         reference_release = "registry.ci.openshift.org/ocp-arm64/release-arm64:whatever-aarch64"
         dest_pullspec = "example.com/foo/release:4.10.99-aarch64"
         cmd_assert_async.reset_mock()
-        await pipeline.build_release_image("4.10.99", "aarch64", previous_list, metadata, dest_pullspec, reference_release, None, keep_manifest_list=False)
+        await pipeline.build_release_image("4.10.99", "aarch64", previous_list, [],
+                                           metadata, dest_pullspec, reference_release, None, keep_manifest_list=False)
         expected_cmd = ["oc", "adm", "release", "new", "-n", "ocp-arm64", "--name=4.10.99", "--to-image=example.com/foo/release:4.10.99-aarch64", f"--from-release={reference_release}", "--previous=4.10.98,4.10.97,4.9.99", "--metadata", "{\"description\": \"whatever\", \"url\": \"https://access.redhat.com/errata/RHBA-2099:2222\"}"]
         cmd_assert_async.assert_awaited_once_with(expected_cmd, env=ANY, stdout=ANY)
 
@@ -653,7 +665,8 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         reference_release = "registry.ci.openshift.org/ocp-arm64/release-arm64:whatever-multi-aarch64"
         dest_pullspec = "example.com/foo/release:4.10.99-multi-aarch64"
         cmd_assert_async.reset_mock()
-        await pipeline.build_release_image("4.10.99", "aarch64", previous_list, metadata, dest_pullspec, reference_release, None, keep_manifest_list=True)
+        await pipeline.build_release_image("4.10.99", "aarch64", previous_list, [],
+                                           metadata, dest_pullspec, reference_release, None, keep_manifest_list=True)
         expected_cmd = ["oc", "adm", "release", "new", "-n", "ocp-arm64", "--name=4.10.99", "--to-image=example.com/foo/release:4.10.99-multi-aarch64", f"--from-release={reference_release}", "--keep-manifest-list", "--previous=4.10.98,4.10.97,4.9.99", "--metadata", "{\"description\": \"whatever\", \"url\": \"https://access.redhat.com/errata/RHBA-2099:2222\"}"]
         cmd_assert_async.assert_awaited_once_with(expected_cmd, env=ANY, stdout=ANY)
 
@@ -671,7 +684,8 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         reference_release = None
         dest_pullspec = "example.com/foo/release:4.10.99-x86_64"
         from_image_stream = "4.10-art-assembly-4.10.99"
-        await pipeline.build_release_image("4.10.99", "x86_64", previous_list, metadata, dest_pullspec, reference_release, from_image_stream, keep_manifest_list=False)
+        await pipeline.build_release_image("4.10.99", "x86_64", previous_list, [],
+                                           metadata, dest_pullspec, reference_release, from_image_stream, keep_manifest_list=False)
         expected_cmd = ['oc', 'adm', 'release', 'new', '-n', 'ocp', '--name=4.10.99', '--to-image=example.com/foo/release:4.10.99-x86_64', '--reference-mode=source', '--from-image-stream=4.10-art-assembly-4.10.99', '--previous=4.10.98,4.10.97,4.9.99', '--metadata', '{"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}']
         cmd_assert_async.assert_awaited_once_with(expected_cmd, env=ANY, stdout=ANY)
 
@@ -680,7 +694,8 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         dest_pullspec = "example.com/foo/release:4.10.99-aarch64"
         from_image_stream = "4.10-art-assembly-4.10.99-arm64"
         cmd_assert_async.reset_mock()
-        await pipeline.build_release_image("4.10.99", "aarch64", previous_list, metadata, dest_pullspec, reference_release, from_image_stream, keep_manifest_list=False)
+        await pipeline.build_release_image("4.10.99", "aarch64", previous_list, [],
+                                           metadata, dest_pullspec, reference_release, from_image_stream, keep_manifest_list=False)
         expected_cmd = ['oc', 'adm', 'release', 'new', '-n', 'ocp-arm64', '--name=4.10.99', '--to-image=example.com/foo/release:4.10.99-aarch64', '--reference-mode=source', '--from-image-stream=4.10-art-assembly-4.10.99-arm64', '--previous=4.10.98,4.10.97,4.9.99', '--metadata', '{"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}']
         cmd_assert_async.assert_awaited_once_with(expected_cmd, env=ANY, stdout=ANY)
 
@@ -732,6 +747,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             release_name="4.10.99",
             include_arches=["x86_64", "aarch64"],
             previous_list=previous_list,
+            next_list=[],
             metadata=metadata,
             tag_stable=True,
             assembly_type=AssemblyTypes.CUSTOM
@@ -806,6 +822,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             release_name="4.10.99",
             include_arches=["x86_64", "aarch64"],
             previous_list=previous_list,
+            next_list=[],
             metadata=metadata,
             tag_stable=True,
             assembly_type=AssemblyTypes.CUSTOM
@@ -818,8 +835,10 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         get_image_stream_tag.assert_awaited_once_with("ocp-multi", "release-multi:4.10.99")
         dest_metadata = metadata.copy()
         dest_metadata["release.openshift.io/architecture"] = "multi"
-        build_release_image.assert_any_await("4.10.99", "aarch64", previous_list, dest_metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-multi-aarch64", 'example.com/ocp-release@fake:deadbeef-source-multi-arm64', None, keep_manifest_list=True)
-        build_release_image.assert_any_await("4.10.99", "x86_64", previous_list, dest_metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-multi-x86_64", 'example.com/ocp-release@fake:deadbeef-source-multi-amd64', None, keep_manifest_list=True)
+        build_release_image.assert_any_await("4.10.99", "aarch64", previous_list, [],
+                                             dest_metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-multi-aarch64", 'example.com/ocp-release@fake:deadbeef-source-multi-arm64', None, keep_manifest_list=True)
+        build_release_image.assert_any_await("4.10.99", "x86_64", previous_list, [],
+                                             dest_metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-multi-x86_64", 'example.com/ocp-release@fake:deadbeef-source-multi-amd64', None, keep_manifest_list=True)
         dest_manifest_list = {'image': 'quay.io/openshift-release-dev/ocp-release:4.10.99-multi', 'manifests': [{'image': 'quay.io/openshift-release-dev/ocp-release:4.10.99-multi-x86_64', 'platform': {'os': 'linux', 'architecture': 'amd64'}}, {'image': 'quay.io/openshift-release-dev/ocp-release:4.10.99-multi-aarch64', 'platform': {'os': 'linux', 'architecture': 'arm64'}}]}
         push_manifest_list.assert_awaited_once_with("4.10.99", dest_manifest_list)
         tag_release.assert_awaited_once_with("quay.io/openshift-release-dev/ocp-release:4.10.99-multi", "ocp-multi/release-multi:4.10.99")
@@ -848,6 +867,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             release_name="4.10.99",
             include_arches=["x86_64", "aarch64"],
             previous_list=previous_list,
+            next_list=[],
             metadata=metadata,
             tag_stable=True,
             assembly_type=AssemblyTypes.CUSTOM
@@ -860,8 +880,10 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         get_image_stream_tag.assert_awaited_once_with("ocp-multi", "release-multi:4.10.99")
         dest_metadata = metadata.copy()
         dest_metadata["release.openshift.io/architecture"] = "multi"
-        build_release_image.assert_any_await("4.10.99", "aarch64", previous_list, dest_metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-multi-aarch64", 'example.com/ocp-release@fake:deadbeef-source-multi-arm64', None, keep_manifest_list=True)
-        build_release_image.assert_any_await("4.10.99", "x86_64", previous_list, dest_metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-multi-x86_64", 'example.com/ocp-release@fake:deadbeef-source-multi-amd64', None, keep_manifest_list=True)
+        build_release_image.assert_any_await("4.10.99", "aarch64", previous_list, [],
+                                             dest_metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-multi-aarch64", 'example.com/ocp-release@fake:deadbeef-source-multi-arm64', None, keep_manifest_list=True)
+        build_release_image.assert_any_await("4.10.99", "x86_64", previous_list, [],
+                                             dest_metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-multi-x86_64", 'example.com/ocp-release@fake:deadbeef-source-multi-amd64', None, keep_manifest_list=True)
         dest_manifest_list = {'image': 'quay.io/openshift-release-dev/ocp-release:4.10.99-multi', 'manifests': [{'image': 'quay.io/openshift-release-dev/ocp-release:4.10.99-multi-x86_64', 'platform': {'os': 'linux', 'architecture': 'amd64'}}, {'image': 'quay.io/openshift-release-dev/ocp-release:4.10.99-multi-aarch64', 'platform': {'os': 'linux', 'architecture': 'arm64'}}]}
         push_manifest_list.assert_awaited_once_with("4.10.99", dest_manifest_list)
         tag_release.assert_awaited_once_with("quay.io/openshift-release-dev/ocp-release:4.10.99-multi", "ocp-multi/release-multi:4.10.99")
@@ -917,6 +939,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             release_name="4.10.99",
             include_arches=["x86_64", "aarch64"],
             previous_list=previous_list,
+            next_list=[],
             metadata=metadata,
             tag_stable=True,
             assembly_type=AssemblyTypes.CUSTOM
@@ -948,6 +971,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             release_name="4.10.99",
             include_arches=["x86_64", "aarch64"],
             previous_list=previous_list,
+            next_list=[],
             metadata=metadata,
             tag_stable=True,
             assembly_type=AssemblyTypes.CUSTOM
@@ -959,8 +983,10 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         get_image_stream_tag.assert_awaited_once_with("ocp-multi", "release-multi:4.10.99-multi")
         dest_metadata = metadata.copy()
         dest_metadata["release.openshift.io/architecture"] = "multi"
-        build_release_image.assert_any_await("4.10.99-multi", "aarch64", [], dest_metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-multi-aarch64", 'example.com/ocp-release@fake:deadbeef-source-multi-arm64', None, keep_manifest_list=True)
-        build_release_image.assert_any_await("4.10.99-multi", "x86_64", [], dest_metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-multi-x86_64", 'example.com/ocp-release@fake:deadbeef-source-multi-amd64', None, keep_manifest_list=True)
+        build_release_image.assert_any_await("4.10.99-multi", "aarch64", [], [],
+                                             dest_metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-multi-aarch64", 'example.com/ocp-release@fake:deadbeef-source-multi-arm64', None, keep_manifest_list=True)
+        build_release_image.assert_any_await("4.10.99-multi", "x86_64", [], [],
+                                             dest_metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-multi-x86_64", 'example.com/ocp-release@fake:deadbeef-source-multi-amd64', None, keep_manifest_list=True)
         dest_manifest_list = {'image': 'quay.io/openshift-release-dev/ocp-release:4.10.99-multi', 'manifests': [{'image': 'quay.io/openshift-release-dev/ocp-release:4.10.99-multi-x86_64', 'platform': {'os': 'linux', 'architecture': 'amd64'}}, {'image': 'quay.io/openshift-release-dev/ocp-release:4.10.99-multi-aarch64', 'platform': {'os': 'linux', 'architecture': 'arm64'}}]}
         push_manifest_list.assert_awaited_once_with("4.10.99-multi", dest_manifest_list)
         tag_release.assert_awaited_once_with("quay.io/openshift-release-dev/ocp-release:4.10.99-multi", "ocp-multi/release-multi:4.10.99-multi")
@@ -988,6 +1014,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             release_name="4.10.99",
             include_arches=["x86_64", "aarch64"],
             previous_list=previous_list,
+            next_list=[],
             metadata=metadata,
             tag_stable=True,
             assembly_type=AssemblyTypes.CUSTOM
@@ -999,8 +1026,10 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         get_image_stream_tag.assert_awaited_once_with("ocp-multi", "release-multi:4.10.99-multi")
         dest_metadata = metadata.copy()
         dest_metadata["release.openshift.io/architecture"] = "multi"
-        build_release_image.assert_any_await("4.10.99-multi", "aarch64", [], dest_metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-multi-aarch64", 'example.com/ocp-release@fake:deadbeef-source-multi-arm64', None, keep_manifest_list=True)
-        build_release_image.assert_any_await("4.10.99-multi", "x86_64", [], dest_metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-multi-x86_64", 'example.com/ocp-release@fake:deadbeef-source-multi-amd64', None, keep_manifest_list=True)
+        build_release_image.assert_any_await("4.10.99-multi", "aarch64", [], [],
+                                             dest_metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-multi-aarch64", 'example.com/ocp-release@fake:deadbeef-source-multi-arm64', None, keep_manifest_list=True)
+        build_release_image.assert_any_await("4.10.99-multi", "x86_64", [], [],
+                                             dest_metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-multi-x86_64", 'example.com/ocp-release@fake:deadbeef-source-multi-amd64', None, keep_manifest_list=True)
         dest_manifest_list = {'image': 'quay.io/openshift-release-dev/ocp-release:4.10.99-multi', 'manifests': [{'image': 'quay.io/openshift-release-dev/ocp-release:4.10.99-multi-x86_64', 'platform': {'os': 'linux', 'architecture': 'amd64'}}, {'image': 'quay.io/openshift-release-dev/ocp-release:4.10.99-multi-aarch64', 'platform': {'os': 'linux', 'architecture': 'arm64'}}]}
         push_manifest_list.assert_awaited_once_with("4.10.99-multi", dest_manifest_list)
         tag_release.assert_awaited_once_with("quay.io/openshift-release-dev/ocp-release:4.10.99-multi", "ocp-multi/release-multi:4.10.99-multi")


### PR DESCRIPTION
Enable `oc adm release new --next [...]`

We do not in our normal process require populating a payload's "next" edges.
In normal flow, each release's "next" edges are the following release's "previous" edges
But in case we miss adding an edge in "previous" list, we can add it in a "next" list
Example: 4.13.a and 4.14.b are shipping together in a week. 4.14.b has 4.13.a in its "previous" list.
Due to new requirements we re-promote 4.13 which becomes 4.13.(a+1) 
4.14.b does not have 4.13.(a+1) in its "previous" list. 
So we need to add 4.14.b in 4.13.(a+1)'s "next" list, 
to make that upgrade path available to customers who will be on 4.13.(a+1),
without repromoting 4.14.

See: https://github.com/openshift-eng/ocp-build-data/pull/5260
https://redhat-internal.slack.com/archives/CJARLA942/p1723736306214179?thread_ts=1723710327.987479&cid=CJARLA942

https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fpromote-assembly/275/console