### PR TITLE
ART-13015: konflux rebase to openshift-priv by default

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -236,14 +236,12 @@ class KonfluxRebaser:
             if source and source_dir:
                 # If the private org branch commit doesn't exist in the public org,
                 # this image contains private fixes
-                is_commit_in_public_upstream = await util.is_commit_in_public_upstream_async(
-                    source.commit_hash, source.public_upstream_branch, source_dir
-                )
-
                 if (
                     source.has_public_upstream
                     and not SourceResolver.is_branch_commit_hash(source.public_upstream_branch)
-                    and not is_commit_in_public_upstream
+                    and not await util.is_commit_in_public_upstream_async(
+                        source.commit_hash, source.public_upstream_branch, source_dir
+                    )
                 ):
                     private_fix = True
             else:

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -39,6 +39,7 @@ KONFLUX_DEFAULT_IMAGE_REPO = (
     "quay.io/redhat-user-workloads/ocp-art-tenant/art-images"  # FIXME: If we change clusters this URL will change
 )
 KONFLUX_DEFAULT_FBC_REPO = "quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc"
+KONFLUX_DEFAULT_REBASE_REMOTE = "openshift-priv"
 ART_PROD_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
 ART_PROD_PRIV_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-v4.0-art-dev-priv"
 DELIVERY_IMAGE_REGISTRY = "registry.redhat.io"

--- a/doozer/tests/backend/test_build_repo.py
+++ b/doozer/tests/backend/test_build_repo.py
@@ -38,7 +38,7 @@ class TestBuildRepo(IsolatedAsyncioTestCase):
 
     @patch("artcommonlib.git_helper.run_git_async", return_value=0)
     async def test_push(self, run_git: AsyncMock):
-        await self.repo.push()
+        await self.repo.push(prod=False)
         run_git.assert_any_await(["-C", "/path/to/repo", "push", "origin", "HEAD"])
         run_git.assert_any_await(["-C", "/path/to/repo", "push", "origin", "--tags"])
 


### PR DESCRIPTION
ref [ART-13015](https://issues.redhat.com//browse/ART-13015)

Changes in this PR:
- By default, after rebase, update the remote URL, by swapping out the org/owner name with `openshift-priv`, and then push to that remote