### PR TITLE
Start recording konflux builds 

### DIFF
--- a/artcommon/artcommonlib/bigquery.py
+++ b/artcommon/artcommonlib/bigquery.py
@@ -37,7 +37,7 @@ class BigQueryClient:
         Execute a query in BigQuery and return a generator object with the results
         """
 
-        self.logger.info('Executing query: %s', query)
+        self.logger.debug('Executing query: %s', query)
 
         try:
             results = self.client.query(query).result()
@@ -53,7 +53,7 @@ class BigQueryClient:
         Asynchronously execute a query in BigQuery and return a generator object with the results
         """
 
-        self.logger.info('Executing query: %s', query)
+        self.logger.debug('Executing query: %s', query)
 
         try:
             results = await asyncio.to_thread(self.client.query(query).result)

--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -19,6 +19,7 @@ class KonfluxEnum(Enum):
 class KonfluxBuildOutcome(KonfluxEnum):
     FAILURE = 'failure'
     SUCCESS = 'success'
+    PENDING = 'pending'
 
 
 class ArtifactType(KonfluxEnum):

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -228,8 +228,6 @@ class KonfluxImageBuilder:
                                  'DB.')
             return
 
-        metadata.runtime.konflux_db.bind(KonfluxBuildRecord)
-
         try:
             rebase_repo_url = build_repo.https_url
             rebase_commit = build_repo.commit_hash

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -484,7 +484,7 @@ class KonfluxImageBuilder:
                             status_message = f"{status} {message}"
                         except AttributeError:
                             pass
-                        self._logger.info(f"PipelineRun %s status: %s.", pipelinerun_name, status_message)
+                        self._logger.info("PipelineRun %s status: %s.", pipelinerun_name, status_message)
                         if status not in ["Unknown", "Not Found"]:
                             return obj
                 except TimeoutError:

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -486,7 +486,7 @@ class KonfluxImageBuilder:
                             status_message = f"{status} {message}"
                         except AttributeError:
                             pass
-                        self._logger.info(f"PipelineRun %s status: %s", pipelinerun_name, status_message)
+                        self._logger.info(f"PipelineRun %s status: %s.", pipelinerun_name, status_message)
                         if status not in ["Unknown", "Not Found"]:
                             return obj
                 except TimeoutError:

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -295,8 +295,8 @@ class KonfluxImageBuilder:
                     'image_pullspec': image_pullspec,
                     'installed_packages': [],  # TODO: populate this
                     'parent_images': [],  # TODO: populate this
-                    'start_time': datetime.strptime(start_time, '%Y-%m-%d %H:%M:%S.%f'),
-                    'end_time': datetime.strptime(end_time, '%Y-%m-%d %H:%M:%S.%f'),
+                    'start_time': datetime.strptime(start_time, '%Y-%m-%dT%H:%M:%SZ'),
+                    'end_time': datetime.strptime(end_time, '%Y-%m-%dT%H:%M:%SZ'),
                     'image_tag': image_digest.split('sha256:')[-1],
                 })
             elif outcome == KonfluxBuildOutcome.FAILURE:

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -254,7 +254,7 @@ class KonfluxImageBuilder:
                 'arches': metadata.get_arches(),
                 'embargoed': 'p1' in release.split('.'),
                 'start_time': datetime.now(),
-                'end_time': datetime.now(),
+                'end_time': None,
                 'nvr': nvr,
                 'group': metadata.runtime.group,
                 'assembly': metadata.runtime.assembly,

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -303,8 +303,8 @@ class KonfluxImageBuilder:
                 start_time = pipelinerun.status.startTime
                 end_time = pipelinerun.status.completionTime
                 build_record_params.update({
-                    'start_time': datetime.strptime(start_time, '%Y-%m-%d %H:%M:%S.%f'),
-                    'end_time': datetime.strptime(end_time, '%Y-%m-%d %H:%M:%S.%f'),
+                    'start_time': datetime.strptime(start_time, '%Y-%m-%dT%H:%M:%SZ'),
+                    'end_time': datetime.strptime(end_time, '%Y-%m-%dT%H:%M:%SZ')
                 })
 
             build_record = KonfluxBuildRecord(**build_record_params)

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -8,7 +8,7 @@ from artcommonlib.telemetry import start_as_current_span_async
 from opentelemetry import trace
 
 from doozerlib import constants
