### PR TITLE
remove pipeline timeout, but keep build

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_build_pipelinerun.yaml
+++ b/doozer/doozerlib/backend/konflux_image_build_pipelinerun.yaml
@@ -16,9 +16,6 @@ metadata:
   name: ui-ocp-4-18-base-rhel-9-on-push
   namespace: crt-nshift-art-pipeli-tenant
 spec:
-  timeouts:
-    # See https://konflux-ci.dev/docs/how-tos/configuring/customizing-the-build/#configuring-timeouts
-    pipeline: 12h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -201,7 +198,7 @@ spec:
           value:
           - $(params.build-platforms)
       name: build-images
-      timeout: 12h
+      timeout: 12h  # See https://konflux-ci.dev/docs/how-tos/configuring/customizing-the-build/#configuring-timeouts
       params:
       - name: IMAGE
         value: $(params.output-image)


### PR DESCRIPTION
Remove pipeline timeout override. We need build time out to be 12 hrs so that during mass rebuilds, the PLR is not pruned while waiting to build, which has happened a couple of times