### PR TITLE
elliott verify-conforma

### DIFF
--- a/artcommon/artcommonlib/exectools.py
+++ b/artcommon/artcommonlib/exectools.py
@@ -586,7 +586,7 @@ async def cmd_gather_async(cmd: Union[List[str], str], check: bool = True, **kwa
         if check:
             raise ChildProcessError(msg)
         else:
-            logger.warning(msg)
+            logger.debug(msg)
     else:
         span.add_event("command_succeeded", {"duration_seconds": duration_seconds})
 

--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -37,7 +37,7 @@ from elliottlib.cli.attach_bugs_cli import attach_bugs_cli
 from elliottlib.cli.attach_cve_flaws_cli import attach_cve_flaws_cli
 from elliottlib.cli.change_state_cli import change_state_cli
 from elliottlib.cli.common import cli, find_default_advisory, use_default_advisory_option
-from elliottlib.cli.conforma_cli import conforma_cli
+from elliottlib.cli.conforma_cli import verify_conforma_cli
 from elliottlib.cli.create_cli import create_cli
 from elliottlib.cli.create_placeholder_cli import create_placeholder_cli
 from elliottlib.cli.create_textonly_cli import create_textonly_cli
@@ -282,7 +282,7 @@ cli.add_command(advisory_images_cli)
 cli.add_command(create_placeholder_cli)
 cli.add_command(create_cli)
 cli.add_command(change_state_cli)
-cli.add_command(conforma_cli)
+cli.add_command(verify_conforma_cli)
 cli.add_command(find_bugs_sweep_cli)
 cli.add_command(find_bugs_cli)
 cli.add_command(find_builds_cli)

--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -37,6 +37,7 @@ from elliottlib.cli.attach_bugs_cli import attach_bugs_cli
 from elliottlib.cli.attach_cve_flaws_cli import attach_cve_flaws_cli
 from elliottlib.cli.change_state_cli import change_state_cli
 from elliottlib.cli.common import cli, find_default_advisory, use_default_advisory_option
+from elliottlib.cli.conforma_cli import conforma_cli
 from elliottlib.cli.create_cli import create_cli
 from elliottlib.cli.create_placeholder_cli import create_placeholder_cli
 from elliottlib.cli.create_textonly_cli import create_textonly_cli
@@ -281,6 +282,7 @@ cli.add_command(advisory_images_cli)
 cli.add_command(create_placeholder_cli)
 cli.add_command(create_cli)
 cli.add_command(change_state_cli)
+cli.add_command(conforma_cli)
 cli.add_command(find_bugs_sweep_cli)
 cli.add_command(find_bugs_cli)
 cli.add_command(find_builds_cli)

--- a/elliott/elliottlib/cli/conforma_cli.py
+++ b/elliott/elliottlib/cli/conforma_cli.py
@@ -233,11 +233,10 @@ class ConformaVerifyCli:
                         "total": 0,
                         "codes": [],
                     }
