### PR TITLE
ART-12761: docs workflow update

### DIFF
--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -154,7 +154,7 @@ def _update_advisory(runtime, advisory, flaw_bugs, bug_tracker, noop):
 
     # Get the advisory name, eg. image|rpm|metadata|microshift
     releases_config = runtime.get_releases_config()
-    advisories = releases_config[runtime.assembly]['assembly']['group']['advisories']
+    advisories = releases_config["releases"][runtime.assembly]['assembly']['group']['advisories']
     art_advisory_key = next((k for k, v in advisories.items() if v == advisory_id), None)
 
     if not art_advisory_key:

--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -155,11 +155,7 @@ def _update_advisory(runtime, advisory, flaw_bugs, bug_tracker, noop):
     # Get the advisory name, eg. image|rpm|metadata|microshift
     releases_config = runtime.get_releases_config()
     advisories = releases_config[runtime.assembly]['assembly']['group']['advisories']
-    art_advisory_key = None
-    for _name, _id in advisories.items():
-        if _id == advisory_id:
-            art_advisory_key = _name
-            break
+    art_advisory_key = next((k for k, v in advisories.items() if v == advisory_id), None)
 
     if not art_advisory_key:
         raise ValueError(f'ART advisory key not found for advisory: {advisory_id} in list {advisories.items()}')

