### PR TITLE
ART-12702 support new rhcos build name

### DIFF
--- a/artcommon/artcommonlib/rhcos.py
+++ b/artcommon/artcommonlib/rhcos.py
@@ -99,7 +99,12 @@ def get_build_id_from_rhcos_pullspec(pullspec):
     image_info = Model(json.loads(image_info_str))
     labels = image_info.config.config.Labels
 
-    if not (build_id := labels.get('org.opencontainers.image.version', None)):
+    # for layered rhcos it has label coreos.build.manifest-list-tag=4.19-9.6-202505081313-node-image-extensions
+    # brew build name looks like rhcos-x86_64-4.19.9.6.202505081313-0 we need build_id 4.19.9.6.202505081313-0
+    if manifest_tag := labels.get('coreos.build.manifest-list-tag'):
+        list_tag = manifest_tag.split('-')
+        build_id = f"{list_tag[0]}.{list_tag[1]}.{list_tag[2]}-0"
+    elif not (build_id := labels.get('org.opencontainers.image.version', None)):
         build_id = labels.version
 
     if not build_id:


### PR DESCRIPTION
Add support for layered rhcos image,
the brew build name follow the format rhcos-$arch-$ocp_major.$ocp_minor.$rhel_major.$rhel_minor.$timestamp-0

test with https://errata.devel.redhat.com/advisory/144055#c443