### PR TITLE
Pin rhcos at the right level

### DIFF
--- a/artcommon/artcommonlib/exectools.py
+++ b/artcommon/artcommonlib/exectools.py
@@ -165,7 +165,7 @@ def cmd_gather(cmd: Union[str, List], set_env: Optional[Dict[str, str]] = None, 
     :return: (rc,stdout,stderr)
     """
 
-    global cmd_counter, cmd_counter_lock
+    global cmd_counter
 
     with cmd_counter_lock:
         my_id = cmd_counter

--- a/artcommon/artcommonlib/lock.py
+++ b/artcommon/artcommonlib/lock.py
@@ -20,7 +20,6 @@ def get_named_semaphore(lock_name: str, is_dir=False, count=1):
         p = '_dir::' + str(Path(str(lock_name)).absolute())  # normalize (e.g. strip trailing /)
     else:
         p = lock_name
-    global _NAMED_SEMAPHORES
     with _NAMED_SEMAPHORES['']:
         if p in _NAMED_SEMAPHORES:
             return _NAMED_SEMAPHORES[p]

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -560,7 +560,6 @@ class KonfluxClient:
         corev1_client = await self._get_corev1()
 
         def _inner():
-            nonlocal overall_timeout_timedelta
             watcher = watch.Watch()
             succeeded_status = "Not Found"
             succeeded_reason = "Not Found"
@@ -746,7 +745,6 @@ class KonfluxClient:
             return resource.ResourceInstance(self.dyn_client, release)
 
         def _inner():
-            nonlocal overall_timeout_timedelta
             watcher = watch.Watch()
             released_status = "Not Found"
             released_reason = "Not Found"

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -555,7 +555,7 @@ class KonfluxImageBuilder:
                     containers_info = []
 
                     def add_container_status(container_status: Dict, is_init_container: bool):
-                        nonlocal containers_info, max_finished_time, all_containers_finished, exit_code_sum
+                        nonlocal max_finished_time, all_containers_finished, exit_code_sum
                         container_state = 'pending'  # when there is no pod state, assume pending
                         container_started_time = None
                         container_finished_time = None

--- a/elliott/elliottlib/cli/pin_builds_cli.py
+++ b/elliott/elliottlib/cli/pin_builds_cli.py
@@ -296,10 +296,10 @@ class AssemblyPinBuildsCli:
                 )
                 rhcos_info[container_conf.name]["images"][arch] = pullspec
 
-        self.assembly_config["group"].setdefault("rhcos", Model({}))
-        current_rhcos = self.assembly_config["group"]["rhcos"].primitive()
+        self.assembly_config.setdefault("rhcos", Model({}))
+        current_rhcos = self.assembly_config["rhcos"].primitive()
         if current_rhcos != rhcos_info:
-            self.assembly_config["group"]["rhcos"] = Model(rhcos_info)
+            self.assembly_config["rhcos"] = Model(rhcos_info)
             changed = True
 
         return changed

--- a/elliott/tests/test_pin_builds_cli.py
+++ b/elliott/tests/test_pin_builds_cli.py
@@ -229,13 +229,12 @@ class TestAssemblyPinBuildsCli(IsolatedAsyncioTestCase):
                 "images": [],
                 "rpms": []
             },
-            "group": {
-                "rhcos": {
-                    "machine-os-content": {
-                        "images": {
-                            "x86_64": "registry.example.com/rhel-coreos/machine-os-content@sha256:abc123",
-                            "aarch64": "registry.example.com/rhel-coreos/machine-os-content@sha256:abc123"
-                        }
+            "group": {},
+            "rhcos": {
+                "machine-os-content": {
+                    "images": {
+                        "x86_64": "registry.example.com/rhel-coreos/machine-os-content@sha256:abc123",
+                        "aarch64": "registry.example.com/rhel-coreos/machine-os-content@sha256:abc123"
                     }
                 }
             }


### PR DESCRIPTION
Summary
- Pin rhcos at the right level
- flake8 fixes (7.2.0)
```
uv run -m flake8
./artcommon/artcommonlib/exectools.py:168:5: F824 `global cmd_counter_lock` is unused: name is never assigned in scope
./artcommon/artcommonlib/lock.py:23:5: F824 `global _NAMED_SEMAPHORES` is unused: name is never assigned in scope
./doozer/doozerlib/backend/konflux_client.py:563:13: F824 `nonlocal overall_timeout_timedelta` is unused: name is never assigned in scope
./doozer/doozerlib/backend/konflux_client.py:749:13: F824 `nonlocal overall_timeout_timedelta` is unused: name is never assigned in scope
./doozer/doozerlib/backend/konflux_image_builder.py:558:25: F824 `nonlocal containers_info` is unused: name is never assigned in scope
```
