### PR TITLE
images-health: look back to latest 30 days

### DIFF
--- a/doozer/doozerlib/cli/images_health.py
+++ b/doozer/doozerlib/cli/images_health.py
@@ -11,7 +11,7 @@ from doozerlib import Runtime
 from doozerlib.cli import cli, pass_runtime, click_coroutine
 from doozerlib.constants import ART_BUILD_HISTORY_URL
 
-DELTA_DAYS = 7  # look at latest 7 days
+DELTA_DAYS = 30  # look at latest 30 days
 
 
 class ImagesHealthPipeline:


### PR DESCRIPTION
Currently, images-health is searching for builds within a 1-week window. This is not enough for images that do not get frequent rebuilds, such as [ose-machine-os-images](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/search?name=ose-machine-os-images&outcome=both&group=openshift-4.15&assembly=stream&after=2024-12-06&engine=brew&art-job-url=). This is causing undesired pings like [this one](https://redhat-internal.slack.com/archives/CB95J6R4N/p1735863147706569)