### PR TITLE
Temporarily run FIPS scan in dry-run mode

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline-task.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/fips-scanning/pipeline-task.yaml
@@ -28,7 +28,7 @@ spec:
         pip install stomp.py==8.1.0
         pip install setuptools==70.0.0
 
-        artcd -vv scan-fips --data-path $(params.data_path) --all-images
+        artcd -vv --dry-run scan-fips --data-path $(params.data_path) --all-images
 
       securityContext:
         runAsGroup: 0


### PR DESCRIPTION
Temporarily run FIPS scan in dry-run mode until retry logic (and message improvements) are implemented to reduce Slack spam caused by false negatives 