### PR TITLE
ART-13331 Implement verify-payload for Konflux shipments

### DIFF
--- a/elliott/elliottlib/cli/verify_payload.py
+++ b/elliott/elliottlib/cli/verify_payload.py
@@ -1,0 +1,132 @@
+import json
+import logging
+
+import click
+from typing import Dict, List
+
+from artcommonlib import rhcos
+from artcommonlib.format_util import green_prefix, yellow_prefix, green_print, red_print, yellow_print
+from elliottlib.cli.common import cli, click_coroutine
+from elliottlib.constants import errata_url
+from elliottlib.errata import get_advisory_nvrs, get_brew_build, get_raw_erratum
+from elliottlib.util import get_nvrs_from_release
+
+LOGGER = logging.getLogger(__name__)
+
+
+@cli.command("verify-payload", short_help="Verify payload contents match advisory builds")
+@click.argument("payload_or_imagestream")
+@click.argument('advisory', type=int)
+@click.pass_obj
+@click_coroutine
+async def verify_payload(runtime, payload_or_imagestream, advisory):
+    """Cross-check that the builds present in PAYLOAD or Imagestream match the builds
+    attached to ADVISORY. The payload is treated as the source of
+    truth. If something is absent or different in the advisory it is
+    treated as an error with the advisory.
+
+    \b
+        PAYLOAD_OR_IMAGESTREAM - Full pullspec of the payload or imagestream to verify
+        ADVISORY - Numerical ID of the advisory
+
+    Two checks are made:
+
+    \b
+     1. Missing in Advisory - No payload/imagestream components are absent from the given advisory
+
+     2. Payload/imagestream Advisory Mismatch - The version-release of each payload/imagestream item match what is in the advisory
+
+    Results are summarily printed at the end of the run. They are also
+    written out to summary_results.json.
+
+         Verify builds in the given payload/imagestream match the builds attached to advisory 41567
+
+     \b
+        $ for paylaod: elliott -g openshift-1 verify-payload quay.io/openshift-release-dev/ocp-release:4.1.0-rc.6 41567
+     \b
+        $ for imagestream: elliott -g openshift-1 verify-payload 4.1-art-assembly-rc.6 41567
+
+    """
+
+    runtime.initialize()
+    rhcos_images = {c['name'] for c in rhcos.get_container_configs(runtime)}
+    all_advisory_nvrs = get_advisory_nvrs(advisory)
+
+    click.echo("Found {} builds".format(len(all_advisory_nvrs)))
+
+    all_payload_nvrs = await get_nvrs_from_release(payload_or_imagestream, rhcos_images, LOGGER)
+
+    missing_in_errata = {}
+    payload_doesnt_match_errata = {}
+    in_pending_advisory = []
+    in_shipped_advisory = []
+    output = {
+        'missing_in_advisory': missing_in_errata,
+        'payload_advisory_mismatch': payload_doesnt_match_errata,
+        "in_pending_advisory": in_pending_advisory,
+        "in_shipped_advisory": in_shipped_advisory,
+    }
+
+    green_prefix("Analyzing data: ")
+    click.echo("{} images to consider from payload".format(len(all_payload_nvrs)))
+
+    for image, vr_tuple in all_payload_nvrs.items():
+        vr = f"{vr_tuple[0]}-{vr_tuple[1]}"
+        imagevr = f"{image}-{vr}"
+        yellow_prefix("Cross-checking from payload: ")
+        click.echo(imagevr)
+        if image not in all_advisory_nvrs:
+            missing_in_errata[image] = imagevr
+            click.echo(f"{imagevr} in payload not found in advisory")
+        elif image in all_advisory_nvrs and vr != all_advisory_nvrs[image]:
+            click.echo(
+                f"{image} from payload has version {vr} which does not match {all_advisory_nvrs[image]} from advisory"
+            )
+            payload_doesnt_match_errata[image] = {
+                'payload': vr,
+                'errata': all_advisory_nvrs[image],
+            }
+
+    if missing_in_errata:  # check if missing images are already shipped or pending to ship
+        advisory_nvrs: Dict[int, List[str]] = {}  # a dict mapping advisory numbers to lists of NVRs
+        green_print(f"Checking if {len(missing_in_errata)} missing images are shipped...")
+        for nvr in missing_in_errata.copy().values():
+            # get the list of advisories that this build has been attached to
+            build = get_brew_build(nvr)
+            # filter out dropped advisories
+            advisories = [ad for ad in build.all_errata if ad["status"] != "DROPPED_NO_SHIP"]
+            if not advisories:
+                red_print(f"Build {nvr} is not attached to any advisories.")
+                continue
+            for advisory in advisories:
+                if advisory["status"] == "SHIPPED_LIVE":
+                    green_print(f"Missing build {nvr} has been shipped with advisory {advisory}.")
+                else:
+                    yellow_print(f"Missing build {nvr} is in another pending advisory.")
+                advisory_nvrs.setdefault(advisory["id"], []).append(nvr)
+            name = nvr.rsplit("-", 2)[0]
+            del missing_in_errata[name]
+        if advisory_nvrs:
+            click.echo(f"Getting information of {len(advisory_nvrs)} advisories...")
+            for advisory, nvrs in advisory_nvrs.items():
+                advisory_obj = get_raw_erratum(advisory)
+                adv_type, adv_info = next(iter(advisory_obj["errata"].items()))
+                item = {
+                    "id": advisory,
+                    "type": adv_type.upper(),
+                    "url": errata_url + f"/{advisory}",
+                    "summary": adv_info["synopsis"],
+                    "state": adv_info["status"],
+                    "nvrs": nvrs,
+                }
+                if adv_info["status"] == "SHIPPED_LIVE":
+                    in_shipped_advisory.append(item)
+                else:
+                    in_pending_advisory.append(item)
+
+    green_print("Summary results:")
+    click.echo(json.dumps(output, indent=4))
+    with open('summary_results.json', 'w') as fp:
+        json.dump(output, fp, indent=4)
+    green_prefix("Wrote out summary results: ")
+    click.echo("summary_results.json")

