### PR TITLE
Doozer: Additional auth fix for FBC import

### DIFF
--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -130,7 +130,7 @@ class KonfluxFbcImporter:
         migrate_level = "none"
         if self.ocp_version >= (4, 17):
             migrate_level = "bundle-object-to-csv-metadata"
-        await opm.render_catalog_from_template(template_file, catalog_file, migrate_level=migrate_level)
+        await opm.render_catalog_from_template(template_file, catalog_file, migrate_level=migrate_level, auth=self.auth)
 
         # Clean up catalog-templates
         if not self.keep_templates:

--- a/doozer/doozerlib/opm.py
+++ b/doozer/doozerlib/opm.py
@@ -142,7 +142,9 @@ async def generate_basic_template(catalog_file: Path, template_file: Path, outpu
         await gather_opm(["alpha", "convert-template", "basic", "-o", output_format, "--", str(catalog_file)], stdout=out)
 
 
-async def render_catalog_from_template(template_file: Path, catalog_file: Path, migrate_level: str = "none", output_format: str = "yaml"):
+async def render_catalog_from_template(
+        template_file: Path, catalog_file: Path, migrate_level: str = "none", output_format: str = "yaml",
+        auth: Optional[OpmRegistryAuth] = None):
     """
     Render a catalog from a template file.
 
@@ -150,6 +152,7 @@ async def render_catalog_from_template(template_file: Path, catalog_file: Path, 
     :param catalog_file: The file to write the rendered catalog to.
     :param migrate_level: The migration level to use when rendering the catalog.
     :param output_format: The output format to use when rendering the catalog. One of "yaml" or "json".
+    :param auth: The registry authentication information to use. If not provided, system-default authentication is used.
     """
     if migrate_level not in ["none", "bundle-object-to-csv-metadata"]:
         raise ValueError(f"Invalid migrate level: {migrate_level}")
@@ -157,7 +160,8 @@ async def render_catalog_from_template(template_file: Path, catalog_file: Path, 
         raise ValueError(f"Invalid output format: {output_format}")
     LOGGER.debug(f"Rendering catalog {catalog_file} from template {template_file}")
     with open(catalog_file, 'w') as out:
-        await gather_opm(["alpha", "render-template", "basic", "--migrate-level", migrate_level, "-o", output_format, "--", str(template_file)], stdout=out)
+        await gather_opm(["alpha", "render-template", "basic", "--migrate-level", migrate_level, "-o",
+                          output_format, "--", str(template_file)], stdout=out, auth=auth)
 
 
 async def generate_dockerfile(dest_dir: Path, dc_dir_name: str, base_image: str, builder_image: str):

--- a/doozer/tests/test_opm.py
+++ b/doozer/tests/test_opm.py
@@ -2,8 +2,9 @@ import unittest
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from doozerlib.opm import (generate_basic_template, generate_dockerfile,
-                           render, render_catalog_from_template, verify_opm)
+from doozerlib.opm import (OpmRegistryAuth, generate_basic_template,
+                           generate_dockerfile, render,
+                           render_catalog_from_template, verify_opm)
 
 
 class TestOpm(unittest.IsolatedAsyncioTestCase):
@@ -45,10 +46,11 @@ class TestOpm(unittest.IsolatedAsyncioTestCase):
     async def test_render_catalog_from_template(self, mock_gather_opm, mock_open):
         template_file = Path('/path/to/template.yaml')
         catalog_file = Path('/path/to/catalog.yaml')
-        await render_catalog_from_template(template_file, catalog_file)
+        auth = MagicMock(spec=OpmRegistryAuth)
+        await render_catalog_from_template(template_file, catalog_file, auth=auth)
         mock_gather_opm.assert_called_once_with([
             'alpha', 'render-template', 'basic', '--migrate-level', 'none', '-o', 'yaml', '--', str(template_file)
-        ], stdout=mock_open.return_value.__enter__.return_value)
+        ], stdout=mock_open.return_value.__enter__.return_value, auth=auth)
 
         with self.assertRaises(ValueError, msg="Invalid migrate level: invalid"):
             await render_catalog_from_template(template_file, catalog_file, migrate_level='invalid')


### PR DESCRIPTION
Follow up https://github.com/openshift-eng/art-tools/pull/1437,

`opm alpha render-template` also needs registry credentials.

Tested with https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/yuxzhu/job/aos-cd-builds/job/build%252Ffbc-import-from-index/18/