### PR TITLE
apply .0 if go version >= 1.22

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -14,6 +14,7 @@ from typing import Dict, List, Optional, Set, Tuple, cast
 import aiofiles
 import bashlex
 import bashlex.errors
+import semver
 import yaml
 from artcommonlib import exectools, release_util
 from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildRecord
@@ -496,32 +497,44 @@ class KonfluxRebaser:
         async with aiofiles.open(df_path, mode='w+', encoding='utf-8') as distgit_dockerfile:
             await distgit_dockerfile.write(source_dockerfile_content)
 
-        append_gomod_patch = self._runtime.group_config.konflux.cachi2.gomod_version_patch
-        if append_gomod_patch and append_gomod_patch is not Missing:
-            gomod_path = dest_dir.joinpath('go.mod')
-            if gomod_path.exists():
-                # Read the gomod contents
-                new_lines = []
-                with open(gomod_path, "r") as file:
-                    lines = file.readlines()
-                    for line in lines:
-                        stripped_line = line.strip()
-                        match = re.match(r"(^go \d\.\d+$)", stripped_line)
-                        if match:
-                            # Append a .0 to the go mod version, if it exists
-                            # Replace the line 'go 1.22' with 'go 1.22.0' for example
-                            self._logger.info(f"Missing patch in golang version: {stripped_line}. Appending .0")
-                            go_version_string = match.group(1)  # eg. 'go 1.23'
-                            go_version_number = float(go_version_string.split(" ")[-1])  # eg. 1.23
-                            if go_version_number >= 1.22:
+        gomod_path = dest_dir.joinpath('go.mod')
+        if gomod_path.exists():
+            # Read the gomod contents
+            new_lines = []
+            with open(gomod_path, "r") as file:
+                lines = file.readlines()
+                for line in lines:
+                    stripped_line = line.strip()
+                    match = re.match(r"(^go \d\.\d+$)", stripped_line)
+                    if match:
+                        # Append a .0 to the go mod version, if it exists
+                        # Replace the line 'go 1.22' with 'go 1.22.0' for example
+                        go_version_string = match.group(1)  # eg. 'go 1.23'
+                        version_part = go_version_string.split(" ")[-1]  # eg. '1.23'
+
+                        # Use semver for reliable version comparison
+                        try:
+                            # Convert to semver format (add .0 patch version for comparison)
+                            current_version = semver.VersionInfo.parse(f"{version_part}.0")
+                            min_version = semver.VersionInfo.parse("1.22.0")
+
+                            if current_version >= min_version:
+                                self._logger.info(f"Missing patch in golang version: {stripped_line}. Appending .0")
                                 stripped_line = stripped_line.replace(go_version_string, f"{go_version_string}.0")
                                 new_lines.append(f"{stripped_line}\n")
                                 continue
+                        except ValueError as e:
+                            self._logger.warning(
+                                f"Failed to parse go version '{version_part}': {e}. Skipping version check."
+                            )
+                            # Fall back to original behavior if version parsing fails
+                            new_lines.append(line)
+                            continue
 
-                        # If there is no match or if the go version is not >= 1.22, use the same go version
-                        new_lines.append(line)
-                async with aiofiles.open(gomod_path, "w") as file:
-                    await file.writelines(new_lines)
+                    # If there is no match or if the go version is not >= 1.22, use the same go version
+                    new_lines.append(line)
+            with open(gomod_path, "w") as file:
+                file.writelines(new_lines)
 
         # Clean up any extraneous Dockerfile.* that might be distractions (e.g. Dockerfile.centos)
         for ent in dest_dir.iterdir():

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -1,9 +1,11 @@
 import asyncio
+import re
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+import semver
 from artcommonlib.model import Missing
 from dockerfile_parse import DockerfileParser
 from doozerlib.backend.rebaser import KonfluxRebaser
@@ -360,3 +362,177 @@ USER 3000
 
         mock_generator.generate_lockfile.assert_not_called()
         rebaser._logger.debug.assert_called_with('RPM lockfile generation is disabled for foo')
