### PR TITLE
Migrate doomsday pipeline to python

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline-task.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline-task.yaml
@@ -22,27 +22,7 @@ spec:
 
         set -e
 
-        mkdir -p workspace 
-        cd workspace
-
-        arches=(x86_64 s390x ppc64le aarch64 multi)
-
-        for arch in "${arches[@]}"; do
-            path=$(params.major)/$(params.version)/$arch
-            command="oc adm release mirror quay.io/openshift-release-dev/ocp-release:$(params.version)-$arch --keep-manifest-list --to-dir=$path"
-            echo "Running command: $command"
-            $command
-            sleep 5
-
-            awscommand="aws s3 sync $path s3://ocp-doomsday-registry/release-image/$path"
-            echo Running aws command: $awscommand
-            $awscommand
-            sleep 5
-
-
-            echo "Cleaning dir: $(params.major)/$(params.version)"
-            rm -rf $path
-        done
+        artcd -vv doomsday-sync --version $(params.version) --all-arches
       securityContext:
         runAsGroup: 0
         runAsUser: 0

--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
@@ -39,6 +39,9 @@ WORKDIR /home/dev
 # Fixes issue "ERROR: Cannot uninstall requests 2.25.1, RECORD file not found. Hint: The package was installed by rpm."
 RUN rpm -e --nodeps python3-requests
 
+# Setup uv package manager
+RUN pip3 install uv && uv venv --python 3.11
+
 # Copy art-tools and run the install script
 COPY . .
 

--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
@@ -46,7 +46,7 @@ COPY . .
 # running ./install.sh
 RUN pip3 install setuptools==70.0.0
 
-RUN ./install.sh
+RUN pip3 install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
 
 # Install check-payload tool for FIPS scanning, and copy to a location in PATH
 RUN git clone https://github.com/openshift/check-payload check-payload &&  \

--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
@@ -39,9 +39,6 @@ WORKDIR /home/dev
 # Fixes issue "ERROR: Cannot uninstall requests 2.25.1, RECORD file not found. Hint: The package was installed by rpm."
 RUN rpm -e --nodeps python3-requests
 
-# Setup uv package manager
-RUN pip3 install uv && uv venv --python 3.11
-
 # Copy art-tools and run the install script
 COPY . .
 

--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.latest
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.latest
@@ -11,7 +11,7 @@ WORKDIR /home/dev
 
 # Copy art-tools and run the install script
 COPY . .
-RUN ./install.sh
+RUN pip3 install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
 
 # Install check-payload tool for FIPS scanning, and copy to a location in PATH
 # They update the tool often, so lets keep in update for now

--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.latest
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.latest
@@ -9,9 +9,6 @@ RUN pip3 install --upgrade pip
 # Set workspace
 WORKDIR /home/dev
 
-# Setup uv package manager
-RUN pip3 install uv && uv venv --python 3.11
-
 # Copy art-tools and run the install script
 COPY . .
 RUN ./install.sh

--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.latest
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.latest
@@ -9,6 +9,9 @@ RUN pip3 install --upgrade pip
 # Set workspace
 WORKDIR /home/dev
 
+# Setup uv package manager
+RUN pip3 install uv && uv venv --python 3.11
+
 # Copy art-tools and run the install script
 COPY . .
 RUN ./install.sh

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -4,7 +4,7 @@ from pyartcd.cli import cli
 from pyartcd.pipelines import (
     build_microshift, check_bugs, gen_assembly, ocp4_konflux, prepare_release, promote, rebuild,
     review_cvp, tarball_sources, build_sync, build_rhcos, ocp4_scan, images_health, operator_sdk_sync,
-    olm_bundle, ocp4, scan_for_kernel_bugs, tag_rpms, advisory_drop, cleanup_locks, brew_scan_osh, sigstore_sign, update_golang, rebuild_golang_rpms, scan_fips, doomsday
+    olm_bundle, ocp4, scan_for_kernel_bugs, tag_rpms, advisory_drop, cleanup_locks, brew_scan_osh, sigstore_sign, update_golang, rebuild_golang_rpms, scan_fips, quay_doomsday_backup
 )
 from pyartcd.pipelines.scheduled import schedule_ocp4_scan
 

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -4,7 +4,7 @@ from pyartcd.cli import cli
 from pyartcd.pipelines import (
     build_microshift, check_bugs, gen_assembly, ocp4_konflux, prepare_release, promote, rebuild,
     review_cvp, tarball_sources, build_sync, build_rhcos, ocp4_scan, images_health, operator_sdk_sync,
-    olm_bundle, ocp4, scan_for_kernel_bugs, tag_rpms, advisory_drop, cleanup_locks, brew_scan_osh, sigstore_sign, update_golang, rebuild_golang_rpms, scan_fips
+    olm_bundle, ocp4, scan_for_kernel_bugs, tag_rpms, advisory_drop, cleanup_locks, brew_scan_osh, sigstore_sign, update_golang, rebuild_golang_rpms, scan_fips, doomsday
 )
 from pyartcd.pipelines.scheduled import schedule_ocp4_scan
 

