### PR TITLE
feat(konflux): add prerelease GPG check disable for RPM prefetch

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -402,6 +402,11 @@ class KonfluxImageBuilder:
                     for repo_name in enabled_repos:
                         repo = repos[repo_name]  # Use public interface
                         for arch in building_arches:
+                            # Only apply to repositories with baseurl containing '/plashets/'
+                            baseurl = repo.baseurl("unsigned", arch)
+                            if "/plashets/" not in baseurl:
+                                continue
+
                             content_set_id = repo.content_set(arch)
                             if content_set_id is None:
                                 # Fallback to repo name + arch (same as lockfile)

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -390,26 +390,19 @@ class KonfluxImageBuilder:
                 "path": lockfile_path,
             }
 
-            # Add prerelease-specific DNF configuration
             phase = metadata.runtime.group_config.software_lifecycle.phase
             if phase == 'pre-release':
-                enabled_repos = metadata.get_enabled_repos()  # Returns set[str] of repo names
+                enabled_repos = metadata.get_enabled_repos()
                 if enabled_repos:
                     dnf_options = {}
-                    repos = metadata.runtime.repos  # Repos instance
+                    repos = metadata.runtime.repos
                     building_arches = metadata.get_arches()
 
                     for repo_name in enabled_repos:
-                        repo = repos[repo_name]  # Use public interface
+                        repo = repos[repo_name]
                         for arch in building_arches:
-                            # Only apply to repositories with baseurl containing '/plashets/'
-                            baseurl = repo.baseurl("unsigned", arch)
-                            if "/plashets/" not in baseurl:
-                                continue
-
                             content_set_id = repo.content_set(arch)
                             if content_set_id is None:
-                                # Fallback to repo name + arch (same as lockfile)
                                 content_set_id = f'{repo_name}-{arch}'
 
                             dnf_options[content_set_id] = {"gpgcheck": "0"}

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -17,7 +17,7 @@ from artcommonlib.build_visibility import is_release_embargoed
 from artcommonlib.exectools import limit_concurrency
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.model import Missing
-from artcommonlib.release_util import isolate_el_version_in_release
+from artcommonlib.release_util import SoftwareLifecyclePhase, isolate_el_version_in_release
 from artcommonlib.util import fetch_slsa_attestation, get_konflux_data
 from dockerfile_parse import DockerfileParser
 from doozerlib import constants, util
@@ -390,8 +390,8 @@ class KonfluxImageBuilder:
                 "path": lockfile_path,
             }
 
-            phase = metadata.runtime.group_config.software_lifecycle.phase
-            if phase == 'pre-release':
+            phase = SoftwareLifecyclePhase.from_name(metadata.runtime.group_config.software_lifecycle.phase)
+            if phase <= SoftwareLifecyclePhase.SIGNING:
                 enabled_repos = metadata.get_enabled_repos()
                 if enabled_repos:
                     dnf_options = {}

--- a/doozer/tests/backend/test_konflux_cachi2.py
+++ b/doozer/tests/backend/test_konflux_cachi2.py
@@ -110,6 +110,8 @@ class TestKonfluxCachi2(TestCase):
         metadata.config.cachito.packages = {'gomod': [{'path': '.'}]}
         metadata.config.konflux.cachi2.lockfile.get.return_value = "."
 
+        metadata.runtime.group_config.software_lifecycle.phase = 'release'
+
         result = builder._prefetch(metadata=metadata)
         expected = [{'type': 'rpm', 'path': '.'}, {'type': 'gomod', 'path': '.'}]
         self.assertEqual(result, expected)
@@ -125,6 +127,8 @@ class TestKonfluxCachi2(TestCase):
         metadata.config.content.source.pkg_managers = ["npm"]
         metadata.config.cachito.packages = {'npm': [{'path': 'frontend'}]}
         metadata.config.konflux.cachi2.lockfile.get.return_value = "custom/path"
+
+        metadata.runtime.group_config.software_lifecycle.phase = 'release'
 
         result = builder._prefetch(metadata=metadata)
         expected = [{'type': 'rpm', 'path': 'custom/path'}, {'type': 'npm', 'path': 'frontend'}]
@@ -167,7 +171,6 @@ class TestKonfluxCachi2(TestCase):
         builder = KonfluxImageBuilder(MagicMock())
         metadata = MagicMock()
 
