### PR TITLE
[konflux] update sync_to_quay

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -465,20 +465,6 @@ async def get_konflux_slsa_attestation(pullspec: str, registry_auth_file: Option
 
 async def sync_to_quay(source_pullspec, destination_repo):
     LOGGER.info(f"Syncing image from {source_pullspec} to {destination_repo}")
-    cmd = [
-        'oc',
-        'image',
-        'mirror',
-        '--keep-manifest-list',
-        source_pullspec,
-        destination_repo,
-    ]
-
-    konflux_registry_auth_file = os.getenv("KONFLUX_ART_IMAGES_AUTH_FILE")
-    if konflux_registry_auth_file:
-        cmd += [f'--registry-config={konflux_registry_auth_file}']
-
-    await asyncio.wait_for(cmd_assert_async(cmd), timeout=7200)
 
     # Sync the builds to a "sha" tag as well to prevent it from being garbage collected in quay
     shasum = source_pullspec.split("@sha256:")[1]
@@ -488,9 +474,11 @@ async def sync_to_quay(source_pullspec, destination_repo):
         'image',
         'mirror',
         '--keep-manifest-list',
-        f"{destination_repo}@sha256:{shasum}",
+        source_pullspec,
         f"{destination_repo}:sha256-{shasum}",
     ]
+
+    konflux_registry_auth_file = os.getenv("KONFLUX_ART_IMAGES_AUTH_FILE")
     if konflux_registry_auth_file:
         cmd += [f'--registry-config={konflux_registry_auth_file}']
     await asyncio.wait_for(cmd_assert_async(cmd), timeout=7200)


### PR DESCRIPTION
Syncing the build to the tag, should sync the manifest SHA as well