### PR TITLE
Increase jenkins client timeout

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -63,7 +63,8 @@ def init_jenkins():
         username=os.environ['JENKINS_SERVICE_ACCOUNT'],
         password=os.environ['JENKINS_SERVICE_ACCOUNT_TOKEN'],
         requester=requester,
-        lazy=True
+        lazy=True,
+        timeout=60,
     )
     logger.info('Connected to Jenkins server %s', jenkins_client.base_server_url())
 


### PR DESCRIPTION
Sometimes fetching build/builds would timeout since default is 10 seconds,
increase it to 60 seconds. 

Run: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/maintenance/job/maintenance%252Fcleanup-locks/34863/parameters/