### PR TITLE
[konflux] add -container while searching for brew builds

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1829,6 +1829,7 @@ class KonfluxRebaser:
         # FIXME: This is based on Brew/OSBS. Needs to figure out how to do this with Konflux
         with self._runtime.pooled_koji_client_session() as koji_api:
             component_name = metadata.get_component_name()
+            component_name = component_name + "-container" if not component_name.endswith("-container") else component_name
             package_info = koji_api.getPackage(component_name)  # e.g. {'id': 66873, 'name': 'atomic-openshift-descheduler-container'}
             if not package_info:
                 raise IOError(f'No brew package is defined for {component_name}')


### PR DESCRIPTION
We had stopped adding `-container` to image names recently, but while searching through the brew database, we need to search with that suffix.

Fixes error
```
doozerlib.cli.images_konflux ERROR Failed to rebase cluster-nfd-operator: No brew package is defined for cluster-nfd-operator
```

https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/5900/console