### PR TITLE
Konflux assemblies should not reference advisories handled by shipment

### DIFF
--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -835,6 +835,12 @@ class GenAssemblyCli:
             f"Reusing advisories and release ticket from previous assembly {previous_assembly}, {advisories}, {release_jira}"
         )
 
+        # As a final check, make sure Konflux advisories do not contain image, extras and metadata
+        if self.runtime.build_system == 'konflux':
+            advisories.pop('image', None)
+            advisories.pop('extras', None)
+            advisories.pop('metadata', None)
+
         return advisories, release_jira
 
     def _generate_assembly_definition(self) -> dict:


### PR DESCRIPTION
Advisories are updated with what's defined in the previous group, for missing keys. For Konflux, this generates an invalid assembly when, for example, `ec.4` has:
```
group:
  advisories:
    image: -1
    rpm: 149403
    extras: -1
    metadata: -1
    prerelease: -1
    microshift: 151969
```
as it currently does. As a consequence, `ec.5` will also have
```
group:
  advisories:
    rpm: 149403
    microshift: 151969
    image: -1
    extras: -1
    metadata: -1
```
and this will break prepare-release-konflux because
```
ValueError: Shipment config should not specify advisories that are already defined in assembly.group.advisories: {'extras', 'metadata', 'image'}
```