### PR TITLE
Fix prepare-release-konflux issues

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -397,7 +397,7 @@ class KonfluxDb:
         outcome: KonfluxBuildOutcome = KonfluxBuildOutcome.SUCCESS,
         where: typing.Optional[typing.Dict[str, typing.Any]] = None,
         strict: bool = True,
-    ) -> typing.List[KonfluxRecord]:
+    ) -> list[KonfluxRecord | None]:
         """Get build records by NVRS.
         Note that this function only searches for the build records in the last 3 years.
         :param nvrs: The NVRS of the builds.
@@ -421,14 +421,12 @@ class KonfluxDb:
             where.update({"nvr": nvr, "outcome": str(outcome)})
             return await anext(self.search_builds_by_fields(where=where, limit=1, strict=strict), None)
 
-        tasks = [asyncio.create_task(_task(nvr)) for nvr in nvrs]
-        records = await asyncio.gather(*tasks, return_exceptions=True)
+        records = await asyncio.gather(*(_task(nvr) for nvr in nvrs), return_exceptions=True)
 
-        error_or_not_found = [
-            (nvr, record) for nvr, record in zip(nvrs, records) if record is None or isinstance(record, BaseException)
-        ]
-        if error_or_not_found:
-            error_message = f"Failed to fetch NVRs from Konflux DB: {', '.join(nvr for nvr, _ in error_or_not_found)}"
-            if strict:
-                raise IOError(error_message)
-        return typing.cast(typing.List[KonfluxRecord], records)
+        errors = [(nvr, record) for nvr, record in zip(nvrs, records) if isinstance(record, BaseException)]
+        if errors:
+            error_strings = [f"NVR {nvr}: {str(exc)}" for nvr, exc in errors]
+            error_message = f"Failed to fetch NVRs from Konflux DB: {'; '.join(error_strings)}"
+            raise IOError(error_message, errors)
+
+        return typing.cast(list[KonfluxRecord | None], records)

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 import re
+import sys
 from datetime import date, datetime, timedelta, timezone
 from functools import lru_cache
 from pathlib import Path
@@ -479,7 +480,7 @@ async def sync_to_quay(source_pullspec, destination_repo):
     if konflux_registry_auth_file:
         cmd += [f'--registry-config={konflux_registry_auth_file}']
 
-    await asyncio.wait_for(cmd_assert_async(cmd), timeout=7200)
+    await asyncio.wait_for(cmd_assert_async(cmd, stdout=sys.stderr), timeout=7200)
 
     # Sync the builds to a "sha" tag as well to prevent it from being garbage collected in quay
     shasum = source_pullspec.split("@sha256:")[1]
@@ -494,4 +495,4 @@ async def sync_to_quay(source_pullspec, destination_repo):
     ]
     if konflux_registry_auth_file:
         cmd += [f'--registry-config={konflux_registry_auth_file}']
-    await asyncio.wait_for(cmd_assert_async(cmd), timeout=7200)
+    await asyncio.wait_for(cmd_assert_async(cmd, stdout=sys.stderr), timeout=7200)

--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -8,6 +8,7 @@ from typing import Dict, Iterable, List, Optional, Set
 import click
 from artcommonlib import arch_util
 from artcommonlib.assembly import assembly_config_struct
+from artcommonlib.gitdata import SafeFormatter
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import new_roundtrip_yaml_handler
 from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
@@ -233,12 +234,12 @@ class AttachCveFlaws:
                 art_advisory_key=self.advisory_kind,
                 errata_type='RHSA',
             )
-            release_notes.synopsis = cve_boilerplate['synopsis'].format(MINOR=self.minor, PATCH=self.patch)
+            formatter = SafeFormatter()
             highest_impact = get_highest_security_impact(flaw_bugs)
-            release_notes.topic = cve_boilerplate['topic'].format(
-                IMPACT=highest_impact, MINOR=self.minor, PATCH=self.patch
-            )
-            release_notes.solution = cve_boilerplate['solution'].format(MINOR=self.minor)
+            replace_vars = {"MAJOR": self.major, "MINOR": self.minor, "PATCH": self.patch, "IMPACT": highest_impact}
+            release_notes.synopsis = formatter.format(cve_boilerplate['synopsis'], **replace_vars)
+            release_notes.topic = formatter.format(cve_boilerplate['topic'], **replace_vars)
+            release_notes.solution = formatter.format(cve_boilerplate['solution'], **replace_vars)
 
             # Update description
             formatted_cve_list = '\n'.join(

--- a/elliott/elliottlib/cli/create_cli.py
+++ b/elliott/elliottlib/cli/create_cli.py
@@ -4,6 +4,7 @@ import click
 from artcommonlib import logutil
 from artcommonlib.assembly import AssemblyTypes
 from artcommonlib.format_util import green_prefix
+from artcommonlib.gitdata import SafeFormatter
 
 from elliottlib import errata
 from elliottlib.cli.common import cli, click_coroutine
@@ -144,13 +145,15 @@ async def create_cli(
     )
 
     errata_api = AsyncErrataAPI()
-    _, minor, patch = runtime.get_major_minor_patch()
+    major, minor, patch = runtime.get_major_minor_patch()
+    replace_vars = {"MAJOR": major, "MINOR": minor, "PATCH": patch}
+    formatter = SafeFormatter()
 
     # Format the advisory boilerplate
-    synopsis = advisory_boilerplate['synopsis'].format(MINOR=minor, PATCH=patch)
-    advisory_topic = advisory_boilerplate['topic'].format(MINOR=minor, PATCH=patch)
-    advisory_description = advisory_boilerplate['description'].format(MINOR=minor, PATCH=patch)
-    advisory_solution = advisory_boilerplate['solution'].format(MINOR=minor, PATCH=patch)
+    synopsis = formatter.format(advisory_boilerplate['synopsis'], **replace_vars)
+    advisory_topic = formatter.format(advisory_boilerplate['topic'], **replace_vars)
+    advisory_description = formatter.format(advisory_boilerplate['description'], **replace_vars)
+    advisory_solution = formatter.format(advisory_boilerplate['solution'], **replace_vars)
 
     try:
         if yes:

--- a/elliott/elliottlib/cli/find_bugs_golang_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_golang_cli.py
@@ -10,6 +10,7 @@ from artcommonlib.rhcos import get_container_configs
 from artcommonlib.rpm_utils import parse_nvr
 from doozerlib.cli.get_nightlies import find_rc_nightlies
 from prettytable import PrettyTable
+from pyartcd.util import get_release_name_for_assembly, load_releases_config
 from semver.version import Version
 
 from elliottlib import Runtime, constants, errata
@@ -20,7 +21,6 @@ from elliottlib.cli.get_golang_report_cli import golang_report_for_version
 from elliottlib.exceptions import ElliottFatalError
 from elliottlib.util import get_golang_container_nvrs, get_golang_rpm_nvrs, get_nvrs_from_release
 from pyartcd import constants as pyartcd_constants
-from pyartcd.util import get_release_name_for_assembly, load_releases_config
 
 LOGGER = logging.getLogger(__name__)
 

--- a/elliott/elliottlib/cli/shipment_cli.py
+++ b/elliott/elliottlib/cli/shipment_cli.py
@@ -2,6 +2,7 @@ import sys
 
 import click
 from artcommonlib import logutil
+from artcommonlib.gitdata import SafeFormatter
 from doozerlib.backend.konflux_fbc import KonfluxFbcBuilder
 from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
 from ruamel.yaml import YAML
@@ -59,14 +60,16 @@ class InitShipmentCli:
         data = None
         if self.kind != "fbc":
             et_data = self.runtime.get_errata_config()
-            _, minor, patch = self.runtime.get_major_minor_patch()
+            major, minor, patch = self.runtime.get_major_minor_patch()
             advisory_boilerplate = get_advisory_boilerplate(
                 runtime=self.runtime, et_data=et_data, art_advisory_key=self.kind, errata_type="RHBA"
             )
-            synopsis = advisory_boilerplate['synopsis'].format(MINOR=minor, PATCH=patch)
-            advisory_topic = advisory_boilerplate['topic'].format(MINOR=minor, PATCH=patch)
-            advisory_description = advisory_boilerplate['description'].format(MINOR=minor, PATCH=patch)
-            advisory_solution = advisory_boilerplate['solution'].format(MINOR=minor, PATCH=patch)
+            replace_vars = {"MAJOR": major, "MINOR": minor, "PATCH": patch}
+            formatter = SafeFormatter()
+            synopsis = formatter.format(advisory_boilerplate['synopsis'], **replace_vars)
+            advisory_topic = formatter.format(advisory_boilerplate['topic'], **replace_vars)
+            advisory_description = formatter.format(advisory_boilerplate['description'], **replace_vars)
+            advisory_solution = formatter.format(advisory_boilerplate['solution'], **replace_vars)
 
             data = Data(
                 releaseNotes=ReleaseNotes(

--- a/elliott/elliottlib/cli/snapshot_cli.py
+++ b/elliott/elliottlib/cli/snapshot_cli.py
@@ -48,12 +48,12 @@ def _get_konflux_db(record_cls: type[KonfluxRecord]):
     return db
 
 
-async def get_build_records_by_nvrs(runtime: Runtime, nvrs: list[str], strict: bool = True) -> dict[str, KonfluxRecord]:
+async def get_build_records_by_nvrs(runtime: Runtime, nvrs: list[str]) -> dict[str, KonfluxRecord]:
     where = {"group": runtime.group, "engine": Engine.KONFLUX.value}
 
     async def _get(db: KonfluxDb, nvrs: list[str]) -> list[KonfluxRecord]:
         try:
-            records = await db.get_build_records_by_nvrs(nvrs, where=where, strict=strict)
+            records = await db.get_build_records_by_nvrs(nvrs, where=where, strict=True)
         except IOError as e:
             LOGGER.warning(
                 "A snapshot is expected to exclusively contain ART built image builds "
@@ -285,7 +285,7 @@ class CreateSnapshotCli:
             components.add(nvr['name'])
 
         LOGGER.info("Fetching NVRs from DB...")
-        records = await get_build_records_by_nvrs(self.runtime, self.builds, strict=True)
+        records = await get_build_records_by_nvrs(self.runtime, self.builds)
         return list(records.values())
 
 
@@ -435,7 +435,7 @@ class GetSnapshotCli:
             LOGGER.info("[DRY-RUN] Skipped DB validation")
             return nvrs
 
-        await get_build_records_by_nvrs(self.runtime, nvrs, strict=True)
+        await get_build_records_by_nvrs(self.runtime, nvrs)
         return nvrs
 
     async def extract_nvrs_from_snapshot(self, snapshot_obj: ResourceInstance) -> list[str]:

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -13,6 +13,7 @@ import click
 from artcommonlib import exectools
 from artcommonlib.arch_util import brew_arch_for_go_arch
 from artcommonlib.assembly import AssemblyTypes, assembly_config_struct
+from artcommonlib.gitdata import SafeFormatter
 from artcommonlib.model import Model
 from artcommonlib.util import get_ocp_version_from_group, new_roundtrip_yaml_handler
 from doozerlib.util import isolate_nightly_name_components
@@ -163,12 +164,12 @@ class BuildMicroShiftPipeline:
         errata_api = AsyncErrataAPI()
 
         # Format the advisory boilerplate
-        synopsis = boilerplate['synopsis'].format(MINOR=release_version.minor, PATCH=release_version.patch)
-        advisory_topic = boilerplate['topic'].format(MINOR=release_version.minor, PATCH=release_version.patch)
-        advisory_description = boilerplate['description'].format(
-            MINOR=release_version.minor, PATCH=release_version.patch
-        )
-        advisory_solution = boilerplate['solution'].format(MINOR=release_version.minor, PATCH=release_version.patch)
+        formatter = SafeFormatter()
+        replace_vars = {"MAJOR": release_version.major, "MINOR": release_version.minor, "PATCH": release_version.patch}
+        synopsis = formatter.format(boilerplate['synopsis'], **replace_vars)
+        advisory_topic = formatter.format(boilerplate['topic'], **replace_vars)
+        advisory_description = formatter.format(boilerplate['description'], **replace_vars)
+        advisory_solution = formatter.format(boilerplate['solution'], **replace_vars)
 
         self._logger.info("Creating advisory with type %s art_advisory_key microshift ...", advisory_type)
         if self.runtime.dry_run:

--- a/pyartcd/tests/pipelines/test_ocp4.py
+++ b/pyartcd/tests/pipelines/test_ocp4.py
@@ -3,9 +3,10 @@ import unittest
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from pyartcd import constants
 from pyartcd.jenkins import Jobs
 from pyartcd.pipelines import ocp4
+
+from pyartcd import constants
 
 
 class TestInitialBuildPlan(unittest.IsolatedAsyncioTestCase):

--- a/pyartcd/tests/pipelines/test_prepare_release_konflux.py
+++ b/pyartcd/tests/pipelines/test_prepare_release_konflux.py
@@ -24,12 +24,12 @@ from elliottlib.shipment_model import (
     SnapshotComponent,
     SnapshotSpec,
 )
-
-from pyartcd import constants
 from pyartcd.git import GitRepository
 from pyartcd.pipelines.prepare_release_konflux import PrepareReleaseKonfluxPipeline
 from pyartcd.runtime import Runtime
 from pyartcd.slack import SlackClient
+
+from pyartcd import constants
 
 
 class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -9,7 +9,6 @@ from unittest.mock import ANY, AsyncMock, MagicMock, Mock, PropertyMock, patch
 from artcommonlib.assembly import AssemblyTypes
 from artcommonlib.exceptions import VerificationError
 from artcommonlib.model import Model
-
 from pyartcd.pipelines.promote import PromotePipeline
 
 

--- a/pyartcd/tests/pipelines/test_rebuild.py
+++ b/pyartcd/tests/pipelines/test_rebuild.py
@@ -4,8 +4,9 @@ from pathlib import Path
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
-from pyartcd import constants
 from pyartcd.pipelines.rebuild import PlashetBuildResult, RebuildPipeline, RebuildType
+
+from pyartcd import constants
 
 
 class TestRebuildPipeline(IsolatedAsyncioTestCase):

--- a/pyartcd/tests/test_jenkins.py
+++ b/pyartcd/tests/test_jenkins.py
@@ -2,8 +2,9 @@ import os
 import unittest
 from unittest import mock
 
-from pyartcd import jenkins
 from pyartcd.jenkins import Jobs
+
+from pyartcd import jenkins
 
 
 class TestJenkinsStartBuild(unittest.TestCase):

--- a/pyartcd/tests/test_signatory.py
+++ b/pyartcd/tests/test_signatory.py
@@ -11,7 +11,6 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.x509.oid import NameOID
-
 from pyartcd.signatory import AsyncSignatory
 
 


### PR DESCRIPTION
Fix 2 issues:

1. `elliott shipment init` fails on missing advisory template variables.

With https://github.com/openshift-eng/ocp-build-data/pull/7477, we introduced more template variables, like `x864_DIGEST`, `s390x_DIGEST`. However, their values are unknown when `elliott shipment init` is run. We should use `SafeFormatter` to let Elliott ignore those missing variables during variable substitution and not panic.

2. prepare-release-konflux job reads the stdout from `doozer beta:images:konflux:bundle` command. However, a recent change (https://github.com/openshift-eng/art-tools/pull/1842) introduced additional output to stdout, which breaks prepare-release-konflux's expectation. This PR redirects those output to stderr.


Also makes `get_build_records_by_nvrs` generate more detailed error
    message for troubleshooting.