### PR TITLE
ART-14770 - OCP5 Scheduled mirroring of bugs for a bridge release

### DIFF
--- a/artcommon/artcommonlib/metadata.py
+++ b/artcommon/artcommonlib/metadata.py
@@ -629,3 +629,18 @@ class MetadataBase(object):
         if network_mode not in valid_network_modes:
             raise ValueError(f"Invalid network mode; {network_mode}. Valid modes: {valid_network_modes}")
         return network_mode
+
+    @property
+    def bridge_bug_mirroring_enabled(self) -> bool:
+        group_bridge = self.runtime.group_config.get("bridge_release", {}) or {}
+        group_bug_mirroring = group_bridge.get("bug_mirroring", {}) or {}
+        if not group_bug_mirroring.get("enabled", False):
+            return False
+
+        comp_bridge = self.config.get("bridge_release", {}) or {}
+        comp_bug_mirroring = comp_bridge.get("bug_mirroring", {}) or {}
+        comp_enabled = comp_bug_mirroring.get("enabled")
+        if comp_enabled is not None:
+            return bool(comp_enabled)
+
+        return True

--- a/artcommon/artcommonlib/metadata.py
+++ b/artcommon/artcommonlib/metadata.py
@@ -632,6 +632,7 @@ class MetadataBase(object):
 
     @property
     def bridge_bug_mirroring_enabled(self) -> bool:
+        """Return whether bridge bug mirroring applies to this image."""
         group_bridge = self.runtime.group_config.get("bridge_release", {}) or {}
         group_bug_mirroring = group_bridge.get("bug_mirroring", {}) or {}
         if not group_bug_mirroring.get("enabled", False):

--- a/artcommon/artcommonlib/metadata.py
+++ b/artcommon/artcommonlib/metadata.py
@@ -633,15 +633,11 @@ class MetadataBase(object):
     @property
     def bridge_bug_mirroring_enabled(self) -> bool:
         """Return whether bridge bug mirroring applies to this image."""
-        group_bridge = self.runtime.group_config.get("bridge_release", {}) or {}
-        group_bug_mirroring = group_bridge.get("bug_mirroring", {}) or {}
-        if not group_bug_mirroring.get("enabled", False):
+        if not self.runtime.group_config.bridge_release.bug_mirroring.enabled:
             return False
 
-        comp_bridge = self.config.get("bridge_release", {}) or {}
-        comp_bug_mirroring = comp_bridge.get("bug_mirroring", {}) or {}
-        comp_enabled = comp_bug_mirroring.get("enabled")
-        if comp_enabled is not None:
+        comp_enabled = self.config.bridge_release.bug_mirroring.enabled
+        if comp_enabled is not Missing:
             return bool(comp_enabled)
 
         return True

--- a/artcommon/tests/test_metadata.py
+++ b/artcommon/tests/test_metadata.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest.mock import MagicMock
+
+from artcommonlib.metadata import MetadataBase
+from artcommonlib.model import Model
+
+
+class TestBridgeBugMirroringEnabled(unittest.TestCase):
+    """Test MetadataBase.bridge_bug_mirroring_enabled property logic."""
+
+    def _make_meta(self, group_config: dict, comp_config: dict) -> MetadataBase:
+        meta = MagicMock(spec=MetadataBase)
+        meta.runtime = MagicMock()
+        meta.runtime.group_config = Model(group_config)
+        meta.config = Model(comp_config)
+        meta.bridge_bug_mirroring_enabled = MetadataBase.bridge_bug_mirroring_enabled.fget(meta)
+        return meta
+
+    def test_group_disabled(self):
+        meta = self._make_meta(
+            group_config={"bridge_release": {"bug_mirroring": {"enabled": False}}},
+            comp_config={},
+        )
+        self.assertFalse(meta.bridge_bug_mirroring_enabled)
+
+    def test_group_missing(self):
+        meta = self._make_meta(group_config={}, comp_config={})
+        self.assertFalse(meta.bridge_bug_mirroring_enabled)
+
+    def test_group_enabled_no_comp_override(self):
+        meta = self._make_meta(
+            group_config={"bridge_release": {"bug_mirroring": {"enabled": True}}},
+            comp_config={},
+        )
+        self.assertTrue(meta.bridge_bug_mirroring_enabled)
+
+    def test_group_enabled_comp_disables(self):
+        meta = self._make_meta(
+            group_config={"bridge_release": {"bug_mirroring": {"enabled": True}}},
+            comp_config={"bridge_release": {"bug_mirroring": {"enabled": False}}},
+        )
+        self.assertFalse(meta.bridge_bug_mirroring_enabled)
+
+    def test_group_enabled_comp_explicitly_enables(self):
+        meta = self._make_meta(
+            group_config={"bridge_release": {"bug_mirroring": {"enabled": True}}},
+            comp_config={"bridge_release": {"bug_mirroring": {"enabled": True}}},
+        )
+        self.assertTrue(meta.bridge_bug_mirroring_enabled)
+
+    def test_group_disabled_comp_enables_still_false(self):
+        """Group-level disable is a hard gate; component override cannot override it."""
+        meta = self._make_meta(
+            group_config={"bridge_release": {"bug_mirroring": {"enabled": False}}},
+            comp_config={"bridge_release": {"bug_mirroring": {"enabled": True}}},
+        )
+        self.assertFalse(meta.bridge_bug_mirroring_enabled)

--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -882,6 +882,7 @@ class JIRABugTracker(BugTracker):
 
     @property
     def project(self):
+        """Return the configured JIRA project key."""
         return self._project
 
     def looks_like_a_jira_project_bug(self, bug_id) -> bool:
@@ -947,6 +948,24 @@ class JIRABugTracker(BugTracker):
         versions: Optional[List[str]] = None,
         noop: bool = False,
     ) -> JIRABug:
+        """Create a JIRA issue, filling in tracker defaults when fields omit them.
+
+        Args:
+            fields: Raw JIRA issue fields to submit. The mapping may omit
+                `project`, `versions`, and target-version fields because this
+                helper fills them from tracker configuration when needed.
+            target_status: Optional workflow status to transition the new issue
+                to after creation.
+            target_releases: Optional target-version values to use instead of the
+                tracker's configured target releases.
+            versions: Optional affects-version values to use instead of the
+                tracker's configured versions.
+            noop: If `True`, log the create request without creating the issue.
+
+        Returns:
+            JIRABug | None: The created issue wrapper, or `None` when `noop` is
+            enabled.
+        """
         fields = fields.copy()
         fields.setdefault('project', {'key': self._project})
         if versions is None:
@@ -1114,6 +1133,23 @@ class JIRABugTracker(BugTracker):
         custom_query: Optional[str] = None,
         verbose: bool = False,
     ) -> List[JIRABug]:
