### PR TITLE
Let oc login into the QCI registry

### DIFF
--- a/pyartcd/pyartcd/oc.py
+++ b/pyartcd/pyartcd/oc.py
@@ -53,16 +53,39 @@ async def get_release_image_info(pullspec: str, raise_if_not_found: bool = False
     return info
 
 
-async def registry_login(runtime: Runtime):
+async def registry_login():
+    """
+    Login into OC registry using KUBECONFIG env var
+    """
+
     try:
         await exectools.cmd_gather_async(f'oc --kubeconfig {os.environ["KUBECONFIG"]} registry login')
 
     except KeyError:
-        runtime.logger.error('KUBECONFIG env var must be defined!')
+        logger.error('KUBECONFIG env var must be defined!')
         raise
 
     except ChildProcessError:
-        runtime.logger.error('Failed to login into OC registry')
+        logger.error('Failed to login into OC registry')
+        raise
+
+
+async def qci_registry_login():
+    """
+    Log in to quay.io with credentials necessary to push to DPTP's QCI registry (quay.io/openshift/ci)
+    """
+
+    try:
+        await exectools.cmd_gather_async(
+            f'oc registry login --registry=quay.io/openshift --auth-basic={os.environ["QCI_USER"]}:{os.environ["QCI_PASSWORD"]}'
+        )
+
+    except KeyError:
+        logger.error('QCI_USER and QCI_PASSWORD env vars must be defined!')
+        raise
+
+    except ChildProcessError:
+        logger.error('Failed to login into QCI registry')
         raise
 
 

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -98,7 +98,7 @@ class BuildMicroShiftPipeline:
 
     async def run(self):
         # Make sure our api.ci token is fresh
-        await oc.registry_login(self.runtime)
+        await oc.registry_login()
 
         group_config = await load_group_config(self.group, self.assembly, env=self._doozer_env_vars)
         advisories = group_config.get("advisories", {})

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -83,7 +83,7 @@ class BuildMicroShiftBootcPipeline:
 
     async def run(self):
         # Make sure our api.ci token is fresh
-        await oc.registry_login(self.runtime)
+        await oc.registry_login()
         self.releases_config = await load_releases_config(
             group=self.group,
             data_path=self._doozer_env_vars["DOOZER_DATA_PATH"],

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -171,7 +171,7 @@ class BuildSyncPipeline:
             await self.comment_on_assembly_pr(text_body)
 
         # Make sure we're logged into the OC registry
-        await registry_login(self.runtime)
+        await registry_login()
 
         # Should we retrigger current nightly?
         if self.retrigger_current_nightly:

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -567,7 +567,12 @@ class Ocp4Pipeline:
             self.runtime.logger.warning('apiserver rebuilt: mirroring streams to CI...')
 
             # Make sure our api.ci token is fresh
-            await oc.registry_login(self.runtime)
+            await oc.registry_login()
+
+            # Log into QCI registry
+            await oc.qci_registry_login()
+
+            # Mirror out ART equivalent images to CI
             cmd = self._doozer_base_command.copy()
             cmd.extend(['images:streams', 'mirror'])
             await exectools.cmd_assert_async(cmd)

--- a/pyartcd/tests/pipelines/test_ocp4.py
+++ b/pyartcd/tests/pipelines/test_ocp4.py
@@ -316,11 +316,12 @@ class TestBuilds(unittest.IsolatedAsyncioTestCase):
     @patch("pyartcd.util.default_release_suffix", return_value="2100123111.p?")
     @patch("artcommonlib.exectools.cmd_gather_async", autospec=True, return_value=(0, "rhaos-4.11-rhel-8", ""))
     @patch("pyartcd.util.load_group_config", return_value={'software_lifecycle': {'phase': 'release'}})
+    @patch("pyartcd.oc.qci_registry_login")
     @patch("pyartcd.oc.registry_login")
     @patch("pyartcd.record.parse_record_log")
     @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_build_and_rebase_images(
-        self, cmd_assert_mock: AsyncMock, parse_record_log_mock, registry_login_mock, *_
+        self, cmd_assert_mock: AsyncMock, parse_record_log_mock, registry_login_mock, qci_login_mock, *_
     ):
         parse_record_log_mock.return_value = {}
 
@@ -351,6 +352,7 @@ class TestBuilds(unittest.IsolatedAsyncioTestCase):
             ],
         )
         registry_login_mock.assert_not_awaited()
+        qci_login_mock.assert_not_awaited()
 
         # Exclude images
         cmd_assert_mock.reset_mock()
@@ -375,6 +377,7 @@ class TestBuilds(unittest.IsolatedAsyncioTestCase):
             ],
         )
         registry_login_mock.assert_not_awaited()
+        qci_login_mock.assert_not_awaited()
 
         # Dry run
         cmd_assert_mock.reset_mock()
@@ -385,6 +388,7 @@ class TestBuilds(unittest.IsolatedAsyncioTestCase):
         await self.ocp4._build_images()
         cmd_assert_mock.assert_not_awaited()
         registry_login_mock.assert_not_awaited()
+        qci_login_mock.assert_not_awaited()
 
         # ApiServer rebuilt
         cmd_assert_mock.reset_mock()
@@ -397,6 +401,7 @@ class TestBuilds(unittest.IsolatedAsyncioTestCase):
         self.ocp4.build_plan.images_excluded = []
         await self.ocp4._build_images()
         registry_login_mock.assert_awaited_once()
+        qci_login_mock.assert_awaited_once()
         cmd_assert_mock.assert_awaited_with(
             [
                 'doozer',


### PR DESCRIPTION
The only usage I've found of `doozer images:streams mirror` is by the `ocp4` pipeline. Log into the QCI registry before mirroring images.