### PR TITLE
Fix _thread_does_image_need_change async call

### DIFF
--- a/doozer/doozerlib/cli/scan_sources.py
+++ b/doozer/doozerlib/cli/scan_sources.py
@@ -434,7 +434,7 @@ class ConfigScanSources:
                 loop = asyncio.new_event_loop()
                 asyncio.set_event_loop(loop)
                 try:
-                    return asyncio.run(image_meta.does_image_need_change(
+                    return loop.run_until_complete(image_meta.does_image_need_change(
                         changing_rpm_packages=self.changing_rpm_packages,
                         buildroot_tag=image_meta.build_root_tag(),
                         newest_image_event_ts=self.newest_image_event_ts,


### PR DESCRIPTION
Hoping to fix `RuntimeError: await wasn't used with future` as seen [here](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4_scan/65059/console)