### PR TITLE
Do not dump html as part of jira search fails

### DIFF
--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -840,9 +840,10 @@ class JIRABugTracker(BugTracker):
             # Setting maxResults=0 retrieves all matching issues from the JIRA API.
             results = self._client.search_issues(query, maxResults=0)
         except JIRAError as e:
-            # truncate the error message to avoid flooding the logs
-            if len(e.text) > 1000:
-                e.text = e.text[:1000] + '...[truncated]'
+            # a lot of times we get JIRAError with massive HTML dump in the error text
+            # do not dump full html in the logs
+            if "<html>" in e.text:
+                e.text = e.text.strip()[:100] + '...[truncated html]'
             raise e
 
         if results is None:

--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -694,7 +694,7 @@ class JIRABugTracker(BugTracker):
         client = JIRA(self._server, token_auth=token_auth)
         return client
 
-    @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(5))
+    @retry(reraise=True, stop=stop_after_attempt(10), wait=wait_fixed(30))
     def _init_fields(self):
         for f in self._client.fields():
             if f['name'] == 'Target Version':


### PR DESCRIPTION
Example: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift/2306/console