+        """Search JIRA bugs with optional status, label, and query filters.
+
+        Args:
+            status: Optional allowed workflow statuses.
+            search_filter: Named component filter to exclude non-relevant
+                components.
+            include_labels: Optional labels that matching issues must include.
+            exclude_labels: Optional labels that matching issues must not include.
+            with_target_release: If `True`, constrain the search to the tracker's
+                configured target releases.
+            custom_query: Extra JQL appended to the generated query.
+            verbose: If `True`, log the generated JQL before searching.
+
+        Returns:
+            list[JIRABug]: Matching issues, or an empty list if version filtering
+            removes all configured target releases.
+        """
         query = self._query(
             status=status,
             search_filter=search_filter,
@@ -1127,6 +1163,7 @@ class JIRABugTracker(BugTracker):
         return self._search(query, verbose=verbose)
 
     def create_issue_link(self, link_name: str, inward_issue: str, outward_issue: str):
+        """Create a JIRA issue link between two issues."""
         self._client.create_issue_link(link_name, inward_issue, outward_issue)
 
     def remove_bugs(self, advisory_obj, bugids: List, noop=False):
@@ -1198,10 +1235,12 @@ class BugzillaBugTracker(BugTracker):
 
     @property
     def product(self):
+        """Return the configured Bugzilla product name."""
         return self.config.get('product', '')
 
     @property
     def project(self):
+        """Return the Bugzilla product for tracker-agnostic callers."""
         return self.config.get('product', '')
 
     def get_bug(self, bugid, **kwargs):

--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -782,7 +782,7 @@ class JIRABugTracker(BugTracker):
 
     def __init__(self, config):
         super().__init__(config, 'jira')
-        self._project = self.config.get('project', '')
+        self.project = self.config.get('project', '')
         self._client: JIRA = self.login()
         self._init_fields()
         self._available_target_versions = None
@@ -807,10 +807,10 @@ class JIRABugTracker(BugTracker):
                 target_versions = self._get_target_versions_via_project_issue_types()
 
             self._available_target_versions = target_versions
-            logger.info(f"Found {len(self._available_target_versions)} target versions in JIRA project {self._project}")
+            logger.info(f"Found {len(self._available_target_versions)} target versions in JIRA project {self.project}")
             return self._available_target_versions
         except Exception as e:
-            logger.error(f"Failed to fetch target versions for project {self._project}: {e}")
+            logger.error(f"Failed to fetch target versions for project {self.project}: {e}")
             self._available_target_versions = []
             return self._available_target_versions
 
@@ -822,13 +822,13 @@ class JIRABugTracker(BugTracker):
             list[str]: List of target version names for the Bug issue type.
         """
         # Use createmeta API which is compatible with newer JIRA Cloud instances
-        create_meta = self._client.createmeta(projectKeys=[self._project], expand='projects.issuetypes.fields')
+        create_meta = self._client.createmeta(projectKeys=[self.project], expand='projects.issuetypes.fields')
 
         target_versions = []
         # Navigate through the createmeta structure to find target version field
         if create_meta and 'projects' in create_meta:
             for project in create_meta['projects']:
-                if project.get('key') == self._project:
+                if project.get('key') == self.project:
                     for issue_type in project.get('issuetypes', []):
                         if issue_type.get('name') == 'Bug':
                             fields = issue_type.get('fields', {})
@@ -849,7 +849,7 @@ class JIRABugTracker(BugTracker):
         Return Value(s):
             list[str]: List of target version names for the Bug issue type.
         """
-        issue_types = self._client.project_issue_types(self._project)
+        issue_types = self._client.project_issue_types(self.project)
 
         bug_issue_type = None
         for issue_type in issue_types:
@@ -858,11 +858,11 @@ class JIRABugTracker(BugTracker):
                 break
 
         if not bug_issue_type:
-            logger.warning(f"Bug issue type not found in JIRA project {self._project}")
+            logger.warning(f"Bug issue type not found in JIRA project {self.project}")
             return []
 
         bug_id = getattr(bug_issue_type, 'id', None)
-        fields = self._client.project_issue_fields(self._project, bug_id)
+        fields = self._client.project_issue_fields(self.project, bug_id)
 
         target_versions = []
         for field in fields:
@@ -878,15 +878,10 @@ class JIRABugTracker(BugTracker):
 
     @property
     def product(self):
-        return self._project
-
-    @property
-    def project(self):
-        """Return the configured JIRA project key."""
-        return self._project
+        return self.project
 
     def looks_like_a_jira_project_bug(self, bug_id) -> bool:
-        pattern = re.compile(rf'{self._project}-\d+')
+        pattern = re.compile(rf'{self.project}-\d+')
         return bool(pattern.match(str(bug_id)))
 
     def get_bug(self, bugid: str, **kwargs) -> JIRABug:
@@ -895,9 +890,7 @@ class JIRABugTracker(BugTracker):
     def get_bugs(self, bugids: List[str], permissive=False, verbose=False, **kwargs) -> List[JIRABug]:
         invalid_bugs = [b for b in bugids if not self.looks_like_a_jira_project_bug(b)]
         if invalid_bugs:
-            logger.warn(
-                f"Cannot fetch bugs from a different project (current project: {self._project}): {invalid_bugs}"
-            )
+            logger.warn(f"Cannot fetch bugs from a different project (current project: {self.project}): {invalid_bugs}")
         bugids = [b for b in bugids if self.looks_like_a_jira_project_bug(b)]
         if not bugids:
             return []
@@ -967,7 +960,7 @@ class JIRABugTracker(BugTracker):
             enabled.
         """
         fields = fields.copy()
-        fields.setdefault('project', {'key': self._project})
+        fields.setdefault('project', {'key': self.project})
         if versions is None:
             versions = self.config.get('version')
         if versions and 'versions' not in fields:
@@ -1016,7 +1009,7 @@ class JIRABugTracker(BugTracker):
             available_versions = self._get_available_target_versions()
             if not available_versions:
                 logger.warning(
-                    f"Could not fetch available target versions for project {self._project}. Proceeding with original query."
+                    f"Could not fetch available target versions for project {self.project}. Proceeding with original query."
                 )
             else:
                 valid_target_releases = [tr for tr in target_release if tr in available_versions]
@@ -1024,13 +1017,13 @@ class JIRABugTracker(BugTracker):
 
                 if invalid_target_releases:
                     logger.warning(
-                        f"Target versions {invalid_target_releases} do not exist in JIRA project {self._project}. "
+                        f"Target versions {invalid_target_releases} do not exist in JIRA project {self.project}. "
                         f"They will be excluded from the query."
                     )
 
                 if not valid_target_releases:
                     logger.warning(
-                        f"No valid target versions found for query. All requested versions do not exist in JIRA project {self._project}."
+                        f"No valid target versions found for query. All requested versions do not exist in JIRA project {self.project}."
                     )
                     logger.warning(
                         f"Target version filtering removed configured versions. "
@@ -1050,7 +1043,7 @@ class JIRABugTracker(BugTracker):
         if search_filter:
             exclude_components = self.component_filter(search_filter)
 
-        query = f"project={self._project}"
+        query = f"project={self.project}"
         if bugids:
             query += f" and issue in ({','.join(bugids)})"
         if status:

--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -880,6 +880,10 @@ class JIRABugTracker(BugTracker):
     def product(self):
         return self._project
 
+    @property
+    def project(self):
+        return self._project
+
     def looks_like_a_jira_project_bug(self, bug_id) -> bool:
         pattern = re.compile(rf'{self._project}-\d+')
         return bool(pattern.match(str(bug_id)))
@@ -927,21 +931,39 @@ class JIRABugTracker(BugTracker):
         self, bug_title: str, bug_description: str, target_status: str, keywords: List, noop=False
     ) -> JIRABug:
         fields = {
-            'project': {'key': self._project},
             'issuetype': {'name': 'Bug'},
             'components': [{'name': 'Release'}],
-            'versions': [{'name': self.config.get('version')[0]}],  # Affects Version/s
-            self.field_target_version: [{'name': self.config.get('target_release')[0]}],  # Target Version
             'summary': bug_title,
             'labels': keywords,
             'description': bug_description,
         }
+        return self.create_issue(fields=fields, target_status=target_status, noop=noop)
+
+    def create_issue(
+        self,
+        fields: Dict,
+        target_status: Optional[str] = None,
+        target_releases: Optional[List[str]] = None,
+        versions: Optional[List[str]] = None,
+        noop: bool = False,
+    ) -> JIRABug:
+        fields = fields.copy()
+        fields.setdefault('project', {'key': self._project})
+        if versions is None:
+            versions = self.config.get('version')
+        if versions and 'versions' not in fields:
+            fields['versions'] = [{'name': version} for version in versions]
+        if target_releases is None:
+            target_releases = self.target_release()
+        if target_releases and self.field_target_version not in fields:
+            fields[self.field_target_version] = [{'name': target_release} for target_release in target_releases]
         if noop:
             logger.info(f"Would have created JIRA Issue with status={target_status} and fields={fields}")
             return
-        bug = self._client.create_issue(fields=fields)
-        self._client.transition_issue(bug, target_status)
-        return JIRABug(bug)
+        issue = self._client.create_issue(fields=fields)
+        if target_status:
+            self._client.transition_issue(issue, target_status)
+        return JIRABug(issue)
 
     def _update_bug_status(self, bugid, target_status):
         return self._client.transition_issue(bugid, target_status)
@@ -1148,7 +1170,14 @@ class BugzillaBugTracker(BugTracker):
     def __init__(self, config):
         super().__init__(config, 'bugzilla')
         self._client = self.login()
-        self.product = self.config.get('product', '')
+
+    @property
+    def product(self):
+        return self.config.get('product', '')
+
+    @property
+    def project(self):
+        return self.config.get('product', '')
 
     def get_bug(self, bugid, **kwargs):
         return BugzillaBug(self._client.getbug(bugid, **kwargs))

--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -1104,6 +1104,31 @@ class JIRABugTracker(BugTracker):
             return []
         return self._search(query, verbose=verbose)
 
+    def search_bugs(
+        self,
+        status: Optional[List] = None,
+        search_filter: Optional[str] = None,
+        include_labels: Optional[List] = None,
+        exclude_labels: Optional[List] = None,
+        with_target_release: bool = True,
+        custom_query: Optional[str] = None,
+        verbose: bool = False,
+    ) -> List[JIRABug]:
+        query = self._query(
+            status=status,
+            search_filter=search_filter,
+            include_labels=include_labels,
+            exclude_labels=exclude_labels,
+            with_target_release=with_target_release,
+            custom_query=custom_query,
+        )
+        if query is None:
+            return []
+        return self._search(query, verbose=verbose)
+
+    def create_issue_link(self, link_name: str, inward_issue: str, outward_issue: str):
+        self._client.create_issue_link(link_name, inward_issue, outward_issue)
+
     def remove_bugs(self, advisory_obj, bugids: List, noop=False):
         if noop:
             print(f"Would've removed bugs: {bugids}")

--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -42,6 +42,7 @@ from elliottlib.cli.create_cli import create_cli
 from elliottlib.cli.create_placeholder_cli import create_placeholder_cli
 from elliottlib.cli.create_textonly_cli import create_textonly_cli
 from elliottlib.cli.find_bugs_blocker_cli import find_bugs_blocker_cli
+from elliottlib.cli.find_bugs_bridge_cli import find_bugs_bridge_cli
 from elliottlib.cli.find_bugs_cli import find_bugs_cli
 from elliottlib.cli.find_bugs_golang_cli import find_bugs_golang_cli
 from elliottlib.cli.find_bugs_kernel_cli import find_bugs_kernel_cli
@@ -287,6 +288,7 @@ cli.add_command(change_state_cli)
 cli.add_command(verify_conforma_cli)
 cli.add_command(find_bugs_sweep_cli)
 cli.add_command(find_bugs_cli)
+cli.add_command(find_bugs_bridge_cli)
 cli.add_command(find_builds_cli)
 cli.add_command(get_network_mode_cli)
 cli.add_command(tag_builds_cli)

--- a/elliott/elliottlib/cli/find_bugs_bridge_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_bridge_cli.py
@@ -130,7 +130,7 @@ class FindBugsBridgeCli:
         self.images_by_component = {}
         self.images_by_jira_component = {}
         for image_meta in self.runtime.image_metas():
-            if not image_meta.config.get("for_payload", False):
+            if not image_meta.bridge_bug_mirroring_enabled:
                 continue
             self.images_by_component[image_meta.get_component_name()] = image_meta
         component_mapping = self._get_product_config().bug_mapping.components
@@ -154,7 +154,6 @@ class FindBugsBridgeCli:
         candidates: List[Tuple[JIRABug, object]] = []
         tracker_filtered = 0
         unmapped_filtered = 0
-        mirroring_disabled_filtered = 0
         for bug in sorted(bugs, key=lambda item: item.id):
             if bug.is_tracker_bug():
                 tracker_filtered += 1
@@ -165,20 +164,13 @@ class FindBugsBridgeCli:
                 unmapped_filtered += 1
                 LOGGER.debug("Skipping %s because it does not map to a target image", bug.id)
                 continue
-            if not self._image_bug_mirroring_enabled(image_meta):
-                mirroring_disabled_filtered += 1
-                LOGGER.debug(
-                    "Skipping %s because bridge bug mirroring is disabled for %s", bug.id, image_meta.distgit_key
-                )
-                continue
             candidates.append((bug, image_meta))
-        total_filtered = tracker_filtered + unmapped_filtered + mirroring_disabled_filtered
+        total_filtered = tracker_filtered + unmapped_filtered
         LOGGER.info(
-            "Filtered %d bugs: tracker/CVE=%d, unmapped/non-ART/non-payload=%d, mirroring-disabled=%d",
+            "Filtered %d bugs: tracker/CVE=%d, unmapped/non-ART/non-payload=%d",
             total_filtered,
             tracker_filtered,
             unmapped_filtered,
-            mirroring_disabled_filtered,
         )
         LOGGER.info("Found %d candidate bugs in basis group %s", len(candidates), self.bridge_config.basis_group)
         return candidates
@@ -203,12 +195,6 @@ class FindBugsBridgeCli:
             raise IOError("product.yml from the current build-data repo main branch is missing or invalid")
         self._product_config = Model(dict_to_model=product_config)
         return self._product_config
-
-    @staticmethod
-    def _image_bug_mirroring_enabled(image_meta) -> bool:
-        bridge_release = image_meta.config.get("bridge_release", {}) or {}
-        bug_mirroring = bridge_release.get("bug_mirroring", {}) or {}
-        return bug_mirroring.get("enabled", True)
 
     async def _sync_mirror(self, source_bug: JIRABug, image_meta) -> bool:
         assert self.target_tracker is not None

--- a/elliott/elliottlib/cli/find_bugs_bridge_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_bridge_cli.py
@@ -202,12 +202,6 @@ class FindBugsBridgeCli:
             return False
         existing = self.existing_mirrors_by_source.get(source_bug.id, [])
         if existing:
-            if len(existing) != 1:
-                self._record_invalid_bug(
-                    source_bug.id,
-                    f"Expected exactly one bridge mirror, found {len(existing)}: {[mirror.id for mirror in existing]}",
-                )
-                return False
             if any(self._is_closed_wont_fix(mirror) for mirror in existing):
                 LOGGER.info("Skipping %s because an existing mirror is closed as Won't Fix", source_bug.id)
                 return False

--- a/elliott/elliottlib/cli/find_bugs_bridge_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_bridge_cli.py
@@ -1,0 +1,408 @@
+import logging
+import os
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import click
+import yaml
+from artcommonlib.model import Model
+from jira import JIRAError
+
+from elliottlib import Runtime
+from elliottlib.bzutil import JIRABug, JIRABugTracker
+from elliottlib.cli import common
+from elliottlib.cli.common import click_coroutine
+
+LOGGER = logging.getLogger(__name__)
+
+BRIDGE_LABEL = "art:bridge-bug"
+WONT_FIX_RESOLUTIONS = {"won't fix", "wontfix", "wont fix"}
+REQUIRED_LINK_TYPES = {"depends_on", "blocked_by", "clones"}
+
+
+@dataclass(frozen=True)
+class BridgeBugMirroringConfig:
+    basis_group: str
+    enabled: bool
+
+
+@common.cli.command("find-bugs:bridge-mirror", short_help="Mirror basis-group bugs into a bridge release")
+@click.option("--noop", "--dry-run", is_flag=True, default=False, help="Don't change anything")
+@click.pass_obj
+@click_coroutine
+async def find_bugs_bridge_cli(runtime: Runtime, noop: bool):
+    cli = FindBugsBridgeCli(runtime=runtime, noop=noop)
+    await cli.run()
+
+
+class FindBugsBridgeCli:
+    def __init__(self, runtime: Runtime, noop: bool):
+        self.runtime = runtime
+        self.noop = noop
+        self.bridge_config: Optional[BridgeBugMirroringConfig] = None
+        self.source_runtime: Optional[Runtime] = None
+        self.source_tracker: Optional[JIRABugTracker] = None
+        self.target_tracker: Optional[JIRABugTracker] = None
+        self.target_release: Optional[str] = None
+        self.images_by_component: Dict[str, object] = {}
+        self.images_by_jira_component: Dict[str, object] = {}
+        self._product_config: Optional[Model] = None
+        self.existing_mirrors_by_source: Dict[str, List[JIRABug]] = {}
+        self.invalid_bugs: Dict[str, List[str]] = {}
+        self.existing_mirror_count = 0
+        self.created_mirror_count = 0
+        self.updated_mirror_count = 0
+
+    async def run(self):
+        self.runtime.initialize(mode="images")
+        major, minor = self.runtime.get_major_minor_fields()
+        self.major_minor = f"{major}.{minor}"
+        self.bridge_config = self._load_bridge_config(self.runtime)
+        if not self.bridge_config.enabled:
+            LOGGER.info("Bridge bug mirroring is disabled for %s", self.runtime.group)
+            return
+
+        self.source_runtime = self._build_source_runtime(self.bridge_config.basis_group)
+        self.source_runtime.initialize(mode="none")
+        self.source_tracker = self.source_runtime.get_bug_tracker("jira")
+        self.target_tracker = self.runtime.get_bug_tracker("jira")
+
+        target_releases = self.target_tracker.target_release()
+        if not target_releases:
+            raise ValueError(f"No Jira target release configured for {self.runtime.group}")
+        self.target_release = target_releases[0]
+
+        self._build_target_image_maps()
+        candidates = self._get_candidate_bugs()
+        self.existing_mirrors_by_source = self._get_existing_mirrors_by_source([bug.id for bug, _ in candidates])
+        self.existing_mirror_count = len(
+            {mirror.id for mirrors in self.existing_mirrors_by_source.values() for mirror in mirrors}
+        )
+        self.created_mirror_count = 0
+        self.updated_mirror_count = 0
+        LOGGER.info("Found %d existing bridge mirrors for %s", self.existing_mirror_count, self.runtime.group)
+        skipped = 0
+        for bug, image_meta in candidates:
+            if await self._sync_mirror(bug, image_meta):
+                continue
+            else:
+                skipped += 1
+
+        if self.invalid_bugs:
+            self._report_invalid_bugs()
+            raise ValueError(
+                f"Found invalid bridge bug cases for {len(self.invalid_bugs)} source bug(s); see log for details"
+            )
+
+        LOGGER.info(
+            "Bridge bug mirroring complete for %s: existing=%d, created=%d, updated=%d, skipped=%d",
+            self.runtime.group,
+            self.existing_mirror_count,
+            self.created_mirror_count,
+            self.updated_mirror_count,
+            skipped,
+        )
+
+    @staticmethod
+    def _load_bridge_config(runtime: Runtime) -> BridgeBugMirroringConfig:
+        bridge_release = runtime.group_config.get("bridge_release", {}) or {}
+        basis_group = bridge_release.get("basis_group")
+        bug_mirroring = bridge_release.get("bug_mirroring", {}) or {}
+        enabled = bool(bug_mirroring.get("enabled", False))
+        if enabled and not basis_group:
+            raise ValueError(f"bridge_release.basis_group must be set for {runtime.group}")
+        return BridgeBugMirroringConfig(basis_group=basis_group or "", enabled=enabled)
+
+    def _build_source_runtime(self, group: str) -> Runtime:
+        config = self.runtime.cfg_obj.to_dict()
+        config.update(
+            {
+                "group": group,
+                "assembly": self.runtime.assembly,
+                "data_path": self.runtime.data_path,
+                "build_system": self.runtime.build_system,
+                "working_dir": os.path.join(self.runtime.working_dir, f"bridge-source-{group}"),
+            }
+        )
+        return Runtime(cfg_obj=self.runtime.cfg_obj, **config)
+
+    def _build_target_image_maps(self):
+        self.images_by_component = {}
+        self.images_by_jira_component = {}
+        for image_meta in self.runtime.image_metas():
+            if not image_meta.config.get("for_payload", False):
+                continue
+            self.images_by_component[image_meta.get_component_name()] = image_meta
+        component_mapping = self._get_product_config().bug_mapping.components
+        for package_name, component_entry in component_mapping.items():
+            image_meta = self.images_by_component.get(package_name)
+            if not image_meta:
+                continue
+            issue_component = (
+                component_entry.get("issue_component")
+                if isinstance(component_entry, dict)
+                else component_entry.issue_component
+            )
+            if issue_component:
+                self.images_by_jira_component[issue_component] = image_meta
+
+    def _get_candidate_bugs(self) -> List[Tuple[JIRABug, object]]:
+        assert self.source_tracker is not None
+        query = self.source_tracker._query(search_filter="default", custom_query=' and status != "CLOSED"')
+        if query is None:
+            return []
+        bugs = self.source_tracker._search(query, verbose=self.runtime.debug)
+        candidates: List[Tuple[JIRABug, object]] = []
+        tracker_filtered = 0
+        unmapped_filtered = 0
+        mirroring_disabled_filtered = 0
+        for bug in sorted(bugs, key=lambda item: item.id):
+            if bug.is_tracker_bug():
+                tracker_filtered += 1
+                LOGGER.debug("Skipping tracker bug %s", bug.id)
+                continue
+            image_meta = self._resolve_bug_image(bug)
+            if not image_meta:
+                unmapped_filtered += 1
+                LOGGER.debug("Skipping %s because it does not map to a target image", bug.id)
+                continue
+            if not self._image_bug_mirroring_enabled(image_meta):
+                mirroring_disabled_filtered += 1
+                LOGGER.debug(
+                    "Skipping %s because bridge bug mirroring is disabled for %s", bug.id, image_meta.distgit_key
+                )
+                continue
+            candidates.append((bug, image_meta))
+        total_filtered = tracker_filtered + unmapped_filtered + mirroring_disabled_filtered
+        LOGGER.info(
+            "Filtered %d bugs: tracker/CVE=%d, unmapped/non-ART/non-payload=%d, mirroring-disabled=%d",
+            total_filtered,
+            tracker_filtered,
+            unmapped_filtered,
+            mirroring_disabled_filtered,
+        )
+        LOGGER.info("Found %d candidate bugs in basis group %s", len(candidates), self.bridge_config.basis_group)
+        return candidates
+
+    def _resolve_bug_image(self, bug: JIRABug):
+        try:
+            jira_component = bug.component
+        except IndexError:
+            LOGGER.debug("Skipping %s because it does not have a component", bug.id)
+            return None
+        return self.images_by_jira_component.get(jira_component)
+
+    def _get_product_config(self) -> Model:
+        if self._product_config is not None:
+            return self._product_config
+
+        product_yml = self.runtime.get_file_from_branch("main", "product.yml")
+        if not product_yml.strip():
+            raise IOError("product.yml was not found in the current build-data repo main branch")
+        product_config = yaml.safe_load(product_yml)
+        if not isinstance(product_config, dict):
+            raise IOError("product.yml from the current build-data repo main branch is missing or invalid")
+        self._product_config = Model(dict_to_model=product_config)
+        return self._product_config
+
+    @staticmethod
+    def _image_bug_mirroring_enabled(image_meta) -> bool:
+        bridge_release = image_meta.config.get("bridge_release", {}) or {}
+        bug_mirroring = bridge_release.get("bug_mirroring", {}) or {}
+        return bug_mirroring.get("enabled", True)
+
+    async def _sync_mirror(self, source_bug: JIRABug, image_meta) -> bool:
+        assert self.target_tracker is not None
+        if source_bug.id in self.invalid_bugs:
+            return False
+        existing = self.existing_mirrors_by_source.get(source_bug.id, [])
+        if existing:
+            if len(existing) != 1:
+                self._record_invalid_bug(
+                    source_bug.id,
+                    f"Expected exactly one bridge mirror, found {len(existing)}: {[mirror.id for mirror in existing]}",
+                )
+                return False
+            if any(self._is_closed_wont_fix(mirror) for mirror in existing):
+                LOGGER.info("Skipping %s because an existing mirror is closed as Won't Fix", source_bug.id)
+                return False
+            if all(mirror.status.lower() == "closed" for mirror in existing):
+                self._record_invalid_bug(
+                    source_bug.id,
+                    "Existing bridge mirror is closed without Won't Fix; manual investigation required",
+                )
+                return False
+            fields = self._build_issue_fields(source_bug, image_meta)
+            mirror = existing[0]
+            if mirror.status.lower() != "closed":
+                self._update_issue(mirror, fields)
+                self._ensure_issue_links(mirror.id, source_bug.id)
+                self.updated_mirror_count += 1
+            return True
+
+        fields = self._build_issue_fields(source_bug, image_meta)
+        if self.noop:
+            LOGGER.info("[DRY RUN] Would create bridge mirror for %s", source_bug.id)
+            self.created_mirror_count += 1
+            return True
+
+        issue = self.target_tracker.create_issue(fields)
+        self._ensure_issue_links(issue.id, source_bug.id)
+        LOGGER.info("Created bridge mirror %s for %s", issue.id, source_bug.id)
+        self.created_mirror_count += 1
+        return True
+
+    def _build_issue_fields(self, source_bug: JIRABug, image_meta) -> dict:
+        assert self.target_tracker is not None
+        summary = f"{source_bug.summary} [bridge to {self.target_release}]"
+        description = self._build_description(source_bug, image_meta)
+        issue_type = getattr(source_bug.bug.fields.issuetype, "name", "Bug")
+        components = [{"name": component.name} for component in getattr(source_bug.bug.fields, "components", [])]
+        fields = {
+            "summary": summary,
+            "description": description,
+            "issuetype": {"name": issue_type},
+            "components": components,
+            "labels": [BRIDGE_LABEL],
+        }
+        priority = getattr(getattr(source_bug.bug.fields, "priority", None), "name", None)
+        if priority:
+            fields["priority"] = {"name": priority}
+        security = getattr(source_bug.bug.fields, "security", None)
+        if security and getattr(security, "name", None):
+            fields["security"] = {"name": security.name}
+        return fields
+
+    def _build_description(self, source_bug: JIRABug, image_meta) -> str:
+        source_description = getattr(source_bug.bug.fields, "description", "") or "No source description provided."
+        return (
+            f"This issue was automatically created by ART as a bridge-release mirror of {source_bug.id} "
+            f"from {self.bridge_config.basis_group} for {self.major_minor}.\n\n"
+            "Why this issue exists:\n"
+            f"- The source issue is still open in {self.bridge_config.basis_group} and maps to image "
+            f"{image_meta.distgit_key} for this bridge release.\n"
+            f"- This mirror keeps the issue visible for {self.major_minor} advisory workflows until a product "
+            "engineer decides otherwise.\n\n"
+            f"How to disposition it for {self.major_minor}:\n"
+            f"- You do not need to directly manage this issue's state unless you want to remove it from {self.major_minor} advisories.\n"
+            f"- If the issue should not appear in {self.major_minor} advisories, close this mirror with \"Won't Fix\".\n"
+            "- Otherwise, leave it open and ART automation will continue to manage its presence.\n\n"
+            "Original description:\n"
+            "----\n"
+            f"{source_description}"
+        )
+
+    def _get_existing_mirrors_by_source(self, source_bug_ids: List[str]) -> Dict[str, List[JIRABug]]:
+        assert self.target_tracker is not None
+        if not source_bug_ids:
+            return {}
+
+        query = self.target_tracker._query(
+            include_labels=[BRIDGE_LABEL],
+            with_target_release=True,
+            custom_query=" order by created DESC",
+        )
+        if query is None:
+            return {}
+        mirrors = self.target_tracker._search(query, verbose=self.runtime.debug)
+        source_bug_ids = set(source_bug_ids)
+        mirrors_by_source: Dict[str, List[JIRABug]] = {bug_id: [] for bug_id in source_bug_ids}
+        for mirror in mirrors:
+            linked_sources = self._get_linked_sources(mirror, source_bug_ids)
+            for linked_source in linked_sources:
+                mirrors_by_source[linked_source].append(mirror)
+        for source_bug_id, linked_mirrors in mirrors_by_source.items():
+            if len(linked_mirrors) > 1:
+                self._record_invalid_bug(
+                    source_bug_id,
+                    f"Expected exactly one bridge mirror, found {len(linked_mirrors)}: "
+                    f"{[mirror.id for mirror in linked_mirrors]}",
+                )
+            elif linked_mirrors:
+                self._validate_required_links(linked_mirrors[0], source_bug_id)
+        return mirrors_by_source
+
+    def _update_issue(self, mirror_bug: JIRABug, fields: dict):
+        if self.noop:
+            LOGGER.info("[DRY RUN] Would update bridge mirror %s with fields=%s", mirror_bug.id, fields)
+            return
+        merged_labels = sorted(set(mirror_bug.keywords) | set(fields["labels"]))
+        update_fields = fields.copy()
+        update_fields["labels"] = merged_labels
+        mirror_bug.bug.update(fields=update_fields)
+        LOGGER.info("Updated bridge mirror %s", mirror_bug.id)
+
+    def _ensure_issue_links(self, mirror_issue_key: str, source_issue_key: str):
+        assert self.target_tracker is not None
+        if self.noop:
+            LOGGER.info("[DRY RUN] Would add required links between %s and %s", mirror_issue_key, source_issue_key)
+            return
+        link_specs = [
+            ("Blocks", source_issue_key, mirror_issue_key),
+            ("Depend", mirror_issue_key, source_issue_key),
+            ("Cloners", mirror_issue_key, source_issue_key),
+        ]
+        for link_name, inward_issue, outward_issue in link_specs:
+            try:
+                self.target_tracker._client.create_issue_link(link_name, inward_issue, outward_issue)
+            except JIRAError as err:
+                if "already exists" not in str(err).lower():
+                    raise
+
+    @staticmethod
+    def _get_linked_sources(mirror_bug: JIRABug, source_bug_ids: set[str]) -> set[str]:
+        linked_sources = set()
+        for link in getattr(mirror_bug.bug.fields, "issuelinks", []):
+            if link.type.name == "Blocks" and hasattr(link, "inwardIssue"):
+                key = link.inwardIssue.key
+                if key in source_bug_ids:
+                    linked_sources.add(key)
+            if link.type.name == "Depend" and hasattr(link, "outwardIssue"):
+                key = link.outwardIssue.key
+                if key in source_bug_ids:
+                    linked_sources.add(key)
+            if link.type.name == "Cloners":
+                if hasattr(link, "outwardIssue") and link.outwardIssue.key in source_bug_ids:
+                    linked_sources.add(link.outwardIssue.key)
+                if hasattr(link, "inwardIssue") and link.inwardIssue.key in source_bug_ids:
+                    linked_sources.add(link.inwardIssue.key)
+        return linked_sources
+
+    @staticmethod
+    def _required_link_types_for_source(mirror_bug: JIRABug, source_bug_id: str) -> set[str]:
+        found = set()
+        for link in getattr(mirror_bug.bug.fields, "issuelinks", []):
+            if link.type.name == "Blocks" and hasattr(link, "inwardIssue") and link.inwardIssue.key == source_bug_id:
+                found.add("blocked_by")
+            if link.type.name == "Depend" and hasattr(link, "outwardIssue") and link.outwardIssue.key == source_bug_id:
+                found.add("depends_on")
+            if link.type.name == "Cloners":
+                if hasattr(link, "outwardIssue") and link.outwardIssue.key == source_bug_id:
+                    found.add("clones")
+                if hasattr(link, "inwardIssue") and link.inwardIssue.key == source_bug_id:
+                    found.add("clones")
+        return found
+
+    def _validate_required_links(self, mirror_bug: JIRABug, source_bug_id: str):
+        found = self._required_link_types_for_source(mirror_bug, source_bug_id)
+        missing = REQUIRED_LINK_TYPES - found
+        if missing:
+            self._record_invalid_bug(
+                source_bug_id,
+                f"Bridge mirror {mirror_bug.id} is missing required links: {sorted(missing)}",
+            )
+
+    def _record_invalid_bug(self, source_bug_id: str, message: str):
+        self.invalid_bugs.setdefault(source_bug_id, []).append(message)
+
+    def _report_invalid_bugs(self):
+        for source_bug_id in sorted(self.invalid_bugs):
+            for message in self.invalid_bugs[source_bug_id]:
+                LOGGER.error("Invalid bridge bug case for %s: %s", source_bug_id, message)
+
+    @staticmethod
+    def _is_closed_wont_fix(mirror_bug: JIRABug) -> bool:
+        if mirror_bug.status.lower() != "closed":
+            return False
+        resolution = (mirror_bug.resolution or "").replace("’", "'").lower()
+        return resolution in WONT_FIX_RESOLUTIONS

--- a/elliott/elliottlib/cli/find_bugs_bridge_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_bridge_cli.py
@@ -148,10 +148,9 @@ class FindBugsBridgeCli:
 
     def _get_candidate_bugs(self) -> List[Tuple[JIRABug, object]]:
         assert self.source_tracker is not None
-        query = self.source_tracker._query(search_filter="default", custom_query=' and status != "CLOSED"')
-        if query is None:
-            return []
-        bugs = self.source_tracker._search(query, verbose=self.runtime.debug)
+        bugs = self.source_tracker.search_bugs(
+            search_filter="default", custom_query=' and status != "CLOSED"', verbose=self.runtime.debug
+        )
         candidates: List[Tuple[JIRABug, object]] = []
         tracker_filtered = 0
         unmapped_filtered = 0
@@ -297,14 +296,12 @@ class FindBugsBridgeCli:
         if not source_bug_ids:
             return {}
 
-        query = self.target_tracker._query(
+        mirrors = self.target_tracker.search_bugs(
             include_labels=[BRIDGE_LABEL],
             with_target_release=True,
             custom_query=" order by created DESC",
+            verbose=self.runtime.debug,
         )
-        if query is None:
-            return {}
-        mirrors = self.target_tracker._search(query, verbose=self.runtime.debug)
         source_bug_ids = set(source_bug_ids)
         mirrors_by_source: Dict[str, List[JIRABug]] = {bug_id: [] for bug_id in source_bug_ids}
         for mirror in mirrors:
@@ -344,7 +341,7 @@ class FindBugsBridgeCli:
         ]
         for link_name, inward_issue, outward_issue in link_specs:
             try:
-                self.target_tracker._client.create_issue_link(link_name, inward_issue, outward_issue)
+                self.target_tracker.create_issue_link(link_name, inward_issue, outward_issue)
             except JIRAError as err:
                 if "already exists" not in str(err).lower():
                     raise

--- a/elliott/elliottlib/cli/find_bugs_bridge_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_bridge_cli.py
@@ -1,3 +1,5 @@
+"""Mirror eligible basis-group JIRA bugs into a bridge release."""
+
 import logging
 import os
 from dataclasses import dataclass
@@ -22,6 +24,8 @@ REQUIRED_LINK_TYPES = {"depends_on", "blocked_by", "clones"}
 
 @dataclass(frozen=True)
 class BridgeBugMirroringConfig:
+    """Bridge bug mirroring settings derived from group config."""
+
     basis_group: str
     enabled: bool
 
@@ -31,11 +35,22 @@ class BridgeBugMirroringConfig:
 @click.pass_obj
 @click_coroutine
 async def find_bugs_bridge_cli(runtime: Runtime, noop: bool):
+    """Mirror eligible basis-group bugs into the current bridge release.
+
+    Args:
+        runtime: Elliott runtime for the bridge target group.
+        noop: If `True`, log intended changes without creating or updating issues.
+
+    Returns:
+        None.
+    """
     cli = FindBugsBridgeCli(runtime=runtime, noop=noop)
     await cli.run()
 
 
 class FindBugsBridgeCli:
+    """Synchronize bridge-release mirrors for bugs from a basis group."""
+
     def __init__(self, runtime: Runtime, noop: bool):
         self.runtime = runtime
         self.noop = noop
@@ -54,6 +69,15 @@ class FindBugsBridgeCli:
         self.updated_mirror_count = 0
 
     async def run(self):
+        """Create or update bridge mirrors for all eligible source bugs.
+
+        Returns:
+            None.
+
+        Raises:
+            ValueError: If the target group has no configured JIRA target release,
+                or if invalid existing mirror states are detected.
+        """
         self.runtime.initialize(mode="images")
         major, minor = self.runtime.get_major_minor_fields()
         self.major_minor = f"{major}.{minor}"
@@ -105,6 +129,19 @@ class FindBugsBridgeCli:
 
     @staticmethod
     def _load_bridge_config(runtime: Runtime) -> BridgeBugMirroringConfig:
+        """Read bridge bug mirroring settings from the target runtime.
+
+        Args:
+            runtime: Runtime for the bridge target group.
+
+        Returns:
+            BridgeBugMirroringConfig: Parsed bridge mirroring settings for the
+            target group.
+
+        Raises:
+            ValueError: If mirroring is enabled but `bridge_release.basis_group`
+                is missing.
+        """
         bridge_release = runtime.group_config.get("bridge_release", {}) or {}
         basis_group = bridge_release.get("basis_group")
         bug_mirroring = bridge_release.get("bug_mirroring", {}) or {}
@@ -114,6 +151,15 @@ class FindBugsBridgeCli:
         return BridgeBugMirroringConfig(basis_group=basis_group or "", enabled=enabled)
 
     def _build_source_runtime(self, group: str) -> Runtime:
+        """Build a runtime for querying bugs in the basis group.
+
+        Args:
+            group: Basis group name to query for source bugs.
+
+        Returns:
+            Runtime: A runtime configured to read the basis group from the same
+            build-data source and assembly as the target runtime.
+        """
         config = self.runtime.cfg_obj.to_dict()
         config.update(
             {
@@ -127,6 +173,13 @@ class FindBugsBridgeCli:
         return Runtime(cfg_obj=self.runtime.cfg_obj, **config)
 
     def _build_target_image_maps(self):
+        """Map target images by component name and JIRA component.
+
+        Returns:
+            None. This method repopulates `self.images_by_component` and
+            `self.images_by_jira_component` from runtime image metadata and
+            `product.yml` component mappings.
+        """
         self.images_by_component = {}
         self.images_by_jira_component = {}
         for image_meta in self.runtime.image_metas():
@@ -147,6 +200,13 @@ class FindBugsBridgeCli:
                 self.images_by_jira_component[issue_component] = image_meta
 
     def _get_candidate_bugs(self) -> List[Tuple[JIRABug, object]]:
+        """Return source bugs that should be mirrored into the target release.
+
+        Returns:
+            list[tuple[JIRABug, object]]: `(source_bug, image_meta)` pairs for
+            open, non-tracker bugs whose JIRA component maps to a bridge-enabled
+            target image.
+        """
         assert self.source_tracker is not None
         bugs = self.source_tracker.search_bugs(
             search_filter="default", custom_query=' and status != "CLOSED"', verbose=self.runtime.debug
@@ -176,6 +236,15 @@ class FindBugsBridgeCli:
         return candidates
 
     def _resolve_bug_image(self, bug: JIRABug):
+        """Resolve the target image metadata for a source bug.
+
+        Args:
+            bug: Source JIRA bug from the basis group.
+
+        Returns:
+            The target image metadata object for the bug's JIRA component, or
+            `None` if the bug has no component or maps to no bridge-enabled image.
+        """
         try:
             jira_component = bug.component
         except IndexError:
@@ -184,6 +253,16 @@ class FindBugsBridgeCli:
         return self.images_by_jira_component.get(jira_component)
 
     def _get_product_config(self) -> Model:
+        """Load and cache `product.yml` from the build-data main branch.
+
+        Returns:
+            Model: Parsed `product.yml` content used to map package names to JIRA
+            components.
+
+        Raises:
+            IOError: If `product.yml` is missing or invalid in the build-data
+                repository.
+        """
         if self._product_config is not None:
             return self._product_config
 
@@ -197,6 +276,17 @@ class FindBugsBridgeCli:
         return self._product_config
 
     async def _sync_mirror(self, source_bug: JIRABug, image_meta) -> bool:
+        """Create or update the bridge mirror for a source bug.
+
+        Args:
+            source_bug: Source JIRA bug from the basis group.
+            image_meta: Target image metadata matched to the source bug.
+
+        Returns:
+            bool: `True` if the bug was handled by creating or updating a mirror,
+            or by reusing a valid existing mirror. `False` if the bug was skipped
+            because an invalid state or a closed Won't Fix mirror was found.
+        """
         assert self.target_tracker is not None
         if source_bug.id in self.invalid_bugs:
             return False
@@ -232,6 +322,17 @@ class FindBugsBridgeCli:
         return True
 
     def _build_issue_fields(self, source_bug: JIRABug, image_meta) -> dict:
+        """Build the field payload for a bridge mirror issue.
+
+        Args:
+            source_bug: Source JIRA bug being mirrored.
+            image_meta: Target image metadata matched to the source bug.
+
+        Returns:
+            dict: JIRA issue fields for the mirror, including summary,
+            description, issue type, components, labels, and selected copied
+            metadata such as priority and security level.
+        """
         assert self.target_tracker is not None
         summary = f"{source_bug.summary} [bridge to {self.target_release}]"
         description = self._build_description(source_bug, image_meta)
@@ -253,6 +354,16 @@ class FindBugsBridgeCli:
         return fields
 
     def _build_description(self, source_bug: JIRABug, image_meta) -> str:
+        """Build the bridge-specific description for a mirrored issue.
+
+        Args:
+            source_bug: Source JIRA bug being mirrored.
+            image_meta: Target image metadata matched to the source bug.
+
+        Returns:
+            str: A bridge-specific description that explains why the mirror
+            exists and appends the original source issue description.
+        """
         source_description = getattr(source_bug.bug.fields, "description", "") or "No source description provided."
         return (
             f"This issue was automatically created by ART as a bridge-release mirror of {source_bug.id} "
@@ -272,6 +383,17 @@ class FindBugsBridgeCli:
         )
 
     def _get_existing_mirrors_by_source(self, source_bug_ids: List[str]) -> Dict[str, List[JIRABug]]:
+        """Return existing mirror issues keyed by source bug id.
+
+        Args:
+            source_bug_ids: Source JIRA issue keys to look up in existing bridge
+                mirrors.
+
+        Returns:
+            dict[str, list[JIRABug]]: A mapping for every requested source bug id.
+            Lists are empty when no mirror is found and can contain multiple
+            entries when duplicate mirrors exist.
+        """
         assert self.target_tracker is not None
         if not source_bug_ids:
             return {}
@@ -300,6 +422,15 @@ class FindBugsBridgeCli:
         return mirrors_by_source
 
     def _update_issue(self, mirror_bug: JIRABug, fields: dict):
+        """Update an existing bridge mirror with the latest source fields.
+
+        Args:
+            mirror_bug: Existing bridge mirror to update.
+            fields: JIRA update payload derived from the current source bug state.
+
+        Returns:
+            None.
+        """
         if self.noop:
             LOGGER.info("[DRY RUN] Would update bridge mirror %s with fields=%s", mirror_bug.id, fields)
             return
@@ -310,6 +441,19 @@ class FindBugsBridgeCli:
         LOGGER.info("Updated bridge mirror %s", mirror_bug.id)
 
     def _ensure_issue_links(self, mirror_issue_key: str, source_issue_key: str):
+        """Ensure the required links exist between the source and mirror issues.
+
+        Args:
+            mirror_issue_key: JIRA key for the bridge mirror issue.
+            source_issue_key: JIRA key for the basis-group source issue.
+
+        Returns:
+            None.
+
+        Raises:
+            JIRAError: If link creation fails for a reason other than the link
+                already existing.
+        """
         assert self.target_tracker is not None
         if self.noop:
             LOGGER.info("[DRY RUN] Would add required links between %s and %s", mirror_issue_key, source_issue_key)
@@ -328,6 +472,17 @@ class FindBugsBridgeCli:
 
     @staticmethod
     def _get_linked_sources(mirror_bug: JIRABug, source_bug_ids: set[str]) -> set[str]:
+        """Return source bug ids linked to a mirror through required link types.
+
+        Args:
+            mirror_bug: Bridge mirror issue to inspect.
+            source_bug_ids: Source issue keys that are valid candidates for
+                linkage.
+
+        Returns:
+            set[str]: Source issue keys linked to the mirror through any of the
+            required bridge mirror link types.
+        """
         linked_sources = set()
         for link in getattr(mirror_bug.bug.fields, "issuelinks", []):
             if link.type.name == "Blocks" and hasattr(link, "inwardIssue"):
@@ -347,6 +502,16 @@ class FindBugsBridgeCli:
 
     @staticmethod
     def _required_link_types_for_source(mirror_bug: JIRABug, source_bug_id: str) -> set[str]:
+        """Return required link types already present for a source bug.
+
+        Args:
+            mirror_bug: Bridge mirror issue to inspect.
+            source_bug_id: Source issue key whose links should be validated.
+
+        Returns:
+            set[str]: Normalized required link markers already present between
+            the mirror and the source issue.
+        """
         found = set()
         for link in getattr(mirror_bug.bug.fields, "issuelinks", []):
             if link.type.name == "Blocks" and hasattr(link, "inwardIssue") and link.inwardIssue.key == source_bug_id:
@@ -361,6 +526,15 @@ class FindBugsBridgeCli:
         return found
 
     def _validate_required_links(self, mirror_bug: JIRABug, source_bug_id: str):
+        """Record an invalid case when a mirror is missing required links.
+
+        Args:
+            mirror_bug: Bridge mirror issue to validate.
+            source_bug_id: Source issue key that should be linked to the mirror.
+
+        Returns:
+            None.
+        """
         found = self._required_link_types_for_source(mirror_bug, source_bug_id)
         missing = REQUIRED_LINK_TYPES - found
         if missing:
@@ -370,15 +544,26 @@ class FindBugsBridgeCli:
             )
 
     def _record_invalid_bug(self, source_bug_id: str, message: str):
+        """Record an invalid bridge mirroring case for later reporting."""
         self.invalid_bugs.setdefault(source_bug_id, []).append(message)
 
     def _report_invalid_bugs(self):
+        """Log every invalid bridge mirroring case collected during the run."""
         for source_bug_id in sorted(self.invalid_bugs):
             for message in self.invalid_bugs[source_bug_id]:
                 LOGGER.error("Invalid bridge bug case for %s: %s", source_bug_id, message)
 
     @staticmethod
     def _is_closed_wont_fix(mirror_bug: JIRABug) -> bool:
+        """Return whether a mirror is closed with a Won't Fix resolution.
+
+        Args:
+            mirror_bug: Bridge mirror issue to inspect.
+
+        Returns:
+            bool: `True` when the mirror is closed with a Won't Fix style
+            resolution, otherwise `False`.
+        """
         if mirror_bug.status.lower() != "closed":
             return False
         resolution = (mirror_bug.resolution or "").replace("’", "'").lower()

--- a/elliott/elliottlib/cli/find_bugs_bridge_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_bridge_cli.py
@@ -334,7 +334,12 @@ class FindBugsBridgeCli:
             metadata such as priority and security level.
         """
         assert self.target_tracker is not None
-        summary = f"{source_bug.summary} [bridge to {self.target_release}]"
+        suffix = f" [bridge to {self.target_release}]"
+        base = source_bug.summary or ""
+        max_base = 255 - len(suffix)
+        if len(base) > max_base:
+            base = base[: max_base - 3] + "..."
+        summary = f"{base}{suffix}"
         description = self._build_description(source_bug, image_meta)
         issue_type = getattr(source_bug.bug.fields.issuetype, "name", "Bug")
         components = [{"name": component.name} for component in getattr(source_bug.bug.fields, "components", [])]

--- a/elliott/elliottlib/cli/find_bugs_bridge_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_bridge_cli.py
@@ -18,7 +18,7 @@ from elliottlib.cli.common import click_coroutine
 LOGGER = logging.getLogger(__name__)
 
 BRIDGE_LABEL = "art:bridge-bug"
-WONT_FIX_RESOLUTIONS = {"won't fix", "wontfix", "wont fix"}
+WONT_FIX_RESOLUTIONS = {"won't do"}
 REQUIRED_LINK_TYPES = {"depends_on", "blocked_by", "clones"}
 
 
@@ -285,7 +285,7 @@ class FindBugsBridgeCli:
         Returns:
             bool: `True` if the bug was handled by creating or updating a mirror,
             or by reusing a valid existing mirror. `False` if the bug was skipped
-            because an invalid state or a closed Won't Fix mirror was found.
+            because an invalid state or a closed Won't Do mirror was found.
         """
         assert self.target_tracker is not None
         if source_bug.id in self.invalid_bugs:
@@ -293,12 +293,12 @@ class FindBugsBridgeCli:
         existing = self.existing_mirrors_by_source.get(source_bug.id, [])
         if existing:
             if any(self._is_closed_wont_fix(mirror) for mirror in existing):
-                LOGGER.info("Skipping %s because an existing mirror is closed as Won't Fix", source_bug.id)
+                LOGGER.info("Skipping %s because an existing mirror is closed as Won't Do", source_bug.id)
                 return False
             if all(mirror.status.lower() == "closed" for mirror in existing):
                 self._record_invalid_bug(
                     source_bug.id,
-                    "Existing bridge mirror is closed without Won't Fix; manual investigation required",
+                    "Existing bridge mirror is closed without Won't Do; manual investigation required",
                 )
                 return False
             mirror = existing[0]
@@ -384,7 +384,7 @@ class FindBugsBridgeCli:
             "engineer decides otherwise.\n\n"
             f"How to disposition it for {self.major_minor}:\n"
             f"- You do not need to directly manage this issue's state unless you want to remove it from {self.major_minor} advisories.\n"
-            f"- If the issue should not appear in {self.major_minor} advisories, close this mirror with \"Won't Fix\".\n"
+            f"- If the issue should not appear in {self.major_minor} advisories, close this mirror with \"Won't Do\".\n"
             "- Otherwise, leave it open and ART automation will continue to manage its presence.\n\n"
             "Original description:\n"
             "----\n"
@@ -582,13 +582,13 @@ class FindBugsBridgeCli:
 
     @staticmethod
     def _is_closed_wont_fix(mirror_bug: JIRABug) -> bool:
-        """Return whether a mirror is closed with a Won't Fix resolution.
+        """Return whether a mirror is closed with a Won't Do resolution.
 
         Args:
             mirror_bug: Bridge mirror issue to inspect.
 
         Returns:
-            bool: `True` when the mirror is closed with a Won't Fix style
+            bool: `True` when the mirror is closed with a Won't Do
             resolution, otherwise `False`.
         """
         if mirror_bug.status.lower() != "closed":

--- a/elliott/elliottlib/cli/find_bugs_bridge_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_bridge_cli.py
@@ -301,12 +301,15 @@ class FindBugsBridgeCli:
                     "Existing bridge mirror is closed without Won't Fix; manual investigation required",
                 )
                 return False
