### PR TITLE
OCPBUGS-55823: clean up temporary files

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -968,7 +968,7 @@ class KonfluxRebaser:
             gomod_deps_path.joinpath('cachito.env').touch(exist_ok=True)
 
             # The value we will set REMOTE_SOURCES_DIR to.
-            remote_source_dir_env = '/tmp/cachito-emulation'
+            remote_source_dir_env = '/tmp/art/cachito-emulation'
             pkg_managers = metadata.config.content.source.pkg_managers.primitive()
 
             if "npm" in pkg_managers:
@@ -1037,7 +1037,7 @@ class KonfluxRebaser:
         if network_mode != "hermetic":
             konflux_lines += [
                 "USER 0",
-                "RUN mkdir -p /tmp/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/yum_temp/ || true",
+                "RUN mkdir -p /tmp/art/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/art/yum_temp/ || true",
                 f"COPY .oit/{self.repo_type}.repo /etc/yum.repos.d/",
                 f"ADD {constants.KONFLUX_REPO_CA_BUNDLE_HOST}/{constants.KONFLUX_REPO_CA_BUNDLE_FILENAME} {constants.KONFLUX_REPO_CA_BUNDLE_TMP_PATH}",
             ]
@@ -1090,7 +1090,8 @@ class KonfluxRebaser:
             lines = [
                 "\n# Start Konflux-specific steps",
                 "USER 0",
-                "RUN rm -f /etc/yum.repos.d/* && cp /tmp/yum_temp/* /etc/yum.repos.d/ || true",
+                "RUN rm -f /etc/yum.repos.d/* && cp /tmp/art/yum_temp/* /etc/yum.repos.d/ || true",
+                "RUN rm -rf /tmp/art",
                 f"{user_to_set if user_to_set else ''}",
                 "# End Konflux-specific steps\n\n",
             ]

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -27,7 +27,7 @@ BREW_BUILD_TIMEOUT = 100 * 60 * 60  # how long we wait before canceling a task
 # is specified for CA cert, so that 'sslverify=true' can be used in yum repos.
 # To achieve the same in Konflux, we need to 'ADD tls-ca-bundle.pem /tmp/tls-ca-bundle.pem' in every Dockerfile stage
 # and set 'sslcacert=/tmp/Current-IT-Root-CAs.pem'
-KONFLUX_REPO_CA_BUNDLE_TMP_PATH = "/tmp"
+KONFLUX_REPO_CA_BUNDLE_TMP_PATH = "/tmp/art"
 KONFLUX_REPO_CA_BUNDLE_FILENAME = "Current-IT-Root-CAs.pem"
 KONFLUX_REPO_CA_BUNDLE_HOST = "https://certs.corp.redhat.com/certs"
 WORKING_SUBDIR_KONFLUX_BUILD_SOURCES = "konflux_build_sources"

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -69,9 +69,9 @@ ENV ART_BUILD_DEPS_METHOD=cachi2
 ENV ART_BUILD_NETWORK=open
 ENV ART_BUILD_DEPS_MODE=default
 USER 0
-RUN mkdir -p /tmp/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/yum_temp/ || true
+RUN mkdir -p /tmp/art/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/art/yum_temp/ || true
 COPY .oit/unsigned.repo /etc/yum.repos.d/
-ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp
+ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp/art
 # End Konflux-specific steps
 LABEL foo="bar baz"
 USER 1000
@@ -83,9 +83,9 @@ ENV ART_BUILD_DEPS_METHOD=cachi2
 ENV ART_BUILD_NETWORK=open
 ENV ART_BUILD_DEPS_MODE=default
 USER 0
-RUN mkdir -p /tmp/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/yum_temp/ || true
+RUN mkdir -p /tmp/art/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/art/yum_temp/ || true
 COPY .oit/unsigned.repo /etc/yum.repos.d/
-ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp
+ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp/art
 # End Konflux-specific steps
 USER 2000
 RUN commands
@@ -93,7 +93,8 @@ RUN commands
 
 # Start Konflux-specific steps
 USER 0
-RUN rm -f /etc/yum.repos.d/* && cp /tmp/yum_temp/* /etc/yum.repos.d/ || true
+RUN rm -f /etc/yum.repos.d/* && cp /tmp/art/yum_temp/* /etc/yum.repos.d/ || true
+RUN rm -rf /tmp/art
 USER 2000
 # End Konflux-specific steps
 """
@@ -129,9 +130,9 @@ ENV ART_BUILD_DEPS_METHOD=cachi2
 ENV ART_BUILD_NETWORK=open
 ENV ART_BUILD_DEPS_MODE=default
 USER 0
-RUN mkdir -p /tmp/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/yum_temp/ || true
+RUN mkdir -p /tmp/art/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/art/yum_temp/ || true
 COPY .oit/unsigned.repo /etc/yum.repos.d/
-ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp
+ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp/art
 # End Konflux-specific steps
 LABEL foo="bar baz"
 USER 1000
@@ -143,9 +144,9 @@ ENV ART_BUILD_DEPS_METHOD=cachi2
 ENV ART_BUILD_NETWORK=open
 ENV ART_BUILD_DEPS_MODE=default
 USER 0
-RUN mkdir -p /tmp/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/yum_temp/ || true
+RUN mkdir -p /tmp/art/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/art/yum_temp/ || true
 COPY .oit/unsigned.repo /etc/yum.repos.d/
-ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp
+ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp/art
 # End Konflux-specific steps
 USER 2000
 RUN commands
@@ -153,7 +154,8 @@ RUN commands
 
 # Start Konflux-specific steps
 USER 0
-RUN rm -f /etc/yum.repos.d/* && cp /tmp/yum_temp/* /etc/yum.repos.d/ || true
+RUN rm -f /etc/yum.repos.d/* && cp /tmp/art/yum_temp/* /etc/yum.repos.d/ || true
+RUN rm -rf /tmp/art
 USER 3000
 # End Konflux-specific steps
 """
@@ -234,9 +236,9 @@ ENV ART_BUILD_DEPS_METHOD=cachi2
 ENV ART_BUILD_NETWORK=open
 ENV ART_BUILD_DEPS_MODE=default
 USER 0
-RUN mkdir -p /tmp/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/yum_temp/ || true
+RUN mkdir -p /tmp/art/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/art/yum_temp/ || true
 COPY .oit/unsigned.repo /etc/yum.repos.d/
-ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp
+ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp/art
 # End Konflux-specific steps
 LABEL foo="bar baz"
 FROM base2
@@ -247,16 +249,17 @@ ENV ART_BUILD_DEPS_METHOD=cachi2
 ENV ART_BUILD_NETWORK=open
 ENV ART_BUILD_DEPS_MODE=default
 USER 0
-RUN mkdir -p /tmp/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/yum_temp/ || true
+RUN mkdir -p /tmp/art/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/art/yum_temp/ || true
 COPY .oit/unsigned.repo /etc/yum.repos.d/
-ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp
+ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp/art
 # End Konflux-specific steps
 RUN commands
 
 
 # Start Konflux-specific steps
 USER 0
-RUN rm -f /etc/yum.repos.d/* && cp /tmp/yum_temp/* /etc/yum.repos.d/ || true
+RUN rm -f /etc/yum.repos.d/* && cp /tmp/art/yum_temp/* /etc/yum.repos.d/ || true
+RUN rm -rf /tmp/art
 USER 3000
 # End Konflux-specific steps
 """


### PR DESCRIPTION
Keep temporary files under `/tmp/art` and clean up at the end