### PR TITLE
[art-cluster] quay backup override arches to sync from quay for 4.12 releases

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline-task.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline-task.yaml
@@ -14,7 +14,7 @@ spec:
     - env:
         - name: DOCKER_CONFIG
           value: /tmp/.docker
-      image: default-route-openshift-image-registry.apps.artc2023.pc3z.p1.openshiftapps.com/art-cd/art-cd:base
+      image: default-route-openshift-image-registry.apps.artc2023.pc3z.p1.openshiftapps.com/art-cd/art-cd:latest
       name: run-script
       resources: {}
       script: |

--- a/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline-task.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline-task.yaml
@@ -28,7 +28,7 @@ spec:
         source .venv/bin/activate 
         uv pip install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
 
-        artcd -vv quay-doomsday-backup --version $(params.version) --all-arches
+        artcd -vv quay-doomsday-backup --version $(params.version)
       securityContext:
         runAsGroup: 0
         runAsUser: 0

--- a/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline-task.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline-task.yaml
@@ -27,8 +27,9 @@ spec:
         uv venv --system-site-packages --python 3.9  
         source .venv/bin/activate 
         uv pip install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
-
-        artcd -vv quay-doomsday-backup --version $(params.version)
+        
+        touch artcd.toml	
+        artcd -vv --config artcd.toml quay-doomsday-backup --version $(params.version)
       securityContext:
         runAsGroup: 0
         runAsUser: 0

--- a/pyartcd/pyartcd/pipelines/quay_doomsday_backup.py
+++ b/pyartcd/pyartcd/pipelines/quay_doomsday_backup.py
@@ -19,18 +19,12 @@ class QuayDoomsdaySync:
     Backup promoted payloads to AWS bucket, in the event we need to recover a payload or if quay goes down
     """
 
-    def __init__(self, runtime: Runtime, all_arches: bool, version: str, arches: Optional[str]):
+    def __init__(self, runtime: Runtime, version: str, arches: Optional[str]):
         self.runtime = runtime
         self.version = version
         self.workdir = "./workspace"
 
-        if arches and all_arches:
-            raise Exception("Cannot specify both --arches and --all-arches")
-
-        if not (arches or all_arches):
-            raise Exception("Either --arches or --all-arches needs to be specified")
-
-        self.arches = arches.split(",") if not all_arches else ALL_ARCHES_LIST
+        self.arches = arches.split(",") if arches else ALL_ARCHES_LIST
 
     def sync_arch(self, arch: str):
         if arch not in ALL_ARCHES_LIST:
@@ -70,20 +64,17 @@ class QuayDoomsdaySync:
             self.sync_arch(arch)
 
 
-@cli.command("quay-doomsday-backup", help="Run doomsday pipeline for the specified version and arches")
+@cli.command("quay-doomsday-backup", help="Run doomsday pipeline for the specified version and all arches unless --arches is specified")
 @click.option("--arches", required=False, help="Comma separated list of arches to sync")
-@click.option("--all-arches", is_flag=True, required=False, default=False, help="Sync all arches")
 @click.option("--version", required=True, help="Release to sync, e.g. 4.15.3")
 @pass_runtime
-def quay_doomsday_backup(runtime: Runtime, arches: str, all_arches: bool, version: str):
+def quay_doomsday_backup(runtime: Runtime, arches: str, version: str):
 
     # In 4.12 we sync only x86_64 and s390x
     if version.startswith("4.12"):
-        all_arches = False
         arches = "x86_64,s390x"
 
     doomsday_pipeline = QuayDoomsdaySync(runtime=runtime,
                                          arches=arches,
-                                         all_arches=all_arches,
                                          version=version)
     doomsday_pipeline.run()

--- a/pyartcd/pyartcd/pipelines/quay_doomsday_backup.py
+++ b/pyartcd/pyartcd/pipelines/quay_doomsday_backup.py
@@ -44,11 +44,13 @@ class QuayDoomsdaySync:
             f"s3://ocp-doomsday-registry/release-image/{path}"
         ]
 
+        self.runtime.logger.info("Running mirror command: %s", mirror_cmd)
         cmd_assert(mirror_cmd, realtime=True, retries=N_RETRIES)
         if self.runtime.dry_run:
             self.runtime.logger.info("[DRY RUN] Would have run %s", " ".join(aws_cmd))
         else:
             sleep(5)
+            self.runtime.logger.info("Running aws command: %s", aws_cmd)
             cmd_assert(aws_cmd, realtime=True, retries=N_RETRIES)
             sleep(5)
 


### PR DESCRIPTION
For quay backup pipeline running on cluster, sync only `x86_64` and `s390x` in 4.12 releases, since the other arches are deprecated