### PR TITLE
ART-14467 Derive release/image stream names from group major version for OCP5

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -639,19 +639,25 @@ class PromotePipeline:
 
         await self._slack_client.say_in_thread(f":white_check_mark: promote completed for {release_name}.")
 
-    @staticmethod
-    def _get_release_stream_name(assembly_type: AssemblyTypes, arch: str):
+    def _get_release_stream_name(self, assembly_type: AssemblyTypes, arch: str):
+        major, _ = isolate_major_minor_in_group(self.group)
+        if major is None:
+            raise ValueError(f"Cannot determine major version from group name: {self.group}")
         go_arch_suffix = go_suffix_for_arch(arch)
-        return (
-            f'4-dev-preview{go_arch_suffix}' if assembly_type == AssemblyTypes.PREVIEW else f'4-stable{go_arch_suffix}'
-        )
+        if assembly_type == AssemblyTypes.PREVIEW:
+            return f'{major}-dev-preview{go_arch_suffix}'
+        return f'{major}-stable{go_arch_suffix}'
 
-    @staticmethod
-    def _get_image_stream_name(assembly_type: AssemblyTypes, arch: str):
+    def _get_image_stream_name(self, assembly_type: AssemblyTypes, arch: str):
+        major, _ = isolate_major_minor_in_group(self.group)
+        if major is None:
+            raise ValueError(f"Cannot determine major version from group name: {self.group}")
         go_arch_suffix = go_suffix_for_arch(arch)
-        return (
-            f'4-dev-preview{go_arch_suffix}' if assembly_type == AssemblyTypes.PREVIEW else f'release{go_arch_suffix}'
-        )
+        if assembly_type == AssemblyTypes.PREVIEW:
+            return f'{major}-dev-preview{go_arch_suffix}'
+        if major >= 5:
+            return f'release-{major}{go_arch_suffix}'
+        return f'release{go_arch_suffix}'
 
     def send_promote_complete_email(self, name, release_infos):
         content = "PullSpecs: \n"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ART-14467

The promote pipeline hardcoded '4' in release stream and ImageStream names (4-stable, 4-dev-preview, release). For OCP5, these should use 5-stable, 5-dev-preview, and [release-5](https://redhat.atlassian.net/browse/release-5) respectively.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED