### PR TITLE
Replace basic auth with registry config

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -98,7 +98,7 @@ class BuildMicroShiftBootcPipeline:
             'login',
             '--registry',
             'quay.io/redhat-user-workloads',
-            f'--auth-basic={os.environ["KONFLUX_ART_IMAGES_USERNAME"]}:{os.environ["KONFLUX_ART_IMAGES_PASSWORD"]}',
+            f'--registry-config={os.getenv("KONFLUX_ART_IMAGES_AUTH_FILE")}',
         ]
         await exectools.cmd_assert_async(cmd)
 


### PR DESCRIPTION
Follow up to https://github.com/openshift-eng/art-tools/pull/1635 and https://github.com/openshift-eng/aos-cd-jobs/pull/4404/files

Fixes error seen at https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift-bootc/113/console