### PR TITLE
ART-14754: Add Konflux build customization for installer-ove-ui and refactor PLR parameter passing

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -65,6 +65,7 @@ class ImageBuildParams:
     vm_override: Optional[dict] = None
     skip_checks: bool = False
     skip_fips_check: bool = False
+    skip_tasks: Sequence[str] = ()
 
 
 # Label key used to filter PipelineRuns for this process
@@ -1334,27 +1335,21 @@ class KonfluxClient:
             raise IOError(
                 "SAST task is enabled, but the template does not contain it. Please ensure the template is up-to-date."
             )
+        effective_skip: set[str] = set(build_params.skip_tasks)
         if build_params.sast is False and has_sast_task:
-            tasks = []
-            has_sast_task = False
-            for task in obj["spec"]["pipelineSpec"]["tasks"]:
-                task_name = task.get("name")
-                if task_name in ("sast-unicode-check", "sast-shell-check"):
-                    self._logger.info(f"Removing {task_name} tasks since SAST is disabled")
-                    continue
-                tasks.append(task)
-
-            obj["spec"]["pipelineSpec"]["tasks"] = tasks
-
+            effective_skip |= {"sast-unicode-check", "sast-shell-check"}
         if build_params.skip_fips_check:
-            tasks = []
+            effective_skip.add("fbc-fips-check-oci-ta")
+
+        if effective_skip:
+            kept = []
             for task in obj["spec"]["pipelineSpec"]["tasks"]:
                 task_name = task.get("name")
-                if task_name == "fbc-fips-check-oci-ta":
-                    self._logger.info("Removing fbc-fips-check-oci-ta task since skip_fips_check is enabled")
+                if task_name in effective_skip:
+                    self._logger.info("Removing task %s from PipelineRun (skip_tasks)", task_name)
                     continue
-                tasks.append(task)
-            obj["spec"]["pipelineSpec"]["tasks"] = tasks
+                kept.append(task)
+            obj["spec"]["pipelineSpec"]["tasks"] = kept
 
         # https://konflux.pages.redhat.com/docs/users/how-tos/configuring/overriding-compute-resources.html
         # ose-installer-artifacts fails with OOM with default values, hence bumping memory limit

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -1383,9 +1383,7 @@ class KonfluxClient:
                     "limits": {"ephemeral-storage": "1Gi"},
                 }
                 for step_name in ("push", "prepare-sboms", "upload-sbom"):
-                    build_images_step_specs.append(
-                        {"name": step_name, "computeResources": post_build_resources}
-                    )
+                    build_images_step_specs.append({"name": step_name, "computeResources": post_build_resources})
 
             if build_params.build_step_resources:
                 build_images_step_specs.append(

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -11,7 +11,7 @@ import shutil
 import tempfile
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, Sequence, Union, cast
 from urllib.parse import parse_qs, urlparse
@@ -41,6 +41,31 @@ _GIT_AUTH_SECRET_LABEL_KEY = "art.openshift.io/git-auth"
 _GIT_AUTH_SECRET_LABEL_VALUE = "true"
 _GIT_AUTH_GENERATED_BY_LABEL_KEY = "art.openshift.io/generated-by"
 _GIT_AUTH_GENERATED_BY_LABEL_VALUE = "art-automation"
+
+
+@dataclass
+class ImageBuildParams:
+    """Optional build customization parameters for a Konflux PipelineRun."""
+
+    hermetic: Optional[bool] = None
+    sast: Optional[bool] = None
+    dockerfile: Optional[str] = None
+    rebuild: Optional[bool] = None
+    build_args: Optional[list[str]] = None
+    additional_secret: Optional[str] = None
+    privileged_nested: Optional[bool] = None
+    build_step_resources: Optional[dict[str, str]] = None
+    workspace_storage: Optional[str] = None
+    prefetch: Optional[list] = None
+    artifact_type: Optional[str] = None
+    service_account: Optional[str] = None
+    annotations: Optional[dict[str, str]] = None
+    build_priority: Optional[str] = None
+    additional_tags: Optional[list[str]] = field(default_factory=list)
+    vm_override: Optional[dict] = None
+    skip_checks: bool = False
+    skip_fips_check: bool = False
+
 
 # Label key used to filter PipelineRuns for this process
 _COMMON_RUNTIME_LABEL_KEY = "doozer-watch-id"
@@ -1174,23 +1199,13 @@ class KonfluxClient:
         target_branch: str,
         output_image: str,
         build_platforms: Sequence[str],
-        prefetch: Optional[list] = None,
         git_auth_secret: str = "pipelines-as-code-secret",
-        additional_tags: Optional[Sequence[str]] = None,
-        skip_checks: bool = False,
-        skip_fips_check: bool = False,
-        build_priority: str = None,
-        hermetic: Optional[bool] = None,
-        sast: Optional[bool] = None,
-        dockerfile: Optional[str] = None,
         pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL,
-        annotations: Optional[dict[str, str]] = None,
-        artifact_type: Optional[str] = None,
-        service_account: Optional[str] = None,
-        rebuild: Optional[bool] = None,
+        build_params: Optional[ImageBuildParams] = None,
     ) -> dict:
-        if additional_tags is None:
-            additional_tags = []
+        if build_params is None:
+            build_params = ImageBuildParams()
+        additional_tags = build_params.additional_tags or []
         https_url = art_util.convert_remote_git_to_https(git_url)
 
         template = await self._get_pipelinerun_template(pipelinerun_template_url)
@@ -1216,8 +1231,8 @@ class KonfluxClient:
         # Set the application and component names
         obj["metadata"]["annotations"]["build.appstudio.openshift.io/repo"] = f"{https_url}?rev={commit_sha}"
         obj["metadata"]["annotations"]["art-jenkins-job-url"] = os.getenv("BUILD_URL", "n/a")
-        if annotations:
-            obj["metadata"]["annotations"].update(annotations)
+        if build_params.annotations:
+            obj["metadata"]["annotations"].update(build_params.annotations)
         obj["metadata"]["labels"]["appstudio.openshift.io/application"] = application_name
         obj["metadata"]["labels"]["appstudio.openshift.io/component"] = component_name
 
@@ -1226,53 +1241,59 @@ class KonfluxClient:
         obj["metadata"]["labels"].update(watch_labels)
 
         # Add Kueue build priority label if specified
-        if build_priority:
-            priority_class = f"build-priority-{build_priority}"
+        if build_params.build_priority:
+            priority_class = f"build-priority-{build_params.build_priority}"
             obj["metadata"]["labels"]["kueue.x-k8s.io/priority-class"] = priority_class
             self._logger.info(f"Set Kueue priority class label: {priority_class}")
 
-        def _modify_param(params: List, name: str, value: Union[str, bool, list[str]]):
+        def _modify_param(plr_params: List, name: str, value: Union[str, bool, list[str]]):
             """Modify a parameter in the params list. If the parameter does not exist, it is added.
 
-            :param params: The list of parameters.
+            :param plr_params: The list of parameters.
             :param name: The name of the parameter.
             :param value: The value of the parameter.
             """
             if isinstance(value, bool):
-                # boolean value should be converted to string
                 value = "true" if value else "false"
-            for param in params:
+            for param in plr_params:
                 if param["name"] == name:
                     param["value"] = value
                     return
-            params.append({"name": name, "value": value})
+            plr_params.append({"name": name, "value": value})
 
         # PipelineRun parameters to override in the template
-        params = obj["spec"]["params"]
-        _modify_param(params, "output-image", output_image)
-        _modify_param(params, "skip-checks", skip_checks)
+        plr_params = obj["spec"]["params"]
+        _modify_param(plr_params, "output-image", output_image)
+        _modify_param(plr_params, "skip-checks", build_params.skip_checks)
         _modify_param(
-            params, "build-source-image", "true"
+            plr_params, "build-source-image", "true"
         )  # Have to be true always to satisfy Enterprise Contract Policy
-        _modify_param(params, "build-platforms", list(build_platforms))
-        if dockerfile:
-            _modify_param(params, "dockerfile", dockerfile)
+        _modify_param(plr_params, "build-platforms", list(build_platforms))
+        if build_params.dockerfile:
+            _modify_param(plr_params, "dockerfile", build_params.dockerfile)
 
-        if prefetch:
-            _modify_param(params, "prefetch-input", prefetch)
-        if hermetic is not None:
-            _modify_param(params, "hermetic", hermetic)
+        if build_params.prefetch:
+            _modify_param(plr_params, "prefetch-input", build_params.prefetch)
+        if build_params.hermetic is not None:
+            _modify_param(plr_params, "hermetic", build_params.hermetic)
 
-        if rebuild is not None:
-            _modify_param(params, "rebuild", rebuild)
+        if build_params.rebuild is not None:
+            _modify_param(plr_params, "rebuild", build_params.rebuild)
+
+        if build_params.build_args:
+            _modify_param(plr_params, "build-args", build_params.build_args)
 
         # See https://konflux-ci.dev/docs/how-tos/configuring/customizing-the-build/#configuring-timeouts
         obj["spec"]["timeouts"] = {"pipeline": "12h"}
 
-        obj["spec"]["taskRunTemplate"]["serviceAccountName"] = service_account or f"build-pipeline-{component_name}"
+        obj["spec"]["taskRunTemplate"]["serviceAccountName"] = (
+            build_params.service_account or f"build-pipeline-{component_name}"
+        )
 
         # Check if verbose prefetch is being used (RPM, generic, or yarn types)
-        verbose_prefetch_enabled = prefetch and any(item.get("type") in ("rpm", "generic", "yarn") for item in prefetch)
+        verbose_prefetch_enabled = build_params.prefetch and any(
+            item.get("type") in ("rpm", "generic", "yarn") for item in build_params.prefetch
+        )
 
         # Task specific parameters to override in the template
         has_build_images_task = False
@@ -1283,6 +1304,10 @@ class KonfluxClient:
                     has_build_images_task = True
                     task["timeout"] = "12h"
                     _modify_param(task["params"], "SBOM_TYPE", "spdx")
+                    if build_params.additional_secret:
+                        _modify_param(task["params"], "ADDITIONAL_SECRET", build_params.additional_secret)
+                    if build_params.privileged_nested is not None:
+                        _modify_param(task["params"], "PRIVILEGED_NESTED", str(build_params.privileged_nested).lower())
                 case "prefetch-dependencies":
                     _modify_param(task["params"], "sbom-type", "spdx")
                     if verbose_prefetch_enabled:
@@ -1292,8 +1317,6 @@ class KonfluxClient:
                     _modify_param(task["params"], "ADDITIONAL_TAGS", list(additional_tags))
                 case "sast-shell-check":
                     if namespace == "art-logging-tenant" and "vector" in component_name:
-                        # For the component "vector" in the logging namepace, we need to set the TARGET_DIRS
-                        # https://gitlab.cee.redhat.com/openshift-logging/sustaining-eng/konflux-log-collection/-/merge_requests/67/diffs
                         _modify_param(task["params"], "TARGET_DIRS", "./cluster-logging-operator")
                 case "clone-repository":
                     _modify_param(
@@ -1304,14 +1327,14 @@ class KonfluxClient:
                 case "sast-snyk-check":
                     has_sast_task = True
                 case "ecosystem-cert-preflight-checks":
-                    if artifact_type:
-                        _modify_param(task["params"], "artifact-type", artifact_type)
+                    if build_params.artifact_type:
+                        _modify_param(task["params"], "artifact-type", build_params.artifact_type)
 
-        if sast and not has_sast_task:
+        if build_params.sast and not has_sast_task:
             raise IOError(
                 "SAST task is enabled, but the template does not contain it. Please ensure the template is up-to-date."
             )
-        if sast is False and has_sast_task:  # if SAST is explicitly disabled, remove SAST tasks
+        if build_params.sast is False and has_sast_task:
             tasks = []
             has_sast_task = False
             for task in obj["spec"]["pipelineSpec"]["tasks"]:
@@ -1323,7 +1346,7 @@ class KonfluxClient:
 
             obj["spec"]["pipelineSpec"]["tasks"] = tasks
 
-        if skip_fips_check:
+        if build_params.skip_fips_check:
             tasks = []
             for task in obj["spec"]["pipelineSpec"]["tasks"]:
                 task_name = task.get("name")
@@ -1337,22 +1360,48 @@ class KonfluxClient:
         # ose-installer-artifacts fails with OOM with default values, hence bumping memory limit
         task_run_specs = []
         if has_build_images_task:
+            ephemeral_storage = (build_params.build_step_resources or {}).get("ephemeral-storage")
+
+            sbom_syft_resources: dict = {
+                "requests": {"memory": "5Gi"},
+                "limits": {"memory": "10Gi"},
+            }
+            if ephemeral_storage:
+                sbom_syft_resources["requests"]["ephemeral-storage"] = "1Gi"
+                sbom_syft_resources["limits"]["ephemeral-storage"] = "1Gi"
+
+            build_images_step_specs: list[dict] = [
+                {
+                    "name": "sbom-syft-generate",
+                    "computeResources": sbom_syft_resources,
+                },
+            ]
+
+            if ephemeral_storage:
+                post_build_resources: dict = {
+                    "requests": {"ephemeral-storage": "1Gi"},
+                    "limits": {"ephemeral-storage": "1Gi"},
+                }
+                for step_name in ("push", "prepare-sboms", "upload-sbom"):
+                    build_images_step_specs.append(
+                        {"name": step_name, "computeResources": post_build_resources}
+                    )
+
+            if build_params.build_step_resources:
+                build_images_step_specs.append(
+                    {
+                        "name": "build",
+                        "computeResources": {
+                            "requests": dict(build_params.build_step_resources),
+                            "limits": dict(build_params.build_step_resources),
+                        },
+                    }
+                )
+
             task_run_specs += [
                 {
                     "pipelineTaskName": "build-images",
-                    "stepSpecs": [
-                        {
-                            "name": "sbom-syft-generate",
-                            "computeResources": {
-                                "requests": {
-                                    "memory": "5Gi",
-                                },
-                                "limits": {
-                                    "memory": "10Gi",
-                                },
-                            },
-                        }
-                    ],
+                    "stepSpecs": build_images_step_specs,
                 }
             ]
             task_run_specs += [
@@ -1385,6 +1434,27 @@ class KonfluxClient:
 
         obj["spec"]["taskRunSpecs"] = task_run_specs
 
+        if build_params.workspace_storage:
+            pipeline_workspaces = obj["spec"]["pipelineSpec"].setdefault("workspaces", [])
+            if not any(ws.get("name") == "workspace" for ws in pipeline_workspaces):
+                pipeline_workspaces.append({"name": "workspace", "optional": True})
+
+            plr_workspaces = obj["spec"].setdefault("workspaces", [])
+            if not any(ws.get("name") == "workspace" for ws in plr_workspaces):
+                plr_workspaces.append(
+                    {
+                        "name": "workspace",
+                        "volumeClaimTemplate": {
+                            "spec": {
+                                "accessModes": ["ReadWriteOnce"],
+                                "resources": {
+                                    "requests": {"storage": build_params.workspace_storage},
+                                },
+                            },
+                        },
+                    }
+                )
+
         return obj
 
     async def start_pipeline_run_for_image_build(
@@ -1397,22 +1467,10 @@ class KonfluxClient:
         commit_sha: str,
         target_branch: str,
         output_image: str,
-        vm_override: dict,
         building_arches: Sequence[str],
-        prefetch: Optional[list] = None,
-        sast: Optional[bool] = None,
         git_auth_secret: str = "pipelines-as-code-secret",
-        additional_tags: Sequence[str] = [],
-        skip_checks: bool = False,
-        skip_fips_check: bool = False,
-        build_priority: str = None,
-        hermetic: Optional[bool] = None,
-        dockerfile: Optional[str] = None,
         pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL,
-        annotations: Optional[dict[str, str]] = None,
-        artifact_type: Optional[str] = None,
-        service_account: Optional[str] = None,
-        rebuild: Optional[bool] = None,
+        build_params: Optional[ImageBuildParams] = None,
     ) -> PipelineRunInfo:
         """
         Start a PipelineRun for building an image.
@@ -1425,30 +1483,20 @@ class KonfluxClient:
         :param commit_sha: The commit SHA.
         :param target_branch: The target branch.
         :param output_image: The output image.
-        :param vm_override: Override the default konflux VM flavor (in case we need more specs)
         :param building_arches: The architectures to build.
-        :param prefetch: The param values for Konflux prefetch dependencies task
-        :param sast: To enable the SAST task in PLR. If None, use the default value from the pipeline template.
         :param git_auth_secret: The git auth secret.
-        :param additional_tags: Additional tags to apply to the image.
-        :param skip_checks: Whether to skip checks.
-        :param skip_fips_check: Whether to skip the FIPS compliance check.
-        :param hermetic: Whether to build the image in a hermetic environment. If None, the default value is used.
-        :param dockerfile: Optional Dockerfile name
         :param pipelinerun_template_url: The URL to the PipelineRun template.
-        :param annotations: Optional PLR annotations
-        :param artifact_type: The type of artifact artifact_type for ecosystem-cert-preflight-checks. Select from application, operatorbundle, or introspect.
-        :param service_account: The service account to use for the PipelineRun.
-        :param rebuild: Forces rebuild of the image, even if it already exists. If None, the default behavior is to not changed.
-        :param build_priority: The Kueue build priority (1-10, where 1 is highest priority). If specified, adds the kueue.x-k8s.io/priority-class label.
+        :param build_params: Optional build customization parameters bundled in an ImageBuildParams dataclass.
         :return: The PipelineRun resource as a PipelineRunInfo.
         """
+        if build_params is None:
+            build_params = ImageBuildParams()
 
         unsupported_arches = set(building_arches) - set(self.SUPPORTED_ARCHES)
         if unsupported_arches:
             raise ValueError(f"Unsupported architectures: {unsupported_arches}")
 
-        # If vm_override is not one and an override exists for a particular arch, use that. Otherwise, use the default
+        vm_override = build_params.vm_override
         build_platforms = [
             vm_override[arch] if vm_override and arch in vm_override else random.choice(self.SUPPORTED_ARCHES[arch])
             for arch in building_arches
@@ -1465,19 +1513,8 @@ class KonfluxClient:
             output_image=output_image,
             build_platforms=build_platforms,
             git_auth_secret=git_auth_secret,
-            skip_checks=skip_checks,
-            skip_fips_check=skip_fips_check,
-            hermetic=hermetic,
-            additional_tags=additional_tags,
-            dockerfile=dockerfile,
             pipelinerun_template_url=pipelinerun_template_url,
-            prefetch=prefetch,
-            sast=sast,
-            annotations=annotations,
-            artifact_type=artifact_type,
-            service_account=service_account,
-            rebuild=rebuild,
-            build_priority=build_priority,
+            build_params=build_params,
         )
         if self.dry_run:
             fake_pipelinerun = resource.ResourceInstance(self.dyn_client, pipelinerun_manifest)

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -61,7 +61,7 @@ class ImageBuildParams:
     service_account: Optional[str] = None
     annotations: Optional[dict[str, str]] = None
     build_priority: Optional[str] = None
-    additional_tags: Optional[list[str]] = field(default_factory=list)
+    additional_tags: list[str] = field(default_factory=list)
     vm_override: Optional[dict] = None
     skip_checks: bool = False
     skip_fips_check: bool = False
@@ -1206,7 +1206,7 @@ class KonfluxClient:
     ) -> dict:
         if build_params is None:
             build_params = ImageBuildParams()
-        additional_tags = build_params.additional_tags or []
+        additional_tags = build_params.additional_tags
         https_url = art_util.convert_remote_git_to_https(git_url)
 
         template = await self._get_pipelinerun_template(pipelinerun_template_url)

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -1351,6 +1351,11 @@ class KonfluxClient:
                 kept.append(task)
             obj["spec"]["pipelineSpec"]["tasks"] = kept
 
+        remaining_task_names = {t["name"] for t in obj["spec"]["pipelineSpec"]["tasks"]}
+        has_build_images_task = "build-images" in remaining_task_names
+        has_prefetch_task = "prefetch-dependencies" in remaining_task_names
+        has_sast_task = "sast-shell-check" in remaining_task_names
+
         # https://konflux.pages.redhat.com/docs/users/how-tos/configuring/overriding-compute-resources.html
         # ose-installer-artifacts fails with OOM with default values, hence bumping memory limit
         task_run_specs = []
@@ -1397,6 +1402,7 @@ class KonfluxClient:
                     "stepSpecs": build_images_step_specs,
                 }
             ]
