### PR TITLE
Handle istag with null annotations when checking number of accepted multi nightlies

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -1679,7 +1679,8 @@ class GenPayloadCli:
                 # nightly to a new one.
                 def is_accepted(tag):
                     # Returns true if the imagestream tag has been accepted.
-                    return tag.get('annotations', dict()).get('release.openshift.io/phase', 'Unknown') == 'Accepted'
+                    annotations = tag.get('annotations') or {}  # Handle `annotations: null`
+                    return annotations.get('release.openshift.io/phase', 'Unknown') == 'Accepted'
 
                 release_tags: List = obj_model.spec["tags"]._primitive()
                 new_release_tags = release_tags[-5:]  # Preserve the most recent five


### PR DESCRIPTION
When pruning multi-arch nightlies, we look at existing tags to ensure at least 2 accepted nightlies remain. The `is_accepted` function crashes when processing istag that has `annotations: null`