### PR TITLE
ART-11391 build-sync for konflux

### DIFF
--- a/doozer/doozerlib/assembly_inspector.py
+++ b/doozer/doozerlib/assembly_inspector.py
@@ -55,8 +55,8 @@ class AssemblyInspector:
         for image_meta in self.runtime.get_for_release_image_metas():
             latest_build_obj = await image_meta.get_latest_build(default=None, el_target=image_meta.branch_el_target())
             if latest_build_obj:
-                build_record_inspector_cls = BuildRecordInspector.get_build_record_inspector_cls(self.runtime)
-                self._release_build_record_inspectors[image_meta.distgit_key] = build_record_inspector_cls(self.runtime, latest_build_obj)
+                self._release_build_record_inspectors[image_meta.distgit_key] = \
+                    BuildRecordInspector.get_build_record_inspector(self.runtime, latest_build_obj)
             else:
                 self._release_build_record_inspectors[image_meta.distgit_key] = None
 

--- a/doozer/doozerlib/build_info.py
+++ b/doozer/doozerlib/build_info.py
@@ -663,4 +663,4 @@ class KonfluxBuildRecordInspector(BuildRecordInspector):
         return self._inspectors
 
     def get_build_webpage_url(self):
-        return 'TODO'  # TODO art-dash should display build info for a given build ID
+        return self._build_record.build_pipeline_url

--- a/doozer/doozerlib/build_info.py
+++ b/doozer/doozerlib/build_info.py
@@ -1,36 +1,68 @@
 
 import asyncio
-import json
 import logging
+import os
+from abc import ABC, abstractmethod
 from typing import (Awaitable, Dict, List, Optional, Tuple, Union,
                     cast)
 
 import doozerlib
 from artcommonlib.arch_util import brew_arch_for_go_arch, go_arch_for_brew_arch
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord
+from artcommonlib.model import Model
 from artcommonlib.release_util import isolate_el_version_in_release
 from doozerlib import brew, util
 from doozerlib.constants import BREWWEB_URL
 from doozerlib.repodata import OutdatedRPMFinder, Repodata
 
 
-class ArchiveImageInspector:
+class ImageInspector(ABC):
+    def __init__(self, runtime: "doozerlib.Runtime", build_record_inspector: 'BuildRecordInspector' = None):
+        self.runtime = runtime
+        self.build_record_inspector = build_record_inspector
+
+    @abstractmethod
+    def get_pullspec(self):
+        pass
+
+    @abstractmethod
+    def get_digest(self):
+        pass
+
+    @abstractmethod
+    def get_image_meta(self):
+        pass
+
+    @abstractmethod
+    def get_build_inspector(self):
+        pass
+
+    @abstractmethod
+    def image_arch(self):
+        pass
+
+    @abstractmethod
+    def get_manifest_list_digest(self):
+        pass
+
+
+class BrewImageInspector(ImageInspector):
     """
     Represents and returns information about an archive image associated with a brew build.
     """
 
-    def __init__(self, runtime: "doozerlib.Runtime", archive: Dict, brew_build_inspector: 'BrewBuildImageInspector' = None):
+    def __init__(self, runtime: "doozerlib.Runtime", archive: Dict, build_record_inspector: 'BrewBuildRecordInspector' = None):
         """
         :param runtime: The brew build inspector associated with the build that created this archive.
         :param archive: The raw archive dict from brew.
-        :param brew_build_inspector: If the BrewBuildImageInspector is known, pass it in.
+        :param build_record_inspector: If the BrewBuildRecordInspector is known, pass it in.
         """
-        self.runtime = runtime
+        super().__init__(runtime, build_record_inspector)
         self._archive = archive
         self._cache = {}
-        self.brew_build_inspector = brew_build_inspector
 
-        if self.brew_build_inspector:
-            assert (self.brew_build_inspector.get_brew_build_id() == self.get_brew_build_id())
+        if self.build_record_inspector:
+            assert (self.build_record_inspector.get_build_id() == self.get_build_id())
 
     def image_arch(self) -> str:
         """
@@ -65,32 +97,25 @@ class ArchiveImageInspector:
         """
         return dict(self._archive['extra']['docker']['config']['config']['Labels'])
 
-    def get_archive_dict(self) -> Dict:
-        """
-        :return: Returns the raw brew archive object associated with this object.
-                 listArchives output: https://gist.github.com/jupierce/a28a53e4057b550b3c8e5d6a8ac5198c. This method returns a single entry.
-        """
-        return self._archive
-
-    def get_brew_build_id(self) -> int:
+    def get_build_id(self) -> int:
         """
         :return: Returns the brew build id for the build which created this archive.
         """
         return self._archive['build_id']
 
-    def get_brew_build_inspector(self):
+    def get_build_inspector(self):
         """
         :return: Returns a brew build inspector for the build which created this archive.
         """
-        if not self.brew_build_inspector:
-            self.brew_build_inspector = BrewBuildImageInspector(self.runtime, self.get_brew_build_id())
-        return self.brew_build_inspector
+        if not self.build_record_inspector:
+            self.build_record_inspector = BrewBuildRecordInspector(self.runtime, self.get_build_id())
+        return self.build_record_inspector
 
     def get_image_meta(self):  # -> "ImageMetadata":
         """
         :return: Returns the imagemeta associated with this archive's component if there is one. None if no imagemeta represents it.
         """
-        return self.get_brew_build_inspector().get_image_meta()
+        return self.get_build_inspector().get_image_meta()
 
     async def find_non_latest_rpms(self, rpms_to_check: Optional[List[Dict]] = None) -> List[Tuple[str, str, str]]:
         """
@@ -166,24 +191,148 @@ class ArchiveImageInspector:
 
         return self._cache[cn]
 
-    def get_archive_pullspec(self):
+    def get_pullspec(self):
         """
-        :return: Returns an internal pullspec for a specific archive image.
+        :return: Returns an internal pullspec for a specific image.
                  e.g. 'registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-controller-manager:rhaos-4.6-rhel-8-containers-candidate-53809-20210722091236-x86_64'
         """
         return self._archive['extra']['docker']['repositories'][0]
 
-    def get_archive_digest(self):
+    def get_digest(self):
         """
         :return Returns the archive image's sha digest (e.g. 'sha256:1f3ebef02669eca018dbfd2c5a65575a21e4920ebe6a5328029a5000127aaa4b')
         """
         digest = self._archive["extra"]['docker']['digests']['application/vnd.docker.distribution.manifest.v2+json']
-        if not digest.startswith("sha256:"):  # It should start with sha256: for now. Let's raise an error if this changes.
+        # It should start with sha256: for now. Let's raise an error if this changes.
+        if not digest.startswith("sha256:"):
             raise ValueError(f"Received unrecognized digest {digest} for archive {self.get_archive_id()}")
         return digest
 
+    def get_manifest_list_digest(self):
+        return self.build_record_inspector.get_manifest_list_digest()
 
-class BrewBuildImageInspector:
+
+class KonfluxImageInspector(ImageInspector):
+    def __init__(self, runtime: "doozerlib.Runtime", image_info: Dict,
+                 build_record_inspector: 'KonfluxBuildRecordInspector' = None):
+        super().__init__(runtime, build_record_inspector)
+        self._image_info = Model(image_info)
+        assert self._image_info['name'] == build_record_inspector.get_build_obj().image_pullspec
+
+    def get_build_inspector(self):
+        return self.build_record_inspector
+
+    def get_digest(self):
+        return self._image_info.digest
+
+    def get_image_meta(self):
+        return self.build_record_inspector.get_image_meta()
+
+    def get_pullspec(self):
+        return self._image_info['name']
+
+    def image_arch(self):
+        return brew_arch_for_go_arch(self._image_info.config.architecture)
+
+    def get_manifest_list_digest(self):
+        return self._image_info.listDigest
+
+
+class BuildRecordInspector(ABC):
+    def __init__(self, runtime):
+        self.runtime = runtime
+        self._nvr: Optional[str] = None  # Will be resolved to the NVR for the image/manifest list
+        self._build_pullspec = None  # Will track the pullspec of the image/manifest list
+        self._cache = dict()
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}:{self.get_build_id()}:{self.get_nvr()}'
+
+    @classmethod
+    def get_build_record_inspector_cls(cls, runtime):
+        build_system = runtime.build_system
+
+        if build_system == 'brew':
+            return BrewBuildRecordInspector
+
+        elif build_system == 'konflux':
+            return KonfluxBuildRecordInspector
+
+        else:
+            raise ValueError(f'Invalid build system: {build_system}')
+
+    @abstractmethod
+    def get_build_id(self):
+        pass
+
+    @abstractmethod
+    def get_build_obj(self):
+        pass
+
+    def get_nvr(self) -> str:
+        return self._nvr
+
+    @abstractmethod
+    def get_all_installed_package_build_dicts(self):
+        pass
+
+    @abstractmethod
+    def get_rpms_in_pkg_build(self, build_id: int):
+        pass
+
+    @abstractmethod
+    def get_image_meta(self):
+        pass
+
+    @staticmethod
+    def get_source_git_commit():
+        pass
+
+    @staticmethod
+    def find_non_latest_rpms():
+        pass
+
+    @abstractmethod
+    def get_version(self):
+        pass
+
+    @abstractmethod
+    def get_release(self):
+        pass
+
+    @abstractmethod
+    def get_build_webpage_url(self):
+        pass
+
+    @abstractmethod
+    def is_under_embargo(self):
+        pass
+
+    @abstractmethod
+    def get_build_pullspec(self):
+        pass
+
+    def get_image_info(self, arch='amd64') -> Dict:
+        """
+        :return Returns the parsed output of oc image info for the specified arch.
+        """
+        go_arch = go_arch_for_brew_arch(arch)  # Ensure it is a go arch
+        return util.oc_image_info__caching(self._build_pullspec, go_arch)
+
+    @abstractmethod
+    def get_image_inspectors(self):
+        pass
+
+    def get_image_inspector(self, brew_arch: str):
+        """
+        :param brew_arch: one in ["x86_64", "s390x", "ppc64le", "aarch64", "multi"]
+        """
+        arch = brew_arch_for_go_arch(brew_arch)  # Make sure this is a brew arch
+        found = filter(lambda ai: ai.image_arch() == arch, self.get_image_inspectors())
+        return next(found, None)
+
+
+class BrewBuildRecordInspector(BuildRecordInspector):
     """
     Provides an API for common queries we perform against brew built images.
     """
@@ -193,13 +342,10 @@ class BrewBuildImageInspector:
         :param runtime: The koji client session to use.
         :param build: A pullspec to the brew image (it is fine if this is a manifest list OR a single archive image), a brew build id, an NVR, or a brew build dict.
         """
