### PR TITLE
[konflux] switch 4.17 and 4.15 to konflux builds

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -36,5 +36,5 @@ REDIS_PORT = '6379'
 OTEL_EXPORTER_OTLP_ENDPOINT = "http://otel-collector-psi-rhv.hosts.prod.psi.rdu2.redhat.com:4317"
 
 # Sync konflux builds to default (formerly Brew) imagestreams for versions in this list
-KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS = ["4.21", "4.20", "4.19"]
+KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS = ["4.21", "4.20", "4.19", "4.17", "4.15"]
 KONFLUX_ART_IMAGES_SHARE = "quay.io/redhat-user-workloads/ocp-art-tenant/art-images-share"


### PR DESCRIPTION
4.17 and 4.15 are next in line: https://app.smartsheet.com/b/publish?EQBCT=970c5ff6c67a4ca7a153e3a6ef993e77