### PR TITLE
deprecate 2015 IT cert

### DIFF
--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
@@ -6,7 +6,6 @@ LABEL name="openshift-art/artcd-base" \
 
 # Trust Red Hat IT Root CA certificates and add repos
 RUN curl -fLo /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem \
- && curl -fLo /etc/pki/ca-trust/source/anchors/2015-IT-Root-CA.pem https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem \
  && update-ca-trust extract
 
 # Copy repository configurations for software installations

--- a/doozer/doozerlib/coverity.py
+++ b/doozer/doozerlib/coverity.py
@@ -346,7 +346,6 @@ ENV https_proxy ${{HTTPS_PROXY}}
 
 # Certs necessary to install from internal repos
 RUN curl -k https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem --output /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem
-RUN curl -k https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem --output /etc/pki/ca-trust/source/anchors/2015-IT-Root-CA.pem
 RUN update-ca-trust && update-ca-trust enable
 
 # Add typical build repos to the image, but don't add to /etc/yum.repos.d

--- a/ocp-build-data-validator/Dockerfile
+++ b/ocp-build-data-validator/Dockerfile
@@ -4,7 +4,6 @@ RUN microdnf install -y python pip git findutils jq
 RUN git clone https://github.com/openshift-eng/art-tools && cd art-tools/ocp-build-data-validator && pip install .
 RUN pip cache purge \
 && curl -fLo /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem \
-&& curl -fLo /etc/pki/ca-trust/source/anchors/2015-IT-Root-CA.pem https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem \
 && update-ca-trust extract
 
 COPY ocp-build-data-validator/entrypoint.sh /entrypoint.sh

--- a/ocp-build-data-validator/deploy/Dockerfile.base
+++ b/ocp-build-data-validator/deploy/Dockerfile.base
@@ -20,8 +20,6 @@ RUN python3 -m pip install -U pip build \
  && useradd -ms /bin/bash -u 1000 art \
  && curl -o /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem --fail -L \
          https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem \
- && curl -o /etc/pki/ca-trust/source/anchors/2015-IT-Root-CA.pem --fail -L \
-         https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem \
  && update-ca-trust extract  # Trust the Red Hat IT Root CAs
 
 USER art


### PR DESCRIPTION
2015 cert is deprecated on https://certs.corp.redhat.com/certs/