-        self.runtime = runtime
+        super().__init__(runtime)
 
         with self.runtime.pooled_koji_client_session() as koji_api:
-            self._nvr: Optional[str] = None  # Will be resolved to the NVR for the image/manifest list
             self._brew_build_obj: Optional[Dict] = None  # Will be populated with a brew build dict for the NVR
-
-            self._cache = dict()
 
             if isinstance(build, Dict):
                 # Treat as a brew build dict
@@ -226,53 +372,37 @@ class BrewBuildImageInspector:
         """
         return self._brew_build_obj['extra']['image']['index']['digests']['application/vnd.docker.distribution.manifest.list.v2+json']
 
-    def get_brew_build_id(self) -> int:
+    def get_build_id(self) -> int:
         """
         :return: Returns the koji build id for this image.
         """
         return self._brew_build_id
 
-    def get_brew_build_webpage_url(self):
+    def get_build_webpage_url(self):
         """
         :return: Returns a link for humans to go look at details for this brew build.
         """
         return f'{BREWWEB_URL}/buildinfo?buildID={self._brew_build_id}'
 
-    def get_brew_build_dict(self) -> Dict:
+    def get_build_obj(self) -> Dict:
         """
         :return: Returns the koji getBuild dictionary for this iamge.
         """
         return self._brew_build_obj
-
-    def get_nvr(self) -> str:
-        return self._nvr
-
-    def __str__(self):
-        return f'BrewBuild:{self.get_brew_build_id()}:{self.get_nvr()}'
-
-    def __repr__(self):
-        return f'BrewBuild:{self.get_brew_build_id()}:{self.get_nvr()}'
-
-    def get_image_info(self, arch='amd64') -> Dict:
-        """
-        :return Returns the parsed output of oc image info for the specified arch.
-        """
-        go_arch = go_arch_for_brew_arch(arch)  # Ensure it is a go arch
-        return util.oc_image_info_for_arch__caching(self._build_pullspec, go_arch)
 
     def get_labels(self, arch='amd64') -> Dict[str, str]:
         """
         :return: Returns a dictionary of labels associated with the image. If the image is a manifest list,
                  these will be the amd64 labels.
         """
-        return self.get_image_archive_inspector(arch).get_image_labels()
+        return self.get_image_inspector(arch).get_image_labels()
 
     def get_envs(self, arch='amd64') -> Dict[str, str]:
         """
         :param arch: The image architecture to check.
         :return: Returns a dictionary of environment variables set for the image.
         """
-        return self.get_image_archive_inspector(arch).get_image_envs()
+        return self.get_image_inspector(arch).get_image_envs()
 
     def get_component_name(self) -> str:
         return self.get_labels()['com.redhat.component']
@@ -330,11 +460,11 @@ class BrewBuildImageInspector:
         """
         return self.get_envs().get('SOURCE_GIT_COMMIT', None)
 
-    def get_arch_archives(self) -> Dict[str, ArchiveImageInspector]:
+    def get_arch_archives(self) -> Dict[str, BrewImageInspector]:
         """
         :return: Returns a map of architectures -> brew archive Dict  within this brew build.
         """
-        return {a.image_arch(): a for a in self.get_image_archive_inspectors()}
+        return {a.image_arch(): a for a in self.get_image_inspectors()}
 
     def get_build_pullspec(self) -> str:
         """
@@ -361,7 +491,7 @@ class BrewBuildImageInspector:
         """
         return list(filter(lambda a: a['btype'] == 'image', self.get_all_archive_dicts()))
 
-    def get_image_archive_inspectors(self) -> List[ArchiveImageInspector]:
+    def get_image_inspectors(self) -> List[BrewImageInspector]:
         """
         Example listArchives output: https://gist.github.com/jupierce/a28a53e4057b550b3c8e5d6a8ac5198c
         :return: Returns only image archives from the build.
@@ -369,7 +499,7 @@ class BrewBuildImageInspector:
         cn = 'get_image_archives'
         if cn not in self._cache:
             image_archive_dicts = self.get_image_archive_dicts()
-            inspectors = [ArchiveImageInspector(self.runtime, archive, brew_build_inspector=self) for archive in image_archive_dicts]
+            inspectors = [BrewImageInspector(self.runtime, archive, build_record_inspector=self) for archive in image_archive_dicts]
             self._cache[cn] = inspectors
 
         return self._cache[cn]
@@ -391,8 +521,8 @@ class BrewBuildImageInspector:
         cn = 'get_all_installed_rpm_dicts'
         if cn not in self._cache:
             dedupe: Dict[str, Dict] = dict()  # Maps nvr to rpm definition. This is because most archives will have similar RPMS installed.
-            for archive_inspector in self.get_image_archive_inspectors():
-                for rpm_dict in archive_inspector.get_installed_rpm_dicts():
+            for image_inspector in self.get_image_inspectors():
+                for rpm_dict in image_inspector.get_installed_rpm_dicts():
                     dedupe[rpm_dict['nvr']] = rpm_dict
             self._cache[cn] = list(dedupe.values())
         return self._cache[cn]
@@ -407,19 +537,19 @@ class BrewBuildImageInspector:
         cn = 'get_all_installed_package_build_dicts'
         if cn not in self._cache:
             dedupe: Dict[str, Dict] = dict()  # Maps nvr to build dict. This is because most archives will have the similar packages installed.
-            for archive_inspector in self.get_image_archive_inspectors():
-                dedupe.update(archive_inspector.get_installed_package_build_dicts())
+            for image_inspector in self.get_image_inspectors():
+                dedupe.update(image_inspector.get_installed_package_build_dicts())
             self._cache[cn] = dedupe
 
         return self._cache[cn]
 
-    def get_image_archive_inspector(self, arch: str) -> Optional[ArchiveImageInspector]:
+    def get_image_inspector(self, arch: str) -> Optional[BrewImageInspector]:
         """
         Example listArchives output: https://gist.github.com/jupierce/a28a53e4057b550b3c8e5d6a8ac5198c
         :return: Returns the archive inspector for the specified arch    OR    None if the build does not possess one.
         """
         arch = brew_arch_for_go_arch(arch)  # Make sure this is a brew arch
-        found = filter(lambda ai: ai.image_arch() == arch, self.get_image_archive_inspectors())
+        found = filter(lambda ai: ai.image_arch() == arch, self.get_image_inspectors())
         return next(found, None)
 
     def is_under_embargo(self) -> bool:
@@ -474,8 +604,63 @@ class BrewBuildImageInspector:
         arches = meta.get_arches()
         tasks: List[Awaitable[List[Tuple[str, str, str]]]] = []
         for arch in arches:
-            iar = self.get_image_archive_inspector(arch)
+            iar = self.get_image_inspector(arch)
             assert iar is not None
             tasks.append(iar.find_non_latest_rpms(arch_rpms_to_check[arch] if arch_rpms_to_check else None))
         result = dict(zip(arches, await asyncio.gather(*tasks)))
         return result
+
+
+class KonfluxBuildRecordInspector(BuildRecordInspector):
+    def __init__(self, runtime, build_record: KonfluxBuildRecord):
+        super().__init__(runtime)
+        self._build_record = build_record
+        self._nvr = build_record.nvr
+        self.image_pullspec = build_record.image_pullspec
+        self._inspectors = []
+
+    def get_build_id(self):
+        return self._build_record.build_id
+
+    def get_build_obj(self):
+        return self._build_record
+
+    def get_build_pullspec(self):
+        return self._build_record.image_pullspec
+
+    def is_under_embargo(self):
+        return self._build_record.embargoed
+
+    def get_version(self):
+        return self._build_record.version
+
+    def get_release(self):
+        return self._build_record.release
+
+    def get_all_installed_package_build_dicts(self):
+        raise NotImplementedError
+
+    def get_rpms_in_pkg_build(self, build_id: int):
+        raise NotImplementedError
+
+    def get_image_meta(self):
+        return self.runtime.image_map[self.get_build_obj().name]
+
+    def get_image_inspectors(self):
+        if not self._inspectors:
+            info = util.oc_image_info_show_multiarch__caching(
+                pullspec=self.get_build_pullspec(),
+                registry_username=os.environ['KONFLUX_ART_IMAGES_USERNAME'],
+                registry_password=os.environ['KONFLUX_ART_IMAGES_PASSWORD']
+            )
+            if isinstance(info, dict):
+                # The pullspec points to a single arch image
+                self._inspectors.append(KonfluxImageInspector(self.runtime, info, self))
+            else:
+                # The pullspec points to a multi arch manifest list
+                self._inspectors.extend(
+                    [KonfluxImageInspector(self.runtime, item, self) for item in info])
+        return self._inspectors
+
+    def get_build_webpage_url(self):
+        return 'TODO'  # TODO art-dash should display build info for a given build ID

--- a/doozer/doozerlib/build_info.py
+++ b/doozer/doozerlib/build_info.py
@@ -248,18 +248,20 @@ class BuildRecordInspector(ABC):
     def __repr__(self):
         return f'{self.__class__.__name__}:{self.get_build_id()}:{self.get_nvr()}'
 
-    @classmethod
-    def get_build_record_inspector_cls(cls, runtime):
+    @staticmethod
+    def get_build_record_inspector(runtime, build_obj: Union[dict, KonfluxBuildRecord]):
         build_system = runtime.build_system
 
         if build_system == 'brew':
-            return BrewBuildRecordInspector
+            bri_class = BrewBuildRecordInspector
 
         elif build_system == 'konflux':
-            return KonfluxBuildRecordInspector
+            bri_class = KonfluxBuildRecordInspector
 
         else:
             raise ValueError(f'Invalid build system: {build_system}')
+
+        return bri_class(runtime, build_obj)
 
     @abstractmethod
     def get_build_id(self):

--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -18,7 +18,7 @@ from doozerlib.cli import cli, pass_runtime, click_coroutine
 from doozerlib import brew
 from artcommonlib import rhcos, exectools
 from doozerlib.rpmcfg import RPMMetadata
-from doozerlib.brew_info import BrewBuildImageInspector
+from doozerlib.build_info import BrewBuildRecordInspector
 from doozerlib.runtime import Runtime
 
 
@@ -143,7 +143,7 @@ class GenAssemblyCli:
         # Maps RHCOS container name(s) to brew arch name to pullspec(s) from nightly
         self.rhcos_by_tag: Dict[str, Dict[str, str]] = dict()
         # Maps component package_name to brew build dict found for nightly
-        self.component_image_builds: Dict[str, BrewBuildImageInspector] = dict()
+        self.component_image_builds: Dict[str, BrewBuildRecordInspector] = dict()
         # Dict[ package_name ] -> Dict[ el? ] -> brew build dict
         self.component_rpm_builds: Dict[str, Dict[int, Dict]] = dict()
         self.basis_event: int = 0
@@ -261,7 +261,7 @@ class GenAssemblyCli:
             image_labels = image_info['config']['config']['Labels']
             package_name = image_labels['com.redhat.component']
             build_nvr = package_name + '-' + image_labels['version'] + '-' + image_labels['release']
-            brew_build_inspector = BrewBuildImageInspector(self.runtime, build_nvr)
+            brew_build_inspector = BrewBuildRecordInspector(self.runtime, payload_tag_pullspec)
             if package_name in self.component_image_builds:
                 # If we have already encountered this package once in the list of releases we are
                 # processing, then make sure that the original NVR we found matches the new NVR.
@@ -305,7 +305,7 @@ class GenAssemblyCli:
             # short enough to ensure that no other build of this image could have
             # completed before the basis event.
 
-            completion_ts: float = brew_build_inspector.get_brew_build_dict()['completion_ts']
+            completion_ts: float = brew_build_inspector.get_build_obj()['completion_ts']
             # If the basis event for this image is > the basis_event capable of
             # sweeping images we've already analyzed, increase the basis_event_ts.
             self.basis_event_ts = max(self.basis_event_ts, completion_ts + (60.0 * 5))
@@ -358,7 +358,7 @@ class GenAssemblyCli:
                                       f'at estimated brew event {self.basis_event}. No normal reason for this to '
                                       f'happen so exiting out of caution.')
 
-            basis_event_build_dict: BrewBuildImageInspector = BrewBuildImageInspector(
+            basis_event_build_dict: BrewBuildRecordInspector = BrewBuildRecordInspector(
                 self.runtime, basis_event_dict['id'])
             basis_event_build_nvr = basis_event_build_dict.get_nvr()
 
@@ -445,7 +445,7 @@ class GenAssemblyCli:
         with self.runtime.shared_koji_client_session() as koji_api:
 
             archive_lists = brew.list_archives_by_builds(
-                build_ids=[b.get_brew_build_id() for b in self.component_image_builds.values()],
+                build_ids=[b.get_build_id() for b in self.component_image_builds.values()],
                 build_type="image",
                 session=koji_api
             )
@@ -639,7 +639,7 @@ class GenAssemblyCli:
 
     def _get_member_overrides(self):
         """
