### PR TITLE
[Konflux] Add fbc:import command to create FBC from published index

### DIFF
--- a/doozer/doozerlib/backend/build_repo.py
+++ b/doozer/doozerlib/backend/build_repo.py
@@ -1,10 +1,14 @@
+import asyncio
 import logging
 import shutil
 from pathlib import Path
-from typing import Optional, Union
+from typing import List, Optional, Sequence, Union, cast
 
 from artcommonlib import git_helper, exectools
 from artcommonlib import util as art_util
+from doozerlib import constants
+from doozerlib.image import ImageMetadata
+from doozerlib.source_resolver import SourceResolution
 
 LOGGER = logging.getLogger(__name__)
 
@@ -17,7 +21,7 @@ class BuildRepo:
                  url: str,
                  branch: Optional[str],
                  local_dir: Union[str, Path],
-                 logger: Optional[logging.Logger]) -> None:
+                 logger: Optional[logging.Logger] = None) -> None:
         """ Initialize a BuildRepo object.
         :param url: The URL of the build source repository.
         :param branch: The branch of the build source repository to clone. None to not switch to any branch.

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -425,6 +425,7 @@ class KonfluxClient:
         :param git_auth_secret: The git auth secret.
         :param additional_tags: Additional tags to apply to the image.
         :param skip_checks: Whether to skip checks.
+        :param pipelinerun_template_url: The URL to the PipelineRun template.
         :return: The PipelineRun resource.
         """
         unsupported_arches = set(building_arches) - set(self.SUPPORTED_ARCHES)

--- a/doozer/doozerlib/cli/__main__.py
+++ b/doozer/doozerlib/cli/__main__.py
@@ -39,6 +39,7 @@ from doozerlib.cli.images import images_clone, images_list, images_push_distgit,
     images_print, distgit_config_template, query_rpm_version
 from doozerlib.cli.images_konflux import images_konflux_rebase
 from doozerlib.cli.images_konflux import images_konflux_build
