### PR TITLE
ART-12697 Add prepare-release-konflux pipeline

### DIFF
--- a/artcommon/artcommonlib/assembly.py
+++ b/artcommon/artcommonlib/assembly.py
@@ -1,6 +1,6 @@
 import copy
 import typing
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 
 from artcommonlib.model import ListModel, Missing, Model
@@ -294,7 +294,14 @@ def assembly_basis_event(
     if target_assembly.basis.brew_event:
         return int(target_assembly.basis.brew_event)  # Integer for Brew event
     elif target_assembly.basis.time:
-        return target_assembly.basis.time  # Datetime for Konflux
+        # datetime UTC for Konflux
+        time_str = target_assembly.basis.time
+        if not isinstance(time_str, str):
+            raise ValueError(f"Invalid time format for assembly {assembly}: {time_str}")
+        dt = datetime.fromisoformat(time_str)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
     return assembly_basis_event(releases_config, target_assembly.basis.assembly, strict=strict)
 
 

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -427,14 +427,21 @@ def _gen_nvrp_tuples(builds: List[Dict], tag_pv_map: Dict[str, str]):
     return nvrps
 
 
-def _json_dump(as_json, unshipped_builds, kind, tag_pv_map=None):
-    builds = sorted([b.nvr for b in unshipped_builds])
+def _json_dump(as_json: str, builds: list, kind: str, tag_pv_map: dict = None):
+    """Dumps builds as JSON to a file or stdout
+    :param as_json: file name to dump JSON to, or '-' for stdout
+    :param builds: list of Brew build objects
+    :param kind: kind of builds, either 'rpm' or 'image'
+    :param tag_pv_map: mapping of Brew tags to Errata product versions
+    """
+
+    builds = sorted([b.nvr for b in builds])
     json_data = dict(builds=builds, kind=kind)
 
     if tag_pv_map:
         tags = []
         reversed_tag_pv_map = {y: x for x, y in tag_pv_map.items()}
-        for b in sorted(unshipped_builds):
+        for b in sorted(builds):
             tags.append(reversed_tag_pv_map[b.product_version])
         json_data['base_tag'] = tags
 
@@ -706,5 +713,7 @@ async def find_builds_konflux(runtime, payload):
 
     LOGGER.info("Fetching NVRs from DB...")
     tasks = [image.get_latest_build(el_target=image.branch_el_target()) for image in image_metas]
-    records: List[Dict] = list(await asyncio.gather(*tasks))
+    records: List[Dict] = [r for r in await asyncio.gather(*tasks) if r is not None]
+    if len(records) != len(image_metas):
+        raise ElliottFatalError(f"Failed to find Konflux builds for {len(image_metas) - len(records)} images")
     return records

--- a/elliott/elliottlib/errata_async.py
+++ b/elliott/elliottlib/errata_async.py
@@ -74,6 +74,11 @@ class AsyncErrataAPI:
         path = f"/api/v1/erratum/{quote(str(advisory))}"
         return await self._make_request(aiohttp.hdrs.METH_GET, path)
 
+    async def reserve_live_id(self) -> str:
+        path = "/api/v1/advisory/reserve_live_id"
+        result = await self._make_request(aiohttp.hdrs.METH_POST, path)
+        return result.get("live_id")
+
     async def get_builds(self, advisory: Union[int, str]):
         # As of May 25, 2023, /api/v1/erratum/{id}/builds_list doesn't return all builds.
         # Use /api/v1/erratum/{id}/builds instead.

--- a/elliott/elliottlib/shipment_model.py
+++ b/elliott/elliottlib/shipment_model.py
@@ -52,10 +52,6 @@ class Issues(StrictBaseModel):
 class ReleaseNotes(StrictBaseModel):
     """Represents releaseNotes field which contains all advisory metadata, when constructing a Konflux release"""
 
-    # setting attributes after object init can result in weird behavior
-    # when dealing with yaml scalar strings
-    model_config = ConfigDict(frozen=True)
-
     type: Literal['RHEA', 'RHBA', 'RHSA']  # Advisory type
     live_id: int = None
     synopsis: str

--- a/ocp-build-data-validator/validator/json_schemas/assembly_basis.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_basis.schema.json
@@ -6,9 +6,14 @@
   "type": "object",
   "properties": {
     "brew_event": {
-      "description": "A Brew event that ties the release to a particular moment. Images and rpms will be assembled relative to This basis event.",
+      "description": "A Brew event that ties the release to a particular moment. Images and rpms will be assembled relative to this basis event.",
       "type": "integer",
       "minimum": 0
+    },
+    "time": {
+      "description": "A datetime value in ISO 8601 format that ties the release to a particular moment. Similar to brew_event. Images and rpms will be assembled relative to this moment.",
+      "type": "string",
+      "format": "date-time"
     },
     "assembly": {
       "description": "The parent assembly to inherit from",

--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -144,6 +144,44 @@
     "upgrades": {
       "type": "string"
     },
+    "shipment_advisory": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "live_id": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false
+    },
+    "shipment": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "env": {
+          "type": "string",
+          "enum": ["stage", "prod"]
+        },
+        "advisories": {
+          "type": "array",
+          "items": {
+            "$ref": "#/properties/shipment_advisory"
+          }
+        }
+      }
+    },
+    "shipment!": {
+      "$ref": "#/properties/shipment"
+    },
+    "shipment?": {
+      "$ref": "#/properties/shipment"
+    },
+    "shipment-": {},
     "upgrades!": {
       "$ref": "#/properties/upgrades"
     },

--- a/pyartcd/config.example.toml
+++ b/pyartcd/config.example.toml
@@ -7,6 +7,10 @@ package_owner = "jdelft@redhat.com"
 ocp_build_data_url = "https://github.com/openshift-eng/ocp-build-data.git"
 ocp_build_data_repo_push_url = "git@github.com:openshift-eng/ocp-build-data.git"
 
