### PR TITLE
[temp][konflux] disable rebuilds on config changes

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -517,9 +517,10 @@ class ConfigScanSources:
                 if 'scan-sources-konflux:noop' in commit_message.lower():
                     self.logger.info('Ignoring digest change since commit message indicates noop')
                 else:
-                    self.add_image_meta_change(image_meta,
-                                               RebuildHint(RebuildHintCode.CONFIG_CHANGE,
-                                                           'Metadata configuration change'))
+                    self.logger.warning('Would have rebuild %s because of metadata config change', image_meta.distgit_key)
+                    # self.add_image_meta_change(image_meta,
+                    #                            RebuildHint(RebuildHintCode.CONFIG_CHANGE,
+                    #                                        'Metadata configuration change'))
 
         except IOError:
             # IOError is raised by fetch_cgit_file() when config_digest could not be found


### PR DESCRIPTION
**TO BE REVERTED!!!**

Temporarily disable konflux rebuilds on config changes. Some images are continuously being rebuilt, so something might be wrong with our metadata configuration check. Disabling it until we assess the problem 