### PR TITLE
Fix microshift pipeline

### DIFF
--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -236,7 +236,7 @@ async def find_builds_cli(
     )
 
     if as_json:
-        _json_dump(as_json, builds, kind)
+        _json_dump(as_json, builds)
         return
     canonical_nvrs = [b.nvr for b in builds]
 

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -743,7 +743,7 @@ async def get_microshift_builds(group, assembly, env):
         with open(path) as f:
             result = json.load(f)
 
-    nvrs = cast(List[str], result["builds"])
+    nvrs = cast(List[str], result)
 
     # microshift builds are special in that they build for each assembly after payload is promoted
     # and they include the assembly name in its build name


### PR DESCRIPTION
the json dump method chaned recently, update the parameter
the error looks like
`TypeError: _json_dump() takes 2 positional arguments but 3 were given`