### PR TITLE
[konflux] .dockerignore fix

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -264,6 +264,11 @@ class KonfluxRebaser:
             with open(docker_ignore_path, "a") as file:
                 file.write("\n!/.oit/**\n")
 
+            with exectools.Dir(path):
+                rc, _, err = exectools.cmd_gather(f"go mod vendor")
+                if rc != 0:
+                    raise Exception(f"go mod vendor command didn't complete successfully {err}")
+
     def _resolve_parents(self, metadata: ImageMetadata, dfp: DockerfileParser, image_repo: str, uuid_tag: str):
         """ Resolve the parent images for the given image metadata."""
         image_from = metadata.config.get('from', {})


### PR DESCRIPTION
If a .dockerignore file exists, we update it to allow .oit dir: https://github.com/openshift-eng/art-tools/blob/main/doozer/doozerlib/backend/rebaser.py#L257

But this causes an error with pre-fetch dependencies task, where it complains that the go vendors are not upto date. Hence run `go mod vendor` to update.