-                else:
-                    nvr_results[nvr]["violations"]["total"] += len(component["violations"])
-                    nvr_results[nvr]["violations"]["codes"].extend(
-                        set([violation["metadata"]["code"] for violation in component["violations"]])
-                    )
+                nvr_results[nvr]["violations"]["total"] += len(component["violations"])
+                nvr_results[nvr]["violations"]["codes"].extend(
+                    set([violation["metadata"]["code"] for violation in component["violations"]])
+                )
 
         success = rc == 0
         result = {

--- a/elliott/elliottlib/cli/conforma_cli.py
+++ b/elliott/elliottlib/cli/conforma_cli.py
@@ -285,7 +285,7 @@ async def verify_conforma_cli(
         konflux_kubeconfig = os.environ.get('KONFLUX_SA_KUBECONFIG')
 
     if not pull_secret:
-        pull_secret = os.environ.get('KONFLUX_PULL_SECRET')
+        pull_secret = os.environ.get('KONFLUX_ART_IMAGES_AUTH_FILE')
 
     pipeline = ConformaVerifyCli(
         runtime=runtime,

--- a/elliott/elliottlib/cli/conforma_cli.py
+++ b/elliott/elliottlib/cli/conforma_cli.py
@@ -235,7 +235,7 @@ class ConformaVerifyCli:
             policy_file,
             "--ignore-rekor",
             "--timeout",
-            "10m",
+            "30m",
             "--output",
             "yaml",
         ]

--- a/elliott/elliottlib/cli/conforma_cli.py
+++ b/elliott/elliottlib/cli/conforma_cli.py
@@ -30,7 +30,10 @@ class ConformaVerifyCli:
         if not nvrs:
             raise ValueError("nvrs must be provided")
         self.nvrs = nvrs
-        self.policy_path = policy_path or "https://raw.githubusercontent.com/enterprise-contract/config/refs/heads/main/redhat/policy.yaml"
+        self.policy_path = (
+            policy_path
+            or "https://raw.githubusercontent.com/enterprise-contract/config/refs/heads/main/redhat/policy.yaml"
+        )
         self.kubeconfig = kubeconfig
 
     async def run(self) -> Dict[str, Dict]:
@@ -40,20 +43,21 @@ class ConformaVerifyCli:
             raise RuntimeError('Must run Elliott with Konflux DB initialized')
 
         LOGGER.info("Verifying %d NVRs with Conforma", len(self.nvrs))
-        
+
         # Fetch build records from DB
         build_records = await self._fetch_build_records()
-        
+
         # Setup verification environment
         with tempfile.TemporaryDirectory() as temp_dir:
             policy_file, cosign_pub_file = await self._setup_verification_files(temp_dir)
-            
+
             # Run verification for each image
             results = await self._verify_images(build_records, policy_file, cosign_pub_file)
-            
-        # Report results
+
+        # Report results and save to file
         self._report_results(results)
-        
+        self._save_results_to_file(results)
+
         return results
 
     async def _fetch_build_records(self) -> List[KonfluxRecord]:
@@ -65,10 +69,10 @@ class ConformaVerifyCli:
     async def _setup_verification_files(self, temp_dir: str) -> Tuple[str, str]:
         """Download policy.yaml and extract cosign public key."""
         LOGGER.info("Setting up verification files...")
-        
+
         policy_file = os.path.join(temp_dir, "policy.yaml")
         cosign_pub_file = os.path.join(temp_dir, "cosign.pub")
-        
+
         # Download policy.yaml
         if self.policy_path.startswith(('http://', 'https://')):
             cmd = ["wget", "-q", "-O", policy_file, self.policy_path]
@@ -78,34 +82,37 @@ class ConformaVerifyCli:
             if not os.path.exists(self.policy_path):
                 raise FileNotFoundError(f"Policy file not found: {self.policy_path}")
             policy_file = self.policy_path
-        
+
         # Extract cosign public key
         cmd = ["oc", "get", "-n", "openshift-pipelines", "secret", "public-key", "-o", "json"]
         if self.kubeconfig:
             cmd.extend(["--kubeconfig", self.kubeconfig])
         _, stdout, _ = await cmd_gather_async(cmd)
-        
+
         secret_data = json.loads(stdout)
         import base64
+
         cosign_pub_data = base64.b64decode(secret_data['data']['cosign.pub']).decode('utf-8')
-        
+
         with open(cosign_pub_file, 'w') as f:
             f.write(cosign_pub_data)
-        
+
         LOGGER.info("Verification files prepared: policy=%s, cosign.pub=%s", policy_file, cosign_pub_file)
         return policy_file, cosign_pub_file
 
-    async def _verify_images(self, build_records: List[KonfluxRecord], policy_file: str, cosign_pub_file: str) -> Dict[str, Dict]:
+    async def _verify_images(
+        self, build_records: List[KonfluxRecord], policy_file: str, cosign_pub_file: str
+    ) -> Dict[str, Dict]:
         """Run ec validate for each image pullspec."""
         LOGGER.info("Running ec validation for %d images...", len(build_records))
-        
+
         tasks = []
         for record in build_records:
             task = self._verify_single_image(record, policy_file, cosign_pub_file)
             tasks.append(task)
-        
+
         results = await asyncio.gather(*tasks, return_exceptions=True)
-        
+
         # Combine results with NVRs
         verification_results = {}
         for record, result in zip(build_records, results):
@@ -115,33 +122,39 @@ class ConformaVerifyCli:
                     "pullspec": record.image_pullspec,
                     "success": False,
                     "error": str(result),
-                    "output": None
+                    "output": None,
                 }
             else:
                 verification_results[nvr] = result
-                
+
         return verification_results
 
     async def _verify_single_image(self, record: KonfluxRecord, policy_file: str, cosign_pub_file: str) -> Dict:
         """Run ec validate for a single image."""
         pullspec = record.image_pullspec
         nvr = str(record.nvr)
-        
-        LOGGER.debug("Verifying image: %s (NVR: %s)", pullspec, nvr)
-        
+
+        LOGGER.info("Verifying image: %s (NVR: %s)", pullspec, nvr)
+
         cmd = [
-            "ec", "validate", "image",
-            "--image", pullspec,
-            "--public-key", cosign_pub_file,
-            "--policy", policy_file,
+            "ec",
+            "validate",
+            "image",
+            "--image",
+            pullspec,
+            "--public-key",
+            cosign_pub_file,
+            "--policy",
+            policy_file,
             "--ignore-rekor",
-            "--output", "yaml"
+            "--output",
+            "yaml",
         ]
-        
+
         try:
             # Run ec validate command
             _, stdout, stderr = await cmd_gather_async(cmd, check=False)
-            
+
             # Parse YAML output
             output_data = None
             if stdout:
@@ -150,61 +163,77 @@ class ConformaVerifyCli:
                 except yaml.YAMLError as e:
                     LOGGER.warning("Failed to parse YAML output for %s: %s", nvr, e)
                     output_data = {"raw_output": stdout}
-            
+
             # cmd_gather_async with check=False doesn't raise on non-zero return codes
             # Determine success based on whether we got valid output and no significant errors
             # EC command typically outputs validation results even on policy violations,
             # so we rely on the absence of critical errors in stderr
             success = output_data is not None and not any(
-                error_keyword in stderr.lower() 
+                error_keyword in stderr.lower()
                 for error_keyword in ["error:", "fatal:", "failed to", "cannot", "unable to"]
                 if stderr
             )
-            
+
             result = {
                 "pullspec": pullspec,
                 "success": success,
                 "output": output_data,
-                "stderr": stderr if stderr else None
+                "stderr": stderr if stderr else None,
             }
-            
+
             if success:
-                LOGGER.debug("✓ Verification passed for %s", nvr)
+                LOGGER.info("✓ Verification passed for %s", nvr)
             else:
                 LOGGER.warning("✗ Verification failed for %s", nvr)
-                
+
             return result
-            
+
         except Exception as e:
             LOGGER.error("Exception during verification of %s: %s", nvr, e)
-            return {
-                "pullspec": pullspec,
-                "success": False,
-                "error": str(e),
-                "output": None
-            }
+            return {"pullspec": pullspec, "success": False, "error": str(e), "output": None}
 
     def _report_results(self, results: Dict[str, Dict]):
         """Report verification results summary."""
         total = len(results)
         passed = sum(1 for r in results.values() if r["success"])
         failed = total - passed
-        
+
         LOGGER.info("=== Conforma Verification Results ===")
         LOGGER.info("Total: %d, Passed: %d, Failed: %d", total, passed, failed)
-        
+
         if failed > 0:
             LOGGER.warning("Failed verifications:")
             for nvr, result in results.items():
                 if not result["success"]:
                     error_msg = result.get("error") or result.get("stderr") or "Verification failed"
                     LOGGER.warning("  ✗ %s - %s", nvr, error_msg)
-        
+
         if passed > 0:
             LOGGER.info("Passed verifications:")
             for nvr, result in results.items():
                 if result["success"]:
                     LOGGER.info("  ✓ %s", nvr)
+
+    def _save_results_to_file(self, results: Dict[str, Dict]):
+        """Save detailed verification results to results.yaml file."""
+        results_file = "results.yaml"
+
+        # Prepare results data for YAML output
+        results_data = {
+            "summary": {
+                "total": len(results),
+                "passed": sum(1 for r in results.values() if r["success"]),
+                "failed": sum(1 for r in results.values() if not r["success"]),
+            },
+            "verifications": results,
+        }
+
+        try:
+            with open(results_file, 'w') as f:
+                yaml.dump(results_data, f, default_flow_style=False, sort_keys=False)
+            LOGGER.info("Detailed results saved to %s", results_file)
+        except Exception as e:
+            LOGGER.error("Failed to save results to %s: %s", results_file, e)
 
 
 @cli.group("conforma", short_help="Commands for Conforma verification")
@@ -212,9 +241,7 @@ def conforma_cli():
     pass
 
 
-@conforma_cli.command(
-    "verify", short_help="Verify given builds (NVRs) with Conforma"
-)
+@conforma_cli.command("verify", short_help="Verify given builds (NVRs) with Conforma")
 @click.argument('nvrs', metavar='<NVR>', nargs=-1, required=False, default=None)
 @click.option(
     "--nvrs-file",
@@ -278,15 +305,14 @@ async def verify_conforma_cli(
         kubeconfig=kubeconfig,
     )
     results = await pipeline.run()
-    
-    # Output results summary
+
+    # Output brief summary (detailed results are saved to results.yaml)
     total = len(results)
     passed = sum(1 for r in results.values() if r["success"])
     failed = total - passed
-    
-    click.echo(f"\n=== Summary ===")
-    click.echo(f"Total: {total}, Passed: {passed}, Failed: {failed}")
-    
+
+    click.echo(f"Verification complete: {passed}/{total} passed. See results.yaml for details.")
+
     # Exit with non-zero code if any verifications failed
     if failed > 0:
-        sys.exit(1) 
+        sys.exit(1)

--- a/elliott/elliottlib/cli/conforma_cli.py
+++ b/elliott/elliottlib/cli/conforma_cli.py
@@ -6,7 +6,6 @@ import tempfile
 from typing import Dict, List, Tuple
 
 import click
-import yaml
 from artcommonlib import logutil
 from artcommonlib.exectools import cmd_assert_async, cmd_gather_async
 from artcommonlib.konflux.konflux_build_record import KonfluxRecord
@@ -334,7 +333,7 @@ async def verify_conforma_cli(
     )
     results = await pipeline.run()
 
-    click.echo(f"Verification complete. See results.yaml for details.")
+    click.echo("Verification complete. See results.yaml for details.")
 
     if not results["success"]:
         sys.exit(1)

--- a/elliott/elliottlib/cli/conforma_cli.py
+++ b/elliott/elliottlib/cli/conforma_cli.py
@@ -1,0 +1,278 @@
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from typing import Dict, List, Tuple
+
+import click
+import yaml
+from artcommonlib import logutil
+from artcommonlib.exectools import cmd_assert_async, cmd_gather_async
+from artcommonlib.konflux.konflux_build_record import KonfluxRecord
+
+from elliottlib.cli.common import cli, click_coroutine
+from elliottlib.cli.snapshot_cli import get_build_records_by_nvrs
+from elliottlib.runtime import Runtime
+
+LOGGER = logutil.get_logger(__name__)
+
+
+class ConformaVerifyCli:
+    def __init__(
+        self,
+        runtime: Runtime,
+        nvrs: list,
+        policy_path: str = None,
+    ):
+        self.runtime = runtime
+        if not nvrs:
+            raise ValueError("nvrs must be provided")
+        self.nvrs = nvrs
+        self.policy_path = policy_path or "https://raw.githubusercontent.com/enterprise-contract/config/refs/heads/main/redhat/policy.yaml"
+
+    async def run(self) -> Dict[str, Dict]:
+        """Run conforma verification for all NVRs and return results."""
+        self.runtime.initialize(build_system='konflux')
+        if self.runtime.konflux_db is None:
+            raise RuntimeError('Must run Elliott with Konflux DB initialized')
+
+        LOGGER.info("Verifying %d NVRs with Conforma", len(self.nvrs))
+        
+        # Fetch build records from DB
+        build_records = await self._fetch_build_records()
+        
+        # Setup verification environment
+        with tempfile.TemporaryDirectory() as temp_dir:
+            policy_file, cosign_pub_file = await self._setup_verification_files(temp_dir)
+            
+            # Run verification for each image
+            results = await self._verify_images(build_records, policy_file, cosign_pub_file)
+            
+        # Report results
+        self._report_results(results)
+        
+        return results
+
+    async def _fetch_build_records(self) -> List[KonfluxRecord]:
+        """Fetch build records from DB for the given NVRs."""
+        LOGGER.info("Fetching build records from DB...")
+        records_map = await get_build_records_by_nvrs(self.runtime, self.nvrs, strict=True)
+        return list(records_map.values())
+
+    async def _setup_verification_files(self, temp_dir: str) -> Tuple[str, str]:
+        """Download policy.yaml and extract cosign public key."""
+        LOGGER.info("Setting up verification files...")
+        
+        policy_file = os.path.join(temp_dir, "policy.yaml")
+        cosign_pub_file = os.path.join(temp_dir, "cosign.pub")
+        
+        # Download policy.yaml
+        if self.policy_path.startswith(('http://', 'https://')):
+            cmd = ["wget", "-q", "-O", policy_file, self.policy_path]
+            await cmd_assert_async(cmd)
+        else:
+            # Local file path
+            if not os.path.exists(self.policy_path):
+                raise FileNotFoundError(f"Policy file not found: {self.policy_path}")
+            policy_file = self.policy_path
+        
+        # Extract cosign public key
+        cmd = [
+            "kubectl", "get", "-n", "openshift-pipelines", "secret", "public-key", 
+            "-o", "json"
+        ]
+        _, stdout, _ = await cmd_gather_async(cmd)
+        
+        secret_data = json.loads(stdout)
+        import base64
+        cosign_pub_data = base64.b64decode(secret_data['data']['cosign.pub']).decode('utf-8')
+        
+        with open(cosign_pub_file, 'w') as f:
+            f.write(cosign_pub_data)
+        
+        LOGGER.info("Verification files prepared: policy=%s, cosign.pub=%s", policy_file, cosign_pub_file)
+        return policy_file, cosign_pub_file
+
+    async def _verify_images(self, build_records: List[KonfluxRecord], policy_file: str, cosign_pub_file: str) -> Dict[str, Dict]:
+        """Run ec validate for each image pullspec."""
+        LOGGER.info("Running ec validation for %d images...", len(build_records))
+        
+        tasks = []
+        for record in build_records:
+            task = self._verify_single_image(record, policy_file, cosign_pub_file)
+            tasks.append(task)
+        
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        
+        # Combine results with NVRs
+        verification_results = {}
+        for record, result in zip(build_records, results):
+            nvr = str(record.nvr)
+            if isinstance(result, Exception):
+                verification_results[nvr] = {
+                    "pullspec": record.image_pullspec,
+                    "success": False,
+                    "error": str(result),
+                    "output": None
+                }
+            else:
+                verification_results[nvr] = result
+                
+        return verification_results
+
+    async def _verify_single_image(self, record: KonfluxRecord, policy_file: str, cosign_pub_file: str) -> Dict:
+        """Run ec validate for a single image."""
+        pullspec = record.image_pullspec
+        nvr = str(record.nvr)
+        
+        LOGGER.debug("Verifying image: %s (NVR: %s)", pullspec, nvr)
+        
+        cmd = [
+            "ec", "validate", "image",
+            "--image", pullspec,
+            "--public-key", cosign_pub_file,
+            "--policy", policy_file,
+            "--ignore-rekor",
+            "--output", "yaml"
+        ]
+        
+        try:
+            # Run ec validate command
+            _, stdout, stderr = await cmd_gather_async(cmd, check=False)
+            
+            # Parse YAML output
+            output_data = None
+            if stdout:
+                try:
+                    output_data = yaml.safe_load(stdout)
+                except yaml.YAMLError as e:
+                    LOGGER.warning("Failed to parse YAML output for %s: %s", nvr, e)
+                    output_data = {"raw_output": stdout}
+            
+            # cmd_gather_async with check=False doesn't raise on non-zero return codes
+            # Determine success based on whether we got valid output and no significant errors
+            # EC command typically outputs validation results even on policy violations,
+            # so we rely on the absence of critical errors in stderr
+            success = output_data is not None and not any(
+                error_keyword in stderr.lower() 
+                for error_keyword in ["error:", "fatal:", "failed to", "cannot", "unable to"]
+                if stderr
+            )
+            
+            result = {
+                "pullspec": pullspec,
+                "success": success,
+                "output": output_data,
+                "stderr": stderr if stderr else None
+            }
+            
+            if success:
+                LOGGER.debug("✓ Verification passed for %s", nvr)
+            else:
+                LOGGER.warning("✗ Verification failed for %s", nvr)
+                
+            return result
+            
+        except Exception as e:
+            LOGGER.error("Exception during verification of %s: %s", nvr, e)
+            return {
+                "pullspec": pullspec,
+                "success": False,
+                "error": str(e),
+                "output": None
+            }
+
+    def _report_results(self, results: Dict[str, Dict]):
+        """Report verification results summary."""
+        total = len(results)
+        passed = sum(1 for r in results.values() if r["success"])
+        failed = total - passed
+        
+        LOGGER.info("=== Conforma Verification Results ===")
+        LOGGER.info("Total: %d, Passed: %d, Failed: %d", total, passed, failed)
+        
+        if failed > 0:
+            LOGGER.warning("Failed verifications:")
+            for nvr, result in results.items():
+                if not result["success"]:
+                    error_msg = result.get("error") or result.get("stderr") or "Verification failed"
+                    LOGGER.warning("  ✗ %s - %s", nvr, error_msg)
+        
+        if passed > 0:
+            LOGGER.info("Passed verifications:")
+            for nvr, result in results.items():
+                if result["success"]:
+                    LOGGER.info("  ✓ %s", nvr)
+
+
+@cli.group("conforma", short_help="Commands for Conforma verification")
+def conforma_cli():
+    pass
+
+
+@conforma_cli.command(
+    "verify", short_help="Verify given builds (NVRs) with Conforma"
+)
+@click.argument('nvrs', metavar='<NVR>', nargs=-1, required=False, default=None)
+@click.option(
+    "--nvrs-file",
+    "-f",
+    "nvrs_file",
+    help="File to read NVRs from, `-` to read from STDIN.",
+    type=click.File("rt"),
+)
+@click.option(
+    "--policy",
+    metavar="PATH_OR_URL",
+    help="Path to policy.yaml file or URL. Defaults to the official Red Hat Enterprise Contract policy.",
+)
+@click.pass_obj
+@click_coroutine
+async def verify_conforma_cli(
+    runtime: Runtime,
+    nvrs_file,
+    nvrs,
+    policy,
+):
+    """
+    Verify given builds (NVRs) with Conforma
+
+    \b
+    $ elliott -g openshift-4.18 conforma verify --nvrs-file nvrs.txt
+
+    \b
+    $ elliott -g openshift-4.18 conforma verify nvr1 nvr2 nvr3
+
+    \b
+    $ elliott -g openshift-4.18 conforma verify --policy /path/to/custom/policy.yaml nvr1 nvr2
+    """
+    if bool(nvrs) and bool(nvrs_file):
+        raise click.BadParameter("Use only one of nvrs arguments or --nvrs-file")
+
+    if nvrs_file:
+        if nvrs_file == "-":
+            nvrs_file = sys.stdin
+        nvrs = [line.strip() for line in nvrs_file.readlines()]
+
+    if not nvrs:
+        raise click.BadParameter("Must provide NVRs either as arguments or via --nvrs-file")
+
+    pipeline = ConformaVerifyCli(
+        runtime=runtime,
+        nvrs=nvrs,
+        policy_path=policy,
+    )
+    results = await pipeline.run()
+    
+    # Output results summary
+    total = len(results)
+    passed = sum(1 for r in results.values() if r["success"])
+    failed = total - passed
+    
+    click.echo(f"\n=== Summary ===")
+    click.echo(f"Total: {total}, Passed: {passed}, Failed: {failed}")
+    
+    # Exit with non-zero code if any verifications failed
+    if failed > 0:
+        sys.exit(1) 


### PR DESCRIPTION
```
elliott -g openshift-4.18 verify-conforma cluster-nfd-operator-fbc-4.18.0-20250723040450 --env stage

2025-07-23 19:51:10,009 art_tools.elliottlib.cli.snapshot_cli INFO Validating given NVRs...
2025-07-23 19:51:10,009 art_tools.elliottlib.cli.snapshot_cli INFO Fetching NVRs from DB...
2025-07-23 19:51:11,547 art_tools.artcommonlib.exectools INFO Executing:cmd_gather_async: oc image info -o json --filter-by-os=amd64 quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc@sha256:c4700172a4414ac1f073fd8d120b546f9c144ce726198b5d780c59cb51405dae
2025-07-23 19:51:14,319 doozerlib.backend.konflux_client WARNING [DRY RUN] Would have created appstudio.redhat.com/v1alpha1/Snapshot ocp-art-tenant/ose-4-18-20250723235113797360-1
2025-07-23 19:51:14,319 art_tools.elliottlib.cli.snapshot_cli INFO [DRY-RUN] Would have created Konflux Snapshots: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/fbc-openshift-4-18/snapshots/ose-4-18-20250723235113797360-1
2025-07-23 19:51:14,320 art_tools.elliottlib.cli.conforma_cli INFO Found policy for application fbc-openshift-4-18 and env stage: https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/common/product/EnterpriseContractPolicy/fbc-stage.yaml
2025-07-23 19:51:15,264 art_tools.elliottlib.cli.conforma_cli INFO Setting up verification files...
2025-07-23 19:51:15,264 art_tools.artcommonlib.exectools INFO Executing:cmd_assert_async: wget -q -O /tmp/tmpsrupqxra/ec_policy.yaml https://gitlab.cee.redhat.com/releng/konflux-release-data/-/raw/main/config/common/product/EnterpriseContractPolicy/fbc-stage.yaml
2025-07-23 19:51:16,284 art_tools.artcommonlib.exectools INFO Executing:cmd_gather_async: oc get -n openshift-pipelines secret public-key -o json --kubeconfig /home/sid/konflux.kubeconfig.priv
2025-07-23 19:51:16,897 art_tools.elliottlib.cli.conforma_cli INFO Verification files prepared: policy=/tmp/tmpsrupqxra/policy.yaml, cosign.pub=/tmp/tmpsrupqxra/cosign.pub
2025-07-23 19:51:16,897 art_tools.artcommonlib.exectools INFO Executing:cmd_gather_async: ec validate image --images /tmp/tmpeyp3gslf --public-key /tmp/tmpsrupqxra/cosign.pub --policy /tmp/tmpsrupqxra/policy.yaml --ignore-rekor --output yaml
2025-07-23 19:52:13,760 art_tools.elliottlib.cli.conforma_cli WARNING ✗ Verification failed
2025-07-23 19:52:13,776 art_tools.elliottlib.cli.conforma_cli INFO Detailed results saved to results.yaml
Verification complete. See results.yaml for details.
```