### PR TITLE
Don't close 'customer portal' subtask automatically

### DIFF
--- a/pyartcd/pyartcd/pipelines/operator_sdk_sync.py
+++ b/pyartcd/pyartcd/pipelines/operator_sdk_sync.py
@@ -42,10 +42,6 @@ class OperatorSDKPipeline:
             if advisory.errata_state == "SHIPPED_LIVE":
                 self._logger.info("Advisory status already in SHIPPED_LIVE, update subtask 9 ...")
                 self._jira_client.complete_subtask(self.parent_jira_key, "pushes advisory content to production CDN", "Advisory status already in SHIPPED_LIVE")
-                # check fast channel to decide if released on customer portal
-                res = requests.get("https://github.com/openshift/cincinnati-graph-data/raw/master/internal-channels/fast.yaml")
-                if self.assembly in yaml.safe_load(res.content)['versions']:
-                    self._jira_client.complete_subtask(self.parent_jira_key, "pushes release content to customer portal", "Release pushed to fast channel")
             self._logger.info("Advisory status already in post REL_PREP, update subtask 7 ...")
             self._jira_client.complete_subtask(self.parent_jira_key, "moves advisories to REL_PREP", "Advisory status already in REL_PREP")
 


### PR DESCRIPTION
Release present in cincinnati fast channel doesn't mean that it is automatically visible on the customer portal. I'd rather check and close that subtask manually.