### PR TITLE
ART-12164 check cve tracker bug in included bug list

### DIFF
--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -211,6 +211,10 @@ async def get_bugs_sweep(runtime: Runtime, find_bugs_obj, brew_event, bug_tracke
         bug_ids = {b.id for b in bugs}
         included_bug_ids = included_bug_ids - bug_ids
         included_bugs = bug_tracker.get_bugs(included_bug_ids)
+        if find_bugs_obj.cve_only:
+            logger.info("checking if cve tracker bug found in included bug list")
+            included_bugs = [ib for ib in included_bugs if ib.is_tracker_bug()]
+            logger.info(f"filtered cve tracker bug from included bug list: {[getattr(ib, 'id') for ib in included_bugs]}")
         bugs.extend(included_bugs)
     if excluded_bug_ids:
         logger.warning(f"The following {bug_tracker.type} bugs will be excluded because they are explicitly "


### PR DESCRIPTION
filter out cve tracker bug from included bugs defined in `releases.yml`

executed the command from my local
```console
$ elliott --data-path https://github.com/openshift-eng/ocp-build-data.git --group openshift-4.18 --assembly 4.18.1 find-bugs:sweep --cve-only --report --output json
2025-02-24 19:28:06,221 artcommonlib INFO Konflux DB initialized
2025-02-24 19:28:06,221 artcommonlib INFO Cloning config data from https://github.com/openshift-eng/ocp-build-data.git
2025-02-24 19:28:06,226 art_tools.artcommonlib.exectools INFO $0: ['git', 'clone', '--no-single-branch', 'https://github.com/openshift-eng/ocp-build-data.git', '/var/folders/pk/ntb29tq142l2dm5899xcc4yh0000gn/T/elliott-k9813k8q.tmp/ocp-build-data'] - [cwd=None] [env={'GIT_SSH_COMMAND': 'ssh -oBatchMode=yes', 'GIT_TERMINAL_PROMPT': '0'}]: Executing:cmd_gather
2025-02-24 19:28:12,468 art_tools.artcommonlib.exectools INFO $1: ['git', '-C', '/var/folders/pk/ntb29tq142l2dm5899xcc4yh0000gn/T/elliott-k9813k8q.tmp/ocp-build-data', 'checkout', 'openshift-4.18'] - [cwd=None] [env={'GIT_SSH_COMMAND': 'ssh -oBatchMode=yes', 'GIT_TERMINAL_PROMPT': '0'}]: Executing:cmd_gather
2025-02-24 19:28:12,523 art_tools.artcommonlib.exectools INFO $2: ['git', '-C', '/var/folders/pk/ntb29tq142l2dm5899xcc4yh0000gn/T/elliott-k9813k8q.tmp/ocp-build-data', 'remote', 'get-url', 'origin'] - [cwd=None]: Executing:cmd_gather
2025-02-24 19:28:12,546 art_tools.artcommonlib.exectools INFO $3: ['git', '-C', '/var/folders/pk/ntb29tq142l2dm5899xcc4yh0000gn/T/elliott-k9813k8q.tmp/ocp-build-data', 'rev-parse', 'HEAD'] - [cwd=None]: Executing:cmd_gather
2025-02-24 19:28:12,566 art_tools.artcommonlib.exectools INFO $4: ['git', '-C', '/var/folders/pk/ntb29tq142l2dm5899xcc4yh0000gn/T/elliott-k9813k8q.tmp/ocp-build-data', 'rev-parse', '--abbrev-ref', 'HEAD'] - [cwd=None]: Executing:cmd_gather
2025-02-24 19:28:12,586 artcommonlib INFO On commit: 3577d2c67d41841c1cbcbf9ef67ec5a93e5b657c (openshift-4.18)
2025-02-24 19:28:12,665 artcommonlib INFO Using branch from group.yml: rhaos-4.18-rhel-9
2025-02-24 19:28:12,997 artcommonlib INFO Constraining brew event to assembly basis for 4.18.1: 62542297
2025-02-24 19:28:14,303 bugzilla._authfiles INFO Found bugzillarc files: ['/Users/rio.liu/.config/python-bugzilla/bugzillarc']
2025-02-24 19:28:15,950 bugzilla.base INFO Using RHBugzilla for URL containing .redhat.com
2025-02-24 19:28:32,892 art_tools.elliottlib.cli.find_bugs_sweep_cli INFO Determining approximate cutoff timestamp from basis event 62542297...
2025-02-24 19:29:20,829 art_tools.elliottlib.cli.find_bugs_sweep_cli INFO Filtering bugs that have changed (80) to one of the desired statuses before the cutoff time 2025-02-11 10:03:05...
2025-02-24 19:29:31,829 art_tools.elliottlib.cli.find_bugs_sweep_cli INFO 78 of 80 bugs are qualified for the cutoff time 2025-02-11 10:03:05
2025-02-24 19:29:31,829 art_tools.elliottlib.cli.find_bugs_sweep_cli INFO Filtering bugs that haven't been attached to any advisories...
2025-02-24 19:29:40,004 art_tools.elliottlib.cli.find_bugs_sweep_cli INFO Filtered 78 bugs since they are attached to other advisories
2025-02-24 19:29:40,006 art_tools.elliottlib.cli.find_bugs_sweep_cli WARNING The following jira bugs will be additionally included because they are explicitly defined in the assembly config: {'OCPBUGS-50877'}
2025-02-24 19:29:40,684 art_tools.elliottlib.cli.find_bugs_sweep_cli INFO checking if cve tracker bug found in included bug list
2025-02-24 19:29:40,685 art_tools.elliottlib.cli.find_bugs_sweep_cli INFO filtered cve tracker bug from included bug list: []
2025-02-24 19:29:40,699 art_tools.elliottlib.cli.find_bugs_sweep_cli INFO No qualified jira bugs found
2025-02-24 19:29:42,675 art_tools.elliottlib.cli.find_bugs_sweep_cli INFO No qualified bugzilla bugs found
2025-02-24 19:29:42,675 art_tools.elliottlib.cli.find_bugs_sweep_cli INFO No bugs found
```