### PR TITLE
ART-11251: [konflux] set summary, description labels for rebase

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1380,6 +1380,15 @@ class KonfluxRebaser:
         with df_path.open('w', encoding="utf-8") as df:
             df.write("%s\n\n" % df_content)
             if labels:
+                additional_labels = {}
+
+                if "description" not in labels:
+                    additional_labels["description"] = labels.get("io.k8s.description", "Dummy Description")
+                if "summary" not in labels:
+                    additional_labels["summary"] = labels.get("io.k8s.description", "Dummy Summary")
+
+                labels.update(additional_labels)
+
                 df.write("LABEL")
                 for k, v in labels.items():
                     df.write(" \\\n")  # All but the last line should have line extension backslash "\"


### PR DESCRIPTION
Fixes Enterprise Contract issue
```
  - metadata:
      code: labels.disallowed_inherited_labels
    msg: The "description" label should not be inherited from the parent image
  - metadata:
      code: labels.disallowed_inherited_labels
    msg: The "summary" label should not be inherited from the parent image
```
Successful image generated in https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-18/pipelineruns/ose-4-18-openshift-enterprise-base-rhel9-8gcwn

This change is only for konflux, since this function is part of `KonfluxRebaser` class