### PR TITLE
[konflux] append .0 for go version

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -428,6 +428,26 @@ class KonfluxRebaser:
             source_dockerfile_content = source_dockerfile.read()
             distgit_dockerfile.write(source_dockerfile_content)
 
+        gomod_path = dest_dir.joinpath('go.mod')
+        if gomod_path.exists():
+            # Read the gomod contents
+            new_lines = []
+            with open(gomod_path, "r") as file:
+                lines = file.readlines()
+                for line in lines:
+                    stripped_line = line.strip()
+                    match = re.match(r"(^go \d\.\d+$)", stripped_line)
+                    if match:
+                        # Append a .0 to the go mod version, if it exists
+                        # Replace the line 'go 1.22' with 'go 1.22.0' for example
+                        self._logger.info(f"Missing patch in golang version: {stripped_line}. Appending .0")
+                        stripped_line = stripped_line.replace(match.group(1), f"{match.group(1)}.0")
+                        new_lines.append(f"{stripped_line}\n")
+                    else:
+                        new_lines.append(line)
+            with open(gomod_path, "w") as file:
+                file.writelines(new_lines)
+
         # Clean up any extraneous Dockerfile.* that might be distractions (e.g. Dockerfile.centos)
         for ent in dest_dir.iterdir():
             if ent.name.startswith("Dockerfile."):


### PR DESCRIPTION
go versions defined like https://github.com/openshift/prometheus-alertmanager/blob/release-4.18/go.mod#L3 is breaking konflux prefetch task. i.e. the go version has to be defined as `1.22.0` instead of `1.22`.

Since there are 20+ images with this issue, for more than one OCP version, updating our automation to fix it.

Successful rebase: https://github.com/openshift-priv/image-customization-controller/commit/2db4984435298ee339696f1cc122517b5b5b52e3#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3


Custom gomod path support will be added in a follow up PR.
