### PR TITLE
Search by distgit_key instead of name

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -252,7 +252,7 @@ class KonfluxRebaser:
                     name=parent_metadata.distgit_key,
                     assembly=self._runtime.assembly,
                     group=self._runtime.group,
-                    el_target=parent_metadata.branch_el_target(),
+                    el_target=f'el{parent_metadata.branch_el_target()}',
                     engine=Engine.KONFLUX)
                 return build.image_pullspec, build.embargoed
 

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -239,7 +239,7 @@ class KonfluxRebaser:
 
     def _resolve_member_parent(self, member: str, original_parent: str, image_repo: str, uuid_tag: str):
         """ Resolve the parent image for the given image metadata."""
-        parent_metadata = self._runtime.resolve_image(member, required=False)
+        parent_metadata: ImageMetadata = self._runtime.resolve_image(member, required=False)
         private_fix = False
         if parent_metadata is None:
             if not self._runtime.ignore_missing_base:
@@ -249,9 +249,10 @@ class KonfluxRebaser:
                 if not parent_metadata:
                     raise IOError(f"Parent image {member} is not found.")
                 build = self.konflux_db.get_latest_build(
-                    name=parent_metadata.name,
+                    name=parent_metadata.distgit_key,
                     assembly=self._runtime.assembly,
                     group=self._runtime.group,
+                    el_target=parent_metadata.branch_el_target(),
                     engine=Engine.KONFLUX)
                 return build.image_pullspec, build.embargoed
 

--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -880,7 +880,7 @@ class Runtime(GroupRuntime):
         with io.open(os.path.join(distgit_path, distgit + '.patch'), 'w', encoding='utf-8') as f:
             f.write(diff)
 
-    def resolve_image(self, distgit_name, required=True):
+    def resolve_image(self, distgit_name, required=True) -> ImageMetadata:
         """
         Returns an ImageMetadata for the specified group member name.
         :param distgit_name: The name of an image member in this group

--- a/elliott/elliottlib/cli/find_konflux_builds_cli.py
+++ b/elliott/elliottlib/cli/find_konflux_builds_cli.py
@@ -33,7 +33,7 @@ async def find_k_builds_cli(runtime: Runtime, kind, engine, outcome, output):
     outcome = KonfluxBuildOutcome(outcome) if outcome else KonfluxBuildOutcome.SUCCESS
     LOGGER.info(f'searching for {engine_fmt}builds of kind={kind} in group={runtime.group} with outcome={outcome.value}')
     metas = runtime.image_metas() if kind == 'image' else runtime.rpm_metas()
-    names = [meta.name for meta in metas]
+    names = [meta.distgit_key for meta in metas]
 
     args = {
         'names': names,


### PR DESCRIPTION
We are recording metadata.distgit_key in our DB record, so search by that at rebase time
and in find-k-builds.

Test run: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/132/console