### PR TITLE
feat(konflux): add network-mode CLI override for konflux builds

### DIFF
--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -142,6 +142,11 @@ class KonfluxRebaseCli:
     help="Repo group type to use (e.g. signed, unsigned).",
 )
 @click.option('--image-repo', default=constants.KONFLUX_DEFAULT_IMAGE_REPO, help='Image repo for base images')
+@click.option(
+    '--network-mode',
+    type=click.Choice(['hermetic', 'internal-only', 'open']),
+    help='Override network mode for Konflux builds. Takes precedence over image and group config settings.',
+)
 @option_commit_message
 @option_push
 @pass_runtime
@@ -154,12 +159,16 @@ async def images_konflux_rebase(
     force_yum_updates: bool,
     repo_type: str,
     image_repo: str,
+    network_mode: Optional[str],
     message: str,
     push: bool,
 ):
     """
     Refresh a group's konflux content from source content.
     """
+    if network_mode:
+        runtime.network_mode_override = network_mode
+
     cli = KonfluxRebaseCli(
         runtime=runtime,
         version=version,
@@ -275,6 +284,11 @@ class KonfluxBuildCli:
     required=True,
     help='Kueue build priority. Use "auto" for automatic resolution from image/group config, or specify a number 1-10 (where 1 is highest priority). Takes precedence over group and image config settings.',
 )
+@click.option(
+    '--network-mode',
+    type=click.Choice(['hermetic', 'internal-only', 'open']),
+    help='Override network mode for Konflux builds. Takes precedence over image and group config settings.',
+)
 @pass_runtime
 @click_coroutine
 async def images_konflux_build(
@@ -287,7 +301,11 @@ async def images_konflux_build(
     dry_run: bool,
     plr_template: str,
     build_priority: Optional[str],
+    network_mode: Optional[str],
 ):
+    if network_mode:
+        runtime.network_mode_override = network_mode
+
     cli = KonfluxBuildCli(
         runtime=runtime,
         konflux_kubeconfig=konflux_kubeconfig,

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -640,10 +640,13 @@ class Metadata(MetadataBase):
         return False, None
 
     def get_konflux_network_mode(self):
+        runtime_override = getattr(self.runtime, 'network_mode_override', None)
+        if runtime_override:
+            return runtime_override
+
         group_config_network_mode = self.runtime.group_config.konflux.get("network_mode")
         image_config_network_mode = self.config.konflux.get("network_mode")
 
-        # Image config supersedes group config, but set to "open" by default, if missing.
         network_mode = image_config_network_mode or group_config_network_mode or "open"
 
         valid_network_modes = ["hermetic", "internal-only", "open"]

--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -145,6 +145,8 @@ class Runtime(GroupRuntime):
         for key, val in kwargs.items():
             self.__dict__[key] = val
 
+        self.network_mode_override = None
+
         if self.latest_parent_version:
             self.ignore_missing_base = True
 

--- a/doozer/tests/cli/test_scan_sources_konflux.py
+++ b/doozer/tests/cli/test_scan_sources_konflux.py
@@ -610,3 +610,30 @@ class TestTaskBundleIntegration(TestScanSourcesKonflux):
 
             # Should not call get_attestation when image is already changing
             mock_get_attestation.assert_not_called()
+
+    async def test_network_mode_override_end_to_end_integration(self):
+        """Test complete CLI override flow through all components."""
+        runtime = MagicMock()
+        runtime.network_mode_override = "internal-only"
+        runtime.assembly = "test"
+        runtime.get_releases_config.return_value = {}
+
+        group_config = MagicMock()
+        group_config.konflux.get.return_value = "hermetic"
+        runtime.group_config = group_config
+
+        image_config = MagicMock()
+        image_config.konflux.get.return_value = "open"
+
+        data_obj = MagicMock()
+        data_obj.key = "test"
+        data_obj.filename = "test.yml"
+        data_obj.data = {"name": "test"}
+
+        from doozerlib.metadata import Metadata
+
+        meta = Metadata("image", runtime, data_obj)
+        meta.config = image_config
+
+        result = meta.get_konflux_network_mode()
+        self.assertEqual(result, "internal-only")


### PR DESCRIPTION
## Summary
Add --network-mode CLI option to konflux rebase and build commands, enabling runtime override of network mode configuration. Includes PyARTCD integration to pass the override through automated pipelines.

## Problem
**Before:** Network mode can only be configured through image/group metadata files using a rigid hierarchy: Image config > Group config > Default ("open"). No runtime override capability exists. Must manually modify config files to test different network modes or bypass hermetic mode when RPM lockfiles don't exist yet.

**After:** CLI option takes precedence over all configuration hierarchy, enabling runtime override without config file modifications. Supports testing different network modes and provides operational bypass capability.

## Usage Examples
```bash
# Override network mode during rebase
doozer --group=openshift-4.21 beta:images:konflux:rebase --network-mode hermetic --version=4.21 --release=202501011200

# Override network mode during build  
doozer --group=openshift-4.21 beta:images:konflux:build --network-mode open

# PyARTCD automatically passes override to both rebase and build
artcd ocp4-konflux --assembly=stream --version=4.21 --network-mode=open
```

The CLI override establishes a new precedence hierarchy: **CLI Override → Image Config → Group Config → Default ("open")**. This enables operational flexibility for testing hermetic vs open builds and troubleshooting build issues without modifying configuration files.