### PR TITLE
ART-11093 use group arches to get rhcos list

### DIFF
--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -401,7 +401,7 @@ class GenAssemblyCli:
         rhcos_el_major = self.runtime.group_config.vars.RHCOS_EL_MAJOR
         rhcos_el_minor = self.runtime.group_config.vars.RHCOS_EL_MINOR
 
-        for arch in self.runtime.arches:
+        for arch in self.runtime.group_config.arches:
             if arch in self.rhcos_by_tag[self.primary_rhcos_tag]:
                 continue
 


### PR DESCRIPTION
When get rhcos arches, use group config arches instead of parameter arches for nightly.
https://redhat-internal.slack.com/archives/GDBRP5YJH/p1734708885038709?thread_ts=1734705090.164539&cid=GDBRP5YJH