### PR TITLE
fix: add architecture support to RPM resolution in repodata

### DIFF
--- a/doozer/doozerlib/lockfile.py
+++ b/doozer/doozerlib/lockfile.py
@@ -201,7 +201,7 @@ class RpmInfoCollector:
                 self.logger.error(f'repo {repo_name} not found')
                 continue
 
-            found_rpms, missing_rpms = repodata.get_rpms(unresolved_rpms)
+            found_rpms, missing_rpms = repodata.get_rpms(unresolved_rpms, arch)
             rpm_info_list.extend(
                 [
                     RpmInfo.from_rpm(


### PR DESCRIPTION
The get_rpms method in repodata.py wasn't considering architecture when selecting RPMs, which could lead to wrong packages being picked for lockfile generation. This adds an optional arch parameter that:

- Prefers exact architecture matches first
- Falls back to noarch packages if available
- Only uses first match as last resort
- Updates lockfile.py to pass the architecture parameter
- Includes comprehensive tests for all the new behavior

This should fix issues where lockfiles might include wrong-architecture RPMs.