### PR TITLE
Auto-detect package manager for module enablement commands

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1163,12 +1163,55 @@ class KonfluxRebaser:
         self._logger.info(f"Found required {artifact_type} artifact: {matching_artifact}")
         return matching_artifact
 
-    def _get_module_enablement_commands(self, metadata: ImageMetadata, previous_lines: List[str] = None) -> List[str]:
+    def _detect_package_manager_from_dockerfile(self, dfp: DockerfileParser) -> str:
         """
-        Generate DNF module enable commands for RHEL 9+ images with lockfile modules.
+        Detect which package manager is used in the Dockerfile.
+
+        Scans RUN instructions for microdnf or dnf commands. If both are found
+        (e.g., in multistage builds with different package managers), defaults to dnf
+        with a warning.
+
+        Returns:
+            str: 'microdnf' if only microdnf is found, otherwise 'dnf'
+        """
+        has_microdnf = False
+        has_dnf = False
+
+        for instruction in dfp.structure:
+            if instruction['instruction'] == 'RUN':
+                value = instruction['value']
+                if re.search(r'\bmicrodnf\b', value):
+                    has_microdnf = True
+                if re.search(r'\bdnf\b', value):
+                    has_dnf = True
+
+        if has_microdnf and has_dnf:
+            self._logger.warning(
+                "Both dnf and microdnf detected in multistage build. "
+                "Defaulting to 'dnf module enable'. "
+                "Set dnf_modules_enable: false if module enablement fails in microdnf-only stages."
+            )
+            return 'dnf'
+
+        if has_microdnf:
+            self._logger.info("Detected microdnf usage in Dockerfile, will use 'microdnf module enable'")
+            return 'microdnf'
+
+        # Default to dnf (standard for EL9+)
+        self._logger.info("No microdnf detected in Dockerfile, defaulting to 'dnf module enable'")
+        return 'dnf'
+
+    def _get_module_enablement_commands(
+        self, metadata: ImageMetadata, dfp: DockerfileParser, previous_lines: List[str] = None
+    ) -> List[str]:
+        """
+        Generate module enable commands for RHEL 9+ images with lockfile modules.
+
+        Detects the package manager used in the Dockerfile and generates appropriate module enable commands.
 
         Args:
             metadata: ImageMetadata for the image being processed
+            dfp: DockerfileParser instance to detect package manager
             previous_lines: List of previous Dockerfile lines to check for existing USER 0
 
         Returns:
@@ -1177,9 +1220,9 @@ class KonfluxRebaser:
         if not metadata.is_lockfile_generation_enabled():
             return []
 
-        # Check if DNF module enablement is disabled
+        # Check if module enablement is disabled
         if not metadata.is_dnf_modules_enable_enabled():
-            self._logger.info(f"DNF module enablement disabled for {metadata.distgit_key}")
+            self._logger.info(f"Module enablement disabled for {metadata.distgit_key}")
             return []
 
         try:
@@ -1196,6 +1239,9 @@ class KonfluxRebaser:
         modules_list = ' '.join(sorted(modules_to_install))
         self._logger.info(f"Enabling modules for {metadata.distgit_key}: {modules_list}")
 
+        # Detect which package manager to use
+        pkg_manager = self._detect_package_manager_from_dockerfile(dfp)
+
         # Check if USER 0 was already added in recent lines
         user_zero_needed = True
         if previous_lines:
@@ -1210,7 +1256,7 @@ class KonfluxRebaser:
         commands = []
         if user_zero_needed:
             commands.append("USER 0")
-        commands.append(f"RUN dnf module enable -y {modules_list}")
+        commands.append(f"RUN {pkg_manager} module enable -y {modules_list}")
 
         return commands
 
@@ -1412,7 +1458,7 @@ class KonfluxRebaser:
                 "ENV HTTPS_PROXY='http://127.0.0.1:9999'",
             ]
 
-        module_enable_commands = self._get_module_enablement_commands(metadata, konflux_lines)
+        module_enable_commands = self._get_module_enablement_commands(metadata, dfp, konflux_lines)
         if module_enable_commands:
             konflux_lines.extend(module_enable_commands)
 

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1220,10 +1220,27 @@ class KonfluxRebaser:
         """
         has_microdnf = False
         has_dnf = False
