### PR TITLE
Define konflux_db.get_latest_builds()

### DIFF
--- a/artcommon/artcommonlib/bigquery.py
+++ b/artcommon/artcommonlib/bigquery.py
@@ -1,0 +1,112 @@
+import logging
+import os
+
+import typing
+
+from google.cloud import bigquery
+from google.cloud.bigquery.table import RowIterator
+from sqlalchemy import BinaryExpression, UnaryExpression
+from sqlalchemy.dialects import mysql
+
+
+class BigQueryClient:
+    REQUIRED_VARS = ['GOOGLE_CLOUD_PROJECT', 'GOOGLE_APPLICATION_CREDENTIALS', 'DATASET_ID', 'TABLE_ID']
+
+    def __init__(self):
+        self._check_env_vars()
+        self.client = bigquery.Client()
+        self.dataset_id = os.environ['DATASET_ID']
+        self._table_ref = f'{self.client.project}.{self.dataset_id}.{os.environ["TABLE_ID"]}'
+        self.logger = logging.getLogger(__name__)
+
+        # Make the gcp logger less noisy
+        logging.getLogger('google.auth.transport.requests').setLevel(logging.WARNING)
+
+    @property
+    def table_ref(self):
+        return self._table_ref
+
+    def _check_env_vars(self):
+        """
+        Check if all required env vars are defined. Raise an exception otherwise
+        """
+
+        missing_vars = [var for var in self.REQUIRED_VARS if var not in os.environ]
+        if missing_vars:
+            raise EnvironmentError(f"Missing required environment variables: {', '.join(missing_vars)}")
+
+    def query(self, query: str) -> RowIterator:
+        """
+        Execute a query in BigQuery and return a generator object with the results
+        """
+
+        self.logger.info('Executing query: %s', query)
+
+        try:
+            results = self.client.query(query).result()
+            self.logger.debug('Query returned %s result rows', results.total_rows)
+            return results
+
+        except Exception as err:
+            self.logger.error('Failed executing query %s: ', err)
+            raise
+
+    def insert(self, names: typing.List[str], values: list) -> None:
+        """
+        Translate a list of column names and values into an INSERT INTO statement.
+        Execute the query on BigQuery
+
+        This is currently using the standard table API, which could possibly exceed BigQuery quotas
+        See https://cloud.google.com/bigquery/quotas#load_job_per_table.long for details
+        In case this happens, we can use the streaming api, e.g. self.client.insert_rows_json(self.table_ref, builds)
+        This can lead to unconsistent results, as there might be delays from the time a record is inserted,
+        and the time it is actually available for retrieval. If we can't live with this limitation, we should consider
+        adopting the new BigQuery Storage API, safe but harder to implement:
+        https://github.com/googleapis/python-bigquery-storage/blob/main/samples/snippets/append_rows_proto2.py
+        """
+
+        assert isinstance(names, list)
+        assert isinstance(values, list)
+        assert names and values, 'Names and values cannot be empty lists'
+
+        if len(names) != len(values):
+            raise ValueError('Provided value row does not match the column count')
+
+        query = f'INSERT INTO `{self._table_ref}` ({", ".join([f"`{name}`" for name in names])}) VALUES '
+        values = (f"'{value}'" if isinstance(value, str) else str(value) for value in values)
+        query += '(' + ', '.join(values) + ')'
+        self.query(query)
+
+    def select(self, where_clauses: typing.List[BinaryExpression] = None,
+               order_by_clause: typing.Optional[UnaryExpression] = None,
+               limit=None) -> RowIterator:
+        """
+        Execute a SELECT statement and return a generator object with the results.
+
+        where_clauses is an optional list of sqlalchemy.BinaryExpression objects that translate into
+        "name = 'ose-installer-artifacts' AND outcome = 'success'" etc.
+
+        order_by_clause is an optional sqlalchemy.UnaryExpression that translates into '"start_time" DESC' or the like
+
+        limit is an optional value to include in a LIMIT clause
+        """
+
+        query = f"SELECT * FROM `{self.table_ref}`"
+
+        if where_clauses:
+            where_conditions = " AND ".join(
+                [str(where_clause.compile(dialect=mysql.dialect(), compile_kwargs={"literal_binds": True}))
+                 for where_clause in where_clauses])
+            query += f' WHERE {where_conditions}'
+
+        if order_by_clause is not None:
+            order_by_string = order_by_clause.compile(dialect=mysql.dialect(), compile_kwargs={'literal_binds': True})
+            query += f' ORDER BY {order_by_string}'
+
+        if limit is not None:
+            assert isinstance(limit, int)
+            assert limit >= 0, 'LIMIT expects a non-negative integer literal or parameter '
+            query += f' LIMIT {limit}'
+
+        results = self.query(query)
+        return results

