### PR TITLE
ART-12054 add all-types parameter to also find olm builds when find operator builds

### DIFF
--- a/elliott/elliottlib/imagecfg.py
+++ b/elliott/elliottlib/imagecfg.py
@@ -32,3 +32,7 @@ class ImageMetadata(Metadata):
     @property
     def is_payload(self):
         return self.config.get('for_payload', False)
+
+    @property
+    def is_olm_operator(self):
+        return self.config.get('update-csv', False)


### PR DESCRIPTION
When loop all images to find builds for konflux, record a flag whether its an olm operator
Use olm operator's nvr to find its related olm builds in KonfluxBundleBuildrRcord

So find-builds with all-types will not only find a list of payload/non-payload builds, but also find by-product with its olm builds, and also not found olm operator builds we can easily find olm_builds for release without extra logic to loop find-builds results again

```
elliott --group=openshift-4.20 --assembly=ec.3 --build-system=konflux  find-builds --kind=image --all-types --json=-
2025-06-27 09:20:38,472 pyartcd.pipelines.prepare_release_konflux INFO Find image builds: 
{
    "non_payload": [
        "cloud-event-proxy-container-v4.20.0-202506061050.p2.gc76f3ee.assembly.stream.el9",
        ......
    ],
    "olm_builds": [
        "cluster-nfd-operator-metadata-container-v4.20.0.202506081226.p2.gc57e91e.assembly.stream.el9-1",
        ......
    ],
    "olm_builds_not_found": [],
    "payload": [
        "atomic-openshift-cluster-autoscaler-container-v4.20.0-202506061050.p2.gf746d44.assembly.stream.el9",
        ......
    ]
}
```