### PR TITLE
feat: migrate from installed_packages to source_rpms in lockfile gen

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -205,6 +205,7 @@ class KonfluxBuildRecord(KonfluxRecord):
         el_target: str = '',
         arches: list = [],
         installed_packages: list = [],
+        installed_package_nvrs: list = [],
         parent_images: list = [],
         source_repo: str = '',
         commitish: str = '',
@@ -254,6 +255,7 @@ class KonfluxBuildRecord(KonfluxRecord):
         self.el_target = el_target
         self.arches = arches
         self.installed_packages = installed_packages
+        self.installed_package_nvrs = installed_package_nvrs
         self.parent_images = parent_images
         self.embargoed = embargoed
         self.hermetic = hermetic

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -411,6 +411,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             SchemaField('el_target', 'STRING', 'REQUIRED'),
             SchemaField('arches', 'STRING', 'REPEATED'),
             SchemaField('installed_packages', 'STRING', 'REPEATED'),
+            SchemaField('installed_package_nvrs', 'STRING', 'REPEATED'),
             SchemaField('parent_images', 'STRING', 'REPEATED'),
             SchemaField('source_repo', 'STRING', 'REQUIRED'),
             SchemaField('commitish', 'STRING', 'REQUIRED'),

--- a/doozer/doozerlib/cli/rpms.py
+++ b/doozer/doozerlib/cli/rpms.py
@@ -377,6 +377,7 @@ async def update_konflux_db(runtime, rpm: RPMMetadata, record: dict):
             el_target=el_target,
             arches=rpm.get_arches(),
             installed_packages=[],
+            installed_package_nvrs=[],
             parent_images=[],
             source_repo=rpm.public_upstream_url,
             commitish=rpm.pre_init_sha,

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1487,6 +1487,7 @@ class ImageDistGitRepo(DistGitRepo):
                 build_record_params.update(
                     {
                         'installed_packages': self.get_installed_packages(image_pullspec),
+                        'installed_package_nvrs': [],
                         'parent_images': [
                             build['nvr'] for build in build_info['extra']['image']['parent_image_builds'].values()
                         ],


### PR DESCRIPTION
## Problem
The previous implementation used _installed_packages_ from SBOM files, but this data comes from upstream PURLs (Package URLs), not actual installed RPMs. SBOM _installed_packages_ reflects upstream package declarations rather than what's actually installed in the container filesystem.

This creates an accuracy gap - we need a complete, accurate list of all RPMs actually installed in containers for proper build management and dependency tracking.

The approach taken is to follow the current implementation pattern by adding another field (_installed_package_nvrs_) in the database and storing the real list of RPMs installed. This creates a tradeoff: we gain data accuracy but introduce data duplication in the database schema - maintaining both the original _installed_packages_ field (for compatibility) and the new _installed_package_nvrs_ field (for accuracy). While this doubles the storage requirement for package data, we accept this cost and it is not in the scope of this PR to refactor this approach.

 ## Example: openshift-enterprise-base-rhel9 Container

**SBOM installed_packages (150 packages)**: 
https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=openshift-enterprise-base-rhel9-container-v4.20.0-202507021853.p2.g97a3473.assembly.stream.el9&outcome=success&type=image

**Actual container RPMs (206 packages):**
```
  $ docker run quay.io/redhat-user-workloads/ocp-art-tenant/art-images:openshift-enterprise-base-rhel9-v4.20.0-20250702.191448 rpm -qa | wc -l
  206
```
The accuracy gap: 56 missing packages

### BREAKING: Can't be merged without Schema changes