### PR TITLE
Fix brew tag retrieval in doozer images:scan-fips

### DIFF
--- a/doozer/doozerlib/cli/scan_fips.py
+++ b/doozer/doozerlib/cli/scan_fips.py
@@ -90,11 +90,10 @@ class ScanFipsCli:
 
     def get_all_latest_builds(self):
         # Setup brew tags
-        brew_tags = (
-            self.runtime.gitdata.load_data(key='erratatool', replace_vars=self.runtime.group_config.vars)
-            .data.get('brew_tag_product_version_mapping', {})
-            .keys()
-        )
+        et_data = self.runtime.get_errata_config()
+        brew_tags = [
+            tag.format(**self.runtime.group_config.vars) for tag in et_data.get('brew_tag_product_version_mapping', {})
+        ]
         self.runtime.logger.info(f"Retrieved candidate tags: {brew_tags}")
 
         builds = []


### PR DESCRIPTION
`doozer images:scan-fips` is failing for openshift-4.12 and openshift-4.13 because the tags it retrieves from `erratatool.yml` are incorrectly formatted:
```
koji.GenericError: No such tagInfo: 'rhaos-{MAJOR}.{MINOR}-rhel-8-candidate'
```
This is because `erratatool.yml` in these two versions now contains advisory boilerplate - this contains `{PATCH}` variable which is not defined anywhere in `group.yml` and so `runtime.gitdata.load_data()` fails to replace any vars.