### PR TITLE
feat(rpm-lockfile): add configurable parent exclusion for lockfile RPM collection

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -749,42 +749,42 @@ class ImageMetadata(Metadata):
 
         return False
 
-    def is_lockfile_parent_exclude_enabled(self) -> bool:
+    def is_lockfile_parent_inspect_enabled(self) -> bool:
         """
-        Determines whether lockfile parent exclusion is enabled for the current image configuration.
+        Determines whether lockfile parent inspection is enabled for the current image configuration.
 
         The method checks configuration in the following order:
-        1. Image metadata configuration (`self.config.konflux.cachi2.lockfile.exclude_parents`)
-        2. Group configuration (`self.runtime.group_config.konflux.cachi2.lockfile.exclude_parents`)
+        1. Image metadata configuration (`self.config.konflux.cachi2.lockfile.inspect_parent`)
+        2. Group configuration (`self.runtime.group_config.konflux.cachi2.lockfile.inspect_parent`)
 
-        If neither is set, parent exclusion defaults to disabled (False).
+        If neither is set, parent inspection defaults to enabled (True).
 
         Returns:
-            bool: True if lockfile parent exclusion is enabled, False otherwise.
+            bool: True if lockfile parent inspection is enabled, False otherwise.
         """
-        lockfile_exclude_parents_config_override = self.config.konflux.cachi2.lockfile.exclude_parents
-        if lockfile_exclude_parents_config_override not in [Missing, None]:
-            lockfile_exclude_parents = bool(lockfile_exclude_parents_config_override)
-            self.logger.info(f"Lockfile parent exclusion set from metadata config: {lockfile_exclude_parents}")
-            return lockfile_exclude_parents
+        lockfile_inspect_parent_config_override = self.config.konflux.cachi2.lockfile.inspect_parent
+        if lockfile_inspect_parent_config_override not in [Missing, None]:
+            lockfile_inspect_parent = bool(lockfile_inspect_parent_config_override)
+            self.logger.info(f"Lockfile parent inspection set from metadata config: {lockfile_inspect_parent}")
+            return lockfile_inspect_parent
 
-        lockfile_exclude_parents_group_override = self.runtime.group_config.konflux.cachi2.lockfile.exclude_parents
-        if lockfile_exclude_parents_group_override not in [Missing, None]:
-            lockfile_exclude_parents = bool(lockfile_exclude_parents_group_override)
-            self.logger.info(f"Lockfile parent exclusion set from group config: {lockfile_exclude_parents}")
-            return lockfile_exclude_parents
+        lockfile_inspect_parent_group_override = self.runtime.group_config.konflux.cachi2.lockfile.inspect_parent
+        if lockfile_inspect_parent_group_override not in [Missing, None]:
+            lockfile_inspect_parent = bool(lockfile_inspect_parent_group_override)
+            self.logger.info(f"Lockfile parent inspection set from group config: {lockfile_inspect_parent}")
+            return lockfile_inspect_parent
 
-        return False
+        return True
 
     async def fetch_rpms_from_build(self) -> set[str]:
         """
         Fetch RPM packages from database installed_rpms field.
 
         Returns either the full image RPM set or difference from parent packages,
-        based on the exclude_parents configuration. Caches result in installed_rpms attribute.
+        based on the inspect_parent configuration. Caches result in installed_rpms attribute.
 
         Returns:
-            set[str]: Source RPM package names - full set if exclude_parents=True,
+            set[str]: Source RPM package names - full set if inspect_parent=False,
                      otherwise difference between this image's packages and parent packages
         """
         if hasattr(self, 'installed_rpms') and self.installed_rpms is not None:
@@ -807,9 +807,9 @@ class ImageMetadata(Metadata):
                 self.installed_rpms = []
                 return set()
 
