### PR TITLE
log jenkins build url in reconciliation ticket

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -7,7 +7,7 @@ import hashlib
 import time
 import random
 import re
-from typing import Dict, Set
+from typing import Dict, Set, Tuple, Optional
 
 from github import Github, UnknownObjectException, GithubException, PullRequest
 from jira import JIRA, Issue
@@ -696,12 +696,12 @@ def connect_issue_with_pr(pr: PullRequest.PullRequest, issue: str):
         pr.edit(title=f"{issue}: {pr.title}")
 
 
-def reconcile_jira_issues(runtime, pr_map: Dict[str, PullRequest.PullRequest], dry_run: bool):
+def reconcile_jira_issues(runtime, pr_map: Dict[str, Tuple[PullRequest.PullRequest, Optional[str]]], dry_run: bool):
     """
     Ensures there is a Jira issue open for reconciliation PRs.
     Args:
         runtime: The doozer runtime
-        pr_map: a map of distgit_keys->pr_object to open reconciliation PRs
+        pr_map: a map of distgit_keys -> (pr_object, jenkins_build_url) to open reconciliation PRs
         dry_run: If true, new desired jira issues would only be printed to the console.
     """
     major, minor = runtime.get_major_minor_fields()
@@ -719,7 +719,8 @@ def reconcile_jira_issues(runtime, pr_map: Dict[str, PullRequest.PullRequest], d
     jira_project_names = set([project.name for project in jira_projects])
     jira_project_components: Dict[str, Set[str]] = dict()  # Maps project names to the components they expose
 
-    for distgit_key, pr in pr_map.items():
+    for distgit_key, value in pr_map.items():
+        pr, jenkins_build_url = value
         image_meta: ImageMetadata = runtime.image_map[distgit_key]
         potential_project, potential_component = image_meta.get_jira_info()
         summary = f"ART requests updates to {release_version} image {image_meta.get_component_name()}"
@@ -800,6 +801,11 @@ against OCPBUGS/Unknown -- creating unnecessary processing work and delay.
 Component name: {image_meta.get_component_name()} .
 Jira mapping: https://github.com/openshift-eng/ocp-build-data/blob/main/product.yml
 '''
+        if jenkins_build_url:
+            description += f'''
+
+This ticket was created by ART pipline run [sync-ci-images|{jenkins_build_url}]
+'''
 
         fields = {
             'project': {'key': project},
@@ -870,7 +876,8 @@ def images_streams_prs(runtime, github_access_token, bug, interstitial, ignore_c
 
     prs_in_master = (major == master_major and minor == master_minor) and not ignore_ci_master
 
-    pr_dgk_map = {}  # map of distgit_key to PR URLs associated with updates
+    # map of distgit_key to (PR url, jenkins_build_url) associated with updates
+    pr_dgk_map: Dict[str, Tuple[PullRequest.PullRequest, Optional[str]]] = {}
     new_pr_links = {}
     skipping_dgks = set()  # If a distgit key is skipped, it children will see it in this list and skip themselves.
     checked_upstream_images = set()  # A PR will not be opened unless the upstream image exists; keep track of ones we have checked.
@@ -1286,7 +1293,7 @@ If you have any questions about this pull request, please reach out to `@release
                     yellow_print(f'Image has parent {parent_meta.distgit_key} which was skipped; skipping self: {image_meta.distgit_key}')
                     continue
 
-                parent_pr_url = pr_dgk_map.get(parent_meta.distgit_key, None)
+                parent_pr_url = pr_dgk_map.get(parent_meta.distgit_key, None)[0]
                 if parent_pr_url:
                     if parent_meta.config.content.source.ci_alignment.streams_prs.merge_first:
                         skipping_dgks.add(image_meta.distgit_key)
@@ -1297,6 +1304,7 @@ If you have any questions about this pull request, please reach out to `@release
                     # child PR notes that the parent PR should merge first.
                     pr_body += f'\nDepends on {parent_pr_url} . Allow it to merge and then run `/test all` on this PR.'
 
+            jenkins_build_url = None
             if open_prs:
                 existing_pr = open_prs[0]
                 # Update body, but never title; The upstream team may need set something like a Bug XXXX: there.
@@ -1313,7 +1321,7 @@ If you have any questions about this pull request, please reach out to `@release
                     # We are not admin on all repos
                     yellow_print(f'Unable to add labels to {existing_pr.html_url}: {str(pr_e)}')
 
-                pr_dgk_map[dgk] = existing_pr
+                pr_dgk_map[dgk] = (existing_pr, jenkins_build_url)
 
                 # The pr_body may change and the base branch may change (i.e. at branch cut,
                 # a version 4.6 in master starts being tracked in release-4.6 and master tracks
@@ -1338,7 +1346,7 @@ If you have any questions about this pull request, please reach out to `@release
 
             # Otherwise, we need to create a pull request
             if moist_run:
-                pr_dgk_map[dgk] = f'MOIST-RUN-PR:{dgk}'
+                pr_dgk_map[dgk] = (f'MOIST-RUN-PR:{dgk}', jenkins_build_url)
                 green_print(f'Would have opened PR against: {public_source_repo.html_url}/blob/{public_branch}/{dockerfile_name}.')
                 yellow_print('PR body would have been:')
                 yellow_print(pr_body)
@@ -1356,9 +1364,9 @@ If you have any questions about this pull request, please reach out to `@release
                     pr_title = f'Bug {bug}: {pr_title}'
                 try:
                     new_pr = public_source_repo.create_pull(title=pr_title, body=pr_body, base=public_branch, head=fork_branch_head, draft=draft_prs)
-                    build_url = jenkins.get_build_url()
-                    if build_url:
-                        new_pr.create_issue_comment(f"Created by job run {build_url}")
+                    jenkins_build_url = jenkins.get_build_url()
+                    if jenkins_build_url:
+                        new_pr.create_issue_comment(f"Created by ART pipeline job run {jenkins_build_url}")
 
                 except GithubException as ge:
                     if 'already exists' in json.dumps(ge.data):
@@ -1381,9 +1389,9 @@ If you have any questions about this pull request, please reach out to `@release
                     yellow_print(f'Unable to add labels to {existing_pr.html_url}: {str(pr_e)}')
 
                 pr_msg = f'A new PR has been opened: {new_pr.html_url}'
-                pr_dgk_map[dgk] = new_pr
+                pr_dgk_map[dgk] = (new_pr, jenkins_build_url)
                 new_pr_links[dgk] = new_pr.html_url
-                reconcile_jira_issues(runtime, {dgk: new_pr}, moist_run)
+                reconcile_jira_issues(runtime, {dgk: (new_pr, jenkins_build_url)}, moist_run)
                 logger.info(pr_msg)
                 yellow_print(pr_msg)
                 print(f'Sleeping {interstitial} seconds before opening another PR to prevent flooding prow...')
@@ -1395,7 +1403,7 @@ If you have any questions about this pull request, please reach out to `@release
 
     if pr_dgk_map:
         print('Currently open PRs:')
-        print(yaml.safe_dump({key: pr_dgk_map[key].html_url for key in pr_dgk_map}))
+        print(yaml.safe_dump({key: pr_dgk_map[key][0].html_url for key in pr_dgk_map}))
         reconcile_jira_issues(runtime, pr_dgk_map, moist_run)
 
     if skipping_dgks:


### PR DESCRIPTION
In the reconciliation PRs that we raise, we log which Jenkins run created the PR, for easy debugging (example [here](https://github.com/openshift/operator-framework-olm/pull/853#issuecomment-2328085547)). But we don't seem to do so for the tickets that we create along with the PR (https://issues.redhat.com//browse/OCPBUGS-39506). 

This PR is a quick fix so that we start to log which Jenkins job run created the ticket, in the ticket description, so that its easier to debug.

_(PR untested)_