### PR TITLE
Fix YAML parser error message compatibility in format tests

### DIFF
--- a/ocp-build-data-validator/tests/test_format.py
+++ b/ocp-build-data-validator/tests/test_format.py
@@ -12,7 +12,13 @@ class TestFormat(unittest.TestCase):
         """
         (parsed, err) = format.validate(invalid_yaml)
         self.assertIsNone(parsed)
-        self.assertIn("did not find expected key", err)
+        # Check for different possible error messages from different YAML parser versions
+        self.assertTrue(
+            "did not find expected key" in err
+            or "expected <block end>, but found" in err
+            or "while parsing a block mapping" in err,
+            f"Unexpected YAML error message: {err}",
+        )
 
     def test_valid_yaml(self):
         valid_yaml = """


### PR DESCRIPTION
 ## Summary
  - Update format test to handle different error messages from various YAML parser versions
  - Replace exact string match with multiple possible error message patterns

  ## Problem
  The test was failing on systems with different YAML parser versions due to hardcoded error message
  expectations.

  ## Solution
  Modified the test assertion to check for any of the common YAML parsing error messages:
  - "did not find expected key"
  - "expected <block end>, but found"
  - "while parsing a block mapping"