--- a/elliott/elliottlib/cli/verify_payload.py
+++ b/elliott/elliottlib/cli/verify_payload.py
@@ -1,25 +1,142 @@
 import json
 import logging
+from typing import Dict, List, Optional
 
 import click
-from typing import Dict, List
-
 from artcommonlib import rhcos
-from artcommonlib.format_util import green_prefix, yellow_prefix, green_print, red_print, yellow_print
+
+from elliottlib import Runtime
 from elliottlib.cli.common import cli, click_coroutine
 from elliottlib.constants import errata_url
 from elliottlib.errata import get_advisory_nvrs, get_brew_build, get_raw_erratum
 from elliottlib.util import get_nvrs_from_release
 
-LOGGER = logging.getLogger(__name__)
+
+class VerifyPayloadPipeline:
+    def __init__(
+        self, runtime: Runtime, payload_or_imagestream: str, advisory: Optional[int] = None, to_file: bool = False
+    ):
+        self.logger = logging.getLogger(__name__)
+        self.runtime = runtime
+        self.payload_or_imagestream = payload_or_imagestream
+        self.advisory = advisory
+        self.to_file = to_file
+
+        self.all_payload_nvrs: Dict[str, tuple] = {}
+        self.all_advisory_nvrs = {}
+
+    async def run(self):
+        rhcos_images = {c['name'] for c in rhcos.get_container_configs(self.runtime)}
+        self.all_payload_nvrs = await get_nvrs_from_release(self.payload_or_imagestream, rhcos_images, self.logger)
+
+        if self.runtime.build_system == 'brew':
+            results = await self.check_brew_payload()
+        else:
+            results = await self.check_konflux_payload()
+
+        self.logger.info("Summary results:")
+        click.echo(json.dumps(results, indent=4))
+
+        if self.to_file:
+            with open('summary_results.json', 'w') as fp:
+                json.dump(results, fp, indent=4)
+            self.logger.info("Wrote out summary results to summary_results.json")
+
+    async def check_brew_payload(self):
+        self.all_advisory_nvrs = get_advisory_nvrs(self.advisory)
+        self.logger.info("Found {} builds".format(len(self.all_advisory_nvrs)))
+
+        missing_in_errata = {}
+        payload_doesnt_match_errata = {}
+        in_pending_advisory = []
+        in_shipped_advisory = []
+        results = {
+            'missing_in_advisory': missing_in_errata,
+            'payload_advisory_mismatch': payload_doesnt_match_errata,
+            "in_pending_advisory": in_pending_advisory,
+            "in_shipped_advisory": in_shipped_advisory,
+        }
+
+        self.logger.info("Analyzing %s images to consider from payload", len(self.all_payload_nvrs))
+
+        self._check_payload_match_errata(payload_doesnt_match_errata, missing_in_errata)
+        self._check_missing_in_errata(missing_in_errata, in_shipped_advisory, in_pending_advisory)
+
+        return results
+
+    def _check_payload_match_errata(self, payload_doesnt_match_errata, missing_in_errata):
+        for image, vr_tuple in self.all_payload_nvrs.items():
+            vr = f"{vr_tuple[0]}-{vr_tuple[1]}"
+            imagevr = f"{image}-{vr}"
+            self.logger.info("Cross-checking from payload: %s", imagevr)
+
+            if image not in self.all_advisory_nvrs:
+                missing_in_errata[image] = imagevr
+                self.logger.warning(f"{imagevr} in payload not found in advisory")
+
+            elif image in self.all_advisory_nvrs and vr != self.all_advisory_nvrs[image]:
+                self.logger.warning(
+                    f"{image} from payload has version {vr} which does not match {self.all_advisory_nvrs[image]} from advisory"
+                )
+                payload_doesnt_match_errata[image] = {
+                    'payload': vr,
+                    'errata': self.all_advisory_nvrs[image],
+                }
+
+    def _check_missing_in_errata(self, missing_in_errata, in_shipped_advisory, in_pending_advisory):
+        if missing_in_errata:  # check if missing images are already shipped or pending to ship
+            advisory_nvrs: Dict[int, List[str]] = {}  # a dict mapping advisory numbers to lists of NVRs
+            self.logger.info(f"Checking if {len(missing_in_errata)} missing images are shipped...")
+
+            for nvr in missing_in_errata.copy().values():
+                # get the list of advisories that this build has been attached to
+                build = get_brew_build(nvr)
+
+                # filter out dropped advisories
+                advisories = [ad for ad in build.all_errata if ad["status"] != "DROPPED_NO_SHIP"]
+                if not advisories:
+                    self.logger.warning(f"Build {nvr} is not attached to any advisories.")
+                    continue
+
+                for advisory in advisories:
+                    if advisory["status"] == "SHIPPED_LIVE":
+                        self.logger.info(f"Missing build {nvr} has been shipped with advisory {advisory}.")
+                    else:
+                        self.logger.warning(f"Missing build {nvr} is in another pending advisory.")
+                    advisory_nvrs.setdefault(advisory["id"], []).append(nvr)
+
+                name = nvr.rsplit("-", 2)[0]
+                del missing_in_errata[name]
+
+            if advisory_nvrs:
+                self.logger.info(f"Getting information of {len(advisory_nvrs)} advisories...")
+                for advisory, nvrs in advisory_nvrs.items():
+                    advisory_obj = get_raw_erratum(advisory)
+                    adv_type, adv_info = next(iter(advisory_obj["errata"].items()))
+                    item = {
+                        "id": advisory,
+                        "type": adv_type.upper(),
+                        "url": errata_url + f"/{advisory}",
+                        "summary": adv_info["synopsis"],
+                        "state": adv_info["status"],
+                        "nvrs": nvrs,
+                    }
+                    if adv_info["status"] == "SHIPPED_LIVE":
+                        in_shipped_advisory.append(item)
+                    else:
+                        in_pending_advisory.append(item)
+
+    async def check_konflux_payload(self):
+        return {}
 
 
 @cli.command("verify-payload", short_help="Verify payload contents match advisory builds")
 @click.argument("payload_or_imagestream")
