### PR TITLE
ART-14747: Correctly fallback to catalog.json for extracting related images from FBC if related-images.json is not available

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -766,6 +766,10 @@ async def extract_related_images_from_fbc(fbc_pullspec: str, product: str) -> li
     :param product: Product name for URL transformation (e.g., 'openshift', 'oadp')
     :return: List of image pullspecs from art-images repository
     """
+    ATTACHED_ARTIFACT_TYPE = 'application/vnd.konflux-ci.attached-artifact'
+    RELATED_IMAGES_MEDIA_TYPE = 'related-images'
+    RENDERED_CATALOG_MEDIA_TYPE = 'rendered-catalog'
+
     LOGGER.info(f"Extracting related images from FBC: {fbc_pullspec}")
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -784,9 +788,11 @@ async def extract_related_images_from_fbc(fbc_pullspec: str, product: str) -> li
         LOGGER.debug(f"ORAS discover response: {discover_data}")
 
         digest = None
+        catalog_digest = None  # Keep track of catalog artifact as fallback
         referrers = discover_data.get('referrers', [])
         LOGGER.info(f"Found {len(referrers)} referrers")
 
+        # Look for related-images or rendered-catalog (fallback)
         for i, referrer in enumerate(referrers):
             artifact_type = referrer.get('artifactType')
             annotations = referrer.get('annotations', {})
@@ -795,19 +801,35 @@ async def extract_related_images_from_fbc(fbc_pullspec: str, product: str) -> li
                 f"Referrer {i}: artifactType={artifact_type}, attachedMediaType={attached_media_type}, digest={referrer.get('digest')}"
             )
 
-            # Look specifically for the related-images artifact
-            if (
-                artifact_type == 'application/vnd.konflux-ci.attached-artifact'
-                and 'related-images' in attached_media_type
-            ):
-                digest = referrer.get('digest')
-                LOGGER.info(f"Found related-images artifact with digest: {digest}")
-                break
+            if artifact_type == ATTACHED_ARTIFACT_TYPE:
+                if RELATED_IMAGES_MEDIA_TYPE in attached_media_type:
+                    digest = referrer.get('digest')
+                    LOGGER.info(f"Found '{RELATED_IMAGES_MEDIA_TYPE}' artifact with digest: {digest}")
+                    break
+                # If we find rendered-catalog, save it but keep looking for related-images
+                elif RENDERED_CATALOG_MEDIA_TYPE in attached_media_type:
+                    catalog_digest = referrer.get('digest')
+                    LOGGER.info(f"Found '{RENDERED_CATALOG_MEDIA_TYPE}' artifact with digest: {catalog_digest}")
+
+        # If we didn't find related-images, use catalog if available
+        if not digest and catalog_digest:
+            digest = catalog_digest
+            LOGGER.info(
+                f"No '{RELATED_IMAGES_MEDIA_TYPE}' artifact found, using '{RENDERED_CATALOG_MEDIA_TYPE}' artifact with digest: {digest}"
+            )
 
         if not digest:
-            available_types = [r.get('artifactType') for r in referrers]
+            available_artifacts = [
+                {
+                    'artifactType': r.get('artifactType'),
+                    'attachedMediaType': r.get('annotations', {}).get('attachedMediaType', 'N/A'),
+                }
+                for r in referrers
+            ]
             raise RuntimeError(
-                f"No attached artifact found with expected type 'application/vnd.konflux-ci.attached-artifact'. Available types: {available_types}"
+                f"No attached artifact found with type '{ATTACHED_ARTIFACT_TYPE}' and media type containing "
+                f"'{RELATED_IMAGES_MEDIA_TYPE}' or '{RENDERED_CATALOG_MEDIA_TYPE}'. "
+                f"Available artifacts: {available_artifacts}"
             )
 
         # Step 2: Pull the attached artifact

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -829,6 +829,10 @@ async def extract_related_images_from_fbc(fbc_pullspec: str, product: str) -> li
     :param product: Product name for URL transformation (e.g., 'openshift', 'oadp')
     :return: List of image pullspecs from art-images repository
     """
+    ATTACHED_ARTIFACT_TYPE = 'application/vnd.konflux-ci.attached-artifact'
+    RELATED_IMAGES_MEDIA_TYPE = 'related-images'
+    RENDERED_CATALOG_MEDIA_TYPE = 'rendered-catalog'
+
     LOGGER.info(f"Extracting related images from FBC: {fbc_pullspec}")
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -847,9 +851,11 @@ async def extract_related_images_from_fbc(fbc_pullspec: str, product: str) -> li
         LOGGER.debug(f"ORAS discover response: {discover_data}")
 
         digest = None
+        catalog_digest = None  # Keep track of catalog artifact as fallback
         referrers = discover_data.get('referrers', [])
         LOGGER.info(f"Found {len(referrers)} referrers")
 
+        # Look for related-images or rendered-catalog (fallback)
         for i, referrer in enumerate(referrers):
             artifact_type = referrer.get('artifactType')
             annotations = referrer.get('annotations', {})
@@ -858,19 +864,35 @@ async def extract_related_images_from_fbc(fbc_pullspec: str, product: str) -> li
                 f"Referrer {i}: artifactType={artifact_type}, attachedMediaType={attached_media_type}, digest={referrer.get('digest')}"
             )
 
-            # Look specifically for the related-images artifact
-            if (
-                artifact_type == 'application/vnd.konflux-ci.attached-artifact'
-                and 'related-images' in attached_media_type
-            ):
-                digest = referrer.get('digest')
-                LOGGER.info(f"Found related-images artifact with digest: {digest}")
-                break
+            if artifact_type == ATTACHED_ARTIFACT_TYPE:
+                if RELATED_IMAGES_MEDIA_TYPE in attached_media_type:
+                    digest = referrer.get('digest')
+                    LOGGER.info(f"Found '{RELATED_IMAGES_MEDIA_TYPE}' artifact with digest: {digest}")
+                    break
+                # If we find rendered-catalog, save it but keep looking for related-images
+                elif RENDERED_CATALOG_MEDIA_TYPE in attached_media_type:
+                    catalog_digest = referrer.get('digest')
+                    LOGGER.info(f"Found '{RENDERED_CATALOG_MEDIA_TYPE}' artifact with digest: {catalog_digest}")
+
+        # If we didn't find related-images, use catalog if available
+        if not digest and catalog_digest:
+            digest = catalog_digest
+            LOGGER.info(
+                f"No '{RELATED_IMAGES_MEDIA_TYPE}' artifact found, using '{RENDERED_CATALOG_MEDIA_TYPE}' artifact with digest: {digest}"
+            )
 
         if not digest:
