### PR TITLE
[Konflux] Add doozer verb to build stage operator index

### DIFF
--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -425,6 +425,12 @@ class Runtime(GroupRuntime):
         self.group_dir = self.gitdata.data_dir
         self.group_config = self.get_group_config()
 
+        if self.group_config.name != self.group:
+            raise IOError(
+                f"Name in group.yml ({self.group_config.name}) does not match group name ({self.group}). Someone "
+                "may have copied this group without updating group.yml (make sure to check branch)"
+            )
+
         self.hotfix = (
             False  # True indicates builds should be tagged with associated hotfix tag for the artifacts branch
         )
@@ -564,12 +570,6 @@ class Runtime(GroupRuntime):
                     self._logger.warn("Missing RHSM_PULP auth, will skip validating content sets")
                 else:
                     self.repos.validate_content_sets()
-
-            if self.group_config.name != self.group:
-                raise IOError(
-                    f"Name in group.yml ({self.group_config.name}) does not match group name ({self.group}). Someone "
-                    "may have copied this group without updating group.yml (make sure to check branch)"
-                )
 
             if self.branch is None:
                 if self.group_config.branch is not Missing:

--- a/doozer/requirements.txt
+++ b/doozer/requirements.txt
@@ -5,6 +5,8 @@ click == 8.1.8
 dockerfile-parse >= 0.0.13
 defusedxml
 future
+httpx
+httpx_gssapi
 importlib-resources
 koji
 kubernetes ~= 28.0
@@ -20,6 +22,7 @@ requests
 requests_kerberos
 semver
 tenacity ~= 8.4, != 8.4.0  # https://github.com/jd/tenacity/issues/471
+truststore
 wrapt
 mysql-connector-python >= 8.0.21
 python-dateutil >= 2.8.1

--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -1,12 +1,17 @@
 import unittest
 from io import StringIO
 from pathlib import Path
-from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, Mock, call, patch
 
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBundleBuildRecord
 from doozerlib.backend.build_repo import BuildRepo
 from doozerlib.backend.konflux_client import KonfluxClient
-from doozerlib.backend.konflux_fbc import KonfluxFbcBuilder, KonfluxFbcImporter, KonfluxFbcRebaser
+from doozerlib.backend.konflux_fbc import (
+    KonfluxFbcBuilder,
+    KonfluxFbcFragmentMerger,
+    KonfluxFbcImporter,
+    KonfluxFbcRebaser,
+)
 from doozerlib.image import ImageMetadata
 from doozerlib.opm import OpmRegistryAuth, yaml
 
@@ -817,3 +822,91 @@ class TestKonfluxFbcBuilder(unittest.IsolatedAsyncioTestCase):
             bundle_nvrs='foo-bundle-1.0.0-1',
         )
         MockBuildRepo.from_local_dir.assert_awaited_once_with(self.base_dir.joinpath(metadata.distgit_key), ANY)