-@click.argument('advisory', type=int)
+@click.option('--advisory', required=False, type=int)
+@click.option('--to-file', default=False, is_flag=True, help='Write results to file.')
 @click.pass_obj
 @click_coroutine
-async def verify_payload(runtime, payload_or_imagestream, advisory):
+async def verify_payload(runtime, payload_or_imagestream, advisory, to_file):
     """Cross-check that the builds present in PAYLOAD or Imagestream match the builds
     attached to ADVISORY. The payload is treated as the source of
     truth. If something is absent or different in the advisory it is
@@ -48,85 +165,8 @@ async def verify_payload(runtime, payload_or_imagestream, advisory):
 
     """
 
+    if runtime.build_system == 'brew' and not advisory:
+        raise click.UsageError("Advisory ID is required for brew builds.")
+
     runtime.initialize()
-    rhcos_images = {c['name'] for c in rhcos.get_container_configs(runtime)}
-    all_advisory_nvrs = get_advisory_nvrs(advisory)
-
-    click.echo("Found {} builds".format(len(all_advisory_nvrs)))
-
-    all_payload_nvrs = await get_nvrs_from_release(payload_or_imagestream, rhcos_images, LOGGER)
-
-    missing_in_errata = {}
-    payload_doesnt_match_errata = {}
-    in_pending_advisory = []
-    in_shipped_advisory = []
-    output = {
-        'missing_in_advisory': missing_in_errata,
-        'payload_advisory_mismatch': payload_doesnt_match_errata,
-        "in_pending_advisory": in_pending_advisory,
-        "in_shipped_advisory": in_shipped_advisory,
-    }
-
-    green_prefix("Analyzing data: ")
-    click.echo("{} images to consider from payload".format(len(all_payload_nvrs)))
-
-    for image, vr_tuple in all_payload_nvrs.items():
-        vr = f"{vr_tuple[0]}-{vr_tuple[1]}"
-        imagevr = f"{image}-{vr}"
-        yellow_prefix("Cross-checking from payload: ")
-        click.echo(imagevr)
-        if image not in all_advisory_nvrs:
-            missing_in_errata[image] = imagevr
-            click.echo(f"{imagevr} in payload not found in advisory")
-        elif image in all_advisory_nvrs and vr != all_advisory_nvrs[image]:
-            click.echo(
-                f"{image} from payload has version {vr} which does not match {all_advisory_nvrs[image]} from advisory"
-            )
-            payload_doesnt_match_errata[image] = {
-                'payload': vr,
-                'errata': all_advisory_nvrs[image],
-            }
-
-    if missing_in_errata:  # check if missing images are already shipped or pending to ship
-        advisory_nvrs: Dict[int, List[str]] = {}  # a dict mapping advisory numbers to lists of NVRs
-        green_print(f"Checking if {len(missing_in_errata)} missing images are shipped...")
-        for nvr in missing_in_errata.copy().values():
-            # get the list of advisories that this build has been attached to
-            build = get_brew_build(nvr)
-            # filter out dropped advisories
-            advisories = [ad for ad in build.all_errata if ad["status"] != "DROPPED_NO_SHIP"]
-            if not advisories:
-                red_print(f"Build {nvr} is not attached to any advisories.")
-                continue
-            for advisory in advisories:
-                if advisory["status"] == "SHIPPED_LIVE":
-                    green_print(f"Missing build {nvr} has been shipped with advisory {advisory}.")
-                else:
-                    yellow_print(f"Missing build {nvr} is in another pending advisory.")
-                advisory_nvrs.setdefault(advisory["id"], []).append(nvr)
-            name = nvr.rsplit("-", 2)[0]
-            del missing_in_errata[name]
-        if advisory_nvrs:
-            click.echo(f"Getting information of {len(advisory_nvrs)} advisories...")
-            for advisory, nvrs in advisory_nvrs.items():
-                advisory_obj = get_raw_erratum(advisory)
-                adv_type, adv_info = next(iter(advisory_obj["errata"].items()))
-                item = {
-                    "id": advisory,
-                    "type": adv_type.upper(),
-                    "url": errata_url + f"/{advisory}",
-                    "summary": adv_info["synopsis"],
-                    "state": adv_info["status"],
-                    "nvrs": nvrs,
-                }
-                if adv_info["status"] == "SHIPPED_LIVE":
-                    in_shipped_advisory.append(item)
-                else:
-                    in_pending_advisory.append(item)
-
-    green_print("Summary results:")
-    click.echo(json.dumps(output, indent=4))
-    with open('summary_results.json', 'w') as fp:
-        json.dump(output, fp, indent=4)
-    green_prefix("Wrote out summary results: ")
-    click.echo("summary_results.json")
+    await VerifyPayloadPipeline(runtime, payload_or_imagestream, advisory, to_file).run()

