### PR TITLE
Konflux commands should default to build-system konflux

### DIFF
--- a/elliott/elliottlib/cli/common.py
+++ b/elliott/elliottlib/cli/common.py
@@ -40,6 +40,9 @@ context_settings = dict(help_option_names=['-h', '--help'])
     f" {SHIPMENT_DATA_URL_TEMPLATE.format('ocp')}. Defaults to `main` branch for a repo - to point to a "
     "different branch/commit use repo@commitish",
 )
+@click.option(
+    '--disable-gssapi', default=False, is_flag=True, help='Disable gssapi for requests that do not require keytab'
+)
 @click.option('--group', '-g', default=None, metavar='NAME', help='The group of images on which to operate.')
 @click.option(
     "--assembly",

--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -61,7 +61,7 @@ class CreateReleaseCli:
         self.release_env = release_env
 
     async def run(self):
-        self.runtime.initialize(with_shipment=True)
+        self.runtime.initialize(build_system='konflux', with_shipment=True)
 
         LOGGER.info(f"Loading {self.config_path}...")
         config_raw = self.runtime.shipment_gitdata.load_yaml_file(self.config_path)

--- a/elliott/elliottlib/cli/konflux_release_watch_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_watch_cli.py
@@ -38,7 +38,7 @@ class WatchReleaseCli:
         :return: A tuple of (success: bool, release_obj: dict)
         """
 
-        self.runtime.initialize(no_group=True)
+        self.runtime.initialize(no_group=True, build_system='konflux')
         release_obj = await self.konflux_client.wait_for_release(
             self.release, overall_timeout_timedelta=timedelta(hours=self.timeout)
         )

--- a/elliott/elliottlib/cli/shipment_cli.py
+++ b/elliott/elliottlib/cli/shipment_cli.py
@@ -49,7 +49,7 @@ class InitShipmentCli:
         self.advisory_key = advisory_key
 
     async def run(self):
-        self.runtime.initialize(with_shipment=True)
+        self.runtime.initialize(build_system='konflux', with_shipment=True)
 
         # if stage/prod rpa are not given in cli, try to load them from shipment repo config
         # where defaults are set per application

--- a/elliott/elliottlib/cli/snapshot_cli.py
+++ b/elliott/elliottlib/cli/snapshot_cli.py
@@ -95,7 +95,7 @@ class CreateSnapshotCli:
         self.konflux_client.verify_connection()
 
     async def run(self):
-        self.runtime.initialize()
+        self.runtime.initialize(build_system='konflux')
         if self.runtime.konflux_db is None:
             raise RuntimeError('Must run Elliott with Konflux DB initialized')
 

--- a/elliott/elliottlib/runtime.py
+++ b/elliott/elliottlib/runtime.py
@@ -58,6 +58,7 @@ class Runtime(GroupRuntime):
         self.group_commitish = None
         self.load_wip = False
         self.load_disabled = False
+        self.disable_gssapi = False
         self._logger = None
         self.use_jira = True
         if str(os.environ.get('USEJIRA')).lower() in ["false", "0"]:
@@ -487,8 +488,9 @@ class Runtime(GroupRuntime):
         with self.koji_lock:
             if self._koji_client_session is None:
                 self._koji_client_session = self.build_retrying_koji_client()
-                self._logger.info("Authenticating to Brew...")
-                self._koji_client_session.gssapi_login()
+                if not self.disable_gssapi:
+                    self._logger.info("Authenticating to Brew...")
+                    self._koji_client_session.gssapi_login()
             yield self._koji_client_session
 
     @contextmanager

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -305,7 +305,7 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
         result = await cli.run()
 
         # Verify runtime was initialized with shipment
-        self.runtime.initialize.assert_called_once_with(with_shipment=True)
+        self.runtime.initialize.assert_called_once_with(build_system='konflux', with_shipment=True)
 
         # Verify resource existence was checked
         self.konflux_client._get.assert_any_call(


### PR DESCRIPTION
Fix error seen at https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/jobs/36829895 
Also provide an option for elliott to disable-gssapi login, needed for commands that run outside of buildvm, and do not need keytab to auth to brew (shipment repo)

Test: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/jobs/36833578