### PR TITLE
WIP: Fix synk failure

### DIFF
--- a/art-cluster/cloudflare/src/index.ts
+++ b/art-cluster/cloudflare/src/index.ts
@@ -19,6 +19,13 @@ async function proxyToTarget(request: Request, targetBase: string, remainingPath
         body: request.method !== "GET" && request.method !== "HEAD" ? request.body : null,
     });
 
+    const allowedHosts = ["mirror.openshift.com"];
+    const urlObj = new URL(targetUrl);
+
+    if (!allowedHosts.includes(urlObj.hostname)) {
+        throw new Error("Invalid target URL");
+    }
+
     // Fetch the response from the target URL
     const response = await fetch(proxyRequest);
 


### PR DESCRIPTION
```
 ✗ [High] Server-Side Request Forgery (SSRF) 
   Path: art-cluster/cloudflare/src/index.ts, line 23 
   Info: Unsanitized input from an HTTP header flows into fetch, where it is used as an URL to perform a request. This may result in a Server-Side Request Forgery vulnerability.
```

