### PR TITLE
Fix RPM part in ocp4{-konflux} title on Jenkins

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -219,6 +219,12 @@ class Ocp4Pipeline:
         jenkins.update_description('Pinned builds (whether source changed or not).<br/>')
         self.runtime.logger.info('Pinned builds (whether source changed or not)')
 
+        if self.version in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS:
+            self.runtime.logger.info(
+                'Skipping RPM rebase and build for %s since it is being handled by ocp4-konflux', {self.version}
+            )
+            self.build_plan.build_rpms = None
+
         if not self.build_plan.build_rpms:
             jenkins.update_description('RPMs: not building.<br/>')
 
@@ -308,12 +314,6 @@ class Ocp4Pipeline:
     async def _rebase_and_build_rpms(self):
         if not self.build_plan.build_rpms:
             self.runtime.logger.info('Not building RPMs.')
-            return
-
-        if self.version in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS:
-            self.runtime.logger.info(
-                'Skipping RPM rebase and build for %s since it is being handled by ocp4-konflux', {self.version}
-            )
             return
 
         cmd = self._doozer_base_command.copy()

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -473,6 +473,14 @@ class KonfluxOcp4Pipeline:
             jenkins.update_title(' [MASS REBUILD]')
 
     def check_building_rpms(self):
+        # If the version is not in the override list, skip the RPM rebase and build
+        # TODO this can be removed once all versions are handled by ocp4-konflux
+        if self.version not in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS:
+            self.runtime.logger.info(
+                'Skipping RPM rebase and build for %s since it is being handled by ocp4', {self.version}
+            )
+            self.build_plan.rpm_build_strategy = BuildStrategy.NONE
+
         if self.build_plan.rpm_build_strategy == BuildStrategy.NONE:
             jenkins.update_title('[NO RPMs]')
 
@@ -670,14 +678,6 @@ class KonfluxOcp4Pipeline:
             self.build_plan.rpm_build_strategy == BuildStrategy.ONLY and not self.build_plan.rpms_included
         ) or self.build_plan.rpm_build_strategy == BuildStrategy.NONE:
             LOGGER.warning('No RPMs will be built')
-            return
-
-        # If the version is not in the override list, skip the RPM rebase and build
-        # TODO this can be removed once all versions are handled by ocp4-konflux
-        if self.version not in KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS:
-            self.runtime.logger.info(
-                'Skipping RPM rebase and build for %s since it is being handled by ocp4', {self.version}
-            )
             return
 
         cmd = self._doozer_base_command.copy()


### PR DESCRIPTION
`ocp4` and `ocp4-konflux` are erroneously tagging what RPSs are being built in the Jenkins build title. This comes from mistakingly checking for the RPM build strategy in the build plan initialization, without checking whether the building release belongs to the KONFLUX_IMAGESTREAM_OVERRIDE_VERSIONS constant. 