### PR TITLE
Fix bundle build error and hermetic build config

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -244,6 +244,7 @@ class KonfluxImageBuilder:
         )
 
         # Start a PipelineRun
+        hermetic = metadata.config.get("konflux", {}).get("network_mode") == "hermetic"
         pipelinerun = await self._konflux_client.start_pipeline_run_for_image_build(
             generate_name=f"{component_name}-",
             namespace=self._config.namespace,
@@ -256,9 +257,9 @@ class KonfluxImageBuilder:
             building_arches=building_arches,
             additional_tags=additional_tags,
             skip_checks=self._config.skip_checks,
+            hermetic=hermetic,
             vm_override=metadata.config.get("konflux", {}).get("vm_override"),
             pipelinerun_template_url=self._config.plr_template,
-            image_metadata=metadata
         )
 
         logger.info(f"Created PipelineRun: {self._konflux_client.build_pipeline_url(pipelinerun)}")


### PR DESCRIPTION
PR https://github.com/openshift-eng/art-tools/pull/1292 breaks bundle build, because for bundle build` None` ImageMetadata is passed into KonfluxClient.start_pipeline_run_for_image_build.

Also there is a typo with parsing `network_mode` config option, which prevents hermetic build from being enabled.

This PR fixes both issues, and remove the reference of `ImageMetadata` from `KonfluxClient`, because it is designed not only for image build.