### PR TITLE
Improve scan-sources-konflux

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -359,7 +359,7 @@ class ConfigScanSources:
 
         # Does most recent build match the one from the latest upstream commit?
         # If it doesn't, mark for rebuild
-        if latest_build_record.nvr != upstream_commit_build_record.nvr:
+        if latest_build_record.commitish != upstream_commit_hash:
             self.add_image_meta_change(
                 image_meta,
                 RebuildHint(code=RebuildHintCode.UPSTREAM_COMMIT_MISMATCH,


### PR DESCRIPTION
It happened (due to manual build actions mostly) to have multiple builds from the same upstream commit. In this case, scan-sources for konflux compares the NVRs and finds them different (rebase times differ), so concluded that the image needed to be rebuilt. 

To avoid that, compare the commitish of the latest retrieved build with the most recent upstream commit hash. If they match, no need to rebuild even if NVRs differ. Otherwise, scan-sources can conclude that an upstream commit has been reverted, so we need a more recent build from the HEAD commit.