### PR TITLE
fail build if source image signature is missing

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -289,6 +289,8 @@ class KonfluxImageBuilder:
             build_name=distgit_key,
             registry_auth_file=self._config.registry_auth_file,
         )
+        if not attestation:
+            raise ValueError("SLSA attestation cannot be empty")
 
         # Extract tasks from predicate.buildConfig
         tasks = attestation["predicate"]["buildConfig"]["tasks"]

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -18,6 +18,7 @@ from artcommonlib.exectools import limit_concurrency
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.model import Missing
 from artcommonlib.release_util import isolate_el_version_in_release
+from artcommonlib.util import fetch_slsa_attestation, get_konflux_data
 from dockerfile_parse import DockerfileParser
 from doozerlib import constants, util
 from doozerlib.backend.build_repo import BuildRepo
@@ -210,15 +211,12 @@ class KonfluxImageBuilder:
 
                     record["image_pullspec"] = f"{image_pullspec.split(':')[0]}@{image_digest}"
 
-                    # Get SLA attestation from konflux. The command will error out if it cannot find it.
+                    # Validate SLSA attestation and source image signature
                     try:
-                        await artlib_util.get_konflux_slsa_attestation(
-                            pullspec=image_pullspec,
-                            registry_auth_file=self._config.registry_auth_file,
-                        )
+                        await self._validate_build_attestation_and_signature(image_pullspec, metadata.distgit_key)
                     except Exception as e:
                         logger.error(
-                            f"Failed to get SLA attestation from konflux for image {image_pullspec}, marking build as {KonfluxBuildOutcome.FAILURE}. Error: {e}"
+                            f"Failed to get SLA attestation / source signature from konflux for image {image_pullspec}, marking build as {KonfluxBuildOutcome.FAILURE}. Error: {e}"
                         )
                         outcome = KonfluxBuildOutcome.FAILURE
 
@@ -276,6 +274,46 @@ class KonfluxImageBuilder:
             raise ValueError(f"[{distgit_key}] Dockerfile must have a 'release' label.")
 
         return uuid_tag, component_name, version, release
+
+    async def _validate_build_attestation_and_signature(self, image_pullspec: str, distgit_key: str):
+        """
+        Validate SLSA attestation and source image signature for a built image.
+
+        :param image_pullspec: The pullspec of the built image
+        :param distgit_key: The distgit key for logging purposes
+        :raises: Exception if validation fails
+        """
+        # Get SLA attestation from konflux. The command will error out if it cannot find it.
+        attestation = await fetch_slsa_attestation(
+            image_pullspec=image_pullspec,
+            build_name=distgit_key,
+            registry_auth_file=self._config.registry_auth_file,
+        )
+
+        # Extract tasks from predicate.buildConfig
+        tasks = attestation["predicate"]["buildConfig"]["tasks"]
+
+        # Find the build-source-image task and extract IMAGE_REF
+        source_image_pullspec = None
+        for task in tasks:
+            if task["name"] == "build-source-image":
+                for result in task["results"]:
+                    if result["name"] == "IMAGE_REF":
+                        source_image_pullspec = result["value"]
+                        break
+
+        if not source_image_pullspec:
+            raise ValueError(f"Could not find source image pullspec for {distgit_key} in image {image_pullspec}")
+
+        # If the source image is not signed, consider the build as failed, since Conforma will fail
+        # at release time otherwise
+        try:
+            await get_konflux_data(
+                pullspec=source_image_pullspec, mode="signature", registry_auth_file=self._config.registry_auth_file
+            )
+        except ChildProcessError:
+            LOGGER.error(f'Failed to fetch signature for {source_image_pullspec}')
+            raise
 
     async def _wait_for_parent_members(self, metadata: ImageMetadata):
         # If this image is FROM another group member, we need to wait on that group member to be built

--- a/doozer/tests/cli/test_scan_sources_konflux.py
+++ b/doozer/tests/cli/test_scan_sources_konflux.py
@@ -58,30 +58,22 @@ class TestScanTaskBundleChanges(TestScanSourcesKonflux):
     def setUp(self):
         super().setUp()
 
