### PR TITLE
Tweak component name parsing from url

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -208,8 +208,14 @@ class KonfluxRecord:
         plr_url = urlparse(self.build_pipeline_url)
         # Extract the last part of the URL path. e.g. openshift-4-18-helloworld-operator-bundle-prdtg
         plr_name = unquote(plr_url.path.split('/')[-1])
+
         # openshift-4-18-helloworld-operator-bundle-prdtg -> openshift-4-18-helloworld-operator-bundle
-        component_name = plr_name[: plr_name.rindex("-")]
+        # sometimes the component name is too long, so there is no hyphen in the end
+        # first remove the last 5 chars (unique identifier)
+        component_name = plr_name[:-5]
+        # now check if the last char is a hyphen and if so, remove it
+        if component_name.endswith('-'):
+            component_name = component_name[:-1]
         return component_name
 
 

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -629,6 +629,11 @@ class KonfluxOlmBundleBuilder:
         name = f"ose-{name[10:]}" if name.startswith("openshift-") else name
         return name
 
+    @staticmethod
+    def get_old_component_name(application_name: str, bundle_name: str):
+        # TODO: (2025-Jul-09) remove this once we have new builds using the new component name
+        return f"{application_name}-{bundle_name}".replace(".", "-").replace("_", "-")
+
     @limit_concurrency(limit=constants.MAX_KONFLUX_BUILD_QUEUE_SIZE)
     async def _start_build(
         self,

--- a/elliott/elliottlib/cli/snapshot_cli.py
+++ b/elliott/elliottlib/cli/snapshot_cli.py
@@ -168,6 +168,7 @@ class CreateSnapshotCli:
 
         async def _comp(record: KonfluxRecord):
             # get application and component names from PLR url
+            # note: this will change once we have component name stored in the DB
             app_name = record.get_konflux_application_name()
             comp_name = record.get_konflux_component_name()
 
@@ -175,16 +176,21 @@ class CreateSnapshotCli:
             await self.konflux_client.get_application__caching(app_name, strict=True)
 
             # make sure component exists, if not, try to get it from the relevant Builder class
+            # note: this will change once we have component name stored in the DB
             try:
                 await self.konflux_client.get_component__caching(comp_name, strict=True)
             except Exception as e:
-                # note: this will be change once we have component name stored in the DB
                 if isinstance(record, KonfluxBuildRecord):
                     comp_name = KonfluxImageBuilder.get_component_name(app_name, record.name)
                     await self.konflux_client.get_component__caching(comp_name, strict=True)
                 elif isinstance(record, KonfluxBundleBuildRecord):
                     comp_name = KonfluxOlmBundleBuilder.get_component_name(app_name, record.name)
-                    await self.konflux_client.get_component__caching(comp_name, strict=True)
+                    try:
+                        await self.konflux_client.get_component__caching(comp_name, strict=True)
+                    except Exception as e:
+                        # if we still can't find the component, use the old component name
+                        comp_name = KonfluxOlmBundleBuilder.get_old_component_name(app_name, record.name)
+                        await self.konflux_client.get_component__caching(comp_name, strict=True)
                 else:
                     # fbc component name is determined from the image it builds for, which is not stored in the DB
                     # rather than hack something up, let it fail for now

--- a/elliott/elliottlib/cli/snapshot_cli.py
+++ b/elliott/elliottlib/cli/snapshot_cli.py
@@ -187,7 +187,7 @@ class CreateSnapshotCli:
                     comp_name = KonfluxOlmBundleBuilder.get_component_name(app_name, record.name)
                     try:
                         await self.konflux_client.get_component__caching(comp_name, strict=True)
-                    except Exception as e:
+                    except Exception:
                         # if we still can't find the component, use the old component name
                         comp_name = KonfluxOlmBundleBuilder.get_old_component_name(app_name, record.name)
                         await self.konflux_client.get_component__caching(comp_name, strict=True)

--- a/elliott/elliottlib/cli/snapshot_cli.py
+++ b/elliott/elliottlib/cli/snapshot_cli.py
@@ -174,7 +174,7 @@ class CreateSnapshotCli:
                 comp_name = KonfluxImageBuilder.get_component_name(app_name, record.name)
             elif isinstance(record, KonfluxBundleBuildRecord):
                 comp_name = KonfluxOlmBundleBuilder.get_component_name(app_name, record.name)
-            elif isinstance(record, KonfluxFbcBuildRecord):
+            else:
                 # fbc component name is determined from the image it builds for, which is not stored in the DB
                 # rather than hack something up, call the generic method and let it fail in the worst case
                 comp_name = record.get_konflux_component_name()

--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -314,7 +314,7 @@ class PrepareReleaseKonfluxPipeline:
         if self.assembly_type in (AssemblyTypes.PREVIEW, AssemblyTypes.CANDIDATE):
             permissive = True
         for kind, shipment in shipments_by_kind.items():
-            shipment.shipment.data.releaseNotes.issues = await self.find_bugs(kind, permissive=permissive)
+            await self.find_and_attach_bugs(kind, shipment, permissive=permissive)
 
         # Update shipment MR with found bugs
         await self.update_shipment_mr(shipments_by_kind, env, shipment_url)
@@ -564,7 +564,7 @@ class PrepareReleaseKonfluxPipeline:
 
         return kind_to_builds
 
-    async def find_bugs(self, kind: str, shipment: ShipmentConfig, permissive: bool = False) -> Optional[Issues]:
+    async def find_and_attach_bugs(self, kind: str, shipment: ShipmentConfig, permissive: bool = False) -> Optional[Issues]:
         """Find bugs for the given advisory kind and return an Issues object containing the bugs found.
         :param kind: The kind for which to find bugs
         :param shipment: The shipment config to be updated


### PR DESCRIPTION
When component name parsing from url fails, fallback on fetching from staticmethods from Builder class.
This is a temporary hack to let the pipeline work with older builds and until we complete work for storing
and fetching component name from DB.

https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release-konflux/88/console