--- a/elliott/elliottlib/cli/verify_payload.py
+++ b/elliott/elliottlib/cli/verify_payload.py
@@ -16,11 +16,10 @@ from elliottlib.util import get_nvrs_from_release, parse_nvr
 
 
 class VerifyPayloadPipeline:
-    def __init__(self, runtime: Runtime, payload_or_imagestream: str, to_file: bool = False):
+    def __init__(self, runtime: Runtime, payload_or_imagestream: str):
         self.logger = logging.getLogger(__name__)
         self.runtime = runtime
         self.payload_or_imagestream = payload_or_imagestream
-        self.to_file = to_file
 
         self.assembly_group_config = {}
         self.all_payload_nvrs: Dict[str, tuple] = {}
@@ -47,13 +46,8 @@ class VerifyPayloadPipeline:
             # We're dealing with a Brew assembly
             results = await self.check_brew_payload()
 
+        # Dump results to standard output
         click.echo(json.dumps(results, indent=4))
-
-        # Write results to file if requested
-        if self.to_file:
-            with open('summary_results.json', 'w') as fp:
-                json.dump(results, fp, indent=4)
-            self.logger.info("Wrote out summary results to summary_results.json")
 
     def _get_image_advisory_id(self) -> Optional[int]:
         """
@@ -196,10 +190,9 @@ class VerifyPayloadPipeline:
 
 @cli.command("verify-payload", short_help="Verify payload contents match advisory builds")
 @click.argument("payload_or_imagestream")
-@click.option('--to-file', default=False, is_flag=True, help='Write results to file.')
 @click.pass_obj
 @click_coroutine
-async def verify_payload(runtime, payload_or_imagestream, to_file):
+async def verify_payload(runtime, payload_or_imagestream):
     """Cross-check that the builds present in PAYLOAD or Imagestream match the builds
     attached to ADVISORY. The payload is treated as the source of
     truth. If something is absent or different in the advisory it is
