### PR TITLE
[konflux] use bigger IBM VM flavors

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -27,8 +27,8 @@ class KonfluxClient:
     # The arch to Konflux VM name mapping. The specs for each of the VMs can be seen in the doc link shared above.
     SUPPORTED_ARCHES = {
         "x86_64": "linux/x86_64",
-        "s390x": "linux/s390x",
-        "ppc64le": "linux/ppc64le",
+        "s390x": "linux-large/s390x",
+        "ppc64le": "linux-large/ppc64le",
         "aarch64": "linux/arm64",
     }
 


### PR DESCRIPTION
The default IBM VMs have only 2CPU, while the default for other arches are 4CPU. Ref [docs](https://konflux.pages.redhat.com/docs/users/getting-started/multi-platform-builds.html) 

Proposing to use linux-large variant by default, which has 4CPU, to see if it reduces build times and matches the builds of other arches. 