### PR TITLE
ART-11251: [konflux] set dummy default labels

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1382,10 +1382,12 @@ class KonfluxRebaser:
             if labels:
                 additional_labels = {}
 
+                if "io.k8s.description" not in labels:
+                    additional_labels["io.k8s.description"] = "Dummy description"
                 if "description" not in labels:
-                    additional_labels["description"] = labels.get("io.k8s.description", "Dummy Description")
+                    additional_labels["description"] = labels.get("io.k8s.description", "Dummy description")
                 if "summary" not in labels:
-                    additional_labels["summary"] = labels.get("io.k8s.description", "Dummy Summary")
+                    additional_labels["summary"] = labels.get("io.k8s.description", "Dummy summary")
 
                 labels.update(additional_labels)
 


### PR DESCRIPTION
Follows: https://github.com/openshift-eng/art-tools/pull/1121

Set default dummy values for labels konflux is looking for, to fix EC issue

```
The "io.k8s.description" label should not be inherited from the parent image
```