### PR TITLE
ART-10831 Store failed Brew image builds in BigQuery

### DIFF
--- a/artcommon/artcommonlib/git_helper.py
+++ b/artcommon/artcommonlib/git_helper.py
@@ -69,7 +69,7 @@ def git_clone(remote_url: str, target_dir: str, gitargs=[], set_env={}, timeout=
     exectools.cmd_assert(cmd, retries=3, on_retry=["rm", "-rf", target_dir], set_env=set_env)
 
 
-async def run_git(args: Sequence[str], env: Optional[Dict[str, str]] = None, check: bool = True, **kwargs):
+async def run_git_async(args: Sequence[str], env: Optional[Dict[str, str]] = None, check: bool = True, **kwargs):
     """ Run a git command and optionally raises an exception if the return code of the command indicates failure.
     :param args: List of arguments to pass to git
     :param env: Optional environment variables to set
@@ -85,7 +85,7 @@ async def run_git(args: Sequence[str], env: Optional[Dict[str, str]] = None, che
     return await exectools.cmd_assert_async(['git'] + list(args), check=check, env=set_env, **kwargs)
 
 
-async def gather_git(args: Sequence[str], env: Optional[Dict[str, str]] = None, check: bool = True, **kwargs):
+async def gather_git_async(args: Sequence[str], env: Optional[Dict[str, str]] = None, check: bool = True, **kwargs):
     """ Run a git command asynchronously and returns rc,stdout,stderr as a tuple
     :param args: List of arguments to pass to git
     :param env: Optional environment variables to set
@@ -99,3 +99,13 @@ async def gather_git(args: Sequence[str], env: Optional[Dict[str, str]] = None, 
     if env:
         set_env.update(env)
     return await exectools.cmd_gather_async(['git'] + list(args), check=check, env=set_env, **kwargs)
+
+
+def gather_git(args: Sequence[str], **kwargs):
+    """ Run a git command asynchronously and returns rc,stdout,stderr as a tuple
+    :param args: List of arguments to pass to git
+    :param kwargs: Additional arguments to pass to exectools.cmd_gather_async
+    :return: exit code of the git command
+    """
+
+    return exectools.cmd_gather(['git'] + list(args), **kwargs)

--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -58,11 +58,21 @@ class KonfluxDb:
         Insert a build record into Konflux DB
         """
 
+        def value_or_null(value):
+            if value is None:
+                return 'NULL'
+
+            elif isinstance(value, str):
+                return f"'{value}'"
+
+            else:
+                return str(value)
+
         # Fill in missing record fields
         build.ingestion_time = datetime.now()
         build.schema_level = SCHEMA_LEVEL
         query = f'INSERT INTO `{self.table_ref}` {self.column_names} VALUES '
-        values = (f"'{value}'" if isinstance(value, str) else str(value) for value in build.to_dict().values())
+        values = (f"{value_or_null(value)}" for value in build.to_dict().values())
         query += '(' + ', '.join(values) + ')'
         self.logger.info('Executing query: %s', query)
 

--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -59,6 +59,12 @@ class KonfluxDb:
         """
 
         def value_or_null(value):
+            """
+            Return the value representation to be inserted into the query String.
+            Strings need to be quoted in '', other values (e.g. timestamps) are rendered without quotes.
+            None values translate into NULL
+            """
+
             if value is None:
                 return 'NULL'
 

--- a/artcommon/tests/test_git_helper.py
+++ b/artcommon/tests/test_git_helper.py
@@ -9,7 +9,7 @@ class TestGitHelper(unittest.IsolatedAsyncioTestCase):
         from artcommonlib import git_helper
         args = ["init", "local_dir"]
         check = True
-        await git_helper.run_git(args, check=check)
+        await git_helper.run_git_async(args, check=check)
         cmd_assert_async.assert_called_once_with(["git"] + args, env=ANY, check=check)
 
     @patch('artcommonlib.exectools.cmd_gather_async')
@@ -18,5 +18,5 @@ class TestGitHelper(unittest.IsolatedAsyncioTestCase):
         from artcommonlib import git_helper
         args = ["init", "local_dir"]
         check = True
-        await git_helper.gather_git(args, check=check)
+        await git_helper.gather_git_async(args, check=check)
         cmd_gather_async.assert_called_once_with(["git"] + args, env=ANY, check=check)

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1314,72 +1314,59 @@ class ImageDistGitRepo(DistGitRepo):
 
         try:
             dfp = DockerfileParser(str(self.dg_path.joinpath('Dockerfile')))
-            source_repo = self.metadata.config.content.source.git.url
+            source_repo = convert_remote_git_to_https(self.metadata.config.content.source.git.url)
             commitish = dfp.labels['io.openshift.build.commit.url'].split('commit/')[-1]
 
             _, rebase_repo_url, _ = gather_git(['-C', self.distgit_dir, 'remote', 'get-url', 'origin'])
             _, rebase_commitish, _ = gather_git(['-C', self.distgit_dir, 'rev-parse', 'HEAD'])
 
-            try:
-                release_target = self.org_release.split('.')[-1]
-            except KeyError:
-                release_target = ''
-            el_target = release_target if release_target else f'el{self.metadata.branch_el_target()}'
+            build_record_params = {
+                'name': self.metadata.name,
+                'group': self.runtime.group,
+                'assembly': self.runtime.assembly,
+                'source_repo': source_repo,
+                'commitish': commitish,
+                'rebase_repo_url': convert_remote_git_to_https(rebase_repo_url),
+                'rebase_commitish': rebase_commitish.strip(),
+                'artifact_type': ArtifactType.IMAGE,
+                'engine': Engine.BREW,
+                'outcome': outcome,
+                'art_job_url': os.getenv('BUILD_URL', 'n/a'),
+                'build_pipeline_url': build_pipeline_url if build_pipeline_url else '',
+                'pipeline_commit': 'n/a'
+            }
 
             if outcome == KonfluxBuildOutcome.FAILURE:
                 self.logger.info('Storing failed Brew build info for %s in Konflux DB', self.metadata.name)
-                build_record = KonfluxBuildRecord(
-                    name=self.metadata.name,
-                    group=self.runtime.group,
-                    assembly=self.runtime.assembly,
-                    source_repo=convert_remote_git_to_https(source_repo),
-                    commitish=commitish,
-                    rebase_repo_url=convert_remote_git_to_https(rebase_repo_url),
-                    rebase_commitish=rebase_commitish.strip(),
-                    start_time=datetime.now(),  # just a placeholder, as start_time cannot be NULL
-                    end_time=datetime.now(),
-                    artifact_type=ArtifactType.IMAGE,
-                    engine=Engine.BREW,
-                    outcome=outcome,
-                    art_job_url=os.getenv('BUILD_URL', 'n/a'),
-                    build_pipeline_url=build_pipeline_url if build_pipeline_url else '',
-                    nvr='n/a'
-                )
+                build_record_params.update({
+                    'start_time': datetime.now(),  # placeholder, cannot be NULL
+                    'end_time': datetime.now(),  # placeholder, cannot be NULL
+                    'nvr': 'n/a'
+                })
 
             else:
                 self.logger.info('Storing Brew build info for %s in Konflux DB', build_info['nvr'])
-
                 image_pullspec = build_info['extra']['image']['index']['pull'][0]
+                el_target = f'el{isolate_el_version_in_release(build_info["release"])}'
 
-                build_record = KonfluxBuildRecord(
-                    name=self.metadata.name,
-                    group=self.runtime.group,
-                    version=build_info['version'],
-                    release=build_info['release'],
-                    assembly=self.runtime.assembly,
-                    el_target=el_target,
-                    arches=self.metadata.get_arches(),
-                    installed_packages=self.get_installed_packages(image_pullspec),
-                    parent_images=[build['nvr'] for build in build_info['extra']['image']['parent_image_builds'].values()],
-                    source_repo=convert_remote_git_to_https(source_repo),
-                    commitish=commitish,
-                    rebase_repo_url=rebase_repo_url,
-                    rebase_commitish=rebase_commitish,
-                    embargoed='p1' in build_info['release'].split('.'),
-                    start_time=datetime.strptime(build_info['start_time'], '%Y-%m-%d %H:%M:%S.%f'),
-                    end_time=datetime.strptime(build_info['completion_time'], '%Y-%m-%d %H:%M:%S.%f'),
-                    artifact_type=ArtifactType.IMAGE,
-                    engine=Engine.BREW,
-                    image_pullspec=image_pullspec,
-                    image_tag=image_pullspec.split('sha256:')[-1],
-                    outcome=outcome,
-                    art_job_url=os.getenv('BUILD_URL', 'n/a'),
-                    build_pipeline_url=build_pipeline_url,
-                    pipeline_commit='n/a',
-                    nvr=build_info['nvr'],
-                    build_id=str(build_info['id'])
-                )
+                build_record_params.update({
+                    'version': build_info['version'],
+                    'release': build_info['release'],
+                    'el_target': el_target,
+                    'arches': self.metadata.get_arches(),
+                    'installed_packages': self.get_installed_packages(image_pullspec),
+                    'parent_images': [build['nvr']
+                                      for build in build_info['extra']['image']['parent_image_builds'].values()],
+                    'embargoed': 'p1' in build_info['release'].split('.'),
+                    'start_time': datetime.strptime(build_info['start_time'], '%Y-%m-%d %H:%M:%S.%f'),
+                    'end_time': datetime.strptime(build_info['completion_time'], '%Y-%m-%d %H:%M:%S.%f'),
+                    'image_pullspec': image_pullspec,
+                    'image_tag': image_pullspec.split('sha256:')[-1],
+                    'nvr': build_info['nvr'],
+                    'build_id': str(build_info['id'])
+                })
 
+            build_record = KonfluxBuildRecord(**build_record_params)
             self.runtime.konflux_db.add_build(build_record)
             self.logger.info('Brew build info stored successfully')
 

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -25,7 +25,7 @@ from tenacity import (before_sleep_log, retry, retry_if_not_result,
                       stop_after_attempt, wait_fixed)
 
 import doozerlib
-from artcommonlib import assertion, logutil, build_util, exectools
+from artcommonlib import assertion, logutil, exectools
 from artcommonlib.constants import GIT_NO_PROMPTS
 from artcommonlib.format_util import yellow_print
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord, ArtifactType, Engine, KonfluxBuildOutcome
@@ -33,12 +33,12 @@ from artcommonlib.model import Missing, Model, ListModel
 from artcommonlib.pushd import Dir
 from artcommonlib.release_util import isolate_assembly_in_release, isolate_el_version_in_release
 from artcommonlib.rpm_utils import parse_nvr
-from doozerlib import constants, state, util
+from doozerlib import state, util
 from doozerlib.brew import BuildStates
 from doozerlib.dblib import Record
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.brew_info import BrewBuildImageInspector
-from artcommonlib.git_helper import git_clone
+from artcommonlib.git_helper import git_clone, gather_git
 from artcommonlib.lock import get_named_semaphore
 from doozerlib.osbs2_builder import OSBS2Builder, OSBS2BuildError
 from doozerlib.source_modifications import SourceModifierFactory
@@ -1119,6 +1119,12 @@ class ImageDistGitRepo(DistGitRepo):
                     record["task_id"], record["task_url"] = build_err.task_id, build_err.task_url
                     if not dry_run:
                         self.update_build_db(False, task_id=build_err.task_id, scratch=scratch)
+                        self.update_konflux_db(
+                            build_info=build_err,
+                            outcome=KonfluxBuildOutcome.FAILURE,
+                            build_pipeline_url=build_err.task_url,
+                            scratch=scratch
+                        )
                     raise
             record["message"] = "Success"
             record["status"] = 0
@@ -1306,15 +1312,13 @@ class ImageDistGitRepo(DistGitRepo):
             self.logger.warning('Konflux DB connection is not initialized, not writing build record to the Konflux DB.')
             return
 
-        self.logger.info('Storing build info in Konflux for Brew build %s', build_info['nvr'])
         try:
             dfp = DockerfileParser(str(self.dg_path.joinpath('Dockerfile')))
             source_repo = self.metadata.config.content.source.git.url
             commitish = dfp.labels['io.openshift.build.commit.url'].split('commit/')[-1]
 
-            rebase_repo_url, rebase_commitish = build_info['source'].split('#')
-
-            image_pullspec = build_info['extra']['image']['index']['pull'][0]
+            _, rebase_repo_url, _ = gather_git(['-C', self.distgit_dir, 'remote', 'get-url', 'origin'])
+            _, rebase_commitish, _ = gather_git(['-C', self.distgit_dir, 'rev-parse', 'HEAD'])
 
             try:
                 release_target = self.org_release.split('.')[-1]
@@ -1322,34 +1326,60 @@ class ImageDistGitRepo(DistGitRepo):
                 release_target = ''
             el_target = release_target if release_target else f'el{self.metadata.branch_el_target()}'
 
-            build_record = KonfluxBuildRecord(
-                name=self.metadata.name,
-                group=self.runtime.group,
-                version=build_info['version'],
-                release=build_info['release'],
-                assembly=self.runtime.assembly,
-                el_target=el_target,
-                arches=self.metadata.get_arches(),
-                installed_packages=self.get_installed_packages(image_pullspec),
-                parent_images=[build['nvr'] for build in build_info['extra']['image']['parent_image_builds'].values()],
-                source_repo=convert_remote_git_to_https(source_repo),
-                commitish=commitish,
-                rebase_repo_url=rebase_repo_url,
-                rebase_commitish=rebase_commitish,
-                embargoed='p1' in build_info['release'].split('.'),
-                start_time=datetime.strptime(build_info['start_time'], '%Y-%m-%d %H:%M:%S.%f'),
-                end_time=datetime.strptime(build_info['completion_time'], '%Y-%m-%d %H:%M:%S.%f'),
-                artifact_type=ArtifactType.IMAGE,
-                engine=Engine.BREW,
-                image_pullspec=image_pullspec,
-                image_tag=image_pullspec.split('sha256:')[-1],
-                outcome=outcome,
-                art_job_url=os.getenv('BUILD_URL', 'n/a'),
-                build_pipeline_url=build_pipeline_url,
-                pipeline_commit='n/a',
-                nvr=build_info['nvr'],
-                build_id=str(build_info['id'])
-            )
+            if outcome == KonfluxBuildOutcome.FAILURE:
+                self.logger.info('Storing failed Brew build info for %s in Konflux DB', self.metadata.name)
+                build_record = KonfluxBuildRecord(
+                    name=self.metadata.name,
+                    group=self.runtime.group,
+                    assembly=self.runtime.assembly,
+                    source_repo=convert_remote_git_to_https(source_repo),
+                    commitish=commitish,
+                    rebase_repo_url=convert_remote_git_to_https(rebase_repo_url),
+                    rebase_commitish=rebase_commitish.strip(),
+                    start_time=datetime.now(),  # just a placeholder, as start_time cannot be NULL
+                    end_time=datetime.now(),
+                    artifact_type=ArtifactType.IMAGE,
+                    engine=Engine.BREW,
+                    outcome=outcome,
+                    art_job_url=os.getenv('BUILD_URL', 'n/a'),
+                    build_pipeline_url=build_pipeline_url if build_pipeline_url else '',
+                    nvr='n/a'
+                )
+
+            else:
+                self.logger.info('Storing Brew build info for %s in Konflux DB', build_info['nvr'])
+
+                image_pullspec = build_info['extra']['image']['index']['pull'][0]
+
+                build_record = KonfluxBuildRecord(
+                    name=self.metadata.name,
+                    group=self.runtime.group,
+                    version=build_info['version'],
+                    release=build_info['release'],
+                    assembly=self.runtime.assembly,
+                    el_target=el_target,
+                    arches=self.metadata.get_arches(),
+                    installed_packages=self.get_installed_packages(image_pullspec),
+                    parent_images=[build['nvr'] for build in build_info['extra']['image']['parent_image_builds'].values()],
+                    source_repo=convert_remote_git_to_https(source_repo),
+                    commitish=commitish,
+                    rebase_repo_url=rebase_repo_url,
+                    rebase_commitish=rebase_commitish,
+                    embargoed='p1' in build_info['release'].split('.'),
+                    start_time=datetime.strptime(build_info['start_time'], '%Y-%m-%d %H:%M:%S.%f'),
+                    end_time=datetime.strptime(build_info['completion_time'], '%Y-%m-%d %H:%M:%S.%f'),
+                    artifact_type=ArtifactType.IMAGE,
+                    engine=Engine.BREW,
+                    image_pullspec=image_pullspec,
+                    image_tag=image_pullspec.split('sha256:')[-1],
+                    outcome=outcome,
+                    art_job_url=os.getenv('BUILD_URL', 'n/a'),
+                    build_pipeline_url=build_pipeline_url,
+                    pipeline_commit='n/a',
+                    nvr=build_info['nvr'],
+                    build_id=str(build_info['id'])
+                )
+
             self.runtime.konflux_db.add_build(build_record)
             self.logger.info('Brew build info stored successfully')
 

--- a/doozer/tests/backend/test_build_repo.py
+++ b/doozer/tests/backend/test_build_repo.py
@@ -17,15 +17,15 @@ class TestBuildRepo(IsolatedAsyncioTestCase):
     async def test_exists(self, _):
         self.assertFalse(self.repo.exists())
 
-    @patch("artcommonlib.git_helper.run_git", return_value=0)
-    @patch("artcommonlib.git_helper.gather_git", return_value=(0, "", ""))
+    @patch("artcommonlib.git_helper.run_git_async", return_value=0)
+    @patch("artcommonlib.git_helper.gather_git_async", return_value=(0, "", ""))
     async def test_clone(self, gather_git: Mock, run_git: Mock):
         await self.repo.clone()
         run_git.assert_any_call(["init", "/path/to/repo"])
         gather_git.assert_any_call(["-C", "/path/to/repo", "fetch", "--depth=1", "origin", self.repo.branch], check=False)
 
-    @patch("artcommonlib.git_helper.gather_git", return_value=(0, "deadbeef", ""))
-    @patch("artcommonlib.git_helper.run_git", return_value=0)
+    @patch("artcommonlib.git_helper.gather_git_async", return_value=(0, "deadbeef", ""))
+    @patch("artcommonlib.git_helper.run_git_async", return_value=0)
     async def test_commit(self, run_git: AsyncMock, gather_git: AsyncMock):
         await self.repo.commit("commit message")
         run_git.assert_any_await(["-C", "/path/to/repo", "add", "."])
@@ -33,15 +33,15 @@ class TestBuildRepo(IsolatedAsyncioTestCase):
         gather_git.assert_awaited_once_with(["-C", "/path/to/repo", "rev-parse", "HEAD"])
         self.assertEqual(self.repo.commit_hash, "deadbeef")
 
-    @patch("artcommonlib.git_helper.run_git", return_value=0)
+    @patch("artcommonlib.git_helper.run_git_async", return_value=0)
     async def test_push(self, run_git: AsyncMock):
         await self.repo.push()
         run_git.assert_awaited_once_with(["-C", "/path/to/repo", "push", "origin", self.repo.branch])
 
     @patch("pathlib.Path.exists", return_value=True)
     @patch("shutil.rmtree")
-    @patch("artcommonlib.git_helper.run_git", return_value=0)
-    @patch("artcommonlib.git_helper.gather_git", return_value=(0, "", ""))
+    @patch("artcommonlib.git_helper.run_git_async", return_value=0)
+    @patch("artcommonlib.git_helper.gather_git_async", return_value=(0, "", ""))
     async def test_ensure_source_upcycle(self, gather_git: AsyncMock, run_git: AsyncMock, rmtree: Mock, _):
         await self.repo.ensure_source(upcycle=True)
         rmtree.assert_called_with("/path/to/repo")


### PR DESCRIPTION
Storing failed builds in BigQuery will enable us to migrate images-health away from Brew API.

[Test build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/8851/console) stored:
```
SELECT * 
FROM `openshift-gce-devel.art_test.builds`
WHERE start_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
AND `outcome` = 'failure'
```