### PR TITLE
Konflux: Add beta:fbc:rebase verb to rebase FBC

### DIFF
--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -1,14 +1,18 @@
 
 import asyncio
 import logging
+import os
 import shutil
+from os import PathLike
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from artcommonlib.konflux.konflux_build_record import KonfluxBundleBuildRecord
 from async_lru import alru_cache
+from dockerfile_parse import DockerfileParser
 from tenacity import retry, stop_after_attempt, wait_fixed
 
-from doozerlib import constants, opm
+from doozerlib import constants, opm, util
 from doozerlib.backend.build_repo import BuildRepo
 from doozerlib.image import ImageMetadata
 
@@ -195,3 +199,241 @@ class KonfluxFbcImporter:
             if not package_name:
                 raise IOError(f"Package name not found in {package_yaml_file}")
             return str(package_name)
+
+
+class KonfluxFbcRebaser:
+    def __init__(
+            self,
+            base_dir: str | PathLike,
+            group: str,
+            assembly: str,
+            version: str,
+            release: str,
+            commit_message: str,
+            push: bool,
+            fbc_repo: str,
+            upcycle: bool,
+    ) -> None:
+        self.base_dir = Path(base_dir)
+        self.group = group
+        self.assembly = assembly
+        self.version = version
+        self.release = release
+        self.commit_message = commit_message
+        self.push = push
+        self.fbc_repo = fbc_repo or constants.ART_FBC_GIT_REPO
+        self.upcycle = upcycle
+        self._logger = LOGGER.getChild(self.__class__.__name__)
+
+    async def rebase(self, metadata: ImageMetadata, bundle_build: KonfluxBundleBuildRecord, version: str, release: str):
+        bundle_short_name = metadata.get_olm_bundle_short_name()
+        logger = self._logger.getChild(f"[{bundle_short_name}]")
+        repo_dir = self.base_dir.joinpath(metadata.distgit_key)
+
+        # Clone the FBC repo
+        fbc_build_branch = "art-{group}-assembly-{assembly_name}-fbc-{distgit_key}".format_map({
+            "group": self.group,
+            "assembly_name": self.assembly,
+            "distgit_key": metadata.distgit_key,
+        })
+        logger.info("Cloning FBC repo %s branch %s into %s", self.fbc_repo, fbc_build_branch, repo_dir)
+        build_repo = BuildRepo(url=self.fbc_repo, branch=fbc_build_branch, local_dir=repo_dir, logger=logger)
+        await build_repo.ensure_source(upcycle=self.upcycle, strict=True)  # FIXME: Currently rebasing against an empty FBC repo is not supported
+
+        # Update the FBC repo
+        await self._rebase_dir(metadata, build_repo, bundle_build, version, release, logger)
+
+        # Validate the updated catalog
+        logger.info("Validating the updated catalog")
+        await opm.validate(build_repo.local_dir.joinpath("catalog"))
+
+        # Commit and push the changes
+        addtional_message = f"\n\n---\noperator: {bundle_build.operator_nvr}\noperands: {','.join(bundle_build.operand_nvrs)}"
+        await build_repo.commit(self.commit_message + addtional_message, allow_empty=True)
+        if self.push:
+            await build_repo.push()
+        else:
+            logger.info("Not pushing changes to remote repository")
+
+        logger.info("rebase complete")
+
+    async def _rebase_dir(self, metadata: ImageMetadata, build_repo: BuildRepo, bundle_build: KonfluxBundleBuildRecord,
+                          version: str, release: str, logger: logging.Logger):
+        logger.info("Rebasing dir %s", build_repo.local_dir)
+
+        # Fetch bundle image info and blob
+        logger.info("Fetching OLM bundle image %s from %s", bundle_build.nvr, bundle_build.image_pullspec)
+        olm_bundle_image_info = await self._fetch_olm_bundle_image_info(bundle_build)
+        labels = olm_bundle_image_info["config"]["config"]["Labels"]
+        image_name = labels.get("name")
+        if not image_name:
+            raise IOError("Image name not found in bundle image")
+        channel_names = labels.get("operators.operatorframework.io.bundle.channels.v1")
+        if not channel_names:
+            raise IOError("Channel name not found in bundle image")
+        channel_names = channel_names.split(",")
+        default_channel_name = labels.get("operators.operatorframework.io.bundle.channel.default.v1")
+        olm_bundle_name, olm_package, olm_bundle_blob = await self._fetch_olm_bundle_blob(bundle_build)
+        if olm_package != labels.get("operators.operatorframework.io.bundle.package.v1"):
+            raise IOError(f"Package name mismatch: {olm_package} != {labels.get('operators.operatorframework.io.bundle.package.v1')}")
+        olm_csv_metadata = next((entry for entry in olm_bundle_blob["properties"] if entry["type"] == "olm.csv.metadata"), None)
+        if not olm_csv_metadata:
+            raise IOError(f"CSV metadata not found in bundle {olm_bundle_name}")
+        olm_skip_range = olm_csv_metadata["value"]["annotations"].get("olm.skipRange", None)
+
+        # Load current catalog
+        catalog_file_path = build_repo.local_dir.joinpath("catalog", olm_package, "catalog.yaml")
+        logger.info("Loading catalog from %s", catalog_file_path)
+        if not catalog_file_path.is_file():
+            raise FileNotFoundError(f"Catalog file {catalog_file_path} not found. The FBC repo is not properly initialized.")
+        with catalog_file_path.open() as f:
+            catalog_blobs = list(yaml.load_all(f))
+        categorized_catalog_blobs = self._catagorize_catalog_blobs(catalog_blobs)
+        if olm_package not in categorized_catalog_blobs:
+            raise IOError(f"Package {olm_package} not found in catalog. The FBC repo is not properly initialized.")
+        if len(categorized_catalog_blobs) > 1:
+            logger.warning(f"The catalog file {catalog_file_path} has multiple packages: {','.join(categorized_catalog_blobs.keys())}")
+
+        # Update the catalog
+        def _update_channel(channel: Dict):
+            # Update "skips" in the channel
+            # FIXME: We try to mimic how `skips` field is updated by the old ET centric process.
+            # We should verify if this is correct.
+            skips = None
+            bundle_with_skips = next((it for it in channel['entries'] if it.get('skips')), None)  # Find which bundle has the skips field
+            if bundle_with_skips:
+                # Then we move the skips field to the new bundle
+                # and add the bundle name of bundle_with_skips to the skips field
+                skips = set(bundle_with_skips.pop('skips'))
+                skips = (skips | {bundle_with_skips['name']}) - {olm_bundle_name}
+
+            # Add the current bundle to the specified channel in the catalog
+            entry = next((entry for entry in channel['entries'] if entry['name'] == olm_bundle_name), None)
+            if not entry:
+                logger.info("Adding bundle %s to channel %s", olm_bundle_name, channel['name'])
+                entry = {"name": olm_bundle_name}
+                channel['entries'].append(entry)
+            else:
+                logger.warning("Bundle %s already exists in channel %s. Replacing...", olm_bundle_name, channel['name'])
+                entry.clear()
+                entry["name"] = olm_bundle_name
+            if olm_skip_range:
+                entry["skipRange"] = olm_skip_range
+            if skips:
+                entry["skips"] = sorted(skips)
+
+        for channel_name in channel_names:
+            logger.info("Updating channel %s", channel_name)
+            channel = categorized_catalog_blobs[olm_package]["olm.channel"].get(channel_name, None)
+            if not channel:
+                raise IOError(f"Channel {channel_name} not found in package {olm_package}. The FBC repo is not properly initialized.")
+            _update_channel(channel)
+
+        # Set default channel
+        if default_channel_name:
+            package_blob = categorized_catalog_blobs[olm_package]["olm.package"][olm_package]
+            if package_blob.get("defaultChannel") != default_channel_name:
+                logger.info("Setting default channel to %s", default_channel_name)
+                package_blob["defaultChannel"] = default_channel_name
+
+        # Replace image references in relatedImages to use the prod registry
+        related_images = olm_bundle_blob.get("relatedImages", [])
+        if related_images:
+            target_entry = next((it for it in related_images if it['name'] == ""), None)
+            if target_entry:
+                new_image_name = image_name.replace('openshift/', 'openshift4/')
+                new_pullspec = f"{constants.DELIVERY_IMAGE_REGISTRY}/{new_image_name}@sha256:{bundle_build.image_tag}"
+                logger.info("Replacing image reference %s with %s", target_entry['image'], new_pullspec)
+                target_entry['image'] = new_pullspec
+
+        # Add the new bundle blob to the catalog
+        if olm_bundle_name not in categorized_catalog_blobs[olm_package]["olm.bundle"]:
+            logger.info("Adding bundle %s to package %s", olm_bundle_name, olm_package)
+            catalog_blobs.append(olm_bundle_blob)
+        else:  # Update the existing bundle blob
+            logger.warning("Bundle %s already exists in package %s. Replacing...", olm_bundle_name, olm_package)
+            target_entry = categorized_catalog_blobs[olm_package]["olm.bundle"][olm_bundle_name]
+            target_entry.clear()
+            target_entry.update(olm_bundle_blob)
+
+        # Write the updated catalog back to the file
+        logger.info("Writing updated catalog to %s", catalog_file_path)
+        with catalog_file_path.open("w") as f:
+            yaml.dump_all(catalog_blobs, f)
+
+        # Update Dockerfile
+        dockerfile_path = build_repo.local_dir.joinpath("catalog.Dockerfile")
+        logger.info("Updating Dockerfile %s", dockerfile_path)
+        if not dockerfile_path.is_file():
+            raise FileNotFoundError(f"Dockerfile {dockerfile_path} not found")
+        dfp = DockerfileParser(str(dockerfile_path))
+        metadata_envs: Dict[str, str] = {
+            '__doozer_group': self.group,
+            '__doozer_key': metadata.distgit_key,
+            '__doozer_version': version,
+            '__doozer_release': release,
+            '__doozer_bundle_nvrs': ','.join([str(bundle_build.nvr)]),
+        }
+        for key, value in metadata_envs.items():
+            if dfp.envs.get(key) != value:
+                logger.info("Setting %s=%s", key, value)
+                dfp.envs[key] = value
+
+        dfp.labels['io.openshift.build.source-location'] = bundle_build.source_repo
+        dfp.labels['io.openshift.build.commit.id'] = bundle_build.commitish
+
+    async def _fetch_olm_bundle_image_info(self, bundle_build: KonfluxBundleBuildRecord):
+        return await util.oc_image_info_for_arch_async__caching(
+            bundle_build.image_pullspec,
+            registry_config=os.environ.get("KONFLUX_ART_IMAGES_AUTH_FILE"),
+            registry_username=os.environ.get("KONFLUX_ART_IMAGES_USERNAME"),
+            registry_password=os.environ.get("KONFLUX_ART_IMAGES_PASSWORD"),
+        )
+
+    async def _fetch_olm_bundle_blob(self, bundle_build: KonfluxBundleBuildRecord):
+        """ Fetch the olm.bundle blob for the given bundle build.
+
+        :param bundle_build: The bundle build record.
+        :return: A tuple of (bundle name, package name, bundle blob).
+        """
+        registry_auth = opm.OpmRegistryAuth(
+            path=os.environ.get("KONFLUX_ART_IMAGES_AUTH_FILE"),
+            username=os.environ.get("KONFLUX_ART_IMAGES_USERNAME"),
+            password=os.environ.get("KONFLUX_ART_IMAGES_PASSWORD"))
+        rendered_blobs = await opm.render(bundle_build.image_pullspec, migrate=True, auth=registry_auth)
+        if not isinstance(rendered_blobs, list) or len(rendered_blobs) != 1:
+            raise IOError(f"Expected exactly one rendered blob, but got {len(rendered_blobs)}")
+        olm_bundle_blob = rendered_blobs[0]
+        if olm_bundle_blob.get('schema') != 'olm.bundle':
+            raise IOError(f"Bundle blob has invalid schema: {olm_bundle_blob.get('schema')}")
+        olm_package = olm_bundle_blob["package"]
+        if not olm_package:
+            raise IOError("Package not found in bundle blob")
+        assert isinstance(olm_package, str), f"Expected package name to be a string, but got {type(olm_package)}"
+        olm_bundle_name = olm_bundle_blob["name"]
+        if not olm_bundle_name:
+            raise IOError("Name not found in bundle blob")
+        assert isinstance(olm_bundle_name, str), f"Expected bundle name to be a string, but got {type(olm_bundle_name)}"
+        return olm_bundle_name, olm_package, olm_bundle_blob
+
+    def _catagorize_catalog_blobs(self, blobs: List[Dict]):
+        """ Given a list of catalog blobs, categorize them by schema and package name.
+
+        :param blobs: A list of catalog blobs.
+        :return: a dictionary of the form {package_name: {schema: {blob_name: blob}}}
+        """
+        categorized_blobs = {}
+        for blob in blobs:
+            schema = blob["schema"]
+            package_name = None
+            match schema:
+                case "olm.package":
+                    package_name = blob["name"]
+                case "olm.channel" | "olm.bundle" | "olm.deprecations":
+                    package_name = blob["package"]
+                case _:  # Unknown schema
+                    raise IOError(f"Found unsupported schema: {schema}")
+            if not package_name:
+                raise IOError(f"Couldn't determine package name for unknown schema: {schema}")
+            categorized_blobs.setdefault(package_name, {}).setdefault(schema, {})[blob["name"]] = blob
+        return categorized_blobs

