### PR TITLE
verify-bugs: Check for invalid bug status first

### DIFF
--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -189,6 +189,9 @@ class BugValidator:
 
     def validate(self, non_flaw_bugs: List[Bug], verify_bug_status: bool, no_verify_blocking_bugs: bool,
                  is_attached: bool = False):
+        if verify_bug_status:
+            self._verify_bug_status(non_flaw_bugs)
+
         non_flaw_bugs = self.filter_bugs_by_release(non_flaw_bugs, complain=True)
         self._find_invalid_trackers(non_flaw_bugs)
 
@@ -207,9 +210,6 @@ class BugValidator:
         if not no_verify_blocking_bugs:
             blocking_bugs_for = self._get_blocking_bugs_for(non_flaw_bugs)
             self._verify_blocking_bugs(blocking_bugs_for, is_attached=is_attached)
-
-        if verify_bug_status:
-            self._verify_bug_status(non_flaw_bugs)
 
     def verify_bugs_advisory_type(self, non_flaw_bugs, advisory_id_map, advisory_bug_map, permitted_bug_ids):
         advance_release = False

--- a/elliott/tests/test_verify_attached_bugs_cli.py
+++ b/elliott/tests/test_verify_attached_bugs_cli.py
@@ -110,9 +110,11 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
 
         bugs = [
             flexmock(id="OCPBUGS-1", target_release=['4.6.z'], depends_on=['OCPBUGS-4'],
-                     status='ON_QA', is_ocp_bug=lambda: True, is_tracker_bug=lambda: False, is_invalid_tracker_bug=lambda: False),
+                     status='ON_QA', is_ocp_bug=lambda: True, is_tracker_bug=lambda: False,
+                     is_invalid_tracker_bug=lambda: False, is_flaw_bug=lambda: False),
             flexmock(id="OCPBUGS-2", target_release=['4.6.z'], depends_on=['OCPBUGS-3'],
-                     status='ON_QA', is_ocp_bug=lambda: True, is_tracker_bug=lambda: False, is_invalid_tracker_bug=lambda: False)
+                     status='ON_QA', is_ocp_bug=lambda: True, is_tracker_bug=lambda: False,
+                     is_invalid_tracker_bug=lambda: False, is_flaw_bug=lambda: False)
         ]
         depend_on_bugs = [
             flexmock(id="OCPBUGS-3", target_release=['4.7.z'], status='MODIFIED',


### PR DESCRIPTION
Right now we check for invalid status after filtering bugs by desired target release.
Sometimes we want to get info about invalid bug status before invalid target release check.
Example, when we have invalid target release 4.17.z when the desired is 4.17.0, the bug might
still be valid to be attached. But not if it has invalid bug status.
