### PR TITLE
bigger vm for arm default builds

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -43,7 +43,7 @@ class KonfluxClient:
         "x86_64": ["linux/x86_64"],
         "s390x": ["linux/s390x"],
         "ppc64le": ["linux/ppc64le"],
-        "aarch64": ["linux/arm64"],
+        "aarch64": ["linux-mxlarge/arm64"],
     }
 
     def __init__(


### PR DESCRIPTION
https://konflux.pages.redhat.com/docs/users/getting-started/multi-platform-builds.html

Since max instances is same for both, we should be good.

- https://github.com/redhat-appstudio/infra-deployments/blob/main/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml#L73
- https://github.com/redhat-appstudio/infra-deployments/blob/main/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml#L114