### PR TITLE
[konflux] fix missing dir issue

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -798,6 +798,7 @@ class KonfluxRebaser:
         # The config digest is used by scan-sources to detect config changes
         self._logger.debug("Calculating config digest...")
         digest = metadata.calculate_config_digest(self._runtime.group_config, self._runtime.streams)
+        os.makedirs(f"{dest_dir}/.oit")
         with dest_dir.joinpath(".oit", "config_digest").open('w') as f:
             f.write(digest)
         self._logger.info("Saved config digest %s to .oit/config_digest", digest)


### PR DESCRIPTION
Erroring out due to missing .oit folder

Tested, [works](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/1213/console)