### PR TITLE
fix(image): add group config fallback to is_lockfile_force_enabled

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -726,10 +726,11 @@ class ImageMetadata(Metadata):
         """
         Determines whether lockfile force generation is enabled for the current image configuration.
 
-        This method only checks the image metadata configuration for the force parameter:
-        - Image metadata configuration (`self.config.konflux.cachi2.lockfile.force`)
+        The method checks configuration in the following order:
+        1. Image metadata configuration (`self.config.konflux.cachi2.lockfile.force`)
+        2. Group configuration (`self.runtime.group_config.konflux.cachi2.lockfile.force`)
 
-        If not set, force generation defaults to disabled.
+        If neither is set, force generation defaults to disabled.
 
         Returns:
             bool: True if lockfile force generation is enabled, False otherwise.
@@ -737,7 +738,13 @@ class ImageMetadata(Metadata):
         lockfile_force_config_override = self.config.konflux.cachi2.lockfile.force
         if lockfile_force_config_override not in [Missing, None]:
             lockfile_force = bool(lockfile_force_config_override)
-            self.logger.info(f"Lockfile force generation set from metadata config {lockfile_force}")
+            self.logger.info(f"Lockfile force generation set from metadata config: {lockfile_force}")
+            return lockfile_force
+
+        lockfile_force_group_override = self.runtime.group_config.konflux.cachi2.lockfile.force
+        if lockfile_force_group_override not in [Missing, None]:
+            lockfile_force = bool(lockfile_force_group_override)
+            self.logger.info(f"Lockfile force generation set from group config: {lockfile_force}")
             return lockfile_force
 
         return False

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -373,7 +373,7 @@ class TestImageMetadata(unittest.TestCase):
 
         result = metadata.is_lockfile_force_enabled()
         self.assertTrue(result)
-        self.logger.info.assert_any_call("Lockfile force generation set from metadata config True")
+        self.logger.info.assert_any_call("Lockfile force generation set from metadata config: True")
 
     def test_lockfile_force_enabled_metadata_override_false(self):
         self.logger = MagicMock()
@@ -386,7 +386,7 @@ class TestImageMetadata(unittest.TestCase):
 
         result = metadata.is_lockfile_force_enabled()
         self.assertFalse(result)
-        self.logger.info.assert_any_call("Lockfile force generation set from metadata config False")
+        self.logger.info.assert_any_call("Lockfile force generation set from metadata config: False")
 
     def test_lockfile_force_enabled_missing_override(self):
         self.logger = MagicMock()
@@ -395,6 +395,7 @@ class TestImageMetadata(unittest.TestCase):
         mock_config = MagicMock()
         mock_config.konflux.cachi2.lockfile.force = Missing
         metadata.config = mock_config
+        metadata.runtime.group_config.konflux.cachi2.lockfile.force = Missing
         metadata.logger = self.logger
 
         result = metadata.is_lockfile_force_enabled()
@@ -408,11 +409,54 @@ class TestImageMetadata(unittest.TestCase):
         mock_config = MagicMock()
         mock_config.konflux.cachi2.lockfile.force = None
         metadata.config = mock_config
+        metadata.runtime.group_config.konflux.cachi2.lockfile.force = None
         metadata.logger = self.logger
 
         result = metadata.is_lockfile_force_enabled()
         self.assertFalse(result)
         # Should not log anything when using default
+
+    def test_lockfile_force_enabled_group_config_true(self):
+        self.logger = MagicMock()
+        metadata = self._create_image_metadata('openshift/test_lockfile_force')
+
+        mock_config = MagicMock()
+        mock_config.konflux.cachi2.lockfile.force = Missing
+        metadata.config = mock_config
+        metadata.runtime.group_config.konflux.cachi2.lockfile.force = True
+        metadata.logger = self.logger
+
+        result = metadata.is_lockfile_force_enabled()
+        self.assertTrue(result)
+        self.logger.info.assert_any_call("Lockfile force generation set from group config: True")
+
+    def test_lockfile_force_enabled_group_config_false(self):
+        self.logger = MagicMock()
+        metadata = self._create_image_metadata('openshift/test_lockfile_force')
+
+        mock_config = MagicMock()
+        mock_config.konflux.cachi2.lockfile.force = Missing
+        metadata.config = mock_config
+        metadata.runtime.group_config.konflux.cachi2.lockfile.force = False
+        metadata.logger = self.logger
+
+        result = metadata.is_lockfile_force_enabled()
+        self.assertFalse(result)
+        self.logger.info.assert_any_call("Lockfile force generation set from group config: False")
+
+    def test_lockfile_force_enabled_metadata_precedence(self):
+        self.logger = MagicMock()
+        metadata = self._create_image_metadata('openshift/test_lockfile_force')
+
+        mock_config = MagicMock()
+        mock_config.konflux.cachi2.lockfile.force = False
+        metadata.config = mock_config
+        metadata.runtime.group_config.konflux.cachi2.lockfile.force = True
+        metadata.logger = self.logger
+
+        result = metadata.is_lockfile_force_enabled()
+        self.assertFalse(result)
+        self.logger.info.assert_any_call("Lockfile force generation set from metadata config: False")
 
 
 class TestImageInspector(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
Add missing group configuration fallback to `is_lockfile_force_enabled()` method to maintain consistency with sibling configuration hierarchy methods in the ImageMetadata class.

## Problem
**Before:** The `is_lockfile_force_enabled()` method only checked image metadata configuration (`self.config.konflux.cachi2.lockfile.force`) and immediately returned `False` if not set, skipping group configuration check entirely.

**After:** The method now follows the same configuration hierarchy pattern as `is_cachi2_enabled()` and `is_lockfile_generation_enabled()`:
1. Check image metadata configuration first (highest priority)
2. If not set, check group configuration (`self.runtime.group_config.konflux.cachi2.lockfile.force`)
3. Default to `False` if neither is set

## Changes
- **doozer/doozerlib/image.py**: Add group configuration fallback logic and update docstring
- **doozer/tests/test_image.py**: Add comprehensive test coverage for group config scenarios