### PR TITLE
[fips-scan] handle emtpy result_json

### DIFF
--- a/pyartcd/pyartcd/pipelines/scan_fips.py
+++ b/pyartcd/pyartcd/pipelines/scan_fips.py
@@ -47,9 +47,10 @@ class ScanFips:
                 cmd.append("--all-images")
 
             _, result, _ = await exectools.cmd_gather_async(cmd, stderr=True)
-            result_json = json.loads(result)
 
-            results.update(result_json)
+            if result:
+                result_json = json.loads(result)
+                results.update(result_json)
 
         self.runtime.logger.info(f"Result: {results}")
 


### PR DESCRIPTION
`json` cannot handle empty `result` variable