-            fields = self._build_issue_fields(source_bug, image_meta)
             mirror = existing[0]
             if mirror.status.lower() != "closed":
-                self._update_issue(mirror, fields)
-                self._ensure_issue_links(mirror.id, source_bug.id)
-                self.updated_mirror_count += 1
+                fields = self._build_issue_fields(source_bug, image_meta)
+                if self._needs_update(mirror, fields):
+                    self._update_issue(mirror, fields)
+                    self.updated_mirror_count += 1
+                missing_links = REQUIRED_LINK_TYPES - self._required_link_types_for_source(mirror, source_bug.id)
+                if missing_links:
+                    self._ensure_issue_links(mirror.id, source_bug.id)
             return True
 
         fields = self._build_issue_fields(source_bug, image_meta)
@@ -350,6 +353,7 @@ class FindBugsBridgeCli:
             "components": components,
             "labels": [BRIDGE_LABEL],
         }
+        fields["versions"] = []
         priority = getattr(getattr(source_bug.bug.fields, "priority", None), "name", None)
         if priority:
             fields["priority"] = {"name": priority}
@@ -425,6 +429,24 @@ class FindBugsBridgeCli:
             elif linked_mirrors:
                 self._validate_required_links(linked_mirrors[0], source_bug_id)
         return mirrors_by_source