-from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder, KonfluxImageBuilderConfig
+from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder, KonfluxImageBuilderConfig, KonfluxBuildRecord
 from doozerlib.backend.rebaser import KonfluxRebaser
 from doozerlib.cli import (cli, click_coroutine, option_commit_message,
                            option_push, pass_runtime,
@@ -132,6 +132,7 @@ class KonfluxBuildCli:
     async def run(self):
         runtime = self.runtime
         runtime.initialize(mode='images', clone_distgits=False)
+        runtime.konflux_db.bind(KonfluxBuildRecord)
         assert runtime.source_resolver is not None, "source_resolver is not initialized. Doozer bug?"
         metas = runtime.ordered_image_metas()
         config = KonfluxImageBuilderConfig(

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -35,6 +35,8 @@ KONFLUX_DEFAULT_PIPELINERUN_SERVICE_ACCOUNT = "appstudio-pipeline"
 KONFLUX_DEFAULT_PIPELINERUN_TIMEOUT = "1h0m0s"
 KONFLUX_DEFAULT_PIPRLINE_DOCKER_BUILD_BUNDLE_PULLSPEC = "quay.io/konflux-ci/tekton-catalog/pipeline-docker-build:devel"
 KONFLUX_DEFAULT_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-v4.0-art-dev-test"   # FIXME: This is a temporary repo.
+KONFLUX_UI_HOST = "https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com"
+KONFLUX_UI_DEFAULT_WORKSPACE = "ocp-art"  # associated with ocp-art-tenant
 
 REGISTRY_PROXY_BASE_URL = "registry-proxy.engineering.redhat.com"
 BREW_REGISTRY_BASE_URL = "brew.registry.redhat.io"

--- a/elliott/elliottlib/cli/find_konflux_builds_cli.py
+++ b/elliott/elliottlib/cli/find_konflux_builds_cli.py
@@ -38,6 +38,7 @@ async def find_k_builds_cli(runtime: Runtime, kind, engine, outcome, output):
     args = {
         'names': names,
         'group': runtime.group,
+        'assembly': runtime.assembly,
         'outcome': outcome
     }
     if engine:

--- a/elliott/elliottlib/cli/find_konflux_builds_cli.py
+++ b/elliott/elliottlib/cli/find_konflux_builds_cli.py
@@ -1,7 +1,7 @@
 import click
 
 from artcommonlib import logutil
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, Engine, ArtifactType
 from elliottlib import Runtime
 from elliottlib.cli.common import cli, pass_runtime, click_coroutine
 
@@ -11,23 +11,31 @@ LOGGER = logutil.get_logger(__name__)
 @cli.command('find-k-builds', short_help='Find Konflux builds')
 @click.option(
     '--kind', '-k', metavar='KIND', required=True,
-    type=click.Choice(['rpm', 'image']),
-    help='Find builds of the given KIND [rpm, image]')
+    type=click.Choice([e.value for e in ArtifactType]),
+    help=f'Find builds of the given KIND {[e.value for e in ArtifactType]}')
+@click.option(
+    '--engine', '-e', metavar='ENGINE', required=False,
+    type=click.Choice([e.value for e in Engine]),
+    help=f'Limit builds to ones built in the given ENGINE {[e.value for e in Engine]}')
 @pass_runtime
 @click_coroutine
-async def find_k_builds_cli(runtime: Runtime, kind):
+async def find_k_builds_cli(runtime: Runtime, kind, engine):
     runtime.initialize(mode='images' if kind == 'image' else 'rpms')
     if runtime.konflux_db is None:
         raise RuntimeError('Must run Elliott with Konflux DB initialized')
 
-    LOGGER.info('searching for builds of kind %s in group %s', kind, runtime.group)
+    engine_fmt = f"{engine} " if engine else ""
+    LOGGER.info(f'searching for {engine_fmt}builds of kind %s in group %s', kind, runtime.group)
     metas = runtime.image_metas() if kind == 'image' else runtime.rpm_metas()
     names = [meta.name for meta in metas]
-    builds = await runtime.konflux_db.get_latest_builds(
-        names=names,
-        group=runtime.group,
-        outcome=KonfluxBuildOutcome.SUCCESS
-    )
+    args = {
+        'names': names,
+        'group': runtime.group,
+        'outcome': KonfluxBuildOutcome.SUCCESS
+    }
+    if engine:
+        args.update({'engine': engine})
+    builds = await runtime.konflux_db.get_latest_builds(**args)
 
     missing_builds = [name for name in names if name not in [b.name for b in builds]]
     if missing_builds:

--- a/elliott/elliottlib/cli/find_konflux_builds_cli.py
+++ b/elliott/elliottlib/cli/find_konflux_builds_cli.py
@@ -50,7 +50,7 @@ async def find_k_builds_cli(runtime: Runtime, kind, engine, outcome, output):
 
     LOGGER.info('Found %s builds', len(builds))
 
-    if output == 'json':
+    if output == 'json' and builds:
         click.echo(str(builds[0]))
     else:
         for build in builds:

--- a/elliott/elliottlib/cli/find_konflux_builds_cli.py
+++ b/elliott/elliottlib/cli/find_konflux_builds_cli.py
@@ -1,7 +1,7 @@
 import click
 
 from artcommonlib import logutil
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, Engine, ArtifactType
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, Engine, ArtifactType, KonfluxBuildRecord
 from elliottlib import Runtime
 from elliottlib.cli.common import cli, pass_runtime, click_coroutine
 
@@ -14,27 +14,34 @@ LOGGER = logutil.get_logger(__name__)
     type=click.Choice([e.value for e in ArtifactType]),
     help=f'Find builds of the given KIND {[e.value for e in ArtifactType]}')
 @click.option(
-    '--engine', '-e', metavar='ENGINE', required=False,
+    '--engine', '-e', metavar='ENGINE',
     type=click.Choice([e.value for e in Engine]),
     help=f'Limit builds to ones built in the given ENGINE {[e.value for e in Engine]}')
