### PR TITLE
[konflux] disable ppc

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -350,7 +350,8 @@ class ConfigScanSources:
             return
 
         # Check for changes in image arches
-        await self.scan_arch_changes(image_meta)
+        # TODO remove once we have full capacity
+        # await self.scan_arch_changes(image_meta)
 
         # Check if there's already a build from upstream latest commit
         await self.scan_for_upstream_changes(image_meta)

--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -57,6 +57,7 @@ class Ocp4ScanPipeline:
                 build_version=self.version,
                 assembly='stream',
                 image_list=image_list,
+                limit_arches=['x86_64', 'aarch64', 's390x']  # TODO remove once we have full capacity
             )
 
         else:


### PR DESCRIPTION
Since PPC VMs on Konflux are not spawning correctly, disabling triggering builds temporarily until Konflux fixes are in. 

ref [thread](https://redhat-internal.slack.com/archives/C06Q309QUDV/p1740589236365859) for details