### PR TITLE
pyartcd: Add build-fbc job to rebase and build FBC

### DIFF
--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -6,7 +6,7 @@ from pyartcd.pipelines import (
     review_cvp, tarball_sources, build_sync, build_rhcos, ocp4_scan, ocp4_scan_konflux, images_health,
     operator_sdk_sync, olm_bundle, ocp4, scan_for_kernel_bugs, tag_rpms, advisory_drop, cleanup_locks, brew_scan_osh,
     sigstore_sign, update_golang, rebuild_golang_rpms, scan_fips, quay_doomsday_backup,
-    olm_bundle_konflux
+    olm_bundle_konflux, build_fbc
 )
 from pyartcd.pipelines.scheduled import schedule_ocp4_scan, schedule_ocp4_scan_konflux
 

--- a/pyartcd/pyartcd/constants.py
+++ b/pyartcd/pyartcd/constants.py
@@ -51,3 +51,4 @@ GITHUB_OWNER = "openshift-eng"
 
 KONFLUX_IMAGE_BUILD_PLR_TEMPLATE_URL_FORMAT = "https://raw.githubusercontent.com/{owner}/art-konflux-template/refs/heads/{branch_name}/.tekton/art-konflux-template-push.yaml"  # Konflux PipelineRun (PLR) template for image builds
 KONFLUX_BUNDLE_BUILD_PLR_TEMPLATE_URL_FORMAT = "https://raw.githubusercontent.com/{owner}/art-konflux-template/refs/heads/{branch_name}/.tekton/art-bundle-konflux-template-push.yaml"  # Konflux PipelineRun (PLR) template for bundle builds
+KONFLUX_FBC_BUILD_PLR_TEMPLATE_URL_FORMAT = "https://raw.githubusercontent.com/{owner}/art-konflux-template/refs/heads/{branch_name}/.tekton/art-fbc-konflux-template-push.yaml"  # Konflux PipelineRun (PLR) template for FBC builds

--- a/pyartcd/pyartcd/pipelines/build_fbc.py
+++ b/pyartcd/pyartcd/pipelines/build_fbc.py
@@ -40,20 +40,20 @@ class BuildFbcPipeline:
             # Rebase FBC repo
             release_str = datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
             self._logger.info('Rebasing FBC repo with release %s', release_str)
