### PR TITLE
[konflux] update UI url generation

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -520,8 +520,8 @@ class KonfluxClient:
         """
         pipelinerun_name = pipelinerun['metadata']['name']
         application = pipelinerun['metadata']['labels']['appstudio.openshift.io/application']
-        return (f"{constants.KONFLUX_UI_HOST}/application-pipeline/"
-                f"workspaces/{constants.KONFLUX_UI_DEFAULT_WORKSPACE}/"
+        return (f"{constants.KONFLUX_UI_HOST}/ns/"
+                f"{constants.KONFLUX_UI_DEFAULT_WORKSPACE}/"
                 f"applications/{application}/"
                 f"pipelineruns/{pipelinerun_name}")
 

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+from unittest.mock import patch
+from doozerlib.backend.konflux_client import KonfluxClient
+
+
+class TestPLRUrl(TestCase):
+    @patch("doozerlib.constants.KONFLUX_UI_HOST", "https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com")
+    @patch("doozerlib.constants.KONFLUX_UI_DEFAULT_WORKSPACE", "ocp-art-tenant")
+    def test_pipelinerun_url(self):
+        pipeline_run = {
+            "metadata": {
+                "name": "ose-4-19-ose-ovn-kubernetes-6wv6l",
+                "labels": {
+                    "appstudio.openshift.io/application": "openshift-4-19"
+                }
+
+            }
+        }
+        actual = KonfluxClient.build_pipeline_url(pipeline_run)
+        expected = "https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-ose-ovn-kubernetes-6wv6l"
+
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
URL has changed from 
```
https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-19/pipelineruns/ose-4-19-ose-ovn-kubernetes-6wv6l
```
to 
```
https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-ose-ovn-kubernetes-6wv6l
```