### PR TITLE
Fix manifest-tool 401 Unauthorized for Konflux builds

### DIFF
--- a/artcommon/artcommonlib/exectools.py
+++ b/artcommon/artcommonlib/exectools.py
@@ -29,7 +29,7 @@ from artcommonlib.telemetry import start_as_current_span_async
 from future.utils import as_native_str
 from opentelemetry import trace
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
-from tenacity import stop_after_attempt, wait_fixed
+from tenacity import stop_after_attempt, wait_exponential
 
 SUCCESS = 0
 
@@ -493,13 +493,14 @@ def unpack_tuple_args(func):
     return wrapper
 
 
-@tenacity.retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(60))
-async def manifest_tool(options, dry_run=False):
+async def manifest_tool(options: str | list[str], dry_run: bool = False, auth_file: str | None = None):
     auth_opt = ""
-    if os.environ.get("XDG_RUNTIME_DIR"):
-        auth_file = os.path.expandvars("${XDG_RUNTIME_DIR}/containers/auth.json")
-        if Path(auth_file).is_file():
-            auth_opt = f"--docker-cfg={auth_file}"
+    if auth_file:
+        auth_opt = f"--docker-cfg={auth_file}"
+    elif os.environ.get("XDG_RUNTIME_DIR"):
+        default_auth = os.path.expandvars("${XDG_RUNTIME_DIR}/containers/auth.json")
+        if Path(default_auth).is_file():
+            auth_opt = f"--docker-cfg={default_auth}"
 
     if isinstance(options, str):
         cmd = f'manifest-tool {auth_opt} {options}'
@@ -515,7 +516,31 @@ async def manifest_tool(options, dry_run=False):
         logger.warning("[DRY RUN] Would have run %s", cmd)
         return
 
-    await cmd_assert_async(cmd)
+    rc, stdout, stderr = await cmd_gather_async(cmd, check=False)
+    if rc != 0:
+        raise ChildProcessError(f"manifest-tool exited with code {rc}.\nstdout: {stdout}\nstderr: {stderr}")
+
+
+def _is_rate_limit_or_auth_error(exception: BaseException) -> bool:
+    msg = str(exception).lower()
+    return '401' in msg or '429' in msg or 'unauthorized' in msg or 'too many requests' in msg
+
+
+@limit_concurrency(10)
+@tenacity.retry(
+    reraise=True,
+    retry=tenacity.retry_if_exception(_is_rate_limit_or_auth_error),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential(multiplier=10, max=120),
+)
+async def manifest_tool_with_throttle(options: str | list[str], dry_run: bool = False, auth_file: str | None = None):
+    """Wrapper around manifest_tool that limits concurrency and retries on rate-limit/auth errors.
+
+    Each manifest-tool invocation spawns a separate process that independently authenticates
+    with the registry's OAuth endpoint. When many are launched in parallel, the auth endpoint
+    can rate-limit requests (429), causing subsequent API calls to fail with 401 Unauthorized.
+    """
+    await manifest_tool(options, dry_run=dry_run, auth_file=auth_file)
 
 
 @start_as_current_span_async(TRACER, "cmd_gather_async")

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -23,7 +23,7 @@ from artcommonlib.assembly import AssemblyIssue, AssemblyIssueCode, AssemblyType
 from artcommonlib.constants import (
     COREOS_RHEL10_STREAMS,
 )
-from artcommonlib.exectools import manifest_tool
+from artcommonlib.exectools import manifest_tool_with_throttle
 from artcommonlib.format_util import red_print
 from artcommonlib.konflux.package_rpm_finder import PackageRpmFinder
 from artcommonlib.model import Model
@@ -1935,7 +1935,9 @@ class GenPayloadCli:
         # write the manifest list to a file and push it to the registry.
         async with aiofiles.open(component_manifest_path, mode="w+") as ml:
             await ml.write(yaml.safe_dump(dict(image=output_pullspec, manifests=manifests), default_flow_style=False))
-        await manifest_tool(f'push from-spec {str(component_manifest_path)}')
+        await manifest_tool_with_throttle(
+            f'push from-spec {str(component_manifest_path)}', auth_file=os.getenv("KONFLUX_ART_IMAGES_AUTH_FILE")
+        )
 
         # we are pushing a new manifest list, so return its sha256 based pullspec
         sha = await find_manifest_list_sha(output_pullspec)
