### PR TITLE
ART-12119 konflux: look at stream builds for member parents even for test assembly

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -288,7 +288,8 @@ class KonfluxRebaser:
 
                 build = asyncio.run(parent_metadata.get_latest_build(
                     el_target=f'el{parent_metadata.branch_el_target()}',
-                    engine=Engine.KONFLUX
+                    engine=Engine.KONFLUX,
+                    assembly='stream'
                 ))
 
                 if not build:


### PR DESCRIPTION
When doing a `test` konflux build, the rebaser is currently looking at `test` builds when rebasing parent FROM clauses. This should change because test builds are not being run often, and might result in obsolete or garbage collected parent image pullspecs.
This PR aims to use latest `stream` build pullspec when rebasing parents that are not loaded (not included in the rebase command via the `--images` option).

## Current behavior
### `test` assembly, parent not included
```bash
doozer \
    --assembly=test \
    --group=openshift-4.19 \
    --latest-parent-version \
    --images=ironic \
    beta:images:konflux:rebase
```
The parent pullspec is `quay.io/redhat-user-workloads/ocp-art-tenant/art-images:openshift-enterprise-base-rhel9-v4.19.0-20241220.140726`, which is an expired `test` build tracked in BigQuery

### `test` assembly, parent included
```bash
doozer \
    --assembly=test \
    --group=openshift-4.19 \
    --latest-parent-version \
    --images=ironic,openshift-enterprise-base-rhel9 \
    beta:images:konflux:rebase
```
The parent pullspec does not exist yet (not tracked in BigQuery), and matches what we include in the parent Dockerfile as the `__doozer_uuid_tag` env var.

## Proposed behavior
## `test` assembly, parent not included
Since the parent is not loaded, the FROM clause for `openshift-enterprise-base-rhel9` is rebased using the latest `stream` build from the same group:
```bash
$ oc image info quay.io/redhat-user-workloads/ocp-art-tenant/art-images:openshift-enterprise-base-rhel9-v4.19.0-20250214.110951 -o json --filter-by-os=linux/amd64 | jq -r .config.config.Labels.release
202502141109.p0.gcec03e0.assembly.stream.el9
```

### `test` assembly, parent included
The parent pullspec does not exist yet (not tracked in BigQuery), and matches what we include in the parent Dockerfile as the `__doozer_uuid_tag` env var.