-            available_types = [r.get('artifactType') for r in referrers]
+            available_artifacts = [
+                {
+                    'artifactType': r.get('artifactType'),
+                    'attachedMediaType': r.get('annotations', {}).get('attachedMediaType', 'N/A'),
+                }
+                for r in referrers
+            ]
             raise RuntimeError(
-                f"No attached artifact found with expected type 'application/vnd.konflux-ci.attached-artifact'. Available types: {available_types}"
+                f"No attached artifact found with type '{ATTACHED_ARTIFACT_TYPE}' and media type containing "
+                f"'{RELATED_IMAGES_MEDIA_TYPE}' or '{RENDERED_CATALOG_MEDIA_TYPE}'. "
+                f"Available artifacts: {available_artifacts}"
             )
 
         # Step 2: Pull the attached artifact

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -821,6 +821,63 @@ async def sync_to_quay(source_pullspec, destination_repo, tags=None):
             LOGGER.info(f"Tagging from {destination_repo}@sha256:{shasum} to {destination_repo}:{tag} completed")
 
 
+def _extract_images_from_catalog_json(catalog_path: str) -> list[str]:
+    """Parse catalog.json (FBC format) and return relatedImages from the channel head olm.bundle.
+
+    Handles both NDJSON (one JSON object per line) and top-level JSON array formats.
+    Uses olm.channel to identify the current (head) bundle version, then extracts
+    only that bundle's relatedImages, mirroring:
+        jq -r 'select(.schema == "olm.bundle" and .name == HEAD) | .relatedImages[].image'
+    """
+    with open(catalog_path, 'r') as f:
+        content = f.read()
+
+    entries: list[dict] = []
+    try:
+        parsed = json.loads(content)
+        if isinstance(parsed, list):
+            entries = parsed
+        elif isinstance(parsed, dict):
+            entries = [parsed]
+    except json.JSONDecodeError:
+        pass
+
+    if not entries:
+        for line in content.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+                if isinstance(obj, dict):
+                    entries.append(obj)
+            except json.JSONDecodeError:
+                continue
+
+    if not entries:
+        raise RuntimeError(f"Failed to parse catalog.json: no valid JSON entries found in {catalog_path}")
+
+    # Find the channel head bundle name from olm.channel
+    head_bundle_name = None
+    for entry in entries:
+        if entry.get('schema') == 'olm.channel':
+            channel_entries = entry.get('entries', [])
+            if channel_entries:
+                head_bundle_name = channel_entries[-1].get('name')
+                LOGGER.info(f"Channel head bundle from olm.channel: {head_bundle_name}")
+            break
+
+    for entry in entries:
+        if entry.get('schema') == 'olm.bundle' and entry.get('name') == head_bundle_name:
+            images = [ri.get('image') for ri in entry.get('relatedImages', []) if ri.get('image')]
+            LOGGER.info(f"Extracted {len(images)} relatedImages from catalog.json (bundle: {head_bundle_name})")
+            return images
+
+    raise RuntimeError(
+        f"No olm.bundle entry found matching channel head '{head_bundle_name}' in {catalog_path}"
+    )
+
+
 async def extract_related_images_from_fbc(fbc_pullspec: str, product: str) -> list[str]:
     """
     Extract related image pullspecs from FBC image using ORAS workflow.
@@ -987,19 +1044,13 @@ async def extract_related_images_from_fbc(fbc_pullspec: str, product: str) -> li
         else:
             catalog_json_path = os.path.join(temp_dir, 'catalog.json')
             if os.path.exists(catalog_json_path):
-                LOGGER.warning(
-                    "related-images.json not found, falling back to catalog.json (this may extract many images)"
+                LOGGER.info(
+                    "related-images.json not found, extracting relatedImages "
+                    "from olm.bundle entries in catalog.json"
                 )
-                with open(catalog_json_path, 'r') as f:
-                    catalog_content = f.read()
+                found_images = _extract_images_from_catalog_json(catalog_json_path)
 
-                registry_pattern = r'registry\.redhat\.io/[^\s"\'<>]+|quay\.io/[^\s"\'<>]+'
-                found_images = re.findall(registry_pattern, catalog_content)
-
-                # Use the same registry namespace for catalog.json fallback
                 for img_url in found_images:
-                    img_url = img_url.rstrip('",')
-                    # Check if the URL matches the registry namespace pattern
                     if f'registry.redhat.io/{registry_namespace}/' in img_url:
                         transformed_url = re.sub(
                             registry_transform_pattern,
@@ -1011,7 +1062,7 @@ async def extract_related_images_from_fbc(fbc_pullspec: str, product: str) -> li
                         related_images.append(img_url)
 
                 related_images = list(set(related_images))
-                LOGGER.warning(f"Extracted {len(related_images)} unique images from catalog.json")
+                LOGGER.info(f"Extracted {len(related_images)} unique images from catalog.json")
             else:
                 raise RuntimeError(
                     f"Neither related-images.json nor catalog.json found in pulled artifact. Available files: {pulled_files}"

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -822,12 +822,11 @@ async def sync_to_quay(source_pullspec, destination_repo, tags=None):
 
 
 def _extract_images_from_catalog_json(catalog_path: str) -> list[str]:
-    """Parse catalog.json (FBC format) and return relatedImages from the channel head olm.bundle.
+    """Parse catalog.json (FBC format) and return relatedImages from olm.bundle entries.
 
     Handles both NDJSON (one JSON object per line) and top-level JSON array formats.
-    Uses olm.channel to identify the current (head) bundle version, then extracts
-    only that bundle's relatedImages, mirroring:
-        jq -r 'select(.schema == "olm.bundle" and .name == HEAD) | .relatedImages[].image'
+    Only extracts from entries where schema == "olm.bundle", mirroring:
+        jq -r 'select(.schema == "olm.bundle") | .relatedImages[].image'
     """
     with open(catalog_path, 'r') as f:
         content = f.read()
