### PR TITLE
[konflux] gen-payload for named assemblies

### DIFF
--- a/artcommon/artcommonlib/assembly.py
+++ b/artcommon/artcommonlib/assembly.py
@@ -1,4 +1,5 @@
 import copy
+from datetime import datetime
 from enum import Enum
 
 import typing
@@ -273,7 +274,9 @@ def _assembly_field(field_name: str, releases_config: Model, assembly: str) -> M
     return Model(dict_to_model=config_dict)
 
 
-def assembly_basis_event(releases_config: Model, assembly: str, strict: bool = False) -> typing.Optional[int]:
+def assembly_basis_event(
+    releases_config: Model, assembly: str, strict: bool = False
+) -> typing.Optional[typing.Union[int, datetime]]:
     """
     :param releases_config: The content of releases.yml in Model form.
     :param assembly: The name of the assembly to assess
@@ -288,8 +291,11 @@ def assembly_basis_event(releases_config: Model, assembly: str, strict: bool = F
 
     _check_recursion(releases_config, assembly)
     target_assembly = releases_config.releases[assembly].assembly
+
     if target_assembly.basis.brew_event:
-        return int(target_assembly.basis.brew_event)
+        return int(target_assembly.basis.brew_event)  # Integer for Brew event
+    elif target_assembly.basis.time:
+        return target_assembly.basis.time  # Datetime for Konflux
     return assembly_basis_event(releases_config, target_assembly.basis.assembly, strict=strict)
 
 

--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -5,7 +5,7 @@ import random
 import uuid
 from datetime import datetime
 from enum import Enum
-from typing import Dict, List, Optional, Union
+from typing import List, Optional, Union
 
 from artcommonlib import constants
 from artcommonlib import util as artlib_util

--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -25,7 +25,7 @@ class KonfluxDb:
         self.bq_client = bigquery.BigQueryClient()
         self.record_cls = None
 
-    def bind(self, record_cls: KonfluxRecord):
+    def bind(self, record_cls: typing.Type[KonfluxRecord]):
         """
         Binds the DB client to a specific table, via the KonfluxRecord class definition that represents it.
         When bound, all insert/select statements will target that table, until the DB is bound to a different one.
@@ -301,12 +301,7 @@ class KonfluxDb:
         if completed_before:
             completed_before = completed_before.astimezone(timezone.utc)
             self.logger.info('Searching for %s builds completed before %s', name, completed_before)
-            base_clauses.extend(
-                [
-                    Column('end_time').isnot(None),
-                    Column('end_time', DateTime) < completed_before,
-                ]
-            )
+            base_clauses.extend([Column('end_time').isnot(None), Column('end_time', DateTime) <= completed_before])
 
         if el_target:
             base_clauses.append(Column('el_target', String) == el_target)

--- a/artcommon/artcommonlib/konflux/package_rpm_finder.py
+++ b/artcommon/artcommonlib/konflux/package_rpm_finder.py
@@ -88,6 +88,7 @@ class PackageRpmFinder:
         return {
             self._packages_build_dicts[package_nvr]['name']: self._packages_build_dicts[package_nvr]
             for package_nvr in installed_packages
+            if package_nvr not in self._not_found_packages
         }
 
     def get_rpms_in_pkg_build(self, nvr: str) -> list:

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -327,7 +327,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE name = 'ironic' "
             "AND `group` = 'openshift-4.18' AND outcome = 'success' "
             "AND assembly = 'stream' AND end_time IS NOT NULL "
-            f"AND end_time < '{now}' "
+            f"AND end_time <= '{now}' "
             f"AND start_time >= '{str(lower_bound)}' "
             f"AND start_time < '{now}' "
             "ORDER BY `start_time` DESC LIMIT 1"

