### PR TITLE
Make get_latest_konflux_build() consistent with get_latest_brew_build()

### DIFF
--- a/artcommon/artcommonlib/metadata.py
+++ b/artcommon/artcommonlib/metadata.py
@@ -426,7 +426,7 @@ class MetadataBase(object):
 
     async def get_latest_konflux_build(
         self,
-        default=None,
+        default=-1,
         assembly: Optional[str] = None,
         outcome: KonfluxBuildOutcome = KonfluxBuildOutcome.SUCCESS,
         el_target: Optional[Union[int, str]] = None,
@@ -436,7 +436,7 @@ class MetadataBase(object):
         **kwargs,
     ) -> Optional[KonfluxBuildRecord]:
         """
-        :param default: the value to be returned when no build is found
+        :param default: the value to be returned when no build is found (if not specified, an exception will be thrown)
         :param assembly: A non-default assembly name to search relative to. If not specified, runtime.assembly
                          will be used. If runtime.assembly is also None, the search will return true latest.
                          If the assembly parameter is set to '', this search will also return true latest.
@@ -509,13 +509,14 @@ class MetadataBase(object):
                 )
 
         if not build_record:
-            self.logger.warning(
-                'No build found for %s in group and %s assembly %s',
-                self.distgit_key,
-                self.runtime.group,
-                self.runtime.assembly,
+            msg = (
+                f'No build found for {self.distgit_key} in group {self.runtime.group} '
+                f'and assembly {self.runtime.assembly}'
             )
-            return default
+            if default != -1:
+                self.logger.info(msg)
+                return default
+            raise IOError(msg)
         return build_record
 
     async def get_latest_brew_build_async(self, **kwargs):

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -390,8 +390,6 @@ class KonfluxRebaser:
                     engine=Engine.KONFLUX,
                 )
 
-                if not build:
-                    raise IOError(f"A build of parent image {member} is not found.")
                 return build.image_pullspec, build.embargoed
 
             return original_parent, False
@@ -2079,8 +2077,6 @@ class KonfluxRebaser:
                     el_target=f'el{meta.branch_el_target()}',
                     engine=Engine.KONFLUX,
                 )
-                if not build:
-                    raise ValueError(f'Could not find latest build for {meta.distgit_key}')
                 v = build.version
                 r = build.release
                 image_tag = '{}:{}-{}'.format(meta.image_name_short, v, r)

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -470,7 +470,7 @@ class FbcRebaseAndBuildCli:
             operator_metas: List[ImageMetadata] = [
                 operator_meta for operator_meta in self.runtime.ordered_image_metas() if operator_meta.is_olm_operator
             ]
-            records = await asyncio.gather(*(metadata.get_latest_build() for metadata in operator_metas))
+            records = await asyncio.gather(*(metadata.get_latest_build(default=None) for metadata in operator_metas))
             not_found = [metadata.distgit_key for metadata, record in zip(operator_metas, records) if record is None]
             if not_found:
                 raise DoozerFatalError(f"Couldn't find build records for {not_found}")

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -384,7 +384,7 @@ class KonfluxBundleCli:
             operator_metas: List[ImageMetadata] = [
                 operator_meta for operator_meta in runtime.ordered_image_metas() if operator_meta.is_olm_operator
             ]
-            records = await asyncio.gather(*(metadata.get_latest_build() for metadata in operator_metas))
+            records = await asyncio.gather(*(metadata.get_latest_build(default=None) for metadata in operator_metas))
             not_found = [metadata.distgit_key for metadata, record in zip(operator_metas, records) if record is None]
             if not_found:
                 raise IOError(f"Couldn't find build records for {not_found}")

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -717,7 +717,7 @@ async def find_builds_konflux(runtime, payload):
         image_metas.append(image)
 
     LOGGER.info("Fetching NVRs from DB...")
-    tasks = [image.get_latest_build(el_target=image.branch_el_target()) for image in image_metas]
+    tasks = [image.get_latest_build(default=None, el_target=image.branch_el_target()) for image in image_metas]
     records: List[Dict] = [r for r in await asyncio.gather(*tasks) if r is not None]
     if len(records) != len(image_metas):
         raise ElliottFatalError(f"Failed to find Konflux builds for {len(image_metas) - len(records)} images")
@@ -766,7 +766,7 @@ async def find_builds_konflux_all_types(runtime) -> Dict[str, List]:
     for is_payload, image in image_metas:
         olm_flags.append(image.is_olm_operator)
         payload_flags.append(is_payload)
-        tasks.append(image.get_latest_build(el_target=image.branch_el_target()))
+        tasks.append(image.get_latest_build(default=None, el_target=image.branch_el_target()))
     results = await asyncio.gather(*[task for task in tasks])
     records_with_olm = [
         (is_olm, is_payload, r) for is_olm, is_payload, r in zip(olm_flags, payload_flags, results) if r is not None


### PR DESCRIPTION
Currently `get_latest_konflux_build()` and `get_latest_brew_build()` behave differently when no build is found. Brew raises a clear IOError with `default=-1`, while Konflux returns None with `default=None`. This causes issues where code expects both to behave the same way.

This changes Konflux to match Brew's behavior: default to -1 and raise IOError when no build is found. Callers that explicitly want None returned (without raising IOError) now pass `default=None`. The PR also updates affected files to maintain existing functionality.