### PR TITLE
ART-12118: Add TaskRun outcome & timing to bigquery

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -19,6 +19,7 @@ GOOGLE_CLOUD_PROJECT = 'openshift-art'
 DATASET_ID = 'events'
 BUILDS_TABLE_ID = 'builds'
 BUNDLES_TABLE_ID = 'bundles'
+TASKRUN_TABLE_ID = 'taskruns'
 
 # Redis related vars
 REDIS_HOST = 'master.redis.gwprhd.use1.cache.amazonaws.com'

--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -5,6 +5,7 @@ import random
 import uuid
 from datetime import datetime
 from enum import Enum
+from typing import Dict, Optional
 
 from artcommonlib import constants
 
@@ -20,6 +21,16 @@ class KonfluxBuildOutcome(KonfluxEnum):
     FAILURE = 'failure'
     SUCCESS = 'success'
     PENDING = 'pending'
+
+    @classmethod
+    def extract_from_pipelinerun_succeeded_condition(cls, succeeded_condition: Optional[Dict]) -> "KonfluxBuildOutcome":
+        if succeeded_condition:
+            succeeded_status = succeeded_condition.get('status', 'Unknown')
+            if succeeded_status == 'True':
+                return cls.SUCCESS
+            elif succeeded_status == 'False':
+                return cls.FAILURE
+        return cls.PENDING
 
 
 class ArtifactType(KonfluxEnum):

--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -73,7 +73,7 @@ class KonfluxDb:
         self.logger.info('Generated DB schema:\n%s', pprint.pformat(fields))
         return fields
 
-    def add_build(self, build):
+    def add_build(self, build: konflux_build_record.KonfluxBuildRecord):
         """
         Insert a build record into Konflux DB
         """

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -148,7 +148,7 @@ class KonfluxImageBuilder:
                 await self.update_konflux_db(metadata, build_repo, pipelinerun, KonfluxBuildOutcome.PENDING, building_arches)
 
                 logger.info("Waiting for PipelineRun %s to complete...", pipelinerun_name)
-                pipelinerun = await self._konflux_client.wait_for_pipelinerun(pipelinerun_name, namespace=self._config.namespace)
+                pipelinerun, pods = await self._konflux_client.wait_for_pipelinerun(pipelinerun_name, namespace=self._config.namespace)
                 logger.info("PipelineRun %s completed", pipelinerun_name)
 
                 succeeded_condition = self._konflux_client.extract_status_condition(pipelinerun, 'Succeeded')

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -482,7 +482,7 @@ class KonfluxOlmBundleBuilder:
                     logger.warning("Dry run: Would update Konflux DB for %s with outcome %s", pipelinerun_name, outcome)
 
                 # Wait for the PipelineRun to complete
-                pipelinerun = await konflux_client.wait_for_pipelinerun(pipelinerun_name, self.konflux_namespace)
+                pipelinerun, pods = await konflux_client.wait_for_pipelinerun(pipelinerun_name, self.konflux_namespace)
                 status = pipelinerun.status.conditions[0].status
                 outcome = KonfluxBuildOutcome.SUCCESS if status == "True" else KonfluxBuildOutcome.FAILURE
                 logger.info(f"PipelineRun {url} completed with outcome {outcome}")


### PR DESCRIPTION
UI is broken and tekton results are too slow to be useful. Adding pod logs to Jenkins output and metrics that will help us find which tasks are failing during builds.