### PR TITLE
[konflux] fix bootc

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -83,6 +83,11 @@ class BuildMicroShiftBootcPipeline:
         else:
             raise ValueError(f"Could not find bootc image build for assembly {self.assembly}")
 
+        # Login to Konflux registry
+        cmd = ['oc', 'registry', 'login', '--registry', 'quay.io/redhat-user-workloads',
+               f'--auth-basic={os.environ["KONFLUX_ART_IMAGES_USERNAME"]}:{os.environ["KONFLUX_ART_IMAGES_PASSWORD"]}']
+        await exectools.cmd_assert_async(cmd)
+
         # get image digests from manifest list for all arches
         cmd = [
             "skopeo",


### PR DESCRIPTION
To provide pull access to konflux build repo

Same logic as build sync: https://github.com/openshift-eng/art-tools/blob/29f04b71d7e8e1b5a2cbfd4901840de82917059e/doozer/doozerlib/cli/release_gen_payload.py#L883-L887