### PR TITLE
ART-10881 Store Brew bundle builds in BigQuery

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -16,7 +16,8 @@ ACTIVE_OCP_VERSIONS = [4.12, 4.13, 4.14, 4.15, 4.16, 4.17, 4.18]
 # Konflux DB related vars
 GOOGLE_CLOUD_PROJECT = 'openshift-art'
 DATASET_ID = 'events'
-TABLE_ID = 'builds'
+BUILDS_TABLE_ID = 'builds'
+BUNDLES_TABLE_ID = 'bundles'
 
 # Redis related vars
 REDIS_HOST = 'master.redis.gwprhd.use1.cache.amazonaws.com'

--- a/artcommon/artcommonlib/runtime.py
+++ b/artcommon/artcommonlib/runtime.py
@@ -56,8 +56,7 @@ class GroupRuntime(ABC):
     def initialize_konxflux_db(self):
         try:
             self.konflux_db = KonfluxDb()
-            self._logger.info('Konflux DB initialized using table %s',
-                              f'{constants.DATASET_ID}.{constants.DATASET_ID}.{constants.TABLE_ID}')
+            self._logger.info('Konflux DB initialized ')
 
         except Exception as err:
             self._logger.warning('Cannot connect to the Konflux DB: %s', str(err))

--- a/artcommon/tests/test_big_query.py
+++ b/artcommon/tests/test_big_query.py
@@ -13,29 +13,22 @@ class TestBigQuery(TestCase):
     @patch('artcommonlib.bigquery.bigquery.Client')
     def setUp(self, _):
         self.client = BigQueryClient()
-        self.client._table_ref = constants.TABLE_ID
+        self.client._table_ref = constants.BUILDS_TABLE_ID
 
 
 class TestInsert(TestBigQuery):
     @patch('artcommonlib.bigquery.BigQueryClient.query')
     def test_insert(self, query_mock):
-
         query_mock.reset_mock()
-        self.client.insert(['name', 'group'], ["'ironic'", "'openshift-4.18'"])
+        self.client.insert({'name': "'ironic'"})
         query_mock.assert_called_once_with(
-            f"INSERT INTO `{constants.TABLE_ID}` (`name`, `group`) VALUES ('ironic', 'openshift-4.18')")
+            f"INSERT INTO `{constants.BUILDS_TABLE_ID}` (`name`) VALUES ('ironic')")
 
         query_mock.reset_mock()
-        with self.assertRaises(ValueError):
-            self.client.insert(['name', 'group'], ['ironic'])
-
-        query_mock.reset_mock()
-        with self.assertRaises(AssertionError):
-            self.client.insert([], [])
-
-        query_mock.reset_mock()
-        with self.assertRaises(AssertionError):
-            self.client.insert(None, None)
+        self.client.insert({'name': "'ironic'", 'group': "'openshift-4.18'"})
+        query_mock.assert_called_once_with(
+            f"INSERT INTO `{constants.BUILDS_TABLE_ID}` (`name`, `group`) VALUES ('ironic', 'openshift-4.18')")
+        return
 
 
 class TestSelect(TestBigQuery):

--- a/doozer/doozerlib/cli/olm_bundle.py
+++ b/doozer/doozerlib/cli/olm_bundle.py
@@ -1,12 +1,22 @@
+import os
+from datetime import datetime
+
 import click
 import sys
 import traceback
 import koji
 from urllib.parse import urlparse
 
+from dockerfile_parse import DockerfileParser
+
 from artcommonlib import exectools, logutil
+from artcommonlib.git_helper import gather_git
+from artcommonlib.konflux.konflux_build_record import (KonfluxBuildOutcome, Engine, ArtifactType,
+                                                       KonfluxBundleBuildRecord)
 from artcommonlib.model import Missing
 from artcommonlib.constants import BREW_HUB
+from artcommonlib.release_util import isolate_el_version_in_release
+from artcommonlib.util import convert_remote_git_to_https
 from doozerlib import Runtime, brew
 from doozerlib.cli import cli, pass_runtime
 from typing import Optional, Tuple