-        self.component_image_builds now contains a mapping of package_name -> BrewBuildImageInspector
+        self.component_image_builds now contains a mapping of package_name -> BuildRecordInspector
         for all images that should be included in the assembly.
 
         self.component_rpm_builds now contains a mapping of package_name to different RHEL versions
@@ -653,7 +653,7 @@ class GenAssemblyCli:
 
         for package_name in self.force_is:
             if package_name in self.component_image_builds:
-                build_inspector: BrewBuildImageInspector = self.component_image_builds[package_name]
+                build_inspector: BrewBuildRecordInspector = self.component_image_builds[package_name]
                 dgk = build_inspector.get_image_meta().distgit_key
                 image_member_overrides.append({
                     'distgit_key': dgk,

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -31,7 +31,7 @@ from doozerlib.brew import KojiWrapperMetaReturn
 from doozerlib.rhcos import RHCOSBuildInspector
 from doozerlib.cli import cli, pass_runtime, click_coroutine
 from doozerlib.image import ImageMetadata
-from doozerlib.brew_info import BrewBuildImageInspector, ArchiveImageInspector
+from doozerlib.build_info import BuildRecordInspector, ImageInspector
 from doozerlib.assembly_inspector import AssemblyInspector
 from doozerlib.runtime import Runtime
 from artcommonlib.telemetry import start_as_current_span_async
@@ -150,14 +150,17 @@ read and propagate/expose this annotation in its display of the release image.
     ).run()
 
 
-def default_imagestream_base_name(version: str) -> str:
-    return f"{version}-art-latest"
+def default_imagestream_base_name(version: str, runtime: Runtime) -> str:
+    if runtime.build_system == 'brew':
+        return f"{version}-art-latest"
+    else:  # konflux
+        return f"{version}-konflux-art-latest"
 
 
 def assembly_imagestream_base_name(runtime: Runtime) -> str:
     version = runtime.get_minor_version()
     if runtime.assembly == 'stream' and runtime.assembly_type is AssemblyTypes.STREAM:
-        return default_imagestream_base_name(version)
+        return default_imagestream_base_name(version, runtime)
     else:
         return f"{version}-art-assembly-{runtime.assembly}"
 
@@ -241,9 +244,9 @@ class PayloadEntry(NamedTuple):
     # The image metadata which associated with the payload
     image_meta: Optional[ImageMetadata] = None
     # An inspector associated with the overall brew build (manifest list) found for the release
-    build_inspector: Optional[BrewBuildImageInspector] = None
+    build_record_inspector: Optional[BuildRecordInspector] = None
     # The brew build archive (arch specific image) that should be tagged into the payload
-    archive_inspector: Optional[ArchiveImageInspector] = None
+    image_inspector: Optional[ImageInspector] = None
 
     # If the entry is for RHCOS, this value will be set
     rhcos_build: Optional[RHCOSBuildInspector] = None
@@ -275,6 +278,7 @@ class GenPayloadCli:
                  moist_run: bool = False, embargo_permit_ack: bool = False):
 
         self.runtime = runtime
+        self.payload_generator = PayloadGenerator(runtime)
         self.logger = runtime.logger if runtime else MagicMock()  # in tests, blackhole logs by default
         # release-controller IS to update (modified per arch, privacy)
         self.base_imagestream = (is_namespace, is_name)
@@ -325,6 +329,7 @@ class GenPayloadCli:
         self.logger.info(f"Collecting latest information associated with the assembly: {rt.assembly}")
         with TRACER.start_as_current_span("Calls AssemblyInspector.__init__"):
             assembly_inspector = AssemblyInspector(rt, rt.build_retrying_koji_client())
+            await assembly_inspector.initialize(lookup_mode='both')
 
         self.payload_entries_for_arch, self.private_payload_entries_for_arch = self.generate_payload_entries(assembly_inspector)
         assembly_report: Dict = await self.generate_assembly_report(assembly_inspector)
@@ -375,7 +380,6 @@ class GenPayloadCli:
         """
         Generate a status report of the search for inconsistencies across all payloads generated.
         """
-
         rt = self.runtime
         report = dict(
             non_release_images=[image_meta.distgit_key for image_meta in rt.get_non_release_image_metas()],
@@ -385,8 +389,14 @@ class GenPayloadCli:
                 if ii is None
             ],  # A list of metas where the assembly did not find a build
         )
-        report["viable"], report["assembly_issues"] = await self.generate_assembly_issues_report(assembly_inspector)
+        if self.runtime.build_system == 'konflux':
+            # TODO to be removed once assembly issues check is implemented for konflux
+            report["viable"] = True
+            report["assembly_issues"] = {}
+            self.payload_permitted = True
+            return report
 
+        report["viable"], report["assembly_issues"] = await self.generate_assembly_issues_report(assembly_inspector)
         self.payload_permitted = report["viable"]
 
         return report
@@ -402,11 +412,15 @@ class GenPayloadCli:
         span.add_event("Checking assembly content for inconsistencies")
         self.detect_mismatched_siblings(assembly_inspector)
         assembly_build_ids: Set[int] = self.collect_assembly_build_ids(assembly_inspector)
+        # Build IDs can either be integers (Brew builds, e.g. 3403040)
+        # or strings (Konflux builds, e.g. 'ose-4-18-vsphere-problem-detector-j5n7r'
+        assembly_brew_build_ids = list(filter(lambda build_id: isinstance(build_id, int), assembly_build_ids))
+        # assembly_konflux_build_ids = list(filter(lambda build_id: isinstance(build_id, str), assembly_build_ids))
 
         with rt.shared_build_status_detector() as bsd:
             # Use the list of builds associated with the group/assembly to warm up BSD caches
