### PR TITLE
[konflux] sync multiarch payloads

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -226,7 +226,7 @@ class KonfluxOcp4Pipeline:
             doozer_data_gitref=self.data_gitref,
             build_system='konflux',
             exclude_arches=exclude_arches,
-            SKIP_MULTI_ARCH_PAYLOAD=True,  # TODO to be removed
+            SKIP_MULTI_ARCH_PAYLOAD=False
         )
 
     async def init_build_plan(self):


### PR DESCRIPTION
Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/16409/

Updated multi is:
```
$ oc -n ocp-multi get is 4.19-konflux-art-latest-multi
NAME                            IMAGE REPOSITORY                                                    TAGS                                       UPDATED
4.19-konflux-art-latest-multi   registry.ci.openshift.org/ocp-multi/4.19-konflux-art-latest-multi   4.19.0-0.nightly-multi-2025-03-27-090653   2 hours ago
```