### PR TITLE
ART-14961 Define a config manager for registry auths

### DIFF
--- a/artcommon/artcommonlib/registry_config.py
+++ b/artcommon/artcommonlib/registry_config.py
@@ -1,0 +1,328 @@
+"""
+Context manager for managing container registry credentials from multiple sources.
+
+This module provides RegistryConfig, a context manager that merges credentials
+from multiple auth files and provides a temporary file path for use with
+container tools like oc, podman, etc.
+"""
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import List, Optional
+
+
+class RegistryConfig:
+    """
+    Context manager for managing container registry credentials from multiple sources.
+
+    This class merges credentials from:
+    1. Existing default auth file (e.g., /run/user/<uid>/containers/auth.json)
+    2. Additional auth files specified via environment variables
+
+    It filters credentials to avoid conflicts (e.g., skipping org-level
+    credentials from additional sources if they conflict with existing repo-specific ones).
+
+    The context manager creates a temporary auth file in the current directory and
+    returns its path. The file is automatically deleted when exiting the context.
+
+    Example usage:
+        # Using filter_patterns to filter credentials
+        with RegistryConfig(
+            additional_sources=['KONFLUX_ART_IMAGES_AUTH_FILE'],
+            filter_patterns=['quay.io/redhat-user-workloads/']
+        ) as auth_file:
+            # Use auth_file path with oc or other tools
+            exectools.cmd_assert(f'oc image mirror --registry-config={auth_file} ...')
+
+        # Using registries to require specific registries (ignores filter_patterns)
+        with RegistryConfig(
+            registries=['quay.io/openshift-release-dev', 'registry.redhat.io'],
+            additional_sources=['KONFLUX_ART_IMAGES_AUTH_FILE'],
+        ) as auth_file:
+            # Validates that both registries exist in merged credentials
+            exectools.cmd_assert(f'oc image mirror --registry-config={auth_file} ...')
+    """
+
+    def __init__(
+        self,
+        registries: Optional[List[str]] = None,
+        additional_sources: Optional[List[str]] = None,
+        filter_patterns: Optional[List[str]] = None,
+        default_auth_file: Optional[str] = None,
+    ):
+        """
+        Initialize the RegistryConfig context manager.
+
+        :param Optional[List[str]] registries: List of specific registries that must be present in the merged credentials.
+            If provided, filter_patterns is ignored and all credentials are loaded.
+            After merging, validates that all specified registries exist in the credentials.
+        :param Optional[List[str]] additional_sources: List of environment variable names containing paths to additional auth files
+        :param Optional[List[str]] filter_patterns: List of registry patterns to include.
+            Only credentials matching these patterns will be added. If None, all credentials are included.
+            Ignored if registries parameter is provided.
+        :param Optional[str] default_auth_file: Path to the default auth file. If None, uses XDG_RUNTIME_DIR/containers/auth.json
+        """
+
+        self.registries = registries
+        self.additional_sources = additional_sources
+        self.filter_patterns = filter_patterns
+        self.logger = logging.getLogger(__name__)
+
+        # Determine default auth file location
+        if default_auth_file:
+            self.default_auth_file = default_auth_file
+
+        else:
+            runtime_dir = os.environ.get('XDG_RUNTIME_DIR', f'/run/user/{os.getuid()}')
+            self.default_auth_file = os.path.join(runtime_dir, 'containers', 'auth.json')
+
+        # Temporary file for merged credentials
+        self.temp_auth_file: Optional[Path] = None
+        self.merged_auths: dict = {}
+
+    def __enter__(self) -> str:
+        """
+        Enter the context manager: read, merge, and write credentials to a temporary file.
+
+        :return: Path to the temporary auth file containing merged credentials
+        :raises ValueError: If registries parameter is provided and any required registry is not found
+        """
+
+        self.logger.info(f'Default auth file: {self.default_auth_file}')
+
+        # Read existing credentials
+        self._read_existing_credentials()
+
+        # Add credentials from additional sources
+        self._add_additional_credentials()
+
+        # Validate required registries are present
+        if self.registries:
+            self._validate_required_registries()
+
+        # Write merged credentials to temporary file in current directory
+        self._write_merged_credentials()
+
+        return str(self.temp_auth_file)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Exit the context manager: clean up temporary auth file.
+
+        :param exc_type: Exception type if an exception occurred
+        :param exc_val: Exception value if an exception occurred
+        :param exc_tb: Exception traceback if an exception occurred
+        :return: False to not suppress exceptions
+        """
+
+        if self.temp_auth_file and self.temp_auth_file.exists():
+            try:
+                self.temp_auth_file.unlink()
+                self.logger.debug(f'Cleaned up temporary auth file: {self.temp_auth_file}')
+
+            except Exception as e:
+                self.logger.error(f'Failed to clean up temporary auth file {self.temp_auth_file}: {e}')
+
+        # Don't suppress exceptions
+        return False
+
+    def _read_existing_credentials(self):
+        """
+        Read existing credentials from the default auth file.
+        If registries parameter is provided, filtering is skipped.
+        """
+
+        if os.path.exists(self.default_auth_file):
+            try:
+                with open(self.default_auth_file, 'r') as f:
+                    existing_config = json.load(f)
+                    all_auths = existing_config.get('auths', {})
+
+                    self.logger.debug(f'Read {len(all_auths)} existing auth entries from default file')
+
+                    # Skip filtering if registries parameter is provided
+                    if self.registries is not None:
+                        # No filtering when specific registries are required
+                        self.merged_auths = all_auths
+                        self.logger.debug(
+                            f'Registries parameter provided - kept all {len(self.merged_auths)} credentials'
+                        )
+
+                    # Apply filtering to default credentials if filter_patterns is provided
+                    elif self.filter_patterns is None:
+                        # No filtering - include all credentials
+                        self.merged_auths = all_auths
+                        self.logger.debug(f'No filtering applied - kept all {len(self.merged_auths)} credentials')
+
+                    else:
+                        # Filter credentials based on patterns
+                        filtered_count = 0
+                        for registry, creds in all_auths.items():
+                            if any(registry.startswith(pattern) for pattern in self.filter_patterns):
+                                self.merged_auths[registry] = creds
+                                filtered_count += 1
+                            else:
+                                self.logger.debug(f'Skipping {registry} (does not match filter patterns)')
+
+                        self.logger.debug(f'Kept {filtered_count} credentials after filtering')
+
+            except Exception as e:
+                self.logger.error(f'Failed to read existing auth file: {e}')
+                raise
+
+        else:
+            self.logger.warning(f'No existing credentials found at {self.default_auth_file}')
+            self.merged_auths = {}
+
+    def _add_additional_credentials(self):
+        """
+        Add credentials from additional sources.
+        If registries parameter is provided, filtering is skipped.
+        """
+
+        if not self.additional_sources:
+            self.logger.debug('No additional sources specified')
+            return
+
+        total_added = 0
+
+        for source_env_var in self.additional_sources:
+            auth_file_path = os.environ.get(source_env_var)
+
+            if not auth_file_path:
+                self.logger.debug(f'Environment variable {source_env_var} not set, skipping')
+                continue
+
+            if not os.path.exists(auth_file_path):
+                self.logger.warning(f'Auth file not found: {auth_file_path} (from {source_env_var})')
+                continue
+
+            try:
+                with open(auth_file_path, 'r') as f:
+                    additional_config = json.load(f)
+                    additional_auths = additional_config.get('auths', {})
+
+                    self.logger.info(f'Found {len(additional_auths)} auth entries in {source_env_var}')
+
+                    # Skip filtering if registries parameter is provided
+                    added_count = 0
+                    if self.registries is not None:
+                        # No filtering when specific registries are required
+                        for registry, creds in additional_auths.items():
+                            self.merged_auths[registry] = creds
+                            added_count += 1
+                            self.logger.info(f'Added credential for {registry}')
+
+                    # Filter credentials based on patterns (if filter_patterns is provided)
+                    elif self.filter_patterns is None:
+                        # No filtering - add all credentials
+                        for registry, creds in additional_auths.items():
+                            self.merged_auths[registry] = creds
+                            added_count += 1
+                            self.logger.info(f'Added credential for {registry}')
+                    else:
+                        # Filter credentials based on patterns
+                        for registry, creds in additional_auths.items():
+                            # Check if registry matches any filter pattern
+                            if any(registry.startswith(pattern) for pattern in self.filter_patterns):
+                                self.merged_auths[registry] = creds
+                                added_count += 1
+                                self.logger.info(f'Added credential for {registry}')
+                            else:
+                                self.logger.debug(f'Skipping {registry} (does not match filter patterns)')
+
+                    self.logger.info(f'Added {added_count} credentials from {source_env_var}')
+                    total_added += added_count
+
+            except Exception as e:
+                self.logger.error(f'Failed to read auth file from {source_env_var}: {e}')
+                raise
+
+        if total_added == 0:
+            self.logger.warning('No additional credentials were added')
+
+    def _validate_required_registries(self):
+        """
+        Validate that all required registries are present in merged credentials.
+
+        :raises ValueError: If any required registry is not found in the merged credentials
+        """
+
+        missing_registries = []
+        for required_registry in self.registries:
+            if required_registry not in self.merged_auths:
+                missing_registries.append(required_registry)
+                self.logger.error(f'Required registry not found: {required_registry}')
+
+        if missing_registries:
+            available = list(self.merged_auths.keys())
+            raise ValueError(
+                f"Required registries not found in credentials: {missing_registries}. Available registries: {available}"
+            )
+
+        self.logger.info(f'All required registries present: {self.registries}')
+
+    def _write_merged_credentials(self):
+        """
+        Write merged credentials to a temporary file in the current directory.
+        """
+        try:
+            # Create temporary file in current directory with delete=False so we control deletion
+            fd, temp_path = tempfile.mkstemp(prefix='registry-auth-', suffix='.json', dir='.', text=True)
+
+            self.temp_auth_file = Path(temp_path)
+
+            # Write the merged credentials
+            merged_config = {'auths': self.merged_auths}
+            with os.fdopen(fd, 'w') as f:
+                json.dump(merged_config, f, indent=2)
+
+            self.logger.debug(f'Wrote {len(self.merged_auths)} total auth entries to {self.temp_auth_file}')
+            self.logger.info(f'Enabled registries: {list(self.merged_auths.keys())}')
+
+            # Verify writing was successful
+            with open(self.temp_auth_file, 'r') as f:
+                verify_config = json.load(f)
+                verify_auths = verify_config.get('auths', {})
+                if len(verify_auths) != len(self.merged_auths):
+                    raise RuntimeError(
+                        f'Verification failed: Expected {len(self.merged_auths)} entries, got {len(verify_auths)}'
+                    )
+
+        except Exception:
+            # Clean up on error
+            if self.temp_auth_file and self.temp_auth_file.exists():
+                try:
+                    self.temp_auth_file.unlink()
+                except:
+                    pass
+            raise
+
+    def get_registries(self) -> List[str]:
+        """
+        Get list of registries in the merged credentials.
+
+        :return: List of registry names
+        """
+
+        return list(self.merged_auths.keys())
+
+    def has_credential_for(self, registry: str) -> bool:
+        """
+        Check if credentials exist for a specific registry.
+
+        :param str registry: Registry name to check (e.g., 'quay.io/openshift/')
+        :return: True if credentials exist, False otherwise
+        """
+
+        # Check exact match first
+        if registry in self.merged_auths:
+            return True
+
+        # Check if any existing credential is a parent/child of the requested registry
+        return any(
+            registry.startswith(auth_key) or auth_key.startswith(registry) for auth_key in self.merged_auths.keys()
+        )

--- a/artcommon/tests/test_registry_config.py
+++ b/artcommon/tests/test_registry_config.py
@@ -1,0 +1,580 @@
+"""
+Test the RegistryConfig class. Verify that it works as a context manager
+for merging container registry credentials from multiple sources.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, mock_open, patch
+
+from artcommonlib.registry_config import RegistryConfig
+
+
+class RegistryConfigTestCase(unittest.TestCase):
+    """
+    Test the features of the RegistryConfig class. This is a context manager
+    for merging container registry credentials from multiple auth files.
+    """
+
+    def setUp(self):
+        """
+        Set up test fixtures
+        """
+        self.test_dir = tempfile.mkdtemp()
+        self.default_auth = {
+            'auths': {
+                'quay.io/openshift-release-dev': {'auth': 'token1'},
+                'quay.io/redhat-user-workloads/test': {'auth': 'token2'},
+                'registry.ci.openshift.org': {'auth': 'token3'},
+            }
+        }
+        self.additional_auth = {
+            'auths': {
+                'quay.io/redhat-user-workloads/konflux': {'auth': 'konflux-token'},
+                'quay.io/openshift': {'auth': 'openshift-token'},
+            }
+        }
+
+    def tearDown(self):
+        """
+        Clean up test fixtures
+        """
+        # Clean up any leftover temp files in current directory
+        for file in Path('.').glob('registry-auth-*.json'):
+            try:
+                file.unlink()
+            except:
+                pass
+
+    def test_init_default_values(self):
+        """
+        Verify default initialization values
+        """
+        with patch('os.path.exists', return_value=False):
+            config = RegistryConfig()
+            self.assertIsNone(config.additional_sources)
+            self.assertIsNone(config.filter_patterns)
+            self.assertIsNotNone(config.default_auth_file)
+            self.assertIn('containers/auth.json', config.default_auth_file)
+
+    def test_init_custom_auth_file(self):
+        """
+        Verify custom default_auth_file path is used
+        """
+        custom_path = '/custom/path/auth.json'
+        with patch('os.path.exists', return_value=False):
+            config = RegistryConfig(default_auth_file=custom_path)
+            self.assertEqual(config.default_auth_file, custom_path)
+
+    def test_init_custom_filter_patterns(self):
+        """
+        Verify custom filter_patterns are stored
+        """
+        patterns = ['quay.io/test/', 'registry.example.com/']
+        with patch('os.path.exists', return_value=False):
+            config = RegistryConfig(filter_patterns=patterns)
+            self.assertEqual(config.filter_patterns, patterns)
+
+    def test_context_manager_creates_temp_file(self):
+        """
+        Verify that context manager creates a temporary auth file
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        with RegistryConfig(default_auth_file=default_auth_file) as auth_file:
+            # Verify temp file exists
+            self.assertTrue(os.path.exists(auth_file))
+            # Verify filename pattern (may or may not have ./ prefix)
+            basename = os.path.basename(auth_file)
+            self.assertTrue(basename.startswith('registry-auth-'))
+            self.assertTrue(basename.endswith('.json'))
+
+            # Verify temp file contains credentials
+            with open(auth_file, 'r') as f:
+                content = json.load(f)
+                self.assertIn('auths', content)
+
+        # Verify temp file is cleaned up after exit
+        self.assertFalse(os.path.exists(auth_file))
+
+    def test_context_manager_cleanup_on_exception(self):
+        """
+        Verify that temporary file is cleaned up even when exception occurs
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        temp_file_path = None
+        try:
+            with RegistryConfig(default_auth_file=default_auth_file) as auth_file:
+                temp_file_path = auth_file
+                self.assertTrue(os.path.exists(auth_file))
+                raise ValueError("Test exception")
+        except ValueError:
+            pass
+
+        # Verify temp file is cleaned up despite exception
+        self.assertFalse(os.path.exists(temp_file_path))
+
+    def test_read_existing_credentials_no_filtering(self):
+        """
+        Verify that all credentials are read when no filter_patterns is provided
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        with RegistryConfig(default_auth_file=default_auth_file) as auth_file:
+            with open(auth_file, 'r') as f:
+                content = json.load(f)
+                # All 3 credentials should be present
+                self.assertEqual(len(content['auths']), 3)
+                self.assertIn('quay.io/openshift-release-dev', content['auths'])
+                self.assertIn('quay.io/redhat-user-workloads/test', content['auths'])
+                self.assertIn('registry.ci.openshift.org', content['auths'])
+
+    def test_read_existing_credentials_with_filtering(self):
+        """
+        Verify that credentials are filtered when filter_patterns is provided
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        filter_patterns = ['quay.io/redhat-user-workloads/']
+
+        with RegistryConfig(default_auth_file=default_auth_file, filter_patterns=filter_patterns) as auth_file:
+            with open(auth_file, 'r') as f:
+                content = json.load(f)
+                # Only 1 credential should match the filter
+                self.assertEqual(len(content['auths']), 1)
+                self.assertIn('quay.io/redhat-user-workloads/test', content['auths'])
+                self.assertNotIn('quay.io/openshift-release-dev', content['auths'])
+                self.assertNotIn('registry.ci.openshift.org', content['auths'])
+
+    def test_read_existing_credentials_multiple_patterns(self):
+        """
+        Verify that credentials match any of multiple filter patterns
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        filter_patterns = ['quay.io/redhat-user-workloads/', 'registry.ci.openshift.org']
+
+        with RegistryConfig(default_auth_file=default_auth_file, filter_patterns=filter_patterns) as auth_file:
+            with open(auth_file, 'r') as f:
+                content = json.load(f)
+                # 2 credentials should match
+                self.assertEqual(len(content['auths']), 2)
+                self.assertIn('quay.io/redhat-user-workloads/test', content['auths'])
+                self.assertIn('registry.ci.openshift.org', content['auths'])
+                self.assertNotIn('quay.io/openshift-release-dev', content['auths'])
+
+    def test_no_existing_credentials(self):
+        """
+        Verify behavior when default auth file does not exist
+        """
+        non_existent_file = os.path.join(self.test_dir, 'nonexistent.json')
+
+        with RegistryConfig(default_auth_file=non_existent_file) as auth_file:
+            with open(auth_file, 'r') as f:
+                content = json.load(f)
+                # Should have empty auths
+                self.assertEqual(content['auths'], {})
+
+    def test_add_additional_credentials_no_sources(self):
+        """
+        Verify behavior when additional_sources is None
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        with RegistryConfig(default_auth_file=default_auth_file, additional_sources=None) as auth_file:
+            with open(auth_file, 'r') as f:
+                content = json.load(f)
+                # Should only have default credentials
+                self.assertEqual(len(content['auths']), 3)
+
+    @patch.dict(os.environ, {'KONFLUX_AUTH': '/path/to/konflux.json'})
+    def test_add_additional_credentials_with_filtering(self):
+        """
+        Verify that additional credentials are added and filtered
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        additional_auth_file = os.path.join(self.test_dir, 'konflux.json')
+        with open(additional_auth_file, 'w') as f:
+            json.dump(self.additional_auth, f)
+
+        with patch.dict(os.environ, {'KONFLUX_AUTH': additional_auth_file}):
+            with RegistryConfig(
+                default_auth_file=default_auth_file,
+                additional_sources=['KONFLUX_AUTH'],
+                filter_patterns=['quay.io/redhat-user-workloads/'],
+            ) as auth_file:
+                with open(auth_file, 'r') as f:
+                    content = json.load(f)
+                    # Should have 2 credentials: one from default, one from additional
+                    self.assertEqual(len(content['auths']), 2)
+                    self.assertIn('quay.io/redhat-user-workloads/test', content['auths'])
+                    self.assertIn('quay.io/redhat-user-workloads/konflux', content['auths'])
+
+    @patch.dict(os.environ, {'KONFLUX_AUTH': '/path/to/konflux.json'})
+    def test_add_additional_credentials_no_filtering(self):
+        """
+        Verify that all additional credentials are added when no filtering
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        additional_auth_file = os.path.join(self.test_dir, 'konflux.json')
+        with open(additional_auth_file, 'w') as f:
+            json.dump(self.additional_auth, f)
+
+        with patch.dict(os.environ, {'KONFLUX_AUTH': additional_auth_file}):
+            with RegistryConfig(
+                default_auth_file=default_auth_file,
+                additional_sources=['KONFLUX_AUTH'],
+                filter_patterns=None,  # No filtering
+            ) as auth_file:
+                with open(auth_file, 'r') as f:
+                    content = json.load(f)
+                    # Should have all 5 credentials (3 from default + 2 from additional)
+                    self.assertEqual(len(content['auths']), 5)
+
+    def test_add_additional_credentials_env_var_not_set(self):
+        """
+        Verify behavior when environment variable for additional source is not set
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        # Ensure env var is not set
+        if 'NONEXISTENT_AUTH' in os.environ:
+            del os.environ['NONEXISTENT_AUTH']
+
+        with RegistryConfig(default_auth_file=default_auth_file, additional_sources=['NONEXISTENT_AUTH']) as auth_file:
+            with open(auth_file, 'r') as f:
+                content = json.load(f)
+                # Should only have default credentials
+                self.assertEqual(len(content['auths']), 3)
+
+    @patch.dict(os.environ, {'KONFLUX_AUTH': '/nonexistent/file.json'})
+    def test_add_additional_credentials_file_not_found(self):
+        """
+        Verify behavior when additional auth file does not exist
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        with RegistryConfig(default_auth_file=default_auth_file, additional_sources=['KONFLUX_AUTH']) as auth_file:
+            with open(auth_file, 'r') as f:
+                content = json.load(f)
+                # Should only have default credentials
+                self.assertEqual(len(content['auths']), 3)
+
+    def test_get_registries(self):
+        """
+        Verify get_registries returns list of registry names
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        config = RegistryConfig(default_auth_file=default_auth_file)
+        with config:
+            registries = config.get_registries()
+            self.assertEqual(len(registries), 3)
+            self.assertIn('quay.io/openshift-release-dev', registries)
+            self.assertIn('quay.io/redhat-user-workloads/test', registries)
+            self.assertIn('registry.ci.openshift.org', registries)
+
+    def test_has_credential_for_exact_match(self):
+        """
+        Verify has_credential_for returns True for exact match
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        config = RegistryConfig(default_auth_file=default_auth_file)
+        with config:
+            self.assertTrue(config.has_credential_for('quay.io/openshift-release-dev'))
+            self.assertTrue(config.has_credential_for('quay.io/redhat-user-workloads/test'))
+            self.assertTrue(config.has_credential_for('registry.ci.openshift.org'))
+
+    def test_has_credential_for_prefix_match(self):
+        """
+        Verify has_credential_for returns True for prefix match
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        config = RegistryConfig(default_auth_file=default_auth_file)
+        with config:
+            # Should match because 'quay.io/redhat-user-workloads/test/image' starts with registry
+            self.assertTrue(config.has_credential_for('quay.io/redhat-user-workloads/test/image'))
+            # Should match because registry starts with search term
+            self.assertTrue(config.has_credential_for('quay.io/openshift'))
+
+    def test_has_credential_for_no_match(self):
+        """
+        Verify has_credential_for returns False when no match
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        config = RegistryConfig(default_auth_file=default_auth_file)
+        with config:
+            self.assertFalse(config.has_credential_for('docker.io'))
+            self.assertFalse(config.has_credential_for('gcr.io'))
+
+    def test_temp_file_created_in_current_directory(self):
+        """
+        Verify that temporary auth file is created in current directory
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        with RegistryConfig(default_auth_file=default_auth_file) as auth_file:
+            # Verify filename pattern
+            basename = os.path.basename(auth_file)
+            self.assertTrue(basename.startswith('registry-auth-'))
+            # Verify the path is in current directory
+            abs_path = os.path.abspath(auth_file)
+            current_dir = os.getcwd()
+            self.assertTrue(abs_path.startswith(current_dir))
+            # Verify it's directly in current directory (not in subdirectory)
+            self.assertEqual(os.path.dirname(abs_path), current_dir)
+
+    def test_merged_credentials_format(self):
+        """
+        Verify that merged credentials have correct JSON format
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        with RegistryConfig(default_auth_file=default_auth_file) as auth_file:
+            with open(auth_file, 'r') as f:
+                content = json.load(f)
+                # Verify top-level structure
+                self.assertIn('auths', content)
+                self.assertIsInstance(content['auths'], dict)
+                # Verify each auth entry has expected structure
+                for registry, creds in content['auths'].items():
+                    self.assertIsInstance(registry, str)
+                    self.assertIsInstance(creds, dict)
+                    self.assertIn('auth', creds)
+
+    def test_invalid_json_in_default_auth_file(self):
+        """
+        Verify that invalid JSON in default auth file raises exception
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            f.write('invalid json content {]')
+
+        with self.assertRaises(json.JSONDecodeError):
+            with RegistryConfig(default_auth_file=default_auth_file):
+                pass
+
+    @patch.dict(os.environ, {'KONFLUX_AUTH': '/path/to/konflux.json'})
+    def test_invalid_json_in_additional_auth_file(self):
+        """
+        Verify that invalid JSON in additional auth file raises exception
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        additional_auth_file = os.path.join(self.test_dir, 'konflux.json')
+        with open(additional_auth_file, 'w') as f:
+            f.write('invalid json {]')
+
+        with patch.dict(os.environ, {'KONFLUX_AUTH': additional_auth_file}):
+            with self.assertRaises(json.JSONDecodeError):
+                with RegistryConfig(default_auth_file=default_auth_file, additional_sources=['KONFLUX_AUTH']):
+                    pass
+
+    def test_empty_default_auth_file(self):
+        """
+        Verify behavior with empty default auth file
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump({'auths': {}}, f)
+
+        with RegistryConfig(default_auth_file=default_auth_file) as auth_file:
+            with open(auth_file, 'r') as f:
+                content = json.load(f)
+                self.assertEqual(content['auths'], {})
+
+    def test_credential_override_from_additional_source(self):
+        """
+        Verify that credentials from additional sources override default ones
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump({'auths': {'quay.io/redhat-user-workloads/test': {'auth': 'old-token'}}}, f)
+
+        additional_auth_file = os.path.join(self.test_dir, 'konflux.json')
+        with open(additional_auth_file, 'w') as f:
+            json.dump({'auths': {'quay.io/redhat-user-workloads/test': {'auth': 'new-token'}}}, f)
+
+        with patch.dict(os.environ, {'KONFLUX_AUTH': additional_auth_file}):
+            with RegistryConfig(default_auth_file=default_auth_file, additional_sources=['KONFLUX_AUTH']) as auth_file:
+                with open(auth_file, 'r') as f:
+                    content = json.load(f)
+                    # Additional source should override default
+                    self.assertEqual(content['auths']['quay.io/redhat-user-workloads/test']['auth'], 'new-token')
+
+    def test_registries_parameter_all_present(self):
+        """
+        Verify that registries parameter validates successfully when all registries are present
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        required_registries = ['quay.io/openshift-release-dev', 'registry.ci.openshift.org']
+
+        with RegistryConfig(default_auth_file=default_auth_file, registries=required_registries) as auth_file:
+            with open(auth_file, 'r') as f:
+                content = json.load(f)
+                # Should have all default credentials (no filtering)
+                self.assertEqual(len(content['auths']), 3)
+                # Required registries should be present
+                for registry in required_registries:
+                    self.assertIn(registry, content['auths'])
+
+    def test_registries_parameter_missing_registry(self):
+        """
+        Verify that registries parameter raises ValueError when required registry is missing
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        required_registries = ['quay.io/openshift-release-dev', 'registry.does-not-exist.com']
+
+        with self.assertRaises(ValueError) as context:
+            with RegistryConfig(default_auth_file=default_auth_file, registries=required_registries):
+                pass
+
+        # Verify error message contains missing registry
+        self.assertIn('registry.does-not-exist.com', str(context.exception))
+        self.assertIn('Required registries not found', str(context.exception))
+
+    def test_registries_parameter_ignores_filter_patterns(self):
+        """
+        Verify that filter_patterns is ignored when registries parameter is provided
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        required_registries = ['quay.io/openshift-release-dev']
+        filter_patterns = ['registry.ci.openshift.org']  # Different pattern
+
+        with RegistryConfig(
+            default_auth_file=default_auth_file, registries=required_registries, filter_patterns=filter_patterns
+        ) as auth_file:
+            with open(auth_file, 'r') as f:
+                content = json.load(f)
+                # Should have all 3 credentials (filter_patterns should be ignored)
+                self.assertEqual(len(content['auths']), 3)
+                self.assertIn('quay.io/openshift-release-dev', content['auths'])
+                self.assertIn('quay.io/redhat-user-workloads/test', content['auths'])
+                self.assertIn('registry.ci.openshift.org', content['auths'])
+
+    @patch.dict(os.environ, {'KONFLUX_AUTH': '/path/to/konflux.json'})
+    def test_registries_parameter_with_additional_sources(self):
+        """
+        Verify that registries parameter works with additional sources and validates across all sources
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        additional_auth_file = os.path.join(self.test_dir, 'konflux.json')
+        with open(additional_auth_file, 'w') as f:
+            json.dump(self.additional_auth, f)
+
+        # Require registries from both sources
+        required_registries = ['quay.io/openshift-release-dev', 'quay.io/redhat-user-workloads/konflux']
+
+        with patch.dict(os.environ, {'KONFLUX_AUTH': additional_auth_file}):
+            with RegistryConfig(
+                default_auth_file=default_auth_file,
+                additional_sources=['KONFLUX_AUTH'],
+                registries=required_registries,
+            ) as auth_file:
+                with open(auth_file, 'r') as f:
+                    content = json.load(f)
+                    # Should have all credentials from both sources (no filtering)
+                    self.assertEqual(len(content['auths']), 5)
+                    # Required registries should be present
+                    for registry in required_registries:
+                        self.assertIn(registry, content['auths'])
+
+    @patch.dict(os.environ, {'KONFLUX_AUTH': '/path/to/konflux.json'})
+    def test_registries_parameter_missing_from_additional_source(self):
+        """
+        Verify that ValueError is raised when required registry is missing even with additional sources
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        additional_auth_file = os.path.join(self.test_dir, 'konflux.json')
+        with open(additional_auth_file, 'w') as f:
+            json.dump(self.additional_auth, f)
+
+        # Require a registry that doesn't exist in either source
+        required_registries = ['registry.does-not-exist.com']
+
+        with patch.dict(os.environ, {'KONFLUX_AUTH': additional_auth_file}):
+            with self.assertRaises(ValueError) as context:
+                with RegistryConfig(
+                    default_auth_file=default_auth_file,
+                    additional_sources=['KONFLUX_AUTH'],
+                    registries=required_registries,
+                ):
+                    pass
+
+            self.assertIn('registry.does-not-exist.com', str(context.exception))
+
+    def test_registries_parameter_empty_list(self):
+        """
+        Verify that empty registries list works (no validation)
+        """
+        default_auth_file = os.path.join(self.test_dir, 'auth.json')
+        with open(default_auth_file, 'w') as f:
+            json.dump(self.default_auth, f)
+
+        with RegistryConfig(default_auth_file=default_auth_file, registries=[]) as auth_file:
+            with open(auth_file, 'r') as f:
+                content = json.load(f)
+                # Should have all credentials (no filtering, no validation)
+                self.assertEqual(len(content['auths']), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Add registry config manager

## Summary

This PR introduces `RegistryConfig`, a context manager for managing container registry credentials from multiple sources, and integrates it into the Konflux OCP4 pipeline for improved credential handling during image mirroring operations.

## Changes

### New Components

#### 1. `artcommonlib/registry_config.py`
A new context manager class that provides centralized container registry credential management:

**Key Features:**
- **Multi-source credential merging**: Combines credentials from default auth file and additional sources specified via environment variables
- **Flexible filtering**: Supports both pattern-based filtering and registry-specific validation
- **Automatic cleanup**: Creates temporary auth files that are automatically deleted on context exit
- **Conflict resolution**: Intelligently handles credential conflicts between different sources

**Usage Modes:**
1. **Filter patterns mode**: Include only credentials matching specific patterns (e.g., `quay.io/redhat-user-workloads/`)
2. **Required registries mode**: Validate that specific registries exist in merged credentials
3. **No filtering mode**: Include all credentials from all sources

**Example:**
```python
from artcommonlib.registry_config import RegistryConfig

# Basic usage - merge all credentials
with RegistryConfig() as auth_file:
    cmd = f'oc image mirror --registry-config={auth_file} ...'

# Filter specific registries
with RegistryConfig(
    filter_patterns=['quay.io/redhat-user-workloads/']
) as auth_file:
    cmd = f'oc image mirror --registry-config={auth_file} ...'

# Require specific registries
with RegistryConfig(
    registries=['quay.io/openshift-release-dev', 'registry.redhat.io'],
    additional_sources=['KONFLUX_ART_IMAGES_AUTH_FILE']
) as auth_file:
    cmd = f'oc image mirror --registry-config={auth_file} ...'
```

#### 2. `artcommon/tests/test_registry_config.py`
Comprehensive unit tests covering:
- Basic credential merging functionality
- Filter pattern matching
- Required registry validation
- Additional source handling
- Error conditions and edge cases
- Temporary file creation and cleanup
- JSON format validation

### Integration

#### `pyartcd/pipelines/ocp4_konflux.py`
Updated the `mirror_streams_to_ci()` method in the `KonfluxOcp4Pipeline` class to use `RegistryConfig` for better credential management when mirroring ART equivalent images to CI.

**Impact:**
This change ensures that when the apiserver is rebuilt and streams need to be mirrored to CI, all registry credentials (including those for registry.ci.openshift.org and quay.io/openshift/ci) are properly available to the doozer command in an isolated, temporary auth file.

## Testing

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/23085/console
