### PR TITLE
[konflux] scan-sources: merge Konflux config if present before scan

### DIFF
--- a/doozer/doozerlib/build_info.py
+++ b/doozer/doozerlib/build_info.py
@@ -744,9 +744,7 @@ class KonfluxBuildRecordInspector(BuildRecordInspector):
 
         # Get enabled repos
         enabled_repos = {r.name for r in group_repos.values() if r.enabled}
-        if meta.config.konflux.enabled_repos is not Missing:
-            enabled_repos |= set(meta.config.konflux.enabled_repos)
-        elif meta.config.enabled_repos is not Missing:
+        if meta.config.enabled_repos is not Missing:
             enabled_repos |= set(meta.config.enabled_repos)
 
         # If there are no enabled repos, nothing to do here

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -23,6 +23,7 @@ from artcommonlib.model import Missing, Model
 from artcommonlib.pushd import Dir
 from artcommonlib.release_util import isolate_timestamp_in_release
 from artcommonlib.rpm_utils import parse_nvr
+from artcommonlib.util import deep_merge
 from async_lru import alru_cache
 
 from doozerlib.build_info import KonfluxBuildRecordInspector
@@ -388,6 +389,8 @@ class ConfigScanSources:
     @skip_check_if_changing
     async def scan_image(self, image_meta: ImageMetadata):
         self.logger.info(f'Scanning {image_meta.distgit_key} for changes')
+        if image_meta.config.konflux is not Missing:
+            image_meta.config = Model(deep_merge(image_meta.config.primitive(), image_meta.config.konflux.primitive()))
 
         # Check if the component has ever been built
         latest_build_record = self.latest_image_build_records_map.get(image_meta.distgit_key, None)


### PR DESCRIPTION
Follows https://github.com/openshift-eng/art-tools/pull/1626 with a more robust approach