### PR TITLE
[ART-10504]  Update cmd_assert_async and cmd_assert_async in artcommonlib

### DIFF
--- a/doozer/doozerlib/cli/get_nightlies.py
+++ b/doozer/doozerlib/cli/get_nightlies.py
@@ -284,7 +284,7 @@ class Nightly:
         """
         retrieve release_image_info from output of `oc adm release info -o json` for the nightly pullspec.
         """
-        release_json_str, _ = await exectools.cmd_assert_async(f"oc adm release info {self.pullspec} -o=json", retries=3)
+        _, release_json_str, _ = await exectools.cmd_gather_async(f"oc adm release info {self.pullspec} -o=json")
         self.release_image_info = json.loads(release_json_str)
         self._process_nightly_release_data()
 
@@ -338,9 +338,8 @@ class Nightly:
     async def retrieve_image_info_async(self, pullspec: str) -> Model:
         """pull/cache/return json info for a container pullspec (enable concurrency)"""
         if pullspec not in image_info_cache:
-            image_json_str, _ = await exectools.cmd_assert_async(
+            _, image_json_str, _ = await exectools.cmd_gather_async(
                 f"oc image info {pullspec} -o=json --filter-by-os=amd64",
-                retries=3
             )
             image_info_cache[pullspec] = Model(json.loads(image_json_str))
         return image_info_cache[pullspec]

--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -234,7 +234,7 @@ class GenAssemblyCli:
     async def _process_release(self, brew_cpu_arch, pullspec, rhcos_tag_names):
         self.runtime.logger.info(f'Processing release: {pullspec}')
 
-        release_json_str, _ = await exectools.cmd_assert_async(f'oc adm release info {pullspec} -o=json', retries=3)
+        _, release_json_str, _ = await exectools.cmd_gather_async(f'oc adm release info {pullspec} -o=json')
         release_info = Model(dict_to_model=json.loads(release_json_str))
 
         if not release_info.references.spec.tags:

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -820,7 +820,7 @@ class GenPayloadCli:
         if self.apply or self.apply_multi_arch:
             self.logger.info(f"Mirroring images from {str(src_dest_path)}")
             await asyncio.wait_for(exectools.cmd_assert_async(
-                f"oc image mirror --keep-manifest-list --filename={str(src_dest_path)}", retries=3), timeout=7200)
+                f"oc image mirror --keep-manifest-list --filename={str(src_dest_path)}"), timeout=7200)
 
     async def generate_specific_payload_imagestreams(self, arch: str, private_mode: bool,
                                                      payload_entries: Dict[str, PayloadEntry],
@@ -1162,7 +1162,7 @@ class GenPayloadCli:
             auth_file = os.path.expandvars("${XDG_RUNTIME_DIR}/containers/auth.json")
             if Path(auth_file).is_file():
                 auth_opt = f"--docker-cfg={auth_file}"
-        await exectools.cmd_assert_async(f"manifest-tool {auth_opt} push from-spec {str(component_manifest_path)}", retries=3)
+        await exectools.cmd_assert_async(f"manifest-tool {auth_opt} push from-spec {str(component_manifest_path)}")
 
         # we are pushing a new manifest list, so return its sha256 based pullspec
         sha = await find_manifest_list_sha(output_pullspec)
@@ -1824,7 +1824,7 @@ class PayloadGenerator:
         rc = -1
         pullspec = f"registry.ci.openshift.org/ocp{rc_suffix}/release{rc_suffix}:{nightly}"
         while retries > 0:
-            rc, release_json_str, err = await exectools.cmd_gather_async(f"oc adm release info {pullspec} -o=json")
+            rc, release_json_str, err = await exectools.cmd_gather_async(f"oc adm release info {pullspec} -o=json", check=False)
             if rc == 0:
                 break
             runtime.logger.warn(f"Error accessing nightly release info for {pullspec}:  {err}")

--- a/doozer/doozerlib/cli/scan_fips.py
+++ b/doozer/doozerlib/cli/scan_fips.py
@@ -70,7 +70,7 @@ class ScanFipsCli:
         cmd = self.make_command(f"check-payload -V {self.runtime.group.split('-')[-1]} scan image --spec {pull_spec}")
 
         self.runtime.logger.info(f"Running check-payload command: {cmd}")
-        rc_scan, out_scan, _ = await cmd_gather_async(cmd)
+        rc_scan, out_scan, _ = await cmd_gather_async(cmd, check=False)
 
         await self.clean_image(nvr, pull_spec)
 
@@ -80,7 +80,7 @@ class ScanFipsCli:
         return "sudo " + cmd if not self.is_root else cmd
 
     async def am_i_root(self):
-        rc, out, _ = await cmd_gather_async("whoami")
+        rc, out, _ = await cmd_gather_async("whoami", check=False)
         self.runtime.logger.info(f"Running as user {out}")
         return rc == 0 and "root" in out
 

--- a/doozer/doozerlib/cli/scan_osh.py
+++ b/doozer/doozerlib/cli/scan_osh.py
@@ -102,7 +102,7 @@ class ScanOshCli:
 
         @exectools.limit_concurrency(16)
         async def run_get_untriggered_nvrs(nvr):
-            rc, _, _ = await exectools.cmd_gather_async(f"osh-cli find-tasks --nvr {nvr}")
+            rc, _, _ = await exectools.cmd_gather_async(f"osh-cli find-tasks --nvr {nvr}", check=False)
 
             return None if rc == 0 else nvr
 

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -408,7 +408,7 @@ class DistGitRepo(object):
         # time, a single push invocation can take hours to complete -- making the
         # timeout value counterproductive. Limit to 5 simultaneous pushes.
         timeout = str(self.runtime.global_opts['rhpkg_push_timeout'])
-        await exectools.cmd_assert_async(["timeout", f"{timeout}", "git", "push", "--follow-tags"], cwd=self.distgit_dir, retries=3)
+        await exectools.cmd_assert_async(["timeout", f"{timeout}", "git", "push", "--follow-tags"], cwd=self.distgit_dir)
 
     def get_branch_el(self) -> Optional[int]:
         """
@@ -2748,8 +2748,8 @@ class RPMDistGitRepo(DistGitRepo):
 
         async def _get_nvr():
             cmd = ["rpmspec", "-q", "--qf", "%{name}-%{version}-%{release}", "--srpm", "--undefine", "dist", "--", spec_path]
-            out, _ = await exectools.cmd_assert_async(cmd, strip=True)
-            return out.rsplit("-", 2)
+            _, out, _ = await exectools.cmd_gather_async(cmd)
+            return out.strip().rsplit("-", 2)
 
         async def _get_commit():
             async with aiofiles.open(spec_path, "r") as f:

--- a/doozer/tests/test_distgit/test_rpm_distgit.py
+++ b/doozer/tests/test_distgit/test_rpm_distgit.py
@@ -16,7 +16,7 @@ class TestRPMDistGit(TestDistgit):
         self.rpm_dg.runtime.group_config = Model()
 
     @patch("aiofiles.open")
-    @patch("doozerlib.distgit.exectools.cmd_assert_async", return_value=("foo-1.2.3-1", ""))
+    @patch("doozerlib.distgit.exectools.cmd_gather_async", return_value=(0, "foo-1.2.3-1", ""))
     @patch("glob.glob", return_value=["/path/to/distgit/foo.spec"])
     async def test_resolve_specfile_async(self, mocked_glob: Mock, mocked_cmd_assert_async: Mock, mocked_open: Mock):
         self.rpm_dg.distgit_dir = "/path/to/distgit"
@@ -29,7 +29,7 @@ class TestRPMDistGit(TestDistgit):
         mocked_glob.assert_called_once_with(self.rpm_dg.distgit_dir + "/*.spec")
         mocked_cmd_assert_async.assert_called_once_with(
             ["rpmspec", "-q", "--qf", "%{name}-%{version}-%{release}",
-                "--srpm", "--undefine", "dist", "--", Path("/path/to/distgit/foo.spec")], strip=True)
+                "--srpm", "--undefine", "dist", "--", Path("/path/to/distgit/foo.spec")])
 
 
 if __name__ == "__main__":

--- a/pyartcd/pyartcd/git.py
+++ b/pyartcd/pyartcd/git.py
@@ -3,14 +3,15 @@
 from logging import getLogger
 from pathlib import Path
 import os
+from typing import Union
 
-from pyartcd import StrOrBytesPath, exectools
+from artcommonlib import exectools
 
 LOGGER = getLogger(__name__)
 
 
 class GitRepository:
-    def __init__(self, directory: StrOrBytesPath, dry_run: bool = False) -> None:
+    def __init__(self, directory: Union[str, Path], dry_run: bool = False) -> None:
         self._directory = Path(directory)
         self._dry_run = dry_run
 

--- a/pyartcd/pyartcd/oc.py
+++ b/pyartcd/pyartcd/oc.py
@@ -5,7 +5,7 @@ import openshift_client as octool
 from typing import List, Optional
 from tenacity import retry, stop_after_attempt
 
-from pyartcd import exectools
+from artcommonlib import exectools
 from pyartcd.runtime import Runtime
 
 

--- a/pyartcd/pyartcd/pipelines/advisory_drop.py
+++ b/pyartcd/pyartcd/pipelines/advisory_drop.py
@@ -1,7 +1,7 @@
 import click
 import os
 from pyartcd.runtime import Runtime
-from pyartcd import exectools
+from artcommonlib import exectools
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 
 

--- a/pyartcd/pyartcd/pipelines/brew_scan_osh.py
+++ b/pyartcd/pyartcd/pipelines/brew_scan_osh.py
@@ -3,7 +3,7 @@ This job scans the candidate tags for a particular version, and triggers scans f
 """
 import click
 from typing import Optional
-from pyartcd import exectools
+from artcommonlib import exectools
 from artcommonlib import redis
 from pyartcd.runtime import Runtime
 from pyartcd.cli import cli, pass_runtime, click_coroutine

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -16,13 +16,14 @@ from artcommonlib.arch_util import brew_arch_for_go_arch
 from artcommonlib.assembly import AssemblyTypes
 from artcommonlib.util import get_ocp_version_from_group, isolate_major_minor_in_group
 from artcommonlib.release_util import isolate_assembly_in_release
+from artcommonlib import exectools
 from doozerlib.util import isolate_nightly_name_components
 from ghapi.all import GhApi
 from ruamel.yaml import YAML
 from semver import VersionInfo
 from tenacity import retry, stop_after_attempt, wait_fixed
 
-from pyartcd import constants, exectools, oc, util, jenkins
+from pyartcd import constants, oc, util, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.git import GitRepository
 from pyartcd.record import parse_record_log

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -12,12 +12,14 @@ from artcommonlib.arch_util import go_suffix_for_arch
 from artcommonlib.exectools import limit_concurrency
 from artcommonlib.release_util import SoftwareLifecyclePhase
 from artcommonlib.util import split_git_url
+from artcommonlib import exectools
 from pyartcd.cli import cli, pass_runtime, click_coroutine
 from pyartcd.oc import registry_login
 from artcommonlib.redis import RedisError
 from pyartcd.runtime import Runtime, GroupRuntime
-from pyartcd import exectools, constants, locks
 from artcommonlib.telemetry import start_as_current_span_async
+from pyartcd import constants, locks
+from artcommonlib import exectools
 from pyartcd.util import branch_arches
 from pyartcd.jenkins import get_build_url
 from ghapi.all import GhApi

--- a/pyartcd/pyartcd/pipelines/check_bugs.py
+++ b/pyartcd/pyartcd/pipelines/check_bugs.py
@@ -2,7 +2,8 @@ import asyncio
 
 import click
 
-from pyartcd import exectools, util
+from artcommonlib import exectools
+from pyartcd import util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.constants import OCP_BUILD_DATA_URL
 from pyartcd.runtime import Runtime

--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -13,8 +13,9 @@ from ghapi.all import GhApi
 from ruamel.yaml import YAML
 
 from artcommonlib.util import split_git_url, merge_objects, get_inflight, isolate_major_minor_in_group
+from artcommonlib import exectools
 from doozerlib.cli.get_nightlies import rc_api_url
-from pyartcd import exectools, constants, jenkins
+from pyartcd import constants, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.git import GitRepository
 from pyartcd.jenkins import start_build_sync

--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -1,5 +1,6 @@
 import click
-from pyartcd import util, exectools
+from artcommonlib import exectools
+from pyartcd import util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.runtime import Runtime
 

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -9,7 +9,7 @@ import yaml
 from pyartcd import locks
 from pyartcd import util
 from pyartcd import plashets
-from pyartcd import exectools
+from artcommonlib import exectools
 from pyartcd import constants
 from pyartcd import jenkins
 from pyartcd import record as record_util

--- a/pyartcd/pyartcd/pipelines/ocp4_scan.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan.py
@@ -4,7 +4,8 @@ import yaml
 
 import click
 
-from pyartcd import constants, exectools, util, locks
+from artcommonlib import exectools
+from pyartcd import constants, util, locks
 from pyartcd import jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.locks import Lock

--- a/pyartcd/pyartcd/pipelines/olm_bundle.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle.py
@@ -3,7 +3,8 @@ import os
 import click
 from aioredlock import LockError
 
-from pyartcd import constants, exectools, jenkins
+from artcommonlib import exectools
+from pyartcd import constants, jenkins
 from pyartcd.cli import cli, pass_runtime, click_coroutine
 from pyartcd import locks
 from pyartcd.locks import Lock

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -24,7 +24,7 @@ from artcommonlib.util import get_assembly_release_date
 from elliottlib.errata import set_blocking_advisory, get_blocking_advisories, push_cdn_stage, is_advisory_editable
 from elliottlib.errata_async import AsyncErrataAPI
 from elliottlib.errata import set_blocking_advisory, get_blocking_advisories
-from pyartcd import exectools
+from artcommonlib import exectools
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.jira import JIRAClient
 from pyartcd.slack import SlackClient

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -31,7 +31,8 @@ from artcommonlib.util import isolate_major_minor_in_group
 from pyartcd.locks import Lock
 from pyartcd.signatory import AsyncSignatory, SigstoreSignatory
 from pyartcd.util import nightlies_with_pullspecs
-from pyartcd import constants, exectools, locks, util, jenkins
+from pyartcd import constants, locks, util, jenkins
+from artcommonlib import exectools
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from artcommonlib.exceptions import VerificationError
 from pyartcd.jira import JIRAClient

--- a/pyartcd/pyartcd/pipelines/rebuild.py
+++ b/pyartcd/pyartcd/pipelines/rebuild.py
@@ -15,7 +15,8 @@ import yaml
 
 from artcommonlib.assembly import AssemblyTypes
 from artcommonlib.util import get_ocp_version_from_group
-from pyartcd import constants, exectools, locks, jenkins
+from pyartcd import constants, locks, jenkins
+from artcommonlib import exectools
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.record import parse_record_log
 from pyartcd.runtime import Runtime

--- a/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py
+++ b/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py
@@ -9,7 +9,7 @@ from specfile import Specfile
 
 from artcommonlib.constants import BREW_HUB
 from artcommonlib.rpm_utils import parse_nvr
-from pyartcd import exectools
+from artcommonlib import exectools
 from pyartcd import constants
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.runtime import Runtime

--- a/pyartcd/pyartcd/pipelines/review_cvp.py
+++ b/pyartcd/pyartcd/pipelines/review_cvp.py
@@ -7,7 +7,8 @@ from typing import Dict
 
 import click
 from ghapi.all import GhApi
-from pyartcd import exectools, jenkins, constants
+from artcommonlib import exectools
+from pyartcd import jenkins, constants
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.git import GitRepository
 from pyartcd.runtime import Runtime

--- a/pyartcd/pyartcd/pipelines/scan_fips.py
+++ b/pyartcd/pyartcd/pipelines/scan_fips.py
@@ -9,8 +9,8 @@ import click
 from typing import Optional
 from pyartcd.runtime import Runtime
 from pyartcd.cli import cli, pass_runtime, click_coroutine
-from pyartcd import exectools
 from artcommonlib.constants import ACTIVE_OCP_VERSIONS
+from artcommonlib import exectools
 
 
 class ScanFips:

--- a/pyartcd/pyartcd/pipelines/scan_for_kernel_bugs.py
+++ b/pyartcd/pyartcd/pipelines/scan_for_kernel_bugs.py
@@ -5,7 +5,8 @@ from typing import Optional, Tuple
 
 import click
 
-from pyartcd import constants, exectools
+from artcommonlib import exectools
+from pyartcd import constants
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.runtime import Runtime
 

--- a/pyartcd/pyartcd/pipelines/sigstore_sign.py
+++ b/pyartcd/pyartcd/pipelines/sigstore_sign.py
@@ -6,8 +6,9 @@ import click
 from typing import Dict, List, Optional, Union, Set
 from semver import VersionInfo
 
+from artcommonlib import exectools
 from pyartcd.signatory import SigstoreSignatory
-from pyartcd import constants, exectools, util
+from pyartcd import constants, util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.runtime import Runtime, GroupRuntime
 

--- a/pyartcd/pyartcd/pipelines/tag_rpms.py
+++ b/pyartcd/pyartcd/pipelines/tag_rpms.py
@@ -8,7 +8,8 @@ import click
 
 from artcommonlib import redis
 from artcommonlib.util import isolate_major_minor_in_group
-from pyartcd import constants, exectools
+from artcommonlib import exectools
+from pyartcd import constants
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.jenkins import get_build_url
 from pyartcd.runtime import Runtime

--- a/pyartcd/pyartcd/pipelines/tarball_sources.py
+++ b/pyartcd/pyartcd/pipelines/tarball_sources.py
@@ -5,7 +5,8 @@ from urllib.parse import quote, urljoin, urlparse
 
 import click
 
-from pyartcd import constants, exectools, util
+from artcommonlib import exectools
+from pyartcd import constants, util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.runtime import Runtime
 from pyartcd.util import kinit

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -12,7 +12,7 @@ from ruamel.yaml import YAML
 from artcommonlib.constants import BREW_HUB
 from artcommonlib.release_util import split_el_suffix_in_release
 from artcommonlib.rpm_utils import parse_nvr
-from pyartcd import exectools
+from artcommonlib import exectools
 from pyartcd import jenkins
 from pyartcd.constants import GITHUB_OWNER
 from pyartcd.cli import cli, click_coroutine, pass_runtime

--- a/pyartcd/pyartcd/plashets.py
+++ b/pyartcd/pyartcd/plashets.py
@@ -6,7 +6,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Sequence, Optional, Tuple
 
-from pyartcd import exectools, constants, util
+from artcommonlib import exectools
+
+from pyartcd import constants, util
 from pyartcd.constants import PLASHET_REMOTES
 
 working_dir = "plashet-working"

--- a/pyartcd/pyartcd/s3.py
+++ b/pyartcd/pyartcd/s3.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from typing import Optional
-from pyartcd import exectools
+from artcommonlib import exectools
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 

--- a/pyartcd/pyartcd/signatory.py
+++ b/pyartcd/pyartcd/signatory.py
@@ -17,7 +17,7 @@ import aiofiles
 from cryptography import x509
 from cryptography.x509.oid import NameOID
 
-from pyartcd import exectools
+from artcommonlib import exectools
 from pyartcd.exceptions import SignatoryServerError
 from pyartcd.umb_client import AsyncUMBClient
 from pyartcd.oc import get_release_image_info, get_image_info

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -11,6 +11,7 @@ from typing import Dict, Optional, Union, Iterable
 import yaml
 
 import artcommonlib
+from artcommonlib import exectools
 from artcommonlib.arch_util import go_suffix_for_arch
 from artcommonlib.assembly import assembly_type
 from artcommonlib.model import Model
@@ -18,7 +19,7 @@ from artcommonlib.release_util import SoftwareLifecyclePhase
 from doozerlib import util as doozerutil
 from errata_tool import ErrataConnector
 
-from pyartcd import exectools, constants, jenkins, record
+from pyartcd import constants, jenkins, record
 from pyartcd.mail import MailService
 
 logger = logging.getLogger(__name__)

--- a/pyartcd/tests/pipelines/test_gen_assembly.py
+++ b/pyartcd/tests/pipelines/test_gen_assembly.py
@@ -8,7 +8,7 @@ from pyartcd.pipelines.gen_assembly import GenAssemblyPipeline
 
 
 class TestGenAssemblyPipeline(IsolatedAsyncioTestCase):
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "a b c", ""))
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "a b c", ""))
     def test_get_nightlies(self, cmd_gather_async: AsyncMock):
         runtime = MagicMock()
         pipeline = GenAssemblyPipeline(runtime, "openshift-4.12", "4.12.99", "https://example.com/ocp-build-data.git",
@@ -42,7 +42,7 @@ class TestGenAssemblyPipeline(IsolatedAsyncioTestCase):
              'get-nightlies', '--allow-pending', '--allow-rejected', '--allow-inconsistency', '--matching=n1',
              '--matching=n2'], stderr=None, env=ANY)
 
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True)
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True)
     def test_gen_assembly_from_releases(self, cmd_gather_async: AsyncMock):
         runtime = MagicMock()
         pipeline = GenAssemblyPipeline(runtime, "openshift-4.12", "4.12.99", "https://example.com/ocp-build-data.git",

--- a/pyartcd/tests/pipelines/test_ocp4.py
+++ b/pyartcd/tests/pipelines/test_ocp4.py
@@ -34,7 +34,7 @@ class TestInitialBuildPlan(unittest.IsolatedAsyncioTestCase):
             comment_on_pr=False
         )
 
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
     async def test_initial_build_plan(self, _):
         await self.ocp4._initialize_build_plan()
 
