### PR TITLE
ART-13329 Integrate attach-cve-flaws in prepare-release for Konflux

### DIFF
--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -108,7 +108,7 @@ class AttachCveFlaws:
 
         if not bug_ids:
             self.logger.info("No fixed issues found in the release notes, exiting.")
-            sys.exit(0)
+            return release_notes
 
         # Get the bug trackers
         tracker_bugs = self.get_attached_trackers(bug_ids, self.runtime.get_bug_tracker('jira'))
@@ -119,6 +119,9 @@ class AttachCveFlaws:
 
             # Turn the advisory type into an RHSA
             self.update_advisory_konflux(release_notes, flaw_bugs, tracker_bugs, tracker_flaws)
+
+        else:
+            self.logger.info('No flaw bugs found, leaving release notes unchanged')
 
         return release_notes
 

--- a/pyartcd/tests/pipelines/test_prepare_release_konflux.py
+++ b/pyartcd/tests/pipelines/test_prepare_release_konflux.py
@@ -370,6 +370,7 @@ class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
             await pipeline.validate_shipment_config(pipeline.shipment_config)
         self.assertIn("Shipment config `env` should be either `prod` or `stage`", str(context.exception))
 
+    @patch.object(PrepareReleaseKonfluxPipeline, 'attach_cve_flaws', new_callable=AsyncMock)
     @patch('pyartcd.pipelines.prepare_release_konflux.AsyncErrataAPI', spec=AsyncErrataAPI)
     @patch.object(PrepareReleaseKonfluxPipeline, 'update_shipment_mr', new_callable=AsyncMock)
     @patch.object(PrepareReleaseKonfluxPipeline, 'create_update_build_data_pr', new_callable=AsyncMock)
@@ -390,6 +391,7 @@ class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
         mock_create_build_data_pr,
         mock_update_shipment_mr,
         mock_errata_api,
+        *_,
     ):
         pipeline = PrepareReleaseKonfluxPipeline(
             slack_client=self.mock_slack_client,
@@ -601,7 +603,7 @@ class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
         mock_find_bugs.assert_any_call("image", permissive=False)
         self.assertEqual(mock_find_bugs.call_count, 2)
 
-        mock_update_shipment_mr.assert_awaited_once()
+        self.assertEqual(mock_update_shipment_mr.call_count, 2)
         updated_shipments_arg = mock_update_shipment_mr.call_args[0][0]
 
         mock_shipment_image_update = copy.deepcopy(mock_shipment_image_create)


### PR DESCRIPTION
Integrate `elliott attach-cve-flaws` into Konflux prepare-release pipeline.

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release-konflux/67/console

Created shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/41

Ref. [ART-13329](https://issues.redhat.com/browse/ART-13329)