### PR TITLE
[konflux] Fix final stage user bug

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -978,7 +978,7 @@ class KonfluxRebaser:
             all_stages=True,
         )
 
-        config_final_stage_user = metadata.config.final_stage_user if metadata.config.final_stage_user not in [None, Missing] else None
+        config_final_stage_user = f"USER {metadata.config.final_stage_user}" if metadata.config.final_stage_user not in [None, Missing] else None
         config_final_stage_user_set = False
 
         # Just for last stage

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -105,7 +105,7 @@ USER 2000
         metadata = MagicMock()
         metadata.config.konflux.network_mode = Missing
         metadata.config.konflux.cachito.mode = Missing
-        metadata.config.final_stage_user = "USER 3000"
+        metadata.config.final_stage_user = "3000"
 
         dfp = DockerfileParser()
         dfp.content = """
@@ -165,7 +165,7 @@ USER 3000
         metadata = MagicMock()
         metadata.config.konflux.network_mode = "hermetic"
         metadata.config.konflux.cachito.mode = Missing
-        metadata.config.final_stage_user = "USER 3000"
+        metadata.config.final_stage_user = "3000"
 
         dfp = DockerfileParser()
         dfp.content = """
@@ -212,7 +212,7 @@ USER 3000
         metadata = MagicMock()
         metadata.config.konflux.network_mode = Missing
         metadata.config.konflux.cachito.mode = Missing
-        metadata.config.final_stage_user = "USER 3000"
+        metadata.config.final_stage_user = "3000"
 
         dfp = DockerfileParser()
         dfp.content = """


### PR DESCRIPTION
follows https://github.com/openshift-eng/art-tools/pull/1452

since `metadata.config.final_stage_user` is defined without the `USER` perfix