### PR TITLE
Fix ocp4 title and description; do not sweep unless needed

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -224,7 +224,10 @@ class Ocp4Pipeline:
                 'Skipping RPM rebase and build for %s since it is being handled by ocp4-konflux', {self.version}
             )
             self.build_plan.build_rpms = None
+            self.build_plan.rpms_included = []
+            self.build_plan.rpms_excluded = []
 
+        # Update description with building RPMs
         if not self.build_plan.build_rpms:
             jenkins.update_description('RPMs: not building.<br/>')
 
@@ -237,6 +240,7 @@ class Ocp4Pipeline:
         else:
             jenkins.update_description('RPMs: building all.<br/>')
 
+        # Update title with building RPMs
         if self.build_plan.rpms_included:
             jenkins.update_title(self._display_tag_for(self.build_plan.rpms_included, 'RPM'))
 
@@ -246,8 +250,10 @@ class Ocp4Pipeline:
         elif self.build_plan.build_rpms:
             jenkins.update_title(' [all RPMs]')
 
-        jenkins.update_description('Will create RPM compose.<br/>')
+        else:
+            jenkins.update_title(' [no RPMs]')
 
+        # Update description with building images
         if not self.build_plan.build_images:
             jenkins.update_description('Images: not building.<br/>')
 
@@ -268,6 +274,7 @@ class Ocp4Pipeline:
         else:
             jenkins.update_description('Images: building all.<br/>')
 
+        # Update title with building images
         if self.build_plan.images_included:
             jenkins.update_title(self._display_tag_for(self.build_plan.images_included, 'image'))
 
@@ -276,6 +283,13 @@ class Ocp4Pipeline:
 
         elif self.build_plan.build_images:
             jenkins.update_title(' [all images]')
+
+        else:
+            jenkins.update_title(' [no images]')
+
+        # Update description with plashets info
+        if not self.skip_plashets:
+            jenkins.update_description('Will create RPM compose.<br/>')
 
     def _report(self, msg: str):
         """
@@ -797,7 +811,9 @@ class Ocp4Pipeline:
         await self._sync_images()
 
         # Find MODIFIED bugs for the target-releases, and set them to ON_QA
-        await self._sweep()
+        # but only if there were RPMs or images built
+        if self.build_plan.build_rpms or self.build_plan.build_images:
+            await self._sweep()
 
         # All good
         self._report_success()


### PR DESCRIPTION
### Description

This PR introduces a few fixes and improvements to the ocp4 pipeline:

1.  **More Accurate Jenkins Job Status:** The Jenkins job title and description have been improved to provide a clearer and more accurate status of the build process. Specifically:
    *   The title now indicates whether all, some, or no RPMs/images are being built.
    *   The description is updated to reflect the build plan for RPMs and images.
    *   The message about creating an RPM compose is now only displayed when it's relevant.

2.  **Conditional Bug Sweep:** The bug sweep, which transitions bugs from `MODIFIED` to `ON_QA`, will now only run if there were actual RPMs or images built during the pipeline execution. This prevents unnecessary bug state changes when no artifacts are produced.

3.  **Build Plan Consistency:** When RPM builds are handled by `ocp4-konflux` and skipped in this pipeline, the `rpms_included` and `rpms_excluded` lists are now properly cleared to ensure a consistent build plan state.