+        if has_prefetch_task:
             task_run_specs += [
                 {
                     "pipelineTaskName": "prefetch-dependencies",

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -32,7 +32,7 @@ from async_lru import alru_cache
 from dockerfile_parse import DockerfileParser
 from doozerlib import constants, opm, util
 from doozerlib.backend.build_repo import BuildRepo
-from doozerlib.backend.konflux_client import KonfluxClient
+from doozerlib.backend.konflux_client import ImageBuildParams, KonfluxClient
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
 from doozerlib.constants import KONFLUX_DEFAULT_IMAGE_REPO
 from doozerlib.image import ImageMetadata
@@ -641,15 +641,15 @@ class KonfluxFbcFragmentMerger:
             commit_sha=commit_sha,
             target_branch=self.fbc_git_branch or commit_sha,
             output_image=f"{output_image_repo}:{output_image_tag}",
-            additional_tags=[],
-            vm_override={},
             building_arches=arches,
-            hermetic=True,
-            dockerfile="catalog.Dockerfile",
-            skip_checks=self.skip_checks,
-            skip_fips_check=self.skip_fips_check,
             pipelinerun_template_url=self.plr_template,
-            build_priority=FBC_BUILD_PRIORITY,
+            build_params=ImageBuildParams(
+                hermetic=True,
+                dockerfile="catalog.Dockerfile",
+                skip_checks=self.skip_checks,
+                skip_fips_check=self.skip_fips_check,
+                build_priority=FBC_BUILD_PRIORITY,
+            ),
         )
         if git_auth_secret:
             build_kwargs["git_auth_secret"] = git_auth_secret
@@ -2001,14 +2001,15 @@ class KonfluxFbcBuilder:
             commit_sha=build_repo.commit_hash,
             target_branch=build_repo.branch or build_repo.commit_hash,
             output_image=output_image,
-            vm_override={},
             building_arches=arches,
-            additional_tags=list(additional_tags),
-            skip_checks=self.skip_checks,
-            hermetic=True,
-            dockerfile="catalog.Dockerfile",
             pipelinerun_template_url=self.pipelinerun_template_url,
-            build_priority=FBC_BUILD_PRIORITY,
+            build_params=ImageBuildParams(
+                additional_tags=list(additional_tags),
+                skip_checks=self.skip_checks,
+                hermetic=True,
+                dockerfile="catalog.Dockerfile",
+                build_priority=FBC_BUILD_PRIORITY,
+            ),
         )
         if git_auth_secret:
             build_kwargs["git_auth_secret"] = git_auth_secret

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -366,6 +366,7 @@ class KonfluxFbcFragmentMerger:
         registry_auth: Optional[str] = None,
         skip_checks: bool = False,
         skip_fips_check: bool = False,
+        skip_tasks: Sequence[str] = (),
         plr_template: Optional[str] = None,
         major_minor_override: Optional[Tuple[int, int]] = None,
         logger: logging.Logger | None = None,
@@ -391,6 +392,7 @@ class KonfluxFbcFragmentMerger:
         self.registry_auth = registry_auth
         self.skip_checks = skip_checks
         self.skip_fips_check = skip_fips_check
+        self.skip_tasks = tuple(skip_tasks)
         self.plr_template = plr_template or constants.KONFLUX_DEFAULT_FBC_BUILD_PLR_TEMPLATE_URL
         self.major_minor_override = major_minor_override
         self._logger = logger or LOGGER.getChild(self.__class__.__name__)
@@ -648,6 +650,7 @@ class KonfluxFbcFragmentMerger:
                 dockerfile="catalog.Dockerfile",
                 skip_checks=self.skip_checks,
                 skip_fips_check=self.skip_fips_check,
+                skip_tasks=self.skip_tasks,
                 build_priority=FBC_BUILD_PRIORITY,
             ),
         )
@@ -1592,6 +1595,7 @@ class KonfluxFbcBuilder:
         konflux_context: Optional[str] = None,
         image_repo: str = constants.KONFLUX_DEFAULT_IMAGE_REPO,
         skip_checks: bool = False,
+        skip_tasks: Sequence[str] = (),
         pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_FBC_BUILD_PLR_TEMPLATE_URL,
         dry_run: bool = False,
         major_minor_override: Optional[Tuple[int, int]] = None,
@@ -1609,6 +1613,7 @@ class KonfluxFbcBuilder:
         self.konflux_context = konflux_context
         self.image_repo = image_repo
         self.skip_checks = skip_checks
+        self.skip_tasks = tuple(skip_tasks)
         self.pipelinerun_template_url = pipelinerun_template_url
         self.dry_run = dry_run
         self.major_minor_override = major_minor_override
@@ -2006,6 +2011,7 @@ class KonfluxFbcBuilder:
             build_params=ImageBuildParams(
                 additional_tags=list(additional_tags),
                 skip_checks=self.skip_checks,
+                skip_tasks=self.skip_tasks,
                 hermetic=True,
                 dockerfile="catalog.Dockerfile",
                 build_priority=FBC_BUILD_PRIORITY,

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -32,7 +32,7 @@ from async_lru import alru_cache
 from dockerfile_parse import DockerfileParser
 from doozerlib import constants, opm, util
 from doozerlib.backend.build_repo import BuildRepo
-from doozerlib.backend.konflux_client import KonfluxClient
+from doozerlib.backend.konflux_client import ImageBuildParams, KonfluxClient
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
 from doozerlib.constants import KONFLUX_DEFAULT_IMAGE_REPO
 from doozerlib.image import ImageMetadata
@@ -641,15 +641,15 @@ class KonfluxFbcFragmentMerger:
             commit_sha=commit_sha,
             target_branch=self.fbc_git_branch or commit_sha,
             output_image=f"{output_image_repo}:{output_image_tag}",
-            additional_tags=[],
-            vm_override={},
             building_arches=arches,
-            hermetic=True,
-            dockerfile="catalog.Dockerfile",
-            skip_checks=self.skip_checks,
-            skip_fips_check=self.skip_fips_check,
             pipelinerun_template_url=self.plr_template,
-            build_priority=FBC_BUILD_PRIORITY,
+            build_params=ImageBuildParams(
+                hermetic=True,
+                dockerfile="catalog.Dockerfile",
+                skip_checks=self.skip_checks,
+                skip_fips_check=self.skip_fips_check,
+                build_priority=FBC_BUILD_PRIORITY,
+            ),
         )
         if git_auth_secret:
             build_kwargs["git_auth_secret"] = git_auth_secret
@@ -2003,14 +2003,15 @@ class KonfluxFbcBuilder:
             commit_sha=build_repo.commit_hash,
             target_branch=build_repo.branch or build_repo.commit_hash,
             output_image=output_image,
-            vm_override={},
             building_arches=arches,
-            additional_tags=list(additional_tags),
-            skip_checks=self.skip_checks,
-            hermetic=True,
-            dockerfile="catalog.Dockerfile",
             pipelinerun_template_url=self.pipelinerun_template_url,
-            build_priority=FBC_BUILD_PRIORITY,
+            build_params=ImageBuildParams(
+                additional_tags=list(additional_tags),
+                skip_checks=self.skip_checks,
+                hermetic=True,
+                dockerfile="catalog.Dockerfile",
+                build_priority=FBC_BUILD_PRIORITY,
+            ),
         )
         if git_auth_secret:
             build_kwargs["git_auth_secret"] = git_auth_secret

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -634,6 +634,9 @@ class KonfluxFbcFragmentMerger:
 
         arches = self.group_config.get("arches", list(KonfluxClient.SUPPORTED_ARCHES.keys()))
 
+        group_skip_tasks = self.group_config.get("konflux", {}).get("skip_tasks", [])
+        merged_skip_tasks = tuple(dict.fromkeys([*self.skip_tasks, *group_skip_tasks]))
+
         build_kwargs = dict(
             generate_name=f"{comp_name}-",
             namespace=self.konflux_namespace,
@@ -650,7 +653,7 @@ class KonfluxFbcFragmentMerger:
                 dockerfile="catalog.Dockerfile",
                 skip_checks=self.skip_checks,
                 skip_fips_check=self.skip_fips_check,
-                skip_tasks=self.skip_tasks,
+                skip_tasks=merged_skip_tasks,
                 build_priority=FBC_BUILD_PRIORITY,
             ),
         )
@@ -1999,6 +2002,9 @@ class KonfluxFbcBuilder:
         else:
             logger.info("No additional tags to be added")
 
+        group_skip_tasks = metadata.runtime.group_config.get("konflux", {}).get("skip_tasks", [])
+        merged_skip_tasks = tuple(dict.fromkeys([*self.skip_tasks, *group_skip_tasks]))
+
         build_kwargs = dict(
             generate_name=f"{component_name}-",
             namespace=self.konflux_namespace,
@@ -2013,7 +2019,7 @@ class KonfluxFbcBuilder:
             build_params=ImageBuildParams(
                 additional_tags=list(additional_tags),
                 skip_checks=self.skip_checks,
-                skip_tasks=self.skip_tasks,
+                skip_tasks=merged_skip_tasks,
                 hermetic=True,
                 dockerfile="catalog.Dockerfile",
                 build_priority=FBC_BUILD_PRIORITY,

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -366,6 +366,7 @@ class KonfluxFbcFragmentMerger:
         registry_auth: Optional[str] = None,
         skip_checks: bool = False,
         skip_fips_check: bool = False,
+        skip_tasks: Sequence[str] = (),
         plr_template: Optional[str] = None,
         major_minor_override: Optional[Tuple[int, int]] = None,
         logger: logging.Logger | None = None,
@@ -391,6 +392,7 @@ class KonfluxFbcFragmentMerger:
         self.registry_auth = registry_auth
         self.skip_checks = skip_checks
         self.skip_fips_check = skip_fips_check
+        self.skip_tasks = tuple(skip_tasks)
         self.plr_template = plr_template or constants.KONFLUX_DEFAULT_FBC_BUILD_PLR_TEMPLATE_URL
         self.major_minor_override = major_minor_override
         self._logger = logger or LOGGER.getChild(self.__class__.__name__)
@@ -648,6 +650,7 @@ class KonfluxFbcFragmentMerger:
                 dockerfile="catalog.Dockerfile",
                 skip_checks=self.skip_checks,
                 skip_fips_check=self.skip_fips_check,
+                skip_tasks=self.skip_tasks,
                 build_priority=FBC_BUILD_PRIORITY,
             ),
         )
@@ -1594,6 +1597,7 @@ class KonfluxFbcBuilder:
         konflux_context: Optional[str] = None,
         image_repo: str = constants.KONFLUX_DEFAULT_IMAGE_REPO,
         skip_checks: bool = False,