-        # Setup metadata for prerelease RPM lockfile scenario
         metadata.is_cachi2_enabled.return_value = True
         metadata.is_lockfile_generation_enabled.return_value = True
         metadata.is_artifact_lockfile_enabled.return_value = False
@@ -176,24 +179,14 @@ class TestKonfluxCachi2(TestCase):
         metadata.config.cachito.packages = {'gomod': [{'path': '.'}]}
         metadata.config.konflux.cachi2.lockfile.get.return_value = "."
 
-        # Setup prerelease phase
         metadata.runtime.group_config.software_lifecycle.phase = 'pre-release'
         metadata.get_enabled_repos.return_value = {'repo1', 'repo2'}
         metadata.get_arches.return_value = ['x86_64', 'aarch64']
 
-        # Mock repository objects with plashets URLs
         mock_repo1 = MagicMock()
         mock_repo1.content_set.side_effect = lambda arch: f'repo1-content-set-{arch}'
-        mock_repo1.baseurl.side_effect = (
-            lambda repotype,
-            arch: f'https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/4.21/test/el9/latest/{arch}/os/'
-        )
         mock_repo2 = MagicMock()
         mock_repo2.content_set.side_effect = lambda arch: f'repo2-content-set-{arch}'
-        mock_repo2.baseurl.side_effect = (
-            lambda repotype,
-            arch: f'https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/4.21/test/el9-embargoed/latest/{arch}/os/'
-        )
 
         metadata.runtime.repos = {'repo1': mock_repo1, 'repo2': mock_repo2}
 
@@ -220,7 +213,6 @@ class TestKonfluxCachi2(TestCase):
         builder = KonfluxImageBuilder(MagicMock())
         metadata = MagicMock()
 
-        # Setup metadata for non-prerelease RPM lockfile scenario
         metadata.is_cachi2_enabled.return_value = True
         metadata.is_lockfile_generation_enabled.return_value = True
         metadata.is_artifact_lockfile_enabled.return_value = False
@@ -229,14 +221,12 @@ class TestKonfluxCachi2(TestCase):
         metadata.config.cachito.packages = {'gomod': [{'path': '.'}]}
         metadata.config.konflux.cachi2.lockfile.get.return_value = "."
 
-        # Setup non-prerelease phase
         metadata.runtime.group_config.software_lifecycle.phase = 'production'
         metadata.get_enabled_repos.return_value = {'repo1', 'repo2'}
         metadata.get_arches.return_value = ['x86_64']
 
         result = builder._prefetch(metadata=metadata)
 
-        # Should NOT have DNF options
         expected = [{'type': 'rpm', 'path': '.'}, {'type': 'gomod', 'path': '.'}]
         self.assertEqual(result, expected)
 
@@ -246,20 +236,15 @@ class TestKonfluxCachi2(TestCase):
         builder = KonfluxImageBuilder(MagicMock())
         metadata = MagicMock()
 
-        # Setup metadata for prerelease without RPM lockfile
         metadata.is_cachi2_enabled.return_value = True
-        metadata.is_lockfile_generation_enabled.return_value = False  # No RPM lockfile
+        metadata.is_lockfile_generation_enabled.return_value = False
         metadata.is_artifact_lockfile_enabled.return_value = False
         metadata.get_konflux_network_mode.return_value = "hermetic"
         metadata.config.content.source.pkg_managers = ["gomod"]
         metadata.config.cachito.packages = {'gomod': [{'path': '.'}]}
 
-        # Setup prerelease phase
-        metadata.runtime.group_config.software_lifecycle.phase = 'pre-release'
-
         result = builder._prefetch(metadata=metadata)
 
-        # Should NOT have RPM data at all
         expected = [{'type': 'gomod', 'path': '.'}]
         self.assertEqual(result, expected)
 
@@ -269,7 +254,6 @@ class TestKonfluxCachi2(TestCase):
         builder = KonfluxImageBuilder(MagicMock())
         metadata = MagicMock()
 
-        # Setup metadata for prerelease RPM lockfile scenario with empty repos
         metadata.is_cachi2_enabled.return_value = True
         metadata.is_lockfile_generation_enabled.return_value = True
         metadata.is_artifact_lockfile_enabled.return_value = False
