### PR TITLE
Add awscli to pyartcd requirements

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 # Requires a local virtualenv at ./.venv. This can be created with "uv venv --python 3.11"
-uv pip install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
+# Ignore .egg-info dirs in repo that might exist
+uv --no-cache pip install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/

--- a/install.sh
+++ b/install.sh
@@ -2,4 +2,4 @@
 
 # Requires a local virtualenv at ./.venv. This can be created with "uv venv --python 3.11"
 # Ignore .egg-info dirs in repo that might exist
-uv --no-cache pip install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/
+uv pip install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 # Requires a local virtualenv at ./.venv. This can be created with "uv venv --python 3.11"
-# Ignore .egg-info dirs in repo that might exist
 uv pip install -e artcommon/ -e doozer/ -e elliott/ -e pyartcd/ -e ocp-build-data-validator/

--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -4,6 +4,7 @@ aiohttp[speedups] >= 3.6
 aiohttp_retry
 aioredlock >= 0.7.3
 click == 8.1.8
+awscli >= 1.37.0
 contextvars
 errata-tool ~= 1.31.0
 cryptography


### PR DESCRIPTION
pyartcd requires awscli to sync packages to mirror.
This will make it not depend on the global installation on buildvm.