### PR TITLE
[konflux] increase yarn install timeout

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -813,6 +813,10 @@ class KonfluxRebaser:
                     # we comment that out earlier
                     if line.strip().startswith("&&"):
                         line = line.replace("&&", "RUN", 1)
+
+                    # Due to network flakiness, yarn install commands error out due to insufficient retries.
+                    # So increase timeout to 600000 ms, i.e. 10 mins
+                    line = line.replace("yarn install", "yarn config set network-timeout 600000 && yarn install")
                 updated_lines.append(line)
                 line_commented = False
 


### PR DESCRIPTION
Builds were erroring out due to yarn install timeouts. 

Rebased line example: https://github.com/openshift-priv/networking-console-plugin/blob/art-openshift-4.19-assembly-stream-dgk-networking-console-plugin/Dockerfile#L31