### PR TITLE
ART-14551: Revert "Skip rhel version check for OKD"

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1033,7 +1033,7 @@ class KonfluxRebaser:
         df_lines = filtered_content
 
         # ART-8476 assert rhel version equivalence
-        if metadata.canonical_builders_enabled and self.variant is not BuildVariant.OKD:
+        if metadata.canonical_builders_enabled:
             el_version = metadata.branch_el_target()
             df_lines.extend(
                 [


### PR DESCRIPTION
Reverts openshift-eng/art-tools#2477

Related to [ART-14551](https://issues.redhat.com/browse/ART-14551)