--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -67,7 +67,7 @@ async def attach_cve_flaws_cli(
 
     # Get the advisory kind-id mapping
     releases_config = runtime.get_releases_config()
-    advisories_by_kind = releases_config["releases"][runtime.assembly]['assembly']['group']['advisories']
+    advisories_by_kind = releases_config['releases'][runtime.assembly]['assembly']['group']['advisories']
 
     exit_code = 0
     flaw_bug_tracker = runtime.get_bug_tracker('bugzilla')

--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -64,6 +64,11 @@ async def attach_cve_flaws_cli(
         advisories = [find_default_advisory(runtime, default_advisory_type)]
     else:
         advisories = [advisory_id]
+
+    # Get the advisory kind-id mapping
+    releases_config = runtime.get_releases_config()
+    advisories_by_kind = releases_config["releases"][runtime.assembly]['assembly']['group']['advisories']
+
     exit_code = 0
     flaw_bug_tracker = runtime.get_bug_tracker('bugzilla')
     errata_config = runtime.get_errata_config()
@@ -81,7 +86,7 @@ async def attach_cve_flaws_cli(
 
         try:
             if flaw_bugs:
-                _update_advisory(runtime, advisory, flaw_bugs, flaw_bug_tracker, noop)
+                _update_advisory(runtime, advisory, advisories_by_kind, flaw_bugs, flaw_bug_tracker, noop)
                 # Associate builds with CVEs
                 LOGGER.info('Associating CVEs with builds')
                 await associate_builds_with_cves(
@@ -148,17 +153,15 @@ def get_flaws(flaw_bug_tracker: BugTracker, tracker_bugs: Iterable[Bug], brew_ap
     return tracker_flaws, first_fix_flaw_bugs
 
 
-def _update_advisory(runtime, advisory, flaw_bugs, bug_tracker, noop):
+def _update_advisory(runtime, advisory, advisories_by_kind, flaw_bugs, bug_tracker, noop):
     advisory_id = advisory.errata_id
     errata_config = runtime.get_errata_config()
 
-    # Get the advisory name, eg. image|rpm|metadata|microshift
-    releases_config = runtime.get_releases_config()
-    advisories = releases_config["releases"][runtime.assembly]['assembly']['group']['advisories']
-    art_advisory_key = next((k for k, v in advisories.items() if v == advisory_id), None)
+    # Get the name of the advisory (eg. image|rpm|metadata|microshift etc.)
+    art_advisory_key = next((k for k, v in advisories_by_kind.items() if v == advisory_id), None)
 
     if not art_advisory_key:
-        raise ValueError(f'ART advisory key not found for advisory: {advisory_id} in list {advisories.items()}')
+        raise ValueError(f'ART advisory key not found for advisory: {advisory_id} in list {advisories_by_kind.items()}')
 
     cve_boilerplate = get_advisory_boilerplate(
         runtime=runtime, et_data=errata_config, art_advisory_key=art_advisory_key, errata_type='RHSA'

--- a/elliott/elliottlib/cli/create_cli.py
+++ b/elliott/elliottlib/cli/create_cli.py
@@ -24,6 +24,12 @@ def get_common_advisory_template(runtime):
 
 
 def get_advisory_boilerplate(runtime: Runtime, et_data, art_advisory_key, errata_type):
+    # rhsa/rhba keys are in lower case: https://github.com/openshift-eng/ocp-build-data/blob/main/config/advisory_templates.yml#L3
+    # Also if advisory type is RHEA, use the RHBA advisory template
+    errata_type = errata_type.lower()
+    errata_type = "rhba" if errata_type == "rhea" else errata_type
+
+    et_data["errata_type"] = errata_type
     # Group level overrides common config present in openshift-eng/ocp-build-data main branch
     # Try to get the group level boilerplate first
     boilerplate = et_data.get("boilerplates", {})

--- a/elliott/elliottlib/cli/shipment_cli.py
+++ b/elliott/elliottlib/cli/shipment_cli.py
@@ -18,6 +18,7 @@ from elliottlib.shipment_model import (
     Snapshot,
     Spec,
 )
+from elliottlib.util import get_advisory_boilerplate
 
 LOGGER = logutil.get_logger(__name__)
 
@@ -76,19 +77,22 @@ class InitShipmentCli:
 
             if self.advisory_key:
                 et_data = self.runtime.get_errata_config()
-                if "boilerplates" not in et_data:
-                    raise ValueError("`boilerplates` is required in erratatool.yml")
-                if self.advisory_key not in et_data["boilerplates"]:
-                    raise ValueError(f"Boilerplate {self.advisory_key} not found in erratatool.yml")
-                boilerplate = et_data["boilerplates"][self.advisory_key]
+                _, minor, patch = self.runtime.get_major_minor_patch()
+                advisory_boilerplate = get_advisory_boilerplate(
+                    runtime=self.runtime, et_data=et_data, art_advisory_key=self.advisory_key, errata_type="RHBA"
+                )
+                synopsis = advisory_boilerplate['synopsis'].format(MINOR=minor, PATCH=patch)
+                advisory_topic = advisory_boilerplate['topic'].format(MINOR=minor, PATCH=patch)
+                advisory_description = advisory_boilerplate['description'].format(MINOR=minor, PATCH=patch)
+                advisory_solution = advisory_boilerplate['solution'].format(MINOR=minor, PATCH=patch)
 
                 data = Data(
                     releaseNotes=ReleaseNotes(
                         type="RHBA",
-                        synopsis=boilerplate["synopsis"],
-                        topic=boilerplate["topic"],
-                        description=boilerplate["description"],
-                        solution=boilerplate["solution"],
+                        synopsis=synopsis,
+                        topic=advisory_topic,
+                        description=advisory_description,
+                        solution=advisory_solution,
                     ),
                 )
 

--- a/elliott/elliottlib/runtime.py
+++ b/elliott/elliottlib/runtime.py
@@ -94,6 +94,17 @@ class Runtime(GroupRuntime):
     def get_major_minor(self):
         return self.group_config.vars.MAJOR, self.group_config.vars.MINOR
 
+    def get_major_minor_patch(self):
+        pattern = r"\d+.\d+.\d+"
+        match = re.search(pattern, self.assembly)
+        if match:
+            self._logger.debug(f"Found major.minor.patch {match.group()} for assembly {self.assembly}")
+            return self.assembly.split(".")
+        else:
+            raise ValueError(
+                f"Could not find major.minor.patch for assembly {self.assembly}. Use get_major_minor() instead for major.minor"
+            )
+
     def get_default_advisories(self):
         return self.group_config.get('advisories', {})
 

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -26,8 +26,6 @@ default_release_date = datetime.datetime(1970, 1, 1, 0, 0)
 now = datetime.datetime.now()
 YMD = '%Y-%b-%d'
 LOGGER = get_logger(__name__)
-GIT_REPO_BRANCH = "main"
-COMMON_ADVISORY_TEMPLATE_FILE = "config/advisory_templates.yml"
 
 
 def exit_unauthenticated():
@@ -584,7 +582,7 @@ def fix_summary_suffix(summary, summary_suffix):
 
 
 def get_common_advisory_template(runtime):
-    out = runtime.get_file_from_branch(GIT_REPO_BRANCH, COMMON_ADVISORY_TEMPLATE_FILE)
+    out = runtime.get_file_from_branch(branch="main", filename="config/advisory_templates.yml")
     return yaml.safe_load(out)
 
 
@@ -593,8 +591,8 @@ def get_advisory_boilerplate(runtime, et_data, art_advisory_key, errata_type):
     # Also if advisory type is RHEA, use the RHBA advisory template
     errata_type = errata_type.lower()
     errata_type = "rhba" if errata_type == "rhea" else errata_type
-
     et_data["errata_type"] = errata_type
+
     # Group level overrides common config present in openshift-eng/ocp-build-data main branch
     # Try to get the group level boilerplate first
     boilerplate = et_data.get("boilerplates", {})

--- a/elliott/tests/test_create_cli.py
+++ b/elliott/tests/test_create_cli.py
@@ -1,0 +1,121 @@
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock
+
+import yaml
+from elliottlib.cli.create_cli import get_advisory_boilerplate
+
+COMMON_ADVISORY_TEMPLATE = """
+boilerplates:
+  images:
+    rhsa:
+      synopsis: Common advisory rhsa synopsis
+      topic: Common advisory rhsa topic
+      description: Common advisory rhsa description
+      solution: Common advisory rhsa solution
+    rhba:
+      synopsis: Common advisory rhba synopsis
+      topic: Common advisory rhba topic
+      description: Common advisory rhba description
+      solution: Common advisory rhba solution
+"""
+
+GROUP_ADVISORY_TEMPLATE = """
+boilerplates:
+  images:
+    rhsa:
+      synopsis: Group advisory rhsa synopsis
+      topic: Group advisory rhsa topic
+      description: Group advisory rhsa description
+      solution: Group advisory rhsa solution
+    rhba:
+      synopsis: Group advisory rhba synopsis
+      topic: Group advisory rhba topic
+      description: Group advisory rhba description
+      solution: Group advisory rhba solution
+"""
+
+GROUP_ADVISORY_TEMPLATE_LEGACY = """
+boilerplates:
+  images:
+    synopsis: Group advisory rhba synopsis
+    topic: Group advisory rhba topic
+    description: Group advisory rhba description
+    solution: Group advisory rhba solution
+"""
+
+
+class TestGetAdvisoryBoilerplate(unittest.TestCase):
+    @mock.patch("elliottlib.cli.create_cli.get_common_advisory_template")
+    def test_get_common_advisory_rhsa(self, mock_get_common_advisory_template):
+        # Arrange
+        et_data = {}
+        mock_get_common_advisory_template.return_value = yaml.safe_load(COMMON_ADVISORY_TEMPLATE)
+        art_advisory_key = "images"
+        errata_type = "rhsa"
+        runtime = MagicMock()
+        # Act
+        result = get_advisory_boilerplate(runtime, et_data, art_advisory_key, errata_type)
+
+        # Assert
+        self.assertEqual(result["synopsis"], "Common advisory rhsa synopsis")
+
+    @mock.patch("elliottlib.cli.create_cli.get_common_advisory_template")
+    def test_get_common_advisory_rhba(self, mock_get_common_advisory_template):
+        # Arrange
+        et_data = {}
+        mock_get_common_advisory_template.return_value = yaml.safe_load(COMMON_ADVISORY_TEMPLATE)
+        art_advisory_key = "images"
+        errata_type = "rhba"
+        runtime = MagicMock()
+
+        # Act
+        result = get_advisory_boilerplate(runtime, et_data, art_advisory_key, errata_type)
+
+        # Assert
+        self.assertEqual(result["synopsis"], "Common advisory rhba synopsis")
+
+    @mock.patch("elliottlib.cli.create_cli.get_common_advisory_template")
+    def test_get_group_advisory(self, mock_get_common_advisory_template):
+        # Arrange
+        et_data = yaml.safe_load(GROUP_ADVISORY_TEMPLATE)
+        mock_get_common_advisory_template.return_value = yaml.safe_load(COMMON_ADVISORY_TEMPLATE)
+        art_advisory_key = "images"
+        errata_type = "rhsa"
+        runtime = MagicMock()
+
+        # Act
+        result = get_advisory_boilerplate(runtime, et_data, art_advisory_key, errata_type)
+
+        # Assert
+        self.assertEqual(result["synopsis"], "Group advisory rhsa synopsis")
+
+    @mock.patch("elliottlib.cli.create_cli.get_common_advisory_template")
+    def test_get_group_advisory_legacy_rhsa(self, mock_get_common_advisory_template):
+        # Arrange
+        et_data = yaml.safe_load(GROUP_ADVISORY_TEMPLATE_LEGACY)
+        mock_get_common_advisory_template.return_value = yaml.safe_load(COMMON_ADVISORY_TEMPLATE)
+        art_advisory_key = "images"
+        errata_type = "rhsa"
+        runtime = MagicMock()
+
+        # Act
+        result = get_advisory_boilerplate(runtime, et_data, art_advisory_key, errata_type)
+
+        # Assert
+        self.assertEqual(result["synopsis"], "Group advisory rhba synopsis")
+
+    @mock.patch("elliottlib.cli.create_cli.get_common_advisory_template")
+    def test_get_group_advisory_legacy_rhba(self, mock_get_common_advisory_template):
+        # Arrange
+        et_data = yaml.safe_load(GROUP_ADVISORY_TEMPLATE_LEGACY)
+        mock_get_common_advisory_template.return_value = yaml.safe_load(COMMON_ADVISORY_TEMPLATE)
+        art_advisory_key = "images"
+        errata_type = "rhba"
+        runtime = MagicMock()
+
+        # Act
+        result = get_advisory_boilerplate(runtime, et_data, art_advisory_key, errata_type)
+
+        # Assert
+        self.assertEqual(result["synopsis"], "Group advisory rhba synopsis")

--- a/elliott/tests/test_create_cli.py
+++ b/elliott/tests/test_create_cli.py
@@ -3,11 +3,11 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import yaml
-from elliottlib.cli.create_cli import get_advisory_boilerplate
+from elliottlib.util import get_advisory_boilerplate
 
 COMMON_ADVISORY_TEMPLATE = """
 boilerplates:
-  images:
+  image:
     rhsa:
       synopsis: Common advisory rhsa synopsis
       topic: Common advisory rhsa topic
@@ -22,7 +22,7 @@ boilerplates:
 
 GROUP_ADVISORY_TEMPLATE = """
 boilerplates:
-  images:
+  image:
     rhsa:
       synopsis: Group advisory rhsa synopsis
       topic: Group advisory rhsa topic
@@ -37,7 +37,7 @@ boilerplates:
 
 GROUP_ADVISORY_TEMPLATE_LEGACY = """
 boilerplates:
-  images:
+  image:
     synopsis: Group advisory rhba synopsis
     topic: Group advisory rhba topic
     description: Group advisory rhba description
@@ -46,12 +46,12 @@ boilerplates:
 
 
 class TestGetAdvisoryBoilerplate(unittest.TestCase):
-    @mock.patch("elliottlib.cli.create_cli.get_common_advisory_template")
+    @mock.patch("elliottlib.util.get_common_advisory_template")
     def test_get_common_advisory_rhsa(self, mock_get_common_advisory_template):
         # Arrange
         et_data = {}
         mock_get_common_advisory_template.return_value = yaml.safe_load(COMMON_ADVISORY_TEMPLATE)
-        art_advisory_key = "images"
+        art_advisory_key = "image"
         errata_type = "rhsa"
         runtime = MagicMock()
         # Act
@@ -60,12 +60,12 @@ class TestGetAdvisoryBoilerplate(unittest.TestCase):
         # Assert
         self.assertEqual(result["synopsis"], "Common advisory rhsa synopsis")
 
-    @mock.patch("elliottlib.cli.create_cli.get_common_advisory_template")
+    @mock.patch("elliottlib.util.get_common_advisory_template")
     def test_get_common_advisory_rhba(self, mock_get_common_advisory_template):
         # Arrange
         et_data = {}
         mock_get_common_advisory_template.return_value = yaml.safe_load(COMMON_ADVISORY_TEMPLATE)
-        art_advisory_key = "images"
+        art_advisory_key = "image"
         errata_type = "rhba"
         runtime = MagicMock()
 
@@ -75,12 +75,12 @@ class TestGetAdvisoryBoilerplate(unittest.TestCase):
         # Assert
         self.assertEqual(result["synopsis"], "Common advisory rhba synopsis")
 
-    @mock.patch("elliottlib.cli.create_cli.get_common_advisory_template")
+    @mock.patch("elliottlib.util.get_common_advisory_template")
     def test_get_group_advisory(self, mock_get_common_advisory_template):
         # Arrange
         et_data = yaml.safe_load(GROUP_ADVISORY_TEMPLATE)
         mock_get_common_advisory_template.return_value = yaml.safe_load(COMMON_ADVISORY_TEMPLATE)
-        art_advisory_key = "images"
+        art_advisory_key = "image"
         errata_type = "rhsa"
         runtime = MagicMock()
 
@@ -90,12 +90,12 @@ class TestGetAdvisoryBoilerplate(unittest.TestCase):
         # Assert
         self.assertEqual(result["synopsis"], "Group advisory rhsa synopsis")
 
-    @mock.patch("elliottlib.cli.create_cli.get_common_advisory_template")
+    @mock.patch("elliottlib.util.get_common_advisory_template")
     def test_get_group_advisory_legacy_rhsa(self, mock_get_common_advisory_template):
         # Arrange
         et_data = yaml.safe_load(GROUP_ADVISORY_TEMPLATE_LEGACY)
         mock_get_common_advisory_template.return_value = yaml.safe_load(COMMON_ADVISORY_TEMPLATE)
-        art_advisory_key = "images"
+        art_advisory_key = "image"
         errata_type = "rhsa"
         runtime = MagicMock()
 
@@ -105,12 +105,12 @@ class TestGetAdvisoryBoilerplate(unittest.TestCase):
         # Assert
         self.assertEqual(result["synopsis"], "Group advisory rhba synopsis")
 
-    @mock.patch("elliottlib.cli.create_cli.get_common_advisory_template")
+    @mock.patch("elliottlib.util.get_common_advisory_template")
     def test_get_group_advisory_legacy_rhba(self, mock_get_common_advisory_template):
         # Arrange
         et_data = yaml.safe_load(GROUP_ADVISORY_TEMPLATE_LEGACY)
         mock_get_common_advisory_template.return_value = yaml.safe_load(COMMON_ADVISORY_TEMPLATE)
-        art_advisory_key = "images"
+        art_advisory_key = "image"
         errata_type = "rhba"
         runtime = MagicMock()
 

--- a/elliott/tests/test_runtime.py
+++ b/elliott/tests/test_runtime.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest.mock import MagicMock
+
+from elliott.elliottlib.runtime import Runtime
+
+
+class TestGetMajorMinorPatch(unittest.TestCase):
+    def setUp(self):
+        self.runtime = Runtime()
+        self.runtime._logger = MagicMock()
+
+    def test_valid_assembly(self):
+        self.runtime.assembly = "4.10.0"
+
+        result = self.runtime.get_major_minor_patch()
+        self.assertEqual(result, ["4", "10", "0"])
+
+    def test_invalid_assembly(self):
+        self.runtime.assembly = "stream"
+        with self.assertRaises(ValueError):
+            self.runtime.get_major_minor_patch()
+
+    def test_valid_assembly_with_major_min_only(self):
+        self.runtime.assembly = "4.10"
+        with self.assertRaises(ValueError):
+            self.runtime.get_major_minor_patch()


### PR DESCRIPTION
For https://github.com/openshift-eng/ocp-build-data/pull/6706

In this PR:
- Store the template thats common to all OCP versions in openshift-eng/ocp-build-data#main
- The config can be overridden in the group level, if necessary
- As a first step, use the updated template. Follow up features include (updating the description to include the advisory id, adding the SHAs for the release digest)