### PR TITLE
Enhanced pipeline run configuration to support RPM lockfile generation for hermetic builds:

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -462,6 +462,9 @@ class KonfluxClient:
 
         obj["spec"]["taskRunTemplate"]["serviceAccountName"] = f"build-pipeline-{component_name}"
 
+        # Check if RPM lockfile prefetch is being used
+        rpm_lockfile_prefetch_enabled = prefetch and any(item.get("type") == "rpm" for item in prefetch)
+
         # Task specific parameters to override in the template
         has_build_images_task = False
         has_sast_task = False
@@ -473,6 +476,8 @@ class KonfluxClient:
                     _modify_param(task["params"], "SBOM_TYPE", "spdx")
                 case "prefetch-dependencies":
                     _modify_param(task["params"], "sbom-type", "spdx")
+                    if rpm_lockfile_prefetch_enabled:
+                        _modify_param(task["params"], "dev-package-managers", "true")
                 case "apply-tags":
                     _modify_param(task["params"], "ADDITIONAL_TAGS", list(additional_tags))
                 case "clone-repository":

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -478,6 +478,7 @@ class KonfluxClient:
                     _modify_param(task["params"], "sbom-type", "spdx")
                     if rpm_lockfile_prefetch_enabled:
                         _modify_param(task["params"], "dev-package-managers", "true")
+                        _modify_param(task["params"], "log-level", "debug")
                 case "apply-tags":
                     _modify_param(task["params"], "ADDITIONAL_TAGS", list(additional_tags))
                 case "clone-repository":

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -321,8 +321,9 @@ class KonfluxImageBuilder:
         if required_package_managers in [Missing, None]:
             raise ValueError(f"{required_package_managers} should not be empty if cachi2 is enabled")
 
+        network_mode = metadata.get_konflux_network_mode()
         lockfile_enabled = metadata.is_lockfile_generation_enabled()
-        if lockfile_enabled:
+        if network_mode == "hermetic" and lockfile_enabled:
             lockfile_path = metadata.config.konflux.cachi2.lockfile.get("path", ".")
             data = {
                 "type": "rpm",
@@ -331,7 +332,7 @@ class KonfluxImageBuilder:
             prefetch.append(data)
             logger.info(f"Adding RPM prefetch for lockfile {DEFAULT_LOCKFILE_NAME} at path: {lockfile_path}")
         else:
-            logger.debug("RPM lockfile generation is disabled, skipping RPM prefetch")
+            logger.debug(f"Skipping RPM prefetch - network_mode: {network_mode}, lockfile_enabled: {lockfile_enabled}")
 
         for package_manager in ["gomod", "npm", "pip", "yarn"]:
             if package_manager in required_package_managers:

--- a/doozer/doozerlib/lockfile.py
+++ b/doozer/doozerlib/lockfile.py
@@ -22,7 +22,7 @@ from doozerlib.repodata import Repodata, Rpm
 from doozerlib.repos import Repos
 
 TRACER = trace.get_tracer(__name__)
-LOCKFILE_FILENAME = 'rpms.lock.yaml'
+DEFAULT_LOCKFILE_NAME = "rpms.lock.yaml"
 
 
 @total_ordering
@@ -292,7 +292,7 @@ class RPMLockfileGenerator:
         )
 
     async def should_generate_lockfile(
-        self, image_meta: ImageMetadata, dest_dir: Path, filename: str = LOCKFILE_FILENAME
+        self, image_meta: ImageMetadata, dest_dir: Path, filename: str = DEFAULT_LOCKFILE_NAME
     ) -> tuple[bool, set[str]]:
         """
         Determine if lockfile generation is needed and return RPMs to install.
@@ -409,7 +409,7 @@ class RPMLockfileGenerator:
             self.logger.info("No images need lockfile generation - skipping repository loading")
 
     async def _sync_from_upstream_if_needed(
-        self, image_meta: ImageMetadata, dest_dir: Path, filename: str = LOCKFILE_FILENAME
+        self, image_meta: ImageMetadata, dest_dir: Path, filename: str = DEFAULT_LOCKFILE_NAME
     ) -> None:
         """
         Download existing lockfile and digest from target branch if available.
