### PR TITLE
Create download modification

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -568,6 +568,7 @@ class KonfluxRebaser:
                     "component_name": metadata.distgit_key,
                     "kind": "Dockerfile",
                     "content": new_dockerfile_data,
+                    "dest_dir": dest_dir,
                     "set_env": {
                         "PATH": path,
                         # "BREW_EVENT": f'{self._runtime.brew_event}',

--- a/doozer/doozerlib/source_modifications.py
+++ b/doozer/doozerlib/source_modifications.py
@@ -241,3 +241,29 @@ class RemoveModifier(object):
 
 
 SourceModifierFactory.MODIFICATIONS["remove"] = RemoveModifier
+
+class DownloadModifier(object):
+    """
+    A source modifier that supports downloading files to a location in the destination dir
+    """
+    def __init__(self, *args, **kwargs):
+        self.from_param = kwargs["from"]
+        self.to_param = kwargs["to"]
+
+    def act(self, *args, **kwargs):
+        context = kwargs["context"]
+        dest_dir = context["dest_dir"]
+        file_name = self.from_param.split("/")[-1]
+        path = f"{dest_dir}/{self.to_param}"
+        os.makedirs(path, exist_ok=True)
+
+        LOGGER.info(f"Downloading {self.from_param} to {path}")
+        response = requests.get(self.from_param)
+        if response.status_code == 200:
+            with open(f"{path}/{file_name}", "wb") as file:
+                file.write(response.content)
+            LOGGER.info("File downloaded successfully")
+        else:
+            raise Exception(f"Failed to download file from {self.from_param}: {response.status_code}")
+
+SourceModifierFactory.MODIFICATIONS["download"] = DownloadModifier


### PR DESCRIPTION
As a quick fix for https://issues.redhat.com/browse/ART-12521, we can directly download the missing files to the location that we need, with a modification

for example
```
modifications:
- action: download
  from: "https://raw.githubusercontent.com/mistifyio/go-zfs/refs/heads/master/Vagrantfile"
  to: "vendor/github.com/mistifyio/go-zfs"
```