### PR TITLE
Revert "also get inflight for konflux release"

### DIFF
--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -75,7 +75,7 @@ class GenAssemblyPipeline:
         self.gen_microshift = gen_microshift
         if in_flight:
             self.in_flight = in_flight
-        elif not custom and not pre_ga_mode:
+        elif not custom and not pre_ga_mode and build_system == 'brew':
             self.in_flight = get_inflight(assembly, group)
         else:
             self.in_flight = None


### PR DESCRIPTION
Reverts openshift-eng/art-tools#1942
there are some issue that need Authentication credentials
{"detail":"Authentication credentials were not provided."}