### PR TITLE
konflux: Fix wrong bundle CSV pullspec with uuid tag

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1433,7 +1433,7 @@ class KonfluxRebaser:
 
             meta = self._runtime.image_map.get(distgit, None)
             if meta:  # image is currently be processed
-                image_tag = f"{image_repo}:{meta.image_name_short}-{uuid_tag}"
+                image_tag = f"{meta.image_name_short}:{uuid_tag}"
             else:
                 meta = self._runtime.late_resolve_image(distgit)
                 assert meta is not None


### PR DESCRIPTION
Update-csv should generate pullspec in the form of `image-registry.openshift-image-registry.svc:5000/openshift/<image-name-short>:<uuid-tag>`.