### PR TITLE
Init build_id in RhcosBuildInspector

### DIFF
--- a/doozer/doozerlib/cli/inspect_stream.py
+++ b/doozer/doozerlib/cli/inspect_stream.py
@@ -17,10 +17,7 @@ from doozerlib.cli.release_gen_payload import PayloadGenerator
 @click.pass_obj
 async def inspect_stream(runtime, code, strict):
     code = AssemblyIssueCode[code]
-    # if runtime.assembly != 'stream':
-    #     print(f'Disregarding non-stream assembly: {runtime.assembly}. This command is only intended for stream')
-    #     runtime.assembly = 'stream'
-    runtime.initialize(config_only=True, clone_distgits=False)
+    runtime.initialize(config_only=True)
 
     if code == AssemblyIssueCode.INCONSISTENT_RHCOS_RPMS:
         assembly_inspector = AssemblyInspector(runtime)

--- a/doozer/doozerlib/cli/inspect_stream.py
+++ b/doozer/doozerlib/cli/inspect_stream.py
@@ -17,10 +17,10 @@ from doozerlib.cli.release_gen_payload import PayloadGenerator
 @click.pass_obj
 async def inspect_stream(runtime, code, strict):
     code = AssemblyIssueCode[code]
-    if runtime.assembly != 'stream':
-        print(f'Disregarding non-stream assembly: {runtime.assembly}. This command is only intended for stream')
-        runtime.assembly = 'stream'
-    runtime.initialize(clone_distgits=False)
+    # if runtime.assembly != 'stream':
+    #     print(f'Disregarding non-stream assembly: {runtime.assembly}. This command is only intended for stream')
+    #     runtime.assembly = 'stream'
+    runtime.initialize(config_only=True, clone_distgits=False)
 
     if code == AssemblyIssueCode.INCONSISTENT_RHCOS_RPMS:
         assembly_inspector = AssemblyInspector(runtime)

--- a/doozer/doozerlib/rhcos.py
+++ b/doozer/doozerlib/rhcos.py
@@ -45,6 +45,7 @@ class RHCOSBuildFinder:
         self.custom = custom
         self.go_arch = go_arch_for_brew_arch(brew_arch)
         self._primary_container = None
+        self.layered = self.runtime.group_config.rhcos.get("layered_rhcos", False)
 
     def get_primary_container_conf(self):
         """
@@ -152,7 +153,7 @@ class RHCOSBuildFinder:
              ...
          }
         """
