### PR TITLE
Bring back -container suffix in bundle build records

### DIFF
--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -149,13 +149,14 @@ class KonfluxOlmBundleRebaser:
 
         # Read the operator's Dockerfile
         operator_df = DockerfileParser(str(operator_dir.joinpath('Dockerfile')))
+        operator_component_name = operator_df.labels.get('com.redhat.component')
         operator_version = operator_df.labels.get('version')
         operator_release = operator_df.labels.get('release')
-        if not operator_version or not operator_release:
+        if not operator_component_name or not operator_version or not operator_release:
             raise ValueError(
-                f"[{metadata.distgit_key}] Label 'version' or 'release' is not set in the operator's Dockerfile"
+                f"[{metadata.distgit_key}] Label 'com.redhat.component', 'version', or 'release' is not set in the operator's Dockerfile"
             )
-        operator_nvr = f"{metadata.distgit_key}-{operator_version}-{operator_release}"
+        operator_nvr = f"{operator_component_name}-{operator_version}-{operator_release}"
 
         # Get operator package name and channel from its package YAML
         # This info will be used to generate bundle's Dockerfile labels and metadata/annotations.yaml

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -405,7 +405,7 @@ spec:
             'test-package',
             'test-operator.v1.0.0',
             bundle_dir,
-            'test-distgit-key-1.0-1',
+            'test-component-1.0-1',
             {
                 'image': ('old_pullspec', 'new_pullspec', 'test-component-1.0-1'),
             },
@@ -500,7 +500,10 @@ spec:
 
         with self.assertRaises(ValueError) as context:
             await self.rebaser._rebase_dir(metadata, operator_dir, bundle_dir, MagicMock(), input_release)
-        self.assertIn("Label 'version' or 'release' is not set in the operator's Dockerfile", str(context.exception))
+        self.assertIn(
+            "Label 'com.redhat.component', 'version', or 'release' is not set in the operator's Dockerfile",
+            str(context.exception),
+        )
 
     @patch("pathlib.Path.iterdir", return_value=iter([]))
     async def test_rebase_dir_no_files_in_bundle_dir(self, _):


### PR DESCRIPTION
https://github.com/openshift-eng/art-tools/pull/1596 missed `operator_nvr` field in `events.bundles` table, which breaks recent FBC builds.