### PR TITLE
Define metadata.get_latest_konflux_build()

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -210,7 +210,7 @@ class KonfluxDb:
             name: str,
             group: str,
             outcome: KonfluxBuildOutcome = KonfluxBuildOutcome.SUCCESS,
-            assembly: str = None,
+            assembly: typing.Optional[str] = None,
             el_target: typing.Optional[str] = None,
             artifact_type: typing.Optional[ArtifactType] = None,
             engine: typing.Optional[Engine] = None,

--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -210,7 +210,7 @@ class KonfluxDb:
             name: str,
             group: str,
             outcome: KonfluxBuildOutcome = KonfluxBuildOutcome.SUCCESS,
-            assembly: str = 'stream',
+            assembly: str = None,
             el_target: typing.Optional[str] = None,
             artifact_type: typing.Optional[ArtifactType] = None,
             engine: typing.Optional[Engine] = None,
@@ -224,7 +224,7 @@ class KonfluxDb:
         :param name: component name, e.g. 'ironic'
         :param group: e.g. 'openshift-4.18'
         :param outcome: 'success' | 'failure'
-        :param assembly: non-standard assembly name, defaults to 'stream' if omitted
+        :param assembly: assembly name, if omitted any assembly is matched
         :param el_target: e.g. 'el8'
         :param artifact_type: 'rpm' | 'image'
         :param engine: 'brew' | 'konflux'
@@ -242,8 +242,10 @@ class KonfluxDb:
             Column('name', String) == name,
             Column('group', String) == group,
             Column('outcome', String) == str(outcome),
-            Column('assembly', String) == assembly,
         ]
+        if assembly:
+            base_clauses.append(Column('assembly', String) == assembly)
+
         order_by_clause = Column('start_time', quote=True).desc()
 
         if completed_before:

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -187,13 +187,23 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
         await self.db.get_latest_build(name='ironic', group='openshift-4.18', outcome='success')
         query_mock.assert_called_once_with(f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE name = 'ironic' "
                                            "AND `group` = 'openshift-4.18' AND outcome = 'success' "
+                                           f"AND start_time >= '{str(lower_bound)}' "
+                                           f"AND start_time < '{now}' "
+                                           "ORDER BY `start_time` DESC LIMIT 1")
+
+        query_mock.reset_mock()
+        await self.db.get_latest_build(name='ironic', group='openshift-4.18',
+                                       outcome='success', assembly='stream')
+        query_mock.assert_called_once_with(f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE name = 'ironic' "
+                                           "AND `group` = 'openshift-4.18' AND outcome = 'success' "
                                            "AND assembly = 'stream' "
                                            f"AND start_time >= '{str(lower_bound)}' "
                                            f"AND start_time < '{now}' "
                                            "ORDER BY `start_time` DESC LIMIT 1")
 
         query_mock.reset_mock()
