### PR TITLE
ART-3761 ADD release_date in gen-assembly

### DIFF
--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -15,6 +15,7 @@ from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, Konfl
 from artcommonlib.konflux.package_rpm_finder import PackageRpmFinder
 from artcommonlib.model import Missing, Model
 from artcommonlib.release_util import isolate_el_version_in_release
+from artcommonlib.util import get_assembly_release_date_async
 from requests.adapters import HTTPAdapter
 from ruamel.yaml import YAML
 from semver import VersionInfo

--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -910,6 +910,7 @@ class GenAssemblyCli:
         except Exception as ex:
             raise ValueError(f"Failed to fetch release date from release schedule for {self.release_name}: {ex}")
         self.logger.info("Release date: %s", self.release_date)
+        return self.release_date
 
     def _get_member_overrides(self):
         """

--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -55,6 +55,7 @@ class GenAssemblyPipeline:
         ignore_non_x86_nightlies: Optional[bool] = False,
         logger: Optional[logging.Logger] = None,
         gen_microshift: bool = False,
+        date: Optional[str] = None,
     ):
         self.runtime = runtime
         self.group = group
@@ -69,6 +70,7 @@ class GenAssemblyPipeline:
         self.auto_trigger_build_sync = auto_trigger_build_sync
         self.custom = custom
         self.arches = arches
+        self.date = date
         self.skip_get_nightlies = skip_get_nightlies
         self.gen_microshift = gen_microshift
         if in_flight:
@@ -241,6 +243,8 @@ class GenAssemblyPipeline:
             cmd.append(f"--pre-ga-mode={self.pre_ga_mode}")
         if self.gen_microshift:
             cmd.append("--gen-microshift")
+        if self.date:
+            cmd.append(f"--date={self.date}")
         if self.custom:
             cmd.append("--custom")
         else:
@@ -424,6 +428,7 @@ class GenAssemblyPipeline:
     is_flag=True,
     help="Create microshift entry for assembly release.",
 )
+@click.option("--date", metavar="YYYY-MMM-DD", help="Expected release date (e.g. 2020-Nov-25)")
 @pass_runtime
 @click_coroutine
 async def gen_assembly(
@@ -446,6 +451,7 @@ async def gen_assembly(
     skip_get_nightlies: bool,
     ignore_non_x86_nightlies: bool,
     gen_microshift: bool,
+    date: Optional[str],
 ):
     pipeline = GenAssemblyPipeline(
         runtime=runtime,
@@ -467,5 +473,6 @@ async def gen_assembly(
         skip_get_nightlies=skip_get_nightlies,
         ignore_non_x86_nightlies=ignore_non_x86_nightlies,
         gen_microshift=gen_microshift,
+        date=date,
     )
     await pipeline.run()


### PR DESCRIPTION
add elease_date and brew_event key in gen-assembly

test job: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/ximhan/job/build%252Fgen-assembly/10/console
created pr: https://github.com/openshift-eng/ocp-build-data/pull/7200
```
group:
  ....
  release_date: 2025-Oct-30
```