-            bsd.populate_archive_lists(assembly_build_ids)
-            bsd.find_shipped_builds(assembly_build_ids)
+            bsd.populate_archive_lists(assembly_brew_build_ids)
+            bsd.find_shipped_builds(assembly_brew_build_ids)
 
         # check that RPMs belonging to this assembly/group are consistent with the assembly definition.
         for rpm_meta in rt.rpm_metas():
@@ -425,7 +439,7 @@ class GenPayloadCli:
         await self.detect_extend_payload_entry_issues(assembly_inspector)
 
         # If the assembly claims to have reference nightlies, assert that our payload matches them exactly.
-        self.assembly_issues.extend(await PayloadGenerator.check_nightlies_consistency(assembly_inspector))
+        self.assembly_issues.extend(await self.payload_generator.check_nightlies_consistency(assembly_inspector))
 
         span.add_event("Summarizing assembly issue permits")
         return self.summarize_issue_permits(assembly_inspector)
@@ -437,9 +451,9 @@ class GenPayloadCli:
         """
         span = trace.get_current_span()
         self.logger.debug("Checking for mismatched sibling sources...")
-        group_images: List = assembly_inspector.get_group_release_images().values()
+        group_images: List = list(assembly_inspector.get_group_release_images().values())
         issues = []
-        for mismatched, sibling in PayloadGenerator.find_mismatched_siblings(group_images):
+        for mismatched, sibling in self.payload_generator.find_mismatched_siblings(group_images):
             issue = AssemblyIssue(
                 f"{mismatched.get_nvr()} was built from a different upstream "
                 f"source commit ({mismatched.get_source_git_commit()[:7]}) "
@@ -459,7 +473,7 @@ class GenPayloadCli:
         """
 
         return [  # (build_id, desired non-GC tag)
-            (bbii.get_brew_build_id(), bbii.get_image_meta().hotfix_brew_tag())
+            (bbii.get_build_id(), bbii.get_image_meta().hotfix_brew_tag())
             for bbii in assembly_inspector.get_group_release_images().values()
             if bbii
         ]
@@ -611,40 +625,41 @@ class GenPayloadCli:
             entries: Dict[str, PayloadEntry]  # Key of this dict is release payload tag name
             payload_issues: List[AssemblyIssue]
             public_repo = self.full_component_repo(repo_type=RepositoryType.PUBLIC)
-            entries, payload_issues = PayloadGenerator.find_payload_entries(assembly_inspector, arch, public_repo)
+            entries, payload_issues = self.payload_generator.find_payload_entries(assembly_inspector, arch, public_repo)
 
             public_entries: Dict[str, PayloadEntry] = dict()
             for k, v in entries.items():
-                if not v.build_inspector:
+                if not v.build_record_inspector:
                     # Its RHCOS, since it doesn't have a build inspector. Put it in for now, but change once RHCOS
                     # supports private nightlies
                     public_entries[k] = v
                     continue
 
-                if v.build_inspector.is_under_embargo() and self.runtime.assembly_type == AssemblyTypes.STREAM:
+                if v.build_record_inspector.is_under_embargo() and self.runtime.assembly_type == AssemblyTypes.STREAM:
                     public_build = v.image_meta.get_latest_brew_build(default=None,
                                                                       el_target=v.image_meta.branch_el_target(),
                                                                       extra_pattern='*.p0.*')
                     if not public_build:
                         raise IOError(f'Unable to find last public build for {v.image_meta.distgit_key}')
 
-                    public_bbi = BrewBuildImageInspector(runtime=self.runtime, build=public_build)
-                    public_archive_inspector = public_bbi.get_image_archive_inspector(arch)
+                    build_record_inspector_cls = BuildRecordInspector.get_build_record_inspector_cls(self.runtime)
+                    public_bbi = build_record_inspector_cls(runtime=self.runtime, build=public_build)
+                    public_image_inspector = public_bbi.get_image_inspector(arch)
 
-                    dest_pullspec = PayloadGenerator.get_mirroring_destination(
-                        public_archive_inspector.get_archive_digest(), public_repo)
-                    dest_manifest_list_pullspec = PayloadGenerator.get_mirroring_destination(
-                        public_archive_inspector.get_brew_build_inspector().get_manifest_list_digest(), public_repo)
+                    dest_pullspec = self.payload_generator.get_mirroring_destination(
+                        public_image_inspector.get_digest(), public_repo)
+                    dest_manifest_list_pullspec = self.payload_generator.get_mirroring_destination(
+                        public_image_inspector.get_manifest_list_digest(), public_repo)
                     public_entry = PayloadEntry(
                         image_meta=v.image_meta,
-                        build_inspector=public_bbi,
-                        archive_inspector=public_archive_inspector,
+                        build_record_inspector=public_bbi,
+                        image_inspector=public_image_inspector,
                         dest_pullspec=dest_pullspec,
                         dest_manifest_list_pullspec=dest_manifest_list_pullspec,
                         issues=list(),
                     )
 
-                    self.logger.info(f'Replacing embargoed image {v.build_inspector.get_nvr()} with public image {public_bbi.get_nvr()} for public imagestream')
+                    self.logger.info(f'Replacing embargoed image {v.build_record_inspector.get_nvr()} with public image {public_bbi.get_nvr()} for public imagestream')
                     public_entries[k] = public_entry
                     # It's an embargoed build. Filter it out if its stream
                     continue
@@ -656,10 +671,11 @@ class GenPayloadCli:
 
             # Report issues for any embargoed content being made public.
             # If releasing after embargo lift, these can be permitted using 'EMBARGOED_CONTENT' code
-            embargo_issues = PayloadGenerator.embargo_issues_for_payload(public_entries, arch)
+            embargo_issues = self.payload_generator.embargo_issues_for_payload(public_entries, arch)
             self.assembly_issues.extend(embargo_issues)
 
-            private_entries, private_payload_issues = PayloadGenerator.find_payload_entries(assembly_inspector, arch, self.full_component_repo(repo_type=RepositoryType.PRIVATE))
+            private_entries, private_payload_issues = self.payload_generator.find_payload_entries(
+                assembly_inspector, arch, self.full_component_repo(repo_type=RepositoryType.PRIVATE))
             private_entries_for_arch[arch] = private_entries
 
             # Check to see if there are private only issues, and add them to the list of assembly issues
