### PR TITLE
Elliott: Fix unit tests that take too much time

### DIFF
--- a/elliott/elliottlib/errata.py
+++ b/elliott/elliottlib/errata.py
@@ -417,7 +417,7 @@ def get_brew_build(nvr, product_version='', session=None) -> brew.Build:
 
     """
     if session is None:
-        session = requests.session()
+        session = requests.Session()
 
     res = session.get(constants.errata_get_build_url.format(id=nvr),
                       verify=ssl.get_default_verify_paths().openssl_cafile,


### PR DESCRIPTION
`test_get_brew_build_failure` has a few issues that causes the execution takes too much time (> 30 seconds):
- `requests.get` is not property mocked, causing actual HTTP requests send to Errata.
- It retries 10 times on error. For each retry it waits for 3 seconds.

This PR fixes the issue and also updates `test_get_brew_build_success` and `test_get_brew_build_success_session` to follow the same pattern.