@@ -857,25 +856,22 @@ def _extract_images_from_catalog_json(catalog_path: str) -> list[str]:
     if not entries:
         raise RuntimeError(f"Failed to parse catalog.json: no valid JSON entries found in {catalog_path}")
 
-    # Find the channel head bundle name from olm.channel
-    head_bundle_name = None
+    images: list[str] = []
+    bundle_count = 0
     for entry in entries:
-        if entry.get('schema') == 'olm.channel':
-            channel_entries = entry.get('entries', [])
-            if channel_entries:
-                head_bundle_name = channel_entries[-1].get('name')
-                LOGGER.info(f"Channel head bundle from olm.channel: {head_bundle_name}")
-            break
+        if entry.get('schema') != 'olm.bundle':
+            continue
+        bundle_count += 1
+        for ri in entry.get('relatedImages', []):
+            img = ri.get('image')
+            if img:
+                images.append(img)
 
-    for entry in entries:
-        if entry.get('schema') == 'olm.bundle' and entry.get('name') == head_bundle_name:
-            images = [ri.get('image') for ri in entry.get('relatedImages', []) if ri.get('image')]
-            LOGGER.info(f"Extracted {len(images)} relatedImages from catalog.json (bundle: {head_bundle_name})")
-            return images
-
-    raise RuntimeError(
-        f"No olm.bundle entry found matching channel head '{head_bundle_name}' in {catalog_path}"
+    LOGGER.info(
+        f"Parsed catalog.json: {len(entries)} entries, {bundle_count} olm.bundle(s), "
+        f"{len(images)} relatedImages extracted"
     )
+    return images
 
 
 async def extract_related_images_from_fbc(fbc_pullspec: str, product: str) -> list[str]:
@@ -1045,8 +1041,7 @@ async def extract_related_images_from_fbc(fbc_pullspec: str, product: str) -> li
             catalog_json_path = os.path.join(temp_dir, 'catalog.json')
             if os.path.exists(catalog_json_path):
                 LOGGER.info(
-                    "related-images.json not found, extracting relatedImages "
-                    "from olm.bundle entries in catalog.json"
+                    "related-images.json not found, extracting relatedImages from olm.bundle entries in catalog.json"
                 )
                 found_images = _extract_images_from_catalog_json(catalog_json_path)
 

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -1,4 +1,7 @@
+import asyncio
+import json
 import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import yaml
 from artcommonlib import build_util, release_util, util
@@ -6,6 +9,7 @@ from artcommonlib.model import Model
 from artcommonlib.release_util import SoftwareLifecyclePhase
 from artcommonlib.util import (
     deep_merge,
+    extract_related_images_from_fbc,
     isolate_major_minor_in_group,
     normalize_group_name_for_k8s,
 )
@@ -549,3 +553,232 @@ class TestIsFutureReleaseDate(unittest.TestCase):
 
 # Legacy group-based resolver tests removed - functions no longer exist
 # Use product-based resolvers: resolve_konflux_kubeconfig_by_product() and resolve_konflux_namespace_by_product()
+
+
+class TestExtractRelatedImagesFromFBC(unittest.TestCase):
+    """Tests for extract_related_images_from_fbc function with artifact fallback logic"""
+
+    def setUp(self):
+        """Set up common test data"""
+        self.fbc_pullspec = "quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc@sha256:abc123"
+        self.product = "ocp"
+
+        # Sample related-images.json content
+        self.related_images_json = [
+            "registry.redhat.io/openshift4/ose-operator@sha256:111",
+            "registry.redhat.io/openshift4/ose-cli@sha256:222",
+            "quay.io/other/image@sha256:333",
+        ]
+
+        # Sample catalog.json content with embedded images
+        self.catalog_json_content = '''
+        {
+            "schema": "olm.package",
+            "name": "test-operator",
+            "relatedImages": [
+                {"image": "registry.redhat.io/openshift4/ose-operator@sha256:444"},
+                {"image": "registry.redhat.io/openshift4/ose-cli@sha256:555"}
+            ]
+        }
+        '''
+
+    def _create_discover_response(self, include_related_images=True, include_rendered_catalog=False):
+        """Helper to create ORAS discover response JSON"""
+        referrers = []
+
+        if include_related_images:
+            referrers.append(
+                {
+                    'digest': 'sha256:related-digest-111',
+                    'artifactType': 'application/vnd.konflux-ci.attached-artifact',
+                    'annotations': {
+                        'attachedMediaType': 'application/vnd.konflux-ci.attached-artifact.related-images+json'
+                    },
+                }
+            )
+
+        if include_rendered_catalog:
+            referrers.append(
+                {
+                    'digest': 'sha256:catalog-digest-222',
+                    'artifactType': 'application/vnd.konflux-ci.attached-artifact',
+                    'annotations': {
+                        'attachedMediaType': 'application/vnd.konflux-ci.attached-artifact.rendered-catalog+json'
+                    },
+                }
+            )
+
+        return json.dumps({'referrers': referrers})
+
+    @patch('artcommonlib.util.cmd_gather_async', new_callable=AsyncMock)
+    @patch('builtins.open', new_callable=MagicMock)
+    @patch('os.path.exists')
+    @patch('os.listdir')
+    def test_prefers_related_images_artifact(self, mock_listdir, mock_exists, mock_open, mock_cmd):
+        """Test that 'related-images' artifact is preferred when both artifacts exist"""
+        # Setup mocks - cmd_gather_async is called twice (discover + pull)
+        mock_cmd.side_effect = [
+            # First call: ORAS discover
+            (0, self._create_discover_response(include_related_images=True, include_rendered_catalog=True), ''),
+            # Second call: ORAS pull
+            (0, 'Pulled artifact successfully', ''),
+        ]
+
+        mock_listdir.return_value = ['related-images.json']
+        mock_exists.side_effect = lambda path: 'related-images.json' in path
+
+        # Mock file reading
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.read.return_value = json.dumps(self.related_images_json)
+        mock_open.return_value = mock_file
+
+        # Run async test
+        result = asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
+
+        # Verify
+        self.assertGreater(len(result), 0)
+        # Should pull the related-images artifact (digest sha256:related-digest-111)
+        pull_call = mock_cmd.call_args_list[1]  # Second call is the pull
+        self.assertIn('sha256:related-digest-111', str(pull_call))
+
+    @patch('artcommonlib.util.cmd_gather_async', new_callable=AsyncMock)
+    @patch('builtins.open', new_callable=MagicMock)
+    @patch('os.path.exists')
+    @patch('os.listdir')
+    def test_falls_back_to_rendered_catalog_artifact(self, mock_listdir, mock_exists, mock_open, mock_cmd):
+        """Test that 'rendered-catalog' artifact is used when 'related-images' is missing (ART-14747 fix)"""
+        # Setup mocks - only rendered-catalog artifact exists
+        mock_cmd.side_effect = [
+            # First call: ORAS discover
+            (0, self._create_discover_response(include_related_images=False, include_rendered_catalog=True), ''),
+            # Second call: ORAS pull
+            (0, 'Pulled artifact successfully', ''),
+        ]
+
+        mock_listdir.return_value = ['catalog.json']
+        mock_exists.side_effect = lambda path: 'catalog.json' in path
+
+        # Mock file reading
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.read.return_value = self.catalog_json_content
+        mock_open.return_value = mock_file
+
+        # Run async test
+        result = asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
+
+        # Verify
+        self.assertGreater(len(result), 0)
+        # Should pull the rendered-catalog artifact (digest sha256:catalog-digest-222)
+        pull_call = mock_cmd.call_args_list[1]  # Second call is the pull
+        self.assertIn('sha256:catalog-digest-222', str(pull_call))
+
+    @patch('artcommonlib.util.cmd_gather_async', new_callable=AsyncMock)
+    def test_error_when_no_artifacts_found(self, mock_cmd):
+        """Test detailed error message when neither artifact type exists"""
+        # Setup mocks - no matching artifacts
+        other_artifact_response = json.dumps(
+            {
+                'referrers': [
+                    {
+                        'digest': 'sha256:other-digest',
+                        'artifactType': 'application/vnd.other.type',
+                        'annotations': {'attachedMediaType': 'application/vnd.other+json'},
+                    }
+                ]
+            }
+        )
+
+        mock_cmd.return_value = (0, other_artifact_response, '')
+
+        # Run async test and expect RuntimeError
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
+
+        # Verify error message includes both artifactType and attachedMediaType
+        error_msg = str(ctx.exception)
+        self.assertIn('application/vnd.konflux-ci.attached-artifact', error_msg)
+        self.assertIn('related-images', error_msg)
+        self.assertIn('rendered-catalog', error_msg)
+        self.assertIn('attachedMediaType', error_msg)
+
+    @patch('artcommonlib.util.cmd_gather_async', new_callable=AsyncMock)
+    @patch('builtins.open', new_callable=MagicMock)
+    @patch('os.path.exists')
+    @patch('os.listdir')
+    def test_file_level_fallback_from_related_images_to_catalog(self, mock_listdir, mock_exists, mock_open, mock_cmd):
+        """Test file-level fallback: related-images artifact exists but only catalog.json file inside"""
+        # Setup mocks - related-images artifact exists
+        mock_cmd.side_effect = [
+            # First call: ORAS discover
+            (0, self._create_discover_response(include_related_images=True, include_rendered_catalog=False), ''),
+            # Second call: ORAS pull
+            (0, 'Pulled artifact successfully', ''),
+        ]
+
+        mock_listdir.return_value = ['catalog.json']  # Only catalog.json inside the artifact
+        # First check for related-images.json (False), then catalog.json (True)
+        mock_exists.side_effect = lambda path: 'catalog.json' in path
+
+        # Mock file reading
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.read.return_value = self.catalog_json_content
+        mock_open.return_value = mock_file
+
+        # Run async test
+        result = asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
+
+        # Verify
+        self.assertGreater(len(result), 0)
+
+    @patch('artcommonlib.util.cmd_gather_async', new_callable=AsyncMock)
+    @patch('builtins.open', new_callable=MagicMock)
+    @patch('os.path.exists')
+    @patch('os.listdir')
+    def test_catalog_json_expected_from_rendered_catalog_artifact(self, mock_listdir, mock_exists, mock_open, mock_cmd):
+        """Test that using catalog.json from rendered-catalog artifact doesn't log warning"""
+        # Setup mocks - rendered-catalog artifact exists
+        mock_cmd.side_effect = [
+            # First call: ORAS discover
+            (0, self._create_discover_response(include_related_images=False, include_rendered_catalog=True), ''),
+            # Second call: ORAS pull
+            (0, 'Pulled artifact successfully', ''),
+        ]
+
+        mock_listdir.return_value = ['catalog.json']
+        mock_exists.side_effect = lambda path: 'catalog.json' in path
+
+        # Mock file reading
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.read.return_value = self.catalog_json_content
+        mock_open.return_value = mock_file
+
+        # Run async test
+        result = asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
+
+        # Verify - should successfully extract images
+        self.assertGreater(len(result), 0)
+
+    @patch('artcommonlib.util.cmd_gather_async', new_callable=AsyncMock)
+    @patch('os.path.exists')
+    @patch('os.listdir')
+    def test_error_when_neither_file_found(self, mock_listdir, mock_exists, mock_cmd):
+        """Test error when neither related-images.json nor catalog.json found in pulled artifact"""
+        # Setup mocks
+        mock_cmd.side_effect = [
+            # First call: ORAS discover
+            (0, self._create_discover_response(include_related_images=True, include_rendered_catalog=False), ''),
+            # Second call: ORAS pull
+            (0, 'Pulled artifact successfully', ''),
+        ]
+
+        mock_listdir.return_value = ['other-file.txt']
+        mock_exists.return_value = False  # Neither file exists
+
+        # Run async test and expect RuntimeError
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
+
+        # Verify error message includes artifact type and available files
+        error_msg = str(ctx.exception)
+        self.assertIn('artifact', error_msg.lower())
+        self.assertIn('other-file.txt', error_msg)

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -1,4 +1,7 @@
+import asyncio
+import json
 import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import yaml
 from artcommonlib import build_util, release_util, util
@@ -6,6 +9,7 @@ from artcommonlib.model import Model
 from artcommonlib.release_util import SoftwareLifecyclePhase
 from artcommonlib.util import (
     deep_merge,
+    extract_related_images_from_fbc,
     isolate_major_minor_in_group,
     normalize_group_name_for_k8s,
 )
@@ -584,3 +588,232 @@ class TestIsFutureReleaseDate(unittest.TestCase):
 
 # Legacy group-based resolver tests removed - functions no longer exist
 # Use product-based resolvers: resolve_konflux_kubeconfig_by_product() and resolve_konflux_namespace_by_product()
+
+
+class TestExtractRelatedImagesFromFBC(unittest.TestCase):
+    """Tests for extract_related_images_from_fbc function with artifact fallback logic"""
+
+    def setUp(self):
+        """Set up common test data"""
+        self.fbc_pullspec = "quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc@sha256:abc123"
+        self.product = "ocp"
+
+        # Sample related-images.json content
+        self.related_images_json = [
+            "registry.redhat.io/openshift4/ose-operator@sha256:111",
+            "registry.redhat.io/openshift4/ose-cli@sha256:222",
+            "quay.io/other/image@sha256:333",
+        ]
+
+        # Sample catalog.json content with embedded images
+        self.catalog_json_content = '''
+        {
+            "schema": "olm.package",
+            "name": "test-operator",
+            "relatedImages": [
+                {"image": "registry.redhat.io/openshift4/ose-operator@sha256:444"},
+                {"image": "registry.redhat.io/openshift4/ose-cli@sha256:555"}
+            ]
+        }
+        '''
+
+    def _create_discover_response(self, include_related_images=True, include_rendered_catalog=False):
+        """Helper to create ORAS discover response JSON"""
+        referrers = []
+
+        if include_related_images:
+            referrers.append(
+                {
+                    'digest': 'sha256:related-digest-111',
+                    'artifactType': 'application/vnd.konflux-ci.attached-artifact',
+                    'annotations': {
+                        'attachedMediaType': 'application/vnd.konflux-ci.attached-artifact.related-images+json'
+                    },
+                }
+            )
+
+        if include_rendered_catalog:
+            referrers.append(
+                {
+                    'digest': 'sha256:catalog-digest-222',
+                    'artifactType': 'application/vnd.konflux-ci.attached-artifact',
+                    'annotations': {
+                        'attachedMediaType': 'application/vnd.konflux-ci.attached-artifact.rendered-catalog+json'
+                    },
+                }
+            )
+
+        return json.dumps({'referrers': referrers})
+
+    @patch('artcommonlib.util.cmd_gather_async', new_callable=AsyncMock)
+    @patch('builtins.open', new_callable=MagicMock)
+    @patch('os.path.exists')
+    @patch('os.listdir')
+    def test_prefers_related_images_artifact(self, mock_listdir, mock_exists, mock_open, mock_cmd):
+        """Test that 'related-images' artifact is preferred when both artifacts exist"""
+        # Setup mocks - cmd_gather_async is called twice (discover + pull)
+        mock_cmd.side_effect = [
+            # First call: ORAS discover
+            (0, self._create_discover_response(include_related_images=True, include_rendered_catalog=True), ''),
+            # Second call: ORAS pull
+            (0, 'Pulled artifact successfully', ''),
+        ]
+
+        mock_listdir.return_value = ['related-images.json']
+        mock_exists.side_effect = lambda path: 'related-images.json' in path
+
+        # Mock file reading
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.read.return_value = json.dumps(self.related_images_json)
+        mock_open.return_value = mock_file
+
+        # Run async test
+        result = asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
+
+        # Verify
+        self.assertGreater(len(result), 0)
+        # Should pull the related-images artifact (digest sha256:related-digest-111)
+        pull_call = mock_cmd.call_args_list[1]  # Second call is the pull
+        self.assertIn('sha256:related-digest-111', str(pull_call))
+
+    @patch('artcommonlib.util.cmd_gather_async', new_callable=AsyncMock)
+    @patch('builtins.open', new_callable=MagicMock)
+    @patch('os.path.exists')
+    @patch('os.listdir')
+    def test_falls_back_to_rendered_catalog_artifact(self, mock_listdir, mock_exists, mock_open, mock_cmd):
+        """Test that 'rendered-catalog' artifact is used when 'related-images' is missing (ART-14747 fix)"""
+        # Setup mocks - only rendered-catalog artifact exists
+        mock_cmd.side_effect = [
+            # First call: ORAS discover
+            (0, self._create_discover_response(include_related_images=False, include_rendered_catalog=True), ''),
+            # Second call: ORAS pull
+            (0, 'Pulled artifact successfully', ''),
+        ]
+
+        mock_listdir.return_value = ['catalog.json']
+        mock_exists.side_effect = lambda path: 'catalog.json' in path
+
+        # Mock file reading
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.read.return_value = self.catalog_json_content
+        mock_open.return_value = mock_file
+
+        # Run async test
+        result = asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
+
+        # Verify
+        self.assertGreater(len(result), 0)
+        # Should pull the rendered-catalog artifact (digest sha256:catalog-digest-222)
+        pull_call = mock_cmd.call_args_list[1]  # Second call is the pull
+        self.assertIn('sha256:catalog-digest-222', str(pull_call))
+
+    @patch('artcommonlib.util.cmd_gather_async', new_callable=AsyncMock)
+    def test_error_when_no_artifacts_found(self, mock_cmd):
+        """Test detailed error message when neither artifact type exists"""
+        # Setup mocks - no matching artifacts
+        other_artifact_response = json.dumps(
+            {
+                'referrers': [
+                    {
+                        'digest': 'sha256:other-digest',
+                        'artifactType': 'application/vnd.other.type',
+                        'annotations': {'attachedMediaType': 'application/vnd.other+json'},
+                    }
+                ]
+            }
+        )
+
+        mock_cmd.return_value = (0, other_artifact_response, '')
+
+        # Run async test and expect RuntimeError
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
+
+        # Verify error message includes both artifactType and attachedMediaType
+        error_msg = str(ctx.exception)
+        self.assertIn('application/vnd.konflux-ci.attached-artifact', error_msg)
+        self.assertIn('related-images', error_msg)
+        self.assertIn('rendered-catalog', error_msg)
+        self.assertIn('attachedMediaType', error_msg)
+
+    @patch('artcommonlib.util.cmd_gather_async', new_callable=AsyncMock)
+    @patch('builtins.open', new_callable=MagicMock)
+    @patch('os.path.exists')
+    @patch('os.listdir')
+    def test_file_level_fallback_from_related_images_to_catalog(self, mock_listdir, mock_exists, mock_open, mock_cmd):
+        """Test file-level fallback: related-images artifact exists but only catalog.json file inside"""
+        # Setup mocks - related-images artifact exists
+        mock_cmd.side_effect = [
+            # First call: ORAS discover
+            (0, self._create_discover_response(include_related_images=True, include_rendered_catalog=False), ''),
+            # Second call: ORAS pull
+            (0, 'Pulled artifact successfully', ''),
+        ]
+
+        mock_listdir.return_value = ['catalog.json']  # Only catalog.json inside the artifact
+        # First check for related-images.json (False), then catalog.json (True)
+        mock_exists.side_effect = lambda path: 'catalog.json' in path
+
+        # Mock file reading
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.read.return_value = self.catalog_json_content
+        mock_open.return_value = mock_file
+
+        # Run async test
+        result = asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
+
+        # Verify
+        self.assertGreater(len(result), 0)
+
+    @patch('artcommonlib.util.cmd_gather_async', new_callable=AsyncMock)
+    @patch('builtins.open', new_callable=MagicMock)
+    @patch('os.path.exists')
+    @patch('os.listdir')
+    def test_catalog_json_expected_from_rendered_catalog_artifact(self, mock_listdir, mock_exists, mock_open, mock_cmd):
+        """Test that using catalog.json from rendered-catalog artifact doesn't log warning"""
+        # Setup mocks - rendered-catalog artifact exists
+        mock_cmd.side_effect = [
+            # First call: ORAS discover
+            (0, self._create_discover_response(include_related_images=False, include_rendered_catalog=True), ''),
+            # Second call: ORAS pull
+            (0, 'Pulled artifact successfully', ''),
+        ]
+
+        mock_listdir.return_value = ['catalog.json']
+        mock_exists.side_effect = lambda path: 'catalog.json' in path
+
+        # Mock file reading
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.read.return_value = self.catalog_json_content
+        mock_open.return_value = mock_file
+
+        # Run async test
+        result = asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
+
+        # Verify - should successfully extract images
+        self.assertGreater(len(result), 0)
+
+    @patch('artcommonlib.util.cmd_gather_async', new_callable=AsyncMock)
+    @patch('os.path.exists')
+    @patch('os.listdir')
+    def test_error_when_neither_file_found(self, mock_listdir, mock_exists, mock_cmd):
+        """Test error when neither related-images.json nor catalog.json found in pulled artifact"""
+        # Setup mocks
+        mock_cmd.side_effect = [
+            # First call: ORAS discover
+            (0, self._create_discover_response(include_related_images=True, include_rendered_catalog=False), ''),
+            # Second call: ORAS pull
+            (0, 'Pulled artifact successfully', ''),
+        ]
+
+        mock_listdir.return_value = ['other-file.txt']
+        mock_exists.return_value = False  # Neither file exists
+
+        # Run async test and expect RuntimeError
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
+
+        # Verify error message includes artifact type and available files
+        error_msg = str(ctx.exception)
+        self.assertIn('artifact', error_msg.lower())
+        self.assertIn('other-file.txt', error_msg)

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -606,30 +606,38 @@ class TestExtractRelatedImagesFromFBC(unittest.TestCase):
         ]
 
         # Sample catalog.json content -- FBC NDJSON with olm.bundle schema
