### PR TITLE
Re-write konflux_db.search_builds_by_fields() to handle extra patterns

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -109,8 +109,8 @@ class KonfluxDb:
             await asyncio.gather(*(loop.run_in_executor(pool, self.add_build, build) for build in builds))
 
     async def search_builds_by_fields(self, start_search: datetime, end_search: datetime = None,
-                                      where: typing.Dict[str, typing.Any] = None, order_by: str = '',
-                                      sorting: str = 'DESC', limit: int = None) -> list:
+                                      where: typing.Dict[str, typing.Any] = None, extra_patterns: dict = None,
+                                      order_by: str = '', sorting: str = 'DESC', limit: int = None) -> list:
         """
         Execute a SELECT * from the BigQuery table.
 
@@ -121,31 +121,32 @@ class KonfluxDb:
         Return a (possibly empty) list of results
         """
 
-        query = f'SELECT * FROM `{self.bq_client.table_ref}`'
-        query += f" WHERE `start_time` > '{start_search}'"
+        where_clauses = [
+            Column('start_time', DateTime) >= start_search,
+        ]
+
         if end_search:
-            query += f" AND `start_time` < '{end_search}'"
+            where_clauses.append(Column('start_time', DateTime) < end_search)
 
-        where_clauses = []
-        where = where if where is not None else {}
-        for name, value in where.items():
-            if value is not None:
-                where_clauses.append(f"`{name}` = '{value}'")
+        where = where if where else {}
+        for col_name, col_value in where.items():
+            if col_value is not None:
+                where_clauses.append(Column(col_name, String) == col_value)
             else:
-                where_clauses.append(f"`{name}` IS NULL")
-        if where_clauses:
-            query += ' AND '
-            query += ' AND '.join(where_clauses)
+                where_clauses.append(Column(col_name, String).is_(None))
 
-        if order_by:
-            query += f' ORDER BY `{order_by}` {sorting}'
+        extra_patterns = extra_patterns if extra_patterns else {}
+        for col_name, col_value in extra_patterns.items():
+            where_clauses.append(Column(col_name, String).like(f"%{col_value}%"))
 
-        if limit is not None:
-            assert isinstance(limit, int)
-            assert limit >= 0, 'LIMIT expects a non-negative integer literal or parameter '
-            query += f' LIMIT {limit}'
+        order_by_clause = Column(order_by if order_by else 'start_time', quote=True)
+        order_by_clause = order_by_clause.desc() if sorting == 'DESC' else order_by_clause.asc()
 
-        results = await self.bq_client.query_async(query)
+        results = await self.bq_client.select(
+            where_clauses=where_clauses,
+            order_by_clause=order_by_clause,
+            limit=limit)
+
         self.logger.debug('Found %s builds', results.total_rows)
         return [self.from_result_row(result) for result in results]
 

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -42,37 +42,40 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
         start_search = datetime(2024, 9, 23, 9, 0, 0, 0)
         await self.db.search_builds_by_fields(start_search=start_search, where={})
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE `start_time` > '2024-09-23 09:00:00'")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00' "
+            "ORDER BY `start_time` DESC")
 
         query_mock.reset_mock()
         end_search = start_search + timedelta(days=7)
         await self.db.search_builds_by_fields(start_search=start_search, end_search=end_search, where={})
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE `start_time` > '2024-09-23 09:00:00'"
-            " AND `start_time` < '2024-09-30 09:00:00'")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
+            " AND start_time < '2024-09-30 09:00:00' ORDER BY `start_time` DESC")
 
         query_mock.reset_mock()
         await self.db.search_builds_by_fields(start_search=start_search, where=None)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE `start_time` > '2024-09-23 09:00:00'")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00' "
+            "ORDER BY `start_time` DESC")
 
         query_mock.reset_mock()
         await self.db.search_builds_by_fields(start_search=start_search,
                                               where={'name': 'ironic', 'group': 'openshift-4.18'})
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE `start_time` > '2024-09-23 09:00:00'"
-            " AND `name` = 'ironic' AND `group` = 'openshift-4.18'")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
+            " AND name = 'ironic' AND `group` = 'openshift-4.18' ORDER BY `start_time` DESC")
 
         query_mock.reset_mock()
         await self.db.search_builds_by_fields(start_search=start_search, where={'name': None})
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE `start_time` > '2024-09-23 09:00:00' AND `name` IS NULL")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00' AND name IS NULL"
+            " ORDER BY `start_time` DESC")
 
         query_mock.reset_mock()
         await self.db.search_builds_by_fields(start_search=start_search, where={'name': None, 'group': None})
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE `start_time` > '2024-09-23 09:00:00'"
-            " AND `name` IS NULL AND `group` IS NULL")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
+            " AND name IS NULL AND `group` IS NULL ORDER BY `start_time` DESC")
 
         query_mock.reset_mock()
         await self.db.search_builds_by_fields(
@@ -80,8 +83,8 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             where={'name': 'ironic', 'group': 'openshift-4.18'},
             order_by='start_time')
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE `start_time` > '2024-09-23 09:00:00'"
-            " AND `name` = 'ironic' AND `group` = 'openshift-4.18' ORDER BY `start_time` DESC")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
+            " AND name = 'ironic' AND `group` = 'openshift-4.18' ORDER BY `start_time` DESC")
 
         query_mock.reset_mock()
         await self.db.search_builds_by_fields(
@@ -89,8 +92,8 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             where={'name': 'ironic', 'group': 'openshift-4.18'},
             order_by='start_time', sorting='ASC')
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE `start_time` > '2024-09-23 09:00:00'"
-            " AND `name` = 'ironic' AND `group` = 'openshift-4.18' ORDER BY `start_time` ASC")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
+            " AND name = 'ironic' AND `group` = 'openshift-4.18' ORDER BY `start_time` ASC")
 
         query_mock.reset_mock()
         await self.db.search_builds_by_fields(
@@ -98,8 +101,8 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             where={'name': 'ironic', 'group': 'openshift-4.18'},
             order_by='start_time', sorting='ASC', limit=0)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE `start_time` > '2024-09-23 09:00:00'"
-            " AND `name` = 'ironic' AND `group` = 'openshift-4.18' ORDER BY `start_time` ASC LIMIT 0")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
+            " AND name = 'ironic' AND `group` = 'openshift-4.18' ORDER BY `start_time` ASC LIMIT 0")
 
         query_mock.reset_mock()
         await self.db.search_builds_by_fields(
@@ -107,8 +110,8 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             where={'name': 'ironic', 'group': 'openshift-4.18'},
             order_by='start_time', sorting='ASC', limit=10)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE `start_time` > '2024-09-23 09:00:00'"
-            " AND `name` = 'ironic' AND `group` = 'openshift-4.18' ORDER BY `start_time` ASC LIMIT 10")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
+            " AND name = 'ironic' AND `group` = 'openshift-4.18' ORDER BY `start_time` ASC LIMIT 10")
 
         query_mock.reset_mock()
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
Update the function to allow us query for `WHERE name LIKE '%installer%'` or the like

Tested with art-build-history: https://konflux-build-history-hackspace-dpaolell.apps.artc2023.pc3z.p1.openshiftapps.com/search?name=installer&outcome=failure&group=-&assembly=stream&after=2024-11-13&engine=brew