### PR TITLE
ART-10563 Refactor build-microshift pipeline

### DIFF
--- a/doozer/doozerlib/rpm_builder.py
+++ b/doozer/doozerlib/rpm_builder.py
@@ -249,22 +249,21 @@ class RPMBuilder:
                 else:
                     logger.warning("DRY RUN - Would have downloaded Brew logs with %s", cmd)
             failed_tasks = {task_id for task_id, error in errors.items() if error is not None}
-            if not failed_tasks:
-                if not self._dry_run:
-                    # All tasks complete.
-                    with self._runtime.shared_koji_client_session() as koji_api:
-                        if not koji_api.logged_in:
-                            koji_api.gssapi_login()
+            if not failed_tasks and not self._dry_run:
+                # All tasks complete.
+                with self._runtime.shared_koji_client_session() as koji_api:
+                    if not koji_api.logged_in:
+                        koji_api.gssapi_login()
+                    with koji_api.multicall(strict=True) as m:
+                        multicall_tasks = [m.listBuilds(taskID=task_id, completeBefore=None) for task_id in task_ids]    # this call should not be constrained by brew event
+                    nvrs = [task.result[0]["nvr"] for task in multicall_tasks]
+                    if self._runtime.hotfix:
+                        # Tag rpms so they don't get garbage collected.
+                        hotfix_tags = rpm.hotfix_brew_tags()
+                        self._runtime.logger.info(f'Tagging build(s) {nvrs} info {hotfix_tags} to prevent garbage collection')
                         with koji_api.multicall(strict=True) as m:
-                            multicall_tasks = [m.listBuilds(taskID=task_id, completeBefore=None) for task_id in task_ids]    # this call should not be constrained by brew event
-                        nvrs = [task.result[0]["nvr"] for task in multicall_tasks]
-                        if self._runtime.hotfix:
-                            # Tag rpms so they don't get garbage collected.
-                            hotfix_tags = rpm.hotfix_brew_tags()
-                            self._runtime.logger.info(f'Tagging build(s) {nvrs} info {hotfix_tags} to prevent garbage collection')
-                            with koji_api.multicall(strict=True) as m:
-                                for nvr, hotfix_tag in zip(nvrs, hotfix_tags):
-                                    m.tagBuild(hotfix_tag, nvr)
+                            for nvr, hotfix_tag in zip(nvrs, hotfix_tags):
+                                m.tagBuild(hotfix_tag, nvr)
 
                 logger.info("Successfully built rpm: %s", rpm.rpm_name)
                 rpm.build_status = True

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -489,6 +489,7 @@ class BuildMicroShiftPipeline:
 @click_coroutine
 async def build_microshift(runtime: Runtime, data_path: str, group: str, assembly: str, payloads: Tuple[str, ...],
                            no_rebase: bool, force: bool):
+    # slack client is dry-run aware and will not send messages if dry-run is enabled
     slack_client = runtime.new_slack_client()
     slack_client.bind_channel(group)
     try:
@@ -500,9 +501,8 @@ async def build_microshift(runtime: Runtime, data_path: str, group: str, assembl
         reaction = None
         error_message = slack_message + f"\n {traceback.format_exc()}"
         runtime.logger.error(error_message)
-        if not runtime.dry_run:
-            if assembly not in ["stream", "test", "microshift"]:
-                slack_message += "\n@release-artists"
-                reaction = "art-attention"
-            await slack_client.say_in_thread(slack_message, reaction)
+        if assembly not in ["stream", "test", "microshift"]:
+            slack_message += "\n@release-artists"
+            reaction = "art-attention"
+        await slack_client.say_in_thread(slack_message, reaction)
         raise

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -183,7 +183,12 @@ class BuildMicroShiftPipeline:
         if self.assembly_type in [AssemblyTypes.PREVIEW, AssemblyTypes.CANDIDATE]:
             version = f'{major}.{minor}'
             try:
-                jenkins.start_microshift_sync(version=version, assembly=self.assembly)
+                if self.runtime.dry_run:
+                    self._logger.info("[DRY RUN] Would have triggered microshift_sync job for version %s and assembly %s",
+                                      version, self.assembly)
+                else:
+                    jenkins.start_microshift_sync(version=version, assembly=self.assembly)
+
                 message = f"microshift_sync for version {version} and assembly {self.assembly} has been triggered\n" \
                           f"This will publish the microshift build to mirror"
                 await self.slack_client.say_in_thread(message)
@@ -215,6 +220,8 @@ class BuildMicroShiftPipeline:
             "--member-only",
             "--use-default-advisory", "microshift"
         ]
