### PR TITLE
Prevent form-urlencoded/parm interpretation of + in URI

### DIFF
--- a/art-cluster/cloudfront/mirror/lambda_art-srv-request-basic-auth.py
+++ b/art-cluster/cloudfront/mirror/lambda_art-srv-request-basic-auth.py
@@ -3,7 +3,7 @@ import hmac
 from bisect import bisect
 from ipaddress import ip_address
 from typing import Dict, List, Optional
-from urllib.parse import quote, unquote_plus
+from urllib.parse import quote, unquote
 
 import boto3
 from botocore.client import Config
@@ -199,7 +199,7 @@ def lambda_handler(event: Dict, context: Dict):
             ClientMethod='get_object',
             Params={
                 'Bucket': S3_BUCKET_NAME,
-                'Key': unquote_plus(uri[1:]),  # Strip '/'
+                'Key': unquote(uri[1:]),  # Strip '/'
             },
             ExpiresIn=20 * 60,  # Expire in 20 minutes
         )
@@ -210,5 +210,5 @@ def lambda_handler(event: Dict, context: Dict):
     # in order for the URL to resolve via an S3 HTTP request. decoding and then
     # re-encoding should ensure that clients that do or don't encode will always
     # head toward the S3 origin encoded.
-    request['uri'] = quote(unquote_plus(uri))
+    request['uri'] = quote(unquote(uri))
     return request

--- a/art-cluster/cloudfront/mirror/lambda_r2_art-srv-request-basic-auth.py
+++ b/art-cluster/cloudfront/mirror/lambda_r2_art-srv-request-basic-auth.py
@@ -5,7 +5,7 @@ import ipaddress
 
 from botocore.exceptions import ClientError
 from typing import Dict, List, Optional
-from urllib.parse import quote, unquote_plus
+from urllib.parse import quote, unquote
 
 import boto3
 from lambda_r2_lib import get_r2_s3_client, get_secrets_manager_secret_dict, S3_BUCKET_NAME
@@ -191,7 +191,7 @@ def lambda_handler(event: Dict, context: Dict):
     else:
         # If we have not initialized an R2 client, do so now.
         s3_client = get_r2_s3_client()
-        file_key = unquote_plus(uri.lstrip('/'))  # Strip '/' prefix and decode any uri encoding like "%2B"
+        file_key = unquote(uri.lstrip('/'))  # Strip '/' prefix and decode any uri encoding like "%2B"
 
         try:
             s3_client.head_object(Bucket=S3_BUCKET_NAME, Key=file_key)
@@ -249,5 +249,5 @@ def lambda_handler(event: Dict, context: Dict):
     # in order for the URL to resolve via an S3 HTTP request. decoding and then
     # re-encoding should ensure that clients that do or don't encode will always
     # head toward the S3 origin encoded.
-    request['uri'] = quote(unquote_plus(uri))
+    request['uri'] = quote(unquote(uri))
     return request


### PR DESCRIPTION
Given a uri like 'https://.../x86_64/dependencies/rpms/4.19-el9-beta/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm' unquote_plus is interpretting and replacing the '+' as a space (' '). This encoding rule is only valid in a form submission (which the CloudFront request is not) and query string parameters (which we are not parsing here).
Applied here, the encoding rule mangles the filename which does include a literal +. unquote (vs unquote_plus) does not replace + with ' '.