### PR TITLE
Check group config for determining rhcos job name

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -504,7 +504,7 @@ class Ocp4Pipeline:
 
             if self.runtime.dry_run:
                 self.runtime.logger.info(
-                    'Would have triggered job: rhcos for %s, job_name=%s', job_name, self.version.stream, job_name
+                    'Would have triggered job: rhcos for %s, job_name=%s', self.version.stream, job_name
                 )
             else:
                 jenkins.start_rhcos(build_version=self.version.stream, new_build=False, job_name=job_name)

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -112,9 +112,6 @@ class Ocp4Pipeline:
         self._slack_client = runtime.new_slack_client()
         self._mail_client = self.runtime.new_mail_client()
 
-        if self.runtime.dry_run:
-            jenkins.update_title(" [dry-run]")
-
     async def _check_assembly(self):
         """
         If assembly != 'stream' and assemblies not enabled for <version>, raise an error
@@ -156,7 +153,10 @@ class Ocp4Pipeline:
         self.version.release = util.default_release_suffix()
 
         self.runtime.logger.info('Initializing build:\n%s', str(self.version))
-        jenkins.update_title(f' - {self.version.stream}-{self.version.release} ')
+        
+        title_update = " [dry-run]" if self.runtime.dry_run else ""
+        title_update += f' - {self.version.stream}-{self.version.release} '
+        jenkins.update_title(title_update)
 
     async def _initialize_build_plan(self):
         """

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -153,7 +153,7 @@ class Ocp4Pipeline:
         self.version.release = util.default_release_suffix()
 
         self.runtime.logger.info('Initializing build:\n%s', str(self.version))
-        
+
         title_update = " [dry-run]" if self.runtime.dry_run else ""
         title_update += f' - {self.version.stream}-{self.version.release} '
         jenkins.update_title(title_update)

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -273,6 +273,22 @@ async def get_freeze_automation(
     return out.strip()
 
 
+async def has_layered_rhcos(doozer_base_command: list) -> bool:
+    """
+    Check if the current version uses layered RHCOS
+    """
+
+    cmd = doozer_base_command + [
+        'config:read-group',
+        'rhcos.layered_rhcos',
+        '--default=False',
+    ]
+    _, out, _ = await exectools.cmd_gather_async(cmd)
+    layered_rhcos = out.strip() == 'True'
+    logger.info('Layered RHCOS %s enabled', 'NOT' if not layered_rhcos else '')
+    return layered_rhcos
+
+
 def is_manual_build() -> bool:
     """
     Builds that are triggered manually by a Jenkins user carry a BUILD_USER_EMAIL environment variable.

--- a/pyartcd/tests/pipelines/test_ocp4.py
+++ b/pyartcd/tests/pipelines/test_ocp4.py
@@ -542,7 +542,7 @@ class TestBuildCompose(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(res, True)
         self.ocp4._slack_client.say.assert_awaited_once()
 
-    @patch("pyartcd.pipelines.ocp4.Ocp4Pipeline._check_layered_rhcos", return_value=False)
+    @patch("pyartcd.pipelines.ocp4.has_layered_rhcos", return_value=False)
     @patch("pyartcd.locks.LockManager.from_lock", return_value=AsyncMock)
     @patch("pyartcd.plashets.build_plashets", return_value=AsyncMock)
     @patch("pyartcd.jenkins.start_sync_for_ci")

--- a/pyartcd/tests/pipelines/test_ocp4.py
+++ b/pyartcd/tests/pipelines/test_ocp4.py
@@ -542,11 +542,14 @@ class TestBuildCompose(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(res, True)
         self.ocp4._slack_client.say.assert_awaited_once()
 
+    @patch("pyartcd.pipelines.ocp4.Ocp4Pipeline._check_layered_rhcos", return_value=False)
     @patch("pyartcd.locks.LockManager.from_lock", return_value=AsyncMock)
     @patch("pyartcd.plashets.build_plashets", return_value=AsyncMock)
     @patch("pyartcd.jenkins.start_sync_for_ci")
     @patch("pyartcd.jenkins.start_rhcos")
-    async def test_build_compose(self, mocked_rhcos, mocked_sync_for_ci, mocked_build_plashets, mocked_lm):
+    async def test_build_compose(
+        self, mocked_rhcos, mocked_sync_for_ci, mocked_build_plashets, mocked_lm, mock_layered_rhcos
+    ):
         mocked_cm = AsyncMock()
         mocked_cm.__aenter__ = AsyncMock()
         mocked_cm.__aexit__ = AsyncMock()
@@ -583,6 +586,24 @@ class TestBuildCompose(unittest.IsolatedAsyncioTestCase):
         await self.ocp4._build_compose()
         mocked_build_plashets.assert_awaited_once()
         mocked_sync_for_ci.assert_called_once_with(version='4.13', block_until_building=False)
+        mock_layered_rhcos.assert_called_once()
+        mocked_rhcos.assert_called_once_with(build_version='4.13', new_build=False, job_name='build')
+        self.assertEqual(self.ocp4.rpm_mirror.local_plashet_path, '')
+        self.assertEqual(self.ocp4.rpm_mirror.plashet_dir_name, '')
+
+        # Build permitted, assembly = 'stream'
+        mocked_build_plashets.reset_mock()
+        mocked_rhcos.reset_mock()
+        mocked_sync_for_ci.reset_mock()
+        self.ocp4._is_compose_build_permitted = AsyncMock(return_value=True)
+        self.ocp4.assembly = 'stream'
+        mock_layered_rhcos.reset_mock()
+        mock_layered_rhcos.return_value = True
+        await self.ocp4._build_compose()
+        mocked_build_plashets.assert_awaited_once()
+        mocked_sync_for_ci.assert_called_once_with(version='4.13', block_until_building=False)
+        mock_layered_rhcos.assert_called_once()
+        mocked_rhcos.assert_called_once_with(build_version='4.13', new_build=False, job_name='build-node-image')
         self.assertEqual(self.ocp4.rpm_mirror.local_plashet_path, '')
         self.assertEqual(self.ocp4.rpm_mirror.plashet_dir_name, '')
 


### PR DESCRIPTION
Right now, the incorrect rhcos job gets triggered for 4.19. instead of hardcoding values, check group config.
https://redhat-internal.slack.com/archives/GDBRP5YJH/p1748616572132659

Test: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/18876/console
```
2025-05-30 18:35:46,239 pyartcd      INFO Layered RHCOS  enabled for 4.19
2025-05-30 18:35:46,239 pyartcd      INFO Would have triggered job: rhcos for 4.19, job_name=build-node-image
```