@@ -229,4 +222,4 @@ async def verify_payload(runtime, payload_or_imagestream, to_file):
     """
 
     runtime.initialize()
-    await VerifyPayloadPipeline(runtime, payload_or_imagestream, to_file).run()
+    await VerifyPayloadPipeline(runtime, payload_or_imagestream).run()

--- a/elliott/elliottlib/cli/verify_payload.py
+++ b/elliott/elliottlib/cli/verify_payload.py
@@ -172,13 +172,9 @@ class VerifyPayloadPipeline:
 
         missing_in_errata = {}
         payload_doesnt_match_errata = {}
-        in_pending_advisory = []
-        in_shipped_advisory = []
         results = {
             'missing_in_advisory': missing_in_errata,
             'payload_advisory_mismatch': payload_doesnt_match_errata,
-            "in_pending_advisory": in_pending_advisory,
-            "in_shipped_advisory": in_shipped_advisory,
         }
 
         self.logger.info("Analyzing %s images to consider from payload", len(self.all_payload_nvrs))

--- a/elliott/elliottlib/cli/verify_payload.py
+++ b/elliott/elliottlib/cli/verify_payload.py
@@ -84,12 +84,12 @@ class VerifyPayloadPipeline:
 
         self.logger.info("Analyzing %s images to consider from payload", len(self.all_payload_nvrs))
 
-        self._check_payload_match_errata(payload_doesnt_match_errata, missing_in_errata)
-        self._check_missing_in_errata(missing_in_errata, in_shipped_advisory, in_pending_advisory)
+        self._populate_payload_match_errata(payload_doesnt_match_errata, missing_in_errata)
+        self._populate_missing_in_errata(missing_in_errata, in_shipped_advisory, in_pending_advisory)
 
         return results
 
-    def _check_payload_match_errata(self, payload_doesnt_match_errata, missing_in_errata):
+    def _populate_payload_match_errata(self, payload_doesnt_match_errata, missing_in_errata):
         """
         Check if the payload matches the advisory builds.
         """
@@ -112,7 +112,7 @@ class VerifyPayloadPipeline:
                     'errata': self.all_advisory_nvrs[image],
                 }
 
-    def _check_missing_in_errata(self, missing_in_errata, in_shipped_advisory, in_pending_advisory):
+    def _populate_missing_in_errata(self, missing_in_errata, in_shipped_advisory, in_pending_advisory):
         """
         Check if the missing images are already shipped or pending to ship.
         """
@@ -189,7 +189,7 @@ class VerifyPayloadPipeline:
 
         self.logger.info("Analyzing %s images to consider from payload", len(self.all_payload_nvrs))
 
-        self._check_payload_match_errata(payload_doesnt_match_errata, missing_in_errata)
+        self._populate_payload_match_errata(payload_doesnt_match_errata, missing_in_errata)
 
         return results
 

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -511,6 +511,10 @@ def all_same(items: Iterable[Any]):
 
 
 async def get_nvrs_from_release(pullspec_or_imagestream, rhcos_images, logger=None):
+    """
+    Get all payload NVRs from a release pullspec or imagestream.
+    """
+
     def log(msg):
         if logger:
             logger.info(msg)

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -814,7 +814,7 @@ class PrepareReleasePipeline:
         cmd = self._elliott_base_command + [
             "verify-payload",
             f"{pullspec_or_imagestream}",
-            f"{advisory}",
+            f"--advisory={advisory}",
         ]
         if self.dry_run:
             _LOGGER.info("Would have run: %s", cmd)

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -404,7 +404,7 @@ class PrepareReleasePipeline:
             ]
             for is_namespace_and_name in imagestreams_per_arch:
                 is_str = f"{is_namespace_and_name[0]}/{is_namespace_and_name[1]}"
-                self.verify_payload(is_str, advisories["image"])
+                self.verify_payload(is_str)
 
         # Verify greenwave tests
         for impetus, advisory in advisories.items():
@@ -810,11 +810,10 @@ class PrepareReleasePipeline:
         await exectools.cmd_assert_async(cmd, cwd=self.working_dir)
 
     @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(10))
-    def verify_payload(self, pullspec_or_imagestream: str, advisory: int):
+    def verify_payload(self, pullspec_or_imagestream: str):
         cmd = self._elliott_base_command + [
             "verify-payload",
             f"{pullspec_or_imagestream}",
-            f"--advisory={advisory}",
         ]
         if self.dry_run:
             _LOGGER.info("Would have run: %s", cmd)


### PR DESCRIPTION
## Overview
This pull request introduces a significant refactor and enhancement to the `elliott verify-payload` command. The changes focus on improving code maintainability, simplifying the user interface, and expanding functionality to support new workflows, particularly for Konflux assemblies.

## Scope of Changes

### 1. Refactored to Object-Oriented Design
- The core logic of the `verify-payload` command has been encapsulated in a new `VerifyPayloadPipeline` class.

### 2. Removal of the `--advisory` Option
- The `--advisory` CLI option has been **removed**.
- The command now automatically determines the relevant image advisory by inspecting the assembly definition (group/assembly config), eliminating the need for the user to specify it manually.
- This is related with the removal of the `prerelease` job (see https://github.com/openshift-eng/aos-cd-jobs/pull/4429); `verify-payload` is now only executed by the `prepare-release` pipeline, which only refers to the image advisory.

### 3. Support for Konflux Assemblies
- The command now supports verification of payloads for **Konflux-based assemblies** in addition to traditional Brew-based assemblies.
- The pipeline detects whether the current assembly is a Konflux assembly (by inspecting the `basis` block in the assembly config) and adapts its verification logic accordingly.
- For Konflux assemblies, the command fetches build information from the shipment merge request and cross-checks it with the payload contents.
- This enables seamless verification for both legacy and new (Konflux) release processes.

### 4. User Experience and Output
- The command continues to output a summary of verification results to the console in JSON format.
- An optional `--to-file` flag allows writing the results to `summary_results.json` for further analysis or automation.

## Usage Example
```sh
elliott --data-path=https://github.com/locriandev/ocp-build-data.git --group=openshift-4.20 --assembly=4.20.99 --build-system=konflux verify-payload ocp/4.20-art-assembly-ec.3 [--to-file]
```