### PR TITLE
Use resource_url method to get pipeline url

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -688,24 +688,8 @@ class KonfluxClient:
             return fake_pipelinerun
 
         pipelinerun = await self._create(pipelinerun_manifest, async_req=True)
-        LOGGER.debug(f"Created PipelineRun: {self.build_pipeline_url(pipelinerun)}")
+        LOGGER.debug(f"Created PipelineRun: {self.resource_url(pipelinerun)}")
         return pipelinerun
-
-    @staticmethod
-    def build_pipeline_url(pipelinerun):
-        """Returns the URL to the Konflux UI for the given PipelineRun.
-
-        :param pipelinerun: The PipelineRun.
-        :return: The URL.
-        """
-        pipelinerun_name = pipelinerun['metadata']['name']
-        application = pipelinerun['metadata']['labels']['appstudio.openshift.io/application']
-        return (
-            f"{constants.KONFLUX_UI_HOST}/ns/"
-            f"{constants.KONFLUX_DEFAULT_NAMESPACE}/"
-            f"applications/{application}/"
-            f"pipelineruns/{pipelinerun_name}"
-        )
 
     @staticmethod
     def resource_url(resource_instance: resource.ResourceInstance) -> str:

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -848,7 +848,7 @@ class KonfluxFbcBuilder:
             dockerfile="catalog.Dockerfile",
             pipelinerun_template_url=self.pipelinerun_template_url,
         )
-        url = konflux_client.build_pipeline_url(pipelinerun)
+        url = konflux_client.resource_url(pipelinerun)
         logger.info(f"PipelineRun {pipelinerun.metadata.name} created: {url}")
         return pipelinerun, url
 
@@ -885,7 +885,7 @@ class KonfluxFbcBuilder:
             nvr = "-".join([name, version, release])
 
             pipelinerun_name = pipelinerun.metadata.name
-            build_pipeline_url = KonfluxClient.build_pipeline_url(pipelinerun)
+            build_pipeline_url = KonfluxClient.resource_url(pipelinerun)
             build_component = pipelinerun.metadata.labels.get('appstudio.openshift.io/component')
 
             build_record_params = {

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -179,7 +179,7 @@ class KonfluxImageBuilder:
                 )
                 pipelinerun_name = pipelinerun['metadata']['name']
                 record["task_id"] = pipelinerun_name
-                record["task_url"] = self._konflux_client.build_pipeline_url(pipelinerun)
+                record["task_url"] = self._konflux_client.resource_url(pipelinerun)
                 await self.update_konflux_db(
                     metadata, build_repo, pipelinerun, KonfluxBuildOutcome.PENDING, building_arches
                 )
@@ -434,7 +434,7 @@ class KonfluxImageBuilder:
             annotations={"art-network-mode": metadata.get_konflux_network_mode()},
         )
 
-        logger.info(f"Created PipelineRun: {self._konflux_client.build_pipeline_url(pipelinerun)}")
+        logger.info(f"Created PipelineRun: {self._konflux_client.resource_url(pipelinerun)}")
         return pipelinerun
 
     @staticmethod
@@ -553,8 +553,9 @@ class KonfluxImageBuilder:
         pipelinerun_name = pipelinerun['metadata']['name']
         # Pipelinerun names will eventually repeat over time, so also gather the pipelinerun uid
         pipelinerun_uid = pipelinerun['metadata']['uid']
-        build_pipeline_url = self._konflux_client.build_pipeline_url(pipelinerun)
+        build_pipeline_url = self._konflux_client.resource_url(pipelinerun)
         build_component = pipelinerun['metadata']['labels']['appstudio.openshift.io/component']
+
         build_record_params = {
             'name': metadata.distgit_key,
             'version': version,

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -689,7 +689,7 @@ class KonfluxOlmBundleBuilder:
             pipelinerun_template_url=self.pipelinerun_template_url,
             artifact_type="operatorbundle",
         )
-        url = konflux_client.build_pipeline_url(pipelinerun)
+        url = konflux_client.resource_url(pipelinerun)
         logger.info(f"PipelineRun {pipelinerun.metadata.name} created: {url}")
         return pipelinerun, url
 
@@ -725,8 +725,9 @@ class KonfluxOlmBundleBuilder:
             nvr = "-".join([component_name, version, release])
 
             pipelinerun_name = pipelinerun.metadata.name
