### PR TITLE
Suppress test warnings in RepodataLoader async tests for cleaner output

### DIFF
--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -417,23 +417,25 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
 
         mock_fetch_olm_bundle_image_info.assert_called_once_with(bundle_build)
         mock_fetch_olm_bundle_blob.assert_called_once_with(bundle_build)
-        self.assertDictContainsSubset(
-            {
-                "__doozer_group": "test-group",
-                "__doozer_key": "test-distgit-key",
-                "__doozer_version": "1.0.0",
-                "__doozer_release": "1",
-                "__doozer_bundle_nvrs": "foo-bundle-1.0.0-1",
-            },
-            mock_dfp.envs,
-        )
-        self.assertDictContainsSubset(
-            {
-                "io.openshift.build.source-location": "https://example.com/foo-operator.git",
-                "io.openshift.build.commit.id": "beefdead",
-            },
-            mock_dfp.labels,
-        )
+        # Replace deprecated assertDictContainsSubset with explicit checks
+        expected_envs = {
+            "__doozer_group": "test-group",
+            "__doozer_key": "test-distgit-key",
+            "__doozer_version": "1.0.0",
+            "__doozer_release": "1",
+            "__doozer_bundle_nvrs": "foo-bundle-1.0.0-1",
+        }
+        for k, v in expected_envs.items():
+            self.assertIn(k, mock_dfp.envs)
+            self.assertEqual(mock_dfp.envs[k], v)
+
+        expected_labels = {
+            "io.openshift.build.source-location": "https://example.com/foo-operator.git",
+            "io.openshift.build.commit.id": "beefdead",
+        }
+        for k, v in expected_labels.items():
+            self.assertIn(k, mock_dfp.labels)
+            self.assertEqual(mock_dfp.labels[k], v)
 
         result_catalog_file.seek(0)
         result_catalog_blobs = list(yaml.load_all(result_catalog_file))

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -130,7 +130,7 @@ class TestGenPayloadCli(IsolatedAsyncioTestCase):
             collect_assembly_build_ids=MagicMock(return_value={1, 2, 3}),
             detect_mismatched_siblings=None,
             detect_non_latest_rpms=None,
-            detect_inconsistent_images=AsyncMock(),
+            detect_inconsistent_images=Mock(),
             detect_installed_rpms_issues=None,
             detect_extend_payload_entry_issues=AsyncMock(),
             summarize_issue_permits=(True, {}),

--- a/doozer/tests/test_repodata.py
+++ b/doozer/tests/test_repodata.py
@@ -166,6 +166,7 @@ class TestRepodataLoader(IsolatedAsyncioTestCase):
   </data>
 </repomd>
 """
+        resp.__aenter__.return_value.raise_for_status = Mock()
 
         def _fake_fetch_remote_compressed(_, url: Optional[str]):
             primary_xml = """<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
This PR addresses warnings that were being emitted during the execution of some tests.

- In test_repodata.py, particularly in the async test for `RepodataLoader`. These warnings were cluttering the test output, making it harder to review results. The changes include:
- Adjustments to the mocking of async context managers and methods to ensure no warnings are raised during test execution.
- Improved test setup for the `test_load` method to avoid unnecessary warnings from unawaited coroutines or improper mock usage.

No changes to test logic or coverage; all tests continue to pass as before.

 An example [here](https://github.com/openshift-eng/art-tools/actions/runs/15556259601/job/43797605578?pr=1628#step:9:488)

```
tests/cli/test_gen_payload.py::TestGenPayloadCli::test_generate_assembly_issues_report
  /__w/art-tools/art-tools/doozer/doozerlib/cli/release_gen_payload.py:541: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  Coroutine created at (most recent call last)
    File "/github/home/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/asyncio/base_events.py", line 1928, in _run_once
      handle._run()
    File "/github/home/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/asyncio/events.py", line 84, in _run
      self._context.run(self._callback, *self._args)
    File "/github/home/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/unittest/mock.py", line 1395, in patched
      return await func(*newargs, **newkeywargs)
    File "/__w/art-tools/art-tools/doozer/tests/cli/test_gen_payload.py", line 139, in test_generate_assembly_issues_report
      await gpcli.generate_assembly_issues_report(Mock(AssemblyInspector))
    File "/__w/art-tools/art-tools/artcommon/artcommonlib/telemetry.py", line 37, in wrapper
      return await function(*args, **kwargs)
    File "/__w/art-tools/art-tools/doozer/doozerlib/cli/release_gen_payload.py", line 541, in generate_assembly_issues_report
      self.detect_inconsistent_images(assembly_inspector)
    File "/__w/art-tools/art-tools/.venv/lib/python3.11/site-packages/flexmock/_api.py", line 512, in mock_method
      return _handle_matched_expectation(expectation, runtime_self, *kargs, **kwargs)
    File "/__w/art-tools/art-tools/.venv/lib/python3.11/site-packages/flexmock/_api.py", line 492, in _handle_matched_expectation
      return _replace_with(*kargs, **kwargs)
    File "/github/home/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/unittest/mock.py", line 1124, in __call__
      return self._mock_call(*args, **kwargs)
    File "/github/home/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/unittest/mock.py", line 1128, in _mock_call
      return self._execute_mock_call(*args, **kwargs)
    self.detect_inconsistent_images(assembly_inspector)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_repodata.py::TestRepodataLoader::test_load
  /__w/art-tools/art-tools/doozer/doozerlib/repodata.py:242: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  Coroutine created at (most recent call last)
    File "/github/home/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/asyncio/base_events.py", line 608, in run_forever
      self._run_once()
    File "/github/home/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/asyncio/base_events.py", line 1928, in _run_once
      handle._run()
    File "/github/home/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/asyncio/events.py", line 84, in _run
      self._context.run(self._callback, *self._args)
    File "/github/home/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/unittest/mock.py", line 1395, in patched
      return await func(*newargs, **newkeywargs)
    File "/__w/art-tools/art-tools/doozer/tests/test_repodata.py", line 401, in test_load
      repodata = await loader.load(repo_name, repo_url)
    File "/__w/art-tools/art-tools/.venv/lib/python3.11/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
      return await copy(fn, *args, **kwargs)
    File "/__w/art-tools/art-tools/.venv/lib/python3.11/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
      result = await fn(*args, **kwargs)
    File "/__w/art-tools/art-tools/doozer/doozerlib/repodata.py", line 242, in load
      resp.raise_for_status()
    File "/github/home/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/unittest/mock.py", line 1124, in __call__
      return self._mock_call(*args, **kwargs)
    File "/github/home/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/unittest/mock.py", line 1128, in _mock_call
      return self._execute_mock_call(*args, **kwargs)
    resp.raise_for_status()
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
  ```