### PR TITLE
remove parameter strict=True from the call to get_build_records_by_nvrs in  wrapper function in elliottlib

### DIFF
--- a/elliott/elliottlib/cli/conforma_cli.py
+++ b/elliott/elliottlib/cli/conforma_cli.py
@@ -141,7 +141,7 @@ class ConformaVerifyCli:
         pullspec_by_name = {comp.name: comp.containerImage for comp in snapshot_spec.components}
 
         # we need to fetch build records so we can map nvrs to pullspecs
-        build_records_by_nvrs = await get_build_records_by_nvrs(self.runtime, batch_nvrs, strict=True)
+        build_records_by_nvrs = await get_build_records_by_nvrs(self.runtime, batch_nvrs)
         nvrs_by_pullspec = {str(record.image_pullspec): record.nvr for record in build_records_by_nvrs.values()}
 
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:


### PR DESCRIPTION
wrapper function get_build_records_by_nvrs in elliott/elliottlib/cli/snapshot_cli.py does not accept a keyword parameter called strict.
This change fixes this issue:
The issue was seen as follows:

verify-conforma command called:
elliott -g openshift-4.16 --data-path=https://github.com/openshift-eng/ocp-build-data verify-conforma --pullspec [registry.ci.openshift.org/ocp/release:4.16.0-0.nightly-2025-10-07-073920](http://registry.ci.openshift.org/ocp/release:4.16.0-0.nightly-2025-10-07-073920) --konflux-kubeconfig /home/fedora/pullsandkube/artkubeconfig

Error in the trace:

2025-10-07 16:59:19,960 art_tools.elliottlib.cli.conforma_cli ERROR Failed to process batch 19: get_build_records_by_nvrs() **got an unexpected keyword argument 'strict'**
2025-10-07 16:59:19,960 art_tools.elliottlib.cli.conforma_cli ERROR === Batch 19/19 Results ===
2025-10-07 16:59:19,960 art_tools.elliottlib.cli.conforma_cli ERROR Batch success: False (Exception: get_build_records_by_nvrs() got an unexpected keyword argument 'strict')

This issue has now been fixed with the code change in the PR:
2025-10-08 11:21:55,491 art_tools.elliottlib.cli.conforma_cli INFO ✓ Batch verification passed
2025-10-08 11:21:55,491 art_tools.elliottlib.cli.conforma_cli INFO === Batch 19/19 Results ===