### PR TITLE
Fix BigQueryClient

### DIFF
--- a/artcommon/artcommonlib/bigquery.py
+++ b/artcommon/artcommonlib/bigquery.py
@@ -16,7 +16,7 @@ class BigQueryClient:
         if 'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ:
             raise EnvironmentError('Missing required environment variable GOOGLE_APPLICATION_CREDENTIALS')
 
-        self.client = bigquery.Client()
+        self.client = bigquery.Client(project=constants.GOOGLE_CLOUD_PROJECT)
         self._table_ref = f'{self.client.project}.{constants.DATASET_ID}.{constants.TABLE_ID}'
         self.logger = logging.getLogger(__name__)
 
@@ -65,7 +65,6 @@ class BigQueryClient:
             raise ValueError('Provided value row does not match the column count')
 
         query = f'INSERT INTO `{self._table_ref}` ({", ".join([f"`{name}`" for name in names])}) VALUES '
-        values = (f"'{value}'" if isinstance(value, str) else str(value) for value in values)
         query += '(' + ', '.join(values) + ')'
         self.query(query)
 

--- a/artcommon/tests/test_big_query.py
+++ b/artcommon/tests/test_big_query.py
@@ -21,7 +21,7 @@ class TestInsert(TestBigQuery):
     def test_insert(self, query_mock):
 
         query_mock.reset_mock()
-        self.client.insert(['name', 'group'], ['ironic', 'openshift-4.18'])
+        self.client.insert(['name', 'group'], ["'ironic'", "'openshift-4.18'"])
         query_mock.assert_called_once_with(
             f"INSERT INTO `{constants.TABLE_ID}` (`name`, `group`) VALUES ('ironic', 'openshift-4.18')")
 


### PR DESCRIPTION
- initialize `bigquery.Client` with `project=constants.GOOGLE_CLOUD_PROJECT` (required since we're not feeding in an env var for the project
- remove extra `'` from values in query strings (not needed since [value_or_null()](https://github.com/openshift-eng/art-tools/blob/main/artcommon/artcommonlib/konflux/konflux_db.py#L46) got in)

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/9106/console