### PR TITLE
Rename medatata.get_latest_build into get_latest_brew_build

### DIFF
--- a/doozer/doozerlib/assembly_inspector.py
+++ b/doozer/doozerlib/assembly_inspector.py
@@ -48,7 +48,7 @@ class AssemblyInspector:
         # If an image component has a latest build, an ImageInspector associated with the image.
         self._release_image_inspectors: Dict[str, Optional[BrewBuildImageInspector]] = dict()
         for image_meta in runtime.get_for_release_image_metas():
-            latest_build_obj = image_meta.get_latest_build(default=None, el_target=image_meta.branch_el_target())
+            latest_build_obj = image_meta.get_latest_brew_build(default=None, el_target=image_meta.branch_el_target())
             if latest_build_obj:
                 self._release_image_inspectors[image_meta.distgit_key] = BrewBuildImageInspector(self.runtime, latest_build_obj['nvr'])
             else:
@@ -424,7 +424,7 @@ class AssemblyInspector:
             # Maps of component names to the latest brew build dicts. If there is no latest build, the value will be None
             for rpm_meta in self.runtime.rpm_metas():
                 if el_ver in rpm_meta.determine_rhel_targets():
-                    latest_build = rpm_meta.get_latest_build(default=None, el_target=el_ver)
+                    latest_build = rpm_meta.get_latest_brew_build(default=None, el_target=el_ver)
                     if not latest_build:
                         raise IOError(f'RPM {rpm_meta.distgit_key} claims to have a rhel-{el_ver} build target, but no build was detected')
                     assembly_rpm_dicts[rpm_meta.distgit_key] = latest_build

--- a/doozer/doozerlib/build_status_detector.py
+++ b/doozer/doozerlib/build_status_detector.py
@@ -143,7 +143,7 @@ class BuildStatusDetector:
                 # We need to check any group members for their latest build in the
                 # current assembly. This may be different than what is in the tag.
                 for rpm_meta in self.runtime.rpm_metas():
-                    assembly_build_dict = rpm_meta.get_latest_build(default=None, el_target=candidate_tag)
+                    assembly_build_dict = rpm_meta.get_latest_brew_build(default=None, el_target=candidate_tag)
                     if not assembly_build_dict:
                         # Likely this RPM has not been built for this RHEL version.
                         continue

--- a/doozer/doozerlib/cli/olm_bundle.py
+++ b/doozer/doozerlib/cli/olm_bundle.py
@@ -84,7 +84,7 @@ def olm_bundles_print(runtime: Runtime, skip_missing, pattern: Optional[str]):
         s = s.replace("{distgit_key}", image.distgit_key)
         s = s.replace("{component}", image.get_component_name())
 
-        build_info = image.get_latest_build(default=None)
+        build_info = image.get_latest_brew_build(default=None)
         if build_info is None:
             if "{" in s:
                 if skip_missing:
@@ -187,7 +187,7 @@ def rebase_and_build_olm_bundle(runtime: Runtime, operator_nvrs: Tuple[str, ...]
         # This will respect --images if specified
         operator_metas = [meta for meta in runtime.ordered_image_metas() if
                           meta.enabled and meta.config['update-csv'] is not Missing]
-        results = exectools.parallel_exec(lambda meta, _: meta.get_latest_build(), operator_metas)
+        results = exectools.parallel_exec(lambda meta, _: meta.get_latest_brew_build(), operator_metas)
         operator_builds = results.get()
 
     def rebase_and_build(olm_bundle: OLMBundle):

--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -345,7 +345,7 @@ class GenAssemblyCli:
 
             dgk = image_meta.distgit_key
             package_name = image_meta.get_component_name()
-            basis_event_dict = image_meta.get_latest_build(default=None, complete_before_event=self.basis_event)
+            basis_event_dict = image_meta.get_latest_brew_build(default=None, complete_before_event=self.basis_event)
             if not basis_event_dict:
                 self._exit_with_error(f'No image was found for assembly {self.runtime.assembly} for component {dgk} '
                                       f'at estimated brew event {self.basis_event}. No normal reason for this to '
@@ -474,7 +474,7 @@ class GenAssemblyCli:
 
                 # Now it is time to see whether a query for the RPM from the basis event
                 # estimate comes up with this RPM NVR.
-                basis_event_build_dict = rpm_meta.get_latest_build(
+                basis_event_build_dict = rpm_meta.get_latest_brew_build(
                     el_target=el_ver, complete_before_event=self.basis_event)
 
                 if not basis_event_build_dict:

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -621,9 +621,9 @@ class GenPayloadCli:
                     continue
 
                 if v.build_inspector.is_under_embargo() and self.runtime.assembly_type == AssemblyTypes.STREAM:
-                    public_build = v.image_meta.get_latest_build(default=None,
-                                                                 el_target=v.image_meta.branch_el_target(),
-                                                                 extra_pattern='*.p0.*')
+                    public_build = v.image_meta.get_latest_brew_build(default=None,
+                                                                      el_target=v.image_meta.branch_el_target(),
+                                                                      extra_pattern='*.p0.*')
                     if not public_build:
                         raise IOError(f'Unable to find last public build for {v.image_meta.distgit_key}')
 

--- a/doozer/doozerlib/cli/scan_sources.py
+++ b/doozer/doozerlib/cli/scan_sources.py
@@ -298,7 +298,7 @@ class ConfigScanSources:
             if image_meta in self.changing_image_metas:
                 return
 
-            build_info = await image_meta.get_latest_build_async(default=None)
+            build_info = await image_meta.get_latest_brew_build_async(default=None)
 
             if build_info is None:
                 return
@@ -352,7 +352,7 @@ class ConfigScanSources:
                                             image_meta.distgit_key, dep_key)
                 return
 
-            dep_info = dep.get_latest_build(default=None)
+            dep_info = dep.get_latest_brew_build(default=None)
             if not dep_info:
                 return
 

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1653,7 +1653,7 @@ class ImageDistGitRepo(DistGitRepo):
         # If you are here trying to figure out how to change this behavior, you should
         # consider using 'from!:' in the assembly metadata for this component. This will
         # allow you to fully pin the parent images (e.g. {'from!:' ['image': <pullspec>] })
-        latest_build = self.metadata.get_latest_build(default=None)
+        latest_build = self.metadata.get_latest_brew_build(default=None)
         assembly_msg = f'{self.metadata.distgit_key} in assembly {self.runtime.assembly} ' \
                        f'with basis event {self.runtime.assembly_basis_event}'
         if not latest_build:

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -350,7 +350,7 @@ class ImageMetadata(Metadata):
         runtime = self.runtime
 
         with runtime.pooled_koji_client_session() as koji_api:
-            image_build = self.get_latest_build(default='')
+            image_build = self.get_latest_brew_build(default='')
             if not image_build:
                 # Seems this have never been built. Mark it as needing change.
                 return self, RebuildHint(RebuildHintCode.NO_LATEST_BUILD, 'Image has never been built before')
@@ -442,7 +442,7 @@ class ImageMetadata(Metadata):
             # we do not want to react because of an RPM build in the 'test' assembly.
             group_rpm_builds_nvrs: Dict[str, str] = dict()  # Maps package name to latest brew build nvr
             for rpm_meta in self.runtime.rpm_metas():
-                latest_rpm_build = rpm_meta.get_latest_build(default=None)
+                latest_rpm_build = rpm_meta.get_latest_brew_build(default=None)
                 if latest_rpm_build:
                     group_rpm_builds_nvrs[rpm_meta.get_package_name()] = latest_rpm_build['nvr']
 

--- a/doozer/doozerlib/plashet.py
+++ b/doozer/doozerlib/plashet.py
@@ -138,7 +138,7 @@ class PlashetBuilder:
 
         self._logger.info("Finding image builds...")
         for distgit_key, image_meta in image_map.items():
-            build = image_meta.get_latest_build(default=None, honor_is=False)
+            build = image_meta.get_latest_brew_build(default=None, honor_is=False)
             if build:  # Ignore None in case we build for an basis event that is prior to the first build of an image
                 image_builds[distgit_key] = build
 

--- a/doozer/tests/test_metadata.py
+++ b/doozer/tests/test_metadata.py
@@ -149,14 +149,14 @@ class TestMetadata(TestCase):
 
         # If listBuilds returns nothing, no build should be returned
         builds = []
-        self.assertIsNone(meta.get_latest_build(default=None))
+        self.assertIsNone(meta.get_latest_brew_build(default=None))
 
         # If listBuilds returns a build from an assembly that is not ours
         # get_latest_builds should not return it.
         builds = [
             self.build_record(now, assembly='not_ours', el_target=8)
         ]
-        self.assertIsNone(meta.get_latest_build(default=None))
+        self.assertIsNone(meta.get_latest_brew_build(default=None))
 
         # If there is a build from the 'stream' assembly, it should be
         # returned.
@@ -164,13 +164,13 @@ class TestMetadata(TestCase):
             self.build_record(now, assembly='not_ours', el_target=8),
             self.build_record(now, assembly='stream', el_target=8)
         ]
-        self.assertEqual(meta.get_latest_build(default=None), builds[1])
+        self.assertEqual(meta.get_latest_brew_build(default=None), builds[1])
 
         # If there is a build for our assembly, it should be returned
         builds = [
             self.build_record(now, assembly=runtime.assembly, el_target=8)
         ]
-        self.assertEqual(meta.get_latest_build(default=None), builds[0])
+        self.assertEqual(meta.get_latest_brew_build(default=None), builds[0])
 
         # If there is a build for our assembly and stream, our assembly
         # should be preferred even if stream is more recent.
@@ -179,7 +179,7 @@ class TestMetadata(TestCase):
             self.build_record(now, assembly='not_ours', el_target=8),
             self.build_record(now, assembly=runtime.assembly, el_target=8)
         ]
