### PR TITLE
fix konflux_db dry_run

### DIFF
--- a/doozer/doozerlib/cli/rpms.py
+++ b/doozer/doozerlib/cli/rpms.py
@@ -371,8 +371,5 @@ async def update_konflux_db(runtime, rpm: RPMMetadata, record: dict):
         )
 
         runtime.konflux_db.bind(KonfluxBuildRecord)
-        if not runtime.dry_run:
-            runtime.konflux_db.add_build(build_record)
-            rpm.logger.info('Brew build info for %s stored successfully', build["nvr"])
-        else:
-            rpm.logger.info('DRY-RUN: Would have stored build info for %s', build["nvr"])
+        runtime.konflux_db.add_build(build_record)
+        rpm.logger.info('Brew build info for %s stored successfully', build["nvr"])


### PR DESCRIPTION
jenkins [job](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/10024/console)

```
Traceback (most recent call last):
  File "/mnt/jenkins-workspace/aos-cd-builds_build_ocp4@3/art-tools/doozer/doozerlib/cli/rpms.py", line 303, in _build_rpm
    await update_konflux_db(runtime, rpm, record)
  File "/mnt/jenkins-workspace/aos-cd-builds_build_ocp4@3/art-tools/doozer/doozerlib/cli/rpms.py", line 374, in update_konflux_db
    if not runtime.dry_run:
           ^^^^^^^^^^^^^^^
AttributeError: 'Runtime' object has no attribute 'dry_run'
```
Updating logic, since we are already checking dry_run outside the function