+@click.option('--outcome', type=click.Choice([e.value for e in KonfluxBuildOutcome]),
+              help=f'Limit builds to given OUTCOME {[e.value for e in KonfluxBuildOutcome]}')
+@click.option('--output', '-o', type=click.Choice(['json']),
+              help='Output in the given format')
 @pass_runtime
 @click_coroutine
-async def find_k_builds_cli(runtime: Runtime, kind, engine):
+async def find_k_builds_cli(runtime: Runtime, kind, engine, outcome, output):
     runtime.initialize(mode='images' if kind == 'image' else 'rpms')
     if runtime.konflux_db is None:
         raise RuntimeError('Must run Elliott with Konflux DB initialized')
+    runtime.konflux_db.bind(KonfluxBuildRecord)
 
     engine_fmt = f"{engine} " if engine else ""
-    LOGGER.info(f'searching for {engine_fmt}builds of kind %s in group %s', kind, runtime.group)
+    outcome = KonfluxBuildOutcome(outcome) if outcome else KonfluxBuildOutcome.SUCCESS
+    LOGGER.info(f'searching for {engine_fmt}builds of kind={kind} in group={runtime.group} with outcome={outcome.value}')
     metas = runtime.image_metas() if kind == 'image' else runtime.rpm_metas()
     names = [meta.name for meta in metas]
+
     args = {
         'names': names,
         'group': runtime.group,
-        'outcome': KonfluxBuildOutcome.SUCCESS
+        'outcome': outcome
     }
     if engine:
-        args.update({'engine': engine})
+        args.update({'engine': Engine(engine)})
     builds = await runtime.konflux_db.get_latest_builds(**args)
 
     missing_builds = [name for name in names if name not in [b.name for b in builds]]
@@ -42,5 +49,9 @@ async def find_k_builds_cli(runtime: Runtime, kind, engine):
         LOGGER.warning('Builds have not been found for these components: %s', ', '.join(missing_builds))
 
     LOGGER.info('Found %s builds', len(builds))
-    for build in builds:
-        click.echo(build.nvr)
+
+    if output == 'json':
+        click.echo(str(builds[0]))
+    else:
+        for build in builds:
+            click.echo(build.nvr)


### PR DESCRIPTION
Changes
- Start recording konflux build at trigger time and complete time
- Some log message updates, post UI link and pipelinerun "message"
- Also record some extra info that is available for failed brew builds, like nvr from rebase time
- In elliott find-k-builds, add flags to search by engine/outcome and output to json

