### PR TITLE
[Konflux] Use bundle delivery repo specified in ocp-build-data

### DIFF
--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -333,6 +333,9 @@ class KonfluxFbcRebaser:
     ):
         logger.info("Rebasing dir %s", build_repo.local_dir)
 
+        # This will raise an ValueError if the bundle delivery repo name is not set in the metadata config.
+        delivery_repo_name = metadata.get_olm_bundle_delivery_repo_name()
+
         # Fetch bundle image info and blob
         logger.info("Fetching OLM bundle image %s from %s", bundle_build.nvr, bundle_build.image_pullspec)
         olm_bundle_image_info = await self._fetch_olm_bundle_image_info(bundle_build)
@@ -433,9 +436,8 @@ class KonfluxFbcRebaser:
                 package_blob["defaultChannel"] = default_channel_name
 
         # Replace pullspecs to use the prod registry
-        new_image_name = image_name.replace('openshift/', 'openshift4/')
         digest = bundle_build.image_pullspec.split('@', 1)[-1]
-        bundle_prod_pullspec = f"{constants.DELIVERY_IMAGE_REGISTRY}/{new_image_name}@{digest}"
+        bundle_prod_pullspec = f"{constants.DELIVERY_IMAGE_REGISTRY}/{delivery_repo_name}@{digest}"
         olm_bundle_blob["image"] = bundle_prod_pullspec
         related_images = olm_bundle_blob.get("relatedImages", [])
         if related_images:

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -3,7 +3,7 @@ import json
 from collections import OrderedDict
 from copy import copy
 from multiprocessing import Event
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple, cast
 
 from artcommonlib import util as artlib_util
 from artcommonlib.model import Missing, Model
@@ -97,6 +97,21 @@ class ImageMetadata(Metadata):
         if not short_name.startswith('ose-'):
             short_name = 'ose-' + short_name
         return f"openshift/{short_name}"
+
+    def get_olm_bundle_delivery_repo_name(self):
+        """Returns the delivery repository name for the OLM bundle of this OLM operator.
+
+        :return: The delivery repository name for the OLM bundle.
+        :raises IOError: If the image is not an OLM operator.
+        """
+        if not self.is_olm_operator:
+            raise IOError(f"[{self.distgit_key}] No update-csv config found in the image's metadata")
+        repo_name = self.config.delivery.bundle_delivery_repo_name
+        if repo_name is Missing:
+            raise IOError(
+                f"[{self.distgit_key}] No delivery.bundle_delivery_repo_name config found in the image's metadata"
+            )
+        return cast(str, repo_name)
 
     def get_assembly_rpm_package_dependencies(self, el_ver: int) -> Tuple[Dict[str, str], Dict[str, str]]:
         """

--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -320,6 +320,7 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
         metadata = MagicMock(spec=ImageMetadata)
         metadata.distgit_key = "test-distgit-key"
         metadata.runtime = MagicMock()
+        metadata.get_olm_bundle_delivery_repo_name = MagicMock(return_value="openshift4/foo-bundle")
         build_repo = MagicMock()
         build_repo.local_dir = self.base_dir
         bundle_build = MagicMock(


### PR DESCRIPTION
When building FBC, we need to convert image repo names of OLM bundles to delivery repo names, so that Conforma can validate those bundles in FBC even before they are shipped to the delivery repo. However, we found the name of the internal build repo doesn't always match the delivery repo. Therefore, explicitly specifying delivery repo names for OLM bundles in ocp-build-data image config is the only way to go. Fortunately, those delivery repo names can be dumped from Pyxis.

This PR make Doozer use the bundle_delivery_repo_name field in ocp-build-data image config.