### PR TITLE
feat(doozer): enhance get_rpms to extract names from NVRs and return all versions

### DIFF
--- a/doozer/doozerlib/repodata.py
+++ b/doozer/doozerlib/repodata.py
@@ -185,11 +185,18 @@ class Repodata:
         not_found: list[str] = []
 
         for item in items:
-            # Find RPMs matching name/nvr AND (arch or noarch)
+            rpm_name = item
+
+            try:
+                parsed = parse_nvr(item)
+                extracted_name = parsed.get('name')
+                if extracted_name:
+                    rpm_name = extracted_name
+            except Exception:
+                pass
+
             matching_rpms = [
-                rpm
-                for rpm in self.primary_rpms
-                if (rpm.name == item or rpm.nvr == item) and (rpm.arch == arch or rpm.arch == 'noarch')
+                rpm for rpm in self.primary_rpms if rpm.name == rpm_name and (rpm.arch == arch or rpm.arch == 'noarch')
             ]
 
             if not matching_rpms:


### PR DESCRIPTION
## Summary
Enhanced the `get_rpms` method in repodata.py to automatically extract RPM names from NVR inputs and return all available versions instead of requiring exact matches.

## Problem
**Before:** `get_rpms` only returned exact NVR matches when given an NVR like `pam-1.5.1-24.el9_4`, returning only that specific version
**After:** `get_rpms` extracts the name (`pam`) from NVRs and returns all available versions of that RPM

## Changes
- `doozer/doozerlib/repodata.py`: Modified `get_rpms` method to parse NVRs and extract names using existing `parse_nvr` function
- `doozer/tests/test_repodata.py`: Added comprehensive test cases covering NVR extraction scenarios

**Technical Notes**
- Uses existing `parse_nvr` function from artcommonlib.rpm_utils for safe NVR parsing
- Maintains backward compatibility for plain name inputs
- Graceful error handling for malformed NVRs
- All tests pass including new test cases for mixed NVR/name inputs