### PR TITLE
Set cachito as explicit default for osbs builds

### DIFF
--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -616,6 +616,7 @@ class ImageDistGitRepo(DistGitRepo):
             elif self.config.content.source.path:  # source is in subdirectory
                 remote_source['packages'] = {pkg_manager: [{"path": self.config.content.source.path}] for pkg_manager in pkg_managers}
             config_overrides.update({
+                'remote_sources_version': 1,  # https://spaces.redhat.com/pages/viewpage.action?pageId=591269742
                 'remote_sources': [
                     {
                         'name': 'cachito-gomod-with-deps',  # The remote source name is always `cachito-gomod-with-deps` for backward compatibility even if gomod is not used.


### PR DESCRIPTION
Locking osbs to `remote_sources_version: 1 `until a deprecation date is announced for cachito. Ideally it would land after 4.19 GA and we won't have to worry about it.

Docs: https://spaces.redhat.com/pages/viewpage.action?pageId=591269742

