### PR TITLE
[konflux] setup art-db custom task

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -478,6 +478,9 @@ class KonfluxImageBuilder:
             if task["name"] == "build-images":
                 updated_tasks.append({
                     "name": "art-db",
+                    "params": [
+                        {"name": "IMAGE_URL", "value": "$(tasks.build-image-index.results.IMAGE_URL)"},
+                    ],
                     "taskRef": {
                         "resolver": "git",
                         "params": [
@@ -486,8 +489,7 @@ class KonfluxImageBuilder:
                             {"name": "revision", "value": "main"},
                             {"name": "pathInRepo", "value": "custom-tasks/art-store-to-db.yaml"},
                             {"name": "token", "value": "openshift-art-build-bot-read-only"},
-                            {"name": "tokenKey", "value": "token"},
-                            {"name": "IMAGE_URL", "value": "$(tasks.build-image-index.results.IMAGE_URL)"},
+                            {"name": "tokenKey", "value": "token"}
                         ]
                     },
                     "runAfter": ["build-image-index"],

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -487,6 +487,7 @@ class KonfluxImageBuilder:
                             {"name": "pathInRepo", "value": "custom-tasks/art-store-to-db.yaml"},
                             {"name": "token", "value": "openshift-art-build-bot-read-only"},
                             {"name": "tokenKey", "value": "token"},
+                            {"name": "IMAGE_URL", "value": "$(tasks.build-image-index.results.IMAGE_URL)"},
                         ]
                     },
                     "runAfter": ["build-image-index"],


### PR DESCRIPTION
If the Jenkins pipeline fails due to some reason, after triggering konflux builds, the builds will still be running. Since the pipeline is not running anymore, we won't be able to store the status of the build, once it completes on Konflux.

Tekton has [git resolvers](https://tekton.dev/docs/pipelines/git-resolver/) that we can leverage for creating custom tasks. Task defined here: https://github.com/openshift-priv/art-konflux-template/blob/main/custom-tasks/art-store-to-db.yaml.
