### PR TITLE
Make oc_image_info option generic

### DIFF
--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -250,7 +250,7 @@ class KonfluxOlmBundleRebaser:
         for pullspec, (namespace, image_short_name, image_tag) in references.items():
             build_pullspec = f"{self.image_repo}:{image_short_name}-{image_tag}"
             image_info_tasks.append(asyncio.create_task(
-                util.oc_image_info_async__caching(
+                util.oc_image_info_for_arch_async__caching(
                     build_pullspec,
                     registry_username=os.environ.get('KONFLUX_ART_IMAGES_USERNAME'),
                     registry_password=os.environ.get('KONFLUX_ART_IMAGES_PASSWORD'),

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1309,7 +1309,7 @@ class KonfluxRebaser:
 
         try:
             self._logger.debug('Retrieving image info for image %s', original_parent)
-            labels = util.oc_image_info__caching(original_parent)['config']['config']['Labels']
+            labels = util.oc_image_info_for_arch__caching(original_parent)['config']['config']['Labels']
 
             # Get builder X.Y
             major, minor, _ = util.extract_version_fields(labels['version'])

--- a/doozer/doozerlib/brew_info.py
+++ b/doozer/doozerlib/brew_info.py
@@ -258,7 +258,7 @@ class BrewBuildImageInspector:
         :return Returns the parsed output of oc image info for the specified arch.
         """
         go_arch = go_arch_for_brew_arch(arch)  # Ensure it is a go arch
-        return util.oc_image_info__caching(self._build_pullspec, go_arch)
+        return util.oc_image_info_for_arch__caching(self._build_pullspec, go_arch)
 
     def get_labels(self, arch='amd64') -> Dict[str, str]:
         """

--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -925,7 +925,7 @@ def images_streams_prs(runtime, github_access_token, bug, interstitial, ignore_c
                 # We don't know yet whether this image exists; perhaps a buildconfig is
                 # failing. Don't open PRs for images that don't yet exist.
                 try:
-                    util.oc_image_info__caching(upstream_image)
+                    util.oc_image_info_for_arch__caching(upstream_image)
                 except:
                     yellow_print(f'Unable to access upstream image {upstream_image} for {dgk}-- check whether buildconfigs are running successfully.')
                     if not ignore_missing_images:

--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -257,7 +257,7 @@ class GenAssemblyCli:
 
             # The brew_build_inspector will take this archive image and find the actual
             # brew build which created it.
-            image_info = await util.oc_image_info_async(payload_tag_pullspec)
+            image_info = await util.oc_image_info_for_arch_async(payload_tag_pullspec)
             image_labels = image_info['config']['config']['Labels']
             package_name = image_labels['com.redhat.component']
             build_nvr = package_name + '-' + image_labels['version'] + '-' + image_labels['release']

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -28,7 +28,7 @@ from doozerlib.rpmcfg import RPMMetadata
 from doozerlib.runtime import Runtime
 from doozerlib.source_resolver import SourceResolver
 from artcommonlib.release_util import isolate_timestamp_in_release
-from doozerlib.util import oc_image_info_async__caching, isolate_el_version_in_brew_tag
+from doozerlib.util import oc_image_info_for_arch_async__caching, isolate_el_version_in_brew_tag
 
 DEFAULT_THRESHOLD_HOURS = 6
 
@@ -589,7 +589,7 @@ class ConfigScanSources:
             builder_image_url = self.runtime.resolve_brew_image_url(builder_image_name)
 
         # Find and map the builder image NVR
-        latest_builder_image_info = Model(await oc_image_info_async__caching(builder_image_url))
+        latest_builder_image_info = Model(await oc_image_info_for_arch_async__caching(builder_image_url))
         builder_info_labels = latest_builder_image_info.config.config.Labels
         builder_nvr_list = [builder_info_labels['com.redhat.component'], builder_info_labels['version'],
                             builder_info_labels['release']]

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1539,7 +1539,7 @@ class ImageDistGitRepo(DistGitRepo):
 
         try:
             self.logger.debug('Retrieving image info for image %s', original_parent)
-            labels = util.oc_image_info__caching(original_parent)['config']['config']['Labels']
+            labels = util.oc_image_info_for_arch__caching(original_parent)['config']['config']['Labels']
 
             # Get builder X.Y
             major, minor, _ = extract_version_fields(labels['version'])
@@ -1758,7 +1758,7 @@ class ImageDistGitRepo(DistGitRepo):
 
             # We will infer the rhel version from the last build layer in the upstream Dockerfile
             last_layer_pullspec = parent_images[-1]
-            image_labels = util.oc_image_info__caching(last_layer_pullspec)['config']['config']['Labels']
+            image_labels = util.oc_image_info_for_arch__caching(last_layer_pullspec)['config']['config']['Labels']
             if 'version' not in image_labels or 'release' not in image_labels:
                 # This does not appear to be a brew image. We can't determine RHEL.
                 return None

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -410,7 +410,7 @@ class ImageMetadata(Metadata):
                 builder_brew_build = ImageMetadata.builder_image_builds.get(builder_image_url, None)
 
                 if not builder_brew_build:
-                    latest_builder_image_info = Model(util.oc_image_info__caching(builder_image_url))
+                    latest_builder_image_info = Model(util.oc_image_info_for_arch__caching(builder_image_url))
                     builder_info_labels = latest_builder_image_info.config.config.Labels
                     builder_nvr_list = [builder_info_labels['com.redhat.component'], builder_info_labels['version'], builder_info_labels['release']]
 

--- a/doozer/doozerlib/olm/bundle.py
+++ b/doozer/doozerlib/olm/bundle.py
@@ -427,7 +427,7 @@ class OLMBundle(object):
 
         pull_spec = '{}/{}'.format(registry, image)
         try:
-            image_info = util.oc_image_info__caching(pull_spec)
+            image_info = util.oc_image_info_for_arch__caching(pull_spec)
         except:
             self.runtime.logger.error(f'Unable to find image from CSV: {pull_spec}. Image may have failed to build after CSV rebase.')
             raise

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -489,8 +489,8 @@ def get_release_calc_previous(version, arch,
     return sort_semver(list(upgrade_from))
 
 
-async def find_manifest_list_sha(pull_spec):
-    image_data = oc_image_info__caching(pull_spec)
+async def find_manifest_list_sha(pullspec):
+    image_data = oc_image_info_for_arch__caching(pullspec)
     if 'listDigest' not in image_data:
         raise ValueError('Specified image is not a manifest-list.')
     return image_data['listDigest']
@@ -540,46 +540,56 @@ def get_release_name_for_assembly(group_name: str, releases_config: Model, assem
     return get_release_name(assembly_type, group_name, assembly_name, patch_version)
 
 
-def oc_image_info(pull_spec: str, go_arch: str = 'amd64') -> Dict:
+def oc_image_info(pullspec: str, *options):
     """
     Returns a Dict of the parsed JSON output of `oc image info` for the specified
     pullspec. Use oc_image_info__caching if you do not believe the image will change
     during the course of doozer's execution.
+
+    :param pullspec: e.g. registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-vsphere-problem-detector-rhel9:v4.19.0-202501230108.p0.gcbd8539.assembly.stream.el9
+    :param options: list of extra args to use with oc, e.g. '--show-multiarch', '--filter-by-os=linux/amd64'
     """
-    # Filter by os because images can be multi-arch manifest lists (which cause oc image info to throw an error if not filtered).
-    cmd = ['oc', 'image', 'info', f'--filter-by-os={go_arch}', '-o', 'json', pull_spec]
+
+    cmd = ['oc', 'image', 'info', '-o', 'json', pullspec]
+    cmd.extend(options)
     out, _ = exectools.cmd_assert(cmd, retries=3)
     return json.loads(out)
 
 
+def oc_image_info_for_arch(pullspec: str, go_arch: str = 'amd64') -> Dict:
+    """
+    Filter by os because images can be multi-arch manifest lists
+    (which cause oc image info to throw an error if not filtered).
+    """
+    return oc_image_info(pullspec, f'--filter-by-os={go_arch}')
+
+
 @lru_cache(maxsize=1000)
-def oc_image_info__caching(pull_spec: str, go_arch: str = 'amd64') -> Dict:
+def oc_image_info_for_arch__caching(pullspec: str, go_arch: str = 'amd64') -> Dict:
     """
     Returns a Dict of the parsed JSON output of `oc image info` for the specified
     pullspec. This function will cache that output per pullspec, so do not use it
     if you expect the image to change during the course of doozer's execution.
     """
-    return oc_image_info(pull_spec, go_arch)
+    return oc_image_info_for_arch(pullspec, go_arch)
 
 
 async def oc_image_info_async(
-        pull_spec: str,
-        go_arch: str = 'amd64',
+        pullspec: str,
+        *options,
         registry_config: Optional[str] = None,
         registry_username: Optional[str] = None,
         registry_password: Optional[str] = None,
-) -> Dict:
+) -> Union[Dict, List]:
     """
     Returns a Dict of the parsed JSON output of `oc image info` for the specified
-    pullspec. Filter by os because images can be multi-arch manifest lists
-    (which cause oc image info to throw an error if not filtered).
+    pullspec.
     This function will authenticate with the registry using the provided registry_config or username and password.
 
     Use oc_image_info_async__caching if you think the image won't change during the course of doozer
     execution.
 
-    :param pull_spec: The image pullspec to query.
-    :param go_arch: The Go architecture to filter by.
+    :param pullspec: The image pullspec to query.
     :param registry_config: The path to the registry config file.
     :param registry_username: The username to authenticate with the registry.
     :param registry_password: The password to authenticate with the registry.
@@ -587,38 +597,79 @@ async def oc_image_info_async(
     """
 
     @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(10))
-    async def _run_command(auth_file: Optional[str]):
-        options = [f'--filter-by-os={go_arch}', '-o', 'json']
+    async def run_oc(auth_file: Optional[str]):
+        opts = ['-o', 'json']
         if auth_file:
-            options.extend([f'--registry-config={auth_file}'])
-        cmd = ['oc', 'image', 'info'] + options + [pull_spec]
+            opts.extend([f'--registry-config={auth_file}'])
+        opts.extend(options)
+        cmd = ['oc', 'image', 'info'] + opts + [pullspec]
         _, out, _ = await exectools.cmd_gather_async(cmd)
         return json.loads(out)
 
+    # If neither a username nor a password were provided, assume an auth file is being used or no auth at all
     if not registry_username and not registry_password:
-        return await _run_command(auth_file=registry_config)
+        return await run_oc(auth_file=registry_config)
 
-    if not registry_password:
-        raise ValueError('registry_password must be provided if auth is needed.')
-    if not registry_username:
-        auth = registry_password
-    else:
+    # Otherwise, a password is always needed for basic auth
+    assert registry_password, 'registry_password must be provided if auth is needed.'
+
+    # Build the basic auth string
+    if registry_username:
         auth = base64.b64encode(f'{registry_username}:{registry_password}'.encode()).decode()
+    else:
+        auth = registry_password
+
+    # Store the basic auth info in a temporary temp file to be used with --registry-config
     with tempfile.NamedTemporaryFile(mode='w', prefix="_doozer_") as registry_config_file:
         registry_config_file.write(json.dumps({
             'auths': {
-                pull_spec.split('/')[0]: {
+                pullspec.split('/')[0]: {
                     'auth': auth,
                 }
             }
         }))
         registry_config_file.flush()
-        return await _run_command(auth_file=registry_config_file.name)
+        return await run_oc(auth_file=registry_config_file.name)
+
+
+async def oc_image_info_for_arch_async(
+        pullspec: str,
+        go_arch: str = 'amd64',
+        registry_config: Optional[str] = None,
+        registry_username: Optional[str] = None,
+        registry_password: Optional[str] = None,
+) -> Dict:
+    """
+    Runs oc image info with --filter-by-os because images can be multi-arch manifest lists
+    (which cause oc image info to throw an error if not filtered).
+    Will return a single dictionary repesenting the amd64 arch
+    """
+    return await oc_image_info_async(pullspec, f'--filter-by-os={go_arch}',
+                                     registry_config=registry_config,
+                                     registry_username=registry_username,
+                                     registry_password=registry_password)
+
+
+async def oc_image_info_show_multiarch_async(
+        pullspec: str,
+        registry_config: Optional[str] = None,
+        registry_username: Optional[str] = None,
+        registry_password: Optional[str] = None,
+) -> Union[Dict, List]:
+    """
+    Runs oc image info with --show-multiarch which can be used with both single and multi arch images.
+    For single arch images, it will return a dict representing the supported arch manifest.
+    For multi arch images, it will return a list of dictionaries, each of these representing a single arch
+    """
+    return await oc_image_info_async(pullspec, '--show-multiarch',
+                                     registry_config=registry_config,
+                                     registry_username=registry_username,
+                                     registry_password=registry_password)
 
 
 @alru_cache
-async def oc_image_info_async__caching(
-        pull_spec: str,
+async def oc_image_info_for_arch_async__caching(
+        pullspec: str,
         go_arch: str = 'amd64',
         registry_config: Optional[str] = None,
         registry_username: Optional[str] = None,
@@ -630,14 +681,14 @@ async def oc_image_info_async__caching(
     This function will cache that output per pullspec, so do not use it
     if you expect the image to change during the course of doozer's execution.
 
-    :param pull_spec: The image pullspec to query.
+    :param pullspec: The image pullspec to query.
     :param go_arch: The Go architecture to filter by.
     :param registry_config: The path to the registry config file.
     :param registry_username: The username to authenticate with the registry.
     :param registry_password: The password to authenticate with the registry.
     :return: The parsed JSON output of `oc image info`.
     """
-    return await oc_image_info_async(pull_spec, go_arch, registry_config, registry_username, registry_password)
+    return await oc_image_info_for_arch_async(pullspec, go_arch, registry_config, registry_username, registry_password)
 
 
 def infer_assembly_type(custom, assembly_name):

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -67,7 +67,7 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
         self.assertEqual(match.group(1), "namespace/image")
         self.assertEqual(match.group(2), "tag")
 
-    @patch("doozerlib.util.oc_image_info_async__caching")
+    @patch("doozerlib.util.oc_image_info_for_arch_async__caching")
     async def test_replace_image_references(self, mock_oc_image_info):
         old_registry = "registry.example.com"
         content = """

--- a/doozer/tests/test_distgit/test_resolve_image_from_upstream_parent.py
+++ b/doozer/tests/test_distgit/test_resolve_image_from_upstream_parent.py
@@ -13,7 +13,7 @@ class TestResolveImageFromUpstreamParent(TestDistgit):
         self.dg = distgit.ImageDistGitRepo(self.md, autoclone=False)
         self.dg.runtime.group_config = Model()
 
-    @patch('doozerlib.util.oc_image_info__caching')
+    @patch('doozerlib.util.oc_image_info_for_arch__caching')
     def test_resolve_parent_1(self, oc_mock, ):
         # Matching MAJOR.MINOR
         # Matching RHEL version
@@ -28,7 +28,7 @@ class TestResolveImageFromUpstreamParent(TestDistgit):
         image = self.dg._resolve_image_from_upstream_parent('unused', MagicMock())
         self.assertEqual(image, streams['golang']['image'])
 
-    @patch('doozerlib.util.oc_image_info__caching')
+    @patch('doozerlib.util.oc_image_info_for_arch__caching')
     def test_resolve_parent_2(self, oc_mock, ):
         # Matching MAJOR.MINOR
         # Mismatching RHEL version
@@ -42,7 +42,7 @@ class TestResolveImageFromUpstreamParent(TestDistgit):
         image = self.dg._resolve_image_from_upstream_parent('unused', MagicMock())
         self.assertEqual(image, None)
 
-    @patch('doozerlib.util.oc_image_info__caching')
+    @patch('doozerlib.util.oc_image_info_for_arch__caching')
     def test_resolve_parent_3(self, oc_mock, ):
         # Misatching MAJOR
         # Matching RHEL version
@@ -56,7 +56,7 @@ class TestResolveImageFromUpstreamParent(TestDistgit):
         image = self.dg._resolve_image_from_upstream_parent('unused', MagicMock())
         self.assertEqual(image, None)
 
-    @patch('doozerlib.util.oc_image_info__caching')
+    @patch('doozerlib.util.oc_image_info_for_arch__caching')
     def test_resolve_parent_4(self, oc_mock, ):
         # Misatching MINOR
         # Matching RHEL version
@@ -70,7 +70,7 @@ class TestResolveImageFromUpstreamParent(TestDistgit):
         image = self.dg._resolve_image_from_upstream_parent('unused', MagicMock())
         self.assertEqual(image, None)
 
-    @patch('doozerlib.util.oc_image_info__caching')
+    @patch('doozerlib.util.oc_image_info_for_arch__caching')
     def test_resolve_parent_5(self, oc_mock, ):
         # Misatching MINOR
         # Matching RHEL version


### PR DESCRIPTION
Currently, we run `oc image info` with --filter-by-os always on. This PR suggests making the `oc_image_info()` function generic, and create new specific functions to be used with the `--filter-by-os` and `--show-multiarch` options instead.