### PR TITLE
Fix ocp4 on rebase errors

### DIFF
--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -15,7 +15,7 @@ import koji
 import yaml
 from artcommonlib import exectools
 from artcommonlib.format_util import color_print, green_print, yellow_print
-from artcommonlib.model import Missing
+from artcommonlib.model import Missing, Model
 from artcommonlib.pushd import Dir
 from dockerfile_parse import DockerfileParser
 from future import standard_library
@@ -783,7 +783,7 @@ def images_build_image(
     if pre_step:
         for img, status in pre_step['images'].items():
             if status is not True:  # anything other than true is fail
-                img_obj = runtime.image_map[img]
+                img_obj = runtime.image_map.get(img, Model())
                 failed.append(img)
                 if img_obj.required:
                     required.append(img)

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -515,6 +515,9 @@ class Ocp4Pipeline:
                     filter(lambda item: item[1] is not True, state['images:rebase']['images'].items()),
                 ).keys(),
             )
+            self.runtime.logger.warning(
+                'Following images failed to rebase and won\'t be built: %s', ', '.join(failed_images)
+            )
 
             # Notify about rebase failures
             if self.assembly == 'stream':


### PR DESCRIPTION
`ocp4` should not crash on rebase failures; it should rather exclude the failed images from the build plan and continue.

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/18167/console