### PR TITLE
ART-12444- changes in ocp4-konflux

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -468,6 +468,21 @@ class KonfluxOcpPipeline:
             self.slack_client.bind_channel(f'openshift-{self.version}')
             await self.slack_client.say(f'Golang bug sweep failed for {self.version}. Please investigate')
 
+    async def sweep_second_fix_bugs(self):
+        # find-bugs:second-fix closes CVE trackers that are not first-fix in pre-release branches
+        # The command itself checks the software lifecycle phase and only runs for pre-release/signing phases
+        cmd = [
+            'elliott',
+            f'--group=openshift-{self.version}',
+            "find-bugs:second-fix",
+            "--close",
+        ]
+        try:
+            await exectools.cmd_assert_async(cmd)
+        except ChildProcessError:
+            self.slack_client.bind_channel(f'openshift-{self.version}')
+            await self.slack_client.say(f'Second-fix bug sweep failed for {self.version}. Please investigate')
+
     async def init_build_plan(self):
         # Get number of images in current group
         shutil.rmtree(self.runtime.doozer_working, ignore_errors=True)
@@ -762,6 +777,10 @@ class KonfluxOcpPipeline:
             if uses_konflux_imagestream_override(self.version):
                 await self.sweep_bugs()
                 await self.sweep_golang_bugs()
+                if not self.runtime.dry_run:
+                    await self.sweep_second_fix_bugs()
+                else:
+                    LOGGER.info('Skipping second-fix bug sweep in dry run mode')
             else:
                 LOGGER.info(
                     f'Skipping bug sweep for {self.version} since it is not in the override list and is handled by ocp4'


### PR DESCRIPTION
for **find-bugs:second-fix**
which closes OCPBUGS that are found/determined as not first-fix when running ocp4_konflux jobs - only and when the software-lifecycle phase is pre-release or signed (so before release)
  
test-job:
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/mbiarnes/job/ocp4-konflux/49/console

> 13:24:01  2025-12-05 12:24:01,001 artcommonlib INFO On commit: 9b492cc4fd8dcf2093ca5997fcc0365255e7a6fd (openshift-4.22)
13:24:01  2025-12-05 12:24:01,119 artcommonlib INFO Using branch from group.yml: rhaos-4.22-rhel-9
13:24:02  2025-12-05 12:24:01,980 art_tools.elliottlib.cli.find_bugs_second_fix_cli INFO Software lifecycle is pre-release. Performing second-fix action ...
13:24:02  2025-12-05 12:24:01,980 art_tools.elliottlib.cli.find_bugs_second_fix_cli INFO Fetching tracker bugs .. 
13:24:05  2025-12-05 12:24:05,008 art_tools.elliottlib.cli.find_bugs_second_fix_cli INFO 0 trackers found: []
13:24:05  2025-12-05 12:24:05,008 art_tools.elliottlib.cli.find_bugs_second_fix_cli INFO 0 valid trackers found: []
13:24:05  2025-12-05 12:24:05,008 art_tools.elliottlib.cli.find_bugs_second_fix_cli INFO Computing second-fix tracker ids .. 
13:24:05  2025-12-05 12:24:05,014 bugzilla._authfiles INFO Found bugzillarc files: ['/home/jenkins/.config/python-bugzilla/bugzillarc']
13:24:05  2025-12-05 12:24:05,274 bugzilla.base INFO Using RHBugzilla for URL containing .redhat.com
13:24:06  2025-12-05 12:24:06,040 art_tools.elliottlib.cli.find_bugs_second_fix_cli INFO 0 CVE trackers that are second-fix: []

