### PR TITLE
[konflux] use bigger ppc vm

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -57,7 +57,7 @@ class KonfluxImageBuilder:
     SUPPORTED_ARCHES = {
         "x86_64": "linux/x86_64",
         "s390x": "linux/s390x",
-        "ppc64le": "linux/ppc64le",
+        "ppc64le": "linux-large/ppc64le",
         "aarch64": "linux/arm64",
     }
 


### PR DESCRIPTION
ppc64le builds are running out of storage space (example [run](https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-18/pipelineruns/4-18-ose-cli-artifacts-rpk2m/logs?task=build-images))

Proposing to use a bigger VM. Available VMs listed [here](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/multi-platform-controller/production-downstream/host-config.yaml#L41C5-L41C16). Docs [here](https://konflux.pages.redhat.com/docs/users/getting-started/multi-platform-builds.html#ppc64le-2)