### PR TITLE
Konflux: Add OLM bundle rebase/build support

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -115,7 +115,7 @@ class KonfluxDb:
             self,
             start_search: typing.Optional[datetime] = None,
             end_search: typing.Optional[datetime] = None,
-            window_size: int | None = None,
+            window_size: typing.Optional[int] = None,
             where: typing.Optional[typing.Dict[str, typing.Any]] = None,
             extra_patterns: typing.Optional[dict] = None,
             order_by: str = '',
@@ -129,7 +129,7 @@ class KonfluxDb:
         "where" is an optional dictionary that maps names and values to define a WHERE clause.
         "start_search" is a lower bound to be applied to the partitioning field `start_time`. If None, the search starts 360 days ago.
         "end_search" can optionally be provided as an upper bound for the same field. If None, the search ends now.
-        "window_size" is the number of days to search in each iteration.
+        "window_size" is the number of days to search in each iteration. If None, defaults to DEFAULT_SEARCH_WINDOW.
         "extra_patterns" is an optional dictionary that maps names and values to define extra patterns to be matched.
         "order_by" is the column to order by.
         "sorting" is the sorting order.

--- a/artcommon/artcommonlib/runtime.py
+++ b/artcommon/artcommonlib/runtime.py
@@ -54,6 +54,8 @@ class GroupRuntime(ABC):
         self._logger = logging.getLogger('artcommonlib')
 
     def initialize_konxflux_db(self):
+        if self.konflux_db:
+            return  # already initialized
         try:
             self.konflux_db = KonfluxDb()
             self._logger.info('Konflux DB initialized ')

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 import logging
 from typing import OrderedDict, Optional, Tuple, Iterable, List
 from datetime import datetime, timezone, timedelta, date
@@ -53,6 +54,7 @@ def new_roundtrip_yaml_handler():
     return yaml
 
 
+@lru_cache(maxsize=512)
 def convert_remote_git_to_https(source_url: str):
     """
     Accepts a source git URL in ssh or https format and return it in a normalized
@@ -77,6 +79,7 @@ def convert_remote_git_to_https(source_url: str):
     return f'https://{server}/{org_repo}'
 
 
+@lru_cache(maxsize=512)
 def convert_remote_git_to_ssh(url):
     """
     Accepts a remote git URL and turns it into a git@

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -1,9 +1,9 @@
 import asyncio
 from datetime import datetime, timedelta, timezone
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from google.cloud.bigquery import SchemaField
+from google.cloud.bigquery import SchemaField, Row
 
 from artcommonlib import constants
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord, KonfluxBundleBuildRecord, KonfluxBuildOutcome
@@ -149,6 +149,34 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE REGEXP_CONTAINS(name, 'installer') AND REGEXP_CONTAINS(`group`, 'openshift') "
             "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' ORDER BY `start_time` ASC LIMIT 10")
 
+    @patch('artcommonlib.bigquery.BigQueryClient.query_async')
+    async def test_search_builds_by_fields_windowed(self, mock_query_async: AsyncMock):
+        mocked_rows = [
+            [Row(('ironic', '1.0.0', '3'), {'name': 0, 'version': 1, 'release': 2})],
+            [],
+            [],
+            [Row(('ironic', '1.0.0', '2'), {'name': 0, 'version': 1, 'release': 2}), Row(('ironic', '1.0.0', '1'), {'name': 0, 'version': 1, 'release': 2})]
+        ]
+        mock_query_async.side_effect = [
+            MagicMock(total_rows=len(batch), __iter__=MagicMock(return_value=iter(batch)))
+            for batch in mocked_rows
+        ]
+        records = [record async for record in self.db.search_builds_by_fields(
+            start_search=datetime(2024, 10, 1, 8, 0, 0, tzinfo=timezone.utc),
+            end_search=datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            window_size=30,
+            where={'name': 'ironic', 'group': 'openshift-4.18'},
+        )]
+        expected_queries = [
+            "SELECT * FROM `builds` WHERE name = 'ironic' AND `group` = 'openshift-4.18' AND start_time >= '2024-12-02 12:00:00+00:00' AND start_time < '2025-01-01 12:00:00+00:00' ORDER BY `start_time` DESC",
+            "SELECT * FROM `builds` WHERE name = 'ironic' AND `group` = 'openshift-4.18' AND start_time >= '2024-11-02 12:00:00+00:00' AND start_time < '2024-12-02 12:00:00+00:00' ORDER BY `start_time` DESC",
+            "SELECT * FROM `builds` WHERE name = 'ironic' AND `group` = 'openshift-4.18' AND start_time >= '2024-10-03 12:00:00+00:00' AND start_time < '2024-11-02 12:00:00+00:00' ORDER BY `start_time` DESC",
+            "SELECT * FROM `builds` WHERE name = 'ironic' AND `group` = 'openshift-4.18' AND start_time >= '2024-10-01 08:00:00+00:00' AND start_time < '2024-10-03 12:00:00+00:00' ORDER BY `start_time` DESC",
+        ]
+        actual_queries = [call[0][0] for call in mock_query_async.await_args_list]
+        self.assertListEqual(actual_queries, expected_queries)
+        self.assertEqual(len(records), 3)
+
     @patch('artcommonlib.konflux.konflux_db.datetime')
     @patch('artcommonlib.bigquery.BigQueryClient.query_async')
     async def test_get_latest_build(self, query_mock, datetime_mock):
@@ -204,6 +232,27 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
                       f"AND start_time >= '{str(lower_bound)}' "
                       f"AND start_time < '{now}' "
                       "ORDER BY `start_time` DESC LIMIT 1", actual_calls)
+
+    @patch('artcommonlib.konflux.konflux_db.datetime')
+    @patch('artcommonlib.bigquery.BigQueryClient.query_async')
+    async def test_get_latest_build_windowed(self, mock_query_async: AsyncMock, datetime_mock: MagicMock):
+        datetime_mock.now.return_value = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        mock_query_async.side_effect = [
+            MagicMock(total_rows=0, __next__=MagicMock(side_effect=StopIteration)),
+            MagicMock(total_rows=0, __next__=MagicMock(side_effect=StopIteration)),
+            MagicMock(total_rows=0, __next__=MagicMock(side_effect=StopIteration)),
+            MagicMock(total_rows=0, __next__=MagicMock(return_value=Row(('ironic', '1.0.0', '2', "ironic-1.0.0-2"), {'name': 0, 'version': 1, 'release': 2, 'nvr': 3}))),
+        ]
+        record = await self.db.get_latest_build(name='ironic', group='openshift-4.18', assembly='stream')
+        expected_queries = [
+            "SELECT * FROM `builds` WHERE name = 'ironic' AND `group` = 'openshift-4.18' AND outcome = 'success' AND assembly = 'stream' AND start_time >= '2024-10-03 12:00:00+00:00' AND start_time < '2025-01-01 12:00:00+00:00' ORDER BY `start_time` DESC LIMIT 1",
+            "SELECT * FROM `builds` WHERE name = 'ironic' AND `group` = 'openshift-4.18' AND outcome = 'success' AND assembly = 'stream' AND start_time >= '2024-07-05 12:00:00+00:00' AND start_time < '2024-10-03 12:00:00+00:00' ORDER BY `start_time` DESC LIMIT 1",
+            "SELECT * FROM `builds` WHERE name = 'ironic' AND `group` = 'openshift-4.18' AND outcome = 'success' AND assembly = 'stream' AND start_time >= '2024-04-06 12:00:00+00:00' AND start_time < '2024-07-05 12:00:00+00:00' ORDER BY `start_time` DESC LIMIT 1",
+            "SELECT * FROM `builds` WHERE name = 'ironic' AND `group` = 'openshift-4.18' AND outcome = 'success' AND assembly = 'stream' AND start_time >= '2024-01-07 12:00:00+00:00' AND start_time < '2024-04-06 12:00:00+00:00' ORDER BY `start_time` DESC LIMIT 1",
+        ]
+        actual_queries = [call[0][0] for call in mock_query_async.await_args_list]
+        self.assertListEqual(actual_queries, expected_queries)
+        self.assertEqual(record.nvr, "ironic-1.0.0-2")
 
     def test_generate_builds_schema(self):
         expected_fields = [

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch
 
@@ -37,116 +37,117 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
         asyncio.run(self.db.add_builds([build for _ in range(10)]))
         self.assertEqual(query_mock.call_count, 10)
 
+    @patch('artcommonlib.konflux.konflux_db.datetime')
     @patch('artcommonlib.bigquery.BigQueryClient.query_async')
-    async def test_search_builds_by_fields(self, query_mock):
-        start_search = datetime(2024, 9, 23, 9, 0, 0, 0)
-        await self.db.search_builds_by_fields(start_search=start_search, where={})
+    async def test_search_builds_by_fields(self, query_mock, datetime_mock):
+        datetime_mock.now.return_value = datetime(2024, 9, 30, 9, 0, 0, tzinfo=timezone.utc)
+        start_search = datetime(2024, 9, 23, 9, 0, 0, 0, tzinfo=timezone.utc)
+        await anext(self.db.search_builds_by_fields(start_search=start_search, where={}), None)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00' "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' "
             "ORDER BY `start_time` DESC")
 
         query_mock.reset_mock()
         end_search = start_search + timedelta(days=7)
-        await self.db.search_builds_by_fields(start_search=start_search, end_search=end_search, where={})
+        await anext(self.db.search_builds_by_fields(start_search=start_search, end_search=end_search, where={}), None)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
-            " AND start_time < '2024-09-30 09:00:00' ORDER BY `start_time` DESC")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00+00:00'"
+            " AND start_time < '2024-09-30 09:00:00+00:00' ORDER BY `start_time` DESC")
 
         query_mock.reset_mock()
-        await self.db.search_builds_by_fields(start_search=start_search, where=None)
+        await anext(self.db.search_builds_by_fields(start_search=start_search, where=None), None)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00' "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' "
             "ORDER BY `start_time` DESC")
 
         query_mock.reset_mock()
-        await self.db.search_builds_by_fields(start_search=start_search,
-                                              where={'name': 'ironic', 'group': 'openshift-4.18'})
+        await anext(self.db.search_builds_by_fields(start_search=start_search,
+                                                    where={'name': 'ironic', 'group': 'openshift-4.18'}), None)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
-            " AND name = 'ironic' AND `group` = 'openshift-4.18' ORDER BY `start_time` DESC")
-
-        query_mock.reset_mock()
-        await self.db.search_builds_by_fields(start_search=start_search, where={'name': None})
-        query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00' AND name IS NULL"
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE name = 'ironic' AND `group` = 'openshift-4.18' AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00'"
             " ORDER BY `start_time` DESC")
 
         query_mock.reset_mock()
-        await self.db.search_builds_by_fields(start_search=start_search, where={'name': None, 'group': None})
+        await anext(self.db.search_builds_by_fields(start_search=start_search, where={'name': None}), None)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
-            " AND name IS NULL AND `group` IS NULL ORDER BY `start_time` DESC")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE name IS NULL AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00'"
+            " ORDER BY `start_time` DESC")
 
         query_mock.reset_mock()
-        await self.db.search_builds_by_fields(
-            start_search=start_search,
-            where={'name': 'ironic', 'group': 'openshift-4.18'},
-            order_by='start_time')
+        await anext(self.db.search_builds_by_fields(start_search=start_search, where={'name': None, 'group': None}), None)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
-            " AND name = 'ironic' AND `group` = 'openshift-4.18' ORDER BY `start_time` DESC")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE name IS NULL AND `group` IS NULL "
+            "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' ORDER BY `start_time` DESC")
 
         query_mock.reset_mock()
-        await self.db.search_builds_by_fields(
+        await anext(self.db.search_builds_by_fields(
             start_search=start_search,
             where={'name': 'ironic', 'group': 'openshift-4.18'},
-            order_by='start_time', sorting='ASC')
+            order_by='start_time'), None)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
-            " AND name = 'ironic' AND `group` = 'openshift-4.18' ORDER BY `start_time` ASC")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE name = 'ironic' AND `group` = 'openshift-4.18' "
+            "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' ORDER BY `start_time` DESC")
 
         query_mock.reset_mock()
-        await self.db.search_builds_by_fields(
+        await anext(self.db.search_builds_by_fields(
             start_search=start_search,
             where={'name': 'ironic', 'group': 'openshift-4.18'},
-            order_by='start_time', sorting='ASC', limit=0)
+            order_by='start_time', sorting='ASC'), None)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
-            " AND name = 'ironic' AND `group` = 'openshift-4.18' ORDER BY `start_time` ASC LIMIT 0")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE name = 'ironic' AND `group` = 'openshift-4.18' "
+            "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' ORDER BY `start_time` ASC")
 
         query_mock.reset_mock()
-        await self.db.search_builds_by_fields(
+        await anext(self.db.search_builds_by_fields(
             start_search=start_search,
             where={'name': 'ironic', 'group': 'openshift-4.18'},
-            order_by='start_time', sorting='ASC', limit=10)
+            order_by='start_time', sorting='ASC', limit=0), None)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
-            " AND name = 'ironic' AND `group` = 'openshift-4.18' ORDER BY `start_time` ASC LIMIT 10")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE name = 'ironic' AND `group` = 'openshift-4.18' "
+            "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' ORDER BY `start_time` ASC LIMIT 0")
+
+        query_mock.reset_mock()
+        await anext(self.db.search_builds_by_fields(
+            start_search=start_search,
+            where={'name': 'ironic', 'group': 'openshift-4.18'},
+            order_by='start_time', sorting='ASC', limit=10), None)
+        query_mock.assert_called_once_with(
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE name = 'ironic' AND `group` = 'openshift-4.18' "
+            "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' ORDER BY `start_time` ASC LIMIT 10")
 
         query_mock.reset_mock()
         with self.assertRaises(AssertionError):
-            await self.db.search_builds_by_fields(
+            await anext(self.db.search_builds_by_fields(
                 start_search=start_search,
                 where={'name': 'ironic', 'group': 'openshift-4.18'},
-                order_by='start_time', sorting='ASC', limit=-1)
+                order_by='start_time', sorting='ASC', limit=-1), None)
 
         query_mock.reset_mock()
-        await self.db.search_builds_by_fields(
+        await anext(self.db.search_builds_by_fields(
             start_search=start_search,
             extra_patterns={'name': 'installer'},
-            order_by='start_time', sorting='ASC', limit=10)
+            order_by='start_time', sorting='ASC', limit=10), None)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
-            " AND REGEXP_CONTAINS(name, 'installer') ORDER BY `start_time` ASC LIMIT 10")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE REGEXP_CONTAINS(name, 'installer') "
+            "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' ORDER BY `start_time` ASC LIMIT 10")
 
         query_mock.reset_mock()
-        await self.db.search_builds_by_fields(
+        await anext(self.db.search_builds_by_fields(
             start_search=start_search,
             extra_patterns={'name': '^ose-installer$'},
-            order_by='start_time', sorting='ASC', limit=10)
+            order_by='start_time', sorting='ASC', limit=10), None)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
-            " AND REGEXP_CONTAINS(name, '^ose-installer$') ORDER BY `start_time` ASC LIMIT 10")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE REGEXP_CONTAINS(name, '^ose-installer$') "
+            "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' ORDER BY `start_time` ASC LIMIT 10")
 
         query_mock.reset_mock()
-        await self.db.search_builds_by_fields(
+        await anext(self.db.search_builds_by_fields(
             start_search=start_search,
             extra_patterns={'name': 'installer', 'group': 'openshift'},
-            order_by='start_time', sorting='ASC', limit=10)
+            order_by='start_time', sorting='ASC', limit=10), None)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE start_time >= '2024-09-23 09:00:00'"
-            " AND REGEXP_CONTAINS(name, 'installer') AND REGEXP_CONTAINS(`group`, 'openshift')"
-            " ORDER BY `start_time` ASC LIMIT 10")
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE REGEXP_CONTAINS(name, 'installer') AND REGEXP_CONTAINS(`group`, 'openshift') "
+            "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' ORDER BY `start_time` ASC LIMIT 10")
 
     @patch('artcommonlib.konflux.konflux_db.datetime')
     @patch('artcommonlib.bigquery.BigQueryClient.query_async')

