### PR TITLE
Konflux: Use single-arch pipelinerun template to build OLM bundles

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -367,29 +367,32 @@ class KonfluxClient:
         obj["spec"]["timeouts"] = {"pipeline": "12h"}
 
         # Task specific parameters to override in the template
+        has_build_images_task = False
         for task in obj["spec"]["pipelineSpec"]["tasks"]:
             match task["name"]:
                 case "build-images":
+                    has_build_images_task = True
                     task["timeout"] = "12h"
                 case "apply-tags":
                     _modify_param(task["params"], "ADDITIONAL_TAGS", list(additional_tags))
 
         # https://konflux.pages.redhat.com/docs/users/how-tos/configuring/overriding-compute-resources.html
         # ose-installer-artifacts fails with OOM with default values, hence bumping memory limit
-        obj["spec"]["taskRunSpecs"] = [{
-            "pipelineTaskName": "build-images",
-            "stepSpecs": [{
-                "name": "sbom-syft-generate",
-                "computeResources": {
-                    "requests": {
-                        "memory": "5Gi"
-                    },
-                    "limits": {
-                        "memory": "10Gi"
+        if has_build_images_task:
+            obj["spec"]["taskRunSpecs"] = [{
+                "pipelineTaskName": "build-images",
+                "stepSpecs": [{
+                    "name": "sbom-syft-generate",
+                    "computeResources": {
+                        "requests": {
+                            "memory": "5Gi"
+                        },
+                        "limits": {
+                            "memory": "10Gi"
+                        }
                     }
-                }
+                }]
             }]
-        }]
 
         return obj
 

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -31,18 +31,15 @@ class KonfluxClient:
         "aarch64": "linux/arm64",
     }
 
-    def __init__(self, default_namespace: str, config: Configuration, plr_template: str, dry_run: bool = False, logger: logging.Logger = LOGGER) -> None:
+    def __init__(self, default_namespace: str, config: Configuration, dry_run: bool = False, logger: logging.Logger = LOGGER) -> None:
         self.api_client = ApiClient(configuration=config)
         self.dyn_client = DynamicClient(self.api_client)
         self.default_namespace = default_namespace
         self.dry_run = dry_run
         self._logger = logger
 
-        plr_template_owner, plr_template_branch = plr_template.split("@") if plr_template else ["openshift-priv", "main"]
-        self.konflux_plr_template_url = constants.KONFLUX_PlR_TEMPLATE_URL.format(owner=plr_template_owner, branch_name=plr_template_branch)
-
     @staticmethod
-    def from_kubeconfig(default_namespace: str, config_file: Optional[str], context: Optional[str], plr_template: Optional[str], dry_run: bool = False, logger: logging.Logger = LOGGER) -> "KonfluxClient":
+    def from_kubeconfig(default_namespace: str, config_file: Optional[str], context: Optional[str], dry_run: bool = False, logger: logging.Logger = LOGGER) -> "KonfluxClient":
         """ Create a KonfluxClient from a kubeconfig file.
 
         :param config_file: The path to the kubeconfig file.
@@ -50,12 +47,11 @@ class KonfluxClient:
         :param default_namespace: The default namespace.
         :param dry_run: Whether to run in dry-run mode.
         :param logger: The logger.
-        :param plr_template: Override the Pipeline Run template commit from openshift-priv/art-konflux-template
         :return: The KonfluxClient.
         """
         cfg = Configuration()
         config.load_kube_config(config_file=config_file, context=context, persist_config=False, client_configuration=cfg)
-        return KonfluxClient(default_namespace=default_namespace, config=cfg, dry_run=dry_run, logger=logger, plr_template=plr_template)
+        return KonfluxClient(default_namespace=default_namespace, config=cfg, dry_run=dry_run, logger=logger)
 
     @alru_cache
     async def _get_api(self, api_version: str, kind: str):
@@ -308,10 +304,10 @@ class KonfluxClient:
                 return template
 
     async def _new_pipelinerun_for_image_build(self, generate_name: str, namespace: Optional[str], application_name: str, component_name: str,
-                                         git_url: str, commit_sha: str, target_branch: str, output_image: str,
-                                         build_platforms: Sequence[str], git_auth_secret: str = "pipelines-as-code-secret",
-                                         additional_tags: Optional[Sequence[str]] = None, skip_checks: bool = False,
-                                         pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL) -> dict:
+                                               git_url: str, commit_sha: str, target_branch: str, output_image: str,
+                                               build_platforms: Sequence[str], git_auth_secret: str = "pipelines-as-code-secret",
+                                               additional_tags: Optional[Sequence[str]] = None, skip_checks: bool = False,
+                                               pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL) -> dict:
         if additional_tags is None:
             additional_tags = []
         https_url = art_util.convert_remote_git_to_https(git_url)

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -64,7 +64,7 @@ class KonfluxImageBuilder:
     def __init__(self, config: KonfluxImageBuilderConfig, logger: Optional[logging.Logger] = None) -> None:
         self._config = config
         self._logger = logger or LOGGER
-        self._konflux_client = KonfluxClient.from_kubeconfig(default_namespace=config.namespace, config_file=config.kubeconfig, context=config.context, dry_run=config.dry_run, plr_template=config.plr_template)
+        self._konflux_client = KonfluxClient.from_kubeconfig(default_namespace=config.namespace, config_file=config.kubeconfig, context=config.context, dry_run=config.dry_run)
 
         if self._config.image_repo == constants.KONFLUX_DEFAULT_IMAGE_REPO:
             for secret in ["KONFLUX_ART_IMAGES_USERNAME", "KONFLUX_ART_IMAGES_PASSWORD"]:
@@ -211,7 +211,8 @@ class KonfluxImageBuilder:
             building_arches=building_arches,
             additional_tags=additional_tags,
             skip_checks=self._config.skip_checks,
-            vm_override=metadata.config.get("konflux", {}).get("vm_override")
+            vm_override=metadata.config.get("konflux", {}).get("vm_override"),
+            pipelinerun_template_url=self._config.plr_template,
         )
 
         logger.info(f"Created PipelineRun: {self.build_pipeline_url(pipelinerun)}")

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -375,6 +375,7 @@ class KonfluxOlmBundleBuilder:
                  konflux_context: Optional[str] = None,
                  image_repo: str = constants.KONFLUX_DEFAULT_IMAGE_REPO,
                  skip_checks: bool = False,
