### PR TITLE
Make get_latest_build_info compatible with Konflux

### DIFF
--- a/artcommon/artcommonlib/metadata.py
+++ b/artcommon/artcommonlib/metadata.py
@@ -543,6 +543,12 @@ class MetadataBase(object):
             return self.get_latest_brew_build(**kwargs)
 
         elif self.runtime.build_system == 'konflux':
+            # Ensure get_latest_konflux_build() raises IOError when no default specified,
+            # matching get_latest_brew_build() behavior
+            default = kwargs.get('default', -1)
+            if default == -1:
+                kwargs['strict'] = True
+
             basis_event = self.runtime.assembly_basis_event
             if basis_event:
                 kwargs['completed_before'] = basis_event

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -310,17 +310,19 @@ class Metadata(MetadataBase):
 
     def get_latest_build_info(self, default=-1, **kwargs):
         """
-        Queries brew to determine the most recently built release of the component
+        Queries Brew or Konflux DB (controlled by --build-system) to determine the most recently built release of the component
         associated with this image. This method does not rely on the "release"
         label needing to be present in the Dockerfile. kwargs will be passed on
         to get_latest_build.
         :param default: A value to return if no latest is found (if not specified, an exception will be thrown)
         :return: A tuple: (component name, version, release); e.g. ("registry-console-docker", "v3.6.173.0.75", "1")
         """
-        build = self.get_latest_brew_build(default=default, **kwargs)
+        build = self.get_latest_build_sync(default=default, **kwargs)
         if default != -1 and build == default:
             return default
-        return build['name'], build['version'], build['release']
+        if self.runtime.build_system == "brew":
+            build = Model(build)
+        return build.name, build.version, build.release
 
     def has_source(self):
         """


### PR DESCRIPTION
`doozer --build-system=konflux images:print '{component}-{version}-{release}'` does not currently look at Konflux builds when trying to get the version and release of latest image builds. 

Use `get_latest_build_sync()` instead of `get_latest_brew_build()` to honor `--build-system` option passed to doozer


Required for https://github.com/openshift-eng/art-bot/pull/224