### PR TITLE
ART-11251: [konflux] Build source image by default

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_build_pipelinerun.yaml
+++ b/doozer/doozerlib/backend/konflux_image_build_pipelinerun.yaml
@@ -86,7 +86,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string


### PR DESCRIPTION
```
  - metadata:
      code: source_image.exists
    msg: No source image references found
  - metadata:
      code: tasks.required_tasks_found
    msg: One of "source-build", "source-build-oci-ta" tasks is missing
```
Enterprise Contract was failing because `build-source-image` was set to false. Since we always want in enabled, setting it to true. Can override it later if needed