--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -12,17 +12,22 @@ from google.cloud.bigquery.table import Row
 LOGGER = logging.getLogger(__name__)
 
 
-class KonfluxBuildOutcome(Enum):
+class KonfluxEnum(Enum):
+    def __str__(self):
+        return self.value
+
+
+class KonfluxBuildOutcome(KonfluxEnum):
     FAILURE = 'failure'
     SUCCESS = 'success'
 
 
-class ArtifactType(Enum):
+class ArtifactType(KonfluxEnum):
     RPM = 'rpm'
     IMAGE = 'image'
 
 
-class Engine(Enum):
+class Engine(KonfluxEnum):
     KONFLUX = 'konflux'
     BREW = 'brew'
 

--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -1,14 +1,16 @@
 import asyncio
 import concurrent
+import copy
 import inspect
 import logging
-import os
 import typing
-from datetime import datetime
+from datetime import datetime, timedelta
 
-from google.cloud import bigquery
+from sqlalchemy import Column, String, DateTime
 
+from artcommonlib import bigquery
 from artcommonlib.konflux import konflux_build_record
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, ArtifactType
 
 SCHEMA_LEVEL = 1
 
@@ -17,29 +19,14 @@ class KonfluxDb:
     REQUIRED_VARS = ['GOOGLE_CLOUD_PROJECT', 'GOOGLE_APPLICATION_CREDENTIALS', 'DATASET_ID', 'TABLE_ID']
 
     def __init__(self):
-        self._check_env_vars()
-        self.client = bigquery.Client()
-        self.dataset_id = os.environ['DATASET_ID']
-        self.table_ref = f'{self.client.project}.{self.dataset_id}.{os.environ["TABLE_ID"]}'
         self.logger = logging.getLogger(__name__)
+        self.bq_client = bigquery.BigQueryClient()
         self.column_names = self._get_column_names()  # e.g. "(name, group, version, release, ... )"
 
-        # Make the gcp logger less noisy
-        logging.getLogger('google.auth.transport.requests').setLevel(logging.WARNING)
-
-    def _check_env_vars(self):
-        """
-        Check if all required env vars are defined. Raise an exception otherwise
-        """
-
-        missing_vars = [var for var in self.REQUIRED_VARS if var not in os.environ]
-        if missing_vars:
-            raise EnvironmentError(f"Missing required environment variables: {', '.join(missing_vars)}")
-
     @staticmethod
-    def _get_column_names() -> str:
+    def _get_column_names() -> list:
         """
-        Inspects the KonfluxBuildRecord class definition, and returns its fields a list
+        Inspects the KonfluxBuildRecord class definition, and returns a list of fields
         To be used with INSERT statements
         """
 
@@ -49,9 +36,9 @@ class KonfluxDb:
         for param_name, _ in parameters.items():
             if param_name == 'self':
                 continue
-            fields.append(f"`{param_name}`")
+            fields.append(param_name)
 
-        return f'({", ".join(fields)})'
+        return fields
 
     def add_build(self, build: konflux_build_record.KonfluxBuildRecord):
         """
@@ -77,100 +64,134 @@ class KonfluxDb:
         # Fill in missing record fields
         build.ingestion_time = datetime.now()
         build.schema_level = SCHEMA_LEVEL
-        query = f'INSERT INTO `{self.table_ref}` {self.column_names} VALUES '
-        values = (f"{value_or_null(value)}" for value in build.to_dict().values())
-        query += '(' + ', '.join(values) + ')'
-        self.logger.info('Executing query: %s', query)
 
-        # This is using the standard table API, which could possibly exceed BigQuery quotas
-        # See https://cloud.google.com/bigquery/quotas#load_job_per_table.long for details
-        # In case this happens, we can use the streaming api, e.g. self.client.insert_rows_json(self.table_ref, builds)
-        # This can lead to unconsistent results, as there might be delays from the time a record is inserted,
-        # and the time it is actually available for retrieval. If we can't live with this limitation, we should consider
-        # adopting the new BigQuery Storage API, safe but harder to implement:
-        # https://github.com/googleapis/python-bigquery-storage/blob/main/samples/snippets/append_rows_proto2.py
-        self.client.query(query).result()
+        # Execute query
+        values = (f"{value_or_null(value)}" for value in build.to_dict().values())
+        self.bq_client.insert(self.column_names, values)
 
     async def add_builds(self, builds: typing.List[konflux_build_record.KonfluxBuildRecord]):
         """
