### PR TITLE
pyartcd unit test fixes and cleanups

### DIFF
--- a/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py
+++ b/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py
@@ -6,7 +6,6 @@ import os
 import asyncio
 from typing import List
 from ghapi.all import GhApi
-from specfile import Specfile
 
 from artcommonlib.constants import BREW_HUB
 from artcommonlib.rpm_utils import parse_nvr
@@ -19,12 +18,19 @@ from pyartcd.pipelines.update_golang import (is_latest_and_available,
                                              extract_and_validate_golang_nvrs,
                                              move_golang_bugs)
 
+try:
+    from specfile import Specfile  # Linux only
+except ImportError:
+    pass
+
 _LOGGER = logging.getLogger(__name__)
 
 
 class RebuildGolangRPMsPipeline:
     def __init__(self, runtime: Runtime, ocp_version: str, art_jira: str, cves: List[str],
                  go_nvrs: List[str], force: bool = False, rpms: List[str] = None):
+        if "Specfile" not in globals():
+            raise RuntimeError("This pipeline requires the 'specfile' module, which is only available on Linux")
         self.runtime = runtime
         self.ocp_version = ocp_version
         self.go_nvrs = go_nvrs

--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -23,7 +23,7 @@ slack_sdk >= 3.13.0
 stomp.py ~= 8.1.0
 tenacity ~= 8.4, != 8.4.0 # https://github.com/jd/tenacity/issues/471
 tomli ~= 2.0.1
-specfile
+specfile; sys_platform == "linux"
 aiohttp>=3.10.2 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.32.0 # not directly required, pinned by Snyk to avoid a vulnerability
 setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -24,7 +24,6 @@ stomp.py ~= 8.1.0
 tenacity ~= 8.4, != 8.4.0 # https://github.com/jd/tenacity/issues/471
 tomli ~= 2.0.1
 specfile
-awscli
 aiohttp>=3.10.2 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.32.0 # not directly required, pinned by Snyk to avoid a vulnerability
 setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/pyartcd/tests/pipelines/test_gen_assembly.py
+++ b/pyartcd/tests/pipelines/test_gen_assembly.py
@@ -129,13 +129,13 @@ releases:
                                                  base='openshift-4.12', title='Add assembly 4.12.99', body=ANY,
                                                  maintainer_can_modify=True)
 
+    @patch("pyartcd.pipelines.gen_assembly.GenAssemblyPipeline._get_latest_accepted_nightly", return_value="nightly2")
     @patch("pyartcd.pipelines.gen_assembly.GenAssemblyPipeline._create_or_update_pull_request", autospec=True,
            return_value=MagicMock(html_url="https://github.example.com/foo/bar/pull/1234", number=1234))
     @patch("pyartcd.pipelines.gen_assembly.GenAssemblyPipeline._gen_assembly_from_releases", autospec=True)
     @patch("pyartcd.pipelines.gen_assembly.GenAssemblyPipeline._get_nightlies", autospec=True)
     async def test_run(self, get_nightlies: AsyncMock, _gen_assembly_from_releases: AsyncMock,
-                       _create_or_update_pull_request: AsyncMock):
-
+                       _create_or_update_pull_request: AsyncMock, _get_latest_accepted_nightly: AsyncMock):
         os.environ["GITHUB_TOKEN"] = "irrelevant"
 
         runtime = MagicMock(dry_run=False, config={"build_config": {

--- a/pyartcd/tests/test_rebuild_golang_rpms.py
+++ b/pyartcd/tests/test_rebuild_golang_rpms.py
@@ -1,12 +1,14 @@
 import unittest
+import sys
 from unittest import TestCase
 from unittest.mock import MagicMock
 from pyartcd.pipelines.rebuild_golang_rpms import RebuildGolangRPMsPipeline
 
-
 class TestBumpRelease(TestCase):
 
     def setUp(self):
+        if "specfile" not in sys.modules:
+            self.skipTest("specfile is only available on Linux")
         runtime = MagicMock()
         self.pipeline = RebuildGolangRPMsPipeline(runtime, ocp_version="4.17", go_nvrs=["go1.16"], art_jira="JIRA-123",
                                                   cves=None)

--- a/pyartcd/tests/test_rebuild_golang_rpms.py
+++ b/pyartcd/tests/test_rebuild_golang_rpms.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 from pyartcd.pipelines.rebuild_golang_rpms import RebuildGolangRPMsPipeline
 
+
 class TestBumpRelease(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
- Mute unit test warnings (mostly with better mock)
- Eliminate HTTP requests from unit tests (by mocking functions that makes HTTP requests) 
- Minor cleanups

See individual commits for details.