### PR TITLE
errata: reverse advisory dependencies

### DIFF
--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -758,9 +758,10 @@ update JIRA accordingly, then notify QE and multi-arch QE for testing.""")
     async def set_advisory_dependencies(self, advisories):
         # dict keys should ship after values.
         blocked_by = {
-            'rpm': {'image', 'extras'},
+            'image': {'rpm'},
+            'extras': {'rpm'},
             'metadata': {'image', 'extras'},
-            'microshift': {'rpm', 'image'},
+            'microshift': {'image', 'rpm'},
         }
         for target_kind in blocked_by.keys():
             target_advisory_id = advisories.get(target_kind, 0)


### PR DESCRIPTION
Looks like the image advisory cannot ship when the rpm advisory is not PUSH_READY. Reverse the dependencies.