### PR TITLE
[konflux] skip SBOM components with incorrect purl

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -258,8 +258,8 @@ class KonfluxImageBuilder:
                             source_rpm = purl.qualifiers.get("upstream", None)
                             if source_rpm:
                                 source_rpms.add(source_rpm.rstrip(".src.rpm"))
-                    except ValueError:
-                        logger.warning(f"Failed to get SBOM contents of {x['name']}")
+                    except Exception as e:
+                        logger.warning(f"Failed to parse purl: {x['purl']} {e}")
                         continue
             return source_rpms
 


### PR DESCRIPTION
purl error

```
ERROR Failed writing record to the konflux DB: Invalid purl 'pkg:github/docker:/#morphy/revive-action:v2' cannot contain a "user:pass@host:port" URL Authority component: ''.
```
Skip SBOM components with invalid purl