+        lines = dfp.lines
 
         for instruction in dfp.structure:
             if instruction['instruction'] == 'RUN':
                 value = instruction.get('value') or ""
+
+                # Handle heredoc RUN instructions (e.g., RUN <<EOF ... EOF)
+                delim = self._heredoc_delimiter(value)
+                if delim:
+                    startline = instruction.get("startline", 0)
+                    full_run, endline = self._extract_heredoc_run_from_lines(lines, startline, delim)
+                    if full_run is None:
+                        self._logger.warning(
+                            "Could not find closing heredoc delimiter %s for RUN at line %s",
+                            delim,
+                            startline + 1,
+                        )
+                        continue
+                    value = full_run
+
+                # Extract command names from RUN instruction
                 for cmd_name in self._iter_run_command_names(value):
                     if re.search(r'(^|/)microdnf$', cmd_name):
                         has_microdnf = True

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1163,6 +1163,50 @@ class KonfluxRebaser:
         self._logger.info(f"Found required {artifact_type} artifact: {matching_artifact}")
         return matching_artifact
 
+    def _iter_run_command_names(self, cmd: str):
+        """
+        Yield command names from a RUN instruction value.
+
+        Parses the shell command and yields only the command executables,
+        not arguments or package names.
+
+        Args:
+            cmd: RUN instruction value (shell command)
+
+        Yields:
+            Command names (e.g., 'microdnf', 'dnf')
+        """
+        # Build a list of command nodes from the AST
+        cmd_nodes = []
+
+        def append_nodes_from(node):
+            if node.kind in ["list", "compound"]:
+                sublist = node.parts if node.kind == "list" else node.list
+                for subnode in sublist:
+                    append_nodes_from(subnode)
+            elif node.kind == "command":
+                cmd_nodes.append(node)
+
+        # Remove dockerfile directive options that bashlex doesn't parse (e.g "RUN --mount=foobar")
+        for word in cmd.split():
+            if word.startswith("--"):
+                cmd = cmd.replace(word, "")
+            else:
+                break
+
+        try:
+            append_nodes_from(bashlex.parse(cmd)[0])
+        except bashlex.errors.ParsingError:
+            # If we can't parse, skip this RUN instruction
+            return
+
+        # Yield first word (command name) from each command node
+        for subcmd in cmd_nodes:
+            if subcmd.parts:
+                cmd_name = getattr(subcmd.parts[0], "word", None)
+                if cmd_name:
+                    yield cmd_name
+
     def _detect_package_manager_from_dockerfile(self, dfp: DockerfileParser) -> str:
         """
         Detect which package manager is used in the Dockerfile.
@@ -1179,11 +1223,12 @@ class KonfluxRebaser:
 
         for instruction in dfp.structure:
             if instruction['instruction'] == 'RUN':
-                value = instruction['value']
-                if re.search(r'\bmicrodnf\b', value):
-                    has_microdnf = True
-                if re.search(r'\bdnf\b', value):
-                    has_dnf = True
+                value = instruction.get('value') or ""
+                for cmd_name in self._iter_run_command_names(value):
+                    if re.search(r'(^|/)microdnf$', cmd_name):
+                        has_microdnf = True
+                    elif re.search(r'(^|/)dnf$', cmd_name):
+                        has_dnf = True
 
         if has_microdnf and has_dnf:
             self._logger.warning(

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -843,6 +843,44 @@ USER 3000
             "Expected warning about mixed package managers",
         )
 
+    def test_get_module_enablement_commands_microdnf_with_dnf_package(self):
+        """Test _get_module_enablement_commands correctly detects microdnf when dnf appears only as package name"""
+        rebaser = KonfluxRebaser(
+            runtime=MagicMock(), base_dir=Path("/tmp"), source_resolver=MagicMock(), repo_type="test"
+        )
+        rebaser._logger = MagicMock()
+
+        mock_metadata = MagicMock()
+        mock_metadata.distgit_key = "test-image"
+        mock_metadata.is_lockfile_generation_enabled.return_value = True
+        mock_metadata.is_dnf_modules_enable_enabled.return_value = True
+        mock_metadata.branch_el_target.return_value = 9
+        mock_metadata.get_lockfile_modules_to_install.return_value = {"postgresql:15"}
+
+        # Create mock DockerfileParser with microdnf installing dnf-plugins-core package
+        # This should NOT trigger "both detected" warning
+        mock_dfp = MagicMock()
+        mock_dfp.structure = [
+            {'instruction': 'FROM', 'value': 'ubi9-minimal'},
+            {'instruction': 'RUN', 'value': 'microdnf install -y dnf-plugins-core'},
+        ]
+
+        result = rebaser._get_module_enablement_commands(mock_metadata, mock_dfp)
+
+        # Should use microdnf (not dnf) since dnf appears only as package name
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], "USER 0")
+        self.assertIn("RUN microdnf module enable -y", result[1])
+        self.assertIn("postgresql:15", result[1])
+
+        # Should NOT have logged a warning about mixed package managers
+        if rebaser._logger.warning.called:
+            log_calls = [call[0][0] for call in rebaser._logger.warning.call_args_list]
+            self.assertFalse(
+                any("Both dnf and microdnf detected" in msg for msg in log_calls),
+                "Should not warn about mixed package managers when 'dnf' is only a package name",
+            )
+
     def test_make_actual_release_string_ocp_with_el_suffix(self):
         """Test _make_actual_release_string uses el# suffix for OCP builds"""
         from artcommonlib.variants import BuildVariant

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -3,7 +3,7 @@ import re
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import semver
 from artcommonlib.model import Missing, Model
