### PR TITLE
Konflux: make get_latest_build async

### DIFF
--- a/artcommon/artcommonlib/bigquery.py
+++ b/artcommon/artcommonlib/bigquery.py
@@ -85,9 +85,9 @@ class BigQueryClient:
         query += ')'
         self.query(query)
 
-    def select(self, where_clauses: typing.List[BinaryExpression] = None,
-               order_by_clause: typing.Optional[UnaryExpression] = None,
-               limit=None) -> RowIterator:
+    async def select(self, where_clauses: typing.List[BinaryExpression] = None,
+                     order_by_clause: typing.Optional[UnaryExpression] = None,
+                     limit=None) -> RowIterator:
         """
         Execute a SELECT statement and return a generator object with the results.
 
@@ -116,5 +116,4 @@ class BigQueryClient:
             assert limit >= 0, 'LIMIT expects a non-negative integer literal or parameter '
             query += f' LIMIT {limit}'
 
-        results = self.query(query)
-        return results
+        return await self.query_async(query)

--- a/artcommon/tests/test_big_query.py
+++ b/artcommon/tests/test_big_query.py
@@ -1,5 +1,5 @@
 import os
-from unittest import TestCase
+from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch
 
 from sqlalchemy import Column, String
@@ -8,7 +8,7 @@ from artcommonlib import constants
 from artcommonlib.bigquery import BigQueryClient
 
 
-class TestBigQuery(TestCase):
+class TestBigQuery(IsolatedAsyncioTestCase):
     @patch('os.environ', {'GOOGLE_APPLICATION_CREDENTIALS': ''})
     @patch('artcommonlib.bigquery.bigquery.Client')
     def setUp(self, _):
@@ -32,69 +32,69 @@ class TestInsert(TestBigQuery):
 
 
 class TestSelect(TestBigQuery):
-    @patch('artcommonlib.bigquery.BigQueryClient.query')
-    def test_where_clauses(self, query_mock):
-        self.client.select()
+    @patch('artcommonlib.bigquery.BigQueryClient.query_async')
+    async def test_where_clauses(self, query_mock):
+        await self.client.select()
         query_mock.assert_called_once_with('SELECT * FROM `builds`')
 
         query_mock.reset_mock()
-        self.client.select(where_clauses=[])
+        await self.client.select(where_clauses=[])
         query_mock.assert_called_once_with('SELECT * FROM `builds`')
 
         query_mock.reset_mock()
-        self.client.select(where_clauses=None)
+        await self.client.select(where_clauses=None)
         query_mock.assert_called_once_with('SELECT * FROM `builds`')
 
         query_mock.reset_mock()
         where_clauses = [Column('name', String) == 'ironic']
-        self.client.select(where_clauses=where_clauses)
+        await self.client.select(where_clauses=where_clauses)
         query_mock.assert_called_once_with("SELECT * FROM `builds` WHERE name = 'ironic'")
 
         query_mock.reset_mock()
         where_clauses = [Column('name', String) == 'ironic',
                          Column('group', String) == 'openshift-4.18']
-        self.client.select(where_clauses=where_clauses)
+        await self.client.select(where_clauses=where_clauses)
         query_mock.assert_called_once_with(
             "SELECT * FROM `builds` WHERE name = 'ironic' AND `group` = 'openshift-4.18'")
 
-    @patch('artcommonlib.bigquery.BigQueryClient.query')
-    def test_order_by(self, query_mock):
+    @patch('artcommonlib.bigquery.BigQueryClient.query_async')
+    async def test_order_by(self, query_mock):
         order_by_clause = None
-        self.client.select(order_by_clause=order_by_clause)
+        await self.client.select(order_by_clause=order_by_clause)
         query_mock.assert_called_once_with('SELECT * FROM `builds`')
 
         query_mock.reset_mock()
         order_by_clause = Column('start_time', quote=True)
-        self.client.select(order_by_clause=order_by_clause)
+        await self.client.select(order_by_clause=order_by_clause)
         query_mock.assert_called_once_with('SELECT * FROM `builds` ORDER BY `start_time`')
 
         query_mock.reset_mock()
         order_by_clause = Column('start_time', quote=True).desc()
-        self.client.select(order_by_clause=order_by_clause)
+        await self.client.select(order_by_clause=order_by_clause)
         query_mock.assert_called_once_with('SELECT * FROM `builds` ORDER BY `start_time` DESC')
 
         query_mock.reset_mock()
         order_by_clause = Column('start_time', quote=True).asc()
-        self.client.select(order_by_clause=order_by_clause)
+        await self.client.select(order_by_clause=order_by_clause)
         query_mock.assert_called_once_with('SELECT * FROM `builds` ORDER BY `start_time` ASC')
 
-    @patch('artcommonlib.bigquery.BigQueryClient.query')
-    def test_limit(self, query_mock):
-        self.client.select(limit=None)
+    @patch('artcommonlib.bigquery.BigQueryClient.query_async')
+    async def test_limit(self, query_mock):
+        await self.client.select(limit=None)
         query_mock.assert_called_once_with('SELECT * FROM `builds`')
 
         query_mock.reset_mock()
-        self.client.select(limit=0)
+        await self.client.select(limit=0)
         query_mock.assert_called_once_with('SELECT * FROM `builds` LIMIT 0')
 
         query_mock.reset_mock()
-        self.client.select(limit=10)
+        await self.client.select(limit=10)
         query_mock.assert_called_once_with('SELECT * FROM `builds` LIMIT 10')
 
         query_mock.reset_mock()
         with self.assertRaises(AssertionError):
-            self.client.select(limit=-1)
+            await self.client.select(limit=-1)
 
         query_mock.reset_mock()
         with self.assertRaises(AssertionError):
-            self.client.select(limit='1')
+            await self.client.select(limit='1')


### PR DESCRIPTION
- make `bigquery.select()` async, to allow concurrent queries to the DB
- make `konflux_db.get_latest_build()` async to boost scan-sources for Konflux performance
- fix a small bug in `konflux_db.get_latest_build()` that was messing up log messages (fortunately, not the behavior of the function itself)