### PR TITLE
Konflux object date to microsecond precision

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -20,7 +20,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def get_utc_now_formatted_str():
-    return datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S")
+    return datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S%f")
 
 
 def remove_prefix(s: str, prefix: str) -> str:


### PR DESCRIPTION
We trigger pipelines in parallel and sometimes we fetch date to the exact second, in which case object creation fails.
Setting it to microsecond precision will not let that happen.

Example of collision occuring
- https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/jobs/37132356
- https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/jobs/37132357