### PR TITLE
ART-13935 scan-sources-konflux: also output RHCOS and RPMs changes

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -1194,7 +1194,7 @@ class ConfigScanSources:
 @click.option(
     "--ci-kubeconfig",
     metavar='KC_PATH',
-    required=False,
+    required=True,
     help="File containing kubeconfig for looking at release-controller imagestreams",
 )
 @click.option("--yaml", "as_yaml", default=False, is_flag=True, help='Print results in a yaml block')

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -15,7 +15,7 @@ import dateutil.parser
 import pycares
 import yaml
 from artcommonlib import exectools
-from artcommonlib.arch_util import go_arch_for_brew_arch, brew_arch_for_go_arch
+from artcommonlib.arch_util import brew_arch_for_go_arch, go_arch_for_brew_arch
 from artcommonlib.exectools import cmd_gather_async
 from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.konflux.package_rpm_finder import PackageRpmFinder
@@ -1038,9 +1038,9 @@ class ConfigScanSources:
                 pullspec_for_tag = dict()
                 build_id = ""
                 for container_conf in self.runtime.group_config.rhcos.payload_tags:
-                    build_id, pullspec = rhcos.RHCOSBuildFinder(self.runtime, version, brew_arch, private).latest_container(
-                        container_conf
-                    )
+                    build_id, pullspec = rhcos.RHCOSBuildFinder(
+                        self.runtime, version, brew_arch, private
+                    ).latest_container(container_conf)
                     pullspec_for_tag[container_conf.name] = pullspec
                 non_latest_rpms = await rhcos.RHCOSBuildInspector(
                     self.runtime, pullspec_for_tag, brew_arch, build_id

--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -95,7 +95,6 @@ class Ocp4ScanPipeline:
             f'--group={group_param}',
             f'--assembly={self.assembly}',
             '--build-system=konflux',
-            f'--ci-kubeconfig={os.environ["KUBECONFIG"]}',
         ]
         if self.image_list:
             cmd.append(f'--images={self.image_list}')
@@ -103,6 +102,7 @@ class Ocp4ScanPipeline:
             [
                 'beta:config:konflux:scan-sources',
                 '--yaml',
+                f'--ci-kubeconfig={os.environ["KUBECONFIG"]}',
             ]
         )
         if self.runtime.dry_run:

--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import click
 import yaml
@@ -94,6 +95,7 @@ class Ocp4ScanPipeline:
             f'--group={group_param}',
             f'--assembly={self.assembly}',
             '--build-system=konflux',
+            f'--ci-kubeconfig={os.environ["KUBECONFIG"]}',
         ]
         if self.image_list:
             cmd.append(f'--images={self.image_list}')
@@ -131,6 +133,10 @@ class Ocp4ScanPipeline:
 @pass_runtime
 @click_coroutine
 async def ocp4_scan(runtime: Runtime, version: str, assembly: str, data_path: str, data_gitref, image_list: str):
+    # KUBECONFIG env var must be defined in order to scan sources
+    if not os.getenv('KUBECONFIG'):
+        raise RuntimeError('Environment variable KUBECONFIG must be defined')
+
     jenkins.init_jenkins()
 
     pipeline = Ocp4ScanPipeline(


### PR DESCRIPTION
Currently, only ocp4-scan is looking at outdated/updated RHCOS content, and triggers rhcos builds or build-sync pipelines accordingly. We'll eventually need to migrate these operations to the Konflux-specific pipelines, if we ever want to get rid of the OSBS code. This PR takes the first step in that direction, by teaching Konflux scan-sources to look at RHCOS as well.

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/26019/console

Ref. [ART-13935](https://issues.redhat.com/browse/ART-13935)