### PR TITLE
  feat: add contextual logging to RPM lockfile generation pipeline

### DIFF
--- a/doozer/doozerlib/repos.py
+++ b/doozer/doozerlib/repos.py
@@ -4,7 +4,7 @@ import json
 import os
 import threading
 import time
-from typing import Dict, List, cast
+from typing import Dict, List, Optional, cast
 
 import requests
 import yaml
@@ -236,13 +236,13 @@ class Repo(object):
 
         return result
 
-    async def get_repodata(self, arch: str):
+    async def get_repodata(self, arch: str, entity: Optional[str] = None):
         repodata = self._repodatas.get(arch)
         if repodata:
             return repodata
         name = f"{self.name}-{arch}"
         repourl = cast(str, self.baseurl("unsigned", arch))
-        repodata = self._repodatas[arch] = await RepodataLoader().load(name, repourl)
+        repodata = self._repodatas[arch] = await RepodataLoader(entity=entity).load(name, repourl)
 
         if self.excludepkgs:
             LOGGER.info(f"Excluding packages from {name} based on following patterns: {self.excludepkgs}")


### PR DESCRIPTION

  ## Summary
  Fixes async logging context interleaving during concurrent RPM lockfile generation by adding EntityLoggingAdapter throughout the pipeline.

  ## Problem
  Concurrent image processing created unreadable logs - couldn't trace errors back to specific images.

  **Before:**
  ```log
  INFO Loading repos: baseos, appstream for arch x86_64
  WARNING Could not find rpm1,rpm2 in baseos, appstream for arch x86_64

  After:
  INFO [ose-oauth-proxy] Loading repos: baseos, appstream for arch x86_64  
  WARNING [ose-oauth-proxy] Could not find rpm1,rpm2 in baseos, appstream for arch x86_64

  Changes

  - rebaser.py: Creates contextual logger with distgit_key at entry point
  - lockfile.py: Propagates context through RPMLockfileGenerator and RpmInfoCollector
  - repodata.py: RepodataLoader accepts entity parameter for contextual logging
  - repos.py: Passes entity information to repodata loading
  - test_lockfile.py: Updates test assertions for new method signatures

  Technical Notes

  - Uses method-level logger creation to avoid race conditions
  - Maintains backward compatibility with optional parameters
  - All 26 tests passing, no regressions
```

  Now you can actually tell which image is having issues during concurrent builds.
  
  ## Tests
[Passing build with enhanced logging](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/12251/console)