-        Insert a list of Konflux build records
+        Insert a list of Konflux build records using a parallel async loop to enable concurrent queries.
         """
 
         loop = asyncio.get_event_loop()
         with concurrent.futures.ThreadPoolExecutor() as pool:
             await asyncio.gather(*(loop.run_in_executor(pool, self.add_build, build) for build in builds))
 
-    def search_builds_by_fields(self, names: list, values: list):
-        query = f'SELECT * FROM `{self.table_ref}` WHERE '
-        where_clauses = [f'`{field}` = "{value}"' for field, value in zip(names, values)]
-        query += ' AND'.join(where_clauses)
+    def search_builds_by_fields(self, names: list, values: list, order_by: str = '', sorting: str = 'DESC',
+                                limit: int = None):
+        """
+        Execute a SELECT * from the BigQuery table. "names" and "values" are lists of strings that can optionally
+        specify a list of WHERE clauses to include into the query.
 
-        self.logger.info('Executing query: %s', query)
-        results = self.client.query(query).result()
+        Examples:
+        - search_builds_by_fields(None, None) will execute "SELECT * FROM `<table>`"
+        - search_builds_by_fields(['name'], None) will throw an exception because no value is provided for 'name'
+        - search_builds_by_fields(['name'], 'ironic') will throw an exception because "values" is not of type list
+        - search_builds_by_fields(['name'], ['ironic']) will execute "SELECT * FROM `<table>` WHERE `name` = 'ironic'"
+        - search_builds_by_fields(['name', 'group'], ['ironic', 'openshift-4.16']) will execute
+          "SELECT * FROM `<table>` WHERE `name` = 'ironic' AND `group` = 'openshift-4.16'"
+
+        This is a generator function, so it must be looped over to get the query results. For each result row,
+        a KonfluxBuildRecord is constructed and yielded at each iteration.
+        """
+
+        query = f'SELECT * FROM `{self.bq_client.table_ref}`'
+
+        if names:
+            assert values and len(values) == len(names), f'Values must be provided for each column in {names}'
+            query += ' WHERE '
+            where_clauses = [f"`{field}` = '{value}'" for field, value in zip(names, values)]
+            query += ' AND '.join(where_clauses)
+
+        if order_by:
+            query += f' ORDER BY `{order_by}` {sorting}'
+
+        if limit is not None:
+            assert isinstance(limit, int)
+            assert limit >= 0, 'LIMIT expects a non-negative integer literal or parameter '
+            query += f' LIMIT {limit}'
+
+        results = self.bq_client.query(query)
         self.logger.info('Found %s builds', results.total_rows)
+        return results
 
-        for row in results:
-            yield konflux_build_record.from_result_row(row)
-
-    def search_builds_by_field(self, name, value):
+    async def get_latest_builds(self, names: typing.List[str], group: str,
+                                outcome: KonfluxBuildOutcome = KonfluxBuildOutcome.SUCCESS, assembly: str = 'stream',
+                                el_target: str = None, artifact_type: ArtifactType = None,
+                                completed_before: datetime = None)\
+            -> typing.List[konflux_build_record.KonfluxBuildRecord]:
         """
-        Search for all builds matching component name
-        Returns a generator of KonfluxBuildRecord objects
-        """
-
-        query = f'SELECT * FROM `{self.table_ref}` WHERE {name} = '
-
-        if isinstance(value, str):
-            query += f'"{value}"'
-        else:
-            query += f'{value}'
-
-        self.logger.info('Executing query: %s', query)
-        results = self.client.query(query).result()
-        self.logger.info('Found %s builds', results.total_rows)
-
-        for row in results:
-            yield konflux_build_record.from_result_row(row)
-
-    def search_builds_by_name(self, name: str):
-        """
-        Search for all builds matching component name
-        Returns a generator of KonfluxBuildRecord objects
+        For a list of component names, run get_latest_build() in a concurrent pool executor.
+        Filter results that are None, which means that no builds have been found for that specific component
         """
 
-        return self.search_builds_by_field('name', name)
+        loop = asyncio.get_event_loop()
+        with concurrent.futures.ThreadPoolExecutor() as pool:
+            results = await asyncio.gather(*(loop.run_in_executor(
+                pool, self.get_latest_build, name, group, outcome, assembly, el_target, artifact_type, completed_before)
+                for name in names))
 
-    def search_build_by_build_id(self, build_id: str) -> typing.Optional[konflux_build_record.KonfluxBuildRecord]:
+        return [r for r in results if r]
+
+    def get_latest_build(self, name: str, group: str, outcome: KonfluxBuildOutcome = KonfluxBuildOutcome.SUCCESS,
+                         assembly: str = 'stream', el_target: str = None, artifact_type: ArtifactType = None,
+                         completed_before: datetime = None) -> typing.Optional[konflux_build_record.KonfluxBuildRecord]:
         """