@@ -880,6 +880,7 @@ USER 3000
                 any("Both dnf and microdnf detected" in msg for msg in log_calls),
                 "Should not warn about mixed package managers when 'dnf' is only a package name",
             )
+
 
     def test_make_actual_release_string_ocp_with_el_suffix(self):
         """Test _make_actual_release_string uses el# suffix for OCP builds"""

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -585,13 +585,16 @@ USER 3000
         mock_metadata.is_lockfile_generation_enabled.return_value = True
         mock_metadata.is_dnf_modules_enable_enabled.return_value = False
 
-        result = rebaser._get_module_enablement_commands(mock_metadata)
+        # Create mock DockerfileParser
+        mock_dfp = MagicMock()
+
+        result = rebaser._get_module_enablement_commands(mock_metadata, mock_dfp)
 
         # Should return empty list
         self.assertEqual(result, [])
 
         # Should log that module enablement is disabled
-        rebaser._logger.info.assert_called_once_with("DNF module enablement disabled for test-image")
+        rebaser._logger.info.assert_called_once_with("Module enablement disabled for test-image")
 
         # Should not call other metadata methods since we returned early
         mock_metadata.branch_el_target.assert_not_called()
@@ -612,7 +615,14 @@ USER 3000
         mock_metadata.branch_el_target.return_value = 9  # RHEL 9
         mock_metadata.get_lockfile_modules_to_install.return_value = {"postgresql:15", "maven:3.8"}
 
-        result = rebaser._get_module_enablement_commands(mock_metadata)
+        # Create mock DockerfileParser with dnf usage
+        mock_dfp = MagicMock()
+        mock_dfp.structure = [
+            {'instruction': 'FROM', 'value': 'ubi9'},
+            {'instruction': 'RUN', 'value': 'dnf install -y something'},
+        ]
+
+        result = rebaser._get_module_enablement_commands(mock_metadata, mock_dfp)
 
         # Should return command list with USER 0 + RUN command
         self.assertEqual(len(result), 2)
@@ -622,9 +632,7 @@ USER 3000
         self.assertIn("postgresql:15", result[1])
 
         # Should log the modules being enabled
-        rebaser._logger.info.assert_called_once()
-        log_message = rebaser._logger.info.call_args[0][0]
-        self.assertIn("Enabling modules for test-image", log_message)
+        self.assertGreaterEqual(rebaser._logger.info.call_count, 2)  # At least module enable + pkg manager detection
 
         # Should have called all metadata methods
         mock_metadata.is_dnf_modules_enable_enabled.assert_called_once()
