### PR TITLE
Revert "Start RHCOS arch jobs earlier"

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_rhcos.py
+++ b/pyartcd/pyartcd/pipelines/build_rhcos.py
@@ -159,7 +159,7 @@ class BuildRhcosPipeline:
     def start_build(self):
         """Start a new build for the given version"""
         # determine parameters
-        params = dict(STREAM=self.stream, EARLY_ARCH_JOBS="true")
+        params = dict(STREAM=self.stream, EARLY_ARCH_JOBS="false")
         if self.new_build:
             params["FORCE"] = "true"
         job_url = f"{JENKINS_BASE_URL}/job/build/buildWithParameters"


### PR DESCRIPTION
This reverts commit 45088161971df1aace0527b32b7d3a6bd0e2d74e.

As mentioned in [1] this can have a few side effects that I don't really think we want to deal with on a continuing basis. Let's just revert back to letting the x86_64 buils pass tests and upload to clouds first (i.e. error prone operations) first.

[1] https://github.com/openshift-eng/art-tools/pull/1164#issuecomment-2620026207