### PR TITLE
fix gh workflow

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     container: fedora:latest
     steps:
       - name: Install dependencies
-        run: dnf install -y git clang
+        run: dnf install -y git clang rpm-python
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Verify uv installation

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     container: registry.access.redhat.com/ubi9/ubi:latest
     steps:
       - name: Install dependencies
-        run: dnf install -y git clang rpm-python
+        run: dnf install -y git clang
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Verify uv installation

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -23,10 +23,6 @@ jobs:
           set-safe-directory: ${{ env.GITHUB_WORKSPACE }}
       - name: Install packages
         run: dnf install -y gcc krb5-devel make glibc
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.9'
       - name: Create venv and install dependencies
         run: make venv
       - name: Run tests

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    container: fedora:latest
+    container: registry.access.redhat.com/ubi9/ubi:latest
     steps:
       - name: Install dependencies
         run: dnf install -y git clang rpm-python

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora:latest
     steps:
-      - name: Install git
-        run: dnf install -y git
+      - name: Install dependencies
+        run: dnf install -y git clang
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Verify uv installation
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.9'
       - name: Create venv and install dependencies
         run: make venv
       - name: Run tests


### PR DESCRIPTION
```
E   ImportError: Failed to import system RPM module. Make sure RPM Python bindings are installed on your system.
```
[run](https://github.com/openshift-eng/art-tools/actions/runs/11630513728/job/32389618965?pr=1105)

pyartcd doesn't seem to work on python3.11, bumping down to 3.9 for now