### PR TITLE
shipment config default env stage

### DIFF
--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -207,7 +207,7 @@ class PrepareReleaseKonfluxPipeline:
         self.validate_shipment_config(self.shipment_config)
 
         shipment_config = self.shipment_config.copy()  # make a copy to avoid modifying the original
-        env = shipment_config.get("env", "prod")
+        env = shipment_config.get("env", "stage")
         generated_shipments: Dict[str, ShipmentConfig] = {}
         for shipment_advisory_config in shipment_config.get("advisories"):
             kind = shipment_advisory_config.get("kind")


### PR DESCRIPTION
If the field is missing, the environment is set to `prod`, which could be undesired. Set the default to `stage`.