### PR TITLE
[konflux] curl before ADDing cert

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1099,6 +1099,8 @@ class KonfluxRebaser:
                 "USER 0",
                 "RUN mkdir -p /tmp/art/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/art/yum_temp/ || true",
                 f"COPY .oit/{self.repo_type}.repo /etc/yum.repos.d/",
+                # Needed by s390x builds: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1751464077655919
+                f"RUN curl {constants.KONFLUX_REPO_CA_BUNDLE_HOST}/{constants.KONFLUX_REPO_CA_BUNDLE_FILENAME}",
                 f"ADD {constants.KONFLUX_REPO_CA_BUNDLE_HOST}/{constants.KONFLUX_REPO_CA_BUNDLE_FILENAME} {constants.KONFLUX_REPO_CA_BUNDLE_TMP_PATH}",
             ]
 

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -77,6 +77,7 @@ ENV ART_BUILD_DEPS_MODE=default
 USER 0
 RUN mkdir -p /tmp/art/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/art/yum_temp/ || true
 COPY .oit/unsigned.repo /etc/yum.repos.d/
+RUN curl https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem
 ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp/art
 # End Konflux-specific steps
 LABEL foo="bar baz"
@@ -91,6 +92,7 @@ ENV ART_BUILD_DEPS_MODE=default
 USER 0
 RUN mkdir -p /tmp/art/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/art/yum_temp/ || true
 COPY .oit/unsigned.repo /etc/yum.repos.d/
+RUN curl https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem
 ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp/art
 # End Konflux-specific steps
 USER 2000
@@ -138,6 +140,7 @@ ENV ART_BUILD_DEPS_MODE=default
 USER 0
 RUN mkdir -p /tmp/art/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/art/yum_temp/ || true
 COPY .oit/unsigned.repo /etc/yum.repos.d/
+RUN curl https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem
 ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp/art
 # End Konflux-specific steps
 LABEL foo="bar baz"
@@ -152,6 +155,7 @@ ENV ART_BUILD_DEPS_MODE=default
 USER 0
 RUN mkdir -p /tmp/art/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/art/yum_temp/ || true
 COPY .oit/unsigned.repo /etc/yum.repos.d/
+RUN curl https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem
 ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp/art
 # End Konflux-specific steps
 USER 2000
@@ -244,6 +248,7 @@ ENV ART_BUILD_DEPS_MODE=default
 USER 0
 RUN mkdir -p /tmp/art/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/art/yum_temp/ || true
 COPY .oit/unsigned.repo /etc/yum.repos.d/
+RUN curl https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem
 ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp/art
 # End Konflux-specific steps
 LABEL foo="bar baz"
@@ -257,6 +262,7 @@ ENV ART_BUILD_DEPS_MODE=default
 USER 0
 RUN mkdir -p /tmp/art/yum_temp; mv /etc/yum.repos.d/*.repo /tmp/art/yum_temp/ || true
 COPY .oit/unsigned.repo /etc/yum.repos.d/
+RUN curl https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem
 ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp/art
 # End Konflux-specific steps
 RUN commands


### PR DESCRIPTION
Konflux seems be failing on just s390x builds with 

```
Error: building at STEP "ADD https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem /tmp/art": reading "https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem": Get "https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem": EOF
```
For the new konflux task bundle: https://github.com/openshift-priv/art-konflux-template/pull/114

But test build succeeded when we ran a curl first: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/13209/parameters/

ref slack thread: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1751464077655919