@@ -2032,7 +2034,9 @@ class GenPayloadCli:
         async with aiofiles.open(release_payload_ml_path, mode="w+") as ml:
             await ml.write(yaml.safe_dump(ml_dict, default_flow_style=False))
 
-        await manifest_tool(f'push from-spec {str(release_payload_ml_path)}')
+        await manifest_tool_with_throttle(
+            f'push from-spec {str(release_payload_ml_path)}', auth_file=os.getenv("KONFLUX_ART_IMAGES_AUTH_FILE")
+        )
 
         # if we are actually pushing a manifest list, then we should derive a sha256 based pullspec
         sha = await find_manifest_list_sha(multi_release_dest)

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -845,7 +845,7 @@ spec:
         gpcli.create_multi_manifest_list.assert_awaited_once_with("spam", arch_to_payload_entry, "ocp")
 
     @patch("doozerlib.cli.release_gen_payload.find_manifest_list_sha")
-    @patch("artcommonlib.exectools.cmd_assert_async")
+    @patch("artcommonlib.exectools.cmd_gather_async")
     @patch("aiofiles.open")
     async def test_create_multi_manifest_list(self, open_mock, exec_mock, fmlsha_mock):
         os.environ['XDG_RUNTIME_DIR'] = 'fake'
@@ -854,7 +854,7 @@ spec:
 
         buffer = io.StringIO()
         open_mock.return_value.__aenter__.return_value.write = AsyncMock(side_effect=lambda s: buffer.write(s))
-        exec_mock.return_value = None  # do not actually run the command
+        exec_mock.return_value = (0, "", "")
         fmlsha_mock.return_value = "sha256:abcdef"
 
         arch_to_payload_entry = dict(
@@ -903,7 +903,7 @@ spec:
 
     @patch("doozerlib.cli.release_gen_payload.find_manifest_list_sha")
     @patch("doozerlib.cli.release_gen_payload.GenPayloadCli.mirror_payload_content")
-    @patch("artcommonlib.exectools.cmd_assert_async")
+    @patch("artcommonlib.exectools.cmd_gather_async")
     @patch("aiofiles.open")
     async def test_create_multi_release_manifest_list(
         self, open_mock, exec_mock, mirror_payload_content_mock, fmlsha_mock
@@ -911,7 +911,7 @@ spec:
         os.environ['XDG_RUNTIME_DIR'] = 'fake'
         gpcli = rgp_cli.GenPayloadCli(output_dir="/tmp")
 
-        exec_mock.return_value = None  # do not actually execute command
+        exec_mock.return_value = (0, "", "")
         buffer = io.StringIO()
         open_mock.return_value.__aenter__.return_value.write = AsyncMock(side_effect=lambda s: buffer.write(s))
         fmlsha_mock.return_value = "sha256:abcdef"

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -27,7 +27,7 @@ from artcommonlib.arch_util import (
 )
 from artcommonlib.assembly import AssemblyTypes
 from artcommonlib.exceptions import VerificationError
-from artcommonlib.exectools import manifest_tool, to_thread
+from artcommonlib.exectools import manifest_tool_with_throttle, to_thread
 from artcommonlib.gitlab import GitLabClient
 from artcommonlib.jira_config import JIRA_EMAIL, JIRA_SERVER_URL
 from artcommonlib.oc_image_info import oc_image_info__cached_async
@@ -1795,7 +1795,9 @@ class PromotePipeline:
         with dest_manifest_list_path.open("w") as ml:
             yaml.dump(dest_manifest_list, ml)
 
-        await manifest_tool(["push", "from-spec", "--", f"{dest_manifest_list_path}"], self.runtime.dry_run)
+        await manifest_tool_with_throttle(
+            ["push", "from-spec", "--", f"{dest_manifest_list_path}"], self.runtime.dry_run
+        )
         auth_opt = ""
         if os.environ.get("XDG_RUNTIME_DIR"):
             auth_file = os.path.expandvars("${XDG_RUNTIME_DIR}/containers/auth.json")


### PR DESCRIPTION
manifest-tool was not using the Konflux auth file (KONFLUX_ART_IMAGES_AUTH_FILE) unlike oc image mirror, causing 401 errors when pushing manifest lists to quay.io/openshift-release-dev/ocp-v5.0-art-dev.

Add auth_file parameter to manifest_tool() and pass KONFLUX_ART_IMAGES_AUTH_FILE at the call sites in release:gen-payload.