### PR TITLE
ART-13270 Use build_component field in snapshot creation

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -199,6 +199,12 @@ class KonfluxRecord:
         Returns the component name for the Konflux record.
         This is used to identify the component in Konflux.
         """
+        if self.build_component:
+            return self.build_component
+
+        # TODO: (2025-07-16) now that we have started storing component name in DB,
+        # we can remove the below fallback (parse the component from url) in a couple of weeks
+
         # Konflux component name can be extracted from the build pipeline URL.
         # e.g. 'https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-18/pipelineruns/openshift-4-18-helloworld-operator-bundle-prdtg' -> 'openshift-4-18-helloworld-operator-bundle'
         # TODO: This is a temporary solution. We may want to change the way we store the component name in the future.

--- a/elliott/elliottlib/cli/snapshot_cli.py
+++ b/elliott/elliottlib/cli/snapshot_cli.py
@@ -169,16 +169,16 @@ class CreateSnapshotCli:
         snapshot_name = f"ose-{major}-{minor}-{get_utc_now_formatted_str()}"
 
         async def _comp(record: KonfluxRecord):
-            # get application and component names from PLR url
-            # note: this will change once we have component name stored in the DB
+            # get application name and make sure it exists in cluster
             app_name = record.get_konflux_application_name()
-            comp_name = record.get_konflux_component_name()
-
-            # make sure application exists
             await self.konflux_client.get_application__caching(app_name, strict=True)
 
-            # make sure component exists, if not, try to get it from the relevant Builder class
-            # note: this will change once we have component name stored in the DB
+            # get component name and make sure it exists in cluster
+            comp_name = record.get_konflux_component_name()
+
+            # if not found, fallback to getting it from the record's Builder class
+            # TODO: (2025-07-16) now that we have started storing component name in DB, we can remove this fallback
+            # in a couple of weeks
             try:
                 await self.konflux_client.get_component__caching(comp_name, strict=True)
             except Exception as e:


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-13270

Follow up to https://github.com/openshift-eng/art-tools/pull/1802 

Start using the new field when creating snapshot

Test:

Build with build_component field populated: https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=ose-aws-efs-csi-driver-operator-bundle-container-v4.17.0.202507161321.p2.gcc86210.assembly.stream.el9-1&outcome=success&type=bundle

```
elliott -g openshift-4.17 snapshot new ose-aws-efs-csi-driver-operator-bundle-container-v
4.17.0.202507161321.p2.gcc86210.assembly.stream.el9-1
...
---
apiVersion: appstudio.redhat.com/v1alpha1
kind: Snapshot
metadata:
  name: ose-4-17-20250716152020649666-1
  namespace: ocp-art-tenant
  labels:
    test.appstudio.openshift.io/type: override
    appstudio.openshift.io/application: openshift-4-17
spec:
  application: openshift-4-17
  components:
    - name: ose-4-17-ose-aws-efs-csi-driver-operator-bundle
...
```