### PR TITLE
[konflux] network modes

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -13,6 +13,7 @@ from kubernetes.dynamic import DynamicClient, exceptions, resource
 from ruamel.yaml import YAML
 
 from doozerlib import constants
+from doozerlib.image import ImageMetadata
 
 yaml = YAML(typ="safe")
 LOGGER = logging.getLogger(__name__)
@@ -304,7 +305,7 @@ class KonfluxClient:
                 return template
 
     async def _new_pipelinerun_for_image_build(self, generate_name: str, namespace: Optional[str], application_name: str, component_name: str,
-                                               git_url: str, commit_sha: str, target_branch: str, output_image: str,
+                                               git_url: str, commit_sha: str, target_branch: str, output_image: str, image_metadata: ImageMetadata,
                                                build_platforms: Sequence[str], git_auth_secret: str = "pipelines-as-code-secret",
                                                additional_tags: Optional[Sequence[str]] = None, skip_checks: bool = False,
                                                pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL) -> dict:
@@ -359,6 +360,9 @@ class KonfluxClient:
         _modify_param(params, "image-expires-after", "6w")
         _modify_param(params, "build-platforms", list(build_platforms))
 
+        if image_metadata.config.get("konflux", {}).get("network-mode") == "hermetic":
+            _modify_param(params, "hermetic", "true")
+
         # See https://konflux-ci.dev/docs/how-tos/configuring/customizing-the-build/#configuring-timeouts
         obj["spec"]["timeouts"] = {"pipeline": "12h"}
 
@@ -408,6 +412,7 @@ class KonfluxClient:
         additional_tags: Sequence[str] = [],
         skip_checks: bool = False,
         pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL,
+        image_metadata: ImageMetadata = None
     ):
         """
         Start a PipelineRun for building an image.
@@ -425,6 +430,7 @@ class KonfluxClient:
         :param git_auth_secret: The git auth secret.
         :param additional_tags: Additional tags to apply to the image.
         :param skip_checks: Whether to skip checks.
+        :param image_metadata: Image metadata
         :return: The PipelineRun resource.
         """
         unsupported_arches = set(building_arches) - set(self.SUPPORTED_ARCHES)
@@ -448,6 +454,7 @@ class KonfluxClient:
             skip_checks=skip_checks,
             additional_tags=additional_tags,
             pipelinerun_template_url=pipelinerun_template_url,
+            image_metadata=image_metadata
         )
         if self.dry_run:
             fake_pipelinerun = resource.ResourceInstance(self.dyn_client, pipelinerun_manifest)

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -213,6 +213,7 @@ class KonfluxImageBuilder:
             skip_checks=self._config.skip_checks,
             vm_override=metadata.config.get("konflux", {}).get("vm_override"),
             pipelinerun_template_url=self._config.plr_template,
+            image_metadata=metadata
         )
 
         logger.info(f"Created PipelineRun: {self.build_pipeline_url(pipelinerun)}")

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -757,20 +757,36 @@ class KonfluxRebaser:
         self._update_environment_variables(metadata, source, df_path, build_update_envs=build_update_env_vars, metadata_envs=metadata_envs)
 
         # Inject build repos for Konflux
-        self._add_build_repos(dfp)
+        self._add_build_repos(dfp, metadata)
 
         self._modify_cachito_commands(metadata, df_path)
 
         self._reflow_labels(df_path)
 
-    def _add_build_repos(self, dfp: DockerfileParser):
+    def _add_build_repos(self, dfp: DockerfileParser, metadata: ImageMetadata):
         # Populating the repo file needs to happen after every FROM before the original Dockerfile can invoke yum/dnf.
+        network_mode = metadata.config.get("konflux", {}).get("network_mode")
+
+        konflux_lines = ["\n# Start Konflux-specific steps"]
+
+        if network_mode != "hermetic":
+            konflux_lines += [
+                "RUN mkdir -p /tmp/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/yum_temp/ || true",
+                f"COPY .oit/{self.repo_type}.repo /etc/yum.repos.d/",
+                f"ADD {constants.KONFLUX_REPO_CA_BUNDLE_HOST}/{constants.KONFLUX_REPO_CA_BUNDLE_FILENAME} {constants.KONFLUX_REPO_CA_BUNDLE_TMP_PATH}"
+            ]
+
+        if network_mode == "internal-only":
+            konflux_lines += [
+                "ENV NO_PROXY='localhost,127.0.0.1,::1,.redhat.com'",
+                "ENV HTTP_PROXY='http://127.0.0.1:9999'",
+                "ENV HTTPS_PROXY='http://127.0.0.1:9999'",
+            ]
+
+        konflux_lines += ["# End Konflux-specific steps\n\n"]
+
         dfp.add_lines(
-            "\n# Start Konflux-specific steps",
-            "RUN mkdir -p /tmp/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/yum_temp/ || true",
-            f"COPY .oit/{self.repo_type}.repo /etc/yum.repos.d/",
-            f"ADD {constants.KONFLUX_REPO_CA_BUNDLE_HOST}/{constants.KONFLUX_REPO_CA_BUNDLE_FILENAME} {constants.KONFLUX_REPO_CA_BUNDLE_TMP_PATH}",
-            "# End Konflux-specific steps\n\n",
+            *konflux_lines,
             at_start=True,
             all_stages=True,
         )


### PR DESCRIPTION
Support two new network modes `hermetic` and `internal-only`. The latter is set by using proxies to allow traffic only to RH internal network, while the former is configured by setting a value `hermetic` to `true` for Konflux PipelineRun