### PR TITLE
ART-12054 also find olm builds when find operator builds

### DIFF
--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -4,7 +4,7 @@ import json
 import logging
 import re
 import sys
-from typing import Dict, List, Set, Union
+from typing import Dict, List, Set, Union, Optional
 
 import click
 import koji
@@ -13,7 +13,7 @@ from artcommonlib import exectools, logutil
 from artcommonlib.arch_util import BREW_ARCHES
 from artcommonlib.assembly import assembly_metadata_config, assembly_rhcos_config
 from artcommonlib.format_util import green_prefix, green_print, red_print, yellow_print
-from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildRecord
+from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildRecord, KonfluxBundleBuildRecord
 from artcommonlib.release_util import isolate_el_version_in_release
 from artcommonlib.rhcos import get_build_id_from_rhcos_pullspec, get_container_configs
 from artcommonlib.rpm_utils import parse_nvr
@@ -174,9 +174,9 @@ async def find_builds_cli(
             )
         if kind != 'image':
             raise click.BadParameter('Konflux only supports --kind image.')
-        records = await find_builds_konflux(runtime, payload)
+        records, olm_records, olm_records_not_found = await find_builds_konflux(runtime, payload)
         if as_json:
-            _json_dump(as_json, records, kind)
+            _json_dump(as_json, records, kind, olm_records, olm_records_not_found)
             return
         for nvr in sorted([r.nvr for r in records]):
             click.echo(nvr)
@@ -427,14 +427,19 @@ def _gen_nvrp_tuples(builds: List[Dict], tag_pv_map: Dict[str, str]):
     return nvrps
 
 
-def _json_dump(as_json: str, builds: list, kind: str):
+def _json_dump(as_json: str, builds: list, kind: str, olm_builds: Optional[list] = [], olm_records_not_found: Optional[list] = []):
     """Dumps builds as JSON to a file or stdout
     :param as_json: file name to dump JSON to, or '-' for stdout
     :param builds: list of Brew build objects
     :param kind: kind of builds, either 'rpm' or 'image'
     """
 
-    json_data = dict(builds=sorted([b.nvr for b in builds]), kind=kind)
+    json_data = {
+        'builds': sorted([b.nvr for b in builds]),
+        'kind': kind,
+        'olm_builds': sorted([b.nvr for b in olm_builds]),
+        'olm_builds_not_found': sorted([b.nvr for b in olm_records_not_found])
+    }
     if as_json == '-':
         click.echo(json.dumps(json_data, indent=4, sort_keys=True))
     else:
@@ -701,9 +706,22 @@ async def find_builds_konflux(runtime, payload):
             continue
         image_metas.append(image)
 
-    LOGGER.info("Fetching NVRs from DB...")
-    tasks = [image.get_latest_build(el_target=image.branch_el_target()) for image in image_metas]
-    records: List[Dict] = [r for r in await asyncio.gather(*tasks) if r is not None]
-    if len(records) != len(image_metas):
-        raise ElliottFatalError(f"Failed to find Konflux builds for {len(image_metas) - len(records)} images")
-    return records
+    tasks = [(image.is_olm_operator, image.get_latest_build(el_target=image.branch_el_target())) for image in image_metas]
+    results = await asyncio.gather(*[task[1] for task in tasks])
+    records_with_olm = [(task[0], r) for task, r in zip(tasks, results) if r is not None]
+    if len(records_with_olm) != len(image_metas):
+        raise ElliottFatalError(f"Failed to find Konflux builds for {len(image_metas) - len(records_with_olm)} images")
+
+    # get related bundle records
+    LOGGER.info("Fetching bundle build from DB ...")
+    runtime.konflux_db.bind(KonfluxBundleBuildRecord)
+    olm_tasks = [
+        (record.nvr, anext(runtime.konflux_db.search_builds_by_fields(
+            where={"operator_nvr": record.nvr},
+            limit=1
+        ), None))
+        for is_olm, record in records_with_olm if is_olm
+    ]
+    olm_records = await asyncio.gather(*[task[1] for task in olm_tasks])
+    olm_records_not_found = [olm_task[0] for olm_task, r in zip(olm_tasks, olm_records) if r is None]
+    return [record for _, record in records_with_olm], olm_records, olm_records_not_found

--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -75,6 +75,7 @@ class PrepareReleaseKonfluxPipeline:
         # these will be initialized later
         self.releases_config = None
         self.group_config = None
+        self.olm_builds = []
 
         group_param = f'--group={group}'
         if self.build_data_gitref:
@@ -299,6 +300,9 @@ class PrepareReleaseKonfluxPipeline:
         if kind in ("image", "extras"):
             snapshot_spec = await self.find_builds(kind)
             shipment.shipment.snapshot.spec = snapshot_spec
+        if kind == "metadata"
+            # TODO: rebuild olm_builds_not_found builds
+            shipment.shipment.snapshot.spec = Spec(nvrs=self.olm_builds)
         else:
             _LOGGER.warning("Shipment kind %s is not supported for build finding", kind)
 
@@ -380,6 +384,7 @@ class PrepareReleaseKonfluxPipeline:
         if stdout:
             out = json.loads(stdout)
             builds = out.get("builds", [])
+            self.olm_builds = self.olm_builds.append(out.get("olm_builds", []))
         return Spec(nvrs=builds)
 
     async def create_update_shipment_mr(


### PR DESCRIPTION
When loop all images to find builds for konflux, record a flag whether its an olm operator
Use olm operator's nvr to find its related olm builds in KonfluxBundleBuildrRcord

So find-builds will not only find a list of payload/non-payload builds, but also find by-product with its olm builds, combine the olm builds from payload/non-payload builds we can easily find olm_builds for release without extra logic to loop find-builds results again