### PR TITLE
Run oc image mirror in sequence

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -846,13 +846,12 @@ class GenPayloadCli:
         # Ensure that all payload images have been mirrored before updating
         # the imagestream. Otherwise, the imagestream will fail to import the
         # image.
-        tasks = []
+        # We don't use asyncio.gather here because we want to limit concurrency
+        # to avoid failing at the registry level.
         for arch, payload_entries in self.private_payload_entries_for_arch.items():
-            tasks.append(self.mirror_payload_content(arch, payload_entries, True))
+            await self.mirror_payload_content(arch, payload_entries, True)
         for arch, payload_entries in self.payload_entries_for_arch.items():
-            tasks.append(self.mirror_payload_content(arch, payload_entries))
-        await asyncio.gather(*tasks)
-
+            await self.mirror_payload_content(arch, payload_entries)
         await asyncio.sleep(120)
 
         # Updating public and private image streams

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -910,7 +910,7 @@ class GenPayloadCli:
                 await asyncio.wait_for(exectools.cmd_assert_async(cmd), timeout=7200)
 
         # Mirror the images in chunks to avoid erroring out due to possible registry issues
-        image_chunk_size = 50
+        image_chunk_size = 100
         i = 0
         for pullspec_pair_chunk in chunk(list(mirror_src_for_dest.items()), image_chunk_size):
             src_dest_path = self.output_path.joinpath(f"src_dest.{arch}-{'private' if private else 'public'}-{i}.txt")


### PR DESCRIPTION
Concurrent `oc image mirror` invokes to ART's quay repo are ending up in failure.
This has recently spiked up due to quay instability. To mitigate, run mirroring one at a time.
This would increase the job time but would decrease outright failures.

example: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/14590/

Note: Depending on the timing, multiple `oc image mirror` could still conflict via parallel build-sync runs going on in for each distinct ocp versions. But this should help.

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/14593/console

past work:
https://github.com/openshift-eng/art-tools/pull/1317
https://github.com/openshift-eng/art-tools/pull/1273