### PR TITLE
Allow excluding components in assembly definition

### DIFF
--- a/artcommon/artcommonlib/assembly.py
+++ b/artcommon/artcommonlib/assembly.py
@@ -428,3 +428,34 @@ def assembly_metadata_config(
             config_dict = _merger(component_entry.metadata.primitive(), config_dict)
 
     return Model(dict_to_model=config_dict)
+
+
+def assembly_excluded_components(releases_config: Model, assembly: typing.Optional[str], meta_type: str) -> set[str]:
+    """
+    Returns a set of distgit_keys that have `exclude: true` in the assembly's members section.
+    Respects assembly inheritance: excluded components from ancestor assemblies are inherited
+    unless a child assembly explicitly sets `exclude: false`.
+    :param releases_config: A Model for releases.yaml.
+    :param assembly: The name of the assembly
+    :param meta_type: 'rpm' or 'image'
+    :return: A set of excluded distgit_keys.
+    """
+    if not assembly or not isinstance(releases_config, Model):
+        return set()
+
+    _check_recursion(releases_config, assembly)
+    target_assembly = releases_config.releases[assembly].assembly
+
+    excluded: set[str] = set()
+    if target_assembly.basis.assembly:
+        excluded = assembly_excluded_components(releases_config, target_assembly.basis.assembly, meta_type)
+
+    component_list = target_assembly.members[f'{meta_type}s']
+    for component_entry in component_list:
+        if component_entry.distgit_key is not Missing:
+            if component_entry.exclude:
+                excluded.add(component_entry.distgit_key)
+            elif component_entry.exclude is not Missing:
+                excluded.discard(component_entry.distgit_key)
+
+    return excluded

--- a/artcommon/tests/test_assembly.py
+++ b/artcommon/tests/test_assembly.py
@@ -6,6 +6,7 @@ from artcommonlib.assembly import (
     _merger,
     assembly_basis_event,
     assembly_config_struct,
+    assembly_excluded_components,
     assembly_group_config,
     assembly_metadata_config,
     assembly_rhcos_config,
@@ -530,6 +531,118 @@ releases:
             pass
         except Exception as e:
             self.fail(f'Expected ValueError on assembly infinite recursion but got: {type(e)}: {e}')
+
+    def test_assembly_excluded_components_no_assembly(self):
+        self.assertEqual(assembly_excluded_components(self.releases_config, None, 'image'), set())
+        self.assertEqual(assembly_excluded_components(self.releases_config, '', 'image'), set())
+        self.assertEqual(assembly_excluded_components(None, 'ART_1', 'image'), set())
+
+    def test_assembly_excluded_components_no_exclusions(self):
+        self.assertEqual(assembly_excluded_components(self.releases_config, 'ART_7', 'image'), set())
+
+    def test_assembly_excluded_components_basic(self):
+        releases_yml = """
+releases:
+  test_assembly:
+    assembly:
+      members:
+        images:
+        - distgit_key: image-a
+          exclude: true
+        - distgit_key: image-b
+          metadata:
+            is: some-nvr
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        excluded = assembly_excluded_components(releases_config, 'test_assembly', 'image')
+        self.assertEqual(excluded, {'image-a'})
+
+    def test_assembly_excluded_components_explicit_false(self):
+        releases_yml = """
+releases:
+  test_assembly:
+    assembly:
+      members:
+        images:
+        - distgit_key: image-a
+          exclude: false
+        - distgit_key: image-b
+          exclude: true
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        excluded = assembly_excluded_components(releases_config, 'test_assembly', 'image')
+        self.assertEqual(excluded, {'image-b'})
+
+    def test_assembly_excluded_components_inheritance(self):
+        releases_yml = """
+releases:
+  parent:
+    assembly:
+      members:
+        images:
+        - distgit_key: image-a
+          exclude: true
+        - distgit_key: image-b
+          exclude: true
+  child:
+    assembly:
+      basis:
+        assembly: parent
+      members:
+        images:
+        - distgit_key: image-c
+          exclude: true
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        excluded = assembly_excluded_components(releases_config, 'child', 'image')
+        self.assertEqual(excluded, {'image-a', 'image-b', 'image-c'})
+
+    def test_assembly_excluded_components_child_overrides_parent(self):
+        releases_yml = """
+releases:
+  parent:
+    assembly:
+      members:
+        images:
+        - distgit_key: image-a
+          exclude: true
+        - distgit_key: image-b
+          exclude: true
+  child:
+    assembly:
+      basis:
+        assembly: parent
+      members:
+        images:
+        - distgit_key: image-a
+          exclude: false
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        excluded = assembly_excluded_components(releases_config, 'child', 'image')
+        self.assertEqual(excluded, {'image-b'})
+
+    def test_assembly_excluded_components_rpms(self):
+        releases_yml = """
+releases:
+  test_assembly:
+    assembly:
+      members:
+        rpms:
+        - distgit_key: rpm-a
+          exclude: true
+        - distgit_key: rpm-b
+          metadata:
+            content: {}
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        excluded = assembly_excluded_components(releases_config, 'test_assembly', 'rpm')
+        self.assertEqual(excluded, {'rpm-a'})
+        # images should be unaffected
+        self.assertEqual(assembly_excluded_components(releases_config, 'test_assembly', 'image'), set())
+
+    def test_assembly_excluded_components_infinite_recursion(self):
+        with self.assertRaises(ValueError):
+            assembly_excluded_components(self.releases_config, 'ART_INFINITE', 'rpm')
 
     def test_merger(self):
         # First value dominates on primitive

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -580,6 +580,14 @@ async def _fetch_builds_by_kind_rpm(
                 f"Assembly {runtime.assembly} is not appliable for build sweep because it contains RHCOS specific dependencies for a custom release."
             )
 
+    excluded = assembly_excluded_components(runtime.get_releases_config(), runtime.assembly, 'rpm')
+    excluded_component_names: set[str] = set()
+    for dk in excluded:
+        rpm_meta = runtime.rpm_map.get(dk)
+        if rpm_meta:
+            excluded_component_names.add(rpm_meta.get_component_name())
+            LOGGER.info(f'Excluding rpm {dk} per assembly definition')
+
     builds: list[dict] = []
 
     pinned_nvrs = set()
@@ -588,7 +596,7 @@ async def _fetch_builds_by_kind_rpm(
             tasks = [
                 rpm.get_latest_build(default=None, el_target=tag, exclude_large_columns=True)
                 for rpm in runtime.rpm_metas()
-                if tag in rpm.determine_targets()
+                if tag in rpm.determine_targets() and rpm.distgit_key not in excluded
             ]
             builds_for_tag = await asyncio.gather(*tasks)
             builds.extend(filter(lambda b: b is not None, builds_for_tag))
@@ -642,6 +650,8 @@ async def _fetch_builds_by_kind_rpm(
                         )
                 component_builds.update(group_deps)
                 pinned_nvrs.update([b['nvr'] for b in group_deps.values()])
+            for name in excluded_component_names:
+                component_builds.pop(name, None)
             builds.extend(component_builds.values())
 
     LOGGER.info(f"Found {len(builds)} qualified rpm builds")

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -9,7 +9,7 @@ import koji
 import requests
 from artcommonlib import logutil
 from artcommonlib.arch_util import BREW_ARCHES
-from artcommonlib.assembly import assembly_metadata_config, assembly_rhcos_config
+from artcommonlib.assembly import assembly_excluded_components, assembly_metadata_config, assembly_rhcos_config
 from artcommonlib.constants import COREOS_RHEL10_STREAMS
 from artcommonlib.format_util import green_print, red_print, yellow_print
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord, KonfluxBundleBuildRecord
@@ -484,9 +484,15 @@ async def _fetch_builds_by_kind_image(
     non_payload_only: bool,
     include_shipped: bool,
 ):
+    excluded = assembly_excluded_components(runtime.get_releases_config(), runtime.assembly, 'image')
     image_metas: list[ImageMetadata] = []
     for image in runtime.image_metas():
         if image.base_only or not image.is_release:
+            continue
+        if image.distgit_key in excluded:
+            if image.is_payload:
+                raise ElliottFatalError(f'Payload image {image.distgit_key} cannot be excluded in assembly definition')
+            LOGGER.info(f'Excluding image {image.distgit_key} per assembly definition')
             continue
         if (payload_only and not image.is_payload) or (non_payload_only and image.is_payload):
             continue
@@ -718,9 +724,15 @@ async def find_builds_konflux(runtime, payload) -> list[dict]:
     """
     runtime.konflux_db.bind(KonfluxBuildRecord)
 
+    excluded = assembly_excluded_components(runtime.get_releases_config(), runtime.assembly, 'image')
     image_metas: list[ImageMetadata] = []
     for image in runtime.image_metas():
         if image.base_only or not image.is_release:
+            continue
+        if image.distgit_key in excluded:
+            if image.is_payload:
+                raise ElliottFatalError(f'Payload image {image.distgit_key} cannot be excluded in assembly definition')
+            LOGGER.info(f'Excluding image {image.distgit_key} per assembly definition')
             continue
         if (payload and not image.is_payload) or (not payload and image.is_payload):
             continue
@@ -767,9 +779,15 @@ async def find_builds_konflux_all_types(runtime: Runtime) -> dict[str, list]:
     """
     runtime.konflux_db.bind(KonfluxBuildRecord)
 
+    excluded = assembly_excluded_components(runtime.get_releases_config(), runtime.assembly, 'image')
     image_metas: list[tuple[bool, ImageMetadata]] = []
     for image in runtime.image_metas():
         if image.base_only or not image.is_release:
+            continue
+        if image.distgit_key in excluded:
+            if image.is_payload:
+                raise ElliottFatalError(f'Payload image {image.distgit_key} cannot be excluded in assembly definition')
+            LOGGER.info(f'Excluding image {image.distgit_key} per assembly definition')
             continue
         image_metas.append((image.is_payload, image))
 

--- a/elliott/tests/test_find_builds_cli.py
+++ b/elliott/tests/test_find_builds_cli.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 from elliottlib import errata as erratalib
 from elliottlib.brew import Build
 from elliottlib.cli.find_builds_cli import (
+    _fetch_builds_by_kind_rpm,
     _filter_out_attached_builds,
     _find_shipped_builds,
     find_builds_konflux,
@@ -218,6 +219,78 @@ class TestFindBuildsKonfluxAllTypes(IsolatedAsyncioTestCase):
         runtime.should_receive("image_metas").and_return([image_meta_1])
         with self.assertRaises(ElliottFatalError):
             await find_builds_konflux_all_types(runtime)
+
+
+class TestFetchBuildsByKindRpm(IsolatedAsyncioTestCase):
+    @mock.patch("elliottlib.cli.find_builds_cli.assembly_excluded_components", return_value={"rpm-b"})
+    @mock.patch("elliottlib.cli.find_builds_cli._find_shipped_builds", return_value=set())
+    @mock.patch("elliottlib.cli.find_builds_cli._ensure_accepted_tags")
+    async def test_member_only_excludes_rpm(self, mock_ensure_tags, mock_shipped, _):
+        runtime = flexmock(assembly="4.17.1", assembly_basis_event=None, rpm_map={})
+        runtime.should_receive("get_releases_config").and_return(MagicMock())
+
+        rpm_a = MagicMock(distgit_key="rpm-a")
+        rpm_a.determine_targets.return_value = ["rhaos-4.17-rhel-9-candidate"]
+        rpm_a.get_latest_build = AsyncMock(
+            return_value={"id": 1, "name": "rpm-a", "version": "1.0", "release": "1.el9", "nvr": "rpm-a-1.0-1.el9"}
+        )
+
+        rpm_b = MagicMock(distgit_key="rpm-b")
+        rpm_b.determine_targets.return_value = ["rhaos-4.17-rhel-9-candidate"]
+        rpm_b.get_latest_build = AsyncMock(
+            return_value={"id": 2, "name": "rpm-b", "version": "2.0", "release": "1.el9", "nvr": "rpm-b-2.0-1.el9"}
+        )
+
+        runtime.should_receive("rpm_metas").and_return([rpm_a, rpm_b])
+
+        tag_pv_map = {"rhaos-4.17-rhel-9-candidate": "RHEL-9-OSE-4.17"}
+
+        def fake_ensure_tags(builds, *args, **kwargs):
+            for b in builds:
+                b["tag_name"] = "rhaos-4.17-rhel-9-candidate"
+
+        mock_ensure_tags.side_effect = fake_ensure_tags
+
+        nvrps = await _fetch_builds_by_kind_rpm(
+            runtime, tag_pv_map, brew_session=MagicMock(), include_shipped=False, member_only=True
+        )
+
+        rpm_a.get_latest_build.assert_called_once()
+        rpm_b.get_latest_build.assert_not_called()
+        self.assertEqual(len(nvrps), 1)
+        self.assertEqual(nvrps[0][0], "rpm-a")
+
+    @mock.patch("elliottlib.cli.find_builds_cli.assembly_excluded_components", return_value={"rpm-b"})
+    @mock.patch("elliottlib.cli.find_builds_cli._find_shipped_builds", return_value=set())
+    @mock.patch("elliottlib.cli.find_builds_cli._ensure_accepted_tags")
+    @mock.patch("elliottlib.cli.find_builds_cli.BuildFinder")
+    async def test_general_sweep_excludes_rpm(self, MockBuildFinder, mock_ensure_tags, mock_shipped, _):
+        rpm_b_meta = MagicMock()
+        rpm_b_meta.get_component_name.return_value = "rpm-b-pkg"
+
+        runtime = flexmock(assembly="4.17.1", assembly_basis_event=None, brew_event=None, rpm_map={"rpm-b": rpm_b_meta})
+        runtime.should_receive("get_releases_config").and_return(MagicMock())
+
+        tag_pv_map = {"rhaos-4.17-rhel-9-candidate": "RHEL-9-OSE-4.17"}
+
+        builder = MockBuildFinder.return_value
+        builder.from_tag.return_value = {
+            "rpm-a-pkg": {"id": 1, "name": "rpm-a", "version": "1.0", "release": "1.el9", "nvr": "rpm-a-1.0-1.el9"},
+            "rpm-b-pkg": {"id": 2, "name": "rpm-b", "version": "2.0", "release": "1.el9", "nvr": "rpm-b-2.0-1.el9"},
+        }
+
+        def fake_ensure_tags(builds, *args, **kwargs):
+            for b in builds:
+                b["tag_name"] = "rhaos-4.17-rhel-9-candidate"
+
+        mock_ensure_tags.side_effect = fake_ensure_tags
+
+        nvrps = await _fetch_builds_by_kind_rpm(
+            runtime, tag_pv_map, brew_session=MagicMock(), include_shipped=False, member_only=False
+        )
+
+        self.assertEqual(len(nvrps), 1)
+        self.assertEqual(nvrps[0][0], "rpm-a")
 
 
 if __name__ == "__main__":

--- a/elliott/tests/test_find_builds_cli.py
+++ b/elliott/tests/test_find_builds_cli.py
@@ -10,6 +10,7 @@ from elliottlib.cli.find_builds_cli import (
     find_builds_konflux,
     find_builds_konflux_all_types,
 )
+from elliottlib.exceptions import ElliottFatalError
 from flexmock import flexmock
 
 
@@ -58,7 +59,8 @@ class TestFindBuildsCli(TestCase):
 class TestFindBuildsKonflux(IsolatedAsyncioTestCase):
     @mock.patch("elliottlib.cli.find_builds_cli.KonfluxBuildRecord")
     async def test_find_builds_konflux(self, MockKonfluxBuildRecord: mock.MagicMock):
-        runtime = flexmock(konflux_db=flexmock())
+        runtime = flexmock(konflux_db=flexmock(), assembly=None)
+        runtime.should_receive("get_releases_config").and_return(None)
         runtime.konflux_db.should_receive("bind").with_args(MockKonfluxBuildRecord)
 
         image_meta_1 = MagicMock(base_only=False, is_release=True, is_payload=True, distgit_key="image1")
@@ -77,13 +79,47 @@ class TestFindBuildsKonflux(IsolatedAsyncioTestCase):
         self.assertEqual(actual_records[0]['nvr'], "image1-1.0.0-1.el8")
         image_meta_1.get_latest_build.assert_called_once_with(el_target="el8", exclude_large_columns=True)
 
+    @mock.patch("elliottlib.cli.find_builds_cli.assembly_excluded_components", return_value={"image2"})
+    @mock.patch("elliottlib.cli.find_builds_cli.KonfluxBuildRecord")
+    async def test_find_builds_konflux_excludes_non_payload(self, MockKonfluxBuildRecord, _):
+        runtime = flexmock(konflux_db=flexmock(), assembly="4.17.1")
+        runtime.should_receive("get_releases_config").and_return(MagicMock())
+        runtime.konflux_db.should_receive("bind").with_args(MockKonfluxBuildRecord)
+
+        image_meta_1 = MagicMock(base_only=False, is_release=True, is_payload=True, distgit_key="image1")
+        image_meta_1.branch_el_target.return_value = "el8"
+        image_meta_1.get_latest_build = AsyncMock(return_value={"nvr": "image1-1.0.0-1.el8"})
+
+        image_meta_2 = MagicMock(base_only=False, is_release=True, is_payload=False, distgit_key="image2")
+        image_meta_2.branch_el_target.return_value = "el9"
+        image_meta_2.get_latest_build = AsyncMock(return_value={"nvr": "image2-2.0.0-1.el9"})
+
+        runtime.should_receive("image_metas").and_return([image_meta_1, image_meta_2])
+        actual_records = await find_builds_konflux(runtime, payload=False)
+        self.assertEqual(len(actual_records), 0)
+        image_meta_2.get_latest_build.assert_not_called()
+
+    @mock.patch("elliottlib.cli.find_builds_cli.assembly_excluded_components", return_value={"image1"})
+    @mock.patch("elliottlib.cli.find_builds_cli.KonfluxBuildRecord")
+    async def test_find_builds_konflux_errors_on_excluded_payload(self, MockKonfluxBuildRecord, _):
+        runtime = flexmock(konflux_db=flexmock(), assembly="4.17.1")
+        runtime.should_receive("get_releases_config").and_return(MagicMock())
+        runtime.konflux_db.should_receive("bind").with_args(MockKonfluxBuildRecord)
+
+        image_meta_1 = MagicMock(base_only=False, is_release=True, is_payload=True, distgit_key="image1")
+
+        runtime.should_receive("image_metas").and_return([image_meta_1])
+        with self.assertRaises(ElliottFatalError):
+            await find_builds_konflux(runtime, payload=True)
+
 
 class TestFindBuildsKonfluxAllTypes(IsolatedAsyncioTestCase):
     @mock.patch("elliottlib.cli.find_builds_cli.KonfluxBuildRecord")
     @mock.patch("elliottlib.cli.find_builds_cli.KonfluxBundleBuildRecord")
     async def test_find_builds_konflux_all_types(self, MockKonfluxBundleBuildRecord, MockKonfluxBuildRecord):
         # Setup runtime and DB mocks
-        runtime = flexmock(konflux_db=flexmock())
+        runtime = flexmock(konflux_db=flexmock(), assembly=None)
+        runtime.should_receive("get_releases_config").and_return(None)
         runtime.konflux_db.should_receive("bind").with_args(MockKonfluxBuildRecord)
         runtime.konflux_db.should_receive("bind").with_args(MockKonfluxBundleBuildRecord)
 
@@ -129,6 +165,59 @@ class TestFindBuildsKonfluxAllTypes(IsolatedAsyncioTestCase):
         self.assertEqual(len(builds_map['olm_builds_not_found']), 0)
         image_meta_1.get_latest_build.assert_called_once_with(el_target="el8", exclude_large_columns=True)
         image_meta_2.get_latest_build.assert_called_once_with(el_target="el9", exclude_large_columns=True)
+
+    @mock.patch("elliottlib.cli.find_builds_cli.assembly_excluded_components", return_value={"image2"})
+    @mock.patch("elliottlib.cli.find_builds_cli.KonfluxBuildRecord")
+    @mock.patch("elliottlib.cli.find_builds_cli.KonfluxBundleBuildRecord")
+    async def test_find_builds_konflux_all_types_excludes_non_payload(
+        self, MockKonfluxBundleBuildRecord, MockKonfluxBuildRecord, _
+    ):
+        runtime = flexmock(konflux_db=flexmock(), assembly="4.17.1")
+        runtime.should_receive("get_releases_config").and_return(MagicMock())
+        runtime.konflux_db.should_receive("bind").with_args(MockKonfluxBuildRecord)
+        runtime.konflux_db.should_receive("bind").with_args(MockKonfluxBundleBuildRecord)
+
+        image_meta_1 = MagicMock(
+            base_only=False, is_release=True, is_payload=True, is_olm_operator=False, distgit_key="image1"
+        )
+        image_meta_1.branch_el_target.return_value = "el8"
+        build_1 = MagicMock(nvr="image1-1.0.0-1.el8")
+        image_meta_1.get_latest_build = AsyncMock(return_value=build_1)
+
+        image_meta_2 = MagicMock(
+            base_only=False, is_release=True, is_payload=False, is_olm_operator=True, distgit_key="image2"
+        )
+        image_meta_2.branch_el_target.return_value = "el9"
+        image_meta_2.get_latest_build = AsyncMock(return_value=MagicMock(nvr="image2-2.0.0-1.el9"))
+
+        runtime.should_receive("image_metas").and_return([image_meta_1, image_meta_2])
+
+        builds_map = await find_builds_konflux_all_types(runtime)
+
+        self.assertEqual(builds_map['payload'], [build_1.nvr])
+        self.assertEqual(builds_map['non_payload'], [])
+        self.assertEqual(builds_map['olm_builds'], [])
+        self.assertEqual(builds_map['olm_builds_not_found'], [])
+        image_meta_2.get_latest_build.assert_not_called()
+
+    @mock.patch("elliottlib.cli.find_builds_cli.assembly_excluded_components", return_value={"image1"})
+    @mock.patch("elliottlib.cli.find_builds_cli.KonfluxBuildRecord")
+    @mock.patch("elliottlib.cli.find_builds_cli.KonfluxBundleBuildRecord")
+    async def test_find_builds_konflux_all_types_errors_on_excluded_payload(
+        self, MockKonfluxBundleBuildRecord, MockKonfluxBuildRecord, _
+    ):
+        runtime = flexmock(konflux_db=flexmock(), assembly="4.17.1")
+        runtime.should_receive("get_releases_config").and_return(MagicMock())
+        runtime.konflux_db.should_receive("bind").with_args(MockKonfluxBuildRecord)
+        runtime.konflux_db.should_receive("bind").with_args(MockKonfluxBundleBuildRecord)
+
+        image_meta_1 = MagicMock(
+            base_only=False, is_release=True, is_payload=True, is_olm_operator=False, distgit_key="image1"
+        )
+
+        runtime.should_receive("image_metas").and_return([image_meta_1])
+        with self.assertRaises(ElliottFatalError):
+            await find_builds_konflux_all_types(runtime)
 
 
 if __name__ == "__main__":

--- a/ocp-build-data-validator/tests/test_releases.py
+++ b/ocp-build-data-validator/tests/test_releases.py
@@ -2,6 +2,7 @@ import unittest
 
 from flexmock import flexmock
 from validator import releases
+from validator.schema import releases_schema
 
 group_config = group_cfg = {
     'vars': {'MAJOR': 4, 'MINOR': 18},
@@ -33,3 +34,145 @@ class TestReleases(unittest.TestCase):
         }
         err = releases.validate(valid_releases)
         self.assertIsNone(err)
+
+    def test_member_exclude_image(self):
+        valid_releases = {
+            "releases": {
+                "4.18.1": {
+                    "assembly": {
+                        "members": {
+                            "images": [
+                                {"distgit_key": "image-a", "exclude": True, "why": "not needed for this release"},
+                                {"distgit_key": "image-c", "why": "pinned build", "metadata": {}},
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        err = releases_schema.validate(None, valid_releases)
+        self.assertIsNone(err)
+
+    def test_member_exclude_rpm(self):
+        valid_releases = {
+            "releases": {
+                "4.18.1": {
+                    "assembly": {
+                        "members": {
+                            "rpms": [
+                                {"distgit_key": "rpm-a", "exclude": True, "why": "not needed for this release"},
+                                {
+                                    "distgit_key": "rpm-c",
+                                    "why": "pinned build",
+                                    "metadata": {"is": {"el9": "rpm-c-1.0-1.el9"}},
+                                },
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        err = releases_schema.validate(None, valid_releases)
+        self.assertIsNone(err)
+
+    def test_member_exclude_false_image_invalid(self):
+        invalid_releases = {
+            "releases": {
+                "4.18.1": {
+                    "assembly": {
+                        "members": {
+                            "images": [
+                                {"distgit_key": "image-a", "exclude": False, "why": "reason"},
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        err = releases_schema.validate(None, invalid_releases)
+        self.assertIsNotNone(err)
+
+    def test_member_exclude_false_rpm_invalid(self):
+        invalid_releases = {
+            "releases": {
+                "4.18.1": {
+                    "assembly": {
+                        "members": {
+                            "rpms": [
+                                {"distgit_key": "rpm-a", "exclude": False, "why": "reason"},
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        err = releases_schema.validate(None, invalid_releases)
+        self.assertIsNotNone(err)
+
+    def test_member_image_why_required_with_exclude(self):
+        invalid_releases = {
+            "releases": {
+                "4.18.1": {
+                    "assembly": {
+                        "members": {
+                            "images": [
+                                {"distgit_key": "image-a", "exclude": True},
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        err = releases_schema.validate(None, invalid_releases)
+        self.assertIsNotNone(err)
+
+    def test_member_rpm_why_required_with_exclude(self):
+        invalid_releases = {
+            "releases": {
+                "4.18.1": {
+                    "assembly": {
+                        "members": {
+                            "rpms": [
+                                {"distgit_key": "rpm-a", "exclude": True},
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        err = releases_schema.validate(None, invalid_releases)
+        self.assertIsNotNone(err)
+
+    def test_member_image_why_required(self):
+        invalid_releases = {
+            "releases": {
+                "4.18.1": {
+                    "assembly": {
+                        "members": {
+                            "images": [
+                                {"distgit_key": "image-a"},
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        err = releases_schema.validate(None, invalid_releases)
+        self.assertIsNotNone(err)
+
+    def test_member_rpm_why_required(self):
+        invalid_releases = {
+            "releases": {
+                "4.18.1": {
+                    "assembly": {
+                        "members": {
+                            "rpms": [
+                                {"distgit_key": "rpm-a"},
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        err = releases_schema.validate(None, invalid_releases)
+        self.assertIsNotNone(err)

--- a/ocp-build-data-validator/validator/json_schemas/member_image.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/member_image.schema.json
@@ -12,6 +12,10 @@
       "type": "string",
       "minLength": 1
     },
+    "exclude": {
+      "description": "If true, exclude this component from the assembly.",
+      "const": true
+    },
     "metadata": {
       "description": "Image configuration",
       "$ref": "image_config.base.schema.json"

--- a/ocp-build-data-validator/validator/json_schemas/member_rpm.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/member_rpm.schema.json
@@ -12,6 +12,10 @@
             "type": "string",
             "minLength": 1
         },
+        "exclude": {
+            "description": "If true, exclude this component from the assembly.",
+            "const": true
+        },
         "metadata": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
Sometimes we want to drop ART-built non-payload components or rpms, allow that in the assembly definition, so that they do not get swept when preparing releases.

Previously the way to do it would be `mode: disabled` in the relevant image/rpm config file. I've chosen to not use that semantic and instead rely on a new `exclude` key to better reflect what the intent is.

If a payload image is excluded, an error is raised.

```
    members:
        images:
        - distgit_key: image-a
          exclude: true
        rpms:
        - distgit_key: rpm-b
          exclude: true
```

- Change: https://github.com/openshift-eng/ocp-build-data/pull/10044
- Test: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release-konflux/823/console