### PR TITLE
Application label in Release

### DIFF
--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -106,7 +106,7 @@ class CreateReleaseCli:
         except exceptions.NotFoundError:
             raise RuntimeError(f"Cannot access {meta.application} in the cluster. Does it exist?")
 
-        release_config = self.get_release_config(config.shipment, self.release_env, meta.application)
+        release_config = self.get_release_config(config.shipment, self.release_env)
         LOGGER.info(
             f"Constructed release config with snapshot={release_config.snapshot}"
             f" releasePlan={release_config.release_plan}"
@@ -144,14 +144,14 @@ class CreateReleaseCli:
         return await self.konflux_client._create(release_obj)
 
     @staticmethod
-    def get_release_config(shipment: Shipment, env: str, application: str) -> ReleaseConfig:
+    def get_release_config(shipment: Shipment, env: str) -> ReleaseConfig:
         """
         Construct a konflux release config based on env and raw config
         """
         rc = ReleaseConfig(
             snapshot=shipment.snapshot.name,
             release_plan=getattr(shipment.environments, env).releasePlan,
-            application=application,
+            application=shipment.metadata.application,
         )
         if shipment.data:
             # Do not set exclude_unset=True when dumping, since Konflux

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -222,6 +222,7 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
             'metadata': {
                 'name': 'ose-4-18-stage-timestamp',
                 'namespace': self.konflux_config['namespace'],
+                'labels': {'appstudio.openshift.io/application': 'openshift-4-18'},
             },
             'spec': {
                 'releasePlan': shipment_config.shipment.environments.stage.releasePlan,


### PR DESCRIPTION
Unless the application name is not present in labels, the Release won't show up in the Konflux UI: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/releases