@@ -645,9 +653,13 @@ USER 3000
         mock_metadata.branch_el_target.return_value = 9
         mock_metadata.get_lockfile_modules_to_install.return_value = {"postgresql:15"}
 
+        # Create mock DockerfileParser
+        mock_dfp = MagicMock()
+        mock_dfp.structure = [{'instruction': 'RUN', 'value': 'dnf install -y something'}]
+
         # Previous lines contain USER 0
         previous_lines = ["ENV TEST=1", "USER 0", "RUN something"]
-        result = rebaser._get_module_enablement_commands(mock_metadata, previous_lines)
+        result = rebaser._get_module_enablement_commands(mock_metadata, mock_dfp, previous_lines)
 
         # Should NOT include USER 0 again
         self.assertEqual(len(result), 1)
@@ -668,9 +680,13 @@ USER 3000
         mock_metadata.branch_el_target.return_value = 9
         mock_metadata.get_lockfile_modules_to_install.return_value = {"postgresql:15"}
 
+        # Create mock DockerfileParser
+        mock_dfp = MagicMock()
+        mock_dfp.structure = [{'instruction': 'RUN', 'value': 'dnf install -y something'}]
+
         # Previous lines contain different USER
         previous_lines = ["ENV TEST=1", "USER 1001", "RUN something"]
-        result = rebaser._get_module_enablement_commands(mock_metadata, previous_lines)
+        result = rebaser._get_module_enablement_commands(mock_metadata, mock_dfp, previous_lines)
 
         # Should include USER 0 since current user is not root
         self.assertEqual(len(result), 2)
@@ -691,9 +707,13 @@ USER 3000
         mock_metadata.branch_el_target.return_value = 9
         mock_metadata.get_lockfile_modules_to_install.return_value = {"postgresql:15"}
 
+        # Create mock DockerfileParser
+        mock_dfp = MagicMock()
+        mock_dfp.structure = [{'instruction': 'RUN', 'value': 'dnf install -y something'}]
+
         # Previous lines contain USER 0 then USER 1001 (most recent)
         previous_lines = ["ENV TEST=1", "USER 0", "RUN something", "USER 1001"]
-        result = rebaser._get_module_enablement_commands(mock_metadata, previous_lines)
+        result = rebaser._get_module_enablement_commands(mock_metadata, mock_dfp, previous_lines)
 
         # Should include USER 0 since current user is 1001 (not root)
         self.assertEqual(len(result), 2)
@@ -714,8 +734,12 @@ USER 3000
         mock_metadata.branch_el_target.return_value = 9
         mock_metadata.get_lockfile_modules_to_install.return_value = {"postgresql:15"}
 
+        # Create mock DockerfileParser
+        mock_dfp = MagicMock()
+        mock_dfp.structure = [{'instruction': 'RUN', 'value': 'dnf install -y something'}]
+
         # No previous lines provided (None)
-        result = rebaser._get_module_enablement_commands(mock_metadata, None)
+        result = rebaser._get_module_enablement_commands(mock_metadata, mock_dfp, None)
 
         # Should include USER 0 by default
         self.assertEqual(len(result), 2)
@@ -736,13 +760,88 @@ USER 3000
         mock_metadata.branch_el_target.return_value = 9
         mock_metadata.get_lockfile_modules_to_install.return_value = {"postgresql:15"}
 
+        # Create mock DockerfileParser
+        mock_dfp = MagicMock()
+        mock_dfp.structure = [{'instruction': 'RUN', 'value': 'dnf install -y something'}]
+
         # Empty previous lines list
-        result = rebaser._get_module_enablement_commands(mock_metadata, [])
+        result = rebaser._get_module_enablement_commands(mock_metadata, mock_dfp, [])
 
         # Should include USER 0 by default
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0], "USER 0")
         self.assertIn("RUN dnf module enable -y", result[1])
