### PR TITLE
Remove release artist ping from rebase fail alerts

### DIFF
--- a/pyartcd/pyartcd/pipelines/art_notify.py
+++ b/pyartcd/pyartcd/pipelines/art_notify.py
@@ -366,7 +366,7 @@ class ArtNotifyPipeline:
                 channel = f'#art-release-{major}-{minor}'
                 response = self.app.client.chat_postMessage(
                     channel=channel,
-                    text=f":warning: @{RELEASE_ARTIST_HANDLE} {len(failures)} image{'s' if len(failures) > 1 else ''} failed to rebase in *{engine.capitalize()}*",
+                    text=f":warning: {len(failures)} image{'s' if len(failures) > 1 else ''} failed to rebase in *{engine.capitalize()}*",
                     link_names=True,
                 )
 


### PR DESCRIPTION
Automated pings every X hours are very disruptive. Proposing to remove this, until we work out a better alert/triage flow for rebase failures.