### PR TITLE
ART-12941 Correctly fetch attached builds and filter

### DIFF
--- a/elliott/elliottlib/errata_async.py
+++ b/elliott/elliottlib/errata_async.py
@@ -31,6 +31,12 @@ class AsyncErrataAPI:
             "Accept": "application/json",
         }
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.close()
+
     async def close(self):
         await self._session.close()
 


### PR DESCRIPTION
Test

```
$ elliott -g openshift-4.17 find-builds --attach 149789 --kind image --build rhcos-aarch
64-417.94.202505140130-0 --build ose-route-controller-manager-container-v4.17.0-202505140543.p0.g02bbf80.assembly.stream.el9

No new builds found for attaching to advisory
```