### PR TITLE
Use correct params in cmd invoke

### DIFF
--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -110,22 +110,22 @@ class PrepareReleasePipeline:
         self._jira_client = JIRAClient.from_url(self.runtime.config["jira"]["url"], token_auth=jira_token)
 
         group_param = f'--group={group}'
-        if data_gitref:
-            group_param += f'@{data_gitref}'
+        if self.data_gitref:
+            group_param += f'@{self.data_gitref}'
 
         self._doozer_base_command = [
             'doozer',
             group_param,
-            f'--assembly={assembly}',
+            f'--assembly={self.assembly}',
             f'--working-dir={self.doozer_working_dir}',
-            f'--data-path={data_path}',
+            f'--data-path={self.data_path}',
         ]
         self._elliott_base_command = [
             'elliott',
             group_param,
-            f'--assembly={assembly}',
+            f'--assembly={self.assembly}',
             f'--working-dir={self.elliott_working_dir}',
-            f'--data-path={data_path}',
+            f'--data-path={self.data_path}',
         ]
         self._build_repo_dir = self.working_dir / "ocp-build-data-push"
 


### PR DESCRIPTION
fixes the bug of `None` being passed to doozer/elliott cmd invokes

seen in: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release/641/console