+        skip_tasks: Sequence[str] = (),
         pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_FBC_BUILD_PLR_TEMPLATE_URL,
         dry_run: bool = False,
         major_minor_override: Optional[Tuple[int, int]] = None,
@@ -1611,6 +1615,7 @@ class KonfluxFbcBuilder:
         self.konflux_context = konflux_context
         self.image_repo = image_repo
         self.skip_checks = skip_checks
+        self.skip_tasks = tuple(skip_tasks)
         self.pipelinerun_template_url = pipelinerun_template_url
         self.dry_run = dry_run
         self.major_minor_override = major_minor_override
@@ -2008,6 +2013,7 @@ class KonfluxFbcBuilder:
             build_params=ImageBuildParams(
                 additional_tags=list(additional_tags),
                 skip_checks=self.skip_checks,
+                skip_tasks=self.skip_tasks,
                 hermetic=True,
                 dockerfile="catalog.Dockerfile",
                 build_priority=FBC_BUILD_PRIORITY,

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -92,6 +92,7 @@ class KonfluxImageBuilderConfig:
     image_repo: str = constants.KONFLUX_DEFAULT_IMAGE_REPO
     registry_auth_file: Optional[str] = None
     skip_checks: bool = False
+    skip_tasks: tuple[str, ...] = ()
     dry_run: bool = False
     build_priority: Optional[str] = None
     ec_policy_configuration: str = constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION
@@ -765,6 +766,10 @@ class KonfluxImageBuilder:
         raw_ws = _get_konflux_config(metadata, "workspace_storage")
         workspace_storage = str(raw_ws) if raw_ws else None
 
+        group_skip_tasks = metadata.runtime.group_config.get("konflux", {}).get("skip_tasks", [])
+        image_skip_tasks = metadata.config.get("konflux", {}).get("skip_tasks", [])
+        merged_skip_tasks = list(set(self._config.skip_tasks) | set(group_skip_tasks) | set(image_skip_tasks))
+
         annotations = {
             "art-network-mode": metadata.get_konflux_network_mode(),
             "art-nvr": nvr,
@@ -786,6 +791,7 @@ class KonfluxImageBuilder:
             workspace_storage=workspace_storage,
             vm_override=metadata.config.get("konflux", {}).get("vm_override"),
             skip_checks=self._config.skip_checks,
+            skip_tasks=merged_skip_tasks,
             annotations=annotations,
             build_priority=build_priority,
             additional_tags=additional_tags or [],

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -31,7 +31,7 @@ from artcommonlib.util import fetch_slsa_attestation, get_konflux_data
 from dockerfile_parse import DockerfileParser
 from doozerlib import constants, util
 from doozerlib.backend.build_repo import BuildRepo
-from doozerlib.backend.konflux_client import KonfluxClient
+from doozerlib.backend.konflux_client import ImageBuildParams, KonfluxClient
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
 from doozerlib.backend.rebaser import KonfluxRebaser
 from doozerlib.image import ImageMetadata
@@ -70,6 +70,13 @@ class KonfluxImageBuildError(Exception):
         super().__init__(message)
         self.pipelinerun_name = pipelinerun_name
         self.pipelinerun_dict = pipelinerun_dict
+
+
+def _get_konflux_config(metadata, key, default=None):
+    """Read a value from konflux config, image-level overrides group-level."""
+    group_val = metadata.runtime.group_config.get("konflux", {}).get(key, default)
+    image_val = metadata.config.get("konflux", {}).get(key, Missing)
+    return image_val if image_val is not Missing else group_val
 
 
 @dataclass
@@ -738,23 +745,51 @@ class KonfluxImageBuilder:
 
         prefetch = self._prefetch(metadata=metadata, dest_dir=dest_dir, group=self._config.group_name)
 
-        # Check if SAST tasks should be enabled (default: True)
-        # Image config value overrides group config value
-        group_config_sast_task = metadata.runtime.group_config.get("konflux", {}).get("sast", {}).get("enabled", True)
-        image_config_sast_task = metadata.config.get("konflux", {}).get("sast", {}).get("enabled", Missing)
-        sast = image_config_sast_task if image_config_sast_task is not Missing else group_config_sast_task
+        sast_config = _get_konflux_config(metadata, "sast", {})
+        sast = sast_config.get("enabled", True) if hasattr(sast_config, 'get') else sast_config
 
-        # Prepare annotations
+        raw_ba = _get_konflux_config(metadata, "build_args", [])
+        build_args = None
+        if raw_ba:
+            build_args = [str(arg.primitive()) if hasattr(arg, 'primitive') else str(arg) for arg in raw_ba]
+
+        raw_secret = _get_konflux_config(metadata, "additional_secret")
+        additional_secret = str(raw_secret) if raw_secret else None
+
+        raw_priv = _get_konflux_config(metadata, "privileged_nested")
+        privileged_nested = bool(raw_priv) if raw_priv else None
+
+        raw_res = _get_konflux_config(metadata, "build_step_resources")
+        build_step_resources = dict(raw_res) if raw_res else None
+
+        raw_ws = _get_konflux_config(metadata, "workspace_storage")
+        workspace_storage = str(raw_ws) if raw_ws else None
+
         annotations = {
             "art-network-mode": metadata.get_konflux_network_mode(),
             "art-nvr": nvr,
         }
 
-        # Add timeout annotation if configured
         build_timeout_minutes = metadata.config.konflux.build_timeout
         if build_timeout_minutes:
             annotations["art-overall-timeout-minutes"] = str(build_timeout_minutes)
             logger.info(f"Setting custom build timeout: {build_timeout_minutes} minutes")
+
+        build_params = ImageBuildParams(
+            hermetic=hermetic,
+            prefetch=prefetch,
+            sast=sast,
+            build_args=build_args,
+            additional_secret=additional_secret,
+            privileged_nested=privileged_nested,
+            build_step_resources=build_step_resources,
+            workspace_storage=workspace_storage,
+            vm_override=metadata.config.get("konflux", {}).get("vm_override"),
+            skip_checks=self._config.skip_checks,
+            annotations=annotations,
+            build_priority=build_priority,
+            additional_tags=additional_tags or [],
+        )
 
         build_kwargs = dict(
             generate_name=f"{component_name}-",
@@ -766,15 +801,8 @@ class KonfluxImageBuilder:
             target_branch=git_branch,
             output_image=output_image,
             building_arches=building_arches,
-            additional_tags=additional_tags,
-            skip_checks=self._config.skip_checks,
-            hermetic=hermetic,
-            vm_override=metadata.config.get("konflux", {}).get("vm_override"),
             pipelinerun_template_url=self._config.plr_template,
-            prefetch=prefetch,
-            sast=sast,
-            annotations=annotations,
-            build_priority=build_priority,
+            build_params=build_params,
         )
         if git_auth_secret:
             build_kwargs["git_auth_secret"] = git_auth_secret

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -91,6 +91,7 @@ class KonfluxImageBuilderConfig:
     image_repo: str = constants.KONFLUX_DEFAULT_IMAGE_REPO
     registry_auth_file: Optional[str] = None
     skip_checks: bool = False
+    skip_tasks: tuple[str, ...] = ()
     dry_run: bool = False
     build_priority: Optional[str] = None
     ec_policy_configuration: str = constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION
@@ -721,6 +722,10 @@ class KonfluxImageBuilder:
         raw_ws = _get_konflux_config(metadata, "workspace_storage")
         workspace_storage = str(raw_ws) if raw_ws else None
 
+        group_skip_tasks = metadata.runtime.group_config.get("konflux", {}).get("skip_tasks", [])
+        image_skip_tasks = metadata.config.get("konflux", {}).get("skip_tasks", [])
+        merged_skip_tasks = list(set(self._config.skip_tasks) | set(group_skip_tasks) | set(image_skip_tasks))
+
         annotations = {
             "art-network-mode": metadata.get_konflux_network_mode(),
             "art-nvr": nvr,
@@ -742,6 +747,7 @@ class KonfluxImageBuilder:
             workspace_storage=workspace_storage,
             vm_override=metadata.config.get("konflux", {}).get("vm_override"),
             skip_checks=self._config.skip_checks,
+            skip_tasks=merged_skip_tasks,
             annotations=annotations,
             build_priority=build_priority,
             additional_tags=additional_tags or [],

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -1011,10 +1011,18 @@ class KonfluxImageBuilder:
 
             definitive_image_pullspec = f"{image_pullspec.split(':')[0]}@{image_digest}"
 
-            # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
-            package_nvrs, source_rpms = await self.get_installed_packages(
-                definitive_image_pullspec, building_arches, self._config.registry_auth_file
-            )
+            # Skip RPM extraction for images that don't use RPMs (e.g. FROM scratch ISO builds).
+            # no_shell implies no /bin/sh and no RPMs installed in the image.
+            skip_rpm_extraction = metadata.config.konflux.get("no_shell", False)
+            if skip_rpm_extraction:
+                logger.info("Skipping RPM extraction (no_shell=true): image does not use RPMs")
+                package_nvrs: set = set()
+                source_rpms: set = set()
+            else:
+                # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
+                package_nvrs, source_rpms = await self.get_installed_packages(
+                    definitive_image_pullspec, building_arches, self._config.registry_auth_file
+                )
 
             build_record_params.update(
                 {

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -32,7 +32,7 @@ from dockerfile_parse import DockerfileParser
 from doozerlib import constants, util
 from doozerlib.backend.base_image_handler import BaseImageHandler, BaseImageSnapshotInput
 from doozerlib.backend.build_repo import BuildRepo
-from doozerlib.backend.konflux_client import KonfluxClient
+from doozerlib.backend.konflux_client import ImageBuildParams, KonfluxClient
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
 from doozerlib.backend.rebaser import KonfluxRebaser
 from doozerlib.image import ImageMetadata
@@ -69,6 +69,13 @@ class KonfluxImageBuildError(Exception):
         super().__init__(message)
         self.pipelinerun_name = pipelinerun_name
         self.pipelinerun_dict = pipelinerun_dict
+
+
+def _get_konflux_config(metadata, key, default=None):
+    """Read a value from konflux config, image-level overrides group-level."""
+    group_val = metadata.runtime.group_config.get("konflux", {}).get(key, default)
+    image_val = metadata.config.get("konflux", {}).get(key, Missing)
+    return image_val if image_val is not Missing else group_val
 
 
 @dataclass
@@ -694,23 +701,51 @@ class KonfluxImageBuilder:
 
         prefetch = self._prefetch(metadata=metadata, dest_dir=dest_dir, group=self._config.group_name)
 
-        # Check if SAST tasks should be enabled (default: True)
-        # Image config value overrides group config value
-        group_config_sast_task = metadata.runtime.group_config.get("konflux", {}).get("sast", {}).get("enabled", True)
-        image_config_sast_task = metadata.config.get("konflux", {}).get("sast", {}).get("enabled", Missing)
-        sast = image_config_sast_task if image_config_sast_task is not Missing else group_config_sast_task
+        sast_config = _get_konflux_config(metadata, "sast", {})
+        sast = sast_config.get("enabled", True) if hasattr(sast_config, 'get') else sast_config
 
-        # Prepare annotations
+        raw_ba = _get_konflux_config(metadata, "build_args", [])
+        build_args = None
+        if raw_ba:
+            build_args = [str(arg.primitive()) if hasattr(arg, 'primitive') else str(arg) for arg in raw_ba]
+
+        raw_secret = _get_konflux_config(metadata, "additional_secret")
+        additional_secret = str(raw_secret) if raw_secret else None
+
+        raw_priv = _get_konflux_config(metadata, "privileged_nested")
+        privileged_nested = bool(raw_priv) if raw_priv else None
+
+        raw_res = _get_konflux_config(metadata, "build_step_resources")
+        build_step_resources = dict(raw_res) if raw_res else None
+
+        raw_ws = _get_konflux_config(metadata, "workspace_storage")
+        workspace_storage = str(raw_ws) if raw_ws else None
+
         annotations = {
             "art-network-mode": metadata.get_konflux_network_mode(),
             "art-nvr": nvr,
         }
 
-        # Add timeout annotation if configured
         build_timeout_minutes = metadata.config.konflux.build_timeout
         if build_timeout_minutes:
             annotations["art-overall-timeout-minutes"] = str(build_timeout_minutes)
             logger.info(f"Setting custom build timeout: {build_timeout_minutes} minutes")
+
+        build_params = ImageBuildParams(
+            hermetic=hermetic,
+            prefetch=prefetch,
+            sast=sast,
+            build_args=build_args,
+            additional_secret=additional_secret,
+            privileged_nested=privileged_nested,
+            build_step_resources=build_step_resources,
+            workspace_storage=workspace_storage,
+            vm_override=metadata.config.get("konflux", {}).get("vm_override"),
+            skip_checks=self._config.skip_checks,
+            annotations=annotations,
+            build_priority=build_priority,
+            additional_tags=additional_tags or [],
+        )
 
         build_kwargs = dict(
             generate_name=f"{component_name}-",
@@ -722,15 +757,8 @@ class KonfluxImageBuilder:
             target_branch=git_branch,
             output_image=output_image,
             building_arches=building_arches,
-            additional_tags=additional_tags,
-            skip_checks=self._config.skip_checks,
-            hermetic=hermetic,
-            vm_override=metadata.config.get("konflux", {}).get("vm_override"),
             pipelinerun_template_url=self._config.plr_template,
-            prefetch=prefetch,
-            sast=sast,
-            annotations=annotations,
-            build_priority=build_priority,
+            build_params=build_params,
         )
         if git_auth_secret:
             build_kwargs["git_auth_secret"] = git_auth_secret

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -967,10 +967,18 @@ class KonfluxImageBuilder:
 
             definitive_image_pullspec = f"{image_pullspec.split(':')[0]}@{image_digest}"
 
-            # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
-            package_nvrs, source_rpms = await self.get_installed_packages(
-                definitive_image_pullspec, building_arches, self._config.registry_auth_file
-            )
+            # Skip RPM extraction for images that don't use RPMs (e.g. FROM scratch ISO builds).
+            # no_shell implies no /bin/sh and no RPMs installed in the image.
+            skip_rpm_extraction = metadata.config.konflux.get("no_shell", False)
+            if skip_rpm_extraction:
+                logger.info("Skipping RPM extraction (no_shell=true): image does not use RPMs")
+                package_nvrs: set = set()
+                source_rpms: set = set()
+            else:
+                # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
+                package_nvrs, source_rpms = await self.get_installed_packages(
+                    definitive_image_pullspec, building_arches, self._config.registry_auth_file
+                )
 
             build_record_params.update(
                 {

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -607,6 +607,7 @@ class KonfluxOlmBundleBuilder:
         konflux_context: Optional[str] = None,
         image_repo: str = constants.KONFLUX_DEFAULT_IMAGE_REPO,
         skip_checks: bool = False,
+        skip_tasks: Sequence[str] = (),
         pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_BUNDLE_BUILD_PLR_TEMPLATE_URL,
         dry_run: bool = False,
         skip_ec_verify: bool = False,
@@ -624,6 +625,7 @@ class KonfluxOlmBundleBuilder:
         self.konflux_context = konflux_context
         self.image_repo = image_repo
         self.skip_checks = skip_checks
+        self.skip_tasks = tuple(skip_tasks)
         self.pipelinerun_template_url = pipelinerun_template_url
         self.dry_run = dry_run
         self.skip_ec_verify = skip_ec_verify
@@ -726,6 +728,7 @@ class KonfluxOlmBundleBuilder:
                     output_image,
                     self.konflux_namespace,
                     self.skip_checks,
+                    skip_tasks=self.skip_tasks,
                     git_auth_secret=git_auth_secret,
                 )
                 pipelinerun_name = pipelinerun_info.name
@@ -879,6 +882,7 @@ class KonfluxOlmBundleBuilder:
         output_image: str,
         namespace: str,
         skip_checks: bool = False,
+        skip_tasks: Sequence[str] = (),
         additional_tags: Optional[Sequence[str]] = None,
         git_auth_secret: Optional[str] = None,
     ) -> Tuple[PipelineRunInfo, str]:
@@ -924,6 +928,7 @@ class KonfluxOlmBundleBuilder:
             build_params=ImageBuildParams(
                 additional_tags=list(additional_tags),
                 skip_checks=skip_checks,
+                skip_tasks=skip_tasks,
                 hermetic=True,
                 artifact_type="operatorbundle",
                 build_priority=BUNDLE_BUILD_PRIORITY,

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -27,7 +27,7 @@ from artcommonlib.util import sync_to_quay
 from dockerfile_parse import DockerfileParser
 from doozerlib import constants, util
 from doozerlib.backend.build_repo import BuildRepo
-from doozerlib.backend.konflux_client import KonfluxClient
+from doozerlib.backend.konflux_client import ImageBuildParams, KonfluxClient
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
 from doozerlib.image import ImageMetadata
 from doozerlib.record_logger import RecordLogger
@@ -919,14 +919,15 @@ class KonfluxOlmBundleBuilder:
             commit_sha=bundle_build_repo.commit_hash,
             target_branch=target_branch,
             output_image=output_image,
-            vm_override={},
             building_arches=["x86_64"],
-            additional_tags=list(additional_tags),
-            skip_checks=skip_checks,
-            hermetic=True,
             pipelinerun_template_url=self.pipelinerun_template_url,
-            artifact_type="operatorbundle",
-            build_priority=BUNDLE_BUILD_PRIORITY,
+            build_params=ImageBuildParams(
+                additional_tags=list(additional_tags),
+                skip_checks=skip_checks,
+                hermetic=True,
+                artifact_type="operatorbundle",
+                build_priority=BUNDLE_BUILD_PRIORITY,
+            ),
         )
         if git_auth_secret:
             build_kwargs["git_auth_secret"] = git_auth_secret

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -607,6 +607,7 @@ class KonfluxOlmBundleBuilder:
         konflux_context: Optional[str] = None,
         image_repo: str = constants.KONFLUX_DEFAULT_IMAGE_REPO,
         skip_checks: bool = False,
+        skip_tasks: Sequence[str] = (),
         pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_BUNDLE_BUILD_PLR_TEMPLATE_URL,
         dry_run: bool = False,
         skip_ec_verify: bool = False,
@@ -624,6 +625,7 @@ class KonfluxOlmBundleBuilder:
         self.konflux_context = konflux_context
         self.image_repo = image_repo
         self.skip_checks = skip_checks
+        self.skip_tasks = tuple(skip_tasks)
         self.pipelinerun_template_url = pipelinerun_template_url
         self.dry_run = dry_run
         self.skip_ec_verify = skip_ec_verify
@@ -726,6 +728,7 @@ class KonfluxOlmBundleBuilder:
                     output_image,
                     self.konflux_namespace,
                     self.skip_checks,
+                    skip_tasks=self.skip_tasks,
                     git_auth_secret=git_auth_secret,
                 )
                 pipelinerun_name = pipelinerun_info.name
@@ -863,6 +866,7 @@ class KonfluxOlmBundleBuilder:
         output_image: str,
         namespace: str,
         skip_checks: bool = False,
+        skip_tasks: Sequence[str] = (),
         additional_tags: Optional[Sequence[str]] = None,
         git_auth_secret: Optional[str] = None,
     ) -> Tuple[PipelineRunInfo, str]:
@@ -908,6 +912,7 @@ class KonfluxOlmBundleBuilder:
             build_params=ImageBuildParams(
                 additional_tags=list(additional_tags),
                 skip_checks=skip_checks,
+                skip_tasks=skip_tasks,
                 hermetic=True,
                 artifact_type="operatorbundle",
                 build_priority=BUNDLE_BUILD_PRIORITY,

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -27,7 +27,7 @@ from artcommonlib.util import sync_to_quay
 from dockerfile_parse import DockerfileParser
 from doozerlib import constants, util
 from doozerlib.backend.build_repo import BuildRepo
-from doozerlib.backend.konflux_client import KonfluxClient
+from doozerlib.backend.konflux_client import ImageBuildParams, KonfluxClient
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
 from doozerlib.image import ImageMetadata
 from doozerlib.record_logger import RecordLogger
@@ -903,14 +903,15 @@ class KonfluxOlmBundleBuilder:
             commit_sha=bundle_build_repo.commit_hash,
             target_branch=target_branch,
             output_image=output_image,
-            vm_override={},
             building_arches=["x86_64"],
-            additional_tags=list(additional_tags),
-            skip_checks=skip_checks,
-            hermetic=True,
             pipelinerun_template_url=self.pipelinerun_template_url,
-            artifact_type="operatorbundle",
-            build_priority=BUNDLE_BUILD_PRIORITY,
+            build_params=ImageBuildParams(
+                additional_tags=list(additional_tags),
+                skip_checks=skip_checks,
+                hermetic=True,
+                artifact_type="operatorbundle",
+                build_priority=BUNDLE_BUILD_PRIORITY,
+            ),
         )
         if git_auth_secret:
             build_kwargs["git_auth_secret"] = git_auth_secret

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1558,7 +1558,7 @@ class KonfluxRebaser:
         config_final_stage_user_set = False
 
         # Just for last stage
-        if network_mode != "hermetic":
+        if network_mode != "hermetic" and not no_shell:
             last_stage = self.split_dockerfile_into_stages(dfp)[-1]
 
             # Find all the USERs in the last stage
@@ -1567,7 +1567,7 @@ class KonfluxRebaser:
                 if "USER" in line.keys():
                     final_stage_user = f"USER {line['USER']}"
 
-            if final_stage_user.split()[-1] == '0':
+            if final_stage_user and final_stage_user.split()[-1] == '0':
                 final_stage_user = None  # Avoid redundant USER 0 statement after repo removal
 
             # But if set in image config, that supersedes the USER that doozer remembers

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1596,7 +1596,7 @@ class KonfluxRebaser:
         config_final_stage_user_set = False
 
         # Just for last stage
-        if network_mode != "hermetic":
+        if network_mode != "hermetic" and not no_shell:
             last_stage = self.split_dockerfile_into_stages(dfp)[-1]
 
             # Find all the USERs in the last stage
@@ -1605,7 +1605,7 @@ class KonfluxRebaser:
                 if "USER" in line.keys():
                     final_stage_user = f"USER {line['USER']}"
 
-            if final_stage_user.split()[-1] == '0':
+            if final_stage_user and final_stage_user.split()[-1] == '0':
                 final_stage_user = None  # Avoid redundant USER 0 statement after repo removal
 
             # But if set in image config, that supersedes the USER that doozer remembers

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -208,9 +208,10 @@ class FbcMergeCli:
         message: Optional[str],
         skip_checks: bool,
         skip_fips_check: bool,
-        plr_template: Optional[str],
-        target_index: Optional[str],
-        major_minor: Optional[str],
+        skip_tasks: tuple[str, ...] = (),
+        plr_template: Optional[str] = None,
+        target_index: Optional[str] = None,
+        major_minor: Optional[str] = None,
     ):
         """
         Initialize the FBCFragmentMergerCli.
@@ -228,6 +229,7 @@ class FbcMergeCli:
         self.message = message
         self.skip_checks = skip_checks
         self.skip_fips_check = skip_fips_check
+        self.skip_tasks = skip_tasks
         self.plr_template = plr_template
         self.target_index = target_index
         self.major_minor = major_minor
@@ -326,6 +328,7 @@ class FbcMergeCli:
             konflux_namespace=self.konflux_namespace,
             skip_checks=self.skip_checks,
             skip_fips_check=self.skip_fips_check,
+            skip_tasks=self.skip_tasks,
             plr_template=self.plr_template,
             major_minor_override=(major, minor) if self.major_minor else None,
         )
@@ -398,6 +401,12 @@ class FbcMergeCli:
 @click.option('--skip-checks', is_flag=True, default=False, help='Skip all post build checks')
 @click.option('--skip-fips-check', is_flag=True, default=False, help='Skip the FIPS compliance check task')
 @click.option(
+    '--skip-task',
+    'skip_tasks',
+    multiple=True,
+    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan).',
+)
+@click.option(
     '--target-index',
     metavar='TARGET_INDEX',
     default=None,
@@ -424,6 +433,7 @@ async def fbc_merge(
     registry_auth: Optional[str],
     skip_checks: bool,
     skip_fips_check: bool,
+    skip_tasks: tuple,
     plr_template: Optional[str],
     target_index: Optional[str],
     major_minor: Optional[str],
@@ -454,6 +464,7 @@ async def fbc_merge(
         konflux_namespace=resolved_namespace,
         skip_checks=skip_checks,
         skip_fips_check=skip_fips_check,
+        skip_tasks=skip_tasks,
         plr_template=plr_template,
         target_index=target_index,
         major_minor=major_minor,
@@ -483,6 +494,7 @@ class FbcRebaseAndBuildCli:
         prod_registry_auth: Optional[str] = None,
         major_minor: Optional[str] = None,
         insert_missing_entry: bool = False,
+        skip_tasks: tuple[str, ...] = (),
     ):
         self.runtime = runtime
         self.version = version
@@ -495,6 +507,7 @@ class FbcRebaseAndBuildCli:
         self.konflux_namespace = konflux_namespace
         self.image_repo = image_repo
         self.skip_checks = skip_checks
+        self.skip_tasks = skip_tasks
         self.plr_template = plr_template
         self.dry_run = dry_run
         self.force = force
@@ -745,6 +758,7 @@ class FbcRebaseAndBuildCli:
             konflux_namespace=self.konflux_namespace,
             image_repo=self.image_repo,
             skip_checks=self.skip_checks,
+            skip_tasks=self.skip_tasks,
             pipelinerun_template_url=self.plr_template,
             dry_run=self.dry_run,
             major_minor_override=ocp_version if self.major_minor else None,
@@ -853,6 +867,12 @@ class FbcRebaseAndBuildCli:
 )
 @click.option('--image-repo', default=constants.KONFLUX_DEFAULT_FBC_REPO, help='Push images to the specified repo.')
 @click.option('--skip-checks', default=False, is_flag=True, help='Skip all post build checks')
+@click.option(
+    '--skip-task',
+    'skip_tasks',
+    multiple=True,
+    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan).',
+)
 @click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
 @click.option(
     '--force',
@@ -911,6 +931,7 @@ async def fbc_rebase_and_build(
     konflux_namespace: str,
     image_repo: str,
     skip_checks: bool,
+    skip_tasks: tuple,
     dry_run: bool,
     force: bool,
     plr_template: str,
@@ -951,6 +972,7 @@ async def fbc_rebase_and_build(
         konflux_namespace=konflux_namespace,
         image_repo=image_repo,
         skip_checks=skip_checks,
+        skip_tasks=skip_tasks,
         plr_template=plr_template,
         dry_run=dry_run,
         force=force,

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -404,7 +404,7 @@ class FbcMergeCli:
     '--skip-task',
     'skip_tasks',
     multiple=True,
-    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan).',
+    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan --skip-task sast-snyk-check).',
 )
 @click.option(
     '--target-index',
@@ -871,7 +871,7 @@ class FbcRebaseAndBuildCli:
     '--skip-task',
     'skip_tasks',
     multiple=True,
-    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan).',
+    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan --skip-task sast-snyk-check).',
 )
 @click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
 @click.option(

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -263,6 +263,7 @@ class KonfluxBuildCli:
         plr_template: str,
         build_priority: Optional[str],
         skip_ec_verify: bool = False,
+        skip_tasks: tuple[str, ...] = (),
     ):
         self.runtime = runtime
         self.konflux_kubeconfig = konflux_kubeconfig
@@ -271,6 +272,7 @@ class KonfluxBuildCli:
         self.image_repo = image_repo
         self.registry_auth_file = registry_auth_file
         self.skip_checks = skip_checks
+        self.skip_tasks = skip_tasks
         self.dry_run = dry_run
         self.plr_template = plr_template
         self.build_priority = build_priority
@@ -309,6 +311,7 @@ class KonfluxBuildCli:
             image_repo=self.image_repo,
             registry_auth_file=self.registry_auth_file,
             skip_checks=self.skip_checks,
+            skip_tasks=self.skip_tasks,
             dry_run=self.dry_run,
             plr_template=self.plr_template,
             build_priority=self.build_priority,
@@ -373,6 +376,12 @@ class KonfluxBuildCli:
 )
 @click.option('--image-repo', default=constants.KONFLUX_DEFAULT_IMAGE_REPO, help='Push images to the specified repo.')
 @click.option('--skip-checks', default=False, is_flag=True, help='Skip all post build checks')
+@click.option(
+    '--skip-task',
+    'skip_tasks',
+    multiple=True,
+    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan --skip-task sast-snyk-check).',
+)
 @click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
 @click.option(
     '--plr-template',
@@ -408,6 +417,7 @@ async def images_konflux_build(
     konflux_namespace: str,
     image_repo: str,
     skip_checks: bool,
+    skip_tasks: tuple,
     dry_run: bool,
     plr_template: str,
     build_priority: Optional[str],
@@ -425,6 +435,7 @@ async def images_konflux_build(
         image_repo=image_repo,
         registry_auth_file=runtime.registry_config,
         skip_checks=skip_checks,
+        skip_tasks=skip_tasks,
         dry_run=dry_run,
         plr_template=plr_template,
         build_priority=build_priority,
@@ -448,6 +459,7 @@ class KonfluxBundleCli:
         release: Optional[str],
         plr_template: str,
         output: str,
+        skip_tasks: tuple[str, ...] = (),
     ):
         self.runtime = runtime
         self.operator_nvrs = list(operator_nvrs)
@@ -458,6 +470,7 @@ class KonfluxBundleCli:
         self.konflux_namespace = konflux_namespace
         self.image_repo = image_repo
         self.skip_checks = skip_checks
+        self.skip_tasks = skip_tasks
         self.release = release
         self.output = output
         self.plr_template = plr_template
@@ -607,6 +620,7 @@ class KonfluxBundleCli:
             konflux_context=self.konflux_context,
             image_repo=self.image_repo,
             skip_checks=self.skip_checks,
+            skip_tasks=self.skip_tasks,
             pipelinerun_template_url=self.plr_template,
             dry_run=self.dry_run,
             assembly_type=runtime.assembly_type,
@@ -712,6 +726,12 @@ class KonfluxBundleCli:
 )
 @click.option('--image-repo', default=constants.KONFLUX_DEFAULT_IMAGE_REPO, help='Push images to the specified repo.')
 @click.option('--skip-checks', default=False, is_flag=True, help='Skip all post build checks')
+@click.option(
+    '--skip-task',
+    'skip_tasks',
+    multiple=True,
+    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan --skip-task sast-snyk-check).',
+)
 @click.option("--release", metavar='RELEASE', help="Release string to populate in bundle's Dockerfiles.")
 @click.option(
     '--plr-template',
@@ -738,6 +758,7 @@ async def images_konflux_bundle(
     konflux_namespace: str,
     image_repo: str,
     skip_checks: bool,
+    skip_tasks: tuple,
     release: Optional[str],
     plr_template: str,
     output: str,
@@ -752,6 +773,7 @@ async def images_konflux_bundle(
         konflux_namespace=konflux_namespace,
         image_repo=image_repo,
         skip_checks=skip_checks,
+        skip_tasks=skip_tasks,
         release=release,
         plr_template=plr_template,
         output=output,

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -3,6 +3,7 @@ import logging
 from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import jinja2
 from artcommonlib.konflux.konflux_build_record import KonfluxECStatus
 from doozerlib.backend.konflux_client import (
     API_VERSION,
@@ -842,3 +843,119 @@ class TestNewPipelinerunEphemeralStorage(IsolatedAsyncioTestCase):
         self.assertNotIn("push", step_names)
         self.assertNotIn("prepare-sboms", step_names)
         self.assertNotIn("upload-sbom", step_names)
+
+
+class TestSkipTasks(IsolatedAsyncioTestCase):
+    """Tests for the generic skip_tasks mechanism in _new_pipelinerun_for_image_build."""
+
+    MINIMAL_TEMPLATE = jinja2.Template(
+        json.dumps(
+            {
+                "metadata": {
+                    "name": "test-plr",
+                    "namespace": "test-ns",
+                    "annotations": {
+                        "pipelinesascode.tekton.dev/on-cel-expression": "dummy",
+                        "build.appstudio.openshift.io/repo": "",
+                    },
+                    "labels": {
+                        "appstudio.openshift.io/application": "test-app",
+                        "appstudio.openshift.io/component": "test-comp",
+                    },
+                },
+                "spec": {
+                    "params": [],
+                    "timeouts": {},
+                    "taskRunTemplate": {"serviceAccountName": "default"},
+                    "pipelineSpec": {
+                        "tasks": [
+                            {"name": "clone-repository", "params": [{"name": "refspec", "value": ""}]},
+                            {"name": "build-images", "params": [{"name": "SBOM_TYPE", "value": ""}]},
+                            {"name": "clair-scan", "params": []},
+                            {"name": "sast-snyk-check", "params": []},
+                            {"name": "sast-unicode-check", "params": []},
+                            {"name": "sast-shell-check", "params": []},
+                            {"name": "apply-tags", "params": [{"name": "ADDITIONAL_TAGS", "value": []}]},
+                            {"name": "fbc-fips-check-oci-ta", "params": []},
+                        ],
+                    },
+                },
+            }
+        )
+    )
+
+    def _make_client(self):
+        client = MagicMock(spec=KonfluxClient)
+        client._logger = logging.getLogger("test")
+        client.dry_run = False
+
+        async def fake_get_template(url):
+            return self.MINIMAL_TEMPLATE
+
+        client._get_pipelinerun_template = fake_get_template
+        return client
+
+    async def _build_plr(self, **kwargs):
+        """Helper to call _new_pipelinerun_for_image_build with minimal defaults."""
+        defaults = dict(
+            generate_name="test-",
+            namespace="ns",
+            application_name="app",
+            component_name="comp",
+            git_url="https://github.com/org/repo",
+            commit_sha="abc123",
+            target_branch="main",
+            output_image="quay.io/test:latest",
+            build_platforms=["linux/x86_64"],
+        )
+        defaults.update(kwargs)
+        client = self._make_client()
+        return await KonfluxClient._new_pipelinerun_for_image_build(client, **defaults)
+
+    async def test_skip_tasks_removes_named_tasks(self):
+        result = await self._build_plr(build_params=ImageBuildParams(skip_tasks=["clair-scan"]))
+        task_names = [t["name"] for t in result["spec"]["pipelineSpec"]["tasks"]]
+        self.assertNotIn("clair-scan", task_names)
+        self.assertIn("build-images", task_names)
+        self.assertIn("sast-snyk-check", task_names)
+
+    async def test_skip_tasks_multiple(self):
+        result = await self._build_plr(build_params=ImageBuildParams(skip_tasks=["clair-scan", "sast-snyk-check"]))
+        task_names = [t["name"] for t in result["spec"]["pipelineSpec"]["tasks"]]
+        self.assertNotIn("clair-scan", task_names)
+        self.assertNotIn("sast-snyk-check", task_names)
+        self.assertIn("build-images", task_names)
+
+    async def test_legacy_sast_false_still_removes_tasks(self):
+        result = await self._build_plr(build_params=ImageBuildParams(sast=False))
+        task_names = [t["name"] for t in result["spec"]["pipelineSpec"]["tasks"]]
+        self.assertNotIn("sast-unicode-check", task_names)
+        self.assertNotIn("sast-shell-check", task_names)
+        self.assertIn("clair-scan", task_names)
+
+    async def test_legacy_skip_fips_check_still_removes_task(self):
+        result = await self._build_plr(build_params=ImageBuildParams(skip_fips_check=True))
+        task_names = [t["name"] for t in result["spec"]["pipelineSpec"]["tasks"]]
+        self.assertNotIn("fbc-fips-check-oci-ta", task_names)
+        self.assertIn("clair-scan", task_names)
+
+    async def test_skip_tasks_combined_with_legacy_flags(self):
+        result = await self._build_plr(
+            build_params=ImageBuildParams(
+                skip_tasks=["clair-scan"],
+                sast=False,
+                skip_fips_check=True,
+            )
+        )
+        task_names = [t["name"] for t in result["spec"]["pipelineSpec"]["tasks"]]
+        self.assertNotIn("clair-scan", task_names)
+        self.assertNotIn("sast-unicode-check", task_names)
+        self.assertNotIn("sast-shell-check", task_names)
+        self.assertNotIn("fbc-fips-check-oci-ta", task_names)
+        self.assertIn("build-images", task_names)
+        self.assertIn("clone-repository", task_names)
+
+    async def test_skip_tasks_unknown_name_is_silently_ignored(self):
+        result = await self._build_plr(build_params=ImageBuildParams(skip_tasks=["nonexistent-task"]))
+        task_names = [t["name"] for t in result["spec"]["pipelineSpec"]["tasks"]]
+        self.assertEqual(len(task_names), 8)

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from unittest import IsolatedAsyncioTestCase, TestCase
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from artcommonlib.konflux.konflux_build_record import KonfluxECStatus
 from doozerlib.backend.konflux_client import (
@@ -11,9 +11,78 @@ from doozerlib.backend.konflux_client import (
     KIND_INTEGRATION_TEST_SCENARIO,
     ECVerificationResult,
     GitHubApiUrlInfo,
+    ImageBuildParams,
     KonfluxClient,
     parse_github_api_url,
 )
+
+# Shared minimal PLR template used by all _new_pipelinerun_for_image_build tests
+_MINIMAL_PLR_TEMPLATE = """
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: test-plr
+  namespace: test-ns
+  annotations:
+    build.appstudio.openshift.io/repo: "{{ source_url }}?rev={{ revision }}"
+    pipelinesascode.tekton.dev/on-cel-expression: "true"
+  labels:
+    appstudio.openshift.io/application: test-app
+    appstudio.openshift.io/component: test-component
+spec:
+  params:
+  - name: output-image
+    value: ""
+  - name: skip-checks
+    value: "false"
+  - name: build-source-image
+    value: "false"
+  - name: build-platforms
+    value: []
+  - name: build-args
+    value: []
+  pipelineSpec:
+    tasks:
+    - name: build-images
+      params:
+      - name: IMAGE
+        value: ""
+    - name: apply-tags
+      params:
+      - name: ADDITIONAL_TAGS
+        value: []
+    - name: clone-repository
+      params: []
+  taskRunTemplate:
+    serviceAccountName: default
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: "{{ git_auth_secret }}"
+"""
+
+# Common required kwargs for _new_pipelinerun_for_image_build calls
+_COMMON_KWARGS = dict(
+    generate_name="test-",
+    namespace="test-ns",
+    application_name="test-app",
+    component_name="test-component",
+    git_url="https://github.com/openshift/test.git",
+    commit_sha="abc123",
+    target_branch="main",
+    output_image="quay.io/test/image:tag",
+    build_platforms=["linux/amd64"],
+)
+
+
+def _make_mock_client(mock_get_template):
+    """Create a KonfluxClient instance with a mocked template."""
+    import jinja2
+
+    mock_get_template.return_value = jinja2.Template(_MINIMAL_PLR_TEMPLATE, autoescape=True)
+    client = KonfluxClient.__new__(KonfluxClient)
+    client._logger = MagicMock()
+    return client
 
 
 class TestResourceUrl(TestCase):
@@ -95,11 +164,10 @@ class TestParseGitHubApiUrl(TestCase):
         result = parse_github_api_url(url)
 
         self.assertIsInstance(result, GitHubApiUrlInfo)
-        # Test named tuple access
-        self.assertEqual(result[0], "owner")  # owner
-        self.assertEqual(result[1], "repo")  # repo
-        self.assertEqual(result[2], "file.yaml")  # file_path
-        self.assertEqual(result[3], "main")  # ref
+        self.assertEqual(result[0], "owner")
+        self.assertEqual(result[1], "repo")
+        self.assertEqual(result[2], "file.yaml")
+        self.assertEqual(result[3], "main")
 
 
 class TestNewIntegrationTestScenario(TestCase):
@@ -533,3 +601,246 @@ class TestVerifyEnterpriseContract(IsolatedAsyncioTestCase):
             application_name="openshift-4-21",
             policy_configuration="rhtap-releng-tenant/registry-ocp-art-base-prod",
         )
+
+
+class TestNewPipelinerunBuildArgs(IsolatedAsyncioTestCase):
+    """Tests for build_args in _new_pipelinerun_for_image_build."""
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_build_args_set_on_params(self, mock_get_template):
+        """Test that build_args are set as the build-args pipeline parameter."""
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(
+                build_args=[
+                    "RELEASE_FLAG=--release-image-url",
+                    "RELEASE_VALUE=$(params.release-value)",
+                    "MAJOR_MINOR_VERSION=$(params.major-minor-version)",
+                    "ARCH=x86_64",
+                ]
+            ),
+        )
+
+        plr_params = result["spec"]["params"]
+        param_dict = {p["name"]: p["value"] for p in plr_params}
+
+        self.assertEqual(
+            param_dict["build-args"],
+            [
+                "RELEASE_FLAG=--release-image-url",
+                "RELEASE_VALUE=$(params.release-value)",
+                "MAJOR_MINOR_VERSION=$(params.major-minor-version)",
+                "ARCH=x86_64",
+            ],
+        )
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_build_args_none_is_noop(self, mock_get_template):
+        """Test that None build_args leaves the default build-args param unchanged."""
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(build_args=None),
+        )
+
+        plr_params = result["spec"]["params"]
+        param_dict = {p["name"]: p["value"] for p in plr_params}
+        self.assertEqual(param_dict["build-args"], [])
+
+
+class TestNewPipelinerunAdditionalSecret(IsolatedAsyncioTestCase):
+    """Tests for additional_secret in _new_pipelinerun_for_image_build."""
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_additional_secret_set_on_build_images_task(self, mock_get_template):
+        """Test that additional_secret is set as ADDITIONAL_SECRET on the build-images task."""
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(additional_secret="ove-ui-image-pull-secret"),
+        )
+
+        tasks = result["spec"]["pipelineSpec"]["tasks"]
+        build_images_task = next(t for t in tasks if t["name"] == "build-images")
+        task_param_dict = {p["name"]: p["value"] for p in build_images_task["params"]}
+
+        self.assertEqual(task_param_dict["ADDITIONAL_SECRET"], "ove-ui-image-pull-secret")
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_additional_secret_none_is_noop(self, mock_get_template):
+        """Test that None additional_secret doesn't add ADDITIONAL_SECRET to the task."""
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(additional_secret=None),
+        )
+
+        tasks = result["spec"]["pipelineSpec"]["tasks"]
+        build_images_task = next(t for t in tasks if t["name"] == "build-images")
+        task_param_names = {p["name"] for p in build_images_task["params"]}
+
+        self.assertNotIn("ADDITIONAL_SECRET", task_param_names)
+
+
+class TestNewPipelinerunPrivilegedNested(IsolatedAsyncioTestCase):
+    """Tests for privileged_nested in _new_pipelinerun_for_image_build."""
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_privileged_nested_true_set_on_build_images_task(self, mock_get_template):
+        """Test that privileged_nested=True sets PRIVILEGED_NESTED=true on the build-images task."""
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(privileged_nested=True),
+        )
+
+        tasks = result["spec"]["pipelineSpec"]["tasks"]
+        build_images_task = next(t for t in tasks if t["name"] == "build-images")
+        task_param_dict = {p["name"]: p["value"] for p in build_images_task["params"]}
+
+        self.assertEqual(task_param_dict["PRIVILEGED_NESTED"], "true")
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_privileged_nested_none_is_noop(self, mock_get_template):
+        """Test that None privileged_nested doesn't add PRIVILEGED_NESTED to the task."""
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(privileged_nested=None),
+        )
+
+        tasks = result["spec"]["pipelineSpec"]["tasks"]
+        build_images_task = next(t for t in tasks if t["name"] == "build-images")
+        task_param_names = {p["name"] for p in build_images_task["params"]}
+
+        self.assertNotIn("PRIVILEGED_NESTED", task_param_names)
+
+
+class TestNewPipelinerunBuildStepResources(IsolatedAsyncioTestCase):
+    """Tests for build_step_resources in _new_pipelinerun_for_image_build."""
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_build_step_resources_set_on_build_step(self, mock_get_template):
+        """Test that build_step_resources are applied to the build step."""
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(build_step_resources={"memory": "8Gi"}),
+        )
+
+        task_run_specs = result["spec"]["taskRunSpecs"]
+        build_images_spec = next(s for s in task_run_specs if s["pipelineTaskName"] == "build-images")
+        build_step = next(s for s in build_images_spec["stepSpecs"] if s["name"] == "build")
+        self.assertEqual(build_step["computeResources"]["requests"]["memory"], "8Gi")
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_build_step_resources_none_is_noop(self, mock_get_template):
+        """Test that None build_step_resources doesn't add a build stepSpec."""
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(build_step_resources=None),
+        )
+
+        task_run_specs = result["spec"]["taskRunSpecs"]
+        build_images_spec = next(s for s in task_run_specs if s["pipelineTaskName"] == "build-images")
+        step_names = {s["name"] for s in build_images_spec["stepSpecs"]}
+        self.assertNotIn("build", step_names)
+
+
+class TestNewPipelinerunWorkspaceStorage(IsolatedAsyncioTestCase):
+    """Tests for workspace_storage volumeClaimTemplate injection."""
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_workspace_storage_adds_volume_claim(self, mock_get_template):
+        """Test that workspace_storage injects a volumeClaimTemplate into the PLR."""
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(workspace_storage="100Gi"),
+        )
+
+        pipeline_workspaces = result["spec"]["pipelineSpec"].get("workspaces", [])
+        ws_entry = next((ws for ws in pipeline_workspaces if ws["name"] == "workspace"), None)
+        self.assertIsNotNone(ws_entry)
+        self.assertTrue(ws_entry.get("optional"))
+
+        plr_workspaces = result["spec"].get("workspaces", [])
+        plr_ws = next((ws for ws in plr_workspaces if ws["name"] == "workspace"), None)
+        self.assertIsNotNone(plr_ws)
+        self.assertIn("volumeClaimTemplate", plr_ws)
+        self.assertEqual(
+            plr_ws["volumeClaimTemplate"]["spec"]["resources"]["requests"]["storage"],
+            "100Gi",
+        )
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_no_workspace_storage_no_volume_claim(self, mock_get_template):
+        """Test that without workspace_storage, no volumeClaimTemplate is injected."""
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(),
+        )
+
+        plr_workspaces = result["spec"].get("workspaces", [])
+        ws_entry = next((ws for ws in plr_workspaces if ws.get("name") == "workspace"), None)
+        self.assertIsNone(ws_entry)
+
+
+class TestNewPipelinerunEphemeralStorage(IsolatedAsyncioTestCase):
+    """Tests for ephemeral-storage in build_step_resources propagating to post-build steps."""
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_ephemeral_storage_propagates_to_post_build_steps(self, mock_get_template):
+        """Test that ephemeral-storage in build_step_resources adds 1Gi to post-build steps."""
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(build_step_resources={"memory": "8Gi", "ephemeral-storage": "250Gi"}),
+        )
+
+        task_run_specs = result["spec"]["taskRunSpecs"]
+        build_images_spec = next(s for s in task_run_specs if s["pipelineTaskName"] == "build-images")
+        step_specs = {s["name"]: s for s in build_images_spec["stepSpecs"]}
+
+        self.assertEqual(
+            step_specs["build"]["computeResources"]["requests"]["ephemeral-storage"], "250Gi"
+        )
+        for step_name in ("push", "sbom-syft-generate", "prepare-sboms", "upload-sbom"):
+            self.assertIn(step_name, step_specs, f"Missing stepSpec for {step_name}")
+            self.assertEqual(
+                step_specs[step_name]["computeResources"]["requests"]["ephemeral-storage"],
+                "1Gi",
+                f"Wrong ephemeral-storage for {step_name}",
+            )
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_no_ephemeral_storage_no_post_build_steps(self, mock_get_template):
+        """Test that without ephemeral-storage, post-build steps don't get extra resources."""
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(build_step_resources={"memory": "8Gi"}),
+        )
+
+        task_run_specs = result["spec"]["taskRunSpecs"]
+        build_images_spec = next(s for s in task_run_specs if s["pipelineTaskName"] == "build-images")
+        step_names = {s["name"] for s in build_images_spec["stepSpecs"]}
+        self.assertIn("build", step_names)
+        self.assertNotIn("push", step_names)
+        self.assertNotIn("prepare-sboms", step_names)
+        self.assertNotIn("upload-sbom", step_names)

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from unittest import IsolatedAsyncioTestCase, TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from artcommonlib.konflux.konflux_build_record import KonfluxECStatus
 from doozerlib.backend.konflux_client import (
@@ -816,9 +816,7 @@ class TestNewPipelinerunEphemeralStorage(IsolatedAsyncioTestCase):
         build_images_spec = next(s for s in task_run_specs if s["pipelineTaskName"] == "build-images")
         step_specs = {s["name"]: s for s in build_images_spec["stepSpecs"]}
 
-        self.assertEqual(
-            step_specs["build"]["computeResources"]["requests"]["ephemeral-storage"], "250Gi"
-        )
+        self.assertEqual(step_specs["build"]["computeResources"]["requests"]["ephemeral-storage"], "250Gi")
         for step_name in ("push", "sbom-syft-generate", "prepare-sboms", "upload-sbom"):
             self.assertIn(step_name, step_specs, f"Missing stepSpec for {step_name}")
             self.assertEqual(

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -78,8 +78,6 @@ _COMMON_KWARGS = dict(
 
 def _make_mock_client(mock_get_template):
     """Create a KonfluxClient instance with a mocked template."""
-    import jinja2
-
     mock_get_template.return_value = jinja2.Template(_MINIMAL_PLR_TEMPLATE, autoescape=True)
     client = KonfluxClient.__new__(KonfluxClient)
     client._logger = MagicMock()

--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -7,7 +7,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, Mock, call, patch
 from artcommonlib.assembly import AssemblyTypes
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBundleBuildRecord, KonfluxECStatus
 from doozerlib.backend.build_repo import BuildRepo
-from doozerlib.backend.konflux_client import KonfluxClient
+from doozerlib.backend.konflux_client import ImageBuildParams, KonfluxClient
 from doozerlib.backend.konflux_fbc import (
     AssemblyBundleCsvInfo,
     KonfluxFbcBuilder,
@@ -2176,14 +2176,15 @@ class TestKonfluxFbcBuilder(unittest.IsolatedAsyncioTestCase):
             commit_sha="deadbeef",
             target_branch='test-branch',
             output_image='test-image-pullspec',
-            vm_override={},
             building_arches=['x86_64', 's390x'],
-            additional_tags=[],
-            skip_checks=False,
-            hermetic=True,
-            dockerfile='catalog.Dockerfile',
             pipelinerun_template_url='https://example.com/template.yaml',
-            build_priority='2',
+            build_params=ImageBuildParams(
+                hermetic=True,
+                dockerfile='catalog.Dockerfile',
+                skip_checks=False,
+                skip_fips_check=False,
+                build_priority='2',
+            ),
         )
         self.assertEqual(result, (pplr, "https://example.com/pipelinerun/test-pipeline-run-name"))
 
@@ -2229,14 +2230,15 @@ class TestKonfluxFbcBuilder(unittest.IsolatedAsyncioTestCase):
             commit_sha="deadbeef",
             target_branch='test-branch',
             output_image='test-image-pullspec',
-            vm_override={},
             building_arches=['x86_64', 's390x'],
-            additional_tags=["ocp__4.20__sample-operator-1", "ocp__4.20__sample-operator-2"],
-            skip_checks=False,
-            hermetic=True,
-            dockerfile='catalog.Dockerfile',
             pipelinerun_template_url='https://example.com/template.yaml',
-            build_priority='2',
+            build_params=ImageBuildParams(
+                additional_tags=["ocp__4.20__sample-operator-1", "ocp__4.20__sample-operator-2"],
+                skip_checks=False,
+                hermetic=True,
+                dockerfile='catalog.Dockerfile',
+                build_priority='2',
+            ),
         )
         self.assertEqual(result, (pplr, "https://example.com/pipelinerun/test-pipeline-run-name"))
 
@@ -2511,14 +2513,15 @@ class TestKonfluxFbcBuilder(unittest.IsolatedAsyncioTestCase):
             commit_sha="deadbeef",
             target_branch='test-branch',
             output_image='test-image-pullspec',
-            vm_override={},
             building_arches=['x86_64', 's390x'],
-            additional_tags=expected_additional_tags,
-            skip_checks=False,
-            hermetic=True,
-            dockerfile='catalog.Dockerfile',
             pipelinerun_template_url='https://example.com/template.yaml',
-            build_priority='2',
+            build_params=ImageBuildParams(
+                additional_tags=expected_additional_tags,
+                skip_checks=False,
+                hermetic=True,
+                dockerfile='catalog.Dockerfile',
+                build_priority='2',
+            ),
         )
         self.assertEqual(result, (pplr, "https://example.com/pipelinerun/test-pipeline-run-name"))
 
@@ -2564,14 +2567,15 @@ class TestKonfluxFbcBuilder(unittest.IsolatedAsyncioTestCase):
             commit_sha="deadbeef",
             target_branch='test-branch',
             output_image='test-image-pullspec',
-            vm_override={},
             building_arches=['x86_64', 's390x'],
-            additional_tags=expected_additional_tags,
-            skip_checks=False,
-            hermetic=True,
-            dockerfile='catalog.Dockerfile',
             pipelinerun_template_url='https://example.com/template.yaml',
-            build_priority='2',
+            build_params=ImageBuildParams(
+                additional_tags=expected_additional_tags,
+                skip_checks=False,
+                hermetic=True,
+                dockerfile='catalog.Dockerfile',
+                build_priority='2',
+            ),
         )
         self.assertEqual(result, (pplr, "https://example.com/pipelinerun/test-pipeline-run-name"))
 

