### PR TITLE
[konflux] update konflux log

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -544,14 +544,11 @@ class KonfluxImageBuilder:
                         assert isinstance(event, Dict)
                         obj = resource.ResourceInstance(api, event["object"])
                         # status takes some time to appear
-                        status_message = status
                         try:
                             status = obj.status.conditions[0].status
-                            message = obj.status.conditions[0].message
-                            status_message = f"{status} {message}"
                         except AttributeError:
                             pass
-                        self._logger.info("PipelineRun %s status: %s.", pipelinerun_name, status_message)
+                        self._logger.info("PipelineRun %s status: %s.", pipelinerun_name, status)
                         if status not in ["Unknown", "Not Found"]:
                             return obj
                 except TimeoutError:


### PR DESCRIPTION
Right now we display the build log as 
```
24-10-18 14:26:42,009 doozerlib.backend.konflux_image_builder INFO PipelineRun 4-18-ose-cli-artifacts-z82js status: Unknown Tasks Completed: 3 (Failed: 0, Cancelled 0), Incomplete: 11, Skipped: 0.
2024-10-18 14:26:42,234 doozerlib.backend.konflux_image_builder INFO PipelineRun 4-18-ose-cli-artifacts-z82js status: Unknown Tasks Completed: 3 (Failed: 0, Cancelled 0), Incomplete: 11, Skipped: 0.
```

To keep the logs clean, we can remove the task details from being displayed, since it doesn't provide any useful insight, and print just the pipeline status. So the new log will look like:

```
24-10-18 14:26:42,009 doozerlib.backend.konflux_image_builder INFO PipelineRun 4-18-ose-cli-artifacts-z82js status: Unknown
2024-10-18 14:26:42,234 doozerlib.backend.konflux_image_builder INFO PipelineRun 4-18-ose-cli-artifacts-z82js status: Unknown
```