### PR TITLE
[ART-11902] konflux prefetch support

### DIFF
--- a/artcommon/tests/test_cachito.py
+++ b/artcommon/tests/test_cachito.py
@@ -1,0 +1,63 @@
+from unittest.mock import MagicMock, patch
+
+from artcommonlib.util import is_cachito_enabled, detect_package_managers
+from artcommonlib.model import Missing
+from unittest import TestCase
+
+
+class TestKonfluxCachi2(TestCase):
+    def test_cachito_metadata_config(self):
+        metadata = MagicMock()
+        group_config = MagicMock()
+
+        metadata.config.cachito.enabled = True
+        group_config.cachito.enabled = False
+
+        self.assertTrue(is_cachito_enabled(metadata, group_config, logger=MagicMock()))
+
+    def test_cachito_group_config_1(self):
+        metadata = MagicMock()
+        group_config = MagicMock()
+
+        metadata.config.cachito.enabled = Missing
+        group_config.cachito.enabled = True
+
+        self.assertTrue(is_cachito_enabled(metadata, group_config, logger=MagicMock()))
+
+    def test_cachito_group_config_2(self):
+        metadata = MagicMock()
+        group_config = MagicMock()
+
+        metadata.config.cachito.enabled = Missing
+        group_config.cachito.enabled = False
+
+        self.assertFalse(is_cachito_enabled(metadata, group_config, logger=MagicMock()))
+
+    def test_cachito_group_config_3(self):
+        metadata = MagicMock()
+        group_config = MagicMock()
+
+        metadata.config.cachito.enabled = Missing
+        group_config.cachito.enabled = True
+
+        self.assertTrue(is_cachito_enabled(metadata, group_config, logger=MagicMock()))
+
+    def test_cachito_has_source(self):
+        metadata = MagicMock()
+        group_config = MagicMock()
+
+        metadata.config.cachito.enabled = Missing
+        group_config.cachito.enabled = True
+        metadata.has_source.return_value = False
+
+        self.assertFalse(is_cachito_enabled(metadata, group_config, logger=MagicMock()))
+
+    def test_cachito_has_source_2(self):
+        metadata = MagicMock()
+        group_config = MagicMock()
+
+        metadata.config.cachito.enabled = Missing
+        group_config.cachito.enabled = True
+        metadata.has_source.return_value = True
+
+        self.assertTrue(is_cachito_enabled(metadata, group_config, logger=MagicMock()))

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -329,7 +329,7 @@ class KonfluxClient:
 
     async def _new_pipelinerun_for_image_build(self, generate_name: str, namespace: Optional[str], application_name: str, component_name: str,
                                                git_url: str, commit_sha: str, target_branch: str, output_image: str,
-                                               build_platforms: Sequence[str], git_auth_secret: str = "pipelines-as-code-secret",
+                                               build_platforms: Sequence[str], prefetch: Optional[list] = None, git_auth_secret: str = "pipelines-as-code-secret",
                                                additional_tags: Optional[Sequence[str]] = None, skip_checks: bool = False,
                                                hermetic: Optional[bool] = None,
                                                dockerfile: Optional[str] = None,
@@ -386,6 +386,9 @@ class KonfluxClient:
         _modify_param(params, "build-platforms", list(build_platforms))
         if dockerfile:
             _modify_param(params, "dockerfile", dockerfile)
+
+        if prefetch:
+            _modify_param(params, "prefetch-input", prefetch)
         if hermetic is not None:
             _modify_param(params, "hermetic", hermetic)
 
@@ -439,6 +442,7 @@ class KonfluxClient:
         output_image: str,
         vm_override: dict,
         building_arches: Sequence[str],
+        prefetch: Optional[list] = None,
         git_auth_secret: str = "pipelines-as-code-secret",
         additional_tags: Sequence[str] = [],
         skip_checks: bool = False,
@@ -464,8 +468,8 @@ class KonfluxClient:
         :param skip_checks: Whether to skip checks.
         :param hermetic: Whether to build the image in a hermetic environment. If None, the default value is used.
         :param image_metadata: Image metadata
-        :param dockerfile: Override the Dockerfile to use.
         :param pipelinerun_template_url: The URL to the PipelineRun template.
+        :param prefetch: The param values for Konflux prefetch dependencies task
         :return: The PipelineRun resource.
         """
         unsupported_arches = set(building_arches) - set(self.SUPPORTED_ARCHES)
@@ -491,6 +495,7 @@ class KonfluxClient:
             additional_tags=additional_tags,
             dockerfile=dockerfile,
             pipelinerun_template_url=pipelinerun_template_url,
+            prefetch=prefetch
         )
         if self.dry_run:
             fake_pipelinerun = resource.ResourceInstance(self.dyn_client, pipelinerun_manifest)

--- a/doozer/tests/backend/test_konflux_cachi2.py
+++ b/doozer/tests/backend/test_konflux_cachi2.py
@@ -1,0 +1,113 @@
+from unittest import TestCase
+
+from artcommonlib.model import Missing
+from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
+from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
+
+
+class TestKonfluxCachi2(TestCase):
+    def test_cachi2_enabled_1(self):
+        metadata = MagicMock()
+        metadata.config.konflux.cachi2.enabled = True
+
+        self.assertTrue(KonfluxImageBuilder._is_cachi2_enabled(metadata))
+
+    def test_cachi2_enabled_2(self):
+        metadata = MagicMock()
+        metadata.config.konflux.cachi2.enabled = False
+
+        self.assertFalse(KonfluxImageBuilder._is_cachi2_enabled(metadata))
+
+    def test_cachi2_enabled_3(self):
+        metadata = MagicMock()
+        metadata.config.konflux.cachi2.enabled = None
+        metadata.runtime.group_config.konflux.cachi2.enabled = True
+
+        self.assertTrue(KonfluxImageBuilder._is_cachi2_enabled(metadata))
+
+    def test_cachi2_enabled_4(self):
+        metadata = MagicMock()
+        metadata.config.konflux.cachi2.enabled = Missing
+        metadata.runtime.group_config.konflux.cachi2.enabled = False
+
+        self.assertFalse(KonfluxImageBuilder._is_cachi2_enabled(metadata))
+
+    @patch("artcommonlib.util.is_cachito_enabled")
+    def test_cachi2_enabled_5(self, is_cachito_enabled):
+        metadata = MagicMock()
+        metadata.config.konflux.cachi2.enabled = Missing
+        metadata.runtime.group_config.konflux.cachi2.enabled = Missing
+        is_cachito_enabled.return_value = True
+
+        self.assertTrue(KonfluxImageBuilder._is_cachi2_enabled(metadata))
+
+    @patch("artcommonlib.util.is_cachito_enabled")
+    def test_cachi2_enabled_6(self, is_cachito_enabled):
+        metadata = MagicMock()
+        metadata.config.konflux.cachi2.enabled = False
+        metadata.runtime.group_config.konflux.cachi2.enabled = Missing
+        is_cachito_enabled.return_value = True
+
+        self.assertFalse(KonfluxImageBuilder._is_cachi2_enabled(metadata))
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.konflux_image_builder.KonfluxImageBuilder._is_cachi2_enabled")
+    def test_prefetch_1(self, mock_konflux_client_init, mock_is_cachito_enabled):
+        builder = KonfluxImageBuilder(MagicMock())
+        mock_is_cachito_enabled.return_value = False
+        metadata = MagicMock()
+
+        self.assertEqual(builder._prefetch(metadata=metadata), [])
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.konflux_image_builder.KonfluxImageBuilder._is_cachi2_enabled")
+    def test_prefetch_2(self, mock_konflux_client_init, mock_is_cachito_enabled):
+        builder = KonfluxImageBuilder(MagicMock())
+        mock_is_cachito_enabled.return_value = False
+        metadata = MagicMock()
+        metadata.config.content.source.pkg_managers = ["unknown"]
+
+        self.assertEqual(builder._prefetch(metadata=metadata), [])
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.konflux_image_builder.KonfluxImageBuilder._is_cachi2_enabled")
+    def test_prefetch_3(self, mock_konflux_client_init, mock_is_cachito_enabled):
+        builder = KonfluxImageBuilder(MagicMock())
+        mock_is_cachito_enabled.return_value = False
+        metadata = MagicMock()
+        metadata.config.content.source.pkg_managers = ["gomod"]
+
+        self.assertEqual(builder._prefetch(metadata=metadata), [{"type": "gomod", "path": "."}])
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.konflux_image_builder.KonfluxImageBuilder._is_cachi2_enabled")
+    def test_prefetch_4(self, mock_konflux_client_init, mock_is_cachito_enabled):
+        builder = KonfluxImageBuilder(MagicMock())
+        mock_is_cachito_enabled.return_value = False
+        metadata = MagicMock()
+        metadata.config.content.source.pkg_managers = ["gomod"]
+        metadata.config.cachito.packages = {'gomod': [{'path': 'api'}]}
+
+        self.assertEqual(builder._prefetch(metadata=metadata), [{"type": "gomod", "path": "api"}])
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.konflux_image_builder.KonfluxImageBuilder._is_cachi2_enabled")
+    def test_prefetch_4(self, mock_konflux_client_init, mock_is_cachito_enabled):
+        builder = KonfluxImageBuilder(MagicMock())
+        mock_is_cachito_enabled.return_value = False
+        metadata = MagicMock()
+        metadata.config.content.source.pkg_managers = ["gomod"]
+        metadata.config.cachito.packages = {"gomod": [{"path": "."}, {"path": "api"}, {"path": "client/pkg"}]}
+
+        self.assertEqual(builder._prefetch(metadata=metadata), [{"type": "gomod", "path": "."}, {"type": "gomod", "path": "api"}, {"type": "gomod", "path": "client/pkg"}])
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.konflux_image_builder.KonfluxImageBuilder._is_cachi2_enabled")
+    def test_prefetch_5(self, mock_konflux_client_init, mock_is_cachito_enabled):
+        builder = KonfluxImageBuilder(MagicMock())
+        mock_is_cachito_enabled.return_value = False
+        metadata = MagicMock()
+        metadata.config.content.source.pkg_managers = ["npm", "gomod"]
+        metadata.config.cachito.packages = {'npm': [{'path': 'web'}], 'gomod': [{'path': '.'}]}
+
+        self.assertEqual(builder._prefetch(metadata=metadata), [{'type': 'gomod', 'path': '.'}, {'type': 'npm', 'path': 'web'}])


### PR DESCRIPTION
pre-fetch is the first step towards hermetic builds. The pre-fetch dependencies konflux task uses cachi2 to get the required packages and make it available to the hermetic build. Right now, we can enable pre-fetch without enabling hermetic to make sure that all images work with cachi2. If not, we need to work with upstream image owners to make changes to their repos.

image config `konflux.cachi2.enabled` > group config `konflux.cachi2.enabled` > cachito enabled/disabled

Ticket: https://issues.redhat.com/browse/ART-11902