### PR TITLE
[konflux] Fail builds fix

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -77,7 +77,7 @@ class KonfluxImageBuilder:
 
             # Start the build
             LOGGER.info("Starting Konflux image build for %s...", metadata.distgit_key)
-            retries = 10
+            retries = 3
             error = None
             for attempt in range(retries):
                 self._logger.info("Build attempt %s/%s", attempt + 1, retries)
@@ -100,6 +100,7 @@ class KonfluxImageBuilder:
                 raise error
         except KonfluxImageBuildError:
             metadata.build_status = False
+            raise Exception(metadata.distgit_key)
 
         metadata.build_event.set()
 


### PR DESCRIPTION
In images.py we collect failed builds as follows:

```
failed = [r for r in results if isinstance(r, Exception)]
        if failed:
            raise DoozerFatalError(f"Failed to build images: {failed}")
```

during refactoring, we removed the child function from raising a error if it fails, adding that back in