### PR TITLE
Fix batch creation

### DIFF
--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -419,7 +419,6 @@ class PrepareReleasePipeline:
                                                   release_name="RHOSE ASYNC - AUTO",
                                                   release_date=release_date,
                                                   description=batch_name)
-            batch = batch["data"]
             _LOGGER.info("Created errata batch id %s", int(batch["id"]))
         else:
             batch = batches[0]


### PR DESCRIPTION
The returned object of `AsyncErrataAPI.create_batch` is flattened since https://github.com/openshift-eng/art-tools/pull/1139. Getting the "data" field is no longer needed.