+                 pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_BUNDLE_BUILD_PLR_TEMPLATE_URL,
                  dry_run: bool = False,
                  logger: logging.Logger = _LOGGER) -> None:
         self.base_dir = base_dir
@@ -387,9 +388,10 @@ class KonfluxOlmBundleBuilder:
         self.konflux_context = konflux_context
         self.image_repo = image_repo
         self.skip_checks = skip_checks
+        self.pipelinerun_template_url = pipelinerun_template_url
         self.dry_run = dry_run
         self._logger = logger
-        self._konflux_client = KonfluxClient.from_kubeconfig(self.konflux_namespace, self.konflux_kubeconfig, self.konflux_context, plr_template=None, dry_run=self.dry_run)
+        self._konflux_client = KonfluxClient.from_kubeconfig(self.konflux_namespace, self.konflux_kubeconfig, self.konflux_context, dry_run=self.dry_run)
 
     async def build(self, metadata: ImageMetadata):
         """ Build a bundle with Konflux. """
@@ -517,6 +519,7 @@ class KonfluxOlmBundleBuilder:
             building_arches=["x86_64"],  # We always build bundles on x86_64
             additional_tags=list(additional_tags),
             skip_checks=skip_checks,
+            pipelinerun_template_url=self.pipelinerun_template_url,
         )
         url = konflux_client.build_pipeline_url(pipelinerun)
         logger.info(f"PipelineRun {pipelinerun.metadata.name} created: {url}")

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -135,7 +135,7 @@ class KonfluxBuildCli:
         image_repo: str,
         skip_checks: bool,
         dry_run: bool,