--- a/doozer/doozerlib/brew.py
+++ b/doozer/doozerlib/brew.py
@@ -335,6 +335,14 @@ def list_build_rpms(build_ids: List[int], session: koji.ClientSession) -> List[O
     return [task.result for task in tasks]
 
 
+def brew_event_from_datetime(datetime_obj: datetime, koji_api) -> int:
+    """
+    Return the latest Brew event that happened before a given time.
+    For example: datetime.datetime(2025, 4, 4, 11, 38, 42) -> 63259598
+    """
+    return koji_api.getLastEvent(KojiWrapperOpts(brew_event_aware=False), before=datetime_obj.timestamp())['id']
+
+
 # Map that records tagId -> dict of latest package tagging event associated with that tag
 latest_tag_change_events = {}
 cache_lock = Lock()

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -137,12 +137,12 @@ class Metadata(MetadataBase):
                 pass
             else:
                 # Ooof.. it is not defined in the assembly, so we need to find it dynamically.
-                build_obj = self.get_latest_brew_build(default=None, el_target=self.determine_rhel_targets()[0])
+                build_obj = self.get_latest_build_sync(default=None, el_target=self.determine_rhel_targets()[0])
                 if build_obj:
                     self.commitish = isolate_git_commit_in_release(build_obj['nvr'])
                     self.logger.info(
                         'Pinning upstream source to commit of assembly selected build '
-                        f'({build_obj["id"]}) -> commit {self.commitish}'
+                        f'({build_obj["build_id"]}) -> commit {self.commitish}'
                     )
                 else:
                     # If this is part of a unit test, don't make the caller's life more difficult than it already is; skip the exception.

--- a/doozer/requirements.txt
+++ b/doozer/requirements.txt
@@ -9,6 +9,7 @@ importlib-resources
 koji
 kubernetes ~= 28.0
 kubernetes-asyncio ~= 28.0
+nest-asyncio >= 1.6.0
 openshift ~= 0.13.2
 opentelemetry-sdk
 opentelemetry-exporter-otlp-proto-grpc

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -129,7 +129,7 @@ class TestGenPayloadCli(IsolatedAsyncioTestCase):
     @patch("doozerlib.cli.release_gen_payload.PayloadGenerator.check_nightlies_consistency")
     async def test_generate_assembly_issues_report(self, cnc_mock):
         gpcli = flexmock(
-            rgp_cli.GenPayloadCli(runtime=MagicMock(assembly="stream")),
+            rgp_cli.GenPayloadCli(runtime=MagicMock(assembly="stream", build_system="brew")),
             collect_assembly_build_ids=MagicMock(return_value={1, 2, 3}),
             detect_mismatched_siblings=None,
             detect_non_latest_rpms=None,

--- a/doozer/tests/cli/test_rpms_build.py
+++ b/doozer/tests/cli/test_rpms_build.py
@@ -22,6 +22,7 @@ class TestRPMsBuildCli(IsolatedAsyncioTestCase):
         stream = io.StringIO()
         logging.basicConfig(level=logging.INFO, stream=stream)
         runtime.logger = logging.getLogger()
+        runtime.build_system = "brew"
         return runtime
 
     @patch("doozerlib.cli.rpms.RPMBuilder")

--- a/doozer/tests/test_osbs2.py
+++ b/doozer/tests/test_osbs2.py
@@ -31,7 +31,7 @@ class TestOSBS2Builder(unittest.IsolatedAsyncioTestCase):
         return meta
 
     def test_construct_build_source_url(self):
-        runtime = MagicMock()
+        runtime = MagicMock(build_system="brew")
         osbs2 = OSBS2Builder(runtime)
         meta = self._make_image_meta(runtime)
         dg = ImageDistGitRepo(meta, autoclone=False)
@@ -45,7 +45,7 @@ class TestOSBS2Builder(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(actual, f"{constants.DISTGIT_GIT_URL}/containers/foo#deadbeef")
 
     async def test_start_build(self):
-        runtime = MagicMock()
+        runtime = MagicMock(build_system="brew")
         osbs2 = OSBS2Builder(runtime)
         meta = self._make_image_meta(runtime)
         dg = ImageDistGitRepo(meta, autoclone=False)
@@ -87,7 +87,7 @@ class TestOSBS2Builder(unittest.IsolatedAsyncioTestCase):
         koji_api = MagicMock(logged_in=False)
         koji_api.getTaskResult = MagicMock(return_value={"koji_builds": [42]})
         koji_api.getBuild = MagicMock(return_value={"id": 42, "nvr": "foo-v4.12.0-12345.p0.assembly.test"})
-        runtime = MagicMock()
+        runtime = MagicMock(build_system="brew")
         runtime.build_retrying_koji_client = MagicMock(return_value=koji_api)
         osbs2 = OSBS2Builder(runtime)
         meta = self._make_image_meta(runtime)

--- a/doozer/tests/test_rpmcfg.py
+++ b/doozer/tests/test_rpmcfg.py
@@ -27,8 +27,8 @@ targets:
 
     @mock.patch("artcommonlib.logutil.EntityLoggingAdapter")
     @mock.patch("doozerlib.rpmcfg.Dir")
-    def test_assert_golang_versions(self, MockDir, MockEntityLoggingAdapter):
-        runtime = mock.MagicMock(brew_logs_dir="/path/to/brew/logs")
+    def test_assert_golang_versions(self, *_):
+        runtime = mock.MagicMock(brew_logs_dir="/path/to/brew/logs", build_system="brew")
         koji_session = runtime.build_retrying_koji_client.return_value
         data_obj = mock.MagicMock(
             key="foo",


### PR DESCRIPTION
Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/dpaolell/job/build-sync-konflux/7/console

Create imagestreams:
- `4.18-konflux-art-assembly-4.18.100`
- `4.18-konflux-art-assembly-4.18.100-multi`
- `4.18-konflux-art-assembly-4.18.100-s390x`
- `4.18-konflux-art-assembly-4.18.100-ppc64le`
- `4.18-konflux-art-assembly-4.18.100-arm64`
