### PR TITLE
shipment pipeline update

### DIFF
--- a/elliott/elliottlib/shipment_model.py
+++ b/elliott/elliottlib/shipment_model.py
@@ -62,7 +62,7 @@ class ReleaseNotes(StrictBaseModel):
     topic: str
     description: str
     solution: str
-    issues: Optional[Issues]
+    issues: Optional[Issues] = None
 
     # Konflux pipeline expects certain keys like issues, cves to always be set, even if empty
     # therefore allow these to have default empty values

--- a/elliott/elliottlib/shipment_model.py
+++ b/elliott/elliottlib/shipment_model.py
@@ -62,10 +62,10 @@ class ReleaseNotes(StrictBaseModel):
     topic: str
     description: str
     solution: str
+    issues: Optional[Issues]
 
     # Konflux pipeline expects certain keys like issues, cves to always be set, even if empty
     # therefore allow these to have default empty values
-    issues: Optional[Issues] = {}
     cves: Optional[List[CveAssociation]] = []
 
     references: Optional[List[str]] = None

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -234,7 +234,6 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
                         'topic': shipment_config.shipment.data.releaseNotes.topic,
                         'description': shipment_config.shipment.data.releaseNotes.description,
                         'solution': shipment_config.shipment.data.releaseNotes.solution,
-                        'issues': {},
                         'cves': [],
                     },
                 },

--- a/ocp-build-data-validator/validator/json_schemas/shipment.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/shipment.schema.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Schema generated on 2025-05-14 18:32 UTC from elliottlib.shipment_model",
+  "$comment": "Schema generated on 2025-05-16 14:39 UTC from elliottlib.shipment_model",
   "$defs": {
     "CveAssociation": {
       "additionalProperties": false,
@@ -194,8 +194,7 @@
             {
               "type": "null"
             }
-          ],
-          "default": {}
+          ]
         },
         "cves": {
           "anyOf": [
@@ -233,7 +232,8 @@
         "synopsis",
         "topic",
         "description",
-        "solution"
+        "solution",
+        "issues"
       ],
       "title": "ReleaseNotes",
       "type": "object"


### PR DESCRIPTION
Issues should not be set to `issues: {}` if the field is not populated from the shipment config. It should be omitted instead.

Ref thread: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1747402808869269?thread_ts=1747343024.598559&cid=C04PZ7H0VA8

The mandatory fields are defined here: https://github.com/konflux-ci/release-service-catalog/blob/development/schema/dataKeys.json#L673, everything else should be omitted, if they don't have a value.