### PR TITLE
ART-10668 Replace pip with uv

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - name: Install git
         run: dnf install -y git
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Verify uv installation
+        run: uv --version
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,20 @@
 .PHONY: venv tox lint test
 
 venv:
-	python3.11 -m venv venv
-	./venv/bin/pip install --upgrade pip
-	./venv/bin/pip install -e artcommon/ doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
-	./venv/bin/pip install -r doozer/requirements-dev.txt -r pyartcd/requirements-dev.txt -r ocp-build-data-validator/requirements-dev.txt
-	cd elliott && ../venv/bin/pip install '.[tests]'
-	# source venv/bin/activate
+	uv venv --python 3.11
+	uv self update
+	./install.sh
+	uv pip install -r doozer/requirements-dev.txt -r pyartcd/requirements-dev.txt -r ocp-build-data-validator/requirements-dev.txt
+	cd elliott && uv pip install '.[tests]'
 
 lint:
-	./venv/bin/python -m flake8
+	./.venv/bin/python -m flake8
 
 unit:
-	./venv/bin/python -m pytest --verbose --color=yes artcommon/tests/
-	./venv/bin/python -m pytest --verbose --color=yes doozer/tests/
-	./venv/bin/python -m pytest --verbose --color=yes elliott/tests/
-	./venv/bin/python -m pytest --verbose --color=yes pyartcd/tests/
-	./venv/bin/python -m pytest --verbose --color=yes ocp-build-data-validator/tests/
+	./.venv/bin/python -m pytest --verbose --color=yes artcommon/tests/
+	./.venv/bin/python -m pytest --verbose --color=yes doozer/tests/
+	./.venv/bin/python -m pytest --verbose --color=yes elliott/tests/
+	./.venv/bin/python -m pytest --verbose --color=yes pyartcd/tests/
+	./.venv/bin/python -m pytest --verbose --color=yes ocp-build-data-validator/tests/
 
 test: lint unit
-
-default-python-venv:
-	python3 -m venv venv
-	./venv/bin/pip install --upgrade pip
-	./venv/bin/pip install -e artcommon/ doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
-	./venv/bin/pip install -r doozer/requirements-dev.txt -r pyartcd/requirements-dev.txt -r ocp-build-data-validator/requirements-dev.txt
-	cd elliott && ../venv/bin/pip install '.[tests]'
-	# source venv/bin/activate

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-pip3 install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/
+# Requires a local virtualenv at ./.venv. This can be created with "uv venv --python 3.11"
+uv pip install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/

--- a/tox.ini
+++ b/tox.ini
@@ -31,5 +31,5 @@ ignore =
     # missing whitespace around arithmetic operator
     E226,
 
-exclude = build/*, *.ini, *.in, MANIFEST*, *.md, .eggs, .tox, venv
+exclude = build/*, *.ini, *.in, MANIFEST*, *.md, .eggs, .tox, .venv
 max-complexity = -1


### PR DESCRIPTION
Replace `pip` with `uv` in CI, as it's showing significant improvements in performance.

By default, `uv venv --python 3.11` creates a Python 3.11 virtual environment at `./.venv`. This also simplifies the `venv` rule in the Makefile, as `uv` commands require that a virtual env is activated, or that a local env exists at `.venv`

Looking at the CI jobs for this PR, the `Create venv and install dependencies` step took less than 2 minutes, while it takes around 4 with pip (see for example [here](https://github.com/openshift-eng/art-tools/actions/runs/10770743899/job/29864744957), [here](https://github.com/openshift-eng/art-tools/actions/runs/10745829285/job/29805637933) and [here](https://github.com/openshift-eng/art-tools/actions/runs/10744242388/job/29800728516))