### PR TITLE
[konflux] set build source image as true

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -341,6 +341,7 @@ class KonfluxClient:
         params = obj["spec"]["params"]
         _modify_param(params, "output-image", output_image)
         _modify_param(params, "skip-checks", skip_checks)
+        _modify_param(params, "build-source-image", "true")  # Have to be true always to satisfy Enterprise Contract Policy
         _modify_param(params, "image-expires-after", "6w")
         _modify_param(params, "build-platforms", list(build_platforms))
 

--- a/doozer/doozerlib/backend/konflux_image_build_pipelinerun.yaml
+++ b/doozer/doozerlib/backend/konflux_image_build_pipelinerun.yaml
@@ -86,7 +86,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "true"
+    - default: "false"
       description: Build a source image.
       name: build-source-image
       type: string


### PR DESCRIPTION
Enterprise Contract (EC) requires us to build source image always. This value was set in the yaml file, but the default value there is `false`. Setting that value in code as per current pattern.