### PR TITLE
[konflux] update prefetch-dependencies sbom-type param

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -383,7 +383,7 @@ class KonfluxClient:
                     task["timeout"] = "12h"
                     _modify_param(task["params"], "SBOM_TYPE", "cyclonedx")
                 case "prefetch-dependencies":
-                    _modify_param(task["params"], "SBOM_TYPE", "cyclonedx")
+                    _modify_param(task["params"], "sbom-type", "cyclonedx")
                 case "apply-tags":
                     _modify_param(task["params"], "ADDITIONAL_TAGS", list(additional_tags))
                 case "clone-repository":


### PR DESCRIPTION
For `prefetch-dependencies` the sbom type override param key is `sbom-type`. 

Ref: https://github.com/konflux-ci/build-definitions/blob/main/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml#L48

Test build [succeeded](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/5667/console)