### PR TITLE
ART-13868: tag latest fbc builds with version

### DIFF
--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -845,8 +845,9 @@ class KonfluxFbcBuilder:
         logger.info("Starting Konflux pipeline run...")
 
         additional_tags = []
-        if metadata.runtime.assembly == "stream":
-            version = metadata.runtime.group.removeprefix("openshift-")
+        group_name = metadata.runtime.group
+        if metadata.runtime.assembly == "stream" and group_name.startswith("openshift-"):
+            version = group_name.removeprefix("openshift-")
             delivery_repo_names = metadata.config.delivery.delivery_repo_names
             for delivery_repo in delivery_repo_names:
                 additional_tags.append(f"ocp__{version}__{delivery_repo.split('/')[-1]}")

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -843,7 +843,14 @@ class KonfluxFbcBuilder:
         logger.info(f"Konflux component {component_name} created")
         # Create a new pipeline run
         logger.info("Starting Konflux pipeline run...")
+
         additional_tags = []
+        if metadata.runtime.assembly == "stream":
+            version = metadata.runtime.group.removeprefix("openshift-")
+            delivery_repo_names = metadata.config.delivery.delivery_repo_names
+            for delivery_repo in delivery_repo_names:
+                additional_tags.append(f"ocp__{version}__{delivery_repo.split('/')[-1]}")
+
         pipelinerun = await konflux_client.start_pipeline_run_for_image_build(
             generate_name=f"{component_name}-",
             namespace=self.konflux_namespace,


### PR DESCRIPTION
FBC builds are pushed out to the public mono repo [art-fbc](https://quay.io/repository/redhat-user-workloads/ocp-art-tenant/art-fbc?tab=tags&tag=latest), in order for stakeholders to get the latest tag per operator per version, tag it like `ocp__4.20__operator-delivery-repo-name`

https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.20/images/cluster-nfd-operator.yml#L21 - is an example delivery repo name in our config.