### PR TITLE
Fix exectools command logging

### DIFF
--- a/artcommon/artcommonlib/exectools.py
+++ b/artcommon/artcommonlib/exectools.py
@@ -191,7 +191,7 @@ def cmd_gather(cmd: Union[str, List], set_env: Optional[Dict[str, str]] = None, 
     env['LC_ALL'] = 'en_US.UTF-8'
 
     with timer(logger.debug, f'{cmd_info}: Executed:cmd_gather'):
-        logger.info(f'{cmd_info}: Executing:cmd_gather %s', ' '.join(cmd_list))
+        logger.info(f'{cmd_info}: Executing:cmd_gather {" ".join(cmd_list)}')
         try:
             proc = subprocess.Popen(
                 cmd_list, cwd=cwd, env=env,
@@ -484,7 +484,7 @@ async def cmd_gather_async(cmd: Union[List[str], str], check: bool = True, **kwa
             env = kwargs["env"] = os.environ.copy()
         env["TRACEPARENT"] = carrier["traceparent"]
 
-    logger.info("Executing:cmd_gather_async %s", ' '.join(cmd_list))
+    logger.info(f"Executing:cmd_gather_async {' '.join(cmd_list)}'")
     proc = await asyncio.subprocess.create_subprocess_exec(cmd_list[0], *cmd_list[1:], **kwargs)
     stdout, stderr = await proc.communicate()
     stdout = stdout.decode() if stdout else ""
@@ -530,7 +530,7 @@ async def cmd_assert_async(cmd: Union[List[str], str], check: bool = True, **kwa
             env = kwargs["env"] = os.environ.copy()
         env["TRACEPARENT"] = carrier["traceparent"]
 
-    logger.info("Executing:cmd_assert_async %s", ' '.join(cmd_list))
+    logger.info(f"Executing:cmd_assert_async {' '.join(cmd_list)}'")
     proc = await asyncio.subprocess.create_subprocess_exec(cmd_list[0], *cmd_list[1:], **kwargs)
     returncode = await proc.wait()
     span.set_attribute("pyartcd.result.exit_code", str(returncode))


### PR DESCRIPTION
Using logger lazy evaluation is causing an unexpected exception inside the logging library, apparently when the command list contains a `%`, e.g.
```
['git', 'log', '-1', '--format=%ct']
```
causes
```
Message: "$10: ['git', 'log', '-1', '--format=%ct'] - [cwd=/tmp/working/sources/containers_ironic_ironic-image]: Executing:cmd_gather %s"
Arguments: ('git log -1 --format=%ct',)
...
  File "/usr/lib64/python3.11/logging/__init__.py", line 377, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: %c requires int or char
```
Using the f-string formatting, although not performance-ideal, fixes this issue.