### PR TITLE
[konflux] skip-checks by default, replaces dots with dashes

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_build_pipelinerun.yaml
+++ b/doozer/doozerlib/backend/konflux_image_build_pipelinerun.yaml
@@ -25,6 +25,8 @@ spec:
     value: quay.io/redhat-user-workloads/crt-nshift-art-pipeli-tenant/ui-openshift-4-18/ui-ocp-4-18-base-rhel-9:{{revision}}
   - name: dockerfile
     value: Dockerfile
+  - name: skip-checks
+    value: "false"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -65,7 +67,7 @@ spec:
       description: Force rebuild image
       name: rebuild
       type: string
-    - default: "true"
+    - default: "false"
       description: Skip checks against built image
       name: skip-checks
       type: string

--- a/doozer/doozerlib/backend/konflux_image_build_pipelinerun.yaml
+++ b/doozer/doozerlib/backend/konflux_image_build_pipelinerun.yaml
@@ -65,7 +65,7 @@ spec:
       description: Force rebuild image
       name: rebuild
       type: string
-    - default: "false"
+    - default: "true"
       description: Skip checks against built image
       name: skip-checks
       type: string

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -135,7 +135,8 @@ class KonfluxImageBuilder:
         self._logger.info(f"Using application: {app['metadata']['name']}")
 
         # Ensure the component resource exists
-        component_name = f"{app_name}-{metadata.distgit_key}"
+        # Openshift doesn't allow dots in any of its fields, so we replace them with dashes
+        component_name = f"{app_name}-{metadata.distgit_key}".replace(".", "-")
         dest_image_repo = self._config.image_repo
         dest_image_tag = df.envs["__doozer_uuid_tag"]
         default_revision = f"art-{self._config.group_name}-assembly-test-dgk-{metadata.distgit_key}"

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -98,9 +98,10 @@ class KonfluxImageBuilder:
                         break
             if not metadata.build_status and error:
                 raise error
-        finally:
-            # Signal that the build is complete
-            metadata.build_event.set()
+        except:
+            metadata.build_status = False
+
+        metadata.build_event.set()
 
         return pipelinerun_name, pipelinerun
 

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -77,7 +77,7 @@ class KonfluxImageBuilder:
 
             # Start the build
             LOGGER.info("Starting Konflux image build for %s...", metadata.distgit_key)
-            retries = 6
+            retries = 10
             error = None
             for attempt in range(retries):
                 self._logger.info("Build attempt %s/%s", attempt + 1, retries)

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -98,7 +98,7 @@ class KonfluxImageBuilder:
                         break
             if not metadata.build_status and error:
                 raise error
-        except:
+        except KonfluxImageBuildError:
             metadata.build_status = False
 
         metadata.build_event.set()

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -273,6 +273,8 @@ class KonfluxImageBuilder:
         for param in obj["spec"]["params"]:
             if param["name"] == "output-image":
                 param["value"] = output_image
+            if param["name"] == "skip-checks":
+                param["value"] = "true"
         obj["spec"]["params"].append({"name": "build-platforms", "value": list(build_platforms)})
         return obj
 

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -77,7 +77,7 @@ class KonfluxImageBuilder:
 
             # Start the build
             LOGGER.info("Starting Konflux image build for %s...", metadata.distgit_key)
-            retries = 3
+            retries = 6
             error = None
             for attempt in range(retries):
                 self._logger.info("Build attempt %s/%s", attempt + 1, retries)

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -222,6 +222,7 @@ class KonfluxImageBuilder:
                 "name": name,
                 "annotations": {
                     "build.appstudio.openshift.io/pipeline": '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}',
+                    "build.appstudio.openshift.io/status": '{"pac":{"state":"disabled"}}',
                     # "build.appstudio.openshift.io/request": "configure-pac",
                     "mintmaker.appstudio.redhat.com/disabled": "true",  # https://gitlab.cee.redhat.com/konflux/docs/users/-/blob/main/topics/mintmaker/user.md#offboarding-a-repository
                 }

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -216,6 +216,14 @@ class KonfluxRebaser:
         for builder in image_from.get("builder", []):
             parents.append(builder)
         parents.append(image_from)
+
+        # Remove duplicates
+        temp = []
+        for parent in parents:
+            if parent not in temp:
+                temp.append(parent)
+        parents = temp
+
         if len(parents) != len(dfp.parent_images):
             raise ValueError(f"Build metadata for {metadata.distgit_key} expected {len(parents)} parent images, but found {len(dfp.parent_images)} in Dockerfile")
 

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -213,16 +213,7 @@ class KonfluxRebaser:
         """ Resolve the parent images for the given image metadata."""
         image_from = metadata.config.get('from', {})
         parents = image_from.get("builder", []).copy()
-        for builder in image_from.get("builder", []):
-            parents.append(builder)
         parents.append(image_from)
-
-        # Remove duplicates
-        temp = []
-        for parent in parents:
-            if parent not in temp:
-                temp.append(parent)
-        parents = temp
 
         if len(parents) != len(dfp.parent_images):
             raise ValueError(f"Build metadata for {metadata.distgit_key} expected {len(parents)} parent images, but found {len(dfp.parent_images)} in Dockerfile")


### PR DESCRIPTION
Changes in this PR:
- Skip checks by default for now (since its failing the pipeline runs)
- Fix issue with successful / failed builds
- Replace dots with dashes, since openshift doesn't support dots