### PR TITLE
[konflux] ENV variables for cachito/cachi2 and network mode identifcation

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -785,7 +785,9 @@ class KonfluxRebaser:
 
         cachito_emulation = metadata.config.get("konflux", {}).get("cachito", {}).get("emulation", False)
         if cachito_emulation:
-            with open(f"{dest_dir}/cachi2-emulation/app/.dir"):
+            emulation_dir = f"{dest_dir}/cachi2-emulation/app"
+            os.makedirs(emulation_dir, exist_ok=True)
+            with open(f"{emulation_dir}/.dir", "w"):
                 # Create an emtpy file for rebase
                 pass
 

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -764,7 +764,7 @@ class KonfluxRebaser:
 
     def _add_build_repos(self, dfp: DockerfileParser, metadata: ImageMetadata, dest_dir: Path):
         # Populating the repo file needs to happen after every FROM before the original Dockerfile can invoke yum/dnf.
-        network_mode = metadata.config.get("konflux", {}).get("network_mode")
+        network_mode = metadata.config.get("konflux", {}).get("network_mode", "open")
         valid_network_modes = ["hermetic", "internal-only", "open"]
         if network_mode not in valid_network_modes:
             raise ValueError(f"Invalid network mode; {network_mode}. Valid modes: {valid_network_modes}")
@@ -780,7 +780,7 @@ class KonfluxRebaser:
         konflux_lines += [
             "ENV ART_BUILD_ENGINE=konflux",
             "ENV ART_BUILD_DEPS_METHOD=cachi2",
-            f"ENV ART_BUILD_NETWORK={network_mode if network_mode else 'open'}"
+            f"ENV ART_BUILD_NETWORK={network_mode}"
         ]
 
         cachito_emulation = metadata.config.get("konflux", {}).get("cachito", {}).get("emulation", False)

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1863,6 +1863,22 @@ class ImageDistGitRepo(DistGitRepo):
         # Write rebased from directives
         dfp.parent_images = mapped_images
 
+    def _cachito_env_vars(self, dfp):
+        """
+        Insert ENV variables so that image owners can differentiate between cachito and cachi2 environments
+        """
+        env_variables = [
+            "ENV ART_BUILD_ENGINE=brew",
+            "ENV ART_BUILD_DEPS_METHOD=cachito",
+            "ENV ART_BUILD_NETWORK=internal-only",
+        ]
+        self.logger.info(f"Inserting cachito ENV variables: {env_variables}")
+        dfp.add_lines(
+            *env_variables,
+            at_start=True,
+            all_stages=True,
+        )
+
     def update_distgit_dir(self, version, release, prev_release=None, force_yum_updates=False):
         dg_path = self.dg_path
         with Dir(self.distgit_dir):
@@ -1885,6 +1901,8 @@ class ImageDistGitRepo(DistGitRepo):
             dfp = DockerfileParser(path=str(dg_path.joinpath('Dockerfile')))
 
             self._clean_repos(dfp)
+
+            self._cachito_env_vars(dfp)
 
             # If no version has been specified, we will leave the version in the Dockerfile. Extract it.
             if version is None:


### PR DESCRIPTION
Per [doc](https://docs.google.com/document/d/1Ajc6MSNJz20b34L7QNwoPcWKxId7Fy-eRt7oqyaJl8c/edit?tab=t.0#heading=h.4fbec24ysdh3)

Inserting ENV variables so that upstream can indentify if the build environment is brew/konflux and if the dependency manager that's available is cachito or cachi2