### PR TITLE
replace deprecated function

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_rhcos.py
+++ b/pyartcd/pyartcd/pipelines/build_rhcos.py
@@ -52,7 +52,7 @@ class BuildRhcosPipeline:
         retries = Retry(
             total=5, backoff_factor=1,
             status_forcelist=[500, 502, 503, 504],
-            method_whitelist=["HEAD", "GET", "POST"],
+            allowed_methods=["HEAD", "GET", "POST"],
         )
         self.request_session.mount("https://", TimeoutHTTPAdapter(max_retries=retries))
 


### PR DESCRIPTION
Deprecated Retry options Retry.DEFAULT_METHOD_WHITELIST, Retry.DEFAULT_REDIRECT_HEADERS_BLACKLIST and Retry(method_whitelist=...) in favor of Retry.DEFAULT_ALLOWED_METHODS, Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT, and Retry(allowed_methods=...) (Pull #2000) Starting in urllib3 v2.0: Deprecated options will be removed
https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#1260-2020-11-10