### PR TITLE
use split instead of strip

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -515,7 +515,7 @@ class KonfluxImageBuilder:
                             # get the source rpm
                             source_rpm = purl.qualifiers.get("upstream", None)
                             if source_rpm:
-                                source_rpms.add(source_rpm.rstrip(".src.rpm"))
+                                source_rpms.add(source_rpm.split(".src.rpm")[0])
                     except Exception as e:
                         logger.warning(f"Failed to parse purl: {x['purl']} {e}")
                         continue

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -515,7 +515,7 @@ class KonfluxImageBuilder:
                             # get the source rpm
                             source_rpm = purl.qualifiers.get("upstream", None)
                             if source_rpm:
-                                source_rpms.add(source_rpm.split(".src.rpm")[0])
+                                source_rpms.add(source_rpm. removesuffix(".src.rpm"))
                     except Exception as e:
                         logger.warning(f"Failed to parse purl: {x['purl']} {e}")
                         continue


### PR DESCRIPTION
[libreswan-5.2-1.el9fdp](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3562713) is being stored in the database as `libreswan-5.2-1.el9fd` in the database (https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=ose-ovn-kubernetes-v4.20.0-202505090050.p2.g4789689.assembly.stream.el9&outcome=success). i.e. the `p` at the end of the NVR is missing.

Seems like its cause of the `rstrip` method
```
> print("libreswan-5.2-1.el9fdp.src.rpm".rstrip(".src.rpm"))
libreswan-5.2-1.el9fd
```