### PR TITLE
art-cd: use current IT root CA

### DIFF
--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
@@ -5,7 +5,7 @@ LABEL name="openshift-art/artcd-base" \
   maintainer="OpenShift Team Automated Release Tooling <aos-team-art@redhat.com>"
 
 # Trust Red Hat IT Root CA certificates and add repos
-RUN curl -fLo /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem \
+RUN curl -fLo /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem \
  && update-ca-trust extract
 
 # Copy repository configurations for software installations


### PR DESCRIPTION
fixes this
```
2024-12-16 15:03:20,231 koji         ERROR (gssapi auth failed: requests.exceptions.SSLError: HTTPSConnectionPool(host='brewhub.engineering.redhat.com', port=443): Max retries exceeded with url: /brewhub/ssllogin (Caused by SSLError(SSLCertVerificationError(5, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1006)'))))
```
