### PR TITLE
Make images-health configurable

### DIFF
--- a/doozer/doozerlib/cli/images_health.py
+++ b/doozer/doozerlib/cli/images_health.py
@@ -6,7 +6,6 @@ import urllib.parse
 
 import click
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBuildRecord
-from sqlalchemy.testing.plugin.plugin_base import engines
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from doozerlib import Runtime
@@ -80,9 +79,9 @@ class ImagesHealthPipeline:
         key = image_meta.distgit_key
         builds = await self.query(image_meta, engine)
         if not builds:
-            self.logger.info(
-                'Image build for %s has never been attempted during last %s days', image_meta.distgit_key, DELTA_DAYS
-            )
+            message = f'Image build for {image_meta.distgit_key} has never been attempted during last {DELTA_DAYS} days'
+            self.logger.info(message)
+            self.add_concern(key, engine, message)
             return
 
         latest_success_idx = -1

--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -7,31 +7,56 @@ from artcommonlib.constants import KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS
 
 from pyartcd import util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.constants import OCP_BUILD_DATA_URL
 from pyartcd.runtime import Runtime
 
 
 class ImagesHealthPipeline:
-    def __init__(self, runtime: Runtime, version: str, send_to_release_channel: bool, send_to_forum_ocp_art: bool):
+    def __init__(
+        self,
+        runtime: Runtime,
+        version: str,
+        send_to_release_channel: bool,
+        send_to_forum_ocp_art: bool,
+        data_path: str,
+        data_gitref: str,
+        image_list: str,
+    ):
         self.runtime = runtime
         self.doozer_working = self.runtime.working_dir / "doozer_working"
         self.version = version
         self.send_to_release_channel = send_to_release_channel
         self.send_to_forum_ocp_art = send_to_forum_ocp_art
+        self.data_path = data_path
+        self.data_gitref = data_gitref
+        self.image_list = image_list.split(',') if image_list else []
         self.report = {}
 
     async def run(self):
         # Check if automation is frozen for current group
-        if not await util.is_build_permitted(self.version, doozer_working=self.doozer_working):
+        if not await util.is_build_permitted(
+            self.version,
+            doozer_working=str(self.doozer_working),
+            data_path=self.data_path,
+            doozer_data_gitref=self.data_gitref,
+        ):
             self.runtime.logger.info('Skipping this build as it\'s not permitted')
             return
 
         # Get doozer report
+        group_param = f'--group=openshift-{self.version}'
+        if self.data_gitref:
+            group_param += f'@{self.data_gitref}'
         cmd = [
             'doozer',
             f'--working-dir={self.doozer_working}',
-            f'--group=openshift-{self.version}',
-            'images:health',
+            f'--data-path={self.data_path}',
+            group_param,
         ]
+        if self.image_list:
+            cmd.append(f'--images={",".join(self.image_list)}')
+        cmd.append('images:health')
+
         _, out, err = await exectools.cmd_gather_async(cmd, stderr=None)
         self.report = json.loads(out.strip())
         self.runtime.logger.info('images:health output for openshift-%s:\n%s', self.version, out)
@@ -44,7 +69,7 @@ class ImagesHealthPipeline:
             return True
         if engine == "brew":
             return self.version not in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS
-        raise ValueError(f'Engine {self.engine} not recognized')
+        raise ValueError(f'Engine {engine} not recognized')
 
     async def _send_notifications(self, engine):
         slack_client = self.runtime.new_slack_client()
@@ -83,7 +108,29 @@ class ImagesHealthPipeline:
 @click.option('--version', required=True, help='OCP version to scan')
 @click.option('--send-to-release-channel', is_flag=True, help='If true, send output to #art-release-4-<version>')
 @click.option('--send-to-forum-ocp-art', is_flag=True, help='"If true, send notification to #forum-ocp-art')
+@click.option(
+    '--data-path',
+    required=False,
+    default=OCP_BUILD_DATA_URL,
+    help='ocp-build-data fork to use (e.g. assembly definition in your own fork)',
+)
+@click.option('--data-gitref', required=False, default='', help='Doozer data path git [branch / tag / sha] to use')
+@click.option(
+    '--image-list',
+    required=False,
+    help='Comma/space-separated list to include/exclude per --image-build-strategy (e.g. ironic,hypershift)',
+)
 @pass_runtime
 @click_coroutine
-async def images_health(runtime: Runtime, version: str, send_to_release_channel: bool, send_to_forum_ocp_art: bool):
-    await ImagesHealthPipeline(runtime, version, send_to_release_channel, send_to_forum_ocp_art).run()
+async def images_health(
+    runtime: Runtime,
+    version: str,
+    send_to_release_channel: bool,
+    send_to_forum_ocp_art: bool,
+    data_path: str,
+    data_gitref: str,
+    image_list: str,
+):
+    await ImagesHealthPipeline(
+        runtime, version, send_to_release_channel, send_to_forum_ocp_art, data_path, data_gitref, image_list
+    ).run()


### PR DESCRIPTION
### Images health improvements: configurability and stricter missing-build detection

- **Scope**: `pyartcd` pipeline (`pyartcd/pyartcd/pipelines/images_health.py`), `doozer` CLI health scan (`doozer/doozerlib/cli/images_health.py`)
- **Commits**:
  - 923e5c1a — Treat missing builds in DELTA_DAYS as an issue
  - 82b24238 — Make images-health configurable

### What changed
- **Treat missing builds as a concern** (doozer)
  - If no builds are found within `DELTA_DAYS`, we now log the situation and record a concern via `add_concern(...)` so it surfaces in the health report and notifications.
  - Removed an unused import.

- **Configurable images-health pipeline** (pyartcd)
  - Added optional parameters propagated to `doozer` and `is_build_permitted`:
    - `--data-path` (defaults to `OCP_BUILD_DATA_URL`)
    - `--data-gitref` (optional ref for ocp-build-data; used as `openshift-<version>@<gitref>`)
    - `--image-list` (comma-separated list to include/exclude per strategy; forwarded as `--images` to `doozer`)
  - Ensures `doozer_working` is passed as a string path where required.
  - Improved error messaging when engine is unrecognized.

### Why
- Ensure images with no attempted builds in the recent window are treated as actionable issues, not silently ignored.
- Allow targeted scans and use of forks/branches of `ocp-build-data` for experimentation or assembly-specific checks.

### Impact
- Health reports and downstream notifications will now include concerns for images with no builds in the last `DELTA_DAYS`.
- Existing usage remains compatible: new CLI options are optional with sensible defaults.

### Usage examples
- Default run (no changes to current behavior):
```bash
pyartcd images-health --version 4.18
```

- Using a custom data source and ref, targeting a subset of images and sending to the release channel:
```bash
pyartcd images-health \
  --version 4.18 \
  --data-path https://github.com/yourfork/ocp-build-data.git \
  --data-gitref my-feature-branch \
  --image-list ironic,hypershift \
  --send-to-release-channel
```

### Files changed
- `doozer/doozerlib/cli/images_health.py`
- `pyartcd/pyartcd/pipelines/images_health.py`
