### PR TITLE
gen-assembly read from private nightlies

### DIFF
--- a/doozer/doozerlib/cli/get_nightlies.py
+++ b/doozer/doozerlib/cli/get_nightlies.py
@@ -201,8 +201,8 @@ async def find_rc_nightlies(runtime: Runtime, arches: Set[str], allow_pending: b
             # Get the token
             rc, token, err = exectools.cmd_gather(["oc", "whoami", "-t"], strip=True)
 
-            if rc:
-                raise ValueError("Error while trying to get the token for reading private nightlies")
+            if rc != 0 or err:
+                raise ValueError(f"Error while trying to get the token for reading private nightlies: {err}")
 
             if not token:
                 raise ValueError("Token empty, might not be logged in to correct cluster")

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -1,4 +1,5 @@
 RC_BASE_URL = "https://{arch}.ocp.releases.ci.openshift.org"
+RC_BASE_PRIV_URL = "https://openshift-release{arch}-priv.apps.ci.l2s4.p1.openshiftapps.com"
 
 GITHUB_TOKEN = "GITHUB_TOKEN"
 BREWWEB_URL = "https://brewweb.engineering.redhat.com/brew"

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -1,5 +1,5 @@
 RC_BASE_URL = "https://{arch}.ocp.releases.ci.openshift.org"
-RC_BASE_PRIV_URL = "https://openshift-release{arch}-priv.apps.ci.l2s4.p1.openshiftapps.com"
+RC_BASE_PRIV_URL = "https://{arch}.ocp.internal.releases.ci.openshift.org"
 
 GITHUB_TOKEN = "GITHUB_TOKEN"
 BREWWEB_URL = "https://brewweb.engineering.redhat.com/brew"


### PR DESCRIPTION
This change will allow get_nightlies to auto pick the set of consistent nightlies from private release controller

Tests:
- works with private nightlies [correctly](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgen-assembly/197/)
- works with public nightlies [correctly](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgen-assembly/198/)

Needs rebase if https://github.com/openshift-eng/art-tools/pull/924 is merged first