### PR TITLE
Retry failed arch only

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -1306,7 +1306,7 @@ class GenPayloadCli:
 
         @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(60))
         async def _run(to_image, to_image_base):
-            await exectools.cmd_assert_async([
+            return await exectools.cmd_assert_async([
                 "oc", "adm", "release", "new",
                 f"--name={multi_release_name}",
                 "--reference-mode=source",


### PR DESCRIPTION
Currently `@retry` applies for the func which runs `oc adm release new` for all arches.
Instead wrap it on the command itself, so only the failed arch invocation is retried.