### PR TITLE
Add future to artcommon requirements

### DIFF
--- a/artcommon/requirements.txt
+++ b/artcommon/requirements.txt
@@ -1,3 +1,4 @@
+future
 google-api-core
 google-auth
 google-cloud-bigquery


### PR DESCRIPTION
`future` is getting installed somewhere else, but artcommonlib needs it and this is breaking art-build-history that only install artcommon requirements