### PR TITLE
ART-10516 Fetch and validate fixed in versions from go vulnerability DB

### DIFF
--- a/elliott/elliottlib/cli/find_bugs_golang_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_golang_cli.py
@@ -433,7 +433,7 @@ class FindBugsGolangCli:
             else:
                 logger.warning(f"{cve_id} is not compatible with in-use golang versions for {ocp_version}.")
 
-            cve_table.add_row([flaw_id, cve_id, comp_in_title, flaw_fixed_in, compatible])
+            cve_table.add_row([flaw_id, cve_id, comp_in_title, _fmt(flaw_fixed_in), compatible])
         self._logger.info(f"Found trackers for {len(cves)} CVEs")
         self._logger.info(f"\n{cve_table}")
 

--- a/elliott/elliottlib/cli/find_bugs_golang_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_golang_cli.py
@@ -112,10 +112,8 @@ class FindBugsGolangCli:
             for existing_version in versions_to_build_map.keys():
                 if fixed_version.major > existing_version.major:
                     fixed_in_is_ahead = True
-                    self._logger.info(f"{str(fixed_version)} is ahead of {str(existing_version)}")
                 elif fixed_version.major == existing_version.major and fixed_version.minor > existing_version.minor:
                     fixed_in_is_ahead = True
-                    self._logger.info(f"{str(fixed_version)} is ahead of {str(existing_version)}")
                 elif (existing_version.major == fixed_version.major and existing_version.minor == fixed_version.minor
                       and existing_version.patch >= fixed_version.patch):
                     self._logger.info(f"{bug.id} for {bug.whiteboard_component} is fixed in {str(existing_version)}")

--- a/elliott/elliottlib/cli/find_bugs_golang_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_golang_cli.py
@@ -106,25 +106,10 @@ class FindBugsGolangCli:
         self._logger.info(f'Found parent go build versions {[str(v) for v in sorted(versions_to_build_map.keys())]}')
 
         fixed_in_versions = set()
-        older_fixed_in_versions = set()
-        for fixed_version in tracker_fixed_in:
-            fixed_in_is_ahead = False
-            for existing_version in versions_to_build_map.keys():
-                if fixed_version.major > existing_version.major:
-                    fixed_in_is_ahead = True
-                elif fixed_version.major == existing_version.major and fixed_version.minor > existing_version.minor:
-                    fixed_in_is_ahead = True
-                elif (existing_version.major == fixed_version.major and existing_version.minor == fixed_version.minor
-                      and existing_version.patch >= fixed_version.patch):
-                    self._logger.info(f"{bug.id} for {bug.whiteboard_component} is fixed in {str(existing_version)}")
-                    fixed_in_versions.add(existing_version)
-            if not fixed_in_is_ahead:
-                older_fixed_in_versions.add(fixed_version)
-
-        if not fixed_in_versions and len(older_fixed_in_versions) == len(tracker_fixed_in):
-            self._logger.info("All fixed in versions are older than parent go build versions, therefore considered "
-                              "fixed.")
-            fixed_in_versions = set(versions_to_build_map.keys())
+        for existing_version in versions_to_build_map.keys():
+            for fixed_version in tracker_fixed_in:
+                if (existing_version.major == fixed_version.major and existing_version.minor == fixed_version.minor
+                   and existing_version.patch >= fixed_version.patch):
 
         fixed = False
         if fixed_in_versions:
@@ -408,54 +393,25 @@ class FindBugsGolangCli:
             if self.fixed_in_nvrs:
                 compatible = True
             else:
