### PR TITLE
update file_upload_v2 parameters

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -453,18 +453,17 @@ class BuildMicroShiftPipeline:
     async def _notify_microshift_alerts(self, version_release: str):
         doozer_log_file = Path(self._doozer_env_vars["DOOZER_WORKING_DIR"]) / "debug.log"
         slack_client = self.runtime.new_slack_client()
-        slack_client.channel = "#microshift-alerts"
+        slack_client.channel = "C0310LGMQQY"  # microshift-alerts
         message = f":alert: @here ART build failure: microshift-{version_release}."
         message += "\nPing @ release-artists if you need help."
         slack_response = await slack_client.say(message)
         slack_thread = slack_response["message"]["ts"]
         if doozer_log_file.exists():
-            with doozer_log_file.open() as f:
-                await slack_client.upload_file(
-                    file=f,
-                    filename="microshift-build.log",
-                    initial_comment="Build logs",
-                    thread_ts=slack_thread)
+            await slack_client.upload_file(
+                file=doozer_log_file,
+                filename="microshift-build.log",
+                initial_comment="Build logs",
+                thread_ts=slack_thread)
         else:
             await slack_client.say("Logs are not available.", thread_ts=slack_thread)
 

--- a/pyartcd/pyartcd/slack.py
+++ b/pyartcd/pyartcd/slack.py
@@ -76,22 +76,21 @@ class SlackClient:
     async def upload_file(self, file=None, content=None, filename=None, initial_comment=None, thread_ts: Optional[str] = None):
         response = await self._client.files_upload_v2(
             file=file,
-            filename=content,
-            filetype=filename,
+            content=content,
+            filename=filename,
             initial_comment=initial_comment,
-            channels=self.channel,
+            channel=self.channel,
             thread_ts=thread_ts)
         return response.data
 
-    async def upload_content(self, content, intro=None, filename=None, filetype=None, thread_ts: Optional[str] = None):
+    async def upload_content(self, content, intro=None, filename=None, thread_ts: Optional[str] = None):
         """
         Similar to upload_file but can upload from a variable instead of a file
         """
         response = await self._client.files_upload_v2(
             initial_comment=intro,
-            channels=self.channel,
+            channel=self.channel,
             content=content,
             filename=filename,
-            filetype=filetype,
             thread_ts=thread_ts)
         return response.data


### PR DESCRIPTION
fix error
```
UserWarning: Although the channels parameter is still supported for smooth migration from legacy files.upload, we recommend using the new channel parameter with a single str value instead for more clarity.
The filetype parameter is no longer supported. Please remove it from the arguments.
```
update channels parameter to channel
remove filetype parameter
file parameter should accept file path string
and file_upload_v2 will call files.completeUploadExternal which seems only accept channel_id so set channel with id instead of its name
