### PR TITLE
[Elliott] Accept target version summary prefixes

### DIFF
--- a/elliott/elliottlib/cli/find_bugs_qe_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_qe_cli.py
@@ -69,8 +69,8 @@ def find_bugs_qe(runtime, find_bugs_obj, noop, bug_tracker):
                 bug_tracker.add_comment(bug.id, comment, private=True, noop=noop)
 
                 # get summary of tracker bug and update it if needed
-                new_s = bug.get_summary_with_ocp_suffix(major_version, minor_version)
-                if new_s != bug.summary:
+                if not bug.has_valid_target_version_in_summary(major_version, minor_version):
+                    new_s = bug.make_summary_with_target_version(major_version, minor_version)
                     LOGGER.info(f"Updating summary for bug {bug.id} from '{bug.summary}' to '{new_s}'")
                     try:
                         bug.update_summary(new_s, noop=noop)

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -454,12 +454,12 @@ def categorize_bugs_by_type(
     invalid_summary_trackers: type_bug_set = set()
     for b in tracker_bugs:
         logger.info(f'Tracker bug, component: {(b.id, b.whiteboard_component)}')
-        if not b.has_valid_summary_suffix(major_version, minor_version):
+        if not b.has_valid_target_version_in_summary(major_version, minor_version):
             invalid_summary_trackers.add(b)
 
     if invalid_summary_trackers:
         sorted_ids = sorted([t.id for t in invalid_summary_trackers])
-        message = f"Tracker Bug(s) {sorted_ids} have invalid summary suffixes."
+        message = f"Tracker Bug(s) {sorted_ids} have invalid summary."
         if permissive:
             logger.warning(f"{message} Ignoring them.")
             issues.append(message)

--- a/elliott/tests/test_bzutil.py
+++ b/elliott/tests/test_bzutil.py
@@ -31,10 +31,10 @@ class TestBug(unittest.TestCase):
             ("Wrong version [openshift-4.19]", (4, 20), "Wrong version [openshift-4.20]"),
         ]
     )
-    def test_get_summary_with_ocp_suffix(self, summary, version, expected):
+    def test_make_summary_with_target_version(self, summary, version, expected):
         major, minor = version
         bug = JIRABug(flexmock(fields=flexmock(summary=summary)))
