### PR TITLE
cancel watch if plr GCed

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -952,9 +952,34 @@ class KonfluxClient:
                                 self._logger.error('Error trying to cancel PipelineRun %s', pipelinerun_name)
                                 traceback.print_exc()
 
-                    self._logger.info(
-                        "No updates for PipelineRun %s during watch timeout period; requerying", pipelinerun_name
-                    )
+                    # Check if the PipelineRun still exists before continuing to watch
+                    try:
+                        _ = api.get(
+                            name=pipelinerun_name,
+                            namespace=namespace,
+                            _request_timeout=self.request_timeout,
+                        )
+                        self._logger.info(
+                            "No updates for PipelineRun %s during watch timeout period; requerying", pipelinerun_name
+                        )
+                    except exceptions.NotFoundError:
+                        self._logger.info(
+                            "PipelineRun %s no longer exists (likely garbage collected); stopping watch",
+                            pipelinerun_name,
+                        )
+
+                        # Create a placeholder indicating the resource was garbage collected
+                        placeholder_pipelinerun = {
+                            "metadata": {"name": pipelinerun_name, "namespace": namespace},
+                            "apiVersion": "tekton.dev/v1",
+                            "kind": "PipelineRun",
+                            "status": {
+                                "conditions": [{"status": "Unknown", "type": "Succeeded", "reason": "GarbageCollected"}]
+                            },
+                        }
+                        return resource.ResourceInstance(self.dyn_client, placeholder_pipelinerun), list(
+                            pod_history.values()
+                        )
                 except TimeoutError:
                     self._logger.error("Timeout waiting for PipelineRun %s to complete", pipelinerun_name)
                     continue


### PR DESCRIPTION
Seeing several instances of ocp4 job where the watcher is trying to watch a PipelineRun(PLR) that had already been completed and garbage collected. Looks like the PLR completed and got pruned before the watcher got to it again. For example: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/17278/consoleText
```
2025-09-21 21:27:13,849 doozerlib.backend.konflux_client INFO No updates for PipelineRun ose-4-21-local-storage-operator-96mmc during watch timeout period; requerying
2025-09-21 21:32:13,861 doozerlib.backend.konflux_client INFO No updates for PipelineRun ose-4-21-local-storage-operator-96mmc during watch timeout period; requerying
...
```
For now, stop the watcher if it sees that the PLR doesn't exist .