### PR TITLE
Revert "ART-10995 fix false alarm for regression check"

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -1,6 +1,6 @@
 import logging
 from typing import OrderedDict, Optional, Tuple, Iterable, List
-from datetime import datetime, timezone, timedelta, date
+from datetime import datetime, timezone
 import re
 import asyncio
 
@@ -142,25 +142,6 @@ def get_assembly_release_date(assembly, group):
 
     except KeyError:
         return None
-
-
-def is_release_this_week(release_date):
-    """
-    Check if release date is in the near week
-    """
-    return datetime.strptime(release_date, "%Y-%m-%d").date() <= date.today() + timedelta(days=7)
-
-
-def get_next_release_schedule(group):
-    """
-    Get next release date based on current date
-    """
-    dev_schedules = requests.get(f'{RELEASE_SCHEDULES}/{group}.z/schedule-tasks/?flags_and__in=dev&fields=path,date_finish', headers={'Accept': 'application/json'})
-    dev_schedules.raise_for_status()
-    for release in dev_schedules.json():
-        if datetime.strptime(release['date_finish'], "%Y-%m-%d").date() > date.today():
-            return release['date_finish']
-    return None
 
 
 def get_inflight(assembly, group):

--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -11,7 +11,6 @@ from artcommonlib import logutil, arch_util
 from artcommonlib.assembly import assembly_issues_config
 from artcommonlib.format_util import red_print
 from artcommonlib.rpm_utils import parse_nvr
-from artcommonlib.util import get_next_release_schedule, is_release_this_week
 from elliottlib import bzutil, constants
 from elliottlib.cli.common import cli, click_coroutine, pass_runtime
 from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
@@ -454,8 +453,6 @@ class BugValidator:
 
     def _verify_blocking_bugs(self, blocking_bugs_for, is_attached=False):
         # complain about blocking bugs that aren't verified or shipped
-        major, minor = self.runtime.get_major_minor()
-        release_next_week = is_release_this_week(get_next_release_schedule(f"openshift-{major}.{minor + 1}"))
         for bug, blockers in blocking_bugs_for.items():
             for blocker in blockers:
                 message = str()
@@ -482,7 +479,7 @@ class BugValidator:
                         message = f"`{bug.status}` bug <{bug.weburl}|{bug.id}> is a backport of bug " \
                             f"<{blocker.weburl}|{blocker.id}> which was CLOSED `{blocker.resolution}`"
                     self._complain(message)
-                if is_attached and blocker.status in ['ON_QA', 'Verified', 'VERIFIED'] and release_next_week:
+                if is_attached and blocker.status in ['ON_QA', 'Verified', 'VERIFIED']:
                     try:
                         blocker_advisories = blocker.all_advisory_ids()
                     except ErrataException:

--- a/elliott/tests/test_verify_attached_bugs_cli.py
+++ b/elliott/tests/test_verify_attached_bugs_cli.py
@@ -51,9 +51,7 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
         result = runner.invoke(cli, ['-g', 'openshift-4.6', '--assembly=4.6.6', 'verify-bugs'])
         self.assertEqual(result.exit_code, 0)
 
-    @patch('elliottlib.cli.verify_attached_bugs_cli.is_release_this_week', return_value=True)
-    @patch('elliottlib.cli.verify_attached_bugs_cli.get_next_release_schedule', return_value="2024-10-24")
-    def test_verify_bugs_with_sweep_cli(self, *_):
+    def test_verify_bugs_with_sweep_cli(self):
         runner = CliRunner()
         flexmock(Runtime).should_receive("initialize")
         flexmock(Runtime).should_receive("get_errata_config").and_return({})
@@ -95,8 +93,6 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
 
     @patch('elliottlib.cli.verify_attached_bugs_cli.BugValidator.verify_bugs_multiple_advisories')
     @patch('elliottlib.errata_async.AsyncErrataAPI._generate_auth_header')
-    @patch('elliottlib.cli.verify_attached_bugs_cli.is_release_this_week', return_value=True)
-    @patch('elliottlib.cli.verify_attached_bugs_cli.get_next_release_schedule', return_value="2024-10-24")
     def test_verify_attached_bugs_cli_fail(self, *_):
         runner = CliRunner()
         flexmock(Runtime).should_receive("initialize")


### PR DESCRIPTION
Reverts openshift-eng/art-tools#1066

This has caused an error when promoting 4.12.68: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fpromote-assembly/402/consoleFull