-        plr_template,
+        plr_template: str,
     ):
         self.runtime = runtime
         self.konflux_kubeconfig = konflux_kubeconfig
@@ -188,13 +188,13 @@ class KonfluxBuildCli:
 @click.option('--image-repo', default=constants.KONFLUX_DEFAULT_IMAGE_REPO, help='Push images to the specified repo.')
 @click.option('--skip-checks', default=False, is_flag=True, help='Skip all post build checks')
 @click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
-@click.option('--plr-template', required=False, default='',
-              help='Override the Pipeline Run template commit from openshift-priv/art-konflux-template')
+@click.option('--plr-template', required=False, default=constants.KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL,
+              help='Use a custom PipelineRun template to build the bundle. Overrides the default template from openshift-priv/art-konflux-template')
 @pass_runtime
 @click_coroutine
 async def images_konflux_build(
         runtime: Runtime, konflux_kubeconfig: Optional[str], konflux_context: Optional[str],
-        konflux_namespace: str, image_repo: str, skip_checks: bool, dry_run: bool, plr_template):
+        konflux_namespace: str, image_repo: str, skip_checks: bool, dry_run: bool, plr_template: str):
     cli = KonfluxBuildCli(
         runtime=runtime, konflux_kubeconfig=konflux_kubeconfig,
         konflux_context=konflux_context, konflux_namespace=konflux_namespace,
@@ -215,6 +215,7 @@ class KonfluxBundleCli:
         image_repo: str,
         skip_checks: bool,
         release: Optional[str],
+        plr_template: str,
     ):
         self.runtime = runtime
         self.operator_nvrs = list(operator_nvrs)
@@ -226,6 +227,7 @@ class KonfluxBundleCli:
         self.image_repo = image_repo
         self.skip_checks = skip_checks
         self.release = release
