### PR TITLE
ART-9439 - modifications in prepare-release

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -159,10 +159,14 @@ def default_imagestream_base_name(version: str, runtime: Runtime) -> str:
 
 def assembly_imagestream_base_name(runtime: Runtime) -> str:
     version = runtime.get_minor_version()
-    if runtime.assembly == 'stream' and runtime.assembly_type is AssemblyTypes.STREAM:
-        return default_imagestream_base_name(version, runtime)
+    return assembly_imagestream_base_name_generic(version, runtime.assembly, runtime.assembly_type)
+
+
+def assembly_imagestream_base_name_generic(version, assembly_name, assembly_type):
+    if assembly_name == 'stream' and assembly_type is AssemblyTypes.STREAM:
+        return default_imagestream_base_name(version)
     else:
-        return f"{version}-art-assembly-{runtime.assembly}"
+        return f"{version}-art-assembly-{assembly_name}"
 
 
 def default_imagestream_namespace_base_name() -> str:

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -762,11 +762,7 @@ class PrepareReleasePipeline:
 
     @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(10))
     def verify_payload(self, pullspec_or_imagestream: str, advisory: int):
-        cmd = [
-            "elliott",
-            f"--working-dir={self.elliott_working_dir}",
-            f"--group={self.group_name}",
-            "--assembly", self.assembly,
+       cmd = self._elliott_base_command + [
             "verify-payload",
             f"{pullspec_or_imagestream}",
             f"{advisory}",

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -22,6 +22,7 @@ from artcommonlib.assembly import AssemblyTypes, assembly_group_config
 from artcommonlib import git_helper
 from artcommonlib.model import Model
 from artcommonlib.util import get_assembly_release_date_async, new_roundtrip_yaml_handler, convert_remote_git_to_ssh
+from doozerlib.cli.release_gen_payload import assembly_imagestream_base_name_generic, default_imagestream_namespace_base_name, payload_imagestream_namespace_and_name
 from elliottlib.errata import set_blocking_advisory, get_blocking_advisories, push_cdn_stage, is_advisory_editable
 from elliottlib.errata_async import AsyncErrataAPI
 from elliottlib.errata import set_blocking_advisory, get_blocking_advisories
@@ -369,9 +370,19 @@ class PrepareReleasePipeline:
         if self.release_version[0] < 4:
             _LOGGER.info("Don't verify payloads for OCP3 releases")
         else:
-            _LOGGER.info("Verify the swept builds match the nightlies...")
-            for _, payload in self.candidate_nightlies.items():
-                self.verify_payload(payload, advisories["image"])
+            _LOGGER.info("Verify the swept builds match the imagestreams that were updated during build-sync...")
+            image_stream_version = f'{self.release_version[0]}.{self.release_version[1]}'
+
+            assembly_is_base_name = assembly_imagestream_base_name_generic(image_stream_version, self.assembly, assembly_type)
+            arches = group_config.get("arches", [])
+            imagestreams_per_arch = [
+                payload_imagestream_namespace_and_name(default_imagestream_namespace_base_name(),
+                                                       assembly_is_base_name, arch, private=False)
+                for arch in arches
+            ]
+            for is_namespace_and_name in imagestreams_per_arch:
+                is_str = f"{is_namespace_and_name[0]}/{is_namespace_and_name[1]}"
+                self.verify_payload(is_str, advisories["image"])
 
         # Verify greenwave tests
         for impetus, advisory in advisories.items():
@@ -750,10 +761,14 @@ class PrepareReleasePipeline:
         await exectools.cmd_assert_async(cmd, cwd=self.working_dir)
 
     @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(10))
-    def verify_payload(self, pullspec: str, advisory: int):
-        cmd = self._elliott_base_command + [
+    def verify_payload(self, pullspec_or_imagestream: str, advisory: int):
+        cmd = [
+            "elliott",
+            f"--working-dir={self.elliott_working_dir}",
+            f"--group={self.group_name}",
+            "--assembly", self.assembly,
             "verify-payload",
-            f"{pullspec}",
+            f"{pullspec_or_imagestream}",
             f"{advisory}",
         ]
         if self.dry_run:
@@ -764,12 +779,12 @@ class PrepareReleasePipeline:
         # elliott verify-payload always writes results to $cwd/"summary_results.json".
         # move it to a different location to avoid overwritting the result.
         results_path = self.working_dir / "summary_results.json"
-        new_path = self.working_dir / f"verify-payload-results-{pullspec.split(':')[-1]}.json"
+        new_path = self.working_dir / f"verify-payload-results-{pullspec_or_imagestream.split(':')[-1]}.json"
         shutil.move(results_path, new_path)
         with open(new_path, "r") as f:
             results = json.load(f)
             if results.get("missing_in_advisory") or results.get("payload_advisory_mismatch"):
-                raise ValueError(f"""Failed to verify payload for nightly {pullspec}.
+                raise ValueError(f"""Failed to verify payload for nightly {pullspec_or_imagestream}.
 Please fix advisories and nightlies to match each other, manually verify them with `elliott verify-payload`,
 update JIRA accordingly, then notify QE and multi-arch QE for testing.""")
 

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -762,7 +762,7 @@ class PrepareReleasePipeline:
 
     @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(10))
     def verify_payload(self, pullspec_or_imagestream: str, advisory: int):
-       cmd = self._elliott_base_command + [
+        cmd = self._elliott_base_command + [
             "verify-payload",
             f"{pullspec_or_imagestream}",
             f"{advisory}",


### PR DESCRIPTION
get version number out of an imagestream

makes only sense to merge after: https://github.com/openshift-eng/art-tools/pull/1301

Test prepare-release with these changes https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release/618/console (dry-run!!!)