### PR TITLE
Adjust build-sync for Konflux

### DIFF
--- a/artcommon/artcommonlib/assembly.py
+++ b/artcommon/artcommonlib/assembly.py
@@ -294,7 +294,6 @@ def assembly_basis_event(
     if target_assembly.basis.brew_event:
         return int(target_assembly.basis.brew_event)  # Integer for Brew event
     elif target_assembly.basis.time:
-        # datetime UTC for Konflux
         time_str = target_assembly.basis.time
         if not isinstance(time_str, str):
             raise ValueError(f"Invalid time format for assembly {assembly}: {time_str}")

--- a/artcommon/artcommonlib/assembly.py
+++ b/artcommon/artcommonlib/assembly.py
@@ -294,6 +294,7 @@ def assembly_basis_event(
     if target_assembly.basis.brew_event:
         return int(target_assembly.basis.brew_event)  # Integer for Brew event
     elif target_assembly.basis.time:
+        # datetime UTC for Konflux
         time_str = target_assembly.basis.time
         if not isinstance(time_str, str):
             raise ValueError(f"Invalid time format for assembly {assembly}: {time_str}")

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -2286,7 +2286,12 @@ class PayloadGenerator:
         if major_minor != runtime.get_minor_version():
             return terminal_issue(f"Specified nightly {nightly} does not match group major.minor")
 
-        release_suffix = f"{'konflux-' if runtime.build_system == 'konflux' else ''}release"
+        # For 4.20, remove the -konflux suffix as Konflux builds are being mirrored to standard imagestreams
+        if runtime.build_system == 'brew' or major_minor in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS:
+            release_suffix = 'release'
+        else:
+            release_suffix = 'konflux-release'
+
         rc_suffix = go_suffix_for_arch(brew_cpu_arch, priv)
 
         retries: int = 3


### PR DESCRIPTION
- `assembly.basis.time` is now a string, and needs to be converted back into a `datetime` object
- for 4.20 we're syncing out Konflux builds to standard nightlies, so we need to remove the `-konflux` suffix in the pullspec