### PR TITLE
Add microshift plashet repo config

### DIFF
--- a/pyartcd/pyartcd/plashets.py
+++ b/pyartcd/pyartcd/plashets.py
@@ -110,6 +110,22 @@ def plashet_config_for_major_minor(major, minor):
             "embargoed_tags": [f"rhaos-{major}.{minor}-rhel-7-embargoed"],
             "include_previous_packages": previous_packages,
         },
+        "rhel-8-server-microshift-rpms": {
+            "slug": "microshift-el8",
+            "tag": f"rhaos-{major}.{minor}-rhel-8-candidate",
+            "product_version": f"RHEL-8-OSE-{major}.{minor}",
+            "include_embargoed": False,
+            "embargoed_tags": [],
+            "include_previous_packages": [],
+        },
+        "rhel-9-server-microshift-rpms": {
+            "slug": "microshift-el9",
+            "tag": f"rhaos-{major}.{minor}-rhel-9-candidate",
+            "product_version": f"RHEL-9-OSE-{major}.{minor}",
+            "include_embargoed": False,
+            "embargoed_tags": [],
+            "include_previous_packages": [],
+        }
     }
 
 

--- a/pyartcd/pyartcd/plashets.py
+++ b/pyartcd/pyartcd/plashets.py
@@ -110,14 +110,6 @@ def plashet_config_for_major_minor(major, minor):
             "embargoed_tags": [f"rhaos-{major}.{minor}-rhel-7-embargoed"],
             "include_previous_packages": previous_packages,
         },
-        "rhel-8-server-microshift-rpms": {
-            "slug": "microshift-el8",
-            "tag": f"rhaos-{major}.{minor}-rhel-8-candidate",
-            "product_version": f"RHEL-8-OSE-{major}.{minor}",
-            "include_embargoed": False,
-            "embargoed_tags": [],
-            "include_previous_packages": [],
-        },
         "rhel-9-server-microshift-rpms": {
             "slug": "microshift-el9",
             "tag": f"rhaos-{major}.{minor}-rhel-9-candidate",


### PR DESCRIPTION
To enable bootc image builds, we need microshift rpm available at build time in a plashet
See https://github.com/openshift-eng/ocp-build-data/pull/5345/files

Test run: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/8011/console

https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/RHOCP/plashets/4.18/microshift/microshift-el9/latest/