@@ -537,7 +537,7 @@ class RPMLockfileGenerator:
             return None
 
     async def generate_lockfile(
-        self, image_meta: ImageMetadata, dest_dir: Path, filename: str = LOCKFILE_FILENAME
+        self, image_meta: ImageMetadata, dest_dir: Path, filename: str = DEFAULT_LOCKFILE_NAME
     ) -> None:
         """
         Generate RPM lockfile for image with resolved package metadata.

--- a/doozer/tests/backend/test_konflux_cachi2.py
+++ b/doozer/tests/backend/test_konflux_cachi2.py
@@ -31,6 +31,7 @@ class TestKonfluxCachi2(TestCase):
         metadata = MagicMock()
         metadata.is_cachi2_enabled.return_value = True
         metadata.is_lockfile_generation_enabled.return_value = False
+        metadata.get_konflux_network_mode.return_value = "open"
         metadata.config.content.source.pkg_managers = ["gomod"]
 
         self.assertEqual(builder._prefetch(metadata=metadata), [{"type": "gomod", "path": "."}])
@@ -41,6 +42,7 @@ class TestKonfluxCachi2(TestCase):
         metadata = MagicMock()
         metadata.is_cachi2_enabled.return_value = True
         metadata.is_lockfile_generation_enabled.return_value = False
+        metadata.get_konflux_network_mode.return_value = "open"
         metadata.config.content.source.pkg_managers = ["gomod"]
         metadata.config.cachito.packages = {'gomod': [{'path': 'api'}]}
 
@@ -52,6 +54,7 @@ class TestKonfluxCachi2(TestCase):
         metadata = MagicMock()
         metadata.is_cachi2_enabled.return_value = True
         metadata.is_lockfile_generation_enabled.return_value = False
+        metadata.get_konflux_network_mode.return_value = "open"
         metadata.config.content.source.pkg_managers = ["gomod"]
         metadata.config.cachito.packages = {"gomod": [{"path": "."}, {"path": "api"}, {"path": "client/pkg"}]}
 
@@ -66,6 +69,7 @@ class TestKonfluxCachi2(TestCase):
         metadata = MagicMock()
         metadata.is_cachi2_enabled.return_value = True
         metadata.is_lockfile_generation_enabled.return_value = False
+        metadata.get_konflux_network_mode.return_value = "open"
         metadata.config.content.source.pkg_managers = ["npm", "gomod"]
         metadata.config.cachito.packages = {'npm': [{'path': 'web'}], 'gomod': [{'path': '.'}]}
 
@@ -74,11 +78,26 @@ class TestKonfluxCachi2(TestCase):
         )
 
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
-    def test_prefetch_rpm_lockfile_enabled(self, mock_konflux_client_init):
+    def test_prefetch_rpm_lockfile_enabled_non_hermetic(self, mock_konflux_client_init):
         builder = KonfluxImageBuilder(MagicMock())
         metadata = MagicMock()
         metadata.is_cachi2_enabled.return_value = True
         metadata.is_lockfile_generation_enabled.return_value = True
+        metadata.get_konflux_network_mode.return_value = "open"
+        metadata.config.content.source.pkg_managers = ["gomod"]
+        metadata.config.cachito.packages = {'gomod': [{'path': '.'}]}
+
+        result = builder._prefetch(metadata=metadata)
+        expected = [{'type': 'gomod', 'path': '.'}]
+        self.assertEqual(result, expected)
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    def test_prefetch_rpm_lockfile_enabled_hermetic(self, mock_konflux_client_init):
+        builder = KonfluxImageBuilder(MagicMock())
+        metadata = MagicMock()
+        metadata.is_cachi2_enabled.return_value = True
+        metadata.is_lockfile_generation_enabled.return_value = True
+        metadata.get_konflux_network_mode.return_value = "hermetic"
         metadata.config.content.source.pkg_managers = ["gomod"]
         metadata.config.cachito.packages = {'gomod': [{'path': '.'}]}
         metadata.config.konflux.cachi2.lockfile.get.return_value = "."
@@ -93,6 +112,7 @@ class TestKonfluxCachi2(TestCase):
         metadata = MagicMock()
         metadata.is_cachi2_enabled.return_value = True
         metadata.is_lockfile_generation_enabled.return_value = True
+        metadata.get_konflux_network_mode.return_value = "hermetic"
         metadata.config.content.source.pkg_managers = ["npm"]
         metadata.config.cachito.packages = {'npm': [{'path': 'frontend'}]}
         metadata.config.konflux.cachi2.lockfile.get.return_value = "custom/path"

--- a/doozer/tests/backend/test_konflux_cachi2.py
+++ b/doozer/tests/backend/test_konflux_cachi2.py
@@ -7,51 +7,51 @@ from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
 
 class TestKonfluxCachi2(TestCase):
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
-    @patch("doozerlib.image.ImageMetadata.is_cachi2_enabled")
-    def test_prefetch_1(self, mock_konflux_client_init, mock_is_cachito_enabled):
+    def test_prefetch_1(self, mock_konflux_client_init):
         builder = KonfluxImageBuilder(MagicMock())
-        mock_is_cachito_enabled.return_value = False
         metadata = MagicMock()
+        metadata.is_cachi2_enabled.return_value = False
+        metadata.is_lockfile_generation_enabled.return_value = False
 
         self.assertEqual(builder._prefetch(metadata=metadata), [])
 
-    @patch("doozerlib.image.ImageMetadata.is_cachi2_enabled")
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
-    def test_prefetch_2(self, mock_konflux_client_init, mock_is_cachito_enabled):
+    def test_prefetch_2(self, mock_konflux_client_init):
         builder = KonfluxImageBuilder(MagicMock())
-        mock_is_cachito_enabled.return_value = False
         metadata = MagicMock()
+        metadata.is_cachi2_enabled.return_value = False
+        metadata.is_lockfile_generation_enabled.return_value = False
         metadata.config.content.source.pkg_managers = ["unknown"]
 
         self.assertEqual(builder._prefetch(metadata=metadata), [])
 
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
-    @patch("doozerlib.image.ImageMetadata.is_cachi2_enabled")
-    def test_prefetch_3(self, mock_is_cachito_enabled, mock_konflux_client_init):
+    def test_prefetch_3(self, mock_konflux_client_init):
         builder = KonfluxImageBuilder(MagicMock())
-        mock_is_cachito_enabled.return_value = False
         metadata = MagicMock()
+        metadata.is_cachi2_enabled.return_value = True
+        metadata.is_lockfile_generation_enabled.return_value = False
         metadata.config.content.source.pkg_managers = ["gomod"]
 
         self.assertEqual(builder._prefetch(metadata=metadata), [{"type": "gomod", "path": "."}])
 
-    @patch("doozerlib.image.ImageMetadata.is_cachi2_enabled")
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
-    def test_prefetch_4(self, mock_konflux_client_init, mock_is_cachito_enabled):
+    def test_prefetch_4(self, mock_konflux_client_init):
         builder = KonfluxImageBuilder(MagicMock())
-        mock_is_cachito_enabled.return_value = False
         metadata = MagicMock()
+        metadata.is_cachi2_enabled.return_value = True
+        metadata.is_lockfile_generation_enabled.return_value = False
         metadata.config.content.source.pkg_managers = ["gomod"]
         metadata.config.cachito.packages = {'gomod': [{'path': 'api'}]}
 
         self.assertEqual(builder._prefetch(metadata=metadata), [{"type": "gomod", "path": "api"}])
 
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
-    @patch("doozerlib.image.ImageMetadata.is_cachi2_enabled")
-    def test_prefetch_5(self, mock_is_cachito_enabled, mock_konflux_client_init):
+    def test_prefetch_5(self, mock_konflux_client_init):
         builder = KonfluxImageBuilder(MagicMock())
-        mock_is_cachito_enabled.return_value = False
         metadata = MagicMock()
+        metadata.is_cachi2_enabled.return_value = True
+        metadata.is_lockfile_generation_enabled.return_value = False
         metadata.config.content.source.pkg_managers = ["gomod"]
         metadata.config.cachito.packages = {"gomod": [{"path": "."}, {"path": "api"}, {"path": "client/pkg"}]}
 
@@ -61,14 +61,42 @@ class TestKonfluxCachi2(TestCase):
         )
 
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
-    @patch("doozerlib.image.ImageMetadata.is_cachi2_enabled")
-    def test_prefetch_6(self, mock_is_cachito_enabled, mock_konflux_client_init):
+    def test_prefetch_6(self, mock_konflux_client_init):
         builder = KonfluxImageBuilder(MagicMock())
-        mock_is_cachito_enabled.return_value = False
         metadata = MagicMock()
+        metadata.is_cachi2_enabled.return_value = True
+        metadata.is_lockfile_generation_enabled.return_value = False
         metadata.config.content.source.pkg_managers = ["npm", "gomod"]
         metadata.config.cachito.packages = {'npm': [{'path': 'web'}], 'gomod': [{'path': '.'}]}
 
         self.assertEqual(
             builder._prefetch(metadata=metadata), [{'type': 'gomod', 'path': '.'}, {'type': 'npm', 'path': 'web'}]
         )
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    def test_prefetch_rpm_lockfile_enabled(self, mock_konflux_client_init):
+        builder = KonfluxImageBuilder(MagicMock())
+        metadata = MagicMock()
+        metadata.is_cachi2_enabled.return_value = True
+        metadata.is_lockfile_generation_enabled.return_value = True
+        metadata.config.content.source.pkg_managers = ["gomod"]
+        metadata.config.cachito.packages = {'gomod': [{'path': '.'}]}
+        metadata.config.konflux.cachi2.lockfile.get.return_value = "."
+
+        result = builder._prefetch(metadata=metadata)
+        expected = [{'type': 'rpm', 'path': '.'}, {'type': 'gomod', 'path': '.'}]
+        self.assertEqual(result, expected)
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    def test_prefetch_rpm_lockfile_custom_path(self, mock_konflux_client_init):
+        builder = KonfluxImageBuilder(MagicMock())
+        metadata = MagicMock()
+        metadata.is_cachi2_enabled.return_value = True
+        metadata.is_lockfile_generation_enabled.return_value = True
+        metadata.config.content.source.pkg_managers = ["npm"]
+        metadata.config.cachito.packages = {'npm': [{'path': 'frontend'}]}
+        metadata.config.konflux.cachi2.lockfile.get.return_value = "custom/path"
+
+        result = builder._prefetch(metadata=metadata)
+        expected = [{'type': 'rpm', 'path': 'custom/path'}, {'type': 'npm', 'path': 'frontend'}]
+        self.assertEqual(result, expected)

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -172,10 +172,11 @@ USER 3000
 
     def test_add_build_repos_3(self):
         """
