### PR TITLE
[konflux] Build only for x86 for now

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -350,7 +350,8 @@ class ConfigScanSources:
             return
 
         # Check for changes in image arches
-        await self.scan_arch_changes(image_meta)
+        # TODO: Uncomment once we are ready to build and sync all arches
+        # await self.scan_arch_changes(image_meta)
 
         # Check if there's already a build from upstream latest commit
         await self.scan_for_upstream_changes(image_meta)

--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -57,6 +57,7 @@ class Ocp4ScanPipeline:
                 build_version=self.version,
                 assembly='stream',
                 image_list=image_list,
+                limit_arches=['x86_64']
             )
 
         else:


### PR DESCRIPTION
In the Konflux call, it was discussed that we build only x86, for now, for rapid development, until a single arch payload is generated.