### PR TITLE
ART-11446: images-health should report only failures

### DIFF
--- a/doozer/doozerlib/cli/images_health.py
+++ b/doozer/doozerlib/cli/images_health.py
@@ -107,6 +107,9 @@ class ImagesHealthPipeline:
             elif latest_success_idx > 1:
                 msg += (f'Last {self.url_text(latest_success_bi_task_url, "success")} '
                         f'was {latest_success_idx} attempts ago')
+            elif latest_success_idx == 1:
+                # Do nothing
+                pass
 
             # Append the Art-Dash link to the message
             msg += f'. {self.url_text(art_dash_link, "Details")}'

--- a/doozer/doozerlib/cli/images_health.py
+++ b/doozer/doozerlib/cli/images_health.py
@@ -109,7 +109,7 @@ class ImagesHealthPipeline:
                         f'was {latest_success_idx} attempts ago')
             elif latest_success_idx == 1:
                 # Do nothing
-                pass
+                return  # skipping notifications when only latest attempt failed
 
             # Append the Art-Dash link to the message
             msg += f'. {self.url_text(art_dash_link, "Details")}'


### PR DESCRIPTION
when there are more than one build