### PR TITLE
Update build-data after an advisory is created

### DIFF
--- a/doozer/tests/cli/test_scan_sources_konflux.py
+++ b/doozer/tests/cli/test_scan_sources_konflux.py
@@ -3,7 +3,7 @@ import json
 import random
 from datetime import datetime, timezone
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import yaml
@@ -335,7 +335,7 @@ class TestGetCurrentTaskBundleShas(TestScanSourcesKonflux):
         """Test successful fetching and parsing of task bundle SHAs."""
         # Mock successful HTTP response
         mock_response = AsyncMock()
-        mock_response.raise_for_status = Mock()
+        mock_response.raise_for_status = AsyncMock()
         mock_response.text = AsyncMock(return_value=yaml.dump(self.sample_yaml))
 
         self.session.get.return_value.__aenter__.return_value = mock_response
@@ -354,8 +354,8 @@ class TestGetCurrentTaskBundleShas(TestScanSourcesKonflux):
         """Test handling of HTTP errors when fetching from GitHub."""
         # Mock HTTP error
         mock_response = AsyncMock()
-        mock_response.raise_for_status = Mock(
-            side_effect=aiohttp.ClientResponseError(request_info=MagicMock(), history=[], status=404)
+        mock_response.raise_for_status.side_effect = aiohttp.ClientResponseError(
+            request_info=MagicMock(), history=[], status=404
         )
 
         self.session.get.return_value.__aenter__.return_value = mock_response
@@ -368,7 +368,7 @@ class TestGetCurrentTaskBundleShas(TestScanSourcesKonflux):
         """Test handling of YAML parsing errors."""
         # Mock successful HTTP response with invalid YAML
         mock_response = AsyncMock()
-        mock_response.raise_for_status = Mock()
+        mock_response.raise_for_status = AsyncMock()
         mock_response.text = AsyncMock(return_value="invalid: yaml: content: [unclosed")
 
         self.session.get.return_value.__aenter__.return_value = mock_response
@@ -382,7 +382,7 @@ class TestGetCurrentTaskBundleShas(TestScanSourcesKonflux):
         yaml_without_tasks = {"spec": {"resources": []}}
 
         mock_response = AsyncMock()
-        mock_response.raise_for_status = Mock()
+        mock_response.raise_for_status = AsyncMock()
         mock_response.text = AsyncMock(return_value=yaml.dump(yaml_without_tasks))
 
         self.session.get.return_value.__aenter__.return_value = mock_response
@@ -430,7 +430,7 @@ class TestGetCurrentTaskBundleShas(TestScanSourcesKonflux):
         }
 
         mock_response = AsyncMock()
-        mock_response.raise_for_status = Mock()
+        mock_response.raise_for_status = AsyncMock()
         mock_response.text = AsyncMock(return_value=yaml.dump(nested_yaml))
 
         self.session.get.return_value.__aenter__.return_value = mock_response

--- a/pyartcd/tests/pipelines/test_prepare_release_konflux.py
+++ b/pyartcd/tests/pipelines/test_prepare_release_konflux.py
@@ -385,7 +385,7 @@ class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
             slack_client=self.mock_slack_client,
             runtime=self.runtime,
             group=self.group,
-            assembly=self.assembly,
+            assembly="4.18.0",  # Use the assembly that matches releases_config
         )
         pipeline.release_date = "2024-07-01"
         pipeline.assembly_type = AssemblyTypes.STANDARD

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -152,8 +152,6 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
     )
     @patch("pyartcd.pipelines.promote.util.load_group_config", return_value=dict(arches=["x86_64", "s390x"]))
     async def test_run_with_stream_assembly(self, load_group_config: AsyncMock, load_releases_config: AsyncMock, _):
-        mock_slack_client = AsyncMock()
-        mock_slack_client.bind_channel = Mock()  # bind_channel is synchronous
         runtime = MagicMock(
             config={
                 "build_config": {
@@ -166,11 +164,10 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             working_dir=Path("/path/to/working"),
             dry_run=False,
         )
-        runtime.new_slack_client.return_value = mock_slack_client
         pipeline = await PromotePipeline.create(
             runtime, group="openshift-4.10", assembly="stream", signing_env="prod", skip_sigstore=True
         )
-        with self.assertRaisesRegex(ValueError, "missing the required.*upgrades.*field"):
+        with self.assertRaisesRegex(ValueError, "not supported"):
             await pipeline.run()
         load_group_config.assert_awaited_once()
         load_releases_config.assert_awaited_once_with(


### PR DESCRIPTION
slack ref: https://redhat-internal.slack.com/archives/C05FEGT8SH2/p1755796051305789?thread_ts=1755787879.981409&cid=C05FEGT8SH2

If ocp-build-data is not updated here, then find-bugs and attach-cve-flaws cannot find the newly created advisory