### PR TITLE
Disable scan_network_mode_changes()

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -414,7 +414,7 @@ class ConfigScanSources:
         await self.scan_extra_packages(image_meta)
 
         # Check for changes in the network mode
-        await self.scan_network_mode_changes(image_meta)
+        # await self.scan_network_mode_changes(image_meta)
 
     def find_upstream_commit_hash(self, meta: Metadata):
         """


### PR DESCRIPTION
Currently breaking scan-sources:
```
ChildProcessError: Process ['cosign', 'download', 'attestation', 'quay.io/redhat-user-workloads/ocp-art-tenant/art-images@sha256:39599c3f255239e2e8f072af35f041511a75abf80149b2a0bef6a5715fbf62b4', '--registry-username', ****, '--registry-password', ****] exited with code 1.
```