-        self.assertEqual(meta.get_latest_build(default=None), builds[2])
+        self.assertEqual(meta.get_latest_brew_build(default=None), builds[2])
 
         # The most recent assembly build should be preferred.
         builds = [
@@ -188,7 +188,7 @@ class TestMetadata(TestCase):
             self.build_record(now, assembly='not_ours', el_target=8),
             self.build_record(now, assembly=runtime.assembly, el_target=8)
         ]
-        self.assertEqual(meta.get_latest_build(default=None), builds[3])
+        self.assertEqual(meta.get_latest_brew_build(default=None), builds[3])
 
         # Make sure that just matching the prefix of an assembly is not sufficient.
         builds = [
@@ -197,7 +197,7 @@ class TestMetadata(TestCase):
             self.build_record(now, assembly='not_ours', el_target=8),
             self.build_record(now, assembly=f'{runtime.assembly}b', el_target=8)
         ]
-        self.assertEqual(meta.get_latest_build(default=None), builds[1])
+        self.assertEqual(meta.get_latest_brew_build(default=None), builds[1])
 
         # el7 should not match.
         builds = [
@@ -206,14 +206,14 @@ class TestMetadata(TestCase):
             self.build_record(now, assembly='not_ours', el_target=8),
             self.build_record(now, assembly=f'{runtime.assembly}', el_target=7)
         ]
-        self.assertEqual(meta.get_latest_build(default=None), builds[1])
+        self.assertEqual(meta.get_latest_brew_build(default=None), builds[1])
 
         # By default, we should only be finding COMPLETE builds
         builds = [
             self.build_record(now - datetime.timedelta(hours=5), assembly='stream', el_target=8, build_state=BuildStates.COMPLETE),
             self.build_record(now, assembly='stream', el_target=8, build_state=BuildStates.FAILED),
         ]
-        self.assertEqual(meta.get_latest_build(default=None), builds[0])
+        self.assertEqual(meta.get_latest_brew_build(default=None), builds[0])
 
         # By default, we should only be finding COMPLETE builds
         builds = [
@@ -221,7 +221,7 @@ class TestMetadata(TestCase):
             self.build_record(now, assembly=None, el_target=8, build_state=BuildStates.FAILED),
             self.build_record(now, assembly=None, el_target=8, build_state=BuildStates.COMPLETE),
         ]
