### PR TITLE
RepodataLoader: retry on ClientConnectionError

### DIFF
--- a/doozer/doozerlib/repodata.py
+++ b/doozer/doozerlib/repodata.py
@@ -202,7 +202,8 @@ class RepodataLoader:
                 modules_url = parse.urljoin(repo_url, modules_location.attrib['href'])
 
             @retry(reraise=True, stop=stop_after_attempt(5), wait=wait_exponential(multiplier=1, min=1, max=10),
-                   retry=(retry_if_exception_type((aiohttp.ServerDisconnectedError, aiohttp.ClientResponseError, aiohttp.ClientPayloadError))),
+                   retry=(retry_if_exception_type(
+                       (aiohttp.ServerDisconnectedError, aiohttp.ClientResponseError, aiohttp.ClientPayloadError, aiohttp.ClientConnectionError))),
                    before_sleep=before_sleep_log(LOGGER, logging.WARNING))
             async def fetch_remote_compressed(url: Optional[str]):
                 return await self._fetch_remote_compressed(session, url)


### PR DESCRIPTION
To fix errors as seen in https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4_scan/69301/console:

```
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host rhsm-pulp.corp.redhat.com:443 ssl:default [Connect call failed ('10.2.66.234', 443)]
```