### PR TITLE
Add hermetic field in DB record

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -211,6 +211,7 @@ class KonfluxBuildRecord(KonfluxRecord):
         rebase_repo_url: str = '',
         rebase_commitish: str = '',
         embargoed: bool = False,
+        hermetic: bool = False,
         start_time: datetime = None,
         end_time: datetime = None,
         artifact_type: ArtifactType = ArtifactType.IMAGE,
@@ -255,6 +256,7 @@ class KonfluxBuildRecord(KonfluxRecord):
         self.installed_packages = installed_packages
         self.parent_images = parent_images
         self.embargoed = embargoed
+        self.hermetic = hermetic
         self.artifact_type = artifact_type if isinstance(artifact_type, ArtifactType) else ArtifactType(artifact_type)
         self.init_uuids(record_id, build_id, nvr)
 

--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -328,13 +328,9 @@ class KonfluxDb:
             )
 
             results = await self.bq_client.select(where_clauses, order_by_clause=order_by_clause, limit=1)
-
-            try:
-                return self.from_result_row(next(results))
-
-            except (StopIteration, Exception):
-                # No builds found in current window, shift to the earlier one
-                continue
+            if results.total_rows == 0:
+                continue  # No builds found in this window, try the next one
+            return self.from_result_row(next(results))
 
         # If we got here, no builds have been found in the whole 36 months period
         if strict:

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -382,7 +382,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             MagicMock(total_rows=0, __next__=MagicMock(side_effect=StopIteration)),
             MagicMock(total_rows=0, __next__=MagicMock(side_effect=StopIteration)),
             MagicMock(
-                total_rows=0,
+                total_rows=1,
                 __next__=MagicMock(
                     return_value=Row(
                         ('ironic', '1.0.0', '2', "ironic-1.0.0-2"), {'name': 0, 'version': 1, 'release': 2, 'nvr': 3}
@@ -417,6 +417,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             SchemaField('rebase_repo_url', 'STRING', 'REQUIRED'),
             SchemaField('rebase_commitish', 'STRING', 'REQUIRED'),
             SchemaField('embargoed', 'BOOLEAN', 'REQUIRED'),
+            SchemaField('hermetic', 'BOOLEAN', 'REQUIRED'),
             SchemaField('start_time', 'TIMESTAMP', 'REQUIRED'),
             SchemaField('end_time', 'TIMESTAMP', 'REQUIRED'),
             SchemaField('artifact_type', 'STRING', 'REQUIRED'),


### PR DESCRIPTION
Querying is (silently) broken right now, because a new field was added in DB table, but not in code.

```
TypeError: KonfluxBuildRecord.__init__() got an unexpected keyword argument 'hermetic'
```