### PR TITLE
[Konflux] Fix images-mirror-set to include the bundle itself

### DIFF
--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -361,10 +361,11 @@ class KonfluxFbcRebaser:
         konflux_db: KonfluxDb = metadata.runtime.konflux_db
         konflux_db.bind(KonfluxBuildRecord)
         ref_builds = await self._get_referenced_images(konflux_db, bundle_build)
-        ref_pullspecs = [
+        ref_builds.append(bundle_build)  # Include the bundle build itself
+        ref_pullspecs = {
             b.image_pullspec.replace(constants.REGISTRY_PROXY_BASE_URL, constants.BREW_REGISTRY_BASE_URL)
             for b in ref_builds
-        ]
+        }
 
         # Load current catalog
         catalog_dir = build_repo.local_dir.joinpath("catalog", olm_package)

--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -325,7 +325,7 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
         bundle_build = MagicMock(
             spec=KonfluxBundleBuildRecord,
             nvr="foo-bundle-1.0.0-1",
-            image_pullspec="dev.example.com/foo-bundle:1.0.0",
+            image_pullspec="dev.example.com/foo-bundle@1",
             image_tag="deadbeef",
             source_repo="https://example.com/foo-operator.git",
             commitish="beefdead",
@@ -409,7 +409,6 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
         images_mirror_set_file = StringIO()
         mock_open.return_value.__enter__.side_effect = [org_catalog_file, result_catalog_file, images_mirror_set_file]
         mock_get_referenced_images.return_value = [
-            MagicMock(image_pullspec="example.com/art-images@1"),
             MagicMock(image_pullspec="example.com/art-images@2"),
         ]
 


### PR DESCRIPTION
Conforma (EC) requires the OLM bundle image itself to be included in `images-mirror-set.yaml`. This PR will make EC happy.

Tested with https://github.com/openshift-priv/art-fbc/commit/650489b69fec62dbd3676b9732dd21093cb89e46