### PR TITLE
[sast] lower priority of requested OSH scans to 9

### DIFF
--- a/doozer/doozerlib/cli/scan_osh.py
+++ b/doozer/doozerlib/cli/scan_osh.py
@@ -362,7 +362,9 @@ class ScanOshCli:
         cmds = []
 
         for nvr in nvrs:
-            cmd = f"osh-cli mock-build --config=auto --profile custom-ocp --nvr {nvr} --nowait"
+            # default priority is 10, set it to 9 so that OCP scans don't cause
+            # long scan delays for other OSH users
+            cmd = f"osh-cli mock-build --config=auto --priority=9 --profile custom-ocp --nvr {nvr} --nowait"
             cmds.append(cmd)
             self.runtime.logger.debug(f"Generating command: {cmd}")
 


### PR DESCRIPTION
OCP scans are often requested on OSH in large batches, and can take several hours to process. This can cause delays for other OSH users, for example those looking to ship async advisories. Let's lower the priority from 10 (default) -> 9, so that OCP scans don't block other scans requestors for long periods.

CC @hpvyas - My understanding is that OSH scans for OCP are not regularly reviewed as part of the release process, so I don't expect this will have any adverse impact.