### PR TITLE
Schedule ocp4-scan-konflux

### DIFF
--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -7,7 +7,7 @@ from pyartcd.pipelines import (
     operator_sdk_sync, olm_bundle, ocp4, scan_for_kernel_bugs, tag_rpms, advisory_drop, cleanup_locks, brew_scan_osh,
     sigstore_sign, update_golang, rebuild_golang_rpms, scan_fips, quay_doomsday_backup
 )
-from pyartcd.pipelines.scheduled import schedule_ocp4_scan
+from pyartcd.pipelines.scheduled import schedule_ocp4_scan, schedule_ocp4_scan_konflux
 
 
 def main(args: Optional[Sequence[str]] = None):

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -29,6 +29,7 @@ class Jobs(Enum):
     OCP4 = 'aos-cd-builds/build%2Focp4'
     OCP4_KONFLUX = 'aos-cd-builds/build%2Focp4-konflux'
     OCP4_SCAN = 'aos-cd-builds/build%2Focp4_scan'
+    OCP4_SCAN_KONFLUX = 'aos-cd-builds/build%2Focp4-scan-konflux'
     RHCOS = 'aos-cd-builds/build%2Frhcos'
     OLM_BUNDLE = 'aos-cd-builds/build%2Folm_bundle'
     SYNC_FOR_CI = 'scheduled-builds/sync-for-ci'
@@ -276,7 +277,8 @@ def start_ocp4(build_version: str, assembly: str, rpm_list: list,
     )
 
 
