### PR TITLE
find-builds: Check for False instead of None

### DIFF
--- a/elliott/elliottlib/brew.py
+++ b/elliott/elliottlib/brew.py
@@ -145,6 +145,8 @@ def get_builds_tags(build_nvrs, session=None):
     tasks = []
     with session.multicall(strict=True) as m:
         for nvr in build_nvrs:
+            if not (isinstance(nvr, str) or isinstance(nvr, int)):
+                raise ValueError(f"expected str or int but got {type(nvr)}")
             tasks.append(m.listTags(build=nvr))
     return [task.result for task in tasks]
 


### PR DESCRIPTION
Because of the recent change of get_latest_build returning Model/MissingModel,
we want to check for bool(MissingModel)/False instead of None.