-        self.catalog_json_content = '\n'.join([
-            json.dumps({
-                "schema": "olm.package",
-                "name": "test-operator",
-                "defaultChannel": "stable",
-            }),
-            json.dumps({
-                "schema": "olm.channel",
-                "name": "stable",
-                "package": "test-operator",
-                "entries": [
-                    {"name": "test-operator.v1.0.0", "skipRange": ">=0.0.1 <1.0.0"},
-                ],
-            }),
-            json.dumps({
-                "schema": "olm.bundle",
-                "name": "test-operator.v1.0.0",
-                "package": "test-operator",
-                "relatedImages": [
-                    {"name": "operator", "image": "registry.redhat.io/openshift4/ose-operator@sha256:444"},
-                    {"name": "cli", "image": "registry.redhat.io/openshift4/ose-cli@sha256:555"},
-                ],
-            }),
-        ])
+        self.catalog_json_content = '\n'.join(
+            [
+                json.dumps(
+                    {
+                        "schema": "olm.package",
+                        "name": "test-operator",
+                        "defaultChannel": "stable",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "schema": "olm.channel",
+                        "name": "stable",
+                        "package": "test-operator",
+                        "entries": [
+                            {"name": "test-operator.v1.0.0", "skipRange": ">=0.0.1 <1.0.0"},
+                        ],
+                    }
+                ),
+                json.dumps(
+                    {
+                        "schema": "olm.bundle",
+                        "name": "test-operator.v1.0.0",
+                        "package": "test-operator",
+                        "relatedImages": [
+                            {"name": "operator", "image": "registry.redhat.io/openshift4/ose-operator@sha256:444"},
+                            {"name": "cli", "image": "registry.redhat.io/openshift4/ose-cli@sha256:555"},
+                        ],
+                    }
+                ),
+            ]
+        )
 
     def _create_discover_response(self, include_related_images=True, include_rendered_catalog=False):
         """Helper to create ORAS discover response JSON"""