@@ -703,7 +719,7 @@ class GenPayloadCli:
 
                     if cross_payload_requirements:
                         self.assembly_issues.extend(
-                            PayloadGenerator.find_rhcos_payload_rpm_inconsistencies(
+                            self.payload_generator.find_rhcos_payload_rpm_inconsistencies(
                                 payload_entry.rhcos_build,
                                 assembly_inspector.get_group_release_images(),
                                 cross_payload_requirements,
@@ -735,7 +751,7 @@ class GenPayloadCli:
         for privacy_mode in self.privacy_modes:  # only for relevant modes
             rhcos_builds = targeted_rhcos_builds[privacy_mode]
             rhcos_inconsistencies: Dict[str, List[str]] = \
-                PayloadGenerator.find_rhcos_build_rpm_inconsistencies(rhcos_builds)
+                self.payload_generator.find_rhcos_build_rpm_inconsistencies(rhcos_builds)
             if rhcos_inconsistencies:
                 self.assembly_issues.append(AssemblyIssue(
                     f"Found RHCOS inconsistencies in builds {rhcos_builds} "
@@ -747,7 +763,7 @@ class GenPayloadCli:
         for privacy_mode in self.privacy_modes:  # only for relevant modes
             rhcos_builds = targeted_rhcos_builds[privacy_mode]
             for rhcos_build in rhcos_builds:
-                inconsistencies = PayloadGenerator.find_rhcos_build_kernel_inconsistencies(rhcos_build)
+                inconsistencies = self.payload_generator.find_rhcos_build_kernel_inconsistencies(rhcos_build)
                 if inconsistencies:
                     self.assembly_issues.append(AssemblyIssue(
                         f"Found kernel inconsistencies in RHCOS build {rhcos_build} "
@@ -864,16 +880,22 @@ class GenPayloadCli:
         # Prevents writing the same destination twice (not supported by oc if in the same mirroring file):
         mirror_src_for_dest: Dict[str, str] = dict()
 
+        # Login to the konflux registry
+        if self.runtime.build_system == 'konflux':
+            cmd = ['oc', 'registry', 'login', '--registry', 'quay.io/redhat-user-workloads',
+                   f'--auth-basic={os.environ["KONFLUX_ART_IMAGES_USERNAME"]}:{os.environ["KONFLUX_ART_IMAGES_PASSWORD"]}']
+            await exectools.cmd_assert_async(cmd)
+
         for payload_entry in payload_entries.values():
-            if not payload_entry.archive_inspector:
+            if not payload_entry.image_inspector:
                 continue  # Nothing to mirror (e.g. RHCOS)
-            mirror_src_for_dest[payload_entry.dest_pullspec] = payload_entry.archive_inspector.get_archive_pullspec()
+            mirror_src_for_dest[payload_entry.dest_pullspec] = payload_entry.image_inspector.get_pullspec()
             if payload_entry.dest_manifest_list_pullspec:
                 # For heterogeneous release payloads, if a component builds for all arches
                 # (without using -alt images), we can use the manifest list for the images directly from OSBS.
                 # This saves a significant amount of time compared to building the manifest list again.
                 mirror_src_for_dest[payload_entry.dest_manifest_list_pullspec] = \
-                    payload_entry.build_inspector.get_build_pullspec()
+                    payload_entry.build_record_inspector.get_build_pullspec()
 
         @exectools.limit_concurrency(500)
         @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(60))
@@ -920,8 +942,8 @@ class GenPayloadCli:
         for payload_tag_name, payload_entry in payload_entries.items():
             multi_specs[private_mode].setdefault(payload_tag_name, dict())
 
-            if (private_mode is False and payload_entry.build_inspector
-               and payload_entry.build_inspector.is_under_embargo()
+            if (private_mode is False and payload_entry.build_record_inspector
+               and payload_entry.build_record_inspector.is_under_embargo()
                and self.runtime.assembly_type == AssemblyTypes.STREAM):
                 # No embargoed images for assembly stream
                 # should go to the public release controller, so we will not have
@@ -929,7 +951,7 @@ class GenPayloadCli:
                 incomplete_payload_update = True
                 continue
 
-            istags.append(PayloadGenerator.build_payload_istag(payload_tag_name, payload_entry))
+            istags.append(self.payload_generator.build_payload_istag(payload_tag_name, payload_entry))
             multi_specs[private_mode][payload_tag_name][arch] = payload_entry
 
         imagestream_namespace, imagestream_name = payload_imagestream_namespace_and_name(
@@ -951,8 +973,7 @@ class GenPayloadCli:
         filename = f"updated-tags-for.{imagestream_namespace}.{imagestream_name}" \
                    f"{'-partial' if incomplete_payload_update else ''}.yaml"
         async with aiofiles.open(self.output_path.joinpath(filename), mode="w+", encoding="utf-8") as out_file:
-            istream_spec = PayloadGenerator.build_payload_imagestream(
-                self.runtime,
+            istream_spec = self.payload_generator.build_payload_imagestream(
                 imagestream_name, imagestream_namespace,
                 istags, self.assembly_issues
             )
@@ -1050,7 +1071,7 @@ class GenPayloadCli:
                 # Remove old inconsistency information if it exists
                 new_annotations.pop("release.openshift.io/inconsistency", None)
 
-            new_annotations.update(PayloadGenerator.build_imagestream_annotations(self.runtime, self.assembly_issues))
+            new_annotations.update(self.payload_generator.build_imagestream_annotations(self.assembly_issues))
 
             apiobj.model.metadata["annotations"] = new_annotations
 
@@ -1162,8 +1183,7 @@ class GenPayloadCli:
             # now multi_istags contains istags which all point to component manifest lists. We must
             # run oc adm release new on this set of tags -- once for each arch - to create the arch
             # specific release payloads.
-            multi_release_is = PayloadGenerator.build_payload_imagestream(
-                self.runtime,
+            multi_release_is = self.payload_generator.build_payload_imagestream(
                 imagestream_name, imagestream_namespace, multi_istags,
                 assembly_wide_inconsistencies=self.assembly_issues)
 
@@ -1228,7 +1248,7 @@ class GenPayloadCli:
             # Flow 1: Just reuse the manifest list built in brew and synced to a tag in quay.
             output_digest_pullspec = exchange_pullspec_tag_for_shasum(
                 manifest_list_dests.pop(),
-                entries[0].build_inspector.get_manifest_list_digest())
+                entries[0].image_inspector.get_manifest_list_digest())
             self.logger.info(f"Reusing brew manifest-list {output_digest_pullspec} for component {tag_name}")
         else:
             # Flow 2: Build a new manifest list and push it to quay.
@@ -1238,7 +1258,7 @@ class GenPayloadCli:
         issues = list(issue  # collect issues from each payload entry.
                       for payload_entry in entries
                       for issue in payload_entry.issues or [])
-        return PayloadGenerator.build_payload_istag(
+        return self.payload_generator.build_payload_istag(
             tag_name, PayloadEntry(
                 dest_pullspec=output_digest_pullspec,
                 issues=issues,
@@ -1472,29 +1492,31 @@ class GenPayloadCli:
 
 
 class PayloadGenerator:
+    def __init__(self, runtime: Runtime = None):
+        self.runtime = runtime
 
     @staticmethod
-    def find_mismatched_siblings(build_image_inspectors: Iterable[Optional[BrewBuildImageInspector]]) -> \
-            List[Tuple[BrewBuildImageInspector, BrewBuildImageInspector]]:
+    def find_mismatched_siblings(build_record_inspectors: Iterable[Optional[BuildRecordInspector]]) -> \
+            List[Tuple[BuildRecordInspector, BuildRecordInspector]]:
         """
         Sibling images are those built from the same repository. We need to throw an error
         if there are sibling built from different commits.
-        :return: Returns a list of (BrewBuildImageInspector,BrewBuildImageInspector)
+        :return: Returns a list of (BuildRecordInspector,BuildRecordInspector)
                  where the first item is a mismatched sibling of the second
         """
 
         class RepoBuildRecord(NamedTuple):
-            build_image_inspector: BrewBuildImageInspector
+            build_record_inspector: BuildRecordInspector
             source_git_commit: str
 
         # Maps SOURCE_GIT_URL -> RepoBuildRecord(SOURCE_GIT_COMMIT, DISTGIT_KEY, NVR).
         # Where the Tuple is the first build encountered claiming it is sourced from the SOURCE_GIT_URL
         repo_builds: Dict[str, RepoBuildRecord] = dict()
 
-        mismatched_siblings: List[Tuple[BrewBuildImageInspector, BrewBuildImageInspector]] = []
-        for build_image_inspector in build_image_inspectors:
+        mismatched_siblings: List[Tuple[BuildRecordInspector, BuildRecordInspector]] = []
+        for build_record_inspector in build_record_inspectors:
 
-            if not build_image_inspector:
+            if not build_record_inspector:
                 # No build for this component at present.
                 continue
 
@@ -1502,9 +1524,9 @@ class PayloadGenerator:
             # If an artist overrides one sibling's git url, but not another, the following
             # scan would not be able to detect that they were siblings. Instead, we rely on the
             # original image metadata to determine sibling-ness.
-            source_url = build_image_inspector.get_image_meta().raw_config.content.source.git.url
+            source_url = build_record_inspector.get_image_meta().raw_config.content.source.git.url
 
-            source_git_commit = build_image_inspector.get_source_git_commit()
+            source_git_commit = build_record_inspector.get_source_git_commit()
             if not source_url or not source_git_commit:
                 # This is true for distgit only components.
                 continue
@@ -1517,14 +1539,14 @@ class PayloadGenerator:
                 # Another component has build from this repo before. Make
                 # sure it built from the same commit.
                 if potential_conflict.source_git_commit != source_git_commit:
-                    mismatched_siblings.append((build_image_inspector, potential_conflict.build_image_inspector))
+                    mismatched_siblings.append((build_record_inspector, potential_conflict.build_record_inspector))
                     red_print("The following NVRs are siblings but built from different commits: "
-                              f"{potential_conflict.build_image_inspector.get_nvr()} and "
-                              f"{build_image_inspector.get_nvr()}", file=sys.stderr)
+                              f"{potential_conflict.build_record_inspector.get_nvr()} and "
+                              f"{build_record_inspector.get_nvr()}", file=sys.stderr)
             else:
                 # No conflict, so this is our first encounter for this repo; add it to our tracking dict.
                 repo_builds[source_url] = RepoBuildRecord(
-                    build_image_inspector=build_image_inspector, source_git_commit=source_git_commit)
+                    build_record_inspector=build_record_inspector, source_git_commit=source_git_commit)
 
         return mismatched_siblings
 
@@ -1596,7 +1618,7 @@ class PayloadGenerator:
     @staticmethod
     def find_rhcos_payload_rpm_inconsistencies(
             primary_rhcos_build: RHCOSBuildInspector,
-            payload_bbii: Dict[str, BrewBuildImageInspector],
+            payload_bri: Dict[str, BuildRecordInspector],
             # payload tag -> [pkg_name1, ...]
             payload_consistency_config: Dict[str, List[str]]) -> List[AssemblyIssue]:
         """
@@ -1622,7 +1644,7 @@ class PayloadGenerator:
         # check that each member consistency condition is met
         primary_rhcos_build.runtime.logger.debug(f"Running payload consistency checks against {primary_rhcos_build}")
         for payload_tag, consistent_pkgs in payload_consistency_config.items():
-            bbii = payload_bbii.get(payload_tag)
+            bbii = payload_bri.get(payload_tag)
             if not bbii:
                 issues.append(AssemblyIssue(
                     f"RHCOS consistency configuration specifies a payload tag '{payload_tag}'"
@@ -1639,14 +1661,14 @@ class PayloadGenerator:
     @staticmethod
     def validate_pkg_consistency_req(
             payload_tag: str, pkg: str,
-            bbii: BrewBuildImageInspector,
+            bri: BuildRecordInspector,
             rhcos_rpm_vrs: Dict[str, str],
             rhcos_build_id: str) -> Optional[AssemblyIssue]:
         """check that the specified package in the member is consistent with the RHCOS build"""
-        logger = bbii.runtime.logger
-        payload_tag_nvr: str = bbii.get_nvr()
+        logger = bri.runtime.logger
+        payload_tag_nvr: str = bri.get_nvr()
         logger.debug(f"Checking consistency of {pkg} for {payload_tag_nvr} against {rhcos_build_id}")
-        member_nvrs: Dict[str, Dict] = bbii.get_all_installed_package_build_dicts()  # by name
+        member_nvrs: Dict[str, Dict] = bri.get_all_installed_package_build_dicts()  # by name
         try:
             build = member_nvrs[pkg]
         except KeyError:
@@ -1657,7 +1679,7 @@ class PayloadGenerator:
 
         # get names of all the actual RPMs included in this package build, because that's what we
         # have for comparison in the RHCOS metadata (not the package name).
-        rpm_names = set(rpm["name"] for rpm in bbii.get_rpms_in_pkg_build(build["build_id"]))
+        rpm_names = set(rpm["name"] for rpm in bri.get_rpms_in_pkg_build(build["build_id"]))
 
         # find package RPM names in the RHCOS build and check that they have the same version
         required_vr = "-".join([build["version"], build["release"]])
@@ -1689,8 +1711,7 @@ class PayloadGenerator:
         tag = sha256.replace(":", "-")  # sha256:abcdef -> sha256-abcdef
         return f"{dest_repo}:{tag}"
 
-    @classmethod
-    def find_payload_entries(cls, assembly_inspector: AssemblyInspector,
+    def find_payload_entries(self, assembly_inspector: AssemblyInspector,
                              arch: str, dest_repo: str) -> (Dict[str, PayloadEntry], List[AssemblyIssue]):
         """
         Returns a list of images which should be included in the architecture specific release payload.
@@ -1701,35 +1722,34 @@ class PayloadGenerator:
         :return: Map[payload_tag_name] -> PayloadEntry.
         """
 
-        members: Dict[str, PayloadEntry] = cls._find_initial_payload_entries(assembly_inspector, arch, dest_repo)
-        members = cls._replace_missing_payload_entries(members, arch)
-        rhcos_members, issues = cls._find_rhcos_payload_entries(assembly_inspector, arch)
+        members: Dict[str, PayloadEntry] = self._find_initial_payload_entries(assembly_inspector, arch, dest_repo)
+        members = self._replace_missing_payload_entries(members, arch)
+        rhcos_members, issues = self._find_rhcos_payload_entries(assembly_inspector, arch)
         members.update(rhcos_members)
         return members, issues
 
-    @staticmethod
-    def _find_initial_payload_entries(assembly_inspector: AssemblyInspector,
+    def _find_initial_payload_entries(self, assembly_inspector: AssemblyInspector,
                                       arch: str, dest_repo: str) -> Dict[str, PayloadEntry]:
 
         # Maps release payload tag name to the PayloadEntry for the image.
         members: Dict[str, Optional[PayloadEntry]] = dict()
-        for payload_tag, archive_inspector in \
-                PayloadGenerator.get_group_payload_tag_mapping(assembly_inspector, arch).items():
+        for payload_tag, image_inspector in \
+                self.get_group_payload_tag_mapping(assembly_inspector, arch).items():
 
-            if not archive_inspector:
+            if not image_inspector:
                 # There is no build for this payload tag for this CPU arch. This
                 # will be filled in later in this method for the final list.
                 members[payload_tag] = None
                 continue
 
             members[payload_tag] = PayloadEntry(
-                image_meta=archive_inspector.get_image_meta(),
-                build_inspector=archive_inspector.get_brew_build_inspector(),
-                archive_inspector=archive_inspector,
+                image_meta=image_inspector.get_image_meta(),
+                build_record_inspector=image_inspector.get_build_inspector(),
+                image_inspector=image_inspector,
                 dest_pullspec=PayloadGenerator.get_mirroring_destination(
-                    archive_inspector.get_archive_digest(), dest_repo),
+                    image_inspector.get_digest(), dest_repo),
                 dest_manifest_list_pullspec=PayloadGenerator.get_mirroring_destination(
-                    archive_inspector.get_brew_build_inspector().get_manifest_list_digest(), dest_repo),
+                    image_inspector.get_manifest_list_digest(), dest_repo),
                 issues=list(),
             )
         return members
@@ -1810,8 +1830,7 @@ class PayloadGenerator:
             }
         }
 
-    @staticmethod
-    def build_payload_imagestream(runtime, imagestream_name: str, imagestream_namespace: str,
+    def build_payload_imagestream(self, imagestream_name: str, imagestream_namespace: str,
                                   payload_istags: Iterable[Dict],
                                   assembly_wide_inconsistencies: Iterable[AssemblyIssue]) -> Dict:
         """
@@ -1830,7 +1849,7 @@ class PayloadGenerator:
             "metadata": {
                 "name": imagestream_name,
                 "namespace": imagestream_namespace,
-                "annotations": PayloadGenerator.build_imagestream_annotations(runtime, assembly_wide_inconsistencies)
+                "annotations": self.build_imagestream_annotations(assembly_wide_inconsistencies)
             },
             "spec": {
                 "tags": list(payload_istags),
@@ -1839,8 +1858,7 @@ class PayloadGenerator:
 
         return istream_obj
 
-    @staticmethod
-    def build_pipeline_metadata_annotations(runtime) -> Dict:
+    def build_pipeline_metadata_annotations(self) -> Dict:
         """
         :return: If the metadata is available, include information like the Jenkins job URL
                  in a nightly annotation.
@@ -1849,7 +1867,7 @@ class PayloadGenerator:
 
         pipeline_metadata = {
             'release.openshift.io/build-url': os.getenv('BUILD_URL', ''),
-            'release.openshift.io/runtime-brew-event': str(runtime.brew_event),
+            'release.openshift.io/runtime-brew-event': str(self.runtime.brew_event),
         }
 
         return pipeline_metadata
@@ -1879,16 +1897,16 @@ class PayloadGenerator:
             msgs[5:] = ["(...and more)"]
         return {"release.openshift.io/inconsistency": json.dumps(msgs)}
 
-    @staticmethod
-    def build_imagestream_annotations(runtime, inconsistencies: Iterable[AssemblyIssue]) -> Dict:
+    def build_imagestream_annotations(self, inconsistencies: Iterable[AssemblyIssue]) -> Dict:
+        if self.runtime.build_system == 'konflux':
+            return {}  # TODO to be removed
         annotations = {}
-        annotations.update(PayloadGenerator.build_inconsistency_annotations(inconsistencies))
-        annotations.update(PayloadGenerator.build_pipeline_metadata_annotations(runtime))
+        annotations.update(self.build_inconsistency_annotations(inconsistencies))
+        annotations.update(self.build_pipeline_metadata_annotations())
         return annotations
 
-    @staticmethod
-    def get_group_payload_tag_mapping(assembly_inspector: AssemblyInspector,
-                                      arch: str) -> Dict[str, Optional[ArchiveImageInspector]]:
+    def get_group_payload_tag_mapping(self, assembly_inspector: AssemblyInspector,
+                                      arch: str) -> Dict[str, Optional[ImageInspector]]:
 
         """
         Each payload tag name used to map exactly to one release imagemeta. With the advent of '-alt' images,
@@ -1900,7 +1918,7 @@ class PayloadGenerator:
 
         brew_arch = brew_arch_for_go_arch(arch)  # Make certain this is brew arch nomenclature
         members: Dict[str, Optional[
-            ArchiveImageInspector]] = dict()  # Maps release payload tag name to the archive which should populate it
+            ImageInspector]] = dict()  # Maps release payload tag name to the archive which should populate it
         for dgk, build_inspector in assembly_inspector.get_group_release_images().items():
 
             if build_inspector is None:
@@ -1934,21 +1952,24 @@ class PayloadGenerator:
                 # This was tag not explicitly declared, so ignore the duplicate image.
                 continue
 
-            archive_inspector = build_inspector.get_image_archive_inspector(brew_arch)
+            try:
+                image_inspector = build_inspector.get_image_inspector(brew_arch)
+            except ChildProcessError:  # raised by Konflux in case oc image info fails
+                image_inspector = None
 
-            if not archive_inspector:
+            if not image_inspector and not self.runtime.build_system == 'konflux':
+                # TODO allowing this for konflux, in the future will should always raise an exception
                 # There is no build for this CPU architecture for this image_meta/build. This finding
                 # conflicts with the `arch not in image_meta.get_arches()` check above.
                 # Best to fail.
                 raise IOError(f"{dgk} claims to be built for {image_meta.get_arches()} "
-                              f"but did not find {brew_arch} build for {build_inspector.get_brew_build_webpage_url()}")
+                              f"but did not find {brew_arch} build for {build_inspector.get_build_webpage_url()}")
 
-            members[tag_name] = archive_inspector
+            members[tag_name] = image_inspector
 
         return members
 
-    @staticmethod
-    async def _check_nightly_consistency(assembly_inspector: AssemblyInspector,
+    async def _check_nightly_consistency(self, assembly_inspector: AssemblyInspector,
                                          nightly: str, arch: str) -> List[AssemblyIssue]:
 
         runtime = assembly_inspector.runtime
@@ -1985,7 +2006,7 @@ class PayloadGenerator:
 
         payload_entries: Dict[str, PayloadEntry]
         issues: List[AssemblyIssue]
-        payload_entries, issues = PayloadGenerator.find_payload_entries(assembly_inspector, arch, "")
+        payload_entries, issues = self.find_payload_entries(assembly_inspector, arch, "")
         rhcos_container_configs = {tag.name: tag for tag in rhcos.get_container_configs(runtime)}
         for component_tag in release_info.references.spec.tags:  # For each tag in the imagestream
             payload_tag_name: str = component_tag.name  # e.g. "aws-ebs-csi-driver"
@@ -2001,15 +2022,15 @@ class PayloadGenerator:
             if not entry:
                 raise IOError(f"Did not find {nightly} payload tag {payload_tag_name} in computed assembly payload")
 
-            if entry.archive_inspector:
-                if entry.archive_inspector.get_archive_digest() != pullspec_sha:
+            if entry.image_inspector:
+                if entry.image_inspector.get_digest() != pullspec_sha:
                     # Impermissible because the artist should remove
                     # the reference nightlies from the assembly definition
                     issues.append(
                         AssemblyIssue(
                             f"{nightly} contains {payload_tag_name} sha {pullspec_sha} but assembly computed archive: "
-                            f"{entry.archive_inspector.get_archive_id()} and "
-                            f"{entry.archive_inspector.get_archive_pullspec()}", component="reference-releases"))
+                            f"{entry.image_inspector.get_archive_id()} and "
+                            f"{entry.image_inspector.get_pullspec()}", component="reference-releases"))
 
             elif entry.rhcos_build:
                 actual_digest = entry.rhcos_build.get_container_digest(rhcos_container_configs[payload_tag_name])
@@ -2052,13 +2073,13 @@ class PayloadGenerator:
         """
         issues = []
         for payload_tag, entry in entries.items():
-            if not entry.build_inspector:
+            if not entry.build_record_inspector:
                 # Probably RHCOS
                 continue
 
-            if entry.build_inspector.is_under_embargo():
+            if entry.build_record_inspector.is_under_embargo():
                 issues.append(AssemblyIssue(
-                    f"Found embargoed build {entry.build_inspector.get_nvr()} in payload entries for arch {arch}",
+                    f"Found embargoed build {entry.build_record_inspector.get_nvr()} in payload entries for arch {arch}",
                     component=entry.image_meta.name,
                     code=AssemblyIssueCode.EMBARGOED_CONTENT
                 ))

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -414,7 +414,7 @@ class GenPayloadCli:
         assembly_build_ids: Set[int] = self.collect_assembly_build_ids(assembly_inspector)
         # Build IDs can either be integers (Brew builds, e.g. 3403040)
         # or strings (Konflux builds, e.g. 'ose-4-18-vsphere-problem-detector-j5n7r'
-        assembly_brew_build_ids = list(filter(lambda build_id: isinstance(build_id, int), assembly_build_ids))
+        assembly_brew_build_ids = list(filter(lambda build_id: str(build_id).isdigit(), assembly_build_ids))
         # assembly_konflux_build_ids = list(filter(lambda build_id: isinstance(build_id, str), assembly_build_ids))
 
         with rt.shared_build_status_detector() as bsd:

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -642,8 +642,8 @@ class GenPayloadCli:
                     if not public_build:
                         raise IOError(f'Unable to find last public build for {v.image_meta.distgit_key}')
 
-                    build_record_inspector_cls = BuildRecordInspector.get_build_record_inspector_cls(self.runtime)
-                    public_bbi = build_record_inspector_cls(runtime=self.runtime, build=public_build)
+                    public_bbi = BuildRecordInspector.get_build_record_inspector(
+                        runtime=self.runtime, build=public_build)
                     public_image_inspector = public_bbi.get_image_inspector(arch)
 
                     dest_pullspec = self.payload_generator.get_mirroring_destination(

--- a/doozer/doozerlib/cli/scan_sources.py
+++ b/doozer/doozerlib/cli/scan_sources.py
@@ -581,7 +581,7 @@ class ConfigScanSources:
     def _tagged_rhcos_id(self, container_name, version, arch, private) -> Optional[str]:
         """determine the most recently tagged RHCOS in given imagestream"""
         base_namespace = rgp.default_imagestream_namespace_base_name()
-        base_name = rgp.default_imagestream_base_name(version)
+        base_name = rgp.default_imagestream_base_name(version, self.runtime)
         namespace, name = rgp.payload_imagestream_namespace_and_name(base_namespace, base_name, arch, private)
         stdout, _ = exectools.cmd_assert(
             f"oc --kubeconfig '{self.ci_kubeconfig}' --namespace '{namespace}' get istag '{name}:{container_name}' -o json",

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -37,7 +37,7 @@ from doozerlib import state, util
 from doozerlib.brew import BuildStates
 from doozerlib.dblib import Record
 from doozerlib.exceptions import DoozerFatalError
-from doozerlib.brew_info import BrewBuildImageInspector
+from doozerlib.build_info import BrewBuildRecordInspector
 from artcommonlib.git_helper import git_clone, gather_git
 from artcommonlib.lock import get_named_semaphore
 from doozerlib.osbs2_builder import OSBS2Builder, OSBS2BuildError
@@ -1308,7 +1308,7 @@ class ImageDistGitRepo(DistGitRepo):
                         self.logger.error(f'Unable to extract brew task information for {task_id}')
 
     def get_installed_packages(self, image_pullspec) -> list:
-        bbii = BrewBuildImageInspector(self.runtime, image_pullspec)
+        bbii = BrewBuildRecordInspector(self.runtime, image_pullspec)
         installed_packages_dict = bbii.get_all_installed_package_build_dicts()
         return sorted([p['nvr'] for p in installed_packages_dict.values()])
 
@@ -1763,7 +1763,7 @@ class ImageDistGitRepo(DistGitRepo):
                 # This does not appear to be a brew image. We can't determine RHEL.
                 return None
 
-            bbii = BrewBuildImageInspector(self.runtime, last_layer_pullspec)
+            bbii = BrewBuildRecordInspector(self.runtime, last_layer_pullspec)
             version = bbii.get_rhel_base_version()
 
         except Exception as e:

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -11,7 +11,7 @@ from artcommonlib.pushd import Dir
 from artcommonlib.rpm_utils import parse_nvr, to_nevra
 from doozerlib import util
 from doozerlib import brew, coverity
-from doozerlib.brew_info import BrewBuildImageInspector
+from doozerlib.build_info import BrewBuildRecordInspector
 from doozerlib.distgit import pull_image
 from doozerlib.metadata import Metadata, RebuildHint, RebuildHintCode
 
@@ -427,7 +427,7 @@ class ImageMetadata(Metadata):
                     return self, RebuildHint(RebuildHintCode.BUILDER_CHANGING, f'A builder or parent image {builder_image_name} has changed since {image_nvr} was built')
 
             self.logger.info("Getting RPMs contained in %s", image_nvr)
-            bbii = BrewBuildImageInspector(self.runtime, image_build)
+            bbii = BrewBuildRecordInspector(self.runtime, image_build)
 
             arch_archives = bbii.get_arch_archives()
             build_arches = set(arch_archives.keys())

--- a/doozer/tests/cli/test_scan_sources.py
+++ b/doozer/tests/cli/test_scan_sources.py
@@ -14,7 +14,7 @@ class TestScanSourcesCli(TestCase):
             '{"image": {"dockerImageMetadata": {"Config": {"Labels": {"org.opencontainers.image.version": "id-1"}}}}}',
             "stderr")
 
-        runtime = MagicMock(rpm_map=[])
+        runtime = MagicMock(rpm_map=[], build_system='brew')
         cli = ConfigScanSources(runtime, "kc.conf", False)
 
         self.assertEqual("id-1", cli._tagged_rhcos_id("cname", "4.2", "s390x", True))

--- a/doozer/tests/test_assembly_inspector.py
+++ b/doozer/tests/test_assembly_inspector.py
@@ -8,7 +8,7 @@ from doozerlib.assembly_inspector import AssemblyInspector
 
 
 class TestAssemblyInspector(IsolatedAsyncioTestCase):
-    def test_check_installed_packages_for_rpm_delivery(self):
+    async def test_check_installed_packages_for_rpm_delivery(self):
         # Test a standard release with a package tagged into my-ship-ok-tag
         rt = MagicMock(mode="both", group_config=Model({
             "rpm_deliveries": [
@@ -27,6 +27,7 @@ class TestAssemblyInspector(IsolatedAsyncioTestCase):
             {"name": "my-integration-tag"},
         ]
         ai = AssemblyInspector(rt, brew_session)
+        await ai.initialize()
         ai.assembly_type = AssemblyTypes.STANDARD
         rpm_packages = {
             "kernel": {"nvr": "kernel-1.2.3-1", "id": 1}

--- a/doozer/tests/test_brew_inspector.py
+++ b/doozer/tests/test_brew_inspector.py
@@ -9,7 +9,7 @@ import logging
 import unittest
 from unittest.mock import MagicMock, Mock, patch
 
-from doozerlib.brew_info import BrewBuildImageInspector
+from doozerlib.build_info import BrewBuildRecordInspector
 
 
 class MockRuntime(object):
@@ -18,7 +18,7 @@ class MockRuntime(object):
         self.logger = logger
 
 
-class TestBrewBuildImageInspector(unittest.TestCase):
+class TestBrewBuildRecordInspector(unittest.TestCase):
 
     def setUp(self):
         self.logger = MagicMock(spec=logging.Logger)
@@ -56,7 +56,7 @@ class TestBrewBuildImageInspector(unittest.TestCase):
         self.koji_mock.getBuild.return_value = image_build_dict
         self.koji_mock.listArchives.return_value = image_archives
         fake_cmd_assert.return_value = (json.dumps(oc_info_dict), "")
-        bbii = BrewBuildImageInspector(self.runtime, image_build_dict['nvr'])
+        bbii = BrewBuildRecordInspector(self.runtime, image_build_dict['nvr'])
 
         self.assertEqual(bbii.get_nvr(), image_build_dict['nvr'])
         self.assertEqual(bbii.get_source_git_url(), 'https://github.com/openshift/sriov-network-operator')
@@ -74,7 +74,7 @@ class TestBrewBuildImageInspector(unittest.TestCase):
         self.koji_mock.getBuild = MagicMock()  # Get rid of old return_value
         self.koji_mock.getBuild.side_effect = canned_getBuild
         self.koji_mock.listRPMs.side_effect = canned_listRPMs
-        archive_inspectors = bbii.get_image_archive_inspectors()
+        archive_inspectors = bbii.get_image_inspectors()
         self.assertEqual(len(archive_inspectors), 4)  # One per image archive
 
         for ai in archive_inspectors:
@@ -83,13 +83,13 @@ class TestBrewBuildImageInspector(unittest.TestCase):
             bd = ai.get_installed_package_build_dicts()
             self.assertEqual(bd['grep']['nvr'], 'grep-3.1-6.el8')
 
-        self.assertIsNone(bbii.get_image_archive_inspector('s390x').get_installed_package_build_dicts().get('tzdata', None))  # Remove this from the resource data by hand for this test
-        self.assertIsNotNone(bbii.get_image_archive_inspector('x86_64').get_installed_package_build_dicts().get('tzdata', None))  # Remove this from the resource data by hand for this test
+        self.assertIsNone(bbii.get_image_inspector('s390x').get_installed_package_build_dicts().get('tzdata', None))  # Remove this from the resource data by hand for this test
+        self.assertIsNotNone(bbii.get_image_inspector('x86_64').get_installed_package_build_dicts().get('tzdata', None))  # Remove this from the resource data by hand for this test
         self.assertIsNotNone(bbii.get_all_installed_package_build_dicts().get('tzdata', None))  # Even though not in s390x, it should be in aggregate
         self.assertEqual(bbii.get_all_installed_package_build_dicts()['grep']['nvr'], 'grep-3.1-6.el8')  # Ensure aggregate has the same nvr for grep
 
-        self.assertEqual(bbii.get_image_archive_inspector('s390x').get_archive_pullspec(), 'registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-sriov-operator-must-gather:rhaos-4.9-rhel-8-containers-candidate-98861-20210726154614-s390x')
-        self.assertEqual(bbii.get_image_archive_inspector('s390x').get_archive_digest(), 'sha256:1f3ebef02669eca018dbfd2c5a65575a21e4920ebe6a5328029a5000127aaa4b')
+        self.assertEqual(bbii.get_image_inspector('s390x').get_pullspec(), 'registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-sriov-operator-must-gather:rhaos-4.9-rhel-8-containers-candidate-98861-20210726154614-s390x')
+        self.assertEqual(bbii.get_image_inspector('s390x').get_digest(), 'sha256:1f3ebef02669eca018dbfd2c5a65575a21e4920ebe6a5328029a5000127aaa4b')
 
 
 if __name__ == "__main__":

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -520,7 +520,7 @@ class BuildSyncPipeline:
 @click.option("--embargo-permit-ack", is_flag=True, default=False,
               help="To permit embargoed builds to be promoted after embargo lift")
 @click.option("--build-system", required=False, default='brew',
-              help="To permit embargoed builds to be promoted after embargo lift")
+              help="Whether a Brew payload or a Konflux one has to be produced")
 @pass_runtime
 @click_coroutine
 @start_as_current_span_async(TRACER, "build-sync")

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -42,7 +42,8 @@ class BuildSyncPipeline:
 
     def __init__(self, runtime: Runtime, version: str, assembly: str, publish: bool, data_path: str,
                  emergency_ignore_issues: bool, retrigger_current_nightly: bool, doozer_data_gitref: str,
-                 images: str, exclude_arches: str, skip_multiarch_payload: bool, embargo_permit_ack: bool):
+                 images: str, exclude_arches: str, skip_multiarch_payload: bool, embargo_permit_ack: bool,
+                 build_system: str):
         self.runtime = runtime
         self.version = version
         self.group = f'openshift-{version}'
@@ -56,6 +57,7 @@ class BuildSyncPipeline:
         self.exclude_arches = [] if not exclude_arches else exclude_arches.replace(',', ' ').split()
         self.skip_multiarch_payload = skip_multiarch_payload
         self.embargo_permit_ack = embargo_permit_ack
+        self.build_system = build_system
         self.logger = runtime.logger
         self.working_dir = self.runtime.working_dir
         self.fail_count_name = f'count:build-sync-failure:{assembly}:{version}'
@@ -63,6 +65,11 @@ class BuildSyncPipeline:
 
         self.slack_client = self.runtime.new_slack_client()
         self.slack_client.bind_channel(f'openshift-{self.version}')
+
+        # Imagestream name for Brew builds is 4.y-art-latest
+        # For konflux, it is 4.y-konflux-art-latest
+        self.is_base_name = f'{self.version}-art-latest' if build_system == 'brew'\
+            else f'{self.version}-konflux-art-latest'
 
     async def comment_on_assembly_pr(self, text_body):
         """
@@ -183,7 +190,7 @@ class BuildSyncPipeline:
                              arch)
             suffix = go_suffix_for_arch(arch, is_private=False)
             cmd = f'oc --kubeconfig {os.environ["KUBECONFIG"]} -n ocp{suffix} tag registry.access.redhat.com/ubi9 ' \
-                f'{self.version}-art-latest{suffix}:trigger-release-controller --import-mode=PreserveOriginal'
+                f'{self.is_base_name}{suffix}:trigger-release-controller --import-mode=PreserveOriginal'
             _, out, _, = await exectools.cmd_gather_async(cmd)
             self.logger.info('oc output: %s', out)
 
@@ -191,7 +198,7 @@ class BuildSyncPipeline:
             await asyncio.sleep(120)
 
             cmd = f'oc --kubeconfig {os.environ["KUBECONFIG"]} -n ocp{suffix} tag ' \
-                f'{self.version}-art-latest{suffix}:trigger-release-controller -d'
+                f'{self.is_base_name}{suffix}:trigger-release-controller -d'
             _, out, _, = await exectools.cmd_gather_async(cmd)
             self.logger.info('oc output: %s', out)
 
@@ -254,7 +261,7 @@ class BuildSyncPipeline:
         # isolate the pullspec trom the ART imagestream tag
         # (e.g. quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:<sha>)
         cmd = f'oc --kubeconfig {os.environ["KUBECONFIG"]} -n ocp{arch_suffix} ' \
-              f'get istag/{self.version}-art-latest{arch_suffix}:{tag} -o=json'
+              f'get istag/{self.is_base_name}{arch_suffix}:{tag} -o=json'
         _, out, _ = await exectools.cmd_gather_async(cmd)
         tag_pullspec = json.loads(out)['tag']['from']['name']
 
@@ -340,6 +347,7 @@ class BuildSyncPipeline:
         if self.doozer_data_gitref:
             group_param += f'@{self.doozer_data_gitref}'
         cmd.append(group_param)
+        cmd.append(f'--build-system={self.build_system}')
         cmd.extend([
             'release:gen-payload',
             f'--output-dir={GEN_PAYLOAD_ARTIFACTS_OUT_DIR}',
@@ -511,12 +519,15 @@ class BuildSyncPipeline:
                    "heterogeneous release payload by setting this to true")
 @click.option("--embargo-permit-ack", is_flag=True, default=False,
               help="To permit embargoed builds to be promoted after embargo lift")
+@click.option("--build-system", required=False, default='brew',
+              help="To permit embargoed builds to be promoted after embargo lift")
 @pass_runtime
 @click_coroutine
 @start_as_current_span_async(TRACER, "build-sync")
 async def build_sync(runtime: Runtime, version: str, assembly: str, publish: bool, data_path: str,
                      emergency_ignore_issues: bool, retrigger_current_nightly: bool, data_gitref: str,
-                     images: str, exclude_arches: str, skip_multiarch_payload: bool, embargo_permit_ack: bool):
+                     images: str, exclude_arches: str, skip_multiarch_payload: bool, embargo_permit_ack: bool,
+                     build_system: str):
     pipeline = await BuildSyncPipeline.create(
         runtime=runtime,
         version=version,
@@ -529,7 +540,8 @@ async def build_sync(runtime: Runtime, version: str, assembly: str, publish: boo
         images=images,
         exclude_arches=exclude_arches,
         skip_multiarch_payload=skip_multiarch_payload,
-        embargo_permit_ack=embargo_permit_ack
+        embargo_permit_ack=embargo_permit_ack,
+        build_system=build_system
     )
     span = trace.get_current_span()
     span.set_attributes({


### PR DESCRIPTION
This PR aims at starting to sync out Konflux image builds, and to update the related imagestreams on the CI cluster. For this purpose, some brew-specific classes have been made flexible enough to handle Konflux build records as well. Specifically:
- `BuildImageInspector` has been renamed into `BuildRecordInspector`; this acts as an abstract superclass for `BrewBuildRecordInspector` and `KonfluxBuildRecordInspector`
- `ArchiveImageInspector` has been renamed into `ImageInspector`; again, this acts as an abstract superclass for `BrewImageInspector` and `KonfluxImageInspector`

The concrete implementations of `BuildRecordInspector` and `ImageInspector` have what it takes to gather the payload entries for both build systems.

The assembly checks [are being skipped](https://github.com/openshift-eng/art-tools/pull/1319/files#diff-7478a485633db5704dff147794623034ddced235335821f1ee0e5d8445c377c7R1901) for Konflux at the moment, and will be implemented at a later moment. That conditional `return` statement should go away.
I've left TODOs [here](https://github.com/openshift-eng/art-tools/pull/1319/files#diff-7478a485633db5704dff147794623034ddced235335821f1ee0e5d8445c377c7R393), [here](https://github.com/openshift-eng/art-tools/pull/1319/files#diff-7478a485633db5704dff147794623034ddced235335821f1ee0e5d8445c377c7R1902) and [here](https://github.com/openshift-eng/art-tools/pull/1319/files#diff-7478a485633db5704dff147794623034ddced235335821f1ee0e5d8445c377c7R1961) to remind us to remove the Konflux simplifications once we're ready.

Depending on the `--build-system` option given to Doozer, the imagestream name in the CI cluster where images are being mirrored to [is chosen](https://github.com/openshift-eng/art-tools/pull/1319/files#diff-7478a485633db5704dff147794623034ddced235335821f1ee0e5d8445c377c7R153) among:
- `{version}-art-latest` for Brew builds
- `{version}-konflux-art-latest` for konflux builds

Test build for Konflux: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/dpaolell/job/build-sync/9/console

I've also also compared the results of a legacy build-sync for Brew, with a build-sync run from this PR with the `--build-system='brew'` option enabled:
- [legacy build-sync run](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/14443)
- [this PR run](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/dpaolell/job/build-sync/11)

The build artifacts stay unchanged, for example:
- [src_dest.x86_64-public-0.txt](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/14443/artifact/gen-payload-artifacts/src_dest.x86_64-public-0.txt) vs [src_dest.x86_64-public-0.txt](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/dpaolell/job/build-sync/11/artifact/gen-payload-artifacts/src_dest.x86_64-public-0.txt)
- [assembly-report.yaml](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/14443/artifact/gen-payload-artifacts/assembly-report.yaml) vs [assembly-report.yaml](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/dpaolell/job/build-sync/11/artifact/gen-payload-artifacts/assembly-report.yaml)

Needs https://github.com/openshift-eng/aos-cd-jobs/pull/4345
Ref. [ART-11391](https://issues.redhat.com/browse/ART-11391)