### PR TITLE
trigger rhcos_sync with shortname

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -448,7 +448,11 @@ class PromotePipeline:
                     for arch, pullspec in pullspecs.items():
                         if arch == "multi":
                             continue
-                        jenkins.start_rhcos_sync(pullspec, dry_run=self.runtime.dry_run)
+
+                        # '4.19.0-ec.0-aarch64' from 'quay.io/openshift-release-dev/ocp-release:4.19.0-ec.0-aarch64'
+                        # Since rhocs_sync does not take the quay URL as prefix
+                        short_name = pullspec.split(":")[-1]
+                        jenkins.start_rhcos_sync(short_name, dry_run=self.runtime.dry_run)
 
         except Exception as err:
             self._logger.exception(err)


### PR DESCRIPTION
Noticed that rhcos_sync jobs were [failing](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Frhcos_sync/115/parameters/) because we were passing the entire pull spec as param.