+from doozerlib.cli.fbc import fbc_import
 
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.util import analyze_debug_timing

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -1,0 +1,182 @@
+import asyncio
+import logging
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+import click
+
+from doozerlib import opm
+from doozerlib.cli import cli, click_coroutine, pass_runtime
+from doozerlib.image import ImageMetadata
+from doozerlib.runtime import Runtime
+from doozerlib.source_resolver import SourceResolver
+
+LOGGER = logging.getLogger(__name__)
+yaml = opm.yaml
+
+PRODUCTION_INDEX_PULLSPEC_FORMAT = "registry.redhat.io/redhat/redhat-operator-index:v{major}.{minor}"
+BASE_IMAGE_RHEL9_PULLSPEC_FORMAT = "registry.redhat.io/openshift4/ose-operator-registry-rhel9:v{major}.{minor}"
+BASE_IMAGE_RHEL8_PULLSPEC_FORMAT = "registry.redhat.io/openshift4/ose-operator-registry:v{major}.{minor}"
+
+
+class FbcImportCli:
+    def __init__(self, runtime: Runtime, index_image: str | None, dest_dir: str):
+        self.runtime = runtime
+        self.index_image = index_image
+        self.dest_dir = dest_dir
+
+    async def run(self):
+        """ Run the FBC import process
+        This function implements the main logic of the FBC import process
+        following https://github.com/konflux-ci/olm-operator-konflux-sample/blob/main/docs/konflux-onboarding.md#create-the-fbc-in-the-git-repository.
+        """
+        # Ensure opm is installed
+        try:
+            await opm.verify_opm()
+        except (IOError, FileNotFoundError):
+            LOGGER.error("Please install the latest opm cli binary from https://github.com/operator-framework/operator-registry/releases")
+            raise
+
+        # Initialize runtime
+        runtime = self.runtime
+        runtime.initialize(mode="images", clone_distgits=False)
+        if "MAJOR" not in runtime.group_config.vars or "MINOR" not in runtime.group_config.vars:
+            raise ValueError("MAJOR and MINOR vars must be set in group config")
+        major = runtime.group_config.vars.MAJOR
+        minor = runtime.group_config.vars.MINOR
+        source_resolver = runtime.source_resolver
+        assert source_resolver, "source_resolver is not set; Doozer bug?"
+        if not self.index_image:
+            self.index_image = PRODUCTION_INDEX_PULLSPEC_FORMAT.format(major=major, minor=minor)
+
+        # Load package.yaml files and operator index image
+        base_dir = Path(self.dest_dir)
+        base_dir.mkdir(parents=True, exist_ok=True)
+        operator_metas: List[ImageMetadata] = [operator_meta for operator_meta in runtime.ordered_image_metas() if operator_meta.is_olm_operator]
+
+        LOGGER.info("Loading package.yaml files and remote operator index image...")
+        package_names, org_catalog_blobs = await asyncio.gather(
+            self.load_package_names(operator_metas, source_resolver),
+            opm.render(self.index_image),
+        )
+
+        LOGGER.info("Filtering catalog blobs...")
+        org_catalog_blobs = self.filter_catalog_blobs(org_catalog_blobs, set(package_names))
+
+        # Write catalog_blobs to catalog-migrate/<package>/catalog.json
+        LOGGER.info("Writing original catalog blobs to catalog-migrate")
+        org_catalog_dir = base_dir.joinpath("catalog-migrate")
+        org_catalog_dir.mkdir(parents=True, exist_ok=True)
+        org_catalog_files: Dict[str, Path] = {}  # key is package name, value is catalog file path
+        for package_name, blobs in org_catalog_blobs.items():
+            org_catalog_subdir = org_catalog_dir.joinpath(package_name)
+            org_catalog_subdir.mkdir(parents=True, exist_ok=True)
+            org_catalog_file = org_catalog_subdir.joinpath("catalog.yaml")
+            with org_catalog_file.open('w') as f:
+                yaml.dump_all(blobs, f)
+                # for blob in blobs:
+                #     json.dump(blob, f, indent=2)
+            org_catalog_files[package_name] = org_catalog_file
+
+        # Generate basic fbc templates to catalog-templates/<package>.yaml
+        LOGGER.info("Generating basic FBC templates")
+        templates_dir = base_dir.joinpath("catalog-templates")
+        templates_dir.mkdir(parents=True, exist_ok=True)
+        template_files: Dict[str, Path] = {}  # key is package name, value is template file path
+        tasks = []
+        for package_name, org_catalog_file in org_catalog_files.items():
+            template_file = templates_dir.joinpath(f"{package_name}.yaml")
+            tasks.append(asyncio.create_task(opm.generate_basic_template(org_catalog_file, template_file)))
+            template_files[package_name] = template_file
+        await asyncio.gather(*tasks)
+
+        LOGGER.info("Cleaning up catalog-migrate")
+        shutil.rmtree(org_catalog_dir)
+
+        # Render final FBC catalogs from templates at catalog/<package>/catalog.yaml
+        LOGGER.info("Rendering final FBC catalogs")
+        migrate_level = "none"
+        if (major, minor) >= (4, 17):
+            migrate_level = "bundle-object-to-csv-metadata"
+        catalog_dir = base_dir.joinpath("catalog")
+        catalog_dir.mkdir(parents=True, exist_ok=True)
+        tasks = []
+        for package_name, template_file in template_files.items():
+            catalog_subdir = catalog_dir.joinpath(package_name)
+            catalog_subdir.mkdir(parents=True, exist_ok=True)
+            catalog_file = catalog_subdir.joinpath("catalog.yaml")
+            LOGGER.info("Rendering catalog %s", catalog_file)
+            tasks.append(asyncio.create_task(opm.render_catalog_from_template(template_file, catalog_file, migrate_level=migrate_level)))
+        await asyncio.gather(*tasks)
+
+        # Generate Dockerfile
+        LOGGER.info("Generating Dockerfile")
+        base_image_format = BASE_IMAGE_RHEL9_PULLSPEC_FORMAT if (major, minor) > (4, 15) else BASE_IMAGE_RHEL8_PULLSPEC_FORMAT
+        base_image = base_image_format.format(major=major, minor=minor)
+        await opm.generate_dockerfile(base_dir, "catalog", base_image=base_image, builder_image=base_image)
+
+    async def load_package_names(self, operator_metas: List[ImageMetadata], source_resolver: SourceResolver) -> List[str]:
+        """ Load OLM package names for operator images.
+        This function loads OLM package names for operator images by resolving sources and loading package.yaml files.
+
+        :param operator_metas: List of operator image metadata.
+        :param source_resolver: SourceResolver instance.
+        :return: List of OLM package names.
+        """
+        package_names: List[str] = []
+        sources = await asyncio.gather(*(asyncio.to_thread(source_resolver.resolve_source, operator_meta) for operator_meta in operator_metas))
+        for operator_meta, source in zip(operator_metas, sources):
+            source_dir = source_resolver.get_source_dir(source, operator_meta)
+            csv_config = operator_meta.config.get('update-csv')
+            if not csv_config:
+                raise ValueError(f"update-csv config not found for {operator_meta.distgit_key}")
+            source_path = source_dir.joinpath(csv_config['manifests-dir'])
+            package_yaml_file = next(source_path.glob('**/*package.yaml'))
+            with package_yaml_file.open() as f:
+                package_yaml = yaml.load(f)
+            package_name = str(package_yaml['packageName'])
+            package_names.append(package_name)
+        return package_names
+
+    def filter_catalog_blobs(self, blobs: List[Dict], allowed_package_names: Set[str]):
+        """ Filter catalog blobs by package names.
+
+        :param blobs: List of catalog blobs.
+        :param allowed_package_names: Set of allowed package names.
+        :return: Dict of filtered catalog blobs.
+        """
+        filtered: Dict[str, List[Dict[str, Any]]] = {}  # key is package name, value is blobs
+        for blob in blobs:
+            schema = blob["schema"]
+            package_name = None
+            match schema:
+                case "olm.package":
+                    package_name = blob["name"]
+                case "olm.channel" | "olm.bundle" | "olm.deprecations":
+                    package_name = blob["package"]
+            if not package_name:
+                raise IOError(f"Couldn't determine package name for unknown schema: {schema}")
+            if package_name not in allowed_package_names:
+                continue  # filtered out; skipping
+            if package_name not in filtered:
+                filtered[package_name] = []
+            filtered[package_name].append(blob)
+        return filtered
+
+
+@cli.command("beta:fbc:import", short_help="Create FBC by importing from the provided index image")
+@click.option("--from-index", metavar='INDEX_IMAGE', help="The index image to import from")
+@click.argument("dest_dir", metavar='DEST_DIR', default=".")
+@pass_runtime
+@click_coroutine
+async def fbc_import(runtime: Runtime, from_index: Optional[str], dest_dir: str):
+    """
+    Create an FBC repository by importing from the provided index image
+
+    Example usage:
+
+    doozer --group=openshift-4.17 beta:fbc:import registry.redhat.io/redhat/redhat-operator-index:v4.17 ./fbc-4.17
+    """
+    cli = FbcImportCli(runtime=runtime, index_image=from_index, dest_dir=dest_dir)
+    await cli.run()

