### PR TITLE
Allow commands to run without kubeconfig

### DIFF
--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -737,7 +737,9 @@ async def fbc_rebase_and_build(
         konflux_kubeconfig = os.environ.get('KONFLUX_SA_KUBECONFIG')
 
     if not konflux_kubeconfig:
-        raise ValueError("Must pass kubeconfig using --konflux-kubeconfig or KONFLUX_SA_KUBECONFIG env var")
+        LOGGER.info(
+            "--konflux-kubeconfig and KONFLUX_SA_KUBECONFIG env var are not set. Will rely on oc being logged in"
+        )
 
     if reset_to_prod and not prod_registry_auth:
         prod_registry_auth = os.environ.get('KONFLUX_OPERATOR_INDEX_AUTH_FILE')

--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -342,7 +342,9 @@ async def new_release_cli(
         konflux_kubeconfig = os.environ.get('KONFLUX_SA_KUBECONFIG')
 
     if not konflux_kubeconfig:
-        raise ValueError("Must pass kubeconfig using --konflux-kubeconfig or KONFLUX_SA_KUBECONFIG env var")
+        LOGGER.info(
+            "--konflux-kubeconfig and KONFLUX_SA_KUBECONFIG env var are not set. Will rely on oc being logged in"
+        )
 
     konflux_config = {
         'kubeconfig': konflux_kubeconfig,

--- a/elliott/elliottlib/cli/konflux_release_watch_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_watch_cli.py
@@ -110,7 +110,9 @@ async def watch_release_cli(
         konflux_kubeconfig = os.environ.get('KONFLUX_SA_KUBECONFIG')
 
     if not konflux_kubeconfig:
-        raise ValueError("Must pass kubeconfig using --konflux-kubeconfig or KONFLUX_SA_KUBECONFIG env var")
+        LOGGER.info(
+            "--konflux-kubeconfig and KONFLUX_SA_KUBECONFIG env var are not set. Will rely on oc being logged in"
+        )
 
     konflux_config = {
         'kubeconfig': konflux_kubeconfig,

--- a/elliott/elliottlib/cli/snapshot_cli.py
+++ b/elliott/elliottlib/cli/snapshot_cli.py
@@ -361,7 +361,9 @@ async def new_snapshot_cli(
         konflux_kubeconfig = os.environ.get('KONFLUX_SA_KUBECONFIG')
 
     if not konflux_kubeconfig:
-        raise ValueError("Must pass kubeconfig using --konflux-kubeconfig or KONFLUX_SA_KUBECONFIG env var")
+        LOGGER.info(
+            "--konflux-kubeconfig and KONFLUX_SA_KUBECONFIG env var are not set. Will rely on oc being logged in"
+        )
 
     if builds_file:
         if builds_file == "-":
@@ -516,7 +518,9 @@ async def get_snapshot_cli(
         konflux_kubeconfig = os.environ.get('KONFLUX_SA_KUBECONFIG')
 
     if not konflux_kubeconfig:
-        raise ValueError("Must pass kubeconfig using --konflux-kubeconfig or KONFLUX_SA_KUBECONFIG env var")
+        LOGGER.info(
+            "--konflux-kubeconfig and KONFLUX_SA_KUBECONFIG env var are not set. Will rely on oc being logged in"
+        )
 
     konflux_config = {
         'kubeconfig': konflux_kubeconfig,


### PR DESCRIPTION
Previously konflux recomended users to login in via cli using a kubeconfig w oidc/toolchain
Recently that got changed, so stop enforcing that a kubeconfig is provided when running commands.

https://konflux.pages.redhat.com/docs/users/getting-started/getting-access-new.html#logging-in-using-oc-login-web
https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1757488512749149