### PR TITLE
[Konflux] Bootstrap FBC git repo for new operators

### DIFF
--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -260,7 +260,7 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
             local_dir=self.base_dir.joinpath(metadata.distgit_key),
             logger=ANY,
         )
-        build_repo.ensure_source.assert_called_once_with(upcycle=self.upcycle, strict=True)
+        build_repo.ensure_source.assert_called_once_with(upcycle=self.upcycle, strict=False)
         mock_rebase_dir.assert_called_once_with(metadata, build_repo, bundle_build, version, release, ANY)
         mock_opm.validate.assert_called_once_with(self.base_dir.joinpath(metadata.distgit_key, "catalog"))
         build_repo.commit.assert_called_once_with(ANY, allow_empty=True)
@@ -294,7 +294,7 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
             local_dir=self.base_dir.joinpath(metadata.distgit_key),
             logger=ANY,
         )
-        build_repo.ensure_source.assert_called_once_with(upcycle=self.upcycle, strict=True)
+        build_repo.ensure_source.assert_called_once_with(upcycle=self.upcycle, strict=False)
         mock_rebase_dir.assert_called_once_with(metadata, build_repo, bundle_build, version, release, ANY)
         mock_opm.validate.assert_called_once_with(self.base_dir.joinpath(metadata.distgit_key, "catalog"))
         build_repo.commit.assert_called_once_with(ANY, allow_empty=True)


### PR DESCRIPTION
Currently, the FBC git repo must be initialized by importing from a previous index (i.e. the beta:fbc:import verb). This PR enables bootstraping the FBC git repos from scratch.

Note the PR uses default values following
https://github.com/konflux-ci/olm-operator-konflux-sample/blob/main/v4.13/catalog-template.json, although I am not sure of it is the right source of truth.

Test job: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-fbc/17/console
The git commit created by the above job: https://github.com/openshift-priv/art-fbc/commit/d923f09b14fd10b35c18fa2d24bb7bf4a4e2ffe1