### PR TITLE
Pin vendor label to Red Hat, Inc.

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -756,6 +756,9 @@ class KonfluxRebaser:
         # Set the image name
         dfp.labels["name"] = metadata.config.name
 
+        # The vendor should always be Red Hat, Inc.
+        dfp.labels["vendor"] = "Red Hat, Inc."
+
         # Set the distgit repo name
         dfp.labels["com.redhat.component"] = metadata.get_component_name()
 


### PR DESCRIPTION
Fixes failing Conforma policy check: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/openshift-4-19/pipelineruns/managed-f7ftx/logs

```
  Reason: The "vendor" label has an unexpected "Red Hat" value. Must be one of: Red Hat, Inc.
```

Since upstream has defined it like that: https://github.com/openshift/console/blob/release-4.20/Dockerfile#L73

Since this is the correct name that we should always be setting for all images that ART is releasing in Konflux, pin it in art-tools.