### PR TITLE
group option for bundle and fbc

### DIFF
--- a/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
@@ -21,6 +21,13 @@ from pyartcd.runtime import Runtime
     default=constants.OCP_BUILD_DATA_URL,
     help='ocp-build-data fork to use (e.g. assembly definition in your own fork)',
 )
+@click.option(
+    "-g",
+    "--group",
+    metavar='NAME',
+    required=False,
+    help="The group of components on which to operate. e.g. openshift-4.9 / oadp-1.5",
+)
 @click.option('--data-gitref', required=False, help='(Optional) Doozer data path git [branch / tag / sha] to use')
 @click.option(
     '--nvrs',
@@ -66,14 +73,19 @@ async def olm_bundle_konflux(
     force: bool,
     kubeconfig: str,
     plr_template: str,
+    group: str,
 ):
+    # If unspecified, assume it's for openshift
+    if not group:
+        group = f"openshift-{version}"
+
     # Create Doozer invocation
     cmd = [
         'doozer',
         '--build-system=konflux',
         f'--assembly={assembly}',
         f'--working-dir={runtime.doozer_working}',
-        f'--group=openshift-{version}@{data_gitref}' if data_gitref else f'--group=openshift-{version}',
+        f'--group={group}@{data_gitref}' if data_gitref else f'--group={group}',
         f'--data-path={data_path}',
     ]
     if only:


### PR DESCRIPTION
OADP is being onboarded to ART and they live on seperate branches in ocp-build-data: https://github.com/openshift-eng/ocp-build-data/tree/oadp-1.3

Allow the bundle and FBC build jobs to pass in a group option to let the new operators build, since they are not related to openshift

Alongside: https://github.com/openshift-eng/aos-cd-jobs/pull/4480