@@ -838,27 +846,35 @@ class TestExtractRelatedImagesFromFBC(unittest.TestCase):
     @patch('os.listdir')
     def test_catalog_json_ignores_non_bundle_entries(self, mock_listdir, mock_exists, mock_open, mock_cmd):
         """Structured extraction only reads olm.bundle entries, not olm.package or olm.channel"""
-        catalog_with_noise = '\n'.join([
-            json.dumps({
-                "schema": "olm.package",
-                "name": "test-operator",
-                "description": "Ships registry.redhat.io/openshift4/should-not-match@sha256:999",
-            }),
-            json.dumps({
-                "schema": "olm.channel",
-                "name": "stable",
-                "package": "test-operator",
-                "entries": [{"name": "test-operator.v1.0.0"}],
-            }),
-            json.dumps({
-                "schema": "olm.bundle",
-                "name": "test-operator.v1.0.0",
-                "package": "test-operator",
-                "relatedImages": [
-                    {"name": "op", "image": "registry.redhat.io/openshift4/ose-operator@sha256:444"},
-                ],
-            }),
-        ])
+        catalog_with_noise = '\n'.join(
+            [
+                json.dumps(
+                    {
+                        "schema": "olm.package",
+                        "name": "test-operator",
+                        "description": "Ships registry.redhat.io/openshift4/should-not-match@sha256:999",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "schema": "olm.channel",
+                        "name": "stable",
+                        "package": "test-operator",
+                        "entries": [{"name": "test-operator.v1.0.0"}],
+                    }
+                ),
+                json.dumps(
+                    {
+                        "schema": "olm.bundle",
+                        "name": "test-operator.v1.0.0",
+                        "package": "test-operator",
+                        "relatedImages": [
+                            {"name": "op", "image": "registry.redhat.io/openshift4/ose-operator@sha256:444"},
+                        ],
+                    }
+                ),
+            ]
+        )
 
         mock_cmd.side_effect = [
             (0, self._create_discover_response(include_related_images=False, include_rendered_catalog=True), ''),
@@ -880,40 +896,50 @@ class TestExtractRelatedImagesFromFBC(unittest.TestCase):
     @patch('builtins.open', new_callable=MagicMock)
     @patch('os.path.exists')
     @patch('os.listdir')
-    def test_catalog_json_extracts_only_channel_head(self, mock_listdir, mock_exists, mock_open, mock_cmd):
-        """Only the channel head bundle's relatedImages are extracted, not older versions"""
-        catalog_multi_bundle = '\n'.join([
-            json.dumps({
-                "schema": "olm.package",
-                "name": "test-operator",
-                "defaultChannel": "stable",
-            }),
-            json.dumps({
-                "schema": "olm.channel",
-                "name": "stable",
-                "package": "test-operator",
-                "entries": [
-                    {"name": "test-operator.v1.0.0", "skipRange": ">=0.0.1 <1.0.0"},
-                    {"name": "test-operator.v1.1.0", "skipRange": ">=0.0.1 <1.1.0"},
-                ],
-            }),
-            json.dumps({
-                "schema": "olm.bundle",
-                "name": "test-operator.v1.0.0",
-                "package": "test-operator",
-                "relatedImages": [
-                    {"name": "old-op", "image": "registry.redhat.io/openshift4/ose-operator@sha256:old111"},
-                ],
-            }),
-            json.dumps({
-                "schema": "olm.bundle",
-                "name": "test-operator.v1.1.0",
-                "package": "test-operator",
-                "relatedImages": [
-                    {"name": "new-op", "image": "registry.redhat.io/openshift4/ose-operator@sha256:new222"},
-                ],
-            }),
-        ])
+    def test_catalog_json_extracts_all_bundles(self, mock_listdir, mock_exists, mock_open, mock_cmd):
+        """All olm.bundle relatedImages are extracted (not filtered by channel head)"""
+        catalog_multi_bundle = '\n'.join(
+            [
+                json.dumps(
+                    {
+                        "schema": "olm.package",
+                        "name": "test-operator",
+                        "defaultChannel": "stable",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "schema": "olm.channel",
+                        "name": "stable",
+                        "package": "test-operator",
+                        "entries": [
+                            {"name": "test-operator.v1.0.0", "skipRange": ">=0.0.1 <1.0.0"},
+                            {"name": "test-operator.v1.1.0", "skipRange": ">=0.0.1 <1.1.0"},
+                        ],
+                    }
+                ),
+                json.dumps(
+                    {
+                        "schema": "olm.bundle",
+                        "name": "test-operator.v1.0.0",
+                        "package": "test-operator",
+                        "relatedImages": [
+                            {"name": "old-op", "image": "registry.redhat.io/openshift4/ose-operator@sha256:old111"},
+                        ],
+                    }
+                ),
+                json.dumps(
+                    {
+                        "schema": "olm.bundle",
+                        "name": "test-operator.v1.1.0",
+                        "package": "test-operator",
+                        "relatedImages": [
+                            {"name": "new-op", "image": "registry.redhat.io/openshift4/ose-operator@sha256:new222"},
+                        ],
+                    }
+                ),
+            ]
+        )
 
         mock_cmd.side_effect = [
             (0, self._create_discover_response(include_related_images=False, include_rendered_catalog=True), ''),
@@ -928,6 +954,6 @@ class TestExtractRelatedImagesFromFBC(unittest.TestCase):
 
         result = asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
 
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result), 2)
         self.assertIn('sha256:new222', str(result))
