### PR TITLE
fix retry issue for sync-to-quay

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -15,7 +15,7 @@ from artcommonlib.exectools import cmd_assert_async, cmd_gather_async, limit_con
 from artcommonlib.model import ListModel, Missing
 from ruamel.yaml import YAML
 from semver import VersionInfo
-from tenacity import retry, stop_after_attempt, wait_fixed
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 LOGGER = logging.getLogger(__name__)
 
@@ -465,7 +465,7 @@ async def get_konflux_slsa_attestation(pullspec: str, registry_auth_file: Option
 
 
 @limit_concurrency(limit=32)
-@retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(5))
+@retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(5), retry=retry_if_exception_type(ChildProcessError))
 async def sync_to_quay(source_pullspec, destination_repo):
     LOGGER.info(f"Syncing image from {source_pullspec} to {destination_repo}")
     cmd = [


### PR DESCRIPTION
In https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/16497/console

```2025-09-03 07:47:52,832 artcommonlib.util INFO Syncing image from quay.io/redhat-user-workloads/ocp-art-tenant/art-images@sha256:2157ed0c5270734b3992340f31baea522c976e248264fcd5c25f01af8d26c2db to quay.io/redhat-user-workloads/ocp-art-tenant/art-images-share
2025-09-03 07:47:52,833 art_tools.artcommonlib.exectools INFO Executing:cmd_assert_async: oc image mirror --keep-manifest-list quay.io/redhat-user-workloads/ocp-art-tenant/art-images@sha256:2157ed0c5270734b3992340f31baea522c976e248264fcd5c25f01af8d26c2db quay.io/redhat-user-workloads/ocp-art-tenant/art-images-share --registry-config=****

error: unable to retrieve source image quay.io/redhat-user-workloads/ocp-art-tenant/art-images manifest #3 from manifest list: received unexpected HTTP status: 502 Bad Gateway
error: an error occurred during planning
```
The code didn't retry as expected