### PR TITLE
ocp4 build all fix

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -564,7 +564,7 @@ class Ocp4Pipeline:
     async def _build_images(self):
         # Even if the computed build plan included images, some may have been removed because they failed to rebase.
         # Check once again if the current build plan includes any image, return otherwise
-        if not self.build_plan.build_images:
+        if not self.build_plan.build_images and self.build_images.lower() != 'all':
             self.runtime.logger.warning('No images to build according to current build plan')
             return
 


### PR DESCRIPTION
When we specify the build plan `all` the pipeline should not error out with `No images to build according to current build plan`, like its happening here: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/17237/


Seems to have triggered correctly: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/17259/console