### PR TITLE
ART-10995 fix false alarm for regression check

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -1,6 +1,6 @@
 import logging
 from typing import OrderedDict, Optional, Tuple, Iterable, List
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta, date
 import re
 import asyncio
 
@@ -142,6 +142,18 @@ def get_assembly_release_date(assembly, group):
 
     except KeyError:
         return None
+
+
+def is_release_next_week(group):
+    """
+    Check if there release of group need to release in the near week
+    """
+    release_schedules = requests.get(f'{RELEASE_SCHEDULES}/{group}.z/schedule-tasks/?fields=all_ga_tasks', headers={'Accept': 'application/json'})
+    for release in release_schedules.json()['all_ga_tasks']:
+        release_date = datetime.strptime(release['date_finish'], "%Y-%m-%d").date()
+        if release_date > date.today() and release_date <= date.today() + timedelta(days=7):
+            return True
+    return False
 
 
 def get_inflight(assembly, group):

--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -11,6 +11,7 @@ from artcommonlib import logutil, arch_util
 from artcommonlib.assembly import assembly_issues_config
 from artcommonlib.format_util import red_print
 from artcommonlib.rpm_utils import parse_nvr
+from artcommonlib.util import is_release_next_week
 from elliottlib import bzutil, constants
 from elliottlib.cli.common import cli, click_coroutine, pass_runtime
 from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
@@ -453,6 +454,7 @@ class BugValidator:
 
     def _verify_blocking_bugs(self, blocking_bugs_for, is_attached=False):
         # complain about blocking bugs that aren't verified or shipped
+        major, minor = self.runtime.get_major_minor()
         for bug, blockers in blocking_bugs_for.items():
             for blocker in blockers:
                 message = str()
@@ -479,7 +481,7 @@ class BugValidator:
                         message = f"`{bug.status}` bug <{bug.weburl}|{bug.id}> is a backport of bug " \
                             f"<{blocker.weburl}|{blocker.id}> which was CLOSED `{blocker.resolution}`"
                     self._complain(message)
-                if is_attached and blocker.status in ['ON_QA', 'Verified', 'VERIFIED']:
+                if is_attached and blocker.status in ['ON_QA', 'Verified', 'VERIFIED'] and is_release_next_week(f"openshift-{major}.{minor + 1}"):
                     try:
                         blocker_advisories = blocker.all_advisory_ids()
                     except ErrataException:

--- a/elliott/tests/test_verify_attached_bugs_cli.py
+++ b/elliott/tests/test_verify_attached_bugs_cli.py
@@ -51,7 +51,8 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
         result = runner.invoke(cli, ['-g', 'openshift-4.6', '--assembly=4.6.6', 'verify-bugs'])
         self.assertEqual(result.exit_code, 0)
 
-    def test_verify_bugs_with_sweep_cli(self):
+    @patch('elliottlib.cli.verify_attached_bugs_cli.is_release_next_week', return_value=True)
+    def test_verify_bugs_with_sweep_cli(self, *_):
         runner = CliRunner()
         flexmock(Runtime).should_receive("initialize")
         flexmock(Runtime).should_receive("get_errata_config").and_return({})
@@ -93,6 +94,7 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
 
     @patch('elliottlib.cli.verify_attached_bugs_cli.BugValidator.verify_bugs_multiple_advisories')
     @patch('elliottlib.errata_async.AsyncErrataAPI._generate_auth_header')
+    @patch('elliottlib.cli.verify_attached_bugs_cli.is_release_next_week', return_value=True)
     def test_verify_attached_bugs_cli_fail(self, *_):
         runner = CliRunner()
         flexmock(Runtime).should_receive("initialize")


### PR DESCRIPTION
relate to https://github.com/openshift-eng/art-tools/pull/1101
in https://github.com/openshift-eng/art-tools/pull/1066 we use development_cut_off date as a line to check is_release_next_week, but as 4.12 release is going to slow down the latest release of development_cut_off could be the day before release prepare day
so use the schedule of release in fast channel, if there is a date in next week then means we need to prepare it today.