@@ -48,7 +48,7 @@ class TestInitialBuildPlan(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.ocp4.build_plan.images_included, [])
         self.assertEqual(self.ocp4.build_plan.images_excluded, [])
 
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
     async def test_initial_build_plan_no_images_no_rpms(self, _):
         self.ocp4.build_rpms = 'none'
         self.ocp4.build_images = 'none'
@@ -58,7 +58,7 @@ class TestInitialBuildPlan(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.ocp4.build_plan.build_rpms, False)
         self.assertEqual(self.ocp4.build_plan.build_images, False)
 
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
     async def test_initial_build_plan_include_rpm_list(self, _):
         # RPM list not allowed when build_rpms == "all"
         self.ocp4.rpm_list = 'rpm1, rpm2'
@@ -71,7 +71,7 @@ class TestInitialBuildPlan(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.ocp4.build_plan.rpms_included, ['rpm1', 'rpm2'])
         self.assertEqual(self.ocp4.build_plan.rpms_excluded, [])
 
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
     async def test_initial_build_plan_exclude_rpm_list(self, _):
         # RPM list not allowed when build_rpms == "all"
         self.ocp4.rpm_list = 'rpm1, rpm2'
@@ -84,7 +84,7 @@ class TestInitialBuildPlan(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.ocp4.build_plan.rpms_included, [])
         self.assertEqual(self.ocp4.build_plan.rpms_excluded, ['rpm1', 'rpm2'])
 
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
     async def test_initial_build_plan_include_image_list(self, _):
         # Image list not allowed when build_images == "all"
         self.ocp4.image_list = 'image1, image2'