-        self.assertNotIn('sha256:old111', str(result))
+        self.assertIn('sha256:old111', str(result))

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -605,17 +605,31 @@ class TestExtractRelatedImagesFromFBC(unittest.TestCase):
             "quay.io/other/image@sha256:333",
         ]
 
-        # Sample catalog.json content with embedded images
-        self.catalog_json_content = '''
-        {
-            "schema": "olm.package",
-            "name": "test-operator",
-            "relatedImages": [
-                {"image": "registry.redhat.io/openshift4/ose-operator@sha256:444"},
-                {"image": "registry.redhat.io/openshift4/ose-cli@sha256:555"}
-            ]
-        }
-        '''
+        # Sample catalog.json content -- FBC NDJSON with olm.bundle schema
+        self.catalog_json_content = '\n'.join([
+            json.dumps({
+                "schema": "olm.package",
+                "name": "test-operator",
+                "defaultChannel": "stable",
+            }),
+            json.dumps({
+                "schema": "olm.channel",
+                "name": "stable",
+                "package": "test-operator",
+                "entries": [
+                    {"name": "test-operator.v1.0.0", "skipRange": ">=0.0.1 <1.0.0"},
+                ],
+            }),
+            json.dumps({
+                "schema": "olm.bundle",
+                "name": "test-operator.v1.0.0",
+                "package": "test-operator",
+                "relatedImages": [
+                    {"name": "operator", "image": "registry.redhat.io/openshift4/ose-operator@sha256:444"},
+                    {"name": "cli", "image": "registry.redhat.io/openshift4/ose-cli@sha256:555"},
+                ],
+            }),
+        ])
 
     def _create_discover_response(self, include_related_images=True, include_rendered_catalog=False):
         """Helper to create ORAS discover response JSON"""
