### PR TITLE
ART-12049 Elliott can create Konflux Snapshots

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -176,10 +176,14 @@ class KonfluxDb:
             end_window = end_search - timedelta(days=window)
             start_window = max(end_window - timedelta(days=window_size), start_search)
             where_clauses = base_clauses + [Column('start_time', DateTime) >= start_window, Column('start_time', DateTime) < end_window]
-            rows = await self.bq_client.select(
-                where_clauses=where_clauses,
-                order_by_clause=order_by_clause,
-                limit=limit-total_rows if limit is not None else None)
+            try:
+                rows = await self.bq_client.select(
+                    where_clauses=where_clauses,
+                    order_by_clause=order_by_clause,
+                    limit=limit-total_rows if limit is not None else None)
+            except Exception as e:
+                self.logger.error('Failed executing query: %s', e)
+                raise
             self.logger.debug('Found %s builds in batch %s', rows.total_rows, (window // window_size) + 1)
             for row in rows:
                 total_rows += 1
@@ -343,18 +347,31 @@ class KonfluxDb:
         self.logger.warning('No builds found for NVR %s', nvr)
         return None
 
-    async def get_build_records_by_nvrs(self, nvrs: typing.Sequence[str], outcome: KonfluxBuildOutcome = KonfluxBuildOutcome.SUCCESS, strict: bool = True) -> typing.List[KonfluxRecord]:
+    async def get_build_records_by_nvrs(self, nvrs: typing.Sequence[str],
+                                        outcome: KonfluxBuildOutcome = KonfluxBuildOutcome.SUCCESS,
+                                        where: typing.Optional[typing.Dict[str, typing.Any]] = None,
+                                        strict: bool = True) -> typing.List[KonfluxRecord]:
         """ Get build records by NVRS.
         Note that this function only searches for the build records in the last 3 years.
 
         :param nvrs: The NVRS of the builds.
         :param outcome: The outcome of the builds.
+        :param where: Additional fields to filter the build records.
+        :param strict: If True, raise an exception if any build record is not found.
         :return: The build records.
         """
         nvrs = list(nvrs)
+        if not where:
+            where = {}
+        else:
+            # do not modify the original dict
+            where = where.copy()
+            if "nvr" in where or "outcome" in where:
+                raise ValueError("'nvr' and 'outcome' fields are reserved and should not be used in the 'where' "
+                                 "parameter")
 
         async def _task(nvr):
-            where = {"nvr": nvr, "outcome": str(outcome)}
+            where.update({"nvr": nvr, "outcome": str(outcome)})
             return await anext(self.search_builds_by_fields(where=where, limit=1, strict=True))
         tasks = [asyncio.create_task(_task(nvr)) for nvr in nvrs]
         records = await asyncio.gather(*tasks, return_exceptions=True)

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -8,7 +8,6 @@ import click
 from artcommonlib.konflux.konflux_build_record import (
     ArtifactType, Engine, KonfluxBuildRecord, KonfluxBundleBuildRecord, KonfluxBuildOutcome)
 from artcommonlib.konflux.konflux_db import KonfluxDb
-from artcommonlib.model import Missing
 from artcommonlib.telemetry import start_as_current_span_async
 from doozerlib import constants
 from doozerlib.backend.konflux_image_builder import (KonfluxImageBuilder,

--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -65,6 +65,8 @@ from elliottlib.cli.move_builds_cli import move_builds_cli
 from elliottlib.cli.find_bugs_golang_cli import find_bugs_golang_cli
 from elliottlib.cli.remove_builds_cli import remove_builds_cli
 from elliottlib.cli.get_golang_report_cli import get_golang_report_cli
+from elliottlib.cli.snapshot_cli import snapshot_cli
+
 
 # 3rd party
 import click
@@ -433,6 +435,7 @@ cli.add_command(move_builds_cli)
 cli.add_command(find_bugs_golang_cli)
 cli.add_command(remove_builds_cli)
 cli.add_command(get_golang_report_cli)
+cli.add_command(snapshot_cli)
 
 # -----------------------------------------------------------------------------
 # CLI Entry point

--- a/elliott/elliottlib/cli/find_konflux_builds_cli.py
+++ b/elliott/elliottlib/cli/find_konflux_builds_cli.py
@@ -2,7 +2,7 @@ import click
 
 from artcommonlib import logutil
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, Engine, ArtifactType, KonfluxBuildRecord
-from elliottlib import Runtime
+from elliottlib.runtime import Runtime
 from elliottlib.cli.common import cli, pass_runtime, click_coroutine
 
 LOGGER = logutil.get_logger(__name__)

--- a/elliott/elliottlib/cli/snapshot_cli.py
+++ b/elliott/elliottlib/cli/snapshot_cli.py
@@ -1,0 +1,222 @@
+import click
+import sys
+import os
+import asyncio
+from datetime import datetime, timezone
+
+from kubernetes.dynamic import exceptions
+
+from elliottlib.cli.common import cli, click_coroutine
+from elliottlib.runtime import Runtime
+from doozerlib.util import oc_image_info_for_arch_async
+from doozerlib.constants import KONFLUX_DEFAULT_NAMESPACE
+from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
+from doozerlib.backend.konflux_client import KonfluxClient, API_VERSION, KIND_APPLICATION, KIND_COMPONENT, KIND_SNAPSHOT
+from artcommonlib import logutil
+from artcommonlib.rpm_utils import parse_nvr
+from artcommonlib.konflux.konflux_build_record import (KonfluxRecord,
+                                                       KonfluxBuildRecord,
+                                                       KonfluxBundleBuildRecord,
+                                                       KonfluxFbcBuildRecord,
+                                                       Engine)
+
+LOGGER = logutil.get_logger(__name__)
+
+
+class CreateSnapshotCli:
+    def __init__(self, runtime: Runtime, konflux_config: dict, image_repo_creds_config: dict,
+                 for_bundle: bool, for_fbc: bool, builds: list, dry_run: bool):
+        self.runtime = runtime
+        self.konflux_config = konflux_config
+        self.for_bundle = for_bundle
+        self.for_fbc = for_fbc
+        self.builds = builds
+        self.dry_run = dry_run
+        self.image_repo_creds_config = image_repo_creds_config
+        self.konflux_client = KonfluxClient.from_kubeconfig(default_namespace=self.konflux_config['namespace'],
+                                                            config_file=self.konflux_config['kubeconfig'],
+                                                            context=self.konflux_config['context'],
+                                                            dry_run=self.dry_run)
+        self.konflux_client.verify_connection()
+
+    async def run(self):
+        self.runtime.initialize()
+        if self.runtime.konflux_db is None:
+            raise RuntimeError('Must run Elliott with Konflux DB initialized')
+        if self.for_bundle:
+            self.runtime.konflux_db.bind(KonfluxBundleBuildRecord)
+        elif self.for_fbc:
+            self.runtime.konflux_db.bind(KonfluxFbcBuildRecord)
+        else:
+            self.runtime.konflux_db.bind(KonfluxBuildRecord)
+
+        # Ensure the Snapshot CRD is accessible
+        try:
+            await self.konflux_client._get_api(API_VERSION, KIND_SNAPSHOT)
+        except exceptions.ResourceNotFoundError:
+            raise RuntimeError(f"Cannot access {API_VERSION} {KIND_SNAPSHOT} in the cluster. Passed the right kubeconfig?")
+
+        build_records: list[KonfluxRecord] = await self.fetch_build_records()
+
+        # make sure pullspec is live for each build
+        image_info_tasks = []
+        for record in build_records:
+            image_info_tasks.append(asyncio.create_task(
+                oc_image_info_for_arch_async(
+                    record.image_pullspec,
+                    registry_username=self.image_repo_creds_config['username'],
+                    registry_password=self.image_repo_creds_config['password'],
+                )))
+        image_infos = await asyncio.gather(*image_info_tasks, return_exceptions=True)
+        errors = [(record, result) for record, result in zip(build_records, image_infos)
+                  if isinstance(result, BaseException)]
+        if errors:
+            for record, ex in errors:
+                record: KonfluxRecord
+                LOGGER.error("Failed to inspect nvr %s pullspec %s: %s", record.nvr, record.image_pullspec, ex)
+            raise RuntimeError("Failed to inspect build pullspecs")
+
+        snapshot_obj = await self.new_snapshot(build_records)
+        created = await self.konflux_client._create(snapshot_obj)
+        print(created)
+
+    @staticmethod
+    def get_timestamp():
+        return datetime.strftime(datetime.now(tz=timezone.utc), "%Y%m%d%H%M")
+
+    async def new_snapshot(self, build_records) -> dict:
+        major, minor = self.runtime.get_major_minor()
+        snapshot_name = f"ose-{major}-{minor}-{self.get_timestamp()}"
+        application_name = KonfluxImageBuilder.get_application_name(self.runtime.group)
+
+        # make sure application exists
+        await self.konflux_client._get(API_VERSION, KIND_APPLICATION, application_name)
+
+        async def _comp(record):
+            comp_name = KonfluxImageBuilder.get_component_name(application_name, record.name)
+
+            # make sure component exists
+            await self.konflux_client._get(API_VERSION, KIND_COMPONENT, comp_name)
+
+            source_url = record.rebase_repo_url
+            revision = record.rebase_commitish
+            digest = record.image_tag
+
+            if not (source_url or revision or digest):
+                raise ValueError(f"Could not find all required nvr details {source_url=} {revision=} {digest=}")
+
+            # pullspec is in the form of registry/image:tag
+            # we need to provide snapshot with digest which is stored in image_tag
+            image = record.image_pullspec.split(':')
+            pullspec = f"{image[0]}@sha256:{digest}"
+
+            return {
+                "name": comp_name,
+                "source": {
+                    "git": {
+                        "url": source_url,
+                        "revision": revision,
+                    }
+                },
+                "containerImage": pullspec
+            }
+
+        components = [await _comp(record) for record in build_records]
+
+        snapshot_obj = {
+            "apiVersion": API_VERSION,
+            "kind": KIND_SNAPSHOT,
+            "metadata": {
+                "name": snapshot_name,
+                "namespace": self.konflux_config['namespace'],
+                "labels": {"test.appstudio.openshift.io/type": "override"},
+            },
+            "spec": {
+                "application": application_name,
+                "components": components,
+            }
+        }
+        return snapshot_obj
+
+    async def fetch_build_records(self) -> list[KonfluxRecord]:
+        LOGGER.info("Validating given NVRs...")
+        components = set()
+        for build in self.builds:
+            nvr = parse_nvr(build)
+            if nvr['name'] in components:
+                raise ValueError(f"Multiple builds found for component {nvr['name']}. Please provide only one build per component.")
+            components.add(nvr['name'])
+
+        LOGGER.info("Fetching NVRs from DB...")
+        where = {"group": self.runtime.group, "engine": Engine.KONFLUX.value}
+        records = await self.runtime.konflux_db.get_build_records_by_nvrs(self.builds, where=where, strict=True)
+        return records
+
+
+@cli.group("snapshot", short_help="Commands for managing Konflux Snapshots")
+def snapshot_cli():
+    pass
+
+
+@snapshot_cli.command("new", short_help="Create a new Konflux Snapshot in the given namespace for the given builds (NVRs)")
+@click.option('--konflux-kubeconfig', metavar='PATH', help='Path to the kubeconfig file to use for Konflux cluster connections.')
+@click.option('--konflux-context', metavar='CONTEXT', help='The name of the kubeconfig context to use for Konflux cluster connections.')
+@click.option('--konflux-namespace', metavar='NAMESPACE', default=KONFLUX_DEFAULT_NAMESPACE, help='The namespace to use for Konflux cluster connections.')
+@click.option('--for-bundle', is_flag=True, help='To indicate that the given builds are bundle builds.')
+@click.option('--for-fbc', is_flag=True, help='To indicate that the given builds are fbc builds.')
+@click.argument('builds', metavar='<NVR>', nargs=-1, required=False, default=None)
+@click.option(
+    "--builds-file", "-f", "builds_file",
+    help="File to read builds from, `-` to read from STDIN.",
+    type=click.File("rt"),
+)
+@click.option('--apply', is_flag=True, help='Create the snapshot in cluster')
+@click.pass_obj
+@click_coroutine
+async def new_snapshot_cli(runtime: Runtime, konflux_kubeconfig, konflux_context, konflux_namespace,
+                           builds_file, for_bundle, for_fbc, builds, apply):
+    """
+    Create a new Konflux Snapshot in the given namespace for the given builds
+
+    \b
+    $ elliott -g openshift-4.18 snapshot new --builds-file builds.txt
+
+    \b
+    $ elliott -g openshift-4.18 snapshot new nvr1 nvr2 nvr3 --apply
+    """
+    if bool(builds) and bool(builds_file):
+        raise click.BadParameter("Use only one of --build or --builds-file")
+
+    if bool(for_bundle) and bool(for_fbc):
+        raise click.BadParameter("Use only one of --for-bundle or --for-fbc")
+
+    if not konflux_kubeconfig:
+        konflux_kubeconfig = os.environ.get('KONFLUX_SA_KUBECONFIG')
+
+    if not konflux_kubeconfig:
+        raise ValueError("Must pass kubeconfig using --konflux-kubeconfig or KONFLUX_SA_KUBECONFIG env var")
+
+    # These will be needed for image inspection
+    for secret in ['KONFLUX_ART_IMAGES_USERNAME', 'KONFLUX_ART_IMAGES_PASSWORD']:
+        if secret not in os.environ:
+            raise EnvironmentError(f"Missing required environment variable {secret}")
+
+    image_repo_creds_config = {
+        'username': os.environ.get('KONFLUX_ART_IMAGES_USERNAME'),
+        'password': os.environ.get('KONFLUX_ART_IMAGES_PASSWORD'),
+    }
+
+    if builds_file:
+        if builds_file == "-":
+            builds_file = sys.stdin
+        builds = [line.strip() for line in builds_file.readlines()]
+
+    konflux_config = {
+        'kubeconfig': konflux_kubeconfig,
+        'namespace': konflux_namespace,
+        'context': konflux_context,
+    }
+
+    pipeline = CreateSnapshotCli(runtime, konflux_config, image_repo_creds_config,
+                                 for_bundle, for_fbc, builds, dry_run=not apply)
+    await pipeline.run()

--- a/elliott/functional_tests/test_snapshot.py
+++ b/elliott/functional_tests/test_snapshot.py
@@ -1,0 +1,21 @@
+import unittest
+import subprocess
+
+from doozerlib.backend.konflux_client import KIND_SNAPSHOT, API_VERSION
+from functional_tests import constants
+
+
+class NewSnapshotTestCase(unittest.TestCase):
+    def test_new_snapshot(self):
+        cmd = constants.ELLIOTT_CMD + [
+            "--assembly=stream", "--group=openshift-4.18", "snapshot", "new",
+            "sriov-network-operator-v4.18.0-202502251712.p0.gf496851.assembly.stream.el9"
+        ]
+        result = subprocess.run(cmd, capture_output=True)
+        self.assertEqual(result.returncode, 0,
+                         msg=f"stdout: {result.stdout.decode()}\nstderr: {result.stderr.decode()}")
+        self.assertRegex(result.stderr.decode(), f"Would have created {API_VERSION}/{KIND_SNAPSHOT}")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/elliott/tests/test_snapshot_cli.py
+++ b/elliott/tests/test_snapshot_cli.py
@@ -1,0 +1,118 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch, ANY, Mock
+
+from elliottlib.cli.snapshot_cli import CreateSnapshotCli
+
+
+class TestCreateSnapshotCli(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.runtime = MagicMock()
+        self.runtime.group = "openshift-4.18"
+        self.konflux_config = dict(
+            namespace="test-namespace",
+            kubeconfig="/path/to/kubeconfig",
+            context=None,
+        )
+        self.image_repo_creds_config = dict(
+            username="test_user",
+            password="test_pass"
+        )
+        self.for_bundle = False
+        self.for_fbc = False
+        self.dry_run = False
+
+        self.runtime.konflux_db.bind.return_value = None
+        self.runtime.get_major_minor.return_value = (4, 18)
+        self.runtime.konflux_db = MagicMock()
+
+        self.konflux_client = AsyncMock()
+        self.konflux_client.verify_connection.return_value = True
+
+    @patch("elliottlib.cli.snapshot_cli.CreateSnapshotCli.get_timestamp", return_value="timestamp")
+    @patch("elliottlib.cli.snapshot_cli.oc_image_info_for_arch_async")
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    @patch("elliottlib.runtime.Runtime")
+    async def test_run_happy_path(self, mock_runtime, mock_konflux_client_init, mock_oc_image_info, *_):
+        mock_runtime.return_value = self.runtime
+        mock_konflux_client_init.return_value = self.konflux_client
+        mock_oc_image_info.return_value = AsyncMock()
+
+        build_records = [
+            Mock(
+                nvr='test-nvr-1',
+                image_pullspec='registry/image:tag1',
+                image_tag='digest1',
+                rebase_repo_url='https://github.com/test/repo1',
+                rebase_commitish='foobar'
+            ),
+            Mock(
+                nvr='test-nvr-2',
+                image_pullspec='registry/image:tag2',
+                image_tag='digest2',
+                rebase_repo_url='https://github.com/test/repo2',
+                rebase_commitish='test'
+            )
+        ]
+        # `name` attribute is special so set it after creation
+        # https://docs.python.org/3/library/unittest.mock.html#mock-names-and-the-name-attribute
+        build_records[0].name = 'component1'
+        build_records[1].name = 'component2'
+
+        with patch.object(CreateSnapshotCli, 'fetch_build_records', return_value=build_records):
+            cli = CreateSnapshotCli(
+                runtime=self.runtime,
+                konflux_config=self.konflux_config,
+                image_repo_creds_config=self.image_repo_creds_config,
+                for_bundle=self.for_bundle,
+                for_fbc=self.for_fbc,
+                builds=['test-nvr-1', 'test-nvr-2'],
+                dry_run=self.dry_run
+            )
+
+            await cli.run()
+
+            self.konflux_client._create.assert_called_once_with({
+                'apiVersion': 'appstudio.redhat.com/v1alpha1',
+                'kind': 'Snapshot',
+                'metadata': {
+                    'labels': {
+                        'test.appstudio.openshift.io/type': 'override'
+                    },
+                    'name': 'ose-4-18-timestamp',
+                    'namespace': 'test-namespace'
+                },
+                'spec': {
+                    'application': 'openshift-4-18',
+                    'components': [{'containerImage': 'registry/image@sha256:digest1',
+                                    'name': 'ose-4-18-component1',
+                                    'source': {'git': {'revision': 'foobar', 'url': 'https://github.com/test/repo1'}}},
+                                   {'containerImage': 'registry/image@sha256:digest2',
+                                    'name': 'ose-4-18-component2',
+                                    'source': {'git': {'revision': 'test', 'url': 'https://github.com/test/repo2'}}}]
+                }
+            })
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    @patch('elliottlib.runtime.Runtime')
+    async def test_fetch_build_records_validation(self, mock_runtime, mock_konflux_client_init):
+        mock_runtime.return_value = self.runtime
+        mock_konflux_client_init.return_value = self.konflux_client
+
+        mock_records = ['mock_row1', 'mock_row2']
+        self.runtime.konflux_db.get_build_records_by_nvrs = AsyncMock(return_value=mock_records)
+        builds = ['openshift-v4.18.0-4.el9', 'openshift-clients-v4.18.0-4.el8']
+
+        cli = CreateSnapshotCli(
+            runtime=self.runtime,
+            konflux_config=self.konflux_config,
+            image_repo_creds_config=self.image_repo_creds_config,
+            for_bundle=self.for_bundle,
+            for_fbc=self.for_fbc,
+            builds=builds,
+            dry_run=self.dry_run,
+        )
+
+        records = await cli.fetch_build_records()
+        self.assertEqual(records, mock_records)
+        self.runtime.konflux_db.get_build_records_by_nvrs.assert_called_once_with(
+            builds, where=ANY, strict=True)


### PR DESCRIPTION
Needs https://github.com/openshift-eng/art-tools/pull/1408 

```
$ elliott -g openshift-4.18 snapshot new sriov-network-operator-v4.18.0-202502251712.p0.gf496851.assembly.stream.el9 
--konflux-kubeconfig=~/konflux.kubeconfig.priv
--apply
...
2025-02-25 20:55:53,511 art_tools.elliottlib.cli.release_snapshot_cli INFO Validating given NVRs...
2025-02-25 20:55:53,511 art_tools.elliottlib.cli.release_snapshot_cli INFO Fetching NVRs from DB...
2025-02-25 20:55:55,000 art_tools.artcommonlib.exectools INFO Executing:cmd_gather_async: oc image info -o json --registry-config=/tmp/_doozer_fwmb7qli --filter-by-os=amd64 quay.io/redhat-user-workloads/ocp-art-tenant/art-images:ose-sriov-network-rhel9-operator-v4.18.0-20250225.171216
2025-02-25 20:55:56,961 doozerlib.backend.konflux_client INFO Creating appstudio.redhat.com/v1alpha1/Snapshot ocp-art-tenant/ose-4-18-202502260155...
2025-02-25 20:55:57,113 doozerlib.backend.konflux_client INFO Created appstudio.redhat.com/v1alpha1/Snapshot ocp-art-tenant/ose-4-18-202502260155
...
ResourceInstance[Snapshot]:
  apiVersion: appstudio.redhat.com/v1alpha1
  kind: Snapshot
  metadata:
    labels:
      test.appstudio.openshift.io/type: override
    name: ose-4-18-202503111556
    namespace: ocp-art-tenant
  spec:
    application: openshift-4-18
    components:
    - containerImage: quay.io/redhat-user-workloads/ocp-art-tenant/art-images@sha256:e2b5750eb915d9f910dd7dd330c7c59d6760c3ebfd5ca139122d0e2b5f89ed57
      name: ose-4-18-sriov-network-operator
      source:
        git:
          revision: 84136e597b6a1c095cb77534e174f5185b858add
          url: https://github.com/openshift-priv/sriov-network-operator
```

https://console-openshift-console.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/k8s/ns/ocp-art-tenant/appstudio.redhat.com~v1alpha1~Snapshot/ose-4-18-202502260155/

