### PR TITLE
[konflux] update cachito logic

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -872,7 +872,7 @@ class KonfluxRebaser:
 
             # The value we will set REMOTE_SOURCES_DIR to.
             remote_source_dir_env = '/tmp/cachito-emulation'
-            pkg_managers = self._detect_package_managers(metadata, dest_dir)
+            pkg_managers = metadata.config.content.source.pkg_managers.primitive()
 
             if "npm" in pkg_managers:
                 flag = False


### PR DESCRIPTION
`self._detect_package_managers(metadata, dest_dir)` is not smart enough to find the package managers if it does not exist in current directory.