@@ -278,14 +262,12 @@ class TestKonfluxCachi2(TestCase):
         metadata.config.cachito.packages = {'gomod': [{'path': '.'}]}
         metadata.config.konflux.cachi2.lockfile.get.return_value = "."
 
-        # Setup prerelease phase with empty repos
         metadata.runtime.group_config.software_lifecycle.phase = 'pre-release'
-        metadata.get_enabled_repos.return_value = set()  # Empty repositories
+        metadata.get_enabled_repos.return_value = set()
         metadata.get_arches.return_value = ['x86_64']
 
         result = builder._prefetch(metadata=metadata)
 
-        # Should NOT have DNF options due to empty repos
         expected = [{'type': 'rpm', 'path': '.'}, {'type': 'gomod', 'path': '.'}]
         self.assertEqual(result, expected)
 
@@ -295,7 +277,6 @@ class TestKonfluxCachi2(TestCase):
         builder = KonfluxImageBuilder(MagicMock())
         metadata = MagicMock()
 
-        # Setup metadata for prerelease RPM lockfile scenario
         metadata.is_cachi2_enabled.return_value = True
         metadata.is_lockfile_generation_enabled.return_value = True
         metadata.is_artifact_lockfile_enabled.return_value = False
@@ -304,18 +285,12 @@ class TestKonfluxCachi2(TestCase):
         metadata.config.cachito.packages = {'gomod': [{'path': '.'}]}
         metadata.config.konflux.cachi2.lockfile.get.return_value = "."
 
-        # Setup prerelease phase
         metadata.runtime.group_config.software_lifecycle.phase = 'pre-release'
         metadata.get_enabled_repos.return_value = {'repo1'}
         metadata.get_arches.return_value = ['x86_64']
 
-        # Mock repository object that returns None for content_set
         mock_repo1 = MagicMock()
-        mock_repo1.content_set.return_value = None  # Trigger fallback
-        mock_repo1.baseurl.side_effect = (
-            lambda repotype,
-            arch: f'https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/4.21/test/el9/latest/{arch}/os/'
-        )
+        mock_repo1.content_set.return_value = None
 
         metadata.runtime.repos = {'repo1': mock_repo1}
 
@@ -324,22 +299,17 @@ class TestKonfluxCachi2(TestCase):
         expected_rpm_data = {
             'type': 'rpm',
             'path': '.',
-            'options': {
-                'dnf': {
-                    'repo1-x86_64': {'gpgcheck': '0'}  # Fallback format
-                }
-            },
+            'options': {'dnf': {'repo1-x86_64': {'gpgcheck': '0'}}},
         }
         expected = [expected_rpm_data, {'type': 'gomod', 'path': '.'}]
         self.assertEqual(result, expected)
 
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
-    def test_prefetch_prerelease_non_plashets_repos_excluded(self, mock_konflux_client_init):
-        """Test that prerelease phase excludes repositories without '/plashets/' in baseurl"""
+    def test_prefetch_prerelease_all_repos_included(self, mock_konflux_client_init):
+        """Test that prerelease phase includes ALL repositories regardless of URL"""
         builder = KonfluxImageBuilder(MagicMock())
         metadata = MagicMock()
 
-        # Setup metadata for prerelease RPM lockfile scenario
         metadata.is_cachi2_enabled.return_value = True
         metadata.is_lockfile_generation_enabled.return_value = True
         metadata.is_artifact_lockfile_enabled.return_value = False
@@ -348,37 +318,27 @@ class TestKonfluxCachi2(TestCase):
         metadata.config.cachito.packages = {'gomod': [{'path': '.'}]}
         metadata.config.konflux.cachi2.lockfile.get.return_value = "."
 
-        # Setup prerelease phase
         metadata.runtime.group_config.software_lifecycle.phase = 'pre-release'
         metadata.get_enabled_repos.return_value = {'ocp-repo', 'rhel-repo'}
         metadata.get_arches.return_value = ['x86_64']
 
-        # Mock repository objects: one with plashets, one without
         mock_ocp_repo = MagicMock()
         mock_ocp_repo.content_set.side_effect = lambda arch: f'ocp-repo-content-set-{arch}'
-        mock_ocp_repo.baseurl.side_effect = (
-            lambda repotype,
-            arch: f'https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/4.21/test/el9/latest/{arch}/os/'
-        )
 
         mock_rhel_repo = MagicMock()
         mock_rhel_repo.content_set.side_effect = lambda arch: f'rhel-repo-content-set-{arch}'
