### PR TITLE
Limit Konflux build attempts to 1

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -17,6 +17,7 @@ from artcommonlib.util import extract_group_from_nvr
 from google.cloud.bigquery import Row, SchemaField
 from sqlalchemy import BinaryExpression, Boolean, Column, DateTime, Null, String, func
 from sqlalchemy.sql import text
+from tenacity import retry, stop_after_attempt, wait_fixed
 
 SCHEMA_LEVEL = 1
 
@@ -963,6 +964,7 @@ class KonfluxDb:
         # This will check cache first, then use exponential windows
         return await self.get_latest_build(nvr=nvr, outcome=outcome, strict=strict)
 
+    @retry(reraise=True, wait=wait_fixed(5), stop=stop_after_attempt(3))
     async def get_build_records_by_nvrs(
         self,
         nvrs: typing.Sequence[str],


### PR DESCRIPTION
Currently, we try an image builds to a maximum of 3 times in a row if it fails. This has proven to be ineffective, and we mostly get 3 build failures in a row that only pollute our images health checks. Removing the iteration, while adding retries to functions that could fail to networking/communication issues should fix this.

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/17335/console