### PR TITLE
ART-10995 fix false alarm for regression check

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -162,7 +162,7 @@ def is_release_this_week(release_date):
 
 def get_next_release_schedule(group):
     """
-    Get next release name based on current date
+    Get next release date based on current date
     """
     dev_schedules = requests.get(f'{RELEASE_SCHEDULES}/{group}.z/schedule-tasks/?flags_and__in=dev&fields=path,date_finish', headers={'Accept': 'application/json'})
     dev_schedules.raise_for_status()

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -153,18 +153,23 @@ def get_assembly_release_date(assembly, group):
         return None
 
 
-def get_development_cutoff_schedule(group):
+def is_release_this_week(release_date):
     """
-    Check if there is a release that needs to ship this week.
-    Returns True if there is a release that needs to be prepared, False otherwise.
+    Check if release date is in the near week
+    """
+    return datetime.strptime(release_date, "%Y-%m-%d").date() <= date.today() + timedelta(days=7)
+
+
+def get_next_release_schedule(group):
+    """
+    Get next release name based on current date
     """
     dev_schedules = requests.get(f'{RELEASE_SCHEDULES}/{group}.z/schedule-tasks/?flags_and__in=dev&fields=path,date_finish', headers={'Accept': 'application/json'})
     dev_schedules.raise_for_status()
     for release in dev_schedules.json():
-        finish_date = datetime.strptime(release['date_finish'], "%Y-%m-%d").date()
-        if finish_date > date.today():
-            return finish_date <= date.today() + timedelta(days=7)
-    return False
+        if datetime.strptime(release['date_finish'], "%Y-%m-%d").date() > date.today():
+            return release['date_finish']
+    return None
 
 
 def get_inflight(assembly, group):

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -1,6 +1,6 @@
 import logging
 from typing import OrderedDict, Optional, Tuple, Iterable, List
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone, timedelta, date
 import re
 import asyncio
 

--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -9,6 +9,7 @@ from artcommonlib import logutil, arch_util
 from artcommonlib.assembly import assembly_issues_config
 from artcommonlib.format_util import red_print
 from artcommonlib.rpm_utils import parse_nvr
+from artcommonlib.util import get_next_release_schedule, is_release_this_week
 from elliottlib import bzutil, constants
 from elliottlib.cli.common import cli, click_coroutine, pass_runtime
 from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
@@ -474,6 +475,10 @@ class BugValidator:
                 if is_attached and blocker.status in ['ON_QA', 'Verified', 'VERIFIED']:
                     blocker_advisories = blocker.all_advisory_ids()
                     if not blocker_advisories:
+                        # check if we need to release X+1 release this week
+                        major, minor = self.runtime.get_major_minor()
+                        if not is_release_this_week(get_next_release_schedule(f"openshift-{major}.{minor + 1}")):
+                            continue
                         if self.output == 'text':
                             message = f"Regression possible: {bug.status} bug {bug.id} is a backport of bug " \
                                 f"{blocker.id} which is on {blocker.status} but not attached to any advisory"

--- a/elliott/tests/test_verify_attached_bugs_cli.py
+++ b/elliott/tests/test_verify_attached_bugs_cli.py
@@ -51,7 +51,9 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
         result = runner.invoke(cli, ['-g', 'openshift-4.6', '--assembly=4.6.6', 'verify-bugs'])
         self.assertEqual(result.exit_code, 0)
 
-    def test_verify_bugs_with_sweep_cli(self):
+    @patch('elliottlib.cli.verify_attached_bugs_cli.is_release_this_week', return_value=True)
+    @patch('elliottlib.cli.verify_attached_bugs_cli.get_next_release_schedule', return_value="2024-10-24")
+    def test_verify_bugs_with_sweep_cli(self, *_):
         runner = CliRunner()
         flexmock(Runtime).should_receive("initialize")
         flexmock(Runtime).should_receive("get_errata_config").and_return({})
@@ -93,6 +95,8 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
 
     @patch('elliottlib.cli.verify_attached_bugs_cli.BugValidator.verify_bugs_multiple_advisories')
     @patch('elliottlib.errata_async.AsyncErrataAPI._generate_auth_header')
+    @patch('elliottlib.cli.verify_attached_bugs_cli.is_release_this_week', return_value=True)
+    @patch('elliottlib.cli.verify_attached_bugs_cli.get_next_release_schedule', return_value="2024-10-24")
     def test_verify_attached_bugs_cli_fail(self, *_):
         runner = CliRunner()
         flexmock(Runtime).should_receive("initialize")


### PR DESCRIPTION
add two API function, 
`get_next_release_schedule` will get the next release date for a stream release 
the pp API `schedule-tasks/?flags_and__in=dev&fields=path,date_finish` return list of dates like
```
{
      "path": [
          "OpenShift Container Platform (OCP) 4.16.z GA Release Schedule",
          "4.16.z Release Cycle",
          "4.16.25"
      ],
      "date_finish": "2024-12-04"
  },
  {
      "path": [
          "OpenShift Container Platform (OCP) 4.16.z GA Release Schedule",
          "4.16.z Release Cycle",
          "4.16.26"
      ],
      "date_finish": "2024-12-11"
  },
```
`is_release_this_week` will check if the next release need to prepare this week
so when check regression bug issue, if we don't have next X+1 release need to prepare then blocker not attached to any advisory is expected.