### PR TITLE
Don't prepare shipment for EC and RC releases of microshift-bootc

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -575,13 +575,14 @@ def start_microshift_sync(version: str, assembly: str, dry_run: bool, **kwargs):
     )
 
 
-def start_build_microshift_bootc(version: str, assembly: str, dry_run: bool, **kwargs):
+def start_build_microshift_bootc(version: str, assembly: str, dry_run: bool, prepare_shipment: bool = True, **kwargs):
     return start_build(
         job=Jobs.BUILD_MICROSHIFT_BOOTC,
         params={
             'BUILD_VERSION': version,
             'ASSEMBLY': assembly,
             'DRY_RUN': dry_run,
+            'PREPARE_SHIPMENT': prepare_shipment,
         },
         **kwargs,
     )

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -322,8 +322,17 @@ class BuildMicroShiftPipeline:
 
         major, minor = self._ocp_version
         version = f'{major}.{minor}'
+
+        # Don't create shipment MR for ECs and RCs
+        prepare_shipment = self.assembly_type not in [AssemblyTypes.CANDIDATE, AssemblyTypes.PREVIEW]
+
         try:
-            jenkins.start_build_microshift_bootc(version=version, assembly=self.assembly, dry_run=self.runtime.dry_run)
+            jenkins.start_build_microshift_bootc(
+                version=version,
+                assembly=self.assembly,
+                dry_run=self.runtime.dry_run,
+                prepare_shipment=prepare_shipment,
+            )
             message = (
                 f"build_microshift_bootc for version {version} and assembly {self.assembly} has been triggered\n"
                 f"This will build microshift-bootc and publish it's pullspec to mirror"


### PR DESCRIPTION
For EC and RC releases, `build-microshift-bootc` should be triggered without `--prepare-shipment`. Discussed [here](https://redhat-internal.slack.com/archives/CB95J6R4N/p1764932794112599?thread_ts=1764776417.711039&cid=CB95J6R4N)