-            # Check if we should exclude parents before any parent processing
-            if self.is_lockfile_parent_exclude_enabled():
-                # New behavior: return full image RPM list, skip parent processing entirely
+            # Check if we should skip parent inspection
+            if not self.is_lockfile_parent_inspect_enabled():
+                # Skip parent inspection: return full image RPM list
                 self.installed_rpms = list(rpms)
                 return rpms
 

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -673,8 +673,8 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
 
         metadata.runtime.konflux_db.get_latest_build = AsyncMock(return_value=mock_build)
 
-        # Mock exclude_parents disabled (default behavior)
-        metadata.is_lockfile_parent_exclude_enabled = MagicMock(return_value=False)
+        # Mock inspect_parent enabled (default behavior)
+        metadata.is_lockfile_parent_inspect_enabled = MagicMock(return_value=True)
 
         # Mock no parent members
         with patch.object(metadata, 'get_parent_members', return_value={}):
@@ -705,8 +705,8 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
 
         metadata.runtime.konflux_db.get_latest_build = AsyncMock(side_effect=mock_get_latest_build)
 
-        # Mock exclude_parents disabled (default behavior)
-        metadata.is_lockfile_parent_exclude_enabled = MagicMock(return_value=False)
+        # Mock inspect_parent enabled (default behavior)
+        metadata.is_lockfile_parent_inspect_enabled = MagicMock(return_value=True)
 
         # Mock parent members
         with patch.object(metadata, 'get_parent_members', return_value={'parent-image'}):
@@ -784,8 +784,8 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
 
         metadata.runtime.konflux_db.get_latest_build = AsyncMock(side_effect=mock_get_latest_build)
 
-        # Mock exclude_parents disabled (default behavior)
-        metadata.is_lockfile_parent_exclude_enabled = MagicMock(return_value=False)
+        # Mock inspect_parent enabled (default behavior)
+        metadata.is_lockfile_parent_inspect_enabled = MagicMock(return_value=True)
 
         # Mock parent members
         with patch.object(metadata, 'get_parent_members', return_value={'parent-image'}):
@@ -909,102 +909,102 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         self.assertEqual(result, expected)
         metadata.logger.info.assert_called_once_with('test-image adding 3 RPMs from lockfile config')
 
-    def test_is_lockfile_parent_exclude_enabled_image_config_true(self):
-        """Test exclude_parents enabled via image metadata configuration"""
-        metadata = self._create_image_metadata('openshift/test-exclude-parents')
+    def test_is_lockfile_parent_inspect_enabled_image_config_true(self):
+        """Test inspect_parent enabled via image metadata configuration"""
+        metadata = self._create_image_metadata('openshift/test-inspect-parent')
 
         # Mock image config override
         mock_config = MagicMock()
-        mock_config.konflux.cachi2.lockfile.exclude_parents = True
+        mock_config.konflux.cachi2.lockfile.inspect_parent = True
         metadata.config = mock_config
         metadata.logger = MagicMock()
 
-        result = metadata.is_lockfile_parent_exclude_enabled()
+        result = metadata.is_lockfile_parent_inspect_enabled()
 
         self.assertTrue(result)
-        metadata.logger.info.assert_called_once_with("Lockfile parent exclusion set from metadata config: True")
+        metadata.logger.info.assert_called_once_with("Lockfile parent inspection set from metadata config: True")
 
-    def test_is_lockfile_parent_exclude_enabled_image_config_false(self):
-        """Test exclude_parents disabled via image metadata configuration"""
-        metadata = self._create_image_metadata('openshift/test-exclude-parents')
+    def test_is_lockfile_parent_inspect_enabled_image_config_false(self):
+        """Test inspect_parent disabled via image metadata configuration"""
+        metadata = self._create_image_metadata('openshift/test-inspect-parent')
 
         # Mock image config override
         mock_config = MagicMock()
-        mock_config.konflux.cachi2.lockfile.exclude_parents = False
+        mock_config.konflux.cachi2.lockfile.inspect_parent = False
         metadata.config = mock_config
         metadata.logger = MagicMock()
 
-        result = metadata.is_lockfile_parent_exclude_enabled()
+        result = metadata.is_lockfile_parent_inspect_enabled()
 
         self.assertFalse(result)
-        metadata.logger.info.assert_called_once_with("Lockfile parent exclusion set from metadata config: False")
+        metadata.logger.info.assert_called_once_with("Lockfile parent inspection set from metadata config: False")
 
-    def test_is_lockfile_parent_exclude_enabled_group_config_true(self):
-        """Test exclude_parents enabled via group configuration"""
-        metadata = self._create_image_metadata('openshift/test-exclude-parents')
+    def test_is_lockfile_parent_inspect_enabled_group_config_true(self):
+        """Test inspect_parent enabled via group configuration"""
+        metadata = self._create_image_metadata('openshift/test-inspect-parent')
 
         # Mock image config as Missing
         mock_config = MagicMock()
-        mock_config.konflux.cachi2.lockfile.exclude_parents = Missing
+        mock_config.konflux.cachi2.lockfile.inspect_parent = Missing
         metadata.config = mock_config
 
         # Mock group config override
         mock_group_config = MagicMock()
-        mock_group_config.konflux.cachi2.lockfile.exclude_parents = True
+        mock_group_config.konflux.cachi2.lockfile.inspect_parent = True
         metadata.runtime.group_config = mock_group_config
         metadata.logger = MagicMock()
 
-        result = metadata.is_lockfile_parent_exclude_enabled()
+        result = metadata.is_lockfile_parent_inspect_enabled()
 
         self.assertTrue(result)
-        metadata.logger.info.assert_called_once_with("Lockfile parent exclusion set from group config: True")
+        metadata.logger.info.assert_called_once_with("Lockfile parent inspection set from group config: True")
 
-    def test_is_lockfile_parent_exclude_enabled_group_config_false(self):
-        """Test exclude_parents disabled via group configuration"""
-        metadata = self._create_image_metadata('openshift/test-exclude-parents')
+    def test_is_lockfile_parent_inspect_enabled_group_config_false(self):
+        """Test inspect_parent disabled via group configuration"""
+        metadata = self._create_image_metadata('openshift/test-inspect-parent')
 
         # Mock image config as Missing
         mock_config = MagicMock()
-        mock_config.konflux.cachi2.lockfile.exclude_parents = Missing
+        mock_config.konflux.cachi2.lockfile.inspect_parent = Missing
         metadata.config = mock_config
 
         # Mock group config override
         mock_group_config = MagicMock()
-        mock_group_config.konflux.cachi2.lockfile.exclude_parents = False
+        mock_group_config.konflux.cachi2.lockfile.inspect_parent = False
         metadata.runtime.group_config = mock_group_config
         metadata.logger = MagicMock()
 
-        result = metadata.is_lockfile_parent_exclude_enabled()
+        result = metadata.is_lockfile_parent_inspect_enabled()
 
         self.assertFalse(result)
-        metadata.logger.info.assert_called_once_with("Lockfile parent exclusion set from group config: False")
+        metadata.logger.info.assert_called_once_with("Lockfile parent inspection set from group config: False")
 
-    def test_is_lockfile_parent_exclude_enabled_default_false(self):
-        """Test exclude_parents defaults to False when no configuration is set"""
-        metadata = self._create_image_metadata('openshift/test-exclude-parents')
+    def test_is_lockfile_parent_inspect_enabled_default_true(self):
+        """Test inspect_parent defaults to True when no configuration is set"""
+        metadata = self._create_image_metadata('openshift/test-inspect-parent')
 
         # Mock both configs as Missing
         mock_config = MagicMock()
-        mock_config.konflux.cachi2.lockfile.exclude_parents = Missing
+        mock_config.konflux.cachi2.lockfile.inspect_parent = Missing
         metadata.config = mock_config
 
         mock_group_config = MagicMock()
