### PR TITLE
Enable find-builds for konflux

### DIFF
--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -176,6 +176,7 @@ async def find_builds_cli(
         records = await find_builds_konflux(runtime, payload)
         for record in records:
             print(record.nvr)
+        return
 
     replace_vars = runtime.group_config.vars.primitive() if runtime.group_config.vars else {}
     et_data = runtime.get_errata_config(replace_vars=replace_vars)

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -688,7 +688,7 @@ async def find_builds_konflux(runtime, payload):
     for image in runtime.image_metas():
         if image.base_only or not image.is_release:
             continue
-        if not (payload and image.is_payload):
+        if (payload and not image.is_payload) or (not payload and image.is_payload):
             continue
         image_metas.append(image)
 

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -174,8 +174,8 @@ async def find_builds_cli(
         if kind != 'image':
             raise click.BadParameter('Konflux only supports --kind image.')
         records = await find_builds_konflux(runtime, payload)
-        for record in records:
-            print(record.nvr)
+        for nvr in sorted([r.nvr for r in records]):
+            print(nvr)
         return
 
     replace_vars = runtime.group_config.vars.primitive() if runtime.group_config.vars else {}

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -173,7 +173,9 @@ async def find_builds_cli(
             )
         if kind != 'image':
             raise click.BadParameter('Konflux only supports --kind image.')
-        return await find_builds_konflux(runtime, payload)
+        records = await find_builds_konflux(runtime, payload)
+        for record in records:
+            print(record.nvr)
 
     replace_vars = runtime.group_config.vars.primitive() if runtime.group_config.vars else {}
     et_data = runtime.get_errata_config(replace_vars=replace_vars)
@@ -695,6 +697,4 @@ async def find_builds_konflux(runtime, payload):
     LOGGER.info("Fetching NVRs from DB...")
     tasks = [image.get_latest_build(el_target=image.branch_el_target()) for image in image_metas]
     records: List[Dict] = list(await asyncio.gather(*tasks))
-
-    for record in records:
-        print(record.nvr)
+    return records

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -13,6 +13,7 @@ from artcommonlib import exectools, logutil
 from artcommonlib.arch_util import BREW_ARCHES
 from artcommonlib.assembly import assembly_metadata_config, assembly_rhcos_config
 from artcommonlib.format_util import green_prefix, green_print, red_print, yellow_print
+from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildRecord
 from artcommonlib.release_util import isolate_el_version_in_release
 from artcommonlib.rhcos import get_build_id_from_rhcos_pullspec, get_container_configs
 from artcommonlib.rpm_utils import parse_nvr
@@ -162,6 +163,18 @@ async def find_builds_cli(
         builds = [line.strip() for line in builds_file.readlines()]
 
     runtime.initialize(mode='images' if kind == 'image' else 'rpms')
+
+    if runtime.build_system == 'konflux':
+        if any(
+            [builds, builds_file, advisory_id, default_advisory_type, clean, no_cdn_repos, include_shipped, member_only]
+        ):
+            raise click.BadParameter(
+                'Konflux does not support --build, --builds-file, --attach, --use-default-advisory, --clean, --no-cdn-repos, --include-shipped or --member-only options.'
+            )
+        if kind != 'image':
+            raise click.BadParameter('Konflux only supports --kind image.')
+        return await find_builds_konflux(runtime, payload)
+
     replace_vars = runtime.group_config.vars.primitive() if runtime.group_config.vars else {}
     et_data = runtime.get_errata_config(replace_vars=replace_vars)
     tag_pv_map = et_data.get('brew_tag_product_version_mapping')
@@ -662,3 +675,26 @@ def _filter_out_attached_builds(
         if not in_same_version:
             unattached_builds.append(b)
     return unattached_builds, attached_to_advisories
+
+
+async def find_builds_konflux(runtime, payload):
+    """
+    Find konflux builds for group/assembly
+    """
+
+    runtime.konflux_db.bind(KonfluxBuildRecord)
+
+    image_metas: List[ImageMetadata] = []
+    for image in runtime.image_metas():
+        if image.base_only or not image.is_release:
+            continue
+        if not (payload and image.is_payload):
+            continue
+        image_metas.append(image)
+
+    LOGGER.info("Fetching NVRs from DB...")
+    tasks = [image.get_latest_build(el_target=image.branch_el_target()) for image in image_metas]
+    records: List[Dict] = list(await asyncio.gather(*tasks))
+
+    for record in records:
+        print(record.nvr)

--- a/elliott/tests/test_find_builds_cli.py
+++ b/elliott/tests/test_find_builds_cli.py
@@ -1,11 +1,15 @@
 import asyncio
 import unittest
-from unittest import mock
+from unittest import IsolatedAsyncioTestCase, mock
 
 from elliottlib import errata as erratalib
 from elliottlib.brew import Build
 from elliottlib.cli.find_builds_cli import _filter_out_attached_builds, _find_shipped_builds, find_builds_konflux
 from flexmock import flexmock
+
+
+async def _async_return_val(val):
+    return val
 
 
 class TestFindBuildsCli(unittest.TestCase):
@@ -49,36 +53,27 @@ class TestFindBuildsCli(unittest.TestCase):
         self.assertEqual(expected, actual)
         get_builds_tags.assert_called_once_with(build_ids, mock.ANY)
 
+
+class TestFindBuildsKonflux(IsolatedAsyncioTestCase):
     @mock.patch("elliottlib.cli.find_builds_cli.KonfluxBuildRecord")
-    def test_find_builds_konflux(self, MockKonfluxBuildRecord: mock.MagicMock):
-        runtime = flexmock.flexmock()
-        runtime.should_receive("konflux_db.bind").with_args(MockKonfluxBuildRecord).once()
+    async def test_find_builds_konflux(self, MockKonfluxBuildRecord: mock.MagicMock):
+        runtime = flexmock(konflux_db=flexmock())
+        runtime.konflux_db.should_receive("bind").with_args(MockKonfluxBuildRecord)
 
-        image_meta_1 = flexmock.flexmock(base_only=False, is_release=True, is_payload=True, distgit_key="image1")
-        image_meta_1.should_receive("branch_el_target").and_return("el8").once()
+        image_meta_1 = flexmock(base_only=False, is_release=True, is_payload=True, distgit_key="image1")
+        image_meta_1.should_receive("branch_el_target").and_return("el8")
         image_meta_1.should_receive("get_latest_build").with_args(el_target="el8").and_return(
-            flexmock.flexmock(nvr="image1-1.0.0-1.el8")
-        ).once()
+            _async_return_val(flexmock(nvr="image1-1.0.0-1.el8"))
+        )
 
-        image_meta_2 = flexmock.flexmock(base_only=False, is_release=True, is_payload=False, distgit_key="image2")
-        image_meta_2.should_receive("branch_el_target").and_return("el9").once()
+        image_meta_2 = flexmock(base_only=False, is_release=True, is_payload=False, distgit_key="image2")
+        image_meta_2.should_receive("branch_el_target").and_return("el9")
         image_meta_2.should_receive("get_latest_build").with_args(el_target="el9").and_return(
-            flexmock.flexmock(nvr="image2-2.0.0-1.el9")
-        ).once()
+            _async_return_val(flexmock(nvr="image2-2.0.0-1.el9"))
+        )
 
-        image_meta_3 = flexmock.flexmock(base_only=True, is_release=True, is_payload=True, distgit_key="image3")
-        image_meta_3.should_receive("branch_el_target").never()
-        image_meta_3.should_receive("get_latest_build").never()
-
-        image_meta_4 = flexmock.flexmock(base_only=False, is_release=False, is_payload=True, distgit_key="image4")
-        image_meta_4.should_receive("branch_el_target").never()
-        image_meta_4.should_receive("get_latest_build").never()
-
-        # Scenario 1: payload = True (only image1 should be processed)
-        runtime.should_receive("image_metas").and_return(
-            [image_meta_1, image_meta_2, image_meta_3, image_meta_4]
-        ).once()
-        actual_records = asyncio.run(find_builds_konflux(runtime, payload=True))
+        runtime.should_receive("image_metas").and_return([image_meta_1, image_meta_2])
+        actual_records = await find_builds_konflux(runtime, payload=True)
         self.assertEqual(len(actual_records), 1)
         self.assertEqual(actual_records[0].nvr, "image1-1.0.0-1.el8")
 


### PR DESCRIPTION
Test:

```yaml
releases:
  4.18.100:
    assembly:
      basis:
        reference_releases:
          aarch64: 4.18.0-0.konflux-nightly-arm64-2025-04-24-065555
          x86_64: 4.18.0-0.konflux-nightly-2025-04-24-065624
        time: 2025-04-24 05:59:34+00:00
...
```

Works with pinned builds as well

```
elliott --group openshift-4.18 --assembly 4.18.100 --build-system konflux --data-path .
./ocp-build-data find-builds -k image --non-payload
2025-05-06 16:29:44,008 artcommonlib INFO Konflux DB initialized 
2025-05-06 16:29:44,087 art_tools.artcommonlib.exectools INFO $0: ['git', '-C', '/home/sid/Projects/art/ocp-build-data', 'remote', 'get-url', 'origin'] - [cwd=None]: Executing:cmd_gather: git -C /home/sid/Projects/art/ocp-build-data remote get-url origin
2025-05-06 16:29:44,093 art_tools.artcommonlib.exectools INFO $1: ['git', '-C', '/home/sid/Projects/art/ocp-build-data', 'rev-parse', 'HEAD'] - [cwd=None]: Executing:cmd_gather: git -C /home/sid/Projects/art/ocp-build-data rev-parse HEAD
2025-05-06 16:29:44,098 art_tools.artcommonlib.exectools INFO $2: ['git', '-C', '/home/sid/Projects/art/ocp-build-data', 'rev-parse', '--abbrev-ref', 'HEAD'] - [cwd=None]: Executing:cmd_gather: git -C /home/sid/Projects/art/ocp-build-data rev-parse --abbrev-ref HEAD
2025-05-06 16:29:44,101 artcommonlib INFO On commit: 36695fad02f6fc18f7c64fc7c710a5529783cb5e (openshift-4.18)
2025-05-06 16:29:44,355 artcommonlib INFO Using branch from group.yml: rhaos-4.18-rhel-9
2025-05-06 16:29:45,158 artcommonlib INFO Constraining brew event to assembly basis for 4.18.100: 2025-04-24 05:59:34+00:00
2025-05-06 16:29:45,158 art_tools.elliottlib.cli.find_builds_cli INFO Fetching NVRs from DB...
2025-05-06 16:29:45,160 artcommonlib.konflux.konflux_db INFO Searching for cloud-event-proxy builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:46,184 artcommonlib.konflux.konflux_db INFO Searching for cluster-nfd-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:46,691 artcommonlib.konflux.konflux_db INFO Searching for clusterresourceoverride-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:47,202 artcommonlib.konflux.konflux_db INFO Searching for clusterresourceoverride builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:47,786 artcommonlib.konflux.konflux_db INFO Searching for dpu-cni builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:48,226 artcommonlib.konflux.konflux_db INFO Searching for dpu-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:48,636 artcommonlib.konflux.konflux_db INFO Searching for ib-sriov-cni builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:49,157 artcommonlib.konflux.konflux_db INFO Searching for ingress-node-firewall-daemon builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:49,660 artcommonlib.konflux.konflux_db INFO Searching for ingress-node-firewall-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:50,113 artcommonlib.konflux.konflux_db INFO Searching for kube-compare-artifacts builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:50,567 artcommonlib.konflux.konflux_db INFO Searching for local-storage-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:51,196 artcommonlib.konflux.konflux_db INFO Searching for openshift-enterprise-cluster-capacity builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:51,678 artcommonlib.konflux.konflux_db INFO Searching for openshift-enterprise-helm-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:52,116 artcommonlib.konflux.konflux_db INFO Searching for ose-aws-efs-csi-driver-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:52,630 artcommonlib.konflux.konflux_db INFO Searching for ose-aws-efs-csi-driver builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:53,038 artcommonlib.konflux.konflux_db INFO Searching for ose-gcp-filestore-csi-driver-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:53,518 artcommonlib.konflux.konflux_db INFO Searching for ose-metallb-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:54,061 artcommonlib.konflux.konflux_db INFO Searching for ose-secrets-store-csi-driver-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:54,473 artcommonlib.konflux.konflux_db INFO Searching for ose-smb-csi-driver-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:54,984 artcommonlib.konflux.konflux_db INFO Searching for ose-sriov-network-metrics-exporter builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:55,360 artcommonlib.konflux.konflux_db INFO Searching for ose-sriov-rdma-cni builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:55,786 artcommonlib.konflux.konflux_db INFO Searching for pf-status-relay-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:56,316 artcommonlib.konflux.konflux_db INFO Searching for pf-status-relay builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:56,726 artcommonlib.konflux.konflux_db INFO Searching for ptp-operator-must-gather builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:57,145 artcommonlib.konflux.konflux_db INFO Searching for sriov-cni builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:57,586 artcommonlib.konflux.konflux_db INFO Searching for sriov-dp-admission-controller builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:58,161 artcommonlib.konflux.konflux_db INFO Searching for sriov-network-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:58,673 artcommonlib.konflux.konflux_db INFO Searching for sriov-network-webhook builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:59,083 artcommonlib.konflux.konflux_db INFO Searching for vertical-pod-autoscaler-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:59,515 artcommonlib.konflux.konflux_db INFO Searching for vertical-pod-autoscaler builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:29:59,896 artcommonlib.konflux.konflux_db INFO Searching for dpu-daemon builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:00,384 artcommonlib.konflux.konflux_db INFO Searching for linuxptp-daemon builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:01,539 artcommonlib.konflux.konflux_db INFO Searching for local-storage-diskmaker builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:02,051 artcommonlib.konflux.konflux_db INFO Searching for local-storage-mustgather builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:02,461 artcommonlib.konflux.konflux_db INFO Searching for nmstate-console-plugin builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:02,972 artcommonlib.konflux.konflux_db INFO Searching for node-feature-discovery builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:03,413 artcommonlib.konflux.konflux_db INFO Searching for openshift-enterprise-ansible-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:03,822 artcommonlib.konflux.konflux_db INFO Searching for openshift-enterprise-egress-dns-proxy builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:04,304 artcommonlib.konflux.konflux_db INFO Searching for openshift-enterprise-egress-router builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:04,807 artcommonlib.konflux.konflux_db INFO Searching for openshift-enterprise-operator-sdk builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:05,328 artcommonlib.konflux.konflux_db INFO Searching for openshift-kubernetes-nmstate-handler builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:05,838 artcommonlib.konflux.konflux_db INFO Searching for openshift-kubernetes-nmstate-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:06,352 artcommonlib.konflux.konflux_db INFO Searching for ose-egress-http-proxy builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:06,864 artcommonlib.konflux.konflux_db INFO Searching for ose-gcp-filestore-csi-driver builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:07,375 artcommonlib.konflux.konflux_db INFO Searching for ose-metallb builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:07,815 artcommonlib.konflux.konflux_db INFO Searching for ose-secrets-store-csi-driver builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:08,195 artcommonlib.konflux.konflux_db INFO Searching for ose-secrets-store-csi-mustgather builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:08,605 artcommonlib.konflux.konflux_db INFO Searching for ose-smb-csi-driver builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:09,017 artcommonlib.konflux.konflux_db INFO Searching for ptp-operator builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:09,396 artcommonlib.konflux.konflux_db INFO Searching for sriov-network-config-daemon builds completed before 2025-04-24 05:59:34+00:00
2025-05-06 16:30:09,917 artcommonlib.konflux.konflux_db INFO Searching for sriov-network-device-plugin builds completed before 2025-04-24 05:59:34+00:00
cloud-event-proxy-v4.18.0-202504231922.p2.g15bc9b7.assembly.stream.el9
cluster-nfd-operator-v4.18.0-202504231922.p2.g81dbe28.assembly.stream.el9
clusterresourceoverride-operator-v4.18.0-202504231922.p2.g1777e1b.assembly.stream.el9
clusterresourceoverride-v4.18.0-202504231922.p2.g513e458.assembly.stream.el9
dpu-cni-v4.18.0-202504231922.p2.g99f3e30.assembly.stream.el9
dpu-operator-v4.18.0-202504231922.p2.g99f3e30.assembly.stream.el9
ib-sriov-cni-v4.18.0-202504231922.p2.gc0d7e06.assembly.stream.el9
ingress-node-firewall-daemon-v4.18.0-202504231922.p2.g1e43b4c.assembly.stream.el9
ingress-node-firewall-operator-v4.18.0-202504231922.p2.g1e43b4c.assembly.stream.el9
kube-compare-artifacts-v4.18.0-202504231922.p2.g5f72471.assembly.stream.el9
local-storage-operator-v4.18.0-202504231922.p2.g90b710f.assembly.stream.el9
openshift-enterprise-cluster-capacity-v4.18.0-202504231922.p2.gbe5401d.assembly.stream.el9
openshift-enterprise-helm-operator-v4.18.0-202504231922.p2.gce80aa9.assembly.stream.el9
ose-aws-efs-csi-driver-operator-v4.18.0-202504231922.p2.gcdc9d64.assembly.stream.el9
ose-aws-efs-csi-driver-v4.18.0-202504231922.p2.gcaf6889.assembly.stream.el9
ose-gcp-filestore-csi-driver-operator-v4.18.0-202504231922.p2.g3a8419f.assembly.stream.el9
ose-metallb-operator-v4.18.0-202504231922.p2.gff92846.assembly.stream.el9
ose-secrets-store-csi-driver-operator-v4.18.0-202504231922.p2.g2aac830.assembly.stream.el9
ose-smb-csi-driver-operator-v4.18.0-202504231922.p2.gcdc9d64.assembly.stream.el9
ose-sriov-network-metrics-exporter-v4.18.0-202504231922.p2.gf54736e.assembly.stream.el9
ose-sriov-rdma-cni-v4.18.0-202504231922.p2.gf8e5d55.assembly.stream.el9
pf-status-relay-operator-v4.18.0-202504231922.p2.gc20e0b7.assembly.stream.el9
pf-status-relay-v4.18.0-202504231922.p2.g8b14c8e.assembly.stream.el9
ptp-operator-must-gather-v4.18.0-202504231922.p2.gd47aaca.assembly.stream.el9
sriov-cni-v4.18.0-202504231922.p2.gde7e135.assembly.stream.el9
sriov-dp-admission-controller-v4.18.0-202504231922.p2.ga55be06.assembly.stream.el9
sriov-network-operator-v4.18.0-202504231922.p2.g8a577a5.assembly.stream.el9
sriov-network-webhook-v4.18.0-202504231922.p2.g8a577a5.assembly.stream.el9
vertical-pod-autoscaler-operator-v4.18.0-202504231922.p2.g4966916.assembly.stream.el9
vertical-pod-autoscaler-v4.18.0-202504231922.p2.gd1afaf4.assembly.stream.el9
dpu-daemon-v4.18.0-202504231922.p2.g99f3e30.assembly.stream.el9
linuxptp-daemon-v4.18.0-202504231922.p2.g2e84f0b.assembly.stream.el9
local-storage-diskmaker-v4.18.0-202504231922.p2.g90b710f.assembly.stream.el9
local-storage-mustgather-v4.18.0-202504231922.p2.g90b710f.assembly.stream.el9
nmstate-console-plugin-v4.18.0-202504231922.p2.g9f866a2.assembly.stream.el9
node-feature-discovery-v4.18.0-202504231922.p2.g939df7b.assembly.stream.el9
openshift-enterprise-ansible-operator-v4.18.0-202504231922.p2.gb276665.assembly.stream.el9
openshift-enterprise-egress-dns-proxy-v4.18.0-202504231922.p2.g716eb0e.assembly.stream.el9
openshift-enterprise-egress-router-v4.18.0-202504231922.p2.g716eb0e.assembly.stream.el9
openshift-enterprise-operator-sdk-v4.18.0-202504231922.p2.gce80aa9.assembly.stream.el9
openshift-kubernetes-nmstate-handler-v4.18.0-202504231922.p2.g2179860.assembly.stream.el9
openshift-kubernetes-nmstate-operator-v4.18.0-202504231922.p2.g2179860.assembly.stream.el9
ose-egress-http-proxy-v4.18.0-202504231922.p2.g716eb0e.assembly.stream.el9
ose-gcp-filestore-csi-driver-v4.18.0-202504231922.p2.g38ef2d6.assembly.stream.el9
ose-metallb-v4.18.0-202504231922.p2.gc216036.assembly.stream.el9
ose-secrets-store-csi-driver-v4.18.0-202504231922.p2.gad04a75.assembly.stream.el9
ose-secrets-store-csi-mustgather-v4.18.0-202504231922.p2.g2aac830.assembly.stream.el9
ose-smb-csi-driver-v4.18.0-202504231922.p2.gf54b02e.assembly.stream.el9
ptp-operator-v4.18.0-202504231922.p2.gd47aaca.assembly.stream.el9
sriov-network-config-daemon-v4.18.0-202504231922.p2.g8a577a5.assembly.stream.el9
sriov-network-device-plugin-v4.18.0-202504231922.p2.g33b394e.assembly.stream.el9
```