### PR TITLE
Introduce build plan for konflux builds

### DIFF
--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -79,6 +79,7 @@ class KonfluxRebaseCli:
                 failed_images.append(image_name)
                 LOGGER.error(f"Failed to rebase {image_name}: {result}")
         if failed_images:
+            runtime.state['images:konflux:rebase'] = {'failed-images': failed_images}
             raise DoozerFatalError(f"Failed to rebase images: {failed_images}")
         LOGGER.info("Rebase complete")
 


### PR DESCRIPTION
Instead of crashing the pipeline on rebase failures, exclude those images from the build step.

Prepare ocp4-konflux to accept an image build strategy similar to what we have in ocp4, where can build all images, a pinned subset, or exclude only specific images.

Do not spam us about rebase failures (would happen too often at the moment)