### PR TITLE
[konflux] temporarily increase retries

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -103,7 +103,7 @@ class KonfluxImageBuilder:
 
             # Start the build
             self._logger.info("Starting Konflux image build for %s...", metadata.distgit_key)
-            retries = 6
+            retries = 5
             error = None
             for attempt in range(retries):
                 self._logger.info("[%s] Build attempt %s/%s", metadata.distgit_key, attempt + 1, retries)

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -103,7 +103,7 @@ class KonfluxImageBuilder:
 
             # Start the build
             self._logger.info("Starting Konflux image build for %s...", metadata.distgit_key)
-            retries = 3
+            retries = 6
             error = None
             for attempt in range(retries):
                 self._logger.info("[%s] Build attempt %s/%s", metadata.distgit_key, attempt + 1, retries)


### PR DESCRIPTION
We are seeing increased timeouts for ppc builds. The konflux team is working on increasing the resources, but lets temporarily increase retries for now.