### PR TITLE
Prune dnf cache at end of Dockerfile during image rebase

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1060,6 +1060,21 @@ class KonfluxRebaser:
                 ]
             )
 
+        # Prune dnf cache to reduce image size
+        final_stage_user = metadata.config.final_stage_user or 0
+        cache_prune_lines = ['']
+        if final_stage_user:
+            cache_prune_lines.append('USER 0')
+        cache_prune_lines.extend(
+            [
+                '# Prune dnf cache to reduce image size',
+                'RUN (if command -v microdnf; then microdnf clean all; else dnf clean all; fi && rm -rf /var/cache/dnf/*) || true',
+            ]
+        )
+        if final_stage_user:
+            cache_prune_lines.append(f'USER {final_stage_user}')
+        df_lines.extend(cache_prune_lines)
+
         df_content = "\n".join(df_lines)
 
         if release:

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -2223,6 +2223,21 @@ class ImageDistGitRepo(DistGitRepo):
                     ]
                 )
 
+            # Prune dnf cache to reduce image size
+            final_stage_user = self.metadata.config.final_stage_user or 0
+            cache_prune_lines = ['']
+            if final_stage_user:
+                cache_prune_lines.append('USER 0')
+            cache_prune_lines.extend(
+                [
+                    '# Prune dnf cache to reduce image size',
+                    'RUN (if command -v microdnf; then microdnf clean all; else dnf clean all; fi && rm -rf /var/cache/dnf/*) || true',
+                ]
+            )
+            if final_stage_user:
+                cache_prune_lines.append(f'USER {final_stage_user}')
+            df_lines.extend(cache_prune_lines)
+
             df_content = "\n".join(df_lines)
 
             if release:


### PR DESCRIPTION
## Summary
- Injects a `RUN` step at the end of the Dockerfile during image rebase that cleans the dnf/microdnf cache and removes `/var/cache/dnf/*` to reduce image size
- Uses `microdnf clean all` when available, falling back to `dnf clean all`
- Applied in both the Konflux rebaser (`rebaser.py`) and the Brew distgit rebase path (`distgit.py`)

## Test plan
- [ ] Verify rebased Dockerfiles contain the new cache pruning `RUN` step
- [ ] Verify images using microdnf use `microdnf clean all`
- [ ] Verify images using dnf use `dnf clean all`
- [ ] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)