+
+    def test_get_module_enablement_commands_with_microdnf(self):
+        """Test _get_module_enablement_commands detects microdnf and uses it for module enable"""
+        rebaser = KonfluxRebaser(
+            runtime=MagicMock(), base_dir=Path("/tmp"), source_resolver=MagicMock(), repo_type="test"
+        )
+        rebaser._logger = MagicMock()
+
+        mock_metadata = MagicMock()
+        mock_metadata.distgit_key = "test-image"
+        mock_metadata.is_lockfile_generation_enabled.return_value = True
+        mock_metadata.is_dnf_modules_enable_enabled.return_value = True
+        mock_metadata.branch_el_target.return_value = 9
+        mock_metadata.get_lockfile_modules_to_install.return_value = {"postgresql:15"}
+
+        # Create mock DockerfileParser with microdnf usage only
+        mock_dfp = MagicMock()
+        mock_dfp.structure = [
+            {'instruction': 'FROM', 'value': 'ubi9-minimal'},
+            {'instruction': 'RUN', 'value': 'microdnf install -y something'},
+        ]
+
+        result = rebaser._get_module_enablement_commands(mock_metadata, mock_dfp)
+
+        # Should return command list with microdnf (not dnf)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], "USER 0")
+        self.assertIn("RUN microdnf module enable -y", result[1])
+        self.assertIn("postgresql:15", result[1])
+
+        # Should have logged microdnf detection
+        log_calls = [call[0][0] for call in rebaser._logger.info.call_args_list]
+        self.assertTrue(any("microdnf" in msg for msg in log_calls))
+
+    def test_get_module_enablement_commands_with_mixed_package_managers(self):
+        """Test _get_module_enablement_commands handles multistage builds with both dnf and microdnf"""
+        rebaser = KonfluxRebaser(
+            runtime=MagicMock(), base_dir=Path("/tmp"), source_resolver=MagicMock(), repo_type="test"
+        )
+        rebaser._logger = MagicMock()
+
+        mock_metadata = MagicMock()
+        mock_metadata.distgit_key = "test-image"
+        mock_metadata.is_lockfile_generation_enabled.return_value = True
+        mock_metadata.is_dnf_modules_enable_enabled.return_value = True
+        mock_metadata.branch_el_target.return_value = 9
+        mock_metadata.get_lockfile_modules_to_install.return_value = {"postgresql:15"}
+
+        # Create mock DockerfileParser with BOTH dnf and microdnf (multistage build)
+        mock_dfp = MagicMock()
+        mock_dfp.structure = [
+            {'instruction': 'FROM', 'value': 'ubi9 AS builder'},
+            {'instruction': 'RUN', 'value': 'dnf install -y gcc'},
+            {'instruction': 'FROM', 'value': 'ubi9-minimal'},
+            {'instruction': 'RUN', 'value': 'microdnf install -y something'},
+        ]
+
+        result = rebaser._get_module_enablement_commands(mock_metadata, mock_dfp)
+
+        # Should default to dnf when both are present
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], "USER 0")
+        self.assertIn("RUN dnf module enable -y", result[1])
+        self.assertIn("postgresql:15", result[1])
+
+        # Should have logged a warning about mixed package managers
+        log_calls = [call[0][0] for call in rebaser._logger.warning.call_args_list]
+        self.assertTrue(
+            any("Both dnf and microdnf detected" in msg for msg in log_calls),
+            "Expected warning about mixed package managers",
+        )
 
     def test_make_actual_release_string_ocp_with_el_suffix(self):
         """Test _make_actual_release_string uses el# suffix for OCP builds"""


### PR DESCRIPTION
Previously, module enablement commands were hardcoded to use 'dnf', which would fail on images using only 'microdnf' (e.g., ubi9-minimal based images or images with dnf→microdnf replacements via content.source.modifications in ocp-build-data).

  Changes:
  - Added _detect_package_manager_from_dockerfile() to scan RUN instructions and detect microdnf or dnf usage
  - Detection happens after content.source.modifications are applied, ensuring modified Dockerfiles are correctly detected
  - Handles three scenarios:
    1. Pure microdnf builds: Uses 'microdnf module enable'
    2. Pure dnf builds: Uses 'dnf module enable' (default)
    3. Mixed multistage builds: Defaults to 'dnf' with warning

For mixed builds where different stages use different package managers, the warning directs users to set 'dnf_modules_enable: false' in ocp-build-data if module enablement fails.

Signed-off-by: Franco Bladilo <fbladilo@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED