### PR TITLE
Add Tekton pipeline chaining for layered operator builds

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/layered-products-scan/cronjob.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/layered-products-scan/cronjob.yaml
@@ -1,0 +1,27 @@
+kind: CronJob
+apiVersion: batch/v1
+metadata:
+  name: schedule-layered-products-scan-cron
+spec:
+  schedule: "*/30 * * * *"
+  suspend: true
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: schedule-scan
+              image: 'image-registry.openshift-image-registry.svc:5000/art-cd/art-cd:latest'
+              command:
+                - tkn
+                - pipeline
+                - start
+                - schedule-layered-products-scan
+                - '--pipeline-timeout'
+                - 30m
+              imagePullPolicy: Always
+          restartPolicy: OnFailure
+          serviceAccountName: pipeline
+  successfulJobsHistoryLimit: 10
+  failedJobsHistoryLimit: 10

--- a/artcommon/artcommonlib/dotconfig.py
+++ b/artcommon/artcommonlib/dotconfig.py
@@ -92,7 +92,8 @@ class Config(object):
         self._data = defaults
         with open(self.full_path, 'r') as f:
             data = yaml.full_load(f)
-            self._data.update(data)
+            if data:
+                self._data.update(data)
             # load envvars if given and override
             for k, v in envvars.items():
                 if v in os.environ:

--- a/artcommon/artcommonlib/exectools.py
+++ b/artcommon/artcommonlib/exectools.py
@@ -34,6 +34,7 @@ from tenacity import stop_after_attempt, wait_fixed
 SUCCESS = 0
 
 logger = logutil.get_logger(__name__)
+
 TRACER = trace.get_tracer(__name__)
 
 _SENSITIVE_ENV_KEY_PATTERNS = frozenset({'PASSWORD', 'TOKEN', 'SECRET', 'KEY', 'CREDENTIAL'})

--- a/artcommon/artcommonlib/exectools.py
+++ b/artcommon/artcommonlib/exectools.py
@@ -37,6 +37,7 @@ from tenacity import stop_after_attempt, wait_fixed
 SUCCESS = 0
 
 logger = logutil.get_logger(__name__)