-        Test with network_mode hermetic
+        Test with network_mode hermetic but lockfile disabled
         """
         metadata = MagicMock()
         metadata.get_konflux_network_mode.return_value = "hermetic"
+        metadata.is_lockfile_generation_enabled.return_value = False
         metadata.config.konflux.cachito.mode = Missing
         metadata.config.final_stage_user = "3000"
 
@@ -215,6 +216,56 @@ USER 3000
         rebaser = KonfluxRebaser(MagicMock(), MagicMock(), MagicMock(), "unsigned")
         rebaser._add_build_repos(dfp=dfp, metadata=metadata, dest_dir=Path(self.directory.name))
         dfp.content.strip()
+        self.assertEqual(expected.strip(), dfp.content.strip())
+
+    def test_add_build_repos_hermetic_with_lockfile(self):
+        """
+        Test with network_mode hermetic and lockfile generation enabled
+        """
+        metadata = MagicMock()
+        metadata.get_konflux_network_mode.return_value = "hermetic"
+        metadata.is_lockfile_generation_enabled.return_value = True
+        metadata.get_arches.return_value = ["x86_64", "aarch64"]
+        metadata.config.konflux.cachito.mode = Missing
+        metadata.config.final_stage_user = "3000"
+
+        dfp = DockerfileParser(path=self.directory.name)
+        dfp.content = """
+FROM base1
+LABEL foo="bar baz"
+USER 1000
+FROM base2
+USER 2000
+RUN commands
+               """
+        expected = """
+FROM base1
+
+# Start Konflux-specific steps
+ENV ART_BUILD_ENGINE=konflux
+ENV ART_BUILD_DEPS_METHOD=cachi2
+ENV ART_BUILD_NETWORK=hermetic
+ENV ART_BUILD_DEPS_MODE=default
+# End Konflux-specific steps
+LABEL foo="bar baz"
+USER 1000
+FROM base2
+
+# Start Konflux-specific steps
+ENV ART_BUILD_ENGINE=konflux
+ENV ART_BUILD_DEPS_METHOD=cachi2
+ENV ART_BUILD_NETWORK=hermetic
+ENV ART_BUILD_DEPS_MODE=default
+# End Konflux-specific steps
+USER 2000
+RUN commands
+
+USER 3000
+"""
+        rebaser = KonfluxRebaser(MagicMock(), MagicMock(), MagicMock(), "unsigned")
+        rebaser._add_build_repos(dfp=dfp, metadata=metadata, dest_dir=Path(self.directory.name))
+        dfp.content.strip()
+        self.maxDiff = None
         self.assertEqual(expected.strip(), dfp.content.strip())
 
     def test_add_build_repos_4(self):

--- a/doozer/tests/test_lockfile.py
+++ b/doozer/tests/test_lockfile.py
@@ -3,7 +3,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
-from doozerlib.lockfile import RpmInfo, RpmInfoCollector, RPMLockfileGenerator
+from doozerlib.lockfile import DEFAULT_LOCKFILE_NAME, RpmInfo, RpmInfoCollector, RPMLockfileGenerator
 from doozerlib.repodata import Repodata, Rpm
 from doozerlib.repos import Repo, Repos
 


### PR DESCRIPTION
- Added prefetch logic in konflux_image_builder.py to include rpm lockfile when network mode is hermetic and lockfile generation is enabled
- Updated pipeline run creation in konflux_client.py to handle lockfile-specific parameters
- Added comprehensive test coverage for lockfile scenarios in test_konflux_cachi2.py
- Enhanced rebaser tests to validate lockfile generation workflows

**Unrelated change:**
- Renaming LOCKFILE_FILENAME const