### PR TITLE
Introduce regex matching in konflux_db.search_builds_by_fields()

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -8,7 +8,7 @@ import typing
 from datetime import datetime, timedelta, timezone
 
 from google.cloud.bigquery import SchemaField, Row
-from sqlalchemy import Column, String, DateTime
+from sqlalchemy import Column, String, DateTime, func
 
 from artcommonlib import bigquery
 from artcommonlib.konflux import konflux_build_record
@@ -137,7 +137,8 @@ class KonfluxDb:
 
         extra_patterns = extra_patterns if extra_patterns else {}
         for col_name, col_value in extra_patterns.items():
-            where_clauses.append(Column(col_name, String).like(f"%{col_value}%"))
+            regexp_condition = func.REGEXP_CONTAINS(Column(col_name, String), col_value)
+            where_clauses.append(regexp_condition)
 
         order_by_clause = Column(order_by if order_by else 'start_time', quote=True)
         order_by_clause = order_by_clause.desc() if sorting == 'DESC' else order_by_clause.asc()


### PR DESCRIPTION
In `konflux_db.search_builds_by_fields()` we currently use LIKE to perform simple pattern matching using wildcard characters. This is limited to  basic wildcard patterns (`%` to match zero or more characters, `_` to match exactly one character).

Replace `LIKE` with `REGEXP_CONTAINS` to allow more complex regular expression matching. Supported Features are:

- Anchors (^ for the beginning of a string, $ for the end).
- Character classes (e.g., [abc], [a-z]).
- Quantifiers (e.g., *, +, ?, {n,m}).
- Alternation (| for "or" conditions).