### PR TITLE
[konflux] .dockerignore fix

### DIFF
--- a/doozer/doozerlib/backend/build_repo.py
+++ b/doozer/doozerlib/backend/build_repo.py
@@ -162,10 +162,14 @@ class BuildRepo:
             raise ChildProcessError(f"Failed to get commit hash: {err}")
         return out.strip()
 
+    async def git_add(self):
+        local_dir = str(self.local_dir)
+        await git_helper.run_git_async(["-C", local_dir, "add", "."])
+
     async def commit(self, message: str, allow_empty: bool = False):
         """ Commit changes in the local directory to the build source repository."""
         local_dir = str(self.local_dir)
-        await git_helper.run_git_async(["-C", local_dir, "add", "."])
+        await self.git_add()
         commit_opts = []
         if allow_empty:
             commit_opts.append("--allow-empty")


### PR DESCRIPTION
`hypershift` image has a `.gitignore` file that needs to be present after rebase, in konflux. Usually its removed before rebase to make sure that files/folders that doozer generates are not  excluded by git. But in order to work with cachi2, we need to temporarily rename the file, add all the .oit/* and other files that doozer generates, rename the file back to .gitignore so that konflux can read the correct file.