@@ -817,3 +831,103 @@ class TestExtractRelatedImagesFromFBC(unittest.TestCase):
         error_msg = str(ctx.exception)
         self.assertIn('artifact', error_msg.lower())
         self.assertIn('other-file.txt', error_msg)
+
+    @patch('artcommonlib.util.cmd_gather_async', new_callable=AsyncMock)
+    @patch('builtins.open', new_callable=MagicMock)
+    @patch('os.path.exists')
+    @patch('os.listdir')
+    def test_catalog_json_ignores_non_bundle_entries(self, mock_listdir, mock_exists, mock_open, mock_cmd):
+        """Structured extraction only reads olm.bundle entries, not olm.package or olm.channel"""
+        catalog_with_noise = '\n'.join([
+            json.dumps({
+                "schema": "olm.package",
+                "name": "test-operator",
+                "description": "Ships registry.redhat.io/openshift4/should-not-match@sha256:999",
+            }),
+            json.dumps({
+                "schema": "olm.channel",
+                "name": "stable",
+                "package": "test-operator",
+                "entries": [{"name": "test-operator.v1.0.0"}],
+            }),
+            json.dumps({
+                "schema": "olm.bundle",
+                "name": "test-operator.v1.0.0",
+                "package": "test-operator",
+                "relatedImages": [
+                    {"name": "op", "image": "registry.redhat.io/openshift4/ose-operator@sha256:444"},
+                ],
+            }),
+        ])
+
+        mock_cmd.side_effect = [
+            (0, self._create_discover_response(include_related_images=False, include_rendered_catalog=True), ''),
+            (0, 'Pulled artifact successfully', ''),
+        ]
+        mock_listdir.return_value = ['catalog.json']
+        mock_exists.side_effect = lambda path: 'catalog.json' in path
+
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.read.return_value = catalog_with_noise
+        mock_open.return_value = mock_file
+
+        result = asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
+
+        self.assertEqual(len(result), 1)
+        self.assertNotIn('should-not-match', str(result))
+
+    @patch('artcommonlib.util.cmd_gather_async', new_callable=AsyncMock)
+    @patch('builtins.open', new_callable=MagicMock)
+    @patch('os.path.exists')
+    @patch('os.listdir')
+    def test_catalog_json_extracts_only_channel_head(self, mock_listdir, mock_exists, mock_open, mock_cmd):
+        """Only the channel head bundle's relatedImages are extracted, not older versions"""
+        catalog_multi_bundle = '\n'.join([
+            json.dumps({
+                "schema": "olm.package",
+                "name": "test-operator",
+                "defaultChannel": "stable",
+            }),
+            json.dumps({
+                "schema": "olm.channel",
+                "name": "stable",
+                "package": "test-operator",
+                "entries": [
+                    {"name": "test-operator.v1.0.0", "skipRange": ">=0.0.1 <1.0.0"},
+                    {"name": "test-operator.v1.1.0", "skipRange": ">=0.0.1 <1.1.0"},
+                ],
+            }),
+            json.dumps({
+                "schema": "olm.bundle",
+                "name": "test-operator.v1.0.0",
+                "package": "test-operator",
+                "relatedImages": [
+                    {"name": "old-op", "image": "registry.redhat.io/openshift4/ose-operator@sha256:old111"},
+                ],
+            }),
+            json.dumps({
+                "schema": "olm.bundle",
+                "name": "test-operator.v1.1.0",
+                "package": "test-operator",
+                "relatedImages": [
+                    {"name": "new-op", "image": "registry.redhat.io/openshift4/ose-operator@sha256:new222"},
+                ],
+            }),
+        ])
+
+        mock_cmd.side_effect = [
+            (0, self._create_discover_response(include_related_images=False, include_rendered_catalog=True), ''),
+            (0, 'Pulled artifact successfully', ''),
+        ]
+        mock_listdir.return_value = ['catalog.json']
+        mock_exists.side_effect = lambda path: 'catalog.json' in path
+
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.read.return_value = catalog_multi_bundle
+        mock_open.return_value = mock_file
+
+        result = asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
+
+        self.assertEqual(len(result), 1)
+        self.assertIn('sha256:new222', str(result))
+        self.assertNotIn('sha256:old111', str(result))

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -1814,7 +1814,7 @@ class KonfluxFbcBuilder:
                     record["status"] = 0
 
                     # Sync FBC related images to art-images-share
