### PR TITLE
Allow multiple signing keys and rekor tlog for cosign

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -808,7 +808,9 @@ class PromotePipeline:
             logger=self._logger,
             dry_run=self.runtime.dry_run,
             signing_creds=os.environ.get("KMS_CRED_FILE", "dummy-file"),
-            signing_key_id=os.environ.get("KMS_KEY_ID", "dummy-key"),
+            # Allow AWS_KEY_ID to be a comma delimited list
+            signing_key_ids=os.environ.get("KMS_KEY_ID", "dummy-key").strip().split(','),
+            rekor_url=os.environ.get("REKOR_URL", ""),
             concurrency_limit=CONCURRENCY_LIMIT,
             sign_release=True,
             sign_components=True,

--- a/pyartcd/pyartcd/pipelines/sigstore_sign.py
+++ b/pyartcd/pyartcd/pipelines/sigstore_sign.py
@@ -51,7 +51,9 @@ class SigstorePipeline:
             logger=self._logger,
             dry_run=self.runtime.dry_run,
             signing_creds=os.environ.get("KMS_CRED_FILE", "dummy-file"),
-            signing_key_id=os.environ.get("KMS_KEY_ID", "dummy-key"),
+            # Allow AWS_KEY_ID to be a comma delimited list
+            signing_key_ids=os.environ.get("KMS_KEY_ID", "dummy-key").strip().split(','),
+            rekor_url=os.environ.get("REKOR_URL", ""),
             concurrency_limit=CONCURRENCY_LIMIT,
             sign_release=self.sign_release,
             sign_components=self.sign_components,


### PR DESCRIPTION
Software Product has stood up a rekor instance for TLOG submission. They also have a new prod key that we are supposed to be using, so allow signing with multiple keys to enable graceful transitions between signing keys.