--- a/doozer/doozerlib/cli/__main__.py
+++ b/doozer/doozerlib/cli/__main__.py
@@ -39,7 +39,7 @@ from doozerlib.cli.images import images_clone, images_list, images_push_distgit,
     images_print, distgit_config_template, query_rpm_version
 from doozerlib.cli.images_konflux import images_konflux_rebase
 from doozerlib.cli.images_konflux import images_konflux_build
-from doozerlib.cli.fbc import fbc_import
+from doozerlib.cli.fbc import fbc_import, fbc_rebase
 
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.util import analyze_debug_timing

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -233,7 +233,6 @@ class FbcRebaseCli:
         where = {
             "name": bundle_name,
             "group": self.runtime.group,
-            "assembly": self.runtime.assembly,
             "operator_nvr": operator_build.nvr,
             "outcome": str(KonfluxBuildOutcome.SUCCESS),
         }

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -1,15 +1,20 @@
 import asyncio
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Dict, List, Optional, Sequence, Tuple, cast
 
 import click
+from artcommonlib.konflux.konflux_build_record import (
+    KonfluxBuildOutcome, KonfluxBuildRecord, KonfluxBundleBuildRecord)
+from artcommonlib.konflux.konflux_db import KonfluxDb
 
 from doozerlib import constants, opm
