### PR TITLE
[Konflux] Simplify fbc:import

### DIFF
--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -41,7 +41,6 @@ class KonfluxFbcImporter:
         group: str,
         assembly: str,
         ocp_version: Tuple[int, int],
-        keep_templates: bool,
         upcycle: bool,
         push: bool,
         commit_message: Optional[str] = None,
@@ -53,7 +52,6 @@ class KonfluxFbcImporter:
         self.group = group
         self.assembly = assembly
         self.ocp_version = ocp_version
-        self.keep_templates = keep_templates
         self.upcycle = upcycle
         self.push = push
         self.commit_message = commit_message
@@ -111,40 +109,22 @@ class KonfluxFbcImporter:
         repo_dir = build_repo.local_dir
         # Get package name of the operator
         package_name = await self._get_package_name(metadata)
+
         # Render the catalog from the index image
-        org_catalog_blobs = await self._get_catalog_blobs_from_index_image(index_image, package_name)
-
-        # Write catalog_blobs to catalog-migrate/<package>/catalog.json
-        org_catalog_dir = repo_dir.joinpath("catalog-migrate", package_name)
-        org_catalog_dir.mkdir(parents=True, exist_ok=True)
-        org_catalog_file_path = org_catalog_dir.joinpath("catalog.yaml")
-        logger.info("Writing original catalog blobs to %s", org_catalog_file_path)
-        with org_catalog_file_path.open('w') as f:
-            yaml.dump_all(org_catalog_blobs, f)
-
-        # Generate basic fbc template to catalog-templates/<package>.yaml
-        templates_dir = repo_dir.joinpath("catalog-templates")
-        templates_dir.mkdir(parents=True, exist_ok=True)
-        template_file = templates_dir.joinpath(f"{package_name}.yaml")
-        await opm.generate_basic_template(org_catalog_file_path, template_file)
-
-        logger.info("Cleaning up catalog-migrate")
-        shutil.rmtree(repo_dir.joinpath("catalog-migrate"))
-
-        # Render final FBC catalog at catalog/<package>/catalog.yaml from template
-        catalog_dir = repo_dir.joinpath("catalog", package_name)
-        catalog_dir.mkdir(parents=True, exist_ok=True)
-        catalog_file = catalog_dir.joinpath("catalog.yaml")
-        logger.info("Rendering catalog from template %s to %s", template_file, catalog_file)
         migrate_level = "none"
         if self.ocp_version >= (4, 17):
             migrate_level = "bundle-object-to-csv-metadata"
-        await opm.render_catalog_from_template(template_file, catalog_file, migrate_level=migrate_level, auth=self.auth)
+        catalog_blobs = await self._get_catalog_blobs_from_index_image(
+            index_image, package_name, migrate_level=migrate_level
+        )
 
-        # Clean up catalog-templates
-        if not self.keep_templates:
-            logger.info("Cleaning up catalog-templates")
-            shutil.rmtree(templates_dir)
+        # Write catalog_blobs to catalog/<package>/catalog.json
+        catalog_dir = repo_dir.joinpath("catalog", package_name)
+        catalog_dir.mkdir(parents=True, exist_ok=True)
+        catalog_file_path = catalog_dir.joinpath("catalog.yaml")
+        logger.info("Writing catalog blobs to %s", catalog_file_path)
+        with catalog_file_path.open('w') as f:
+            yaml.dump_all(catalog_blobs, f)
 
         # Generate Dockerfile
         df_path = repo_dir.joinpath("catalog.Dockerfile")
@@ -161,10 +141,11 @@ class KonfluxFbcImporter:
         logger.info("FBC directory updated")
 
     @alru_cache
-    async def _render_index_image(self, index_image: str) -> List[Dict]:
+    async def _render_index_image(self, index_image: str, migrate_level: str = "none") -> List[Dict]:
         blobs = await retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(5))(opm.render)(
             index_image,
             auth=self.auth,
+            migrate_level=migrate_level,
         )
         return blobs
 
@@ -193,8 +174,10 @@ class KonfluxFbcImporter:
             filtered[package_name].append(blob)
         return filtered
 
-    async def _get_catalog_blobs_from_index_image(self, index_image: str, package_name):
-        blobs = await self._render_index_image(index_image)
+    async def _get_catalog_blobs_from_index_image(
+        self, index_image: str, package_name: str, migrate_level: str = "none"
+    ):
+        blobs = await self._render_index_image(index_image, migrate_level=migrate_level)
         filtered_blobs = self._filter_catalog_blobs(blobs, {package_name})
         if package_name not in filtered_blobs:
             raise IOError(f"Package {package_name} not found in index image")

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -36,7 +36,6 @@ class FbcImportCli:
         self,
         runtime: Runtime,
         index_image: str | None,
-        keep_templates: bool,
         push: bool,
         registry_auth: Optional[str],
         fbc_repo: str,
@@ -45,7 +44,6 @@ class FbcImportCli:
     ):
         self.runtime = runtime
         self.index_image = index_image
-        self.keep_templates = keep_templates
         self.push = push
         self.registry_auth = registry_auth
         self.fbc_repo = fbc_repo or constants.ART_FBC_GIT_REPO
@@ -95,7 +93,6 @@ class FbcImportCli:
             group=runtime.group,
             assembly=str(runtime.assembly),
             ocp_version=(major, minor),
-            keep_templates=self.keep_templates,
             upcycle=runtime.upcycle,
             push=self.push,
             commit_message=self.message,
