### PR TITLE
Golang bugs changes to sweep bugs earlier

### DIFF
--- a/elliott/elliottlib/cli/find_bugs_golang_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_golang_cli.py
@@ -243,8 +243,8 @@ class FindBugsGolangCli:
             self._logger.info('Fetching latest accepted nightly...')
             # we fetch pending and rejected nightlies as well since
             # we only need to determine if image builds are complete and have the fix
-            nightlies = await find_rc_nightlies(self._runtime, arches={'x86_64'}, allow_pending=False,
-                                                allow_rejected=False)
+            nightlies = await find_rc_nightlies(self._runtime, arches={'x86_64'}, allow_pending=True,
+                                                allow_rejected=True)
             if len(nightlies['x86_64']) < 1:
                 raise ElliottFatalError("Could not find any accepted nightlies. Please investigate")
             self.pullspec = nightlies['x86_64'][0]['pullSpec']

--- a/elliott/elliottlib/cli/find_bugs_golang_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_golang_cli.py
@@ -401,17 +401,14 @@ class FindBugsGolangCli:
                 if not fixed_in_version_go_db and not flaw_fixed_in:
                     self._logger.warning(f"{flaw_id} - Could not find fixed in versions in go vulnerability "
                                          "database and bugzilla.")
-                    # cve_table.add_row([flaw_id, cve_id, comp_in_title, "NOT FOUND", False])
                 elif fixed_in_version_go_db and flaw_fixed_in:
                     self._logger.warning(
                         f"{flaw_id} - Fixed in versions in go vulnerability database and bugzilla do not "
                         f"match. Go vulnerability database: {_fmt(fixed_in_version_go_db)}, "
                         f"Bugzilla: {_fmt(flaw_fixed_in)}.")
-                    # cve_table.add_row([flaw_id, cve_id, comp_in_title, _fmt(flaw_fixed_in), False])
                 elif not fixed_in_version_go_db and flaw_fixed_in:
                     self._logger.warning(f"{flaw_id} - Could not find fixed in versions in go vulnerability "
                                          f"database. Assuming CVE isn't fixed in stdlib.")
