### PR TITLE
ART-11391 Trigger build-sync after ocp4-konflux

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -330,20 +330,23 @@ def start_rhcos(build_version: str, new_build: bool, **kwargs) -> Optional[str]:
 
 
 def start_build_sync(build_version: str, assembly: str, doozer_data_path: Optional[str] = None,
-                     doozer_data_gitref: Optional[str] = None, **kwargs) -> Optional[str]:
+                     doozer_data_gitref: Optional[str] = None, build_system: Optional[str] = 'brew',
+                     exclude_arches: list = None, **kwargs) -> Optional[str]:
     params = {
         'BUILD_VERSION': build_version,
         'ASSEMBLY': assembly,
+        'BUILD_SYSTEM': build_system,
     }
     if doozer_data_path:
         params['DOOZER_DATA_PATH'] = doozer_data_path
     if doozer_data_gitref:
         params['DOOZER_DATA_GITREF'] = doozer_data_gitref
+    if exclude_arches:
+        params['EXCLUDE_ARCHES'] = ','.join(exclude_arches)
 
     return start_build(
         job=Jobs.BUILD_SYNC,
-        params=params,
-        **kwargs
+        params=params | kwargs,
     )
 
 

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -531,6 +531,7 @@ async def build_sync(runtime: Runtime, version: str, assembly: str, publish: boo
                      emergency_ignore_issues: bool, retrigger_current_nightly: bool, data_gitref: str,
                      images: str, exclude_arches: str, skip_multiarch_payload: bool, embargo_permit_ack: bool,
                      build_system: str):
+    jenkins.init_jenkins()
     pipeline = await BuildSyncPipeline.create(
         runtime=runtime,
         version=version,

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -658,6 +658,10 @@ class Ocp4Pipeline:
             if record['has_olm_bundle'] == '1' and record['status'] == '0' and record.get('nvrs', None):
                 operator_nvrs.append(record['nvrs'].split(',')[0])
 
+        if self.runtime.dry_run:
+            self.runtime.logger.info('Skipping build-sync and olm-bundle for dry run mode')
+            return
+
         if self.assembly == 'test':
             self.runtime.logger.warning('Skipping build-sync job for test assembly')
 

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -158,7 +158,7 @@ class KonfluxOcp4Pipeline:
 
         LOGGER.info("All builds completed successfully")
 
-    def sync_images(self):
+    async def sync_images(self):
         if self.runtime.dry_run:
             LOGGER.info('Not syncing images in dry run mode')
             return
@@ -188,7 +188,8 @@ class KonfluxOcp4Pipeline:
             self.runtime.logger.warning('Skipping build-sync job for test assembly')
             return
 
-        exclude_arches = ['aarch64', 'ppc64le', 's390x', 'x86_64']
+        _, out, _ = await exectools.cmd_gather_async([*self._doozer_base_command.copy(), 'config:read-group', 'arches'])
+        exclude_arches = json.loads(out.strip())
         for arch in self.arches:
             exclude_arches.remove(arch)
 
@@ -312,7 +313,7 @@ class KonfluxOcp4Pipeline:
             await self.build()
 
         finally:
-            self.sync_images()
+            await self.sync_images()
             self.trigger_bundle_build()
             await self.clean_up()
 

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -11,6 +11,7 @@ import click
 import yaml
 
 from artcommonlib import exectools
+from doozerlib.exceptions import DoozerFatalError
 
 from pyartcd import constants, util, jenkins, locks
 from pyartcd.cli import cli, click_coroutine, pass_runtime
@@ -157,6 +158,46 @@ class KonfluxOcp4Pipeline:
 
         LOGGER.info("All builds completed successfully")
 
+    def sync_images(self):
+        LOGGER.info('Syncing images...')
+
+        record_log = self.parse_record_log()
+        if not record_log:
+            LOGGER.error('record.log not found!')
+            return
+
+        built_images = [entry['name'] for entry in record_log['image_build_konflux'] if not int(entry['status'])]
+        failed_images = [entry['name'] for entry in record_log['image_build_konflux'] if int(entry['status'])]
+        if len(failed_images) <= 10:
+            jenkins.update_description(f'Failed images: {", ".join(failed_images)}<br/>')
+        else:
+            jenkins.update_description(f'{len(failed_images)} images failed. Check record.log for details<br/>')
+
+        if not built_images:
+            # Nothing to do, skipping build-sync
+            return
+
+        if self.version != '4.19':
+            return  # TODO to be removed
+
+        if self.assembly == 'test':
+            self.runtime.logger.warning('Skipping build-sync job for test assembly')
+            return
+
+        exclude_arches = ['aarch64', 'ppc64le', 's390x', 'x86_64']
+        for arch in self.arches:
+            exclude_arches.remove(arch)
+
+        jenkins.start_build_sync(
+            build_version=self.version,
+            assembly=self.assembly,
+            doozer_data_path=self.data_path,
+            doozer_data_gitref=self.data_gitref,
+            build_system='konflux',
+            exclude_arches=exclude_arches,
+            SKIP_MULTI_ARCH_PAYLOAD=True,  # TODO to be removed
+        )
+
     async def init_build_plan(self):
         # Get number of images in current group
         shutil.rmtree(self.runtime.doozer_working, ignore_errors=True)
@@ -215,25 +256,40 @@ class KonfluxOcp4Pipeline:
         ])
 
     def trigger_bundle_build(self):
