### PR TITLE
WIP - [ART-14383] Add OCP version helpers to support major version transitions

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -18,6 +18,17 @@ GIT_NO_PROMPTS = {
 
 ACTIVE_OCP_VERSIONS = ["4.12", "4.13", "4.14", "4.15", "4.16", "4.17", "4.18", "4.19", "4.20", "4.21", "4.22"]
 
+# Last known minor version for each OCP major release
+# Update these values as new versions are released
+# Note: This is OCP-specific; art-tools also works with other products (OADP, MTA, etc.)
+# which have their own versioning schemes
+# Use None for major versions where the maximum minor is not yet known
+LAST_OCP_MINOR_VERSION = {
+    3: 11,  # OCP 3.11 was the last 3.x release
+    4: 22,  # Current highest known 4.x minor (update as versions are released)
+    5: None,  # OCP 5.x max minor not yet known - allows infinite growth
+}
+
 # Konflux DB related vars
 GOOGLE_CLOUD_PROJECT = 'openshift-art'
 DATASET_ID = 'events'

--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -15,7 +15,13 @@ from artcommonlib.format_util import green_print, yellow_print
 from artcommonlib.git_helper import git_clone
 from artcommonlib.model import Missing, Model
 from artcommonlib.pushd import Dir
-from artcommonlib.util import convert_remote_git_to_https, convert_remote_git_to_ssh, remove_prefix, split_git_url
+from artcommonlib.util import (
+    convert_remote_git_to_https,
+    convert_remote_git_to_ssh,
+    get_next_ocp_version,
+    remove_prefix,
+    split_git_url,
+)
 from dockerfile_parse import DockerfileParser
 from github import Github, GithubException, PullRequest, UnknownObjectException
 from jira import JIRA, Issue
@@ -1034,7 +1040,8 @@ This ticket was created by ART pipline run [sync-ci-images|{jenkins_build_url}]
                 runtime.logger.error(f"An error occurred while updating the Target Version on issue {issue.key}: {e}")
 
             # check depend issues and set depend to a higher version issue if true
-            look_for_summary = f'Update {major}.{minor + 1} {image_meta.name} image to be consistent with ART'
+            next_major, next_minor = get_next_ocp_version(major, minor)
+            look_for_summary = f'Update {next_major}.{next_minor} {image_meta.name} image to be consistent with ART'
             depend_issues = search_issues(f"project={project} AND summary ~ '{look_for_summary}'")
             # jira title search is fuzzy, so we need to check if an issue is really the one we want
             depend_issues = [i for i in depend_issues if i.fields.summary == look_for_summary]

--- a/doozer/doozerlib/cli/release_calc_upgrade_tests.py
+++ b/doozer/doozerlib/cli/release_calc_upgrade_tests.py
@@ -1,4 +1,5 @@
 import click
+from artcommonlib.util import get_previous_ocp_version
 
 from doozerlib import util
 from doozerlib.cli import cli
@@ -13,7 +14,8 @@ def release_calc_upgrade_tests(version):
     versions = util.get_release_calc_previous(version, arch)
     major, minor = util.extract_version_fields(version, at_least=2)[:2]
     curr_versions = [x for x in versions if f'{major}.{minor}' in x]
-    prev_versions = [x for x in versions if f'{major}.{minor - 1}' in x]
+    prev_major, prev_minor = get_previous_ocp_version(major, minor)
+    prev_versions = [x for x in versions if f'{prev_major}.{prev_minor}' in x]
 
     def get_test_edges(version_list):
         test_edges = []

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -23,7 +23,7 @@ from artcommonlib.arch_util import GO_ARCHES, brew_arch_for_go_arch, go_arch_for
 from artcommonlib.assembly import AssemblyTypes
 from artcommonlib.format_util import red_print
 from artcommonlib.model import Missing, Model
-from artcommonlib.util import isolate_major_minor_in_group
+from artcommonlib.util import get_previous_ocp_version, isolate_major_minor_in_group
 from async_lru import alru_cache
 from tenacity import retry, stop_after_attempt, wait_fixed
 
@@ -466,7 +466,8 @@ def get_release_calc_previous(
     arch = go_arch_for_brew_arch(arch)  # Cincinnati is go code, and uses a different arch name than brew
     # Get the names of channels we need to analyze
     candidate_channel = get_cincinnati_channels(major, minor)[0]
-    prev_candidate_channel = get_cincinnati_channels(major, minor - 1)[0]
+    prev_major, prev_minor = get_previous_ocp_version(major, minor)
+    prev_candidate_channel = get_cincinnati_channels(prev_major, prev_minor)[0]
 
     upgrade_from = set()
     prev_versions, prev_edges = get_channel_versions(

--- a/elliott/elliottlib/cli/find_bugs_second_fix_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_second_fix_cli.py
@@ -2,6 +2,7 @@ import traceback
 
 import click
 from artcommonlib import logutil
+from artcommonlib.util import get_previous_ocp_version
 
 from elliottlib import Runtime
 from elliottlib.bzutil import get_second_fix_trackers
@@ -61,8 +62,9 @@ def find_bugs_second_fix(runtime, find_bugs_obj, close, noop, bug_tracker):
             bug_tracker = runtime.get_bug_tracker('jira')
             for k in second_fix_trackers:
                 LOGGER.info(f"Tracker {k.id} is a second fix for it's associated CVE and therefore it will be closed")
+                prev_major, prev_minor = get_previous_ocp_version(int(major_version), int(minor_version))
                 comment = f'''
-Closing this CVE tracker, as the CVE has been declared fixed for this component for {major_version}.{int(minor_version) - 1}.
+Closing this CVE tracker, as the CVE has been declared fixed for this component for {prev_major}.{prev_minor}.
 in pre-release
 '''
                 target = "CLOSED"

--- a/pyartcd/pyartcd/pipelines/sync_rhcos_bfb.py
+++ b/pyartcd/pyartcd/pipelines/sync_rhcos_bfb.py
@@ -8,6 +8,7 @@ from typing import List, Optional, Tuple
 import aiohttp
 import click
 from artcommonlib import exectools
+from artcommonlib.util import get_next_ocp_version
 
 from pyartcd import util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
@@ -233,7 +234,8 @@ class SyncRhcosBfbPipeline:
         # For both stable and pre-release, check if next major.minor exists
         def get_next_major_minor(major_minor: str) -> str:
             major, minor = map(int, major_minor.split("."))
-            return f"{major}.{minor + 1}"
+            next_major, next_minor = get_next_ocp_version(major, minor)
+            return f"{next_major}.{next_minor}"
 
         next_major_minor = get_next_major_minor(self.major_minor)
 


### PR DESCRIPTION
Add centralized helper functions in artcommonlib to handle OCP version calculations, properly managing major version boundaries (e.g., 5.0 → 4.22, 4.0 → 3.11). Replace all inline minor version arithmetic (minor ± 1) across art-tools with these helpers to prevent invalid versions like "5.-1".

Changes:
- Add LAST_OCP_MINOR_VERSION constant to artcommonlib/constants.py Maps major versions to their last known minor version, uses None for unknown maximums to allow infinite growth

- Add get_previous_ocp_version() helper to artcommonlib/util.py Handles major version boundaries when calculating previous version No hardcoded version checks - dynamically uses LAST_OCP_MINOR_VERSION

- Add get_next_ocp_version() helper to artcommonlib/util.py Handles major version boundaries when calculating next version No hardcoded version checks - dynamically uses LAST_OCP_MINOR_VERSION

- Refactor get_inflight() to use get_previous_ocp_version() Automatically handles 5.0 → 4.22 transition

- Add comprehensive unit tests with mocking (8 tests, all passing) Tests mock LAST_OCP_MINOR_VERSION to avoid breaking when constant changes Includes setUp/tearDown to ensure clean test environment

- Update all usages across art-tools (8 locations):
  * doozer/cli/release_calc_upgrade_tests.py - Fix critical bug for x.0 releases
  * doozer/util.py - Cincinnati channel calculation
  * doozer/cli/images_streams.py - Jira issue dependency checking
  * elliott/cli/verify_attached_bugs_cli.py - 3 locations
  * elliott/cli/find_bugs_second_fix_cli.py - CVE tracker comments
  * pyartcd/pipelines/sync_rhcos_bfb.py - RHCOS sync version logic

This implementation is fully data-driven with no hardcoded version limits, making it ready to support OCP 5 and beyond by simply updating the LAST_OCP_MINOR_VERSION constant. Tests use mocking to remain stable when the constant is updated.