+        self.plr_template = plr_template
 
     async def get_operator_builds(self):
         """ Get build records for the given operator nvrs or latest build records for all operators.
@@ -348,6 +350,7 @@ class KonfluxBundleCli:
             konflux_context=self.konflux_context,
             image_repo=self.image_repo,
             skip_checks=self.skip_checks,
+            pipelinerun_template_url=self.plr_template,
             dry_run=self.dry_run,
         )
 
@@ -380,15 +383,18 @@ class KonfluxBundleCli:
 @click.option('--image-repo', default=constants.KONFLUX_DEFAULT_IMAGE_REPO, help='Push images to the specified repo.')
 @click.option('--skip-checks', default=False, is_flag=True, help='Skip all post build checks')
 @click.option("--release", metavar='RELEASE', help="Release string to populate in bundle's Dockerfiles.")
+@click.option('--plr-template', required=False, default=constants.KONFLUX_DEFAULT_BUNDLE_BUILD_PLR_TEMPLATE_URL,
+              help='Use a custom PipelineRun template to build the bundle. Overrides the default template from openshift-priv/art-konflux-template')
 @pass_runtime
 @click_coroutine
 async def images_konflux_bundle(
         runtime: Runtime, operator_nvrs: Tuple[str, ...], force: bool, dry_run: bool,
         konflux_kubeconfig: Optional[str], konflux_context: Optional[str],
-        konflux_namespace: str, image_repo: str, skip_checks: bool, release: Optional[str]):
+        konflux_namespace: str, image_repo: str, skip_checks: bool, release: Optional[str],
+        plr_template: str):
     cli = KonfluxBundleCli(
         runtime=runtime, operator_nvrs=operator_nvrs, force=force, dry_run=dry_run,
         konflux_kubeconfig=konflux_kubeconfig, konflux_context=konflux_context,
         konflux_namespace=konflux_namespace, image_repo=image_repo, skip_checks=skip_checks,
-        release=release)
+        release=release, plr_template=plr_template)
     await cli.run()

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -39,7 +39,8 @@ ART_PROD_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
 KONFLUX_UI_HOST = "https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com"
 KONFLUX_UI_DEFAULT_WORKSPACE = "ocp-art"  # associated with ocp-art-tenant
 MAX_KONFLUX_BUILD_QUEUE_SIZE = 25  # how many concurrent Konflux pipeline can we spawn per OCP version?
-KONFLUX_PlR_TEMPLATE_URL = "https://raw.githubusercontent.com/{owner}/art-konflux-template/refs/heads/{branch_name}/.tekton/art-konflux-template-push.yaml"  # Konflux PipelineRun (PLR) template
+KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL = "https://github.com/openshift-priv/art-konflux-template/raw/refs/heads/main/.tekton/art-konflux-template-push.yaml"
+KONFLUX_DEFAULT_BUNDLE_BUILD_PLR_TEMPLATE_URL = "https://github.com/openshift-priv/art-konflux-template/raw/refs/heads/main/.tekton/art-bundle-konflux-template-push.yaml"
 
 REGISTRY_PROXY_BASE_URL = "registry-proxy.engineering.redhat.com"
 BREW_REGISTRY_BASE_URL = "brew.registry.redhat.io"

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -9,6 +9,7 @@ from artcommonlib.konflux.konflux_build_record import (
     KonfluxBuildOutcome, KonfluxBundleBuildRecord)
 from artcommonlib.konflux.konflux_db import Engine
 
+from doozerlib import constants
 from doozerlib.backend.konflux_olm_bundler import (KonfluxOlmBundleBuilder,
                                                    KonfluxOlmBundleRebaser)
 
@@ -582,6 +583,7 @@ class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
             building_arches=["x86_64"],
             additional_tags=additional_tags,
             skip_checks=self.skip_checks,
+            pipelinerun_template_url=constants.KONFLUX_DEFAULT_BUNDLE_BUILD_PLR_TEMPLATE_URL,
         )
         self.assertEqual(url, "https://example.com/pipelinerun")
 

--- a/pyartcd/pyartcd/constants.py
+++ b/pyartcd/pyartcd/constants.py
@@ -48,3 +48,5 @@ UMB_BROKERS = {
 }
 
 GITHUB_OWNER = "openshift-eng"
+
+KONFLUX_IMAGE_BUILD_PLR_TEMPLATE_URL_FORMAT = "https://raw.githubusercontent.com/{owner}/art-konflux-template/refs/heads/{branch_name}/.tekton/art-konflux-template-push.yaml"  # Konflux PipelineRun (PLR) template

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -143,7 +143,9 @@ class KonfluxOcp4Pipeline:
         if self.kubeconfig:
             cmd.extend(['--konflux-kubeconfig', self.kubeconfig])
         if self.plr_template:
-            cmd.extend(['--plr-template', self.plr_template])
+            plr_template_owner, plr_template_branch = self.plr_template.split("@") if self.plr_template else ["openshift-priv", "main"]
+            plr_template_url = constants.KONFLUX_IMAGE_BUILD_PLR_TEMPLATE_URL_FORMAT.format(owner=plr_template_owner, branch_name=plr_template_branch)
+            cmd.extend(['--plr-template', plr_template_url])
         if self.runtime.dry_run:
             cmd.append('--dry-run')
         await exectools.cmd_assert_async(cmd)
@@ -245,7 +247,7 @@ class KonfluxOcp4Pipeline:
 @click.option("--arch", "arches", metavar="TAG", multiple=True,
               help="(Optional) [MULTIPLE] Limit included arches to this list")
 @click.option('--plr-template', required=False, default='',
-              help='Override the Pipeline Run template commit from openshift-priv/art-konflux-template')
+              help='Override the Pipeline Run template commit from openshift-priv/art-konflux-template; format: <owner>@<branch>')
 @pass_runtime
 @click_coroutine
 async def ocp4(runtime: Runtime, image_build_strategy: str, image_list: Optional[str], assembly: str,


### PR DESCRIPTION
Per
https://konflux.pages.redhat.com/docs/users/getting-started/building-olm-products.html#_building_file_based_catalog_fbc_components,
we have to build OLM bundles using the single-arch pipelinerun template.

This PR contains multiple commits for fixing some minor issues with using different templates. See the commit message of each commit.