### PR TITLE
added missing arguments for categorize_bugs_by_type

### DIFF
--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -268,14 +268,14 @@ async def find_and_attach_bugs(
     included_bug_ids, _ = get_assembly_bug_ids(runtime, bug_tracker_type=bug_tracker.type)
     major_version, minor_version = runtime.get_major_minor()
     bugs_by_type, _ = categorize_bugs_by_type(
-        bugs,
-        advisory_ids,
-        included_bug_ids,
-        noop,
-        permissive=permissive,
+        bugs=bugs,
+        advisory_id_map=advisory_ids,
+        permitted_bug_ids=included_bug_ids,
+        noop=noop,
         major_version=major_version,
         minor_version=minor_version,
         operator_bundle_advisory=operator_bundle_advisory,
+        permissive=permissive,
     )
     for kind, kind_bugs in bugs_by_type.items():
         logger.info(f'{kind} bugs: {[b.id for b in kind_bugs]}')

--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -271,12 +271,16 @@ class BugValidator:
         if "advance" in advisory_id_map and is_advisory_editable(advisory_id_map["advance"]):
             advance_release = True
         operator_bundle_advisory = "advance" if advance_release else "metadata"
+        major_version, minor_version = self.runtime.get_major_minor()
         bugs_by_type, issues = categorize_bugs_by_type(
             non_flaw_bugs,
             advisory_id_map,
             permitted_bug_ids=permitted_bug_ids,
             permissive=True,
             operator_bundle_advisory=operator_bundle_advisory,
+            noop=True,
+            major_version=major_version,
+            minor_version=minor_version,
         )
         for i in issues:
             self._complain(i)

--- a/elliott/tests/test_verify_attached_bugs_cli.py
+++ b/elliott/tests/test_verify_attached_bugs_cli.py
@@ -221,6 +221,7 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
         runner = CliRunner()
         flexmock(Runtime).should_receive("initialize")
         flexmock(Runtime).should_receive("get_errata_config").and_return({})
+        flexmock(Runtime).should_receive("get_major_minor").and_return((4, 6))
         flexmock(JIRABugTracker).should_receive("get_config").and_return(
             {'project': 'OCPBUGS', 'target_release': ['4.6.z']}
         )


### PR DESCRIPTION
Fixes the following error:

```
Error validating attached bugs: categorize_bugs_by_type() missing 3 required positional arguments: 'noop', 'major_version', and 'minor_version'
2025-05-15 15:01:04,888 pyartcd      WARNING Error verifying attached bugs: Process ['elliott', '--assembly=4.17.30', '--group=openshift-4.17', 'verify-attached-bugs', '--verify-flaws'] exited with code 1.
2025-05-15 15:01:04,888 pyartcd      ERROR Process ['elliott', '--assembly=4.17.30', '--group=openshift-4.17', 'verify-attached-bugs', '--verify-flaws'] exited with code 1.
Traceback (most recent call last):
  File "/mnt/jenkins-workspace/_builds_build_promote-assembly_2@2/art-tools/pyartcd/pyartcd/pipelines/promote.py", line 342, in run
    justification = self._reraise_if_not_permitted(err, "ATTACHED_BUGS", permits)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```