### PR TITLE
allow konflux re-release for non-prod

### DIFF
--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -110,8 +110,8 @@ class CreateReleaseCli:
         release_name = f"ose-{major}-{minor}-{self.release_env}-{get_utc_now_formatted_str()}"
 
         env_config: ShipmentEnv = getattr(config.shipment.environments, self.release_env)
-        if env_config.shipped():
-            LOGGER.warning(
+        if env_config.shipped() and self.release_env == "prod":
+            LOGGER.error(
                 f"existing release metadata is not empty for {self.release_env}: "
                 f"{env_config.model_dump()}. If you want to proceed remove the release metadata from the shipment config and try again."
             )

--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -111,11 +111,10 @@ class CreateReleaseCli:
 
         env_config: ShipmentEnv = getattr(config.shipment.environments, self.release_env)
         if env_config.shipped() and self.release_env == "prod":
-            LOGGER.error(
+            raise ValueError(
                 f"existing release metadata is not empty for {self.release_env}: "
                 f"{env_config.model_dump()}. If you want to proceed remove the release metadata from the shipment config and try again."
             )
-            return None
 
         # Create snapshot first using the spec from shipment config
         LOGGER.info("Creating snapshot from shipment config...")

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -649,8 +649,15 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
         )
 
         # This test checks that pipeline does not create a release when the environment is already shipped
-        result = await cli.run()
+        with self.assertRaises(ValueError) as context:
+            await cli.run()
+
+        self.assertIn(
+            "existing release metadata is not empty for prod: "
+            "{'releasePlan': 'test-prod-rp', 'advisory': {'url': 'https://foo-bar', 'internal_url': 'https://foo-bar-internal'}}"
+            ". If you want to proceed remove the release metadata from the shipment config and try again.",
+            str(context.exception),
+        )
 
         # assert that release did not get created
         self.assertEqual(self.konflux_client._create.call_count, 0)
-        self.assertEqual(result, None)


### PR DESCRIPTION
Right now, re-releases fail: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/jobs/37856445