### PR TITLE
Set the RHCOS build timeout to 6 hours

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_rhcos.py
+++ b/pyartcd/pyartcd/pipelines/build_rhcos.py
@@ -204,7 +204,7 @@ class BuildRhcosPipeline:
         """Wait for all builds for this version to complete, and give status updates on stderr"""
         builds_seen: Dict[Tuple, str] = {}
         completed_builds: Dict[Tuple, Dict] = {}
-        for _ in range(1440):  # x 10s = about 4 hours (slower if bad/no response)
+        for _ in range(2160):  # x 10s = about 6 hours (slower if bad/no response)
             new_builds_seen: Dict[Tuple, str] = {
                 (b["job"], b["number"]): b["description"] or "[no description yet]"
                 for b in self.query_existing_builds()


### PR DESCRIPTION
Currently set to 4 hours. Seeing many failed `build/rhcos` jobs because 
```
Waited too long for builds to complete
```
(e.g. [here](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Frhcos/6261/console))