### PR TITLE
ART-10624: set extra fields in reconciliation issues

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -831,6 +831,21 @@ This ticket was created by ART pipline run [sync-ci-images|{jenkins_build_url}]
             new_issues[distgit_key] = issue
             print(f'A JIRA issue has been opened for {pr.html_url}: {issue.key}')
             connect_issue_with_pr(pr, issue.key)
+            try:
+                # Retrieve the value of the custom field
+                release_notes_text_cf_value = getattr(issue.fields, 'customfield_12317313', None)
+                release_notes_type_cf_value = getattr(issue.fields, 'customfield_12320850', None)
+
+                if release_notes_type_cf_value is None and release_notes_text_cf_value is None:
+                    # Data to update (e.g., changing the Release Notes Type and Release Notes Text)
+                    issue_update = {
+                        'customfield_12317313': 'N/A',  # customfield_12317313 is Release Notes Text in JIRA
+                        'customfield_12320850': {'value': 'Release Note Not Required'},  # customfield_12320850 is Release Notes Type in JIRA
+                    }
+                    # Now update the issue using the retrieved issue object
+                    issue.update(fields=issue_update)
+            except Exception as e:
+                print(f"An error occurred while updating the issue {issue.key}: {e}")
         else:
             new_issues[distgit_key] = 'NEW!'
             print(f'Would have created JIRA issue for {distgit_key} / {pr.html_url}:\n{fields}\n')


### PR DESCRIPTION
The approach of updating the JIRA issue AFTER creating it, works.
This was tested by this script.:

```
from jira import JIRA

token_auth = "dont-leak-tokens"
client = JIRA("https://issues.redhat.com", token_auth=token_auth)

if client:
    print(f"connected")
else:
    print(f"can't connect")

# Issue details payload
issue_data = {
    'project': {'key': 'ART'},
    'issuetype': {'name': 'Bug'},
    'labels': ['art:reconciliation', f'art:package:openshift-enterprise-hyperkube-container'],
    'versions': [{'name': '4.10'}],  # Affects Version/s
    'components': [{'name': 'daily-ops'}],
    'summary': '[test] this ART ticket should be closed once it is not needed anymore',
    'description': 'this ART bug is still for testing'
    }


# Create the issue
new_issue = client.create_issue(fields=issue_data)

# Output the issue key (e.g., PROJECT-123)
print(f"Issue {new_issue.key} created successfully.")

#issue_key = new_issue

try:
    # Check if the custom fields are already set
    release_notes_text_value = new_issue.fields.__dict__.get('customfield_12317313')
    release_notes_type_value = new_issue.fields.__dict__.get('customfield_12320850')

    if release_notes_type_value not in ['Release Notes Not Required'] and release_notes_text_value not in ['N/A']:
        # Data to update (e.g., changing the summary and description)
        issue_update = {
            'customfield_12317313': 'N/A',  # customfield_12317313 is Release Notes Text in JIRA
            'customfield_12320850': {'value': 'Release Note Not Required'},  # customfield_12320850 is Release Notes Type in JIRA
            }
    elif release_notes_type_value in ['Release Notes Not Required'] and release_notes_text_value not in ['N/A']:
        issue_update = {
            'customfield_12317313': 'N/A'  # customfield_12317313 is Release Notes Text in JIRA
            }

    # Use the update_issue method to update the issue
    new_issue.update(fields=issue_update)
    # Output the issue key (e.g., PROJECT-123)
    print(f"Issue {new_issue.key} updated successfully.")
except Exception as e:
    print(f"An error occurred while updating the issue {new_issue.key}: {e}")

```
A JIRA in ART was created and afterwards updated.