### PR TITLE
prepare-release: Add options to use custom ocp-build-data

### DIFF
--- a/doozer/doozerlib/source_resolver.py
+++ b/doozer/doozerlib/source_resolver.py
@@ -199,7 +199,7 @@ class SourceResolver:
                     cmd = ["git", "-C", source_dir, "branch", "--contains", meta.commitish]
                     exectools.cmd_assert(cmd)
                     LOGGER.info(f"Checking out commit-ish {meta.commitish}")
-                    exectools.cmd_assert(["git", "-C", source_dir, "reset", meta.commitish])
+                    exectools.cmd_assert(["git", "-C", source_dir, "reset", "--hard", meta.commitish])
 
                 # fetch public upstream source
                 if has_public_upstream:

--- a/elliott/elliottlib/brew.py
+++ b/elliott/elliottlib/brew.py
@@ -1,6 +1,7 @@
 """
 Utility functions for general interactions with Brew and Builds
 """
+from tenacity import retry, stop_after_attempt, wait_fixed
 from artcommonlib import logutil
 # stdlib
 import json
@@ -149,6 +150,7 @@ def get_builds_tags(build_nvrs, session=None):
     return [task.result for task in tasks]
 
 
+@retry(reraise=True, stop=stop_after_attempt(5), wait=wait_fixed(10))
 def get_brew_build(nvr, product_version='', session=None):
     """5.2.2.1. GET /api/v1/build/{id_or_nvr}
 

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -101,7 +101,6 @@ class Ocp4Pipeline:
             f'--data-path={data_path}',
             group_param
         ]
-
         self._slack_client = runtime.new_slack_client()
         self._mail_client = self.runtime.new_mail_client()
 


### PR DESCRIPTION
Similar to ocp4 job, adds `--data-path` and `--data-gitref` options to allow to override ocp-build-data fork and commit hash.

This also contains some other minor fixes/improvements.