+
+    @staticmethod
+    def _needs_update(mirror_bug: JIRABug, fields: dict) -> bool:
+        """Check whether the mirror's fields differ from the desired state."""
+        mirror_fields = mirror_bug.bug.fields
+        if getattr(mirror_fields, "summary", "") != fields.get("summary"):
+            return True
+        if getattr(mirror_fields, "description", "") != fields.get("description"):
+            return True
+        mirror_components = sorted(c.name for c in getattr(mirror_fields, "components", []))
+        desired_components = sorted(c["name"] for c in fields.get("components", []))
+        if mirror_components != desired_components:
+            return True
+        mirror_priority = getattr(getattr(mirror_fields, "priority", None), "name", None)
+        desired_priority = fields.get("priority", {}).get("name") if "priority" in fields else None
+        if mirror_priority != desired_priority:
+            return True
+        return False
 
     def _update_issue(self, mirror_bug: JIRABug, fields: dict):
         """Update an existing bridge mirror with the latest source fields.

--- a/elliott/tests/test_bzutil.py
+++ b/elliott/tests/test_bzutil.py
@@ -573,9 +573,7 @@ class TestJIRABugTracker(unittest.TestCase):
         flexmock(JIRABugTracker).should_receive("_init_fields")
 
         tracker = JIRABugTracker(config)
-        mock_jira_client.should_receive("create_issue_link").with_args(
-            "Blocks", "OCPBUGS-100", "OCPBUGS-200"
-        ).once()
+        mock_jira_client.should_receive("create_issue_link").with_args("Blocks", "OCPBUGS-100", "OCPBUGS-200").once()
 
         tracker.create_issue_link("Blocks", "OCPBUGS-100", "OCPBUGS-200")
 

--- a/elliott/tests/test_bzutil.py
+++ b/elliott/tests/test_bzutil.py
@@ -536,6 +536,49 @@ class TestJIRABugTracker(unittest.TestCase):
         result = tracker.cve_tracker_search(["NEW"])
         self.assertEqual(result, [])
 
+        # Test search_bugs method
+        result = tracker.search_bugs(status=["NEW"])
+        self.assertEqual(result, [])
+
+    def test_search_bugs_delegates_to_query_and_search(self):
+        config = {
+            "project": "OCPBUGS",
+            "server": JIRA_SERVER_URL,
+            "target_release": ["4.23.z"],
+        }
+        mock_jira_client = flexmock()
+        flexmock(JIRABugTracker).should_receive("login").and_return(mock_jira_client)
+        flexmock(JIRABugTracker).should_receive("_init_fields")
+
+        tracker = JIRABugTracker(config)
+        flexmock(tracker).should_receive("_get_available_target_versions").and_return(["4.23.z"])
+
+        mock_bug = flexmock(key="OCPBUGS-1")
+        mock_jira_client.should_receive("search_issues").and_return([mock_bug])
+
+        results = tracker.search_bugs(
+            search_filter="default",
+            include_labels=["art:bridge-bug"],
+            custom_query=" order by created DESC",
+            verbose=False,
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].id, "OCPBUGS-1")
+
+    def test_create_issue_link_delegates_to_client(self):
+        config = {"project": "OCPBUGS", "server": JIRA_SERVER_URL}
+        mock_jira_client = flexmock()
+        flexmock(JIRABugTracker).should_receive("login").and_return(mock_jira_client)
+        flexmock(JIRABugTracker).should_receive("_init_fields")
+
+        tracker = JIRABugTracker(config)
+        mock_jira_client.should_receive("create_issue_link").with_args(
+            "Blocks", "OCPBUGS-100", "OCPBUGS-200"
+        ).once()
+
+        tracker.create_issue_link("Blocks", "OCPBUGS-100", "OCPBUGS-200")
+
 
 class TestBugzillaBugTracker(unittest.TestCase):
     def test_get_config(self):

--- a/elliott/tests/test_bzutil.py
+++ b/elliott/tests/test_bzutil.py
@@ -171,6 +171,34 @@ class TestJIRABugTracker(unittest.TestCase):
         expected = {"foo": 1, "bar": 2, "server": "https://redhat.atlassian.net"}
         self.assertEqual(actual, expected)
 
+    def test_create_issue_applies_tracker_defaults(self):
+        config = {
+            "project": "OCPBUGS",
+            "server": JIRA_SERVER_URL,
+            "version": ["4.23"],
+            "target_release": ["4.23.z", "4.23.0"],
+        }
+        mock_issue = flexmock(key="OCPBUGS-1")
+        mock_jira_client = flexmock()
+        mock_jira_client.should_receive("create_issue").with_args(
+            fields={
+                "summary": "Bridge bug",
+                "description": "Bridge description",
+                "project": {"key": "OCPBUGS"},
+                "versions": [{"name": "4.23"}],
+                JIRABugTracker.field_target_version: [{"name": "4.23.z"}, {"name": "4.23.0"}],
+            }
+        ).and_return(mock_issue)
+
+        flexmock(JIRABugTracker).should_receive("login").and_return(mock_jira_client)
+        flexmock(JIRABugTracker).should_receive("_init_fields")
+
+        tracker = JIRABugTracker(config)
+        bug = tracker.create_issue({"summary": "Bridge bug", "description": "Bridge description"})
+
+        self.assertIsInstance(bug, JIRABug)
+        self.assertEqual(bug.id, "OCPBUGS-1")
+
     def test_security_filtering_in_query(self):
         """Test that security filtering is included in JQL query when enabled"""
         # Create a minimal tracker for testing

--- a/elliott/tests/test_find_bugs_bridge_cli.py
+++ b/elliott/tests/test_find_bugs_bridge_cli.py
@@ -1,0 +1,240 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+from artcommonlib.model import Model
+from elliottlib.cli.find_bugs_bridge_cli import BRIDGE_LABEL, FindBugsBridgeCli
+
+
+class TestFindBugsBridgeCli(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.runtime = MagicMock()
+        self.runtime.group = "openshift-4.23"
+        self.runtime.debug = False
+        self.runtime.get_major_minor_fields.return_value = (4, 23)
+        self.runtime.group_config = {
+            "bridge_release": {
+                "basis_group": "openshift-5.0",
+                "bug_mirroring": {"enabled": True},
+            }
+        }
+        self.cli = FindBugsBridgeCli(runtime=self.runtime, noop=False)
+        self.cli.bridge_config = self.cli._load_bridge_config(self.runtime)
+        self.cli.major_minor = "4.23"
+        self.cli.target_release = "4.23.z"
+        self.cli.target_tracker = MagicMock()
+        self.cli.target_tracker.project = "OCPBUGS"
+        self.cli.target_tracker.field_target_version = "customfield_12345"
+        self.cli.target_tracker._query.return_value = "mirror query"
+        self.cli.existing_mirrors_by_source = {}
+        self.cli._product_config = Model(
+            {
+                "bug_mapping": {
+                    "components": {
+                        "visible-image-container": {"issue_component": "Visible"},
+                        "disabled-image-container": {"issue_component": "Disabled"},
+                        "non-art-built-container": {"issue_component": "Unmanaged"},
+                    }
+                }
+            }
+        )
+
+    @staticmethod
+    def _link(link_name, inward_key=None, outward_key=None):
+        link = MagicMock()
+        link.type.name = link_name
+        if inward_key:
+            link.inwardIssue.key = inward_key
+        if outward_key:
+            link.outwardIssue.key = outward_key
+        return link
+
+    def test_get_candidate_bugs_filters_trackers_and_disabled_images(self):
+        visible_image = MagicMock()
+        visible_image.distgit_key = "visible-image"
+        visible_image.get_component_name.return_value = "visible-image-container"
+        visible_image.config = {
+            "for_payload": True,
+            "delivery": {"delivery_repo_names": ["openshift4/visible-image-rhel9"]},
+        }
+        disabled_image = MagicMock()
+        disabled_image.distgit_key = "disabled-image"
+        disabled_image.get_component_name.return_value = "disabled-image-container"
+        disabled_image.config = {
+            "for_payload": True,
+            "delivery": {"delivery_repo_names": ["openshift4/disabled-image-rhel9"]},
+            "bridge_release": {"bug_mirroring": {"enabled": False}},
+        }
+        self.cli.images_by_component = {
+            "visible-image-container": visible_image,
+            "disabled-image-container": disabled_image,
+        }
+        self.cli.images_by_jira_component = {
+            "Visible": visible_image,
+            "Disabled": disabled_image,
+        }
+
+        tracker_bug = MagicMock()
+        tracker_bug.id = "OCPBUGS-1"
+        tracker_bug.is_tracker_bug.return_value = True
+
+        disabled_bug = MagicMock()
+        disabled_bug.id = "OCPBUGS-2"
+        disabled_bug.is_tracker_bug.return_value = False
+        disabled_bug.component = "Disabled"
+
+        visible_bug = MagicMock()
+        visible_bug.id = "OCPBUGS-3"
+        visible_bug.is_tracker_bug.return_value = False
+        visible_bug.component = "Visible"
+
+        unmanaged_bug = MagicMock()
+        unmanaged_bug.id = "OCPBUGS-4"
+        unmanaged_bug.is_tracker_bug.return_value = False
+        unmanaged_bug.component = "Unmanaged"
+
+        self.cli.source_tracker = MagicMock()
+        self.cli.source_tracker._query.return_value = "source query"
+        self.cli.source_tracker._search.return_value = [tracker_bug, disabled_bug, visible_bug, unmanaged_bug]
+
+        candidates = self.cli._get_candidate_bugs()
+        self.assertEqual([(bug.id, image.distgit_key) for bug, image in candidates], [("OCPBUGS-3", "visible-image")])
+        self.cli.source_tracker._query.assert_called_once_with(
+            search_filter="default",
+            custom_query=' and status != "CLOSED"',
+        )
+        self.cli.source_tracker._search.assert_called_once_with("source query", verbose=False)
+
+    def test_build_target_image_maps_only_includes_payload_images(self):
+        visible_image = MagicMock()
+        visible_image.get_component_name.return_value = "visible-image-container"
+        visible_image.config = {"for_payload": True}
+
+        non_payload_image = MagicMock()
+        non_payload_image.get_component_name.return_value = "non-art-built-container"
+        non_payload_image.config = {"for_payload": False}
+
+        self.runtime.image_metas.return_value = [visible_image, non_payload_image]
+
+        self.cli._build_target_image_maps()
+
+        self.assertEqual(self.cli.images_by_component, {"visible-image-container": visible_image})
+        self.assertEqual(self.cli.images_by_jira_component, {"Visible": visible_image})
+
+    async def test_sync_mirror_creates_issue_and_link(self):
+        source_bug = MagicMock()
+        source_bug.id = "OCPBUGS-123"
+        source_bug.summary = "Visible bug"
+        source_bug.status = "ON_QA"
+        source_bug.weburl = "https://issues.example.com/OCPBUGS-123"
+        source_bug.component = "visible-image-container"
+        source_bug.whiteboard_component = None
+        source_bug.bug.fields.description = "Source description"
+        source_bug.bug.fields.issuetype.name = "Story"
+        source_bug.bug.fields.components = [MagicMock(name="Visible")]
+        source_bug.bug.fields.components[0].name = "Visible"
+        source_bug.bug.fields.priority = None
+        source_bug.bug.fields.security = None
+
+        image_meta = MagicMock()
+        image_meta.distgit_key = "visible-image"
+        image_meta.get_component_name.return_value = "visible-image-container"
+
+        created_issue = MagicMock()
+        created_issue.id = "OCPBUGS-999"
+        self.cli.target_tracker.create_issue.return_value = created_issue
+
+        result = await self.cli._sync_mirror(source_bug, image_meta)
+
+        self.assertTrue(result)
+        create_call = self.cli.target_tracker.create_issue.call_args.args[0]
+        self.assertEqual(create_call["issuetype"], {"name": "Story"})
+        self.assertEqual(create_call["components"], [{"name": "Visible"}])
+        self.assertIn(BRIDGE_LABEL, create_call["labels"])
+        self.cli.target_tracker._client.create_issue_link.assert_any_call("Blocks", "OCPBUGS-123", "OCPBUGS-999")
+        self.cli.target_tracker._client.create_issue_link.assert_any_call("Depend", "OCPBUGS-999", "OCPBUGS-123")
+        self.cli.target_tracker._client.create_issue_link.assert_any_call("Cloners", "OCPBUGS-999", "OCPBUGS-123")
+        self.assertEqual(self.cli.target_tracker._client.create_issue_link.call_count, 3)
+
+    async def test_sync_mirror_skips_existing_wont_fix(self):
+        source_bug = MagicMock()
+        source_bug.id = "OCPBUGS-123"
+
+        image_meta = MagicMock()
+
+        existing_mirror = MagicMock()
+        existing_mirror.status = "Closed"
+        existing_mirror.resolution = "Won't Fix"
+        self.cli.existing_mirrors_by_source = {"OCPBUGS-123": [existing_mirror]}
+
+        result = await self.cli._sync_mirror(source_bug, image_meta)
+
+        self.assertFalse(result)
+        self.cli.target_tracker.create_issue.assert_not_called()
+
+    def test_get_existing_mirrors_by_source_uses_linked_issue(self):
+        mirror_for_source = MagicMock()
+        mirror_for_source.id = "OCPBUGS-900"
+        mirror_for_source.bug.fields.issuelinks = [
+            self._link("Blocks", inward_key="OCPBUGS-123"),
+            self._link("Depend", outward_key="OCPBUGS-123"),
+            self._link("Cloners", outward_key="OCPBUGS-123"),
+        ]
+        unrelated_mirror = MagicMock()
+        unrelated_mirror.id = "OCPBUGS-901"
+        unrelated_mirror.bug.fields.issuelinks = [self._link("Blocks", inward_key="OCPBUGS-999")]
+        self.cli.target_tracker._search.return_value = [mirror_for_source, unrelated_mirror]
+
+        mirrors_by_source = self.cli._get_existing_mirrors_by_source(["OCPBUGS-123", "OCPBUGS-456"])
+
+        self.assertEqual(mirrors_by_source["OCPBUGS-123"], [mirror_for_source])
+        self.assertEqual(mirrors_by_source["OCPBUGS-456"], [])
+        self.cli.target_tracker._query.assert_called_once_with(
+            include_labels=[BRIDGE_LABEL],
+            with_target_release=True,
+            custom_query=" order by created DESC",
+        )
+        self.cli.target_tracker._search.assert_called_once()
+
+    def test_get_existing_mirrors_by_source_complains_for_duplicate_mirrors(self):
+        mirror_a = MagicMock()
+        mirror_a.id = "OCPBUGS-900"
+        mirror_a.bug.fields.issuelinks = [self._link("Blocks", inward_key="OCPBUGS-123")]
+        mirror_b = MagicMock()
+        mirror_b.id = "OCPBUGS-901"
+        mirror_b.bug.fields.issuelinks = [self._link("Depend", outward_key="OCPBUGS-123")]
+        self.cli.target_tracker._search.return_value = [mirror_a, mirror_b]
+
+        mirrors_by_source = self.cli._get_existing_mirrors_by_source(["OCPBUGS-123"])
+
+        self.assertEqual(mirrors_by_source["OCPBUGS-123"], [mirror_a, mirror_b])
+        self.assertIn("OCPBUGS-123", self.cli.invalid_bugs)
+        self.assertIn("Expected exactly one bridge mirror", self.cli.invalid_bugs["OCPBUGS-123"][0])
+
+    async def test_run_reports_invalid_cases_and_fails_at_end(self):
+        self.cli.runtime.initialize = MagicMock()
+        self.cli.runtime.get_major_minor_fields = MagicMock(return_value=(4, 23))
+        self.cli.source_runtime = MagicMock()
+        self.cli.source_tracker = MagicMock()
+        self.cli.target_tracker = MagicMock()
+        self.cli.target_tracker.target_release.return_value = ["4.23.z"]
+        self.cli.runtime.get_bug_tracker = MagicMock(return_value=self.cli.target_tracker)
+        self.cli.source_runtime.get_bug_tracker = MagicMock(return_value=self.cli.source_tracker)
+        self.cli._build_source_runtime = MagicMock(return_value=self.cli.source_runtime)
+        self.cli._build_target_image_maps = MagicMock()
+        bug = MagicMock()
+        bug.id = "OCPBUGS-123"
+        image_meta = MagicMock()
+        self.cli._get_candidate_bugs = MagicMock(return_value=[(bug, image_meta)])
+
+        def _existing_mirrors(*_args, **_kwargs):
+            self.cli.invalid_bugs.setdefault("OCPBUGS-123", []).append("bad links")
+            return {}
+
+        self.cli._get_existing_mirrors_by_source = MagicMock(side_effect=_existing_mirrors)
+        self.cli._sync_mirror = AsyncMock(return_value=False)
+        self.cli._report_invalid_bugs = MagicMock()
+
+        with self.assertRaisesRegex(ValueError, "Found invalid bridge bug cases"):
+            await self.cli.run()
+
+        self.cli._report_invalid_bugs.assert_called_once()

--- a/elliott/tests/test_find_bugs_bridge_cli.py
+++ b/elliott/tests/test_find_bugs_bridge_cli.py
@@ -48,39 +48,20 @@ class TestFindBugsBridgeCli(IsolatedAsyncioTestCase):
             link.outwardIssue.key = outward_key
         return link
 
-    def test_get_candidate_bugs_filters_trackers_and_disabled_images(self):
+    def test_get_candidate_bugs_filters_trackers_and_unmapped(self):
         visible_image = MagicMock()
         visible_image.distgit_key = "visible-image"
         visible_image.get_component_name.return_value = "visible-image-container"
-        visible_image.config = {
-            "for_payload": True,
-            "delivery": {"delivery_repo_names": ["openshift4/visible-image-rhel9"]},
-        }
-        disabled_image = MagicMock()
-        disabled_image.distgit_key = "disabled-image"
-        disabled_image.get_component_name.return_value = "disabled-image-container"
-        disabled_image.config = {
-            "for_payload": True,
-            "delivery": {"delivery_repo_names": ["openshift4/disabled-image-rhel9"]},
-            "bridge_release": {"bug_mirroring": {"enabled": False}},
-        }
         self.cli.images_by_component = {
             "visible-image-container": visible_image,
-            "disabled-image-container": disabled_image,
         }
         self.cli.images_by_jira_component = {
             "Visible": visible_image,
-            "Disabled": disabled_image,
         }
 
         tracker_bug = MagicMock()
         tracker_bug.id = "OCPBUGS-1"
         tracker_bug.is_tracker_bug.return_value = True
-
-        disabled_bug = MagicMock()
-        disabled_bug.id = "OCPBUGS-2"
-        disabled_bug.is_tracker_bug.return_value = False
-        disabled_bug.component = "Disabled"
 
         visible_bug = MagicMock()
         visible_bug.id = "OCPBUGS-3"
@@ -93,7 +74,7 @@ class TestFindBugsBridgeCli(IsolatedAsyncioTestCase):
         unmanaged_bug.component = "Unmanaged"
 
         self.cli.source_tracker = MagicMock()
-        self.cli.source_tracker.search_bugs.return_value = [tracker_bug, disabled_bug, visible_bug, unmanaged_bug]
+        self.cli.source_tracker.search_bugs.return_value = [tracker_bug, visible_bug, unmanaged_bug]
 
         candidates = self.cli._get_candidate_bugs()
         self.assertEqual([(bug.id, image.distgit_key) for bug, image in candidates], [("OCPBUGS-3", "visible-image")])
@@ -103,21 +84,21 @@ class TestFindBugsBridgeCli(IsolatedAsyncioTestCase):
             verbose=False,
         )
 
-    def test_build_target_image_maps_only_includes_payload_images(self):
-        visible_image = MagicMock()
-        visible_image.get_component_name.return_value = "visible-image-container"
-        visible_image.config = {"for_payload": True}
+    def test_build_target_image_maps_respects_bridge_bug_mirroring_enabled(self):
+        enabled_image = MagicMock()
+        enabled_image.get_component_name.return_value = "visible-image-container"
+        enabled_image.bridge_bug_mirroring_enabled = True
 
-        non_payload_image = MagicMock()
-        non_payload_image.get_component_name.return_value = "non-art-built-container"
-        non_payload_image.config = {"for_payload": False}
+        disabled_image = MagicMock()
+        disabled_image.get_component_name.return_value = "disabled-image-container"
+        disabled_image.bridge_bug_mirroring_enabled = False
 
-        self.runtime.image_metas.return_value = [visible_image, non_payload_image]
+        self.runtime.image_metas.return_value = [enabled_image, disabled_image]
 
         self.cli._build_target_image_maps()
 
-        self.assertEqual(self.cli.images_by_component, {"visible-image-container": visible_image})
-        self.assertEqual(self.cli.images_by_jira_component, {"Visible": visible_image})
+        self.assertEqual(self.cli.images_by_component, {"visible-image-container": enabled_image})
+        self.assertEqual(self.cli.images_by_jira_component, {"Visible": enabled_image})
 
     async def test_sync_mirror_creates_issue_and_link(self):
         source_bug = MagicMock()

--- a/elliott/tests/test_find_bugs_bridge_cli.py
+++ b/elliott/tests/test_find_bugs_bridge_cli.py
@@ -24,7 +24,7 @@ class TestFindBugsBridgeCli(IsolatedAsyncioTestCase):
         self.cli.target_tracker = MagicMock()
         self.cli.target_tracker.project = "OCPBUGS"
         self.cli.target_tracker.field_target_version = "customfield_12345"
-        self.cli.target_tracker._query.return_value = "mirror query"
+        self.cli.target_tracker.search_bugs.return_value = []
         self.cli.existing_mirrors_by_source = {}
         self.cli._product_config = Model(
             {
@@ -93,16 +93,15 @@ class TestFindBugsBridgeCli(IsolatedAsyncioTestCase):
         unmanaged_bug.component = "Unmanaged"
 
         self.cli.source_tracker = MagicMock()
-        self.cli.source_tracker._query.return_value = "source query"
-        self.cli.source_tracker._search.return_value = [tracker_bug, disabled_bug, visible_bug, unmanaged_bug]
+        self.cli.source_tracker.search_bugs.return_value = [tracker_bug, disabled_bug, visible_bug, unmanaged_bug]
 
         candidates = self.cli._get_candidate_bugs()
         self.assertEqual([(bug.id, image.distgit_key) for bug, image in candidates], [("OCPBUGS-3", "visible-image")])
-        self.cli.source_tracker._query.assert_called_once_with(
+        self.cli.source_tracker.search_bugs.assert_called_once_with(
             search_filter="default",
             custom_query=' and status != "CLOSED"',
+            verbose=False,
         )
-        self.cli.source_tracker._search.assert_called_once_with("source query", verbose=False)
 
     def test_build_target_image_maps_only_includes_payload_images(self):
         visible_image = MagicMock()
@@ -150,10 +149,10 @@ class TestFindBugsBridgeCli(IsolatedAsyncioTestCase):
         self.assertEqual(create_call["issuetype"], {"name": "Story"})
         self.assertEqual(create_call["components"], [{"name": "Visible"}])
         self.assertIn(BRIDGE_LABEL, create_call["labels"])
-        self.cli.target_tracker._client.create_issue_link.assert_any_call("Blocks", "OCPBUGS-123", "OCPBUGS-999")
-        self.cli.target_tracker._client.create_issue_link.assert_any_call("Depend", "OCPBUGS-999", "OCPBUGS-123")
-        self.cli.target_tracker._client.create_issue_link.assert_any_call("Cloners", "OCPBUGS-999", "OCPBUGS-123")
-        self.assertEqual(self.cli.target_tracker._client.create_issue_link.call_count, 3)
+        self.cli.target_tracker.create_issue_link.assert_any_call("Blocks", "OCPBUGS-123", "OCPBUGS-999")
+        self.cli.target_tracker.create_issue_link.assert_any_call("Depend", "OCPBUGS-999", "OCPBUGS-123")
+        self.cli.target_tracker.create_issue_link.assert_any_call("Cloners", "OCPBUGS-999", "OCPBUGS-123")
+        self.assertEqual(self.cli.target_tracker.create_issue_link.call_count, 3)
 
     async def test_sync_mirror_skips_existing_wont_fix(self):
         source_bug = MagicMock()
@@ -182,18 +181,18 @@ class TestFindBugsBridgeCli(IsolatedAsyncioTestCase):
         unrelated_mirror = MagicMock()
         unrelated_mirror.id = "OCPBUGS-901"
         unrelated_mirror.bug.fields.issuelinks = [self._link("Blocks", inward_key="OCPBUGS-999")]
-        self.cli.target_tracker._search.return_value = [mirror_for_source, unrelated_mirror]
+        self.cli.target_tracker.search_bugs.return_value = [mirror_for_source, unrelated_mirror]
 
         mirrors_by_source = self.cli._get_existing_mirrors_by_source(["OCPBUGS-123", "OCPBUGS-456"])
 
         self.assertEqual(mirrors_by_source["OCPBUGS-123"], [mirror_for_source])
         self.assertEqual(mirrors_by_source["OCPBUGS-456"], [])
-        self.cli.target_tracker._query.assert_called_once_with(
+        self.cli.target_tracker.search_bugs.assert_called_once_with(
             include_labels=[BRIDGE_LABEL],
             with_target_release=True,
             custom_query=" order by created DESC",
+            verbose=False,
         )
-        self.cli.target_tracker._search.assert_called_once()
 
     def test_get_existing_mirrors_by_source_complains_for_duplicate_mirrors(self):
         mirror_a = MagicMock()
@@ -202,7 +201,7 @@ class TestFindBugsBridgeCli(IsolatedAsyncioTestCase):
         mirror_b = MagicMock()
         mirror_b.id = "OCPBUGS-901"
         mirror_b.bug.fields.issuelinks = [self._link("Depend", outward_key="OCPBUGS-123")]
-        self.cli.target_tracker._search.return_value = [mirror_a, mirror_b]
+        self.cli.target_tracker.search_bugs.return_value = [mirror_a, mirror_b]
 
         mirrors_by_source = self.cli._get_existing_mirrors_by_source(["OCPBUGS-123"])
 

--- a/elliott/tests/test_find_bugs_bridge_cli.py
+++ b/elliott/tests/test_find_bugs_bridge_cli.py
@@ -6,6 +6,8 @@ from elliottlib.cli.find_bugs_bridge_cli import BRIDGE_LABEL, FindBugsBridgeCli
 
 
 class TestFindBugsBridgeCli(IsolatedAsyncioTestCase):
+    """Exercise bridge bug mirroring candidate and sync behavior."""
+
     def setUp(self):
         self.runtime = MagicMock()
         self.runtime.group = "openshift-4.23"
@@ -40,6 +42,7 @@ class TestFindBugsBridgeCli(IsolatedAsyncioTestCase):
 
     @staticmethod
     def _link(link_name, inward_key=None, outward_key=None):
+        """Build a mock issue link with the requested direction."""
         link = MagicMock()
         link.type.name = link_name
         if inward_key:

--- a/elliott/tests/test_find_bugs_bridge_cli.py
+++ b/elliott/tests/test_find_bugs_bridge_cli.py
@@ -154,6 +154,116 @@ class TestFindBugsBridgeCli(IsolatedAsyncioTestCase):
         self.assertFalse(result)
         self.cli.target_tracker.create_issue.assert_not_called()
 
+    async def test_sync_mirror_skips_update_when_unchanged(self):
+        source_bug = MagicMock()
+        source_bug.id = "OCPBUGS-123"
+        source_bug.summary = "Visible bug"
+        source_bug.bug.fields.description = "Source description"
+        source_bug.bug.fields.issuetype.name = "Bug"
+        source_bug.bug.fields.components = [MagicMock()]
+        source_bug.bug.fields.components[0].name = "Visible"
+        source_bug.bug.fields.priority = None
+        source_bug.bug.fields.security = None
+        source_bug.bug.fields.versions = []
+
+        image_meta = MagicMock()
+        image_meta.distgit_key = "visible-image"
+
+        existing_mirror = MagicMock()
+        existing_mirror.id = "OCPBUGS-900"
+        existing_mirror.status = "New"
+        existing_mirror.keywords = [BRIDGE_LABEL]
+        # Mirror fields match what _build_issue_fields would produce
+        existing_mirror.bug.fields.summary = "Visible bug [bridge to 4.23.z]"
+        existing_mirror.bug.fields.description = self.cli._build_description(source_bug, image_meta)
+        existing_mirror.bug.fields.components = source_bug.bug.fields.components
+        existing_mirror.bug.fields.priority = None
+        # All required links present
+        existing_mirror.bug.fields.issuelinks = [
+            self._link("Blocks", inward_key="OCPBUGS-123"),
+            self._link("Depend", outward_key="OCPBUGS-123"),
+            self._link("Cloners", outward_key="OCPBUGS-123"),
+        ]
+        self.cli.existing_mirrors_by_source = {"OCPBUGS-123": [existing_mirror]}
+
+        result = await self.cli._sync_mirror(source_bug, image_meta)
+
+        self.assertTrue(result)
+        existing_mirror.bug.update.assert_not_called()
+        self.cli.target_tracker.create_issue_link.assert_not_called()
+        self.assertEqual(self.cli.updated_mirror_count, 0)
+
+    async def test_sync_mirror_updates_when_summary_changed(self):
+        source_bug = MagicMock()
+        source_bug.id = "OCPBUGS-123"
+        source_bug.summary = "Updated summary"
+        source_bug.bug.fields.description = "Source description"
+        source_bug.bug.fields.issuetype.name = "Bug"
+        source_bug.bug.fields.components = [MagicMock()]
+        source_bug.bug.fields.components[0].name = "Visible"
+        source_bug.bug.fields.priority = None
+        source_bug.bug.fields.security = None
+        source_bug.bug.fields.versions = []
+
+        image_meta = MagicMock()
+        image_meta.distgit_key = "visible-image"
+
+        existing_mirror = MagicMock()
+        existing_mirror.id = "OCPBUGS-900"
+        existing_mirror.status = "New"
+        existing_mirror.keywords = [BRIDGE_LABEL]
+        existing_mirror.bug.fields.summary = "Old summary [bridge to 4.23.z]"
+        existing_mirror.bug.fields.description = self.cli._build_description(source_bug, image_meta)
+        existing_mirror.bug.fields.components = source_bug.bug.fields.components
+        existing_mirror.bug.fields.priority = None
+        existing_mirror.bug.fields.issuelinks = [
+            self._link("Blocks", inward_key="OCPBUGS-123"),
+            self._link("Depend", outward_key="OCPBUGS-123"),
+            self._link("Cloners", outward_key="OCPBUGS-123"),
+        ]
+        self.cli.existing_mirrors_by_source = {"OCPBUGS-123": [existing_mirror]}
+
+        result = await self.cli._sync_mirror(source_bug, image_meta)
+
+        self.assertTrue(result)
+        existing_mirror.bug.update.assert_called_once()
+        self.assertEqual(self.cli.updated_mirror_count, 1)
+
+    async def test_sync_mirror_creates_missing_links(self):
+        source_bug = MagicMock()
+        source_bug.id = "OCPBUGS-123"
+        source_bug.summary = "Visible bug"
+        source_bug.bug.fields.description = "Source description"
+        source_bug.bug.fields.issuetype.name = "Bug"
+        source_bug.bug.fields.components = [MagicMock()]
+        source_bug.bug.fields.components[0].name = "Visible"
+        source_bug.bug.fields.priority = None
+        source_bug.bug.fields.security = None
+        source_bug.bug.fields.versions = []
+
+        image_meta = MagicMock()
+        image_meta.distgit_key = "visible-image"
+
+        existing_mirror = MagicMock()
+        existing_mirror.id = "OCPBUGS-900"
+        existing_mirror.status = "New"
+        existing_mirror.keywords = [BRIDGE_LABEL]
+        existing_mirror.bug.fields.summary = "Visible bug [bridge to 4.23.z]"
+        existing_mirror.bug.fields.description = self.cli._build_description(source_bug, image_meta)
+        existing_mirror.bug.fields.components = source_bug.bug.fields.components
+        existing_mirror.bug.fields.priority = None
+        # Only one of three links present
+        existing_mirror.bug.fields.issuelinks = [
+            self._link("Blocks", inward_key="OCPBUGS-123"),
+        ]
+        self.cli.existing_mirrors_by_source = {"OCPBUGS-123": [existing_mirror]}
+
+        result = await self.cli._sync_mirror(source_bug, image_meta)
+
+        self.assertTrue(result)
+        existing_mirror.bug.update.assert_not_called()
+        self.assertTrue(self.cli.target_tracker.create_issue_link.called)
+
     def test_get_existing_mirrors_by_source_uses_linked_issue(self):
         mirror_for_source = MagicMock()
         mirror_for_source.id = "OCPBUGS-900"

--- a/elliott/tests/test_find_bugs_bridge_cli.py
+++ b/elliott/tests/test_find_bugs_bridge_cli.py
@@ -146,7 +146,7 @@ class TestFindBugsBridgeCli(IsolatedAsyncioTestCase):
 
         existing_mirror = MagicMock()
         existing_mirror.status = "Closed"
-        existing_mirror.resolution = "Won't Fix"
+        existing_mirror.resolution = "Won't Do"
         self.cli.existing_mirrors_by_source = {"OCPBUGS-123": [existing_mirror]}
 
         result = await self.cli._sync_mirror(source_bug, image_meta)

--- a/elliott/tests/test_find_bugs_bridge_cli.py
+++ b/elliott/tests/test_find_bugs_bridge_cli.py
@@ -193,6 +193,40 @@ class TestFindBugsBridgeCli(IsolatedAsyncioTestCase):
         self.assertIn("OCPBUGS-123", self.cli.invalid_bugs)
         self.assertIn("Expected exactly one bridge mirror", self.cli.invalid_bugs["OCPBUGS-123"][0])
 
+    def test_build_issue_fields_truncates_long_summary(self):
+        source_bug = MagicMock()
+        source_bug.summary = "A" * 300
+        source_bug.bug.fields.issuetype.name = "Bug"
+        source_bug.bug.fields.components = []
+        source_bug.bug.fields.description = ""
+        source_bug.bug.fields.priority = None
+        source_bug.bug.fields.security = None
+
+        image_meta = MagicMock()
+        image_meta.distgit_key = "test-image"
+
+        fields = self.cli._build_issue_fields(source_bug, image_meta)
+
+        self.assertLessEqual(len(fields["summary"]), 255)
+        self.assertTrue(fields["summary"].endswith(f" [bridge to {self.cli.target_release}]"))
+        self.assertIn("...", fields["summary"])
+
+    def test_build_issue_fields_short_summary_unchanged(self):
+        source_bug = MagicMock()
+        source_bug.summary = "Short title"
+        source_bug.bug.fields.issuetype.name = "Bug"
+        source_bug.bug.fields.components = []
+        source_bug.bug.fields.description = ""
+        source_bug.bug.fields.priority = None
+        source_bug.bug.fields.security = None
+
+        image_meta = MagicMock()
+        image_meta.distgit_key = "test-image"
+
+        fields = self.cli._build_issue_fields(source_bug, image_meta)
+
+        self.assertEqual(fields["summary"], f"Short title [bridge to {self.cli.target_release}]")
+
     async def test_run_reports_invalid_cases_and_fails_at_end(self):
         self.cli.runtime.initialize = MagicMock()
         self.cli.runtime.get_major_minor_fields = MagicMock(return_value=(4, 23))

--- a/ocp-build-data-validator/tests/test_schema/test_group_schema.py
+++ b/ocp-build-data-validator/tests/test_schema/test_group_schema.py
@@ -1,0 +1,27 @@
+import unittest
+
+from validator.schema import group_schema
+
+
+class TestGroupSchema(unittest.TestCase):
+    def test_validate_with_valid_bridge_release_config(self):
+        valid_data = {
+            "name": "openshift-4.23",
+            "vars": {"MAJOR": 4, "MINOR": 23},
+            "bridge_release": {
+                "basis_group": "openshift-5.0",
+                "bug_mirroring": {"enabled": True},
+            },
+        }
+        self.assertEqual("", group_schema.validate("group.yml", valid_data))
+
+    def test_validate_with_invalid_bridge_release_config(self):
+        invalid_data = {
+            "name": "openshift-4.23",
+            "vars": {"MAJOR": 4, "MINOR": 23},
+            "bridge_release": {
+                "basis_group": "openshift-5.0",
+                "bug_mirroring": {"enabled": "yes"},
+            },
+        }
+        self.assertIn("'yes' is not of type 'boolean'", group_schema.validate("group.yml", invalid_data))

--- a/ocp-build-data-validator/tests/test_schema/test_image_schema.py
+++ b/ocp-build-data-validator/tests/test_schema/test_image_schema.py
@@ -101,6 +101,26 @@ class TestImageSchema(unittest.TestCase):
             image_schema.validate('filename', data),
         )
 
+    def test_validate_with_valid_bridge_release_bug_mirroring_override(self):
+        data = {
+            'from': {},
+            'name': 'my-name',
+            'for_payload': True,
+            'delivery': {'delivery_repo_names': ['foo', 'bar']},
+            'bridge_release': {'bug_mirroring': {'enabled': False}},
+        }
+        self.assertIsNone(image_schema.validate('filename', data))
+
+    def test_validate_with_invalid_bridge_release_bug_mirroring_override(self):
+        data = {
+            'from': {},
+            'name': 'my-name',
+            'for_payload': True,
+            'delivery': {'delivery_repo_names': ['foo', 'bar']},
+            'bridge_release': {'bug_mirroring': {'enabled': 'nope'}},
+        }
+        self.assertIn("'nope' is not of type 'boolean'", image_schema.validate('filename', data))
+
     def test_validate_with_valid_konflux_cachi2_lockfile_rpms(self):
         """Test valid konflux.cachi2.lockfile.rpms configuration"""
         valid_data = {

--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -715,7 +715,61 @@
         "type": "array",
         "items": {"type": "string"}
       }
-    }
+    },
+    "bridge_release": {
+      "type": "object",
+      "properties": {
+        "basis_group": {
+          "type": "string",
+          "minLength": 1
+        },
+        "basis_group!": {
+          "$ref": "#/properties/bridge_release/properties/basis_group"
+        },
+        "basis_group?": {
+          "$ref": "#/properties/bridge_release/properties/basis_group"
+        },
+        "basis_group-": {},
+        "bug_mirroring": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "enabled!": {
+              "$ref": "#/properties/bridge_release/properties/bug_mirroring/properties/enabled"
+            },
+            "enabled?": {
+              "$ref": "#/properties/bridge_release/properties/bug_mirroring/properties/enabled"
+            },
+            "enabled-": {}
+          },
+          "required": [
+            "enabled"
+          ],
+          "additionalProperties": false
+        },
+        "bug_mirroring!": {
+          "$ref": "#/properties/bridge_release/properties/bug_mirroring"
+        },
+        "bug_mirroring?": {
+          "$ref": "#/properties/bridge_release/properties/bug_mirroring"
+        },
+        "bug_mirroring-": {}
+      },
+      "required": [
+        "basis_group",
+        "bug_mirroring"
+      ],
+      "additionalProperties": false
+    },
+    "bridge_release!": {
+      "$ref": "#/properties/bridge_release"
+    },
+    "bridge_release?": {
+      "$ref": "#/properties/bridge_release"
+    },
+    "bridge_release-": {}
   },
   "additionalProperties": false
 }

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -1101,6 +1101,46 @@
       "$ref": "#/properties/for_release"
     },
     "for_release-": {},
+    "bridge_release": {
+      "description": "Bridge release overrides for this image",
+      "type": "object",
+      "properties": {
+        "bug_mirroring": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "enabled!": {
+              "$ref": "#/properties/bridge_release/properties/bug_mirroring/properties/enabled"
+            },
+            "enabled?": {
+              "$ref": "#/properties/bridge_release/properties/bug_mirroring/properties/enabled"
+            },
+            "enabled-": {}
+          },
+          "required": [
+            "enabled"
+          ],
+          "additionalProperties": false
+        },
+        "bug_mirroring!": {
+          "$ref": "#/properties/bridge_release/properties/bug_mirroring"
+        },
+        "bug_mirroring?": {
+          "$ref": "#/properties/bridge_release/properties/bug_mirroring"
+        },
+        "bug_mirroring-": {}
+      },
+      "additionalProperties": false
+    },
+    "bridge_release!": {
+      "$ref": "#/properties/bridge_release"
+    },
+    "bridge_release?": {
+      "$ref": "#/properties/bridge_release"
+    },
+    "bridge_release-": {},
     "name_in_bundle": {
       "description": "How the upstream operator calls this operand in the clusterserviceversion.yaml.",
       "type": "string",

--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -24,6 +24,7 @@ class Ocp4ScanPipeline:
 
         self.logger = logging.getLogger(__name__)
         self._doozer_working = self.runtime.working_dir / "doozer_working"
+        self._elliott_working = self.runtime.working_dir / "elliott_working"
         self.changes = {}
         self.report = {}
         self.issues = []
@@ -63,6 +64,7 @@ class Ocp4ScanPipeline:
         # Scan for changes and RHCOS inconsistencies
         await self.get_changes()
         await self.get_rhcos_inconsistencies()
+        await self.handle_bridge_bug_mirroring()
 
         # Handle image source changes
         self.handle_source_changes()
@@ -266,6 +268,44 @@ class Ocp4ScanPipeline:
                 assembly="stream",
                 build_system="konflux",
             )
+
+    async def handle_bridge_bug_mirroring(self):
+        group = f"openshift-{self.version}"
+        group_config = await util.load_group_config(
+            group=group,
+            assembly=self.assembly,
+            doozer_data_path=self.data_path,
+            doozer_data_gitref=self.data_gitref,
+        )
+        bridge_release = group_config.get("bridge_release", {}) or {}
+        bug_mirroring = bridge_release.get("bug_mirroring", {}) or {}
+        if not bug_mirroring.get("enabled", False):
+            self.logger.info("Bridge bug mirroring is disabled for %s", group)
+            return
+
+        if self.data_gitref:
+            group += f"@{self.data_gitref}"
+        cmd = [
+            "elliott",
+            f"--group={group}",
+            f"--assembly={self.assembly}",
+            "--build-system=konflux",
+            f"--working-dir={self._elliott_working}",
+            f"--data-path={self.data_path}",
+            "find-bugs:bridge-mirror",
+        ]
+        if self.runtime.dry_run:
+            cmd.append("--dry-run")
+
+        try:
+            await exectools.cmd_assert_async(cmd)
+        except ChildProcessError:
+            if self.runtime.dry_run:
+                raise
+            slack_client = self.runtime.new_slack_client()
+            slack_client.bind_channel(f"openshift-{self.version}")
+            await slack_client.say(f"Bridge bug mirroring failed for {self.version}. Please investigate")
+            raise
 
 
 @cli.command('beta:konflux:ocp4-scan')

--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -270,6 +270,16 @@ class Ocp4ScanPipeline:
             )
 
     async def handle_bridge_bug_mirroring(self):
+        """Run bridge bug mirroring for groups that enable it.
+
+        Returns:
+            None.
+
+        Raises:
+            ChildProcessError: If the `elliott find-bugs:bridge-mirror` command
+                fails. In non-dry-run mode, a Slack notification is sent before
+                the exception is re-raised.
+        """
         group = f"openshift-{self.version}"
         group_config = await util.load_group_config(
             group=group,

--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -272,13 +272,7 @@ class Ocp4ScanPipeline:
     async def handle_bridge_bug_mirroring(self):
         """Run bridge bug mirroring for groups that enable it.
 
