### PR TITLE
WIP Konflux mode internal hermetic, prefetch

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -381,6 +381,12 @@ class KonfluxClient:
             else:
                 prefetch_params.append({"type": "pip", "path": "."})
 
+        if "gomod" in package_managers:
+            prefetch_params.append({"type": "gomod", "path": "."})
+
+        if "npm" in package_managers:
+            prefetch_params.append({"type": "npm", "path": "."})
+
         if prefetch_params:
             _modify_param(params, "prefetch-input", prefetch_params)
 

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -409,7 +409,8 @@ class KonfluxClient:
             else:
                 prefetch_params.append({"type": "npm", "path": "."})
 
-        if prefetch_params:
+        cachito_enabled = image_metadata.config.get("cachito", {}).get("enabled", False)
+        if cachito_enabled and prefetch_params:
             _modify_param(params, "prefetch-input", prefetch_params)
 
         # See https://konflux-ci.dev/docs/how-tos/configuring/customizing-the-build/#configuring-timeouts

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -369,7 +369,7 @@ class KonfluxClient:
                 for entry in pip_configs:
                     pip_override = {"type": "pip"}
 
-                    pip_path = entry["path"]
+                    pip_path = entry.get("path")
                     if pip_path:
                         pip_override["path"] = pip_path
 
@@ -382,10 +382,32 @@ class KonfluxClient:
                 prefetch_params.append({"type": "pip", "path": "."})
 
         if "gomod" in package_managers:
-            prefetch_params.append({"type": "gomod", "path": "."})
+            gomod_configs = image_metadata.config.get("cachito", {}).get("packages", {}).get("gomod", [])
+            if gomod_configs:
+                for entry in gomod_configs:
+                    gomod_override = {"type": "gomod"}
+
+                    gomod_path = entry.get("path")
+                    if gomod_path:
+                        gomod_override["path"] = gomod_path
+
+                    prefetch_params.append({"type": "gomod", "path": gomod_path})
+            else:
+                prefetch_params.append({"type": "gomod", "path": "."})
 
         if "npm" in package_managers:
-            prefetch_params.append({"type": "npm", "path": "."})
+            npm_configs = image_metadata.config.get("cachito", {}).get("packages", {}).get("npm", [])
+            if npm_configs:
+                for entry in npm_configs:
+                    npm_override = {"type": "npm"}
+
+                    npm_path = entry.get("path")
+                    if npm_path:
+                        npm_override["path"] = npm_path
+
+                    prefetch_params.append({"type": "npm", "path": npm_path})
+            else:
+                prefetch_params.append({"type": "npm", "path": "."})
 
         if prefetch_params:
             _modify_param(params, "prefetch-input", prefetch_params)

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -213,6 +213,7 @@ class KonfluxImageBuilder:
             skip_checks=self._config.skip_checks,
             vm_override=metadata.config.get("konflux", {}).get("vm_override"),
             pipelinerun_template_url=self._config.plr_template,
+            image_metadata=metadata
         )
 
         logger.info(f"Created PipelineRun: {self.build_pipeline_url(pipelinerun)}")

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -757,20 +757,33 @@ class KonfluxRebaser:
         self._update_environment_variables(metadata, source, df_path, build_update_envs=build_update_env_vars, metadata_envs=metadata_envs)
 
         # Inject build repos for Konflux
-        self._add_build_repos(dfp)
+        self._add_build_repos(dfp, metadata)
 
         self._modify_cachito_commands(metadata, df_path)
 
         self._reflow_labels(df_path)
 
-    def _add_build_repos(self, dfp: DockerfileParser):
+    def _add_build_repos(self, dfp: DockerfileParser, metadata: ImageMetadata):
         # Populating the repo file needs to happen after every FROM before the original Dockerfile can invoke yum/dnf.
-        dfp.add_lines(
-            "\n# Start Konflux-specific steps",
+        konflux_lines = ["\n# Start Konflux-specific steps",
             "RUN mkdir -p /tmp/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/yum_temp/ || true",
             f"COPY .oit/{self.repo_type}.repo /etc/yum.repos.d/",
             f"ADD {constants.KONFLUX_REPO_CA_BUNDLE_HOST}/{constants.KONFLUX_REPO_CA_BUNDLE_FILENAME} {constants.KONFLUX_REPO_CA_BUNDLE_TMP_PATH}",
-            "# End Konflux-specific steps\n\n",
+        ]
+
+        network_mode = metadata.config.get("konflux", {}).get("network_mode")
+
+        if network_mode == "internal-hermetic":
+            konflux_lines += [
+                "ENV NO_PROXY='localhost,127.0.0.1,::1,.redhat.com'",
+                "ENV HTTP_PROXY='http://127.0.0.1:9999'",
+                "ENV HTTPS_PROXY='http://127.0.0.1:9999'",
+            ]
+
+        konflux_lines += ["# End Konflux-specific steps\n\n"]
+
+        dfp.add_lines(
+            konflux_lines,
             at_start=True,
             all_stages=True,
         )

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -766,10 +766,9 @@ class KonfluxRebaser:
     def _add_build_repos(self, dfp: DockerfileParser, metadata: ImageMetadata):
         # Populating the repo file needs to happen after every FROM before the original Dockerfile can invoke yum/dnf.
         konflux_lines = ["\n# Start Konflux-specific steps",
-            "RUN mkdir -p /tmp/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/yum_temp/ || true",
-            f"COPY .oit/{self.repo_type}.repo /etc/yum.repos.d/",
-            f"ADD {constants.KONFLUX_REPO_CA_BUNDLE_HOST}/{constants.KONFLUX_REPO_CA_BUNDLE_FILENAME} {constants.KONFLUX_REPO_CA_BUNDLE_TMP_PATH}",
-        ]
+                         "RUN mkdir -p /tmp/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/yum_temp/ || true",
+                         f"COPY .oit/{self.repo_type}.repo /etc/yum.repos.d/",
+                         f"ADD {constants.KONFLUX_REPO_CA_BUNDLE_HOST}/{constants.KONFLUX_REPO_CA_BUNDLE_FILENAME} {constants.KONFLUX_REPO_CA_BUNDLE_TMP_PATH}"]
 
         network_mode = metadata.config.get("konflux", {}).get("network_mode")
 
@@ -783,7 +782,7 @@ class KonfluxRebaser:
         konflux_lines += ["# End Konflux-specific steps\n\n"]
 
         dfp.add_lines(
-            konflux_lines,
+            *konflux_lines,
             at_start=True,
             all_stages=True,
         )


### PR DESCRIPTION
Changes in this PR:
- `internal-hermetic` mode, which uses proxies to restrict network access to RH internal
- add [prefetch feature](https://konflux.pages.redhat.com/docs/users/how-tos/configuring/prefetching-dependencies.html#_enabling_prefetch_builds_for_gomod) for pip

ocp-build-data change: https://github.com/openshift-eng/ocp-build-data/pull/6003