-        await self.db.get_latest_build(name='ironic', group='openshift-4.18', outcome='success', completed_before=now)
+        await self.db.get_latest_build(name='ironic', group='openshift-4.18', outcome='success',
+                                       completed_before=now, assembly='stream')
         query_mock.assert_called_once_with(f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE name = 'ironic' "
                                            "AND `group` = 'openshift-4.18' AND outcome = 'success' "
                                            "AND assembly = 'stream' AND end_time IS NOT NULL "
@@ -204,7 +214,8 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
 
         query_mock.reset_mock()
         like = {'release': 'b45ea65'}
-        await self.db.get_latest_build(name='ironic', group='openshift-4.18', outcome='success', extra_patterns=like)
+        await self.db.get_latest_build(name='ironic', group='openshift-4.18', outcome='success',
+                                       extra_patterns=like, assembly='stream')
         query_mock.assert_called_once_with(f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE name = 'ironic' "
                                            "AND `group` = 'openshift-4.18' AND outcome = 'success' "
                                            "AND assembly = 'stream' "

--- a/doozer/doozerlib/cli/cli_opts.py
+++ b/doozer/doozerlib/cli/cli_opts.py
@@ -57,6 +57,10 @@ CLI_OPTS = {
     'registry_config_dir': {
         'env': 'DOCKER_CONFIG',
         'help': 'Config directory for the image registry'
+    },
+    'build_system': {
+        'env': 'BUILD_SYSTEM',
+        'help': 'Weather we should look at Brew or at Konflux DB when searching for builds'
     }
 }
 

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -60,13 +60,6 @@ class ConfigScanSources:
         self.assessment_reason = dict()  # maps metadata qualified_key => message describing change
         self.issues = list()  # tracks issues that arose during the scan, which did not interrupt the job
 
-        # Common params for all queries
-        self.base_search_params = {
-            'group': self.runtime.group,
-            'assembly': self.runtime.assembly,  # to let test ocp4-scan in non-stream assemblies, e.g. 'test'
-            'engine': Engine.KONFLUX.value,
-        }
-
         self.latest_image_build_records_map: typing.Dict[str, KonfluxBuildRecord] = {}
         self.latest_rpm_build_records_map: typing.Dict[str, typing.Dict[str, KonfluxBuildRecord]] = {}
         self.image_tree = {}
@@ -292,14 +285,9 @@ class ConfigScanSources:
 
         self.logger.info('Gathering latest RPM build records information...')
 
-        async def _find_target_build(rpm_name, el_target):
-            search_params = {
-                'name': rpm_name,
-                'el_target': el_target,
-                **self.base_search_params,
-                'engine': 'brew'  # for RPMs we only have Brew build engine
-            }
-            build_record = await self.runtime.konflux_db.get_latest_build(**search_params)
+        async def _find_target_build(rpm_meta, el_target):
+            rpm_name = rpm_meta.rpm_name
+            build_record = await rpm_meta.get_latest_build(el_target=el_target)
             if not self.latest_rpm_build_records_map.get(rpm_name):
                 self.latest_rpm_build_records_map[rpm_name] = {}
             self.latest_rpm_build_records_map[rpm_name][el_target] = build_record
@@ -307,16 +295,15 @@ class ConfigScanSources:
         tasks = []
         for rpm in self.runtime.rpm_metas():
             tasks.extend([
-                _find_target_build(rpm.rpm_name, f'el{target}')
+                _find_target_build(rpm, f'el{target}')
                 for target in rpm.determine_rhel_targets()
             ])
         await asyncio.gather(*tasks)
 
     async def find_latest_image_builds(self, image_names: typing.List[str]):
         self.logger.info('Gathering latest image build records information...')
-        latest_image_builds = await self.runtime.konflux_db.get_latest_builds(
-            names=image_names,
-            **self.base_search_params)
+        latest_image_builds = await asyncio.gather(*[
+            self.runtime.image_map[name].get_latest_build(engine=Engine.KONFLUX.value) for name in image_names])
         self.latest_image_build_records_map.update((zip(
             image_names, latest_image_builds)))
 
@@ -421,10 +408,9 @@ class ConfigScanSources:
 
         # Scan for any build in this assembly which includes the git commit.
         upstream_commit_hash = self.find_upstream_commit_hash(image_meta)
-        upstream_commit_build_record = await self.runtime.konflux_db.get_latest_build(
-            **self.base_search_params,
-            name=image_meta.distgit_key,
-            extra_patterns={'commitish': upstream_commit_hash}  # WHERE commitish LIKE '%{upstream_commit_hash}%'
+        upstream_commit_build_record = await image_meta.get_latest_build(
+            engine=Engine.KONFLUX.value,
+            extra_patterns={'commitish': upstream_commit_hash}
         )
 
         # No build from latest upstream commit: handle accordingly
@@ -455,9 +441,7 @@ class ConfigScanSources:
         now = datetime.now(timezone.utc)
 
         # Check whether a build attempt with this commit has failed before.
-        failed_commit_build_record = await self.runtime.konflux_db.get_latest_build(
-            **self.base_search_params,
-            name=image_meta.distgit_key,
+        failed_commit_build_record = await image_meta.get_latest_build(
             extra_patterns={'commitish': upstream_commit_hash},
             outcome=KonfluxBuildOutcome.FAILURE
         )
@@ -641,7 +625,11 @@ class ConfigScanSources:
 
         build = await anext(self.runtime.konflux_db.search_builds_by_fields(
             start_search=start_search,
-            where={'nvr': builder_build_nvr, **self.base_search_params},
+            where={
+                'nvr': builder_build_nvr,
+                'group': self.runtime.group,
+                'assembly': self.runtime.assembly,
+            },
             limit=1,
         ), None)
         if build:
@@ -745,15 +733,11 @@ class ConfigScanSources:
 
             # Scan for any build in this assembly which includes the git commit.
             upstream_commit_hash = await find_rpm_commit_hash(rpm_meta)
-            search_params = {
-                'name': rpm_name,
-                'extra_patterns': {'commitish': upstream_commit_hash},
-                **self.base_search_params,
-                'engine': 'brew'  # for RPMs we only have Brew build engine
-            }
-            if el_target:
-                search_params['el_target'] = el_target
-            upstream_commit_build_record = await self.runtime.konflux_db.get_latest_build(**search_params)
+            upstream_commit_build_record = await rpm_meta.get_latest_build(
+                el_target=el_target,
+                extra_patterns={'commitish': upstream_commit_hash},
+                engine=Engine.BREW.value
+            )
 
             if not upstream_commit_build_record:
                 self.logger.warning('No build for RPM %s from upstream commit %s',

--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -93,7 +93,8 @@ class Ocp4ScanPipeline:
             f'--working-dir={self._doozer_working}',
             f'--data-path={self.data_path}',
             f'--group={group_param}',
-            f'--assembly={self.assembly}'
+            f'--assembly={self.assembly}',
+            '--build-system=konflux'
         ]
         if self.image_list:
             cmd.append(f'--images={self.image_list}')


### PR DESCRIPTION
Follows:
- https://github.com/openshift-eng/art-tools/pull/1266
- https://github.com/openshift-eng/art-tools/pull/1267
- https://github.com/openshift-eng/art-tools/pull/1268

Implement the new `metadata.get_latest_konflux_build()` function and start using it in scan-sources-konflux.
Requires doozer to be called with the `--build-system=konflux` option.

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/8122/console