### PR TITLE
[konflux] Update build timeout

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -359,7 +359,7 @@ class KonfluxClient:
         for task in obj["spec"]["pipelineSpec"]["tasks"]:
             match task["name"]:
                 case "build-images":
-                    task["timeout"] = "12h"
+                    task["timeout"] = "6h"
                 case "apply-tags":
                     _modify_param(task["params"], "ADDITIONAL_TAGS", list(additional_tags))
 


### PR DESCRIPTION
Now that we are in the new cluster, builds are significantly more fast. The max build time that I've seen is ~ 3 hrs. So making sure that we have a buffer, setting the new build time out to 6 hrs.

IBM arches flake out but still hang sometimes, and we see that build running for 12 hrs, so timing out before so that we can trigger a fresh build. I had mentioned this to the konflux team, but this only happens 1% of the time. If it happens more frequently, we need to send our findings to konflux.