### PR TITLE
ART-10785: accept new_versioning scheme in standard assemably names

### DIFF
--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -148,14 +148,10 @@ class GenAssemblyCli:
         self.final_previous_list: List[VersionInfo] = []
 
         # Infer assembly type
-        if self.custom:
-            self.assembly_type = AssemblyTypes.CUSTOM
-        elif re.search(r'^[fr]c\.[0-9]+$', self.gen_assembly_name):
-            self.assembly_type = AssemblyTypes.CANDIDATE
-        elif re.search(r'^ec\.[0-9]+$', self.gen_assembly_name):
-            self.assembly_type = AssemblyTypes.PREVIEW
-        else:
-            self.assembly_type = AssemblyTypes.STANDARD
+        self.assembly_type = util.infer_assembly_type(self.custom, self.gen_assembly_name)
+
+        # Check if OCP should have the new release versioning scheme (i.e. 4.20.0-0)
+        self.includes_release_version = getattr(self.runtime.group_config, 'new_payload_versioning_scheme', None)
 
         # Create a map of package_name to RPMMetadata
         self.package_rpm_meta: Dict[str, RPMMetadata] = \
@@ -200,6 +196,10 @@ class GenAssemblyCli:
 
         if self.pre_ga_mode == "prerelease" and self.assembly_type not in [AssemblyTypes.PREVIEW, AssemblyTypes.CANDIDATE]:
             self._exit_with_error("Prerelease is only valid for preview and candidate assemblies.")
+
+        if self.assembly_type is AssemblyTypes.STANDARD and self.includes_release_version is True:
+            if "-" not in self.gen_assembly_name:
+                self._exit_with_error(f"Invalid assembly name: {self.gen_assembly_name}. Has to include release field. Eg: 4.18.0-0")
 
     def _get_release_pullspecs(self):
         for nightly_name in self.nightlies:
@@ -490,7 +490,8 @@ class GenAssemblyCli:
             # gen_assembly_name should be in the form of `ec.0`, `fc.0`, `rc.1`, or `4.10.1`
             if self.assembly_type == AssemblyTypes.CANDIDATE or self.assembly_type == AssemblyTypes.PREVIEW:
                 major_minor = self.runtime.get_minor_version()  # x.y
-                version = f"{major_minor}.0-{self.gen_assembly_name}"
+                # Support both 4.19+ and lower versions (former has release version while the latter does not)
+                version = f"{major_minor}.0-0.{self.gen_assembly_name}" if self.includes_release_version else f"{major_minor}.0-{self.gen_assembly_name}"
             else:
                 version = self.gen_assembly_name
             for arch in self.runtime.arches:
@@ -525,7 +526,7 @@ class GenAssemblyCli:
         release_jira = "ART-0"
 
         if self.assembly_type not in [AssemblyTypes.PREVIEW, AssemblyTypes.CANDIDATE]:
-            # For standalone assembly, if the advisorirs and jira already exist, reuse them
+            # For standalone assembly, if the advisories and jira already exist, reuse them
             if self.gen_assembly_name in releases_config.releases:
                 advisories = releases_config.releases[self.gen_assembly_name].assembly.group.advisories.primitive()
                 release_jira = releases_config.releases[self.gen_assembly_name].assembly.group.release_jira

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -578,3 +578,15 @@ def oc_image_info__caching(pull_spec: str, go_arch: str = 'amd64') -> Dict:
     if you expect the image to change during the course of doozer's execution.
     """
     return oc_image_info(pull_spec, go_arch)
+
+
+def infer_assembly_type(custom, assembly_name):
+    # Infer assembly type
+    if custom:
+        return AssemblyTypes.CUSTOM
+    elif re.search(r'^[fr]c\.[0-9]+$', assembly_name):
+        return AssemblyTypes.CANDIDATE
+    elif re.search(r'^ec\.[0-9]+$', assembly_name):
+        return AssemblyTypes.PREVIEW
+    else:
+        return AssemblyTypes.STANDARD

--- a/ocp-build-data-validator/validator/json_schemas/releases.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/releases.schema.json
@@ -9,7 +9,7 @@
       "description": "An object containing all releases in a group.",
       "type": "object",
       "patternProperties": {
-        "^stream$|^test$|^art\\d+$|^\\d+\\.\\d+\\.\\d+$|^[fre]c\\.\\d+$": {
+        "^stream$|^test$|^art\\d+$|^\\d+\\.\\d+\\.\\d+$|^\\d+\\.\\d+\\.\\d+$\\-|^[fre]c\\.\\d+$": {
           "$ref": "release.schema.json"
         }
       },


### PR DESCRIPTION
(cherry picked from commit fa2cbfe96dc42db8bceeff43fb842d4290a7ae07)

permit new_versioning scheme to be None

(cherry picked from commit 3159ef44697bc324266c17042df787943753a414)

enhance validator by new_versioning scheme

(cherry picked from commit 0c489598512652494bc4ed54c1766802739fe33e) (cherry picked from commit 5ca196dfa6c4da3e3e4d0a6b1b8b6eb9a981848a)

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED