### PR TITLE
Sync pullspec to latest only when rpm for assembly is present in latest

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -188,7 +188,8 @@ class BuildMicroShiftPipeline:
         major, minor = self._ocp_version
         version = f'{major}.{minor}'
         try:
-            jenkins.start_microshift_sync(version=version, assembly=self.assembly, dry_run=self.runtime.dry_run)
+            jenkins.start_microshift_sync(version=version, assembly=self.assembly,
+                                          dry_run=self.runtime.dry_run, block_until_complete=True)
             message = f"microshift_sync for version {version} and assembly {self.assembly} has been triggered\n" \
                       f"This will publish the microshift build to mirror"
             await self.slack_client.say_in_thread(message)

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -104,12 +104,12 @@ class BuildMicroShiftBootcPipeline:
             await self.sync_to_mirror(arch, bootc_build.el_target, f"{repo_url}@{digest}")
 
     async def is_microshift_for_release_in_latest(self, packages_path):
-        cmd = ["aws", "s3", "ls", packages_path]
+        cmd = ["aws", "s3", "ls", f"s3://art-srv-enterprise{packages_path}"]
         try:
             _, out, _ = await exectools.cmd_gather_async(cmd)
         except Exception:
             return False
-        if self.microshift_nvr in out:
+        if out and self.microshift_nvr in out:
             return True
         return False
 

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -114,7 +114,7 @@ class BuildMicroShiftBootcPipeline:
         except ChildProcessError as ex:
             self._logger.error(f"Could not inspect {packages_path} in S3: {ex}")
             return False
-        self._logger.info(out)
+        self._logger.info(f"Directory contents: \n{out}")
         if self.microshift_nvr in out:
             return True
         return False

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -82,6 +82,10 @@ class BuildMicroShiftBootcPipeline:
             data_path=self._doozer_env_vars["DOOZER_DATA_PATH"]
         )
         self.assembly_type = get_assembly_type(self.releases_config, self.assembly)
+
+        microshift_nvrs = await get_microshift_builds(self.group, self.assembly, env=self._elliott_env_vars)
+        self.microshift_nvr = next(n for n in microshift_nvrs if isolate_el_version_in_release(n) == 9)
+
         bootc_build = await self._rebase_and_build_bootc()
         if bootc_build:
             self._logger.info("Bootc image build: %s", bootc_build.nvr)
@@ -210,8 +214,6 @@ class BuildMicroShiftBootcPipeline:
                     raise ValueError(f"Expected to find microshift package in plashet.yml at"
                                      f" {url}, but could not find it. Use --force to rebuild plashet.")
 
-                microshift_nvrs = await get_microshift_builds(self.group, self.assembly, env=self._elliott_env_vars)
-                self.microshift_nvr = next(n for n in microshift_nvrs if isolate_el_version_in_release(n) == 9)
                 if actual_nvr != self.microshift_nvr:
                     self._logger.info(f"Found nvr {actual_nvr} in plashet.yml is different from expected {self.microshift_nvr}. Plashet build is needed.")
                     return True

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -111,9 +111,11 @@ class BuildMicroShiftBootcPipeline:
         cmd = ["aws", "s3", "ls", f"s3://art-srv-enterprise{packages_path}"]
         try:
             _, out, _ = await exectools.cmd_gather_async(cmd)
-        except Exception:
+        except ChildProcessError as ex:
+            self._logger.error(f"Could not inspect {packages_path} in S3: {ex}")
             return False
-        if out and self.microshift_nvr in out:
+        self._logger.info(out)
+        if self.microshift_nvr in out:
             return True
         return False
 

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -105,7 +105,10 @@ class BuildMicroShiftBootcPipeline:
 
     async def is_microshift_for_release_in_latest(self, packages_path):
         cmd = ["aws", "s3", "ls", packages_path]
-        _, out, _ = await exectools.cmd_gather_async(cmd)
+        try:
+            _, out, _ = await exectools.cmd_gather_async(cmd)
+        except Exception:
+            return False
         if self.microshift_nvr in out:
             return True
         return False

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -160,7 +160,7 @@ class BuildMicroShiftBootcPipeline:
 
         # make sure that the latest path has the same microshift build as the given release assembly
         # only then sync the pullspec to the latest path
-        latest_packages_path = f"{latest_path}/os/Packages"
+        latest_packages_path = f"{latest_path}/os/Packages/"
         if await self.is_microshift_for_release_in_latest(latest_packages_path):
             await _run_for(latest_path)
         else:

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -165,7 +165,8 @@ class BuildMicroShiftBootcPipeline:
             await _run_for(latest_path)
         else:
             self._logger.info(f"Skipping sync to {latest_path} since microshift build for assembly {self.assembly} "
-                              f"was not found in {latest_packages_path}. Make sure that microshift_sync job has run.")
+                              f"was not found in {latest_packages_path}. If {self.assembly} is the desired latest, "
+                              f"make sure that microshift_sync job has successfully completed for the assembly.")
 
     async def get_latest_bootc_build(self):
         bootc_image_name = "microshift-bootc"


### PR DESCRIPTION
Test runs:

Do not sync to latest when check fails:
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift-bootc/15/console

Sync to latest when check succeeds:
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift-bootc/16/console