--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -7,7 +7,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, Mock, call, patch
 from artcommonlib.assembly import AssemblyTypes
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBundleBuildRecord, KonfluxECStatus
 from doozerlib.backend.build_repo import BuildRepo
-from doozerlib.backend.konflux_client import KonfluxClient
+from doozerlib.backend.konflux_client import ImageBuildParams, KonfluxClient
 from doozerlib.backend.konflux_fbc import (
     AssemblyBundleCsvInfo,
     KonfluxFbcBuilder,
@@ -2471,14 +2471,15 @@ class TestKonfluxFbcBuilder(unittest.IsolatedAsyncioTestCase):
             commit_sha="deadbeef",
             target_branch='test-branch',
             output_image='test-image-pullspec',
-            vm_override={},
             building_arches=['x86_64', 's390x'],
-            additional_tags=[],
-            skip_checks=False,
-            hermetic=True,
-            dockerfile='catalog.Dockerfile',
             pipelinerun_template_url='https://example.com/template.yaml',
-            build_priority='2',
+            build_params=ImageBuildParams(
+                hermetic=True,
+                dockerfile='catalog.Dockerfile',
+                skip_checks=False,
+                skip_fips_check=False,
+                build_priority='2',
+            ),
         )
         self.assertEqual(result, (pplr, "https://example.com/pipelinerun/test-pipeline-run-name"))
 
