### PR TITLE
imagestream override konflux

### DIFF
--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -10,7 +10,7 @@ import requests
 from artcommonlib import exectools, rhcos
 from artcommonlib.arch_util import go_arch_for_brew_arch, go_suffix_for_arch
 from artcommonlib.assembly import AssemblyTypes
-from artcommonlib.constants import RHCOS_RELEASES_STREAM_URL
+from artcommonlib.constants import KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS, RHCOS_RELEASES_STREAM_URL
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.konflux.package_rpm_finder import PackageRpmFinder
 from artcommonlib.model import Model
@@ -310,7 +310,7 @@ class GenAssemblyCli:
                 self._exit_with_error(f'Specified nightly {nightly_name} does not match group major.minor')
             self.reference_releases_by_arch[brew_cpu_arch] = nightly_name
             rc_suffix = go_suffix_for_arch(brew_cpu_arch, priv)
-            release_suffix = f'{"konflux-" if self.runtime.build_system == "konflux" else ""}release{rc_suffix}'
+            release_suffix = f'{"konflux-" if self.runtime.build_system == "konflux" and self.runtime.group.removeprefix("openshift-") not in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS else ""}release{rc_suffix}'
             nightly_pullspec = f'registry.ci.openshift.org/ocp{rc_suffix}/{release_suffix}:{nightly_name}'
             if brew_cpu_arch in self.release_pullspecs:
                 raise ValueError(

--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -310,7 +310,11 @@ class GenAssemblyCli:
                 self._exit_with_error(f'Specified nightly {nightly_name} does not match group major.minor')
             self.reference_releases_by_arch[brew_cpu_arch] = nightly_name
             rc_suffix = go_suffix_for_arch(brew_cpu_arch, priv)
-            release_suffix = f'{"konflux-" if self.runtime.build_system == "konflux" and self.runtime.group.removeprefix("openshift-") not in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS else ""}release{rc_suffix}'
+
+            if self.runtime.build_system == 'konflux' and self.runtime.group.removeprefix('openshift-') not in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS:
+                release_suffix = f'konflux-release{rc_suffix}'
+            else:
+                release_suffix = f'release{rc_suffix}'
             nightly_pullspec = f'registry.ci.openshift.org/ocp{rc_suffix}/{release_suffix}:{nightly_name}'
             if brew_cpu_arch in self.release_pullspecs:
                 raise ValueError(

--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -311,7 +311,10 @@ class GenAssemblyCli:
             self.reference_releases_by_arch[brew_cpu_arch] = nightly_name
             rc_suffix = go_suffix_for_arch(brew_cpu_arch, priv)
 
-            if self.runtime.build_system == 'konflux' and self.runtime.group.removeprefix('openshift-') not in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS:
+            if (
+                self.runtime.build_system == 'konflux'
+                and self.runtime.group.removeprefix('openshift-') not in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS
+            ):
                 release_suffix = f'konflux-release{rc_suffix}'
             else:
                 release_suffix = f'release{rc_suffix}'

--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -10,6 +10,7 @@ from typing import Iterable, Optional, OrderedDict, Tuple
 import aiohttp
 import click
 from artcommonlib import exectools
+from artcommonlib.constants import KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS
 from artcommonlib.util import (
     get_inflight,
     isolate_major_minor_in_group,
@@ -140,7 +141,7 @@ class GenAssemblyPipeline:
             self._logger.info("Generated assembly definition:\n%s", out.getvalue())
 
             # For Konflux, stop here at the moment
-            if self.build_system == 'konflux':
+            if self.build_system == 'konflux' and self._ocp_version not in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS:
                 return
 
             # Create a PR

--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -141,7 +141,10 @@ class GenAssemblyPipeline:
             self._logger.info("Generated assembly definition:\n%s", out.getvalue())
 
             # For Konflux, stop here at the moment
-            if self.build_system == 'konflux' and self.group.removeprefix('openshift-') not in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS:
+            if (
+                self.build_system == 'konflux'
+                and self.group.removeprefix('openshift-') not in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS
+            ):
                 return
 
             # Create a PR

--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -141,7 +141,7 @@ class GenAssemblyPipeline:
             self._logger.info("Generated assembly definition:\n%s", out.getvalue())
 
             # For Konflux, stop here at the moment
-            if self.build_system == 'konflux' and self._ocp_version not in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS:
+            if self.build_system == 'konflux' and self.group.removeprefix('openshift-') not in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS:
                 return
 
             # Create a PR


### PR DESCRIPTION
For 4.20 for example, we are syncing konflux builds to formerly brew imagestreams. So we need to look at the usual nightly URLs instead.

Follows: https://github.com/openshift-eng/art-tools/pull/1609