### PR TITLE
ART-11062 ocp4-scan-konflux: check builder changes

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -565,7 +565,7 @@ class ConfigScanSources:
 
         builds = await self.runtime.konflux_db.search_builds_by_fields(
             start_search=start_search,
-            where={'nvr': builder_build_nvr}
+            where={'nvr': builder_build_nvr, **self.base_search_params}
         )
         if builds:
             return builds[0].start_time

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -610,7 +610,7 @@ class ConfigScanSources:
 
             # If the builder build is newer, mark the image as changing
             if build_record.start_time < builder_build_start_time:
-                self.logger.info(f'%s will be rebuilt because a builder or parent image has a newer build: %s',
+                self.logger.info('%s will be rebuilt because a builder or parent image has a newer build: %s',
                                  image_meta.distgit_key, builder_build_nvr)
                 self.add_image_meta_change(
                     image_meta, RebuildHint(RebuildHintCode.BUILDER_CHANGING,

--- a/doozer/requirements.txt
+++ b/doozer/requirements.txt
@@ -1,4 +1,5 @@
 aiofiles
+async-lru
 bashlex
 click >= 8.1.3
 dockerfile-parse >= 0.0.13


### PR DESCRIPTION
Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/65/console

To test this change, a test job has been pointed at `test` assembly and a custom art-tools, where all other checks (upstream changes, config changes, etc.) have been commented out