### PR TITLE
[konflux] skip-checks param

### DIFF
--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -125,6 +125,7 @@ class KonfluxBuildCli:
         konflux_context: Optional[str],
         konflux_namespace: Optional[str],
         image_repo: str,
+        skip_checks: bool,
         dry_run: bool,
     ):
         self.runtime = runtime
@@ -132,6 +133,7 @@ class KonfluxBuildCli:
         self.konflux_context = konflux_context
         self.konflux_namespace = konflux_namespace
         self.image_repo = image_repo
+        self.skip_checks = skip_checks
         self.dry_run = dry_run
 
     @start_as_current_span_async(TRACER, "images:konflux:build")
@@ -148,7 +150,8 @@ class KonfluxBuildCli:
             context=self.konflux_context,
             namespace=self.konflux_namespace,
             image_repo=self.image_repo,
-            dry_run=self.dry_run,
+            skip_checks=self.skip_checks,
+            dry_run=self.dry_run
         )
         builder = KonfluxImageBuilder(config=config)
         tasks = []
@@ -172,14 +175,15 @@ class KonfluxBuildCli:
 @click.option('--konflux-context', metavar='CONTEXT', help='The name of the kubeconfig context to use for Konflux cluster connections.')
 @click.option('--konflux-namespace', metavar='NAMESPACE', required=True, help='The namespace to use for Konflux cluster connections.')
 @click.option('--image-repo', default=constants.KONFLUX_DEFAULT_IMAGE_REPO, help='Push images to the specified repo.')
+@click.option('--skip-checks', default=False, is_flag=True, help='Skip all post build checks')
 @click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
 @pass_runtime
 @click_coroutine
 async def images_konflux_build(
         runtime: Runtime, konflux_kubeconfig: Optional[str], konflux_context: Optional[str],
-        konflux_namespace: Optional[str], image_repo: str, dry_run: bool):
+        konflux_namespace: Optional[str], image_repo: str, skip_checks: bool, dry_run: bool):
     cli = KonfluxBuildCli(
         runtime=runtime, konflux_kubeconfig=konflux_kubeconfig,
         konflux_context=konflux_context, konflux_namespace=konflux_namespace,
-        image_repo=image_repo, dry_run=dry_run)
+        image_repo=image_repo, skip_checks=skip_checks, dry_run=dry_run)
     await cli.run()


### PR DESCRIPTION
Till now we had been skipping post build steps so that we can get the builds working. But skipping them violates enterprise contract policy. So now is a good time to enable the checks and the hash out any issues if any.

But keeping the skip checks as a param if we need it in the future.