### PR TITLE
Deprecate bugzilla in bug sweep

### DIFF
--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -249,8 +249,6 @@ async def find_and_attach_bugs(
     runtime: Runtime,
     advisory_id,
     default_advisory_type,
-    major_version,
-    minor_version,
     find_bugs_obj,
     noop,
     permissive,
@@ -268,7 +266,7 @@ async def find_and_attach_bugs(
 
     advisory_ids = runtime.get_default_advisories()
     included_bug_ids, _ = get_assembly_bug_ids(runtime, bug_tracker_type=bug_tracker.type)
-    major_version, _ = runtime.get_major_minor()
+    major_version, minor_version = runtime.get_major_minor()
     bugs_by_type, _ = categorize_bugs_by_type(
         bugs,
         advisory_ids,

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -154,31 +154,16 @@ async def find_bugs_sweep_cli(
     find_bugs_obj.include_status(include_status)
     find_bugs_obj.exclude_status(exclude_status)
 
-    bugs: type_bug_list = []
-    errors = []
-    for b in [runtime.get_bug_tracker('jira'), runtime.get_bug_tracker('bugzilla')]:
-        try:
-            bugs.extend(
-                await find_and_attach_bugs(
-                    runtime,
-                    advisory_id,
-                    default_advisory_type,
-                    major_version,
-                    minor_version,
-                    find_bugs_obj,
-                    noop=noop,
-                    permissive=permissive,
-                    bug_tracker=b,
-                    operator_bundle_advisory=operator_bundle_advisory,
-                )
-            )
-        except Exception as e:
-            errors.append(e)
-            logger.error(traceback.format_exc())
-            logger.error(f'exception with {b.type} bug tracker: {e}')
-
-    if errors:
-        raise ElliottFatalError(f"Error finding or attaching bugs: {errors}. See logs for more information.")
+    bugs: type_bug_list = await find_and_attach_bugs(
+        runtime,
+        advisory_id,
+        default_advisory_type,
+        find_bugs_obj,
+        noop=noop,
+        permissive=permissive,
+        bug_tracker=runtime.get_bug_tracker('jira'),
+        operator_bundle_advisory=operator_bundle_advisory,
+    )
 
     if not bugs:
         logger.info('No bugs found')

--- a/elliott/tests/test_find_bugs_sweep_cli.py
+++ b/elliott/tests/test_find_bugs_sweep_cli.py
@@ -152,8 +152,10 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         flexmock(JIRABugTracker).should_receive("login").and_return(client)
         flexmock(JIRABugTracker).should_receive("search").and_return(bugs)
         flexmock(JIRABugTracker).should_receive("advisory_bug_ids").and_return([])
-        flexmock(JIRABugTracker).should_receive("attach_bugs").and_return(bugs)
         jira_filter_mock.return_value = []
+        flexmock(JIRABugTracker).should_receive("attach_bugs").with_args(
+            [b.id for b in bugs], advisory_id=123, noop=False, verbose=False
+        )
 
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:sweep', '--use-default-advisory', 'image'])
         if result.exit_code != 0:

--- a/elliott/tests/test_find_bugs_sweep_cli.py
+++ b/elliott/tests/test_find_bugs_sweep_cli.py
@@ -232,8 +232,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
             self.fail(t)
 
     @patch('elliottlib.bzutil.JIRABugTracker.filter_attached_bugs')
-    @patch('elliottlib.bzutil.BugzillaBugTracker.filter_attached_bugs')
-    def test_find_bugs_sweep_default_advisories(self, bugzilla_filter_mock, jira_filter_mock):
+    def test_find_bugs_sweep_default_advisories(self, jira_filter_mock):
         runner = CliRunner()
         image_bugs = [flexmock(id=1), flexmock(id=2)]
         rpm_bugs = [flexmock(id=3), flexmock(id=4)]
@@ -255,19 +254,13 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
             {'image': 123, 'rpm': 123, 'extras': 123, 'metadata': 123}
         )
 
-        # bz mocks
-        flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
-        flexmock(BugzillaBugTracker).should_receive("login")
-        flexmock(BugzillaBugTracker).should_receive("search").and_return(image_bugs + rpm_bugs + extras_bugs)
-        flexmock(BugzillaBugTracker).should_receive("attach_bugs").times(3).and_return()
-        bugzilla_filter_mock.return_value = []
-
         # jira mocks
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         client = flexmock()
         flexmock(client).should_receive("fields").and_return([])
         flexmock(JIRABugTracker).should_receive("login").and_return(client)
-        flexmock(JIRABugTracker).should_receive("search").and_return([])
+        flexmock(JIRABugTracker).should_receive("search").and_return(image_bugs + rpm_bugs + extras_bugs)
+        flexmock(JIRABugTracker).should_receive("attach_bugs").times(3).and_return()
         jira_filter_mock.return_value = []
 
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:sweep', '--into-default-advisories'])

--- a/elliott/tests/test_find_bugs_sweep_cli.py
+++ b/elliott/tests/test_find_bugs_sweep_cli.py
@@ -136,7 +136,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
     @patch('elliottlib.bzutil.JIRABugTracker.filter_attached_bugs')
     def test_find_bugs_sweep_advisory_type(self, jira_filter_mock):
         runner = CliRunner()
-        bugs = [flexmock(id='BZ1')]
+        bugs = [flexmock(id='OCPBUGS-1')]
 
         # common mocks
         flexmock(Runtime).should_receive("initialize")
@@ -150,9 +150,9 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         client = flexmock()
         flexmock(client).should_receive("fields").and_return([])
         flexmock(JIRABugTracker).should_receive("login").and_return(client)
-        flexmock(JIRABugTracker).should_receive("search").and_return([])
+        flexmock(JIRABugTracker).should_receive("search").and_return(bugs)
         flexmock(JIRABugTracker).should_receive("advisory_bug_ids").and_return([])
-        flexmock(JIRABugTracker).should_receive("attach_bugs").and_return()
+        flexmock(JIRABugTracker).should_receive("attach_bugs").and_return(bugs)
         jira_filter_mock.return_value = []
 
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:sweep', '--use-default-advisory', 'image'])


### PR DESCRIPTION
This is in preparation for returning structured json output in the find-bugs:sweep command,
which will be used in the prepare-release-konflux pipeline to prepare shipment.

Removing bugzilla in sweep will remove complexity and branching when dumping output.

Bugzilla is deprecated inside RedHat for filing normal bugs, and is only used for cve bugs only.
So it should be safe to remove from find-bugs:sweep