### PR TITLE
search_builds_by_fields(): match against multiple values

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -845,12 +845,10 @@ class GenPayloadCli:
         # Ensure that all payload images have been mirrored before updating
         # the imagestream. Otherwise, the imagestream will fail to import the
         # image.
-        tasks = []
         for arch, payload_entries in self.private_payload_entries_for_arch.items():
-            tasks.append(self.mirror_payload_content(arch, payload_entries, True))
+            await self.mirror_payload_content(arch, payload_entries, True)
         for arch, payload_entries in self.payload_entries_for_arch.items():
-            tasks.append(self.mirror_payload_content(arch, payload_entries))
-        await asyncio.gather(*tasks)
+            await self.mirror_payload_content(arch, payload_entries)
 
         await asyncio.sleep(120)
 


### PR DESCRIPTION
- teach `search_builds_by_fields()` how to do `WHERE name IN (value1, value2)
- by default, only search for builds in 'failure' or 'success' state