### PR TITLE
[ART-10504] Doozer: Move some fields from ImageDistGitRepo to ImageMetadata

### DIFF
--- a/artcommon/artcommonlib/build_util.py
+++ b/artcommon/artcommonlib/build_util.py
@@ -46,26 +46,3 @@ def find_latest_builds(brew_builds: Iterable[Dict], assembly: Optional[str]) -> 
         chosen_build = find_latest_build(builds, assembly)
         if chosen_build:
             yield chosen_build
-
-
-def canonical_builders_enabled(canonical_builders_from_upstream, runtime) -> bool:
-    """
-    canonical_builders_from_upstream can be set globally, or overridden by single components; this function will take
-    either a global or a local flag, and check if canonical builders apply within this context
-    """
-
-    if canonical_builders_from_upstream is Missing:
-        # Default case: override using ART's config
-        return False
-
-    elif canonical_builders_from_upstream is True:
-        return True
-
-    elif canonical_builders_from_upstream is False:
-        return False
-
-    else:
-        # Invalid value: fallback to default
-        LOGGER.warning(
-            'Invalid value provided for "canonical_builders_from_upstream": %s', canonical_builders_from_upstream)
-        return False

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -496,6 +496,19 @@ class ImageMetadata(Metadata):
         digest = hashlib.sha256(json.dumps(message, sort_keys=True, default=default).encode("utf-8")).hexdigest()
         return "sha256:" + digest
 
+    @property
+    def canonical_builders_enabled(self) -> bool:
+        """ Returns whether canonical_builders is enabled for this image."""
+        # canonical_builders_from_upstream can be overridden by every single image; if it's not, use the global one
+        if self.config.canonical_builders_from_upstream is not Missing:
+            canonical_builders_from_upstream = self.config.canonical_builders_from_upstream
+        else:
+            canonical_builders_from_upstream = self.runtime.group_config.canonical_builders_from_upstream
+
+        if not isinstance(canonical_builders_from_upstream, bool):
+            self.logger.warning('Invalid value provided for "canonical_builders_from_upstream": %s, defaulting to False', canonical_builders_from_upstream)
+            return False
+        return canonical_builders_from_upstream
     def _default_brew_target(self):
         """ Returns derived brew target name from the distgit branch name
         """

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+from multiprocessing import Event
 from typing import (Any, Dict, List, Optional, Set, Tuple)
 from copy import deepcopy
 
@@ -29,6 +30,10 @@ class ImageMetadata(Metadata):
                 continue
             dependent.dependencies.add(self.distgit_key)
             self.children.append(dependent)
+        self.rebase_event = Event()
+        """ Event that is set when this image is being rebased. """
+        self.rebase_status = False
+        """ True if this image has been successfully rebased. """
         if clone_source:
             runtime.source_resolver.resolve_source(self)
 
@@ -509,6 +514,7 @@ class ImageMetadata(Metadata):
             self.logger.warning('Invalid value provided for "canonical_builders_from_upstream": %s, defaulting to False', canonical_builders_from_upstream)
             return False
         return canonical_builders_from_upstream
+
     def _default_brew_target(self):
         """ Returns derived brew target name from the distgit branch name
         """

--- a/doozer/tests/test_distgit/support.py
+++ b/doozer/tests/test_distgit/support.py
@@ -73,6 +73,13 @@ class MockMetadata(object):
     def get_component_name(self):
         pass
 
+    @property
+    def canonical_builders_enabled(self):
+        return False
+
+    def has_source(self):
+        return True
+
 
 class MockScanner(object):
 

--- a/doozer/tests/test_distgit/test_generic_distgit.py
+++ b/doozer/tests/test_distgit/test_generic_distgit.py
@@ -663,7 +663,7 @@ class TestGenericDistGit(TestDistgit):
 
         self.assertIn(msg, actual)
 
