### PR TITLE
[Konflux] beta:fbc:merge Support pushing via https

### DIFF
--- a/doozer/doozerlib/backend/build_repo.py
+++ b/doozer/doozerlib/backend/build_repo.py
@@ -1,9 +1,11 @@
 import asyncio
 import logging
 import shutil
+import urllib.parse
 from pathlib import Path
 from typing import List, Optional, Sequence, Union, cast
 
+import aiofiles
 from artcommonlib import exectools, git_helper
 from artcommonlib import util as art_util
 from artcommonlib.telemetry import start_as_current_span_async
@@ -20,17 +22,27 @@ class BuildRepo:
     """A class to clone a build source repository into a local directory."""
 
     def __init__(
-        self, url: str, branch: Optional[str], local_dir: Union[str, Path], logger: Optional[logging.Logger] = None
+        self,
+        url: str,
+        branch: Optional[str],
+        local_dir: Union[str, Path],
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
         """Initialize a BuildRepo object.
         :param url: The URL of the build source repository.
         :param branch: The branch of the build source repository to clone. None to not switch to any branch.
         :param local_dir: The local directory to clone the build source repository into.
+        :param username: The username to use for accessing the build source repository (optional).
+        :param password: The password to use for accessing the build source repository (optional).
         :param logger: A logger object to use for logging messages
         """
         self.url = url
         self.branch = branch
         self.local_dir = Path(local_dir)
+        self._username = username
+        self._password = password
         self._commit_hash: Optional[str] = None
         self._logger = logger or LOGGER
 
@@ -45,6 +57,48 @@ class BuildRepo:
         Returns None if the branch has no commits yet.
         """
         return self._commit_hash
+
+    async def _set_credentials(self, username: str, password: str):
+        """Set the credentials for accessing the build source repository.
+        This will store the credentials in the ~/.git-credentials file.
+
+        :param username: The username to use for accessing the build source repository.
+        :param password: The password to use for accessing the build source repository.
+        :raises ValueError: If the username or password is not provided.
+        """
+        self._logger.info("Setting credentials for build source repository")
+        # Generate the credentials string
+        if not username or not password:
+            raise ValueError("Username and password must be provided to set credentials")
+        parsed_url = urllib.parse.urlparse(self.url)
+        domain = parsed_url.netloc.split("@")[-1]
+        new_netloc = f"{urllib.parse.quote(username)}:{urllib.parse.quote(password)}@{domain}"
+        credentials_string = urllib.parse.urlunparse(
+            (parsed_url.scheme, new_netloc, parsed_url.path, parsed_url.params, parsed_url.query, parsed_url.fragment)
+        )
+
+        # Run git config credential.helper store
+        git_config_cmd = ["config", "credential.helper", "store"]
+        await git_helper.run_git_async(git_config_cmd, cwd=str(self.local_dir))
+        # Run git config credential.useHttpPath true
+        git_config_cmd = ["config", "credential.useHttpPath", "true"]
+        await git_helper.run_git_async(git_config_cmd, cwd=str(self.local_dir))
+
+        # Check if the credentials are already set in ~/.git-credentials
+        credentials_file = Path.home() / ".git-credentials"
+        if credentials_file.exists():
+            self._logger.info("Checking if credentials already exist in %s", credentials_file)
+            async with aiofiles.open(credentials_file, "r") as f:
+                lines = await f.readlines()
+            for line in lines:
+                if line.strip() == credentials_string:
+                    self._logger.info("Credentials already set for %s", self.url)
+                    return
+
+        # write credentials to ~/.git-credentials
+        LOGGER.info("Writing credentials to %s", credentials_file)
+        async with aiofiles.open(credentials_file, "a+") as f:
+            await f.write(f"{credentials_string}\n")
 
     def exists(self) -> bool:
         """Check if the local directory already exists."""
@@ -86,6 +140,8 @@ class BuildRepo:
         await self.init()
         await self.set_remote_url(self.url)
         self._commit_hash = None
+        if self._username and self._password:
+            await self._set_credentials(self._username, self._password)
         if self.branch is not None:
             if await self.fetch(self.branch, strict=strict):
                 await self.switch(self.branch)

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -235,6 +235,9 @@ class FbcMergeCli:
             else Path(runtime.working_dir, constants.WORKING_SUBDIR_KONFLUX_FBC_SOURCES, "__merged")
         )
 
+        fbc_git_username = os.environ.get("FBC_GIT_USERNAME")
+        fbc_git_password = os.environ.get("FBC_GIT_PASSWORD")
+
         merger = KonfluxFbcFragmentMerger(
             working_dir=working_dir,
             group=runtime.group,
@@ -243,7 +246,9 @@ class FbcMergeCli:
             dry_run=self.dry_run,
             commit_message=self.message,
             fbc_git_repo=self.fbc_repo,
-            fbc_branch=self.fbc_branch or f"art-{runtime.group}-fbc-stage",
+            fbc_git_branch=self.fbc_branch or f"art-{runtime.group}-fbc-stage",
+            fbc_git_username=fbc_git_username,
+            fbc_git_password=fbc_git_password,
             registry_auth=self.registry_auth,
             konflux_context=self.konflux_context,
             konflux_kubeconfig=self.konflux_kubeconfig,
@@ -280,7 +285,10 @@ class FbcMergeCli:
 )
 @click.option('--skip-checks', default=False, is_flag=True, help='Skip all post build checks')
 @click.option(
-    '--fbc-repo', metavar='FBC_REPO', help='The git repository to push the FBC to.', default=constants.ART_FBC_GIT_REPO
+    '--fbc-repo',
+    metavar='FBC_REPO',
+    help='The git repository to push the FBC to. Use FBC_GIT_USERNAME and FBC_GIT_PASSWORD environment variables to set credentials.',
+    default=constants.ART_FBC_GIT_REPO,
 )
 @click.option(
     '--fbc-branch',


### PR DESCRIPTION
Pushing to https requires credentials. This PR allows to push to FBC repo via https by supplying credentials with `FBC_GIT_USERNAME` and `FBC_GIT_PASSWORD` environment variables. Using https is required in our gitlab CI environment because it firewalls ssh.

Also limit concurrency to avoid overwhelming the registry.