### PR TITLE
Add sticky revert functionality to gen-payload

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -287,7 +287,7 @@ class BuildSyncPipeline:
         Starting with 4.12, ART is responsible for populating the CI imagestream (-n ocp is/4.12) with
         references to the latest machine-os-content, rhel-coreos-8, rhel-coreos-8-extensions (and
         potentially more with rhel9). If this is failing, it must be treated as a priority since
-        CI will begin falling being nightly CoreOS content.
+        CI will begin falling behind nightly CoreOS content.
         """
 
         # Only for applicable versions


### PR DESCRIPTION
The CRT 'release-tool' will allow TRT to revert a specific tag in an 4.x-art-latest integration stream to a previous value. When they do this, the implication is that the image they are reverting has an serious issue.
The release-tool directly replaces the bad image with a replacement image specified by TRT.
When this is done, ART should not immediately update the reverted tag with the bad image. To achieve this, 'release-tool' will leave an annotation on the reverted tag specifying the image that was reverted.
When gen-payload finds this annotation, it should only update the tag with a new image IFF the new image does not match the old image identified in the 'reverted-from' annotation.