### PR TITLE
[Konflux] Fix resolving short images in streams.yml

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -260,18 +260,24 @@ class KonfluxRebaser:
 
     def _resolve_stream_parent(self, stream_name: str, original_parent: str, dfp: DockerfileParser):
         stream = self._runtime.resolve_stream(stream_name)
+        stream_image = str(stream.image)
+
+        # For pullspecs not containing full registry URL, like `openshift/golang-builder:foo`,
+        # we need to prepend the full brew registry URL.
+        if stream_image.startswith("openshift/"):
+            stream_image = f"{constants.BREW_REGISTRY_BASE_URL}/{stream_image}"
 
         if not self.should_match_upstream:
             # Do typical stream resolution.
-            return str(stream.image)
+            return stream_image
 
         # canonical_builders_from_upstream flag is either True, or 'auto' and we are before feature freeze
-        image = self._resolve_image_from_upstream_parent(original_parent, dfp)
-        if image:
-            return image
+        matching_image = self._resolve_image_from_upstream_parent(original_parent, dfp)
+        if matching_image:
+            return matching_image
 
-        # Didn't find a match in streams.yml: do typical stream resolution
-        return str(stream.image)
+        # Didn't find a match for upstream parent: do typical stream resolution
+        return stream_image
 
     def _wait_for_parent_members(self, metadata: ImageMetadata):
         # If this image is FROM another group member, we need to wait on that group


### PR DESCRIPTION
We have a lot of stream parant images defined in streams.yml, where short image names are used, such as
`openshift/golang-builder:tag`.

In order to reference those images in Konflux, we need to prepend the Brew registry URL.