### PR TITLE
KonfluxDB: Always use timezone aware datetime objects

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -141,9 +141,8 @@ class KonfluxDb:
 
         if start_search and end_search and start_search >= end_search:
             raise ValueError(f"start_search {start_search} must be earlier than end_search {end_search}")
-        end_search = end_search or datetime.now(tz=timezone.utc)
-        start_search = start_search or end_search - timedelta(days=DEFAULT_SEARCH_DAYS)
-        start_search = start_search.replace(tzinfo=timezone.utc)
+        end_search = end_search.astimezone(timezone.utc) if end_search else datetime.now(tz=timezone.utc)
+        start_search = start_search.astimezone(timezone.utc) if start_search else end_search - timedelta(days=DEFAULT_SEARCH_DAYS)
         assert window_size is None or window_size > 0, f"search_window {window_size} must be a positive integer"
         window_size = window_size or DEFAULT_SEARCH_WINDOW
 
@@ -247,6 +246,7 @@ class KonfluxDb:
         order_by_clause = Column('start_time', quote=True).desc()
 
         if completed_before:
+            completed_before = completed_before.astimezone(timezone.utc)
             self.logger.info('Searching for %s builds completed before %s', name, completed_before)
             base_clauses.extend([
                 Column('end_time').isnot(None),

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -180,7 +180,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
     @patch('artcommonlib.konflux.konflux_db.datetime')
     @patch('artcommonlib.bigquery.BigQueryClient.query_async')
     async def test_get_latest_build(self, query_mock, datetime_mock):
-        now = datetime(2022, 1, 1, 12, 0, 0)
+        now = datetime(2022, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
         lower_bound = now - 3 * timedelta(days=30)
         datetime_mock.now.return_value = now
 

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -625,19 +625,18 @@ class ConfigScanSources:
         If it's not, query Brew API to get the Brew build result. Querying Brew API will eventually go away.
         """
 
-        try:
-            # Look for the build record in Konflux DB. BigQuery is partitioned by start_time, so we need a reasonable
-            # time interval to look at. In most cases, we can infer the builder build date from its NVR, and use that
-            # as the search window lower boundary. In all other cases (e.g. nodejs builder, which has a NVR like
-            # nodejs-18-container-1-98), we can only use a default, broad search window. This is an expensive query,
-            # so an option might be to store this information in Redis
-            nvr_timestamp = datetime.strptime(isolate_timestamp_in_release(builder_build_nvr), "%Y%m%d%H%M%S")
-            start_search = datetime(nvr_timestamp.year, nvr_timestamp.month, nvr_timestamp.day)
-
-        except TypeError:
+        # Look for the build record in Konflux DB. BigQuery is partitioned by start_time, so we need a reasonable
+        # time interval to look at. In most cases, we can infer the builder build date from its NVR, and use that
+        # as the search window lower boundary. In all other cases (e.g. nodejs builder, which has a NVR like
+        # nodejs-18-container-1-98), we can only use a default, broad search window. This is an expensive query,
+        # so an option might be to store this information in Redis
+        nvr_timestamp = isolate_timestamp_in_release(builder_build_nvr)
+        if nvr_timestamp:
+            start_search = datetime.strptime(nvr_timestamp, "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
+        else:
             # Default search window: last 365 days
             self.logger.warning('Could not extract timestamp from NVR %s', builder_build_nvr)
-            start_search = datetime.now() - timedelta(days=365)
+            start_search = datetime.now(tz=timezone.utc) - timedelta(days=365)
 
         build = await anext(self.runtime.konflux_db.search_builds_by_fields(
             start_search=start_search,


### PR DESCRIPTION
- Move the datetime.replace(tzinfo=…) call from search_builds_by_fields to the scan_sources caller. This function is to force set the timezone for a given datetime object. If it is already timezone aware, it will override its timezone and cause an unexpected timezone change. We should only use it on timezone “naive” objects.
- Use datetime.astimezone() to convert all passed datetime objects into timezone aware objects. This makes sure all datetime calculations are timezone aware, and all datetime objects passed to BigQuery are also timezone aware.