### PR TITLE
insert docs advisory urls

### DIFF
--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -22,7 +22,7 @@ from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
 from elliottlib.runtime import Runtime
 from elliottlib.shipment_model import CveAssociation, ReleaseNotes
 from elliottlib.shipment_utils import get_shipment_config_from_mr, set_bugzilla_bug_ids
-from elliottlib.util import get_advisory_boilerplate
+from elliottlib.util import get_advisory_boilerplate, get_advisory_docs_info
 
 YAML = new_roundtrip_yaml_handler()
 
@@ -233,6 +233,9 @@ class AttachCveFlaws:
                 art_advisory_key=self.advisory_kind,
                 errata_type='RHSA',
             )
+            # Get advisory docs info from shipment config
+            advisory_type, live_id, current_year = get_advisory_docs_info(self.runtime, self.advisory_kind)
+
             release_notes.synopsis = cve_boilerplate['synopsis'].format(MINOR=self.minor, PATCH=self.patch)
             highest_impact = get_highest_security_impact(flaw_bugs)
             release_notes.topic = cve_boilerplate['topic'].format(
@@ -244,8 +247,14 @@ class AttachCveFlaws:
             formatted_cve_list = '\n'.join(
                 [f'* {b.summary.replace(b.alias[0], "").strip()} ({b.alias[0]})' for b in flaw_bugs]
             )
+
             release_notes.description = cve_boilerplate['description'].format(
-                CVES=formatted_cve_list, MINOR=self.minor, PATCH=self.patch
+                CVES=formatted_cve_list,
+                MINOR=self.minor,
+                PATCH=self.patch,
+                ADVISORY_TYPE=advisory_type,
+                YEAR=current_year,
+                LIVE_ID=live_id,
             )
         elif self.reconcile:
             # Convert RHSA back to RHBA
@@ -271,10 +280,16 @@ class AttachCveFlaws:
                 art_advisory_key=self.advisory_kind,
                 errata_type='RHBA',
             )
+
+            # Get advisory docs info from shipment config
+            advisory_type, live_id, current_year = get_advisory_docs_info(self.runtime, self.advisory_kind)
+
             release_notes.synopsis = boilerplate['synopsis'].format(MINOR=self.minor, PATCH=self.patch)
             release_notes.topic = boilerplate['topic'].format(MINOR=self.minor, PATCH=self.patch)
             release_notes.solution = boilerplate['solution'].format(MINOR=self.minor, PATCH=self.patch)
-            release_notes.description = boilerplate['description'].format(MINOR=self.minor, PATCH=self.patch)
+            release_notes.description = boilerplate['description'].format(
+                MINOR=self.minor, PATCH=self.patch, ADVISORY_TYPE=advisory_type, YEAR=current_year, LIVE_ID=live_id
+            )
 
     async def handle_brew_cve_flaws(self):
         """

--- a/elliott/elliottlib/cli/shipment_cli.py
+++ b/elliott/elliottlib/cli/shipment_cli.py
@@ -17,7 +17,7 @@ from elliottlib.shipment_model import (
     ShipmentConfig,
     ShipmentEnv,
 )
-from elliottlib.util import get_advisory_boilerplate
+from elliottlib.util import get_advisory_boilerplate, get_advisory_docs_info
 
 LOGGER = logutil.get_logger(__name__)
 
@@ -63,9 +63,15 @@ class InitShipmentCli:
             advisory_boilerplate = get_advisory_boilerplate(
                 runtime=self.runtime, et_data=et_data, art_advisory_key=self.kind, errata_type="RHBA"
             )
+
+            # Get advisory docs info from shipment config
+            advisory_type, live_id, current_year = get_advisory_docs_info(self.runtime, self.kind)
+
             synopsis = advisory_boilerplate['synopsis'].format(MINOR=minor, PATCH=patch)
             advisory_topic = advisory_boilerplate['topic'].format(MINOR=minor, PATCH=patch)
-            advisory_description = advisory_boilerplate['description'].format(MINOR=minor, PATCH=patch)
+            advisory_description = advisory_boilerplate['description'].format(
+                MINOR=minor, PATCH=patch, ADVISORY_TYPE=advisory_type, YEAR=current_year, LIVE_ID=live_id
+            )
             advisory_solution = advisory_boilerplate['solution'].format(MINOR=minor, PATCH=patch)
 
             data = Data(

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -635,7 +635,7 @@ def get_advisory_docs_info(runtime, advisory_kind):
     # Image advisory has a link to the RPM advisory and the RPM advisory has a link to the image advisory
     if advisory_kind == 'image':
         advisory_type, live_id = get_advisory_info_from_shipment('rpm')
-    elif advisory_kind in ['rpm', 'extras']:
+    elif advisory_kind in ['extras']: # TODO: Add 'rpm' to this list, once it moves over to konflux
         advisory_type, live_id = get_advisory_info_from_shipment('image')
     else:
         advisory_type, live_id = None, None


### PR DESCRIPTION
In the Docs template: https://github.com/openshift-eng/ocp-build-data/blob/main/config/advisory_templates.yml

The image advisory has a link to the rpm advisory and rpm and extras have a link to the image advisory. For example:
- https://github.com/openshift-eng/ocp-build-data/blob/main/config/advisory_templates.yml#L23
- https://github.com/openshift-eng/ocp-build-data/blob/main/config/advisory_templates.yml#L121
- https://github.com/openshift-eng/ocp-build-data/blob/main/config/advisory_templates.yml#L191

Since we already know the live ID and advisory type in advance, insert the urls so that the Docs team don't have to manually update them everytime.

For https://github.com/openshift-eng/ocp-build-data/pull/7340