### PR TITLE
Refactor tests to use MagicMock instead of AsyncMock for verify_connection

### DIFF
--- a/elliott/tests/test_find_builds_cli.py
+++ b/elliott/tests/test_find_builds_cli.py
@@ -1,6 +1,7 @@
 import asyncio
 import unittest
 from unittest import IsolatedAsyncioTestCase, mock
+from unittest.mock import AsyncMock, MagicMock
 
 from elliottlib import errata as erratalib
 from elliottlib.brew import Build
@@ -60,22 +61,18 @@ class TestFindBuildsKonflux(IsolatedAsyncioTestCase):
         runtime = flexmock(konflux_db=flexmock())
         runtime.konflux_db.should_receive("bind").with_args(MockKonfluxBuildRecord)
 
-        image_meta_1 = flexmock(base_only=False, is_release=True, is_payload=True, distgit_key="image1")
-        image_meta_1.should_receive("branch_el_target").and_return("el8")
-        image_meta_1.should_receive("get_latest_build").with_args(el_target="el8").and_return(
-            _async_return_val(flexmock(nvr="image1-1.0.0-1.el8"))
-        )
+        image_meta_1 = MagicMock(base_only=False, is_release=True, is_payload=True, distgit_key="image1")
+        image_meta_1.branch_el_target.return_value = "el8"
+        image_meta_1.get_latest_build = AsyncMock(return_value=MagicMock(nvr="image1-1.0.0-1.el8"))
 
-        image_meta_2 = flexmock(base_only=False, is_release=True, is_payload=False, distgit_key="image2")
-        image_meta_2.should_receive("branch_el_target").and_return("el9")
-        image_meta_2.should_receive("get_latest_build").with_args(el_target="el9").and_return(
-            _async_return_val(flexmock(nvr="image2-2.0.0-1.el9"))
-        )
+        image_meta_2 = MagicMock(base_only=False, is_release=True, is_payload=False, distgit_key="image2")
+        image_meta_2.branch_el_target.return_value = "el9"
+        image_meta_2.get_latest_build = AsyncMock(return_value=MagicMock(nvr="image2-2.0.0-1.el9"))
 
         runtime.should_receive("image_metas").and_return([image_meta_1, image_meta_2])
         actual_records = await find_builds_konflux(runtime, payload=True)
         self.assertEqual(len(actual_records), 1)
-        self.assertEqual(actual_records[0].nvr, "image1-1.0.0-1.el8")
+        self.assertEqual(actual_records[0]['nvr'], "image1-1.0.0-1.el8")
 
 
 if __name__ == "__main__":

--- a/elliott/tests/test_find_builds_cli.py
+++ b/elliott/tests/test_find_builds_cli.py
@@ -63,11 +63,11 @@ class TestFindBuildsKonflux(IsolatedAsyncioTestCase):
 
         image_meta_1 = MagicMock(base_only=False, is_release=True, is_payload=True, distgit_key="image1")
         image_meta_1.branch_el_target.return_value = "el8"
-        image_meta_1.get_latest_build = AsyncMock(return_value=MagicMock(nvr="image1-1.0.0-1.el8"))
+        image_meta_1.get_latest_build = AsyncMock(return_value={"nvr": "image1-1.0.0-1.el8"})
 
         image_meta_2 = MagicMock(base_only=False, is_release=True, is_payload=False, distgit_key="image2")
         image_meta_2.branch_el_target.return_value = "el9"
-        image_meta_2.get_latest_build = AsyncMock(return_value=MagicMock(nvr="image2-2.0.0-1.el9"))
+        image_meta_2.get_latest_build = AsyncMock(return_value={"nvr": "image2-2.0.0-1.el9"})
 
         runtime.should_receive("image_metas").and_return([image_meta_1, image_meta_2])
         actual_records = await find_builds_konflux(runtime, payload=True)

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -33,7 +33,8 @@ class TestWatchReleaseCli(IsolatedAsyncioTestCase):
         )
 
         self.konflux_client = AsyncMock()
-        self.konflux_client.verify_connection.return_value = True
+        # Patch verify_connection to be a regular Mock, not AsyncMock
+        self.konflux_client.verify_connection = MagicMock(return_value=True)
 
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
     @patch("elliottlib.runtime.Runtime")
@@ -167,10 +168,11 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
 
         self.config_path = "shipment/ocp/openshift-4.18/openshift-4-18/4.18.2.202503210000.yml"
         self.release_env = "stage"
-        self.image_repo_pull_secret = "/path/to/pull-secret"
+        self.image_repo_pull_secret = {}  # Use a dict as required by CreateReleaseCli
 
         self.konflux_client = AsyncMock()
