### PR TITLE
Don't raise microshift advisory validation error for preGA assembly

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -281,7 +281,16 @@ class BuildMicroShiftPipeline:
             "--verify-flaws",
             str(advisory_id)
         ]
-        await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars)
+        try:
+            await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars)
+        except ChildProcessError as err:
+            self._logger.warning("Error verifying attached bugs: %s", err)
+            if self.assembly_type in [AssemblyTypes.PREVIEW, AssemblyTypes.CANDIDATE]:
+                await self.slack_client.say_in_thread("Attached bugs have some issues. Permitting since "
+                                                       f"assembly is of type {assembly_type}")
+                await self.slack_client.say_in_thread(str(err))
+            else:
+                raise err
 
     # Advisory can have several pending checks, so retry it a few times
     @retry(reraise=True, stop=stop_after_attempt(5), wait=wait_fixed(1200))

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -287,7 +287,7 @@ class BuildMicroShiftPipeline:
             self._logger.warning("Error verifying attached bugs: %s", err)
             if self.assembly_type in [AssemblyTypes.PREVIEW, AssemblyTypes.CANDIDATE]:
                 await self.slack_client.say_in_thread("Attached bugs have some issues. Permitting since "
-                                                       f"assembly is of type {assembly_type}")
+                                                      f"assembly is of type {self.assembly_type}")
                 await self.slack_client.say_in_thread(str(err))
             else:
                 raise err


### PR DESCRIPTION
This aligns with our promote job - don't raise validation error for bugs/advisory
for preGA assemblies. Instead report in slack and proceed.

Test run: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift/1623/console