### PR TITLE
[konflux-release] Only allow live_id for prod

### DIFF
--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -191,7 +191,13 @@ class CreateReleaseCli:
             application=shipment.metadata.application,
             release_name=release_name,
         )
+
         if shipment.data:
+            # We only reserve live_id for prod release, therefore releaseNotes.live_id is only meant for prod
+            # For stage release, we want konflux to automatically assign a live_id to the release
+            if env != "prod":
+                shipment.data.releaseNotes.live_id = None
+
             # Do not set exclude_unset=True when dumping, since Konflux
             # expects certain keys to always be set, even if empty.
             # Those are appropriately set as default values in pydantic shipment model

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -175,7 +175,7 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
         )
 
         self.config_path = "shipment/ocp/openshift-4.18/openshift-4-18/4.18.2.202503210000.yml"
-        self.release_env = "stage"
+        self.release_env = "prod"
         self.image_repo_pull_secret = {}  # Use a dict as required by CreateReleaseCli
 
         self.konflux_client = AsyncMock()
@@ -186,7 +186,7 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
     @patch("elliottlib.cli.konflux_release_cli.get_utc_now_formatted_str", return_value="timestamp")
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
     @patch("elliottlib.runtime.Runtime")
-    async def test_run_happy_path(self, mock_runtime, mock_konflux_client_init, _):
+    async def test_run_prod_happy_path(self, mock_runtime, mock_konflux_client_init, _):
         mock_runtime.return_value = self.runtime
         mock_konflux_client_init.return_value = self.konflux_client
 
