### PR TITLE
use group config to get major version

### DIFF
--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -1541,7 +1541,9 @@ def get_flaws(
         first_fix_flaw_bugs = [
             flaw_bug_info['bug']
             for flaw_bug_info in flaw_tracker_map.values()
-            if is_first_fix_any(flaw_bug_info['bug'], flaw_bug_info['trackers'], flaw_bug_tracker.config.get('version')[0])
+            if is_first_fix_any(
+                flaw_bug_info['bug'], flaw_bug_info['trackers'], flaw_bug_tracker.config.get('version')[0]
+            )
         ]
 
     logger.info(f'{len(first_fix_flaw_bugs)} out of {len(flaw_tracker_map)} flaw bugs considered "first-fix"')


### PR DESCRIPTION
The "assembly" parameter in is_first_fix_any is used to get major minor version, for RC it can't extract the number from assembly value, we can use bug_tracker's version(eg 4.19.0) which is set in ocp-build-data, it can be used similarly to group value(eg openshift-4.19)