### PR TITLE
Doozer: Disallow extra 'v' in version string

### DIFF
--- a/doozer/doozerlib/cli/__init__.py
+++ b/doozer/doozerlib/cli/__init__.py
@@ -190,7 +190,7 @@ def validate_semver_major_minor_patch(ctx, param, version):
 
     vsplit = version.split(".")
     try:
-        int(vsplit[0].lstrip('v'))
+        int(vsplit[0].removeprefix('v'))
         minor_version = int('0' if len(vsplit) < 2 else vsplit[1])
         patch_version = int('0' if len(vsplit) < 3 else vsplit[2])
     except ValueError:


### PR DESCRIPTION
This PR allows Doozer to raise an error if a version string like `--version=vv4.18` is passed through the command line.