### PR TITLE
Cachito emulation fixes

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -3,6 +3,7 @@ import hashlib
 import io
 import logging
 import os
+import pathlib
 import re
 import shutil
 from pathlib import Path
@@ -788,17 +789,60 @@ class KonfluxRebaser:
             f"ENV ART_BUILD_NETWORK={network_mode}"
         ]
 
-        cachito_emulation = metadata.config.get("konflux", {}).get("cachito", {}).get("emulation", False)
-        if cachito_emulation:
-            emulation_dir = f"{dest_dir}/cachi2-emulation/app"
-            os.makedirs(emulation_dir, exist_ok=True)
-            with open(f"{emulation_dir}/.dir", "w"):
-                # Create an emtpy file for rebase
-                pass
+        # Three modes for handling upstreams depending on old
+        # cachito functionality
+        # 1. "pass" or "default" - Do nothing special for the Dockerfile. This may be appropriate for Dockerfiles
+        #    well enough to handle cachito & non-cachito environments already.
+        # 2. "emulation" - inject cachito-like environment variables & resources into Dockerfile.
+        # 3. "remove" - Comment out lines referencing REMOTE_SOURCES.
+        if metadata.config.konflux.cachito.mode == 'emulation':
+            # In cachito emulation mode, we make allowances for the upstream
+            # Dockerfile to have references to cachito env vars that no longer
+            # exist in cachi2 builds.
+            # The most important env vars are "REMOTE_SOURCES" and "REMOTE_SOURCES_DIR"
+            # which cachito injects and are used in Dockerfile commands like
+            # COPY "$REMOTE_SOURCES" "$REMOTE_SOURCES_DIR"
+            # RUN source "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env" && make
+            # Our emulation mode ensures that these env vars are defined
+            # and both the COPY and "source" command will not fail.
+            # This may not satisfy all builds cachito expectations, but can help
+            # folks write Dockerfiles that can be built with cachito and cachi2.
+
+            # The directory will be serve as REMOTE_SOURCES content in the rebased
+            # upstream repository.
+            # i.e. COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR will resolve as
+            #      COPY cachito-emulation $REMOTE_SOURCES_DIR
+            # During the rebase, populate this directory in the git repo with
+            # files & directories cachito users expect to find.
+            emulation_dir = 'cachito-emulation'
+
+            # Create a path to the location where files that will
+            # populate REMOTE_SOURCES should be written.
+            emulation_path = pathlib.Path(dest_dir).joinpath(emulation_dir)
+
+            # Cachito creates a directory under REMOTE_SOURCES called app
+            # where source code would be extracted. We don't reproduce
+            # this behavior, but we do at least ensure the directory exists
+            # so that Dockerfiles can safely reference it.
+            app_path = emulation_path.joinpath('app')
+            app_path.mkdir(parents=True, exist_ok=True)
+            # A file must exist in the dir for it to be established in git.
+            # Create a stub file.
+            app_path.joinpath('.dir').touch(exist_ok=True)
+
+            # Cachito requires Dockerfiles to source
+            # ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env . We don't populate
+            # any env vars here, but we do make it safe to source (i.e. an empty file)
+            gomod_deps_path = emulation_path.joinpath('cachito-gomod-with-deps')
+            gomod_deps_path.mkdir(parents=True, exist_ok=True)
+            # Now ensure the cachito.env file exists in REMOTE_SOURCES so it will
+            # be copied into REMOTE_SOURCES_DIR
+            gomod_deps_path.joinpath('cachito.env').touch(exist_ok=True)
 
             konflux_lines += [
                 "ENV ART_BUILD_DEPS_MODE=cachito-emulation",
-                f"ENV REMOTE_SOURCES={dest_dir}/cachito-emulation",
+                f"ENV REMOTE_SOURCES={emulation_dir}",
+                f"ENV REMOTE_SOURCES_DIR=/tmp/{emulation_dir}",
             ]
         else:
             konflux_lines += [
@@ -862,8 +906,15 @@ class KonfluxRebaser:
                     yarn_line_updated = False
                     continue
 
-            if metadata.config.get("konflux", {}).get("cachito", {}).get("comment", True) and ("REMOTE_SOURCES" in line or "REMOTE_SOURCE_DIR" in line):
-                # Comment lines containing 'REMOTE_SOURCES' or 'REMOTE_SOURCES_DIR' since cachito is not supported in konflux
+            # If konflux cachito mode is set to "remove", comment out
+            # all lines which reference cachito environment variables. If this doesn't work
+            # for a build, you can try 'mode: emulation' which will inject cachito env vars
+            # into the Dockerfile.
+            cachito_mode = metadata.config.konflux.cachito.mode
+            cachito_commenting_enabled = cachito_mode == 'remove'
+
+            if cachito_commenting_enabled and ("REMOTE_SOURCES" in line or "REMOTE_SOURCE_DIR" in line):
+                # Comment lines containing 'REMOTE_SOURCES' or 'REMOTE_SOURCES_DIR' based on cachito mode.
                 updated_lines.append(f"#{line.strip()}\n")
                 line_commented = True
                 self._logger.info("Lines containing 'REMOTE_SOURCES' and 'REMOTE_SOURCES_DIR' have been commented out, since cachito is not supported on konflux")


### PR DESCRIPTION
- REMOTE_SOURCES needs to be injected as relative path instead of absolute
- REMOTE_SOURCES_DIR must be defined
- cachito.env must exist

Also changing to konflux.cachito.mode instead of proliferating booleans in metadata.