Test:

```
$ ./doozer --assembly test -g openshift-4.18 -i openshift-base-rhel9 --latest-parent-version
beta:images:konflux:build --konflux-kubeconfig ~/konflux.kubeconfig.p02 --konflux-namespace ocp-art-tenant
...
2024-10-01 18:33:33,719 doozerlib.backend.konflux_image_builder INFO [openshift-base-rhel9] Created PipelineRun:
 https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/
openshift-4-18/pipelineruns/doozer-build-openshift-4-18-openshift-base-rhel9-84vv4
2024-10-01 18:33:33,719 artcommonlib.bigquery INFO Bound to table openshift-art.events.builds
2024-10-01 18:33:36,115 doozerlib.backend.konflux_image_builder INFO Konflux build info stored successfully
2024-10-01 18:33:36,115 doozerlib.backend.konflux_image_builder INFO [openshift-base-rhel9] Waiting for PipelineRun 
doozer-build-openshift-4-18-openshift-base-rhel9-84vv4 to complete...
2024-10-01 18:33:39,408 doozerlib.backend.konflux_image_builder INFO PipelineRun doozer-build-openshift-4-18-
openshift-base-rhel9-84vv4 status: Unknown PipelineRun ocp-art-tenant/doozer-build-openshift-4-18-openshift-base-
rhel9-84vv4 awaiting remote resource
2024-10-01 18:33:40,116 doozerlib.backend.konflux_image_builder INFO PipelineRun doozer-build-openshift-4-18-
openshift-base-rhel9-84vv4 status: Unknown Tasks Completed: 0 (Failed: 0, Cancelled 0), Incomplete: 14, Skipped: 0
```


```
$ ./elliott --assembly test -g openshift-4.18 -i openshift-base-rhel9 find-k-builds 
-k image -e konflux --outcome pending --output json
...
2024-10-01 18:53:28,901 artcommonlib.bigquery INFO Bound to table openshift-art.events.builds
2024-10-01 18:53:28,901 art_tools.elliottlib.cli.find_konflux_builds_cli INFO searching for konflux builds of kind=image 
in group=openshift-4.18 with outcome=pending
2024-10-01 18:53:28,901 artcommonlib.konflux.konflux_db INFO Searching for openshift-base-rhel9 builds completed
 before 2024-10-01 18:53:28.901454
2024-10-01 18:53:30,046 art_tools.elliottlib.cli.find_konflux_builds_cli INFO Found 1 builds
{
    "name": "openshift-base-rhel9",
    "group": "openshift-4.18",
    "version": "v4.18.0",
    "release": "202410010953.p0.gb45ea65.assembly.test.el9",
    "assembly": "test",
    "source_repo": "https://github.com/openshift-eng/ocp-build-data",
    "commitish": "b45ea65bf6606c558b1a18b92ad878f42a411894",
    "rebase_repo_url": "https://github.com/openshift-eng/ocp-build-data",
    "rebase_commitish": "36dc20cd4a3a976249a26fb3d30a10092f0a7770",
    "start_time": "2024-10-01T18:33:33",
    "end_time": "2024-10-01T18:33:33",
    "artifact_type": "image",
    "engine": "konflux",
    "image_pullspec": "",
    "image_tag": "",
    "outcome": "pending",
    "art_job_url": "n/a",
    "build_pipeline_url": "https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/application-pipeline/
workspaces/ocp-art/applications/openshift-4-18/pipelineruns/doozer-build-openshift-4-18-openshift-base-rhel9-84vv4",
    "pipeline_commit": "n/a",
    "schema_level": 1,
    "ingestion_time": "2024-10-01T18:33:33",
    "record_id": "4b1f4419-b596-d1ff-bd55-fdae231461a1",
    "build_id": "doozer-build-openshift-4-18-openshift-base-rhel9-84vv4",
    "nvr": "openshift-base-rhel9-container-v4.18.0-202410010953.p0.gb45ea65.assembly.test.el9",
    "el_target": "el9",
    "arches": [
        "x86_64",
        "ppc64le",
        "s390x",
        "aarch64"
    ],
    "installed_packages": [],
    "parent_images": [],
    "embargoed": false
}

```
