### PR TITLE
ART-13009 Avoid duplicating plashet builds

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -301,6 +301,8 @@ def start_ocp4_konflux(
     # Limit arches when requested
     if limit_arches:
         params['LIMIT_ARCHES'] = ','.join(limit_arches)
+    # SKIP_PLASHETS defaults to True for manual builds, setting to False for scheduled
+    params['SKIP_PLASHETS'] = False
 
     return start_build(
         job=Jobs.OCP4_KONFLUX,

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -758,7 +758,7 @@ class Ocp4Pipeline:
         await self._rebase_and_build_rpms()
 
         # Build plashets
-        if not self.skip_plashets:
+        if not self.skip_plashets and self.version not in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS:
             jenkins.start_build_plashets(
                 version=self.version.stream,
                 release=self.version.release,


### PR DESCRIPTION
After moving plashets building to their own job, we can trigger repo updates from both OSBS and Konflux builds. With this PR we shall trigger plashets from `ocp4-konflux` pipelines for those versions that we're syncing out to the regular imagestreams (currently, only 4.20). This will allow a smoother migration towards Konflux without having to worry about over building plashets.

Ref. [ART-13009](https://issues.redhat.com/browse/ART-13009)

Needs https://github.com/openshift-eng/aos-cd-jobs/pull/4408