### PR TITLE
Fix build microshift

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -17,6 +17,7 @@ from artcommonlib.util import get_assembly_release_date, get_ocp_version_from_gr
 from doozerlib.util import isolate_nightly_name_components
 from elliottlib.errata import push_cdn_stage
 from elliottlib.errata_async import AsyncErrataAPI
+from elliottlib.util import get_advisory_boilerplate
 from errata_tool import Erratum
 from ghapi.all import GhApi
 from github import Github, GithubException
@@ -145,7 +146,9 @@ class BuildMicroShiftPipeline:
         advisory_type = "RHEA" if VersionInfo.parse(release_name).to_tuple()[2] == 0 else "RHBA"
         release_date = get_assembly_release_date(self.assembly, self.group)
         et_data = self.load_errata_config(self.group, self._doozer_env_vars["DOOZER_DATA_PATH"])
-        boilerplate = et_data["boilerplates"]["microshift"]
+        boilerplate = get_advisory_boilerplate(
+            runtime=self.runtime, et_data=et_data, art_advisory_key="microshift", errata_type=advisory_type
+        )
         errata_api = AsyncErrataAPI()
 
         self._logger.info("Creating advisory with type %s art_advisory_key microshift ...", advisory_type)


### PR DESCRIPTION
The release specific boilerplates were removed for versions 4.16 and down. This was causing an error in the microshift build pipeline. 

```
ERROR: failed shell command: artcd -v --working-dir=./artcd_worki...-g openshift-4.15 --assembly 4.15.51
with rc=1 and output:
[...see full archive #5...]
                  ~~~~~~~^^^^^^^^^^^^^^^^
  File "/mnt/jenkins-workspace/_builds_build_build-microshift_2@2/art-venv/lib64/python3.11/site-packages/ruamel/yaml/comments.py", line 853, in __getitem__
    return ordereddict.__getitem__(self, key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'boilerplates'

Finished: FAILURE
```

I worked around this by leveraging some of the elliottlib code to load the default boilerplate from main but I think this could probably use a larger refactor at some point. This could be shared code but the elliottlib and pyartcd code don't handle fetching contents of the files in the same way and the elliott runtime has a much larger initialization process.