### PR TITLE
scan sources rebuild if hermetic

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -438,7 +438,7 @@ class ConfigScanSources:
         if str(network_mode == "hermetic").lower() != is_hermetic.lower():
             self.add_image_meta_change(
                 image_meta,
-                RebuildHint(code=RebuildHintCode.HERMETIC_MODE_CHANGED,
+                RebuildHint(code=RebuildHintCode.CONFIG_CHANGE,
                             reason=f"Latest build {build_record.image_pullspec} network mode was {is_hermetic} but we need {network_mode}"))
 
     @skip_check_if_changing

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -59,6 +59,7 @@ class RebuildHintCode(Enum):
     PACKAGE_CHANGE = (True, 13)
     ARCHES_CHANGE = (True, 14)
     DEPENDENCY_NEWER = (True, 15)
+    HERMETIC_MODE_CHANGED = (True, 16)
 
 
 class RebuildHint(NamedTuple):

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -59,7 +59,6 @@ class RebuildHintCode(Enum):
     PACKAGE_CHANGE = (True, 13)
     ARCHES_CHANGE = (True, 14)
     DEPENDENCY_NEWER = (True, 15)
-    HERMETIC_MODE_CHANGED = (True, 16)
 
 
 class RebuildHint(NamedTuple):


### PR DESCRIPTION
We have two network modes that we care about, `hermetic` and `open`. Rebuild if the value changes in the config

Test build succeeded: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/17557/console