### PR TITLE
Konflux: Use metadata.get_latest_build in bundle build

### DIFF
--- a/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
@@ -44,6 +44,7 @@ async def olm_bundle_konflux(
     # Create Doozer invocation
     cmd = [
         'doozer',
+        '--build-system=konflux',
         f'--assembly={assembly}',
         f'--working-dir={runtime.doozer_working}',
         f'--group=openshift-{version}@{data_gitref}' if data_gitref else f'--group=openshift-{version}',


### PR DESCRIPTION
Current Konflux bundle build logic is using the
KonfluxDB.get_latest_build, which doesn't strictly follow how we find builds for assembly. Now after `metadata.get_latest_build` is implemented for Konflux, make a change to use that.

Also fixes finding latest bundles for an operator (implemented in _get_bundle_build_for).