@@ -2524,14 +2525,15 @@ class TestKonfluxFbcBuilder(unittest.IsolatedAsyncioTestCase):
             commit_sha="deadbeef",
             target_branch='test-branch',
             output_image='test-image-pullspec',
-            vm_override={},
             building_arches=['x86_64', 's390x'],
-            additional_tags=["ocp__4.20__sample-operator-1", "ocp__4.20__sample-operator-2"],
-            skip_checks=False,
-            hermetic=True,
-            dockerfile='catalog.Dockerfile',
             pipelinerun_template_url='https://example.com/template.yaml',
-            build_priority='2',
+            build_params=ImageBuildParams(
+                additional_tags=["ocp__4.20__sample-operator-1", "ocp__4.20__sample-operator-2"],
+                skip_checks=False,
+                hermetic=True,
+                dockerfile='catalog.Dockerfile',
+                build_priority='2',
+            ),
         )
         self.assertEqual(result, (pplr, "https://example.com/pipelinerun/test-pipeline-run-name"))
 
@@ -2806,14 +2808,15 @@ class TestKonfluxFbcBuilder(unittest.IsolatedAsyncioTestCase):
             commit_sha="deadbeef",
             target_branch='test-branch',
             output_image='test-image-pullspec',
-            vm_override={},
             building_arches=['x86_64', 's390x'],
