### PR TITLE
[konflux] update label to Empty

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1506,7 +1506,7 @@ class KonfluxRebaser:
                 for override_label in ["io.k8s.description", "io.k8s.display-name", "io.openshift.tags",
                                        "description", "summary"]:
                     if override_label not in labels:
-                        additional_labels[override_label] = "None"
+                        additional_labels[override_label] = "Empty"
 
                 labels.update(additional_labels)
 


### PR DESCRIPTION
Successful run: https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-19/pipelineruns/ocp-art-tmp-onboard-policy-stage-4-19-422dh/detail

Setting it to `None` had started failing recently. 

