### PR TITLE
Konflux: Fix bundle build again

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -381,6 +381,7 @@ class KonfluxClient:
         dockerfile: Optional[str] = None,
         pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL,
         annotations: Optional[dict[str, str]] = None,
+        artifact_type: Optional[str] = None,
     ) -> dict:
         if additional_tags is None:
             additional_tags = []
@@ -471,6 +472,9 @@ class KonfluxClient:
                     )
                 case "sast-snyk-check":
                     has_sast_task = True
+                case "ecosystem-cert-preflight-checks":
+                    if artifact_type:
+                        _modify_param(task["params"], "artifact-type", artifact_type)
 
         if not sast:
             tasks = []
@@ -546,6 +550,7 @@ class KonfluxClient:
         dockerfile: Optional[str] = None,
         pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL,
         annotations: Optional[dict[str, str]] = None,
+        artifact_type: Optional[str] = None,
     ):
         """
         Start a PipelineRun for building an image.
@@ -569,6 +574,7 @@ class KonfluxClient:
         :param dockerfile: Optional Dockerfile name
         :param pipelinerun_template_url: The URL to the PipelineRun template.
         :param annotations: Optional PLR annotations
+        :param artifact_type: The type of artifact artifact_type for ecosystem-cert-preflight-checks. Select from application, operatorbundle, or introspect.
         :return: The PipelineRun resource.
         """
         unsupported_arches = set(building_arches) - set(self.SUPPORTED_ARCHES)
@@ -600,6 +606,7 @@ class KonfluxClient:
             prefetch=prefetch,
             sast=sast,
             annotations=annotations,
+            artifact_type=artifact_type,
         )
         if self.dry_run:
             fake_pipelinerun = resource.ResourceInstance(self.dyn_client, pipelinerun_manifest)


### PR DESCRIPTION
After the recent bump of Tekton templates for bundle build (https://github.com/openshift-priv/art-konflux-template/pull/95), we got an build error due to the existance of container.yaml. e.g.
https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-18/pipelineruns/openshift-4-18-openshift-kubernetes-nmstate-operator-bundl68fzn.

This file is only used in Brew/OSBS build. Removing it will resolve the build error. 

Another error is similar to
    https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1747396281747099.
    Applying artifact_type="operatorbundle" will solve the issue.

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Folm_bundle_konflux/1953/