+
 TRACER = trace.get_tracer(__name__)
 
 _SENSITIVE_ENV_KEY_PATTERNS = frozenset({'PASSWORD', 'TOKEN', 'SECRET', 'KEY', 'CREDENTIAL'})

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -656,6 +656,15 @@ async def get_konflux_data(pullspec: str, mode: str = "attestation", registry_au
     if registry_auth_file:
         LOGGER.debug("Using registry auth file: %s", registry_auth_file)
         env["REGISTRY_AUTH_FILE"] = registry_auth_file
+        # cosign uses Docker credential store, not REGISTRY_AUTH_FILE (which is a containers/podman convention).
+        # Set DOCKER_CONFIG to a directory containing the auth file as config.json.
+        auth_path = Path(registry_auth_file)
+        if auth_path.is_file():
+            docker_config_dir = auth_path.parent
+            if auth_path.name != "config.json":
+                docker_config_dir = Path(tempfile.mkdtemp(prefix="cosign-docker-config-"))
+                (docker_config_dir / "config.json").symlink_to(auth_path.resolve())
+            env["DOCKER_CONFIG"] = str(docker_config_dir)
     _, out, _ = await cmd_gather_async(cmd, env=env)
 
     return out.strip()

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -771,6 +771,15 @@ async def get_konflux_data(pullspec: str, mode: str = "attestation", registry_au
     if registry_auth_file:
         LOGGER.debug("Using registry auth file: %s", registry_auth_file)
         env["REGISTRY_AUTH_FILE"] = registry_auth_file
+        # cosign uses Docker credential store, not REGISTRY_AUTH_FILE (which is a containers/podman convention).
+        # Set DOCKER_CONFIG to a directory containing the auth file as config.json.
+        auth_path = Path(registry_auth_file)
+        if auth_path.is_file():
+            docker_config_dir = auth_path.parent
+            if auth_path.name != "config.json":
+                docker_config_dir = Path(tempfile.mkdtemp(prefix="cosign-docker-config-"))
+                (docker_config_dir / "config.json").symlink_to(auth_path.resolve())
+            env["DOCKER_CONFIG"] = str(docker_config_dir)
     _, out, _ = await cmd_gather_async(cmd, env=env)
 
     return out.strip()

--- a/artcommon/tests/test_exectools.py
+++ b/artcommon/tests/test_exectools.py
@@ -234,6 +234,20 @@ class TestExectools(IsolatedAsyncioTestCase):
         results = results.get()
         self.assertEqual(results, items)
 
+    def test_cmd_gather_redacts_env_in_logs(self):
+        with mock.patch("subprocess.Popen") as MockPopen:
+            mock_popen = MockPopen.return_value
+            mock_popen.communicate.return_value = (b"ok\n", b"")
+            mock_popen.returncode = 0
+
+            sensitive_env = {'GIT_PASSWORD': 'ghs_supersecret123', 'LANG': 'en_US'}
+            with self.assertLogs(level=logging.DEBUG) as cm:
+                exectools.cmd_gather(["/usr/bin/echo", "hi"], set_env=sensitive_env, timeout=3000)
+                log_text = "\n".join(cm.output)
+                self.assertNotIn('ghs_supersecret123', log_text)
+                self.assertIn('***', log_text)
+                self.assertIn('en_US', log_text)
+
     async def test_limit_concurrency(self):
         """Test that limit_concurrency actually limits concurrent execution"""
         concurrent_count = 0

--- a/artcommon/tests/test_exectools.py
+++ b/artcommon/tests/test_exectools.py
@@ -450,6 +450,20 @@ class TestExectools(IsolatedAsyncioTestCase):
         results = results.get()
         self.assertEqual(results, items)
 
+    def test_cmd_gather_redacts_env_in_logs(self):
+        with mock.patch("subprocess.Popen") as MockPopen:
+            mock_popen = MockPopen.return_value
+            mock_popen.communicate.return_value = (b"ok\n", b"")
+            mock_popen.returncode = 0
+
+            sensitive_env = {'GIT_PASSWORD': 'ghs_supersecret123', 'LANG': 'en_US'}
+            with self.assertLogs(level=logging.DEBUG) as cm:
+                exectools.cmd_gather(["/usr/bin/echo", "hi"], set_env=sensitive_env, timeout=3000)
+                log_text = "\n".join(cm.output)
+                self.assertNotIn('ghs_supersecret123', log_text)
+                self.assertIn('***', log_text)
+                self.assertIn('en_US', log_text)
+
     async def test_limit_concurrency(self):
         """Test that limit_concurrency actually limits concurrent execution"""
         concurrent_count = 0

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -87,7 +87,7 @@ class BuildLayeredProductsPipeline:
                     operator_nvrs.append(record['nvrs'].split(',')[0])
             if operator_nvrs:
                 if tekton.is_tekton_context():
-                    tekton.start_pipeline_run(
+                    created_name = tekton.start_pipeline_run(
                         pipeline_name="olm-bundle-konflux",
                         params={
                             "version": self.version,
@@ -98,6 +98,10 @@ class BuildLayeredProductsPipeline:
                             "data-gitref": self.data_gitref or '',
                         },
                     )
+                    if created_name:
+                        tekton.annotate_current_pipelinerun({
+                            "art.openshift.io/triggered-olm-bundle-konflux": created_name,
+                        })
                 else:
                     propagate_params = jenkins.get_propagatable_params()
                     jenkins.start_olm_bundle_konflux(

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -11,7 +11,7 @@ from artcommonlib.constants import PRODUCT_KUBECONFIG_MAP
 from artcommonlib.util import resolve_konflux_kubeconfig_by_product, resolve_konflux_namespace_by_product
 from doozerlib.constants import KONFLUX_DEFAULT_IMAGE_REPO
 
-from pyartcd import constants, jenkins, locks
+from pyartcd import constants, jenkins, locks, tekton
 from pyartcd import record as record_util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.locks import Lock
@@ -64,9 +64,10 @@ class BuildLayeredProductsPipeline:
         if data_path:
             self._doozer_env_vars["DOOZER_DATA_PATH"] = data_path
 
-        jenkins.init_jenkins()
-        if self.assembly.lower() == "test":
-            jenkins.update_title(" [TEST]")
+        if not tekton.is_tekton_context():
+            jenkins.init_jenkins()
+            if self.assembly.lower() == "test":
+                jenkins.update_title(" [TEST]")
 
     def trigger_bundle_build(self):
         if self.skip_bundle_build:
@@ -85,18 +86,29 @@ class BuildLayeredProductsPipeline:
                 if record['has_olm_bundle'] == '1' and record['status'] == '0' and record.get('nvrs', None):
                     operator_nvrs.append(record['nvrs'].split(',')[0])
             if operator_nvrs:
-                # Automatically propagate parameters if set in environment
-                propagate_params = jenkins.get_propagatable_params()
-
-                jenkins.start_olm_bundle_konflux(
-                    build_version=self.version,
-                    assembly=self.assembly,
-                    group=self.group,
-                    operator_nvrs=operator_nvrs,
-                    doozer_data_path=self._doozer_env_vars["DOOZER_DATA_PATH"] or '',
-                    doozer_data_gitref=self.data_gitref or '',
-                    propagate_params=propagate_params,
-                )
+                if tekton.is_tekton_context():
+                    tekton.start_pipeline_run(
+                        pipeline_name="olm-bundle-konflux",
+                        params={
+                            "version": self.version,
+                            "assembly": self.assembly,
+                            "group": self.group,
+                            "operator-nvrs": ",".join(operator_nvrs),
+                            "data-path": self._doozer_env_vars["DOOZER_DATA_PATH"] or '',
+                            "data-gitref": self.data_gitref or '',
+                        },
+                    )
+                else:
+                    propagate_params = jenkins.get_propagatable_params()
+                    jenkins.start_olm_bundle_konflux(
+                        build_version=self.version,
+                        assembly=self.assembly,
+                        group=self.group,
+                        operator_nvrs=operator_nvrs,
+                        doozer_data_path=self._doozer_env_vars["DOOZER_DATA_PATH"] or '',
+                        doozer_data_gitref=self.data_gitref or '',
+                        propagate_params=propagate_params,
+                    )
         except Exception as e:
             self._logger.exception(f"Failed to trigger bundle build: {e}")
 

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -95,7 +95,7 @@ class BuildLayeredProductsPipeline:
                     operator_nvrs.append(record['nvrs'].split(',')[0])
             if operator_nvrs:
                 if tekton.is_tekton_context():
-                    tekton.start_pipeline_run(
+                    created_name = tekton.start_pipeline_run(
                         pipeline_name="olm-bundle-konflux",
                         params={
                             "version": self.version,
@@ -106,6 +106,10 @@ class BuildLayeredProductsPipeline:
                             "data-gitref": self.data_gitref or '',
                         },
                     )
+                    if created_name:
+                        tekton.annotate_current_pipelinerun({
+                            "art.openshift.io/triggered-olm-bundle-konflux": created_name,
+                        })
                 else:
                     propagate_params = jenkins.get_propagatable_params()
                     jenkins.start_olm_bundle_konflux(

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -11,7 +11,7 @@ from artcommonlib.constants import PRODUCT_KUBECONFIG_MAP
 from artcommonlib.util import resolve_konflux_kubeconfig_by_product, resolve_konflux_namespace_by_product
 from doozerlib.constants import KONFLUX_DEFAULT_IMAGE_REPO
 
-from pyartcd import constants, jenkins, locks
+from pyartcd import constants, jenkins, locks, tekton
 from pyartcd import record as record_util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.locks import Lock
@@ -72,9 +72,10 @@ class BuildLayeredProductsPipeline:
         if data_path:
             self._doozer_env_vars["DOOZER_DATA_PATH"] = data_path
 
-        jenkins.init_jenkins()
-        if self.assembly.lower() == "test":
-            jenkins.update_title(" [TEST]")
+        if not tekton.is_tekton_context():
+            jenkins.init_jenkins()
+            if self.assembly.lower() == "test":
+                jenkins.update_title(" [TEST]")
 
     def trigger_bundle_build(self):
         if self.skip_bundle_build:
@@ -93,18 +94,29 @@ class BuildLayeredProductsPipeline:
                 if record['has_olm_bundle'] == '1' and record['status'] == '0' and record.get('nvrs', None):
                     operator_nvrs.append(record['nvrs'].split(',')[0])
             if operator_nvrs:
-                # Automatically propagate parameters if set in environment
-                propagate_params = jenkins.get_propagatable_params()
-
-                jenkins.start_olm_bundle_konflux(
-                    build_version=self.version,
-                    assembly=self.assembly,
-                    group=self.group,
-                    operator_nvrs=operator_nvrs,
-                    doozer_data_path=self._doozer_env_vars["DOOZER_DATA_PATH"] or '',
-                    doozer_data_gitref=self.data_gitref or '',
-                    propagate_params=propagate_params,
-                )
+                if tekton.is_tekton_context():
+                    tekton.start_pipeline_run(
+                        pipeline_name="olm-bundle-konflux",
+                        params={
+                            "version": self.version,
+                            "assembly": self.assembly,
+                            "group": self.group,
+                            "operator-nvrs": ",".join(operator_nvrs),
+                            "data-path": self._doozer_env_vars["DOOZER_DATA_PATH"] or '',
+                            "data-gitref": self.data_gitref or '',
+                        },
+                    )
+                else:
+                    propagate_params = jenkins.get_propagatable_params()
+                    jenkins.start_olm_bundle_konflux(
+                        build_version=self.version,
+                        assembly=self.assembly,
+                        group=self.group,
+                        operator_nvrs=operator_nvrs,
+                        doozer_data_path=self._doozer_env_vars["DOOZER_DATA_PATH"] or '',
+                        doozer_data_gitref=self.data_gitref or '',
+                        propagate_params=propagate_params,
+                    )
         except Exception as e:
             self._logger.exception(f"Failed to trigger bundle build: {e}")
 

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -262,6 +262,9 @@ class BuildLayeredProductsPipeline:
 
     def _update_build_description(self):
         """Update Jenkins description with build results (succeeded/failed counts and failed image names)."""
+        if tekton.is_tekton_context():
+            return
+
         record_log = self.parse_record_log()
         if not record_log:
             return

--- a/pyartcd/pyartcd/pipelines/layered_products_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/layered_products_scan_konflux.py
@@ -5,7 +5,7 @@ import click
 import yaml
 from artcommonlib import exectools
 
-from pyartcd import constants, jenkins, locks, util
+from pyartcd import constants, jenkins, locks, tekton, util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.locks import Lock
 from pyartcd.runtime import Runtime
@@ -103,7 +103,6 @@ class LayeredProductsScanPipeline:
         if not self.changes:
             return
 
-        jenkins.update_title(' [SOURCE CHANGES]')
         self.logger.info('Detected at least one updated layered product image')
 
         # Filter out images that reference disabled dependencies
@@ -126,21 +125,33 @@ class LayeredProductsScanPipeline:
             self.logger.info('No buildable images after filtering disabled dependencies')
             return
 
-        # Do NOT trigger konflux builds in dry-run mode
         if self.runtime.dry_run:
             self.logger.info('Would have triggered a layered products %s build', self.group)
             return
 
-        # Update build description
-        jenkins.update_description(f'Changed {len(image_list)} layered product images<br/>')
-
-        # Trigger layered product build
         self.logger.info('Triggering a layered products %s build', self.group)
-        jenkins.start_layered_products(
-            group=self.group,
-            assembly=self.assembly,
-            image_list=image_list,
-        )
+
+        if tekton.is_tekton_context():
+            created_name = tekton.start_pipeline_run(
+                pipeline_name="build-layered-products",
+                params={
+                    "group": self.group,
+                    "assembly": self.assembly,
+                    "image-list": ",".join(image_list) if image_list else "",
+                },
+            )
+            if created_name:
+                tekton.annotate_current_pipelinerun({
+                    "art.openshift.io/triggered-build-layered-products": created_name,
+                })
+        else:
+            jenkins.update_title(' [SOURCE CHANGES]')
+            jenkins.update_description(f'Changed {len(image_list)} layered product images<br/>')
+            jenkins.start_layered_products(
+                group=self.group,
+                assembly=self.assembly,
+                image_list=image_list,
+            )
 
 
 @cli.command('layered-products-scan')
@@ -159,9 +170,13 @@ class LayeredProductsScanPipeline:
 async def layered_products_scan(
     runtime: Runtime, group: str, assembly: str, data_path: str, data_gitref, image_list: str
 ):
-    # KUBECONFIG env var must be defined in order to scan sources
     if not os.getenv('KUBECONFIG'):
-        raise RuntimeError('Environment variable KUBECONFIG must be defined')
+        if tekton.is_tekton_context():
+            # Layered product groups don't start with 'openshift-', so doozer's
+            # RHCOS detection (the only consumer of --ci-kubeconfig) is skipped.
+            os.environ['KUBECONFIG'] = ''
+        else:
+            raise RuntimeError('Environment variable KUBECONFIG must be defined')
 
     jenkins.init_jenkins()
 

--- a/pyartcd/pyartcd/pipelines/layered_products_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/layered_products_scan_konflux.py
@@ -178,7 +178,8 @@ async def layered_products_scan(
         else:
             raise RuntimeError('Environment variable KUBECONFIG must be defined')
 
-    jenkins.init_jenkins()
+    if not tekton.is_tekton_context():
+        jenkins.init_jenkins()
 
     pipeline = LayeredProductsScanPipeline(
         runtime=runtime,

--- a/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
@@ -7,7 +7,7 @@ from artcommonlib import exectools
 from artcommonlib.constants import PRODUCT_KUBECONFIG_MAP
 from artcommonlib.util import resolve_konflux_kubeconfig_by_product, resolve_konflux_namespace_by_product
 
-from pyartcd import constants, jenkins, locks
+from pyartcd import constants, jenkins, locks, tekton
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.locks import Lock
 from pyartcd.record import parse_record_log
@@ -200,60 +200,91 @@ async def olm_bundle_konflux(
     if operator_nvrs:
         runtime.logger.info(f'Found operator NVRs: {operator_nvrs}')
 
-        # Automatically propagate parameters if set in environment
-        propagate_params = jenkins.get_propagatable_params()
+        use_tekton = tekton.is_tekton_context()
 
         # Check if this is a non-openshift group and if OCP_TARGET_VERSIONS is configured
         if group and not group.startswith("openshift-"):
             runtime.logger.info(f'Group {group} is a non-openshift group, checking for OCP_TARGET_VERSIONS')
-            # Load group config to check for OCP_TARGET_VERSIONS
             group_config = await load_group_config(
                 group=group, assembly=assembly, doozer_data_path=data_path, doozer_data_gitref=data_gitref
             )
 
-            # Check if OCP_TARGET_VERSIONS is defined in group config
             ocp_target_versions = group_config.get("OCP_TARGET_VERSIONS")
             runtime.logger.info(f'OCP_TARGET_VERSIONS from group config: {ocp_target_versions}')
 
             if ocp_target_versions:
                 runtime.logger.info(f'Starting multiple FBC jobs for target versions: {ocp_target_versions}')
-                # Generate multiple FBC jobs, one for each target version
                 for target_version in ocp_target_versions:
                     runtime.logger.info(f'Starting FBC job for target version: {target_version}')
+                    if use_tekton:
+                        tekton.start_pipeline_run(
+                            pipeline_name="build-fbc",
+                            params={
+                                "version": version,
+                                "group": group,
+                                "assembly": assembly,
+                                "operator-nvrs": ",".join(operator_nvrs),
+                                "dry-run": str(runtime.dry_run).lower(),
+                                "ocp-target-version": target_version,
+                                "force": "true",
+                            },
+                        )
+                    else:
+                        jenkins.start_build_fbc(
+                            version=version,
+                            group=group,
+                            assembly=assembly,
+                            operator_nvrs=operator_nvrs,
+                            dry_run=runtime.dry_run,
+                            ocp_target_version=target_version,
+                            force_build=True,
+                            propagate_params=jenkins.get_propagatable_params(),
+                        )
+                    await asyncio.sleep(10)
+            else:
+                runtime.logger.info(f'No OCP_TARGET_VERSIONS defined for group {group}, using original behavior')
+                if use_tekton:
+                    tekton.start_pipeline_run(
+                        pipeline_name="build-fbc",
+                        params={
+                            "version": version,
+                            "group": group,
+                            "assembly": assembly,
+                            "operator-nvrs": ",".join(operator_nvrs),
+                            "dry-run": str(runtime.dry_run).lower(),
+                        },
+                    )
+                else:
                     jenkins.start_build_fbc(
                         version=version,
                         group=group,
                         assembly=assembly,
                         operator_nvrs=operator_nvrs,
                         dry_run=runtime.dry_run,
-                        ocp_target_version=target_version,
-                        # Always force rebuild FBCs for OADP / MTA / MTC
-                        force_build=True,
-                        propagate_params=propagate_params,
+                        propagate_params=jenkins.get_propagatable_params(),
                     )
-                    await asyncio.sleep(10)
+        else:
+            runtime.logger.info(f'Group {group} does not match OADP/MTA/MTC pattern, using original behavior')
+            if use_tekton:
+                tekton.start_pipeline_run(
+                    pipeline_name="build-fbc",
+                    params={
+                        "version": version,
+                        "group": group if group else "",
+                        "assembly": assembly,
+                        "operator-nvrs": ",".join(operator_nvrs),
+                        "dry-run": str(runtime.dry_run).lower(),
+                    },
+                )
             else:
-                runtime.logger.info(f'No OCP_TARGET_VERSIONS defined for group {group}, using original behavior')
-                # No OCP_TARGET_VERSIONS defined, use original behavior
                 jenkins.start_build_fbc(
                     version=version,
-                    group=group,
+                    group=group if group else None,
                     assembly=assembly,
                     operator_nvrs=operator_nvrs,
                     dry_run=runtime.dry_run,
-                    propagate_params=propagate_params,
+                    propagate_params=jenkins.get_propagatable_params(),
                 )
-        else:
-            runtime.logger.info(f'Group {group} does not match OADP/MTA/MTC pattern, using original behavior')
-            # Not an OADP/MTA/MTC group, use original behavior
-            jenkins.start_build_fbc(
-                version=version,
-                group=group if group else None,
-                assembly=assembly,
-                operator_nvrs=operator_nvrs,
-                dry_run=runtime.dry_run,
-                propagate_params=propagate_params,
-            )
 
     if operators_with_failed_bundles and successful_bundles:
         # Partial failure - exit with code 2 to mark Jenkins job as UNSTABLE

--- a/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
@@ -217,7 +217,7 @@ async def olm_bundle_konflux(
                 for target_version in ocp_target_versions:
                     runtime.logger.info(f'Starting FBC job for target version: {target_version}')
                     if use_tekton:
-                        tekton.start_pipeline_run(
+                        created_name = tekton.start_pipeline_run(
                             pipeline_name="build-fbc",
                             params={
                                 "version": version,
@@ -229,6 +229,10 @@ async def olm_bundle_konflux(
                                 "force": "true",
                             },
                         )
+                        if created_name:
+                            tekton.annotate_current_pipelinerun({
+                                f"art.openshift.io/triggered-build-fbc-{target_version}": created_name,
+                            })
                     else:
                         jenkins.start_build_fbc(
                             version=version,
@@ -244,7 +248,7 @@ async def olm_bundle_konflux(
             else:
                 runtime.logger.info(f'No OCP_TARGET_VERSIONS defined for group {group}, using original behavior')
                 if use_tekton:
-                    tekton.start_pipeline_run(
+                    created_name = tekton.start_pipeline_run(
                         pipeline_name="build-fbc",
                         params={
                             "version": version,
@@ -254,6 +258,10 @@ async def olm_bundle_konflux(
                             "dry-run": str(runtime.dry_run).lower(),
                         },
                     )
+                    if created_name:
+                        tekton.annotate_current_pipelinerun({
+                            "art.openshift.io/triggered-build-fbc": created_name,
+                        })
                 else:
                     jenkins.start_build_fbc(
                         version=version,
@@ -266,7 +274,7 @@ async def olm_bundle_konflux(
         else:
             runtime.logger.info(f'Group {group} does not match OADP/MTA/MTC pattern, using original behavior')
             if use_tekton:
-                tekton.start_pipeline_run(
+                created_name = tekton.start_pipeline_run(
                     pipeline_name="build-fbc",
                     params={
                         "version": version,
@@ -276,6 +284,10 @@ async def olm_bundle_konflux(
                         "dry-run": str(runtime.dry_run).lower(),
                     },
                 )
+                if created_name:
+                    tekton.annotate_current_pipelinerun({
+                        "art.openshift.io/triggered-build-fbc": created_name,
+                    })
             else:
                 jenkins.start_build_fbc(
                     version=version,

--- a/pyartcd/pyartcd/pipelines/scheduled/schedule_layered_products_scan.py
+++ b/pyartcd/pyartcd/pipelines/scheduled/schedule_layered_products_scan.py
@@ -3,7 +3,7 @@ import asyncio
 import click
 from artcommonlib import redis
 
-from pyartcd import jenkins, util
+from pyartcd import jenkins, tekton, util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.locks import Lock, LockManager
 from pyartcd.runtime import Runtime
@@ -30,9 +30,15 @@ async def run_for(group: str, runtime: Runtime, lock_manager: LockManager):
         return
 
     # Schedule layered products scan
-    runtime.logger.info('[%s] Scheduling layered-products-scan-konflux', group)
+    runtime.logger.info('[%s] Scheduling layered-products-scan', group)
 
-    jenkins.start_layered_products_scan_konflux(group=group, block_until_building=False)
+    if tekton.is_tekton_context():
+        tekton.start_pipeline_run(
+            pipeline_name="layered-products-scan",
+            params={"group": group, "assembly": "stream"},
+        )
+    else:
+        jenkins.start_layered_products_scan_konflux(group=group, block_until_building=False)
 
 
 @cli.command('schedule-layered-products-scan')
@@ -40,7 +46,8 @@ async def run_for(group: str, runtime: Runtime, lock_manager: LockManager):
 @pass_runtime
 @click_coroutine
 async def layered_products_scan(runtime: Runtime, group: tuple):
-    jenkins.init_jenkins()
+    if not tekton.is_tekton_context():
+        jenkins.init_jenkins()
     lock_manager = LockManager([redis.redis_url()])
     try:
         await asyncio.gather(*[run_for(g, runtime, lock_manager) for g in group])

--- a/pyartcd/pyartcd/tekton.py
+++ b/pyartcd/pyartcd/tekton.py
@@ -1,0 +1,69 @@
+import json
+import logging
+import os
+import subprocess
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def is_tekton_context() -> bool:
+    """Detect if currently running inside a Tekton TaskRun.
+
+    The artcd Task sets TASKRUN_NAME via stepTemplate when running in Tekton.
+    """
+    return bool(os.environ.get("TASKRUN_NAME"))
+
+
+def _get_propagatable_params() -> dict:
+    """Collect parameters that should automatically propagate to downstream pipelines."""
+    propagatable = {}
+    art_tools_commit = os.environ.get("ART_TOOLS_COMMIT", "").strip()
+    if art_tools_commit:
+        propagatable["art-tools-commit"] = art_tools_commit
+    return propagatable
+
+
+def start_pipeline_run(
+    pipeline_name: str,
+    params: dict,
+    namespace: Optional[str] = None,
+) -> None:
+    """Create a Tekton PipelineRun to trigger a downstream pipeline.
+
+    Uses ``oc create -f -`` to submit a PipelineRun resource. Parameters with
+    None or empty-string values are omitted. Automatically propagates
+    ``ART_TOOLS_COMMIT`` from the environment as ``art-tools-commit``.
+    """
+    if namespace is None:
+        namespace = os.environ.get("TASKRUN_NAMESPACE", "art-cd")
+
+    merged_params = {**_get_propagatable_params(), **params}
+
+    pipeline_run = {
+        "apiVersion": "tekton.dev/v1",
+        "kind": "PipelineRun",
+        "metadata": {
+            "generateName": f"{pipeline_name}-",
+            "namespace": namespace,
+        },
+        "spec": {
+            "pipelineRef": {"name": pipeline_name},
+            "params": [
+                {"name": k, "value": str(v)} for k, v in merged_params.items() if v is not None and str(v) != ""
+            ],
+        },
+    }
+
+    pr_json = json.dumps(pipeline_run)
+    logger.info("Creating PipelineRun for pipeline %s in namespace %s", pipeline_name, namespace)
+    logger.debug("PipelineRun spec: %s", pr_json)
+
+    result = subprocess.run(
+        ["oc", "create", "-f", "-"],
+        input=pr_json,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    logger.info("PipelineRun created: %s", result.stdout.strip())

--- a/pyartcd/pyartcd/tekton.py
+++ b/pyartcd/pyartcd/tekton.py
@@ -1,10 +1,13 @@
 import json
 import logging
 import os
+import re
 import subprocess
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+ARTC2023_CONSOLE_URL = "https://console-openshift-console.apps.artc2023.pc3z.p1.openshiftapps.com"
 
 
 def is_tekton_context() -> bool:
@@ -13,6 +16,28 @@ def is_tekton_context() -> bool:
     The artcd Task sets TASKRUN_NAME via stepTemplate when running in Tekton.
     """
     return bool(os.environ.get("TASKRUN_NAME"))
+
+
+def get_current_pipelinerun_name() -> Optional[str]:
+    """Return the name of the current PipelineRun, or None if unavailable.
+
+    Reads from TEKTON_PIPELINERUN_NAME which must be set via
+    ``$(context.pipelineRun.name)`` in the Pipeline definition.
+    """
+    return os.environ.get("TEKTON_PIPELINERUN_NAME") or None
+
+
+def _get_namespace() -> str:
+    return os.environ.get("TASKRUN_NAMESPACE", "art-cd")
+
+
+def _get_console_url() -> str:
+    return os.environ.get("TEKTON_CONSOLE_URL", ARTC2023_CONSOLE_URL)
+
+
+def _build_console_pipelinerun_url(pipelinerun_name: str, namespace: Optional[str] = None) -> str:
+    ns = namespace or _get_namespace()
+    return f"{_get_console_url()}/k8s/ns/{ns}/tekton.dev~v1~PipelineRun/{pipelinerun_name}"
 
 
 def _get_propagatable_params() -> dict:
@@ -24,21 +49,67 @@ def _get_propagatable_params() -> dict:
     return propagatable
 
 
+def _parse_created_name(oc_stdout: str) -> Optional[str]:
+    """Extract the resource name from ``oc create`` output like ``pipelinerun.tekton.dev/build-fbc-xyz created``."""
+    match = re.search(r"(?:pipelinerun\.tekton\.dev/)?(\S+)\s+created", oc_stdout)
+    return match.group(1) if match else None
+
+
+def annotate_current_pipelinerun(annotations: dict) -> None:
+    """Annotate the current PipelineRun with the given key-value pairs.
+
+    Silently skips if not running inside a Tekton context or if the
+    PipelineRun name is unavailable.
+    """
+    pr_name = get_current_pipelinerun_name()
+    if not pr_name:
+        return
+    ns = _get_namespace()
+    for key, value in annotations.items():
+        try:
+            subprocess.run(
+                ["oc", "annotate", "pipelinerun", pr_name, f"{key}={value}", "-n", ns, "--overwrite"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except Exception:
+            logger.debug("Failed to annotate pipelinerun %s with %s=%s", pr_name, key, value, exc_info=True)
+
+
 def start_pipeline_run(
     pipeline_name: str,
     params: dict,
     namespace: Optional[str] = None,
-) -> None:
+) -> Optional[str]:
     """Create a Tekton PipelineRun to trigger a downstream pipeline.
 
     Uses ``oc create -f -`` to submit a PipelineRun resource. Parameters with
     None or empty-string values are omitted. Automatically propagates
     ``ART_TOOLS_COMMIT`` from the environment as ``art-tools-commit``.
+
+    When running inside a Tekton PipelineRun, the child PipelineRun is
+    labelled with the parent pipeline/pipelinerun name and annotated with
+    a console URL back to the parent for build-chain traceability.
+
+    Returns the created PipelineRun name, or None if it could not be parsed.
     """
     if namespace is None:
-        namespace = os.environ.get("TASKRUN_NAMESPACE", "art-cd")
+        namespace = _get_namespace()
 
     merged_params = {**_get_propagatable_params(), **params}
+
+    labels = {}
+    annotations = {}
+    parent_pr_name = get_current_pipelinerun_name()
+    if parent_pr_name:
+        parent_pipeline = os.environ.get("TEKTON_PIPELINE_NAME", "")
+        if parent_pipeline:
+            labels["art.openshift.io/parent-pipeline"] = parent_pipeline
+        labels["art.openshift.io/parent-pipelinerun"] = parent_pr_name
+        annotations["art.openshift.io/parent-pipelinerun-console-url"] = _build_console_pipelinerun_url(
+            parent_pr_name, namespace
+        )
 
     pipeline_run = {
         "apiVersion": "tekton.dev/v1",
@@ -46,6 +117,8 @@ def start_pipeline_run(
         "metadata": {
             "generateName": f"{pipeline_name}-",
             "namespace": namespace,
+            "labels": labels,
+            "annotations": annotations,
         },
         "spec": {
             "pipelineRef": {"name": pipeline_name},
@@ -66,4 +139,10 @@ def start_pipeline_run(
         text=True,
         check=True,
     )
-    logger.info("PipelineRun created: %s", result.stdout.strip())
+    stdout = result.stdout.strip()
+    logger.info("PipelineRun created: %s", stdout)
+
+    created_name = _parse_created_name(stdout)
+    if created_name:
+        logger.info("Child PipelineRun name: %s", created_name)
+    return created_name


### PR DESCRIPTION
## Summary

Moves the layered operator build pipelines (build-layered-products → olm-bundle-konflux → build-fbc) and the layered-products scan from Jenkins to Tekton on the artc2023 cluster.

### Changes

- **New module `pyartcd/pyartcd/tekton.py`**: Provides `is_tekton_context()` (detects Tekton via `TASKRUN_NAME` env var), `start_pipeline_run()` (creates PipelineRuns via `oc create -f -`), and `add_labels_and_annotations()` (propagates chain tracking metadata).
- **`build_layered_products.py`**: Conditionally triggers `olm-bundle-konflux` as a Tekton PipelineRun in Tekton context; falls back to Jenkins otherwise.
- **`olm_bundle_konflux.py`**: Conditionally triggers `build-fbc` as a Tekton PipelineRun at all three call sites (multi-target, single-target, and default); falls back to Jenkins otherwise.
- **`layered_products_scan_konflux.py`**: Migrated to run as a Tekton pipeline; skips `jenkins.init_jenkins()` and Jenkins description updates in Tekton context.
- **`schedule_layered_products_scan.py`**: Added Tekton support; also wires up a CronJob resource.
- **`artcommon/exectools.py`**: Redacts sensitive environment variables from exec command debug logs.
- **`art-cluster/.../cronjob.yaml`**: Adds a CronJob (initially suspended) to schedule the layered-products scan every 30 minutes.

### Cluster resources deployed (art-cd namespace on artc2023)

| Resource | Name |
|----------|------|
| Task | `artcd` (reusable, script-driven) |
| Pipeline | `build-layered-products` |
| Pipeline | `olm-bundle-konflux` |
| Pipeline | `build-fbc` |
| CronJob | `layered-products-scan` (initially disabled) |

## Test plan

- [ ] Trigger `build-layered-products` pipeline on artc2023 with dry-run to verify chaining
- [ ] Verify `olm-bundle-konflux` PipelineRun is created as downstream
- [ ] Verify `build-fbc` PipelineRun is created as downstream
- [ ] Verify Jenkins path still works when `TASKRUN_NAME` is not set
- [ ] Verify sensitive env vars are redacted in exec logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for running layered-product builds, scans, and bundle workflows through Tekton.
  - Added scheduling support for layered-product scans with controlled concurrency and retained run history.
  - Tekton-triggered workflows can now link related pipeline runs for improved tracking.

- **Bug Fixes**
  - Sensitive environment values are now redacted from command debug logs.

- **Configuration**
  - Scheduled layered-product scans now target ACM 5.0 instead of MTA 8.0.
  - Updated command-line examples to use ACM 5.0 terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->