-        self.assertEqual(meta.get_latest_build(default=None, assembly=''), builds[2])
+        self.assertEqual(meta.get_latest_brew_build(default=None, assembly=''), builds[2])
 
         # Check whether extra pattern matching works
         builds = [
@@ -231,7 +231,7 @@ class TestMetadata(TestCase):
             self.build_record(now, assembly='not_ours', el_target=8),
             self.build_record(now - datetime.timedelta(hours=8), assembly=f'{runtime.assembly}', el_target=8)
         ]
-        self.assertEqual(meta.get_latest_build(default=None, extra_pattern='*.g1234567.*'), builds[1])
+        self.assertEqual(meta.get_latest_brew_build(default=None, extra_pattern='*.g1234567.*'), builds[1])
 
     def test_get_latest_build_multi_target(self):
         meta = self.meta
@@ -246,7 +246,7 @@ class TestMetadata(TestCase):
         koji_mock.listBuilds.side_effect = list_builds
 
         # If listBuilds returns nothing, no build should be returned
-        self.assertIsNone(meta.get_latest_build(default=None))
+        self.assertIsNone(meta.get_latest_brew_build(default=None))
 
         meta.meta_type = 'rpm'
 
@@ -255,24 +255,24 @@ class TestMetadata(TestCase):
             self.build_record(now, assembly='not_ours', el_target=8, is_rpm=True),
             self.build_record(now, assembly='stream', el_target=8, is_rpm=True)
         ]
-        self.assertEqual(meta.get_latest_build(default=None), builds[1])
+        self.assertEqual(meta.get_latest_brew_build(default=None), builds[1])
 
         builds = [
             self.build_record(now, assembly='not_ours', el_target=8, is_rpm=True),
             self.build_record(now, assembly='stream', el_target=8, is_rpm=True),
         ]
-        self.assertEqual(meta.get_latest_build(default=None), builds[1])  # No target should find el7 or el8
-        self.assertIsNone(meta.get_latest_build(default=None, el_target='7'))
-        self.assertEqual(meta.get_latest_build(default=None, el_target='8'), builds[1])
+        self.assertEqual(meta.get_latest_brew_build(default=None), builds[1])  # No target should find el7 or el8
+        self.assertIsNone(meta.get_latest_brew_build(default=None, el_target='7'))
+        self.assertEqual(meta.get_latest_brew_build(default=None, el_target='8'), builds[1])
 
         builds = [
             self.build_record(now, assembly='not_ours', el_target=8, is_rpm=True),
             self.build_record(now, assembly='stream', el_target=7, is_rpm=True),
             self.build_record(now - datetime.timedelta(hours=1), assembly='stream', el_target=8, is_rpm=True)
         ]
-        self.assertEqual(meta.get_latest_build(default=None), builds[1])  # Latest is el7 by one hour
-        self.assertEqual(meta.get_latest_build(default=None, el_target='7'), builds[1])
-        self.assertEqual(meta.get_latest_build(default=None, el_target='8'), builds[2])
+        self.assertEqual(meta.get_latest_brew_build(default=None), builds[1])  # Latest is el7 by one hour
+        self.assertEqual(meta.get_latest_brew_build(default=None, el_target='7'), builds[1])
+        self.assertEqual(meta.get_latest_brew_build(default=None, el_target='8'), builds[2])
 
     def test_needs_rebuild_disgit_only(self):
         runtime = self.runtime

--- a/doozer/tests/test_plashet.py
+++ b/doozer/tests/test_plashet.py
@@ -148,8 +148,8 @@ class TestPlashetBuilder(TestCase):
         actual = builder.from_images(image_map)
         self.assertEqual({rpm_build["nvr"] for rpm_build in actual["fake-image1"]}, {"fake101-1.2.3-1.el8", "fake102-1.2.3-1.el8", "fake103-1.2.3-1.el8", "fake104-1.2.3-1.el8"})
         self.assertEqual({rpm_build["nvr"] for rpm_build in actual["fake-image2"]}, {"fake201-1.2.3-1.el8", "fake202-1.2.3-1.el8"})
