### PR TITLE
make utc python backwards compatible

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 import pprint
 import typing
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta, timezone
 
 from google.cloud.bigquery import SchemaField, Row
 from sqlalchemy import Column, String, DateTime
@@ -92,7 +92,7 @@ class KonfluxDb:
                 return str(value)
 
         # Fill in missing record fields
-        build.ingestion_time = datetime.now(tz=UTC)
+        build.ingestion_time = datetime.now(tz=timezone.utc)
         build.schema_level = SCHEMA_LEVEL
 
         # Execute query
@@ -187,7 +187,7 @@ class KonfluxDb:
         """
 
         if not completed_before:
-            completed_before = datetime.now(tz=UTC)
+            completed_before = datetime.now(tz=timezone.utc)
         self.logger.info('Searching for %s builds completed before %s', name, completed_before)
 
         # Table is partitioned by start_time. Perform an iterative search within 3-month windows, going back to 3 years

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -1,7 +1,7 @@
 import logging
 from time import sleep
 from typing import OrderedDict, Optional, Tuple, Iterable, List
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 import re
 import asyncio
 
@@ -124,10 +124,10 @@ def is_future_release_date(date_str):
     If the input date is in future then return True elase False
     """
     try:
-        target_date = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=UTC)
+        target_date = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
     except ValueError:
         return False
-    current_date = datetime.now(tz=UTC)
+    current_date = datetime.now(tz=timezone.utc)
     if target_date > current_date:
         return True
     else:

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import os
 import json
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional, Sequence, cast
@@ -289,7 +289,7 @@ class KonfluxImageBuilder:
                 'el_target': f'el{isolate_el_version_in_release(release)}',
                 'arches': metadata.get_arches(),
                 'embargoed': 'p1' in release.split('.'),
-                'start_time': datetime.now(tz=UTC),
+                'start_time': datetime.now(tz=timezone.utc),
                 'end_time': None,
                 'nvr': nvr,
                 'group': metadata.runtime.group,

--- a/doozer/doozerlib/cli/images_health.py
+++ b/doozer/doozerlib/cli/images_health.py
@@ -18,7 +18,7 @@ class ImagesHealthPipeline:
         self.runtime = runtime
         self.limit = limit
         self.url_markup = url_markup
-        self.start_search = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=DELTA_DAYS)
+        self.start_search = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=DELTA_DAYS)
         self.concerns = {}
         self.logger = logging.getLogger(__name__)
         self.runtime.konflux_db.bind(KonfluxBuildRecord)
@@ -107,7 +107,7 @@ class ImagesHealthPipeline:
             self.concerns[key].append(msg)
 
         else:
-            if latest_success_bi_dt < datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=14):
+            if latest_success_bi_dt < datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=14):
                 # Successful build is older than 2 weeks
                 self.concerns[key].append(
                     f'Last {self.url_text(latest_success_bi_task_url, "build")} '

--- a/doozer/doozerlib/cli/olm_bundle.py
+++ b/doozer/doozerlib/cli/olm_bundle.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 
 import click
 import sys
@@ -280,7 +280,7 @@ def rebase_and_build_olm_bundle(runtime: Runtime, operator_nvrs: Tuple[str, ...]
             else:
                 build_record_params.update({
                     'outcome': KonfluxBuildOutcome.FAILURE,
-                    'start_time': datetime.now(tz=UTC),  # TODO: store start time from taskID
+                    'start_time': datetime.now(tz=timezone.utc),  # TODO: store start time from taskID
                     'end_time': None,
                     'nvr': 'n/a'
                 })

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 import hashlib
 import traceback
 import sys
@@ -1179,7 +1179,7 @@ class GenPayloadCli:
         the same.
         """
 
-        multi_ts = datetime.now(tz=UTC).strftime("%Y-%m-%d-%H%M%S")
+        multi_ts = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d-%H%M%S")
         if self.runtime.assembly_type is AssemblyTypes.STREAM:
             # We are publicizing a nightly. Unlike single-arch payloads, the release controller does
             # not react to 4.x-art-latest updates and create a timestamp-based name. We create the

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -12,7 +12,7 @@ import shutil
 import sys
 import time
 import traceback
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from multiprocessing import Lock
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union, Set, cast
 
@@ -1350,7 +1350,7 @@ class ImageDistGitRepo(DistGitRepo):
             if outcome == KonfluxBuildOutcome.FAILURE:
                 self.logger.info('Storing failed Brew build info for %s in Konflux DB', self.metadata.name)
                 build_record_params.update({
-                    'start_time': datetime.now(tz=UTC),  # TODO: store start time from taskID
+                    'start_time': datetime.now(tz=timezone.utc),  # TODO: store start time from taskID
                     'end_time': None,
                 })
 

--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -298,7 +298,7 @@ class Runtime(GroupRuntime):
         if self.lock_runtime_uuid:
             self.uuid = self.lock_runtime_uuid
         else:
-            self.uuid = datetime.datetime.now(tz=datetime.UTC).strftime("%Y%m%d.%H%M%S")
+            self.uuid = datetime.datetime.now(tz=datetime.timezone.utc).strftime("%Y%m%d.%H%M%S")
 
         self.distgits_dir = os.path.join(self.working_dir, "distgits")
         self.distgits_diff_dir = os.path.join(self.working_dir, "distgits-diffs")

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -16,7 +16,7 @@ from typing import Dict, List, Optional, Tuple
 from jira.resources import Issue
 from ruamel.yaml import YAML
 from tenacity import retry, stop_after_attempt, wait_fixed
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta, timezone
 
 from artcommonlib.assembly import AssemblyTypes, assembly_group_config
 from artcommonlib.model import Model
@@ -195,7 +195,7 @@ class PrepareReleasePipeline:
                         elif ad == "prerelease":
                             # Set release date of prerelease advisory to 3 days after when we prepare the release
                             # it should not be a weekend
-                            today = datetime.now(tz=UTC)
+                            today = datetime.now(tz=timezone.utc)
                             release_date = today + timedelta(days=3)
                             if release_date.weekday() == 5:  # Saturday
                                 release_date += timedelta(days=2)

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -5,7 +5,7 @@ import re
 import os
 import base64
 from typing import List
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from ghapi.all import GhApi
 from ruamel.yaml import YAML
 
@@ -338,7 +338,7 @@ class UpdateGolangPipeline:
         _LOGGER.info("Rebasing...")
         branch = self.get_golang_branch(el_v, go_version)
         version = f"v{go_version}"
-        release = datetime.now(tz=UTC).strftime('%Y%m%d%H%M')
+        release = datetime.now(tz=timezone.utc).strftime('%Y%m%d%H%M')
         cmd = [
             "doozer",
             "--group", branch,

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -4,7 +4,7 @@ import re
 import shutil
 import sys
 import tempfile
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Optional, Union, Iterable
 
@@ -382,7 +382,7 @@ def default_release_suffix():
     E.g. "202312311112.p?"
     """
 
-    return f'{datetime.strftime(datetime.now(tz=UTC), "%Y%m%d%H%M")}.p?'
+    return f'{datetime.strftime(datetime.now(tz=timezone.utc), "%Y%m%d%H%M")}.p?'
 
 
 def dockerfile_url_for(url, branch, sub_path) -> str:


### PR DESCRIPTION
`datetime.UTC` is supported only for python 3.11+

art-cd images on art-cluster are still on 3.9 (installation issues with 3.11). So we need to make sure that code is backwards compatible.

suggesting to use [datetime.timezone.utc](https://docs.python.org/3/library/datetime.html#datetime.timezone.utc), since they are the [same](https://docs.python.org/3/library/datetime.html#datetime.UTC)