-            additional_tags=expected_additional_tags,
-            skip_checks=False,
-            hermetic=True,
-            dockerfile='catalog.Dockerfile',
             pipelinerun_template_url='https://example.com/template.yaml',
-            build_priority='2',
+            build_params=ImageBuildParams(
+                additional_tags=expected_additional_tags,
+                skip_checks=False,
+                hermetic=True,
+                dockerfile='catalog.Dockerfile',
+                build_priority='2',
+            ),
         )
         self.assertEqual(result, (pplr, "https://example.com/pipelinerun/test-pipeline-run-name"))
 
@@ -2859,14 +2862,15 @@ class TestKonfluxFbcBuilder(unittest.IsolatedAsyncioTestCase):
             commit_sha="deadbeef",
             target_branch='test-branch',
             output_image='test-image-pullspec',
-            vm_override={},
             building_arches=['x86_64', 's390x'],
-            additional_tags=expected_additional_tags,
-            skip_checks=False,
-            hermetic=True,
-            dockerfile='catalog.Dockerfile',
             pipelinerun_template_url='https://example.com/template.yaml',
-            build_priority='2',
+            build_params=ImageBuildParams(
+                additional_tags=expected_additional_tags,
+                skip_checks=False,
+                hermetic=True,
+                dockerfile='catalog.Dockerfile',
+                build_priority='2',
+            ),
         )
         self.assertEqual(result, (pplr, "https://example.com/pipelinerun/test-pipeline-run-name"))
 

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -49,6 +49,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         metadata.runtime.assembly = "test-assembly"
         metadata.runtime.konflux_db = MagicMock()
         metadata.runtime.group_config.software_lifecycle.phase = "release"
+        metadata.config.konflux.get.return_value = False
         metadata.for_release = True
         metadata.get_latest_build = AsyncMock(return_value=None)
         metadata.get_konflux_build_attempts.return_value = 1
@@ -233,6 +234,74 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
             )
 
         mock_get_installed_packages.assert_awaited_once_with("quay.io/test/image@sha256:testdigest", ["x86_64"], None)