-        mock_group_config.konflux.cachi2.lockfile.exclude_parents = Missing
+        mock_group_config.konflux.cachi2.lockfile.inspect_parent = Missing
         metadata.runtime.group_config = mock_group_config
         metadata.logger = MagicMock()
 
-        result = metadata.is_lockfile_parent_exclude_enabled()
+        result = metadata.is_lockfile_parent_inspect_enabled()
 
-        self.assertFalse(result)
+        self.assertTrue(result)
         # Should not log when using default
         metadata.logger.info.assert_not_called()
 
-    async def test_fetch_rpms_exclude_parents_enabled_returns_full_set(self):
-        """Test fetch_rpms_from_build with exclude_parents=True returns full image RPMs"""
-        metadata = self._create_image_metadata('openshift/test-exclude-parents')
+    async def test_fetch_rpms_inspect_parent_disabled_returns_full_set(self):
+        """Test fetch_rpms_from_build with inspect_parent=False returns full image RPMs"""
+        metadata = self._create_image_metadata('openshift/test-inspect-parent')
 
-        # Mock exclude_parents enabled
-        metadata.is_lockfile_parent_exclude_enabled = MagicMock(return_value=True)
+        # Mock inspect_parent disabled
+        metadata.is_lockfile_parent_inspect_enabled = MagicMock(return_value=False)
 
         # Mock image build with RPMs
         mock_build = MagicMock()
@@ -1017,12 +1017,12 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         self.assertEqual(result, {'pkg1', 'pkg2', 'pkg3', 'pkg4'})
         self.assertEqual(set(metadata.installed_rpms), {'pkg1', 'pkg2', 'pkg3', 'pkg4'})
 
-    async def test_fetch_rpms_exclude_parents_disabled_returns_diff(self):
-        """Test fetch_rpms_from_build with exclude_parents=False returns diff"""
-        metadata = self._create_image_metadata('openshift/test-exclude-parents')
+    async def test_fetch_rpms_inspect_parent_enabled_returns_diff(self):
+        """Test fetch_rpms_from_build with inspect_parent=True returns diff"""
+        metadata = self._create_image_metadata('openshift/test-inspect-parent')
 
-        # Mock exclude_parents disabled
-        metadata.is_lockfile_parent_exclude_enabled = MagicMock(return_value=False)
+        # Mock inspect_parent enabled
+        metadata.is_lockfile_parent_inspect_enabled = MagicMock(return_value=True)
 
         # Mock image build
         mock_build = MagicMock()
@@ -1049,12 +1049,12 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         self.assertEqual(result, {'pkg3', 'pkg4'})
         self.assertEqual(set(metadata.installed_rpms), {'pkg3', 'pkg4'})
 
-    async def test_fetch_rpms_exclude_parents_enabled_skips_parent_fetch(self):
-        """Test that exclude_parents=True skips parent processing entirely"""
-        metadata = self._create_image_metadata('openshift/test-exclude-parents')
+    async def test_fetch_rpms_inspect_parent_disabled_skips_parent_fetch(self):
+        """Test that inspect_parent=False skips parent processing entirely"""
+        metadata = self._create_image_metadata('openshift/test-inspect-parent')
 
-        # Mock exclude_parents enabled
-        metadata.is_lockfile_parent_exclude_enabled = MagicMock(return_value=True)
+        # Mock inspect_parent disabled
+        metadata.is_lockfile_parent_inspect_enabled = MagicMock(return_value=False)
 
         # Mock image build with RPMs
         mock_build = MagicMock()

--- a/ocp-build-data-validator/tests/test_schema/test_image_schema.py
+++ b/ocp-build-data-validator/tests/test_schema/test_image_schema.py
@@ -191,36 +191,36 @@ class TestImageSchema(unittest.TestCase):
         }
         self.assertIn("'not-a-boolean' is not of type 'boolean'", image_schema.validate('filename', invalid_data))
 
