### PR TITLE
[konflux] build-images timeout to 4h

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -409,7 +409,7 @@ class KonfluxClient:
             match task["name"]:
                 case "build-images":
                     has_build_images_task = True
-                    task["timeout"] = "12h"
+                    task["timeout"] = "4h"
                     _modify_param(task["params"], "SBOM_TYPE", "cyclonedx")
                 case "prefetch-dependencies":
                     _modify_param(task["params"], "SBOM_TYPE", "cyclonedx")


### PR DESCRIPTION
This time out is seperate to the pipeline timeout, which is set to [12hr](https://github.com/openshift-eng/art-tools/compare/main...ashwindasr:art-tools:konflux-build-images?expand=1#diff-5874bcbdcbeff43db829c16f9b2684bfb4f7835d4a16f3d9fc09188b36a4a724R404). If a build takes longer than 4 hrs, its most probably an error, and we should retry the build and if its not, we should consider using a VM with higher specs to bring the build time down.