@@ -201,42 +211,107 @@ def rebase_and_build_olm_bundle(runtime: Runtime, operator_nvrs: Tuple[str, ...]
                     record['bundle_nvr'] = bundle_nvr
                     return record
                 runtime.logger.info("%s - No bundle build found", operator_nvr)
-            runtime.logger.info("%s - Rebasing bundle distgit repo", operator_nvr)
+            LOGGER.info("%s - Rebasing bundle distgit repo", operator_nvr)
             olm_bundle.rebase()
-            runtime.logger.info("%s - Building bundle distgit repo", operator_nvr)
-            task_id, task_url, bundle_nvr = olm_bundle.build()
+            LOGGER.info("%s - Building bundle distgit repo", operator_nvr)
+            task_id, task_url, build_info = olm_bundle.build()
             record['status'] = 0
             record['message'] = 'Success'
             record['task_id'] = task_id
             record['task_url'] = task_url
-            record['bundle_nvr'] = bundle_nvr
+            record['bundle_nvr'] = build_info["nvr"]
+            update_konflux_db(olm_bundle, record, build_info)
+
         except Exception as err:
             traceback.print_exc()
-            runtime.logger.error('Error during rebase or build for: {}'.format(operator_nvr))
+            LOGGER.error('Error during rebase or build for: {}'.format(operator_nvr))
             record['message'] = str(err)
+
         finally:
             runtime.record_logger.add_record("build_olm_bundle", **record)
             return record
 
+    def update_konflux_db(olm_bundle, record, build_info):
+        if dry_run:
+            return
+
+        if not runtime.konflux_db:
+            LOGGER.warning('Konflux DB connection is not initialized, not writing build record to the Konflux DB.')
+            return
+
+        runtime.konflux_db.bind(KonfluxBundleBuildRecord)
+        try:
+            dfp = DockerfileParser(f'{olm_bundle.bundle_clone_path}/Dockerfile')
+            source_repo, commitish = dfp.labels['io.openshift.build.commit.url'].split('/commit/')
+            _, rebase_repo_url, _ = gather_git(['-C', olm_bundle.bundle_clone_path, 'remote', 'get-url', 'origin'])
+            _, rebase_commitish, _ = gather_git(['-C', olm_bundle.bundle_clone_path, 'rev-parse', 'HEAD'])
+
+            build_record_params = {
+                'name': olm_bundle.bundle_name,
+                'group': runtime.group,
+                'assembly': runtime.assembly,
+                'source_repo': source_repo,
+                'commitish': commitish,
+                'rebase_repo_url': convert_remote_git_to_https(rebase_repo_url),
+                'rebase_commitish': rebase_commitish.strip(),
+                'artifact_type': ArtifactType.IMAGE,
+                'engine': Engine.BREW,
+                'art_job_url': os.getenv('BUILD_URL', 'n/a'),
+                'build_pipeline_url': record['task_url'],
+                'pipeline_commit': 'n/a',
+                'operator_nvr': olm_bundle.operator_dict['nvr']
+            }
+
+            if record['status'] == 0:
+                image_pullspec = build_info['extra']['image']['index']['pull'][0]
+
+                build_record_params.update({
+                    'version': build_info['version'],
+                    'release': build_info['release'],
+                    'start_time': datetime.strptime(build_info['start_time'], '%Y-%m-%d %H:%M:%S.%f'),
+                    'end_time': datetime.strptime(build_info['completion_time'], '%Y-%m-%d %H:%M:%S.%f'),
+                    'image_pullspec': image_pullspec,
+                    'image_tag': image_pullspec.split('sha256:')[-1],
+                    'operand_nvrs': [v for _, v in olm_bundle.found_image_references.items()],
+                    'build_id': str(build_info['id']),
+                    'outcome': KonfluxBuildOutcome.SUCCESS,
+                    'nvr': record['bundle_nvr']
+                })
+
+            else:
+                build_record_params.update({
+                    'outcome': KonfluxBuildOutcome.FAILURE,
+                    'start_time': datetime.now(),  # placeholder, cannot be NULL
+                    'end_time': datetime.now(),  # placeholder, cannot be NULL
+                    'nvr': 'n/a'
+                })
+
+            build_record = KonfluxBundleBuildRecord(**build_record_params)
+            runtime.konflux_db.add_build(build_record)
+            LOGGER.info('Brew build info stored successfully')
+
+        except Exception as err:
+            LOGGER.error('Failed writing record to the konflux DB: %s', err)
+
     olm_bundles = [OLMBundle(runtime, op, dry_run=dry_run) for op in operator_builds]
     get_branches_results = [bundle.does_bundle_branch_exist() for bundle in olm_bundles]
     if not all([result[0] for result in get_branches_results]):
-        runtime.logger.error('One or more bundle branches do not exist: '
-                             f'{[result[1] for result in get_branches_results if not result[0]]}. Please create them first.')
+        LOGGER.error('One or more bundle branches do not exist: '
+                     f'{[result[1] for result in get_branches_results if not result[0]]}. Please create them first.')
         sys.exit(1)
 
     results = exectools.parallel_exec(lambda bundle, _: rebase_and_build(bundle), olm_bundles).get()
 
     for record in results:
         if record['status'] == 0:
-            runtime.logger.info('Successfully built %s', record['bundle_nvr'])
+            LOGGER.info('Successfully built %s', record['bundle_nvr'])
             click.echo(record['bundle_nvr'])
         else:
-            runtime.logger.error('Error building bundle for %s: %s', record['operator_nvr'], record['message'])
+            LOGGER.error('Error building bundle for %s: %s', record['operator_nvr'], record['message'])
 
     rc = 0 if all(map(lambda i: i['status'] == 0, results)) else 1
 
     if rc:
-        runtime.logger.error('One or more bundles failed')
+        LOGGER.error('One or more bundles failed')
 
     sys.exit(rc)

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1312,6 +1312,7 @@ class ImageDistGitRepo(DistGitRepo):
             self.logger.warning('Konflux DB connection is not initialized, not writing build record to the Konflux DB.')
             return
 
+        self.runtime.konflux_db.bind(KonfluxBuildRecord)
         try:
             dfp = DockerfileParser(str(self.dg_path.joinpath('Dockerfile')))
             source_repo = convert_remote_git_to_https(self.metadata.config.content.source.git.url)

--- a/doozer/doozerlib/olm/bundle.py
+++ b/doozer/doozerlib/olm/bundle.py
@@ -104,10 +104,11 @@ class OLMBundle(object):
         self.create_container_yaml()
         return self.commit_and_push_bundle(commit_msg="Update bundle manifests")
 
-    def build(self) -> Tuple[Optional[int], Optional[int], Optional[str]]:
+    def build(self) -> Tuple[Optional[int], Optional[int], Optional[dict]]:
         """Trigger a brew build of operator's bundle
 
-        :return: (task_id, task_url, nvr) if build succeeds, (task_id, task_url, None) if container-build task is created but build fails,
+        :return: (task_id, task_url, build_info) if build succeeds,
+                 (task_id, task_url, None) if container-build task is created but build fails,
                  or (None, None, None) if unable to create a container-build task.
         """
         self.clone_bundle()
@@ -120,12 +121,12 @@ class OLMBundle(object):
             return task_id, task_url, None
 
         if self.dry_run:
-            return task_id, task_url, f"{self.bundle_brew_component}-v0.0.0-1"
+            return task_id, task_url, {'nvr': f"{self.bundle_brew_component}-v0.0.0-1"}
 
         taskResult = self.brew_session.getTaskResult(task_id)
         build_id = int(taskResult["koji_builds"][0])
         build_info = self.brew_session.getBuild(build_id)
-        return task_id, task_url, build_info["nvr"]
+        return task_id, task_url, build_info
 
     @property
     def bundle_image_name(self):


### PR DESCRIPTION
- make `KonfluxDb.insert()` smarter by using dictionaries instead of lists
- make `KonfluxDb` more flexible (can be dynamically bound to different tables to perform its operations)
- expose the  `generate_build_schema()` function used to generate the DB schema from the class definition
- define a `KonfluxBundleBuildRecord` class to model the bundle builds table
- store Brew bundle builds results in BigQuery, on a distinct table named `bundles`

Test build for olm-bundle: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/dpaolell/job/olm-bundle/7/console produced `local-storage-operator-metadata-container-v4.13.0.202409240037.p0.ga3feaab.assembly.stream.el8-7`:

<details>
  <summary>View JSON representation</summary>

  ```json
  {
      "name": "local-storage-operator-bundle",
      "group": "openshift-4.18",
      "version": "v4.13.0.202409240037.p0.ga3feaab.assembly.stream.el8",
      "release": "7",
      "assembly": "stream",
      "source_repo": "https://github.com/openshift/local-storage-operator",
      "commitish": "a3feaabd9a197499a6a9c7087c85d5ddc50a708a",
      "rebase_repo_url": "https://pkgs.devel.redhat.com/containers/local-storage-operator-bundle",
      "rebase_commitish": "573e1cfe127f79cd40a85c61e98ea6782357e62b",
      "start_time": "2024-09-30T20:44:37",
      "end_time": "2024-09-30T20:45:52",
      "artifact_type": "image",
      "engine": "brew",
      "image_pullspec": "registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-local-storage-operator-bundle@sha256:40c88c37be262b5d5862dd48b717b3b6e9eb7805bee7c0fff45d879021a4c41c",
      "image_tag": "40c88c37be262b5d5862dd48b717b3b6e9eb7805bee7c0fff45d879021a4c41c",
      "outcome": "success",
      "art_job_url": "https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/dpaolell/job/olm-bundle/7/",
      "build_pipeline_url": "https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=64650215",
      "pipeline_commit": "n/a",
      "schema_level": 1,
      "ingestion_time": "2024-09-30T20:49:40",
      "record_id": "a27ace63-0058-e0fe-08f7-5e0339706ef8",
      "build_id": "3314528",
      "nvr": "local-storage-operator-metadata-container-v4.13.0.202409240037.p0.ga3feaab.assembly.stream.el8-7",
      "operand_nvrs": [
          "registry.redhat.io/openshift4/ose-local-storage-operator@sha256:27b926036c086889a0a7be99d23fa241f61f351f9392ba22565f97d7e25ba5ba",
          "registry.redhat.io/openshift4/ose-local-storage-diskmaker@sha256:81e3ca18a5c359793542e2a24be676cc63710160f02ed5a8c68e0cbfd9634b54",
          "registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:9e0fee30842a16d7b8a39d336123c80c5271cb2ceb50759fc7ee51a4ed09ceb3"
      ],
      "operator_nvr": "local-storage-operator-container-v4.13.0-202409240037.p0.ga3feaab.assembly.stream.el8"
  }
```
</details> 


Test build for ocp4 https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/9443/console produced `ironic-container-v4.18.0-202409302101.p0.g857b011.assembly.test.el9`:

<details>
  <summary>View JSON representation</summary>

```json
{
    "name": "ironic",
    "group": "openshift-4.18",
    "version": "v4.18.0",
    "release": "202409302101.p0.g857b011.assembly.test.el9",
    "assembly": "test",
    "source_repo": "https://github.com/openshift-priv/ironic-image",
    "commitish": "857b01123b3f022d7342528891951d23680bb3c2",
    "rebase_repo_url": "https://pkgs.devel.redhat.com/containers/ironic",
    "rebase_commitish": "333564481eac899a662b3288f225a97458b7ae2d",
    "start_time": "2024-09-30T21:08:14",
    "end_time": "2024-09-30T21:16:38",
    "artifact_type": "image",
    "engine": "brew",
    "image_pullspec": "registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ironic-rhel9@sha256:93f658e55fcc1c4d75073cd82f616b52e219dd507f0f2be449d69496ea0328b1",
    "image_tag": "93f658e55fcc1c4d75073cd82f616b52e219dd507f0f2be449d69496ea0328b1",
    "outcome": "success",
    "art_job_url": "https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/9444/",
    "build_pipeline_url": "https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=64650784",
    "pipeline_commit": "n/a",
    "schema_level": 1,
    "ingestion_time": "2024-09-30T21:20:01",
    "record_id": "45932525-7b84-f3c3-f8ae-6ec6d2bb9595",
    "build_id": "3314546",
    "nvr": "ironic-container-v4.18.0-202409302101.p0.g857b011.assembly.test.el9",
    "el_target": "el9",
    "arches": [
        "x86_64",
        "aarch64"
    ],
    "installed_packages": [
        "basesystem-11-13.el9",
        "babel-2.9.1-2.el9",
        "attr-2.5.1-3.el9",
        "dejavu-fonts-2.37-18.el9",
        "brotli-1.0.9-6.el9",
        "bzip2-1.0.8-8.el9",
        "cracklib-2.9.6-27.el9",
        "dbus-python-1.2.18-2.el9",
        "diffutils-3.7-12.el9",
        "dosfstools-4.2-3.el9",
        "langpacks-3.0-16.el9",
        "filesystem-3.16-2.el9",
        "gdbm-1.19-4.el9",
        "grep-3.6-5.el9",
        "mailcap-2.1.49-5.el9",
        "hostname-3.23-6.el9",
        "ipcalc-1.0.0-5.el9",
        "libaio-0.3.111-13.el9",
        "libassuan-2.5.5-3.el9",
        "libidn2-2.3.0-7.el9",
        "libcbor-0.7.0-5.el9",
        "perl-Carp-1.50-460.el9",
        "perl-Digest-1.19-4.el9",
        "perl-Exporter-5.74-461.el9",
        "perl-constant-1.33-461.el9",
        "perl-File-Path-2.18-4.el9",
        "perl-File-Temp-0.231.100-4.el9",
        "perl-Getopt-Long-2.52-4.el9",
        "perl-IO-Socket-IP-0.41-5.el9",
        "perl-libnet-3.13-4.el9",
        "perl-Mozilla-CA-20200520-6.el9",
        "perl-parent-0.238-460.el9",
        "perl-podlators-4.14-460.el9",
        "perl-Pod-Escapes-1.07-460.el9",
        "perl-Pod-Perldoc-3.28.01-461.el9",
        "perl-Pod-Usage-2.01-4.el9",
        "perl-Pod-Simple-3.42-4.el9",
        "perl-Term-ANSIColor-5.01-461.el9",
        "perl-Term-Cap-1.17-460.el9",
        "perl-Text-ParseWords-3.30-460.el9",
        "perl-Time-Local-1.300-7.el9",
        "perl-URI-5.09-3.el9",
        "python-appdirs-1.4.4-4.el9",
        "python-iniparse-0.4-45.el9",
        "python-inotify-0.9.6-25.el9",
        "python-jsonpatch-1.21-16.el9",
        "python-jmespath-0.9.4-11.el9",
        "python-jsonpointer-2.0-4.el9",
        "libpwquality-1.4.4-8.el9",
        "python-pycdlib-1.11.0-5.el9",
        "python-prettytable-0.7.2-27.el9",
        "libsigsegv-2.13-4.el9",
        "rootfiles-8.1-31.el9",
        "libutempter-1.2.1-6.el9",
        "libunistring-0.9.10-15.el9",
        "libverto-0.3.2-3.el9",
        "libxcrypt-4.4.18-3.el9",
        "libyaml-0.2.5-7.el9",
        "lz4-1.9.3-5.el9",
        "mpfr-4.1.0-7.el9",
        "npth-1.6-8.el9",
        "passwd-0.80-12.el9",
        "pcre-8.44-3.el9.3",
        "perl-Data-Dumper-2.174-462.el9",
        "perl-Digest-MD5-2.58-4.el9",
        "perl-MIME-Base64-3.16-4.el9",
        "perl-Scalar-List-Utils-1.56-461.el9",
        "perl-Socket-2.031-4.el9",
        "perl-PathTools-3.78-461.el9",
        "perl-Storable-3.21-460.el9",
        "popt-1.18-8.el9",
        "psmisc-23.4-3.el9",
        "python-netifaces-0.10.6-15.el9",
        "python-systemd-234-18.el9",
        "python-pyrsistent-0.17.3-8.el9",
        "readline-8.1-4.el9",
        "sed-4.8-9.el9",
        "perl-Encode-3.08-462.el9",
        "libmodulemd-2.13.0-2.el9",
        "perl-Text-Tabs+Wrap-2013.0523-460.el9",
        "json-glib-1.6.6-1.el9",
        "json-c-0.14-11.el9",
        "fonts-rpm-macros-2.0.5-7.el9.1",
        "groff-1.22.4-10.el9",
        "libcomps-0.1.18-1.el9",
        "libseccomp-2.5.2-2.el9",
        "libdb-5.3.28-53.el9",
        "libgpg-error-1.42-5.el9",
        "usermode-1.114-4.el9",
        "ima-evm-utils-1.4-4.el9",
        "perl-IO-Socket-SSL-2.073-1.el9",
        "libreport-2.15.2-6.el9",
        "libxslt-1.1.34-9.el9",
        "zstd-1.5.1-2.el9",
        "python-cffi-1.14.5-5.el9",
        "libburn-1.5.4-4.el9",
        "libisoburn-1.5.4-4.el9",
        "libisofs-1.5.4-4.el9",
        "PyYAML-5.4.1-6.el9",
        "libcap-ng-0.8.2-7.el9",
        "python-packaging-20.9-5.el9",
        "python-pycparser-2.20-6.el9",
        "python-ply-3.11-14.el9",
        "python-psutil-5.8.0-12.el9",
        "python-six-1.15.0-9.el9",
        "pyparsing-2.4.7-9.el9",
        "python-pysocks-1.7.1-12.el9",
        "gawk-5.1.0-6.el9",
        "gpgme-1.15.1-6.el9",
        "python-chardet-4.0.0-5.el9",
        "python-PyMySQL-0.10.1-6.el9",
        "python-attrs-20.3.0-7.el9",
        "python-pyghmi-1.5.34-2.el9",
        "ipxe-20200823-9.git4bd064de.el9_0",
        "gzip-1.12-1.el9",
        "ding-libs-0.6.1-53.el9",
        "xz-5.2.5-8.el9_0",
        "python-wcwidth-0.2.5-8.el9",
        "mtools-4.0.26-4.el9_0",
        "pygobject3-3.40.1-6.el9",
        "memcached-1.6.9-7.el9",
        "python-alembic-1.7.5-3.el9",
        "subscription-manager-rhsm-certificates-20220623-1.el9",
        "python-rfc3986-1.2.0-6.el9",
        "python-defusedxml-0.7.1-1.el9",
        "python-ifaddr-0.1.6-6.el9",
        "python-retrying-1.3.3-2.el9.1",
        "python-bcrypt-3.1.6-3.el9",
        "python-statsd-3.2.1-20.el9",
        "python-zeroconf-0.24.4-2.el9",
        "python-pyperclip-1.8.0-3.el9.1",
        "python-sqlparse-0.2.4-10.el9",
        "python-webtest-2.0.33-5.el9",
        "python-singledispatch-3.4.0.3-19.el9",
        "python-jsonpath-rw-1.2.3-23.el9",
        "python-paste-deploy-2.0.1-5.el9",
        "python-tempita-0.5.1-25.el9",
        "python-munch-2.3.2-7.el9",
        "python-repoze-lru-0.7-7.el9",
        "python-cmd2-1.4.0-2.el9.1",
        "python-construct-2.10.56-2.el9",
        "python-pecan-1.3.2-10.el9",
        "python-waitress-2.0.0-2.el9",
        "python-memcached-1.58-12.el9",
        "python-keyring-21.0.0-2.el9",
        "python-soupsieve-2.1.0-2.el9.1",
        "python-prometheus_client-0.7.1-3.el9",
        "python-simplejson-3.17.0-2.el9",
        "python-logutils-0.3.5-7.1.el9",
        "python-redis-3.3.8-2.el9",
        "python-voluptuous-0.11.7-3.el9",
        "python-ironicclient-4.9.0-0.20211209154934.6f1be06.el9",
        "python-kazoo-2.7.0-2.el9",
        "python-colorama-0.4.1-2.el9",
        "python-zipp-0.5.1-3.el9",
        "python-SecretStorage-2.3.1-9.el9",
        "python-iso8601-0.1.12-9.el9",
        "python-simplegeneric-0.8.1-18.el9",
        "python-zake-0.2.2-19.el9",
        "pyOpenSSL-20.0.1-2.el9.1",
        "python-migrate-0.13.0-2.el9",
        "python-funcsigs-1.0.2-17.el9",
        "python-beautifulsoup4-4.9.3-2.el9.1",
        "python-msgpack-0.6.2-2.el9",
        "python-paste-3.5.0-3.el9.1",
        "python-routes-2.4.1-12.el9",
        "python-pint-0.10.1-3.el9",
        "python-cachetools-3.1.0-4.el9",
        "python-yappi-1.3.1-2.el9",
        "python-kombu-5.0.2-1.el9.2",
        "python-vine-5.0.0-3.el9",
        "python-amqp-5.0.6-1.el9",
        "python-autopage-0.4.0-1.el9.2",
        "python-itsdangerous-2.0.1-2.el9",
        "python-click-7.1.2-5.el9.1",
        "perl-Net-SSLeay-1.92-2.el9",
        "crudini-0.9.3-4.el9",
        "python-dogpile-cache-1.1.5-3.el9",
        "python-lxml-4.6.5-3.el9",
        "syslinux-6.04-0.20.el9",
        "dbus-broker-28-7.el9",
        "cyrus-sasl-2.1.27-21.el9",
        "keyutils-1.6.3-1.el9",
        "gobject-introspection-1.68.0-11.el9",
        "python-mako-1.1.4-6.el9",
        "python-oslo-metrics-0.5.0-0.20221128141719.fc22d0d.el9",
        "python-importlib-metadata-4.12.0-2.el9",
        "python-uhashring-2.1-2.el9",
        "python-binary-memcached-0.31.1-1.el9",
        "python-greenlet-1.1.3-1.el9",
        "python-fasteners-0.18-1.el9",
        "libtasn1-4.16.0-8.el9_1",
        "sscg-3.0.0-7.el9",
        "libarchive-3.5.3-4.el9",
        "python-sqlalchemy-1.4.45-3.el9",
        "libksba-1.5.1-6.el9_1",
        "vim-8.2.2637-20.el9_1",
        "libgcrypt-1.10.0-10.el9_2",
        "which-2.21-29.el9",
        "lua-5.4.4-4.el9",
        "libffi-3.4.2-8.el9",
        "gnupg2-2.3.3-4.el9",
        "zlib-1.2.11-40.el9",
        "redhat-logos-90.4-2.el9",
        "python-flask-2.0.1-4.el9.2",
        "kmod-28-9.el9",
        "chkconfig-1.24-1.el9",
        "python-cryptography-36.0.1-4.el9",
        "libeconf-0.4.1-3.el9_2",
        "dbus-1.12.20-8.el9",
        "kbd-2.4.0-9.el9",
        "libsolv-0.7.24-2.el9",
        "python-dns-2.3.0-2.el9",
        "apr-util-1.6.1-23.el9",
        "virt-what-1.25-5.el9",
        "cryptsetup-2.6.0-3.el9",
        "tpm2-tss-3.2.2-2.el9",
        "python-pbr-5.11.1-0.1.el9",
        "python-wrapt-1.14.1-1.el9",
        "python-decorator-4.4.2-6.0.el9",
        "python-tenacity-6.3.1-1.el9",
        "libuser-0.63-13.el9",
        "shadow-utils-4.9-8.el9",
        "libcap-2.48-9.el9_2",
        "pytz-2021.1-5.el9",
        "libedit-3.1-38.20210216cvs.el9",
        "ipmitool-1.8.18-27.el9",
        "gmp-6.2.0-13.el9",
        "python-dateutil-2.8.1-7.el9",
        "findutils-4.8.0-6.el9",
        "ncurses-6.2-10.20210508.el9",
        "numactl-2.0.16-3.el9",
        "acl-2.3.1-4.el9",
        "dnf-4.14.0-9.el9",
        "audit-3.1.2-2.el9",
        "libfido2-1.13.0-2.el9",
        "python-platformdirs-2.3.0-1.el9",
        "python-markupsafe-2.1.1-4.el9",
        "nettle-3.9.1-1.el9",
        "p11-kit-0.25.3-2.el9",
        "perl-5.32.1-481.el9",
        "liburing-2.5-1.el9",
        "file-5.39-16.el9",
        "librepo-1.14.5-2.el9",
        "libtalloc-2.4.1-1.el9",
        "apr-1.7.0-12.el9_3",
        "elfutils-0.190-2.el9",
        "rpm-4.16.1.3-29.el9",
        "e2fsprogs-1.46.5-5.el9",
        "libsepol-3.6-1.el9",
        "libselinux-3.6-1.el9",
        "libsemanage-3.6-1.el9",
        "python-requestsexceptions-1.4.0-0.20231214180655.d7ac0ff.el9",
        "python-pycadf-3.1.1-0.20231214182229.4179996.el9",
        "gdb-10.2-13.el9",
        "python-os-service-types-1.7.0-0.20231218155726.0b2f473.el9",
        "gcc-11.4.1-3.el9",
        "sqlite-3.34.1-7.el9_3",
        "dmidecode-3.5-3.el9",
        "librhsm-0.0.3-7.el9_3.1",
        "python-netaddr-0.9.0-2.el9",
        "dnf-plugins-core-4.3.0-13.el9",
        "perl-HTTP-Tiny-0.076-462.el9",
        "subscription-manager-1.29.40-1.el9",
        "python-smi-lextudio-1.1.13-0.1.el9",
        "python-requests-2.25.1-8.el9",
        "device-mapper-multipath-0.8.7-27.el9",
        "coreutils-8.32-35.el9",
        "tzdata-2024a-1.el9",
        "lvm2-2.03.23-2.el9",
        "crypto-policies-20240202-1.git283706d.el9",
        "setup-2.13.7-10.el9",
        "util-linux-2.37.4-18.el9",
        "openldap-2.6.6-3.el9",
        "pam-1.5.1-19.el9",
        "python-pip-21.2.3-8.el9",
        "bash-5.1.8-9.el9",
        "python-jsonschema-4.17.3-1.el9",
        "pcre2-10.40-5.el9",
        "policycoreutils-3.6-2.1.el9",
        "openssl-fips-provider-3.0.7-2.el9",
        "libbpf-1.3.0-2.el9",
        "rust-coreos-installer-0.21.0-1.el9",
        "iproute-6.2.0-6.el9_4",
        "dnsmasq-2.85-16.el9_4",
        "pysnmp-lextudio-5.0.26-2.el9",
        "python-sushy-5.1.0-0.20240318172512.cbb4daf.el9",
        "python-pyasn1-0.5.1-3.el9",
        "gnutls-3.8.3-4.el9_4",
        "nghttp2-1.43.0-5.el9_4.3",
        "python-eventlet-0.33.1-6.el9",
        "redhat-release-9.4-0.5.el9",
        "python-microversion-parse-1.0.1-0.20240424173932.2c36df6.el9",
        "python-idna-2.10-7.el9_4.1",
        "libxml2-2.9.13-6.el9_4",
        "less-590-4.el9_4",
        "libmnl-1.0.4-16.el9_4",
        "python-werkzeug-2.2.3-3.el9",
        "python-automaton-3.2.0-0.20240522151206.9255778.el9",
        "python-os-traits-3.0.0-0.20240522151907.cff125c.el9",
        "python-osprofiler-4.1.0-0.20240522151957.3c5fead.el9",
        "python-debtcollector-3.0.0-0.20240522153257.0e6ce1c.el9",
        "python-futurist-3.0.0-0.20240522153313.4e14db5.el9",
        "python-osc-lib-3.0.1-0.20240522153856.73ecaa7.el9",
        "python-oslo-config-9.4.0-0.20240522154012.882adf8.el9",
        "python-oslo-versionedobjects-3.3.0-0.20240522154713.25db0cf.el9",
        "python-keystoneauth1-5.6.0-0.20240522155106.e071ad4.el9",
        "python-oslo-i18n-6.3.0-0.20240522155806.0531fb2.el9",
        "python-oslo-upgradecheck-2.3.0-0.20240522160117.b6db590.el9",
        "python-oslo-rootwrap-7.2.0-0.20240522160517.c6cf187.el9",
        "python-oslo-policy-4.3.0-0.20240522161210.4b7a6f7.el9",
        "python-oslo-serialization-5.4.0-0.20240522161219.548c7a3.el9",
        "python-keystoneclient-5.4.0-0.20240522161812.c66d778.el9",
        "python-stevedore-5.2.0-0.20240522162412.21d601f.el9",
        "python-oslo-cache-3.7.0-0.20240522163213.e8de6c9.el9",
        "python-oslo-middleware-6.1.0-0.20240522163319.531f39e.el9",
        "python-oslo-utils-7.1.0-0.20240522163915.17581b5.el9",
        "python-oslo-concurrency-6.0.0-0.20240522165021.53709ba.el9",
        "python-oslo-context-5.5.0-0.20240522165316.e31a7a1.el9",
        "python-proliantutils-2.16.2-0.20240522170920.f655e23.el9",
        "python-sushy-oem-idrac-5.0.1-0.20240522171520.4e51aef.el9",
        "python-scciclient-0.16.0-0.20240523142528.73b4e3d.el9",
        "git-2.43.5-1.el9_4",
        "curl-7.76.1-29.el9_4.1",
        "libdnf-0.69.0-8.el9_4.1",
        "openssh-8.7p1-38.el9_4.4",
        "krb5-1.21.1-2.el9_4",
        "python-oslo-log-6.0.0-0.20240708125539.f05a852.el9",
        "python-openstacksdk-3.1.0-0.20240708125539.385aa2b.el9",
        "python-cliff-4.7.0-0.20240708130156.b75afa0.el9",
        "python-oslo-db-15.1.0-0.20240708130356.e502313.el9",
        "python-oslo-messaging-14.8.0-0.20240708131004.d095241.el9",
        "python-oslo-service-3.5.0-0.20240708131154.a84a9de.el9",
        "python-keystonemiddleware-10.7.0-0.20240708131803.1625b38.el9",
        "python-tooz-6.2.0-0.20240708131954.c65282f.el9",
        "python-jinja2-3.1.4-1.el9",
        "systemd-252-32.el9_4.7",
        "glibc-2.34-100.el9_4.3",
        "python-setuptools-53.0.0-12.el9_4.1",
        "httpd-2.4.57-11.el9_4.1",
        "qemu-kvm-8.2.0-11.el9_4.6",
        "tar-1.34-6.el9_4.1",
        "ca-certificates-2024.2.69_v8.0.303-91.4.el9_4",
        "python-webob-1.8.8-2.el9",
        "libevent-2.1.12-8.el9_4",
        "python-urllib3-1.26.5-5.el9_4.1",
        "python3.9-3.9.18-3.el9_4.5",
        "openssl-3.0.7-28.el9_4",
        "glib2-2.68.4-14.el9_4.1",
        "expat-2.5.0-2.el9_4.1"
    ],
    "parent_images": [
        "openshift-base-rhel9-container-v4.18.0-202409190709.p0.gb45ea65.assembly.stream.el9"
    ],
    "embargoed": false
}
```
</details>