### PR TITLE
Log more when there is an invalid flaw bug

### DIFF
--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -1319,7 +1319,9 @@ def is_first_fix_any(flaw_bug: BugzillaBug, tracker_bugs: Iterable[Bug], current
         raise ValueError(f'flaw bug {flaw_bug.id} does not seem to have trackers')
 
     if not (hasattr(flaw_bug, 'alias') and flaw_bug.alias):
-        raise ValueError(f'flaw bug {flaw_bug.id} does not have an alias')
+        raise ValueError(f'Flaw bug {flaw_bug.id} does not have a CVE alias. Is it a CVE bug? These trackers '
+                         f'reference the bug: {sorted([b.id for b in tracker_bugs])}. If it is not a valid flaw bug'
+                         'please remove references from the tracker bugs.')
 
     alias = flaw_bug.alias[0]
     cve_url = f"https://access.redhat.com/hydra/rest/securitydata/cve/{alias}.json"

--- a/elliott/tests/test_bzutil.py
+++ b/elliott/tests/test_bzutil.py
@@ -479,8 +479,8 @@ class TestBZUtil(unittest.IsolatedAsyncioTestCase):
         tr = '4.8.0'
         self.assertRaisesRegex(
             ValueError,
-            r'does not have an alias',
-            bzutil.is_first_fix_any, BugzillaBug(flexmock(id=1)), ['foobar'], tr)
+            r'does not have a CVE alias',
+            bzutil.is_first_fix_any, BugzillaBug(flexmock(id=1)), [JIRABug(flexmock(key="OCPBUGS-foo"))], tr)
 
     def test_is_first_fix_any(self):
         hydra_data = {


### PR DESCRIPTION
```
Flaw bug 2268195 does not have a CVE alias. Is it a CVE bug? These trackers 
reference the bug: ['OCPBUGS-29804']. If it is not a valid flaw bug
please remove references from the tracker bugs.
```