### PR TITLE
Use safe formatting when loading template

### DIFF
--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -183,12 +183,8 @@ async def find_builds_cli(
         return
 
     replace_vars = runtime.group_config.vars.primitive() if runtime.group_config.vars else {}
-    LOGGER.info(f"replace_vars: {replace_vars}")
     et_data = runtime.get_errata_config(replace_vars=replace_vars)
-    LOGGER.info(f"et_data: {et_data}")
     tag_pv_map = et_data.get('brew_tag_product_version_mapping')
-    LOGGER.info(f"tag_pv_map: {tag_pv_map}")
-    exit(1)
 
     if default_advisory_type is not None:
         advisory_id = find_default_advisory(runtime, default_advisory_type)

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -183,8 +183,12 @@ async def find_builds_cli(
         return
 
     replace_vars = runtime.group_config.vars.primitive() if runtime.group_config.vars else {}
+    LOGGER.info(f"replace_vars: {replace_vars}")
     et_data = runtime.get_errata_config(replace_vars=replace_vars)
+    LOGGER.info(f"et_data: {et_data}")
     tag_pv_map = et_data.get('brew_tag_product_version_mapping')
+    LOGGER.info(f"tag_pv_map: {tag_pv_map}")
+    exit(1)
 
     if default_advisory_type is not None:
         advisory_id = find_default_advisory(runtime, default_advisory_type)
@@ -511,7 +515,7 @@ def _ensure_accepted_tags(
     for build in builds:
         accepted_tag = next(filter(lambda tag: tag in tag_pv_map, build["_tags"]), None)
         if not accepted_tag:
-            msg = f"Build {build['nvr']} has Brew tags {build['_tags']}, but none of them has an associated Errata product version."
+            msg = f"Build {build['nvr']} has Brew tags {build['_tags']}, but none of them has an associated Errata product version. Available tag_pv_map keys: {list(tag_pv_map.keys())}"
             if raise_exception:
                 raise IOError(msg)
             else:


### PR DESCRIPTION
See: https://redhat-internal.slack.com/archives/C03JYDGPX8F/p1751488032244189?thread_ts=1751482523.009209&cid=C03JYDGPX8F

We recently introduced PATCH as a new string variable in erratatool.yml advisory template strings.
This variable is not available as other's are in group.yml. So when we try to load erratatool.yml with 
group config vars (in `find-builds`), we fail to substitute ANY value in template because PATCH isn't provided.

One way could be to have a template value in group.yml `PATCH: PATCH` - this would make sure any placeholder, remains placeholder. But then we will not be able to replace PATCH subsequently using `.format`.

Another way would be to use a safe formatter, which inserts vars that are given and leaves the others as is. This way it can still be substituted later.

