### PR TITLE
Cachito emulation fixes

### DIFF
--- a/artcommon/artcommonlib/bigquery.py
+++ b/artcommon/artcommonlib/bigquery.py
@@ -14,10 +14,11 @@ from artcommonlib import constants
 
 class BigQueryClient:
     def __init__(self):
-        if 'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ:
-            raise EnvironmentError('Missing required environment variable GOOGLE_APPLICATION_CREDENTIALS')
+        try:
+            self.client = bigquery.Client(project=constants.GOOGLE_CLOUD_PROJECT)
+        except:
+            raise EnvironmentError(f'Unable to access {constants.GOOGLE_CLOUD_PROJECT}. Initialize default application context or set GOOGLE_APPLICATION_CREDENTIALS')
 
-        self.client = bigquery.Client(project=constants.GOOGLE_CLOUD_PROJECT)
         self._table_ref = None
         self.logger = logging.getLogger(__name__)
 

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -444,7 +444,7 @@ class Metadata(object):
                                        outcome: KonfluxBuildOutcome = KonfluxBuildOutcome.SUCCESS,
                                        el_target: Optional[Union[int, str]] = None,
                                        honor_is: bool = True,
-                                       completed_before: Optional[datetime] = None,
+                                       completed_before: Optional[datetime.datetime] = None,
                                        extra_patterns: dict = {},
                                        **kwargs) -> Optional[KonfluxBuildRecord]:
         """

--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -29,3 +29,5 @@ requests>=2.32.0 # not directly required, pinned by Snyk to avoid a vulnerabilit
 setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
 mysql-connector-python>=9.1.0 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+async_lru
+packageurl-python


### PR DESCRIPTION
- REMOTE_SOURCES needs to be injected as relative path instead of absolute
- REMOTE_SOURCES_DIR must be defined
- cachito.env must exist

Also:
- Changing to konflux.cachito.mode instead of proliferating booleans in metadata.
- Allowing GCP default application credentials to be used for bigquery access
- Adding missing requirements