### PR TITLE
artcd image rollback to python3.9

### DIFF
--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
@@ -13,9 +13,9 @@ RUN curl -fLo /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem https://certs
 COPY art-cluster/pipelines/data/project/art-cd/image/files/etc/yum.repos.d /etc/yum.repos.d/
 
 # Install necessary packages and Python libraries
-RUN dnf -y install python3.11 python3.11-pip python3.11-wheel python3.11-devel gcc krb5-devel wget tar gzip git krb5-workstation \
+RUN dnf -y install python3 python3-pip python3-wheel python3-devel gcc krb5-devel wget tar gzip git krb5-workstation \
     brewkoji rhpkg go podman \
-    && python3.11 -m pip install --upgrade setuptools pip \
+    && python3 -m pip install --upgrade setuptools pip \
     && dnf clean all
 
 # Set ARG for OC_VERSION
@@ -43,9 +43,10 @@ RUN rpm -e --nodeps python3-requests
 COPY . .
 
 # Fixes issue "TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'" while
-# running ./install.sh
 RUN pip3 install setuptools==70.0.0
 
+# In openshift, we do not need to create virtual envronment because all runs are indepenedent
+# Hence we cannot use ./install.sh since uv needs to have a virtual environment
 RUN pip3 install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
 
 # Install check-payload tool for FIPS scanning, and copy to a location in PATH


### PR DESCRIPTION
artcd does not work with python3.11 on cluster right now 

```
asdas@asdas-thinkpadp1gen3:~$ artcd -h
Traceback (most recent call last):
  File "/home/dev/.venv/bin/artcd", line 5, in <module>
    from pyartcd.__main__ import main
  File "/home/dev/pyartcd/pyartcd/__main__.py", line 4, in <module>
    from pyartcd.pipelines import (
  File "/home/dev/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py", line 8, in <module>
    from specfile import Specfile
  File "/home/dev/.venv/lib64/python3.11/site-packages/specfile/__init__.py", line 8, in <module>
    from specfile.specfile import Specfile
  File "/home/dev/.venv/lib64/python3.11/site-packages/specfile/specfile.py", line 12, in <module>
    import rpm
  File "/home/dev/.venv/lib64/python3.11/site-packages/rpm/__init__.py", line 109, in <module>
    initialize()
  File "/home/dev/.venv/lib64/python3.11/site-packages/rpm/__init__.py", line 98, in initialize
    raise ImportError(
ImportError: Failed to import system RPM module. Make sure RPM Python bindings are installed on your system.
```

Rolling back to 3.9 on cluster until we manage to figure out the root cause.