-            await self._rebase(
-                version=self.version,
+            rebase_records = await self._rebase(
                 release=release_str,
                 commit_message='Rebase FBC segment with release {}'.format(release_str),
             )
 
             # Build FBC segments
-            await self._build()
+            distgit_keys = [str(record['name']) for record in rebase_records]
+            build_records = await self._build(distgit_keys)
 
             # Parse doozer record.log
             self._logger.info('Parsing doozer record.log')
             lines = []
-            for fbc_nvr, bundle_nvrs in await self._parse_record_log():
-                lines.append(f'{fbc_nvr} -> {", ".join(bundle_nvrs)}')
+            for record in build_records:
+                lines.append(f'{record["fbc_nvr"]} -> {record["bundle_nvrs"]}')
             self._logger.info('Successfully built: %s', '\n'.join(lines))
 
         except Exception as e:
@@ -61,7 +61,7 @@ class BuildFbcPipeline:
             await self._slack_client.say(f'*:heavy_exclamation_mark: Error building FBC for {self.version} assembly {self.assembly}*\n')
             raise
 
-    async def _run_doozer(self, opts: List[str]):
+    async def _run_doozer(self, opts: List[str], only: str, exclude: str):
         cmd = [
             'doozer',
             '--build-system=konflux',
@@ -71,18 +71,18 @@ class BuildFbcPipeline:
         ]
         if self.data_path:
             cmd.append(f'--data-path={self.data_path}')
-        if self.only:
-            cmd.append(f'--images={self.only}')
-        if self.exclude:
-            cmd.append(f'--exclude={self.exclude}')
+        if only:
+            cmd.append(f'--images={only}')
+        if exclude:
+            cmd.append(f'--exclude={exclude}')
         cmd += opts
         self._logger.info(f'Running doozer command: {" ".join(cmd)}')
         await exectools.cmd_assert_async(cmd)
 
-    async def _rebase(self, version: str, release: str, commit_message: str):
+    async def _rebase(self, release: str, commit_message: str):
         doozer_opts = [
             'beta:fbc:rebase',
-            '--version', version,
+            '--version', self.version,
             '--release', release,
             '--message', commit_message,
         ]
@@ -92,9 +92,16 @@ class BuildFbcPipeline:
             doozer_opts.extend(['--fbc-repo', self.fbc_repo])
         if self.operator_nvrs:
             doozer_opts.extend([nvr for nvr in self.operator_nvrs.split(',')])
-        await self._run_doozer(doozer_opts)
+        try:
+            await self._run_doozer(doozer_opts, only=self.only, exclude=self.exclude)
+        finally:
+            successful_records, failed_records = await self._parse_record_log('rebase_fbc_konflux')
+            self._logger.info('Successfully rebased: %s', ', '.join([str(entry['name']) for entry in successful_records]))
+            if failed_records:
+                self._logger.error('Failed to rebase: %s', ', '.join([str(entry['name']) for entry in failed_records]))
+        return successful_records
 
-    async def _build(self):
+    async def _build(self, distgit_keys: List[str]):
         doozer_opts = [
             'beta:fbc:build',
         ]
@@ -106,21 +113,29 @@ class BuildFbcPipeline:
             doozer_opts.extend(['--plr-template', plr_template_url])
         if self.skip_checks:
             doozer_opts.append('--skip-checks')
-        await self._run_doozer(doozer_opts)
+        if self.fbc_repo:
+            doozer_opts.extend(['--fbc-repo', self.fbc_repo])
+        if self.runtime.dry_run:
+            doozer_opts.append('--dry-run')
+        try:
+            await self._run_doozer(doozer_opts, only=','.join(distgit_keys), exclude='')
+        finally:
+            successful_records, failed_records = await self._parse_record_log('build_fbc_konflux')
+            self._logger.info('Successfully built: %s', ', '.join([str(entry['name']) for entry in successful_records]))
+            if failed_records:
+                self._logger.error('Failed to build: %s', ', '.join([str(entry['name']) for entry in failed_records]))
+        return successful_records
 
-    async def _parse_record_log(self):
-        results = []
+    async def _parse_record_log(self, entry_type: str):
         record_log_path = Path(self.runtime.doozer_working, 'record.log')
-        if record_log_path.exists():
-            with record_log_path.open() as file:
-                record_log = parse_record_log(file)
-            records = record_log.get('bundle_nvrs', [])
-            for record in records:
-                if record['status'] != '0':
-                    raise RuntimeError('record.log includes unexpected build_fbc_konflux '
-                                       f'record with error message: {record["message"]}')
-                results.append((record['fbc_nvr'], record['bundle_nvrs']))
-        return results
+        if not record_log_path.exists():
+            raise FileNotFoundError('record.log not found')
+        with record_log_path.open() as file:
+            record_log = parse_record_log(file)
+        entries = record_log.get(entry_type, [])
+        successful_records = [entry for entry in entries if entry and int(str(entry['status'])) == 0]
+        failed_records = [entry for entry in entries if entry and int(str(entry['status'])) != 0]
+        return successful_records, failed_records
 
 
 @cli.command('build-fbc', help='Rebase and build FBC segments for OLM operators')
@@ -132,15 +147,15 @@ class BuildFbcPipeline:
               help='(Optional) Doozer data path git [branch / tag / sha] to use')
 @click.option('--only', required=False,
               help='(Optional) List **only** the operators you want to build, everything else gets ignored.\n'
-                   'Format: Comma and/or space separated list of brew packages (e.g.: cluster-nfd-operator-container)\n'
+              'Format: Comma and/or space separated list of brew packages (e.g.: cluster-nfd-operator-container)\n'
                    'Leave empty to build all (except EXCLUDE, if defined)')
 @click.option('--exclude', required=False,
               help='(Optional) List the operators you **don\'t** want to build, everything else gets built.\n'
-                   'Format: Comma and/or space separated list of brew packages (e.g.: cluster-nfd-operator-container)\n'
+              'Format: Comma and/or space separated list of brew packages (e.g.: cluster-nfd-operator-container)\n'
                    'Leave empty to build all (or ONLY, if defined)')
 @click.option('--operator-nvrs', required=False,
               help='(Optional) List **only** the operator NVRs you want to build FBC segments for, everything else '
-                   'gets ignored. The operators should not be mode:disabled/wip in ocp-build-data')
+              'gets ignored. The operators should not be mode:disabled/wip in ocp-build-data')
 @click.option('--fbc-repo', required=False, default='',
               help='(Optional) URL of the FBC repository')
 @click.option("--kubeconfig", required=False, help="Path to kubeconfig file to use for Konflux cluster connections")

