### PR TITLE
Enable defaults for shipment config init

### DIFF
--- a/artcommon/artcommonlib/gitdata.py
+++ b/artcommon/artcommonlib/gitdata.py
@@ -195,10 +195,13 @@ class GitData(object):
         if not os.path.isdir(self.data_dir):
             raise GitDataPathException('{} is not a valid sub-directory in the data'.format(self.sub_dir))
 
-    def load_yaml_file(self, file_path):
+    def load_yaml_file(self, file_path, strict=True):
         full_path = os.path.join(self.data_dir, file_path)
         if not os.path.isfile(full_path):
-            raise ValueError(f"Could not find file at {full_path}")
+            if strict:
+                raise ValueError(f"Could not find file at {full_path}")
+            else:
+                return None
 
         with io.open(full_path, 'r', encoding="utf-8") as f:
             raw_text = f.read()

--- a/elliott/elliottlib/cli/shipment_cli.py
+++ b/elliott/elliottlib/cli/shipment_cli.py
@@ -2,7 +2,6 @@ import sys
 
 import click
 from artcommonlib import logutil
-from artcommonlib.model import Model
 from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
 from ruamel.yaml import YAML
 

--- a/elliott/elliottlib/cli/shipment_cli.py
+++ b/elliott/elliottlib/cli/shipment_cli.py
@@ -58,7 +58,7 @@ class InitShipmentCli:
         # if stage/prod rpa are not given in cli, try to load them from shipment repo config
         # where defaults are set per application
         if not (self.stage_rpa and self.prod_rpa):
-            shipment_config = self.runtime.shipment_gitdata.load_yaml_file('config.yaml') or {}
+            shipment_config = self.runtime.shipment_gitdata.load_yaml_file('config.yaml', strict=False) or {}
             app_env_config = shipment_config.get("applications", {}).get(self.application, {}).get("environments", {})
             self.stage_rpa = self.stage_rpa or app_env_config.get("stage", {}).get("releasePlan", "test-stage-rpa")
             self.prod_rpa = self.prod_rpa or app_env_config.get("prod", {}).get("releasePlan", "test-prod-rpa")

--- a/elliott/elliottlib/cli/shipment_cli.py
+++ b/elliott/elliottlib/cli/shipment_cli.py
@@ -2,6 +2,7 @@ import sys
 
 import click
 from artcommonlib import logutil
+from artcommonlib.model import Model
 from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
 from ruamel.yaml import YAML
 
@@ -44,15 +45,23 @@ class InitShipmentCli:
         advisory_key: str,
     ):
         self.runtime = runtime
-        self.application = application
-        self.snapshot = snapshot
+        self.application = application or KonfluxImageBuilder.get_application_name(self.runtime.group)
+        self.snapshot = snapshot or "test-snapshot"
         self.stage_rpa = stage_rpa
         self.prod_rpa = prod_rpa
         self.for_fbc = for_fbc
         self.advisory_key = advisory_key
 
     async def run(self):
-        self.runtime.initialize()
+        self.runtime.initialize(with_shipment=True)
+
+        # if stage/prod rpa are not given in cli, try to load them from shipment repo config
+        # where defaults are set per application
+        if not (self.stage_rpa and self.prod_rpa):
+            shipment_config = self.runtime.shipment_gitdata.load_yaml_file('config.yaml') or {}
+            app_env_config = shipment_config.get("applications", {}).get(self.application, {}).get("environments", {})
+            self.stage_rpa = self.stage_rpa or app_env_config.get("stage", {}).get("releasePlan", "test-stage-rpa")
+            self.prod_rpa = self.prod_rpa or app_env_config.get("prod", {}).get("releasePlan", "test-prod-rpa")
 
         data = None
         if not self.for_fbc:
@@ -84,21 +93,20 @@ class InitShipmentCli:
                     ),
                 )
 
-        default_application = KonfluxImageBuilder.get_application_name(self.runtime.group)
         shipment = ShipmentConfig(
             shipment=Shipment(
                 metadata=Metadata(
                     product=self.runtime.product,
-                    application=self.application or default_application,
+                    application=self.application,
                     group=self.runtime.group,
                     assembly=self.runtime.assembly,
                     fbc=self.for_fbc,
                 ),
                 environments=Environments(
-                    stage=ShipmentEnv(releasePlan=self.stage_rpa or "test-stage-rpa"),
-                    prod=ShipmentEnv(releasePlan=self.prod_rpa or "test-prod-rpa"),
+                    stage=ShipmentEnv(releasePlan=self.stage_rpa),
+                    prod=ShipmentEnv(releasePlan=self.prod_rpa),
                 ),
-                snapshot=Snapshot(name=self.snapshot or "test-snapshot", spec=Spec(nvrs=[])),
+                snapshot=Snapshot(name=self.snapshot, spec=Spec(nvrs=[])),
                 data=data,
             ),
         )

--- a/elliott/elliottlib/runtime.py
+++ b/elliott/elliottlib/runtime.py
@@ -384,20 +384,6 @@ class Runtime(GroupRuntime):
             if '@' in self.shipment_path:
                 shipment_path, commitish = self.shipment_path.split('@')
 
-            # TODO: find a better solution
-            if 'gitlab.cee.redhat.com' in shipment_path:
-                gitlab_auth_token = os.environ.get('GITLAB_TOKEN')
-                if not gitlab_auth_token:
-                    self._logger.info("GITLAB_TOKEN not found to be set")
-                else:
-                    try:
-                        parsed_url = urlparse(shipment_path)
-                        scheme = parsed_url.scheme
-                        rest_of_the_url = shipment_path[len(scheme + "://") :]
-                        shipment_path = f'https://oauth2:{gitlab_auth_token}@{rest_of_the_url}'
-                    except Exception as e:
-                        self._logger.warning(f"Failed to use GITLAB_TOKEN env var to clone {shipment_path}: {e}")
-
             try:
                 self.shipment_gitdata = gitdata.GitData(
                     data_path=shipment_path, clone_dir=self.working_dir, commitish=commitish, logger=self._logger


### PR DESCRIPTION
This is to have default RP's set per application in shipment-data repo

Test:

https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/20

```
$ elliott -g openshift-4.18 --assembly 4.18.3 --shipment-path https://gitlab.cee.red
hat.com/sidsharm/ocp-shipment-data@add_config shipment init --advisory-key image
...
shipment:
  metadata:
    product: ocp
    application: openshift-4-18
    group: openshift-4.18
    assembly: 4.18.3
    fbc: false
  environments:
    stage:
      releasePlan: ocp-art-advisory-stage-4-18
    prod:
      releasePlan: ocp-art-advisory-prod-4-18
  snapshot:
    name: test-snapshot
    spec:
      nvrs: []
...
```