+
+
+class TestKonfluxFbcFragmentMerger(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.working_dir = Path("/tmp/konflux_fbc_fragment_merger")
+        self.group = "test-group"
+        self.assembly = "test-assembly"
+        self.db = MagicMock()
+        self.fbc_repo = "https://example.com/fbc-repo.git"
+        self.konflux_namespace = "test-namespace"
+        self.konflux_kubeconfig = "/path/to/kube/config"
+        self.konflux_context = None
+        self.image_repo = "quay.io/test-repo"
+        self.skip_checks = False
+        self.pipelinerun_template_url = "https://example.com/template.yaml"
+        self.dry_run = False
+        self.record_logger = MagicMock()
+        self.logger = MagicMock()
+
+        with patch("doozerlib.backend.konflux_fbc.KonfluxClient", spec=KonfluxClient) as MockKonfluxClient:
+            self.kube_client = MockKonfluxClient.from_kubeconfig.return_value = AsyncMock(spec=KonfluxClient)
+            self.merger = KonfluxFbcFragmentMerger(
+                working_dir=self.working_dir,
+                group=self.group,
+                group_config=MagicMock(),
+                fbc_git_repo=self.fbc_repo,
+                konflux_namespace=self.konflux_namespace,
+                konflux_kubeconfig=self.konflux_kubeconfig,
+                konflux_context=self.konflux_context,
+                skip_checks=self.skip_checks,
+                plr_template=self.pipelinerun_template_url,
+                dry_run=self.dry_run,
+                logger=self.logger,
+            )
+
+    @patch("doozerlib.util.oc_image_info_for_arch_async__caching", new_callable=AsyncMock)
+    @patch("httpx.AsyncClient", autospec=True)
+    async def test_merge_idms(self, mock_async_client: Mock, mock_oc_image_info_for_arch_async__caching: AsyncMock):
+        http_client = mock_async_client.return_value.__aenter__.return_value = AsyncMock()
+        http_client.get.side_effect = [
+            MagicMock(
+                text=f"""
+kind: ImageDigestMirrorSet
+apiVersion: config.openshift.io/v1
+metadata:
+  name: art-images-fbc-staging-index
+  namespace: openshift-marketplace
+spec:
+  imageDigestMirrors:
+    - source: example.com/source-a{idx}
+      mirrors:
+        - example.com/mirror-a{idx}
+    - source: example.com/source-b{idx}
+      mirrors:
+        - example.com/mirror-b{idx}
+
+"""
+            )
+            for idx in range(3)
+        ]
+        mock_oc_image_info_for_arch_async__caching.return_value = {
+            "config": {
+                "config": {
+                    "Labels": {
+                        "vcs-ref": "deadbeef",
+                    },
+                },
+            },
+        }
+
+        expected = {
+            'apiVersion': 'config.openshift.io/v1',
+            'kind': 'ImageDigestMirrorSet',
+            'metadata': {'name': 'art-stage-mirror-set', 'namespace': 'openshift-marketplace'},
+            'spec': {
+                'imageDigestMirrors': [
+                    {'source': 'example.com/source-a0', 'mirrors': ['example.com/mirror-a0']},
+                    {'source': 'example.com/source-a1', 'mirrors': ['example.com/mirror-a1']},
+                    {'source': 'example.com/source-a2', 'mirrors': ['example.com/mirror-a2']},
+                    {'source': 'example.com/source-b0', 'mirrors': ['example.com/mirror-b0']},
+                    {'source': 'example.com/source-b1', 'mirrors': ['example.com/mirror-b1']},
+                    {'source': 'example.com/source-b2', 'mirrors': ['example.com/mirror-b2']},
+                ]
+            },
+        }
+
+        result = await self.merger._merge_idms(["example.com/idm1", "example.com/idm2", "example.com/idm3"])
+        self.assertEqual(result, expected)

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -6,6 +6,7 @@ from pyartcd.pipelines import (
     art_notify,
     brew_scan_osh,
     build_fbc,
+    build_merged_fbc,
     build_microshift,
     build_microshift_bootc,
     build_plashets,

--- a/pyartcd/pyartcd/pipelines/build_merged_fbc.py
+++ b/pyartcd/pyartcd/pipelines/build_merged_fbc.py
@@ -1,0 +1,183 @@
+import logging
+from typing import List
+
+import click
+from artcommonlib import exectools
+from ruamel.yaml import YAML
+
+from pyartcd import constants
+from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.runtime import Runtime
+
+yaml = YAML(typ='safe')
+
+
+class BuildMergedFbcPipeline:
+    def __init__(
+        self,
+        runtime: Runtime,
+        version: str,
+        data_path: str,
+        data_gitref: str,
+        only: str,
+        exclude: str,
+        fbc_repo: str,
+        kubeconfig: str,
+        plr_template: str,
+        skip_checks: bool,
+    ):
+        self.runtime = runtime
+        self.version = version
+        self.data_path = data_path
+        self.data_gitref = data_gitref
+        self.only = only
+        self.exclude = exclude
+        self.fbc_repo = fbc_repo
+        self.kubeconfig = kubeconfig
+        self.plr_template = plr_template
+        self.skip_checks = skip_checks
+
+        self._logger = logging.getLogger(__name__)
+        self._slack_client = runtime.new_slack_client()
+        self._slack_client.bind_channel(version)
+
+    async def run(self):
+        logger = self._logger
+        try:
+            logger.info("Loading OCP build data for version %s", self.version)
+            meta_configs = await self._get_meta_configs()
+            operator_dgks = [dgk for dgk, config in meta_configs.get("images", {}).items() if "update-csv" in config]
+
+            logger.info("Merging FBC fragments for OCP %s", self.version)
+            target_index = await self._build_merged_fbc(operator_dgks)
+
+            logger.info("Successfully built merged FBC for OCP %s: %s", self.version, target_index)
+
+        except Exception as e:
+            self._logger.error('Encountered error: %s', e)
+            await self._slack_client.say(
+                f'*:heavy_exclamation_mark: Error building merged stage FBC for {self.version}*\n'
+            )
+            raise
+
+    async def _run_doozer(self, opts: List[str], only: str, exclude: str):
+        cmd = [
+            'doozer',
+            '--build-system=konflux',
+            f'--working-dir={self.runtime.doozer_working}',
+            '--assembly=stream',
+            f'--group=openshift-{self.version}{"@" + self.data_gitref if self.data_gitref else ""}',
+        ]
+        if self.data_path:
+            cmd.append(f'--data-path={self.data_path}')
+        if only:
+            cmd.append(f'--images={only}')
+        if exclude:
+            cmd.append(f'--exclude={exclude}')
+        cmd += opts
+        self._logger.info(f'Running doozer command: {" ".join(cmd)}')
+        return await exectools.cmd_gather_async(cmd, stderr=None)
+
+    async def _build_merged_fbc(self, operator_dgks: List[str]):
+        version = self.version
+        target_index = f"quay.io/openshift-art/stage-fbc-fragments:ocp-{version}"
+        doozer_opts = [
+            'beta:fbc:merge',
+            f'--target-index={target_index}',
+        ]
+        if self.runtime.dry_run:
+            doozer_opts.append('--dry-run')
+        if self.fbc_repo:
+            doozer_opts.extend(['--fbc-repo', self.fbc_repo])
+        if self.kubeconfig:
+            doozer_opts.extend(['--konflux-kubeconfig', self.kubeconfig])
+        if self.plr_template:
+            plr_template_owner, plr_template_branch = (
+                self.plr_template.split("@") if self.plr_template else ["openshift-priv", "main"]
+            )
+            plr_template_url = constants.KONFLUX_FBC_BUILD_PLR_TEMPLATE_URL_FORMAT.format(
+                owner=plr_template_owner, branch_name=plr_template_branch
+            )
+            doozer_opts.extend(['--plr-template', plr_template_url])
+        if self.skip_checks:
+            doozer_opts.append('--skip-checks')
+        doozer_opts.append('--')
+        stage_index_repo = "quay.io/openshift-art/stage-fbc-fragments"
+        for dgk in operator_dgks:
+            doozer_opts.append(f"{stage_index_repo}:ocp__{version}__{dgk}")
+        await self._run_doozer(doozer_opts, only=self.only, exclude=self.exclude)
+        return target_index
+
+    async def _get_meta_configs(self) -> List[dict]:
+        """
+        Retrieve the metadata configurations
+        """
+        # Run doozer config:print for the specified DKGs
+        doozer_opts = [
+            'config:print',
+            '--yaml',
+        ]
+        _, out, _ = await self._run_doozer(doozer_opts, only=self.only, exclude=self.exclude)
+        configs = yaml.load(out)
+        return configs
+
+
+@cli.command('build-merged-fbc', help='Merge per-component FBC fragments into one single operator index')
+@click.option('--version', required=True, help='OCP version')
+@click.option(
+    '--data-path',
+    required=False,
+    default=constants.OCP_BUILD_DATA_URL,
+    help='ocp-build-data fork to use (e.g. assembly definition in your own fork)',
+)
+@click.option('--data-gitref', required=False, help='(Optional) Doozer data path git [branch / tag / sha] to use')
+@click.option(
+    '--only',
+    required=False,
+    help='(Optional) List **only** the operators you want to build, everything else gets ignored.\n'
+    'Format: Comma and/or space separated list of brew packages (e.g.: cluster-nfd-operator-container)\n'
+    'Leave empty to build all (except EXCLUDE, if defined)',
+)
+@click.option(
+    '--exclude',
+    required=False,
+    help='(Optional) List the operators you **don\'t** want to build, everything else gets built.\n'
+    'Format: Comma and/or space separated list of brew packages (e.g.: cluster-nfd-operator-container)\n'
+    'Leave empty to build all (or ONLY, if defined)',
+)
+@click.option('--fbc-repo', required=False, default='', help='(Optional) URL of the FBC repository')
+@click.option("--kubeconfig", required=False, help="Path to kubeconfig file to use for Konflux cluster connections")
+@click.option(
+    '--plr-template',
+    required=False,
+    default='',
+    help='Override the Pipeline Run template commit from openshift-priv/art-konflux-template; format: <owner>@<branch>',
+)
+@click.option("--skip-checks", is_flag=True, help="Skip all post build checks in the FBC build pipeline")
+@pass_runtime
+@click_coroutine
+async def build_merged_fbc(
+    runtime: Runtime,
+    version: str,
+    data_path: str,
+    data_gitref: str,
+    only: str,
+    exclude: str,
+    fbc_repo: str,
+    kubeconfig: str,
+    plr_template: str,
+    skip_checks: bool,
+):
+    pipeline = BuildMergedFbcPipeline(
+        runtime=runtime,
+        version=version,
+        data_path=data_path,
+        data_gitref=data_gitref,
+        only=only,
+        exclude=exclude,
+        fbc_repo=fbc_repo,
+        kubeconfig=kubeconfig,
+        plr_template=plr_template,
+        skip_checks=skip_checks,
+    )
+    await pipeline.run()


### PR DESCRIPTION
This command is to merge per-component FBC fragments into one single
stage index.

Example command:
```sh
doozer --group=openshift-4.18 --assembly=stream beta:fbc:merge --konflux-kubeconfig=/path/to/kubeconfig --target-index=quay.io/openshift-art/stage-fbc-fragments:ocp-4.18 quay.io/openshift-art/stage-fbc-fragments:ocp__4.18__helloworld-operator quay.io/openshift-art/stage-fbc-fragments:ocp__4.18__pf-status-relay-operator
```