### PR TITLE
Populate installed pkgs in konflux build

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -22,6 +22,7 @@ from doozerlib.backend.build_repo import BuildRepo
 from doozerlib.image import ImageMetadata
 from doozerlib.source_resolver import SourceResolution
 
+from artcommonlib.arch_util import go_arch_for_brew_arch
 from artcommonlib.release_util import isolate_assembly_in_release, isolate_el_version_in_release
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord, ArtifactType, Engine, KonfluxBuildOutcome
 
@@ -230,12 +231,14 @@ class KonfluxImageBuilder:
         :return: Returns list of installed rpms for an image pullspec, assumes that the sbom exists in registry
         """
         async def _get_for_arch(arch):
+            go_arch = go_arch_for_brew_arch(arch)
+
             cmd = [
                 "cosign",
                 "download",
                 "sbom",
                 image_pullspec,
-                "--platform", f"linux/{arch}"
+                "--platform", f"linux/{go_arch}"
             ]
             _, stdout, _ = await exectools.cmd_gather_async(cmd)
             sbom_contents = json.loads(stdout)

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -225,6 +225,10 @@ class KonfluxImageBuilder:
 
     @staticmethod
     def get_installed_packages(image_pullspec, arches) -> list:
+        """
+        Example sbom: https://gist.github.com/thegreyd/6718f4e4dae9253310c03b5d492fab68
+        :return: Returns list of installed rpms for an image pullspec, assumes that the sbom exists in registry
+        """
         def _get_for_arch(arch):
             cmd = [
                 "cosign",
@@ -237,7 +241,7 @@ class KonfluxImageBuilder:
             if rc != 0:
                 raise IOError(stderr)
 
-            sbom_contents = json.load(stdout)
+            sbom_contents = json.loads(stdout)
             source_rpms = set()
             for x in sbom_contents["components"]:
                 if x["bom-ref"].startswith("pkg:rpm"):

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1302,7 +1302,7 @@ class ImageDistGitRepo(DistGitRepo):
     def get_installed_packages(self, image_pullspec) -> list:
         bbii = BrewBuildImageInspector(self.runtime, image_pullspec)
         installed_packages_dict = bbii.get_all_installed_package_build_dicts()
-        return [p['nvr'] for p in installed_packages_dict.values()]
+        return sorted([p['nvr'] for p in installed_packages_dict.values()])
 
     def update_konflux_db(self, build_info, outcome, build_pipeline_url='', scratch=False):
         if scratch:


### PR DESCRIPTION
Use cosign command to download sbom and extract installed rpms

`cosign download sbom quay.io/openshift-release-dev/ocp-v4.0-art-dev-test:ose-ironic-agent-rhel9-v4.18.0-20241002.145940 --platform linux/amd64`

## Test

https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/121/console

```
$ ./elliott --assembly test -g openshift-4.18 -i openshift-base-rhel9 find-k-builds -k image -e konflux --output json
2024-10-02 17:52:13,760 art_tools.elliottlib.cli.find_konflux_builds_cli INFO Found 1 builds
{
    "name": "openshift-base-rhel9",
    "group": "openshift-4.18",
    "version": "v4.18.0",
    "release": "202410022059.p0.gb45ea65.assembly.test.el9",
    "assembly": "test",
    "source_repo": "https://github.com/openshift-eng/ocp-build-data",
    "commitish": "b45ea65bf6606c558b1a18b92ad878f42a411894",
    "rebase_repo_url": "https://github.com/openshift-eng/ocp-build-data",
    "rebase_commitish": "8f29e4c3082535e4f153d300491abccb858ab464",
    "start_time": "2024-10-02T20:59:46",
    "end_time": "2024-10-02T21:11:55",
    "artifact_type": "image",
    "engine": "konflux",
    "image_pullspec": "quay.io/openshift-release-dev/ocp-v4.0-art-dev-test:base-rhel9-v4.18.0-20241002.205933",
    "image_tag": "d039b96d2934dc16bbf87c8b78625554e42d6f805f8fa1ffaa50ab49cda0b89b",
    "outcome": "success",
    "art_job_url": "https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/121/",
    "build_pipeline_url": "https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-18/pipelineruns/doozer-build-openshift-4-18-openshift-base-rhel9-c5lf7",
    "pipeline_commit": "n/a",
    "schema_level": 1,
    "ingestion_time": "2024-10-02T21:11:51",
    "record_id": "8ca2c1af-0b75-bc98-1197-e6cf3b3d61db",
    "build_id": "doozer-build-openshift-4-18-openshift-base-rhel9-c5lf7",
    "nvr": "openshift-base-rhel9-container-v4.18.0-202410022059.p0.gb45ea65.assembly.test.el9",
    "el_target": "el9",
    "arches": [
        "x86_64",
        "ppc64le",
        "s390x",
        "aarch64"
    ],
    "installed_packages": [
        "acl-2.3.1-4.el9",
        "attr-2.5.1-3.el9",
        "audit-3.1.2-2.el9",
        "basesystem-11-13.el9",
        "bash-5.1.8-9.el9",
        "bzip2-1.0.8-8.el9",
        "ca-certificates-2024.2.69_v8.0.303-91.4.el9_4",
        "chkconfig-1.24-1.el9",
        "coreutils-8.32-35.el9",
        "cracklib-2.9.6-27.el9",
        "crypto-policies-20240202-1.git283706d.el9",
        "curl-7.76.1-29.el9_4.1",
        "cyrus-sasl-2.1.27-21.el9",
        "dbus-1.12.20-8.el9",
        "dbus-broker-28-7.el9",
        "dbus-python-1.2.18-2.el9",
        "dejavu-fonts-2.37-18.el9",
        "diffutils-3.7-12.el9",
        "dmidecode-3.5-3.el9",
        "dnf-4.14.0-9.el9",
        "dnf-plugins-core-4.3.0-13.el9",
        "e2fsprogs-1.46.5-5.el9",
        "elfutils-0.190-2.el9",
        "expat-2.5.0-2.el9_4.1",
        "file-5.39-16.el9",
        "filesystem-3.16-2.el9",
        "findutils-4.8.0-6.el9",
        "fonts-rpm-macros-2.0.5-7.el9.1",
        "gawk-5.1.0-6.el9",
        "gcc-11.4.1-3.el9",
        "gdb-10.2-13.el9",
        "gdbm-1.19-4.el9",
        "glib2-2.68.4-14.el9_4.1",
        "glibc-2.34-100.el9_4.4",
        "gmp-6.2.0-13.el9",
        "gnupg2-2.3.3-4.el9",
        "gnutls-3.8.3-4.el9_4",
        "gobject-introspection-1.68.0-11.el9",
        "gpgme-1.15.1-6.el9",
        "grep-3.6-5.el9",
        "gzip-1.12-1.el9",
        "ima-evm-utils-1.4-4.el9",
        "iproute-6.2.0-6.el9_4",
        "json-c-0.14-11.el9",
        "json-glib-1.6.6-1.el9",
        "keyutils-1.6.3-1.el9",
        "kmod-28-9.el9",
        "krb5-1.21.1-2.el9_4",
        "langpacks-3.0-16.el9",
        "libarchive-3.5.3-4.el9",
        "libassuan-2.5.5-3.el9",
        "libbpf-1.3.0-2.el9",
        "libcap-2.48-9.el9_2",
        "libcap-ng-0.8.2-7.el9",
        "libcomps-0.1.18-1.el9",
        "libdb-5.3.28-53.el9",
        "libdnf-0.69.0-8.el9_4.1",
        "libeconf-0.4.1-3.el9_2",
        "libevent-2.1.12-8.el9_4",
        "libffi-3.4.2-8.el9",
        "libgcrypt-1.10.0-10.el9_2",
        "libgpg-error-1.42-5.el9",
        "libidn2-2.3.0-7.el9",
        "libksba-1.5.1-6.el9_1",
        "libmnl-1.0.4-16.el9_4",
        "libmodulemd-2.13.0-2.el9",
        "libpwquality-1.4.4-8.el9",
        "librepo-1.14.5-2.el9",
        "libreport-2.15.2-6.el9",
        "librhsm-0.0.3-7.el9_3.1",
        "librtas-2.0.2-14.el9",
        "libseccomp-2.5.2-2.el9",
        "libselinux-3.6-1.el9",
        "libsemanage-3.6-1.el9",
        "libsepol-3.6-1.el9",
        "libsigsegv-2.13-4.el9",
        "libsolv-0.7.24-2.el9",
        "libtasn1-4.16.0-8.el9_1",
        "libunistring-0.9.10-15.el9",
        "libuser-0.63-13.el9",
        "libutempter-1.2.1-6.el9",
        "libverto-0.3.2-3.el9",
        "libxcrypt-4.4.18-3.el9",
        "libxml2-2.9.13-6.el9_4",
        "libyaml-0.2.5-7.el9",
        "lua-5.4.4-4.el9",
        "lz4-1.9.3-5.el9",
        "mpfr-4.1.0-7.el9",
        "ncurses-6.2-10.20210508.el9",
        "nettle-3.9.1-1.el9",
        "nghttp2-1.43.0-5.el9_4.3",
        "npth-1.6-8.el9",
        "openldap-2.6.6-3.el9",
        "openssl-3.0.7-28.el9_4",
        "openssl-fips-provider-3.0.7-2.el9",
        "p11-kit-0.25.3-2.el9",
        "pam-1.5.1-19.el9",
        "passwd-0.80-12.el9",
        "pcre-8.44-3.el9.3",
        "pcre2-10.40-5.el9",
        "policycoreutils-3.6-2.1.el9",
        "popt-1.18-8.el9",
        "psmisc-23.4-3.el9",
        "pygobject3-3.40.1-6.el9",
        "python-chardet-4.0.0-5.el9",
        "python-dateutil-2.8.1-7.el9",
        "python-decorator-4.4.2-6.el9",
        "python-idna-2.10-7.el9_4.1",
        "python-iniparse-0.4-45.el9",
        "python-inotify-0.9.6-25.el9",
        "python-pip-21.2.3-8.el9",
        "python-pysocks-1.7.1-12.el9",
        "python-requests-2.25.1-8.el9",
        "python-setuptools-53.0.0-12.el9_4.1",
        "python-six-1.15.0-9.el9",
        "python-systemd-234-18.el9",
        "python-urllib3-1.26.5-5.el9_4.1",
        "python3.9-3.9.18-3.el9_4.5",
        "readline-8.1-4.el9",
        "redhat-release-9.4-0.5.el9",
        "rootfiles-8.1-31.el9",
        "rpm-4.16.1.3-29.el9",
        "sed-4.8-9.el9",
        "setup-2.13.7-10.el9",
        "shadow-utils-4.9-8.el9",
        "sqlite-3.34.1-7.el9_3",
        "subscription-manager-1.29.40-1.el9",
        "subscription-manager-rhsm-certificates-20220623-1.el9",
        "systemd-252-32.el9_4.7",
        "tar-1.34-6.el9_4.1",
        "tpm2-tss-3.2.2-2.el9",
        "tzdata-2024a-1.el9",
        "usermode-1.114-4.el9",
        "util-linux-2.37.4-18.el9",
        "vim-8.2.2637-20.el9_1",
        "virt-what-1.25-5.el9",
        "which-2.21-29.el9",
        "xz-5.2.5-8.el9_0",
        "zlib-1.2.11-40.el9",
        "zstd-1.5.1-2.el9"
    ],
    "parent_images": [
        "brew.registry.redhat.io/rh-osbs/rhel-els@sha256:0a4a4ab60ce8abac3edab51cacdbed25cd012a3e4169895bce2d18ed74364e08"
    ],
    "embargoed": false
}

```

Compare brew and konflux installed_packages
```
$ diff -u 
<(./elliott --quiet --assembly stream -g openshift-4.18 -i openshift-base-rhel9 find-k-builds -k image -e brew --output json | jq '.installed_packages' | sort) 
<(./elliott --quiet --assembly test -g openshift-4.18 -i openshift-base-rhel9 find-k-builds -k image -e konflux --output json | jq '.installed_packages' | sort)

```