-                    if self.assembly == "stream":
+                    if self.assembly in ["stream", "test"]:
                         if not self.dry_run:
                             try:
                                 results = pipelinerun_dict.get('status', {}).get('results', [])

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -1814,7 +1814,7 @@ class KonfluxFbcBuilder:
                     record["status"] = 0
 
                     # Sync FBC related images to art-images-share
-                    if self.assembly in ["stream", "test"]:
+                    if self.assembly == "stream":
                         if not self.dry_run:
                             try:
                                 results = pipelinerun_dict.get('status', {}).get('results', [])

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -1892,7 +1892,7 @@ class KonfluxFbcBuilder:
                     record["status"] = 0
 
                     # Sync FBC related images to art-images-share
-                    if self.assembly == "stream":
+                    if self.assembly in ["stream", "test"]:
                         if not self.dry_run:
                             try:
                                 results = pipelinerun_dict.get('status', {}).get('results', [])

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -1892,7 +1892,7 @@ class KonfluxFbcBuilder:
                     record["status"] = 0
 
                     # Sync FBC related images to art-images-share
-                    if self.assembly in ["stream", "test"]:
+                    if self.assembly == "stream":
                         if not self.dry_run:
                             try:
                                 results = pipelinerun_dict.get('status', {}).get('results', [])


### PR DESCRIPTION
## Summary

Fixes FBC related images extraction when `related-images.json` is not available by falling back to `catalog.json`.

## Problem

The function `extract_related_images_from_fbc()` fails when `related-images.json` is not available, never reaching the existing fallback logic for `catalog.json`.

## Solution

- Track `rendered-catalog` artifact during discovery and use it when `related-images` artifact is not found
- Improved error messages showing available artifacts when neither file is found

## Testing

- Added 6 unit tests covering all fallback scenarios