### PR TITLE
Stop spamming about tag-rpms failures

### DIFF
--- a/pyartcd/pyartcd/pipelines/tag_rpms.py
+++ b/pyartcd/pyartcd/pipelines/tag_rpms.py
@@ -72,7 +72,6 @@ class TagRPMsPipeline:
         except Exception as err:
             error_message = f"Error running tag-rpms: {err}\n {traceback.format_exc()}"
             self.logger.error(error_message)
-            await self.slack_client.say(":warning: Error running tag-rpms")
             raise
 
     async def tag_rpms(self):


### PR DESCRIPTION
Because:
- errors are kind of expected, when e.g. kernel-rt has the right tags, but kernel does not yet
- we have an aggregate error reporting that reports every 5 error runs