### PR TITLE
Sync konflux builds to default imagestream for 4.20

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -34,3 +34,6 @@ REDIS_PORT = '6379'
 
 # Telemetry
 OTEL_EXPORTER_OTLP_ENDPOINT = "http://otel-collector-psi-rhv.hosts.prod.psi.rdu2.redhat.com:4317"
+
+# Sync konflux builds to default (formerly Brew) imagestreams for versions in this list
+KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS = ["4.20"]

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -34,6 +34,7 @@ from doozerlib.assembly_inspector import AssemblyInspector
 from doozerlib.brew import KojiWrapperMetaReturn
 from doozerlib.build_info import BuildRecordInspector, ImageInspector
 from doozerlib.cli import cli, click_coroutine, pass_runtime
+from doozerlib.constants import KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.image import ImageMetadata
 from doozerlib.rhcos import RHCOSBuildInspector
@@ -236,7 +237,7 @@ def default_imagestream_base_name(version: str, runtime: Runtime) -> str:
 
 
 def default_imagestream_base_name_generic(version: str, build_system) -> str:
-    if build_system == 'brew':
+    if version in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS or build_system == 'brew':
         return f"{version}-art-latest"
     else:  # konflux
         return f"{version}-konflux-art-latest"
@@ -252,7 +253,7 @@ def assembly_imagestream_base_name(runtime: Runtime) -> str:
 def assembly_imagestream_base_name_generic(version, assembly_name, assembly_type, build_system):
     if assembly_name == 'stream' and assembly_type is AssemblyTypes.STREAM:
         return default_imagestream_base_name_generic(version, build_system)
-    elif build_system == 'brew':
+    elif version in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS or build_system == 'brew':
         return f"{version}-art-assembly-{assembly_name}"
     else:  # konflux
         return f"{version}-konflux-art-assembly-{assembly_name}"

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -18,6 +18,7 @@ import yaml
 from artcommonlib import exectools, rhcos
 from artcommonlib.arch_util import brew_arch_for_go_arch, go_arch_for_brew_arch, go_suffix_for_arch
 from artcommonlib.assembly import AssemblyIssue, AssemblyIssueCode, AssemblyTypes, assembly_basis
+from artcommonlib.constants import KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS
 from artcommonlib.exectools import manifest_tool
 from artcommonlib.format_util import red_print
 from artcommonlib.konflux.package_rpm_finder import PackageRpmFinder
@@ -34,7 +35,6 @@ from doozerlib.assembly_inspector import AssemblyInspector
 from doozerlib.brew import KojiWrapperMetaReturn
 from doozerlib.build_info import BuildRecordInspector, ImageInspector
 from doozerlib.cli import cli, click_coroutine, pass_runtime
-from doozerlib.constants import KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.image import ImageMetadata
 from doozerlib.rhcos import RHCOSBuildInspector

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -56,3 +56,6 @@ REGISTRY_PROXY_BASE_URL = "registry-proxy.engineering.redhat.com"
 BREW_REGISTRY_BASE_URL = "brew.registry.redhat.io"
 
 ART_BUILD_HISTORY_URL = 'https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com'
+
+# Sync konflux builds to default (formerly Brew) imagestreams for versions in this list
+KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS = ["4.20"]

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -56,6 +56,3 @@ REGISTRY_PROXY_BASE_URL = "registry-proxy.engineering.redhat.com"
 BREW_REGISTRY_BASE_URL = "brew.registry.redhat.io"
 
 ART_BUILD_HISTORY_URL = 'https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com'
-
-# Sync konflux builds to default (formerly Brew) imagestreams for versions in this list
-KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS = ["4.20"]

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -13,7 +13,6 @@ from artcommonlib.redis import RedisError
 from artcommonlib.release_util import SoftwareLifecyclePhase
 from artcommonlib.telemetry import start_as_current_span_async
 from artcommonlib.util import split_git_url
-from doozerlib.constants import KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS
 from ghapi.all import GhApi
 from opentelemetry import trace
 
@@ -620,13 +619,6 @@ async def build_sync(
     build_system: str,
 ):
     jenkins.init_jenkins()
-
-    # TODO: remove this after we completely migrate to konflux for all versions
-    if version in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS and build_system == 'brew':
-        runtime.logger.info(f'Skipping brew build-sync for {KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS}')
-        jenkins.update_title(' [SKIPPED]')
-        return
-
     pipeline = await BuildSyncPipeline.create(
         runtime=runtime,
         version=version,

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -8,6 +8,7 @@ import click
 import yaml
 from artcommonlib import exectools, redis, rhcos
 from artcommonlib.arch_util import go_arch_for_brew_arch, go_suffix_for_arch
+from artcommonlib.constants import KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS
 from artcommonlib.exectools import limit_concurrency
 from artcommonlib.redis import RedisError
 from artcommonlib.release_util import SoftwareLifecyclePhase

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -6,6 +6,7 @@ import traceback
 import click
 import yaml
 from artcommonlib import exectools, redis
+from artcommonlib.constants import KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS
 
 from pyartcd import constants, jenkins, locks, oc, plashets, util
 from pyartcd import record as record_util
@@ -691,12 +692,14 @@ class Ocp4Pipeline:
             self.runtime.logger.warning('Skipping build-sync job for test assembly')
 
         else:
-            jenkins.start_build_sync(
-                build_version=self.version.stream,
-                assembly=self.assembly,
-                doozer_data_path=self.data_path,
-                doozer_data_gitref=self.data_gitref,
-            )
+            # Trigger ocp4 build sync only for streams that are not being updated with konflux builds
+            if self.version.stream not in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS:
+                jenkins.start_build_sync(
+                    build_version=self.version.stream,
+                    assembly=self.assembly,
+                    doozer_data_path=self.data_path,
+                    doozer_data_gitref=self.data_gitref,
+                )
 
         if operator_nvrs:
             jenkins.start_olm_bundle(

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -693,7 +693,11 @@ class Ocp4Pipeline:
 
         else:
             # Trigger ocp4 build sync only for streams that are not being updated with konflux builds
-            if self.version.stream not in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS:
+            if self.version.stream in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS:
+                self.runtime.logger.info(
+                    f'Skipping build-sync job for streams updated by konflux builds {KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS}'
+                )
+            else:
                 jenkins.start_build_sync(
                     build_version=self.version.stream,
                     assembly=self.assembly,


### PR DESCRIPTION
For 4.20, sync konflux builds to the default image stream `4.20-art-latest`
