### PR TITLE
konflux SA override update

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -401,7 +401,7 @@ class KonfluxClient:
         # See https://konflux-ci.dev/docs/how-tos/configuring/customizing-the-build/#configuring-timeouts
         obj["spec"]["timeouts"] = {"pipeline": "12h"}
 
-        obj["spec"]["taskRunTemplate"]["serviceAccountName"] = "appstudio-pipeline"
+        obj["spec"]["taskRunTemplate"]["serviceAccountName"] = f"build-pipeline-{component_name}"
 
         # Task specific parameters to override in the template
         has_build_images_task = False


### PR DESCRIPTION
Follow up to https://github.com/openshift-eng/art-tools/pull/1547

https://issues.redhat.com/browse/KONFLUX-7956 has been setup i.e. which means that we need to use the per component SA, which is updated as part of the PR