+
+    async def test_update_konflux_db_skips_rpm_extraction_when_no_shell(self):
+        """RPM extraction is skipped for no_shell images (e.g. FROM scratch ISO builds)."""
+        metadata = self._metadata()
+        metadata.config.konflux.get.return_value = True  # no_shell=True
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "test-commit-hash"
+        build_repo.local_dir = Path(self.temp_dir.name)
+
+        pipelinerun = PipelineRunInfo(
+            {
+                "metadata": {
+                    "name": "test-pipelinerun",
+                    "uid": "test-uid",
+                    "labels": {"appstudio.openshift.io/component": "test-component"},
+                },
+                "status": {
+                    "results": [
+                        {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                        {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                    ],
+                    "startTime": "2023-10-01T12:00:00Z",
+                    "completionTime": "2023-10-01T12:30:00Z",
+                },
+            },
+            {},
+        )
+
+        with (
+            patch("doozerlib.backend.konflux_image_builder.DockerfileParser") as mock_dockerfile_parser,
+            patch.object(self.builder, "extract_parent_image_nvrs", new=AsyncMock(return_value=[])),
+            patch.object(
+                self.builder,
+                "get_installed_packages",
+                new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
+            ) as mock_get_installed_packages,
+            patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
+        ):
+            mock_dockerfile = MagicMock()
+            mock_dockerfile.labels = {
+                "io.openshift.build.source-location": "https://example.com/source-repo.git",
+                "io.openshift.build.commit.id": "source-commit-id",
+                "com.redhat.component": "test-component",
+                "version": "1.0",
+                "release": "1.el9",
+            }
+            mock_dockerfile.parent_images = []
+            mock_dockerfile_parser.return_value = mock_dockerfile
+            mock_bigquery_client.return_value.client.insert_rows_json.return_value = None
+
+            await self.builder.update_konflux_db(
+                metadata,
+                build_repo,
+                pipelinerun,
+                KonfluxBuildOutcome.SUCCESS,
+                ["x86_64"],
+                "5",
+            )
+
+        mock_get_installed_packages.assert_not_awaited()
+        # DB record should have empty package lists
+        add_build_call = metadata.runtime.konflux_db.add_build
+        add_build_call.assert_called_once()
+        build_record = add_build_call.call_args[0][0]
+        self.assertEqual(build_record.installed_packages, [])
+        self.assertEqual(build_record.installed_rpms, [])
+        self.assertEqual(build_record.image_pullspec, "quay.io/test/image@sha256:testdigest")
 
     async def test_ec_policy_selection_missing_lifecycle_phase(self):
         """Test that default EC policy is used when lifecycle phase is Missing."""

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -47,6 +47,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         metadata.runtime.assembly = "test-assembly"
         metadata.runtime.konflux_db = MagicMock()
         metadata.runtime.group_config.software_lifecycle.phase = "release"
+        metadata.config.konflux.get.return_value = False
         metadata.for_release = True
         metadata.get_latest_build = AsyncMock(return_value=None)
         metadata.get_konflux_build_attempts.return_value = 1
@@ -229,6 +230,74 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
             )
 
         mock_get_installed_packages.assert_awaited_once_with("quay.io/test/image@sha256:testdigest", ["x86_64"], None)
+
+    async def test_update_konflux_db_skips_rpm_extraction_when_no_shell(self):
+        """RPM extraction is skipped for no_shell images (e.g. FROM scratch ISO builds)."""
+        metadata = self._metadata()
+        metadata.config.konflux.get.return_value = True  # no_shell=True
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "test-commit-hash"
+        build_repo.local_dir = Path(self.temp_dir.name)
+
+        pipelinerun = PipelineRunInfo(
+            {
+                "metadata": {
+                    "name": "test-pipelinerun",
+                    "uid": "test-uid",
+                    "labels": {"appstudio.openshift.io/component": "test-component"},
+                },
+                "status": {
+                    "results": [
+                        {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                        {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                    ],
+                    "startTime": "2023-10-01T12:00:00Z",
+                    "completionTime": "2023-10-01T12:30:00Z",
+                },
+            },
+            {},
+        )
+
+        with (
+            patch("doozerlib.backend.konflux_image_builder.DockerfileParser") as mock_dockerfile_parser,
+            patch.object(self.builder, "extract_parent_image_nvrs", new=AsyncMock(return_value=[])),
+            patch.object(
+                self.builder,
+                "get_installed_packages",
+                new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
+            ) as mock_get_installed_packages,
+            patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
+        ):
+            mock_dockerfile = MagicMock()
+            mock_dockerfile.labels = {
+                "io.openshift.build.source-location": "https://example.com/source-repo.git",
+                "io.openshift.build.commit.id": "source-commit-id",
+                "com.redhat.component": "test-component",
+                "version": "1.0",
+                "release": "1.el9",
+            }
+            mock_dockerfile.parent_images = []
+            mock_dockerfile_parser.return_value = mock_dockerfile
+            mock_bigquery_client.return_value.client.insert_rows_json.return_value = None
+
+            await self.builder.update_konflux_db(
+                metadata,
+                build_repo,
+                pipelinerun,
+                KonfluxBuildOutcome.SUCCESS,
+                ["x86_64"],
+                "5",
+            )
+
+        mock_get_installed_packages.assert_not_awaited()
+        # DB record should have empty package lists
+        add_build_call = metadata.runtime.konflux_db.add_build
+        add_build_call.assert_called_once()
+        build_record = add_build_call.call_args[0][0]
+        self.assertEqual(build_record.installed_packages, [])
+        self.assertEqual(build_record.installed_rpms, [])
+        self.assertEqual(build_record.image_pullspec, "quay.io/test/image@sha256:testdigest")
 
     async def test_ec_policy_selection_missing_lifecycle_phase(self):
         """Test that default EC policy is used when lifecycle phase is Missing."""

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -567,7 +567,7 @@ class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
             f"{self.image_repo}:test-component-1.0-1",
             self.konflux_namespace,
             self.skip_checks,
-            additional_tags,
+            additional_tags=additional_tags,
         )
 
         self.konflux_client.ensure_application.assert_called_once_with(name="test-group", display_name="test-group")

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -9,6 +9,7 @@ import yaml
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBundleBuildRecord
 from artcommonlib.konflux.konflux_db import Engine
 from doozerlib import constants
+from doozerlib.backend.konflux_client import ImageBuildParams
 from doozerlib.backend.konflux_olm_bundler import KonfluxOlmBundleBuilder, KonfluxOlmBundleRebaser
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
 
@@ -587,14 +588,15 @@ class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
             commit_sha=bundle_build_repo.commit_hash,
             target_branch=bundle_build_repo.commit_hash,
             output_image=f"{self.image_repo}:test-component-1.0-1",
-            vm_override={},
             building_arches=["x86_64"],
-            additional_tags=additional_tags,
-            skip_checks=self.skip_checks,
-            hermetic=True,
             pipelinerun_template_url=constants.KONFLUX_DEFAULT_BUNDLE_BUILD_PLR_TEMPLATE_URL,
-            artifact_type="operatorbundle",
-            build_priority="3",
+            build_params=ImageBuildParams(
+                additional_tags=additional_tags,
+                skip_checks=self.skip_checks,
+                hermetic=True,
+                artifact_type="operatorbundle",
+                build_priority="3",
+            ),
         )
         self.assertEqual(url, "https://example.com/pipelinerun")
 

--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -440,6 +440,18 @@
           "$ref": "#/properties/konflux/properties/sast"
         },
         "sast-": {},
+        "skip_tasks": {
+          "description": "List of Tekton task names to remove from PipelineRuns",
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "skip_tasks!": {
+          "$ref": "#/properties/konflux/properties/skip_tasks"
+        },
+        "skip_tasks?": {
+          "$ref": "#/properties/konflux/properties/skip_tasks"
+        },
+        "skip_tasks-": {},
         "network_mode": {
           "type": "string"
         },

--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -488,6 +488,63 @@
           "$ref": "#/properties/konflux/properties/skip_tasks"
         },
         "skip_tasks-": {},
