### PR TITLE
[konflux] allow field to override konflux template url

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -41,6 +41,7 @@ class KonfluxImageBuilderConfig:
     base_dir: Path
     group_name: str
     namespace: str
+    plr_template: str
     kubeconfig: Optional[str] = None
     context: Optional[str] = None
     image_repo: str = constants.KONFLUX_DEFAULT_IMAGE_REPO
@@ -63,7 +64,7 @@ class KonfluxImageBuilder:
     def __init__(self, config: KonfluxImageBuilderConfig, logger: Optional[logging.Logger] = None) -> None:
         self._config = config
         self._logger = logger or LOGGER
-        self._konflux_client = KonfluxClient.from_kubeconfig(config.namespace, config.kubeconfig, config.context, config.dry_run)
+        self._konflux_client = KonfluxClient.from_kubeconfig(config.namespace, config.kubeconfig, config.context, config.dry_run, config.plr_template)
 
         for secret in ["KONFLUX_ART_IMAGES_USERNAME", "KONFLUX_ART_IMAGES_PASSWORD"]:
             if secret not in os.environ:

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -128,6 +128,7 @@ class KonfluxBuildCli:
         image_repo: str,
         skip_checks: bool,
         dry_run: bool,
+        plr_template,
     ):
         self.runtime = runtime
         self.konflux_kubeconfig = konflux_kubeconfig
@@ -136,6 +137,7 @@ class KonfluxBuildCli:
         self.image_repo = image_repo
         self.skip_checks = skip_checks
         self.dry_run = dry_run
+        self.plr_template = plr_template
 
     @start_as_current_span_async(TRACER, "images:konflux:build")
     async def run(self):
@@ -152,7 +154,8 @@ class KonfluxBuildCli:
             namespace=self.konflux_namespace,
             image_repo=self.image_repo,
             skip_checks=self.skip_checks,
-            dry_run=self.dry_run
+            dry_run=self.dry_run,
+            plr_template=self.plr_template
         )
         builder = KonfluxImageBuilder(config=config)
         tasks = []
@@ -178,13 +181,15 @@ class KonfluxBuildCli:
 @click.option('--image-repo', default=constants.KONFLUX_DEFAULT_IMAGE_REPO, help='Push images to the specified repo.')
 @click.option('--skip-checks', default=False, is_flag=True, help='Skip all post build checks')
 @click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
+@click.option('--plr-template', required=False, default='',
+              help='Override the Pipeline Run template commit from openshift-priv/art-konflux-template')
 @pass_runtime
 @click_coroutine
 async def images_konflux_build(
         runtime: Runtime, konflux_kubeconfig: Optional[str], konflux_context: Optional[str],
-        konflux_namespace: str, image_repo: str, skip_checks: bool, dry_run: bool):
+        konflux_namespace: str, image_repo: str, skip_checks: bool, dry_run: bool, plr_template):
     cli = KonfluxBuildCli(
         runtime=runtime, konflux_kubeconfig=konflux_kubeconfig,
         konflux_context=konflux_context, konflux_namespace=konflux_namespace,
-        image_repo=image_repo, skip_checks=skip_checks, dry_run=dry_run)
+        image_repo=image_repo, skip_checks=skip_checks, dry_run=dry_run, plr_template=plr_template)
     await cli.run()

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -39,7 +39,7 @@ ART_DEFAULT_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
 KONFLUX_UI_HOST = "https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com"
 KONFLUX_UI_DEFAULT_WORKSPACE = "ocp-art"  # associated with ocp-art-tenant
 MAX_KONFLUX_BUILD_QUEUE_SIZE = 25  # how many concurrent Konflux pipeline can we spawn per OCP version?
-KONFLUX_PlR_TEMPLATE_URL = "https://raw.githubusercontent.com/openshift-priv/art-konflux-template/refs/heads/main/.tekton/art-konflux-template-push.yaml"  # Konflux PipelineRun (PLR) template
+KONFLUX_PlR_TEMPLATE_URL = "https://raw.githubusercontent.com/{owner}/art-konflux-template/refs/heads/{branch_name}/.tekton/art-konflux-template-push.yaml"  # Konflux PipelineRun (PLR) template
 
 REGISTRY_PROXY_BASE_URL = "registry-proxy.engineering.redhat.com"
 BREW_REGISTRY_BASE_URL = "brew.registry.redhat.io"


### PR DESCRIPTION
Since we are now dynamically pulling the PipelineRun template from https://github.com/openshift-priv/art-konflux-template/blob/main/.tekton/art-konflux-template-push.yaml, in case if there is an issue with one of the newer task builds, having this option will allow us to use a temporary roll back if necessary, instead of merging a revert PR, thereby offering us more flexibility.

Alongside https://github.com/openshift-eng/aos-cd-jobs/pull/4313