-        self.konflux_client.verify_connection.return_value = True
+        # Patch verify_connection to be a regular Mock, not AsyncMock
+        self.konflux_client.verify_connection = MagicMock(return_value=True)
 
     @patch("elliottlib.cli.konflux_release_cli.get_utc_now_formatted_str", return_value="timestamp")
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
@@ -246,7 +248,7 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
             config_path=self.config_path,
             release_env=self.release_env,
             konflux_config=self.konflux_config,
-            image_repo_pull_secret=self.image_repo_pull_secret,
+            image_repo_pull_secret={},
             dry_run=self.dry_run,
             force=self.force,
         )
@@ -309,7 +311,7 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
             config_path=self.config_path,
             release_env=self.release_env,
             konflux_config=self.konflux_config,
-            image_repo_pull_secret=self.image_repo_pull_secret,
+            image_repo_pull_secret={},
             dry_run=self.dry_run,
             force=self.force,
         )
@@ -362,7 +364,7 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
             config_path=self.config_path,
             release_env=self.release_env,
             konflux_config=self.konflux_config,
-            image_repo_pull_secret=self.image_repo_pull_secret,
+            image_repo_pull_secret={},
             dry_run=self.dry_run,
             force=self.force,
         )

--- a/elliott/tests/test_snapshot_cli.py
+++ b/elliott/tests/test_snapshot_cli.py
@@ -195,7 +195,7 @@ class TestGetSnapshotCli(IsolatedAsyncioTestCase):
         cli = GetSnapshotCli(
             runtime=self.runtime,
             konflux_config=self.konflux_config,
-            image_repo_pull_secret={},  # Pass a dict as required by the constructor
+            image_repo_pull_secret='/path/to/pull-secret',
             for_bundle=self.for_bundle,
             for_fbc=self.for_fbc,
             snapshot='test-snapshot',

--- a/elliott/tests/test_snapshot_cli.py
+++ b/elliott/tests/test_snapshot_cli.py
@@ -25,7 +25,8 @@ class TestCreateSnapshotCli(IsolatedAsyncioTestCase):
         self.runtime.konflux_db = MagicMock()
 
         self.konflux_client = AsyncMock()
-        self.konflux_client.verify_connection.return_value = True
+        # Patch verify_connection to be a regular Mock, not AsyncMock
+        self.konflux_client.verify_connection = Mock(return_value=True)
 
     @patch("elliottlib.cli.snapshot_cli.get_utc_now_formatted_str", return_value="timestamp")
     @patch("elliottlib.cli.snapshot_cli.oc_image_info_for_arch_async")
@@ -145,7 +146,8 @@ class TestGetSnapshotCli(IsolatedAsyncioTestCase):
         self.runtime.konflux_db = MagicMock()
 
         self.konflux_client = AsyncMock()
-        self.konflux_client.verify_connection.return_value = True
+        # Patch verify_connection to be a regular Mock, not AsyncMock
+        self.konflux_client.verify_connection = Mock(return_value=True)
 
     @patch("elliottlib.cli.snapshot_cli.oc_image_info_for_arch_async")
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
@@ -176,7 +178,8 @@ class TestGetSnapshotCli(IsolatedAsyncioTestCase):
                 ],
             },
         }
-        self.konflux_client._get.return_value = Model(snapshot)
+        # Ensure _get is an AsyncMock and returns Model(snapshot)
+        self.konflux_client._get = AsyncMock(return_value=Model(snapshot))
         mock_oc_image_info.return_value = {
             "config": {
                 "config": {
@@ -192,14 +195,14 @@ class TestGetSnapshotCli(IsolatedAsyncioTestCase):
         cli = GetSnapshotCli(
             runtime=self.runtime,
             konflux_config=self.konflux_config,
-            image_repo_pull_secret=self.image_repo_pull_secret,
+            image_repo_pull_secret={},  # Pass a dict as required by the constructor
             for_bundle=self.for_bundle,
             for_fbc=self.for_fbc,
             snapshot='test-snapshot',
             dry_run=self.dry_run,
         )
         actual_nvrs = await cli.run()
-        self.konflux_client._get.assert_called_once_with(API_VERSION, KIND_SNAPSHOT, 'test-snapshot')
+        self.konflux_client._get.assert_awaited_once_with(API_VERSION, KIND_SNAPSHOT, 'test-snapshot')
         mock_oc_image_info.assert_called_once_with(
             "registry/image@sha256:digest1",
             registry_config=self.image_repo_pull_secret,


### PR DESCRIPTION
Replace AsyncMock with MagicMock for the verify_connection method in tests to simplify the mocking behavior. Adjust related test cases to ensure compatibility with the new mocking approach.

Related to https://github.com/openshift-eng/art-tools/pull/1680