-    @mock.patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
+    @mock.patch('doozerlib.image.ImageMetadata.canonical_builders_enabled', return_value=False)
     def test_add_missing_pkgs_succeed(self, _):
         md = MockMetadata(MockRuntime(self.logger))
         d = distgit.ImageDistGitRepo(md, autoclone=False)
@@ -672,7 +672,7 @@ class TestGenericDistGit(TestDistgit):
         self.assertEqual(1, len(d.runtime.missing_pkgs))
         self.assertIn("distgit_key image is missing package haproxy", d.runtime.missing_pkgs)
 
-    @mock.patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
+    @mock.patch('doozerlib.image.ImageMetadata.canonical_builders_enabled', return_value=False)
     @mock.patch("requests.head")
     def test_cgit_file_available(self, mocked_head, _):
         meta = MockMetadata(MockRuntime(self.logger))

--- a/doozer/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/doozer/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -21,8 +21,7 @@ from ..support import MockScanner, TestDistgit
 
 class TestImageDistGit(TestDistgit):
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
-    def setUp(self, _):
+    def setUp(self):
         super(TestImageDistGit, self).setUp()
         self.img_dg = distgit.ImageDistGitRepo(self.md, autoclone=False)
         self.img_dg.runtime.group_config = Model()
@@ -52,8 +51,7 @@ class TestImageDistGit(TestDistgit):
             get_major_minor_fields=lambda *_, **__: (4, 14)
         )
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
-    def test_clone_invokes_read_master_data(self, _):
+    def test_clone_invokes_read_master_data(self):
         """
         Mocking `clone` method of parent class, since we are only interested
         in validating that `_read_master_data` is called in the child class.
@@ -69,26 +67,26 @@ class TestImageDistGit(TestDistgit):
         metadata = flexmock(runtime=self.mock_runtime(),
                             config=flexmock(distgit=flexmock(branch=distgit.Missing)),
                             name="_irrelevant_",
+                            canonical_builders_enabled=False,
                             logger="_irrelevant_")
 
         (distgit.ImageDistGitRepo(metadata, autoclone=False)
             .clone("distgits_root_dir", "distgit_branch"))
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
-    def test_image_build_method_default(self, _):
+    def test_image_build_method_default(self):
         metadata = flexmock(runtime=self.mock_runtime(group_config=flexmock(default_image_build_method="default-method")),
                             config=flexmock(distgit=flexmock(branch=distgit.Missing),
                                             image_build_method=distgit.Missing,
                                             get=lambda *_: {}),
                             image_build_method="default-method",
+                            canonical_builders_enabled=False,
                             name="_irrelevant_",
                             logger="_irrelevant_")
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
         self.assertEqual("default-method", repo.image_build_method)
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
-    def test_image_build_method_imagebuilder(self, _):
+    def test_image_build_method_imagebuilder(self):
         get = lambda key, default: dict({"builder": "..."}) if key == "from" else default
 
         metadata = flexmock(runtime=self.mock_runtime(group_config=flexmock(default_image_build_method=distgit.Missing)),
@@ -97,6 +95,7 @@ class TestImageDistGit(TestDistgit):
                                             get=get),
                             name="_irrelevant_",
                             image_build_method="osbs2",
+                            canonical_builders_enabled=False,
                             logger="_irrelevant_")
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -108,6 +107,7 @@ class TestImageDistGit(TestDistgit):
                                             get=get),
                             name="_irrelevant_",
                             image_build_method="osbs2",
+                            canonical_builders_enabled=False,
                             logger="_irrelevant_")
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -119,26 +119,26 @@ class TestImageDistGit(TestDistgit):
                                             get=get),
                             name="_irrelevant_",
                             image_build_method="imagebuilder",
+                            canonical_builders_enabled=False,
                             logger="_irrelevant_")
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
         self.assertEqual("imagebuilder", repo.image_build_method)
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
-    def test_image_build_method_from_config(self, _):
+    def test_image_build_method_from_config(self):
         metadata = flexmock(runtime=self.mock_runtime(group_config=flexmock(default_image_build_method="default-method")),
                             config=flexmock(distgit=flexmock(branch=distgit.Missing),
                                             image_build_method="config-method",
                                             get=lambda _, d: d),
                             name="_irrelevant_",
                             image_build_method="config-method",
+                            canonical_builders_enabled=False,
                             logger="_irrelevant_")
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
         self.assertEqual("config-method", repo.image_build_method)
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
-    def test_wait_for_build_with_build_status_true(self, _):
+    def test_wait_for_build_with_build_status_true(self):
         logger = flexmock()
 
         (logger
@@ -156,6 +156,7 @@ class TestImageDistGit(TestDistgit):
         metadata = flexmock(logger=logger,
                             config=flexmock(distgit=flexmock(branch="_irrelevant_")),
                             runtime=self.mock_runtime(),
+                            canonical_builders_enabled=False,
                             name="_irrelevant_")
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -164,12 +165,12 @@ class TestImageDistGit(TestDistgit):
 
         repo.wait_for_build("i-am-waiting")
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
-    def test_wait_for_build_with_build_status_false(self, _):
+    def test_wait_for_build_with_build_status_false(self):
         metadata = flexmock(qualified_name="my-qualified-name",
                             config=flexmock(distgit=flexmock(branch="_irrelevant_")),
                             runtime=self.mock_runtime(),
                             name="_irrelevant_",
+                            canonical_builders_enabled=False,
                             logger=flexmock(info=lambda *_: None))
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -184,8 +185,7 @@ class TestImageDistGit(TestDistgit):
             actual = str(e)
             self.assertEqual(expected, actual)
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
-    def test_push(self, _):
+    def test_push(self):
         # preventing tests from interacting with the real filesystem
         flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
 
@@ -202,6 +202,7 @@ class TestImageDistGit(TestDistgit):
         metadata = flexmock(runtime=self.mock_runtime(global_opts={"rhpkg_push_timeout": 999}),
                             config=flexmock(distgit=flexmock(branch="_irrelevant_")),
                             name="_irrelevant_",
+                            canonical_builders_enabled=False,
                             logger=flexmock(info=lambda *_: None))
 
         expected = (metadata, True)
@@ -209,8 +210,7 @@ class TestImageDistGit(TestDistgit):
 
         self.assertEqual(expected, actual)
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
-    def test_push_with_io_error(self, _):
+    def test_push_with_io_error(self):
         # preventing tests from interacting with the real filesystem
         flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
 
@@ -223,6 +223,7 @@ class TestImageDistGit(TestDistgit):
         metadata = flexmock(runtime=self.mock_runtime(global_opts={"rhpkg_push_timeout": "_irrelevant_"}),
                             config=flexmock(distgit=flexmock(branch="_irrelevant_")),
                             name="_irrelevant_",
+                            canonical_builders_enabled=False,
                             logger=flexmock(info=lambda *_: None))
 
         expected = (metadata, repr(IOError("io-error")))
@@ -612,21 +613,6 @@ COPY --from=builder /some/path/a /some/path/b
         self.assertEqual(actual["remote_sources"][0]["remote_source"]["ref"], "deadbeef")
         self.assertEqual(actual["remote_sources"][0]["remote_source"]["pkg_managers"], ["gomod"])
         self.assertEqual(actual["remote_sources"][0]["remote_source"]["flags"], ["gomod-vendor-check"])
-
-    def test_canonical_builders_enabled(self):
-        # canonical_builders_from_upstream not defined
-        self.img_dg.config.canonical_builders_from_upstream = Missing
-        self.assertEqual(False, self.img_dg._canonical_builders_enabled())
-
-        # canonical_builders_from_upstream = True in group.yml
-        self.img_dg.config.canonical_builders_from_upstream = Missing
-        self.img_dg.runtime.group_config.canonical_builders_from_upstream = True
-        self.assertEqual(True, self.img_dg._canonical_builders_enabled())
-
-        # canonical_builders_from_upstream = False in image config (override)
-        self.img_dg.config.canonical_builders_from_upstream = False
-        self.img_dg.runtime.group_config.canonical_builders_from_upstream = True
-        self.assertEqual(False, self.img_dg._canonical_builders_enabled())
 
     def test_update_image_config(self):
         self.img_dg.metadata = MagicMock()

--- a/doozer/tests/test_distgit/test_image_distgit/test_push_image.py
+++ b/doozer/tests/test_distgit/test_image_distgit/test_push_image.py
@@ -28,13 +28,14 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
             record_logger=Mock()
         )
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
+    @patch('doozerlib.image.ImageMetadata.canonical_builders_enabled', return_value=False)
     def test_push_image_is_late_push(self, _):
         metadata = flexmock(config=flexmock(push=flexmock(late=True),
                                             distgit=flexmock(branch="_irrelevant_")),
                             distgit_key="distgit_key",
                             runtime=self.mock_runtime(),
                             name="_irrelevant_",
+                            canonical_builders_enabled=False,
                             logger=flexmock(info=lambda *_: None))
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -43,7 +44,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
         actual = repo.push_image([], "push_to_defaults")
         self.assertEqual(expected, actual)
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
+    @patch('doozerlib.image.ImageMetadata.canonical_builders_enabled', return_value=False)
     def test_push_image_nothing_to_push(self, _):
         metadata = flexmock(config=flexmock(push=flexmock(late=distgit.Missing),
                                             distgit=flexmock(branch="_irrelevant_")),
@@ -52,6 +53,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                             get_additional_push_names=lambda *_: [],
                             runtime=self.mock_runtime(),
                             name="_irrelevant_",
+                            canonical_builders_enabled=False,
                             logger=flexmock(info=lambda *_: None))
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -61,7 +63,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
         actual = repo.push_image([], push_to_defaults)
         self.assertEqual(expected, actual)
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
+    @patch('doozerlib.image.ImageMetadata.canonical_builders_enabled', return_value=False)
     def test_push_image_to_defaults(self, _):
         # preventing tests from interacting with the real filesystem
         flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
@@ -87,6 +89,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                             get_default_push_names=lambda *_: ["my-default-name"],
                             get_additional_push_names=lambda *_: [],
                             logger=flexmock(info=lambda *_: None),
+                            canonical_builders_enabled=False,
                             namespace="_irrelevant_")
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -99,7 +102,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                                  version_release_tuple=("version", "release"))
         self.assertEqual(expected, actual)
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
+    @patch('doozerlib.image.ImageMetadata.canonical_builders_enabled', return_value=False)
     def test_push_image_without_version_release_tuple(self, _):
         # preventing tests from interacting with the real filesystem
         flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
@@ -126,6 +129,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                             get_default_push_names=lambda *_: ["my-default-name"],
                             get_additional_push_names=lambda *_: [],
                             logger=flexmock(info=lambda *_: None),
+                            canonical_builders_enabled=False,
                             namespace="_irrelevant_")
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -136,7 +140,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
         actual = repo.push_image(tag_list, push_to_defaults)
         self.assertEqual(expected, actual)
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
+    @patch('doozerlib.image.ImageMetadata.canonical_builders_enabled', return_value=False)
     def test_push_image_no_push_tags(self, _):
         # preventing tests from interacting with the real filesystem
         flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
@@ -164,6 +168,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                             get_default_push_names=lambda *_: ["my/default-name"],
                             get_default_push_tags=lambda *_: [],
                             get_additional_push_names=lambda *_: [],
+                            canonical_builders_enabled=False,
                             logger=flexmock(info=lambda *_: None))
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -177,7 +182,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                                  dry_run=True)
         self.assertEqual(expected, actual)
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
+    @patch('doozerlib.image.ImageMetadata.canonical_builders_enabled', return_value=False)
     def test_push_image_dry_run(self, _):
         # preventing tests from interacting with the real filesystem
         flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
@@ -196,6 +201,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
         metadata = flexmock(config=flexmock(push=flexmock(late=distgit.Missing),
                                             name="my-name",
                                             namespace="my-namespace",
+                                            canonical_builders_enabled=False,
                                             distgit=flexmock(branch="_irrelevant_")),
                             runtime=self.mock_runtime(),
                             distgit_key="my-distgit-key",
@@ -203,6 +209,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                             namespace="my-namespace",
                             get_default_push_names=lambda *_: ["my-default-name"],
                             get_additional_push_names=lambda *_: [],
+                            canonical_builders_enabled=False,
                             logger=flexmock(info=lambda *_: None))
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -216,7 +223,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                                  dry_run=True)
         self.assertEqual(expected, actual)
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
+    @patch('doozerlib.image.ImageMetadata.canonical_builders_enabled', return_value=False)
     def test_push_image_without_a_push_config_dir_previously_present(self, _):
         # preventing tests from interacting with the real filesystem
         flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
@@ -242,6 +249,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                             namespace="my-namespace",
                             get_default_push_names=lambda *_: ["my-default-name"],
                             get_additional_push_names=lambda *_: [],
+                            canonical_builders_enabled=False,
                             logger=flexmock(info=lambda *_: None))
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -254,7 +262,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                                  version_release_tuple=("version", "release"))
         self.assertEqual(expected, actual)
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
+    @patch('doozerlib.image.ImageMetadata.canonical_builders_enabled', return_value=False)
     def test_push_image_fail_to_create_a_push_config_dir(self, _):
         # preventing tests from interacting with the real filesystem
         flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
@@ -282,6 +290,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                             namespace="my-namespace",
                             get_default_push_names=lambda *_: ["my-default-name"],
                             get_additional_push_names=lambda *_: [],
+                            canonical_builders_enabled=False,
                             logger=flexmock(info=lambda *_: None))
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -295,7 +304,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                           push_to_defaults,
                           version_release_tuple=version_release_tuple)
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
+    @patch('doozerlib.image.ImageMetadata.canonical_builders_enabled', return_value=False)
     def test_push_image_push_config_dir_already_created_by_another_thread(self, _):
         # preventing tests from interacting with the real filesystem
         flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
@@ -325,6 +334,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                             namespace="my-namespace",
                             get_default_push_names=lambda *_: ["my-default-name"],
                             get_additional_push_names=lambda *_: [],
+                            canonical_builders_enabled=False,
                             logger=flexmock(info=lambda *_: None))
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -337,7 +347,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                                  version_release_tuple=("version", "release"))
         self.assertEqual(expected, actual)
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
+    @patch('doozerlib.image.ImageMetadata.canonical_builders_enabled', return_value=False)
     def test_push_image_to_defaults_fail_mirroring(self, _):
         # preventing tests from interacting with the real filesystem
         flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
@@ -368,6 +378,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                             namespace="my-namespace",
                             get_default_push_names=lambda *_: ["my-default-name"],
                             get_additional_push_names=lambda *_: [],
+                            canonical_builders_enabled=False,
                             logger=flexmock(info=lambda *_: None))
 
         repo = distgit.ImageDistGitRepo(metadata, autoclone=False)
@@ -384,7 +395,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
             expected_msg = "Error pushing image: stderr"
             self.assertEqual(expected_msg, str(e))
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
+    @patch('doozerlib.image.ImageMetadata.canonical_builders_enabled', return_value=False)
     def test_push_image_to_defaults_with_lstate(self, _):
         # preventing tests from interacting with the real filesystem
         flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
@@ -410,6 +421,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                             get_default_push_names=lambda *_: ["my-default-name"],
                             get_additional_push_names=lambda *_: [],
                             logger=flexmock(info=lambda *_: None),
+                            canonical_builders_enabled=False,
                             namespace="_irrelevant_")
 
         metadata.runtime.state = {"images:push": "my-runtime-state"}
@@ -431,7 +443,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                                  version_release_tuple=("version", "release"))
         self.assertEqual(expected, actual)
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
+    @patch('doozerlib.image.ImageMetadata.canonical_builders_enabled', return_value=False)
     def test_push_image_to_defaults_fail_mirroring_with_lstate(self, _):
         # preventing tests from interacting with the real filesystem
         flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
@@ -463,6 +475,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                             namespace="my-namespace",
                             get_default_push_names=lambda *_: ["my-default-name"],
                             get_additional_push_names=lambda *_: [],
+                            canonical_builders_enabled=False,
                             logger=logger)
 
         metadata.runtime.state = {"images:push": "my-runtime-state"}
@@ -498,7 +511,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
         except IOError as e:
             self.assertEqual(expected_msg, str(e))
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
+    @patch('doozerlib.image.ImageMetadata.canonical_builders_enabled', return_value=False)
     def test_push_image_insecure_source(self, _):
         # preventing tests from interacting with the real filesystem
         flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
@@ -529,6 +542,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                             get_default_push_names=lambda *_: ["my-default-name"],
                             get_additional_push_names=lambda *_: [],
                             logger=flexmock(info=lambda *_: None),
+                            canonical_builders_enabled=False,
                             namespace="_irrelevant_")
 
         metadata.runtime.working_dir = "some-workdir"
@@ -544,7 +558,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                                  version_release_tuple=("version", "release"), filter_by_os='amd64')
         self.assertEqual(expected, actual)
 
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled', return_value=False)
+    @patch('doozerlib.image.ImageMetadata.canonical_builders_enabled', return_value=False)
     def test_push_image_registry_config(self, _):
         # preventing tests from interacting with the real filesystem
         flexmock(distgit).should_receive("Dir").and_return(flexmock(__exit__=None))
@@ -576,6 +590,7 @@ class TestImageDistGitRepoPushImage(unittest.TestCase):
                             get_default_push_names=lambda *_: ["my-default-name"],
                             get_additional_push_names=lambda *_: [],
                             logger=flexmock(info=lambda *_: None),
+                            canonical_builders_enabled=False,
                             namespace="_irrelevant_")
 
         metadata.runtime.working_dir = "some-workdir"

--- a/doozer/tests/test_distgit/test_resolve_image_from_upstream_parent.py
+++ b/doozer/tests/test_distgit/test_resolve_image_from_upstream_parent.py
@@ -6,7 +6,7 @@ from .support import TestDistgit
 
 
 class TestResolveImageFromUpstreamParent(TestDistgit):
-    @patch('doozerlib.distgit.ImageDistGitRepo._canonical_builders_enabled')
+    @patch('doozerlib.image.ImageMetadata.canonical_builders_enabled')
     def setUp(self, canonical_mock):
         super().setUp()
         canonical_mock.return_value = False

--- a/doozer/tests/test_metadata.py
+++ b/doozer/tests/test_metadata.py
@@ -6,6 +6,7 @@ import datetime
 from unittest.mock import MagicMock, Mock, patch
 
 from artcommonlib.model import Model
+from doozerlib.image import ImageMetadata
 from doozerlib.metadata import Metadata, CgitAtomFeedEntry, RebuildHintCode
 from doozerlib.brew import BuildStates
 
@@ -32,7 +33,7 @@ class TestMetadata(TestCase):
         koji_mock.listTags = Mock(return_value=[{'name': 'rhaos-4.7-rhel-8-candidate'}])
 
         runtime.assembly = 'hotfix_a'
-        image_meta = Metadata("image", runtime, data_obj)
+        image_meta = ImageMetadata(runtime, data_obj)
         image_meta.logger = Mock()
         image_meta.get_component_name = Mock(return_value='foo-container')
         image_meta.branch_major_minor = Mock(return_value='4.7')


### PR DESCRIPTION
This PR intends to move some fields that are useful for both Distgit-Brew build and Konflux build, so that the rebase status can be shared regardless of the rebase method.