-        result = bug.get_summary_with_ocp_suffix(major, minor)
+        result = bug.make_summary_with_target_version(major, minor)
         self.assertEqual(result, expected)
 
     @parameterized.expand(
@@ -49,7 +49,7 @@ class TestBug(unittest.TestCase):
     def test_has_valid_summary_suffix(self, summary, version, expected):
         major, minor = version
         bug = JIRABug(flexmock(fields=flexmock(summary=summary)))
-        result = bug.has_valid_summary_suffix(major, minor)
+        result = bug.has_valid_target_version_in_summary(major, minor)
         self.assertEqual(result, expected)
 
 

--- a/elliott/tests/test_find_bugs_sweep_cli.py
+++ b/elliott/tests/test_find_bugs_sweep_cli.py
@@ -275,7 +275,7 @@ class TestCategorizeBugsByType(unittest.TestCase):
                 id='OCPBUGS-0',
                 is_tracker_bug=lambda: True,
                 is_invalid_tracker_bug=lambda: False,
-                has_valid_summary_suffix=lambda *_: True,
+                has_valid_target_version_in_summary=lambda *_: True,
                 whiteboard_component='foo',
                 component='',
                 summary='',
@@ -285,7 +285,7 @@ class TestCategorizeBugsByType(unittest.TestCase):
                 id='OCPBUGS-1',
                 is_tracker_bug=lambda: True,
                 is_invalid_tracker_bug=lambda: False,
-                has_valid_summary_suffix=lambda *_: True,
+                has_valid_target_version_in_summary=lambda *_: True,
                 whiteboard_component='bar',
                 component='',
                 summary='',
@@ -295,7 +295,7 @@ class TestCategorizeBugsByType(unittest.TestCase):
                 id='OCPBUGS-2',
                 is_tracker_bug=lambda: True,
                 is_invalid_tracker_bug=lambda: False,
-                has_valid_summary_suffix=lambda *_: True,
+                has_valid_target_version_in_summary=lambda *_: True,
                 whiteboard_component='buzz',
                 component='',
                 summary='',
@@ -345,7 +345,7 @@ class TestCategorizeBugsByType(unittest.TestCase):
                 id='OCPBUGS-0',
                 is_tracker_bug=lambda: True,
                 is_invalid_tracker_bug=lambda: False,
-                has_valid_summary_suffix=lambda *_: True,
+                has_valid_target_version_in_summary=lambda *_: True,
                 whiteboard_component='foo',
                 component='',
                 summary='',
@@ -355,7 +355,7 @@ class TestCategorizeBugsByType(unittest.TestCase):
                 id='OCPBUGS-1',
                 is_tracker_bug=lambda: True,
                 is_invalid_tracker_bug=lambda: False,
-                has_valid_summary_suffix=lambda *_: True,
+                has_valid_target_version_in_summary=lambda *_: True,
                 whiteboard_component='bar',
                 component='',
                 summary='',
@@ -365,7 +365,7 @@ class TestCategorizeBugsByType(unittest.TestCase):
                 id='OCPBUGS-2',
                 is_tracker_bug=lambda: True,
                 is_invalid_tracker_bug=lambda: False,
-                has_valid_summary_suffix=lambda *_: True,
+                has_valid_target_version_in_summary=lambda *_: True,
                 whiteboard_component='buzz',
                 component='',
                 summary='',
@@ -445,13 +445,13 @@ class TestCategorizeBugsByType(unittest.TestCase):
                 id='OCPBUGS-5',
                 is_tracker_bug=lambda: True,
                 is_invalid_tracker_bug=lambda: False,
-                has_valid_summary_suffix=lambda *_: False,
+                has_valid_target_version_in_summary=lambda *_: False,
                 whiteboard_component='foo',
                 component='',
             )
         ]
         flexmock(sweep_cli).should_receive("extras_bugs").and_return({bugs[0]})
-        with self.assertRaisesRegex(ElliottFatalError, 'invalid summary suffixes'):
+        with self.assertRaisesRegex(ElliottFatalError, 'invalid summary'):
             categorize_bugs_by_type(
                 bugs=bugs,
                 builds_by_advisory_kind=None,
@@ -466,7 +466,7 @@ class TestCategorizeBugsByType(unittest.TestCase):
                 id='OCPBUGS-2',
                 is_tracker_bug=lambda: True,
                 is_invalid_tracker_bug=lambda: False,
-                has_valid_summary_suffix=lambda *_: True,
+                has_valid_target_version_in_summary=lambda *_: True,
                 whiteboard_component='buzz',
                 component='',
                 summary='',
@@ -476,7 +476,7 @@ class TestCategorizeBugsByType(unittest.TestCase):
                 id='OCPBUGS-4',
                 is_tracker_bug=lambda: True,
                 is_invalid_tracker_bug=lambda: False,
-                has_valid_summary_suffix=lambda *_: False,
+                has_valid_target_version_in_summary=lambda *_: False,
                 whiteboard_component='foo',
                 component='',
             ),
@@ -519,7 +519,7 @@ class TestCategorizeBugsByType(unittest.TestCase):
             issues,
             [
                 "Bug(s) ['OCPBUGS-5'] look like CVE trackers, but really are not.",
-                "Tracker Bug(s) ['OCPBUGS-4'] have invalid summary suffixes.",
+                "Tracker Bug(s) ['OCPBUGS-4'] have invalid summary.",
             ],
         )
 


### PR DESCRIPTION
https://github.com/openshift-eng/art-tools/pull/1566 and https://github.com/openshift-eng/art-tools/pull/1749 added a validation to find-bugs. In case a CVE tracker doesn't have a target version suffix, e.g. `[openshift-x.y]` in its summary, it is considered invalid.

Recently, we found some CVE trackers have `[openshift-x.y]` summary prefixes instead of suffixes. Guess those prefixes are valid either.

This PR makes a change in Elliott to accept those kind of prefixes.