### PR TITLE
WIP [konflux] new konflux_arches in group config

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -106,7 +106,7 @@ class KonfluxImageBuilder:
             # Start the build
             logger.info("Starting Konflux image build for %s...", metadata.distgit_key)
             retries = 3
-            building_arches = metadata.get_konflux_arches() if  metadata.get_konflux_arches() else metadata.get_arches()
+            building_arches = metadata.get_konflux_arches() if metadata.get_konflux_arches() else metadata.get_arches()
             error = None
             for attempt in range(retries):
                 logger.info("Build attempt %s/%s", attempt + 1, retries)

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -106,7 +106,7 @@ class KonfluxImageBuilder:
             # Start the build
             logger.info("Starting Konflux image build for %s...", metadata.distgit_key)
             retries = 3
-            building_arches = metadata.get_arches()
+            building_arches = metadata.get_konflux_arches() if  metadata.get_konflux_arches() else metadata.get_arches()
             error = None
             for attempt in range(retries):
                 logger.info("Build attempt %s/%s", attempt + 1, retries)

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1025,7 +1025,7 @@ class KonfluxRebaser:
         """
 
         # list of platform (architecture) names to build this image for
-        arches = metadata.get_arches()
+        arches = metadata.get_konflux_arches() if metadata.get_konflux_arches() else metadata.get_arches()
 
         # override image config with this dict
         config_overrides = {}

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -395,7 +395,7 @@ class ConfigScanSources:
         """
         Check if all arches the image should be built for are present in latest build record
         """
-        target_arches = set(image_meta.get_arches())
+        target_arches = set(image_meta.get_konflux_arches() if image_meta.get_konflux_arches() else image_meta.get_arches())
         build_record = self.latest_image_build_records_map[image_meta.distgit_key]
         build_arches = set(build_record.arches)
 

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -297,6 +297,22 @@ class Metadata(object):
         else:
             return list(self.runtime.get_global_arches())
 
+    def get_konflux_arches(self):
+        """
+        :return: Returns the list of architecture this image/rpm should build for, in Konflux. This is an intersection
+        of config specific arches & globally enabled arches in group.yml
+        """
+        if self.config.arches:
+            ca = self.config.arches
+            intersection = list(set(self.runtime.get_konflux_global_arches()) & set(ca))
+            if len(intersection) != len(ca):
+                self.logger.info(f'Arches are being pruned by group.yml. Using computed {intersection} vs config list {ca}')
+            if not intersection:
+                raise ValueError(f'No arches remained enabled in {self.qualified_key}')
+            return intersection
+        else:
+            return list(self.runtime.get_global_arches())
+
     def cgit_atom_feed(self, commit_hash: Optional[str] = None, branch: Optional[str] = None) -> List[CgitAtomFeedEntry]:
         """
         :param commit_hash: Specify to receive an entry for the specific commit (branch ignored if specified).

--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -755,6 +755,12 @@ class Runtime(GroupRuntime):
         """
         return list(self.arches)
 
+    def get_konflux_global_arches(self):
+        """
+        :return: Returns a list of architectures that are enabled globally in group.yml, for Konflux.
+        """
+        return list(self.konflux_arches)
+
     def get_product_config(self) -> Model:
         """
         Returns a Model of the product.yml in ocp-build-data main branch.


### PR DESCRIPTION
We are waiting on the Konflux team to make new flavors of IBM arches (s390x and ppc64le) available to us. Until then, a handful of images are blocked, for each OCP version.

In order to make progress, we can proceed with a single arch payload for now (x86_64), since all images are building for that arch, for OCP 4.19. Once we can craft a successful single arch payload, we can slowly enable other arches.