### PR TITLE
[konflux] Merge konflux config before rebase

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -14,9 +14,10 @@ import bashlex.errors
 import yaml
 from artcommonlib import exectools, release_util
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord, Engine
-from artcommonlib.model import ListModel, Missing
+from artcommonlib.model import ListModel, Missing, Model
 from dockerfile_parse import DockerfileParser
 
+from artcommonlib.util import deep_merge
 from doozerlib import constants, util
 from doozerlib.backend.build_repo import BuildRepo
 from doozerlib.brew import BuildStates
@@ -91,6 +92,10 @@ class KonfluxRebaser:
             commit_message: str,
             push: bool,
     ) -> None:
+        # If there is a konflux stanza in the image config, merge it with the main config
+        if metadata.config.konflux is not Missing:
+            metadata.config = Model(deep_merge(metadata.config.primitive(), metadata.config.konflux.primitive()))
+
         try:
             # If this image has an upstream source, resolve it
             source = None


### PR DESCRIPTION
We store Konflux specific config data in a `konflux` stanza in the components yaml files. We generally check those fields one by one to override/apply specific behavior.

This can be improved by checking if a `konflux` stanza exists at rebase time, and if it does merging it with the main config, just like we do (or used to do) with `alternative_upstream`. This also lets us automatically override any config we want to replace for Konflux only. As an example, this PR along with https://github.com/openshift-eng/ocp-build-data/compare/openshift-4.19...locriandev:ocp-build-data:4.19-test-dtk  fixed DTK build failures in Konflux: https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-19/pipelineruns/ose-4-19-driver-toolkit-j7qqn

Also ref. https://issues.redhat.com/browse/ART-11911