### PR TITLE
[konflux] support VM override

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -209,6 +209,7 @@ class KonfluxImageBuilder:
             building_arches=building_arches,
             additional_tags=additional_tags,
             skip_checks=self._config.skip_checks,
+            vm_override=metadata.config.get("konflux", {}).get("vm_override")
         )
 
         logger.info(f"Created PipelineRun: {self.build_pipeline_url(pipelinerun)}")


### PR DESCRIPTION
Ref [thread](https://redhat-internal.slack.com/archives/C06Q309QUDV/p1733250810691609) for details

ose-installer-artifacts require more storage, hence a new VM variant was created for ARM

Alongside https://github.com/openshift-eng/ocp-build-data/pull/5798