### PR TITLE
Mirror3

### DIFF
--- a/art-cluster/cloudflare/wrangler.toml
+++ b/art-cluster/cloudflare/wrangler.toml
@@ -3,10 +3,18 @@ main = "src/index.ts"
 compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
 
-workers_dev = true
+
+# Production mode - disable workers.dev subdomain
+workers_dev = false
+
+# Route configuration for mirror3.openshift.com
+# Note: Requires the domain to be configured in Cloudflare first
+routes = [
+    { pattern = "mirror3.openshift.com/*", zone_name = "openshift.com" }
+]
 
 # Bind an R2 Bucket. Use R2 to store arbitrarily large blobs of data, such as files.
 # Docs: https://developers.cloudflare.com/r2/api/workers/workers-api-usage/
 r2_buckets  = [
-    { binding = "BUCKET_bucketname", bucket_name = "lgarciaac-bucket", preview_bucket_name = "lgarciaac-bucket" }
+    { binding = "BUCKET_bucketname", bucket_name = "art-srv-enterprise" }
 ]

--- a/doozer/doozerlib/cli/ci_transforms/rhel-8/ci-build-root/Dockerfile
+++ b/doozer/doozerlib/cli/ci_transforms/rhel-8/ci-build-root/Dockerfile
@@ -9,7 +9,7 @@ FROM replaced-by-buildconfig
 ENV PATH=/opt/google/protobuf/bin:$PATH
 RUN set -euxo pipefail && \
     f=$( mktemp ) && \
-    curl --fail -L http://mirror.openshift.com/pub/openshift-static-ci-deps/protobuf-3.0.0/protoc-3.0.0-linux-x86_64.zip > "${f}" && \
+    curl --fail -L http://mirror3.openshift.com/pub/openshift-static-ci-deps/protobuf-3.0.0/protoc-3.0.0-linux-x86_64.zip > "${f}" && \
     mkdir -p /opt/google/protobuf && \
     unzip "${f}" -d /opt/google/protobuf && \
     curl --fail -L https://github.com/coreos/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-amd64.tar.gz | tar -f - -xz --no-same-owner -C /usr/local/bin --strip-components=1 etcd-v3.4.13-linux-amd64/etcd

--- a/doozer/doozerlib/cli/ci_transforms/rhel-9/ci-build-root/Dockerfile
+++ b/doozer/doozerlib/cli/ci_transforms/rhel-9/ci-build-root/Dockerfile
@@ -9,7 +9,7 @@ FROM replaced-by-buildconfig
 ENV PATH=/opt/google/protobuf/bin:$PATH
 RUN set -euxo pipefail && \
     f=$( mktemp ) && \
-    curl --fail -L http://mirror.openshift.com/pub/openshift-static-ci-deps/protobuf-3.0.0/protoc-3.0.0-linux-x86_64.zip > "${f}" && \
+    curl --fail -L http://mirror3.openshift.com/pub/openshift-static-ci-deps/protobuf-3.0.0/protoc-3.0.0-linux-x86_64.zip > "${f}" && \
     mkdir -p /opt/google/protobuf && \
     unzip "${f}" -d /opt/google/protobuf && \
     curl --fail -L https://github.com/coreos/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-amd64.tar.gz | tar -f - -xz --no-same-owner -C /usr/local/bin --strip-components=1 etcd-v3.4.13-linux-amd64/etcd

--- a/pyartcd/pyartcd/constants.py
+++ b/pyartcd/pyartcd/constants.py
@@ -14,7 +14,7 @@ RELEASE_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-release"
 GIT_AUTHOR = "AOS Automation Release Team <noreply@redhat.com>"
 
 # Maps the name of a release component tag to the filename element to include
-# when creating artifacts on mirror.openshift.com.
+# when creating artifacts on mirror3.openshift.com.
 MIRROR_CLIENTS = {
     "cli": "openshift-client",
     "installer": "openshift-installer",
@@ -31,7 +31,7 @@ JENKINS_SERVER_URL = 'https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.r
 # It shall be used to print clickable logs that redirect the user to the triggered job page
 JENKINS_UI_URL = 'https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com'
 
-MIRROR_BASE_URL = 'https://mirror.openshift.com'
+MIRROR_BASE_URL = 'https://mirror3.openshift.com'
 
 UMB_BROKERS = {
     "prod": "stomp+ssl://umb.api.redhat.com:61612",


### PR DESCRIPTION
The sync of AWS s3 Cloudfront bucket "art-srv-enterprise" and R2 CloudFlare bucket  "art-srv-enterprise"
seem to be syncronized. At least when you doing

- aws s3 ls s3://art-srv-enterprise/enterprise/reposync/ (AWS s3 bucket)
- aws s3 ls s3://art-srv-enterprise/enterprise/reposync/ --profile cloudflare --endpoint-url https://2209d6dda25891dee55b086a469130de.r2.cloudflarestorage.com (CloudFlare bucket)

you get displayed more or less the same content.

Right now the status is, that mirror3.openshift.com, which should point to R2 shows another directory listing then mirror.openshift.com. Mirror3 is still pointing to a test bucket .