--- a/doozer/doozerlib/backend/build_repo.py
+++ b/doozer/doozerlib/backend/build_repo.py
@@ -15,12 +15,12 @@ class BuildRepo:
 
     def __init__(self,
                  url: str,
-                 branch: str,
+                 branch: Optional[str],
                  local_dir: Union[str, Path],
                  logger: Optional[logging.Logger]) -> None:
         """ Initialize a BuildRepo object.
         :param url: The URL of the build source repository.
-        :param branch: The branch of the build source repository to clone.
+        :param branch: The branch of the build source repository to clone. None to not switch to any branch.
         :param local_dir: The local directory to clone the build source repository into.
         :param logger: A logger object to use for logging messages
         """
@@ -39,6 +39,7 @@ class BuildRepo:
     @property
     def commit_hash(self) -> Optional[str]:
         """ Get the commit hash of the current commit in the build source repository.
+        Returns None if the branch has no commits yet.
         """
         return self._commit_hash
 
@@ -47,9 +48,11 @@ class BuildRepo:
         """
         return self.local_dir.joinpath(".git").exists()
 
-    async def ensure_source(self, upcycle: bool = False):
+    async def ensure_source(self, upcycle: bool = False, strict: bool = False):
         """ Ensure that the build source repository is cloned into the local directory.
         :param upcycle: If True, the local directory will be deleted and recreated if it already exists.
+        :param strict: If True, raise an exception if the branch is not found in the build source repository.
+                       Otherwise, create a new branch instead.
         """
         local_dir = str(self.local_dir)
         needs_clone = True
@@ -59,33 +62,98 @@ class BuildRepo:
                 await exectools.to_thread(shutil.rmtree, local_dir)
             else:
                 self._logger.info("Reusing existing build source repository at %s", local_dir)
+                self._commit_hash = await self._get_commit_hash(local_dir)
                 needs_clone = False
         if needs_clone:
             self._logger.info("Cloning build source repository %s on branch %s into %s...", self.url, self.branch, self.local_dir)
-            await self.clone()
+            await self.clone(strict=strict)
 
-    async def clone(self):
+    async def clone(self, strict: bool = False):
         """ Clone the build source repository into the local directory.
+        :param strict: If True, raise an exception if the branch is not found in the build source repository;
+                       otherwise, create a new branch instead.
         """
         local_dir = str(self.local_dir)
         self._logger.info("Cloning build source repository %s on branch %s into %s...", self.url, self.branch, local_dir)
-        await git_helper.run_git_async(["init", local_dir])
-        _, out, _ = await git_helper.gather_git_async(["-C", local_dir, "remote"], stderr=None)
-        if 'origin' not in out.strip().split():
-            await git_helper.run_git_async(["-C", local_dir, "remote", "add", "origin", self.url])
-        else:
-            await git_helper.run_git_async(["-C", local_dir, "remote", "set-url", "origin", self.url])
-        rc, _, err = await git_helper.gather_git_async(["-C", local_dir, "fetch", "--depth=1", "origin", self.branch], check=False)
-        if rc != 0:
-            if "fatal: couldn't find remote ref" in err:
-                self._logger.info("Branch %s not found in build source repository; creating a new branch instead", self.branch)
-                await git_helper.run_git_async(["-C", local_dir, "checkout", "--orphan", self.branch])
+        await self.init()
+        await self.set_remote_url(self.url)
+        self._commit_hash = None
+        if self.branch is not None:
+            if await self.fetch(self.branch, strict=strict):
+                await self.switch(self.branch)
             else:
-                raise ChildProcessError(f"Failed to fetch {self.branch} from {self.url}: {err}")
+                self._logger.info("Branch %s not found in build source repository; creating a new branch instead", self.branch)
+                await self.switch(self.branch, orphan=True)
+
+    async def init(self):
+        """ Initialize the local directory as a git repository."""
+        local_dir = str(self.local_dir)
+        await git_helper.run_git_async(["init", local_dir])
+
+    async def set_remote_url(self, url: Optional[str], remote_name: str = "origin"):
+        """ Set the URL of the remote in the build source repository.
+        :param url: The URL of the remote. None to use the default URL specified in the constructor.
+        :param remote_name: The name of the remote.
+        """
+        if url is None:
+            url = self.url
+        local_dir = str(self.local_dir)
+        _, out, _ = await git_helper.gather_git_async(["-C", local_dir, "remote"], stderr=None)
+        if remote_name not in out.strip().split():
+            await git_helper.run_git_async(["-C", local_dir, "remote", "add", remote_name, url])
         else:
-            await git_helper.run_git_async(["-C", local_dir, "checkout", "-B", self.branch, "-t", f"origin/{self.branch}"])
-            _, commit_hash, _ = await git_helper.gather_git_async(["-C", local_dir, "rev-parse", "HEAD"])
-            self._commit_hash = commit_hash.strip()
+            await git_helper.run_git_async(["-C", local_dir, "remote", "set-url", remote_name, url])
+
+    async def fetch(self, refspec: str, depth: Optional[int] = 1, strict: bool = False):
+        """ Fetch a refspec from the build source repository.
+        :param refspec: The refspec to fetch.
+        :param depth: The depth of the fetch. None to fetch the entire history.
+        :param strict: If True, raise an exception if the refspec is not found in the remote.
+        :return: True if the fetch was successful; False otherwise
+        """
+        local_dir = str(self.local_dir)
+        fetch_options = []
+        if depth is not None:
+            fetch_options.append(f"--depth={depth}")
+        rc, _, err = await git_helper.gather_git_async(["-C", local_dir, "fetch"] + fetch_options + ["origin", refspec], check=False)
+        if rc != 0:
+            if not strict and "fatal: couldn't find remote ref" in err:
+                self._logger.warning("Failed to fetch %s from %s: %s", refspec, self.url, err)
+                return False
+            raise ChildProcessError(f"Failed to fetch {refspec} from {self.url}: {err}")
+        return True
+
+    async def switch(self, branch: str, detach: bool = False, orphan: bool = False):
+        """ Switch to a different branch in the build source repository.
+        :param branch: The branch to switch to.
+        """
+        local_dir = str(self.local_dir)
+        options = []
+        if detach:
+            options.append("--detach")
+        if orphan:
+            options.append("--orphan")
+        await git_helper.run_git_async(["-C", local_dir, "switch"] + options + [branch])
+        self.branch = branch
+        self._commit_hash = await self._get_commit_hash(local_dir)
+
+    async def delete_all_files(self):
+        """ Delete all files in the local directory.
+        """
+        await git_helper.run_git_async(["-C", str(self.local_dir), "rm", "-rf", "--ignore-unmatch", "."])
+
+    @staticmethod
+    async def _get_commit_hash(local_dir: str) -> Optional[str]:
+        """ Get the commit hash of the current commit in the build source repository.
+        :return: The commit hash of the current commit; None if the branch has no commits yet.
+        """
+        rc, out, err = await git_helper.gather_git_async(["-C", str(local_dir), "rev-parse", "HEAD"], check=False)
+        if rc != 0:
+            if "unknown revision or path not in the working tree" in err:
+                # This branch has no commits yet
+                return None
+            raise ChildProcessError(f"Failed to get commit hash: {err}")
+        return out.strip()
 
     async def commit(self, message: str, allow_empty: bool = False):
         """ Commit changes in the local directory to the build source repository."""
@@ -95,13 +163,20 @@ class BuildRepo:
         if allow_empty:
             commit_opts.append("--allow-empty")
         await git_helper.run_git_async(["-C", local_dir, "commit"] + commit_opts + ["-m", message])
-        _, out, _ = await git_helper.gather_git_async(["-C", local_dir, "rev-parse", "HEAD"])
-        self._commit_hash = out.strip()
+        self._commit_hash = await self._get_commit_hash(local_dir)
+
+    async def tag(self, tag: str):
+        """ Tag the current commit in the build source repository.
+
+        :param tag: The tag to apply to the current commit.
+        """
+        local_dir = str(self.local_dir)
+        await git_helper.run_git_async(["-C", local_dir, "tag", "-fam", tag, "--", tag])
 
     async def push(self):
         """ Push changes in the local directory to the build source repository."""
         local_dir = str(self.local_dir)
-        await git_helper.run_git_async(["-C", local_dir, "push", "origin", self.branch])
+        await git_helper.run_git_async(["-C", local_dir, "push", "--follow-tags", "origin", "HEAD"])
 
     @staticmethod
     async def from_local_dir(local_dir: Union[str, Path], logger: Optional[logging.Logger] = None):
@@ -116,7 +191,6 @@ class BuildRepo:
         local_dir = str(local_dir)
         _, url, _ = await git_helper.gather_git_async(["-C", local_dir, "config", "--get", "remote.origin.url"])
         _, branch, _ = await git_helper.gather_git_async(["-C", local_dir, "rev-parse", "--abbrev-ref", "HEAD"])
-        _, commit_hash, _ = await git_helper.gather_git_async(["-C", local_dir, "rev-parse", "HEAD"])
         repo = BuildRepo(url.strip(), branch.strip(), local_dir, logger)
-        repo._commit_hash = commit_hash.strip()
+        repo._commit_hash = await BuildRepo._get_commit_hash(local_dir)
         return repo

--- a/doozer/doozerlib/backend/build_repo.py
+++ b/doozer/doozerlib/backend/build_repo.py
@@ -184,6 +184,7 @@ class BuildRepo:
         :param local_dir: The local directory containing the build source repository.
         :param logger: A logger object to use for logging messages
         :return: A BuildRepo object
+        :raises FileNotFoundError: If the local directory is not a git repository
         """
         local_dir = Path(local_dir)
         if not local_dir.joinpath(".git").exists():

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -86,7 +86,7 @@ class KonfluxImageBuilder:
                 source = None
                 if metadata.has_source():
                     logger.info(f"Resolving source for {metadata.qualified_key}")
-                    source = cast(SourceResolution, await exectools.to_thread(metadata.runtime.source_resolver.resolve_source, metadata))
+                    source = cast(SourceResolution, await exectools.to_thread(metadata.runtime.source_resolver.resolve_source, metadata, no_clone=True))
                 else:
                     raise IOError(f"Image {metadata.qualified_key} doesn't have upstream source. This is no longer supported.")
                 dest_branch = "art-{group}-assembly-{assembly_name}-dgk-{distgit_key}".format_map({

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -1,0 +1,615 @@
+import asyncio
+import glob
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from functools import cached_property, lru_cache
+from pathlib import Path
+import traceback
+from typing import Dict, Optional, Sequence, Tuple, cast
+
+import aiofiles
+import yaml
+from artcommonlib import exectools
+from artcommonlib.exectools import limit_concurrency
+from artcommonlib.konflux.konflux_build_record import (
+    KonfluxBuildOutcome, KonfluxBuildRecord, KonfluxBundleBuildRecord)
+from artcommonlib.konflux.konflux_db import Engine, KonfluxDb
+from artcommonlib.model import Model
+from dockerfile_parse import DockerfileParser
+
+from doozerlib import constants, util
+from doozerlib.backend.build_repo import BuildRepo
+from doozerlib.backend.konflux_client import KonfluxClient, resource
+from doozerlib.image import ImageMetadata
+from doozerlib.source_resolver import SourceResolution, SourceResolver
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class KonfluxOlmBundleRebaser:
+    def __init__(self,
+                 base_dir: Path,
+                 group: str,
+                 assembly: str,
+                 group_config: Model,
+                 konflux_db: KonfluxDb,
+                 source_resolver: SourceResolver,
+                 upcycle: bool = False,
+                 image_repo: str = constants.KONFLUX_DEFAULT_IMAGE_REPO,
+                 dry_run: bool = False,
+                 logger: logging.Logger = _LOGGER,
+                 ):
+        self.base_dir = base_dir
+        self.group = group
+        self.assembly = assembly
+        self._group_config = group_config
+        self._konflux_db = konflux_db
+        self._konflux_db.bind(KonfluxBuildRecord)
+        self._source_resolver = source_resolver
+        self.upcycle = upcycle
+        self.image_repo = image_repo
+        self.dry_run = dry_run
+        self._logger = logger
+
+    async def rebase(self, metadata: ImageMetadata, operator_build: KonfluxBuildRecord, input_release: str):
+        """ Rebase an operator with Konflux.
+
+        :param metadata: The metadata of the operator to rebase.
+        :param operator_build_record: The build record of the operator to rebase. If not provided, the latest build record will be used.
+        :param input_release: The release string for the new bundle. None to let the build backend generate it.
+        """
+        assert operator_build.engine == Engine.KONFLUX, "Operator build must be from Konflux"
+        assert input_release, "input_release must be provided"
+
+        logger = self._logger.getChild(f"[{metadata.distgit_key}]")
+        source = None
+        if metadata.has_source():
+            logger.info("Resolving source...")
+            source = cast(SourceResolution, await exectools.to_thread(self._source_resolver.resolve_source, metadata, no_clone=True))
+        else:
+            raise IOError(f"Image {metadata.qualified_key} doesn't have upstream source. This is no longer supported.")
+
+        logger.info("Cloning operator build source...")
+        operator_dir = self.base_dir.joinpath(metadata.qualified_key)
+        operator_build_repo = BuildRepo(url=source.url, branch=None, local_dir=operator_dir, logger=self._logger)
+        await operator_build_repo.ensure_source(upcycle=self.upcycle)
+        await operator_build_repo.fetch(operator_build.rebase_commitish, strict=True)
+        await operator_build_repo.switch(operator_build.rebase_commitish, detach=True)
+        logger.info(f"operator build source cloned to {operator_dir}")
+
+        logger.info("Cloning bundle repository...")
+        bundle_dir = self.base_dir.joinpath(metadata.get_olm_bundle_short_name())
+        bundle_build_branch = "art-{group}-assembly-{assembly_name}-bundle-{distgit_key}".format_map({
+            "group": self.group,
+            "assembly_name": self.assembly,
+            "distgit_key": metadata.distgit_key,
+        })
+        bundle_build_repo = BuildRepo(url=source.url, branch=bundle_build_branch, local_dir=bundle_dir, logger=self._logger)
+        await bundle_build_repo.ensure_source(upcycle=self.upcycle)
+        logger.info("Bundle repository cloned to %s", bundle_dir)
+        # clean the bundle build directory
+        logger.info("Cleaning bundle build directory...")
+        await bundle_build_repo.delete_all_files()
+        logger.info("Rebasing bundle content...")
+        await self._rebase_dir(metadata, operator_dir, bundle_dir, input_release)
+        # commit and push the changes
+        logger.info("Committing and pushing bundle content...")
+        await bundle_build_repo.commit(f"Update bundle manifests for {operator_build.nvr}", allow_empty=True)
+        if not self.dry_run:
+            await bundle_build_repo.push()
+
+    async def _rebase_dir(self, metadata: ImageMetadata, operator_dir: Path, bundle_dir: Path, input_release: str):
+        """ Rebase an operator directory with Konflux. """
+        csv_config = metadata.config['update-csv']
+        if not csv_config:
+            raise ValueError(f"[{metadata.distgit_key}] No update-csv config found in the operator's metadata")
+        if not csv_config.get('manifests-dir'):
+            raise ValueError(f"[{metadata.distgit_key}] No manifests-dir defined in the operator's update-csv")
+        if not csv_config.get('bundle-dir'):
+            raise ValueError(f"[{metadata.distgit_key}] No bundle-dir defined in the operator's update-csv")
+        if not csv_config.get('valid-subscription-label'):
+            raise ValueError(f"[{metadata.distgit_key}] No valid-subscription-label defined in the operator's update-csv")
+
+        logger = self._logger.getChild(f"[{metadata.distgit_key}]")
+        operator_manifests_dir = operator_dir.joinpath(csv_config['manifests-dir'])
+        operator_bundle_dir = operator_manifests_dir.joinpath(csv_config['bundle-dir'])
+        bundle_manifests_dir = bundle_dir.joinpath("manifests")
+
+        # Read the operator's Dockerfile
+        operator_df = DockerfileParser(str(operator_dir.joinpath('Dockerfile')))
+        operator_component = operator_df.labels.get('com.redhat.component')
+        operator_version = operator_df.labels.get('version')
+        operator_release = operator_df.labels.get('release')
+        if not operator_component or not operator_version or not operator_release:
+            raise ValueError(f"[{metadata.distgit_key}] Label 'com.redhat.component', 'version' or 'release' is not set in the operator's Dockerfile")
+        operator_nvr = f"{operator_component}-{operator_version}-{operator_release}"
+
+        # Get operator package name and channel from its package YAML
+        # This info will be used to generate bundle's Dockerfile labels and metadata/annotations.yaml
+        file_path = glob.glob(f'{operator_manifests_dir}/*package.yaml')[0]
+        async with aiofiles.open(file_path, mode='r') as f:
+            package_yaml = yaml.safe_load(await f.read())
+        package_name = package_yaml['packageName']
+        channel_name = str(package_yaml['channels'][0]['name'])
+
+        # Copy the operator's manifests to the bundle directory
+        if not next(operator_bundle_dir.iterdir(), None):
+            raise FileNotFoundError(f"[{metadata.distgit_key}] No files found in bundle directory {operator_bundle_dir.relative_to(self.base_dir)}")
+        bundle_manifests_dir.mkdir(parents=True, exist_ok=True)
+        # Iterate through all bundle manifests files, replacing any image reference tag by its
+        # corresponding SHA.
+        # That is used to allow disconnected installs, where a cluster can't reach external registries
+        # in order to translate image tags into something "pullable"
+        all_found_operands: Dict[str, Tuple[str, str, str]] = {}  # map of image name to (old_pullspec, new_pullspec, nvr)
+        for src in operator_bundle_dir.iterdir():
+            if src.name == "image-references":
+                continue  # skip image-references file
+            logger.info(f"Processing {src}...")
+            # Read the file content and replace image references
+            async with aiofiles.open(src, 'r') as f:
+                content = await f.read()
+            content, found_images = await self._replace_image_references(str(csv_config['registry']), content)
+            for _, (old_pullspec, new_pullspec, operand_nvr) in found_images.items():
+                logger.info(f"Replaced image reference {old_pullspec} ({operand_nvr}) by {new_pullspec}")
+            all_found_operands.update(found_images)
+            # Write the content to the dest bundle directory
+            dest = bundle_manifests_dir / src.name
+            async with aiofiles.open(dest, 'w') as f:
+                if "clusterserviceversion.yaml" in src.name:
+                    csv = yaml.safe_load(content)
+                    csv['metadata']['annotations']['operators.openshift.io/valid-subscription'] = csv_config['valid-subscription-label']
+                    if found_images:
+                        csv["spec"]["relatedImages"] = [{"name": name, "image": new_pullspec} for name, (_, new_pullspec, _) in found_images.items()]
+                    content = yaml.safe_dump(csv)
+                await f.write(content)
+
+        # Read image references from the operator's image-references file
+        image_references = {}
+        refs_path = operator_bundle_dir / "image-references"
+        if refs_path.exists():
+            async with aiofiles.open(refs_path, 'r') as f:
+                image_refs = yaml.safe_load(await f.read())
+            for entry in image_refs.get('spec', {}).get('tags', []):
+                image_references[entry["name"]] = entry
+        # Warn if the number of images found in the bundle doesn't match the image-references file
+        if len(all_found_operands) != len(image_references):
+            logger.warning(f"Found {len(all_found_operands)} images in the bundle, but {len(image_references)} in the operator's image-references file")
+
+        # Generate bundle's operator-framework tags
+        operator_framework_tags = self._get_operator_framework_tags(channel_name, package_name)
+
+        # Generate bundle's annotations.yaml
+        bundle_metadata_dir = bundle_dir / "metadata"
+        bundle_metadata_dir.mkdir(parents=True, exist_ok=True)
+        dest_annotations_path = bundle_metadata_dir / "annotations.yaml"
+        async with aiofiles.open(dest_annotations_path, 'w') as f:
+            await f.write(yaml.safe_dump({'annotations': operator_framework_tags}))
+
+        # Generate bundle's Dockerfile
+        await asyncio.to_thread(self._create_dockerfile, metadata, operator_dir, bundle_dir, operator_framework_tags, input_release)
+
+        # Write container.yaml for Brew/OSBS
+        filename = bundle_dir / 'container.yaml'
+        await self._create_container_yaml(filename)
+
+        # Write .oit files. Those files are used by Doozer for additional information about the bundle
+        await self._create_oit_files(bundle_dir, operator_nvr, all_found_operands)
+
+    async def _create_oit_files(self, bundle_dir: Path, operator_nvr: str, operands: Dict[str, Tuple[str, str, str]]):
+        """ Create .oit files
+
+        :param bundle_dir: The directory where the bundle is located.
+        :param all_found_operands: A map of all found operands in the bundle, in format of {image_name: (old_pullspec, new_pullspec, nvr)}
+        """
+        # Create a .oit/olm_bundle_info.yaml file to store additional information about the bundle
+        oit_dir = bundle_dir / '.oit'
+        oit_dir.mkdir(exist_ok=True)
+        content = yaml.safe_dump({
+            "operator": {
+                "nvr": operator_nvr,
+            },
+            "operands": {
+                name: {
+                    "nvr": nvr,
+                    "internal_pullspec": old_pullspec,
+                    "public_pullspec": new_pullspec,
+                } for name, (old_pullspec, new_pullspec, nvr) in operands.items()
+            }
+        })
+        async with aiofiles.open(oit_dir / 'olm_bundle_info.yaml', 'w') as f:
+            await f.write(content)
+
+    @lru_cache
+    @staticmethod
+    def _get_image_reference_pattern(registry: str):
+        """ Get a compiled regex pattern to match image references in the format of `registry/namespace/image:tag`.
+        """
+        pattern = r'{}\/([^:]+):([^\'"\\\s]+)'.format(re.escape(registry))
+        return re.compile(pattern)
+
+    async def _replace_image_references(self, old_registry: str, content: str):
+        """
+        Replace image references in the content by their corresponding SHA.
+        Returns the content with the replacements and a map of found images in format of {image_name: (old_pullspec, new_pullspec, nvr)}
+        """
+        new_content = content
+        found_images: Dict[str, Tuple[str, str, str]] = {}
+        # Find all image references in the content
+        pattern = KonfluxOlmBundleRebaser._get_image_reference_pattern(old_registry)
+        matches = pattern.finditer(content)
+        references = {}  # map of image pullspec to (namespace, image_short_name, image_tag)
+        image_info_tasks = []
+        for match in matches:
+            pullspec = match.group(0)
+            namespace, image_short_name = match.group(1).rsplit('/', maxsplit=1)
+            image_tag = match.group(2)
+            references[pullspec] = (namespace, image_short_name, image_tag)
+        # Get image infos for all found images
+        for pullspec, (namespace, image_short_name, image_tag) in references.items():
+            build_pullspec = f"{self.image_repo}:{image_short_name}-{image_tag}"
+            image_info_tasks.append(asyncio.create_task(util.oc_image_info_async__caching(build_pullspec)))
+        image_infos = await asyncio.gather(*image_info_tasks)
+
+        # Replace image references in the content
+        csv_namespace = self._group_config.get('csv_namespace', 'openshift')
+        for pullspec, image_info in zip(references, image_infos):
+            image_labels = image_info['config']['config']['Labels']
+            image_component = image_labels['com.redhat.component']
+            image_version = image_labels['version']
+            image_release = image_labels['release']
+            image_nvr = f"{image_component}-{image_version}-{image_release}"
+            namespace, image_short_name, image_tag = references[pullspec]
+            image_sha = image_info['listDigest'] if self._group_config.operator_image_ref_mode == 'manifest-list' else image_info['contentDigest']
+            new_namespace = 'openshift4' if namespace == csv_namespace else namespace
+            new_pullspec = '{}/{}@{}'.format(
+                'registry.redhat.io',  # hardcoded until appregistry is dead
+                f'{new_namespace}/{image_short_name}',
+                image_sha
+            )
+            new_content = new_content.replace(pullspec, new_pullspec)
+            found_images[image_short_name] = (pullspec, new_pullspec, image_nvr)
+        return new_content, found_images
+
+    @cached_property
+    def _operator_index_mode(self):
+        mode = self._group_config.operator_index_mode or 'ga'  # default when missing
+        if mode in {'pre-release', 'ga', 'ga-plus'}:
+            # pre-release: label for pre-release operator index (unsupported)
+            # ga: label for only this release's operator index
+            # ga-plus: label for this release's operator index and future release indexes as well
+            # [lmeyer 20240108] ref https://chat.google.com/room/AAAAZrx3KlI/6tf0phEdCF8
+            # We may never use ga-plus, since the original motivation no longer seems important, and
+            # it results in a problem: stage pushes for ga-plus v4.y fail when there is staged
+            # v4.(y+1) content already with `skipVersion: v4.y` (because new v4.y content would be
+            # immediately pruned). If we need `ga-plus` again, we can likely find a way around it.
+            return mode
+        self._logger.warning(f'{mode} is not a valid group_config.operator_index_mode. Defaulting to "ga"')
+        return 'ga'
+
+    @cached_property
+    def _redhat_delivery_tags(self):
+        mode = self._operator_index_mode
+        versions = 'v{MAJOR}.{MINOR}' if mode == 'ga-plus' else '=v{MAJOR}.{MINOR}'
+
+        labels = {
+            'com.redhat.delivery.operator.bundle': 'true',
+            'com.redhat.openshift.versions': versions.format(**self._group_config.vars),
+        }
+        if mode == 'pre-release':
+            labels['com.redhat.prerelease'] = 'true'
+        return labels
+
+    def _get_operator_framework_tags(self, channel_name: str, package_name: str):
+        override_channel = channel_name
+        override_default = channel_name
+        stable_channel = "stable"
+        # see: issues.redhat.com/browse/ART-3107
+        if self._group_config.operator_channel_stable in ['default', 'extra']:
+            override_channel = ','.join({channel_name, stable_channel})
+        if self._group_config.operator_channel_stable == 'default':
+            override_default = stable_channel
+        tags = {
+            'operators.operatorframework.io.bundle.channel.default.v1': override_default,
+            'operators.operatorframework.io.bundle.channels.v1': override_channel,
+            'operators.operatorframework.io.bundle.manifests.v1': 'manifests/',
+            'operators.operatorframework.io.bundle.mediatype.v1': 'registry+v1',
+            'operators.operatorframework.io.bundle.metadata.v1': 'metadata/',
+            'operators.operatorframework.io.bundle.package.v1': package_name,
+        }
+        return tags
+
+    def _create_dockerfile(self, metadata: ImageMetadata, operator_dir: Path, bundle_dir: Path,
+                           operator_framework_tags: Dict[str, str], input_release: str):
+        operator_df = DockerfileParser(str(operator_dir.joinpath('Dockerfile')))
+        bundle_df = DockerfileParser(str(bundle_dir.joinpath('Dockerfile')))
+
+        bundle_df.content = 'FROM scratch\nCOPY ./manifests /manifests\nCOPY ./metadata /metadata'
+        bundle_df.labels = operator_df.labels
+        bundle_df.labels['com.redhat.component'] = metadata.get_olm_bundle_brew_component_name()
+        bundle_df.labels['com.redhat.delivery.appregistry'] = False
+        bundle_df.labels['name'] = metadata.get_olm_bundle_image_name()
+        bundle_df.labels['version'] = '{}.{}'.format(
+            operator_df.labels['version'],
+            operator_df.labels['release']
+        )
+        bundle_df.labels = {
+            **bundle_df.labels,
+            **self._redhat_delivery_tags,
+            **operator_framework_tags,
+        }
+        bundle_df.labels['release'] = input_release
+
+    async def _create_container_yaml(self, path: Path):
+        """Use container.yaml to disable unnecessary multiarch.
+        This is only required for Brew/OSBS builds, as Konflux doesn't support container.yaml.
+        """
+        async with aiofiles.open(path, 'w') as writer:
+            await writer.writelines([
+                '# metadata containers are not functional and do not need to be multiarch\n',
+                '\n',
+                yaml.dump({
+                    'platforms': {'only': ['x86_64']},
+                    'operator_manifests': {'manifests_dir': 'manifests'},
+                }),
+            ])
+
+
+class KonfluxOlmBundleBuildError(Exception):
+    def __init__(self, message: str, pipelinerun_name: str, pipelinerun: Optional[resource.ResourceInstance]) -> None:
+        super().__init__(message)
+        self.pipelinerun_name = pipelinerun_name
+        self.pipelinerun = pipelinerun
+
+
+class KonfluxOlmBundleBuilder:
+    def __init__(self,
+                 base_dir: Path,
+                 group: str,
+                 assembly: str,
+                 source_resolver: SourceResolver,
+                 db: KonfluxDb,
+                 konflux_namespace: str,
+                 konflux_kubeconfig: Optional[str] = None,
+                 konflux_context: Optional[str] = None,
+                 image_repo: str = constants.KONFLUX_DEFAULT_IMAGE_REPO,
+                 skip_checks: bool = False,
+                 dry_run: bool = False,
+                 logger: logging.Logger = _LOGGER) -> None:
+        self.base_dir = base_dir
+        self.group = group
+        self.assembly = assembly
+        self._source_resolver = source_resolver
+        self._db = db
+        self.konflux_namespace = konflux_namespace
+        self.konflux_kubeconfig = konflux_kubeconfig
+        self.konflux_context = konflux_context
+        self.image_repo = image_repo
+        self.skip_checks = skip_checks
+        self.dry_run = dry_run
+        self._logger = logger
+        self._konflux_client = KonfluxClient.from_kubeconfig(self.konflux_namespace, self.konflux_kubeconfig, self.konflux_context, self.dry_run)
+
+    async def build(self, metadata: ImageMetadata):
+        """ Build a bundle with Konflux. """
+        logger = self._logger.getChild(f"[{metadata.distgit_key}]")
+        konflux_client = self._konflux_client
+
+        bundle_dir = self.base_dir.joinpath(metadata.get_olm_bundle_short_name())
+        if bundle_dir.exists():
+            # Load exiting build source repository
+            logger.info("Loading existing bundle repository...")
+            bundle_build_repo = await BuildRepo.from_local_dir(bundle_dir, self._logger)
+            logger.info("Bundle repository loaded from %s", bundle_dir)
+        else:
+            source = None
+            if metadata.has_source():
+                logger.info("Resolving source...")
+                source = cast(SourceResolution, await exectools.to_thread(self._source_resolver.resolve_source, metadata, no_clone=True))
+            else:
+                raise IOError(f"Image {metadata.qualified_key} doesn't have upstream source. This is no longer supported.")
+            # Clone the build source repository
+            bundle_build_branch = "art-{group}-assembly-{assembly_name}-bundle-{distgit_key}".format_map({
+                "group": self.group,
+                "assembly_name": self.assembly,
+                "distgit_key": metadata.distgit_key,
+            })
+            logger.info("Cloning bundle repository...")
+            bundle_build_repo = BuildRepo(url=source.url, branch=bundle_build_branch, local_dir=bundle_dir, logger=self._logger)
+            await bundle_build_repo.ensure_source()
+            logger.info("Bundle repository cloned to %s", bundle_dir)
+        if not bundle_build_repo.commit_hash:
+            raise IOError(f"Bundle repository {bundle_build_repo.url} doesn't have any commits to build")
+
+        logger.info("Starting Konflux bundle image build for %s...", metadata.distgit_key)
+        retries = 3
+        for attempt in range(retries):
+            logger.info("Build attempt %d/%d", attempt + 1, retries)
+            pipelinerun, url = await self._start_build(metadata, bundle_build_repo, self.image_repo, self.konflux_namespace, self.skip_checks)
+            pipelinerun_name = pipelinerun.metadata.name
+            logger.info(f"Build started: {url}")
+
+            # Update the Konflux DB with status PENDING
+            outcome = KonfluxBuildOutcome.PENDING
+            if not self.dry_run:
+                await self._update_konflux_db(metadata, bundle_build_repo, pipelinerun, outcome)
+            else:
+                logger.warning("Dry run: Would update Konflux DB for %s with outcome %s", pipelinerun_name, outcome)
+
+            # Wait for the PipelineRun to complete
+            pipelinerun = await konflux_client.wait_for_pipelinerun(pipelinerun_name, self.konflux_namespace)
+            status = pipelinerun.status.conditions[0].status
+            outcome = KonfluxBuildOutcome.SUCCESS if status == "True" else KonfluxBuildOutcome.FAILURE
+            logger.info(f"PipelineRun {url} completed with outcome {outcome}")
+
+            # Update the Konflux DB with the final outcome
+            if not self.dry_run:
+                await self._update_konflux_db(metadata, bundle_build_repo, pipelinerun, outcome)
+            else:
+                logger.warning("Dry run: Would update Konflux DB for %s with outcome %s", pipelinerun_name, outcome)
+            if status != "True":
+                error = KonfluxOlmBundleBuildError(f"Konflux bundle image build for {metadata.distgit_key} failed", pipelinerun_name, pipelinerun)
+                logger.error(f"{error}: {url}")
+            else:
+                error = None
+                break
+
+        if error:
+            raise error
+        return pipelinerun_name, pipelinerun
+
+    @limit_concurrency(limit=constants.MAX_KONFLUX_BUILD_QUEUE_SIZE)
+    async def _start_build(self, metadata: ImageMetadata, bundle_build_repo: BuildRepo, image_repo: str, namespace: str,
+                           skip_checks: bool = False, additional_tags: Optional[Sequence[str]] = None):
+        """ Start a build with Konflux. """
+        assert bundle_build_repo.commit_hash is not None, "Bundle repository must have a commit hash to build"
+        konflux_client = self._konflux_client
+        if additional_tags is None:
+            additional_tags = []
+        target_branch = bundle_build_repo.branch or bundle_build_repo.commit_hash
+        logger = self._logger.getChild(f"[{metadata.distgit_key}]")
+        # Ensure the Application resource exists
+        app_name = self.group.replace(".", "-")
+        logger.info(f"Using Konflux application: {app_name}")
+        await konflux_client.ensure_application(name=app_name, display_name=app_name)
+        logger.info(f"Konflux application {app_name} created")
+        # Ensure the Component resource exists
+        bundle_name = metadata.get_olm_bundle_short_name()
+        # Openshift doesn't allow dots or underscores in any of its fields, so we replace them with dashes
+        component_name = f"{app_name}-{bundle_name}".replace(".", "-").replace("_", "-")
+        logger.info(f"Creating Konflux component: {component_name}")
+        dest_image_repo = image_repo
+        await konflux_client.ensure_component(
+            name=component_name,
+            application=app_name,
+            component_name=component_name,
+            image_repo=dest_image_repo,
+            source_url=bundle_build_repo.https_url,
+            revision=target_branch,
+        )
+        logger.info(f"Konflux component {component_name} created")
+        # Read the bundle's Dockerfile
+        bundle_df = DockerfileParser(str(bundle_build_repo.local_dir.joinpath('Dockerfile')))
+        # Start a PipelineRun
+        component_name = bundle_df.labels.get('com.redhat.component')
+        if not component_name:
+            raise ValueError(f"{metadata.distgit_key}: Label 'com.redhat.component' is not set. Did you run rebase?")
+        version = bundle_df.labels.get('version')
+        if not version:
+            raise ValueError(f"{metadata.distgit_key}: Label 'version' is not set. Did you run rebase?")
+        release = bundle_df.labels.get('release')
+        if not release:
+            raise ValueError(f"{metadata.distgit_key}: Label 'release' is not set. Did you run rebase?")
+        nvr = f"{component_name}-{version}-{release}"
+        logger.info(f"Building bundle {nvr}...")
+        pipelinerun = await konflux_client.start_pipeline_run_for_image_build(
+            generate_name=f"{component_name}-",
+            namespace=namespace,
+            application_name=app_name,
+            component_name=component_name,
+            git_url=bundle_build_repo.https_url,
+            commit_sha=bundle_build_repo.commit_hash,
+            target_branch=target_branch,
+            output_image=f"{dest_image_repo}:{nvr}",
+            vm_override={},
+            building_arches=["x86_64"],  # We always build bundles on x86_64
+            additional_tags=list(additional_tags),
+            skip_checks=skip_checks,
+        )
+        url = konflux_client.build_pipeline_url(pipelinerun)
+        logger.info(f"PipelineRun {pipelinerun.metadata.name} created: {url}")
+        return pipelinerun, url
+
+    async def _update_konflux_db(self, metadata: ImageMetadata, build_repo: BuildRepo,
+                                 pipelinerun: resource.ResourceInstance, outcome: KonfluxBuildOutcome):
+        logger = self._logger.getChild(f"[{metadata.distgit_key}]")
+        db = self._db
+        if not db or db.record_cls != KonfluxBundleBuildRecord:
+            logger.warning('Konflux DB connection is not initialized, not writing build record to the Konflux DB.')
+            return
+        try:
+            rebase_repo_url = build_repo.https_url
+            rebase_commit = build_repo.commit_hash
+
+            df_path = build_repo.local_dir.joinpath("Dockerfile")
+            df = DockerfileParser(str(df_path))
+
+            source_repo = df.labels['io.openshift.build.source-location']
+            commitish = df.labels['io.openshift.build.commit.id']
+
+            component_name = df.labels['com.redhat.component']
+            version = df.labels['version']
+            release = df.labels['release']
+            nvr = "-".join([component_name, version, release])
+
+            pipelinerun_name = pipelinerun['metadata']['name']
+            build_pipeline_url = KonfluxClient.build_pipeline_url(pipelinerun)
+
+            # Load .oit files
+            async with aiofiles.open(build_repo.local_dir / '.oit' / 'olm_bundle_info.yaml', 'r') as f:
+                bundle_info = yaml.safe_load(await f.read())
+            operator_nvr = bundle_info['operator']['nvr']
+            operand_nvrs = sorted({info['nvr'] for info in bundle_info['operands'].values()})
+
+            build_record_params = {
+                'name': metadata.get_olm_bundle_short_name(),
+                'version': version,
+                'release': release,
+                'start_time': datetime.now(tz=timezone.utc),
+                'end_time': None,
+                'nvr': nvr,
+                'group': metadata.runtime.group,
+                'assembly': metadata.runtime.assembly,
+                'source_repo': source_repo,
+                'commitish': commitish,
+                'rebase_repo_url': rebase_repo_url,
+                'rebase_commitish': rebase_commit,
+                'engine': Engine.KONFLUX,
+                'outcome': str(outcome),
+                'art_job_url': os.getenv('BUILD_URL', 'n/a'),
+                'build_id': pipelinerun_name,
+                'build_pipeline_url': build_pipeline_url,
+                'pipeline_commit': 'n/a',  # TODO: populate this
+                'operator_nvr': operator_nvr,
+                'operand_nvrs': operand_nvrs,
+            }
+
+            match outcome:
+                case KonfluxBuildOutcome.SUCCESS:
+                    # results:
+                    # - name: IMAGE_URL
+                    #   value: quay.io/openshift-release-dev/ocp-v4.0-art-dev-test:ose-network-metrics-daemon-rhel9-v4.18.0-20241001.151532
+                    # - name: IMAGE_DIGEST
+                    #   value: sha256:49d65afba393950a93517f09385e1b441d1735e0071678edf6fc0fc1fe501807
+
+                    image_pullspec = next((r['value'] for r in pipelinerun.status.results if r['name'] == 'IMAGE_URL'), None)
+                    image_digest = next((r['value'] for r in pipelinerun.status.results if r['name'] == 'IMAGE_DIGEST'), None)
+
+                    if not (image_pullspec and image_digest):
+                        raise ValueError(f"[{metadata.distgit_key}] Could not find expected results in konflux "
+                                         f"pipelinerun {pipelinerun_name}")
+
+                    start_time = pipelinerun.status.startTime
+                    end_time = pipelinerun.status.completionTime
+
+                    build_record_params.update({
+                        'image_pullspec': image_pullspec,
+                        'start_time': datetime.strptime(start_time, '%Y-%m-%dT%H:%M:%SZ'),
+                        'end_time': datetime.strptime(end_time, '%Y-%m-%dT%H:%M:%SZ'),
+                        'image_tag': image_digest.removeprefix('sha256:'),
+                    })
+                case KonfluxBuildOutcome.FAILURE:
+                    start_time = pipelinerun.status.startTime
+                    end_time = pipelinerun.status.completionTime
+                    build_record_params.update({
+                        'start_time': datetime.strptime(start_time, '%Y-%m-%dT%H:%M:%SZ'),
+                        'end_time': datetime.strptime(end_time, '%Y-%m-%dT%H:%M:%SZ')
+                    })
+
+            build_record = KonfluxBundleBuildRecord(**build_record_params)
+            db.add_build(build_record)
+            logger.info(f'Konflux build info stored successfully with status {outcome}')
+
+        except Exception as err:
+            logger.error('Failed writing record to the konflux DB: %s', err)

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -249,7 +249,7 @@ class KonfluxOlmBundleRebaser:
         # Get image infos for all found images
         for pullspec, (namespace, image_short_name, image_tag) in references.items():
             build_pullspec = f"{self.image_repo}:{image_short_name}-{image_tag}"
-            image_info_tasks.append(asyncio.create_task(util.oc_image_info_async__caching(build_pullspec)))
+            image_info_tasks.append(asyncio.create_task(util.oc_image_info__caching_async(build_pullspec)))
         image_infos = await asyncio.gather(*image_info_tasks)
 
         # Replace image references in the content
@@ -389,7 +389,7 @@ class KonfluxOlmBundleBuilder:
         self.skip_checks = skip_checks
         self.dry_run = dry_run
         self._logger = logger
-        self._konflux_client = KonfluxClient.from_kubeconfig(self.konflux_namespace, self.konflux_kubeconfig, self.konflux_context, self.dry_run)
+        self._konflux_client = KonfluxClient.from_kubeconfig(self.konflux_namespace, self.konflux_kubeconfig, self.konflux_context, plr_template=None, dry_run=self.dry_run)
 
     async def build(self, metadata: ImageMetadata):
         """ Build a bundle with Konflux. """

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -116,10 +116,14 @@ class KonfluxRebaser:
 
             # Rebase the image in the build repository
             self._logger.info("Rebasing image %s to %s in %s...", metadata.distgit_key, dest_branch, dest_dir)
-            await exectools.to_thread(self._rebase_dir, metadata, source, build_repo, version, input_release, force_yum_updates, image_repo)
+            actual_version, actual_release, _ = await exectools.to_thread(self._rebase_dir, metadata, source, build_repo, version, input_release, force_yum_updates, image_repo)
 
             # Commit changes
             await build_repo.commit(commit_message, allow_empty=True)
+
+            # Tag the commit
+            tag = f"{actual_version}-{actual_release}"
+            await build_repo.tag(tag)
 
             # Push changes
             if push:
@@ -141,7 +145,10 @@ class KonfluxRebaser:
             force_yum_updates: bool,
             image_repo: str,
     ):
-        """ Rebase the image in the build repository. """
+        """
+        Rebase the image in the build repository.
+        :return: Tuple of version, release, private_fix
+        """
         # Whether or not the source contains private fixes; None means we don't know yet
         private_fix = None
         if self.force_private_bit:  # --embargoed is set, force private_fix to True
@@ -222,6 +229,7 @@ class KonfluxRebaser:
         self._update_build_dir(metadata, dest_dir, source, version, release, downstream_parents, force_yum_updates,
                                image_repo, uuid_tag)
         metadata.private_fix = private_fix
+        return version, release, private_fix
 
         self._update_dockerignore(build_repo.local_dir)
 

--- a/doozer/doozerlib/cli/images_health.py
+++ b/doozer/doozerlib/cli/images_health.py
@@ -127,8 +127,7 @@ class ImagesHealthPipeline:
         """
         For 'stream' assembly only, query 'builds' table  for component 'name' from BigQuery
         """
-
-        results = await self.runtime.konflux_db.search_builds_by_fields(
+        results = [build async for build in self.runtime.konflux_db.search_builds_by_fields(
             start_search=self.start_search,
             where={
                 'name': image_meta.distgit_key,
@@ -137,8 +136,9 @@ class ImagesHealthPipeline:
                 'assembly': 'stream'
             },
             order_by='start_time',
-            limit=self.limit)
-        return [self.runtime.konflux_db.from_result_row(result) for result in results]
+            limit=self.limit
+        )]
+        return results
 
 
 @cli.command("images:health", short_help="Create a health report for this image group (requires DB read)")

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -1,20 +1,28 @@
 import asyncio
 import logging
-from pathlib import Path
 import traceback
-from typing import Optional
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple, Union, cast
 
 import click
+from artcommonlib.konflux.konflux_build_record import (
+    Engine, KonfluxBuildRecord, KonfluxBundleBuildRecord)
+from artcommonlib.konflux.konflux_db import KonfluxDb
+from artcommonlib.model import Missing
 from artcommonlib.telemetry import start_as_current_span_async
 from opentelemetry import trace
 
 from doozerlib import constants
-from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder, KonfluxImageBuilderConfig, KonfluxBuildRecord
+from doozerlib.backend.konflux_image_builder import (KonfluxImageBuilder,
+                                                     KonfluxImageBuilderConfig)
+from doozerlib.backend.konflux_olm_bundler import (KonfluxOlmBundleBuilder,
+                                                   KonfluxOlmBundleRebaser)
 from doozerlib.backend.rebaser import KonfluxRebaser
 from doozerlib.cli import (cli, click_coroutine, option_commit_message,
                            option_push, pass_runtime,
                            validate_semver_major_minor_patch)
 from doozerlib.exceptions import DoozerFatalError
+from doozerlib.image import ImageMetadata
 from doozerlib.runtime import Runtime
 
 TRACER = trace.get_tracer(__name__)
@@ -192,4 +200,193 @@ async def images_konflux_build(
         runtime=runtime, konflux_kubeconfig=konflux_kubeconfig,
         konflux_context=konflux_context, konflux_namespace=konflux_namespace,
         image_repo=image_repo, skip_checks=skip_checks, dry_run=dry_run, plr_template=plr_template)
+    await cli.run()
+
+
+class KonfluxBundleCli:
+    def __init__(
+        self,
+        runtime: Runtime,
+        operator_nvrs: Sequence[str],
+        force: bool,
+        dry_run: bool,
+        konflux_kubeconfig: Optional[str],
+        konflux_context: Optional[str],
+        konflux_namespace: str,
+        image_repo: str,
+        skip_checks: bool,
+        release: Optional[str],
+    ):
+        self.runtime = runtime
+        self.operator_nvrs = list(operator_nvrs)
+        self.force = force
+        self.dry_run = dry_run
+        self.konflux_kubeconfig = konflux_kubeconfig
+        self.konflux_context = konflux_context
+        self.konflux_namespace = konflux_namespace
+        self.image_repo = image_repo
+        self.skip_checks = skip_checks
+        self.release = release
+
+    @start_as_current_span_async(TRACER, "images:konflux:bundle")
+    async def run(self):
+        runtime = self.runtime
+        if runtime.images and self.operator_nvrs:
+            raise click.BadParameter("Do not specify operator NVRs when --images is specified")
+
+        runtime.initialize(config_only=True)
+        assembly = runtime.assembly
+        if assembly is None:
+            raise ValueError("Assemblies feature is disabled for this group. This is no longer supported.")
+        assert runtime.konflux_db is not None, "konflux_db is not initialized. Doozer bug?"
+        konflux_db = runtime.konflux_db
+        konflux_db.bind(KonfluxBuildRecord)
+
+        dgk_records = {}
+        if self.operator_nvrs:
+            # Get build records for the given operator nvrs
+            LOGGER.info("Fetching given nvrs from Konflux DB...")
+            tasks = []
+            for nvr in self.operator_nvrs:
+                tasks.append(asyncio.create_task(konflux_db.get_build_record_by_nvr(nvr=nvr, strict=True)))
+            records = cast(List[Union[KonfluxBuildRecord, Exception]], await asyncio.gather(*tasks, return_exceptions=True))
+            errors = [(nvr, record) for nvr, record in zip(self.operator_nvrs, records) if isinstance(record, Exception)]
+            if errors:
+                raise DoozerFatalError(f"Failed to fetch NVRs from Konflux DB: {errors}")
+            for nvr, record in zip(self.operator_nvrs, records):
+                assert record is not None and isinstance(record, KonfluxBuildRecord)
+                dgk_records[record.name] = record
+            # Load image metas for the given operators
+            runtime.images = list(dgk_records.keys())
+            runtime.initialize(mode='images', clone_distgits=False)
+            for dkg in dgk_records.keys():
+                metadata = runtime.image_map[dkg]
+                if not metadata.is_olm_operator:
+                    raise DoozerFatalError(f"Operator {dkg} does not have 'update-csv' config")
+        else:
+            # Get latest build records for all specified operators
+            runtime.initialize(mode='images', clone_distgits=False)
+            LOGGER.info("Fetching latest operator builds from Konflux DB...")
+            operator_metas: List[ImageMetadata] = []
+            tasks = []
+            for metadata in runtime.ordered_image_metas():
+                if not metadata.is_olm_operator:
+                    if runtime.images:
+                        LOGGER.warning(f"Skipping non-OLM operator {metadata.distgit_key}")
+                    continue
+                operator_metas.append(metadata)
+                tasks.append(asyncio.create_task(konflux_db.get_latest_build(
+                    name=metadata.distgit_key,
+                    assembly=assembly,
+                    group=self.runtime.group,
+                    el_target=f'el{metadata.branch_el_target()}',
+                    engine=Engine.KONFLUX, strict=True)))
+            records = await asyncio.gather(*tasks, return_exceptions=True)
+            errors = [(meta.distgit_key, record) for meta, record in zip(operator_metas, records) if isinstance(record, Exception)]
+            if errors:
+                raise DoozerFatalError(f"Failed to fetch latest builds from Konflux DB: {errors}")
+            for metadata, record in zip(operator_metas, records):
+                assert record is not None and isinstance(record, KonfluxBuildRecord)
+                dgk_records[metadata.distgit_key] = record
+
+        assert runtime.source_resolver is not None, "source_resolver is not initialized. Doozer bug?"
+        assert runtime.group_config is not None, "group_config is not initialized. Doozer bug?"
+
+        rebaser = KonfluxOlmBundleRebaser(
+            base_dir=Path(runtime.working_dir, constants.WORKING_SUBDIR_KONFLUX_BUILD_SOURCES),
+            group=runtime.group,
+            assembly=assembly,
+            group_config=runtime.group_config,
+            konflux_db=runtime.konflux_db,
+            source_resolver=runtime.source_resolver,
+            upcycle=runtime.upcycle,
+            image_repo=self.image_repo,
+            dry_run=self.dry_run,
+        )
+        db_for_bundles = KonfluxDb()
+        db_for_bundles.bind(KonfluxBundleBuildRecord)
+        builder = KonfluxOlmBundleBuilder(
+            base_dir=Path(runtime.working_dir, constants.WORKING_SUBDIR_KONFLUX_BUILD_SOURCES),
+            group=runtime.group,
+            assembly=assembly,
+            source_resolver=runtime.source_resolver,
+            db=db_for_bundles,
+            konflux_namespace=self.konflux_namespace,
+            konflux_kubeconfig=self.konflux_kubeconfig,
+            konflux_context=self.konflux_context,
+            image_repo=self.image_repo,
+            skip_checks=self.skip_checks,
+            dry_run=self.dry_run,
+        )
+
+        async def _rebase_and_build(image_meta: ImageMetadata, operator_build: KonfluxBuildRecord):
+            logger = LOGGER.getChild(f"[{image_meta.distgit_key}]")
+            input_release = self.release
+            if not self.force or not input_release:
+                logger.info("Checking if a previous bundle build exists...")
+                bundle_build = await db_for_bundles.get_latest_build(
+                    name=image_meta.get_olm_bundle_short_name(),
+                    group=runtime.group,
+                    assembly=assembly,
+                    engine=Engine.KONFLUX,
+                    strict=False,
+                )
+                if bundle_build is not None:
+                    logger.info(f"A previous bundle build already exists: {bundle_build.nvr}")
+                    if not self.force:
+                        logger.info("Skipping because --force is not set")
+                        return
+                    input_release = str(int(bundle_build.release) + 1)
+                    logger.info("Force rebuild requested because --force is set; release string will be %s", input_release)
+                else:
+                    input_release = "1"
+                    logger.info("No previous bundle build found; a new bundle build will be created with release string %s", input_release)
+
+            logger.info("Rebasing OLM bundle...")
+            await rebaser.rebase(image_meta, operator_build, input_release)
+            logger.info("Building OLM bundle...")
+            await builder.build(image_meta)
+
+        tasks = []
+        for dkg, record in dgk_records.items():
+            image_meta = runtime.image_map[dkg]
+            tasks.append(asyncio.create_task(_rebase_and_build(image_meta, record)))
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        failed_tasks = []
+        for dgk, result in zip(dgk_records, results):
+            image_meta = runtime.image_map[dkg]
+            if isinstance(result, Exception):
+                image_name = image_meta.distgit_key
+                failed_tasks.append(image_name)
+                stack_trace = ''.join(traceback.TracebackException.from_exception(result).format())
+                LOGGER.error(f"Failed to rebase/build  OLM bundle for {image_name}: {result}; {stack_trace}")
+        if failed_tasks:
+            raise DoozerFatalError(f"Failed to rebase/build bundles: {failed_tasks}")
+        LOGGER.info("Build complete")
+
+
+@cli.command("beta:images:konflux:bundle", short_help="Rebase and build an OLM bundle for an operator with Konflux.")
+@click.argument('operator_nvrs', nargs=-1, required=False)
+@click.option("-f", "--force", required=False, is_flag=True,
+              help="Perform a build even if previous bundles for given NVRs already exist")
+@click.option('--dry-run', default=False, is_flag=True,
+              help='Do not push to build repo or build anything, but print what would be done.')
+@click.option('--konflux-kubeconfig', metavar='PATH', help='Path to the kubeconfig file to use for Konflux cluster connections.')
+@click.option('--konflux-context', metavar='CONTEXT', help='The name of the kubeconfig context to use for Konflux cluster connections.')
+@click.option('--konflux-namespace', metavar='NAMESPACE', required=True, help='The namespace to use for Konflux cluster connections.')
+@click.option('--image-repo', default=constants.KONFLUX_DEFAULT_IMAGE_REPO, help='Push images to the specified repo.')
+@click.option('--skip-checks', default=False, is_flag=True, help='Skip all post build checks')
+@click.option("--release", metavar='RELEASE', help="Release string to populate in bundle's Dockerfiles.")
+@pass_runtime
+@click_coroutine
+async def images_konflux_bundle(
+        runtime: Runtime, operator_nvrs: Tuple[str, ...], force: bool, dry_run: bool,
+        konflux_kubeconfig: Optional[str], konflux_context: Optional[str],
+        konflux_namespace: str, image_repo: str, skip_checks: bool, release: Optional[str]):
+    cli = KonfluxBundleCli(
+        runtime=runtime, operator_nvrs=operator_nvrs, force=force, dry_run=dry_run,
+        konflux_kubeconfig=konflux_kubeconfig, konflux_context=konflux_context,
+        konflux_namespace=konflux_namespace, image_repo=image_repo, skip_checks=skip_checks,
+        release=release)
     await cli.run()

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -50,6 +50,43 @@ class ImageMetadata(Metadata):
     def image_name_short(self):
         return self.config.name.split('/')[-1]
 
+    @property
+    def is_olm_operator(self):
+        """ Returns whether this image is an OLM operator. """
+        return self.config['update-csv'] is not Missing
+
+    def get_olm_bundle_brew_component_name(self):
+        """ Returns the Brew component name of the OLM bundle for this OLM operator.
+
+        :return: The Brew component name.
+        :raises IOError: If the image is not an OLM operator.
+        """
+        if not self.is_olm_operator:
+            raise IOError(f"[{self.distgit_key}] No update-csv config found in the image's metadata")
+        return str(self.config.distgit.bundle_component or self.get_component_name().replace('-container', '-metadata-container'))
+
+    def get_olm_bundle_short_name(self):
+        """ Returns the short name of the OLM bundle for this OLM operator.
+
+        :return: The short name of the OLM bundle for this OLM operator.
+        :raises IOError: If the image is not an OLM operator.
+        """
+        if not self.is_olm_operator:
+            raise IOError(f"[{self.distgit_key}] No update-csv config found in the image's metadata")
+        return f"{self.distgit_key}-bundle"
+
+    def get_olm_bundle_image_name(self):
+        """ Returns the image name of the OLM bundle for this OLM operator.
+        This is to be used in the "name" label of the OLM bundle.
+
+        :return: The image name of the OLM bundle for this OLM operator.
+        :raises IOError: If the image is not an OLM operator.
+        """
+        short_name = self.get_olm_bundle_short_name()
+        if not short_name.startswith('ose-'):
+            short_name = 'ose-' + short_name
+        return f"openshift/{short_name}"
+
     def get_assembly_rpm_package_dependencies(self, el_ver: int) -> Tuple[Dict[str, str], Dict[str, str]]:
         """
         An assembly can define RPMs which should be installed into a given member

--- a/doozer/doozerlib/source_resolver.py
+++ b/doozer/doozerlib/source_resolver.py
@@ -82,9 +82,10 @@ class SourceResolver:
         self._record_logger = record_logger
         self._state_holder = state_holder
 
-    def resolve_source(self, meta: 'Metadata') -> SourceResolution:
+    def resolve_source(self, meta: 'Metadata', no_clone: bool = False) -> SourceResolution:
         """ Resolve the source code repository for the specified metadata.
         :param meta: The metadata to resolve the source code repository for.
+        :param no_clone: If True, the source code repository will not be cloned. Only the source resolution object will be returned.
         :return: A SourceResolution instance containing the information of the resolved source code repository.
         """
         LOGGER.debug("Resolving source for {}".format(meta.qualified_key))
@@ -162,6 +163,21 @@ class SourceResolver:
             has_public_upstream = False
             if self._group_config.public_upstreams:
                 meta.public_upstream_url, meta.public_upstream_branch, has_public_upstream = self.get_public_upstream(url, self._group_config.public_upstreams)
+
+            if no_clone:
+                https_url = art_util.convert_remote_git_to_https(url)
+                return SourceResolution(
+                    source_path=source_dir,
+                    url=url,
+                    branch=clone_branch,
+                    https_url=https_url,
+                    commit_hash="",
+                    committer_date=datetime.fromtimestamp(0, timezone.utc),
+                    latest_tag="",
+                    has_public_upstream=has_public_upstream,
+                    public_upstream_url=meta.public_upstream_url or https_url,
+                    public_upstream_branch=meta.public_upstream_branch or clone_branch,
+                )
 
             LOGGER.info("Attempting to checkout source '%s' branch %s in: %s" % (url, clone_branch, source_dir))
             try:

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -550,29 +550,6 @@ def oc_image_info(pull_spec: str, go_arch: str = 'amd64') -> Dict:
     return json.loads(out)
 
 
-@retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(3))
-async def oc_image_info_async(pull_spec: str, go_arch: str = 'amd64') -> Dict:
-    """
-    Returns a Dict of the parsed JSON output of `oc image info` for the specified
-    pullspec. Use oc_image_info__caching if you do not believe the image will change
-    during the course of doozer's execution.
-    """
-    # Filter by os because images can be multi-arch manifest lists (which cause oc image info to throw an error if not filtered).
-    cmd = ['oc', 'image', 'info', f'--filter-by-os={go_arch}', '-o', 'json', pull_spec]
-    _, out, _ = await exectools.cmd_gather_async(cmd)
-    return json.loads(out)
-
-
-@alru_cache(maxsize=1000)
-async def oc_image_info_async__caching(pull_spec: str, go_arch: str = 'amd64') -> Dict:
-    """
-    Returns a Dict of the parsed JSON output of `oc image info` for the specified
-    pullspec. This function will cache that output per pullspec, so do not use it
-    if you expect the image to change during the course of doozer's execution.
-    """
-    return await oc_image_info_async(pull_spec, go_arch)
-
-
 @lru_cache(maxsize=1000)
 def oc_image_info__caching(pull_spec: str, go_arch: str = 'amd64') -> Dict:
     """

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -550,6 +550,29 @@ def oc_image_info(pull_spec: str, go_arch: str = 'amd64') -> Dict:
     return json.loads(out)
 
 
+@retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(3))
+async def oc_image_info_async(pull_spec: str, go_arch: str = 'amd64') -> Dict:
+    """
+    Returns a Dict of the parsed JSON output of `oc image info` for the specified
+    pullspec. Use oc_image_info__caching if you do not believe the image will change
+    during the course of doozer's execution.
+    """
+    # Filter by os because images can be multi-arch manifest lists (which cause oc image info to throw an error if not filtered).
+    cmd = ['oc', 'image', 'info', f'--filter-by-os={go_arch}', '-o', 'json', pull_spec]
+    _, out, _ = await exectools.cmd_gather_async(cmd)
+    return json.loads(out)
+
+
+@alru_cache(maxsize=1000)
+async def oc_image_info_async__caching(pull_spec: str, go_arch: str = 'amd64') -> Dict:
+    """
+    Returns a Dict of the parsed JSON output of `oc image info` for the specified
+    pullspec. This function will cache that output per pullspec, so do not use it
+    if you expect the image to change during the course of doozer's execution.
+    """
+    return await oc_image_info_async(pull_spec, go_arch)
+
+
 @lru_cache(maxsize=1000)
 def oc_image_info__caching(pull_spec: str, go_arch: str = 'amd64') -> Dict:
     """

--- a/doozer/tests/backend/test_build_repo.py
+++ b/doozer/tests/backend/test_build_repo.py
@@ -30,13 +30,13 @@ class TestBuildRepo(IsolatedAsyncioTestCase):
         await self.repo.commit("commit message")
         run_git.assert_any_await(["-C", "/path/to/repo", "add", "."])
         run_git.assert_any_await(["-C", "/path/to/repo", "commit", "-m", "commit message"])
-        gather_git.assert_awaited_once_with(["-C", "/path/to/repo", "rev-parse", "HEAD"])
+        gather_git.assert_awaited_once_with(["-C", "/path/to/repo", "rev-parse", "HEAD"], check=False)
         self.assertEqual(self.repo.commit_hash, "deadbeef")
 
     @patch("artcommonlib.git_helper.run_git_async", return_value=0)
     async def test_push(self, run_git: AsyncMock):
         await self.repo.push()
-        run_git.assert_awaited_once_with(["-C", "/path/to/repo", "push", "origin", self.repo.branch])
+        run_git.assert_awaited_once_with(["-C", "/path/to/repo", "push", '--follow-tags', "origin", "HEAD"])
 
     @patch("pathlib.Path.exists", return_value=True)
     @patch("shutil.rmtree")

--- a/doozer/tests/backend/test_build_repo.py
+++ b/doozer/tests/backend/test_build_repo.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -47,3 +48,62 @@ class TestBuildRepo(IsolatedAsyncioTestCase):
         rmtree.assert_called_with("/path/to/repo")
         run_git.assert_any_await(["init", "/path/to/repo"])
         gather_git.assert_any_await(["-C", "/path/to/repo", "fetch", "--depth=1", "origin", self.repo.branch], check=False)
+
+    @patch("doozerlib.backend.build_repo.BuildRepo.clone")
+    @patch("pathlib.Path.exists", return_value=True)
+    @patch("shutil.rmtree")
+    @patch("artcommonlib.git_helper.gather_git_async", return_value=(0, "", ""))
+    async def test_ensure_source_no_upcycle(self, gather_git: AsyncMock, rmtree: Mock, _, clone: AsyncMock):
+        await self.repo.ensure_source(upcycle=False)
+        clone.assert_not_called()
+        rmtree.assert_not_called()
+
+    @patch("artcommonlib.git_helper.run_git_async", return_value=0)
+    @patch("artcommonlib.git_helper.gather_git_async", return_value=(0, "origin", ""))
+    async def test_set_remote_url(self, gather_git: AsyncMock, run_git: AsyncMock):
+        await self.repo.set_remote_url("https://git.example.com/new-repo.git")
+        gather_git.assert_awaited_once_with(["-C", "/path/to/repo", "remote"], stderr=None)
+        run_git.assert_any_await(["-C", "/path/to/repo", "remote", "set-url", "origin", "https://git.example.com/new-repo.git"])
+
+        gather_git.reset_mock()
+        gather_git.reset_mock()
+        gather_git.return_value = (0, "other", "")
+        await self.repo.set_remote_url("https://git.example.com/new-repo.git")
+        gather_git.assert_awaited_once_with(["-C", "/path/to/repo", "remote"], stderr=None)
+        run_git.assert_any_await(["-C", "/path/to/repo", "remote", "add", "origin", "https://git.example.com/new-repo.git"])
+
+    @patch("artcommonlib.git_helper.run_git_async", return_value=0)
+    async def test_delete_all_files(self, run_git: AsyncMock):
+        await self.repo.delete_all_files()
+        run_git.assert_awaited_once_with(["-C", "/path/to/repo", "rm", "-rf", "--ignore-unmatch", "."])
+
+    @patch("doozerlib.backend.build_repo.BuildRepo._get_commit_hash")
+    @patch("artcommonlib.git_helper.run_git_async", return_value=0)
+    async def test_switch(self, run_git: AsyncMock, _):
+        await self.repo.switch("new-branch")
+        run_git.assert_awaited_once_with(["-C", "/path/to/repo", "switch", "new-branch"])
+        self.assertEqual(self.repo.branch, "new-branch")
+
+    @patch("artcommonlib.git_helper.run_git_async", return_value=0)
+    async def test_tag(self, run_git: AsyncMock):
+        await self.repo.tag("v1.0.0")
+        run_git.assert_awaited_once_with(["-C", "/path/to/repo", "tag", "-fam", "v1.0.0", "--", "v1.0.0"])
+
+    @patch("pathlib.Path.exists", return_value=False)
+    @patch("artcommonlib.git_helper.gather_git_async", return_value=(0, "deadbeef", ""))
+    async def test_from_local_dir_not_found(self, _, __):
+        local_dir = Path("/path/to/repo")
+        with patch("pathlib.Path.exists", return_value=False):
+            with self.assertRaises(FileNotFoundError):
+                await BuildRepo.from_local_dir(local_dir)
+
+    @patch("doozerlib.backend.build_repo.BuildRepo._get_commit_hash", return_value="deadbeef")
+    @patch("doozerlib.backend.build_repo.Path")
+    @patch("artcommonlib.git_helper.gather_git_async", return_value=(0, "whatever", ""))
+    async def test_from_local_dir_found(self, gather_git: AsyncMock, MockPath: Mock, _):
+        MockPath.joinpath.return_value.exists.return_value = True
+        local_dir = Path("/path/to/repo")
+        repo = await BuildRepo.from_local_dir(local_dir)
+        self.assertEqual(repo.url, "whatever")
+        self.assertEqual(repo.branch, "whatever")
+        self.assertEqual(repo.commit_hash, "deadbeef")

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -1,0 +1,895 @@
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import yaml
+from artcommonlib.konflux.konflux_build_record import (
+    KonfluxBuildOutcome, KonfluxBundleBuildRecord)
+from artcommonlib.konflux.konflux_db import Engine
+
+from doozerlib.backend.konflux_olm_bundler import (KonfluxOlmBundleBuilder,
+                                                   KonfluxOlmBundleRebaser)
+
+
+class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.base_dir = Path("/path/to/base/dir")
+        self.group = "test-group"
+        self.assembly = "test-assembly"
+        self.group_config = MagicMock()
+        self.konflux_db = MagicMock()
+        self.source_resolver = MagicMock()
+        self.rebaser = KonfluxOlmBundleRebaser(
+            base_dir=self.base_dir,
+            group=self.group,
+            assembly=self.assembly,
+            group_config=self.group_config,
+            konflux_db=self.konflux_db,
+            source_resolver=self.source_resolver,
+        )
+
+    @patch("aiofiles.open")
+    @patch("pathlib.Path.mkdir")
+    async def test_create_oit_files(self, mock_mkdir, mock_open):
+        bundle_dir = Path("/path/to/bundle/dir")
+        operator_nvr = "test-operator-1.0-1"
+        operands = {
+            "operand1": ("old_pullspec1", "new_pullspec1", "operand1-1.0-1"),
+            "operand2": ("old_pullspec2", "new_pullspec2", "operand2-1.0-1"),
+        }
+
+        mock_file = mock_open.return_value.__aenter__.return_value
+
+        await self.rebaser._create_oit_files(bundle_dir, operator_nvr, operands)
+
+        mock_mkdir.assert_called_once_with(exist_ok=True)
+        mock_open.assert_called_once_with(bundle_dir / ".oit" / "olm_bundle_info.yaml", "w")
+        mock_file.write.assert_called_once()
+        written_content = yaml.safe_load(mock_file.write.call_args[0][0])
+        self.assertEqual(written_content["operator"]["nvr"], operator_nvr)
+        self.assertEqual(written_content["operands"]["operand1"]["nvr"], "operand1-1.0-1")
+        self.assertEqual(written_content["operands"]["operand1"]["internal_pullspec"], "old_pullspec1")
+        self.assertEqual(written_content["operands"]["operand1"]["public_pullspec"], "new_pullspec1")
+        self.assertEqual(written_content["operands"]["operand2"]["nvr"], "operand2-1.0-1")
+        self.assertEqual(written_content["operands"]["operand2"]["internal_pullspec"], "old_pullspec2")
+        self.assertEqual(written_content["operands"]["operand2"]["public_pullspec"], "new_pullspec2")
+
+    def test_get_image_reference_pattern(self):
+        registry = "registry.example.com"
+        pattern = KonfluxOlmBundleRebaser._get_image_reference_pattern(registry)
+        self.assertIsInstance(pattern, re.Pattern)
+        match = pattern.match("registry.example.com/namespace/image:tag")
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(0), "registry.example.com/namespace/image:tag")
+        self.assertEqual(match.group(1), "namespace/image")
+        self.assertEqual(match.group(2), "tag")
+
+    @patch("doozerlib.util.oc_image_info__caching_async")
+    async def test_replace_image_references(self, mock_oc_image_info):
+        old_registry = "registry.example.com"
+        content = """
+        apiVersion: v1
+        kind: Pod
+        metadata:
+            name: test-pod
+        spec:
+            containers:
+            - name: test-container
+            image: registry.example.com/namespace/image:tag
+        """
+        mock_image_info = {
+            'config': {
+                'config': {
+                    'Labels': {
+                        'com.redhat.component': 'test-component',
+                        'version': '1.0',
+                        'release': '1',
+                    }
+                }
+            },
+            'listDigest': 'sha256:1234567890abcdef',
+            'contentDigest': 'sha256:abcdef1234567890',
+        }
+        mock_oc_image_info.return_value = mock_image_info
+        self.rebaser._group_config.operator_image_ref_mode = 'manifest-list'
+        self.rebaser._group_config.get.return_value = 'namespace'
+
+        new_content, found_images = await self.rebaser._replace_image_references(old_registry, content)
+
+        expected_new_content = """
+        apiVersion: v1
+        kind: Pod
+        metadata:
+            name: test-pod
+        spec:
+            containers:
+            - name: test-container
+            image: registry.redhat.io/openshift4/image@sha256:1234567890abcdef
+        """
+        self.assertEqual(new_content.strip(), expected_new_content.strip())
+        self.assertIn('image', found_images)
+        self.assertEqual(found_images['image'], (
+            'registry.example.com/namespace/image:tag',
+            'registry.redhat.io/openshift4/image@sha256:1234567890abcdef',
+            'test-component-1.0-1'
+        ))
+
+    def test_operator_index_mode(self):
+        # Test when operator_index_mode is 'pre-release'
+        self.rebaser._group_config.operator_index_mode = 'pre-release'
+        self.assertEqual(self.rebaser._operator_index_mode, 'pre-release')
+
+        # Test when operator_index_mode is 'ga'
+        self.rebaser._group_config.operator_index_mode = 'ga'
+        del self.rebaser._operator_index_mode
+        self.assertEqual(self.rebaser._operator_index_mode, 'ga')
+
+        # Test when operator_index_mode is 'ga-plus'
+        self.rebaser._group_config.operator_index_mode = 'ga-plus'
+        del self.rebaser._operator_index_mode
+        self.assertEqual(self.rebaser._operator_index_mode, 'ga-plus')
+
+        # Test when operator_index_mode is invalid
+        self.rebaser._group_config.operator_index_mode = 'invalid-mode'
+        del self.rebaser._operator_index_mode
+        with self.assertLogs(self.rebaser._logger, level='WARNING') as cm:
+            self.assertEqual(self.rebaser._operator_index_mode, 'ga')
+            self.assertIn('invalid-mode is not a valid group_config.operator_index_mode. Defaulting to "ga"', cm.output[0])
+
+        # Test when operator_index_mode is None (default to 'ga')
+        self.rebaser._group_config.operator_index_mode = None
+        del self.rebaser._operator_index_mode
+        self.assertEqual(self.rebaser._operator_index_mode, 'ga')
+
+    def test_redhat_delivery_tags(self):
+        # Test when operator_index_mode is 'pre-release'
+        self.rebaser._group_config.operator_index_mode = 'pre-release'
+        self.rebaser._group_config.vars = {'MAJOR': '4', 'MINOR': '8'}
+        expected_tags = {
+            'com.redhat.delivery.operator.bundle': 'true',
+            'com.redhat.openshift.versions': '=v4.8',
+            'com.redhat.prerelease': 'true',
+        }
+        self.assertEqual(self.rebaser._redhat_delivery_tags, expected_tags)
+
+        # Test when operator_index_mode is 'ga'
+        self.rebaser._group_config.operator_index_mode = 'ga'
+        del self.rebaser._operator_index_mode
+        del self.rebaser._redhat_delivery_tags
+        expected_tags = {
+            'com.redhat.delivery.operator.bundle': 'true',
+            'com.redhat.openshift.versions': '=v4.8',
+        }
+        self.assertEqual(self.rebaser._redhat_delivery_tags, expected_tags)
+
+        # Test when operator_index_mode is 'ga-plus'
+        self.rebaser._group_config.operator_index_mode = 'ga-plus'
+        del self.rebaser._operator_index_mode
+        del self.rebaser._redhat_delivery_tags
+        expected_tags = {
+            'com.redhat.delivery.operator.bundle': 'true',
+            'com.redhat.openshift.versions': 'v4.8',
+        }
+        self.assertEqual(self.rebaser._redhat_delivery_tags, expected_tags)
+
+        # Test when operator_index_mode is invalid (should default to 'ga')
+        self.rebaser._group_config.operator_index_mode = 'invalid-mode'
+        del self.rebaser._operator_index_mode
+        del self.rebaser._redhat_delivery_tags
+        with self.assertLogs(self.rebaser._logger, level='WARNING') as cm:
+            expected_tags = {
+                'com.redhat.delivery.operator.bundle': 'true',
+                'com.redhat.openshift.versions': '=v4.8',
+            }
+            self.assertEqual(self.rebaser._redhat_delivery_tags, expected_tags)
+            self.assertIn('invalid-mode is not a valid group_config.operator_index_mode. Defaulting to "ga"', cm.output[0])
+
+        # Test when operator_index_mode is None (default to 'ga')
+        self.rebaser._group_config.operator_index_mode = None
+        del self.rebaser._operator_index_mode
+        del self.rebaser._redhat_delivery_tags
+        expected_tags = {
+            'com.redhat.delivery.operator.bundle': 'true',
+            'com.redhat.openshift.versions': '=v4.8',
+        }
+        self.assertEqual(self.rebaser._redhat_delivery_tags, expected_tags)
+
+    def test_get_operator_framework_tags(self):
+        # Test when operator_channel_stable is 'default'
+        self.rebaser._group_config.operator_channel_stable = 'default'
+        channel_name = "test-channel"
+        package_name = "test-package"
+        expected_tags = {
+            'operators.operatorframework.io.bundle.channel.default.v1': 'stable',
+            'operators.operatorframework.io.bundle.channels.v1': 'test-channel,stable',
+            'operators.operatorframework.io.bundle.manifests.v1': 'manifests/',
+            'operators.operatorframework.io.bundle.mediatype.v1': 'registry+v1',
+            'operators.operatorframework.io.bundle.metadata.v1': 'metadata/',
+            'operators.operatorframework.io.bundle.package.v1': 'test-package',
+        }
+        actual_tags = self.rebaser._get_operator_framework_tags(channel_name, package_name)
+        self.assertEqual(actual_tags, expected_tags)
+
+        # Test when operator_channel_stable is 'extra'
+        self.rebaser._group_config.operator_channel_stable = 'extra'
+        expected_tags = {
+            'operators.operatorframework.io.bundle.channel.default.v1': 'test-channel',
+            'operators.operatorframework.io.bundle.channels.v1': 'test-channel,stable',
+            'operators.operatorframework.io.bundle.manifests.v1': 'manifests/',
+            'operators.operatorframework.io.bundle.mediatype.v1': 'registry+v1',
+            'operators.operatorframework.io.bundle.metadata.v1': 'metadata/',
+            'operators.operatorframework.io.bundle.package.v1': 'test-package',
+        }
+        actual_tags = self.rebaser._get_operator_framework_tags(channel_name, package_name)
+        self.assertEqual(actual_tags, expected_tags)
+
+        # Test when operator_channel_stable is None
+        self.rebaser._group_config.operator_channel_stable = None
+        expected_tags = {
+            'operators.operatorframework.io.bundle.channel.default.v1': 'test-channel',
+            'operators.operatorframework.io.bundle.channels.v1': 'test-channel',
+            'operators.operatorframework.io.bundle.manifests.v1': 'manifests/',
+            'operators.operatorframework.io.bundle.mediatype.v1': 'registry+v1',
+            'operators.operatorframework.io.bundle.metadata.v1': 'metadata/',
+            'operators.operatorframework.io.bundle.package.v1': 'test-package',
+        }
+        actual_tags = self.rebaser._get_operator_framework_tags(channel_name, package_name)
+        self.assertEqual(actual_tags, expected_tags)
+
+    def test_create_dockerfile(self):
+        metadata = MagicMock()
+        metadata.get_olm_bundle_brew_component_name.return_value = "test-component"
+        metadata.get_olm_bundle_image_name.return_value = "test-image"
+
+        operator_dir = Path("/path/to/operator/dir")
+        bundle_dir = Path("/path/to/bundle/dir")
+        operator_framework_tags = {
+            'operators.operatorframework.io.bundle.channel.default.v1': 'stable',
+            'operators.operatorframework.io.bundle.channels.v1': 'test-channel,stable',
+            'operators.operatorframework.io.bundle.manifests.v1': 'manifests/',
+            'operators.operatorframework.io.bundle.mediatype.v1': 'registry+v1',
+            'operators.operatorframework.io.bundle.metadata.v1': 'metadata/',
+            'operators.operatorframework.io.bundle.package.v1': 'test-package',
+        }
+        input_release = "1.0-1"
+
+        self.rebaser._group_config.vars = {'MAJOR': '4', 'MINOR': '8'}
+
+        with patch("doozerlib.backend.konflux_olm_bundler.DockerfileParser") as mock_dockerfile_parser:
+            mock_operator_df = MagicMock()
+            mock_operator_df.labels = {
+                'com.redhat.component': 'test-component',
+                'version': '1.0',
+                'release': '1',
+            }
+            mock_bundle_df = MagicMock()
+            mock_dockerfile_parser.side_effect = [mock_operator_df, mock_bundle_df]
+
+            self.rebaser._create_dockerfile(metadata, operator_dir, bundle_dir, operator_framework_tags, input_release)
+
+            mock_dockerfile_parser.assert_any_call(str(operator_dir.joinpath('Dockerfile')))
+            mock_dockerfile_parser.assert_any_call(str(bundle_dir.joinpath('Dockerfile')))
+
+            self.assertEqual(mock_bundle_df.content, 'FROM scratch\nCOPY ./manifests /manifests\nCOPY ./metadata /metadata')
+            self.assertEqual(mock_bundle_df.labels, {
+                'com.redhat.component': 'test-component',
+                'com.redhat.delivery.appregistry': False,
+                'name': 'test-image',
+                'version': '1.0.1',
+                'release': '1.0-1',
+                'com.redhat.delivery.operator.bundle': 'true',
+                'com.redhat.openshift.versions': '=v4.8',
+                'operators.operatorframework.io.bundle.channel.default.v1': 'stable',
+                'operators.operatorframework.io.bundle.channels.v1': 'test-channel,stable',
+                'operators.operatorframework.io.bundle.manifests.v1': 'manifests/',
+                'operators.operatorframework.io.bundle.mediatype.v1': 'registry+v1',
+                'operators.operatorframework.io.bundle.metadata.v1': 'metadata/',
+                'operators.operatorframework.io.bundle.package.v1': 'test-package',
+            })
+
+    @patch("aiofiles.open")
+    async def test_create_container_yaml(self, mock_open):
+        path = Path("/path/to/container.yaml")
+        mock_file = mock_open.return_value.__aenter__.return_value
+
+        await self.rebaser._create_container_yaml(path)
+
+        mock_open.assert_called_once_with(path, "w")
+        mock_file.writelines.assert_called_once()
+        written_lines = mock_file.writelines.call_args[0][0]
+        self.assertIn('# metadata containers are not functional and do not need to be multiarch\n', written_lines)
+        self.assertIn('\n', written_lines)
+        yaml_content = yaml.safe_load(written_lines[2])
+        self.assertEqual(yaml_content, {
+            'platforms': {'only': ['x86_64']},
+            'operator_manifests': {'manifests_dir': 'manifests'},
+        })
+
+    @patch("pathlib.Path.iterdir")
+    @patch("aiofiles.open")
+    @patch("pathlib.Path.mkdir")
+    @patch("glob.glob")
+    @patch("doozerlib.backend.konflux_olm_bundler.DockerfileParser")
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxOlmBundleRebaser._replace_image_references")
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxOlmBundleRebaser._create_dockerfile")
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxOlmBundleRebaser._create_container_yaml")
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxOlmBundleRebaser._create_oit_files")
+    async def test_rebase_dir(self, mock_create_oit_files, mock_create_container_yaml, mock_create_dockerfile,
+                              mock_replace_image_references, mock_dockerfile_parser, mock_glob, mock_mkdir, mock_open,
+                              mock_iterdir):
+        metadata = MagicMock()
+        metadata.config = {
+            'update-csv': {
+                'manifests-dir': 'manifests',
+                'bundle-dir': 'bundle',
+                'valid-subscription-label': 'valid-subscription',
+                'registry': 'registry.example.com'
+            }
+        }
+        metadata.distgit_key = "test-distgit-key"
+        operator_dir = Path("/path/to/operator/dir")
+        bundle_dir = Path("/path/to/bundle/dir")
+        input_release = "1.0-1"
+
+        mock_operator_df = MagicMock()
+        mock_operator_df.labels = {
+            'com.redhat.component': 'test-component',
+            'version': '1.0',
+            'release': '1',
+        }
+        mock_dockerfile_parser.return_value = mock_operator_df
+
+        mock_glob.return_value = ["/path/to/operator/dir/manifests/package.yaml"]
+        mock_file = mock_open.return_value.__aenter__.return_value
+        mock_file.read.return_value = yaml.safe_dump({
+            'packageName': 'test-package',
+            'channels': [{'name': 'test-channel'}]
+        })
+
+        new_content = """
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations: {}
+  name: test-operator.v1.0.1
+spec:
+  description: This is a test operator
+  displayName: Test Operator
+        """
+        mock_replace_image_references.return_value = (new_content, {
+            'image': ('old_pullspec', 'new_pullspec', 'test-component-1.0-1')
+        })
+
+        bundle_files = [
+            Path("/path/to/operator/dir/manifests/bundle/file.yaml"),
+            Path("/path/to/operator/dir/manifests/bundle/another-file.yaml"),
+            Path("/path/to/operator/dir/manifests/bundle/image-references"),
+            Path("/path/to/operator/dir/manifests/bundle/test.clusterserviceversion.yaml"),
+        ]
+        mock_iterdir.side_effect = lambda: iter(bundle_files)
+
+        await self.rebaser._rebase_dir(metadata, operator_dir, bundle_dir, input_release)
+
+        mock_mkdir.assert_any_call(parents=True, exist_ok=True)
+        mock_open.assert_any_call("/path/to/operator/dir/manifests/package.yaml", 'r')
+        mock_open.assert_any_call(Path("/path/to/bundle/dir/manifests/file.yaml"), 'w')
+        mock_open.assert_any_call(Path("/path/to/bundle/dir/manifests/another-file.yaml"), 'w')
+        mock_open.assert_any_call(Path("/path/to/bundle/dir/manifests/test.clusterserviceversion.yaml"), 'w')
+        mock_open.assert_any_call(Path("/path/to/bundle/dir/metadata/annotations.yaml"), 'w')
+        mock_create_dockerfile.assert_called_once_with(metadata, operator_dir, bundle_dir, {
+            'operators.operatorframework.io.bundle.channel.default.v1': 'test-channel',
+            'operators.operatorframework.io.bundle.channels.v1': 'test-channel',
+            'operators.operatorframework.io.bundle.manifests.v1': 'manifests/',
+            'operators.operatorframework.io.bundle.mediatype.v1': 'registry+v1',
+            'operators.operatorframework.io.bundle.metadata.v1': 'metadata/',
+            'operators.operatorframework.io.bundle.package.v1': 'test-package',
+        }, input_release)
+        mock_create_container_yaml.assert_called_once_with(Path("/path/to/bundle/dir/container.yaml"))
+        mock_create_oit_files.assert_called_once_with(bundle_dir, 'test-component-1.0-1', {
+            'image': ('old_pullspec', 'new_pullspec', 'test-component-1.0-1')
+        })
+
+    async def test_rebase_dir_no_update_csv(self):
+        metadata = MagicMock()
+        metadata.config = {}
+        metadata.distgit_key = "test-distgit-key"
+        operator_dir = Path("/path/to/operator/dir")
+        bundle_dir = Path("/path/to/bundle/dir")
+        input_release = "1.0-1"
+
+        with self.assertRaises(ValueError) as context:
+            await self.rebaser._rebase_dir(metadata, operator_dir, bundle_dir, input_release)
+        self.assertIn("No update-csv config found in the operator's metadata", str(context.exception))
+
+    async def test_rebase_dir_no_manifests_dir(self):
+        metadata = MagicMock()
+        metadata.config = {
+            'update-csv': {
+                'bundle-dir': 'bundle',
+                'valid-subscription-label': 'valid-subscription',
+                'registry': 'registry.example.com'
+            }
+        }
+        metadata.distgit_key = "test-distgit-key"
+        operator_dir = Path("/path/to/operator/dir")
+        bundle_dir = Path("/path/to/bundle/dir")
+        input_release = "1.0-1"
+
+        with self.assertRaises(ValueError) as context:
+            await self.rebaser._rebase_dir(metadata, operator_dir, bundle_dir, input_release)
+        self.assertIn("No manifests-dir defined in the operator's update-csv", str(context.exception))
+
+    async def test_rebase_dir_no_bundle_dir(self):
+        metadata = MagicMock()
+        metadata.config = {
+            'update-csv': {
+                'manifests-dir': 'manifests',
+                'valid-subscription-label': 'valid-subscription',
+                'registry': 'registry.example.com'
+            }
+        }
+        metadata.distgit_key = "test-distgit-key"
+        operator_dir = Path("/path/to/operator/dir")
+        bundle_dir = Path("/path/to/bundle/dir")
+        input_release = "1.0-1"
+
+        with self.assertRaises(ValueError) as context:
+            await self.rebaser._rebase_dir(metadata, operator_dir, bundle_dir, input_release)
+        self.assertIn("No bundle-dir defined in the operator's update-csv", str(context.exception))
+
+    async def test_rebase_dir_no_valid_subscription_label(self):
+        metadata = MagicMock()
+        metadata.config = {
+            'update-csv': {
+                'manifests-dir': 'manifests',
+                'bundle-dir': 'bundle',
+                'registry': 'registry.example.com'
+            }
+        }
+        metadata.distgit_key = "test-distgit-key"
+        operator_dir = Path("/path/to/operator/dir")
+        bundle_dir = Path("/path/to/bundle/dir")
+        input_release = "1.0-1"
+
+        with self.assertRaises(ValueError) as context:
+            await self.rebaser._rebase_dir(metadata, operator_dir, bundle_dir, input_release)
+        self.assertIn("No valid-subscription-label defined in the operator's update-csv", str(context.exception))
+
+    @patch("pathlib.Path.iterdir", return_value=iter(["some_file"]))
+    @patch("doozerlib.backend.konflux_olm_bundler.DockerfileParser")
+    async def test_rebase_dir_no_dockerfile_labels(self, mock_dockerfile_parser, _):
+        metadata = MagicMock()
+        metadata.config = {
+            'update-csv': {
+                'manifests-dir': 'manifests',
+                'bundle-dir': 'bundle',
+                'valid-subscription-label': 'valid-subscription',
+                'registry': 'registry.example.com'
+            }
+        }
+        metadata.distgit_key = "test-distgit-key"
+        operator_dir = Path("/path/to/operator/dir")
+        bundle_dir = Path("/path/to/bundle/dir")
+        input_release = "1.0-1"
+
+        mock_operator_df = MagicMock()
+        mock_operator_df.labels = {}
+        mock_dockerfile_parser.return_value = mock_operator_df
+
+        with self.assertRaises(ValueError) as context:
+            await self.rebaser._rebase_dir(metadata, operator_dir, bundle_dir, input_release)
+        self.assertIn("Label 'com.redhat.component', 'version' or 'release' is not set in the operator's Dockerfile", str(context.exception))
+
+    @patch("pathlib.Path.iterdir", return_value=iter([]))
+    async def test_rebase_dir_no_files_in_bundle_dir(self, _):
+        metadata = MagicMock()
+        metadata.config = {
+            'update-csv': {
+                'manifests-dir': 'manifests',
+                'bundle-dir': 'bundle',
+                'valid-subscription-label': 'valid-subscription',
+                'registry': 'registry.example.com'
+            }
+        }
+        metadata.distgit_key = "test-distgit-key"
+        operator_dir = Path("/path/to/base/dir/operator/dir")
+        bundle_dir = Path("/path/to/base/dir/bundle/dir")
+        input_release = "1.0-1"
+
+        with self.assertRaises(FileNotFoundError) as context:
+            await self.rebaser._rebase_dir(metadata, operator_dir, bundle_dir, input_release)
+            self.assertIn("No files found in bundle directory", str(context.exception))
+
+
+class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.base_dir = Path("/path/to/base/dir")
+        self.group = "test-group"
+        self.assembly = "test-assembly"
+        self.source_resolver = MagicMock()
+        self.db = MagicMock(record_cls=KonfluxBundleBuildRecord)
+        self.konflux_namespace = "test-namespace"
+        self.konflux_kubeconfig = None
+        self.konflux_context = None
+        self.image_repo = "test-image-repo"
+        self.skip_checks = False
+        self.dry_run = False
+        self.konflux_client = AsyncMock()
+        with patch("doozerlib.backend.konflux_olm_bundler.KonfluxClient") as mock_konflux_client:
+            mock_konflux_client.return_value = self.konflux_client
+            mock_konflux_client.from_kubeconfig.return_value = self.konflux_client
+            self.builder = KonfluxOlmBundleBuilder(
+                base_dir=self.base_dir,
+                group=self.group,
+                assembly=self.assembly,
+                source_resolver=self.source_resolver,
+                db=self.db,
+                konflux_namespace=self.konflux_namespace,
+                konflux_kubeconfig=self.konflux_kubeconfig,
+                konflux_context=self.konflux_context,
+                image_repo=self.image_repo,
+                skip_checks=self.skip_checks,
+                dry_run=self.dry_run,
+            )
+
+    @patch("doozerlib.backend.konflux_olm_bundler.DockerfileParser")
+    async def test_start_build_success(self, mock_dockerfile_parser):
+        metadata = MagicMock()
+        metadata.distgit_key = "test-distgit-key"
+        metadata.get_olm_bundle_short_name.return_value = "test-bundle"
+        bundle_build_repo = MagicMock()
+        bundle_build_repo.commit_hash = "test-commit-hash"
+        bundle_build_repo.branch = None
+        bundle_build_repo.https_url = "https://example.com/repo.git"
+        additional_tags = ["tag1", "tag2"]
+
+        mock_dockerfile = MagicMock()
+        mock_dockerfile.labels = {
+            'com.redhat.component': 'test-component',
+            'version': '1.0',
+            'release': '1',
+        }
+        mock_dockerfile_parser.return_value = mock_dockerfile
+
+        pipelinerun = MagicMock()
+        pipelinerun.metadata.name = "test-pipelinerun"
+        self.konflux_client.start_pipeline_run_for_image_build.return_value = pipelinerun
+        self.konflux_client.build_pipeline_url = MagicMock(return_value="https://example.com/pipelinerun")
+
+        pipelinerun, url = await self.builder._start_build(metadata, bundle_build_repo, self.image_repo, self.konflux_namespace, self.skip_checks, additional_tags)
+
+        self.konflux_client.ensure_application.assert_called_once_with(name="test-group", display_name="test-group")
+        self.konflux_client.ensure_component.assert_called_once_with(
+            name="test-group-test-bundle",
+            application="test-group",
+            component_name="test-group-test-bundle",
+            image_repo=self.image_repo,
+            source_url=bundle_build_repo.https_url,
+            revision=bundle_build_repo.commit_hash,
+        )
+        self.konflux_client.start_pipeline_run_for_image_build.assert_called_once_with(
+            generate_name="test-component-",
+            namespace=self.konflux_namespace,
+            application_name="test-group",
+            component_name="test-component",
+            git_url=bundle_build_repo.https_url,
+            commit_sha=bundle_build_repo.commit_hash,
+            target_branch=bundle_build_repo.commit_hash,
+            output_image=f"{self.image_repo}:test-component-1.0-1",
+            vm_override={},
+            building_arches=["x86_64"],
+            additional_tags=additional_tags,
+            skip_checks=self.skip_checks,
+        )
+        self.assertEqual(url, "https://example.com/pipelinerun")
+
+    @patch("doozerlib.backend.konflux_olm_bundler.DockerfileParser")
+    async def test_start_build_missing_component_label(self, mock_dockerfile_parser):
+        metadata = MagicMock()
+        metadata.distgit_key = "test-distgit-key"
+        bundle_build_repo = MagicMock()
+        bundle_build_repo.commit_hash = "test-commit-hash"
+        bundle_build_repo.branch = None
+        bundle_build_repo.https_url = "https://example.com/repo.git"
+
+        mock_dockerfile = MagicMock()
+        mock_dockerfile.labels = {
+            'version': '1.0',
+            'release': '1',
+        }
+        mock_dockerfile_parser.return_value = mock_dockerfile
+
+        with self.assertRaises(IOError) as context:
+            await self.builder._start_build(metadata, bundle_build_repo, self.image_repo, self.konflux_namespace)
+        self.assertIn("Label 'com.redhat.component' is not set. Did you run rebase?", str(context.exception))
+
+    @patch("doozerlib.backend.konflux_olm_bundler.DockerfileParser")
+    async def test_start_build_missing_version_label(self, mock_dockerfile_parser):
+        metadata = MagicMock()
+        metadata.distgit_key = "test-distgit-key"
+        bundle_build_repo = MagicMock()
+        bundle_build_repo.commit_hash = "test-commit-hash"
+        bundle_build_repo.branch = None
+        bundle_build_repo.https_url = "https://example.com/repo.git"
+
+        mock_dockerfile = MagicMock()
+        mock_dockerfile.labels = {
+            'com.redhat.component': 'test-component',
+            'release': '1',
+        }
+        mock_dockerfile_parser.return_value = mock_dockerfile
+
+        with self.assertRaises(IOError) as context:
+            await self.builder._start_build(metadata, bundle_build_repo, self.image_repo, self.konflux_namespace)
+        self.assertIn("Label 'version' is not set. Did you run rebase?", str(context.exception))
+
+    @patch("doozerlib.backend.konflux_olm_bundler.DockerfileParser")
+    async def test_start_build_missing_release_label(self, mock_dockerfile_parser):
+        metadata = MagicMock()
+        metadata.distgit_key = "test-distgit-key"
+        bundle_build_repo = MagicMock()
+        bundle_build_repo.commit_hash = "test-commit-hash"
+        bundle_build_repo.branch = None
+        bundle_build_repo.https_url = "https://example.com/repo.git"
+
+        mock_dockerfile = MagicMock()
+        mock_dockerfile.labels = {
+            'com.redhat.component': 'test-component',
+            'version': '1.0',
+        }
+        mock_dockerfile_parser.return_value = mock_dockerfile
+
+        with self.assertRaises(IOError) as context:
+            await self.builder._start_build(metadata, bundle_build_repo, self.image_repo, self.konflux_namespace)
+        self.assertIn("Label 'release' is not set. Did you run rebase?", str(context.exception))
+
+    async def test_start_build_no_commit_hash(self):
+        metadata = MagicMock()
+        metadata.distgit_key = "test-distgit-key"
+        bundle_build_repo = MagicMock()
+        bundle_build_repo.commit_hash = None
+
+        with self.assertRaises(IOError) as context:
+            await self.builder._start_build(metadata, bundle_build_repo, self.image_repo, self.konflux_namespace)
+        self.assertIn("Bundle repository must have a commit to build", str(context.exception))
+
+    @patch("aiofiles.open")
+    @patch("doozerlib.backend.konflux_olm_bundler.DockerfileParser")
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxClient.build_pipeline_url")
+    async def test_update_konflux_db_success(self, mock_build_pipeline_url, mock_dockerfile_parser, mock_open):
+        metadata = MagicMock()
+        metadata.distgit_key = "test-distgit-key"
+        metadata.get_olm_bundle_short_name.return_value = "test-bundle"
+        metadata.runtime.group = "test-group"
+        metadata.runtime.assembly = "test-assembly"
+
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "test-commit-hash"
+        build_repo.local_dir = Path("/path/to/local/dir")
+
+        pipelinerun = MagicMock()
+        pipelinerun.status.results = [
+            {'name': 'IMAGE_URL', 'value': 'quay.io/openshift-release-dev/ocp-v4.0-art-dev-test:test-image'},
+            {'name': 'IMAGE_DIGEST', 'value': 'sha256:49d65afba393950a93517f09385e1b441d1735e0071678edf6fc0fc1fe501807'}
+        ]
+        pipelinerun.metadata.name = "test-pipelinerun"
+        pipelinerun.status.startTime = "2023-10-01T12:00:00Z"
+        pipelinerun.status.completionTime = "2023-10-01T12:30:00Z"
+        pipelinerun.metadata.name = "test-pipelinerun"
+
+        mock_build_pipeline_url.return_value = "https://example.com/pipelinerun"
+
+        mock_dockerfile = MagicMock()
+        mock_dockerfile.labels = {
+            'io.openshift.build.source-location': 'https://example.com/source-repo.git',
+            'io.openshift.build.commit.id': 'source-commit-id',
+            'com.redhat.component': 'test-component',
+            'version': '1.0',
+            'release': '1',
+        }
+        mock_dockerfile_parser.return_value = mock_dockerfile
+
+        mock_file = mock_open.return_value.__aenter__.return_value
+        mock_file.read.return_value = yaml.safe_dump({
+            'operator': {'nvr': 'test-operator-1.0-1'},
+            'operands': {
+                'operand1': {'nvr': 'operand1-1.0-1'},
+                'operand2': {'nvr': 'operand2-1.0-1'}
+            }
+        })
+
+        await self.builder._update_konflux_db(metadata, build_repo, pipelinerun, KonfluxBuildOutcome.SUCCESS)
+
+        self.db.add_build.assert_called_once()
+        build_record = self.db.add_build.call_args[0][0]
+        self.assertEqual(build_record.name, "test-bundle")
+        self.assertEqual(build_record.version, "1.0")
+        self.assertEqual(build_record.release, "1")
+        self.assertEqual(build_record.nvr, "test-component-1.0-1")
+        self.assertEqual(build_record.group, "test-group")
+        self.assertEqual(build_record.assembly, "test-assembly")
+        self.assertEqual(build_record.source_repo, "https://example.com/source-repo.git")
+        self.assertEqual(build_record.commitish, "source-commit-id")
+        self.assertEqual(build_record.rebase_repo_url, "https://example.com/repo.git")
+        self.assertEqual(build_record.rebase_commitish, "test-commit-hash")
+        self.assertEqual(build_record.engine, Engine.KONFLUX)
+        self.assertEqual(build_record.outcome, KonfluxBuildOutcome.SUCCESS)
+        self.assertEqual(build_record.art_job_url, 'n/a')
+        self.assertEqual(build_record.build_id, "test-pipelinerun")
+        self.assertEqual(build_record.build_pipeline_url, "https://example.com/pipelinerun")
+        self.assertEqual(build_record.operator_nvr, "test-operator-1.0-1")
+        self.assertEqual(build_record.operand_nvrs, ["operand1-1.0-1", "operand2-1.0-1"])
+        self.assertEqual(build_record.image_pullspec, "quay.io/openshift-release-dev/ocp-v4.0-art-dev-test:test-image")
+        self.assertEqual(build_record.image_tag, "49d65afba393950a93517f09385e1b441d1735e0071678edf6fc0fc1fe501807")
+        self.assertEqual(build_record.start_time, datetime(2023, 10, 1, 12, 0, 0, tzinfo=timezone.utc))
+        self.assertEqual(build_record.end_time, datetime(2023, 10, 1, 12, 30, 0, tzinfo=timezone.utc))
+
+    @patch("aiofiles.open")
+    @patch("doozerlib.backend.konflux_olm_bundler.DockerfileParser")
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxClient.build_pipeline_url")
+    async def test_update_konflux_db_failure(self, mock_build_pipeline_url, mock_dockerfile_parser, mock_open):
+        metadata = MagicMock()
+        metadata.distgit_key = "test-distgit-key"
+        metadata.get_olm_bundle_short_name.return_value = "test-bundle"
+        metadata.runtime.group = "test-group"
+        metadata.runtime.assembly = "test-assembly"
+
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "test-commit-hash"
+        build_repo.local_dir = Path("/path/to/local/dir")
+
+        pipelinerun = MagicMock()
+        pipelinerun.status.startTime = "2023-10-01T12:00:00Z"
+        pipelinerun.status.completionTime = "2023-10-01T12:30:00Z"
+        pipelinerun.metadata.name = "test-pipelinerun"
+
+        mock_build_pipeline_url.return_value = "https://example.com/pipelinerun"
+
+        mock_dockerfile = MagicMock()
+        mock_dockerfile.labels = {
+            'io.openshift.build.source-location': 'https://example.com/source-repo.git',
+            'io.openshift.build.commit.id': 'source-commit-id',
+            'com.redhat.component': 'test-component',
+            'version': '1.0',
+            'release': '1',
+        }
+        mock_dockerfile_parser.return_value = mock_dockerfile
+
+        mock_file = mock_open.return_value.__aenter__.return_value
+        mock_file.read.return_value = yaml.safe_dump({
+            'operator': {'nvr': 'test-operator-1.0-1'},
+            'operands': {
+                'operand1': {'nvr': 'operand1-1.0-1'},
+                'operand2': {'nvr': 'operand2-1.0-1'}
+            }
+        })
+
+        await self.builder._update_konflux_db(metadata, build_repo, pipelinerun, KonfluxBuildOutcome.FAILURE)
+
+        self.db.add_build.assert_called_once()
+        build_record = self.db.add_build.call_args[0][0]
+        self.assertEqual(build_record.name, "test-bundle")
+        self.assertEqual(build_record.version, "1.0")
+        self.assertEqual(build_record.release, "1")
+        self.assertEqual(build_record.nvr, "test-component-1.0-1")
+        self.assertEqual(build_record.group, "test-group")
+        self.assertEqual(build_record.assembly, "test-assembly")
+        self.assertEqual(build_record.source_repo, "https://example.com/source-repo.git")
+        self.assertEqual(build_record.commitish, "source-commit-id")
+        self.assertEqual(build_record.rebase_repo_url, "https://example.com/repo.git")
+        self.assertEqual(build_record.rebase_commitish, "test-commit-hash")
+        self.assertEqual(build_record.engine, Engine.KONFLUX)
+        self.assertEqual(build_record.outcome, KonfluxBuildOutcome.FAILURE)
+        self.assertEqual(build_record.art_job_url, 'n/a')
+        self.assertEqual(build_record.build_id, "test-pipelinerun")
+        self.assertEqual(build_record.build_pipeline_url, "https://example.com/pipelinerun")
+        self.assertEqual(build_record.operator_nvr, "test-operator-1.0-1")
+        self.assertEqual(build_record.operand_nvrs, ["operand1-1.0-1", "operand2-1.0-1"])
+        self.assertEqual(build_record.start_time, datetime(2023, 10, 1, 12, 0, 0, tzinfo=timezone.utc))
+        self.assertEqual(build_record.end_time, datetime(2023, 10, 1, 12, 30, 0, tzinfo=timezone.utc))
+
+    @patch("aiofiles.open")
+    @patch("doozerlib.backend.konflux_olm_bundler.DockerfileParser")
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxClient.build_pipeline_url")
+    async def test_update_konflux_db_no_db_connection(self, mock_build_pipeline_url, mock_dockerfile_parser, mock_open):
+        metadata = MagicMock()
+        metadata.distgit_key = "test-distgit-key"
+        metadata.get_olm_bundle_short_name.return_value = "test-bundle"
+        metadata.runtime.group = "test-group"
+        metadata.runtime.assembly = "test-assembly"
+
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "test-commit-hash"
+        build_repo.local_dir = Path("/path/to/local/dir")
+
+        pipelinerun = MagicMock()
+        pipelinerun.status.results = [
+            {'name': 'IMAGE_URL', 'value': 'quay.io/openshift-release-dev/ocp-v4.0-art-dev-test:test-image'},
+            {'name': 'IMAGE_DIGEST', 'value': 'sha256:49d65afba393950a93517f09385e1b441d1735e0071678edf6fc0fc1fe501807'}
+        ]
+        pipelinerun.status.startTime = "2023-10-01T12:00:00Z"
+        pipelinerun.status.completionTime = "2023-10-01T12:30:00Z"
+        pipelinerun.metadata.name = "test-pipelinerun"
+
+        mock_build_pipeline_url.return_value = "https://example.com/pipelinerun"
+
+        mock_dockerfile = MagicMock()
+        mock_dockerfile.labels = {
+            'io.openshift.build.source-location': 'https://example.com/source-repo.git',
+            'io.openshift.build.commit.id': 'source-commit-id',
+            'com.redhat.component': 'test-component',
+            'version': '1.0',
+            'release': '1',
+        }
+        mock_dockerfile_parser.return_value = mock_dockerfile
+
+        mock_file = mock_open.return_value.__aenter__.return_value
+        mock_file.read.return_value = yaml.safe_dump({
+            'operator': {'nvr': 'test-operator-1.0-1'},
+            'operands': {
+                'operand1': {'nvr': 'operand1-1.0-1'},
+                'operand2': {'nvr': 'operand2-1.0-1'}
+            }
+        })
+
+        self.builder._db = None
+
+        with self.assertLogs(self.builder._logger, level='WARNING') as cm:
+            await self.builder._update_konflux_db(metadata, build_repo, pipelinerun, KonfluxBuildOutcome.SUCCESS)
+            self.assertIn('Konflux DB connection is not initialized, not writing build record to the Konflux DB.', cm.output[0])
+
+    @patch("aiofiles.open")
+    @patch("doozerlib.backend.konflux_olm_bundler.DockerfileParser")
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxClient.build_pipeline_url")
+    async def test_update_konflux_db_exception(self, mock_build_pipeline_url, mock_dockerfile_parser, mock_open):
+        metadata = MagicMock()
+        metadata.distgit_key = "test-distgit-key"
+        metadata.get_olm_bundle_short_name.return_value = "test-bundle"
+        metadata.runtime.group = "test-group"
+        metadata.runtime.assembly = "test-assembly"
+
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "test-commit-hash"
+        build_repo.local_dir = Path("/path/to/local/dir")
+
+        pipelinerun = MagicMock()
+        pipelinerun.status.results = [
+            {'name': 'IMAGE_URL', 'value': 'quay.io/openshift-release-dev/ocp-v4.0-art-dev-test:test-image'},
+            {'name': 'IMAGE_DIGEST', 'value': 'sha256:49d65afba393950a93517f09385e1b441d1735e0071678edf6fc0fc1fe501807'}
+        ]
+        pipelinerun.status.startTime = "2023-10-01T12:00:00Z"
+        pipelinerun.status.completionTime = "2023-10-01T12:30:00Z"
+        pipelinerun.metadata.name = "test-pipelinerun"
+
+        mock_build_pipeline_url.return_value = "https://example.com/pipelinerun"
+
+        mock_dockerfile = MagicMock()
+        mock_dockerfile.labels = {
+            'io.openshift.build.source-location': 'https://example.com/source-repo.git',
+            'io.openshift.build.commit.id': 'source-commit-id',
+            'com.redhat.component': 'test-component',
+            'version': '1.0',
+            'release': '1',
+        }
+        mock_dockerfile_parser.return_value = mock_dockerfile
+
+        mock_file = mock_open.return_value.__aenter__.return_value
+        mock_file.read.return_value = yaml.safe_dump({
+            'operator': {'nvr': 'test-operator-1.0-1'},
+            'operands': {
+                'operand1': {'nvr': 'operand1-1.0-1'},
+                'operand2': {'nvr': 'operand2-1.0-1'}
+            }
+        })
+
+        self.db.add_build.side_effect = Exception("Test exception")
+
+        with self.assertLogs(self.builder._logger, level='ERROR') as cm:
+            await self.builder._update_konflux_db(metadata, build_repo, pipelinerun, KonfluxBuildOutcome.SUCCESS)
+            self.assertIn('Failed writing record to the konflux DB: Test exception', cm.output[0])

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -20,8 +20,6 @@ from doozerlib.exceptions import DoozerFatalError
 from doozerlib import rhcos
 from artcommonlib.rhcos import RhcosMissingContainerException
 
-from artcommon.artcommonlib.assembly import assembly_type
-
 
 async def no_sleep(arg):
     pass


### PR DESCRIPTION
Test command:
```sh
doozer --assembly=test --group=openshift-4.18 --latest-parent-version beta:images:konflux:bundle --konflux-kubeconfig=/path/to/kubeconfig -
-konflux-namespace=ocp-art-tenant --image-repo=quay.io/openshift-release-dev/ocp-v4.0-art-dev-test ose-metallb-operator-container-v4.18.0-202410251504.p0.gc
5a3b07.assembly.test.el9
```

Test build: https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-18/pipelineruns/ose-metallb-operator-bundle-container-s2724