### PR TITLE
Add defensive checks for lockfile generation preconditions

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -670,29 +670,39 @@ class ImageMetadata(Metadata):
         """
         Determines whether lockfile generation is enabled for the current image configuration.
 
-        The method checks if the cachi2 feature is enabled. If not, lockfile generation is disabled.
-        If cachi2 is enabled, it looks for lockfile generation overrides in the following order:
-        1. Image metadata configuration (`self.config.konflux.cachi2.lockfile.enabled`)
-        2. Group configuration (`self.runtime.group_config.konflux.cachi2.lockfile.enabled`)
-        If neither override is set, lockfile generation defaults to enabled.
+        The method checks preconditions in the following order:
+        1. Cachi2 feature must be enabled
+        2. enabled_repos must be defined and not empty
+        3. Lockfile generation overrides:
+           - Image metadata configuration (`self.config.konflux.cachi2.lockfile.enabled`)
+           - Group configuration (`self.runtime.group_config.konflux.cachi2.lockfile.enabled`)
+        If no override is set, lockfile generation defaults to enabled.
 
         Returns:
             bool: True if lockfile generation is enabled, False otherwise.
         """
         lockfile_enabled = True
 
+        # First check: cachi2 must be enabled
         cachi2_enabled = self.is_cachi2_enabled()
         if not cachi2_enabled:
             return False
 
+        # Second check: enabled_repos must exist and not be empty
+        enabled_repos = self.config.get("enabled_repos", [])
+        if not enabled_repos:
+            self.logger.info("Lockfile generation disabled: enabled_repos is empty or not defined")
+            return False
+
+        # Third check: lockfile-specific overrides
         lockfile_config_override = self.config.konflux.cachi2.lockfile.enabled
         if lockfile_config_override not in [Missing, None]:
-            lockfile_enabled = lockfile_config_override
+            lockfile_enabled = bool(lockfile_config_override)
             self.logger.info(f"Lockfile generation set from metadata config {lockfile_enabled}")
         else:
             lockfile_group_override = self.runtime.group_config.konflux.cachi2.lockfile.enabled
             if lockfile_group_override not in [Missing, None]:
-                lockfile_enabled = lockfile_group_override
+                lockfile_enabled = bool(lockfile_group_override)
                 self.logger.info(f"Lockfile generation set from group config {lockfile_enabled}")
 
         return lockfile_enabled

--- a/doozer/doozerlib/lockfile.py
+++ b/doozer/doozerlib/lockfile.py
@@ -324,6 +324,11 @@ class RPMLockfileGenerator:
             distgit_key (Optional[str]): Distgit key for fetching digest from target branch.
             force (bool): If True, ignore digest comparison and force regeneration.
         """
+        # Defensive check: repositories must not be empty
+        if not repositories:
+            self.logger.warning("Skipping lockfile generation: repositories set is empty")
+            return
+
         fingerprint = self._compute_hash(rpms)
         lockfile_path = path / filename
         digest_path = path / f'{filename}.digest'

--- a/doozer/tests/test_lockfile.py
+++ b/doozer/tests/test_lockfile.py
@@ -508,3 +508,14 @@ class TestRPMLockfileGenerator(unittest.IsolatedAsyncioTestCase):
         mock_write_yaml.assert_called_once()
         self.logger.info.assert_any_call("Found digest in target branch for test-image")
         self.logger.info.assert_any_call("RPM list changed. Regenerating lockfile.")
+
+    async def test_generate_lockfile_skips_when_repositories_empty(self):
+        """Test that generate_lockfile skips when repositories set is empty"""
+        # Mock the fetch_rpms_info method to track if it's called
+        self.generator.builder.fetch_rpms_info = MagicMock()
+
+        await self.generator.generate_lockfile(self.arches, set(), self.rpms, self.path, self.filename)
+
+        # Should skip generation due to empty repositories
+        self.generator.builder.fetch_rpms_info.assert_not_called()
+        self.logger.warning.assert_called_with("Skipping lockfile generation: repositories set is empty")


### PR DESCRIPTION
Adds validation to ensure enabled_repos is defined and not empty before attempting lockfile generation. Checks happen in both is_lockfile_generation_enabled() and generate_lockfile() to catch issues early and provide clear feedback.

[Test job](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/11964/console)