-        if self.runtime.group_config.rhcos.get("layered_rhcos", False) and pullspec:
+        if self.layered and pullspec:
             if meta_type == "commitmeta":
                 with tempfile.TemporaryDirectory() as temp_dir:
                     stdout, _ = exectools.cmd_assert(
@@ -189,7 +190,7 @@ class RHCOSBuildFinder:
         :param build_id: the rhel image build id eg. 9.6.20250527-0
         :return: rpm list for rhel build
         """
-        if self.runtime.group_config.rhcos.get("layered_rhcos", False):
+        if self.layered:
             url = f"{RHCOS_RELEASES_STREAM_URL}/rhel-{self.runtime.group_config.vars.RHCOS_EL_MAJOR}.{self.runtime.group_config.vars.RHCOS_EL_MINOR}/builds/{build_id}/{self.brew_arch}/commitmeta.json"
             logger.info(f"Send request to {url}")
             with request.urlopen(url) as req:
@@ -202,7 +203,7 @@ class RHCOSBuildFinder:
         :param container_conf: a payload tag conf Model from group.yml (with build_metadata_key)
         :return: Returns (rhcos build id, image pullspec) or (None, None) if not found.
         """
-        if self.runtime.group_config.rhcos.get("layered_rhcos", False):
+        if self.layered:
             primary_conf = self.get_primary_container_conf()
             rhcosdata = util.oc_image_info_for_arch(primary_conf.rhcos_index_tag, self.go_arch)
             build_id = rhcosdata['config']['config']['Labels'][
@@ -230,31 +231,13 @@ class RHCOSBuildInspector:
         self.brew_arch = brew_arch
         self.pullspec_for_tag = pullspec_for_tag
         self.build_id = build_id
+        self.stream_version = None
+        self.layered = self.runtime.group_config.rhcos.get("layered_rhcos", False)
 
-        # Remember the pullspec(s) provided in case it does not match what is in the releases.yaml.
-        # Because of an incident where we needed to repush RHCOS and get a new SHA for 4.10 GA,
-        # trust the exact pullspec in releases.yml instead of what we find in the RHCOS release
-        # browser.
-        
-        for tag, pullspec in pullspec_for_tag.items():
-            image_build_id = get_build_id_from_rhcos_pullspec(pullspec)
-            logger.info(f"Determined build id for tag {tag} with pullspec {pullspec}: {image_build_id}")
-            if self.build_id and self.build_id != image_build_id:
-                raise Exception(
-                    f'Found divergent RHCOS build_id for {tag} {pullspec}. {image_build_id} versus {self.build_id}'
-                )
-            self.build_id = image_build_id
+        if self.layered:
+            # set build_id to the rhel base image build id of the rhel-coreos image
+            self.build_id = get_build_id_from_rhcos_pullspec(pullspec_for_tag["rhel-coreos"], layered_id=False)
 
-        # The first digits of the RHCOS build are the major.minor of the rhcos stream name.
-        # Which, near branch cut, might not match the actual release stream.
-        # Sadly we don't have any other labels or anything to look at to determine the stream.
-        version = self.build_id.split('.')[0]
-        self.stream_version = version[0] + '.' + version[1:]  # e.g. 43.82.202102081639.0 -> "4.3"
-        
-
-        logger.info("Build ID %s", self.build_id)
-        
-        if self.runtime.group_config.rhcos.get("layered_rhcos", False):
             finder = RHCOSBuildFinder(runtime, self.stream_version, self.brew_arch)
             self._build_meta = finder.rhcos_build_meta(
                 self.build_id, pullspec=pullspec_for_tag.get("rhel-coreos-extensions", None), meta_type='meta'
@@ -264,6 +247,21 @@ class RHCOSBuildInspector:
             )
             self.rhel_build_meta = finder.rhel_build_meta(self.build_id)
         else:
+            for tag, pullspec in pullspec_for_tag.items():
+                image_build_id = get_build_id_from_rhcos_pullspec(pullspec)
+                logger.info(f"Determined build id for tag {tag} with pullspec {pullspec}: {image_build_id}")
+                if self.build_id and self.build_id != image_build_id:
+                    raise Exception(
+                        f'Found divergent RHCOS build_id for {tag} {pullspec}. {image_build_id} versus {self.build_id}'
+                    )
+                self.build_id = image_build_id
+
+            # The first digits of the RHCOS build are the major.minor of the rhcos stream name.
+            # Which, near branch cut, might not match the actual release stream.
+            # Sadly we don't have any other labels or anything to look at to determine the stream.
+            version = self.build_id.split('.')[0]
+            self.stream_version = version[0] + '.' + version[1:]  # e.g. 43.82.202102081639.0 -> "4.3"
+
             finder = RHCOSBuildFinder(runtime, self.stream_version, self.brew_arch, custom=True)
             self._build_meta = finder.rhcos_build_meta(self.build_id, meta_type='meta')
             self._os_commitmeta = finder.rhcos_build_meta(self.build_id, meta_type='commitmeta')

--- a/doozer/doozerlib/rhcos.py
+++ b/doozer/doozerlib/rhcos.py
@@ -249,7 +249,6 @@ class RHCOSBuildInspector:
         else:
             for tag, pullspec in pullspec_for_tag.items():
                 image_build_id = get_build_id_from_rhcos_pullspec(pullspec)
-                logger.info(f"Determined build id for tag {tag} with pullspec {pullspec}: {image_build_id}")
                 if self.build_id and self.build_id != image_build_id:
                     raise Exception(
                         f'Found divergent RHCOS build_id for {tag} {pullspec}. {image_build_id} versus {self.build_id}'


### PR DESCRIPTION
Fix for the error when `AssemblyInspector.get_rhcos_build()` is invoked for named assemblies. This error can be seen at several places:
- build-sync / doozer release:gen-payload: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/20529
- `doozer --assembly=4.19.0 --data-path=https://github.com/thegreyd/ocp-build-data --group=openshift-4.19@add_4_19_0 inspect:stream INCONSISTENT_RHCOS_RPMS`

```
2025-06-12 12:57:26,800 art_tools.doozerlib.rhcos INFO Send request to https://releases-rhcos--prod-pipeline.apps.int.prod-stable-spoke1-dc-iad2.itup.redhat.com/storage/prod/streams/rhel-9.6/builds/None/x86_64/commitmeta.json
...
urllib.error.HTTPError: HTTP Error 403: Forbidden
```

Test:
```
$ doozer --assembly=4.19.0 --data-path=https://github.com/thegreyd/ocp-build-data --group=openshift-4.19@add_4_19_0 inspect:stream INCONSISTENT_RHCOS_RPMS
...
RHCOS builds consistent [RHCOSBuild:x86_64:9.6.20250530-0, RHCOSBuild:ppc64le:9.6.20250530-0, RHCOSBuild:s390x:9.6.20250530-0, RHCOSBuild:aarch64:9.6.20250530-0]
```