### PR TITLE
ART-13075: Add check for self-referential upgrades

### DIFF
--- a/ocp-build-data-validator/tests/test_releases.py
+++ b/ocp-build-data-validator/tests/test_releases.py
@@ -1,0 +1,35 @@
+import unittest
+
+from flexmock import flexmock
+from validator import releases, support
+
+group_config = group_cfg = {
+    'vars': {'MAJOR': 4, 'MINOR': 18},
+}
+
+
+class TestReleases(unittest.TestCase):
+    def setUp(self):
+        flexmock(releases.support).should_receive('load_group_config_for').and_return(group_config)
+
+    def test_self_referential_upgrades(self):
+        invalid_releases = {
+            "releases": {
+                "4.18.4": {"assembly": {"group": {"upgrades": "4.18.3,4.18.4"}}},
+                "ec.1": {"assembly": {"group": {"upgrades": "4.18.0-ec.1, 4.20.0-ec.0"}}},
+            }
+        }
+        err = releases.validate(invalid_releases)
+        self.assertEqual(
+            err, "The following releases contain references to themselves in their respective 'upgrades': 4.18.4, ec.1"
+        )
+
+    def test_no_self_referential_upgrades(self):
+        valid_releases = {
+            "releases": {
+                "rc.0": {"assembly": {"group": {"upgrades": "4.18.0-ec.1"}}},
+                "ec.1": {"assembly": {"group": {"upgrades": "4.18.0-ec.0"}}},
+            }
+        }
+        err = releases.validate(valid_releases)
+        self.assertIsNone(err)

--- a/ocp-build-data-validator/validator/__main__.py
+++ b/ocp-build-data-validator/validator/__main__.py
@@ -3,7 +3,7 @@ import atexit
 import sys
 from multiprocessing import Pool, cpu_count
 
-from . import cgit, distgit, exceptions, format, github, global_session, schema, support
+from . import cgit, distgit, exceptions, format, github, global_session, releases, schema, support
 
 
 def validate(file, exclude_vpn, schema_only):
@@ -21,11 +21,19 @@ def validate(file, exclude_vpn, schema_only):
         msg = 'Schema mismatch: {}\nReturned error: {}'.format(file, err)
         support.fail_validation(msg, parsed)
 
-    if support.get_artifact_type(file) not in ['image', 'rpm']:
+    if support.get_artifact_type(file) not in ['image', 'rpm', 'releases']:
         print(f'✅ Validated {file}')
         return
 
     if schema_only:
+        print(f'✅ Validated {file}')
+        return
+
+    if support.get_artifact_type(file) == 'releases':
+        err = releases.validate(parsed)
+        if err:
+            msg = "releases.yml validation failed\nReturned error: {}".format(err)
+            support.fail_validation(msg, parsed)
         print(f'✅ Validated {file}')
         return
 

--- a/ocp-build-data-validator/validator/releases.py
+++ b/ocp-build-data-validator/validator/releases.py
@@ -1,0 +1,30 @@
+from typing import List, Optional
+
+from . import support
+
+
+def validate(data: dict) -> Optional[str]:
+    self_referential_upgrades = get_self_referential_upgrades(data)
+    if self_referential_upgrades:
+        return f"The following releases contain references to themselves in their respective 'upgrades': {', '.join(self_referential_upgrades)}"
+
+
+def get_self_referential_upgrades(releases_config: dict) -> List[str]:
+    """
+    Get a list of releases which contain themselves in their 'upgrades'
+    """
+    self_referential_releases = []
+    for release, release_config in releases_config['releases'].items():
+        full_release = release
+
+        if release.startswith('ec') or release.startswith('rc'):
+            # Construct full release name
+            group_config = support.load_group_config_for('releases.yml')
+            full_release = f"{group_config['vars']['MAJOR']}.{group_config['vars']['MINOR']}.0-{release}"
+
+        upgrades_releases_str = release_config.get('assembly', {}).get('group', {}).get('upgrades', "")
+        for upgrade_release in upgrades_releases_str.split(','):
+            if upgrade_release.strip() == full_release:
+                self_referential_releases.append(release)
+
+    return self_referential_releases


### PR DESCRIPTION
Add check to ocp-build-data-validator to ensure that the `upgrades` field in `releases.yml` does not contain references to itself.

If there's self-referential entry, displays the following error:
```
validator.exceptions.ValidationFailed: releases.yml validation failed
Returned error: The following releases contain references to themselves in their respective 'upgrades': 4.18.14, 4.18.13, rc.1, ec.1
```
