### PR TITLE
retry to fix flakes ocp4_konflux

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -581,6 +581,7 @@ def update_title(title: str, append: bool = True):
 
 
 @check_env_vars
+@retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(10))
 def update_description(description: str, append: bool = True):
     """
     Set build description to <description>. If append is True, retrieve current description,


### PR DESCRIPTION
Seeing multiple failures, for example https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/16627/

```
  File "/mnt/jenkins-workspace/aos-cd-builds_build_ocp4-konflux@5/art-tools/pyartcd/pyartcd/pipelines/ocp4_konflux.py", line 312, in sync_images
    jenkins.update_description(f'{len(failed_images)} images failed. Check record.log for details<br/>')
  File "/mnt/jenkins-workspace/aos-cd-builds_build_ocp4-konflux@5/art-tools/pyartcd/pyartcd/jenkins.py", line 128, in wrapped
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/jenkins-workspace/aos-cd-builds_build_ocp4-konflux@5/art-tools/pyartcd/pyartcd/jenkins.py", line 588, in update_description
    job = jenkins_client.get_job(current_job_name)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/jenkins-workspace/aos-cd-builds_build_ocp4-konflux@5/art-venv/lib64/python3.11/site-packages/jenkinsapi/jenkins.py", line 171, in get_job
...
OSError: Could not find a suitable TLS CA certificate bundle, invalid path: /mnt/jenkins-workspace/aos-cd-builds_build_ocp4-konflux@5/art-venv/lib64/python3.11/site-packages/certifi/cacert.pem
```

Adding a retry should fix this issue