### PR TITLE
  fix(elliott): resolve conforma CLI runtime AttributeError

### DIFF
--- a/elliott/elliottlib/cli/conforma_cli.py
+++ b/elliott/elliottlib/cli/conforma_cli.py
@@ -1,4 +1,5 @@
 import base64
+import copy
 import json
 import os
 import sys
@@ -487,6 +488,18 @@ class ConformaVerifyCli:
             LOGGER.warning("✗ Batch verification failed")
 
         return result
+
+    def _truncate_violations_for_yaml(self, result: Dict) -> Dict:
+        """Create a truncated version of results for YAML output (only first 10 violation codes)."""
+        truncated = copy.deepcopy(result)
+
+        if "nvr_results" in truncated:
+            for nvr_data in truncated["nvr_results"].values():
+                if "violations" in nvr_data and "codes" in nvr_data["violations"]:
+                    # Keep only first 10 violation codes for cleaner YAML output
+                    nvr_data["violations"]["codes"] = nvr_data["violations"]["codes"][:10]
+
+        return truncated
 
 
 @cli.command("verify-conforma", short_help="Verify given builds (NVRs) with Conforma")


### PR DESCRIPTION
## Summary
  Fixed missing method in Elliott's verify-conforma command that was causing runtime failures during enterprise contract validation workflows.

## Problem
  **Before:** The verify-conforma command failed with AttributeError when processing compliance validation results:
  ```
     AttributeError: 'ConformaVerifyCli' object has no attribute '_truncate_violations_for_yaml'
      at elliott/elliottlib/cli/conforma_cli.py:269
      truncated_for_yaml = self._truncate_violations_for_yaml(progressive_result)
```

  **After:** The verify-conforma command completes successfully, generating proper results.yaml output with truncated violation codes for readable YAML formatting.

  **Technical Notes**
The missing method was called during progressive results writing but never implemented. The fix adds the method to properly truncate violation codes to the first 10 entries for cleaner YAML output, preventing overly verbose result files while maintaining full compliance data.
  