@@ -124,11 +121,6 @@ class FbcImportCli:
     metavar='INDEX_IMAGE',
     help="The index image to import from. If not set, the production index image will be used.",
 )
-@click.option(
-    "--keep-templates",
-    is_flag=True,
-    help="Keep the generated templates. If not set, the templates will be deleted after rendering the final catalogs.",
-)
 @click.option("--push", is_flag=True, help="Push the generated FBC to the git repository.")
 @click.option(
     "--fbc-repo", metavar='FBC_REPO', help="The git repository to push the FBC to.", default=constants.ART_FBC_GIT_REPO
@@ -141,7 +133,6 @@ class FbcImportCli:
 async def fbc_import(
     runtime: Runtime,
     from_index: Optional[str],
-    keep_templates: bool,
     push: bool,
     fbc_repo: str,
     registry_auth: Optional[str],
@@ -158,7 +149,6 @@ async def fbc_import(
     cli = FbcImportCli(
         runtime=runtime,
         index_image=from_index,
-        keep_templates=keep_templates,
         push=push,
         fbc_repo=fbc_repo,
         registry_auth=registry_auth,

--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -17,7 +17,6 @@ class TestKonfluxFbcImporter(unittest.IsolatedAsyncioTestCase):
         self.group = "test-group"
         self.assembly = "test-assembly"
         self.ocp_version = (4, 9)
-        self.keep_templates = False
         self.upcycle = False
         self.push = False
         self.commit_message = "Test commit message"
@@ -29,7 +28,6 @@ class TestKonfluxFbcImporter(unittest.IsolatedAsyncioTestCase):
             group=self.group,
             assembly=self.assembly,
             ocp_version=self.ocp_version,
-            keep_templates=self.keep_templates,
             upcycle=self.upcycle,
             push=self.push,
             commit_message=self.commit_message,
@@ -111,31 +109,21 @@ class TestKonfluxFbcImporter(unittest.IsolatedAsyncioTestCase):
         await self.importer._update_dir(metadata, build_repo, index_image, logger)
 
         mock_get_package_name.assert_called_once_with(metadata)
-        mock_get_catalog_blobs.assert_called_once_with(index_image, "test-package")
+        mock_get_catalog_blobs.assert_called_once_with(index_image, "test-package", migrate_level="none")
         self.assertEqual(mock_org_catalog_file.getvalue(), '---\nname: test-package\nschema: olm.package\n')
         mock_mkdir.assert_has_calls(
             [
                 call(parents=True, exist_ok=True),
-                call(parents=True, exist_ok=True),
-                call(parents=True, exist_ok=True),
             ]
         )
-        mock_opm.generate_basic_template.assert_called_once()
-        mock_opm.render_catalog_from_template.assert_called_once()
         mock_opm.generate_dockerfile.assert_called_once()
-        mock_rmtree.assert_has_calls(
-            [
-                call(self.base_dir.joinpath("catalog-migrate")),
-                call(self.base_dir.joinpath("catalog-templates")),
-            ]
-        )
 
     @patch("doozerlib.backend.konflux_fbc.opm.render")
     async def test_render_index_image(self, mock_render):
         actual = await self.importer._render_index_image("test-index-image-pullspec")
         self.assertEqual(actual, mock_render.return_value)
         mock_render.assert_called_once_with(
-            "test-index-image-pullspec", auth=OpmRegistryAuth(path='/path/to/auth.json')
+            "test-index-image-pullspec", migrate_level="none", auth=OpmRegistryAuth(path='/path/to/auth.json')
         )
 
     def test_filter_catalog_blobs(self):
@@ -186,7 +174,7 @@ class TestKonfluxFbcImporter(unittest.IsolatedAsyncioTestCase):
                 {"schema": "olm.channel", "name": "test-channel", "package": "test-package"},
             ],
         )
-        mock_render_index_image.assert_called_once_with(index_image)
+        mock_render_index_image.assert_called_once_with(index_image, migrate_level="none")
 
     @patch("pathlib.Path.open")
     @patch("pathlib.Path.glob")

--- a/doozer/tests/cli/test_fbc.py
+++ b/doozer/tests/cli/test_fbc.py
@@ -19,7 +19,6 @@ class TestFbcImportCli(unittest.IsolatedAsyncioTestCase):
         self.fbc_import_cli = FbcImportCli(
             runtime=self.runtime,
             index_image="example.com/test/test-index-image:latest",
-            keep_templates=False,
             push=True,
             fbc_repo="https://example.com/test/fbc.git",
             message="Test commit",

--- a/doozer/tests/test_opm.py
+++ b/doozer/tests/test_opm.py
@@ -33,7 +33,9 @@ class TestOpm(unittest.IsolatedAsyncioTestCase):
         auth = MagicMock()
         blobs = await render('test-catalog', auth=auth)
         self.assertEqual(list(blobs), [{'key': 'value'}])
-        mock_gather_opm.assert_called_once_with(['render', '-o', 'yaml', '--', 'test-catalog'], auth=auth)
+        mock_gather_opm.assert_called_once_with(
+            ['render', '--migrate-level', 'none', '-o', 'yaml', '--', 'test-catalog'], auth=auth
+        )
 
     @patch("builtins.open")
     @patch('doozerlib.opm.gather_opm', new_callable=AsyncMock)


### PR DESCRIPTION
No need to generate templates and render from templates. The migration can be done with the `opm render` command.

Test jobs:
1. 4.17: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Ffbc-import-from-index/17/console
2. 4.16: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Ffbc-import-from-index/18/console