+        if self.runtime.dry_run:
+            cmd.append("--dry-run")
         await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars)
 
     async def _sweep_bugs(self):
@@ -228,6 +235,8 @@ class BuildMicroShiftPipeline:
             "--permissive",  # this is so we don't error out on non-microshift bugs
             "--use-default-advisory", "microshift"
         ]
+        if self.runtime.dry_run:
+            cmd.append("--dry-run")
         await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars)
 
     async def _attach_cve_flaws(self):
@@ -240,6 +249,8 @@ class BuildMicroShiftPipeline:
             "attach-cve-flaws",
             "--use-default-advisory", "microshift"
         ]
+        if self.runtime.dry_run:
+            cmd.append("--dry-run")
         await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars)
 
     async def _verify_microshift_bugs(self, advisory_id):
@@ -269,6 +280,8 @@ class BuildMicroShiftPipeline:
             "--from", "NEW_FILES",
             "--use-default-advisory", "microshift"
         ]
+        if self.runtime.dry_run:
+            cmd.append("--dry-run")
         await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars)
 
     @staticmethod

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -131,10 +131,8 @@ class BuildMicroShiftPipeline:
         except Exception as build_err:
             self._logger.error(build_err)
             # Send a message to #microshift-alerts for STREAM failures
-            try:
-                await self._notify_microshift_alerts(f"{version}-{release}")
-            except Exception as slack_err:
-                self._logger.error(slack_err)
+            await self._notify_microshift_alerts(f"{version}-{release}")
+            raise
 
     async def _rebase_and_build_for_named_assembly(self):
         # Do a sanity check
@@ -170,11 +168,7 @@ class BuildMicroShiftPipeline:
         else:
             # Rebase and build microshift
             version, release = self.generate_microshift_version_release(release_name)
-            try:
-                nvrs = await self._rebase_and_build_rpm(version, release, custom_payloads=None)
-            except Exception as build_err:
-                raise build_err
-
+            nvrs = await self._rebase_and_build_rpm(version, release, custom_payloads=None)
             message = f"microshift for assembly {self.assembly} has been successfully built."
             await self.slack_client.say_in_thread(message)
 

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -497,11 +497,12 @@ async def build_microshift(runtime: Runtime, data_path: str, group: str, assembl
         await pipeline.run()
     except Exception as err:
         slack_message = f"build-microshift pipeline encountered error: {err}"
+        reaction = None
         error_message = slack_message + f"\n {traceback.format_exc()}"
         runtime.logger.error(error_message)
-        if assembly in ["stream", "test"]:
-            slack_message += "\n@release-artists"
-            await slack_client.say_in_thread(slack_message, reaction="art-attention")
-            raise
-        await slack_client.say_in_thread(slack_message)
+        if not runtime.dry_run:
+            if assembly not in ["stream", "test", "microshift"]:
+                slack_message += "\n@release-artists"
+                reaction = "art-attention"
+            await slack_client.say_in_thread(slack_message, reaction)
         raise

--- a/pyartcd/pyartcd/slack.py
+++ b/pyartcd/pyartcd/slack.py
@@ -59,7 +59,7 @@ class SlackClient:
             })
         if self.dry_run:
             _LOGGER.warning("[DRY RUN] Would have sent slack message to %s: %s %s", self.channel, message, attachments)
-            return {"message": {"ts": "fake"}}
+            return {"message": {"ts": "fake"}, "ts": "fake"}
         response = await self._client.chat_postMessage(channel=self.channel, text=message, thread_ts=thread_ts,
                                                        username=self.as_user, link_names=True, attachments=attachments,
                                                        icon_emoji=self.icon_emoji, reply_broadcast=False)


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-10563 is going to add image builds for microshift-bootc image for named 
assemblies

Before that, sanitize the pipeline to be cleaner. 
- Separate methods for stream and named assemblies
- Extract out try-catch-slack outside of the pipeline class
- Fix and enable dry_run across the stack

Test run:
- for stream type assembly: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift/1207/console
- for named assembly: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift/1208/console