### PR TITLE
sync bug with errata before get from errata

### DIFF
--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -214,6 +214,7 @@ class BugzillaBug(Bug):
         return has_keywords or has_cve_in_summary
 
     def all_advisory_ids(self):
+        errata.sync_bugzilla_bug(self.id)
         return ErrataBug(self.id).all_advisory_ids
 
     def is_ocp_bug(self):
@@ -421,6 +422,7 @@ class JIRABug(Bug):
         return None
 
     def all_advisory_ids(self):
+        errata.sync_jira_issue(self.id)
         return ErrataJira(self.id).all_advisory_ids
 
     def creation_time_parsed(self):

--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -214,7 +214,6 @@ class BugzillaBug(Bug):
         return has_keywords or has_cve_in_summary
 
     def all_advisory_ids(self):
-        errata.sync_bugzilla_bug(self.id)
         return ErrataBug(self.id).all_advisory_ids
 
     def is_ocp_bug(self):
@@ -422,7 +421,6 @@ class JIRABug(Bug):
         return None
 
     def all_advisory_ids(self):
-        errata.sync_jira_issue(self.id)
         return ErrataJira(self.id).all_advisory_ids
 
     def creation_time_parsed(self):

--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -486,7 +486,7 @@ class BugValidator:
                         try:
                             sync_jira_issue(blocker.id)
                         except Exception as e:
-                            message = f"Failed to get advisories for bug {blocker.id}: {e}"
+                            message = f"Failed to sync bug {blocker.id}: {e}"
                             logger.error(message)
                             self._complain(message)
                             continue

--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -17,7 +17,7 @@ from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
 from elliottlib.runtime import Runtime
 from elliottlib.util import minor_version_tuple
 from elliottlib.bzutil import Bug
-from elliottlib.errata import get_bug_ids
+from elliottlib.errata import get_bug_ids, sync_jira_issue
 from elliottlib.cli.attach_cve_flaws_cli import get_flaws
 from elliottlib.cli.find_bugs_sweep_cli import FindBugsSweep, categorize_bugs_by_type
 from elliottlib.errata import is_advisory_editable
@@ -249,7 +249,10 @@ class BugValidator:
             try:
                 all_advisories_id = bug.all_advisory_ids()
             except ErrataException as e:
-                return f'Failed to get advisories for bug {bug.id}: {e}'
+                try:
+                    sync_jira_issue(bug.id)
+                except Exception as e:
+                    return f'Failed to get advisories for bug {bug.id}: {e}'
             if len(all_advisories_id) > 1:
                 return f'Bug <{bug.weburl}|{bug.id}> is attached in multiple advisories: {all_advisories_id}'
             return None
@@ -480,10 +483,13 @@ class BugValidator:
                     try:
                         blocker_advisories = blocker.all_advisory_ids()
                     except ErrataException as e:
-                        message = f"Failed to get advisories for bug {blocker.id}: {e}"
-                        logger.error(message)
-                        self._complain(message)
-                        continue
+                        try:
+                            sync_jira_issue(blocker.id)
+                        except Exception as e:
+                            message = f"Failed to get advisories for bug {blocker.id}: {e}"
+                            logger.error(message)
+                            self._complain(message)
+                            continue
                     if not blocker_advisories:
                         if self.output == 'text':
                             message = (f"Regression possible: {bug.status} bug {bug.id} is a backport of bug "

--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -252,7 +252,7 @@ class BugValidator:
                 try:
                     sync_jira_issue(bug.id)
                 except Exception as e:
-                    return f'Failed to get advisories for bug {bug.id}: {e}'
+                    return f'Failed to sync bug {bug.id}: {e}'
             if len(all_advisories_id) > 1:
                 return f'Bug <{bug.weburl}|{bug.id}> is attached in multiple advisories: {all_advisories_id}'
             return None

--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -248,7 +248,7 @@ class BugValidator:
         async def get_all_advisory_ids(bug):
             try:
                 all_advisories_id = bug.all_advisory_ids()
-            except ErrataException as e:
+            except ErrataException:
                 try:
                     sync_jira_issue(bug.id)
                 except Exception as e:
@@ -482,7 +482,7 @@ class BugValidator:
                 if is_attached and blocker.status in ['ON_QA', 'Verified', 'VERIFIED']:
                     try:
                         blocker_advisories = blocker.all_advisory_ids()
-                    except ErrataException as e:
+                    except ErrataException:
                         try:
                             sync_jira_issue(blocker.id)
                         except Exception as e:

--- a/elliott/elliottlib/errata.py
+++ b/elliott/elliottlib/errata.py
@@ -111,6 +111,22 @@ def add_jira_issue(advisory_id, jira_issue_id):
     return ErrataConnector()._post(f"/api/v1/erratum/{advisory_id}/add_jira_issue", json={'jira_issue': jira_issue_id})
 
 
+def sync_jira_issue(jira_issue_id):
+    """
+    Sync a jira issue to advisory
+    Response code will return
+    """
+    return ErrataConnector()._post("/api/v1/jra/refresh", data=[jira_issue_id])
+
+
+def sync_bugzilla_bug(bugzilla_bug_id):
+    """
+    Sync a bugzilla bug to advisory
+    Response code will return
+    """
+    return ErrataConnector()._post("/api/v1/bug/refresh", data=[bugzilla_bug_id])
+
+
 def remove_jira_issue(advisory_id, jira_issue_id):
     """
     Remove a jira issue from advisory

--- a/elliott/elliottlib/errata.py
+++ b/elliott/elliottlib/errata.py
@@ -116,7 +116,7 @@ def sync_jira_issue(jira_issue_id):
     Sync a jira issue to advisory
     Response code will return
     """
-    return ErrataConnector()._post("/api/v1/jra/refresh", json=[jira_issue_id])
+    return ErrataConnector()._post("/api/v1/jira/refresh", json=[jira_issue_id])
 
 
 def remove_jira_issue(advisory_id, jira_issue_id):

--- a/elliott/elliottlib/errata.py
+++ b/elliott/elliottlib/errata.py
@@ -119,14 +119,6 @@ def sync_jira_issue(jira_issue_id):
     return ErrataConnector()._post("/api/v1/jra/refresh", data=[jira_issue_id])
 
 
-def sync_bugzilla_bug(bugzilla_bug_id):
-    """
-    Sync a bugzilla bug to advisory
-    Response code will return
-    """
-    return ErrataConnector()._post("/api/v1/bug/refresh", data=[bugzilla_bug_id])
-
-
 def remove_jira_issue(advisory_id, jira_issue_id):
     """
     Remove a jira issue from advisory

--- a/elliott/elliottlib/errata.py
+++ b/elliott/elliottlib/errata.py
@@ -116,7 +116,7 @@ def sync_jira_issue(jira_issue_id):
     Sync a jira issue to advisory
     Response code will return
     """
-    return ErrataConnector()._post("/api/v1/jra/refresh", data=[jira_issue_id])
+    return ErrataConnector()._post("/api/v1/jra/refresh", json=[jira_issue_id])
 
 
 def remove_jira_issue(advisory_id, jira_issue_id):


### PR DESCRIPTION
fix issue like https://redhat-internal.slack.com/archives/C04L1FPFHNH/p1729169691264399
use jira api
```
>> res=ErrataConnector()._post("/api/v1/jira/refresh", data=["OCPBUGS-43400"])
ValueError: too many values to unpack (expected 2)

>>> res=ErrataConnector()._post("/api/v1/jira/refresh", json=['OCPBUGS-43400'])
>>> res
<Response [200]>
>>> res.text
'[{"key":"OCPBUGS-43400","status":"Closed","updated":"2024-10-16T23:02:00Z"}]'
```