### PR TITLE
move yaml lib into artcommon lib

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -34,7 +34,17 @@ def remove_suffix(s: str, suffix: str) -> str:
         return s[:]
 
 
-def yaml_handler():
+def new_roundtrip_yaml_handler():
+    """
+    Creates and returns a configured YAML handler with specific formatting settings.
+    Returns:
+        YAML: A YAML handler configured with:
+            - round-trip (rt) mode for preserving comments and formatting
+            - disabled flow style for better readability
+            - preserved quotes
+            - 4096 character line width
+            - custom indentation (2 spaces for mappings, 4 for sequences)
+    """
     yaml = YAML(typ="rt")
     yaml.default_flow_style = False
     yaml.preserve_quotes = True

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -34,6 +34,15 @@ def remove_suffix(s: str, suffix: str) -> str:
         return s[:]
 
 
+def yaml_handler():
+    yaml = YAML(typ="rt")
+    yaml.default_flow_style = False
+    yaml.preserve_quotes = True
+    yaml.width = 4096
+    yaml.indent(mapping=2,sequence=4,offset=2)
+    return yaml
+
+
 def convert_remote_git_to_https(source_url: str):
     """
     Accepts a source git URL in ssh or https format and return it in a normalized

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -7,7 +7,7 @@ import asyncio
 import aiohttp
 import requests
 from tenacity import retry, wait_fixed, stop_after_attempt
-
+from ruamel.yaml import YAML
 from artcommonlib.constants import RELEASE_SCHEDULES
 
 LOGGER = logging.getLogger(__name__)
@@ -49,7 +49,7 @@ def new_roundtrip_yaml_handler():
     yaml.default_flow_style = False
     yaml.preserve_quotes = True
     yaml.width = 4096
-    yaml.indent(mapping=2,sequence=4,offset=2)
+    yaml.indent(mapping=2, sequence=4, offset=2)
     return yaml
 
 

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -10,11 +10,10 @@ from typing import Dict, Iterable, List, Optional, Tuple
 
 from artcommonlib.arch_util import brew_arch_for_go_arch
 from artcommonlib.assembly import AssemblyTypes
-from artcommonlib.util import get_ocp_version_from_group
+from artcommonlib.util import get_ocp_version_from_group, yaml_handler
 from artcommonlib import exectools
 from doozerlib.util import isolate_nightly_name_components
 from ghapi.all import GhApi
-from ruamel.yaml import YAML
 from semver import VersionInfo
 from tenacity import retry, stop_after_attempt, wait_fixed
 
@@ -30,10 +29,7 @@ from pyartcd.util import (get_assembly_type,
                           default_release_suffix,
                           get_microshift_builds)
 
-yaml = YAML(typ="rt")
-yaml.default_flow_style = False
-yaml.preserve_quotes = True
-yaml.width = 4096
+yaml = yaml_handler()
 
 
 class BuildMicroShiftPipeline:

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -10,7 +10,7 @@ from typing import Dict, Iterable, List, Optional, Tuple
 
 from artcommonlib.arch_util import brew_arch_for_go_arch
 from artcommonlib.assembly import AssemblyTypes
-from artcommonlib.util import get_ocp_version_from_group, yaml_handler
+from artcommonlib.util import get_ocp_version_from_group, new_roundtrip_yaml_handler
 from artcommonlib import exectools
 from doozerlib.util import isolate_nightly_name_components
 from ghapi.all import GhApi
@@ -29,7 +29,7 @@ from pyartcd.util import (get_assembly_type,
                           default_release_suffix,
                           get_microshift_builds)
 
-yaml = yaml_handler()
+yaml = new_roundtrip_yaml_handler()
 
 
 class BuildMicroShiftPipeline:

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -6,10 +6,9 @@ import requests
 import asyncio
 import traceback
 from typing import Optional
-from ruamel.yaml import YAML
 
 from artcommonlib.assembly import AssemblyTypes
-from artcommonlib.util import get_ocp_version_from_group, isolate_major_minor_in_group
+from artcommonlib.util import get_ocp_version_from_group, isolate_major_minor_in_group, yaml_handler
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, Engine, ArtifactType, KonfluxBuildRecord
 from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.arch_util import brew_arch_for_go_arch
@@ -27,10 +26,7 @@ from pyartcd.util import (get_assembly_type,
 from pyartcd.plashets import build_plashets, plashet_config_for_major_minor
 from doozerlib.constants import ART_DEFAULT_IMAGE_REPO
 
-yaml = YAML(typ="rt")
-yaml.default_flow_style = False
-yaml.preserve_quotes = True
-yaml.width = 4096
+yaml = yaml_handler()
 
 
 class BuildMicroShiftBootcPipeline:

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -8,7 +8,7 @@ import traceback
 from typing import Optional
 
 from artcommonlib.assembly import AssemblyTypes
-from artcommonlib.util import get_ocp_version_from_group, isolate_major_minor_in_group, yaml_handler
+from artcommonlib.util import get_ocp_version_from_group, isolate_major_minor_in_group, new_roundtrip_yaml_handler
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, Engine, ArtifactType, KonfluxBuildRecord
 from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.arch_util import brew_arch_for_go_arch
@@ -26,7 +26,7 @@ from pyartcd.util import (get_assembly_type,
 from pyartcd.plashets import build_plashets, plashet_config_for_major_minor
 from doozerlib.constants import ART_DEFAULT_IMAGE_REPO
 
-yaml = yaml_handler()
+yaml = new_roundtrip_yaml_handler()
 
 
 class BuildMicroShiftBootcPipeline:

--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -10,9 +10,8 @@ from typing import Iterable, Optional, OrderedDict, Tuple
 import aiohttp
 import click
 from ghapi.all import GhApi
-from ruamel.yaml import YAML
 
-from artcommonlib.util import split_git_url, merge_objects, get_inflight, isolate_major_minor_in_group
+from artcommonlib.util import split_git_url, merge_objects, get_inflight, isolate_major_minor_in_group, yaml_handler
 from artcommonlib import exectools
 from doozerlib.cli.get_nightlies import rc_api_url
 from pyartcd import constants, jenkins
@@ -21,10 +20,7 @@ from pyartcd.git import GitRepository
 from pyartcd.jenkins import start_build_sync
 from pyartcd.runtime import Runtime
 
-yaml = YAML(typ="rt")
-yaml.default_flow_style = False
-yaml.preserve_quotes = True
-yaml.width = 4096
+yaml = yaml_handler()
 
 
 class GenAssemblyPipeline:

--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -11,7 +11,7 @@ import aiohttp
 import click
 from ghapi.all import GhApi
 
-from artcommonlib.util import split_git_url, merge_objects, get_inflight, isolate_major_minor_in_group, yaml_handler
+from artcommonlib.util import split_git_url, merge_objects, get_inflight, isolate_major_minor_in_group, new_roundtrip_yaml_handler
 from artcommonlib import exectools
 from doozerlib.cli.get_nightlies import rc_api_url
 from pyartcd import constants, jenkins
@@ -20,7 +20,7 @@ from pyartcd.git import GitRepository
 from pyartcd.jenkins import start_build_sync
 from pyartcd.runtime import Runtime
 
-yaml = yaml_handler()
+yaml = new_roundtrip_yaml_handler()
 
 
 class GenAssemblyPipeline:

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -15,13 +15,12 @@ from pathlib import Path
 from subprocess import PIPE
 from typing import Dict, List, Optional, Sequence, Tuple
 from jira.resources import Issue
-from ruamel.yaml import YAML
 from tenacity import retry, stop_after_attempt, wait_fixed
 from datetime import datetime, timedelta, timezone
 
 from artcommonlib.assembly import AssemblyTypes, assembly_group_config
 from artcommonlib.model import Model
-from artcommonlib.util import get_assembly_release_date
+from artcommonlib.util import get_assembly_release_date, yaml_handler
 from elliottlib.errata import set_blocking_advisory, get_blocking_advisories, push_cdn_stage, is_advisory_editable
 from elliottlib.errata_async import AsyncErrataAPI
 from elliottlib.errata import set_blocking_advisory, get_blocking_advisories
@@ -38,7 +37,7 @@ from pyartcd.util import (get_assembly_basis, get_assembly_type,
 
 
 _LOGGER = logging.getLogger(__name__)
-
+yaml = yaml_handler()
 
 class PrepareReleasePipeline:
     def __init__(
@@ -387,10 +386,6 @@ class PrepareReleasePipeline:
             return None
         async with aiofiles.open(path, "r") as f:
             content = await f.read()
-        yaml = YAML(typ="safe")
-        yaml.default_flow_style = False
-        yaml.preserve_quotes = True
-        yaml.width = 4096
         return yaml.load(content)
 
     @cached_property
@@ -504,10 +499,6 @@ class PrepareReleasePipeline:
             await self.clone_build_data(repo)
         async with aiofiles.open(repo / "group.yml", "r") as f:
             content = await f.read()
-        yaml = YAML(typ="safe")
-        yaml.default_flow_style = False
-        yaml.preserve_quotes = True
-        yaml.width = 4096
         return yaml.load(content)
 
     def check_blockers(self):
@@ -607,10 +598,6 @@ class PrepareReleasePipeline:
                 f.write(group_config)
         else:
             # update releases.yml (if we are operating on a non-stream assembly)
-            yaml = YAML(typ="rt")
-            yaml.default_flow_style = False
-            yaml.preserve_quotes = True
-            yaml.width = 4096
             async with aiofiles.open(repo / "releases.yml", "r") as f:
                 old = await f.read()
             releases_config = yaml.load(old)

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -20,7 +20,7 @@ from datetime import datetime, timedelta, timezone
 
 from artcommonlib.assembly import AssemblyTypes, assembly_group_config
 from artcommonlib.model import Model
-from artcommonlib.util import get_assembly_release_date, yaml_handler
+from artcommonlib.util import get_assembly_release_date, new_roundtrip_yaml_handler
 from elliottlib.errata import set_blocking_advisory, get_blocking_advisories, push_cdn_stage, is_advisory_editable
 from elliottlib.errata_async import AsyncErrataAPI
 from elliottlib.errata import set_blocking_advisory, get_blocking_advisories
@@ -37,7 +37,7 @@ from pyartcd.util import (get_assembly_basis, get_assembly_type,
 
 
 _LOGGER = logging.getLogger(__name__)
-yaml = yaml_handler()
+yaml = new_roundtrip_yaml_handler()
 
 class PrepareReleasePipeline:
     def __init__(

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -39,6 +39,7 @@ from pyartcd.util import (get_assembly_basis, get_assembly_type,
 _LOGGER = logging.getLogger(__name__)
 yaml = new_roundtrip_yaml_handler()
 
+
 class PrepareReleasePipeline:
     def __init__(
         self,

--- a/pyartcd/pyartcd/pipelines/review_cvp.py
+++ b/pyartcd/pyartcd/pipelines/review_cvp.py
@@ -16,6 +16,7 @@ from pyartcd.runtime import Runtime
 
 yaml = new_roundtrip_yaml_handler()
 
+
 class ReviewCVPPipeline:
     def __init__(self, runtime: Runtime, group: str, assembly: str) -> None:
         self.runtime = runtime

--- a/pyartcd/pyartcd/pipelines/review_cvp.py
+++ b/pyartcd/pyartcd/pipelines/review_cvp.py
@@ -8,17 +8,13 @@ from typing import Dict
 import click
 from ghapi.all import GhApi
 from artcommonlib import exectools
+from artcommonlib.util import yaml_handler
 from pyartcd import jenkins, constants
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.git import GitRepository
 from pyartcd.runtime import Runtime
-from ruamel.yaml import YAML
 
-yaml = YAML(typ="rt")
-yaml.default_flow_style = False
-yaml.preserve_quotes = True
-yaml.width = 4096
-
+yaml = yaml_handler()
 
 class ReviewCVPPipeline:
     def __init__(self, runtime: Runtime, group: str, assembly: str) -> None:

--- a/pyartcd/pyartcd/pipelines/review_cvp.py
+++ b/pyartcd/pyartcd/pipelines/review_cvp.py
@@ -8,13 +8,13 @@ from typing import Dict
 import click
 from ghapi.all import GhApi
 from artcommonlib import exectools
-from artcommonlib.util import yaml_handler
+from artcommonlib.util import new_roundtrip_yaml_handler
 from pyartcd import jenkins, constants
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.git import GitRepository
 from pyartcd.runtime import Runtime
 
-yaml = yaml_handler()
+yaml = new_roundtrip_yaml_handler()
 
 class ReviewCVPPipeline:
     def __init__(self, runtime: Runtime, group: str, assembly: str) -> None:

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -14,6 +14,7 @@ from artcommonlib.constants import BREW_HUB
 from artcommonlib.release_util import split_el_suffix_in_release
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib import exectools
+from artcommonlib.util import yaml_handler
 from pyartcd import jenkins
 from pyartcd.constants import GITHUB_OWNER
 from pyartcd.cli import cli, click_coroutine, pass_runtime
@@ -24,11 +25,7 @@ from elliottlib.constants import GOLANG_BUILDER_CVE_COMPONENT
 from elliottlib import util as elliottutil
 
 _LOGGER = logging.getLogger(__name__)
-
-yaml = YAML(typ="rt")
-yaml.default_flow_style = False
-yaml.preserve_quotes = True
-yaml.width = 4096
+yaml = yaml_handler()
 
 
 def is_latest_build(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool:

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -14,7 +14,7 @@ from artcommonlib.constants import BREW_HUB
 from artcommonlib.release_util import split_el_suffix_in_release
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib import exectools
-from artcommonlib.util import yaml_handler
+from artcommonlib.util import new_roundtrip_yaml_handler
 from pyartcd import jenkins
 from pyartcd.constants import GITHUB_OWNER
 from pyartcd.cli import cli, click_coroutine, pass_runtime
@@ -25,7 +25,7 @@ from elliottlib.constants import GOLANG_BUILDER_CVE_COMPONENT
 from elliottlib import util as elliottutil
 
 _LOGGER = logging.getLogger(__name__)
-yaml = yaml_handler()
+yaml = new_roundtrip_yaml_handler()
 
 
 def is_latest_build(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool:


### PR DESCRIPTION
Add yaml_handler function to artcommon lib to set yaml config and load by others to reduce duplication
also set indent config for yaml, this will change list item
```
arches:
- x86_64
- ppc64le
- s390x
- aarch64
```
to
```
arches:
  - x86_64
  - ppc64le
  - s390x
  - aarch64
```
for better reading