-        Returns:
-            None.
-
-        Raises:
-            ChildProcessError: If the `elliott find-bugs:bridge-mirror` command
-                fails. In non-dry-run mode, a Slack notification is sent before
-                the exception is re-raised.
+        Failures are logged and reported to Slack but do not fail the pipeline.
         """
         group = f"openshift-{self.version}"
         group_config = await util.load_group_config(
@@ -309,13 +303,12 @@ class Ocp4ScanPipeline:
 
         try:
             await exectools.cmd_assert_async(cmd)
-        except ChildProcessError:
-            if self.runtime.dry_run:
-                raise
-            slack_client = self.runtime.new_slack_client()
-            slack_client.bind_channel(f"openshift-{self.version}")
-            await slack_client.say(f"Bridge bug mirroring failed for {self.version}. Please investigate")
-            raise
+        except ChildProcessError as e:
+            self.logger.error("Bridge bug mirroring failed for %s: %s", self.version, e)
+            if not self.runtime.dry_run:
+                slack_client = self.runtime.new_slack_client()
+                slack_client.bind_channel(f"openshift-{self.version}")
+                await slack_client.say(f"Bridge bug mirroring failed for {self.version}. Please investigate")
 
 
 @cli.command('beta:konflux:ocp4-scan')

--- a/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
+++ b/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import yaml
-
 from pyartcd.pipelines.ocp4_scan_konflux import Ocp4ScanPipeline
 from pyartcd.runtime import Runtime
 

--- a/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
+++ b/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
@@ -2,9 +2,11 @@
 
 import os
 import unittest
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import yaml
+
 from pyartcd.pipelines.ocp4_scan_konflux import Ocp4ScanPipeline
 from pyartcd.runtime import Runtime
 
@@ -129,6 +131,81 @@ class TestOcp4ScanKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
         pipeline.handle_source_changes.assert_called_once()
         pipeline.handle_rhcos_changes.assert_awaited_once()
         mock_jenkins.update_description.assert_called_with('Scan failures: test-image<br/>')
+
+
+class TestBridgeBugMirroring(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.runtime = MagicMock(spec=Runtime)
+        self.runtime.dry_run = False
+        self.runtime.working_dir = Path("/tmp")
+        self.runtime.new_slack_client.return_value = AsyncMock()
+        self.pipeline = Ocp4ScanPipeline(
+            runtime=self.runtime,
+            version="4.23",
+            data_path="https://github.com/openshift-eng/ocp-build-data",
+            assembly="stream",
+            data_gitref="",
+            image_list="",
+        )
+
+    async def test_run_invokes_bridge_bug_mirroring(self):
+        self.pipeline.get_changes = AsyncMock()
+        self.pipeline.get_rhcos_inconsistencies = AsyncMock()
+        self.pipeline.handle_bridge_bug_mirroring = AsyncMock()
+        self.pipeline.handle_source_changes = MagicMock()
+        self.pipeline.handle_rhcos_changes = AsyncMock()
+
+        await self.pipeline.run()
+
+        self.pipeline.handle_bridge_bug_mirroring.assert_awaited_once()
+        self.pipeline.handle_source_changes.assert_called_once()
+        self.pipeline.handle_rhcos_changes.assert_awaited_once()
+
+    @patch("pyartcd.pipelines.ocp4_scan_konflux.util.load_group_config")
+    @patch("pyartcd.pipelines.ocp4_scan_konflux.exectools.cmd_assert_async")
+    async def test_handle_bridge_bug_mirroring_skips_when_disabled(self, mock_cmd_assert, mock_load_group_config):
+        mock_load_group_config.return_value = {}
+
+        await self.pipeline.handle_bridge_bug_mirroring()
+
+        mock_cmd_assert.assert_not_called()
+
+    @patch("pyartcd.pipelines.ocp4_scan_konflux.util.load_group_config")
+    @patch("pyartcd.pipelines.ocp4_scan_konflux.exectools.cmd_assert_async")
+    async def test_handle_bridge_bug_mirroring_runs_elliott(self, mock_cmd_assert, mock_load_group_config):
+        mock_load_group_config.return_value = {
+            "bridge_release": {
+                "basis_group": "openshift-5.0",
+                "bug_mirroring": {"enabled": True},
+            }
+        }
+
+        await self.pipeline.handle_bridge_bug_mirroring()
+
+        cmd = mock_cmd_assert.call_args.args[0]
+        self.assertIn("find-bugs:bridge-mirror", cmd)
+        self.assertIn("--build-system=konflux", cmd)
+        self.assertIn("--group=openshift-4.23", cmd)
+
+    @patch("pyartcd.pipelines.ocp4_scan_konflux.util.load_group_config")
+    @patch("pyartcd.pipelines.ocp4_scan_konflux.exectools.cmd_assert_async")
+    async def test_handle_bridge_bug_mirroring_alerts_on_failure(self, mock_cmd_assert, mock_load_group_config):
+        mock_load_group_config.return_value = {
+            "bridge_release": {
+                "basis_group": "openshift-5.0",
+                "bug_mirroring": {"enabled": True},
+            }
+        }
+        mock_cmd_assert.side_effect = ChildProcessError("boom")
+        slack_client = AsyncMock()
+        slack_client.bind_channel = MagicMock()
+        self.runtime.new_slack_client.return_value = slack_client
+
+        with self.assertRaises(ChildProcessError):
+            await self.pipeline.handle_bridge_bug_mirroring()
+
+        slack_client.bind_channel.assert_called_once_with("openshift-4.23")
+        slack_client.say.assert_awaited_once_with("Bridge bug mirroring failed for 4.23. Please investigate")
 
 
 if __name__ == '__main__':

--- a/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
+++ b/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
@@ -67,6 +67,7 @@ class TestOcp4ScanKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
 
         pipeline.get_changes = AsyncMock(side_effect=fake_get_changes)
         pipeline.get_rhcos_inconsistencies = AsyncMock()
+        pipeline.handle_bridge_bug_mirroring = AsyncMock()
         pipeline.handle_source_changes = Mock()
         pipeline.handle_rhcos_changes = AsyncMock()
 
@@ -93,6 +94,7 @@ class TestOcp4ScanKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
 
         pipeline.get_changes = AsyncMock(side_effect=fake_get_changes)
         pipeline.get_rhcos_inconsistencies = AsyncMock()
+        pipeline.handle_bridge_bug_mirroring = AsyncMock()
         pipeline.handle_source_changes = Mock()
         pipeline.handle_rhcos_changes = AsyncMock()
 
@@ -120,6 +122,7 @@ class TestOcp4ScanKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
 
         pipeline.get_changes = AsyncMock(side_effect=fake_get_changes)
         pipeline.get_rhcos_inconsistencies = AsyncMock()
+        pipeline.handle_bridge_bug_mirroring = AsyncMock()
         pipeline.handle_source_changes = Mock()
         pipeline.handle_rhcos_changes = AsyncMock()
 

--- a/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
+++ b/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
@@ -136,6 +136,8 @@ class TestOcp4ScanKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
 
 
 class TestBridgeBugMirroring(unittest.IsolatedAsyncioTestCase):
+    """Cover bridge bug mirroring orchestration in the Konflux scan pipeline."""
+
     def setUp(self):
         self.runtime = MagicMock(spec=Runtime)
         self.runtime.dry_run = False

--- a/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
+++ b/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
@@ -205,8 +205,7 @@ class TestBridgeBugMirroring(unittest.IsolatedAsyncioTestCase):
         slack_client.bind_channel = MagicMock()
         self.runtime.new_slack_client.return_value = slack_client
 
-        with self.assertRaises(ChildProcessError):
-            await self.pipeline.handle_bridge_bug_mirroring()
+        await self.pipeline.handle_bridge_bug_mirroring()
 
         slack_client.bind_channel.assert_called_once_with("openshift-4.23")
         slack_client.say.assert_awaited_once_with("Bridge bug mirroring failed for 4.23. Please investigate")


### PR DESCRIPTION
- https://redhat.atlassian.net/browse/ART-14770
- [OCP5 Bridge release handling](https://docs.google.com/document/d/1V-FcCTomk0OU7hV2bs5WnbDD4RL8EgFgiavCs2k_iQg/edit?tab=t.0)
- [Openshift 5 and 4.23 Features and Branching](https://docs.google.com/document/d/1G7E-Esr4wId6fjfuUloaIHUF-qEnTXv_6u_1qvsy_fY/edit?tab=t.0#heading=h.iok0179345tw)
- Needs https://github.com/openshift-eng/aos-cd-jobs/pull/4682
- Created mirror bug example : https://redhat.atlassian.net/browse/OCPBUGS-86837
- Config change: https://github.com/openshift-eng/ocp-build-data/pull/10271

## Summary
- Add a new Elliott command, find-bugs:bridge-mirror, to mirror eligible open Jira bugs from a bridge release’s basis_group into the target release.
- Qualify only bugs that survive Jira’s default component filter, are not tracker/CVE bugs, map through product.yml to ART-managed payload images, and are not opted out via bridge_release.bug_mirroring.enabled.
- Integrate bridge bug mirroring into ocp4-scan-konflux, including skipping when disabled and sending a Slack alert if the mirroring step fails.

group.yml:
```
bridge_release:
  basis_group: openshift-5.0
  bug_mirroring:
    enabled: true
```

Image config:
```
for_payload: true
bridge_release:
  bug_mirroring:
    enabled: false
```

## Test

ocp4-scan job: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/46364/console

```
$ uv run elliott -g openshift-4.23@423_bridge_enable 
--data-path https://github.com/thegreyd/ocp-build-data find-bugs:bridge-mirror 
--dry-run
...
2026-04-29 07:39:23,621 elliottlib.cli.find_bugs_bridge_cli INFO Filtered 37 bugs: tracker/CVE=2, unmapped/non-ART/non-payload=35
2026-04-29 07:39:23,622 elliottlib.cli.find_bugs_bridge_cli INFO Found 35 candidate bugs in basis group openshift-5.0
2026-04-29 07:39:24,379 art_tools.elliottlib.bzutil INFO Found 70 target versions in JIRA project OCPBUGS
2026-04-29 07:39:24,989 elliottlib.cli.find_bugs_bridge_cli INFO Found 0 existing bridge mirrors for openshift-4.23
2026-04-29 07:39:24,989 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-29840
2026-04-29 07:39:24,990 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-38120
2026-04-29 07:39:24,990 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-38898
2026-04-29 07:39:24,990 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-51200
2026-04-29 07:39:24,990 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-59566
2026-04-29 07:39:24,990 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-60093
2026-04-29 07:39:24,990 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-62177
2026-04-29 07:39:24,991 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-62792
2026-04-29 07:39:24,991 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-66263
2026-04-29 07:39:24,991 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-77529
2026-04-29 07:39:24,991 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-77827
2026-04-29 07:39:24,991 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-77972
2026-04-29 07:39:24,991 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-78016
2026-04-29 07:39:24,992 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-79471
2026-04-29 07:39:24,992 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-81452
2026-04-29 07:39:24,992 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-81522
2026-04-29 07:39:24,992 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-81630
2026-04-29 07:39:24,992 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-81631
2026-04-29 07:39:24,992 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-82502
2026-04-29 07:39:24,992 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-82504
2026-04-29 07:39:24,993 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-82505
2026-04-29 07:39:24,993 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-82506
2026-04-29 07:39:24,993 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-82507
2026-04-29 07:39:24,993 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-82508
2026-04-29 07:39:24,993 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-82509
2026-04-29 07:39:24,993 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-82510
2026-04-29 07:39:24,993 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-82512
2026-04-29 07:39:24,993 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-82513
2026-04-29 07:39:24,993 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-83514
2026-04-29 07:39:24,993 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-83790
2026-04-29 07:39:24,993 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-84230
2026-04-29 07:39:24,993 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-84255
2026-04-29 07:39:24,994 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-84307
2026-04-29 07:39:24,994 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-84528
2026-04-29 07:39:24,994 elliottlib.cli.find_bugs_bridge_cli INFO [DRY RUN] Would create bridge mirror for OCPBUGS-84555
2026-04-29 07:39:24,994 elliottlib.cli.find_bugs_bridge_cli INFO Bridge bug mirroring complete for openshift-4.23: existing=0, created=35, updated=0, skipped=0

```