### PR TITLE
fix aligment bug search

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -742,8 +742,7 @@ def reconcile_jira_issues(runtime, pr_map: Dict[str, Tuple[PullRequest.PullReque
             # If the component in prodsec data does not exist in the Jira project, use Unknown.
             component = 'Unknown'
 
-        query = (f'project={project} AND ( summary ~ "{summary}" OR summary ~ "{old_summary_format}" ) '
-                 'AND statusCategory in ("To Do", "In Progress")')
+        query = (f'project={project} AND ( summary ~ "{summary}" OR summary ~ "{old_summary_format}" ) AND issueFunction in linkedIssuesOfRemote("url", "{pr.html_url}")')
 
         @retry(reraise=True, stop=stop_after_attempt(10), wait=wait_fixed(3))
         def search_issues(query):


### PR DESCRIPTION
jira query can't correctly find already opened bug,
eg, for [OCPBUGS-39455](https://issues.redhat.com/browse/OCPBUGS-39455) and [OCPBUGS-41308](https://issues.redhat.com/browse/OCPBUGS-41308)

old query find nothing
https://issues.redhat.com/issues/?jql=project%20%3D%20%22OpenShift%20Bugs%22%20%20AND%20summary%20~%20%22ART%20requests%20updates%20to%204.18%20image%20ose-operator-framework-tools-container%22%20AND%20statusCategory%20in%20(%22To%20Do%22%2C%20%22In%20Progress%22)

while https://issues.redhat.com/browse/OCPBUGS-39455?jql=project%20%3D%20%22OpenShift%20Bugs%22%20%20AND%20issueFunction%20in%20linkedIssuesOfRemote(%22url%22%2C%20%22https%3A%2F%2Fgithub.com%2Fopenshift%2Foperator-framework-olm%2Fpull%2F850%22) can find the already opened one