### PR TITLE
Use the distgit key as primary image name when storing Konflux builds

### DIFF
--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1321,7 +1321,7 @@ class ImageDistGitRepo(DistGitRepo):
             _, rebase_commitish, _ = gather_git(['-C', self.distgit_dir, 'rev-parse', 'HEAD'])
 
             build_record_params = {
-                'name': self.metadata.name,
+                'name': self.metadata.distgit_key,
                 'group': self.runtime.group,
                 'assembly': self.runtime.assembly,
                 'source_repo': source_repo,


### PR DESCRIPTION
Using `image_meta.name` is wrong, because we have multiple images with the same `name`, but different distgit key. For example, `ci-openshift-build-root-latest.rhel8` and `ci-openshift-build-root-latest.rhel9`. 

We can still distinguish builds for these components in BigQuery using the `el_target` column, but only among successful ones. Failed builds won't store the rhel target (as it's being deducted from the build NVR), so actors like `doozer images:health` treat failed builds for the rhel8/rhel9 images as belonging to the same item.

The distgit key is currently the right way to uniquely define an image component. We will eventually need to purge references to `distgit`, but that can be addressed when time comes.