-        # Sample SLSA attestation with task bundles
-        self.sample_attestation = json.dumps(
-            {
-                "payload": base64.b64encode(
-                    json.dumps(
-                        {
-                            "predicate": {
-                                "materials": [
-                                    {
-                                        "uri": "quay.io/konflux-ci/tekton-catalog/task-git-clone",
-                                        "digest": {"sha256": "abc123def456"},
-                                    },
-                                    {
-                                        "uri": "quay.io/konflux-ci/tekton-catalog/task-buildah",
-                                        "digest": {"sha256": "def456ghi789"},
-                                    },
-                                    {"uri": "quay.io/other-registry/some-other-task", "digest": {"sha256": "xyz999"}},
-                                ]
-                            }
-                        }
-                    ).encode()
-                ).decode()
+        # Sample SLSA attestation with task bundles (already parsed)
+        self.sample_attestation = {
+            "predicate": {
+                "materials": [
+                    {
+                        "uri": "quay.io/konflux-ci/tekton-catalog/task-git-clone",
+                        "digest": {"sha256": "abc123def456"},
+                    },
+                    {
+                        "uri": "quay.io/konflux-ci/tekton-catalog/task-buildah",
+                        "digest": {"sha256": "def456ghi789"},
+                    },
+                    {"uri": "quay.io/other-registry/some-other-task", "digest": {"sha256": "xyz999"}},
+                ]
             }
-        )
+        }
 
         # Sample current task bundles from GitHub
         self.current_task_bundles = {
@@ -89,17 +81,17 @@ class TestScanTaskBundleChanges(TestScanSourcesKonflux):
             "task-buildah": "def456ghi789",  # Same SHA - up to date
         }
 
-    @patch('artcommonlib.util.get_konflux_slsa_attestation')
+    @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
     async def test_scan_task_bundle_changes_no_attestation(self, mock_get_attestation):
         """Test handling when SLSA attestation cannot be retrieved."""
-        mock_get_attestation.side_effect = ChildProcessError("Failed to download")
+        mock_get_attestation.return_value = None
 
         await self.scanner.scan_task_bundle_changes(self.image_meta)
 
         # Should not add any changes when attestation fails
         self.assertEqual(len(self.scanner.changing_image_names), 0)
 
-    @patch('artcommonlib.util.get_konflux_slsa_attestation')
+    @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
     async def test_scan_task_bundle_changes_invalid_attestation(self, mock_get_attestation):
         """Test handling when SLSA attestation is malformed."""
         mock_get_attestation.return_value = "invalid json"
@@ -109,7 +101,7 @@ class TestScanTaskBundleChanges(TestScanSourcesKonflux):
         # Should not add any changes when attestation is invalid
         self.assertEqual(len(self.scanner.changing_image_names), 0)
 
-    @patch('artcommonlib.util.get_konflux_slsa_attestation')
+    @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
     async def test_scan_task_bundle_changes_no_task_bundles(self, mock_get_attestation):
         """Test handling when no tekton-catalog task bundles are found."""
         attestation_without_task_bundles = json.dumps(
@@ -134,7 +126,7 @@ class TestScanTaskBundleChanges(TestScanSourcesKonflux):
         # Should not add any changes when no task bundles found
         self.assertEqual(len(self.scanner.changing_image_names), 0)
 
-    @patch('artcommonlib.util.get_konflux_slsa_attestation')
+    @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
     @patch.object(ConfigScanSources, 'get_current_task_bundle_shas')
     async def test_scan_task_bundle_changes_github_fetch_fails(self, mock_get_current, mock_get_attestation):
         """Test handling when GitHub task bundle fetch fails."""
@@ -146,7 +138,7 @@ class TestScanTaskBundleChanges(TestScanSourcesKonflux):
         # Should not add any changes when GitHub fetch fails
         self.assertEqual(len(self.scanner.changing_image_names), 0)
 
-    @patch('artcommonlib.util.get_konflux_slsa_attestation')
+    @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
     @patch.object(ConfigScanSources, 'get_current_task_bundle_shas')
     @patch.object(ConfigScanSources, 'get_task_bundle_age_days')
     async def test_scan_task_bundle_changes_not_old_enough(self, mock_get_age, mock_get_current, mock_get_attestation):
@@ -160,7 +152,7 @@ class TestScanTaskBundleChanges(TestScanSourcesKonflux):
         # Should not add any changes when task bundle is not old enough
         self.assertEqual(len(self.scanner.changing_image_names), 0)
 
-    @patch('artcommonlib.util.get_konflux_slsa_attestation')
+    @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
     @patch.object(ConfigScanSources, 'get_current_task_bundle_shas')
     @patch.object(ConfigScanSources, 'get_task_bundle_age_days')
     @patch.object(ConfigScanSources, 'add_image_meta_change')
@@ -186,7 +178,7 @@ class TestScanTaskBundleChanges(TestScanSourcesKonflux):
         self.assertIn("task-git-clone", rebuild_hint.reason)
         self.assertIn("35 days old", rebuild_hint.reason)
 
-    @patch('artcommonlib.util.get_konflux_slsa_attestation')
+    @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
     @patch.object(ConfigScanSources, 'get_current_task_bundle_shas')
     @patch.object(ConfigScanSources, 'get_task_bundle_age_days')
     @patch.object(ConfigScanSources, 'add_image_meta_change')
@@ -205,7 +197,7 @@ class TestScanTaskBundleChanges(TestScanSourcesKonflux):
         # Should not add change when staggered rebuild condition is not met
         mock_add_change.assert_not_called()
 
-    @patch('artcommonlib.util.get_konflux_slsa_attestation')
+    @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
     @patch.object(ConfigScanSources, 'get_current_task_bundle_shas')
     @patch.object(ConfigScanSources, 'get_task_bundle_age_days')
     async def test_scan_task_bundle_changes_same_sha_no_rebuild(
@@ -227,52 +219,58 @@ class TestScanTaskBundleChanges(TestScanSourcesKonflux):
         mock_get_age.assert_not_called()
         self.assertEqual(len(self.scanner.changing_image_names), 0)
 
-    @patch('artcommonlib.util.get_konflux_slsa_attestation')
-    async def test_scan_task_bundle_changes_for_release_none(self, mock_get_attestation):
+    @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
+    @patch.object(ConfigScanSources, 'get_current_task_bundle_shas')
+    async def test_scan_task_bundle_changes_for_release_none(self, mock_get_current, mock_get_attestation):
         """Test that task bundle scanning proceeds when for_release is None."""
         # Set for_release to None
         self.image_meta.config.for_release = None
 
         mock_get_attestation.return_value = self.sample_attestation
+        mock_get_current.return_value = {}
 
         await self.scanner.scan_task_bundle_changes(self.image_meta)
 
-        # Should call get_attestation when for_release is None (not skipped)
+        # Should call fetch_slsa_attestation when for_release is None (not skipped)
         mock_get_attestation.assert_called_once_with(
-            pullspec=self.build_record.image_pullspec, registry_auth_file=self.scanner.registry_auth_file
+            self.build_record.image_pullspec, self.build_record.name, self.scanner.registry_auth_file
         )
 
-    @patch('artcommonlib.util.get_konflux_slsa_attestation')
-    async def test_scan_task_bundle_changes_for_release_missing(self, mock_get_attestation):
+    @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
+    @patch.object(ConfigScanSources, 'get_current_task_bundle_shas')
+    async def test_scan_task_bundle_changes_for_release_missing(self, mock_get_current, mock_get_attestation):
         """Test that task bundle scanning proceeds when for_release is Missing."""
         # Set for_release to Missing
         self.image_meta.config.for_release = Missing
 
         mock_get_attestation.return_value = self.sample_attestation
+        mock_get_current.return_value = {}
 
         await self.scanner.scan_task_bundle_changes(self.image_meta)
 
-        # Should call get_attestation when for_release is Missing (not skipped)
+        # Should call fetch_slsa_attestation when for_release is Missing (not skipped)
         mock_get_attestation.assert_called_once_with(
-            pullspec=self.build_record.image_pullspec, registry_auth_file=self.scanner.registry_auth_file
+            self.build_record.image_pullspec, self.build_record.name, self.scanner.registry_auth_file
         )
 
-    @patch('artcommonlib.util.get_konflux_slsa_attestation')
-    async def test_scan_task_bundle_changes_for_release_true(self, mock_get_attestation):
+    @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
+    @patch.object(ConfigScanSources, 'get_current_task_bundle_shas')
+    async def test_scan_task_bundle_changes_for_release_true(self, mock_get_current, mock_get_attestation):
         """Test that task bundle scanning proceeds when for_release is True."""
         # for_release is already set to True in setUp, but let's be explicit
         self.image_meta.config.for_release = True
 
         mock_get_attestation.return_value = self.sample_attestation
+        mock_get_current.return_value = {}
 
         await self.scanner.scan_task_bundle_changes(self.image_meta)
 
-        # Should call get_attestation when for_release is True (not skipped)
+        # Should call fetch_slsa_attestation when for_release is True (not skipped)
         mock_get_attestation.assert_called_once_with(
-            pullspec=self.build_record.image_pullspec, registry_auth_file=self.scanner.registry_auth_file
+            self.build_record.image_pullspec, self.build_record.name, self.scanner.registry_auth_file
         )
 
-    @patch('artcommonlib.util.get_konflux_slsa_attestation')
+    @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
     async def test_scan_task_bundle_changes_for_release_false(self, mock_get_attestation):
         """Test that task bundle scanning is skipped when for_release is False."""
         # Set for_release to False
@@ -280,7 +278,7 @@ class TestScanTaskBundleChanges(TestScanSourcesKonflux):
 
         await self.scanner.scan_task_bundle_changes(self.image_meta)
 
-        # Should NOT call get_attestation when for_release is False (skipped)
+        # Should NOT call fetch_slsa_attestation when for_release is False (skipped)
         mock_get_attestation.assert_not_called()
 
 
@@ -524,7 +522,7 @@ class TestGetTaskBundleAgeDays(TestScanSourcesKonflux):
 class TestTaskBundleIntegration(TestScanSourcesKonflux):
     """Integration tests for the complete task bundle scanning workflow."""
 
-    @patch('artcommonlib.util.get_konflux_slsa_attestation')
+    @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
     @patch.object(ConfigScanSources, 'get_current_task_bundle_shas')
     @patch.object(ConfigScanSources, 'get_task_bundle_age_days')
     @patch.object(ConfigScanSources, 'add_image_meta_change')
@@ -534,24 +532,16 @@ class TestTaskBundleIntegration(TestScanSourcesKonflux):
     ):
         """Test the complete workflow when a rebuild should be triggered."""
         # Setup test data
-        attestation = json.dumps(
-            {
-                "payload": base64.b64encode(
-                    json.dumps(
-                        {
-                            "predicate": {
-                                "materials": [
-                                    {
-                                        "uri": "quay.io/konflux-ci/tekton-catalog/git-clone",
-                                        "digest": {"sha256": "old123"},
-                                    }
-                                ]
-                            }
-                        }
-                    ).encode()
-                ).decode()
+        attestation = {
+            "predicate": {
+                "materials": [
+                    {
+                        "uri": "quay.io/konflux-ci/tekton-catalog/git-clone",
+                        "digest": {"sha256": "old123"},
+                    }
+                ]
             }
-        )
+        }
 
         current_bundles = {"git-clone": "new456"}  # Different SHA
 
@@ -564,7 +554,7 @@ class TestTaskBundleIntegration(TestScanSourcesKonflux):
 
         # Verify all methods were called in correct order
         mock_get_attestation.assert_called_once_with(
-            pullspec=self.build_record.image_pullspec, registry_auth_file=self.scanner.registry_auth_file
+            self.build_record.image_pullspec, self.build_record.name, self.scanner.registry_auth_file
         )
         mock_get_current.assert_called_once()
         mock_get_age.assert_called_once_with("git-clone", "old123")
@@ -577,7 +567,7 @@ class TestTaskBundleIntegration(TestScanSourcesKonflux):
         rebuild_hint = mock_add_change.call_args[0][1]
         self.assertEqual(rebuild_hint.code, RebuildHintCode.TASK_BUNDLE_OUTDATED)
 
-    @patch('artcommonlib.util.get_konflux_slsa_attestation')
+    @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
     @patch.object(ConfigScanSources, 'get_current_task_bundle_shas')
     @patch.object(ConfigScanSources, 'get_task_bundle_age_days')
     @patch.object(ConfigScanSources, 'add_image_meta_change')
@@ -586,24 +576,16 @@ class TestTaskBundleIntegration(TestScanSourcesKonflux):
     ):
         """Test the complete workflow when no rebuild is needed."""
         # Setup test data with matching SHAs
-        attestation = json.dumps(
-            {
-                "payload": base64.b64encode(
-                    json.dumps(
-                        {
-                            "predicate": {
-                                "materials": [
-                                    {
-                                        "uri": "quay.io/konflux-ci/tekton-catalog/git-clone",
-                                        "digest": {"sha256": "same123"},
-                                    }
-                                ]
-                            }
-                        }
-                    ).encode()
-                ).decode()
+        attestation = {
+            "predicate": {
+                "materials": [
+                    {
+                        "uri": "quay.io/konflux-ci/tekton-catalog/git-clone",
+                        "digest": {"sha256": "same123"},
+                    }
+                ]
             }
-        )
+        }
 
         current_bundles = {"git-clone": "same123"}  # Same SHA
 
@@ -623,7 +605,7 @@ class TestTaskBundleIntegration(TestScanSourcesKonflux):
         # Add image to changing set
         self.scanner.changing_image_names.add("test-image")
 
-        with patch('artcommonlib.util.get_konflux_slsa_attestation') as mock_get_attestation:
+        with patch('artcommonlib.util.get_konflux_data') as mock_get_attestation:
             await self.scanner.scan_task_bundle_changes(self.image_meta)
 
             # Should not call get_attestation when image is already changing


### PR DESCRIPTION
The konflux build pipeline has a step called build source image. The source image is built and signed as part of that step, but last week there was build that was not signed due to transient error on the konflux's side, which caused us a significant delay to promote the payload.

To prevent that, check to see if the source image is signed or not. If its signed, mark the build as failed, to trigger a rerun.

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/17240

Seeing
```
2025-09-19 16:49:56,691 art_tools.artcommonlib.exectools INFO Executing:cmd_gather_async: cosign download signature quay.io/redhat-user-workloads/ocp-art-tenant/art-images:sha256-c581e65aafeb86d8cd3d9fecd2858118a669c5e16ed723d52c13e09f01ba33ad.src@sha256:e939712b91cd9f51128bd09a9d5a76749baeefbb7527647b55b3e4ed08874e3a
```