### PR TITLE
Fix lockfile pipeline continuity by downloading upstream files when digest matches

### DIFF
--- a/doozer/doozerlib/lockfile.py
+++ b/doozer/doozerlib/lockfile.py
@@ -247,6 +247,24 @@ class RPMLockfileGenerator:
         self.builder = RpmInfoCollector(repos, self.logger)
         self.runtime = runtime
 
+    def _get_target_branch(self, distgit_key: str) -> Optional[str]:
+        """
+        Construct target branch name using the same format as rebaser.
+
+        Args:
+            distgit_key (str): Distgit key to construct the target branch name.
+
+        Returns:
+            Optional[str]: Target branch name, or None if runtime is not available.
+        """
+        if not self.runtime:
+            return None
+        return "art-{group}-assembly-{assembly_name}-dgk-{distgit_key}".format(
+            group=self.runtime.group,
+            assembly_name=self.runtime.assembly,
+            distgit_key=distgit_key,
+        )
+
     @staticmethod
     def _compute_hash(rpms: set[str]) -> str:
         """
@@ -273,15 +291,9 @@ class RPMLockfileGenerator:
         Returns:
             Optional[str]: Digest content if found, None otherwise.
         """
-        if not self.runtime:
+        target_branch = self._get_target_branch(distgit_key)
+        if not target_branch:
             return None
-
-        # Construct target branch name using the same format as rebaser
-        target_branch = "art-{group}-assembly-{assembly_name}-dgk-{distgit_key}".format(
-            group=self.runtime.group,
-            assembly_name=self.runtime.assembly,
-            distgit_key=distgit_key,
-        )
 
         try:
             # Use just the filename since the digest file is in the root of the git repo
@@ -298,6 +310,38 @@ class RPMLockfileGenerator:
                 return None
         except Exception as e:
             self.logger.debug(f"Error fetching digest from git branch '{target_branch}': {e}")
+            return None
+
+    def _get_lockfile_from_target_branch(self, lockfile_path: Path, distgit_key: str) -> Optional[str]:
+        """
+        Fetch lockfile content from the target art branch.
+
+        Args:
+            lockfile_path (Path): Path to the lockfile relative to repo root.
+            distgit_key (str): Distgit key to construct the target branch name.
+
+        Returns:
+            Optional[str]: Lockfile content if found, None otherwise.
+        """
+        target_branch = self._get_target_branch(distgit_key)
+        if not target_branch:
+            return None
+
+        try:
+            # Use just the filename since the lockfile is in the root of the git repo
+            lockfile_filename = lockfile_path.name
+
+            # Use exectools to run git show command
+            rc, stdout, stderr = exectools.cmd_gather(['git', 'show', f'{target_branch}:{lockfile_filename}'])
+            if rc == 0:
+                return stdout
+            else:
+                self.logger.debug(
+                    f"Could not fetch lockfile '{lockfile_filename}' from branch '{target_branch}': {stderr}"
+                )
+                return None
+        except Exception as e:
+            self.logger.debug(f"Error fetching lockfile from git branch '{target_branch}': {e}")
             return None
 
     async def generate_lockfile(
@@ -342,14 +386,39 @@ class RPMLockfileGenerator:
                     self.logger.warning(f"Failed to read local digest file '{digest_path}': {e}")
 
             # If no local digest or distgit_key provided, try fetching from target branch
+            upstream_digest_found = False
             if old_fingerprint is None and distgit_key:
                 old_fingerprint = self._get_digest_from_target_branch(digest_path, distgit_key)
                 if old_fingerprint:
                     self.logger.info(f"Found digest in target branch for {distgit_key}")
+                    upstream_digest_found = True
 
             # Compare fingerprints
             if old_fingerprint == fingerprint:
-                self.logger.info("No changes in RPM list. Skipping lockfile generation.")
+                if upstream_digest_found and distgit_key:
+                    # Download both digest and lockfile from upstream to ensure they're available locally
+                    self.logger.info("No changes in RPM list. Downloading digest and lockfile from upstream.")
+
+                    # Write the digest file locally
+                    if old_fingerprint:
+                        try:
+                            digest_path.write_text(old_fingerprint)
+                            self.logger.info(f"Downloaded digest file to {digest_path}")
+                        except Exception as e:
+                            self.logger.warning(f"Failed to write digest file '{digest_path}': {e}")
+
+                    # Download and write the lockfile locally
+                    upstream_lockfile = self._get_lockfile_from_target_branch(lockfile_path, distgit_key)
+                    if upstream_lockfile:
+                        try:
+                            lockfile_path.write_text(upstream_lockfile)
+                            self.logger.info(f"Downloaded lockfile to {lockfile_path}")
+                        except Exception as e:
+                            self.logger.warning(f"Failed to write lockfile '{lockfile_path}': {e}")
+                    else:
+                        self.logger.warning(f"Could not download lockfile from upstream branch for {distgit_key}")
+                else:
+                    self.logger.info("No changes in RPM list. Skipping lockfile generation.")
                 return
             elif old_fingerprint:
                 self.logger.info("RPM list changed. Regenerating lockfile.")

--- a/doozer/tests/test_lockfile.py
+++ b/doozer/tests/test_lockfile.py
@@ -597,7 +597,7 @@ class TestRPMLockfileGenerator(unittest.IsolatedAsyncioTestCase):
         # Should skip generation since fingerprints match
         self.generator.builder.fetch_rpms_info.assert_not_called()
         mock_write_yaml.assert_not_called()
-        
+
     async def test_generate_lockfile_skips_when_repositories_empty(self):
         """Test that generate_lockfile skips when repositories set is empty"""
         # Mock the fetch_rpms_info method to track if it's called


### PR DESCRIPTION
## Problem

So basically when we find the digest file upstream and it matches, we'd skip generating the lockfile but then not download the files locally. This meant the next time
  the pipeline ran, the files would be missing upstream and we would generate the files again. This would end up in a pattern where we generate the files every second run.

  The flow was:
  1. Find matching digest upstream → skip generation
  2. Don't write anything locally
  3. Next pipeline run → files are gone upstream
  4. Not needed run 🙃

 ## Solution

  Now when we find a matching digest upstream, we actually download both the digest and lockfile to make sure they're availible for the next run:

  - Added `_get_lockfile_from_target_branch()` to grab the lockfile from upstream
  - Added `_get_target_branch()` helper since we were duplicating that logic everywhere
  - Fixed `generate_lockfile()` to actually download both files when digest matches
  - Added proper error handling and logging