### PR TITLE
Decrease konflux_db.search_builds_by_fields() log level

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -146,7 +146,7 @@ class KonfluxDb:
             query += f' LIMIT {limit}'
 
         results = await self.bq_client.query_async(query)
-        self.logger.info('Found %s builds', results.total_rows)
+        self.logger.debug('Found %s builds', results.total_rows)
         return [self.from_result_row(result) for result in results]
 
     async def get_latest_builds(self, names: typing.List[str], group: str,


### PR DESCRIPTION
`search_builds_by_fields()` only logs the number of builds found, without specifying more details. This function has been written to be as flexible as possible, so it's not possible to know what params were specified to make the search. This makes log messages like `artcommonlib.konflux.konflux_db INFO Found 1 builds` quite useless. 

Proposing to set the debug level to DEBUG, to make our pipeline logs more readable.