### PR TITLE
[Konflux] Fix rebase error in bundle build

### DIFF
--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -75,7 +75,7 @@ class KonfluxOlmBundleRebaser:
 
         logger.info("Cloning operator build source...")
         if operator_build.engine is Engine.KONFLUX:
-            operator_build_repo_url = operator_build.rebase_repo_url
+            operator_build_repo_url = source.url
             operator_build_repo_refspec = operator_build.rebase_commitish
         elif operator_build.engine is Engine.BREW:
             operator_build_repo_url = metadata.distgit_remote_url()


### PR DESCRIPTION
https://github.com/openshift-eng/art-tools/pull/1625 introduced an issue that the build repo urls are https urls instead of ssh, which broke bundle rebase.