@@ -97,7 +97,7 @@ class TestInitialBuildPlan(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.ocp4.build_plan.images_included, ['image1', 'image2'])
         self.assertEqual(self.ocp4.build_plan.images_excluded, [])
 
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
     async def test_initial_build_plan_exclude_image_list(self, _):
         # Image list not allowed when build_images == "all"
         self.ocp4.image_list = 'image1, image2'
@@ -116,7 +116,7 @@ class TestPlannedBuilds(unittest.IsolatedAsyncioTestCase):
         super().__init__(*args, **kwargs)
         self.ocp4: ocp4.Ocp4Pipeline = self.default_ocp4_pipeline()
 
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
     def setUp(self, *_) -> None:
         self.ocp4 = self.default_ocp4_pipeline()
         asyncio.get_event_loop().run_until_complete(self.ocp4._initialize_build_plan())
@@ -154,7 +154,7 @@ class TestPlannedBuilds(unittest.IsolatedAsyncioTestCase):
 
     @patch("pyartcd.jenkins.update_description")
     @patch("pyartcd.jenkins.update_title")
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
     async def test_check_changed_rpms(self, *_):
         await self.ocp4._initialize_build_plan()
         self.assertTrue(self.ocp4.build_plan.build_rpms)
@@ -272,7 +272,7 @@ class TestPlannedBuilds(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(children, [])
 
     @patch("pyartcd.jenkins.update_description")
-    @patch("pyartcd.exectools.cmd_gather_async")
+    @patch("artcommonlib.exectools.cmd_gather_async")
     async def test_check_changed_child_images(self, cmd_gather_mock, _):
         cmd_gather_mock.return_value = (0, 'image1:\n  child1:\n    child2: {}\nimage2:\n  child3: {}', '')
         changes = {'images': ['image1']}
@@ -306,7 +306,7 @@ class TestPlannedBuilds(unittest.IsolatedAsyncioTestCase):
 
     @patch("pyartcd.jenkins.update_description")
     @patch("pyartcd.jenkins.update_title")
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True,
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True,
            return_value=(0, 'image1:\n  child1:\n    child2: {}\nimage2:\n  child3: {}', ''))
     async def test_check_changed_images(self, *_):
         # Do not build images, images changed
