### PR TITLE
Sync only x86_64 for 4.12 and 4.13

### DIFF
--- a/pyartcd/pyartcd/pipelines/quay_doomsday_backup.py
+++ b/pyartcd/pyartcd/pipelines/quay_doomsday_backup.py
@@ -110,9 +110,9 @@ class QuayDoomsdaySync:
 @click_coroutine
 async def quay_doomsday_backup(runtime: Runtime, arches: str, version: str):
 
-    # In 4.12 we sync only x86_64 and s390x
-    if version.startswith("4.12"):
-        arches = "x86_64,s390x"
+    # In 4.12 and 4.13 we sync only x86_64
+    if version.startswith("4.12") or version.startswith("4.13"):
+        arches = "x86_64"
 
     doomsday_pipeline = QuayDoomsdaySync(runtime=runtime,
                                          arches=arches,


### PR DESCRIPTION
We are producing only x86_64 for both 4.12 and 4.13. 
Fixes errors like [this](https://redhat-internal.slack.com/archives/C03JYDGPX8F/p1743723045279199?thread_ts=1743723039.998309&cid=C03JYDGPX8F)