### PR TITLE
[konflux] set build retires to 3

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -114,7 +114,7 @@ class KonfluxImageBuilder:
 
             # Start the build
             self._logger.info("Starting Konflux image build for %s...", metadata.distgit_key)
-            retries = 5
+            retries = 3
             error = None
             for attempt in range(retries):
                 self._logger.info("[%s] Build attempt %s/%s", metadata.distgit_key, attempt + 1, retries)


### PR DESCRIPTION
Now that we have our own cluster, we can reduce the number of retires to 3, as it was originally set. If builds fail here, its most likely a legit issue which warrants further investigation and not a flake, so no need for additional retires