-            build_pipeline_url = KonfluxClient.build_pipeline_url(pipelinerun)
+            build_pipeline_url = KonfluxClient.resource_url(pipelinerun)
             build_component = pipelinerun.metadata.labels.get('appstudio.openshift.io/component')
+
             build_record_params = {
                 'name': metadata.get_olm_bundle_short_name(),
                 'version': version,

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -1,22 +1,26 @@
 from unittest import TestCase
 from unittest.mock import patch
 
+from artcommonlib.model import Model
 from doozerlib.backend.konflux_client import KonfluxClient
 
 
-class TestPLRUrl(TestCase):
+class TestResourceUrl(TestCase):
     @patch("doozerlib.constants.KONFLUX_UI_HOST", "https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com")
-    @patch("doozerlib.constants.KONFLUX_DEFAULT_NAMESPACE", "ocp-art-tenant")
-    def test_pipelinerun_url(self):
-        pipeline_run = {
-            "metadata": {
-                "name": "ose-4-19-ose-ovn-kubernetes-6wv6l",
-                "labels": {
-                    "appstudio.openshift.io/application": "openshift-4-19",
+    def test_resource_url(self):
+        pipeline_run = Model(
+            {
+                "kind": "PipelineRun",
+                "metadata": {
+                    "name": "ose-4-19-ose-ovn-kubernetes-6wv6l",
+                    "namespace": "foobar-tenant",
+                    "labels": {
+                        "appstudio.openshift.io/application": "openshift-4-19",
+                    },
                 },
-            },
-        }
-        actual = KonfluxClient.build_pipeline_url(pipeline_run)
-        expected = "https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-ose-ovn-kubernetes-6wv6l"
+            }
+        )
+        actual = KonfluxClient.resource_url(pipeline_run)
+        expected = "https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/foobar-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-ose-ovn-kubernetes-6wv6l"
 
         self.assertEqual(actual, expected)

--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -631,7 +631,7 @@ class TestKonfluxFbcBuilder(unittest.IsolatedAsyncioTestCase):
             spec=BuildRepo, https_url="https://example.com/foo.git", branch="test-branch", commit_hash="deadbeef"
         )
         kube_client = self.kube_client
-        kube_client.build_pipeline_url.return_value = "https://example.com/pipelinerun/test-pipeline-run-name"
+        kube_client.resource_url.return_value = "https://example.com/pipelinerun/test-pipeline-run-name"
         pplr = kube_client.start_pipeline_run_for_image_build.return_value = MagicMock(
             **{"metadata.name": "test-pipeline-run-name"},
         )
@@ -683,7 +683,7 @@ class TestKonfluxFbcBuilder(unittest.IsolatedAsyncioTestCase):
         build_repo = MockBuildRepo.return_value
         build_repo.local_dir = self.base_dir.joinpath(metadata.distgit_key)
         mock_konflux_client.start_pipeline_run_for_image_build = AsyncMock()
-        mock_konflux_client.build_pipeline_url = MagicMock(return_value="https://example.com/pipeline")
+        mock_konflux_client.resource_url = MagicMock(return_value="https://example.com/pipeline")
         mock_start_build.return_value = (
             MagicMock(**{"metadata.name": "test-pipelinerun-name"}),
             "https://example.com/pipeline",
@@ -756,7 +756,7 @@ class TestKonfluxFbcBuilder(unittest.IsolatedAsyncioTestCase):
         build_repo = MockBuildRepo.from_local_dir.return_value
         build_repo.local_dir = self.base_dir.joinpath(metadata.distgit_key)
         mock_konflux_client.start_pipeline_run_for_image_build = AsyncMock()
-        mock_konflux_client.build_pipeline_url = MagicMock(return_value="https://example.com/pipeline")
+        mock_konflux_client.resource_url = MagicMock(return_value="https://example.com/pipeline")
         mock_start_build.return_value = (
             MagicMock(**{"metadata.name": "test-pipelinerun-name"}),
             "https://example.com/pipeline",

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -547,7 +547,7 @@ class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
         pipelinerun = MagicMock()
         pipelinerun.metadata.name = "test-pipelinerun"
         self.konflux_client.start_pipeline_run_for_image_build.return_value = pipelinerun
-        self.konflux_client.build_pipeline_url = MagicMock(return_value="https://example.com/pipelinerun")
+        self.konflux_client.resource_url = MagicMock(return_value="https://example.com/pipelinerun")
 
         pipelinerun, url = await self.builder._start_build(
             metadata,
@@ -598,8 +598,8 @@ class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
 
     @patch("aiofiles.open")
     @patch("doozerlib.backend.konflux_olm_bundler.DockerfileParser")
-    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxClient.build_pipeline_url")
-    async def test_update_konflux_db_success(self, mock_build_pipeline_url, mock_dockerfile_parser, mock_open):
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxClient.resource_url")
+    async def test_update_konflux_db_success(self, mock_resource_url, mock_dockerfile_parser, mock_open):
         metadata = MagicMock()
         metadata.distgit_key = "test-distgit-key"
         metadata.get_olm_bundle_short_name.return_value = "test-bundle"
@@ -624,7 +624,7 @@ class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
         pipelinerun.status.completionTime = "2023-10-01T12:30:00Z"
         pipelinerun.metadata.name = "test-pipelinerun"
 
-        mock_build_pipeline_url.return_value = "https://example.com/pipelinerun"
+        mock_resource_url.return_value = "https://example.com/pipelinerun"
 
         mock_dockerfile = MagicMock()
         mock_dockerfile.labels = {
@@ -687,8 +687,8 @@ class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
 
     @patch("aiofiles.open")
     @patch("doozerlib.backend.konflux_olm_bundler.DockerfileParser")
-    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxClient.build_pipeline_url")
-    async def test_update_konflux_db_failure(self, mock_build_pipeline_url, mock_dockerfile_parser, mock_open):
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxClient.resource_url")
+    async def test_update_konflux_db_failure(self, mock_resource_url, mock_dockerfile_parser, mock_open):
         metadata = MagicMock()
         metadata.distgit_key = "test-distgit-key"
         metadata.get_olm_bundle_short_name.return_value = "test-bundle"
@@ -705,7 +705,7 @@ class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
         pipelinerun.status.completionTime = "2023-10-01T12:30:00Z"
         pipelinerun.metadata.name = "test-pipelinerun"
 
-        mock_build_pipeline_url.return_value = "https://example.com/pipelinerun"
+        mock_resource_url.return_value = "https://example.com/pipelinerun"
 
         mock_dockerfile = MagicMock()
         mock_dockerfile.labels = {
@@ -763,8 +763,8 @@ class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
 
     @patch("aiofiles.open")
     @patch("doozerlib.backend.konflux_olm_bundler.DockerfileParser")
-    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxClient.build_pipeline_url")
-    async def test_update_konflux_db_no_db_connection(self, mock_build_pipeline_url, mock_dockerfile_parser, mock_open):
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxClient.resource_url")
+    async def test_update_konflux_db_no_db_connection(self, mock_resource_url, mock_dockerfile_parser, mock_open):
         metadata = MagicMock()
         metadata.distgit_key = "test-distgit-key"
         metadata.get_olm_bundle_short_name.return_value = "test-bundle"
@@ -788,7 +788,7 @@ class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
         pipelinerun.status.completionTime = "2023-10-01T12:30:00Z"
         pipelinerun.metadata.name = "test-pipelinerun"
 
-        mock_build_pipeline_url.return_value = "https://example.com/pipelinerun"
+        mock_resource_url.return_value = "https://example.com/pipelinerun"
 
         mock_dockerfile = MagicMock()
         mock_dockerfile.labels = {
@@ -830,8 +830,8 @@ class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
 
     @patch("aiofiles.open")
     @patch("doozerlib.backend.konflux_olm_bundler.DockerfileParser")
-    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxClient.build_pipeline_url")
-    async def test_update_konflux_db_exception(self, mock_build_pipeline_url, mock_dockerfile_parser, mock_open):
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxClient.resource_url")
+    async def test_update_konflux_db_exception(self, mock_resource_url, mock_dockerfile_parser, mock_open):
         metadata = MagicMock()
         metadata.distgit_key = "test-distgit-key"
         metadata.get_olm_bundle_short_name.return_value = "test-bundle"
@@ -855,7 +855,7 @@ class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
         pipelinerun.status.completionTime = "2023-10-01T12:30:00Z"
         pipelinerun.metadata.name = "test-pipelinerun"
 
-        mock_build_pipeline_url.return_value = "https://example.com/pipelinerun"
+        mock_resource_url.return_value = "https://example.com/pipelinerun"
 
         mock_dockerfile = MagicMock()
         mock_dockerfile.labels = {


### PR DESCRIPTION
Instead of having separate methods for fetching url for each konflux resource - rely on 
the generic method which works for all resources.