### PR TITLE
[ART-11683] use async get nvr

### DIFF
--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -252,9 +252,11 @@ class GenAssemblyCli:
 
             # The brew_build_inspector will take this archive image and find the actual
             # brew build which created it.
-            brew_build_inspector = BrewBuildImageInspector(self.runtime, payload_tag_pullspec)
-            package_name = brew_build_inspector.get_package_name()
-            build_nvr = brew_build_inspector.get_nvr()
+            image_info = await util.oc_image_info_async(payload_tag_pullspec)
+            image_labels = image_info['config']['config']['Labels']
+            package_name = image_labels['com.redhat.component']
+            build_nvr = package_name + '-' + image_labels['version'] + '-' + image_labels['release']
+            brew_build_inspector = BrewBuildImageInspector(self.runtime, build_nvr)
             if package_name in self.component_image_builds:
                 # If we have already encountered this package once in the list of releases we are
                 # processing, then make sure that the original NVR we found matches the new NVR.

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -586,6 +586,7 @@ async def oc_image_info_async(
     :return: The parsed JSON output of `oc image info`.
     """
 
+    @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(10))
     async def _run_command(auth_file: Optional[str]):
         options = [f'--filter-by-os={go_arch}', '-o', 'json']
         if auth_file:


### PR DESCRIPTION
Use async get nvr in gen-assembly job, optimize the job duration

old run
[4.17.14](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgen-assembly/365/)  take 18 mins

test run
[4.17.14](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgen-assembly/369) take 5 mins