### PR TITLE
Fix scan-sources config changes check

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -95,13 +95,8 @@ class KonfluxRebaser:
             commit_message: str,
             push: bool,
     ) -> None:
-        # If there is a konflux stanza in the image config, merge it with the main config
-        if metadata.config.konflux is not Missing:
-            metadata.config = Model(deep_merge(metadata.config.primitive(), metadata.config.konflux.primitive()))
-
         try:
             # If this image has an upstream source, resolve it
-            source = None
             if metadata.has_source():
                 self._logger.info(f"Resolving source for {metadata.qualified_key}")
                 source = cast(SourceResolution, await exectools.to_thread(self._source_resolver.resolve_source, metadata))

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -518,9 +518,9 @@ class ConfigScanSources:
                     self.logger.info('Ignoring digest change since commit message indicates noop')
                 else:
                     self.logger.warning('Would have rebuild %s because of metadata config change', image_meta.distgit_key)
-                    # self.add_image_meta_change(image_meta,
-                    #                            RebuildHint(RebuildHintCode.CONFIG_CHANGE,
-                    #                                        'Metadata configuration change'))
+                    self.add_image_meta_change(image_meta,
+                                               RebuildHint(RebuildHintCode.CONFIG_CHANGE,
+                                                           'Metadata configuration change'))
 
         except IOError:
             # IOError is raised by fetch_cgit_file() when config_digest could not be found


### PR DESCRIPTION
`scan-sources` and 'images:rebase` compute image config digest at different times; the latter happens after merging the `konflux` config stanza into the main config, and this alters the result. As a consequence, we were continuously finding reasons to rebuild images because the digest computed by scan-sources did not match what we had pushed upstream. 

Moving the config merge inside the function that computes the digest will ensure consistent results across pipelines.

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/12930/console