-from doozerlib.backend.konflux_fbc import KonfluxFbcImporter
+from doozerlib.backend.konflux_fbc import KonfluxFbcImporter, KonfluxFbcRebaser
 from doozerlib.cli import (cli, click_coroutine, option_commit_message,
-                           pass_runtime)
+                           option_push, pass_runtime,
+                           validate_semver_major_minor_patch)
 from doozerlib.exceptions import DoozerFatalError
+from doozerlib.image import ImageMetadata
 from doozerlib.runtime import Runtime
 
 LOGGER = logging.getLogger(__name__)
@@ -97,4 +102,175 @@ async def fbc_import(runtime: Runtime, from_index: Optional[str], keep_templates
     doozer --group=openshift-4.17 beta:fbc:import registry.redhat.io/redhat/redhat-operator-index:v4.17 ./fbc-4.17
     """
     cli = FbcImportCli(runtime=runtime, index_image=from_index, keep_templates=keep_templates, push=push, fbc_repo=fbc_repo, message=message, dest_dir=dest_dir)
+    await cli.run()
+
+
+class FbcRebaseCli:
+    def __init__(
+            self,
+            runtime: Runtime,
+            version: str,
+            release: str,
+            commit_message: str,
+            push: bool,
+            fbc_repo: str,
+            operator_nvrs: Tuple[str, ...]):
+        self.runtime = runtime
+        self.version = version
+        self.release = release
+        self.commit_message = commit_message
+        self.push = push
+        self.fbc_repo = fbc_repo or constants.ART_FBC_GIT_REPO
+        self.operator_nvrs = operator_nvrs
+        self._logger = LOGGER.getChild("FbcRebaseCli")
+        self._db_for_bundles = KonfluxDb()
+        self._db_for_bundles.bind(KonfluxBundleBuildRecord)
+
+    async def run(self):
+        runtime = self.runtime
+        logger = self._logger.getChild("run")
+        if runtime.images and self.operator_nvrs:
+            raise click.BadParameter("Do not specify operator NVRs when --images is specified")
+        runtime.initialize(config_only=True)
+        assembly = runtime.assembly
+        if assembly is None:
+            raise ValueError("Assemblies feature is disabled for this group. This is no longer supported.")
+        assert runtime.konflux_db is not None, "konflux_db is not initialized. Doozer bug?"
+        konflux_db = runtime.konflux_db
+        konflux_db.bind(KonfluxBuildRecord)
+
+        dgk_operator_builds = await self._get_operator_builds()
+        bundle_builds = await self._get_bundle_builds(list(dgk_operator_builds.values()), strict=False)
+        not_found = [dgk for dgk, bundle_build in zip(dgk_operator_builds.keys(), bundle_builds) if bundle_build is None]
+        if not_found:
+            raise IOError(f"Bundle builds not found for {not_found}. Please build the bundles first.")
+        bundle_builds = cast(List[KonfluxBundleBuildRecord], bundle_builds)
+
+        assert runtime.source_resolver is not None, "source_resolver is not initialized. Doozer bug?"
+        assert runtime.group_config is not None, "group_config is not initialized. Doozer bug?"
+
+        rebaser = KonfluxFbcRebaser(
+            base_dir=Path(runtime.working_dir, constants.WORKING_SUBDIR_KONFLUX_FBC_SOURCES),
+            group=runtime.group,
+            assembly=assembly,
+            version=self.version,
+            release=self.release,
+            commit_message=self.commit_message,
+            push=self.push,
+            fbc_repo=self.fbc_repo,
+            upcycle=runtime.upcycle,
+        )
+        tasks = []
+        for dgk, bundle_build in zip(dgk_operator_builds.keys(), bundle_builds):
+            operator_meta = runtime.image_map[dgk]
+            tasks.append(rebaser.rebase(operator_meta, bundle_build, self.version, self.release))
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        failed_bundles = []
+        for dgk, bundle_build, result in zip(dgk_operator_builds.keys(), bundle_builds, results):
+            if isinstance(result, Exception):
+                failed_bundles.append(bundle_build.nvr)
+                LOGGER.error(f"Failed to rebase FBC for {bundle_build.nvr} ({dgk}): {result}")
+        if failed_bundles:
+            raise DoozerFatalError(f"Failed to rebase FBC for bundles: {', '.join(failed_bundles)}")
+        logger.info("Rebase complete")
+
+    async def _get_operator_builds(self):
+        """ Get build records for the given operator nvrs or latest build records for all operators.
+
+        :return: A dictionary of operator name to build records.
+        """
+        runtime = self.runtime
+        assert runtime.konflux_db is not None, "konflux_db is not initialized. Doozer bug?"
+        assert runtime.assembly is not None, "assembly is not initialized. Doozer bug?"
+        dgk_records: Dict[str, KonfluxBuildRecord] = {}  # operator name to build records
+        if self.operator_nvrs:
+            # Get build records for the given operator nvrs
+            LOGGER.info("Fetching given nvrs from Konflux DB...")
+            records = await runtime.konflux_db.get_build_records_by_nvrs(self.operator_nvrs)
+            for record in records:
+                assert record is not None and isinstance(record, KonfluxBuildRecord), "Invalid record. Doozer bug?"
+                dgk_records[record.name] = record
+            # Load image metas for the given operators
+            runtime.images = list(dgk_records.keys())
+            runtime.initialize(mode='images', clone_distgits=False)
+            for dgk in dgk_records.keys():
+                metadata = runtime.image_map[dgk]
+                if not metadata.is_olm_operator:
+                    raise IOError(f"Operator {dgk} does not have 'update-csv' config")
+        else:
+            # Get latest build records for all specified operators
+            runtime.initialize(mode='images', clone_distgits=False)
+            LOGGER.info("Fetching latest operator builds from Konflux DB...")
+            operator_metas: List[ImageMetadata] = [operator_meta for operator_meta in runtime.ordered_image_metas() if operator_meta.is_olm_operator]
+            records = await asyncio.gather(*(metadata.get_latest_build() for metadata in operator_metas))
+            not_found = [metadata.distgit_key for metadata, record in zip(operator_metas, records) if record is None]
+            if not_found:
+                raise IOError(f"Couldn't find build records for {not_found}")
+            for metadata, record in zip(operator_metas, records):
+                assert record is not None and isinstance(record, KonfluxBuildRecord)
+                dgk_records[metadata.distgit_key] = record
+        return dgk_records
+
+    async def _get_bundle_builds(self, operator_builds: Sequence[KonfluxBuildRecord], strict: bool = True) -> List[Optional[KonfluxBundleBuildRecord]]:
+        """ Get bundle build records for the given operator builds.
+
+        :param operator_builds: operator builds.
+        :return: A list of bundle build records.
+        """
+        logger = self._logger.getChild("get_bundle_builds")
+        logger.info("Fetching bundle builds from Konflux DB...")
+        builds = await asyncio.gather(*(self._get_bundle_build_for(operator_build, strict=strict) for operator_build in operator_builds))
+        return builds
+
+    async def _get_bundle_build_for(self, operator_build: KonfluxBuildRecord, strict: bool = True) -> Optional[KonfluxBundleBuildRecord]:
+        """ Get bundle build record for the given operator build.
+
+        :param operator_build: Operator build record.
+        :return: Bundle build record.
+        """
+        bundle_name = f"{operator_build.name}-bundle"
+        LOGGER.info("Fetching bundle build for %s from Konflux DB...", operator_build.nvr)
+        where = {
+            "name": bundle_name,
+            "group": self.runtime.group,
+            "assembly": self.runtime.assembly,
+            "operator_nvr": operator_build.nvr,
+            "outcome": str(KonfluxBuildOutcome.SUCCESS),
+        }
+        bundle_build = await anext(self._db_for_bundles.search_builds_by_fields(where=where, limit=1), None)
+        if not bundle_build:
+            if strict:
+                raise IOError(f"Bundle build not found for {operator_build.name}. Please build the bundle first.")
+            return None
+        assert isinstance(bundle_build, KonfluxBundleBuildRecord)
+        return bundle_build
+
+
+@cli.command("beta:fbc:rebase", short_help="Refresh a group's FBC konflux source content")
+@click.option("--version", metavar='VERSION', required=True, callback=validate_semver_major_minor_patch,
+              help="Version string to populate in Dockerfiles.")
+@click.option("--release", metavar='RELEASE', required=True, help="Release string to populate in Dockerfiles.")
+@option_commit_message
+@option_push
+@click.option("--fbc-repo", metavar='FBC_REPO', help="The git repository to push the FBC to.", default=constants.ART_FBC_GIT_REPO)
+@click.argument('operator_nvrs', nargs=-1, required=False)
+@pass_runtime
+@click_coroutine
+async def fbc_rebase(
+    runtime: Runtime,
+    version: str,
+    release: str,
+    message: str,
+    push: bool,
+    fbc_repo: str,
+    operator_nvrs: Tuple[str, ...]
+):
+    """
+    Refresh a group's FBC source content
+
+    The group's FBC konflux source content will be updated to include OLM bundles of the runtime assembly. The group's Dockerfiles will be
+    updated to use the specified version and release.
+    """
+    cli = FbcRebaseCli(runtime=runtime, version=version, release=release,
+                       commit_message=message, push=push, fbc_repo=fbc_repo, operator_nvrs=operator_nvrs)
     await cli.run()

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -159,6 +159,7 @@ class FbcRebaseCli:
             push=self.push,
             fbc_repo=self.fbc_repo,
             upcycle=runtime.upcycle,
+            record_logger=runtime.record_logger,
         )
         tasks = []
         for dgk, bundle_build in zip(dgk_operator_builds.keys(), bundle_builds):

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -93,7 +93,7 @@ class KonfluxRebaseCli:
 
 @cli.command("beta:images:konflux:rebase", short_help="Refresh a group's konflux source content from source content.")
 @click.option("--version", metavar='VERSION', required=True, callback=validate_semver_major_minor_patch,
-              help="Version string to populate in Dockerfiles. \"auto\" gets version from atomic-openshift RPM")
+              help="Version string to populate in Dockerfiles.")
 @click.option("--release", metavar='RELEASE', required=True, help="Release string to populate in Dockerfiles.")
 @click.option("--embargoed", is_flag=True, help="Add .p1 to the release string for all images, which indicates those images have embargoed fixes")
 @click.option("--force-yum-updates", is_flag=True, default=False,
@@ -250,10 +250,10 @@ class KonfluxBundleCli:
             # Load image metas for the given operators
             runtime.images = list(dgk_records.keys())
             runtime.initialize(mode='images', clone_distgits=False)
-            for dkg in dgk_records.keys():
-                metadata = runtime.image_map[dkg]
+            for dgk in dgk_records.keys():
+                metadata = runtime.image_map[dgk]
                 if not metadata.is_olm_operator:
-                    raise DoozerFatalError(f"Operator {dkg} does not have 'update-csv' config")
+                    raise DoozerFatalError(f"Operator {dgk} does not have 'update-csv' config")
         else:
             # Get latest build records for all specified operators
             runtime.initialize(mode='images', clone_distgits=False)
@@ -367,8 +367,8 @@ class KonfluxBundleCli:
         )
 
         tasks = []
-        for dkg, record in dgk_records.items():
-            image_meta = runtime.image_map[dkg]
+        for dgk, record in dgk_records.items():
+            image_meta = runtime.image_map[dgk]
             tasks.append(asyncio.create_task(self._rebase_and_build(rebaser, builder, image_meta, record)))
 
         results = await asyncio.gather(*tasks, return_exceptions=True)

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -38,6 +38,7 @@ KONFLUX_DEFAULT_PIPRLINE_DOCKER_BUILD_BUNDLE_PULLSPEC = "quay.io/konflux-ci/tekt
 KONFLUX_DEFAULT_IMAGE_REPO = "quay.io/redhat-user-workloads/ocp-art-tenant/art-images"   # FIXME: If we change clusters this URL will change
 ART_PROD_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
 ART_PROD_PRIV_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-v4.0-art-dev-priv"
+DELIVERY_IMAGE_REGISTRY = "registry.redhat.io"
 KONFLUX_UI_HOST = "https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com"
 KONFLUX_UI_DEFAULT_WORKSPACE = "ocp-art"  # associated with ocp-art-tenant
 KONFLUX_DEFAULT_NAMESPACE = f"{KONFLUX_UI_DEFAULT_WORKSPACE}-tenant"

--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -3,9 +3,12 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
+from artcommonlib.konflux.konflux_build_record import KonfluxBundleBuildRecord
+
 from doozerlib.backend.build_repo import BuildRepo
-from doozerlib.backend.konflux_fbc import KonfluxFbcImporter
+from doozerlib.backend.konflux_fbc import KonfluxFbcImporter, KonfluxFbcRebaser
 from doozerlib.image import ImageMetadata
+from doozerlib.opm import yaml
 
 
 class TestKonfluxFbcImporter(unittest.IsolatedAsyncioTestCase):
@@ -184,3 +187,254 @@ class TestKonfluxFbcImporter(unittest.IsolatedAsyncioTestCase):
         actual = await self.importer._get_package_name(metadata)
         self.assertEqual(actual, "test-package-name")
         source_resolver.resolve_source.assert_called_once_with(metadata)
+
+
+class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.base_dir = Path("/tmp/konflux_fbc_rebaser")
+        self.group = "test-group"
+        self.assembly = "test-assembly"
+        self.version = "1.0.0"
+        self.release = "1"
+        self.commit_message = "Test rebase commit message"
+        self.push = False
+        self.fbc_repo = "https://example.com/fbc-repo.git"
+        self.upcycle = False
+        self.logger = MagicMock()
+
+        self.rebaser = KonfluxFbcRebaser(
+            base_dir=self.base_dir,
+            group=self.group,
+            assembly=self.assembly,
+            version=self.version,
+            release=self.release,
+            commit_message=self.commit_message,
+            push=self.push,
+            fbc_repo=self.fbc_repo,
+            upcycle=self.upcycle
+        )
+
+    @patch("doozerlib.backend.konflux_fbc.KonfluxFbcRebaser._rebase_dir")
+    @patch("doozerlib.backend.konflux_fbc.BuildRepo", spec=BuildRepo)
+    @patch("doozerlib.backend.konflux_fbc.opm")
+    async def test_rebase(self, mock_opm, mock_build_repo, mock_rebase_dir):
+        metadata = MagicMock(spec=ImageMetadata)
+        metadata.distgit_key = "test-distgit-key"
+        bundle_build = MagicMock(
+            spec=KonfluxBundleBuildRecord,
+            operator_nvr="foo-operator-1.0.0-1",
+            operand_nvrs=["foo-operand-1.0.0-1"],
+        )
+        version = "1.0.0"
+        release = "1"
+
+        build_repo = mock_build_repo.return_value
+        build_repo.local_dir = self.base_dir.joinpath(metadata.distgit_key)
+        mock_opm.validate = AsyncMock()
+
+        await self.rebaser.rebase(metadata, bundle_build, version, release)
+
+        mock_build_repo.assert_called_once_with(
+            url=self.fbc_repo,
+            branch="art-test-group-assembly-test-assembly-fbc-test-distgit-key",
+            local_dir=self.base_dir.joinpath(metadata.distgit_key),
+            logger=ANY,
+        )
+        build_repo.ensure_source.assert_called_once_with(upcycle=self.upcycle, strict=True)
+        mock_rebase_dir.assert_called_once_with(metadata, build_repo, bundle_build, version, release, ANY)
+        mock_opm.validate.assert_called_once_with(self.base_dir.joinpath(metadata.distgit_key, "catalog"))
+        build_repo.commit.assert_called_once_with(ANY, allow_empty=True)
+        build_repo.push.assert_not_called()
+
+    @patch("doozerlib.backend.konflux_fbc.KonfluxFbcRebaser._rebase_dir")
+    @patch("doozerlib.backend.konflux_fbc.BuildRepo", spec=BuildRepo)
+    @patch("doozerlib.backend.konflux_fbc.opm")
+    async def test_rebase_with_push(self, mock_opm, mock_build_repo, mock_rebase_dir):
+        metadata = MagicMock(spec=ImageMetadata)
+        metadata.distgit_key = "test-distgit-key"
+        bundle_build = MagicMock(
+            spec=KonfluxBundleBuildRecord,
+            operator_nvr="foo-operator-1.0.0-1",
+            operand_nvrs=["foo-operand-1.0.0-1"],
+        )
+        version = "1.0.0"
+        release = "1"
+
+        build_repo = mock_build_repo.return_value
+        build_repo.local_dir = self.base_dir.joinpath(metadata.distgit_key)
+        mock_opm.validate = AsyncMock()
+        self.rebaser.push = True
+
+        await self.rebaser.rebase(metadata, bundle_build, version, release)
+
+        mock_build_repo.assert_called_once_with(
+            url=self.fbc_repo,
+            branch="art-test-group-assembly-test-assembly-fbc-test-distgit-key",
+            local_dir=self.base_dir.joinpath(metadata.distgit_key),
+            logger=ANY,
+        )
+        build_repo.ensure_source.assert_called_once_with(upcycle=self.upcycle, strict=True)
+        mock_rebase_dir.assert_called_once_with(metadata, build_repo, bundle_build, version, release, ANY)
+        mock_opm.validate.assert_called_once_with(self.base_dir.joinpath(metadata.distgit_key, "catalog"))
+        build_repo.commit.assert_called_once_with(ANY, allow_empty=True)
+        build_repo.push.assert_called_once()
+
+    @patch("doozerlib.backend.konflux_fbc.DockerfileParser")
+    @patch("pathlib.Path.is_file", return_value=True)
+    @patch("pathlib.Path.open")
+    @patch("doozerlib.backend.konflux_fbc.KonfluxFbcRebaser._fetch_olm_bundle_image_info", new_callable=AsyncMock)
+    @patch("doozerlib.backend.konflux_fbc.KonfluxFbcRebaser._fetch_olm_bundle_blob", new_callable=AsyncMock)
+    async def test_rebase_dir(self, mock_fetch_olm_bundle_blob, mock_fetch_olm_bundle_image_info, mock_open, mock_is_file, MockDockerfileParser):
+        metadata = MagicMock(spec=ImageMetadata)
+        metadata.distgit_key = "test-distgit-key"
+        build_repo = MagicMock()
+        build_repo.local_dir = self.base_dir
+        bundle_build = MagicMock(
+            spec=KonfluxBundleBuildRecord,
+            nvr="foo-bundle-1.0.0-1",
+            image_pullspec="dev.example.com/foo-bundle:1.0.0",
+            image_tag="deadbeef",
+            source_repo="https://example.com/foo-operator.git",
+            commitish="beefdead",
+        )
+        version = "1.0.0"
+        release = "1"
+        logger = MagicMock()
+
+        mock_fetch_olm_bundle_image_info.return_value = {
+            "config": {
+                "config": {
+                    "Labels": {
+                        "name": "test-image-name",
+                        "operators.operatorframework.io.bundle.channels.v1": "test-channel",
+                        "operators.operatorframework.io.bundle.channel.default.v1": "test-default-channel",
+                        "operators.operatorframework.io.bundle.package.v1": "test-package"
+                    }
+                }
+            }
+        }
+        mock_fetch_olm_bundle_blob.return_value = (
+            "test-bundle-name.1.2.3", "test-package", {
+                "schema": "olm.bundle",
+                "name": "test-bundle-name.1.2.3",
+                "package": "test-package",
+                "properties": [{
+                    "type": "olm.csv.metadata",
+                    "value": {
+                        "annotations": {
+                            "olm.skipRange": ">=4.8.0 <4.17.0"
+                        }
+                    }
+                }],
+                "relatedImages": [
+                    {"name": "", "image": "example.com/test-bundle:1.2.3"},
+                    {"name": "test-operator", "image": "example.com/test-operator:1.2.3"}
+                ]
+            })
+        mock_dfp = MockDockerfileParser.return_value
+        mock_dfp.envs = {}
+        mock_dfp.labels = {}
+
+        org_catalog_blobs = [
+            {"schema": "olm.package", "name": "test-package", "defaultChannel": "test-default-channel"},
+            {"schema": "olm.channel", "name": "test-channel", "package": "test-package", "entries": [
+                {"name": "test-bundle-name.1.0.0", "skipRange": ">=4.8.0 <4.17.0"},
+                {"name": "test-bundle-name.1.0.1", "skipRange": ">=4.8.0 <4.17.0"},
+                {"name": "test-bundle-name.1.1.0", "skipRange": ">=4.8.0 <4.17.0", "skips": ["test-bundle-name.0.0.9", "test-bundle-name.1.0.0", "test-bundle-name.1.0.1"]}
+            ]},
+            {"schema": "olm.bundle", "name": "test-bundle-name.1.0.0", "package": "test-package", "properties": [], "relatedImages": [
+                {"name": "", "image": "example.com/openshift/test-bundle:1.0.0"},
+                {"name": "test-operator", "image": "example.com/test-operator:1.0.0"}
+            ]}
+        ]
+        org_catalog_file = StringIO()
+        yaml.dump_all(org_catalog_blobs, org_catalog_file)
+        org_catalog_file.seek(0)
+        result_catalog_file = StringIO()
+        mock_open.return_value.__enter__.side_effect = [org_catalog_file, result_catalog_file]
+
+        await self.rebaser._rebase_dir(metadata, build_repo, bundle_build, version, release, logger)
+
+        mock_fetch_olm_bundle_image_info.assert_called_once_with(bundle_build)
+        mock_fetch_olm_bundle_blob.assert_called_once_with(bundle_build)
+        self.assertDictContainsSubset({
+            "__doozer_group": "test-group",
+            "__doozer_key": "test-distgit-key",
+            "__doozer_version": "1.0.0",
+            "__doozer_release": "1",
+            "__doozer_bundle_nvrs": "foo-bundle-1.0.0-1",
+        }, mock_dfp.envs)
+        self.assertDictContainsSubset({
+            "io.openshift.build.source-location": "https://example.com/foo-operator.git",
+            "io.openshift.build.commit.id": "beefdead",
+        }, mock_dfp.labels)
+
+        result_catalog_file.seek(0)
+        result_catalog_blobs = list(yaml.load_all(result_catalog_file))
+        result_catalog_blobs = self.rebaser._catagorize_catalog_blobs(result_catalog_blobs)
+        self.assertEqual(result_catalog_blobs.keys(), {"test-package"})
+        self.assertEqual(result_catalog_blobs["test-package"]["olm.channel"]["test-channel"]["entries"], [
+            {"name": "test-bundle-name.1.0.0", "skipRange": ">=4.8.0 <4.17.0"},
+            {"name": "test-bundle-name.1.0.1", "skipRange": ">=4.8.0 <4.17.0"},
+            {"name": "test-bundle-name.1.1.0", "skipRange": ">=4.8.0 <4.17.0"},
+            {"name": "test-bundle-name.1.2.3", "skipRange": ">=4.8.0 <4.17.0", "skips": ["test-bundle-name.0.0.9", "test-bundle-name.1.0.0", "test-bundle-name.1.0.1", "test-bundle-name.1.1.0"]}
+        ])
+        self.assertEqual(result_catalog_blobs["test-package"]["olm.bundle"].keys(), {"test-bundle-name.1.0.0", "test-bundle-name.1.2.3"})
+
+    @patch("doozerlib.util.oc_image_info_for_arch_async__caching", new_callable=AsyncMock)
+    async def test_fetch_olm_bundle_image_info(self, mock_oc_image_info):
+        bundle_build = MagicMock(spec=KonfluxBundleBuildRecord)
+        bundle_build.image_pullspec = "test-image-pullspec"
+        mock_oc_image_info.return_value = {
+            "config": {
+                "config": {
+                    "Labels": {
+                        "name": "test-image-name",
+                        "operators.operatorframework.io.bundle.channels.v1": "test-channel",
+                        "operators.operatorframework.io.bundle.channel.default.v1": "test-default-channel",
+                        "operators.operatorframework.io.bundle.package.v1": "test-package"
+                    }
+                }
+            }
+        }
+        actual = await self.rebaser._fetch_olm_bundle_image_info(bundle_build)
+        labels = actual["config"]["config"]["Labels"]
+        self.assertEqual(labels.get("name"), "test-image-name")
+        self.assertEqual(labels.get("operators.operatorframework.io.bundle.channels.v1"), "test-channel")
+        self.assertEqual(labels.get("operators.operatorframework.io.bundle.channel.default.v1"), "test-default-channel")
+        self.assertEqual(labels.get("operators.operatorframework.io.bundle.package.v1"), "test-package")
+
+    @patch("doozerlib.opm.render", new_callable=AsyncMock)
+    async def test_fetch_olm_bundle_blob(self, mock_render):
+        bundle_build = MagicMock(spec=KonfluxBundleBuildRecord)
+        bundle_build.image_pullspec = "test-image-pullspec"
+        mock_render.return_value = [{
+            "schema": "olm.bundle",
+            "name": "test-bundle-name",
+            "package": "test-package",
+            "properties": [{"type": "olm.csv.metadata", "value": {"annotations": {}}}]
+        }]
+        actual = await self.rebaser._fetch_olm_bundle_blob(bundle_build)
+        self.assertEqual(actual, ("test-bundle-name", "test-package", {"schema": "olm.bundle", "name": "test-bundle-name", "package": "test-package", "properties": [{"type": "olm.csv.metadata", "value": {"annotations": {}}}]}))
+        mock_render.assert_called_once_with("test-image-pullspec", migrate=True, auth=ANY)
+
+    def test_categorize_catalog_blobs(self):
+        catalog_blobs = [
+            {"schema": "olm.package", "name": "test-package"},
+            {"schema": "olm.channel", "name": "test-channel", "package": "test-package"},
+            {"schema": "olm.bundle", "name": "test-bundle", "package": "test-package"},
+            {"schema": "olm.package", "name": "test-package2"},
+            {"schema": "olm.channel", "name": "test-channel2", "package": "test-package2"},
+            {"schema": "olm.bundle", "name": "test-bundle2", "package": "test-package2"},
+        ]
+        actual = self.rebaser._catagorize_catalog_blobs(catalog_blobs)
+        self.assertEqual(actual.keys(), {"test-package", "test-package2"})
+        self.assertEqual(actual["test-package"].keys(), {"olm.package", "olm.channel", "olm.bundle"})
+        self.assertEqual(actual["test-package"]["olm.package"]["test-package"], {"schema": "olm.package", "name": "test-package"})
+        self.assertEqual(actual["test-package"]["olm.channel"]["test-channel"], {"schema": "olm.channel", "name": "test-channel", "package": "test-package"})
+        self.assertEqual(actual["test-package"]["olm.bundle"]["test-bundle"], {"schema": "olm.bundle", "name": "test-bundle", "package": "test-package"})
+        self.assertEqual(actual["test-package2"].keys(), {"olm.package", "olm.channel", "olm.bundle"})
+        self.assertEqual(actual["test-package2"]["olm.package"]["test-package2"], {"schema": "olm.package", "name": "test-package2"})
+        self.assertEqual(actual["test-package2"]["olm.channel"]["test-channel2"], {"schema": "olm.channel", "name": "test-channel2", "package": "test-package2"})
+        self.assertEqual(actual["test-package2"]["olm.bundle"]["test-bundle2"], {"schema": "olm.bundle", "name": "test-bundle2", "package": "test-package2"})

--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -223,6 +223,7 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
         metadata.distgit_key = "test-distgit-key"
         bundle_build = MagicMock(
             spec=KonfluxBundleBuildRecord,
+            nvr="foo-bundle-1.0.0-1",
             operator_nvr="foo-operator-1.0.0-1",
             operand_nvrs=["foo-operand-1.0.0-1"],
         )
@@ -255,6 +256,7 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
         metadata.distgit_key = "test-distgit-key"
         bundle_build = MagicMock(
             spec=KonfluxBundleBuildRecord,
+            nvr="foo-bundle-1.0.0-1",
             operator_nvr="foo-operator-1.0.0-1",
             operand_nvrs=["foo-operand-1.0.0-1"],
         )


### PR DESCRIPTION
This verb is to rebase the art-fbc repo to include the bundles for the runtime assembly.

Test command:
```sh
doozer --group=openshift-4.18 --assembly=test --images=ose-metallb-operator --latest-parent-version beta:fbc:rebase --version=v4.18.0 --release=0.2 --message=test
```