--- a/doozer/doozerlib/opm.py
+++ b/doozer/doozerlib/opm.py
@@ -1,0 +1,96 @@
+from io import StringIO
+import logging
+import re
+from pathlib import Path
+
+from ruamel.yaml import YAML
+from artcommonlib import exectools
+from semver import VersionInfo
+
+LOGGER = logging.getLogger(__name__)
+yaml = YAML(typ='safe')
+yaml.default_flow_style = False
+
+
+async def verify_opm():
+    """ Verify that opm is installed and at least version 1.47.0 """
+    try:
+        _, out, _ = await exectools.cmd_gather_async(["opm", "version"])
+    except FileNotFoundError:
+        raise FileNotFoundError("opm binary not found.")
+    m = re.search(r"OpmVersion:\"v([^\"]+)\"", out)
+    if not m:
+        raise IOError(f"Failed to parse opm version: {out}")
+    version = VersionInfo.parse(m.group(1))
+    if version < VersionInfo(1, 47, 0):
+        raise IOError(f"opm version {version} is too old. Please upgrade to at least 1.47.0.")
+
+
+async def render(catalog: str, output_format: str = "yaml"):
+    """
+    Run `opm render` on the given index and return the parsed file-based catalog blobs.
+
+    :param catalog: The catalog to render.
+    :param output_format: The output format to use when rendering the catalog. One of "yaml" or "json".
+    """
+    if output_format not in ["yaml", "json"]:
+        raise ValueError(f"Invalid output format: {output_format}")
+    LOGGER.debug(f"Rendering catalog {catalog}")
+    _, out, _ = await exectools.cmd_gather_async(["opm", "render", "-o", "yaml", "--", catalog])
+    blobs = yaml.load_all(StringIO(out))
+    return blobs
+
+
+async def generate_basic_template(catalog_file: Path, template_file: Path, output_format: str = "yaml"):
+    """
+    Generate a basic FBC template from a catalog file.
+
+    :param catalog_file: The catalog file to generate the template from.
+    :param template_file: The file to write the template to.
+    :param output_format: The output format to use when generating the template. One of "yaml" or "json".
+    """
+    if output_format not in ["yaml", "json"]:
+        raise ValueError(f"Invalid output format: {output_format}")
+    LOGGER.debug(f"Generating basic template {template_file} from {catalog_file}")
+    with open(template_file, 'w') as out:
+        await exectools.cmd_assert_async([
+            "opm", "alpha", "convert-template", "basic", "-o", output_format, "--", str(catalog_file),
+        ], stdout=out)
+
+
+async def render_catalog_from_template(template_file: Path, catalog_file: Path, migrate_level: str = "none", output_format: str = "yaml"):
+    """
+    Render a catalog from a template file.
+
+    :param template_file: The template file to render.
+    :param catalog_file: The file to write the rendered catalog to.
+    :param migrate_level: The migration level to use when rendering the catalog.
+    :param output_format: The output format to use when rendering the catalog. One of "yaml" or "json".
+    """
+    if migrate_level not in ["none", "bundle-object-to-csv-metadata"]:
+        raise ValueError(f"Invalid migrate level: {migrate_level}")
+    if output_format not in ["yaml", "json"]:
+        raise ValueError(f"Invalid output format: {output_format}")
+    LOGGER.debug(f"Rendering catalog {catalog_file} from template {template_file}")
+    with open(catalog_file, 'w') as out:
+        await exectools.cmd_assert_async([
+            "opm", "alpha", "render-template", "basic", "--migrate-level", migrate_level, "-o", output_format, "--", str(template_file),
+        ], stdout=out)
+
+
+async def generate_dockerfile(dest_dir: Path, dc_dir_name: str, base_image: str, builder_image: str):
+    """
+    Generate a Dockerfile for for a file-based catalog.
+
+    :param dest_dir: The directory to generate the Dockerfile in.
+    :param dc_dir_name: The directory containing the file-based catalog.
+    :param base_image: Image base to use to build catalog.
+    """
+    options = [
+        "--builder-image", builder_image,
+        "--base-image", base_image,
+    ]
+    LOGGER.debug(f"Generating FBC Dockerfile in {dest_dir}")
+    await exectools.cmd_assert_async(
+        ["opm", "generate", "dockerfile"] + options + ["--", dc_dir_name],
+        cwd=dest_dir)

