### PR TITLE
Konflux: Support building child images

### DIFF
--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -34,8 +34,7 @@ WORKING_SUBDIR_KONFLUX_BUILD_SOURCES = "konflux_build_sources"
 KONFLUX_DEFAULT_PIPELINERUN_SERVICE_ACCOUNT = "appstudio-pipeline"
 KONFLUX_DEFAULT_PIPELINERUN_TIMEOUT = "1h0m0s"
 KONFLUX_DEFAULT_PIPRLINE_DOCKER_BUILD_BUNDLE_PULLSPEC = "quay.io/konflux-ci/tekton-catalog/pipeline-docker-build:devel"
-KONFLUX_DEFAULT_DEST_IMAGE_REPO = "quay.io/yuxzhu/test-ocp-v4-art-konflux-dev"  # FIXME: This is a temporary repo.
-
+KONFLUX_DEFAULT_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-v4.0-art-dev-test"   # FIXME: This is a temporary repo.
 
 REGISTRY_PROXY_BASE_URL = "registry-proxy.engineering.redhat.com"
 BREW_REGISTRY_BASE_URL = "brew.registry.redhat.io"


### PR DESCRIPTION
Adds logic to build child images with Konflux. Note since DB integration hasn't been fully done, currently we have to build the parent image and the child image together.

Also changes the default image repo to
`quay.io/openshift-release-dev/ocp-v4.0-art-dev-test`, which can be customized using `--image-repo` parameter.