### PR TITLE
Raise for status build/rhcos

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_rhcos.py
+++ b/pyartcd/pyartcd/pipelines/build_rhcos.py
@@ -49,7 +49,7 @@ class BuildRhcosPipeline:
         self.request_session = requests.Session()
         retries = Retry(
             total=5, backoff_factor=1,
-            status_forcelist=tuple(range(400, 600)),
+            status_forcelist=[401, 500, 502, 503, 504],
             allowed_methods=["HEAD", "GET", "POST"],
             raise_on_status=True,
         )

--- a/pyartcd/pyartcd/pipelines/build_rhcos.py
+++ b/pyartcd/pyartcd/pipelines/build_rhcos.py
@@ -49,7 +49,7 @@ class BuildRhcosPipeline:
         self.request_session = requests.Session()
         retries = Retry(
             total=5, backoff_factor=1,
-            status_forcelist=[401, 500, 502, 503, 504],
+            status_forcelist=[401, 403, 500, 502, 503, 504],
             allowed_methods=["HEAD", "GET", "POST"],
             raise_on_status=True,
         )

--- a/pyartcd/pyartcd/pipelines/build_rhcos.py
+++ b/pyartcd/pyartcd/pipelines/build_rhcos.py
@@ -48,7 +48,7 @@ class BuildRhcosPipeline:
         self.dry_run = self.runtime.dry_run
         self.request_session = requests.Session()
         retries = Retry(
-            total=10, backoff_factor=1,
+            total=5, backoff_factor=1,
             status_forcelist=[401, 403, 500, 502, 503, 504],
             allowed_methods=["HEAD", "GET", "POST"],
             raise_on_status=True,

--- a/pyartcd/pyartcd/pipelines/build_rhcos.py
+++ b/pyartcd/pyartcd/pipelines/build_rhcos.py
@@ -49,7 +49,6 @@ class BuildRhcosPipeline:
         self.request_session = requests.Session()
         retries = Retry(
             total=5, backoff_factor=1,
-            status_forcelist=[500, 502, 503, 504],
             allowed_methods=["HEAD", "GET", "POST"],
         )
         self.request_session.mount("https://", TimeoutHTTPAdapter(max_retries=retries))

--- a/pyartcd/pyartcd/pipelines/build_rhcos.py
+++ b/pyartcd/pyartcd/pipelines/build_rhcos.py
@@ -48,7 +48,7 @@ class BuildRhcosPipeline:
         self.dry_run = self.runtime.dry_run
         self.request_session = requests.Session()
         retries = Retry(
-            total=5, backoff_factor=1,
+            total=10, backoff_factor=1,
             status_forcelist=[401, 403, 500, 502, 503, 504],
             allowed_methods=["HEAD", "GET", "POST"],
             raise_on_status=True,

--- a/pyartcd/pyartcd/pipelines/build_rhcos.py
+++ b/pyartcd/pyartcd/pipelines/build_rhcos.py
@@ -49,7 +49,9 @@ class BuildRhcosPipeline:
         self.request_session = requests.Session()
         retries = Retry(
             total=5, backoff_factor=1,
+            status_forcelist=tuple(range(400, 600)),
             allowed_methods=["HEAD", "GET", "POST"],
+            raise_on_status=True,
         )
         self.request_session.mount("https://", TimeoutHTTPAdapter(max_retries=retries))
 
@@ -122,7 +124,6 @@ class BuildRhcosPipeline:
             response = self.request_session.get(
                 f"{JENKINS_BASE_URL}/job/{job}/api/json?tree=builds[number,description,result,actions[parameters[name,value]]]",
             )
-            response.raise_for_status()
             builds_info = response.json()["builds"]
             for b in builds_info:
                 # build is still running when it has no status


### PR DESCRIPTION
Raise appropriately when api request fails

https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry

Before:
```
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

After:
```
requests.exceptions.RetryError: HTTPSConnectionPool(host='jenkins-rhcos--prod-pipeline.apps.int.prod-stable-spoke1
-dc-iad2.itup.redhat.com', port=443): Max retries exceeded with url: /job/build/api/json?
tree=builds%5Bnumber,description,result,actions%5Bparameters%5Bname,value%5D%5D%5D (Caused by 
ResponseError('too many 403 error responses'))
```

https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Frhcos/12838/console