### PR TITLE
Get source rpm from purl

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -9,13 +9,6 @@ from typing import Optional, cast
 
 from artcommonlib import exectools
 from artcommonlib.arch_util import go_arch_for_brew_arch
-from artcommonlib import util as art_util
-from dockerfile_parse import DockerfileParser
-from importlib_resources import files
-from kubernetes import client, config, watch
-from kubernetes.client import Configuration
-from kubernetes.dynamic import DynamicClient, exceptions, resource
-from ruamel.yaml import YAML
 from packageurl import PackageURL
 
 from artcommonlib.exectools import limit_concurrency

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -239,7 +239,7 @@ class KonfluxImageBuilder:
                 # example: pkg:rpm/rhel/coreutils-single@8.32-35.el9?arch=x86_64&upstream=coreutils-8.32-35.el9.src.rpm&distro=rhel-9.4
                 # https://github.com/package-url/packageurl-python does not support purl schemes other than "pkg"
                 # so filter them out
-                if x["purl"].startswith("pkg:"):
+                if x.get("purl", '').startswith("pkg:"):
                     purl = PackageURL.from_string(x["purl"])
                     # right now, we only care about rpms
                     if purl.type == "rpm":

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -9,6 +9,15 @@ from typing import Optional, cast
 
 from artcommonlib import exectools
 from artcommonlib.arch_util import go_arch_for_brew_arch
+from artcommonlib import util as art_util
+from dockerfile_parse import DockerfileParser
+from importlib_resources import files
+from kubernetes import client, config, watch
+from kubernetes.client import Configuration
+from kubernetes.dynamic import DynamicClient, exceptions, resource
+from ruamel.yaml import YAML
+from packageurl import PackageURL
+
 from artcommonlib.exectools import limit_concurrency
 from artcommonlib.konflux.konflux_build_record import (ArtifactType, Engine,
                                                        KonfluxBuildOutcome,
@@ -232,11 +241,19 @@ class KonfluxImageBuilder:
             sbom_contents = json.loads(stdout)
             source_rpms = set()
             for x in sbom_contents["components"]:
-                if x["bom-ref"].startswith("pkg:rpm"):
-                    for i in x["properties"]:
-                        if i["name"] == "syft:metadata:sourceRpm":
-                            source_rpms.add(i["value"].rstrip(".src.rpm"))
-                            break
+                # konflux generates sbom in cyclonedx schema: https://cyclonedx.org
+                # sbom uses purl or package-url convention https://github.com/package-url/purl-spec
+                # example: pkg:rpm/rhel/coreutils-single@8.32-35.el9?arch=x86_64&upstream=coreutils-8.32-35.el9.src.rpm&distro=rhel-9.4
+                # https://github.com/package-url/packageurl-python does not support purl schemes other than "pkg"
+                # so filter them out
+                if x["purl"].startswith("pkg:"):
+                    purl = PackageURL.from_string(x["purl"])
+                    # right now, we only care about rpms
+                    if purl.type == "rpm":
+                        # get the source rpm
+                        source_rpm = purl.qualifiers.get("upstream", None)
+                        if source_rpm:
+                            source_rpms.add(source_rpm.rstrip(".src.rpm"))
             return source_rpms
 
         results = await asyncio.gather(*(_get_for_arch(arch) for arch in arches))

--- a/doozer/requirements.txt
+++ b/doozer/requirements.txt
@@ -30,3 +30,4 @@ aiohttp
 jira>=3.4.1
 ghapi
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+packageurl-python


### PR DESCRIPTION
We rely on "syft:metadata:sourceRpm" which is generated by syft, the cli tool konflux uses to generate sbom. 
It is not the official identifier in the sbom spec, it can go away if another tool is used. 
Instead rely on purl which is the identifier in the sbom spec 
https://cyclonedx.org/docs/1.6/json/#components_items_purl
Use https://github.com/package-url/packageurl-python to parse purl

Note: https://cyclonedx-python-library.readthedocs.io/en/latest/schema-support.html is a nice lib to 
work with the whole sbom, but lacks support for some schema keys in the latest version which konflux uses.

Test

```
$ python3 -m asyncio
>>> from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
>>> pullspec = "quay.io/openshift-release-dev/ocp-v4.0-art-dev:microshift-bootc-v4.18.0-20241126.173547"
>>> await KonfluxImageBuilder.get_installed_packages(pullspec, ['amd64'])
['NetworkManager-1.46.0-19.el9_4', 'PyYAML-5.4.1-6.el9', 'WALinuxAgent-2.7.0.6-9.el9_2.1' ...
```