### PR TITLE
gomod add patch version update

### DIFF
--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -32,6 +32,7 @@ from artcommonlib.pushd import Dir
 from artcommonlib.release_util import isolate_assembly_in_release, isolate_el_version_in_release
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import (
+    add_golang_version_patch,
     convert_remote_git_to_https,
     deep_merge,
     isolate_el_version_in_brew_tag,
@@ -2835,6 +2836,8 @@ class ImageDistGitRepo(DistGitRepo):
             # to the required distgit location.
             source_dockerfile_content = source_dockerfile.read()
             distgit_dockerfile.write(source_dockerfile_content)
+
+        add_golang_version_patch(dest_dir=dg_path, logger=self.logger)
 
         # Clean up any extraneous Dockerfile.* that might be distractions (e.g. Dockerfile.centos)
         for ent in dg_path.iterdir():


### PR DESCRIPTION
Since we are switching from cachito to cachi2/hermeto for Brew as well, hermeto is less forgiving when it comes to missing patch values in go versions. i.e. it should be `go 1.22.0` instead of `go 1.22` in the go.mod files. We had already been doing this for Konflux, so us the same logic for Brew as well.

Changes in this PR:
- Create a new `add_golang_version_patch` function and move the code to artcommonlib to prevent duplication.
- Add the patch by default, and do not check `group_config.konflux.cachi2.gomod_version_patch` since we need this anyways for all