### PR TITLE
[konflux] build-sync: re-enable a few assembly issues checks

### DIFF
--- a/artcommon/artcommonlib/konflux/package_rpm_finder.py
+++ b/artcommon/artcommonlib/konflux/package_rpm_finder.py
@@ -2,6 +2,7 @@ import logging
 from typing import Dict, List
 
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord
+from artcommonlib.rpm_utils import parse_nvr
 from doozerlib import brew
 
 
@@ -12,53 +13,71 @@ class PackageRpmFinder:
     installed_packages, so this will help us limit redundant Brew API calls.
     """
 
-    def __init__(self):
+    def __init__(self, runtime):
         self._logger = logging.getLogger(__name__)
         self._package_to_rpms: Dict[str, List[Dict]] = {}
+        self._not_found_packages = []
+        self._runtime = runtime
 
-    def get_brew_rpms_from_build_record(self, build_record: KonfluxBuildRecord, runtime) -> List[Dict]:
+    def _cache_packages(self, packages: list):
         """
-        For each package NVR listed in a KonfluxBuildRecord installed_packages:
+        For each package NVR:
         - call koji.GetBuild(nvr) to get a build info dict
         - some of these will return None (the Brew build could not be found), and can be excluded
         - call koji.listBuildRPMs(build_id) to get a list of RPMs
         - cache the package build <-> RPMs mapping to avoid identical API calls in the future
         """
-        installed_packages = build_record.installed_packages
+
+        caching_packages = [p for p in packages if not self._package_to_rpms.get(p, None)]
+        if not caching_packages:
+            # All packages have already been mapped to an RPM build list
+            return
 
         # Query Brew to fetch RPMs included in packages not yet cached
-        caching_packages = [p for p in installed_packages if not self._package_to_rpms.get(p, None)]
-        if caching_packages:
-            with runtime.shared_koji_client_session() as session:
-                self._logger.debug('Caching RPM build info for package NVRs %s', ', '.join(caching_packages))
+        with self._runtime.shared_koji_client_session() as session:
+            self._logger.debug('Caching RPM build info for package NVRs %s', ', '.join(caching_packages))
 
-                # Get package build IDs from package names
-                with session.multicall(strict=True) as multicall:
-                    tasks = [multicall.getBuild(package) for package in caching_packages]
-                builds = [task.result for task in tasks]
+            # Get package build IDs from package names
+            with session.multicall(strict=True) as multicall:
+                tasks = [multicall.getBuild(package) for package in caching_packages]
+            builds = [task.result for task in tasks]
 
-                # Identify builds that could not be found
-                not_found_packages = [pkg for pkg, build in zip(caching_packages, builds) if not build]
-                if not_found_packages:
-                    self._logger.warning(
-                        'The following packages could not be found in Brew and will be excluded from the check: %s',
-                        ', '.join(not_found_packages)
-                    )
+            # Identify builds that could not be found
+            not_found_packages = [pkg for pkg, build in zip(caching_packages, builds) if not build]
+            if not_found_packages:
+                self._logger.warning(
+                    'The following packages could not be found in Brew and will be excluded from the check: %s',
+                    ', '.join(not_found_packages)
+                )
+                self._not_found_packages.extend(not_found_packages)
 
-                # Remove missing builds from packages in need for caching
-                caching_packages = [pkg for pkg, build in zip(caching_packages, builds) if build]
-                builds = [build for build in builds if build]
+            # Remove missing builds from packages in need for caching
+            caching_packages = [pkg for pkg, build in zip(caching_packages, builds) if build]
+            builds = [build for build in builds if build]
 
-                # Remove missing builds from installed_packages
-                installed_packages = [pkg for pkg in installed_packages if pkg not in not_found_packages]
+            # Get RPM list from package build IDs using koji_api.listBuildRPMs
+            build_ids = [build['build_id'] for build in builds]
+            results: List[List[Dict]] = brew.list_build_rpms(build_ids, session)
 
-                # Get RPM list from package build IDs using koji_api.listBuildRPMs
-                build_ids = [build['build_id'] for build in builds]
-                results: List[List[Dict]] = brew.list_build_rpms(build_ids, session)
+            # Cache retrieved RPM builds for package
+            for package_build, rpm_builds in zip(caching_packages, results):
+                self._package_to_rpms[package_build] = rpm_builds
 
-                # Cache retrieved RPM builds for package
-                for package_build, rpm_builds in zip(caching_packages, results):
-                    self._package_to_rpms[package_build] = rpm_builds
+    def get_brew_rpms_from_build_record(self, build_record: KonfluxBuildRecord) -> List[Dict]:
+        """
+        Return a list of RPM build dictionaries associated with the packages installed in a Konflux build
+        """
 
-        # Gather RPMs associated with the given KonfluxBuildRecord
-        return [rpm for package in installed_packages for rpm in self._package_to_rpms[package]]
+        installed_packages = build_record.installed_packages
+        installed_packages = [pkg for pkg in installed_packages if pkg not in self._not_found_packages]
+        self._cache_packages(installed_packages)
+        return [rpm for package in installed_packages for rpm in self._package_to_rpms.get(package, [])]
+
+    def get_packages_to_rpms_mapping(self, build_record: KonfluxBuildRecord) -> Dict[str, dict]:
+        """
+        Return a {package-name} -> {list[RPM build]} mapping associated with the packages installed in a Konflux build
+        """
+        installed_packages = build_record.installed_packages
+        installed_packages = [pkg for pkg in installed_packages if pkg not in self._not_found_packages]
+        self._cache_packages(installed_packages)
+        return {rpm['name']: rpm for package in installed_packages for rpm in self._package_to_rpms.get(package, [])if rpm['arch'] == 'x86_64'}

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -62,7 +62,7 @@ class ConfigScanSources:
         self.assessment_reason = dict()  # maps metadata qualified_key => message describing change
         self.issues = list()  # tracks issues that arose during the scan, which did not interrupt the job
 
-        self.package_rpm_finder = PackageRpmFinder()
+        self.package_rpm_finder = PackageRpmFinder(runtime)
         self.latest_image_build_records_map: typing.Dict[str, KonfluxBuildRecord] = {}
         self.latest_rpm_build_records_map: typing.Dict[str, typing.Dict[str, KonfluxBuildRecord]] = {}
         self.image_tree = {}

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -195,6 +195,7 @@ class TestGenPayloadCli(IsolatedAsyncioTestCase):
 
     async def test_detect_non_latest_rpms(self):
         gpcli = rgp_cli.GenPayloadCli()
+        gpcli.runtime = MagicMock(build_system='brew')
         bbii = AsyncMock(BrewBuildRecordInspector)
         bbii.get_image_meta.return_value = Mock(ImageMetadata, is_rpm_exempt=Mock(return_value=(False, None)))
         bbii.find_non_latest_rpms.return_value = {"x86_64": [("foo-0:1.2.0-1.el9.x86_64", "foo-0:1.2.1-1.el9.x86_64", "repo_name")], "s390x": []}

--- a/doozer/tests/test_assembly_inspector.py
+++ b/doozer/tests/test_assembly_inspector.py
@@ -67,6 +67,6 @@ class TestAssemblyInspector(IsolatedAsyncioTestCase):
         build_inspector.get_all_installed_package_build_dicts.return_value = {
             "kernel": {"nvr": "kernel-1.2.3-1", "id": 1}
         }
-        issues = ai.check_installed_rpms_in_image("foo", build_inspector)
+        issues = ai.check_installed_rpms_in_image("foo", build_inspector, None)
         self.assertEqual(issues, [])
     pass


### PR DESCRIPTION
Re-enabling these checks in Konflux gen-payload:
- detect_non_latest_rpms
- detect_inconsistent_images
- detect_installed_rpms_issues

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/16020