-                if fixed_in_version_go_db != flaw_fixed_in:
-                    if not fixed_in_version_go_db and not flaw_fixed_in:
-                        self._logger.error(f"{flaw_id} - Could not find fixed in versions in go vulnerability "
-                                           "database and bugzilla. Skipping, please investigate")
-                        cve_table.add_row([flaw_id, cve_id, comp_in_title, "NOT FOUND", False])
-                        continue
-                    elif fixed_in_version_go_db and flaw_fixed_in:
-                        self._logger.warning(f"{flaw_id} - Fixed in versions in go vulnerability database and bugzilla do not "
-                                             f"match. Go vulnerability database: {_fmt(fixed_in_version_go_db)}, "
-                                             f"Bugzilla: {_fmt(flaw_fixed_in)}. Skipping, please investigate")
-                        cve_table.add_row([flaw_id, cve_id, comp_in_title, _fmt(flaw_fixed_in), False])
-                        continue
-                    elif not fixed_in_version_go_db and flaw_fixed_in:
-                        self._logger.warning(f"{flaw_id} - Could not find fixed in versions in go vulnerability "
-                                             f"database. Assuming CVE isn't fixed in stdlib. Skipping")
-                        cve_table.add_row([flaw_id, cve_id, comp_in_title, _fmt(flaw_fixed_in), False])
-                        continue
-                    else:
-                        self._logger.warning(f"{flaw_id} - Could not find fixed in versions in bugzilla, but found in go "
-                                             f"vulnerability database: {_fmt(fixed_in_version_go_db)}. Using go "
-                                             "vulnerability database as the source of truth.")
-                        flaw_fixed_in = fixed_in_version_go_db
+                flaw_fixed_in = self.flaw_fixed_in(flaw_bug)
+                if not flaw_fixed_in:
+                    self._logger.error(
+                        f"Could not determine fixed in version for {flaw_id}")
+                    cve_table.add_row([flaw_id, cve_id, comp_in_title, "NOT FOUND", "NOT FOUND"])
+                    continue
 
-                older_fixed_in = set()
                 for fixed_in_version in flaw_fixed_in:
-                    is_fixed_in_ahead = False
                     for go_version in [entry['go_version'] for entry in golang_report]:
                         go_v = Version.parse(go_version)
                         if fixed_in_version.major == go_v.major and fixed_in_version.minor == go_v.minor:
                             compatible = True
-                        if fixed_in_version.major > go_v.major:
-                            is_fixed_in_ahead = True
-                        elif fixed_in_version.major == go_v.major and fixed_in_version.minor > go_v.minor:
-                            is_fixed_in_ahead = True
+                            break
                     if compatible:
                         break
-                    if not is_fixed_in_ahead:
-                        older_fixed_in.add(fixed_in_version)
-
-                if len(older_fixed_in) == len(flaw_fixed_in):
-                    compatible = True
-
             if compatible:
                 self.compatible_cves.add(cve_id)
-            else:
-                logger.warning(f"{cve_id} is not compatible with in-use golang versions for {ocp_version}.")
 
-            cve_table.add_row([flaw_id, cve_id, comp_in_title, _fmt(flaw_fixed_in), compatible])
+            cve_table.add_row([flaw_id, cve_id, comp_in_title, flaw_fixed_in, compatible])
         self._logger.info(f"Found trackers for {len(cves)} CVEs")
         self._logger.info(f"\n{cve_table}")
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-10516

Sometimes we find that bugzilla flaw bugs are missing fixed_in_version CVE metadata. In that case, and
other cases we want to query Go vulnerability database to double the field, and
use it to determine fixed bugs.

Example:
`CVE-2024-24791`
- https://bugzilla.redhat.com/show_bug.cgi?id=2295310 is missing "Fixed in version"  field value
- https://pkg.go.dev/search?q=CVE-2024-24791
- https://vuln.go.dev/ID/GO-2024-2963.json

```
$ ./elliott -g openshift-4.17 find-bugs:golang --analyze

2024-09-02 13:28:04,709 elliottlib.cli.find_bugs_golang_cli INFO Current golang versions being used in 4.17: 
[{'go_version': '1.22.5', 'building_image_count': 244, 'building_rpm_count': 5}, {'go_version': '1.21.11', 
'building_image_count': 2}]
2024-09-02 13:28:04,709 elliottlib.cli.find_bugs_golang_cli INFO Searching for open golang security trackers with target
 version 4.17.0
2024-09-02 13:28:05,429 elliottlib.cli.find_bugs_golang_cli INFO Found 2 bugs
2024-09-02 13:28:05,681 elliottlib.cli.find_bugs_golang_cli INFO Found CVE-2024-24791 in go vulnerability database:
 GO-2024-2963
2024-09-02 13:28:08,208 elliottlib.cli.find_bugs_golang_cli WARNING 2295310 doesn't have valid fixed_in value: 
2024-09-02 13:28:08,208 elliottlib.cli.find_bugs_golang_cli WARNING 2295310 - Could not find fixed in versions in 
bugzilla, but found in go vulnerability database: 1.21.12, 1.22.5. Using go vulnerability database as the source of truth.
2024-09-02 13:28:08,455 elliottlib.cli.find_bugs_golang_cli INFO Found CVE-2023-45290 in go vulnerability database: 
GO-2024-2599
...
```