-def start_ocp4_konflux(build_version: str, assembly: str, image_list: list, **kwargs) -> Optional[str]:
+def start_ocp4_konflux(build_version: str, assembly: str, image_list: list,
+                       limit_arches: list = None, **kwargs) -> Optional[str]:
     params = {
         'BUILD_VERSION': build_version,
         'ASSEMBLY': assembly
@@ -285,6 +287,9 @@ def start_ocp4_konflux(build_version: str, assembly: str, image_list: list, **kw
     # Build only changed images or none
     if image_list:
         params['IMAGE_LIST'] = ','.join(image_list)
+    # Limit arches when requested
+    if limit_arches:
+        params['LIMIT_ARCHES'] = ','.join(limit_arches)
 
     return start_build(
         job=Jobs.OCP4_KONFLUX,
@@ -299,6 +304,17 @@ def start_ocp4_scan(version: str, **kwargs) -> Optional[str]:
     }
     return start_build(
         job=Jobs.OCP4_SCAN,
+        params=params,
+        **kwargs
+    )
+
+
+def start_ocp4_scan_konflux(version: str, **kwargs) -> Optional[str]:
+    params = {
+        'VERSION': version,
+    }
+    return start_build(
+        job=Jobs.OCP4_SCAN_KONFLUX,
         params=params,
         **kwargs
     )

--- a/pyartcd/pyartcd/locks.py
+++ b/pyartcd/pyartcd/locks.py
@@ -14,10 +14,12 @@ class Lock(enum.Enum):
     MIRRORING_RPMS = 'lock:mirroring-rpms:{version}'
     PLASHET = 'lock:compose:{assembly}:{version}'
     BUILD = 'lock:build:{version}'
+    BUILD_KONFLUX = 'lock:build-konflux:{version}'
     MASS_REBUILD = 'lock:mass-rebuild-serializer'
     SIGNING = 'lock:signing:{signing_env}'
     BUILD_SYNC = 'lock:build-sync:{version}'
     SCAN = 'lock:scan:{version}'
+    SCAN_KONFLUX = 'lock:scan-konflux:{version}'
 
 
 class Keys(enum.Enum):
@@ -55,6 +57,11 @@ LOCK_POLICY = {
         'retry_delay_min': 0.1,
         'lock_timeout': DEFAULT_LOCK_TIMEOUT
     },
+    Lock.BUILD_KONFLUX: {
+        'retry_count': 36000 * 1,
+        'retry_delay_min': 0.1,
+        'lock_timeout': DEFAULT_LOCK_TIMEOUT
+    },
     Lock.MASS_REBUILD: {
         'retry_count': 36000 * 8,
         'retry_delay_min': 0.1,
@@ -71,6 +78,11 @@ LOCK_POLICY = {
         'lock_timeout': DEFAULT_LOCK_TIMEOUT
     },
     Lock.SCAN: {
+        'retry_count': 36000,
+        'retry_delay_min': 0.1,
+        'lock_timeout': DEFAULT_LOCK_TIMEOUT
+    },
+    Lock.SCAN_KONFLUX: {
         'retry_count': 36000,
         'retry_delay_min': 0.1,
         'lock_timeout': DEFAULT_LOCK_TIMEOUT

--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -3,9 +3,10 @@ import logging
 import click
 import yaml
 
-from pyartcd import util, jenkins
+from pyartcd import util, jenkins, locks
 from pyartcd import constants, exectools
 from pyartcd.cli import cli, pass_runtime, click_coroutine
+from pyartcd.locks import Lock
 from pyartcd.runtime import Runtime
 
 
@@ -22,8 +23,13 @@ class Ocp4ScanPipeline:
         self._doozer_working = self.runtime.working_dir / "doozer_working"
         self.changes = {}
 
+        self.skipped = True  # True by default; if not locked, run() will set it to False
+
     async def run(self):
+        # If we get here, lock could be acquired
+        self.skipped = False
         scan_info = f'Scanning version {self.version}, assembly {self.assembly}, data path {self.data_path}'
+
         if self.data_gitref:
             scan_info += f'@{self.data_gitref}'
         self.logger.info(scan_info)
@@ -50,6 +56,7 @@ class Ocp4ScanPipeline:
                 build_version=self.version,
                 assembly='stream',
                 image_list=image_list,
+                limit_arches=['x86_64']  # TODO remove once we have full capacity
             )
 
         else:
@@ -125,15 +132,49 @@ async def ocp4_scan(runtime: Runtime, version: str, assembly: str, data_path: st
                     image_list: str, ignore_locks: bool):
     jenkins.init_jenkins()
 
-    # TODO handle locks
-    if ignore_locks and not runtime.dry_run:
-        raise RuntimeError('--ignore-locks can only by used with --dry-run')
+    lock = Lock.SCAN_KONFLUX
+    lock_name = lock.value.format(version=version)
+    lock_identifier = jenkins.get_build_path()
+    if not lock_identifier:
+        runtime.logger.warning('Env var BUILD_URL has not been defined: a random identifier will be used for the locks')
 
-    await Ocp4ScanPipeline(
+    pipeline = Ocp4ScanPipeline(
         runtime=runtime,
         version=version,
         assembly=assembly,
         data_path=data_path,
         data_gitref=data_gitref,
         image_list=image_list,
-    ).run()
+    )
+
+    if ignore_locks:
+        if not runtime.dry_run:
+            raise RuntimeError('--ignore-locks can only by used with --dry-run')
+        await pipeline.run()
+
+    else:
+        # Scheduled builds are already being skipped if the lock is already acquired.
+        # For manual builds, we need to check if the build and scan locks are already acquired,
+        # and skip the current build if that's the case.
+        # Should that happen, signal it by appending a [SKIPPED][LOCKED] to the build title
+        async def run_with_build_lock():
+            build_lock = Lock.BUILD_KONFLUX
+            build_lock_name = build_lock.value.format(version=version)
+            await locks.run_with_lock(
+                coro=pipeline.run(),
+                lock=build_lock,
+                lock_name=build_lock_name,
+                lock_id=lock_identifier,
+                skip_if_locked=True
+            )
+
+        await locks.run_with_lock(
+            coro=run_with_build_lock(),
+            lock=lock,
+            lock_name=lock_name,
+            lock_id=lock_identifier,
+            skip_if_locked=True
+        )
+
+    if pipeline.skipped:
+        jenkins.update_title(' [SKIPPED][LOCKED]')

--- a/pyartcd/pyartcd/pipelines/scheduled/schedule_ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/scheduled/schedule_ocp4_scan_konflux.py
@@ -1,0 +1,45 @@
+import asyncio
+
+import click
+
+from artcommonlib import redis
+from pyartcd import util, jenkins
+from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.locks import Lock, LockManager
+from pyartcd.runtime import Runtime
+
+
+async def run_for(version: str, runtime: Runtime, lock_manager: LockManager):
+    # Skip if locked on scan
+    scan_lock_name = Lock.SCAN_KONFLUX.value.format(version=version)
+    if await lock_manager.is_locked(scan_lock_name):
+        runtime.logger.info(f'[{version}] Locked on {scan_lock_name}, skipping')
+        return
+
+    # Skip if locked on build
+    build_lock_name = Lock.BUILD_KONFLUX.value.format(version=version)
+    if await lock_manager.is_locked(build_lock_name):
+        runtime.logger.info(f'[{version}] Locked on {build_lock_name}, skipping')
+        return
+
+    # Skip if frozen
+    if not await util.is_build_permitted(version, doozer_working=str(runtime.working_dir / "doozer_working-" / version)):
+        runtime.logger.info('[%s] Not permitted, skipping', version)
+        return
+
+    # Schedule scan
+    runtime.logger.info('[%s] Scheduling ocp4-scan-konflux', version)
+    jenkins.start_ocp4_scan_konflux(version=version, block_until_building=False)
+
+
+@cli.command('schedule-ocp4-scan-konflux')
+@click.option('--version', '-v', required=True, help='OCP version to scan', multiple=True)
+@pass_runtime
+@click_coroutine
+async def ocp4_scan_konflux(runtime: Runtime, version: tuple):
+    jenkins.init_jenkins()
+    lock_manager = LockManager([redis.redis_url()])
+    try:
+        await asyncio.gather(*[run_for(v, runtime, lock_manager) for v in version])
+    finally:
+        await lock_manager.destroy()


### PR DESCRIPTION
- Add pipeline to schedule ocp4-scan for Konflux
- Schedule ocp4-konflux only for x86
- Introduce per-version locks for Konflux builds and scans