-        mock_rhel_repo.baseurl.side_effect = (
-            lambda repotype, arch: f'https://cdn.redhat.com/content/dist/rhel9/{arch}/appstream/os/'
-        )
 
         metadata.runtime.repos = {'ocp-repo': mock_ocp_repo, 'rhel-repo': mock_rhel_repo}
 
         result = builder._prefetch(metadata=metadata)
 
-        # Should only have DNF options for OCP repo with plashets, not RHEL repo
         expected_rpm_data = {
             'type': 'rpm',
             'path': '.',
             'options': {
                 'dnf': {
                     'ocp-repo-content-set-x86_64': {'gpgcheck': '0'},
-                    # rhel-repo should NOT be present
+                    'rhel-repo-content-set-x86_64': {'gpgcheck': '0'},
                 }
             },
         }

--- a/doozer/tests/backend/test_konflux_cachi2.py
+++ b/doozer/tests/backend/test_konflux_cachi2.py
@@ -181,11 +181,19 @@ class TestKonfluxCachi2(TestCase):
         metadata.get_enabled_repos.return_value = {'repo1', 'repo2'}
         metadata.get_arches.return_value = ['x86_64', 'aarch64']
 
-        # Mock repository objects
+        # Mock repository objects with plashets URLs
         mock_repo1 = MagicMock()
         mock_repo1.content_set.side_effect = lambda arch: f'repo1-content-set-{arch}'
+        mock_repo1.baseurl.side_effect = (
+            lambda repotype,
+            arch: f'https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/4.21/test/el9/latest/{arch}/os/'
+        )
         mock_repo2 = MagicMock()
         mock_repo2.content_set.side_effect = lambda arch: f'repo2-content-set-{arch}'
+        mock_repo2.baseurl.side_effect = (
+            lambda repotype,
+            arch: f'https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/4.21/test/el9-embargoed/latest/{arch}/os/'
+        )
 
         metadata.runtime.repos = {'repo1': mock_repo1, 'repo2': mock_repo2}
 
@@ -304,6 +312,10 @@ class TestKonfluxCachi2(TestCase):
         # Mock repository object that returns None for content_set
         mock_repo1 = MagicMock()
         mock_repo1.content_set.return_value = None  # Trigger fallback
+        mock_repo1.baseurl.side_effect = (
+            lambda repotype,
+            arch: f'https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/4.21/test/el9/latest/{arch}/os/'
+        )
 
         metadata.runtime.repos = {'repo1': mock_repo1}
 
@@ -315,6 +327,58 @@ class TestKonfluxCachi2(TestCase):
             'options': {
                 'dnf': {
                     'repo1-x86_64': {'gpgcheck': '0'}  # Fallback format
+                }
+            },
+        }
+        expected = [expected_rpm_data, {'type': 'gomod', 'path': '.'}]
+        self.assertEqual(result, expected)
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    def test_prefetch_prerelease_non_plashets_repos_excluded(self, mock_konflux_client_init):
+        """Test that prerelease phase excludes repositories without '/plashets/' in baseurl"""
+        builder = KonfluxImageBuilder(MagicMock())
+        metadata = MagicMock()
+
+        # Setup metadata for prerelease RPM lockfile scenario
+        metadata.is_cachi2_enabled.return_value = True
+        metadata.is_lockfile_generation_enabled.return_value = True
+        metadata.is_artifact_lockfile_enabled.return_value = False
+        metadata.get_konflux_network_mode.return_value = "hermetic"
+        metadata.config.content.source.pkg_managers = ["gomod"]
+        metadata.config.cachito.packages = {'gomod': [{'path': '.'}]}
+        metadata.config.konflux.cachi2.lockfile.get.return_value = "."
+
+        # Setup prerelease phase
+        metadata.runtime.group_config.software_lifecycle.phase = 'pre-release'
+        metadata.get_enabled_repos.return_value = {'ocp-repo', 'rhel-repo'}
+        metadata.get_arches.return_value = ['x86_64']
+
+        # Mock repository objects: one with plashets, one without
+        mock_ocp_repo = MagicMock()
+        mock_ocp_repo.content_set.side_effect = lambda arch: f'ocp-repo-content-set-{arch}'
+        mock_ocp_repo.baseurl.side_effect = (
+            lambda repotype,
+            arch: f'https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/4.21/test/el9/latest/{arch}/os/'
+        )
+
+        mock_rhel_repo = MagicMock()
+        mock_rhel_repo.content_set.side_effect = lambda arch: f'rhel-repo-content-set-{arch}'
+        mock_rhel_repo.baseurl.side_effect = (
+            lambda repotype, arch: f'https://cdn.redhat.com/content/dist/rhel9/{arch}/appstream/os/'
+        )
+
+        metadata.runtime.repos = {'ocp-repo': mock_ocp_repo, 'rhel-repo': mock_rhel_repo}
+
+        result = builder._prefetch(metadata=metadata)
+
+        # Should only have DNF options for OCP repo with plashets, not RHEL repo
+        expected_rpm_data = {
+            'type': 'rpm',
+            'path': '.',
+            'options': {
+                'dnf': {
+                    'ocp-repo-content-set-x86_64': {'gpgcheck': '0'},
+                    # rhel-repo should NOT be present
                 }
             },
         }