--- a/pyartcd/pyartcd/pipelines/doomsday.py
+++ b/pyartcd/pyartcd/pipelines/doomsday.py
@@ -1,0 +1,74 @@
+import os
+from typing import Optional
+import click
+from time import sleep
+import shutil
+
+from pyartcd.runtime import Runtime
+from pyartcd.cli import cli, pass_runtime
+from artcommonlib.exectools import cmd_assert
+from doozerlib.util import mkdirs
+
+
+class DoomsdaySync:
+    ALL_ARCHES_LIST = ["x86_64", "s390x", "ppc64le", "aarch64", "multi"]
+    N_RETRIES = 4
+
+    def __init__(self, runtime: Runtime, all_arches: bool, arches: Optional[list[str]], version: str):
+        self.runtime = runtime
+        self.version = version
+        self.workdir = "./workspace"
+
+        if arches and all_arches:
+            raise Exception("Cannot specify both --arches and --all-arches")
+
+        if not (arches or all_arches):
+            raise Exception("Either --arches or --all-arches needs to be specified")
+
+        self.arches = arches.split(",") if not all_arches else self.ALL_ARCHES_LIST
+
+    def sync_arch(self, arch: str):
+        if arch not in self.ALL_ARCHES_LIST:
+            raise Exception(f"Invalid arch: {arch}")
+
+        major_minor = ".".join(self.version.split(".")[:2])
+        path = f"{self.workdir}/{major_minor}/{self.version}/{arch}"
+        mirror_cmd = f"oc adm release mirror quay.io/openshift-release-dev/ocp-release:{self.version}-{arch} --keep-manifest-list --to-dir={path}"
+        aws_cmd = f"aws s3 sync {path} s3://ocp-doomsday-registry/release-image/{path}"
+
+        try:
+            if self.runtime.dry_run:
+                self.runtime.logger.info("[DRY RUN] Would have run %s", mirror_cmd)
+                self.runtime.logger.info("[DRY RUN] Would have run %s", aws_cmd)
+            else:
+                cmd_assert(mirror_cmd, retries=self.N_RETRIES)
+                sleep(5)
+                cmd_assert(aws_cmd, retries=self.N_RETRIES)
+                sleep(5)
+
+        except ChildProcessError:
+            self.runtime.logger.error("Failed to sync arch %s", arch)
+
+        if os.path.exists(path):
+            self.runtime.logger.info("Cleaning dir: %s", path)
+            shutil.rmtree(path)
+
+    def run(self):
+        mkdirs(self.workdir)
+
+        for arch in self.arches:
+            self.runtime.logger.info("Now syncing arch %s", arch)
+            self.sync_arch(arch)
+
+
+@cli.command("doomsday-sync", help="Run doomsday pipeline for the specified version and arches")
+@click.option("--arches", required=False, help="Comma separated list of arches to sync")
+@click.option("--all-arches", is_flag=True, required=False, default=False, help="Sync all arches")
+@click.option("--version", required=True, help="Release to sync, e.g. 4.15.3")
+@pass_runtime
+def doomsday_sync(runtime: Runtime, arches: str, all_arches: bool, version: bool):
+    doomsday_pipeline = DoomsdaySync(runtime=runtime,
+                                     arches=arches,
+                                     all_arches=all_arches,
+                                     version=version)
+    doomsday_pipeline.run()


### PR DESCRIPTION
Migrate doomsday pipeline to Python and add retries to running `oc adm release mirror ...` and `aws s3 sync ...` commands