-        image_map["fake-image1"].get_latest_build.assert_called_once()
-        image_map["fake-image2"].get_latest_build.assert_called_once()
+        image_map["fake-image1"].get_latest_brew_build.assert_called_once()
+        image_map["fake-image2"].get_latest_brew_build.assert_called_once()
         builder._get_builds.assert_called_once_with({101, 102, 103, 104, 201, 202})
         list_archives_by_builds.assert_called_once()
 

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -475,7 +475,7 @@ async def _fetch_builds_by_kind_rpm(runtime: Runtime, tag_pv_map: Dict[str, str]
     pinned_nvrs = set()
     if member_only:  # Sweep only member rpms
         for tag in tag_pv_map:
-            tasks = [exectools.to_thread(progress_func, functools.partial(rpm.get_latest_build, default=None, el_target=tag)) for rpm in runtime.rpm_metas()]
+            tasks = [exectools.to_thread(progress_func, functools.partial(rpm.get_latest_brew_build, default=None, el_target=tag)) for rpm in runtime.rpm_metas()]
             builds_for_tag = await asyncio.gather(*tasks)
             builds.extend(filter(lambda b: b is not None, builds_for_tag))
 


### PR DESCRIPTION
`get_latest_build` will serve as a unique entry point to find builds in both Brew and Konflux, based on a new `build-system`  option that will be given to the runtime. Renaming `medatata.get_latest_build()` into `get_latest_brew_build()` will later let us define a `get_latest_konflux_build()` function and make `get_latest_build` a unique entrypoint for both, being controlled by the build-system option.

Test builds:
- [gen-assembly](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgen-assembly/356/console)
- [build-sync](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/13532/console)
- [ocp4](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/13759/console)
- [ocp4-konflux](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/1945/console)
- [ocp4-scan-konflux](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/7862/console)
- [ocp4-scan](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4_scan/97337/console)

Also tested elliott find-builds with `elliott --group=openshift-4.18 --assembly rc.4 find-builds --kind=image --non-payload`, which returned
```text
 cloud-event-proxy-container-v4.18.0-202412200437.p0.g7cfad7b.assembly.stream.el9
 cluster-nfd-operator-container-v4.18.0-202501071837.p0.gb8c54f7.assembly.stream.el9
 dpu-cni-container-v4.18.0-202412170221.p0.g99f3e30.assembly.stream.el9
 dpu-daemon-container-v4.18.0-202412170221.p0.g99f3e30.assembly.stream.el9
 dpu-operator-container-v4.18.0-202412170221.p0.g99f3e30.assembly.stream.el9
 ib-sriov-cni-container-v4.18.0-202412170221.p0.gceb851e.assembly.stream.el9
 ingress-node-firewall-daemon-container-v4.18.0-202412170221.p0.g1e43b4c.assembly.stream.el9
 ingress-node-firewall-operator-container-v4.18.0-202412170221.p0.g1e43b4c.assembly.stream.el9
 kube-compare-artifacts-container-v4.18.0-202501072109.p0.gc77f189.assembly.stream.el9
 local-storage-diskmaker-container-v4.18.0-202412170221.p0.gfa575fb.assembly.stream.el9
 local-storage-operator-container-v4.18.0-202501072109.p0.gfa575fb.assembly.stream.el9
 nmstate-console-plugin-container-v4.18.0-202501080108.p0.gee25996.assembly.stream.el9
 node-feature-discovery-container-v4.18.0-202501071837.p0.g939df7b.assembly.stream.el9
 openshift-enterprise-ansible-operator-container-v4.18.0-202412170221.p0.ge6ff7e5.assembly.stream.el9
 openshift-enterprise-cluster-capacity-container-v4.18.0-202412170221.p0.gbe5401d.assembly.stream.el9
 openshift-enterprise-egress-dns-proxy-container-v4.18.0-202412170221.p0.g716eb0e.assembly.stream.el9
 openshift-enterprise-egress-router-container-v4.18.0-202412170221.p0.g716eb0e.assembly.stream.el9
 openshift-enterprise-helm-operator-container-v4.18.0-202412170221.p0.g24c01ae.assembly.stream.el9
 openshift-enterprise-operator-sdk-container-v4.18.0-202501080108.p0.g24c01ae.assembly.stream.el9
 openshift-kubernetes-nmstate-handler-rhel-9-container-v4.18.0-202412170221.p0.gef1ef81.assembly.stream.el9
 ose-aws-efs-csi-driver-container-v4.18.0-202412170221.p0.gcaf6889.assembly.stream.el9
 ose-aws-efs-csi-driver-operator-container-v4.18.0-202501080108.p0.gc451e94.assembly.stream.el9
 ose-clusterresourceoverride-container-v4.18.0-202412170221.p0.g513e458.assembly.stream.el9
 ose-clusterresourceoverride-operator-container-v4.18.0-202412170221.p0.g410270c.assembly.stream.el9
 ose-egress-http-proxy-container-v4.18.0-202412170221.p0.g716eb0e.assembly.stream.el9
 ose-gcp-filestore-csi-driver-container-v4.18.0-202412170221.p0.g38ef2d6.assembly.stream.el9
 ose-gcp-filestore-csi-driver-operator-container-v4.18.0-202501071837.p0.g3a8419f.assembly.stream.el9
 ose-kubernetes-nmstate-operator-container-v4.18.0-202501080108.p0.gef1ef81.assembly.stream.el9
 ose-linuxptp-daemon-container-v4.18.0-202412241015.p0.g4f38eb5.assembly.stream.el9
 ose-local-storage-mustgather-container-v4.18.0-202501072109.p0.gfa575fb.assembly.stream.el9
 ose-metallb-container-v4.18.0-202412170221.p0.g81cda77.assembly.stream.el9
 ose-metallb-operator-container-v4.18.0-202412180044.p0.g47068b2.assembly.stream.el9
 ose-ptp-operator-container-v4.18.0-202412241015.p0.g161d040.assembly.stream.el9
 ose-secrets-store-csi-driver-container-v4.18.0-202412170221.p0.g0ec312e.assembly.stream.el9
 ose-secrets-store-csi-driver-operator-container-v4.18.0-202501072109.p0.gd075aae.assembly.stream.el9
 ose-secrets-store-csi-mustgather-container-v4.18.0-202501072109.p0.gd075aae.assembly.stream.el9
 ose-smb-csi-driver-container-v4.18.0-202412170221.p0.gf54b02e.assembly.stream.el9
 ose-smb-csi-driver-operator-container-v4.18.0-202501031639.p0.gc451e94.assembly.stream.el9
 ose-sriov-network-metrics-exporter-container-v4.18.0-202412170221.p0.g4098872.assembly.stream.el9
 ose-sriov-rdma-cni-container-v4.18.0-202412170221.p0.g36ae553.assembly.stream.el9
 ose-vertical-pod-autoscaler-container-v4.18.0-202412170221.p0.g44d929e.assembly.stream.el9
 ose-vertical-pod-autoscaler-operator-container-v4.18.0-202412170221.p0.g4966916.assembly.stream.el9
 pf-status-relay-container-v4.18.0-202412170221.p0.g8b14c8e.assembly.stream.el9
 pf-status-relay-operator-container-v4.18.0-202412181237.p0.g1c649ad.assembly.stream.el9
 ptp-operator-must-gather-container-v4.18.0-202501072109.p0.g161d040.assembly.stream.el9
 sriov-cni-container-v4.18.0-202412170221.p0.g150a2eb.assembly.stream.el9
 sriov-dp-admission-controller-container-v4.18.0-202412170221.p0.g6869af8.assembly.stream.el9
 sriov-network-config-daemon-container-v4.18.0-202501021644.p0.gf496851.assembly.stream.el9
 sriov-network-device-plugin-container-v4.18.0-202412170221.p0.g699b968.assembly.stream.el9
 sriov-network-operator-container-v4.18.0-202501021644.p0.gf496851.assembly.stream.el9
 sriov-network-webhook-container-v4.18.0-202501021644.p0.gf496851.assembly.stream.el9
```
