### PR TITLE
Handle exceptions raised when failing to get Konflux SLSA attestation

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -470,11 +470,16 @@ class ConfigScanSources:
         build_record = self.latest_image_build_records_map[image_meta.distgit_key]
 
         # get_konflux_slsa_attestation command will raise an exception if it cannot find the attestation
-        attestation = await artcommonlib.util.get_konflux_slsa_attestation(
-            pull_spec=build_record.image_pullspec,
-            registry_username=self.art_images_username,
-            registry_password=self.art_images_password,
-        )
+        try:
+            attestation = await artcommonlib.util.get_konflux_slsa_attestation(
+                pull_spec=build_record.image_pullspec,
+                registry_username=self.art_images_username,
+                registry_password=self.art_images_password,
+            )
+
+        except ChildProcessError as e:
+            self.logger.warning('Failed to download SLSA attestation: %s', e)
+            return
 
         try:
             # Equivalent bash code: jq -r ' .payload | @base64d | fromjson | .predicate.invocation.parameters.hermetic'


### PR DESCRIPTION
`scan_network_mode_changes()` is breaking many ocp4-scan-konflux builds. Handling ChildProcessErrors to keep the pipeline intact