### PR TITLE
Fail build-sync for konflux in case of missing builds

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -1957,8 +1957,7 @@ class PayloadGenerator:
             except ChildProcessError:  # raised by Konflux in case oc image info fails
                 image_inspector = None
 
-            if not image_inspector and not self.runtime.build_system == 'konflux':
-                # TODO allowing this for konflux, in the future will should always raise an exception
+            if not image_inspector:
                 # There is no build for this CPU architecture for this image_meta/build. This finding
                 # conflicts with the `arch not in image_meta.get_arches()` check above.
                 # Best to fail.


### PR DESCRIPTION
We had introduced a temporary permit for missing builds when syncing Konflux images. This was needed because not all components had available builds, as most of them had been garbage-collected and been failing to rebuild since then.

Now this should be fixed at least for 4.19, so re-introducing the constraint.