### PR TITLE
[konflux] slsa attestation raise exception

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -454,6 +454,6 @@ async def get_konflux_slsa_attestation(pull_spec: str, registry_username: str, r
     Retrieve the SLSA attestation: https://konflux.pages.redhat.com/docs/users/metadata/attestations.html
     """
     cmd = f"cosign download attestation {pull_spec} --registry-username {registry_username} --registry-password {registry_password}"
-    rc, out, err = await cmd_gather_async(cmd, check=False)
+    _, out, _ = await cmd_gather_async(cmd)
 
-    return rc, out.strip(), err
+    return out.strip()

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -212,14 +212,15 @@ class KonfluxImageBuilder:
                         (r['value'] for r in pipelinerun.status.results if r['name'] == 'IMAGE_URL'), None
                     )
                     # Get SLA attestation from konflux. The command will error out if it cannot find it.
-                    rc, _, err = await artlib_util.get_konflux_slsa_attestation(
-                        pull_spec=image_pullspec,
-                        registry_username=self._config.image_repo_creds["username"],
-                        registry_password=self._config.image_repo_creds["password"],
-                    )
-                    if rc != 0:
+                    try:
+                        await artlib_util.get_konflux_slsa_attestation(
+                            pull_spec=image_pullspec,
+                            registry_username=self._config.image_repo_creds["username"],
+                            registry_password=self._config.image_repo_creds["password"],
+                        )
+                    except Exception as e:
                         logger.error(
-                            f"Failed to get SLA attestation from konflux for image {image_pullspec}, marking build as {KonfluxBuildOutcome.FAILURE}. Error: {err}"
+                            f"Failed to get SLA attestation from konflux for image {image_pullspec}, marking build as {KonfluxBuildOutcome.FAILURE}. Error: {e}"
                         )
                         outcome = KonfluxBuildOutcome.FAILURE
 

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -465,16 +465,13 @@ class ConfigScanSources:
         network_mode = image_meta.get_konflux_network_mode()
         self.logger.debug(f"Network mode of {image_meta.name} in config is {network_mode}")
         build_record = self.latest_image_build_records_map[image_meta.distgit_key]
-        rc, attestation, err = await artcommonlib.util.get_konflux_slsa_attestation(
+
+        # get_konflux_slsa_attestation command will raise an exception if it cannot find the attestation
+        attestation = await artcommonlib.util.get_konflux_slsa_attestation(
             pull_spec=build_record.image_pullspec,
             registry_username=self.art_images_username,
             registry_password=self.art_images_password,
         )
-
-        if rc != 0:
-            self.logger.error(
-                f"Failed to get SLA attestation from konflux for image {build_record.image_pullspec}. Error: {err}"
-            )
 
         try:
             # Equivalent bash code: jq -r ' .payload | @base64d | fromjson | .predicate.invocation.parameters.hermetic'


### PR DESCRIPTION
Looks like there is a 1-3 second delay from when the PLR completes and the attestation is created.

`@retry(reraise=True, wait=wait_fixed(10), stop=stop_after_attempt(3))` can retry it after 10 seconds, but the subcommand needs to raise an exception first