### PR TITLE
ocp4-scan-konflux: only look at Konflux builds by default

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -61,6 +61,7 @@ class ConfigScanSources:
         self.base_search_params = {
             'group': self.runtime.group,
             'assembly': self.runtime.assembly,  # to let test ocp4-scan in non-stream assemblies, e.g. 'test'
+            'engine': Engine.KONFLUX.value,
         }
 
         self.latest_image_build_records_map: typing.Dict[str, KonfluxBuildRecord] = {}
@@ -268,7 +269,6 @@ class ConfigScanSources:
         self.logger.info('Gathering latest image build records information...')
         latest_image_builds = await self.runtime.konflux_db.get_latest_builds(
             names=image_names,
-            engine=Engine.KONFLUX,
             **self.base_search_params)
         self.latest_image_build_records_map.update((zip(
             image_names, latest_image_builds)))


### PR DESCRIPTION
BigQuery also stored Brew build records. This was confusing ocp4-scan-konflux that kept on finding multiple builds from the same upstream commit of a given component. Setting engine=Konflux in the search base params will fix that. We'll then need to override this param when scanning RPM builds, that are only built by Brew

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/164/console