### PR TITLE
ART-10884: accept assembly name with new versioning scheme

### DIFF
--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -390,7 +390,7 @@ class Runtime(GroupRuntime):
         self.hotfix = False  # True indicates builds should be tagged with associated hotfix tag for the artifacts branch
 
         if self.group_config.assemblies.enabled or self.enable_assemblies:
-            if re.fullmatch(r'[\w.]+', self.assembly) is None or self.assembly[0] == '.' or self.assembly[-1] == '.':
+            if re.fullmatch(r'[\w.-]+', self.assembly) is None or self.assembly[0] == '.' or self.assembly[-1] == '.':
                 raise ValueError('Assembly names may only consist of alphanumerics, ., and _, but not start or end with a dot (.).')
         else:
             # If assemblies are not enabled for the group,


### PR DESCRIPTION
(cherry picked from commit 47d88c60d05939b7064326053d8a44009009bfd5)

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED