### PR TITLE
[konflux] Build aarch64 regularly as well

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -57,7 +57,7 @@ class Ocp4ScanPipeline:
                 build_version=self.version,
                 assembly='stream',
                 image_list=image_list,
-                limit_arches=['x86_64']  # TODO remove once we have full capacity
+                limit_arches=['x86_64', 'aarch64']  # TODO remove once we have full capacity
             )
 
         else:


### PR DESCRIPTION
Since we are good to build aarch64 regularly now as well.

Other arches have to wait until konflux setups up the VM