### PR TITLE
Fix build issue on python3.13

### DIFF
--- a/artcommon/requirements.txt
+++ b/artcommon/requirements.txt
@@ -1,3 +1,4 @@
+pydantic >= 2.11
 future
 google-api-core
 google-auth
@@ -8,4 +9,4 @@ google-resumable-media
 googleapis-common-protos
 opentelemetry-api
 sqlalchemy
-pip-system-certs==5.0
+pip-system-certs>=5.2

--- a/doozer/requirements.txt
+++ b/doozer/requirements.txt
@@ -22,7 +22,6 @@ semver
 tenacity ~= 8.4, != 8.4.0  # https://github.com/jd/tenacity/issues/471
 wrapt
 mysql-connector-python >= 8.0.21
-pydantic ~= 2.0.0
 python-dateutil >= 2.8.1
 openshift-client ~= 2.0.1
 ruamel.yaml

--- a/elliott/pyproject.toml
+++ b/elliott/pyproject.toml
@@ -49,7 +49,6 @@ dependencies = [
     "koji >= 1.18",
     "semver",
     "pip_system_certs",
-    "pydantic ~= 2.0.0",
     "pygit2 >= 1.11.1",  # https://github.com/libgit2/pygit2/issues/1176
     "python-bugzilla >= 3.2",
     "pyyaml",


### PR DESCRIPTION
Ran into this error while building pydantic on python3.13:

```
TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'
```
Recent versions do not have it.
Also, set lower boud for pip-system-certs, as the 5.1 issue is solved in 5.2.