### PR TITLE
[konflux] build/sync microshift-bootc location

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -13,7 +13,7 @@ from sqlalchemy import Column, String, DateTime, func
 
 from artcommonlib import bigquery
 from artcommonlib.konflux import konflux_build_record
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, ArtifactType, KonfluxRecord, Engine, KonfluxBuildRecord
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, ArtifactType, KonfluxRecord, Engine
 
 SCHEMA_LEVEL = 1
 DEFAULT_SEARCH_WINDOW = 90
@@ -216,7 +216,7 @@ class KonfluxDb:
             completed_before: typing.Optional[datetime] = None,
             extra_patterns: dict = {},
             strict: bool = False,
-    ) -> typing.Optional[KonfluxBuildRecord]:
+    ) -> typing.Optional[KonfluxRecord]:
         """
         Search for the latest Konflux build information in BigQuery.
 

--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -13,7 +13,7 @@ from sqlalchemy import Column, String, DateTime, func
 
 from artcommonlib import bigquery
 from artcommonlib.konflux import konflux_build_record
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, ArtifactType, KonfluxRecord, Engine
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, ArtifactType, KonfluxRecord, Engine, KonfluxBuildRecord
 
 SCHEMA_LEVEL = 1
 DEFAULT_SEARCH_WINDOW = 90
@@ -216,7 +216,7 @@ class KonfluxDb:
             completed_before: typing.Optional[datetime] = None,
             extra_patterns: dict = {},
             strict: bool = False,
-    ) -> typing.Optional[KonfluxRecord]:
+    ) -> typing.Optional[KonfluxBuildRecord]:
         """
         Search for the latest Konflux build information in BigQuery.
 

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -36,6 +36,7 @@ KONFLUX_DEFAULT_PIPELINERUN_TIMEOUT = "1h0m0s"
 KONFLUX_DEFAULT_PIPRLINE_DOCKER_BUILD_BUNDLE_PULLSPEC = "quay.io/konflux-ci/tekton-catalog/pipeline-docker-build:devel"
 KONFLUX_DEFAULT_IMAGE_REPO = "quay.io/redhat-user-workloads/ocp-art-tenant/art-images"   # FIXME: If we change clusters this URL will change
 ART_PROD_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+ART_PROD_PRIV_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-v4.0-art-dev-priv"
 KONFLUX_UI_HOST = "https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com"
 KONFLUX_UI_DEFAULT_WORKSPACE = "ocp-art"  # associated with ocp-art-tenant
 KONFLUX_DEFAULT_NAMESPACE = f"{KONFLUX_UI_DEFAULT_WORKSPACE}-tenant"

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -24,7 +24,7 @@ from pyartcd.util import (get_assembly_type,
                           get_release_name_for_assembly,
                           get_microshift_builds)
 from pyartcd.plashets import build_plashets, plashet_config_for_major_minor
-from doozerlib.constants import ART_PROD_IMAGE_REPO
+from doozerlib.constants import ART_PROD_IMAGE_REPO, ART_PROD_PRIV_IMAGE_REPO, KONFLUX_DEFAULT_IMAGE_REPO
 
 yaml = new_roundtrip_yaml_handler()
 
@@ -97,6 +97,26 @@ class BuildMicroShiftBootcPipeline:
         repo_url = bootc_build.image_pullspec.rsplit(":")[0]
         for arch, digest in digest_by_arch.items():
             await self.sync_to_mirror(arch, bootc_build.el_target, f"{repo_url}@{digest}")
+
+        if not self.runtime.dry_run:
+            if bootc_build.embargoed:
+                await self.sync_to_quay(bootc_build.image_pullspec, ART_PROD_PRIV_IMAGE_REPO)
+            else:
+                await self.sync_to_quay(bootc_build.image_pullspec, ART_PROD_IMAGE_REPO)
+        else:
+            self._logger("Skipping sync to quay.io/openshift-release-dev/ocp-v4.0-art-dev since in dry-run mode")
+
+    async def sync_to_quay(self, source_pullspec, destination_repo):
+        """
+        Microshift team needs the image on quay.io/openshift-release-dev/ocp-v4.0-art-dev as well.
+        """
+        # eg: extract 'ose-baremetal-installer-rhel9-v4.19.0-20250210.224515' from
+        # quay.io/redhat-user-workloads/ocp-art-tenant/art-images:ose-baremetal-installer-rhel9-v4.19.0-20250210.224515
+        destination_pullspec = f"{destination_repo}:{source_pullspec.split(':')[-1]}"
+
+        self._logger.info(f"Syncing bootc image from {source_pullspec} to {destination_pullspec}")
+        cmd = ['oc', 'image', 'mirror', '--keep-manifest-list', source_pullspec, destination_pullspec]
+        await asyncio.wait_for(exectools.cmd_assert_async(cmd), timeout=7200)
 
     async def sync_to_mirror(self, arch, el_target, pullspec):
         arch = brew_arch_for_go_arch(arch)
@@ -268,7 +288,7 @@ class BuildMicroShiftBootcPipeline:
             # also not passing this breaks the command since we try to use brew to find the appropriate commit
             "--lock-upstream", bootc_image_name, "HEAD",
             "beta:images:konflux:build",
-            "--image-repo", ART_PROD_IMAGE_REPO,
+            "--image-repo", KONFLUX_DEFAULT_IMAGE_REPO,
             "--konflux-kubeconfig", kubeconfig,
             "--konflux-namespace", "ocp-art-tenant"
         ]

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -110,10 +110,11 @@ class BuildMicroShiftBootcPipeline:
         """
         Microshift team needs the image on quay.io/openshift-release-dev/ocp-v4.0-art-dev as well.
         """
-        # eg: extract 'ose-baremetal-installer-rhel9-v4.19.0-20250210.224515' from
+        # extract tag
+        # e.g.'ose-baremetal-installer-rhel9-v4.19.0-20250210.224515' from
         # quay.io/redhat-user-workloads/ocp-art-tenant/art-images:ose-baremetal-installer-rhel9-v4.19.0-20250210.224515
-        destination_pullspec = f"{destination_repo}:{source_pullspec.split(':')[-1]}"
-
+        tag = source_pullspec.split(':')[-1]
+        destination_pullspec = f"{destination_repo}:{tag}"
         self._logger.info(f"Syncing bootc image from {source_pullspec} to {destination_pullspec}")
         cmd = ['oc', 'image', 'mirror', '--keep-manifest-list', source_pullspec, destination_pullspec]
         await asyncio.wait_for(exectools.cmd_assert_async(cmd), timeout=7200)


### PR DESCRIPTION
ref [thread](https://redhat-internal.slack.com/archives/GDBRP5YJH/p1739373251573739?thread_ts=1739372936.015079&cid=GDBRP5YJH)

Konflux needs images to be built to the default build repo in order for it to be released. But the microshift team has an additional requirement that it has to be synced to `quay.io/openshift-release-dev/ocp-v4.0-art-dev` as well