### PR TITLE
[konflux] DB log print distgit name

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -344,7 +344,7 @@ class KonfluxImageBuilder:
 
             build_record = KonfluxBuildRecord(**build_record_params)
             metadata.runtime.konflux_db.add_build(build_record)
-            self._logger.info('Konflux build info stored successfully')
+            self._logger.info(f'[{metadata.distgit_key}] Konflux build info stored successfully with status {outcome}')
 
         except Exception as err:
             self._logger.error('Failed writing record to the konflux DB: %s', err)


### PR DESCRIPTION
```
2024-10-10 21:11:04,742 doozerlib.backend.konflux_image_builder INFO Konflux build info stored successfully
```
Since builds are running async, we don't know which distgit components build got stored correctly. Hence proposing to prepend the distgit name