+        "build_args": {
+          "description": "List of KEY=VALUE strings passed as the build-args pipeline param",
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "build_args!": {
+          "$ref": "#/properties/konflux/properties/build_args"
+        },
+        "build_args?": {
+          "$ref": "#/properties/konflux/properties/build_args"
+        },
+        "build_args-": {},
+        "additional_secret": {
+          "description": "Kubernetes secret name set as ADDITIONAL_SECRET on the build-images task",
+          "type": "string"
+        },
+        "additional_secret!": {
+          "$ref": "#/properties/konflux/properties/additional_secret"
+        },
+        "additional_secret?": {
+          "$ref": "#/properties/konflux/properties/additional_secret"
+        },
+        "additional_secret-": {},
+        "privileged_nested": {
+          "description": "Enable PRIVILEGED_NESTED on the build-images task",
+          "type": "boolean"
+        },
+        "privileged_nested!": {
+          "$ref": "#/properties/konflux/properties/privileged_nested"
+        },
+        "privileged_nested?": {
+          "$ref": "#/properties/konflux/properties/privileged_nested"
+        },
+        "privileged_nested-": {},
+        "build_step_resources": {
+          "description": "Kubernetes resource requests/limits for the build step (e.g. memory, ephemeral-storage)",
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "build_step_resources!": {
+          "$ref": "#/properties/konflux/properties/build_step_resources"
+        },
+        "build_step_resources?": {
+          "$ref": "#/properties/konflux/properties/build_step_resources"
+        },
+        "build_step_resources-": {},
+        "workspace_storage": {
+          "description": "PVC storage size for workspace volume (e.g. 100Gi)",
+          "type": "string"
+        },
+        "workspace_storage!": {
+          "$ref": "#/properties/konflux/properties/workspace_storage"
+        },
+        "workspace_storage?": {
+          "$ref": "#/properties/konflux/properties/workspace_storage"
+        },
+        "workspace_storage-": {},
         "network_mode": {
           "type": "string"
         },

--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -476,6 +476,18 @@
           "$ref": "#/properties/konflux/properties/sast"
         },
         "sast-": {},
+        "skip_tasks": {
+          "description": "List of Tekton task names to remove from PipelineRuns",
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "skip_tasks!": {
+          "$ref": "#/properties/konflux/properties/skip_tasks"
+        },
+        "skip_tasks?": {
+          "$ref": "#/properties/konflux/properties/skip_tasks"
+        },
+        "skip_tasks-": {},
         "network_mode": {
           "type": "string"
         },

--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -452,6 +452,63 @@
           "$ref": "#/properties/konflux/properties/skip_tasks"
         },
         "skip_tasks-": {},
+        "build_args": {
+          "description": "List of KEY=VALUE strings passed as the build-args pipeline param",
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "build_args!": {
+          "$ref": "#/properties/konflux/properties/build_args"
+        },
+        "build_args?": {
+          "$ref": "#/properties/konflux/properties/build_args"
+        },
+        "build_args-": {},
+        "additional_secret": {
+          "description": "Kubernetes secret name set as ADDITIONAL_SECRET on the build-images task",
+          "type": "string"
+        },
+        "additional_secret!": {
+          "$ref": "#/properties/konflux/properties/additional_secret"
+        },
+        "additional_secret?": {
+          "$ref": "#/properties/konflux/properties/additional_secret"
+        },
+        "additional_secret-": {},
+        "privileged_nested": {
+          "description": "Enable PRIVILEGED_NESTED on the build-images task",
+          "type": "boolean"
+        },
+        "privileged_nested!": {
+          "$ref": "#/properties/konflux/properties/privileged_nested"
+        },
+        "privileged_nested?": {
+          "$ref": "#/properties/konflux/properties/privileged_nested"
+        },
+        "privileged_nested-": {},
+        "build_step_resources": {
+          "description": "Kubernetes resource requests/limits for the build step (e.g. memory, ephemeral-storage)",
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "build_step_resources!": {
+          "$ref": "#/properties/konflux/properties/build_step_resources"
+        },
+        "build_step_resources?": {
+          "$ref": "#/properties/konflux/properties/build_step_resources"
+        },
+        "build_step_resources-": {},
+        "workspace_storage": {
+          "description": "PVC storage size for workspace volume (e.g. 100Gi)",
+          "type": "string"
+        },
+        "workspace_storage!": {
+          "$ref": "#/properties/konflux/properties/workspace_storage"
+        },
+        "workspace_storage?": {
+          "$ref": "#/properties/konflux/properties/workspace_storage"
+        },
+        "workspace_storage-": {},
         "network_mode": {
           "type": "string"
         },

--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -491,7 +491,7 @@
         "build_args": {
           "description": "List of KEY=VALUE strings passed as the build-args pipeline param",
           "type": "array",
-          "items": { "type": "string", "minLength": 1 }
+          "items": { "type": "string", "pattern": "^[^=\\s]+=.+$" }
         },
         "build_args!": {
           "$ref": "#/properties/konflux/properties/build_args"

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -1402,6 +1402,18 @@
           "$ref": "#/properties/konflux/properties/build_attempts"
         },
         "build_attempts-": {},
+        "skip_tasks": {
+          "description": "List of Tekton task names to remove from PipelineRuns for this image",
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "skip_tasks!": {
+          "$ref": "#/properties/konflux/properties/skip_tasks"
+        },
+        "skip_tasks?": {
+          "$ref": "#/properties/konflux/properties/skip_tasks"
+        },
+        "skip_tasks-": {},
         "content": {
           "$ref": "image_content.base.schema.json"
         }

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -1414,6 +1414,63 @@
           "$ref": "#/properties/konflux/properties/skip_tasks"
         },
         "skip_tasks-": {},
+        "build_args": {
+          "description": "List of KEY=VALUE strings passed as the build-args pipeline param for this image",
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "build_args!": {
+          "$ref": "#/properties/konflux/properties/build_args"
+        },
+        "build_args?": {
+          "$ref": "#/properties/konflux/properties/build_args"
+        },
+        "build_args-": {},
+        "additional_secret": {
+          "description": "Kubernetes secret name set as ADDITIONAL_SECRET on the build-images task",
+          "type": "string"
+        },
+        "additional_secret!": {
+          "$ref": "#/properties/konflux/properties/additional_secret"
+        },
+        "additional_secret?": {
+          "$ref": "#/properties/konflux/properties/additional_secret"
+        },
+        "additional_secret-": {},
+        "privileged_nested": {
+          "description": "Enable PRIVILEGED_NESTED on the build-images task",
+          "type": "boolean"
+        },
+        "privileged_nested!": {
+          "$ref": "#/properties/konflux/properties/privileged_nested"
+        },
+        "privileged_nested?": {
+          "$ref": "#/properties/konflux/properties/privileged_nested"
+        },
+        "privileged_nested-": {},
+        "build_step_resources": {
+          "description": "Kubernetes resource requests/limits for the build step (e.g. memory, ephemeral-storage)",
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "build_step_resources!": {
+          "$ref": "#/properties/konflux/properties/build_step_resources"
+        },
+        "build_step_resources?": {
+          "$ref": "#/properties/konflux/properties/build_step_resources"
+        },
+        "build_step_resources-": {},
+        "workspace_storage": {
+          "description": "PVC storage size for workspace volume (e.g. 100Gi)",
+          "type": "string"
+        },
+        "workspace_storage!": {
+          "$ref": "#/properties/konflux/properties/workspace_storage"
+        },
+        "workspace_storage?": {
+          "$ref": "#/properties/konflux/properties/workspace_storage"
+        },
+        "workspace_storage-": {},
         "content": {
           "$ref": "image_content.base.schema.json"
         }

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -1453,7 +1453,7 @@
         "build_args": {
           "description": "List of KEY=VALUE strings passed as the build-args pipeline param for this image",
           "type": "array",
-          "items": { "type": "string", "minLength": 1 }
+          "items": { "type": "string", "pattern": "^[^=\\s]+=.+$" }
         },
         "build_args!": {
           "$ref": "#/properties/konflux/properties/build_args"

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -1450,6 +1450,63 @@
           "$ref": "#/properties/konflux/properties/skip_tasks"
         },
         "skip_tasks-": {},
+        "build_args": {
+          "description": "List of KEY=VALUE strings passed as the build-args pipeline param for this image",
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "build_args!": {
+          "$ref": "#/properties/konflux/properties/build_args"
+        },
+        "build_args?": {
+          "$ref": "#/properties/konflux/properties/build_args"
+        },
+        "build_args-": {},
+        "additional_secret": {
+          "description": "Kubernetes secret name set as ADDITIONAL_SECRET on the build-images task",
+          "type": "string"
+        },
+        "additional_secret!": {
+          "$ref": "#/properties/konflux/properties/additional_secret"
+        },
+        "additional_secret?": {
+          "$ref": "#/properties/konflux/properties/additional_secret"
+        },
+        "additional_secret-": {},
+        "privileged_nested": {
+          "description": "Enable PRIVILEGED_NESTED on the build-images task",
+          "type": "boolean"
+        },
+        "privileged_nested!": {
+          "$ref": "#/properties/konflux/properties/privileged_nested"
+        },
+        "privileged_nested?": {
+          "$ref": "#/properties/konflux/properties/privileged_nested"
+        },
+        "privileged_nested-": {},
+        "build_step_resources": {
+          "description": "Kubernetes resource requests/limits for the build step (e.g. memory, ephemeral-storage)",
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "build_step_resources!": {
+          "$ref": "#/properties/konflux/properties/build_step_resources"
+        },
+        "build_step_resources?": {
+          "$ref": "#/properties/konflux/properties/build_step_resources"
+        },
+        "build_step_resources-": {},
+        "workspace_storage": {
+          "description": "PVC storage size for workspace volume (e.g. 100Gi)",
+          "type": "string"
+        },
+        "workspace_storage!": {
+          "$ref": "#/properties/konflux/properties/workspace_storage"
+        },
+        "workspace_storage?": {
+          "$ref": "#/properties/konflux/properties/workspace_storage"
+        },
+        "workspace_storage-": {},
         "content": {
           "$ref": "image_content.base.schema.json"
         }

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -1438,6 +1438,18 @@
           "$ref": "#/properties/konflux/properties/image_repo"
         },
         "image_repo-": {},
+        "skip_tasks": {
+          "description": "List of Tekton task names to remove from PipelineRuns for this image",
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "skip_tasks!": {
+          "$ref": "#/properties/konflux/properties/skip_tasks"
+        },
+        "skip_tasks?": {
+          "$ref": "#/properties/konflux/properties/skip_tasks"
+        },
+        "skip_tasks-": {},
         "content": {
           "$ref": "image_content.base.schema.json"
         }

--- a/pyartcd/pyartcd/pipelines/build_fbc.py
+++ b/pyartcd/pyartcd/pipelines/build_fbc.py
@@ -59,13 +59,14 @@ class BuildFbcPipeline:
         kubeconfig: str,
         plr_template: str,
         skip_checks: bool,
-        reset_to_prod: bool,
-        prod_registry_auth: Optional[str],
-        force: bool,
-        group: str,
-        major_minor: Optional[str],
-        ignore_locks: bool,
-        insert_missing_entry: bool,
+        skip_tasks: tuple[str, ...] = (),
+        reset_to_prod: bool = True,
+        prod_registry_auth: Optional[str] = None,
+        force: bool = False,
+        group: str = '',
+        major_minor: Optional[str] = None,
+        ignore_locks: bool = False,
+        insert_missing_entry: bool = False,
     ):
         self.runtime = runtime
         self.version = version
@@ -80,6 +81,7 @@ class BuildFbcPipeline:
         self.kubeconfig = kubeconfig
         self.plr_template = plr_template
         self.skip_checks = skip_checks
+        self.skip_tasks = skip_tasks
         self.reset_to_prod = reset_to_prod
         self.prod_registry_auth = prod_registry_auth
         self.force = force
@@ -216,6 +218,8 @@ class BuildFbcPipeline:
             doozer_opts.extend(['--plr-template', plr_template_url])
         if self.skip_checks:
             doozer_opts.append('--skip-checks')
+        for task_name in self.skip_tasks:
+            doozer_opts.extend(['--skip-task', task_name])
         if self.reset_to_prod:
             doozer_opts.append('--reset-to-prod')
         else:
@@ -314,6 +318,12 @@ class BuildFbcPipeline:
 )
 @click.option("--skip-checks", is_flag=True, help="Skip all post build checks in the FBC build pipeline")
 @click.option(
+    '--skip-task',
+    'skip_tasks',
+    multiple=True,
+    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan).',
+)
+@click.option(
     "--reset-to-prod/--no-reset-to-prod", is_flag=True, help="Reset FBC builds to the latest production version"
 )
 @click.option(
@@ -354,6 +364,7 @@ async def build_fbc(
     kubeconfig: str,
     plr_template: str,
     skip_checks: bool,
+    skip_tasks: tuple,
     reset_to_prod: bool,
     prod_registry_auth: Optional[str],
     force: bool,
@@ -379,6 +390,7 @@ async def build_fbc(
         kubeconfig=kubeconfig,
         plr_template=plr_template,
         skip_checks=skip_checks,
+        skip_tasks=skip_tasks,
         reset_to_prod=reset_to_prod,
         prod_registry_auth=prod_registry_auth,
         force=force,

--- a/pyartcd/pyartcd/pipelines/build_fbc.py
+++ b/pyartcd/pyartcd/pipelines/build_fbc.py
@@ -321,7 +321,7 @@ class BuildFbcPipeline:
     '--skip-task',
     'skip_tasks',
     multiple=True,
-    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan).',
+    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan --skip-task sast-snyk-check).',
 )
 @click.option(
     "--reset-to-prod/--no-reset-to-prod", is_flag=True, help="Reset FBC builds to the latest production version"

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -128,7 +128,8 @@ class BuildLayeredProductsPipeline:
 
         # Extract product from group config
         product = group_config.get('product', 'ocp')
-        await self._rebase_and_build(product)
+        image_repo = group_config.get('konflux', {}).get('image_repo', KONFLUX_DEFAULT_IMAGE_REPO)
+        await self._rebase_and_build(product, image_repo)
         self.trigger_bundle_build()
 
     def _group_param(self) -> str:
@@ -147,7 +148,7 @@ class BuildLayeredProductsPipeline:
             "--latest-parent-version",
         ]
 
-    async def _rebase_and_build(self, product: str):
+    async def _rebase_and_build(self, product: str, image_repo: str):
         """Rebase and build layered product image"""
         image_list = self.image_list
 
@@ -160,7 +161,7 @@ class BuildLayeredProductsPipeline:
             self._logger.warning('No buildable images remaining after rebase; skipping build')
             return
 
-        await self._build(image_list, product)
+        await self._build(image_list, product, image_repo)
 
     async def _rebase(self, image_list: str) -> str:
         """Rebase layered product images.
@@ -221,7 +222,7 @@ class BuildLayeredProductsPipeline:
             remaining = [img for img in requested if img not in excluded]
             return ','.join(remaining)
 
-    async def _build(self, image_list: str, product: str):
+    async def _build(self, image_list: str, product: str, image_repo: str):
         """Build layered product images."""
         self._logger.info(f"Building {image_list} image(s) for assembly {self.assembly}")
 
@@ -230,7 +231,7 @@ class BuildLayeredProductsPipeline:
             [
                 f"--images={image_list}",
                 "beta:images:konflux:build",
-                f"--image-repo={KONFLUX_DEFAULT_IMAGE_REPO}",
+                f"--image-repo={image_repo}",
                 "--build-priority=1",
             ]
         )

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -128,7 +128,7 @@ class BuildLayeredProductsPipeline:
 
         # Extract product from group config
         product = group_config.get('product', 'ocp')
-        image_repo = group_config.get('konflux', {}).get('image_repo', KONFLUX_DEFAULT_IMAGE_REPO)
+        image_repo = group_config.get('konflux', {}).get('image_repo') or KONFLUX_DEFAULT_IMAGE_REPO
         await self._rebase_and_build(product, image_repo)
         self.trigger_bundle_build()
 

--- a/pyartcd/pyartcd/pipelines/build_merged_fbc.py
+++ b/pyartcd/pyartcd/pipelines/build_merged_fbc.py
@@ -25,6 +25,7 @@ class BuildMergedFbcPipeline:
         kubeconfig: str,
         plr_template: str,
         skip_checks: bool,
+        skip_tasks: tuple[str, ...] = (),
     ):
         self.runtime = runtime
         self.version = version
@@ -36,6 +37,7 @@ class BuildMergedFbcPipeline:
         self.kubeconfig = kubeconfig
         self.plr_template = plr_template
         self.skip_checks = skip_checks
+        self.skip_tasks = skip_tasks
 
         self._logger = logging.getLogger(__name__)
         self._slack_client = runtime.new_slack_client()
@@ -101,6 +103,8 @@ class BuildMergedFbcPipeline:
             doozer_opts.extend(['--plr-template', plr_template_url])
         if self.skip_checks:
             doozer_opts.append('--skip-checks')
+        for task_name in self.skip_tasks:
+            doozer_opts.extend(['--skip-task', task_name])
         doozer_opts.append('--')
         stage_index_repo = "quay.io/openshift-art/stage-fbc-fragments"
         for dgk in operator_dgks:
@@ -154,6 +158,12 @@ class BuildMergedFbcPipeline:
     help='Override the Pipeline Run template commit from openshift-priv/art-konflux-template; format: <owner>@<branch>',
 )
 @click.option("--skip-checks", is_flag=True, help="Skip all post build checks in the FBC build pipeline")
+@click.option(
+    '--skip-task',
+    'skip_tasks',
+    multiple=True,
+    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan).',
+)
 @pass_runtime
 @click_coroutine
 async def build_merged_fbc(
@@ -167,6 +177,7 @@ async def build_merged_fbc(
     kubeconfig: str,
     plr_template: str,
     skip_checks: bool,
+    skip_tasks: tuple,
 ):
     pipeline = BuildMergedFbcPipeline(
         runtime=runtime,
@@ -179,5 +190,6 @@ async def build_merged_fbc(
         kubeconfig=kubeconfig,
         plr_template=plr_template,
         skip_checks=skip_checks,
+        skip_tasks=skip_tasks,
     )
     await pipeline.run()

--- a/pyartcd/pyartcd/pipelines/build_merged_fbc.py
+++ b/pyartcd/pyartcd/pipelines/build_merged_fbc.py
@@ -162,7 +162,7 @@ class BuildMergedFbcPipeline:
     '--skip-task',
     'skip_tasks',
     multiple=True,
-    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan).',
+    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan --skip-task sast-snyk-check).',
 )
 @pass_runtime
 @click_coroutine

--- a/pyartcd/tests/pipelines/test_build_layered_products.py
+++ b/pyartcd/tests/pipelines/test_build_layered_products.py
@@ -5,6 +5,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import yaml
+from doozerlib.constants import KONFLUX_DEFAULT_IMAGE_REPO
 from pyartcd.pipelines.build_layered_products import BuildLayeredProductsPipeline
 from pyartcd.runtime import Runtime
 
@@ -161,7 +162,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
             new_callable=AsyncMock,
             side_effect=ChildProcessError('exit code 1'),
         ):
-            await self.pipeline._rebase_and_build('oadp')
+            await self.pipeline._rebase_and_build('oadp', KONFLUX_DEFAULT_IMAGE_REPO)
 
         self.pipeline._logger.warning.assert_any_call('No buildable images remaining after rebase; skipping build')
 
@@ -192,7 +193,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
                 return_value='/path/to/kubeconfig',
             ),
         ):
-            await self.pipeline._rebase_and_build('oadp')
+            await self.pipeline._rebase_and_build('oadp', KONFLUX_DEFAULT_IMAGE_REPO)
 
         self.assertEqual(call_count, 2)
         self.pipeline._logger.info.assert_any_call('Successfully built oadp-velero-restic-restore-helper')
@@ -211,9 +212,85 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
                 return_value='/path/to/kubeconfig',
             ),
         ):
-            await self.pipeline._rebase_and_build('oadp')
+            await self.pipeline._rebase_and_build('oadp', KONFLUX_DEFAULT_IMAGE_REPO)
 
         mock_cmd.assert_called_once()
         cmd = mock_cmd.call_args[0][0]
         self.assertIn(f'--images={self.pipeline.image_list}', cmd)
         self.assertIn('beta:images:konflux:build', cmd)
+
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.init_jenkins')
+    @patch('pyartcd.pipelines.build_layered_products.load_group_config')
+    @patch('pyartcd.pipelines.build_layered_products.exectools.cmd_assert_async', new_callable=AsyncMock)
+    @patch(
+        'pyartcd.pipelines.build_layered_products.resolve_konflux_kubeconfig_by_product',
+        return_value='/path/to/kubeconfig',
+    )
+    @patch('pyartcd.pipelines.build_layered_products.resolve_konflux_namespace_by_product', return_value='test-ns')
+    async def test_image_repo_from_group_config(
+        self, mock_resolve_ns, mock_resolve_kube, mock_cmd, mock_load_config, mock_jenkins
+    ):
+        """When group config has konflux.image_repo, it should be used instead of the default."""
+        mock_load_config.return_value = {
+            'product': 'installer-ove-ui',
+            'version': '4.20',
+            'konflux': {
+                'image_repo': 'quay.io/redhat-user-workloads/ocp-agent-based-installer-tenant/ove-ui-iso',
+            },
+        }
+
+        pipeline = BuildLayeredProductsPipeline(
+            runtime=self.runtime,
+            group='installer-ove-ui-4.20',
+            version='4.20',
+            assembly='stream',
+            image_list='art-agent-installer-iso',
+            data_path='https://github.com/openshift-eng/ocp-build-data',
+            skip_bundle_build=True,
+            skip_rebase=True,
+        )
+
+        await pipeline.run()
+
+        build_cmd = mock_cmd.call_args[0][0]
+        image_repo_args = [arg for arg in build_cmd if arg.startswith('--image-repo=')]
+        self.assertEqual(len(image_repo_args), 1)
+        self.assertEqual(
+            image_repo_args[0],
+            '--image-repo=quay.io/redhat-user-workloads/ocp-agent-based-installer-tenant/ove-ui-iso',
+        )
+
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.init_jenkins')
+    @patch('pyartcd.pipelines.build_layered_products.load_group_config')
+    @patch('pyartcd.pipelines.build_layered_products.exectools.cmd_assert_async', new_callable=AsyncMock)
+    @patch(
+        'pyartcd.pipelines.build_layered_products.resolve_konflux_kubeconfig_by_product',
+        return_value='/path/to/kubeconfig',
+    )
+    @patch('pyartcd.pipelines.build_layered_products.resolve_konflux_namespace_by_product', return_value='test-ns')
+    async def test_image_repo_falls_back_to_default(
+        self, mock_resolve_ns, mock_resolve_kube, mock_cmd, mock_load_config, mock_jenkins
+    ):
+        """When group config does not have konflux.image_repo, fall back to KONFLUX_DEFAULT_IMAGE_REPO."""
+        mock_load_config.return_value = {
+            'product': 'ocp',
+            'version': '4.18',
+        }
+
+        pipeline = BuildLayeredProductsPipeline(
+            runtime=self.runtime,
+            group='openshift-4.18',
+            version='4.18',
+            assembly='stream',
+            image_list='some-image',
+            data_path='https://github.com/openshift-eng/ocp-build-data',
+            skip_bundle_build=True,
+            skip_rebase=True,
+        )
+
+        await pipeline.run()
+
+        build_cmd = mock_cmd.call_args[0][0]
+        image_repo_args = [arg for arg in build_cmd if arg.startswith('--image-repo=')]
+        self.assertEqual(len(image_repo_args), 1)
+        self.assertEqual(image_repo_args[0], f'--image-repo={KONFLUX_DEFAULT_IMAGE_REPO}')


### PR DESCRIPTION
## Summary

Support building `art-agent-installer-iso` on Konflux by adding configurable build parameters, a generic task-skipping mechanism, and RPM extraction bypass for non-RPM images.

Group config: https://github.com/openshift-eng/ocp-build-data/blob/installer-ove-ui-4.21/group.yml

## Key Architectural Changes

### 1. `ImageBuildParams` dataclass replaces flat kwargs

All build customization parameters (`hermetic`, `sast`, `build_args`, `skip_tasks`, `workspace_storage`, etc.) are now bundled into a single `ImageBuildParams` dataclass in `konflux_client.py`. This is the **only argument** that flows through `start_pipeline_run_for_image_build` and `_new_pipelinerun_for_image_build` — no more 18+ individual kwargs.

All callers (`konflux_image_builder.py`, `konflux_fbc.py`, `konflux_olm_bundler.py`) updated.

### 2. Generic `skip_tasks` mechanism

Replaces the accumulating one-off boolean flags (`sast=False`, `skip_fips_check`) with a generic `skip_tasks: list[str]` that removes named Tekton tasks from the PipelineRun spec by name. Existing SAST/FIPS logic is unified into a single `effective_skip` set.

Sources merged at build time: CLI `--skip-task` flags + `group.yml konflux.skip_tasks` + image-level `konflux.skip_tasks`.

### 3. RPM extraction skipped for `no_shell` images

Images with `konflux.no_shell: true` (e.g. `art-agent-installer-iso`, built `FROM scratch`) have no RPMs installed. The post-build `cosign download sbom` → PURL parse step is now skipped for these images, storing empty `installed_packages`/`installed_rpms` in the DB record. Without this, builds fail with `"Could not get rpms from SBOM for arch ..."`.

### 4. New ocp-build-data `konflux.*` config fields

| Field | Scope | Effect |
|-------|-------|--------|
| `build_args` | group/image | `KEY=VALUE` list → `build-args` pipeline param |
| `additional_secret` | group/image | K8s secret name → `ADDITIONAL_SECRET` on `build-images` task |
| `privileged_nested` | group/image | Enables `PRIVILEGED_NESTED` on `build-images` task |
| `build_step_resources` | group/image | Resource requests/limits on the `build` step (memory, ephemeral-storage) |
| `workspace_storage` | group/image | PVC size for workspace volume (large builds needing disk > ephemeral) |
| `skip_tasks` | group/image | List of Tekton task names to remove from PipelineRun |

All fields support image-level override of group-level values via `_get_konflux_config()` helper.

### 5. Rebaser fixes for `FROM scratch` images

- `no_shell` guard added to yum repo cleanup block (prevents `fork/exec /bin/sh` errors)
- Null-check on `final_stage_user` before `.split()` (prevents `AttributeError` when no USER directive)

## Test plan

- [x] All backend unit tests pass (278 tests)
- [x] `test_build_layered_products.py` passes
- [x] Ruff lint clean
- [x] Verify with a real layered-products build using the `installer-ove-ui` group