-    def test_validate_with_valid_konflux_cachi2_lockfile_exclude_parents_true(self):
-        """Test valid konflux.cachi2.lockfile.exclude_parents = true"""
+    def test_validate_with_valid_konflux_cachi2_lockfile_inspect_parent_true(self):
+        """Test valid konflux.cachi2.lockfile.inspect_parent = true"""
         valid_data = {
             'from': {},
             'name': 'my-name',
             'for_payload': True,
             'delivery': {'delivery_repo_names': ['foo', 'bar']},
-            'konflux': {'cachi2': {'lockfile': {'exclude_parents': True}}},
+            'konflux': {'cachi2': {'lockfile': {'inspect_parent': True}}},
         }
         self.assertIsNone(image_schema.validate('filename', valid_data))
 
-    def test_validate_with_valid_konflux_cachi2_lockfile_exclude_parents_false(self):
-        """Test valid konflux.cachi2.lockfile.exclude_parents = false"""
+    def test_validate_with_valid_konflux_cachi2_lockfile_inspect_parent_false(self):
+        """Test valid konflux.cachi2.lockfile.inspect_parent = false"""
         valid_data = {
             'from': {},
             'name': 'my-name',
             'for_payload': True,
             'delivery': {'delivery_repo_names': ['foo', 'bar']},
-            'konflux': {'cachi2': {'lockfile': {'exclude_parents': False}}},
+            'konflux': {'cachi2': {'lockfile': {'inspect_parent': False}}},
         }
         self.assertIsNone(image_schema.validate('filename', valid_data))
 
-    def test_validate_with_invalid_konflux_cachi2_lockfile_exclude_parents_type(self):
-        """Test invalid exclude_parents data type (not boolean)"""
+    def test_validate_with_invalid_konflux_cachi2_lockfile_inspect_parent_type(self):
+        """Test invalid inspect_parent data type (not boolean)"""
         invalid_data = {
             'from': {},
             'name': 'my-name',
             'for_payload': True,
             'delivery': {'delivery_repo_names': ['foo', 'bar']},
-            'konflux': {'cachi2': {'lockfile': {'exclude_parents': 'not-a-boolean'}}},
+            'konflux': {'cachi2': {'lockfile': {'inspect_parent': 'not-a-boolean'}}},
         }
         self.assertIn("'not-a-boolean' is not of type 'boolean'", image_schema.validate('filename', invalid_data))
 

--- a/ocp-build-data-validator/tests/test_schema/test_image_schema.py
+++ b/ocp-build-data-validator/tests/test_schema/test_image_schema.py
@@ -191,6 +191,39 @@ class TestImageSchema(unittest.TestCase):
         }
         self.assertIn("'not-a-boolean' is not of type 'boolean'", image_schema.validate('filename', invalid_data))
 
