### PR TITLE
Revert "[konflux] use bigger ppc vm"

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -57,7 +57,7 @@ class KonfluxImageBuilder:
     SUPPORTED_ARCHES = {
         "x86_64": "linux/x86_64",
         "s390x": "linux/s390x",
-        "ppc64le": "linux-large/ppc64le",
+        "ppc64le": "linux/ppc64le",
         "aarch64": "linux/arm64",
     }
 


### PR DESCRIPTION
Reverts openshift-eng/art-tools#1078

Not core issue. 

https://konflux.pages.redhat.com/docs/users/troubleshooting/index.html#no-space-left-on-device is the actual fix