@@ -355,7 +355,7 @@ class TestInitialize(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.ocp4 = self.default_ocp4_pipeline()
 
-    @patch("pyartcd.exectools.cmd_gather_async")
+    @patch("artcommonlib.exectools.cmd_gather_async")
     async def test_check_assembly(self, cmd_gather_async_mock):
         # Assemblies enabled, assembly = 'stream': no exception
         cmd_gather_async_mock.return_value = (0, 'True', '')
@@ -378,7 +378,7 @@ class TestInitialize(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(RuntimeError):
             await self.ocp4._check_assembly()
 
-    @patch("pyartcd.exectools.cmd_gather_async", return_value=(0, 'rhaos-4.12-rhel-8', ''))
+    @patch("artcommonlib.exectools.cmd_gather_async", return_value=(0, 'rhaos-4.12-rhel-8', ''))
     @patch("pyartcd.jenkins.update_title")
     async def test_initialize_version(self, *_):
 
@@ -403,7 +403,7 @@ class TestInitialize(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.ocp4.version.major, 4)
         self.assertEqual(self.ocp4.version.minor, 14)
 
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
     async def test_initialize_build_plan_default(self, *_):
         # Default ocp4 pipeline
         await self.ocp4._initialize_build_plan()
@@ -411,7 +411,7 @@ class TestInitialize(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.ocp4.build_plan.build_images, True)
         self.assertEqual(self.ocp4.build_plan.build_rpms, True)
 
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
     async def test_initialize_build_plan_no_images_no_rpms(self, *_):
         # No images, rpms
         self.ocp4.build_images = 'none'
@@ -420,7 +420,7 @@ class TestInitialize(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.ocp4.build_plan.build_images, False)
         self.assertEqual(self.ocp4.build_plan.build_rpms, False)
 
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
     async def test_initialize_build_plan_include_images_rpms(self, *_):
         # Include images/rpms, empty lists
         self.ocp4.build_images = 'only'
@@ -441,7 +441,7 @@ class TestInitialize(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.ocp4.build_plan.images_excluded, [])
         self.assertEqual(self.ocp4.build_plan.rpms_excluded, [])
 
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "219 images", ""))
     async def test_initialize_build_plan_exclude_images_rpms(self, *_):
         # Exclude images/rpms, empty lists
         self.ocp4.build_images = 'except'
@@ -500,8 +500,8 @@ class TestBuilds(unittest.IsolatedAsyncioTestCase):
     @patch("shutil.rmtree")
     @patch("pyartcd.jenkins.update_title")
     @patch("pyartcd.util.default_release_suffix", return_value="2100123111.p?")
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "rhaos-4.13-rhel-8", ""))
-    @patch("pyartcd.exectools.cmd_assert_async")
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "rhaos-4.13-rhel-8", ""))
+    @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_build_rpms(self, cmd_assert_mock: AsyncMock, *_):
         await self.ocp4._initialize_version()
 
@@ -545,11 +545,11 @@ class TestBuilds(unittest.IsolatedAsyncioTestCase):
     @patch("pyartcd.jenkins.update_title")
     @patch("pyartcd.jenkins.update_description")
     @patch("pyartcd.util.default_release_suffix", return_value="2100123111.p?")
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "rhaos-4.13-rhel-8", ""))
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "rhaos-4.13-rhel-8", ""))
     @patch("pyartcd.util.load_group_config", return_value={'software_lifecycle': {'phase': 'release'}})
     @patch("pyartcd.oc.registry_login")
     @patch("pyartcd.record.parse_record_log")
-    @patch("pyartcd.exectools.cmd_assert_async")
+    @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_build_and_rebase_images(self, cmd_assert_mock: AsyncMock, parse_record_log_mock, registry_login_mock, *_):
         parse_record_log_mock.return_value = {}
         await self.ocp4._initialize_version()
@@ -623,9 +623,9 @@ class TestBuilds(unittest.IsolatedAsyncioTestCase):
     @patch("pyartcd.jenkins.update_title")
     @patch("pyartcd.jenkins.update_description")
     @patch("pyartcd.util.default_release_suffix", return_value="2100123111.p?")
-    @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "rhaos-4.13-rhel-8", ""))
+    @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "rhaos-4.13-rhel-8", ""))
     @patch("pyartcd.util.load_group_config", return_value={'software_lifecycle': {'phase': 'release'}})
-    @patch("pyartcd.exectools.cmd_assert_async")
+    @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_mass_rebuild(self, cmd_assert_async_mock: AsyncMock, *_):
         # Build plan includes more than half of the images: it's a mass rebuild
         self.ocp4.build_plan.build_images = True
@@ -795,7 +795,7 @@ class TestUpdateDistgit(unittest.IsolatedAsyncioTestCase):
     @patch("os.path.abspath", return_value='doozer_working')
     @patch("pyartcd.util.notify_dockerfile_reconciliations")
     @patch("pyartcd.util.notify_bz_info_missing")
-    @patch("pyartcd.exectools.cmd_assert_async")
+    @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_update_distgit(self, cmd_assert_mock: AsyncMock, bz_info_missing_mock, reconciliations_mock, *_):
         pipeline = ocp4.Ocp4Pipeline(
             runtime=MagicMock(dry_run=False),

--- a/pyartcd/tests/pipelines/test_rebuild.py
+++ b/pyartcd/tests/pipelines/test_rebuild.py
@@ -9,7 +9,7 @@ from pyartcd.pipelines.rebuild import (PlashetBuildResult, RebuildPipeline, Rebu
 
 
 class TestRebuildPipeline(IsolatedAsyncioTestCase):
-    @patch("pyartcd.exectools.cmd_gather_async")
+    @patch("artcommonlib.exectools.cmd_gather_async")
     def test_ocp_build_data_url(self, cmd_gather_async: Mock):
         runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, dry_run=False)
         fork_url = 'https://fork.com/ocp-build-data-fork.git'
@@ -22,7 +22,7 @@ class TestRebuildPipeline(IsolatedAsyncioTestCase):
     @patch("pathlib.Path.mkdir")
     @patch("pathlib.Path.exists", return_value=True)
     @patch("shutil.rmtree")
-    @patch("pyartcd.exectools.cmd_assert_async")
+    @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_build_plashet_from_tags(self, cmd_assert_async: AsyncMock, rmtree: Mock, path_exists: Mock, path_mkdir: Mock):
         runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
         pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
@@ -40,7 +40,7 @@ class TestRebuildPipeline(IsolatedAsyncioTestCase):
     @patch("pathlib.Path.mkdir")
     @patch("pathlib.Path.exists", return_value=True)
     @patch("shutil.rmtree")
-    @patch("pyartcd.exectools.cmd_assert_async")
+    @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_build_plashet_for_assembly_rhcos(self, cmd_assert_async: AsyncMock, rmtree: Mock, path_exists: Mock, path_mkdir: Mock):
         runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
         pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
@@ -56,7 +56,7 @@ class TestRebuildPipeline(IsolatedAsyncioTestCase):
     @patch("pathlib.Path.mkdir")
     @patch("pathlib.Path.exists", return_value=True)
     @patch("shutil.rmtree")
-    @patch("pyartcd.exectools.cmd_assert_async")
+    @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_build_plashet_for_assembly_image(self, cmd_assert_async: AsyncMock, rmtree: Mock, path_exists: Mock, path_mkdir: Mock):
         runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
         pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
@@ -69,7 +69,7 @@ class TestRebuildPipeline(IsolatedAsyncioTestCase):
         rmtree.assert_called_once_with(expected_local_dir)
         path_mkdir.assert_called_once_with(parents=True, exist_ok=True)
 
-    @patch("pyartcd.exectools.cmd_assert_async")
+    @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_copy_plashet_out_to_remote(self, cmd_assert_async: AsyncMock):
         runtime = MagicMock(dry_run=False)
         pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
@@ -218,7 +218,7 @@ priority = 1
         """.strip()
         self.assertEqual(out_file.getvalue().strip(), expected)
 
-    @patch("pyartcd.exectools.cmd_gather_async")
+    @patch("artcommonlib.exectools.cmd_gather_async")
     async def test_get_meta_config(self, cmd_gather_async: Mock):
         runtime = MagicMock(dry_run=False)
         pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
@@ -231,7 +231,7 @@ images:
         actual = await pipeline._get_meta_config()
         self.assertEqual(actual, {"some_key": "some_value"})
 
-    @patch("pyartcd.exectools.cmd_assert_async")
+    @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_rebase_image(self, cmd_assert_async: Mock):
         runtime = MagicMock(dry_run=False)
         pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
@@ -243,7 +243,7 @@ images:
         await pipeline._rebase_image("202107160000.p?")
 
     @patch("builtins.open")
-    @patch("pyartcd.exectools.cmd_assert_async")
+    @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_build_image(self, cmd_assert_async: Mock, open: Mock):
         runtime = MagicMock(dry_run=False, working_dir=Path("/path/to/working"))
         pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],
@@ -260,7 +260,7 @@ images:
         self.assertEqual(nvrs, [])
 
     @patch("builtins.open")
-    @patch("pyartcd.exectools.cmd_assert_async")
+    @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_rebase_and_build_rpm(self, cmd_assert_async: Mock, open: Mock):
         runtime = MagicMock(dry_run=False, working_dir=Path("/path/to/working"))
         pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", plashet_remote=constants.PLASHET_REMOTES[0],

--- a/pyartcd/tests/pipelines/test_tarball_sources.py
+++ b/pyartcd/tests/pipelines/test_tarball_sources.py
@@ -5,7 +5,7 @@ from pyartcd.pipelines.tarball_sources import TarballSourcesPipeline
 
 
 class TestTarballSourcesPipeline(IsolatedAsyncioTestCase):
-    @patch("pyartcd.exectools.cmd_gather_async")
+    @patch("artcommonlib.exectools.cmd_gather_async")
     async def test_create_tarball_sources(self, cmd_gather_async: Mock):
         cmd_gather_async.return_value = (0, """
 Created tarball source /mnt/nfs/home/jenkins/yuxzhu/OSE-4.6-RHEL-8/84693/release/logging-fluentd-container-v4.6.0-202111191944.p0.gf73a1dd.assembly.stream.tar.gz.
@@ -26,7 +26,7 @@ OSE-4.6-RHEL-8/84693/release/logging-fluentd-container-v4.6.0-202111191944.p0.gf
         actual = await pipeline._create_tarball_sources([10000, 10001], "fake-working/sources")
         self.assertEqual(actual, expected)
 
-    @patch("pyartcd.exectools.cmd_assert_async")
+    @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_copy_to_rcm_guest(self, cmd_assert_async: AsyncMock):
         cmd_assert_async.return_value = (0, "whatever", "whatever")
         pipeline = TarballSourcesPipeline(MagicMock(dry_run=False), "fake-group-4.10", "fake-assembly", ["fake-component"], [])

--- a/pyartcd/tests/test_util.py
+++ b/pyartcd/tests/test_util.py
@@ -32,7 +32,7 @@ class TestUtil(IsolatedAsyncioTestCase):
 
     @patch("tempfile.mkdtemp")
     @patch("shutil.rmtree")
-    @patch("pyartcd.exectools.cmd_gather_async")
+    @patch("artcommonlib.exectools.cmd_gather_async")
     async def test_load_group_config(self, cmd_gather_async: AsyncMock, *_):
         group_config_content = """
         key: "value"
@@ -90,7 +90,7 @@ class TestUtil(IsolatedAsyncioTestCase):
         )
         self.assertEqual(url, 'https///github.com/openshift/ironic-image/blob/release-4.13/')
 
-    @patch("pyartcd.exectools.cmd_gather_async")
+    @patch("artcommonlib.exectools.cmd_gather_async")
     async def test_get_freeze_automation(self, cmd_gather_async: AsyncMock):
         cmd_gather_async.return_value = (0, '', '')
 


### PR DESCRIPTION
We have 2 different implementations of cmd_assert_async/cmd_gather_async in artcommonlib (previously moved from doozer) and pyartcd. Those 2 implementations have slight differences in their parameter names and log handling and create confusions.

This PR updates cmd_assert_async and cmd_assert_async in artcommonlib to use the pyartcd's implementation. Pyartcd's implementation is much clean, and its parameter names are almost identical to the wrapped `asyncio.subprocess.create_subprocess_exec` function. Furthermore, it also handles OpenTelemetry trace propagation.

Note 2 arguments are removed: retries, strip. Those are not commonly used and we can use tenacity for retries.