### PR TITLE
fix gen assembly

### DIFF
--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -906,9 +906,9 @@ class GenAssemblyCli:
             raise ValueError("For non standard release you need to manually set release date from job")
         self.logger.info("Release date not provided. Fetching release date from release schedule...")
         try:
-            self.release_date = await get_assembly_release_date_async(self.release_name)
+            self.release_date = await get_assembly_release_date_async(self.gen_assembly_name)
         except Exception as ex:
-            raise ValueError(f"Failed to fetch release date from release schedule for {self.release_name}: {ex}")
+            raise ValueError(f"Failed to fetch release date from release schedule for {self.gen_assembly_name}: {ex}")
         self.logger.info("Release date: %s", self.release_date)
         return self.release_date
 


### PR DESCRIPTION
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgen-assembly/679/

```
Traceback (most recent call last):
  File "/mnt/jenkins-workspace/s-cd-builds_build_gen-assembly_2/art-tools/doozer/doozerlib/cli/release_gen_assembly.py", line 909, in _get_release_date
    self.release_date = await get_assembly_release_date_async(self.release_name)
```

Build succeeded with fix: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgen-assembly/680/