### PR TITLE
Make quay-doomsday-backup sync

### DIFF
--- a/pyartcd/pyartcd/pipelines/quay_doomsday_backup.py
+++ b/pyartcd/pyartcd/pipelines/quay_doomsday_backup.py
@@ -1,13 +1,12 @@
 import os
 from typing import Optional
 import click
+from time import sleep
 import shutil
-import asyncio
-from tenacity import AsyncRetrying, stop_after_attempt
 
 from pyartcd.runtime import Runtime
-from pyartcd.cli import cli, pass_runtime, click_coroutine
-from artcommonlib.exectools import cmd_assert_async
+from pyartcd.cli import cli, pass_runtime
+from artcommonlib.exectools import cmd_assert
 from doozerlib.util import mkdirs
 
 
@@ -24,12 +23,10 @@ class QuayDoomsdaySync:
         self.runtime = runtime
         self.version = version
         self.workdir = "./workspace"
-        self.slack_client = self.runtime.new_slack_client()
-        self.slack_client.bind_channel(version)
 
         self.arches = arches.split(",") if arches else ALL_ARCHES_LIST
 
-    async def sync_arch(self, arch: str) -> bool:
+    def sync_arch(self, arch: str):
         if arch not in ALL_ARCHES_LIST:
             raise Exception(f"Invalid arch: {arch}")
 
@@ -47,68 +44,39 @@ class QuayDoomsdaySync:
             f"s3://ocp-doomsday-registry/release-image/{path}"
         ]
 
-        # Setup tenacity retry behavior for calling mirror_cmd and aws_cmd
-        # because cmd_assert_async does not have retry logic
-        retry = AsyncRetrying(reraise=True, stop=stop_after_attempt(N_RETRIES))
         try:
-            self.runtime.logger.info("[%s] Running mirror command: %s", arch, mirror_cmd)
-            await retry(cmd_assert_async, mirror_cmd)
-            self.runtime.logger.info("[%s] Mirror command ran successfully", arch)
+            self.runtime.logger.info("Running mirror command: %s", mirror_cmd)
+            cmd_assert(mirror_cmd, retries=N_RETRIES)
+            self.runtime.logger.info("Mirror command ran successfully")
             if self.runtime.dry_run:
-                self.runtime.logger.info("[DRY RUN] [%s] Would have run %s", arch, " ".join(aws_cmd))
-                self.runtime.logger.info("[DRY RUN] [%s] Would have messaged Slack", arch)
+                self.runtime.logger.info("[DRY RUN] Would have run %s", " ".join(aws_cmd))
             else:
-                await asyncio.sleep(5)
-                self.runtime.logger.info("[%s] Running aws command: %s", arch, aws_cmd)
-                await retry(cmd_assert_async, aws_cmd)
-                self.runtime.logger.info("[%s] AWS command ran successfully", arch)
-                await asyncio.sleep(5)
+                sleep(5)
+                self.runtime.logger.info("Running aws command: %s", aws_cmd)
+                cmd_assert(aws_cmd, retries=N_RETRIES)
+                self.runtime.logger.info("AWS command ran successfully")
+                sleep(5)
 
-                await self.slack_client.say_in_thread(f":white_check_mark: Successfully synced {self.version}-{arch}")
-
-        except ChildProcessError as e:
+        except Exception as e:
             self.runtime.logger.error("[%s] Failed to sync: %s", arch, e)
-            if self.runtime.dry_run:
-                self.runtime.logger.info("[DRY RUN] [%s] Would have messaged Slack", arch)
-            else:
-                await self.slack_client.say_in_thread(f":warning: Failed to sync {self.version}-{arch}: {e}")
-            return False
 
         if os.path.exists(f"{self.workdir}/{path}"):
-            self.runtime.logger.info("[%s] Cleaning dir: %s", arch, f"{self.workdir}/{path}")
+            self.runtime.logger.info("Cleaning dir: %s", f"{self.workdir}/{path}")
             shutil.rmtree(f"{self.workdir}/{path}")
 
-        return True
-
-    async def run(self) -> None:
+    def run(self):
         mkdirs(self.workdir)
 
-        if not self.runtime.dry_run:
-            slack_response = await self.slack_client.say_in_thread(f":construction: Syncing arches {', '.join(self.arches)} of {self.version} to AWS S3 Bucket :construction:")
-            slack_channel_id = slack_response["channel"]
-            main_message_ts = slack_response["message"]["ts"]
-        else:
-            self.runtime.logger.info("[DRY RUN] Would have messaged Slack")
-
-        tasks = [self.sync_arch(arch) for arch in self.arches]
-        results = await asyncio.gather(*tasks)
-
-        # Report the results to Slack
-        if not self.runtime.dry_run:
-            if all(results):
-                await self.slack_client._client.reactions_add(channel=slack_channel_id, timestamp=main_message_ts, name="done_it_is")
-            else:
-                await self.slack_client.say_in_thread(":x: Failed to sync some arches", broadcast=True)
-        else:
-            self.runtime.logger.info("[DRY RUN] Would have messaged Slack")
+        for arch in self.arches:
+            self.runtime.logger.info("Now syncing arch %s", arch)
+            self.sync_arch(arch)
 
 
 @cli.command("quay-doomsday-backup", help="Run doomsday pipeline for the specified version and all arches unless --arches is specified")
 @click.option("--arches", required=False, help="Comma separated list of arches to sync")
 @click.option("--version", required=True, help="Release to sync, e.g. 4.15.3")
 @pass_runtime
-@click_coroutine
-async def quay_doomsday_backup(runtime: Runtime, arches: str, version: str):
+def quay_doomsday_backup(runtime: Runtime, arches: str, version: str):
 
     # In 4.12 and 4.13 we sync only x86_64
     if version.startswith("4.12") or version.startswith("4.13"):
@@ -117,4 +85,4 @@ async def quay_doomsday_backup(runtime: Runtime, arches: str, version: str):
     doomsday_pipeline = QuayDoomsdaySync(runtime=runtime,
                                          arches=arches,
                                          version=version)
-    await doomsday_pipeline.run()
+    doomsday_pipeline.run()


### PR DESCRIPTION
Make `quay-doomsday-backup` synchronous again to hopefully prevent quay.io returning 502 status (as seen [here](https://console-openshift-console.apps.artc2023.pc3z.p1.openshiftapps.com/k8s/ns/art-cd/tekton.dev~v1~PipelineRun/doomsday-pipeline-run-nbpjk/) while syncing `multi` arch)

Slack reporting will be added back in a future PR