### PR TITLE
[konflux] use force for git add

### DIFF
--- a/doozer/doozerlib/backend/build_repo.py
+++ b/doozer/doozerlib/backend/build_repo.py
@@ -165,7 +165,7 @@ class BuildRepo:
     async def commit(self, message: str, allow_empty: bool = False, force: bool = False):
         """ Commit changes in the local directory to the build source repository."""
         local_dir = str(self.local_dir)
-        await git_helper.run_git_async(["-C", local_dir, "."] + (["-f"] if force else []))
+        await git_helper.run_git_async(["-C", local_dir, "add", "."] + (["-f"] if force else []))
         commit_opts = []
         if allow_empty:
             commit_opts.append("--allow-empty")

--- a/doozer/doozerlib/backend/build_repo.py
+++ b/doozer/doozerlib/backend/build_repo.py
@@ -162,10 +162,10 @@ class BuildRepo:
             raise ChildProcessError(f"Failed to get commit hash: {err}")
         return out.strip()
 
-    async def commit(self, message: str, allow_empty: bool = False):
+    async def commit(self, message: str, allow_empty: bool = False, force: bool = False):
         """ Commit changes in the local directory to the build source repository."""
         local_dir = str(self.local_dir)
-        await git_helper.run_git_async(["-C", local_dir, "add", "."])
+        await git_helper.run_git_async(["-C", local_dir, f"{'-f' if force else ''}", "."])
         commit_opts = []
         if allow_empty:
             commit_opts.append("--allow-empty")

--- a/doozer/doozerlib/backend/build_repo.py
+++ b/doozer/doozerlib/backend/build_repo.py
@@ -165,7 +165,7 @@ class BuildRepo:
     async def commit(self, message: str, allow_empty: bool = False, force: bool = False):
         """ Commit changes in the local directory to the build source repository."""
         local_dir = str(self.local_dir)
-        await git_helper.run_git_async(["-C", local_dir, f"{'-f' if force else ''}", "."])
+        await git_helper.run_git_async(["-C", local_dir, "."] + (["-f"] if force else []))
         commit_opts = []
         if allow_empty:
             commit_opts.append("--allow-empty")

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -127,7 +127,7 @@ class KonfluxRebaser:
             actual_version, actual_release, _ = await exectools.to_thread(self._rebase_dir, metadata, source, build_repo, version, input_release, force_yum_updates, image_repo)
 
             # Commit changes
-            await build_repo.commit(commit_message, allow_empty=True)
+            await build_repo.commit(commit_message, allow_empty=True, force=True)
 
             # Tag the commit
             # 1. components should have tagging modes in metadata; tagging_mode:  `disabled | enabled | legacy` .
@@ -436,11 +436,6 @@ class KonfluxRebaser:
         containerfile = dest_dir.joinpath('Containerfile')
         if containerfile.is_file():
             containerfile.unlink()
-
-        # Delete .gitignore since it may block full sync and is not needed here
-        gitignore_path = dest_dir.joinpath('.gitignore')
-        if gitignore_path.is_file():
-            gitignore_path.unlink()
 
         owners = []
         if metadata.config.owners is not Missing and isinstance(metadata.config.owners, list):


### PR DESCRIPTION
`hypershift` image has a .gitignore file that needs to be present after rebase, in konflux. Usually its removed before rebase to make sure that files/folders that doozer generates are not excluded by git.