### PR TITLE
ART-12599: Add Doomsday PipelineRun URL to the Slack message

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline-task.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline-task.yaml
@@ -10,6 +10,9 @@ spec:
     - description: 'Full version, eg: 4.15.5'
       name: version
       type: string
+    - description: 'URL of the PipelineRun'
+      name: pipelinerun_url
+      type: string
   steps:
     - env:
         - name: DOCKER_CONFIG
@@ -19,6 +22,8 @@ spec:
             secretKeyRef:
               key: api-token
               name: slack-bot-creds
+        - name: PIPELINERUN_URL
+          value: $(params.pipelinerun_url)
       image: default-route-openshift-image-registry.apps.artc2023.pc3z.p1.openshiftapps.com/art-cd/art-cd:latest
       name: run-script
       resources: {}

--- a/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/quay-doomsday-backup/base/doomsday-pipeline.yaml
@@ -17,6 +17,8 @@ spec:
           value: $(params.major)
         - name: version
           value: $(params.version)
+        - name: pipelinerun_url
+          value: 'https://console-openshift-console.apps.artc2023.pc3z.p1.openshiftapps.com/k8s/ns/$(context.pipelineRun.namespace)/tekton.dev~v1beta1~PipelineRun/$(context.pipelineRun.name)'
       taskRef:
         kind: Task
         name: doomsday-script-task

--- a/pyartcd/pyartcd/pipelines/quay_doomsday_backup.py
+++ b/pyartcd/pyartcd/pipelines/quay_doomsday_backup.py
@@ -21,6 +21,7 @@ class QuayDoomsdaySync:
     """
 
     def __init__(self, runtime: Runtime, version: str, arches: Optional[str]):
+        self.pipelinerun_url = os.environ.get("PIPELINERUN_URL")
         self.runtime = runtime
         self.version = version
         self.workdir = "./workspace"
@@ -84,7 +85,7 @@ class QuayDoomsdaySync:
         mkdirs(self.workdir)
 
         if not self.runtime.dry_run:
-            slack_response = await self.slack_client.say_in_thread(f":construction: Syncing arches {', '.join(self.arches)} of {self.version} to AWS S3 Bucket :construction:")
+            slack_response = await self.slack_client.say_in_thread(f":construction: Started <{self.pipelinerun_url}|Doomsday pipeline>: syncing arches {', '.join(self.arches)} of {self.version} to AWS S3 Bucket :construction:")
             slack_channel_id = slack_response["channel"]
             main_message_ts = slack_response["message"]["ts"]
         else:


### PR DESCRIPTION
Include link to the doomsday PipelineRun (such as [this](https://console-openshift-console.apps.artc2023.pc3z.p1.openshiftapps.com/k8s/ns/art-cd/tekton.dev~v1~PipelineRun/doomsday-pipeline-run-ghscf)) in the message posted in version specific Slack channel.

[Test run triggered from the cluster](https://redhat-internal.slack.com/archives/C05HB1F1THP/p1745844135783889) (modified to only post the message without syncing anything)