--- a/doozer/tests/cli/test_fbc.py
+++ b/doozer/tests/cli/test_fbc.py
@@ -1,0 +1,88 @@
+import unittest
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+from artcommonlib.model import Model
+
+from doozerlib.cli.fbc import FbcImportCli
+from doozerlib.runtime import Runtime
+from doozerlib.source_resolver import SourceResolver
+
+
+class TestFbcImportCli(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.runtime = mock.Mock(spec=Runtime)
+        self.runtime.group_config.vars = Model({"MAJOR": 4, "MINOR": 17})
+        self.runtime.working_dir = "/tmp"
+        self.runtime.source_resolver = mock.Mock(spec=SourceResolver)
+        self.fbc_import_cli = FbcImportCli(runtime=self.runtime, index_image=None, dest_dir="/tmp/fbc")
+
+    async def test_run(self):
+        self.runtime.ordered_image_metas.return_value = [
+            mock.Mock(is_olm_operator=True, distgit_key="foo", **{"get_olm_bundle_short_name.return_value": "foo-bundle"}),
+        ]
+        with mock.patch("doozerlib.opm.verify_opm", return_value=None), \
+                mock.patch("doozerlib.opm.render", return_value=[]), \
+                mock.patch("doozerlib.opm.generate_basic_template", return_value=None), \
+                mock.patch("doozerlib.opm.render_catalog_from_template", return_value=None), \
+                mock.patch("doozerlib.opm.generate_dockerfile", return_value=None), \
+                mock.patch("doozerlib.cli.fbc.FbcImportCli.load_package_names", return_value=["foo-package", "bar-package"]), \
+                mock.patch("shutil.rmtree", return_value=None):
+            await self.fbc_import_cli.run()
+
+    @mock.patch("pathlib.Path.open")
+    @mock.patch("pathlib.Path.glob")
+    async def test_load_package_names(self, mock_glob, mock_open):
+        operator_metas = [
+            mock.Mock(distgit_key="foo", **{
+                "get_olm_bundle_short_name.return_value": "foo-bundle",
+                "config": {"update-csv": {"manifests-dir": "manifests/"}},
+            }),
+            mock.Mock(distgit_key="bar", **{
+                "get_olm_bundle_short_name.return_value": "bar-bundle",
+                "config": {"update-csv": {"manifests-dir": "manifests/"}},
+            }),
+        ]
+        source_resolver = mock.Mock(spec=SourceResolver)
+        source_resolver.get_source_dir.side_effect = [
+            Path("/path/to/sources/foo/"),
+            Path("/path/to/sources/bar/"),
+        ]
+        source_resolver.resolve_source.side_effect = [
+            {"package.yaml": {"name": "foo-package"}},
+            {"package.yaml": {"name": "bar-package"}},
+        ]
+        mock_glob.side_effect = [
+            iter([Path("/path/to/sources/foo/manifests/foo-package.yaml")]),
+            iter([Path("/path/to/sources/foo/manifests/bar-package.yaml")]),
+        ]
+        mock_open.return_value.__enter__.side_effect = [
+            StringIO("packageName: foo-package"),
+            StringIO("packageName: bar-package"),
+        ]
+        package_names = await self.fbc_import_cli.load_package_names(operator_metas, source_resolver)
+        self.assertListEqual(package_names, ["foo-package", "bar-package"])
+
+    def test_filter_catalog_blobs(self):
+        blobs = [
+            {"schema": "olm.package", "name": "package1"},
+            {"schema": "olm.channel", "package": "package1"},
+            {"schema": "olm.bundle", "package": "package2"},
+            {"schema": "olm.deprecations", "package": "package3"},
+        ]
+        allowed_package_names = {"package1", "package2"}
+        filtered = self.fbc_import_cli.filter_catalog_blobs(blobs, allowed_package_names)
+        self.assertIn("package1", filtered)
+        self.assertIn("package2", filtered)
+        self.assertNotIn("package3", filtered)
+        self.assertEqual(len(filtered["package1"]), 2)
+        self.assertEqual(len(filtered["package2"]), 1)
+
+        blobs = [
+            {"schema": "olm.package", "name": "package1"},
+            {"schema": "unknown.schema"},
+        ]
+        with self.assertRaises(IOError, msg="Couldn't determine package name for unknown schema: unknown.schema"):
+            self.fbc_import_cli.filter_catalog_blobs(blobs, allowed_package_names)

--- a/doozer/tests/test_opm.py
+++ b/doozer/tests/test_opm.py
@@ -1,0 +1,65 @@
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from doozerlib.opm import (generate_basic_template, generate_dockerfile,
+                           render, render_catalog_from_template, verify_opm)
+
+
+class TestOpm(unittest.IsolatedAsyncioTestCase):
+
+    @patch('doozerlib.opm.exectools.cmd_gather_async', new_callable=AsyncMock)
+    async def test_verify_opm(self, mock_cmd_gather_async):
+        mock_cmd_gather_async.return_value = (0, 'OpmVersion:"v1.47.0"', '')
+        await verify_opm()
+        mock_cmd_gather_async.assert_called_once_with(['opm', 'version'])
+
+        mock_cmd_gather_async.return_value = (0, 'OpmVersion:"v1.46.0"', '')
+        with self.assertRaises(IOError, msg="opm version 1.46.0 is too old. Please upgrade to at least 1.47.0."):
+            await verify_opm()
+
+        mock_cmd_gather_async.side_effect = FileNotFoundError
+        with self.assertRaises(FileNotFoundError, msg="opm binary not found. Please install opm."):
+            await verify_opm()
+
+    @patch('doozerlib.opm.exectools.cmd_gather_async', new_callable=AsyncMock)
+    async def test_render(self, mock_cmd_gather_async):
+        mock_cmd_gather_async.return_value = (0, '---\nkey: value\n', '')
+        blobs = await render('test-catalog')
+        self.assertEqual(list(blobs), [{'key': 'value'}])
+        mock_cmd_gather_async.assert_called_once_with(['opm', 'render', '-o', 'yaml', '--', 'test-catalog'])
+
+    @patch("builtins.open")
+    @patch('doozerlib.opm.exectools.cmd_assert_async', new_callable=AsyncMock)
+    async def test_generate_basic_template(self, mock_cmd_assert_async, mock_open):
+        catalog_file = Path('/path/to/catalog.yaml')
+        template_file = Path('/path/to/template.yaml')
+        await generate_basic_template(catalog_file, template_file)
+        mock_cmd_assert_async.assert_called_once_with([
+            'opm', 'alpha', 'convert-template', 'basic', '-o', 'yaml', '--', str(catalog_file)
+        ], stdout=mock_open.return_value.__enter__.return_value)
+
+    @patch("builtins.open")
+    @patch('doozerlib.opm.exectools.cmd_assert_async', new_callable=AsyncMock)
+    async def test_render_catalog_from_template(self, mock_cmd_assert_async, mock_open):
+        template_file = Path('/path/to/template.yaml')
+        catalog_file = Path('/path/to/catalog.yaml')
+        await render_catalog_from_template(template_file, catalog_file)
+        mock_cmd_assert_async.assert_called_once_with([
+            'opm', 'alpha', 'render-template', 'basic', '--migrate-level', 'none', '-o', 'yaml', '--', str(template_file)
+        ], stdout=mock_open.return_value.__enter__.return_value)
+
+        with self.assertRaises(ValueError, msg="Invalid migrate level: invalid"):
+            await render_catalog_from_template(template_file, catalog_file, migrate_level='invalid')
+
+    @patch('doozerlib.opm.exectools.cmd_assert_async', new_callable=AsyncMock)
+    async def test_generate_dockerfile(self, mock_cmd_assert_async):
+        dest_dir = Path('/path/to/dest')
+        dc_dir_name = 'dc-dir'
+        base_image = 'base-image'
+        builder_image = 'builder-image'
+        await generate_dockerfile(dest_dir, dc_dir_name, base_image, builder_image)
+        mock_cmd_assert_async.assert_called_once_with(
+            ['opm', 'generate', 'dockerfile', '--builder-image', builder_image, '--base-image', base_image, '--', dc_dir_name],
+            cwd=dest_dir
+        )


### PR DESCRIPTION
This command implements the procedule described in https://github.com/konflux-ci/olm-operator-konflux-sample/blob/main/docs/konflux-onboarding.md#create-the-fbc-in-the-git-repository to create an FBC repo from a given published index. Non-ART managed OLM packages will be filtered out.

Test command:

```
doozer --debug --group=openshift-4.17 beta:fbc:import --from-index=registry.redhat.io/redhat/redhat-operator-index:v4.17 ./fbc-4.17
```