### PR TITLE
[konflux] fix sast bug

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -433,9 +433,15 @@ class KonfluxClient:
             }]
 
         if not sast:
-            params = [p for p in params if p.get("name") not in ("sast-unicode-check", "sast-shell-check")]
+            tasks = []
+            for task in obj["spec"]["pipelineSpec"]["tasks"]:
+                task_name = task.get("name")
+                if task_name in ("sast-unicode-check", "sast-shell-check"):
+                    self._logger.info(f"Removing {task_name} tasks since SAST is disabled")
+                    continue
+                tasks.append(task)
 
-        obj["spec"]["params"] = params
+            obj["spec"]["pipelineSpec"]["tasks"] = tasks
 
         return obj
 


### PR DESCRIPTION
We need to remove the SAST tasks from `obj["spec"]["pipelineSpec"]["tasks"]` instead of `obj["spec"]["params"]`