--- a/pyartcd/pyartcd/pipelines/build_fbc.py
+++ b/pyartcd/pyartcd/pipelines/build_fbc.py
@@ -1,0 +1,170 @@
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional
+
+import click
+from artcommonlib import exectools
+
+from pyartcd import constants
+from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.record import parse_record_log
+from pyartcd.runtime import Runtime
+
+
+class BuildFbcPipeline:
+    def __init__(self, runtime: Runtime,
+                 version: str, assembly: str, data_path: str, data_gitref: str,
+                 only: str, exclude: str, operator_nvrs: str, fbc_repo: str,
+                 kubeconfig: str, plr_template: str, skip_checks: bool
+                 ):
+        self.runtime = runtime
+        self.version = version
+        self.assembly = assembly
+        self.data_path = data_path
+        self.data_gitref = data_gitref
+        self.only = only
+        self.exclude = exclude
+        self.operator_nvrs = operator_nvrs
+        self.fbc_repo = fbc_repo
+        self.kubeconfig = kubeconfig
+        self.plr_template = plr_template
+        self.skip_checks = skip_checks
+
+        self._logger = logging.getLogger(__name__)
+        self._slack_client = runtime.new_slack_client()
+        self._slack_client.bind_channel(version)
+
+    async def run(self):
+        try:
+            # Rebase FBC repo
+            release_str = datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
+            self._logger.info('Rebasing FBC repo with release %s', release_str)
+            await self._rebase(
+                version=self.version,
+                release=release_str,
+                commit_message='Rebase FBC segment with release {}'.format(release_str),
+            )
+
+            # Build FBC segments
+            await self._build()
+
+            # Parse doozer record.log
+            self._logger.info('Parsing doozer record.log')
+            lines = []
+            for fbc_nvr, bundle_nvrs in await self._parse_record_log():
+                lines.append(f'{fbc_nvr} -> {", ".join(bundle_nvrs)}')
+            self._logger.info('Successfully built: %s', '\n'.join(lines))
+
+        except Exception as e:
+            self._logger.error('Encountered error: %s', e)
+            await self._slack_client.say(f'*:heavy_exclamation_mark: Error building FBC for {self.version} assembly {self.assembly}*\n')
+            raise
+
+    async def _run_doozer(self, opts: List[str]):
+        cmd = [
+            'doozer',
+            '--build-system=konflux',
+            f'--working-dir={self.runtime.doozer_working}',
+            f'--assembly={self.assembly}',
+            f'--group=openshift-{self.version}{"@" + self.data_gitref if self.data_gitref else ""}',
+        ]
+        if self.data_path:
+            cmd.append(f'--data-path={self.data_path}')
+        if self.only:
+            cmd.append(f'--images={self.only}')
+        if self.exclude:
+            cmd.append(f'--exclude={self.exclude}')
+        cmd += opts
+        self._logger.info(f'Running doozer command: {" ".join(cmd)}')
+        await exectools.cmd_assert_async(cmd)
+
+    async def _rebase(self, version: str, release: str, commit_message: str):
+        doozer_opts = [
+            'beta:fbc:rebase',
+            '--version', version,
+            '--release', release,
+            '--message', commit_message,
+        ]
+        if not self.runtime.dry_run:
+            doozer_opts.append('--push')
+        if self.fbc_repo:
+            doozer_opts.extend(['--fbc-repo', self.fbc_repo])
+        if self.operator_nvrs:
+            doozer_opts.extend([nvr for nvr in self.operator_nvrs.split(',')])
+        await self._run_doozer(doozer_opts)
+
+    async def _build(self):
+        doozer_opts = [
+            'beta:fbc:build',
+        ]
+        if self.kubeconfig:
+            doozer_opts.extend(['--konflux-kubeconfig', self.kubeconfig])
+        if self.plr_template:
+            plr_template_owner, plr_template_branch = self.plr_template.split("@") if self.plr_template else ["openshift-priv", "main"]
+            plr_template_url = constants.KONFLUX_FBC_BUILD_PLR_TEMPLATE_URL_FORMAT.format(owner=plr_template_owner, branch_name=plr_template_branch)
+            doozer_opts.extend(['--plr-template', plr_template_url])
+        if self.skip_checks:
+            doozer_opts.append('--skip-checks')
+        await self._run_doozer(doozer_opts)
+
+    async def _parse_record_log(self):
+        results = []
+        record_log_path = Path(self.runtime.doozer_working, 'record.log')
+        if record_log_path.exists():
+            with record_log_path.open() as file:
+                record_log = parse_record_log(file)
+            records = record_log.get('bundle_nvrs', [])
+            for record in records:
+                if record['status'] != '0':
+                    raise RuntimeError('record.log includes unexpected build_fbc_konflux '
+                                       f'record with error message: {record["message"]}')
+                results.append((record['fbc_nvr'], record['bundle_nvrs']))
+        return results
+
+
+@cli.command('build-fbc', help='Rebase and build FBC segments for OLM operators')
+@click.option('--version', required=True, help='OCP version')
+@click.option('--assembly', required=True, help='Assembly name')
+@click.option('--data-path', required=False, default=constants.OCP_BUILD_DATA_URL,
+              help='ocp-build-data fork to use (e.g. assembly definition in your own fork)')
+@click.option('--data-gitref', required=False,
+              help='(Optional) Doozer data path git [branch / tag / sha] to use')
+@click.option('--only', required=False,
+              help='(Optional) List **only** the operators you want to build, everything else gets ignored.\n'
+                   'Format: Comma and/or space separated list of brew packages (e.g.: cluster-nfd-operator-container)\n'
+                   'Leave empty to build all (except EXCLUDE, if defined)')
+@click.option('--exclude', required=False,
+              help='(Optional) List the operators you **don\'t** want to build, everything else gets built.\n'
+                   'Format: Comma and/or space separated list of brew packages (e.g.: cluster-nfd-operator-container)\n'
+                   'Leave empty to build all (or ONLY, if defined)')
+@click.option('--operator-nvrs', required=False,
+              help='(Optional) List **only** the operator NVRs you want to build FBC segments for, everything else '
+                   'gets ignored. The operators should not be mode:disabled/wip in ocp-build-data')
+@click.option('--fbc-repo', required=False, default='',
+              help='(Optional) URL of the FBC repository')
+@click.option("--kubeconfig", required=False, help="Path to kubeconfig file to use for Konflux cluster connections")
+@click.option('--plr-template', required=False, default='',
+              help='Override the Pipeline Run template commit from openshift-priv/art-konflux-template; format: <owner>@<branch>')
+@click.option("--skip-checks", is_flag=True, help="Skip all post build checks in the FBC build pipeline")
+@pass_runtime
+@click_coroutine
+async def build_fbc(
+        runtime: Runtime, version: str, assembly: str, data_path: str, data_gitref: str,
+        only: str, exclude: str, operator_nvrs: str, fbc_repo: str, kubeconfig: str, plr_template: str,
+        skip_checks: bool):
+    pipeline = BuildFbcPipeline(
+        runtime=runtime,
+        version=version,
+        assembly=assembly,
+        data_path=data_path,
+        data_gitref=data_gitref,
+        only=only,
+        exclude=exclude,
+        operator_nvrs=operator_nvrs,
+        fbc_repo=fbc_repo,
+        kubeconfig=kubeconfig,
+        plr_template=plr_template,
+        skip_checks=skip_checks,
+    )
+    await pipeline.run()


### PR DESCRIPTION
This job uses `doozer beta:fbc:rebase` and `doozer beta:fbc:build` to build file-based catalog (FBC) segments for OLM operators.

Requires: https://github.com/openshift-eng/art-tools/pull/1364 and https://github.com/openshift-eng/art-tools/pull/1403

Test pipeline run: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/yuxzhu/job/aos-cd-builds/job/build%252Fbuild-fbc/15/console