### PR TITLE
Fix unbounded variable error for blocker_advisories

### DIFF
--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -488,6 +488,7 @@ class BugValidator:
                     except ErrataException:
                         try:
                             sync_jira_issue(blocker.id)
+                            blocker_advisories = blocker.all_advisory_ids()
                         except Exception as e:
                             message = f"Failed to sync bug {blocker.id}: {e}"
                             logger.error(message)


### PR DESCRIPTION
blocker_advisories is not assigned when ErrataException occurs. We should retry `blocker_advisories = blocker.all_advisory_ids()` after calling `sync_jira_issue`.