### PR TITLE
Fix lockfile repo ID extraction to use content_set values

### DIFF
--- a/doozer/doozerlib/lockfile.py
+++ b/doozer/doozerlib/lockfile.py
@@ -232,11 +232,15 @@ class RpmInfoCollector:
                 continue
 
             found_rpms, missing_rpms = repodata.get_rpms(unresolved_rpms, arch)
+
+            content_set_id = repo.content_set(arch)
+            if content_set_id is None:
+                self.logger.warning(f'repo {repo_name} has no content_set for {arch}, falling back to repo key')
+                content_set_id = f'{repo_name}-{arch}'
+
             rpm_info_list.extend(
                 [
-                    RpmInfo.from_rpm(
-                        rpm, repoid=f'{repo_name}-{arch}', baseurl=repo.baseurl(repotype="unsigned", arch=arch)
-                    )
+                    RpmInfo.from_rpm(rpm, repoid=content_set_id, baseurl=repo.baseurl(repotype="unsigned", arch=arch))
                     for rpm in found_rpms
                 ]
             )


### PR DESCRIPTION
## Summary
Fixed lockfile generation to use proper content_set values instead of repository definition keys for repo IDs.

## Problem
**Before:** Lockfile generation used repository definition keys (like "rhel-96-highavailability-x86_64") as repo IDs
**After:** Uses proper content_set values (like "rhel-9-for-x86_64-highavailability-eus-rpms__9_DOT_6") with fallback to original behavior

## Changes
- `doozer/doozerlib/lockfile.py` - Modified _fetch_rpms_info_per_arch method to use repo.content_set(arch) instead of repo key concatenation

**Technical Notes**
- Added content_set_id extraction with architecture-specific handling
- Includes fallback logic when content_set returns None
- Maintains backward compatibility with warning message for repos without content_set