### PR TITLE
[konflux] explicitly use appstudio-pipeline

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -399,6 +399,8 @@ class KonfluxClient:
         # See https://konflux-ci.dev/docs/how-tos/configuring/customizing-the-build/#configuring-timeouts
         obj["spec"]["timeouts"] = {"pipeline": "12h"}
 
+        obj["spec"]["taskRunTemplate"]["serviceAccountName"] = "appstudio-pipeline"
+
         # Task specific parameters to override in the template
         has_build_images_task = False
         has_sast_task = False


### PR DESCRIPTION
ref announcement: https://groups.google.com/a/redhat.com/g/konflux-announce/c/NxOyzi8wGxo

Konflux Build team is going to switch from the current "appstudio-pipeline" Service Account that is used for all build pipelines of all Components in the namespace (tenant) to a dedicated Service Account named "build-pipeline-<component-name>" for each Component build pipelines. In other words, each Component will have a dedicated Service Account for build pipelines.

But that would mean that we have to override the serviceAccountName for each component AND add these secrets to each of those SAs (which would be thousands, since we have thousands of Components)
```
  - name: art-fbc-image-push
  - name: art-images-image-push
```

Andrew has raised a ticket for a workaround: https://issues.redhat.com/browse/KONFLUX-7956
Ref thread for details: https://redhat-internal.slack.com/archives/C06Q309QUDV/p1745521470063809
 

To insulate us from this change: https://github.com/openshift-priv/art-konflux-template/pull/83