+[shipment_config]
+shipment_data_url = "https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data.git"
+shipment_data_push_url = "https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data.git"
+
 [email]
 smtp_server = "smtp.corp.redhat.com"
 from = "aos-art-automation@redhat.com"

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -22,6 +22,7 @@ from pyartcd.pipelines import (
     olm_bundle_konflux,
     operator_sdk_sync,
     prepare_release,
+    prepare_release_konflux,
     promote,
     quay_doomsday_backup,
     rebuild,

--- a/pyartcd/pyartcd/git.py
+++ b/pyartcd/pyartcd/git.py
@@ -5,7 +5,10 @@ from logging import getLogger
 from pathlib import Path
 from typing import Union
 
+import aiofiles
 from artcommonlib import exectools
+from artcommonlib.constants import GIT_NO_PROMPTS
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 LOGGER = getLogger(__name__)
 
@@ -20,6 +23,7 @@ class GitRepository:
         # Ensure local repo directory exists
         self._directory.mkdir(parents=True, exist_ok=True)
         env = os.environ.copy()
+        env.update(GIT_NO_PROMPTS)
         repo_dir = str(self._directory)
         await exectools.cmd_assert_async(["git", "init", "--", repo_dir], env=env)
 
@@ -46,16 +50,58 @@ class GitRepository:
         elif 'upstream' in remotes:
             await exectools.cmd_assert_async(["git", "-C", repo_dir, "remote", "remove", "upstream"], env=env)
 
-    async def fetch_switch_branch(self, branch, upstream_ref=None):
+    async def read_file(self, relative_filepath: Union[str, Path]) -> str:
+        """Read a file from the git repository."""
+        path = self._directory / relative_filepath
+        async with aiofiles.open(path, "r") as f:
+            content = await f.read()
+        return content
+
+    async def write_file(self, relative_filepath: Union[str, Path], content: str) -> Path:
+        """Write content to a file in the git repository."""
+        path = self._directory / relative_filepath
+        async with aiofiles.open(path, "w") as f:
+            await f.write(content)
+        return path
+
+    async def log_diff(self, ref: str = "HEAD"):
+        """Log diff of the current working tree against the specified reference."""
+        env = os.environ.copy()
+        env.update(GIT_NO_PROMPTS)
+        await exectools.cmd_assert_async(["git", "-C", str(self._directory), "--no-pager", "diff", ref], env=env)
+
+    async def create_branch(self, branch: str):
+        """Create a new branch in the git repository."""
+        env = os.environ.copy()
+        env.update(GIT_NO_PROMPTS)
+        repo_dir = str(self._directory)
+        await exectools.cmd_assert_async(["git", "-C", repo_dir, "checkout", "-b", branch], env=env)
+
+    @retry(stop=stop_after_attempt(3), wait=wait_fixed(5), retry=retry_if_exception_type(ChildProcessError))
+    async def does_branch_exist_on_remote(self, branch: str, remote: str) -> bool:
+        """Check if a branch exists on the remote repository."""
+        env = os.environ.copy()
+        env.update(GIT_NO_PROMPTS)
+        repo_dir = str(self._directory)
+        # assume that the remote is already set up
+        cmd = ["git", "-C", repo_dir, "ls-remote", "--heads", remote, branch]
+        _, out, _ = await exectools.cmd_gather_async(cmd, env=env)
+        return branch in out
+
+    async def fetch_switch_branch(self, branch, upstream_ref=None, remote=None):
         """Fetch `upstream_ref` from the remote repo, create the `branch` and start it at `upstream_ref`.
         If `branch` already exists, then reset it to `upstream_ref`.
         """
         env = os.environ.copy()
+        env.update(GIT_NO_PROMPTS)
         repo_dir = str(self._directory)
-        # Fetch remote
-        _, out, _ = await exectools.cmd_gather_async(["git", "-C", repo_dir, "remote"], env=env)
-        remotes = set(out.strip().split())
-        fetch_remote = "upstream" if "upstream" in remotes else "origin"
+        if remote:
+            fetch_remote = remote
+        else:
+            # Fetch remote
+            _, out, _ = await exectools.cmd_gather_async(["git", "-C", repo_dir, "remote"], env=env)
+            remotes = set(out.strip().split())
+            fetch_remote = "upstream" if "upstream" in remotes else "origin"
         await exectools.cmd_assert_async(
             ["git", "-C", repo_dir, "fetch", "--depth=1", "--", fetch_remote, upstream_ref or branch], env=env
         )
@@ -68,11 +114,13 @@ class GitRepository:
         # Clean workdir
         await exectools.cmd_assert_async(["git", "-C", repo_dir, "clean", "-fdx"], env=env)
 
-    async def commit_push(self, commit_message: str):
+    @retry(stop=stop_after_attempt(3), wait=wait_fixed(5), retry=retry_if_exception_type(ChildProcessError))
+    async def commit_push(self, commit_message: str) -> bool:
         """Create a commit that includes all file changes in the working tree and push the commit to the remote repository.
         If there are no changes in thw working tree, do nothing.
         """
         env = os.environ.copy()
+        env.update(GIT_NO_PROMPTS)
         repo_dir = str(self._directory)
         cmd = ["git", "-C", repo_dir, "add", "."]
         await exectools.cmd_assert_async(cmd, env=env)

--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -1,0 +1,657 @@
+import json
+import logging
+import os
+import shutil
+from datetime import datetime, timezone
+from functools import cached_property
+from io import StringIO
+from pathlib import Path
+from typing import Dict, Optional
+from urllib.parse import urlparse
+
+import click
+import gitlab
+from artcommonlib import exectools
+from artcommonlib.assembly import AssemblyTypes, assembly_group_config
+from artcommonlib.constants import SHIPMENT_DATA_URL_TEMPLATE
+from artcommonlib.model import Model
+from artcommonlib.util import new_roundtrip_yaml_handler
+from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
+from elliottlib.errata_async import AsyncErrataAPI
+from elliottlib.shipment_model import ShipmentConfig, Spec
+from ghapi.all import GhApi
+
+from pyartcd import constants
+from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.git import GitRepository
+from pyartcd.runtime import Runtime
+from pyartcd.slack import SlackClient
+from pyartcd.util import (
+    get_assembly_type,
+    get_release_name_for_assembly,
+)
+
+_LOGGER = logging.getLogger(__name__)
+yaml = new_roundtrip_yaml_handler()
+
+
+class PrepareReleaseKonfluxPipeline:
+    def __init__(
+        self,
+        slack_client: SlackClient,
+        runtime: Runtime,
+        group: str,
+        assembly: str,
+        github_token: str,
+        gitlab_token: str,
+        build_repo_url: Optional[str] = None,
+        shipment_repo_url: Optional[str] = None,
+        job_url: Optional[str] = None,
+    ) -> None:
+        self.runtime = runtime
+        self.assembly = assembly
+        self.group = group
+        self._slack_client = slack_client
+        self.github_token = github_token
+        self.gitlab_token = gitlab_token
+
+        self.gitlab_url = self.runtime.config.get("gitlab_url", "https://gitlab.cee.redhat.com")
+        self.application = KonfluxImageBuilder.get_application_name(self.group)
+        self.working_dir = self.runtime.working_dir.absolute()
+        self.elliott_working_dir = self.working_dir / "elliott-working"
+        self._build_repo_dir = self.working_dir / "ocp-build-data-push"
+        self._shipment_repo_dir = self.working_dir / "shipment-data-push"
+        self.job_url = job_url
+        self.dry_run = self.runtime.dry_run
+        self.product = 'ocp'  # assume that product is ocp for now
+
+        # Have clear pull and push targets for both the build and shipment repos
+        build_repo_vars = self._build_repo_vars(build_repo_url)
+        self.build_repo_pull_url, self.build_data_gitref, self.build_data_push_url = build_repo_vars
+        self.shipment_repo_pull_url, self.shipment_repo_push_url = self._shipment_repo_vars(shipment_repo_url)
+        self.build_data_repo = GitRepository(self._build_repo_dir, self.dry_run)
+        self.shipment_data_repo = GitRepository(self._shipment_repo_dir, self.dry_run)
+
+        # these will be initialized later
+        self.releases_config = None
+        self.group_config = None
+
+        group_param = f'--group={group}'
+        if self.build_data_gitref:
+            group_param += f'@{self.build_data_gitref}'
+
+        self._elliott_base_command = [
+            'elliott',
+            group_param,
+            f'--assembly={self.assembly}',
+            '--build-system=konflux',
+            f'--working-dir={self.elliott_working_dir}',
+            f'--data-path={self.build_repo_pull_url}',
+        ]
+
+    @staticmethod
+    def basic_auth_url(url: str, token: str) -> str:
+        parsed_url = urlparse(url)
+        scheme = parsed_url.scheme
+        rest_of_the_url = url[len(scheme + "://") :]
+        # the assumption here is that username can be anything
+        # so we use oauth2 as a placeholder username
+        # and the token as the password
+        return f'https://oauth2:{token}@{rest_of_the_url}'
+
+    def _build_repo_vars(self, build_repo_url: Optional[str]):
+        build_repo_pull_url = (
+            build_repo_url
+            or self.runtime.config.get("build_config", {}).get("ocp_build_data_url")
+            or constants.OCP_BUILD_DATA_URL
+        )
+        build_data_gitref = None
+        if "@" in build_repo_pull_url:
+            build_repo_pull_url, build_data_gitref = build_repo_pull_url.split("@", 1)
+
+        build_data_push_url = (
+            self.runtime.config.get("build_config", {}).get("ocp_build_data_push_url") or constants.OCP_BUILD_DATA_URL
+        )
+        return build_repo_pull_url, build_data_gitref, build_data_push_url
+
+    def _shipment_repo_vars(self, shipment_repo_url: Optional[str]):
+        shipment_repo_pull_url = (
+            shipment_repo_url
+            or self.runtime.config.get("shipment_config", {}).get("shipment_data_url")
+            or SHIPMENT_DATA_URL_TEMPLATE.format(self.product)
+        )
+        shipment_repo_push_url = self.runtime.config.get("shipment_config", {}).get(
+            "shipment_data_push_url"
+        ) or SHIPMENT_DATA_URL_TEMPLATE.format(self.product)
+        return shipment_repo_pull_url, shipment_repo_push_url
+
+    @cached_property
+    def _errata_api(self) -> AsyncErrataAPI:
+        return AsyncErrataAPI()
+
+    @cached_property
+    def _gitlab(self) -> gitlab.Gitlab:
+        gl = gitlab.Gitlab(self.gitlab_url, private_token=self.gitlab_token)
+        gl.auth()
+        return gl
+
+    @property
+    def release_name(self) -> str:
+        return get_release_name_for_assembly(self.group, self.releases_config, self.assembly)
+
+    @property
+    def assembly_group_config(self) -> dict:
+        return self.releases_config["releases"][self.assembly].setdefault("assembly", {}).setdefault("group", {})
+
+    @property
+    def shipment_config(self) -> dict:
+        shipment_key = next(k for k in self.assembly_group_config.keys() if k.startswith("shipment"))
+        return self.assembly_group_config.get(shipment_key, [])
+
+    async def run(self):
+        self.setup_working_dir()
+        await self.setup_repos()
+        await self.validate_assembly()
+        await self.prepare_shipment()
+
+    def setup_working_dir(self):
+        self.working_dir.mkdir(parents=True, exist_ok=True)
+        if self._build_repo_dir.exists():
+            shutil.rmtree(self._build_repo_dir, ignore_errors=True)
+        if self._shipment_repo_dir.exists():
+            shutil.rmtree(self._shipment_repo_dir, ignore_errors=True)
+        if self.elliott_working_dir.exists():
+            shutil.rmtree(self.elliott_working_dir, ignore_errors=True)
+
+    async def setup_repos(self):
+        await self.build_data_repo.setup(
+            remote_url=self.build_data_push_url,
+            upstream_remote_url=self.build_repo_pull_url,
+        )
+        await self.build_data_repo.fetch_switch_branch(self.build_data_gitref or self.group)
+        await self.shipment_data_repo.setup(
+            remote_url=self.basic_auth_url(self.shipment_repo_push_url, self.gitlab_token),
+            upstream_remote_url=self.shipment_repo_pull_url,
+        )
+        await self.shipment_data_repo.fetch_switch_branch("main")
+
+        self.releases_config = yaml.load(await self.build_data_repo.read_file("releases.yml"))
+        self.group_config = yaml.load(await self.build_data_repo.read_file("group.yml"))
+
+    async def validate_assembly(self):
+        # validate assembly and init release vars
+        if self.releases_config.get("releases", {}).get(self.assembly) is None:
+            raise ValueError(f"Assembly not found: {self.assembly}")
+        assembly_type = get_assembly_type(self.releases_config, self.assembly)
+        if assembly_type == AssemblyTypes.STREAM:
+            raise ValueError("Preparing a release from a stream assembly is no longer supported.")
+
+        # validate product from group config
+        merged_group_config = assembly_group_config(
+            Model(self.releases_config), self.assembly, Model(self.group_config)
+        ).primitive()
+        group_product = merged_group_config.get("product", self.product)
+        if group_product != self.product:
+            raise ValueError(
+                f"Product mismatch: {group_product} != {self.product}. This pipeline only supports {self.product}."
+            )
+
+    async def prepare_shipment(self):
+        """Prepare the shipment for the assembly.
+        This includes:
+        - Validating the shipment MR if it exists
+        - Initializing shipment advisories
+        - Finding builds for the advisories
+        - Creating or updating the shipment MR
+        - Creating or updating the build data PR with the shipment config
+        """
+
+        shipment_config = self.shipment_config.copy()
+        shipment_url = shipment_config.get("url")
+        # if shipment MR isn't valid, complain and exit early
+        if shipment_url:
+            self.validate_shipment_mr(shipment_url)
+
+        shipment_advisories = shipment_config.get("advisories")
+        if not shipment_advisories:
+            raise ValueError(
+                "Operation not supported: shipment config should specify which advisories to create and prepare"
+            )
+
+        group_advisories = set(self.assembly_group_config.get("advisories", {}).keys())
+        shipment_advisory_kinds = {advisory.get("kind") for advisory in shipment_advisories}
+        common = shipment_advisory_kinds & group_advisories
+        if common:
+            raise ValueError(
+                f"shipment config should not specify advisories that are already defined in assembly.group.advisories: {common}"
+            )
+
+        env = shipment_config.get("env", "prod")
+        if env not in ["prod", "stage"]:
+            raise ValueError("shipment config `env` should be either `prod` or `stage`")
+
+        generated_shipments: Dict[str, ShipmentConfig] = {}
+        for shipment_advisory_config in shipment_advisories:
+            kind = shipment_advisory_config.get("kind")
+            if not kind:
+                raise ValueError("shipment config should specify `kind` for an advisory")
+            shipment: ShipmentConfig = await self.init_shipment(kind)
+
+            # a liveID is required for prod, but not for stage
+            # so if it is missing, we need to reserve one
+            live_id = shipment_advisory_config.get("live_id")
+            if env == "prod" and not live_id:
+                _LOGGER.info("Requesting liveID for %s advisory", kind)
+                if self.dry_run:
+                    _LOGGER.info("[DRY-RUN] Would've reserved liveID for %s advisory", kind)
+                    live_id = "DRY_RUN_LIVE_ID"
+                else:
+                    live_id = await self._errata_api.reserve_live_id()
+                if not live_id:
+                    raise ValueError(f"Failed to get liveID for {kind} advisory")
+                shipment_advisory_config["live_id"] = live_id
+            if live_id:
+                shipment.shipment.data.releaseNotes.live_id = live_id
+
+            # find builds for the advisory
+            if kind in ("image", "extras"):
+                snapshot_spec = await self.find_builds(kind)
+                shipment.shipment.snapshot.spec = snapshot_spec
+            else:
+                _LOGGER.warning("Shipment kind %s is not supported for build finding", kind)
+
+            generated_shipments[kind] = shipment
+
+        # close errata API connection now that we have the liveIDs
+        # since it's a cached_property, check if it got initialized
+        if "_errata_api" in self.__dict__:
+            await self._errata_api.close()
+
+        if not shipment_url or shipment_url == "N/A":
+            shipment_mr_url = await self.create_shipment_mr(generated_shipments, env)
+            shipment_config["url"] = shipment_mr_url
+            await self._slack_client.say_in_thread(f"Shipment MR created: {shipment_mr_url}")
+        else:
+            _LOGGER.info("Shipment MR already exists: %s. Checking if it needs an update..", shipment_url)
+            updated = await self.update_shipment_mr(generated_shipments, env, shipment_url)
+            if updated:
+                await self._slack_client.say_in_thread(f"Shipment MR updated: {shipment_url}")
+
+        await self.create_update_build_data_pr(shipment_config)
+
+    def validate_shipment_mr(self, shipment_url: str):
+        """Validate the shipment MR
+        :param shipment_url: The URL of the existing shipment MR to validate
+        :raises ValueError: If the MR is not valid or does not match the expected repositories.
+        """
+
+        # Parse the shipment URL to extract project and MR details
+        parsed_url = urlparse(shipment_url)
+        target_project_path = parsed_url.path.strip('/').split('/-/merge_requests')[0]
+        mr_id = parsed_url.path.split('/')[-1]
+
+        # Load the existing MR
+        project = self._gitlab.projects.get(target_project_path)
+        mr = project.mergerequests.get(mr_id)
+
+        # Make sure MR is valid
+        # and aligns with the push and pull repos
+        if mr.state != "opened":
+            raise ValueError(f"MR state {mr.state} is not opened. This is not supported.")
+
+        if target_project_path not in self.shipment_repo_pull_url:
+            raise ValueError(
+                f"MR target project {target_project_path} does not match the pull repo {self.shipment_repo_pull_url}"
+            )
+
+        source_project_path = self._gitlab.projects.get(mr.source_project_id).path_with_namespace
+        if source_project_path not in self.shipment_repo_push_url:
+            raise ValueError(
+                f"MR source project {source_project_path} does not match the push repo {self.shipment_repo_push_url}"
+            )
+
+        if mr.target_branch != "main":
+            raise ValueError(f"MR target branch {mr.target_branch} is not main. This is not supported.")
+
+        _LOGGER.info("Shipment MR is valid: %s", shipment_url)
+
+    async def init_shipment(self, kind: str) -> ShipmentConfig:
+        """Initialize a shipment for the given kind.
+        :param kind: The kind for which to initialize shipment
+        :return: A ShipmentConfig object initialized with the given kind
+        """
+
+        create_cmd = self._elliott_base_command + [
+            f'--shipment-path={self.shipment_repo_pull_url}',
+            "shipment",
+            "init",
+            f"--advisory-key={kind}",
+            f"--application={self.application}",
+        ]
+        rc, stdout, stderr = await exectools.cmd_gather_async(create_cmd, check=False)
+        if stderr:
+            _LOGGER.info("Shipment init command stderr:\n %s", stderr)
+        if stdout:
+            _LOGGER.info("Shipment init command stdout:\n %s", stdout)
+        if rc != 0:
+            raise RuntimeError(f"cmd failed with exit code {rc}: {create_cmd}")
+
+        out = yaml.load(stdout)
+        shipment = ShipmentConfig(**out)
+        return shipment
+
+    async def find_builds(self, kind: str) -> Spec:
+        """Find builds for the given kind and return a snapshot Spec object containing the NVRs.
+        :param kind: The kind for which to find builds
+        :return: A Spec object containing the NVRs of the builds found (part of shipment definition)
+        """
+
+        if kind not in ("image", "extras"):
+            raise ValueError(f"Invalid kind: {kind}. Only image and extras are supported")
+        payload = True if kind == "image" else False
+
+        find_builds_cmd = self._elliott_base_command + [
+            "find-builds",
+            "--kind=image",
+            "--payload" if payload else "--non-payload",
+            "--json=-",
+        ]
+        rc, stdout, stderr = await exectools.cmd_gather_async(find_builds_cmd)
+        if stderr:
+            _LOGGER.info("Shipment find-builds command stderr:\n %s", stderr)
+        if stdout:
+            _LOGGER.info("Shipment find-builds command stdout:\n %s", stdout)
+        if rc != 0:
+            raise RuntimeError(f"cmd failed with exit code {rc}: {find_builds_cmd}")
+
+        builds = []
+        if stdout:
+            out = json.loads(stdout)
+            builds = out.get("builds", [])
+        return Spec(nvrs=builds)
+
+    async def create_shipment_mr(self, shipment_configs: Dict[str, ShipmentConfig], env: str) -> str:
+        """Create a new shipment MR with the given shipment config files.
+        :param shipment_configs: The shipment configurations to create the MR with
+        :param env: The environment for which the shipment is being prepared (prod or stage)
+        :return: The URL of the created MR
+        """
+
+        _LOGGER.info("Creating shipment MR...")
+
+        # Create branch name
+        timestamp = datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
+        source_branch = f"prepare-shipment-{self.assembly}-{timestamp}"
+        target_branch = "main"
+
+        # Create and checkout branch
+        await self.shipment_data_repo.create_branch(source_branch)
+
+        # update shipment data repo with shipment configs
+        commit_message = f"Add shipment configurations for {self.release_name}"
+        updated = await self.update_shipment_data(shipment_configs, env, commit_message, source_branch)
+        if not updated:
+            # this should not happen
+            raise ValueError("Failed to update shipment data repo. Please investigate.")
+
+        def _get_project(url):
+            parsed_url = urlparse(url)
+            project_path = parsed_url.path.strip('/').removesuffix('.git')
+            return self._gitlab.projects.get(project_path)
+
+        source_project = _get_project(self.shipment_repo_push_url)
+        target_project = _get_project(self.shipment_repo_pull_url)
+
+        mr_title = f"Shipment for {self.release_name}"
+        mr_description = f"Created by job: {self.job_url}\n\n" if self.job_url else commit_message
+
+        if self.dry_run:
+            _LOGGER.info("[DRY-RUN] Would have created MR with title: %s", mr_title)
+            mr_url = f"{self.gitlab_url}/placeholder/placeholder/-/merge_requests/placeholder"
+        else:
+            mr = source_project.mergerequests.create(
+                {
+                    'source_branch': source_branch,
+                    'target_project_id': target_project.id,
+                    'target_branch': target_branch,
+                    'title': mr_title,
+                    'description': mr_description,
+                    'remove_source_branch': True,
+                }
+            )
+            mr_url = mr.web_url
+            _LOGGER.info("Created Merge Request: %s", mr_url)
+
+        return mr_url
+
+    async def update_shipment_mr(self, shipments: Dict[str, ShipmentConfig], env: str, shipment_url: str) -> bool:
+        """Update existing shipment MR with the given shipment config files.
+        :param shipments: The shipment configurations to update in the shipment MR
+        :param env: The environment for which the shipment is being prepared (prod or stage)
+        :param shipment_url: The URL of the existing shipment MR to update
+        :return: True if the MR was updated successfully, False otherwise.
+        """
+
+        _LOGGER.info("Updating shipment MR: %s", shipment_url)
+
+        # Parse the shipment URL to extract project and MR details
+        parsed_url = urlparse(shipment_url)
+        target_project_path = parsed_url.path.strip('/').split('/-/merge_requests')[0]
+        mr_id = parsed_url.path.split('/')[-1]
+
+        # Load the existing MR
+        project = self._gitlab.projects.get(target_project_path)
+        mr = project.mergerequests.get(mr_id)
+
+        # Checkout the MR branch
+        source_branch = mr.source_branch
+        await self.shipment_data_repo.fetch_switch_branch(source_branch, remote="origin")
+
+        # Update shipment data
+        commit_message = f"Update shipment configurations for {self.release_name}"
+        updated = await self.update_shipment_data(shipments, env, commit_message, source_branch)
+        if not updated:
+            _LOGGER.info("No changes in shipment data. MR will not be updated.")
+            return False
+
+        # Update the MR description
+        description_update = f"Updated by job: {self.job_url}\n\n" if self.job_url else commit_message
+        mr.description = f"{mr.description}\n\n{description_update}"
+
+        if self.dry_run:
+            _LOGGER.info("[DRY-RUN] Would have updated MR description: %s", mr.description)
+        else:
+            mr.save()
+            _LOGGER.info("Shipment MR updated: %s", shipment_url)
+
+        return True
+
+    async def update_shipment_data(
+        self, shipments: Dict[str, ShipmentConfig], env: str, commit_message: str, branch: str
+    ) -> bool:
+        """Update shipment data repo with the given shipment config files.
+        Commits the changes and push to the remote repo.
+        :param shipments: The shipment configurations to update in the shipment data repo
+        :param env: The environment for which the shipment is being prepared (prod or stage)
+        :param commit_message: The commit message to use for the changes
+        :param branch: The branch to update in the shipment data repo
+        :return: True if the changes were committed and pushed successfully, False otherwise.
+        """
+
+        relative_target_dir = Path("shipment") / self.product / self.group / self.application / env
+        target_dir = self.shipment_data_repo._directory / relative_target_dir
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        # Get the timestamp from the branch name
+        # which we need for filenames
+        # The branch name is expected to be in the format: prepare-shipment-<assembly>-<timestamp>
+        timestamp = branch.split("-")[-1]
+
+        for advisory_key, shipment_config in shipments.items():
+            filename = f"{self.assembly}.{advisory_key}.{timestamp}.yaml"
+            filepath = relative_target_dir / filename
+            _LOGGER.info("Updating shipment file: %s", filename)
+            shipment_dump = shipment_config.model_dump(exclude_unset=True, exclude_none=True)
+            out = StringIO()
+            yaml.dump(shipment_dump, out)
+            await self.shipment_data_repo.write_file(filepath, out.getvalue())
+        await self.shipment_data_repo.log_diff()
+        return await self.shipment_data_repo.commit_push(commit_message)
+
+    async def create_update_build_data_pr(self, shipment_config: dict) -> bool:
+        """Create or update a pull request in the build data repo with the updated shipment config.
+        :param shipment_config: The shipment configuration to update in the assembly definition
+        :return: True if the PR was created or updated successfully, False otherwise.
+        """
+
+        branch = f"update-shipment-{self.release_name}"
+        updated = await self.update_build_data(shipment_config, branch)
+        if not updated:
+            return False
+
+        api = GhApi()
+        target_repo = self.build_repo_pull_url.split('/')[-1].replace('.git', '')
+        source_owner = self.build_data_push_url.split('/')[-2]
+        target_owner = self.build_repo_pull_url.split('/')[-2]
+
+        head = f"{source_owner}:{branch}"
+        base = self.build_data_gitref or self.group
+        api = GhApi(owner=target_owner, repo=target_repo, token=self.github_token)
+        existing_prs = api.pulls.list(
+            state="open",
+            head=head,
+            base=base,
+        )
+        if not existing_prs.items:
+            pr_title = f"Update shipment for assembly {self.assembly}"
+            pr_body = f"This PR updates the shipment data for assembly {self.assembly}."
+            if self.job_url:
+                pr_body += f"\n\nCreated by job: {self.job_url}"
+
+            if self.dry_run:
+                _LOGGER.info("[DRY-RUN] Would have created a new PR with title '%s'", pr_title)
+                return True
+
+            result = api.pulls.create(
+                head=head,
+                base=base,
+                title=pr_title,
+                body=pr_body,
+                maintainer_can_modify=True,
+            )
+            _LOGGER.info("PR to update shipment created: %s", result.html_url)
+            await self._slack_client.say_in_thread(f"PR to update shipment created: {result.html_url}")
+        else:
+            _LOGGER.info("Existing PR to update shipment found: %s", existing_prs.items[0].html_url)
+            pull_number = existing_prs.items[0].number
+
+            if self.dry_run:
+                _LOGGER.info("[DRY-RUN] Would have updated PR with number %s", pull_number)
+                return True
+
+            pr_body = existing_prs.items[0].body
+            if self.job_url:
+                pr_body += f"\n\nUpdated by job: {self.job_url}"
+            result = api.pulls.update(
+                pull_number=pull_number,
+                body=pr_body,
+            )
+            _LOGGER.info("PR to update shipment updated: %s", result.html_url)
+            await self._slack_client.say_in_thread(f"PR to update shipment updated: {result.html_url}")
+
+        return True
+
+    async def update_build_data(self, shipment_config: dict, branch: str) -> bool:
+        """Update releases.yml in build data repo with the given shipment assembly config.
+        Commits the changes and push to the remote repo.
+        :param shipment_config: The shipment configuration to update in the assembly definition
+        :param branch: The branch to update in the build data repo
+        :return: True if the changes were committed and pushed successfully, False otherwise.
+        """
+
+        group_config = (
+            self.releases_config["releases"][self.assembly].setdefault("assembly", {}).setdefault("group", {})
+        )
+
+        # Assembly key names are not always exact, they can end in special chars like !,?,-
+        # to indicate special inheritance rules. So respect those
+        # https://art-docs.engineering.redhat.com/assemblies/#inheritance-rules
+        shipment_key = next(k for k in group_config.keys() if k.startswith("shipment"))
+        group_config[shipment_key] = shipment_config
+
+        if await self.build_data_repo.does_branch_exist_on_remote(branch, remote="origin"):
+            await self.build_data_repo.fetch_switch_branch(branch, remote="origin")
+        else:
+            await self.build_data_repo.create_branch(branch)
+
+        out = StringIO()
+        yaml.dump(self.releases_config, out)
+        await self.build_data_repo.write_file("releases.yml", out.getvalue())
+        await self.build_data_repo.log_diff()
+
+        commit_message = f"Update shipment for assembly {self.assembly}"
+        return await self.build_data_repo.commit_push(commit_message)
+
+
+@cli.command("prepare-release-konflux")
+@click.option(
+    "-g",
+    "--group",
+    metavar='NAME',
+    required=True,
+    help="The group to operate on e.g. openshift-4.18",
+)
+@click.option(
+    "--assembly",
+    metavar="ASSEMBLY_NAME",
+    required=True,
+    help="The assembly to operate on e.g. 4.18.5",
+)
+@click.option(
+    '--build-repo-url',
+    help='ocp-build-data repo to use. Defaults to group branch - to use a different branch/commit use repo@branch',
+)
+@click.option(
+    '--shipment-repo-url',
+    help='shipment-data repo to use for reading and as shipment MR target. Defaults to main branch. Should reside in gitlab.cee.redhat.com',
+)
+@pass_runtime
+@click_coroutine
+async def prepare_release(
+    runtime: Runtime, group: str, assembly: str, build_repo_url: Optional[str], shipment_repo_url: Optional[str]
+):
+    job_url = os.getenv('BUILD_URL')
+
+    github_token = os.getenv('GITHUB_TOKEN')
+    if not github_token:
+        raise ValueError("GITHUB_TOKEN environment variable is required to create a pull request")
+
+    gitlab_token = os.getenv("GITLAB_TOKEN")
+    if not gitlab_token:
+        raise ValueError("GITLAB_TOKEN environment variable is required to create a merge request")
+
+    if assembly == "stream":
+        raise click.BadParameter("Release cannot be prepared from stream assembly.")
+
+    slack_client = runtime.new_slack_client()
+    slack_client.bind_channel(group)
+    await slack_client.say_in_thread(f":construction: prepare-release-konflux for {assembly} :construction:")
+
+    try:
+        # start pipeline
+        pipeline = PrepareReleaseKonfluxPipeline(
+            slack_client=slack_client,
+            runtime=runtime,
+            group=group,
+            assembly=assembly,
+            github_token=github_token,
+            gitlab_token=gitlab_token,
+            build_repo_url=build_repo_url,
+            shipment_repo_url=shipment_repo_url,
+            job_url=job_url,
+        )
+        await pipeline.run()
+        await slack_client.say_in_thread(f":white_check_mark: prepare-release-konflux for {assembly} completes.")
+    except Exception as e:
+        await slack_client.say_in_thread(f":warning: prepare-release-konflux for {assembly} has result FAILURE.")
+        raise e

--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -31,3 +31,4 @@ mysql-connector-python>=9.1.0 # not directly required, pinned by Snyk to avoid a
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
 async_lru
 packageurl-python
+python-gitlab

--- a/pyartcd/tests/pipelines/test_prepare_release_konflux.py
+++ b/pyartcd/tests/pipelines/test_prepare_release_konflux.py
@@ -1,0 +1,358 @@
+import copy
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, call, patch
+
+from artcommonlib.assembly import AssemblyTypes
+from artcommonlib.constants import SHIPMENT_DATA_URL_TEMPLATE
+from artcommonlib.model import Model
+from elliottlib.errata_async import AsyncErrataAPI
+from elliottlib.shipment_model import (
+    Data,
+    Environments,
+    Metadata,
+    ReleaseNotes,
+    Shipment,
+    ShipmentConfig,
+    ShipmentEnv,
+    Snapshot,
+    Spec,
+)
+
+from pyartcd import constants
+from pyartcd.git import GitRepository
+from pyartcd.pipelines.prepare_release_konflux import PrepareReleaseKonfluxPipeline
+from pyartcd.runtime import Runtime
+from pyartcd.slack import SlackClient
+
+
+class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.runtime = Mock(spec=Runtime)
+        self.runtime.working_dir = Path("/tmp/working-dir")
+        self.runtime.dry_run = False
+        self.runtime.config = {
+            "gitlab_url": "https://gitlab.example.com",
+            "build_config": {
+                "ocp_build_data_url": "https://build.url/repo",
+                "ocp_build_data_push_url": "https://build.push.url/repo",
+            },
+            "shipment_config": {
+                "shipment_data_url": "https://shipment.url/repo",
+                "shipment_data_push_url": "https://shipment.push.url/repo",
+            },
+        }
+        self.mock_slack_client = Mock(spec=SlackClient)
+        self.group = "openshift-4.18"
+        self.assembly = "test-assembly"
+        self.github_token = "gh_token"
+        self.gitlab_token = "gl_token"
+        self.job_url = "http://jenkins/job/test-job/1"
+
+    def test_init(self):
+        pipeline = PrepareReleaseKonfluxPipeline(
+            slack_client=self.mock_slack_client,
+            runtime=self.runtime,
+            group=self.group,
+            assembly=self.assembly,
+            github_token=self.github_token,
+            gitlab_token=self.gitlab_token,
+        )
+        self.assertEqual(pipeline.build_repo_pull_url, self.runtime.config["build_config"]["ocp_build_data_url"])
+        self.assertEqual(pipeline.build_data_gitref, None)
+        self.assertEqual(pipeline.build_data_push_url, self.runtime.config["build_config"]["ocp_build_data_push_url"])
+        self.assertEqual(pipeline.shipment_repo_pull_url, self.runtime.config["shipment_config"]["shipment_data_url"])
+        self.assertEqual(
+            pipeline.shipment_repo_push_url, self.runtime.config["shipment_config"]["shipment_data_push_url"]
+        )
+
+    def test_init_empty_config(self):
+        self.runtime.config = {}
+        pipeline = PrepareReleaseKonfluxPipeline(
+            slack_client=self.mock_slack_client,
+            runtime=self.runtime,
+            group=self.group,
+            assembly=self.assembly,
+            github_token=self.github_token,
+            gitlab_token=self.gitlab_token,
+        )
+        self.assertEqual(pipeline.build_repo_pull_url, constants.OCP_BUILD_DATA_URL)
+        self.assertEqual(pipeline.build_data_gitref, None)
+        self.assertEqual(pipeline.build_data_push_url, constants.OCP_BUILD_DATA_URL)
+        self.assertEqual(pipeline.shipment_repo_pull_url, SHIPMENT_DATA_URL_TEMPLATE.format("ocp"))
+        self.assertEqual(pipeline.shipment_repo_push_url, SHIPMENT_DATA_URL_TEMPLATE.format("ocp"))
+
+    def test_init_with_custom_urls(self):
+        pipeline = PrepareReleaseKonfluxPipeline(
+            slack_client=self.mock_slack_client,
+            runtime=self.runtime,
+            group=self.group,
+            assembly=self.assembly,
+            github_token=self.github_token,
+            gitlab_token=self.gitlab_token,
+            build_repo_url="https://github.com/foo/build-repo@branch",
+            shipment_repo_url="https://gitlab.com/bar/shipment-repo",
+        )
+        self.assertEqual(pipeline.build_repo_pull_url, "https://github.com/foo/build-repo")
+        self.assertEqual(pipeline.build_data_gitref, "branch")
+        self.assertEqual(pipeline.build_data_push_url, self.runtime.config["build_config"]["ocp_build_data_push_url"])
+        self.assertEqual(pipeline.shipment_repo_pull_url, "https://gitlab.com/bar/shipment-repo")
+        self.assertEqual(
+            pipeline.shipment_repo_push_url, self.runtime.config["shipment_config"]["shipment_data_push_url"]
+        )
+
+    @patch('pyartcd.pipelines.prepare_release_konflux.GitRepository')
+    async def test_setup_repos(self, MockGitRepositoryClass):
+        # Mock file contents for YAML parsing
+        file_contents = {"releases.yml": 'releases_key: releases_value', "group.yml": 'group_key: group_value'}
+
+        # Create mock repositories
+        mock_build_repo = AsyncMock(spec=GitRepository)
+        mock_build_repo.read_file.side_effect = lambda f: file_contents[f]
+
+        mock_shipment_repo = AsyncMock(spec=GitRepository)
+
+        MockGitRepositoryClass.side_effect = [mock_build_repo, mock_shipment_repo]
+
+        # Create pipeline and call setup_repos
+        pipeline = PrepareReleaseKonfluxPipeline(
+            slack_client=self.mock_slack_client,
+            runtime=self.runtime,
+            group=self.group,
+            assembly=self.assembly,
+            github_token=self.github_token,
+            gitlab_token=self.gitlab_token,
+        )
+        await pipeline.setup_repos()
+
+        # Verify GitRepository instantiation
+        self.assertEqual(MockGitRepositoryClass.call_count, 2)
+
+        # Verify build repo setup
+        mock_build_repo.setup.assert_awaited_once_with(
+            remote_url=pipeline.build_data_push_url,
+            upstream_remote_url=pipeline.build_repo_pull_url,
+        )
+        mock_build_repo.fetch_switch_branch.assert_awaited_once_with(self.group)
+        mock_build_repo.read_file.assert_has_awaits([call("releases.yml"), call("group.yml")])
+
+        # Verify shipment repo setup
+        mock_shipment_repo.setup.assert_awaited_once_with(
+            remote_url=pipeline.basic_auth_url(pipeline.shipment_repo_push_url, pipeline.gitlab_token),
+            upstream_remote_url=pipeline.shipment_repo_pull_url,
+        )
+        mock_shipment_repo.fetch_switch_branch.assert_awaited_once_with("main")
+        mock_shipment_repo.read_file.assert_not_awaited()
+
+        # Verify config parsing
+        self.assertEqual(pipeline.releases_config, {'releases_key': 'releases_value'})
+        self.assertEqual(pipeline.group_config, {'group_key': 'group_value'})
+
+    async def test_validate_assembly_valid(self):
+        pipeline = PrepareReleaseKonfluxPipeline(
+            slack_client=self.mock_slack_client,
+            runtime=self.runtime,
+            group=self.group,
+            assembly=self.assembly,
+            github_token=self.github_token,
+            gitlab_token=self.gitlab_token,
+        )
+        pipeline.releases_config = Model(
+            {
+                "releases": {
+                    "test-assembly": {"assembly": {"type": AssemblyTypes.STANDARD.value, "group": {"product": "ocp"}}}
+                }
+            }
+        )
+        pipeline.group_config = Model({"product": "ocp"})
+        await pipeline.validate_assembly()  # Should not raise
+
+    async def test_validate_assembly_missing_assembly(self):
+        pipeline = PrepareReleaseKonfluxPipeline(
+            slack_client=self.mock_slack_client,
+            runtime=self.runtime,
+            group=self.group,
+            assembly=self.assembly,
+            github_token=self.github_token,
+            gitlab_token=self.gitlab_token,
+        )
+        pipeline.releases_config = Model({"releases": {}})
+        with self.assertRaises(ValueError) as context:
+            await pipeline.validate_assembly()
+        self.assertIn("Assembly not found: test-assembly", str(context.exception))
+
+    async def test_validate_assembly_stream_type(self):
+        pipeline = PrepareReleaseKonfluxPipeline(
+            slack_client=self.mock_slack_client,
+            runtime=self.runtime,
+            group=self.group,
+            assembly=self.assembly,
+            github_token=self.github_token,
+            gitlab_token=self.gitlab_token,
+        )
+        pipeline.releases_config = Model(
+            {"releases": {self.assembly: {"assembly": {"type": AssemblyTypes.STREAM.value}}}}
+        )
+        with self.assertRaises(ValueError) as context:
+            await pipeline.validate_assembly()
+        self.assertIn("Preparing a release from a stream assembly is no longer supported.", str(context.exception))
+
+    async def test_validate_assembly_product_mismatch(self):
+        pipeline = PrepareReleaseKonfluxPipeline(
+            slack_client=self.mock_slack_client,
+            runtime=self.runtime,
+            group=self.group,
+            assembly=self.assembly,
+            github_token=self.github_token,
+            gitlab_token=self.gitlab_token,
+        )
+        pipeline.releases_config = Model(
+            {
+                "releases": {
+                    "test-assembly": {
+                        "assembly": {
+                            "type": AssemblyTypes.STANDARD.value,
+                            "group": {"product": "other-product"},
+                        },
+                    },
+                },
+            },
+        )
+        pipeline.group_config = Model({})  # No product override from group.yml
+        with self.assertRaises(ValueError) as context:
+            await pipeline.validate_assembly()
+        self.assertIn("Product mismatch: other-product != ocp.", str(context.exception))
+
+        # Second part: group_config product takes precedence
+        pipeline.releases_config = Model(
+            {
+                "releases": {
+                    "test-assembly": {
+                        "assembly": {
+                            "type": AssemblyTypes.STANDARD.value,
+                            "group": {},  # No product in assembly definition
+                        }
+                    }
+                }
+            }
+        )
+        pipeline.group_config = Model({"product": "another-product"})  # Product defined in group.yml
+        with self.assertRaises(ValueError) as context:
+            await pipeline.validate_assembly()
+        self.assertIn("Product mismatch: another-product != ocp.", str(context.exception))
+
+    @patch('pyartcd.pipelines.prepare_release_konflux.AsyncErrataAPI', spec=AsyncErrataAPI)
+    @patch.object(PrepareReleaseKonfluxPipeline, 'create_update_build_data_pr', new_callable=AsyncMock)
+    @patch.object(PrepareReleaseKonfluxPipeline, 'create_shipment_mr', new_callable=AsyncMock)
+    @patch.object(PrepareReleaseKonfluxPipeline, 'find_builds', new_callable=AsyncMock)
+    @patch.object(PrepareReleaseKonfluxPipeline, 'init_shipment', new_callable=AsyncMock)
+    async def test_prepare_shipment_new_mr_prod_env(
+        self, mock_init_shipment, mock_find_builds, mock_create_mr, mock_create_pr, mock_errata_api
+    ):
+        pipeline = PrepareReleaseKonfluxPipeline(
+            slack_client=self.mock_slack_client,
+            runtime=self.runtime,
+            group=self.group,
+            assembly=self.assembly,
+            github_token=self.github_token,
+            gitlab_token=self.gitlab_token,
+        )
+        pipeline.releases_config = Model(
+            {
+                "releases": {
+                    self.assembly: {
+                        "assembly": {
+                            "group": {
+                                "shipment": {
+                                    "env": "prod",
+                                    "advisories": [{"kind": "image"}, {"kind": "extras"}],
+                                    # No 'url'
+                                },
+                                "advisories": {"rpm": 123},
+                            }
+                        }
+                    }
+                }
+            }
+        )
+
+        mock_live_id = "LIVE_ID_FROM_ERRATA"
+        mock_errata_api_instance = mock_errata_api.return_value
+        mock_errata_api_instance.reserve_live_id = AsyncMock(return_value=mock_live_id)
+        mock_errata_api_instance.close = AsyncMock()
+
+        mock_data = Data(
+            releaseNotes=ReleaseNotes(
+                type="RHBA",
+                synopsis="synopsis",
+                topic="topic",
+                description="description",
+                solution="solution",
+            )
+        )
+
+        mock_shipment_image_data = Shipment(
+            metadata=Metadata(product="ocp", group=self.group, assembly=self.assembly, application="app-image"),
+            snapshot=Snapshot(spec=Spec(nvrs=[]), name="snapshot1"),
+            environments=Environments(
+                stage=ShipmentEnv(releasePlan="rp-img-stage"), prod=ShipmentEnv(releasePlan="rp-img-prod")
+            ),
+            data=mock_data,
+        )
+        mock_shipment_image = ShipmentConfig(shipment=mock_shipment_image_data)
+
+        mock_shipment_extras_data = Shipment(
+            metadata=Metadata(product="ocp", group=self.group, assembly=self.assembly, application="app-extras"),
+            snapshot=Snapshot(spec=Spec(nvrs=[]), name="snapshot2"),
+            environments=Environments(
+                stage=ShipmentEnv(releasePlan="rp-ext-stage"), prod=ShipmentEnv(releasePlan="rp-ext-prod")
+            ),
+            data=mock_data,
+        )
+        mock_shipment_extras = ShipmentConfig(shipment=mock_shipment_extras_data)
+
+        # copy since the original objects will be modified
+        mock_init_shipment.side_effect = [copy.deepcopy(mock_shipment_image), copy.deepcopy(mock_shipment_extras)]
+        mock_find_builds.side_effect = [Spec(nvrs=["nvr1"]), Spec(nvrs=["nvr2"])]
+        mock_create_mr.return_value = "https://gitlab.example.com/mr/1"
+
+        await pipeline.prepare_shipment()
+
+        mock_errata_api.assert_called_once()
+        self.assertEqual(mock_errata_api_instance.reserve_live_id.call_count, 2)
+
+        mock_init_shipment.assert_any_call("image")
+        mock_init_shipment.assert_any_call("extras")
+        self.assertEqual(mock_init_shipment.call_count, 2)
+
+        mock_find_builds.assert_any_call("image")
+        mock_find_builds.assert_any_call("extras")
+        self.assertEqual(mock_find_builds.call_count, 2)
+
+        mock_create_mr.assert_awaited_once()
+        generated_shipments_arg = mock_create_mr.call_args[0][0]
+
+        mock_shipment_image.shipment.snapshot.spec.nvrs = ["nvr1"]
+        mock_shipment_image.shipment.data.releaseNotes.live_id = mock_live_id
+
+        mock_shipment_extras.shipment.snapshot.spec.nvrs = ["nvr2"]
+        mock_shipment_extras.shipment.data.releaseNotes.live_id = mock_live_id
+
+        self.assertEqual(generated_shipments_arg["image"], mock_shipment_image)
+        self.assertEqual(generated_shipments_arg["extras"], mock_shipment_extras)
+        self.assertEqual(mock_create_mr.call_args[0][1], "prod")
+
+        mock_create_pr.assert_awaited_once()
+        final_shipment_config_arg = mock_create_pr.call_args[0][0]
+        self.assertEqual(
+            final_shipment_config_arg,
+            {
+                "env": "prod",
+                "advisories": [
+                    {"kind": "image", "live_id": mock_live_id},
+                    {"kind": "extras", "live_id": mock_live_id},
+                ],
+                "url": "https://gitlab.example.com/mr/1",
+            },
+        )
+        mock_errata_api_instance.close.assert_called_once()


### PR DESCRIPTION
Links
- Job run: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Fprepare-release-konflux/48/console
- Test assembly config: https://github.com/thegreyd/ocp-build-data/blob/418_shipment_Test/releases.yml
- Created MR: https://gitlab.cee.redhat.com/sidsharm/ocp-shipment-data/-/merge_requests/6

TODOs:
- [X] Setup a scaffold for prepare-release-konflux job
- [X] Ability to clone shipment-data repos in gitlab (including forks) 
  - Any project with visibility=public in gitlab should be cloneable
- [X] Ability to create a new branch and push to official shipment repo
  - Created and using a new access token for hybrid-platforms/art/ocp-shipment-data
  - Credentials stored in bitwarden
- [X] design assembly config directives for shipment
  - shipment is a single object with "url", "advisories" and "env" keys. a shipment MR can have multiple advisories defined, which have kind and live_id keys.
  - for an existing open shipment MR - pipeline can work on it idempotently - making sure all advisories are included in the shipment MR. if there exists an advisory which is not, then it gets added to the MR
  - complain in case of a closed shipment MR
  - `env: stage` can be set to only release to stage. `env: prod` is the default
  - `fbc` is not included in the config, since it will closely be associated with `kind: extras` advisory. details for this would have to be figured out

```yaml
releases:
  ec.5:
    assembly:
      group:
        shipment:
          url: N/A  # gitlab MR url 
          env: stage  # only for release to stage. default is prod
          advisories:
            - kind: image
              live_id: 1128  # required for prod, not required for stage
``` 
- [X] Call ErrataAPI to reserve liveID
- [X] Find and attach builds
- [x] Pipeline is idempotent when MR url is specified

Finding and attaching bugs will come later.