### PR TITLE
[konflux] explicitly pass cyclonedx

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -372,6 +372,9 @@ class KonfluxClient:
                 case "build-images":
                     has_build_images_task = True
                     task["timeout"] = "12h"
+                    _modify_param(task["params"], "SBOM_TYPE", "cyclonedx")
+                case "prefetch-dependencies":
+                    _modify_param(task["params"], "SBOM_TYPE", "cyclonedx")
                 case "apply-tags":
                     _modify_param(task["params"], "ADDITIONAL_TAGS", list(additional_tags))
                 case "clone-repository":


### PR DESCRIPTION
To follow this change: https://github.com/openshift-priv/art-konflux-template/pull/46

We have the option to pass it as a param: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml#L88