@@ -228,6 +228,7 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
                 data=Data(
                     releaseNotes=ReleaseNotes(
                         type="RHBA",
+                        live_id=123456,
                         synopsis="Red Hat Openshift Test Release",
                         topic="Topic for a test release for Red Hat Openshift.",
                         description="Description for a test release for Red Hat Openshift.",
@@ -275,6 +276,7 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
                 'data': {
                     'releaseNotes': {
                         'type': shipment_config.shipment.data.releaseNotes.type,
+                        'live_id': shipment_config.shipment.data.releaseNotes.live_id,
                         'synopsis': shipment_config.shipment.data.releaseNotes.synopsis,
                         'topic': shipment_config.shipment.data.releaseNotes.topic,
                         'description': shipment_config.shipment.data.releaseNotes.description,
@@ -312,6 +314,156 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
             API_VERSION, KIND_APPLICATION, shipment_config.shipment.metadata.application
         )
         self.konflux_client._get.assert_any_call(
+            API_VERSION, KIND_RELEASE_PLAN, shipment_config.shipment.environments.prod.releasePlan
+        )
+
+        # Verify snapshot was created first, then release
+        expected_calls = [
+            ((expected_snapshot,), {}),
+            ((expected_release,), {}),
+        ]
+        self.assertEqual(len(self.konflux_client._create.call_args_list), 2)
+        self.assertEqual(
+            self.konflux_client._create.call_args_list[0], expected_calls[0], "Snapshot resources do not match"
+        )
+        self.assertEqual(
+            self.konflux_client._create.call_args_list[1], expected_calls[1], "Release resources do not match"
+        )
+
+        # Check result
+        self.assertEqual(result, created_release)
+
+    @patch("elliottlib.cli.konflux_release_cli.get_utc_now_formatted_str", return_value="timestamp")
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    @patch("elliottlib.runtime.Runtime")
+    async def test_run_stage_happy_path(self, mock_runtime, mock_konflux_client_init, _):
+        mock_runtime.return_value = self.runtime
+        mock_konflux_client_init.return_value = self.konflux_client
+
+        shipment_config = ShipmentConfig(
+            shipment=Shipment(
+                metadata=Metadata(
+                    product="ocp",
+                    application="openshift-4-18",
+                    group="openshift-4.18",
+                    assembly="4.18.2",
+                    fbc=False,
+                ),
+                environments=Environments(
+                    stage=ShipmentEnv(releasePlan="test-stage-rp"),
+                    prod=ShipmentEnv(releasePlan="test-prod-rp"),
+                ),
+                snapshot=Snapshot(
+                    nvrs=["test-nvr-1", "test-nvr-2"],
+                    spec=SnapshotSpec(
+                        application="openshift-4-18",
+                        components=[
+                            SnapshotComponent(
+                                name="test-rpm",
+                                source=ComponentSource(
+                                    git=GitSource(url="https://github.com/test-rpm.git", revision="abc123")
+                                ),
+                                containerImage="foo",
+                            ),
+                            SnapshotComponent(
+                                name="test-container",
+                                source=ComponentSource(
+                                    git=GitSource(url="https://github.com/test-container.git", revision="def456")
+                                ),
+                                containerImage="bar",
+                            ),
+                        ],
+                    ),
+                ),
+                data=Data(
+                    releaseNotes=ReleaseNotes(
+                        type="RHBA",
+                        live_id=123456,
+                        synopsis="Red Hat Openshift Test Release",
+                        topic="Topic for a test release for Red Hat Openshift.",
+                        description="Description for a test release for Red Hat Openshift.",
+                        solution="Solution for a test release for Red Hat Openshift.",
+                    ),
+                ),
+            ),
+        )
+        self.runtime.shipment_gitdata.load_yaml_file.return_value = shipment_config.model_dump(exclude_none=True)
+
+        # Mock API queries
+        self.konflux_client._get_api.return_value = MagicMock()
+        self.konflux_client._get.return_value = MagicMock()
+
+        # Mock snapshot creation
+        created_snapshot_name = "ose-4-18-timestamp"
+        created_snapshot = MagicMock()
+        created_snapshot.metadata.name = created_snapshot_name
+
+        expected_snapshot = {
+            "apiVersion": API_VERSION,
+            "kind": "Snapshot",
+            "metadata": {
+                "name": created_snapshot_name,
+                "namespace": self.konflux_config['namespace'],
+                "labels": {
+                    "test.appstudio.openshift.io/type": "override",
+                    "appstudio.openshift.io/application": shipment_config.shipment.metadata.application,
+                },
+            },
+            "spec": shipment_config.shipment.snapshot.spec.model_dump(exclude_none=True),
+        }
+
+        expected_release = {
+            "apiVersion": API_VERSION,
+            "kind": KIND_RELEASE,
+            'metadata': {
+                'name': 'ose-4-18-stage-timestamp',
+                'namespace': self.konflux_config['namespace'],
+                'labels': {'appstudio.openshift.io/application': 'openshift-4-18'},
+            },
+            'spec': {
+                'releasePlan': shipment_config.shipment.environments.stage.releasePlan,
+                'snapshot': created_snapshot_name,
+                'data': {
+                    'releaseNotes': {
+                        'type': shipment_config.shipment.data.releaseNotes.type,
+                        'live_id': None,
+                        'synopsis': shipment_config.shipment.data.releaseNotes.synopsis,
+                        'topic': shipment_config.shipment.data.releaseNotes.topic,
+                        'description': shipment_config.shipment.data.releaseNotes.description,
+                        'solution': shipment_config.shipment.data.releaseNotes.solution,
+                        'cves': [],
+                    },
+                },
+            },
+        }
+
+        created_release = Model(expected_release)
+        self.konflux_client._create.side_effect = [
+            created_snapshot,
+            created_release,
+        ]  # First call for snapshot, second for release
+        self.konflux_client.resource_url.return_value = f"https://cluster/api/snapshot/{created_snapshot_name}"
+
+        cli = CreateReleaseCli(
+            runtime=self.runtime,
+            config_path=self.config_path,
+            release_env="stage",
+            konflux_config=self.konflux_config,
+            image_repo_pull_secret={},
+            dry_run=self.dry_run,
+            force=self.force,
+        )
+
+        result = await cli.run()
+
+        # Verify runtime was initialized with shipment
+        self.runtime.initialize.assert_called_once_with(build_system='konflux', with_shipment=True)
+
+        # Verify resource existence was checked
+        self.konflux_client._get.assert_any_call(
+            API_VERSION, KIND_APPLICATION, shipment_config.shipment.metadata.application
+        )
+        self.konflux_client._get.assert_any_call(
             API_VERSION, KIND_RELEASE_PLAN, shipment_config.shipment.environments.stage.releasePlan
         )
 
@@ -320,7 +472,13 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
             ((expected_snapshot,), {}),
             ((expected_release,), {}),
         ]
-        self.assertEqual(self.konflux_client._create.call_args_list, expected_calls)
+        self.assertEqual(len(self.konflux_client._create.call_args_list), 2)
+        self.assertEqual(
+            self.konflux_client._create.call_args_list[0], expected_calls[0], "Snapshot resources do not match"
+        )
+        self.assertEqual(
+            self.konflux_client._create.call_args_list[1], expected_calls[1], "Release resources do not match"
+        )
 
         # Check result
         self.assertEqual(result, created_release)

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -266,12 +266,12 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
             "apiVersion": API_VERSION,
             "kind": KIND_RELEASE,
             'metadata': {
-                'name': 'ose-4-18-stage-timestamp',
+                'name': 'ose-4-18-prod-timestamp',
                 'namespace': self.konflux_config['namespace'],
                 'labels': {'appstudio.openshift.io/application': 'openshift-4-18'},
             },
             'spec': {
-                'releasePlan': shipment_config.shipment.environments.stage.releasePlan,
+                'releasePlan': shipment_config.shipment.environments.prod.releasePlan,
                 'snapshot': created_snapshot_name,
                 'data': {
                     'releaseNotes': {
@@ -426,7 +426,6 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
                 'data': {
                     'releaseNotes': {
                         'type': shipment_config.shipment.data.releaseNotes.type,
-                        'live_id': None,
                         'synopsis': shipment_config.shipment.data.releaseNotes.synopsis,
                         'topic': shipment_config.shipment.data.releaseNotes.topic,
                         'description': shipment_config.shipment.data.releaseNotes.description,


### PR DESCRIPTION
We only reserve live_id for prod release, therefore releaseNotes.live_id is only meant for prod
For stage release, we want konflux to automatically assign a live_id to the release

see: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1753275935250019