-        record_log_path = Path(self.runtime.doozer_working, 'record.log')
-        if not record_log_path.exists():
+        if self.skip_bundle_build:
+            LOGGER.warning("Skipping bundle build step because --skip-bundle-build flag is set")
+            return
+
+        record_log = self.parse_record_log()
+        if not record_log:
             LOGGER.warning('record.log not found, skipping bundle build')
             return
+
+        try:
+            records = record_log.get('image_build_konflux', [])
+            operator_nvrs = []
+            for record in records:
+                if record['has_olm_bundle'] == '1' and record['status'] == '0' and record.get('nvrs', None):
+                    operator_nvrs.append(record['nvrs'].split(',')[0])
+            if operator_nvrs:
+                jenkins.start_olm_bundle_konflux(
+                    build_version=self.version,
+                    assembly=self.assembly,
+                    operator_nvrs=operator_nvrs,
+                    doozer_data_path=self.data_path or '',
+                    doozer_data_gitref=self.data_gitref or '',
+                )
+        except Exception as e:
+            LOGGER.exception(f"Failed to trigger bundle build: {e}")
+
+    def parse_record_log(self) -> Optional[dict]:
+        record_log_path = Path(self.runtime.doozer_working, 'record.log')
+        if not record_log_path.exists():
+            return None
+
         with record_log_path.open('r') as file:
             record_log: dict = record_util.parse_record_log(file)
-        records = record_log.get('image_build_konflux', [])
-        operator_nvrs = []
-        for record in records:
-            if record['has_olm_bundle'] == '1' and record['status'] == '0' and record.get('nvrs', None):
-                operator_nvrs.append(record['nvrs'].split(',')[0])
-        if operator_nvrs:
-            jenkins.start_olm_bundle_konflux(
-                build_version=self.version,
-                assembly=self.assembly,
-                operator_nvrs=operator_nvrs,
-                doozer_data_path=self.data_path or '',
-                doozer_data_gitref=self.data_gitref or '',
-            )
+            return record_log
 
     async def run(self):
         await self.initialize()
@@ -250,14 +306,10 @@ class KonfluxOcp4Pipeline:
         LOGGER.info(f"Building images for OCP {self.version} with release {input_release}")
         try:
             await self.build()
+
         finally:
-            if self.skip_bundle_build:
-                LOGGER.warning("Skipping bundle build step because --skip-bundle-build flag is set")
-            else:
-                try:
-                    self.trigger_bundle_build()
-                except Exception as e:
-                    LOGGER.exception(f"Failed to trigger bundle build: {e}")
+            self.sync_images()
+            self.trigger_bundle_build()
             await self.clean_up()
 
 

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -159,6 +159,10 @@ class KonfluxOcp4Pipeline:
         LOGGER.info("All builds completed successfully")
 
     def sync_images(self):
+        if self.runtime.dry_run:
+            LOGGER.info('Not syncing images in dry run mode')
+            return
+
         LOGGER.info('Syncing images...')
 
         record_log = self.parse_record_log()

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -349,36 +349,6 @@ def log_file_content(path_to_file):
         logger.info(f.read())
 
 
-async def sync_images(version: str, assembly: str, operator_nvrs: list,
-                      doozer_data_path: str = constants.OCP_BUILD_DATA_URL, doozer_data_gitref: str = ''):
-    """
-    Run an image sync after a build. This will mirror content from internal registries to quay.
-    After a successful sync an image stream is updated with the new tags and pullspecs.
-    Also update the app registry with operator manifests.
-    If operator_nvrs is given, will only build manifests for specified operator NVRs.
-    If builds don't succeed, email and set result to UNSTABLE.
-    """
-
-    if assembly == 'test':
-        logger.warning('Skipping build-sync job for test assembly')
-    else:
-        jenkins.start_build_sync(
-            build_version=version,
-            assembly=assembly,
-            doozer_data_path=doozer_data_path,
-            doozer_data_gitref=doozer_data_gitref
-        )
-
-    if operator_nvrs:
-        jenkins.start_olm_bundle(
-            build_version=version,
-            assembly=assembly,
-            operator_nvrs=operator_nvrs,
-            doozer_data_path=doozer_data_path,
-            doozer_data_gitref=doozer_data_gitref
-        )
-
-
 def default_release_suffix():
     """
     Returns a release suffix based on current timestamp


### PR DESCRIPTION
Hooking up build-sync for Konflux runs to ocp4-konflux. Currently, this is being limited to 4.19 only; we can remove the [switch](https://github.com/openshift-eng/art-tools/compare/main...locriandev:trigger-build-sync-for-konflux?expand=1#diff-722ce25d123c3fd8f7c2ebbbd5ab0e9f310f3f4b82b1f4a37d568f6f8f17dd47R180) once we think we're ready to start syncing all version building for Konflux. 

Test run for [ocp4-konflux](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/4148/console) triggered [this build-sync](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/14516/)