+
+    def test_go_version_regex_pattern(self):
+        """Test the regex pattern used to match go version lines"""
+        pattern = r"(^go \d\.\d+$)"
+
+        # Test cases that should match
+        valid_cases = ["go 1.22", "go 1.23", "go 1.30"]
+
+        for case in valid_cases:
+            with self.subTest(case=case):
+                match = re.match(pattern, case)
+                self.assertIsNotNone(match, f"Should match: {case}")
+                self.assertEqual(match.group(1), case)
+
+        # Test cases that should NOT match
+        invalid_cases = [
+            "go 1.22.0",  # already has patch
+            "go 1.invalid",  # non-numeric
+            "go invalid.version",  # completely invalid
+            "go 1",  # missing minor version
+            " go 1.22",  # leading space
+            "go 1.22 ",  # trailing space
+            "golang 1.22",  # wrong prefix
+        ]
+
+        for case in invalid_cases:
+            with self.subTest(case=case):
+                match = re.match(pattern, case)
+                self.assertIsNone(match, f"Should NOT match: {case}")
+
+    def test_semver_version_comparison_valid_versions(self):
+        """Test semver version comparison for valid go versions"""
+        min_version = semver.VersionInfo.parse("1.22.0")
+
+        # Test cases that should be >= 1.22.0
+        valid_higher_versions = [
+            ("1.22", True),  # exactly minimum
+            ("1.23", True),  # above minimum
+            ("1.30", True),  # higher minor
+            ("2.0", True),  # higher major
+            ("1.999", True),  # very high minor
+        ]
+
+        for version_str, should_be_higher in valid_higher_versions:
+            with self.subTest(version=version_str):
+                current_version = semver.VersionInfo.parse(f"{version_str}.0")
+                result = current_version >= min_version
+                self.assertEqual(result, should_be_higher, f"Version {version_str} comparison failed")
+
+        # Test cases that should be < 1.22.0
+        valid_lower_versions = [
+            ("1.21", False),
+            ("1.20", False),
+            ("1.19", False),
+            ("1.0", False),
+            ("0.99", False),
+        ]
+
+        for version_str, should_be_higher in valid_lower_versions:
+            with self.subTest(version=version_str):
+                current_version = semver.VersionInfo.parse(f"{version_str}.0")
+                result = current_version >= min_version
+                self.assertEqual(result, should_be_higher, f"Version {version_str} comparison failed")
+
+    def test_semver_version_comparison_invalid_versions(self):
+        """Test semver version parsing with invalid version strings"""
+        invalid_versions = [
+            "1.invalid",
+            "invalid.version",
+            "1.22.3.4",  # too many parts
+            "",  # empty string
+            "abc",  # non-numeric
+        ]
+
+        for invalid_version in invalid_versions:
+            with self.subTest(version=invalid_version):
+                with self.assertRaises(ValueError):
+                    semver.VersionInfo.parse(f"{invalid_version}.0")
+
+    def test_go_version_string_replacement(self):
+        """Test the string replacement logic for go version lines"""
+        test_cases = [
+            # (input_line, go_version_string, expected_output)
+            ("go 1.22", "go 1.22", "go 1.22.0"),
+            ("go 1.23", "go 1.23", "go 1.23.0"),
+            ("go 1.30", "go 1.30", "go 1.30.0"),
+        ]
+
+        for input_line, go_version_string, expected_output in test_cases:
+            with self.subTest(input=input_line):
+                # Simulate the replacement logic from the actual code
+                result = input_line.replace(go_version_string, f"{go_version_string}.0")
+                self.assertEqual(result, expected_output)
+
+    def test_go_version_processing_logic_integration(self):
+        """Test the complete go version processing logic flow"""
+
+        def process_go_version_line(line):
+            """Simulate the exact logic from the rebaser"""
+            stripped_line = line.strip()
+            match = re.match(r"(^go \d\.\d+$)", stripped_line)
+
+            if not match:
+                return line, False, None  # line, modified, error
+
+            go_version_string = match.group(1)
+            version_part = go_version_string.split(" ")[-1]
+
+            try:
+                current_version = semver.VersionInfo.parse(f"{version_part}.0")
+                min_version = semver.VersionInfo.parse("1.22.0")
+
+                if current_version >= min_version:
+                    new_line = stripped_line.replace(go_version_string, f"{go_version_string}.0")
+                    return f"{new_line}\n", True, None
+                else:
+                    return line, False, None
+            except ValueError as e:
+                return line, False, str(e)
+
+        # Test cases
+        test_cases = [
+            # (input, expected_output, should_be_modified, should_have_error)
+            ("go 1.22\n", "go 1.22.0\n", True, False),
+            ("go 1.23\n", "go 1.23.0\n", True, False),
+            ("go 1.21\n", "go 1.21\n", False, False),
+            ("go 1.20\n", "go 1.20\n", False, False),
+            ("go 1.22.0\n", "go 1.22.0\n", False, False),  # doesn't match regex
+            ("go 1.invalid\n", "go 1.invalid\n", False, False),  # doesn't match regex
+            ("  go 1.22  \n", "go 1.22.0\n", True, False),  # with whitespace
+        ]
+
+        for input_line, expected_output, should_be_modified, should_have_error in test_cases:
+            with self.subTest(input=repr(input_line)):
+                result_line, was_modified, error = process_go_version_line(input_line)
+
+                if should_have_error:
+                    self.assertIsNotNone(error)
+                else:
+                    self.assertIsNone(error)
+
+                self.assertEqual(was_modified, should_be_modified)
+
+                if should_be_modified:
+                    self.assertEqual(result_line, expected_output)
+
+    def test_go_version_boundary_conditions(self):
+        """Test boundary conditions for go version comparisons"""
+        min_version = semver.VersionInfo.parse("1.22.0")
+
+        boundary_cases = [
+            # (version_string, expected_result, description)
+            ("1.21.99", False, "just below minimum with high patch"),
+            ("1.22.0", True, "exact minimum"),
+            ("1.22.1", True, "just above minimum"),
+            ("1.21", False, "one minor version below"),
+            ("1.23", True, "one minor version above"),
+        ]
+
+        for version_str, expected_result, description in boundary_cases:
+            with self.subTest(version=version_str, desc=description):
+                try:
+                    if "." in version_str and len(version_str.split(".")) == 2:
+                        # For X.Y format, add .0 for comparison
+                        test_version = semver.VersionInfo.parse(f"{version_str}.0")
+                    else:
+                        # For X.Y.Z format, use as-is
+                        test_version = semver.VersionInfo.parse(version_str)
+
+                    result = test_version >= min_version
+                    self.assertEqual(result, expected_result, f"Boundary test failed for {version_str}: {description}")
+                except ValueError:
+                    # If version parsing fails, it should be handled gracefully
+                    pass


### PR DESCRIPTION
Do not need to check for `self._runtime.group_config.konflux.cachi2.gomod_version_patch` since we need to add the .0 if its missing