### PR TITLE
ART-10785: check version aginst threshold

### DIFF
--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -188,6 +188,7 @@ def extract_version_fields(version, at_least=0):
     :param version: A version to parse
     :param at_least: The minimum number of fields to find (else raise an error)
     """
+    # .split('-')[0] accounts for both 4.19.1-0 / 4.19.0-0.rc.1 (with versioning) and 4.19.1 / 4.19.0.rc-1  (without versioning)
     fields = [int(f) for f in version.strip().split('-')[0].lstrip('v').split('.')]  # v1.17.1 => [ '1', '17', '1' ]
     if len(fields) < at_least:
         raise IOError(f'Unable to find required {at_least} fields in {version}')
@@ -578,3 +579,15 @@ def oc_image_info__caching(pull_spec: str, go_arch: str = 'amd64') -> Dict:
     if you expect the image to change during the course of doozer's execution.
     """
     return oc_image_info(pull_spec, go_arch)
+
+def infer_assembly_type(custom, assembly_name):
+    # Infer assembly type
+    if custom:
+        return AssemblyTypes.CUSTOM
+    elif re.search(r'^[fr]c\.[0-9]+$', assembly_name):
+        return AssemblyTypes.CANDIDATE
+    elif re.search(r'^ec\.[0-9]+$', assembly_name):
+        return AssemblyTypes.PREVIEW
+    else:
+        return AssemblyTypes.STANDARD
+


### PR DESCRIPTION
1st approach:
Checks if the ASSEMBLY_NAME in the params of gen-assembly job is previous to OCP version 4.17 or post  to 4.17 (this threshold value is to change to 4.19!!!) To do some tests here the threshold value for OCP version was selected to 4.17.
In case it it is a previous to 4.17 the gen-assembly job runs normally - in case x.y version in ASSEMBLY_NAME >= OCP version it is checked if the ASSEMBLY_NAME is like i.e. x.y.x-{assembly}-0, if it has not `-0` the job will fail.