### PR TITLE
Skip snapshot if builds are not found

### DIFF
--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -135,15 +135,18 @@ class CreateReleaseCli:
         release_obj = await self.new_release(release_config)
         created_release = await self.konflux_client._create(release_obj)
         release_url = self.konflux_client.resource_url(created_release)
-        LOGGER.info("Successfully created Release %s", release_url)
+        if self.dry_run:
+            LOGGER.info("[DRY-RUN] Would have created Konflux Release at %s", release_url)
+        else:
+            LOGGER.info("Successfully created Release %s", release_url)
         return created_release
 
     async def create_snapshot(self, shipment: Shipment) -> dict:
         """
-        Create a snapshot object from the shipment's snapshot spec
+        Create a Konflux Snapshot manifest from the given shipment's snapshot spec.
         """
-        if not shipment.snapshot.spec.components:
-            raise ValueError("Snapshot spec must have components")
+        if not (shipment.snapshot and shipment.snapshot.spec.components):
+            raise ValueError("A valid snapshot must be provided")
 
         major, minor = self.runtime.get_major_minor()
         snapshot_name = f"ose-{major}-{minor}-{get_utc_now_formatted_str()}"

--- a/elliott/elliottlib/cli/snapshot_cli.py
+++ b/elliott/elliottlib/cli/snapshot_cli.py
@@ -116,7 +116,10 @@ class CreateSnapshotCli:
         snapshot_obj = await self.konflux_client._create(snapshot_obj)
 
         snapshot_url = self.konflux_client.resource_url(snapshot_obj)
-        LOGGER.info("Created Konflux Snapshot %s", snapshot_url)
+        if self.dry_run:
+            LOGGER.info("[DRY-RUN] Would have created Konflux Snapshot at %s", snapshot_url)
+        else:
+            LOGGER.info("Created Konflux Snapshot %s", snapshot_url)
 
         return snapshot_obj
 

--- a/elliott/elliottlib/shipment_utils.py
+++ b/elliott/elliottlib/shipment_utils.py
@@ -67,8 +67,10 @@ def get_builds_from_mr(mr_url: str) -> Dict[str, List[str]]:
     builds_by_kind = {}
     shipment_configs = get_shipment_configs_by_kind(mr_url)
     for kind, shipment_config in shipment_configs.items():
-        nvrs = shipment_config.shipment.snapshot.spec.nvrs
-        logger.info(f"Found {len(nvrs)} builds for {kind}")
+        nvrs = []
+        if shipment_config.shipment.snapshot:
+            nvrs = shipment_config.shipment.snapshot.spec.nvrs
+            logger.info(f"Found {len(nvrs)} builds for {kind}")
         builds_by_kind[kind] = nvrs
 
     return builds_by_kind

--- a/elliott/elliottlib/shipment_utils.py
+++ b/elliott/elliottlib/shipment_utils.py
@@ -69,7 +69,7 @@ def get_builds_from_mr(mr_url: str) -> Dict[str, List[str]]:
     for kind, shipment_config in shipment_configs.items():
         nvrs = []
         if shipment_config.shipment.snapshot:
-            nvrs = shipment_config.shipment.snapshot.spec.nvrs
+            nvrs = shipment_config.shipment.snapshot.nvrs
             logger.info(f"Found {len(nvrs)} builds for {kind}")
         builds_by_kind[kind] = nvrs
 

--- a/elliott/tests/test_shipment_utils.py
+++ b/elliott/tests/test_shipment_utils.py
@@ -162,9 +162,9 @@ shipment:
         """Test successful build extraction from merge request"""
         # Setup mock shipment config
         mock_shipment_config_rpm = Mock()
-        mock_shipment_config_rpm.shipment.snapshot.spec.nvrs = ["test-rpm-1.0.0-1.el8"]
+        mock_shipment_config_rpm.shipment.snapshot.nvrs = ["test-rpm-1.0.0-1.el8"]
         mock_shipment_config_image = Mock()
-        mock_shipment_config_image.shipment.snapshot.spec.nvrs = ["test-container-v1.0.0-202312010000.p0.git12345"]
+        mock_shipment_config_image.shipment.snapshot.nvrs = ["test-container-v1.0.0-202312010000.p0.git12345"]
         mock_get_configs.return_value = {'rpm': mock_shipment_config_rpm, 'image': mock_shipment_config_image}
 
         # Execute test

--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -394,13 +394,16 @@ class PrepareReleaseKonfluxPipeline:
         shipment = ShipmentConfig(**out)
         return shipment
 
-    async def get_snapshot(self, kind: str) -> Snapshot:
-        """Get a snapshot for the given kind.
-        :param kind: The kind for which to get a snapshot
-        :return: A Snapshot object
+    async def get_snapshot(self, kind: str) -> Optional[Snapshot]:
+        """Construct a snapshot for the given kind, by finding builds and creating a snapshot object.
+        :param kind: The kind for which to get a snapshot e.g. "image"
+        :return: A Snapshot object comprising of all the builds found for the given kind, or None if no builds are found.
         """
 
         builds = await self.find_builds(kind)
+        if not builds:
+            return None
+
         # store builds in a temporary file, each nvr string in a new line
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:
             for nvr in builds:


### PR DESCRIPTION
These fixes are needed in prepare-release-konflux, if build finding does not return anything or is skipped.

Seen at https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release-konflux/41/console

Test run: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release-konflux/44/console