### PR TITLE
[fips-scan] pin setuptools to fix ./install.sh error

### DIFF
--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
@@ -41,6 +41,11 @@ RUN rpm -e --nodeps python3-requests
 
 # Copy art-tools and run the install script
 COPY . .
+
+# Fixes issue "TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'" while
+# running ./install.sh
+RUN pip3 install setuptools==70.0.0
+
 RUN ./install.sh
 
 # Install check-payload tool for FIPS scanning, and copy to a location in PATH


### PR DESCRIPTION
Latest version of `setuptools` has issue `TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'`. Pinning to older version for now