### PR TITLE
images:health look back to latest 90 days

### DIFF
--- a/doozer/doozerlib/cli/images_health.py
+++ b/doozer/doozerlib/cli/images_health.py
@@ -11,7 +11,7 @@ from doozerlib import Runtime
 from doozerlib.cli import cli, pass_runtime, click_coroutine
 from doozerlib.constants import ART_BUILD_HISTORY_URL
 
-DELTA_DAYS = 30  # look at latest 30 days
+DELTA_DAYS = 90  # look at latest 90 days
 
 
 class ImagesHealthPipeline:
@@ -73,7 +73,6 @@ class ImagesHealthPipeline:
     async def get_concerns(self, image_meta, engine):
         key = image_meta.distgit_key
         builds = await self.query(image_meta, engine)
-        builds = [build for build in builds if build.outcome != KonfluxBuildOutcome.PENDING]
         if not builds:
             self.logger.info('Image build for %s has never been attempted during last %s days',
                              image_meta.distgit_key, DELTA_DAYS)


### PR DESCRIPTION
Look at latest 90 days, as 30 could not be enough for slowly updating images and might result in unwanted pings.

Also, no need to filter builds in `PENDING` state as `search_builds_by_field()` is doing that in a smarter way:

```
if 'outcome' not in where:
    base_clauses.append(Column('outcome', String).in_(['success', 'failure']))
```