### PR TITLE
[konflux] set None for label value

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1474,7 +1474,7 @@ class KonfluxRebaser:
                 for override_label in ["io.k8s.description", "io.k8s.display-name", "io.openshift.tags",
                                        "description", "summary"]:
                     if override_label not in labels:
-                        additional_labels[override_label] = ""
+                        additional_labels[override_label] = "None"
 
                 labels.update(additional_labels)
 


### PR DESCRIPTION
`""` was being interperted as an empty string, which was failing EnterpriseContract policy. Setting to None fixes it.

Successful run: https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-19/pipelineruns/ocp-art-tmp-onboard-policy-stage-4-19-9lxqr

