### PR TITLE
[konflux] remove unused code

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -56,14 +56,6 @@ class KonfluxImageBuilderConfig:
 class KonfluxImageBuilder:
     """ This class is responsible for building container images with Konflux. """
 
-    # https://gitlab.cee.redhat.com/konflux/docs/users/-/blob/main/topics/getting-started/multi-platform-builds.md
-    SUPPORTED_ARCHES = {
-        "x86_64": "linux/x86_64",
-        "s390x": "linux/s390x",
-        "ppc64le": "linux/ppc64le",
-        "aarch64": "linux/arm64",
-    }
-
     def __init__(
         self,
         config: KonfluxImageBuilderConfig,


### PR DESCRIPTION
SUPPORTED_ARCHES is defined here: https://github.com/openshift-eng/art-tools/blob/main/doozer/doozerlib/backend/konflux_client.py#L30, which seems to be the source of truth. 