-        Search for a build matching build ID.
-        If no build is found, return None.
-        If more than one build is found, raise an error.
-        Otherwise, return a KonfluxBuildRecord object
-        """
+        Search for the latest Konflux build information in BigQuery.
 
-        self.logger.info('Searching for a build matching ID "%s"', build_id)
-        builds = list(self.search_builds_by_field('build_id', build_id))
-
-        if not builds:
-            return None
-
-        elif len(builds) > 1:
-            raise ValueError('More than one build found with build ID equal to "%s"', build_id)
-
-        return builds[0]
-
-    def search_builds_by_record_id(self, record_id: str):
-        """
-        Search for all builds matching record ID
-        Returns a generator of KonfluxBuildRecord objects
+        :param name: component name, e.g. 'ironic'
+        :param group: e.g. 'openshift-4.18'
+        :param outcome: 'success' | 'failure'
+        :param assembly: non-standard assembly name, defaults to 'stream' if omitted
+        :param el_target: e.g. 'el8'
+        :param artifact_type: 'rpm' | 'image'
+        :param completed_before: cut off timestamp for builds completion time
         """
 
-        return self.search_builds_by_field('record_id', record_id)
+        if not completed_before:
+            completed_before = datetime.now()
+        self.logger.info('Searching for %s builds completed before %s', name, completed_before)
 
-    def search_builds_by_nvr(self, nvr: str):
-        """
-        Search for all builds matching NVR
-        Returns a generator of KonfluxBuildRecord objects
-        """
+        # Table is partitioned by start_time. Perform an iterative search within 3-month windows, going back to 3 years
+        # at most. This will let us reduce the amount of scanned data (and the BigQuery usage cost), as in the vast
+        # majority of cases we would find a build in the first 3-month interval.
+        base_clauses = [
+            Column('name', String) == name,
+            Column('group', String) == group,
+            Column('outcome', String) == str(outcome),
+            Column('assembly', String) == assembly,
+            Column('end_time').isnot(None),
+            Column('end_time', DateTime) < completed_before
+        ]
+        order_by_clause = Column('start_time', quote=True).desc()
 
-        return self.search_builds_by_field('nvr', nvr)
+        if el_target:
+            base_clauses.append(Column('el_target', String) == el_target)
+
+        if artifact_type:
+            base_clauses.append(Column('artifact_type', String) == str(artifact_type))
+
+        for window in range(12):
+            end_search = completed_before - window * 3 * timedelta(days=30)
+            start_search = end_search - 3 * timedelta(days=30)
+
+            where_clauses = copy.copy(base_clauses)
+            where_clauses.extend([
+                Column('start_time', DateTime) >= start_search,
+                Column('start_time', DateTime) < end_search,
+            ])
+
+            results = self.bq_client.select(where_clauses, order_by_clause=order_by_clause, limit=1)
+
+            try:
+                return konflux_build_record.from_result_row(next(results))
+
+            except (StopIteration, Exception):
+                # No builds found in current window, shift to the earlier one
+                continue
+
+        # If we got here, no builds have been found in the whole 36 months period
+        self.logger.warning('No builds found for %s with status %s in assembly %s and target %s',
+                            name, outcome.value, assembly, el_target)
+        return None

--- a/artcommon/artcommonlib/runtime.py
+++ b/artcommon/artcommonlib/runtime.py
@@ -57,7 +57,7 @@ class GroupRuntime(ABC):
         try:
             self.konflux_db = KonfluxDb()
             self._logger.info('Konflux DB initialized: using dataset %s on project %s',
-                              self.konflux_db.dataset_id, self.konflux_db.client.project)
+                              self.konflux_db.bq_client.dataset_id, self.konflux_db.bq_client.client.project)
 
         except Exception as err:
             self._logger.warning('Cannot connect to the Konflux DB: %s\n%s', str(err), traceback.format_exc())

--- a/artcommon/requirements.txt
+++ b/artcommon/requirements.txt
@@ -6,3 +6,4 @@ google-crc32c
 google-resumable-media
 googleapis-common-protos
 opentelemetry-api
+sqlalchemy

--- a/artcommon/tests/test_big_query.py
+++ b/artcommon/tests/test_big_query.py
@@ -1,0 +1,106 @@
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+from sqlalchemy import Column, String
+
+from artcommonlib.bigquery import BigQueryClient
+
+
+class TestBigQuery(TestCase):
+    @patch('os.environ', {'DATASET_ID': '', 'TABLE_ID': 'builds',
+                          'GOOGLE_CLOUD_PROJECT': '', 'GOOGLE_APPLICATION_CREDENTIALS': ''})
+    @patch('artcommonlib.bigquery.bigquery.Client')
+    def setUp(self, _):
+        self.client = BigQueryClient()
+        self.client._table_ref = os.environ['TABLE_ID']
+
+
+class TestInsert(TestBigQuery):
+    @patch('artcommonlib.bigquery.BigQueryClient.query')
+    def test_insert(self, query_mock):
+
+        query_mock.reset_mock()
+        self.client.insert(['name', 'group'], ['ironic', 'openshift-4.18'])
+        query_mock.assert_called_once_with("INSERT INTO `builds` (`name`, `group`) VALUES ('ironic', 'openshift-4.18')")
+
+        query_mock.reset_mock()
+        with self.assertRaises(ValueError):
+            self.client.insert(['name', 'group'], ['ironic'])
+
+        query_mock.reset_mock()
+        with self.assertRaises(AssertionError):
+            self.client.insert([], [])
+
+        query_mock.reset_mock()
+        with self.assertRaises(AssertionError):
+            self.client.insert(None, None)
+
+
+class TestSelect(TestBigQuery):
+    @patch('artcommonlib.bigquery.BigQueryClient.query')
+    def test_where_clauses(self, query_mock):
+        self.client.select()
+        query_mock.assert_called_once_with('SELECT * FROM `builds`')
+
+        query_mock.reset_mock()
+        self.client.select(where_clauses=[])
+        query_mock.assert_called_once_with('SELECT * FROM `builds`')
+
+        query_mock.reset_mock()
+        self.client.select(where_clauses=None)
+        query_mock.assert_called_once_with('SELECT * FROM `builds`')
+
+        query_mock.reset_mock()
+        where_clauses = [Column('name', String) == 'ironic']
+        self.client.select(where_clauses=where_clauses)
+        query_mock.assert_called_once_with("SELECT * FROM `builds` WHERE name = 'ironic'")
+
+        query_mock.reset_mock()
+        where_clauses = [Column('name', String) == 'ironic',
+                         Column('group', String) == 'openshift-4.18']
+        self.client.select(where_clauses=where_clauses)
+        query_mock.assert_called_once_with(
+            "SELECT * FROM `builds` WHERE name = 'ironic' AND `group` = 'openshift-4.18'")
+
+    @patch('artcommonlib.bigquery.BigQueryClient.query')
+    def test_order_by(self, query_mock):
+        order_by_clause = None
+        self.client.select(order_by_clause=order_by_clause)
+        query_mock.assert_called_once_with('SELECT * FROM `builds`')
+
+        query_mock.reset_mock()
+        order_by_clause = Column('start_time', quote=True)
+        self.client.select(order_by_clause=order_by_clause)
+        query_mock.assert_called_once_with('SELECT * FROM `builds` ORDER BY `start_time`')
+
+        query_mock.reset_mock()
+        order_by_clause = Column('start_time', quote=True).desc()
+        self.client.select(order_by_clause=order_by_clause)
+        query_mock.assert_called_once_with('SELECT * FROM `builds` ORDER BY `start_time` DESC')
+
+        query_mock.reset_mock()
+        order_by_clause = Column('start_time', quote=True).asc()
+        self.client.select(order_by_clause=order_by_clause)
+        query_mock.assert_called_once_with('SELECT * FROM `builds` ORDER BY `start_time` ASC')
+
+    @patch('artcommonlib.bigquery.BigQueryClient.query')
+    def test_limit(self, query_mock):
+        self.client.select(limit=None)
+        query_mock.assert_called_once_with('SELECT * FROM `builds`')
+
+        query_mock.reset_mock()
+        self.client.select(limit=0)
+        query_mock.assert_called_once_with('SELECT * FROM `builds` LIMIT 0')
+
+        query_mock.reset_mock()
+        self.client.select(limit=10)
+        query_mock.assert_called_once_with('SELECT * FROM `builds` LIMIT 10')
+
+        query_mock.reset_mock()
+        with self.assertRaises(AssertionError):
+            self.client.select(limit=-1)
+
+        query_mock.reset_mock()
+        with self.assertRaises(AssertionError):
+            self.client.select(limit='1')

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -1,0 +1,121 @@
+import asyncio
+import os
+from datetime import datetime, timedelta
+from unittest import TestCase
+from unittest.mock import patch
+
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord
+from artcommonlib.konflux.konflux_db import KonfluxDb
+
+
+class TestKonfluxDB(TestCase):
+    @patch('os.environ', {'DATASET_ID': 'dataset', 'TABLE_ID': 'builds',
+                          'GOOGLE_CLOUD_PROJECT': 'project', 'GOOGLE_APPLICATION_CREDENTIALS': ''})
+    @patch('artcommonlib.bigquery.bigquery.Client')
+    def setUp(self, _):
+        self.db = KonfluxDb()
+        self.db.bq_client._table_ref = \
+            f'{os.environ["GOOGLE_CLOUD_PROJECT"]}.{os.environ["DATASET_ID"]}.{os.environ["TABLE_ID"]}'
+
+    def test_column_names(self):
+        expected_names = {'name', 'group', 'version', 'release', 'assembly', 'el_target', 'arches',
+                          'installed_packages', 'parent_images', 'source_repo', 'commitish', 'rebase_repo_url',
+                          'rebase_commitish', 'embargoed', 'start_time', 'end_time', 'artifact_type', 'engine',
+                          'image_pullspec', 'image_tag', 'outcome', 'art_job_url', 'build_pipeline_url',
+                          'pipeline_commit', 'schema_level', 'ingestion_time', 'record_id', 'build_id', 'nvr'}
+        names = set(self.db.column_names)
+        self.assertEqual(names, expected_names)
+
+    @patch('artcommonlib.bigquery.BigQueryClient.query')
+    def test_add_builds(self, query_mock):
+        build = KonfluxBuildRecord()
+
+        self.db.add_build(build)
+        query_mock.assert_called_once()
+
+        query_mock.reset_mock()
+        asyncio.run(self.db.add_builds([]))
+        query_mock.assert_not_called()
+
+        query_mock.reset_mock()
+        asyncio.run(self.db.add_builds([build]))
+        query_mock.assert_called_once()
+
+        query_mock.reset_mock()
+        asyncio.run(self.db.add_builds([build for _ in range(10)]))
+        self.assertEqual(query_mock.call_count, 10)
+
+    @patch('artcommonlib.bigquery.BigQueryClient.query')
+    def test_search_builds_by_fields(self, query_mock):
+        self.db.search_builds_by_fields(names=[], values=[])
+        query_mock.assert_called_once_with('SELECT * FROM `project.dataset.builds`')
+
+        query_mock.reset_mock()
+        self.db.search_builds_by_fields(names=['name', 'group'], values=['ironic', 'openshift-4.18'])
+        query_mock.assert_called_once_with(
+            "SELECT * FROM `project.dataset.builds` WHERE `name` = 'ironic' AND `group` = 'openshift-4.18'")
+
+        query_mock.reset_mock()
+        self.db.search_builds_by_fields(names=['name', 'group'], values=['ironic', 'openshift-4.18'],
+                                        order_by='start_time')
+        query_mock.assert_called_once_with("SELECT * FROM `project.dataset.builds` WHERE `name` = 'ironic' "
+                                           "AND `group` = 'openshift-4.18' ORDER BY `start_time` DESC")
+
+        query_mock.reset_mock()
+        self.db.search_builds_by_fields(names=['name', 'group'], values=['ironic', 'openshift-4.18'],
+                                        order_by='start_time', sorting='ASC')
+        query_mock.assert_called_once_with("SELECT * FROM `project.dataset.builds` WHERE `name` = 'ironic' "
+                                           "AND `group` = 'openshift-4.18' ORDER BY `start_time` ASC")
+
+        query_mock.reset_mock()
+        self.db.search_builds_by_fields(names=['name', 'group'], values=['ironic', 'openshift-4.18'],
+                                        order_by='start_time', sorting='ASC', limit=0)
+        query_mock.assert_called_once_with("SELECT * FROM `project.dataset.builds` WHERE `name` = 'ironic' "
+                                           "AND `group` = 'openshift-4.18' ORDER BY `start_time` ASC LIMIT 0")
+
+        query_mock.reset_mock()
+        self.db.search_builds_by_fields(names=['name', 'group'], values=['ironic', 'openshift-4.18'],
+                                        order_by='start_time', sorting='ASC', limit=10)
+        query_mock.assert_called_once_with("SELECT * FROM `project.dataset.builds` WHERE `name` = 'ironic' "
+                                           "AND `group` = 'openshift-4.18' ORDER BY `start_time` ASC LIMIT 10")
+
+        query_mock.reset_mock()
+        with self.assertRaises(AssertionError):
+            self.db.search_builds_by_fields(names=['name', 'group'], values=['ironic', 'openshift-4.18'],
+                                            order_by='start_time', sorting='ASC', limit=-1)
+
+    @patch('artcommonlib.konflux.konflux_db.datetime')
+    @patch('artcommonlib.bigquery.BigQueryClient.query')
+    def test_get_latest_build(self, query_mock, datetime_mock):
+        now = datetime(2022, 1, 1, 12, 0, 0)
+        lower_bound = now - 3 * timedelta(days=30)
+        datetime_mock.now.return_value = now
+        self.db.get_latest_build(name='ironic', group='openshift-4.18', outcome='success')
+        query_mock.assert_called_once_with("SELECT * FROM `project.dataset.builds` WHERE name = 'ironic' "
+                                           "AND `group` = 'openshift-4.18' AND outcome = 'success' "
+                                           "AND assembly = 'stream' AND end_time IS NOT NULL "
+                                           f"AND end_time < '{str(now)}' "
+                                           f"AND start_time >= '{str(lower_bound)}' "
+                                           f"AND start_time < '{now}' "
+                                           "ORDER BY `start_time` DESC LIMIT 1")
+
+        query_mock.reset_mock()
+        asyncio.run(self.db.get_latest_builds(names=['ironic', 'ose-installer-artifacts'], group='openshift-4.18',
+                                              outcome='success'))
+
+        actual_calls = [query_mock.call_args_list[x][0][0] for x in range(0, 2)]
+        self.assertIn("SELECT * FROM `project.dataset.builds` WHERE name = 'ironic' "
+                      "AND `group` = 'openshift-4.18' AND outcome = 'success' "
+                      "AND assembly = 'stream' AND end_time IS NOT NULL "
+                      f"AND end_time < '{str(now)}' "
+                      f"AND start_time >= '{str(lower_bound)}' "
+                      f"AND start_time < '{now}' "
+                      "ORDER BY `start_time` DESC LIMIT 1", actual_calls)
+
+        self.assertIn("SELECT * FROM `project.dataset.builds` WHERE name = 'ose-installer-artifacts' "
+                      "AND `group` = 'openshift-4.18' AND outcome = 'success' "
+                      "AND assembly = 'stream' AND end_time IS NOT NULL "
+                      f"AND end_time < '{str(now)}' "
+                      f"AND start_time >= '{str(lower_bound)}' "
+                      f"AND start_time < '{now}' "
+                      "ORDER BY `start_time` DESC LIMIT 1", actual_calls)


### PR DESCRIPTION
- create a separate abstraction layer to model BigQuery interactions in `bigquery.py`
- introduce `sqlalchemy` to let us easily construct higher level queries from Python objects
- define `get_latest_builds()`
- add unit tests for Konflux DB and BigQuery abstractions
- improve `elliott find-k-builds` stub

The `get_latest_builds()` implementation uses a scanning pattern that aims to limit as much as possible the amount of data that BigQuery needs to scan to satisfy our requests. The builds table has been partitioned by `start_time`, and the search function performs queries within 3-month wide time intervals of `start_time`. In the most frequent scenario, we would find a build for each component in the first window; for hotfix builds where we are dealing with old assembly definitions we would be moving backwards in time by shifting the search window.

Tested with:
```
elliott --group=openshift-4.18 find-k-builds --kind=image
```