### PR TITLE
[konflux] move overrides to code

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_build_pipelinerun.yaml
+++ b/doozer/doozerlib/backend/konflux_image_build_pipelinerun.yaml
@@ -16,9 +16,6 @@ metadata:
   name: ui-ocp-4-18-base-rhel-9-on-push
   namespace: crt-nshift-art-pipeli-tenant
 spec:
-  timeouts:
-    # See https://konflux-ci.dev/docs/how-tos/configuring/customizing-the-build/#configuring-timeouts
-    pipeline: 12h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -28,8 +25,6 @@ spec:
     value: quay.io/redhat-user-workloads/crt-nshift-art-pipeli-tenant/ui-openshift-4-18/ui-ocp-4-18-base-rhel-9:{{revision}}
   - name: dockerfile
     value: Dockerfile
-  - name: skip-checks
-    value: "false"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -201,7 +196,6 @@ spec:
           value:
           - $(params.build-platforms)
       name: build-images
-      timeout: 12h
       params:
       - name: IMAGE
         value: $(params.output-image)


### PR DESCRIPTION
Based on existing pattern, move overrides to code so that we can use the [template](https://github.com/openshift-priv/art-konflux-template/blob/main/.tekton/art-konflux-template-push.yaml) from openshift-priv/art-konflux-template