### PR TITLE
Enable --dump in watch release cli

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -949,7 +949,7 @@ class KonfluxClient:
                         namespace=namespace,
                         serialize=False,
                         field_selector=f"metadata.name={release_name}",
-                        timeout_seconds=5 * 60,
+                        timeout_seconds=60,
                     )
                     for event in release_obj:
                         assert isinstance(event, Dict)

--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -124,7 +124,6 @@ class CreateReleaseCli:
                 )
 
         # verify snapshot
-        # TODO: make it work for bundle
         get_snapshot_cli = GetSnapshotCli(
             self.runtime,
             self.konflux_config,

--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -143,9 +143,8 @@ class CreateReleaseCli:
 
         release_obj = await self.new_release(release_config)
         created_release = await self.konflux_client._create(release_obj)
-        LOGGER.info(
-            f"Successfully created Release {KONFLUX_UI_HOST}/ns/{self.konflux_config['namespace']}/applications/{release_config.application}/releases/{release_config.release_name}"
-        )
+        release_url = self.konflux_client.resource_url(created_release)
+        LOGGER.info("Successfully created Release %s", release_url)
         return created_release
 
     @staticmethod

--- a/elliott/elliottlib/cli/snapshot_cli.py
+++ b/elliott/elliottlib/cli/snapshot_cli.py
@@ -111,7 +111,12 @@ class CreateSnapshotCli:
         await self.get_pullspecs([b.image_pullspec for b in build_records], self.image_repo_pull_secret)
 
         snapshot_obj = await self.new_snapshot(build_records)
-        return await self.konflux_client._create(snapshot_obj)
+        snapshot_obj = await self.konflux_client._create(snapshot_obj)
+
+        snapshot_url = self.konflux_client.resource_url(snapshot_obj)
+        LOGGER.info("Created Konflux Snapshot %s", snapshot_url)
+
+        return snapshot_obj
 
     @staticmethod
     async def get_pullspecs(pullspecs: list, image_repo_pull_secret: str):

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -70,8 +70,9 @@ class TestWatchReleaseCli(IsolatedAsyncioTestCase):
         }
         self.konflux_client.wait_for_release.return_value = Model(release)
 
-        status = await cli.run()
+        status, obj = await cli.run()
         self.assertEqual(status, True)
+        self.assertEqual(obj, Model(release))
 
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
     @patch("elliottlib.runtime.Runtime")
@@ -107,8 +108,9 @@ class TestWatchReleaseCli(IsolatedAsyncioTestCase):
         }
         self.konflux_client.wait_for_release.return_value = Model(release)
 
-        status = await cli.run()
+        status, obj = await cli.run()
         self.assertEqual(status, False)
+        self.assertEqual(obj, Model(release))
 
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
     @patch("elliottlib.runtime.Runtime")
@@ -144,8 +146,9 @@ class TestWatchReleaseCli(IsolatedAsyncioTestCase):
         }
         self.konflux_client.wait_for_release.return_value = Model(release)
 
-        status = await cli.run()
+        status, obj = await cli.run()
         self.assertEqual(status, False)
+        self.assertEqual(obj, Model(release))
 
 
 class TestCreateReleaseCli(IsolatedAsyncioTestCase):


### PR DESCRIPTION
This will let `elliott release watch <release_name> --dump` watch the release as it progresses, and dump out the object in yaml at the end. This info is needed for post-processing in shipment-ci pipelines

Test

```
$ elliott release watch ash-test-4-18-stage-release-5fjk9 --dump
2025-06-18 12:34:08,738 artcommonlib INFO Konflux DB initialized 
2025-06-18 13:06:25,472 doozerlib.backend.konflux_client INFO Found release at https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-18/releases/ash-test-4-18-stage-release-5fjk9
2025-06-18 12:34:08,984 doozerlib.backend.konflux_client INFO Release ash-test-4-18-stage-release-5fjk9 [status=True][reason=Succeeded]
2025-06-18 12:34:08,985 art_tools.elliottlib.cli.konflux_release_watch_cli INFO Release successful!
apiVersion: appstudio.redhat.com/v1alpha1
kind: Release
metadata:
...
```