### PR TITLE
[konflux] append .0 for go version

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -427,6 +427,29 @@ class KonfluxRebaser:
             source_dockerfile_content = source_dockerfile.read()
             distgit_dockerfile.write(source_dockerfile_content)
 
+        gomod_path = dest_dir.joinpath('go.mod')
+        if gomod_path.exists():
+            # Read the gomod contents
+            with open(gomod_path, 'r') as file:
+                lines = file.readlines()
+
+            # Append a .0 to the go mod version, if it exists
+            # Replace the line 'go 1.22' with 'go 1.22.0' for example
+            with open(gomod_path, 'w') as file:
+                for line in lines:
+                    line_content = line.strip()
+                    if line_content.startswith("go"):
+                        version = line_content.split(" ")[-1]
+
+                        if len(version.split(".")) == 2:
+                            self._logger.info(f"Missing golang minor version: {line_content}. Appending .0")
+                            file.write(f"go {version + '.0'}\n")
+                        else:
+                            file.write(line)
+                            continue
+                    else:
+                        file.write(line)
+
         # Clean up any extraneous Dockerfile.* that might be distractions (e.g. Dockerfile.centos)
         for ent in dest_dir.iterdir():
             if ent.name.startswith("Dockerfile."):


### PR DESCRIPTION
go versions defined like https://github.com/openshift/prometheus-alertmanager/blob/release-4.18/go.mod#L3 is breaking konflux prefetch task. i.e. the go version has to be defined as `1.22.0` instead of `1.22`.

Since there are 20+ images with this issue, for more than one OCP version, updating our automation to fix it.

Successfully rebased file: https://github.com/openshift-priv/image-customization-controller/blob/art-openshift-4.18-assembly-stream-dgk-ose-image-customization-controller/go.mod#L3
Successful prefetch: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/6683/