### PR TITLE
Add beta:fbc:build verb to build FBC segments

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -317,6 +317,7 @@ class KonfluxClient:
                                                build_platforms: Sequence[str], git_auth_secret: str = "pipelines-as-code-secret",
                                                additional_tags: Optional[Sequence[str]] = None, skip_checks: bool = False,
                                                hermetic: Optional[bool] = None,
+                                               dockerfile: Optional[str] = None,
                                                pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL) -> dict:
         if additional_tags is None:
             additional_tags = []
@@ -368,6 +369,8 @@ class KonfluxClient:
         _modify_param(params, "skip-checks", skip_checks)
         _modify_param(params, "build-source-image", "true")  # Have to be true always to satisfy Enterprise Contract Policy
         _modify_param(params, "build-platforms", list(build_platforms))
+        if dockerfile:
+            _modify_param(params, "dockerfile", dockerfile)
         if hermetic is not None:
             _modify_param(params, "hermetic", hermetic)
 
@@ -425,6 +428,7 @@ class KonfluxClient:
         additional_tags: Sequence[str] = [],
         skip_checks: bool = False,
         hermetic: Optional[bool] = None,
+        dockerfile: Optional[str] = None,
         pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL,
     ):
         """
@@ -445,6 +449,7 @@ class KonfluxClient:
         :param skip_checks: Whether to skip checks.
         :param hermetic: Whether to build the image in a hermetic environment. If None, the default value is used.
         :param image_metadata: Image metadata
+        :param dockerfile: Override the Dockerfile to use.
         :param pipelinerun_template_url: The URL to the PipelineRun template.
         :return: The PipelineRun resource.
         """
@@ -469,6 +474,7 @@ class KonfluxClient:
             skip_checks=skip_checks,
             hermetic=hermetic,
             additional_tags=additional_tags,
+            dockerfile=dockerfile,
             pipelinerun_template_url=pipelinerun_template_url,
         )
         if self.dry_run:
@@ -560,7 +566,7 @@ class KonfluxClient:
                         # while waiting for a long pipelinerun. If we somehow miss
                         # an event, it also ensures we will come back and check
                         # the object with an explicit get at least once per period.
-                        timeout_seconds=5*60
+                        timeout_seconds=5 * 60
                     ):
                         assert isinstance(event, Dict)
                         cancel_pipelinerun = False  # If set to true, an attempt will be made to cancel the pipelinerun within the loop

--- a/doozer/doozerlib/cli/__main__.py
+++ b/doozer/doozerlib/cli/__main__.py
@@ -39,7 +39,7 @@ from doozerlib.cli.images import images_clone, images_list, images_push_distgit,
     images_print, distgit_config_template, query_rpm_version
 from doozerlib.cli.images_konflux import images_konflux_rebase
 from doozerlib.cli.images_konflux import images_konflux_build
-from doozerlib.cli.fbc import fbc_import, fbc_rebase
+from doozerlib.cli.fbc import fbc_import, fbc_rebase, fbc_build
 
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.util import analyze_debug_timing

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -45,6 +45,7 @@ KONFLUX_DEFAULT_NAMESPACE = f"{KONFLUX_UI_DEFAULT_WORKSPACE}-tenant"
 MAX_KONFLUX_BUILD_QUEUE_SIZE = 25  # how many concurrent Konflux pipeline can we spawn per OCP version?
 KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL = "https://github.com/openshift-priv/art-konflux-template/raw/refs/heads/main/.tekton/art-konflux-template-push.yaml"
 KONFLUX_DEFAULT_BUNDLE_BUILD_PLR_TEMPLATE_URL = "https://github.com/openshift-priv/art-konflux-template/raw/refs/heads/main/.tekton/art-bundle-konflux-template-push.yaml"
+KONFLUX_DEFAULT_FBC_BUILD_PLR_TEMPLATE_URL = "https://github.com/openshift-priv/art-konflux-template/raw/refs/heads/main/.tekton/art-fbc-konflux-template-push.yaml"
 ART_FBC_GIT_REPO = "git@github.com:openshift-priv/art-fbc.git"
 REGISTRY_PROXY_BASE_URL = "registry-proxy.engineering.redhat.com"
 BREW_REGISTRY_BASE_URL = "brew.registry.redhat.io"

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -588,6 +588,7 @@ class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
             building_arches=["x86_64"],
             additional_tags=additional_tags,
             skip_checks=self.skip_checks,
+            hermetic=True,
             pipelinerun_template_url=constants.KONFLUX_DEFAULT_BUNDLE_BUILD_PLR_TEMPLATE_URL,
         )
         self.assertEqual(url, "https://example.com/pipelinerun")


### PR DESCRIPTION
This verb is used to build File-based catalog (FBC) segments from the art-fbc repo. `beta:fbc:rebase` must be run before this command.

Requires https://github.com/openshift-eng/art-tools/pull/1364

Test command:
```sh
doozer --group=openshift-4.18 --assembly=stream --images=ose-metallb-operator --latest-parent-version beta:fbc:build --konflux-kubeconfig=/path/to/config-konflux-prod --konflux-namespace=ocp-art-tenant --skip-checks
```

Note: `--skip-test` is to instruct the Konflux pipeline to skip validations. Those validations are expected to fail if any of bundles, operators, or operands are not shipped live.

Test build on jenkins: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/yuxzhu/job/aos-cd-builds/job/build%252Fbuild-fbc/15/console