--- a/doozer/tests/backend/test_konflux_cachi2.py
+++ b/doozer/tests/backend/test_konflux_cachi2.py
@@ -221,7 +221,7 @@ class TestKonfluxCachi2(TestCase):
         metadata.config.cachito.packages = {'gomod': [{'path': '.'}]}
         metadata.config.konflux.cachi2.lockfile.get.return_value = "."
 
-        metadata.runtime.group_config.software_lifecycle.phase = 'production'
+        metadata.runtime.group_config.software_lifecycle.phase = 'release'
         metadata.get_enabled_repos.return_value = {'repo1', 'repo2'}
         metadata.get_arches.return_value = ['x86_64']
 


### PR DESCRIPTION
## Summary
Extended RPM prefetch functionality to conditionally disable GPG checking during prerelease phase by adding DNF repository configuration with gpgcheck=0 for all enabled repositories using proper repository IDs.

## Problem
**Before:** Current RPM prefetch only includes basic structure `{"type": "rpm", "path": "."}` without any DNF repository configuration options, regardless of software lifecycle phase.
**After:** When building images during prerelease phase, RPM prefetch includes DNF repository configuration that disables GPG checking (`"gpgcheck": "0"`) for all repositories, following the Hermeto specification format with proper content set IDs.

## Changes
- `doozer/doozerlib/backend/konflux_image_builder.py`: Enhanced _prefetch() method (lines 393-416) to detect prerelease phase and add DNF repository configuration with proper repository ID extraction
- `doozer/tests/backend/test_konflux_cachi2.py`: Added 5 comprehensive test cases covering prerelease functionality, edge cases, and repository ID validation

**Technical Notes**
- Uses `metadata.runtime.group_config.software_lifecycle.phase == 'pre-release'` for phase detection  
- Accesses repository objects via public `metadata.runtime.repos[repo_name]` interface
- Extracts proper content set IDs using `repo.content_set(arch)` method for all building architectures
- Includes fallback logic when content_set returns None (same pattern as lockfile generation)
- Generates prefetch structure: `{"type": "rpm", "path": ".", "options": {"dnf": {"repo-id": {"gpgcheck": "0"}}}}`
- Maintains backward compatibility - zero impact on non-prerelease builds

**Example Output:**
```json
{
  "type": "rpm",
  "path": ".",
  "options": {
    "dnf": {
      "fast-datapath-for-rhel-9-aarch64-rpms": {"gpgcheck": "0"},
      "fast-datapath-for-rhel-9-x86_64-rpms": {"gpgcheck": "0"},
      "rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4": {"gpgcheck": "0"},
      "rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_4": {"gpgcheck": "0"},
      "rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4": {"gpgcheck": "0"},
      "rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_4": {"gpgcheck": "0"},
      "rhocp-4.21-for-rhel-9-aarch64-rpms": {"gpgcheck": "0"},
      "rhocp-4.21-for-rhel-9-x86_64-rpms": {"gpgcheck": "0"}
    }
  }
}
```

**Related:**
- Successfully tested with hermetic build: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-21/pipelineruns/ose-4-21-dpu-intel-ipu-vsp-26m8b/
- Closes: https://issues.redhat.com/browse/ART-14028