### PR TITLE
ART-9439: added new function for verify-paylaod

### DIFF
--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -172,11 +172,11 @@ Fields for the short format: Release date, State, Synopsys, URL
 
 
 @cli.command("verify-payload", short_help="Verify payload contents match advisory builds")
-@click.argument("payload")
+@click.argument("payload_or_imagestream")
 @click.argument('advisory', type=int)
 @click.pass_obj
 @click_coroutine
-async def verify_payload(runtime, payload, advisory):
+async def verify_payload(runtime, payload_or_imagestream, advisory):
     """Cross-check that the builds present in PAYLOAD match the builds
 attached to ADVISORY. The payload is treated as the source of
 truth. If something is absent or different in the advisory it is
@@ -209,7 +209,7 @@ written out to summary_results.json.
 
     click.echo("Found {} builds".format(len(all_advisory_nvrs)))
 
-    all_payload_nvrs = await util.get_nvrs_from_payload(payload, rhcos_images, LOGGER)
+    all_payload_nvrs = await util.get_nvrs_from_payload(payload_or_imagestream, rhcos_images, LOGGER)
 
     missing_in_errata = {}
     payload_doesnt_match_errata = {}

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -505,14 +505,24 @@ def all_same(items: Iterable[Any]):
     return all(x == first for x in it)
 
 
-async def get_nvrs_from_payload(pullspec, rhcos_images, logger=None):
+async def get_nvrs_from_payload(pullspec_or_imagestream, rhcos_images, logger=None):
     def log(msg):
         if logger:
             logger.info(msg)
 
+    # a pullspec looks like this: quay.io/openshift-release-dev/ocp-release:4.17.14-x86_64
+    # an imagestream looks like this: 4.17-art-assembly-4.17.14
+    if '@' in pullspec_or_imagestream or ':' in pullspec_or_imagestream:
+        is_pullspec = True
+    else:
+        is_pullspec = False
+
     all_payload_nvrs = {}
     log("Fetching release info...")
-    release_export_cmd = f'oc adm release info {pullspec} -o json'
+    if is_pullspec:
+        release_export_cmd = f'oc adm release info -o json {pullspec_or_imagestream}'
+    else:
+        release_export_cmd = f'oc -n ocp -o json get is/{pullspec_or_imagestream}'
 
     rc, stdout, stderr = exectools.cmd_gather(release_export_cmd)
     if rc != 0:
@@ -521,15 +531,17 @@ async def get_nvrs_from_payload(pullspec, rhcos_images, logger=None):
         raise RuntimeError(msg)
 
     payload_json = json.loads(stdout)
+    if is_pullspec:
+        payload_json = payload_json["references"]
     log("Looping over payload images...")
-    log(f"{len(payload_json['references']['spec']['tags'])} images to check")
+    log(f"{len(payload_json['spec']['tags'])} images to check")
     cmds = [['oc', 'image', 'info', '-o', 'json', tag['from']['name']] for tag in
-            payload_json['references']['spec']['tags']]
+            payload_json['spec']['tags']]
 
     log("Querying image infos...")
     cmd_results = await asyncio.gather(*[exectools.cmd_gather_async(cmd) for cmd in cmds])
 
-    for image, cmd, cmd_result in zip(payload_json['references']['spec']['tags'], cmds, cmd_results):
+    for image, cmd, cmd_result in zip(payload_json['spec']['tags'], cmds, cmd_results):
         image_name = image['name']
         rc, stdout, stderr = cmd_result
         if rc != 0:


### PR DESCRIPTION
elliott verify-payload works now for a payload or image stream

tested locally with
 with payload:
**elliott -g openshift-4.17 --assembly=4.17.14 verify-payload quay.io/openshift-release-dev/ocp-release:4.17.13-x86_64 144853**
with imagestream:
**elliott -g openshift-4.17 --assembly=4.17.14 verify-payload 4.17-art-assembly-4.17.14 145170** 