### PR TITLE
Fix time comparison

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -108,7 +108,7 @@ def is_future_release_date(date_str):
     If the input date is in future then return True elase False
     """
     try:
-        target_date = datetime.strptime(date_str, "%Y-%m-%d")
+        target_date = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=UTC)
     except ValueError:
         return False
     current_date = datetime.now(tz=UTC)


### PR DESCRIPTION
Fix error like this

```
  File "/mnt/jenkins-workspace/s-cd-builds_build_gen-assembly_2@2/art-tools/artcommon/artcommonlib/util.py", line 115, in is_future_release_date
    if target_date > current_date:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can't compare offset-naive and offset-aware datetimes
```