### PR TITLE
fix construction of elliott cmd

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -739,8 +739,8 @@ class Ocp4Pipeline:
 
         cmd = [
             'elliott',
-            '--assembly', 'stream'
-            '--group=openshift', self.version.stream,
+            '--assembly', 'stream',
+            f'--group=openshift-{self.version.stream}',
             "find-bugs:golang",
             "--analyze",
             "--update-tracker"


### PR DESCRIPTION
rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED

fixes: 2024-10-18 05:17:28,375 art_tools.artcommonlib.exectools INFO Executing:cmd_assert_async ['elliott', '_**--assembly', 'stream--group=openshift', '4.18',**_ 'find-bugs:golang', '--analyze', '--update-tracker']
Usage: elliott [OPTIONS] COMMAND [ARGS]...
Try 'elliott -h' for help.

in ocp4 builds