### PR TITLE
build-fbc: Push to a dedicated quay repo

### DIFF
--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -342,7 +342,7 @@ class FbcBuildCli:
 @click.option('--konflux-kubeconfig', metavar='PATH', help='Path to the kubeconfig file to use for Konflux cluster connections.')
 @click.option('--konflux-context', metavar='CONTEXT', help='The name of the kubeconfig context to use for Konflux cluster connections.')
 @click.option('--konflux-namespace', metavar='NAMESPACE', default=constants.KONFLUX_DEFAULT_NAMESPACE, help='The namespace to use for Konflux cluster connections.')
-@click.option('--image-repo', default=constants.KONFLUX_DEFAULT_IMAGE_REPO, help='Push images to the specified repo.')
+@click.option('--image-repo', default=constants.KONFLIX_DEFAILT_FBC_REPO, help='Push images to the specified repo.')
 @click.option('--skip-checks', default=False, is_flag=True, help='Skip all post build checks')
 @click.option('--fbc-repo', metavar='FBC_REPO', help='The git repository to push the FBC to.', default=constants.ART_FBC_GIT_REPO)
 @click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -36,6 +36,7 @@ KONFLUX_DEFAULT_PIPELINERUN_SERVICE_ACCOUNT = "appstudio-pipeline"
 KONFLUX_DEFAULT_PIPELINERUN_TIMEOUT = "1h0m0s"
 KONFLUX_DEFAULT_PIPRLINE_DOCKER_BUILD_BUNDLE_PULLSPEC = "quay.io/konflux-ci/tekton-catalog/pipeline-docker-build:devel"
 KONFLUX_DEFAULT_IMAGE_REPO = "quay.io/redhat-user-workloads/ocp-art-tenant/art-images"   # FIXME: If we change clusters this URL will change
+KONFLIX_DEFAILT_FBC_REPO = "quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc"
 ART_PROD_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
 ART_PROD_PRIV_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-v4.0-art-dev-priv"
 DELIVERY_IMAGE_REGISTRY = "registry.redhat.io"


### PR DESCRIPTION
Due to a limitation in Konflux, FBC artifacts must be pushed to a public quay repo (instead of the private art-images repo). Making this change shouldn't cause any security concerns since FBC only includes metadata.