### PR TITLE
add 4.21 to build-sync override

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -36,5 +36,5 @@ REDIS_PORT = '6379'
 OTEL_EXPORTER_OTLP_ENDPOINT = "http://otel-collector-psi-rhv.hosts.prod.psi.rdu2.redhat.com:4317"
 
 # Sync konflux builds to default (formerly Brew) imagestreams for versions in this list
-KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS = ["4.20", "4.19"]
+KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS = ["4.21", "4.20", "4.19"]
 KONFLUX_ART_IMAGES_SHARE = "quay.io/redhat-user-workloads/ocp-art-tenant/art-images-share"


### PR DESCRIPTION
Sync konflux builds to 4.21 image streams