-                    # cve_table.add_row([flaw_id, cve_id, comp_in_title, _fmt(flaw_fixed_in), False])
                 else:
                     self._logger.warning(
                         f"{flaw_id} - Could not find fixed in versions in bugzilla, but found in go "

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -739,7 +739,8 @@ class Ocp4Pipeline:
 
         cmd = [
             'elliott',
-            f'--group=openshift-{self.version.stream}',
+            '--assembly', 'stream'
+            '--group=openshift', self.version.stream,
             "find-bugs:golang",
             "--analyze",
             "--update-tracker"

--- a/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py
+++ b/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py
@@ -124,7 +124,10 @@ class RebuildGolangRPMsPipeline:
         if failed_rpms:
             await self.notify_failed_rpms(failed_rpms)
 
-        await move_golang_bugs(self, self.cves, self.go_nvrs)
+        args = {'dry_run': self.runtime.dry_run}
+        if self.cves:
+            args.update({'cves': self.cves, 'nvrs': self.go_nvrs})
+        await move_golang_bugs(**args)
 
     async def notify_failed_rpms(self, rpms: list):
         slack_client = self.runtime.new_slack_client()

--- a/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py
+++ b/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py
@@ -124,10 +124,12 @@ class RebuildGolangRPMsPipeline:
         if failed_rpms:
             await self.notify_failed_rpms(failed_rpms)
 
-        args = {'dry_run': self.runtime.dry_run}
-        if self.cves:
-            args.update({'cves': self.cves, 'nvrs': self.go_nvrs})
-        await move_golang_bugs(**args)
+        await move_golang_bugs(
+            ocp_version=self.ocp_version,
+            cves=self.cves,
+            nvrs=self.go_nvrs if self.cves else None,
+            dry_run=self.runtime.dry_run,
+        )
 
     async def notify_failed_rpms(self, rpms: list):
         slack_client = self.runtime.new_slack_client()

--- a/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py
+++ b/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py
@@ -3,6 +3,7 @@ import koji
 import datetime
 import logging
 import os
+import asyncio
 from typing import List
 from ghapi.all import GhApi
 from specfile import Specfile

--- a/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py
+++ b/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py
@@ -15,7 +15,8 @@ from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.runtime import Runtime
 from elliottlib import util as elliottutil
 from pyartcd.pipelines.update_golang import (is_latest_and_available,
-                                             extract_and_validate_golang_nvrs)
+                                             extract_and_validate_golang_nvrs,
+                                             move_bugs)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -121,6 +122,8 @@ class RebuildGolangRPMsPipeline:
 
         if failed_rpms:
             await self.notify_failed_rpms(failed_rpms)
+
+        await move_bugs()
 
     async def notify_failed_rpms(self, rpms: list):
         slack_client = self.runtime.new_slack_client()

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -117,6 +117,24 @@ def extract_and_validate_golang_nvrs(ocp_version: str, go_nvrs: List[str]):
         el_nvr_map[el_version] = nvr
     return go_version, el_nvr_map
 
+async def move_bugs(self, cves: List[str] = None, nvrs: List[str] = None):
+    cmd = [
+        'elliott',
+        '--group', self.ocp_version,
+        '--assembly', 'stream',
+        'find-bugs:golang',
+        '--analyze',
+        '--update-tracker',
+    ]
+    if cves:
+        for cve in cves:
+            cmd.extend(['--cve-id', cve])
+    if nvrs:
+        for nvr in nvrs:
+            cmd.extend(['--fixed-in-nvr', nvr])
+    if self.runtime.dry_run:
+        cmd.append('--dry-run')
+    await exectools.cmd_assert_async(cmd)
 
 class UpdateGolangPipeline:
     def __init__(self, runtime: Runtime, ocp_version: str, create_ticket: bool, go_nvrs: List[str], art_jira: str,

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -118,8 +118,7 @@ def extract_and_validate_golang_nvrs(ocp_version: str, go_nvrs: List[str]):
     return go_version, el_nvr_map
 
 
-async def move_golang_bugs(self,
-                           cves: List[str] = None,
+async def move_golang_bugs(cves: List[str] = None,
                            nvrs: List[str] = None,
                            components: List[str] = None,
                            force_update_tracker: bool = False,

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -127,7 +127,7 @@ async def move_golang_bugs(ocp_version: str,
                            ):
     cmd = [
         'elliott',
-        '--group', ocp_version,
+        '--group', f'openshift-{ocp_version}',
         '--assembly', 'stream',
         'find-bugs:golang',
         '--analyze',

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -3,6 +3,7 @@ import koji
 import logging
 import re
 import os
+import asyncio
 import base64
 from typing import List
 from datetime import datetime, timezone

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -117,7 +117,8 @@ def extract_and_validate_golang_nvrs(ocp_version: str, go_nvrs: List[str]):
         el_nvr_map[el_version] = nvr
     return go_version, el_nvr_map
 
-async def move_bugs(self, cves: List[str] = None, nvrs: List[str] = None):
+
+async def move_golang_bugs(self, cves: List[str] = None, nvrs: List[str] = None):
     cmd = [
         'elliott',
         '--group', self.ocp_version,
@@ -136,14 +137,16 @@ async def move_bugs(self, cves: List[str] = None, nvrs: List[str] = None):
         cmd.append('--dry-run')
     await exectools.cmd_assert_async(cmd)
 
+
 class UpdateGolangPipeline:
-    def __init__(self, runtime: Runtime, ocp_version: str, create_ticket: bool, go_nvrs: List[str], art_jira: str,
-                 scratch: bool = False):
+    def __init__(self, runtime: Runtime, ocp_version: str, create_ticket: bool, cves: List[str],
+                 go_nvrs: List[str], art_jira: str, scratch: bool = False):
         self.runtime = runtime
         self.dry_run = runtime.dry_run
         self.scratch = scratch
         self.ocp_version = ocp_version
         self.create_ticket = create_ticket
+        self.cves = cves
         self.go_nvrs = go_nvrs
         self.art_jira = art_jira
         self.koji_session = koji.ClientSession(BREW_HUB)
@@ -224,6 +227,8 @@ class UpdateGolangPipeline:
 
         _LOGGER.info("Updating streams.yml with found builder images")
         await self.update_golang_streams(go_version, builder_nvrs)
+
+        await move_golang_bugs(self, self.cves, self.go_nvrs)
 
     def get_existing_builders(self, el_nvr_map, go_version):
         component = GOLANG_BUILDER_CVE_COMPONENT
@@ -472,13 +477,16 @@ The new NVRs are:
 @click.option('--create-tagging-ticket', 'create_ticket', is_flag=True, default=False,
               help='Create CWFCONF Jira ticket for tagging request')
 @click.option('--art-jira', required=True, help='Related ART Jira ticket e.g. ART-1234')
+@click.option('--cves', help='CVE-IDs that are confirmed to be fixed with given nvrs (comma separated) e.g. CVE-2024-1234')
 @click.option('--confirm', is_flag=True, default=False, help='Confirm to proceed with rebase and build')
 @click.argument('go_nvrs', metavar='GO_NVRS...', nargs=-1, required=True)
 @pass_runtime
 @click_coroutine
 async def update_golang(runtime: Runtime, ocp_version: str, scratch: bool, create_ticket: bool, art_jira: str,
-                        confirm: bool, go_nvrs: List[str]):
+                        cves: str, confirm: bool, go_nvrs: List[str]):
     if not runtime.dry_run and not confirm:
         _LOGGER.info('--confirm is not set, running in dry-run mode')
         runtime.dry_run = True
-    await UpdateGolangPipeline(runtime, ocp_version, create_ticket, go_nvrs, art_jira, scratch).run()
+    if cves:
+        cves = cves.split(',')
+    await UpdateGolangPipeline(runtime, ocp_version, create_ticket, cves, go_nvrs, art_jira, scratch).run()

--- a/pyartcd/pyartcd/runtime.py
+++ b/pyartcd/pyartcd/runtime.py
@@ -31,6 +31,7 @@ class Runtime:
         handler = logging.StreamHandler()
         handler.setFormatter(formatter)
         logger.addHandler(handler)
+        logger.propagate = False
         return logger
 
     @classmethod

--- a/pyartcd/tests/test_rebuild_golang_rpms.py
+++ b/pyartcd/tests/test_rebuild_golang_rpms.py
@@ -8,7 +8,8 @@ class TestBumpRelease(TestCase):
 
     def setUp(self):
         runtime = MagicMock()
-        self.pipeline = RebuildGolangRPMsPipeline(runtime, ocp_version="4.17", go_nvrs=["go1.16"], art_jira="JIRA-123")
+        self.pipeline = RebuildGolangRPMsPipeline(runtime, ocp_version="4.17", go_nvrs=["go1.16"], art_jira="JIRA-123",
+                                                  cves=None)
 
     def test_bump_up_case_1(self):
         fake_releases = "42.rhaos4.17.abcd"


### PR DESCRIPTION
Changes:
- Consider latest pending and failed nightlies when determining if golang builder container is fixed for an OCP version
- Support passing `--cves` in `update_golang` and `rebuild_golang_rpms` jobs. This is useful to operate on trackers of CVEs that got fixed downstream.
- Support passing `--force-update-tracker` and `--component` in `update_golang` job and `find-bugs:golang` command. This is useful to update tracker bugs manually