+    def test_validate_with_valid_konflux_cachi2_lockfile_exclude_parents_true(self):
+        """Test valid konflux.cachi2.lockfile.exclude_parents = true"""
+        valid_data = {
+            'from': {},
+            'name': 'my-name',
+            'for_payload': True,
+            'delivery': {'delivery_repo_names': ['foo', 'bar']},
+            'konflux': {'cachi2': {'lockfile': {'exclude_parents': True}}},
+        }
+        self.assertIsNone(image_schema.validate('filename', valid_data))
+
+    def test_validate_with_valid_konflux_cachi2_lockfile_exclude_parents_false(self):
+        """Test valid konflux.cachi2.lockfile.exclude_parents = false"""
+        valid_data = {
+            'from': {},
+            'name': 'my-name',
+            'for_payload': True,
+            'delivery': {'delivery_repo_names': ['foo', 'bar']},
+            'konflux': {'cachi2': {'lockfile': {'exclude_parents': False}}},
+        }
+        self.assertIsNone(image_schema.validate('filename', valid_data))
+
+    def test_validate_with_invalid_konflux_cachi2_lockfile_exclude_parents_type(self):
+        """Test invalid exclude_parents data type (not boolean)"""
+        invalid_data = {
+            'from': {},
+            'name': 'my-name',
+            'for_payload': True,
+            'delivery': {'delivery_repo_names': ['foo', 'bar']},
+            'konflux': {'cachi2': {'lockfile': {'exclude_parents': 'not-a-boolean'}}},
+        }
+        self.assertIn("'not-a-boolean' is not of type 'boolean'", image_schema.validate('filename', invalid_data))
+
     def test_validate_with_valid_komplux_cachi2_enabled(self):
         """Test valid konflux.cachi2.enabled configuration"""
         valid_data = {

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -1222,7 +1222,18 @@
                 "rpms!": {
                   "$ref": "#/properties/konflux/properties/cachi2/properties/lockfile/properties/rpms"
                 },
-                "rpms-": {}
+                "rpms-": {},
+                "exclude_parents": {
+                  "description": "Exclude parent RPMs from lockfile generation, returning only image-specific RPMs",
+                  "type": "boolean"
+                },
+                "exclude_parents?": {
+                  "$ref": "#/properties/konflux/properties/cachi2/properties/lockfile/properties/exclude_parents"
+                },
+                "exclude_parents!": {
+                  "$ref": "#/properties/konflux/properties/cachi2/properties/lockfile/properties/exclude_parents"
+                },
+                "exclude_parents-": {}
               },
               "additionalProperties": false
             },

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -1223,17 +1223,17 @@
                   "$ref": "#/properties/konflux/properties/cachi2/properties/lockfile/properties/rpms"
                 },
                 "rpms-": {},
-                "exclude_parents": {
-                  "description": "Exclude parent RPMs from lockfile generation, returning only image-specific RPMs",
+                "inspect_parent": {
+                  "description": "Inspect parent RPMs during lockfile generation (default: true)",
                   "type": "boolean"
                 },
-                "exclude_parents?": {
-                  "$ref": "#/properties/konflux/properties/cachi2/properties/lockfile/properties/exclude_parents"
+                "inspect_parent?": {
+                  "$ref": "#/properties/konflux/properties/cachi2/properties/lockfile/properties/inspect_parent"
                 },
-                "exclude_parents!": {
-                  "$ref": "#/properties/konflux/properties/cachi2/properties/lockfile/properties/exclude_parents"
+                "inspect_parent!": {
+                  "$ref": "#/properties/konflux/properties/cachi2/properties/lockfile/properties/inspect_parent"
                 },
-                "exclude_parents-": {}
+                "inspect_parent-": {}
               },
               "additionalProperties": false
             },


### PR DESCRIPTION
## Summary
Implement exclude_parents configuration option to control RPM collection behavior in fetch_rpms_from_build method. This enables lockfile generation to choose between differential updates and complete package inventories based on use case requirements.

## Problem
**Before:** Method always calculates `diff_rpms = rpms - parent_rpms` and returns only RPMs unique to this image, with fallback to full set only on parent lookup failures. This causes issues where an image attempts to install packages that are already in the base image.
**After:** Method should provide both diff and full list behaviors based on use case requirements - some scenarios need only new RPMs (diff), while others need complete package inventories (union). Configuration-driven approach provides this flexibility and prevents base image package conflicts.

**Technical Notes**
- Configuration Hierarchy: Follows established pattern from is_lockfile_force_enabled() - image config overrides group config overrides default
- Schema Consistency: Uses existing konflux.cachi2.lockfile section with standard property variants (?, \!, -)
- Backward Compatibility: Default exclude_parents=False maintains current diff behavior
- Method Naming: Follows established is_lockfile_*_enabled() naming convention

## Tests
- Jenkins job: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/lgarciaa/job/build%252Focp4-konflux/49/
- Konflux build: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-egress-router-cni-l8k99/