### PR TITLE
[konflux] pass registry username-password for cosign

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -236,7 +236,11 @@ class KonfluxImageBuilder:
                 "--registry-username", f"{os.environ['KONFLUX_ART_IMAGES_USERNAME']}",
                 "--registry-password", f"{os.environ['KONFLUX_ART_IMAGES_PASSWORD']}",
             ]
-            _, stdout, _ = await exectools.cmd_gather_async(cmd)
+            rc, stdout, _ = await exectools.cmd_gather_async(cmd)
+
+            if rc != 0:
+                raise ChildProcessError("cosign command failed to download SBOM")
+
             sbom_contents = json.loads(stdout)
             source_rpms = set()
             for x in sbom_contents["components"]:


### PR DESCRIPTION
cosign doesn't seem to be correctly pulling the auth for the art-images registry. But it does support params to allow passing in values directly, which seems to fix the issue.

Tested, [works](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/489/console)