### PR TITLE
[konflux] update apply-tags timeout

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -345,6 +345,8 @@ class KonfluxClient:
                 case "build-images":
                     task["timeout"] = "12h"
                 case "apply-tags":
+                    # microshift-bootc times out after the default '2h' for the apply-tags task. So increasing to '4h'
+                    task["timeout"] = "4h"
                     _modify_param(task["params"], "ADDITIONAL_TAGS", list(additional_tags))
 
         # https://konflux.pages.redhat.com/docs/users/how-tos/configuring/overriding-compute-resources.html


### PR DESCRIPTION
microshift-bootc times out after the default '2h' for the apply-tags task. So increasing to '4h'