### PR TITLE
Limit number of concurrent Konflux pipelines

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -17,6 +17,7 @@ from kubernetes.client import Configuration
 from kubernetes.dynamic import DynamicClient, exceptions, resource
 from ruamel.yaml import YAML
 
+from artcommonlib.exectools import limit_concurrency
 from doozerlib import constants
 from doozerlib.backend.build_repo import BuildRepo
 from doozerlib.image import ImageMetadata
@@ -64,6 +65,7 @@ class KonfluxImageBuilder:
         self._config = config
         self._logger = logger or LOGGER
 
+    @limit_concurrency(limit=constants.MAX_KONFLUX_BUILD_QUEUE_SIZE)
     async def build(self, metadata: ImageMetadata):
         """ Build a container image with Konflux. """
         metadata.build_status = False

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -37,6 +37,7 @@ KONFLUX_DEFAULT_PIPRLINE_DOCKER_BUILD_BUNDLE_PULLSPEC = "quay.io/konflux-ci/tekt
 KONFLUX_DEFAULT_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-v4.0-art-dev-test"   # FIXME: This is a temporary repo.
 KONFLUX_UI_HOST = "https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com"
 KONFLUX_UI_DEFAULT_WORKSPACE = "ocp-art"  # associated with ocp-art-tenant
+MAX_KONFLUX_BUILD_QUEUE_SIZE = 10  # how many concurrent Konflux pipeline can we spawn?
 
 REGISTRY_PROXY_BASE_URL = "registry-proxy.engineering.redhat.com"
 BREW_REGISTRY_BASE_URL = "brew.registry.redhat.io"


### PR DESCRIPTION
Currently, Konflux has very low capacity and we must ensure we do not allocate more pipelines than the cluster can handle. According to previous discussions, we should limit concurrent builds to 2 for now. Setting an explicit constant to let us bump this number easily once we get a green flag.