### PR TITLE
feat(lockfile): implement RPM version fallback recovery for hermetic …

### DIFF
--- a/doozer/doozerlib/lockfile.py
+++ b/doozer/doozerlib/lockfile.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from functools import total_ordering
 from logging import Logger
 from pathlib import Path
-from typing import Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import aiohttp
 import yaml
@@ -505,22 +505,28 @@ class RPMLockfileGenerator:
         self.runtime = runtime
         self.lockfile_seed_nvrs = lockfile_seed_nvrs
 
-    def _validate_cross_arch_version_sets(self, rpms_info_by_arch: dict[str, list[RpmInfo]]) -> None:
-        """Validate that RPM latest version sets are consistent across architectures where packages exist."""
+    def _validate_cross_arch_version_sets(
+        self, rpms_info_by_arch: dict[str, list[RpmInfo]]
+    ) -> Optional[Dict[str, Dict[str, str]]]:
+        """Validate that RPM latest version sets are consistent across architectures where packages exist.
+
+        Returns fallback recommendations when mismatches are detected, None when validation passes.
+
+        Returns:
+            Optional[Dict[str, Dict[str, str]]]: Package name to architecture-version mapping for fallback,
+            or None if no mismatches detected.
+        """
         package_arch_evrs = {}
 
         for arch, rpm_list in rpms_info_by_arch.items():
-            # Group RPMs by package name
             packages = {}
             for rpm in rpm_list:
                 packages.setdefault(rpm.name, []).append(rpm)
 
-            # For each package, find latest version and add to validation set
             for package_name, package_rpms in packages.items():
                 if len(package_rpms) == 1:
                     latest_rpm = package_rpms[0]
                 else:
-                    # Find latest using RpmInfo comparison (leverages @total_ordering)
                     latest_rpm = package_rpms[0]
                     for rpm in package_rpms[1:]:
                         if rpm > latest_rpm:
@@ -528,7 +534,7 @@ class RPMLockfileGenerator:
 
                 package_arch_evrs.setdefault(package_name, {}).setdefault(arch, set()).add(latest_rpm.evr)
 
-        mismatches = []
+        mismatched_packages = []
         for package_name, arch_evrs in package_arch_evrs.items():
             if len(arch_evrs) < 2:
                 continue
@@ -537,11 +543,112 @@ class RPMLockfileGenerator:
             reference_set = evr_sets[0]
 
             if not all(evr_set == reference_set for evr_set in evr_sets[1:]):
-                arch_details = [f"{arch}:{{{','.join(sorted(evr_set))}}}" for arch, evr_set in arch_evrs.items()]
-                mismatches.append(f"{package_name} ({'; '.join(arch_details)})")
+                mismatched_packages.append(package_name)
 
-        if mismatches:
-            raise ValueError(f"RPM version set mismatches: {'; '.join(mismatches)}")
+        if mismatched_packages:
+            self.logger.warning(
+                f"Cross-architecture version mismatches detected for packages: {', '.join(mismatched_packages)}"
+            )
+            return {
+                pkg: {arch: list(evrs)[0] for arch, evrs in package_arch_evrs[pkg].items()}
+                for pkg in mismatched_packages
+            }
+
+        return None
+
+    def _find_common_fallback_versions(self, package_name: str, arch_versions: Dict[str, str]) -> str:
+        """
+        Find the lowest version among mismatched architectures for fallback.
+
+        Args:
+            package_name: Name of the RPM package to find fallback for
+            arch_versions: Current architecture to version mapping showing the mismatch
+
+        Returns:
+            str: Lowest EVR string among the mismatched versions
+        """
+        evr_list = list(arch_versions.values())
+
+        rpm_infos = []
+        for evr in evr_list:
+            if ':' in evr:
+                epoch_str, version_release = evr.split(':', 1)
+                epoch = int(epoch_str)
+            else:
+                epoch = 0
+                version_release = evr
+
+            if '-' in version_release:
+                version, release = version_release.rsplit('-', 1)
+            else:
+                version = version_release
+                release = ""
+
+            rpm_info = RpmInfo(
+                name=package_name,
+                evr=evr,
+                checksum="",
+                repoid="",
+                size=0,
+                sourcerpm="",
+                url="",
+                epoch=epoch,
+                version=version,
+                release=release,
+            )
+            rpm_infos.append(rpm_info)
+
+        lowest_rpm = min(rpm_infos)
+
+        self.logger.info(
+            f"Selected fallback version {lowest_rpm.evr} (lowest among mismatched versions) for {package_name}"
+        )
+        return lowest_rpm.evr
+
+    def _apply_fallback_versions(
+        self, rpms_info_by_arch: Dict[str, List[RpmInfo]], fallback_recommendations: Dict[str, str]
+    ) -> None:
+        """
+        Apply fallback versions to the package collection for Case 1 scenarios.
+
+        Only handles cases where the fallback version already exists in all architecture collections.
+        Throws error for Case 2 scenarios where fallback version needs to be resolved from repositories.
+
+        Args:
+            rpms_info_by_arch: Architecture to RPM list mapping to modify in place
+            fallback_recommendations: Package name to fallback EVR mapping
+        """
+        for package_name, fallback_evr in fallback_recommendations.items():
+            self.logger.info(f"Applying fallback version {fallback_evr} for package {package_name}")
+
+            fallback_rpms_by_arch = {}
+            for arch, rpm_list in rpms_info_by_arch.items():
+                package_rpms = [rpm for rpm in rpm_list if rpm.name == package_name]
+
+                if not package_rpms:
+                    continue
+
+                fallback_rpm = None
+                for rpm in package_rpms:
+                    if rpm.evr == fallback_evr:
+                        fallback_rpm = rpm
+                        break
+
+                if fallback_rpm is None:
+                    raise ValueError(
+                        f"Fallback version {fallback_evr} not available for {package_name} in {arch} - requires repository resolution (Case 2)"
+                    )
+
+                fallback_rpms_by_arch[arch] = fallback_rpm
+
+            for arch, fallback_rpm in fallback_rpms_by_arch.items():
+                rpm_list = rpms_info_by_arch[arch]
+                rpms_info_by_arch[arch] = [rpm for rpm in rpm_list if rpm.name != package_name]
+                rpms_info_by_arch[arch].append(fallback_rpm)
+
+                self.logger.debug(f"Applied fallback {package_name}={fallback_evr} for {arch}")
+
+            self.logger.info(f"Successfully applied fallback for {package_name} across all architectures (Case 1)")
 
     async def should_generate_lockfile(
         self, image_meta: ImageMetadata, dest_dir: Path, filename: str = DEFAULT_RPM_LOCKFILE_NAME
@@ -675,8 +782,15 @@ class RPMLockfileGenerator:
             self.builder.fetch_modules_info(arches, enabled_repos, modules_to_install),
         )
 
-        # Validate cross-architecture version set consistency
-        self._validate_cross_arch_version_sets(rpms_info_by_arch)
+        mismatch_data = self._validate_cross_arch_version_sets(rpms_info_by_arch)
+        if mismatch_data is not None:
+            fallback_recommendations = {}
+            for package_name, arch_versions in mismatch_data.items():
+                fallback_evr = self._find_common_fallback_versions(package_name, arch_versions)
+                fallback_recommendations[package_name] = fallback_evr
+
+            self._apply_fallback_versions(rpms_info_by_arch, fallback_recommendations)
+            self.logger.info(f"Applied fallback recovery for {len(fallback_recommendations)} packages")
 
         if image_meta.is_cross_arch_enabled():
             self.logger.info("Cross-architecture lockfile inclusion enabled")

--- a/doozer/doozerlib/lockfile.py
+++ b/doozer/doozerlib/lockfile.py
@@ -605,18 +605,23 @@ class RPMLockfileGenerator:
         )
         return lowest_rpm.evr
 
-    def _apply_fallback_versions(
-        self, rpms_info_by_arch: Dict[str, List[RpmInfo]], fallback_recommendations: Dict[str, str]
+    async def _apply_fallback_versions(
+        self,
+        rpms_info_by_arch: Dict[str, List[RpmInfo]],
+        fallback_recommendations: Dict[str, str],
+        arches: List[str],
+        enabled_repos: set[str],
     ) -> None:
         """
-        Apply fallback versions to the package collection for Case 1 scenarios.
+        Apply fallback versions to the package collection.
 
-        Only handles cases where the fallback version already exists in all architecture collections.
-        Throws error for Case 2 scenarios where fallback version needs to be resolved from repositories.
+        Handles both Case 1 (fallback version already in collections) and Case 2 (fetch from repositories).
 
         Args:
             rpms_info_by_arch: Architecture to RPM list mapping to modify in place
             fallback_recommendations: Package name to fallback EVR mapping
+            arches: Target architectures for repository resolution
+            enabled_repos: Repository names for fetching missing packages
         """
         for package_name, fallback_evr in fallback_recommendations.items():
             self.logger.info(f"Applying fallback version {fallback_evr} for package {package_name}")
@@ -635,9 +640,21 @@ class RPMLockfileGenerator:
                         break
 
                 if fallback_rpm is None:
-                    raise ValueError(
-                        f"Fallback version {fallback_evr} not available for {package_name} in {arch} - requires repository resolution (Case 2)"
-                    )
+                    # Case 2: Fetch missing fallback version from repositories
+                    self.logger.info(f"Attempting repository resolution for {package_name} {fallback_evr} on {arch}")
+
+                    missing_nvr = f"{package_name}-{fallback_evr}"
+                    fetch_result = await self.builder.fetch_rpms_info([arch], enabled_repos, {missing_nvr})
+
+                    if fetch_result and arch in fetch_result and fetch_result[arch]:
+                        fallback_rpm = fetch_result[arch][0]  # Take the first (and only) result
+                        self.logger.info(
+                            f"Successfully resolved {package_name} {fallback_evr} for {arch} from repositories"
+                        )
+                    else:
+                        raise ValueError(
+                            f"Fallback version {fallback_evr} not available for {package_name} in {arch} - not found in any repository"
+                        )
 
                 fallback_rpms_by_arch[arch] = fallback_rpm
 
@@ -789,7 +806,7 @@ class RPMLockfileGenerator:
                 fallback_evr = self._find_common_fallback_versions(package_name, arch_versions)
                 fallback_recommendations[package_name] = fallback_evr
 
-            self._apply_fallback_versions(rpms_info_by_arch, fallback_recommendations)
+            await self._apply_fallback_versions(rpms_info_by_arch, fallback_recommendations, arches, enabled_repos)
             self.logger.info(f"Applied fallback recovery for {len(fallback_recommendations)} packages")
 
         if image_meta.is_cross_arch_enabled():

--- a/doozer/tests/test_lockfile_validation.py
+++ b/doozer/tests/test_lockfile_validation.py
@@ -132,8 +132,9 @@ class TestCrossArchVersionSetValidation:
             ],
         }
 
-        # Act & Assert: Should not raise exception
-        self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
+        # Act & Assert: Should return None (no fallback needed)
+        result = self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
+        assert result is None
 
     def test_version_set_mismatch_single_package_single_architecture(self):
         """Test validation fails when one package has different version sets across architectures."""
@@ -193,15 +194,14 @@ class TestCrossArchVersionSetValidation:
             ],
         }
 
-        # Act & Assert: Should raise ValueError
-        with pytest.raises(ValueError) as exc_info:
-            self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
+        # Act: Should return mismatch data instead of raising exception
+        result = self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
 
-        # Verify error message contains specific details (now shows only latest versions)
-        error_message = str(exc_info.value)
-        assert "audit-libs" in error_message
-        assert "x86_64:{0:3.1.5-4.el9}" in error_message
-        assert "aarch64:{0:3.1.5-6.el9}" in error_message
+        # Assert: Should return fallback recommendations
+        assert result is not None
+        assert "audit-libs" in result
+        assert "x86_64" in result["audit-libs"]
+        assert "aarch64" in result["audit-libs"]
 
     def test_version_set_mismatch_multiple_packages_multiple_architectures(self):
         """Test validation fails with detailed errors for multiple package mismatches across architectures."""
@@ -323,20 +323,19 @@ class TestCrossArchVersionSetValidation:
             ],
         }
 
-        # Act & Assert: Should raise ValueError with multiple mismatches
-        with pytest.raises(ValueError) as exc_info:
-            self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
+        # Act: Should return mismatch data for multiple packages
+        result = self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
 
-        # Verify error message contains all mismatched packages
-        error_message = str(exc_info.value)
-        assert "audit-libs" in error_message
-        assert "curl" in error_message
-        assert "openssl-libs" in error_message
+        # Assert: Should return all mismatched packages
+        assert result is not None
+        assert "audit-libs" in result
+        assert "curl" in result
+        assert "openssl-libs" in result
 
-        # Verify architecture-specific version sets are listed
-        assert "x86_64" in error_message
-        assert "aarch64" in error_message
-        assert "s390x" in error_message
+        # Verify architecture data is present
+        assert "x86_64" in result["audit-libs"]
+        assert "aarch64" in result["audit-libs"]
+        assert "s390x" in result["audit-libs"]
 
     def test_single_architecture_always_passes_validation(self):
         """Test validation always passes for single architecture scenarios."""
@@ -382,8 +381,9 @@ class TestCrossArchVersionSetValidation:
             ],
         }
 
-        # Act & Assert: Should not raise exception
-        self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
+        # Act & Assert: Should return None (no fallback needed)
+        result = self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
+        assert result is None
 
     def test_empty_rpm_list_passes_validation(self):
         """Test validation passes when RPM lists are empty."""
@@ -394,8 +394,9 @@ class TestCrossArchVersionSetValidation:
             "ppc64le": [],
         }
 
-        # Act & Assert: Should not raise exception
-        self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
+        # Act & Assert: Should return None (no fallback needed)
+        result = self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
+        assert result is None
 
     def test_architecture_specific_packages_allowed(self):
         """Test validation passes when packages exist on subset of architectures."""
@@ -418,8 +419,9 @@ class TestCrossArchVersionSetValidation:
             "aarch64": [],
         }
 
-        # Act & Assert: Should not raise exception
-        self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
+        # Act & Assert: Should return None (no fallback needed)
+        result = self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
+        assert result is None
 
     def test_complex_epoch_version_release_combinations(self):
         """Test validation with complex EVR combinations including different epochs."""
@@ -629,14 +631,15 @@ class TestCrossArchVersionSetValidation:
             ],
         }
 
-        # Act & Assert: Should raise ValueError
-        with pytest.raises(ValueError) as exc_info:
-            self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
+        # Act: Should return mismatch data
+        result = self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
 
-        # Verify error message shows only latest versions (not all historical versions)
-        error_message = str(exc_info.value)
-        assert "x86_64:{0:3.0.0-1.el9}" in error_message
-        assert "aarch64:{0:4.0.0-1.el9}" in error_message
+        # Assert: Should return fallback data for latest versions only
+        assert result is not None
+        assert "test-package" in result
+        # Verify that only latest versions are considered for fallback
+        assert result["test-package"]["x86_64"] == "0:3.0.0-1.el9"
+        assert result["test-package"]["aarch64"] == "0:4.0.0-1.el9"
 
     def test_mixed_single_and_multi_arch_packages_validation(self):
         """Test that single-arch packages are ignored while multi-arch version mismatches still trigger failures."""
@@ -696,16 +699,16 @@ class TestCrossArchVersionSetValidation:
             ],
         }
 
-        # Act & Assert: Should fail due to shared-lib version mismatch but ignore single-arch packages
-        with pytest.raises(ValueError) as exc_info:
-            self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
+        # Act: Should return mismatch data for shared-lib but ignore single-arch packages
+        result = self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
 
-        error_message = str(exc_info.value)
-        assert "shared-lib" in error_message
-        assert "x86_64:{0:2.0.0-1.el9}" in error_message
-        assert "aarch64:{0:2.0.0-2.el9}" in error_message
-        assert "x86-only-driver" not in error_message
-        assert "arm-specific-tool" not in error_message
+        # Assert: Should only include shared-lib in mismatch data
+        assert result is not None
+        assert "shared-lib" in result
+        assert "x86-only-driver" not in result
+        assert "arm-specific-tool" not in result
+        assert result["shared-lib"]["x86_64"] == "0:2.0.0-1.el9"
+        assert result["shared-lib"]["aarch64"] == "0:2.0.0-2.el9"
 
     def test_mixed_single_and_multi_arch_packages_with_matching_versions(self):
         """Test that single-arch packages are ignored and multi-arch packages with identical versions pass."""
@@ -765,14 +768,118 @@ class TestCrossArchVersionSetValidation:
             ],
         }
 
-        # Act: Should pass - single-arch packages ignored, shared-lib has identical versions
-        try:
-            self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
-            validation_passed = True
-        except ValueError:
-            validation_passed = False
+        # Act: Should return None - single-arch packages ignored, shared-lib has identical versions
+        result = self.generator._validate_cross_arch_version_sets(rpms_info_by_arch)
 
-        # Assert: Validation should pass with no exceptions
-        assert validation_passed, (
-            "Validation should pass when single-arch packages are present and multi-arch packages have identical versions"
-        )
+        # Assert: Should return None (no mismatches)
+        assert result is None
+
+
+class TestRPMLockfileFallback:
+    """Test suite for RPM lockfile version fallback recovery."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_repos = Mock()
+        self.generator = RPMLockfileGenerator(self.mock_repos)
+
+    def test_find_common_fallback_versions_simple_case(self):
+        """Test fallback version selection picks lowest version."""
+        arch_versions = {"x86_64": "0:1.0-3", "aarch64": "0:1.0-4"}
+        result = self.generator._find_common_fallback_versions("pkg1", arch_versions)
+        assert result == "0:1.0-3"
+
+    def test_find_common_fallback_versions_complex_epoch(self):
+        """Test fallback with epoch comparison."""
+        arch_versions = {"x86_64": "2:1.0-1", "aarch64": "1:2.0-1"}
+        result = self.generator._find_common_fallback_versions("pkg1", arch_versions)
+        assert result == "1:2.0-1"
+
+    def test_apply_fallback_versions_case_1_success(self):
+        """Test fallback application when fallback version exists in all architectures."""
+        rpms_info_by_arch = {
+            "x86_64": [
+                RpmInfo("pkg1", "0:1.0-2", "checksum1", "repo1", 1000, "src1", "url1", 0, "1.0", "2"),
+                RpmInfo("pkg1", "0:1.0-3", "checksum2", "repo1", 1000, "src1", "url2", 0, "1.0", "3"),
+            ],
+            "aarch64": [
+                RpmInfo("pkg1", "0:1.0-2", "checksum3", "repo1", 1000, "src1", "url3", 0, "1.0", "2"),
+                RpmInfo("pkg1", "0:1.0-4", "checksum4", "repo1", 1000, "src1", "url4", 0, "1.0", "4"),
+            ],
+        }
+
+        fallback_recommendations = {"pkg1": "0:1.0-2"}
+        self.generator._apply_fallback_versions(rpms_info_by_arch, fallback_recommendations)
+
+        for arch in rpms_info_by_arch:
+            pkg_rpms = [rpm for rpm in rpms_info_by_arch[arch] if rpm.name == "pkg1"]
+            assert len(pkg_rpms) == 1
+            assert pkg_rpms[0].evr == "0:1.0-2"
+
+    def test_apply_fallback_versions_case_2_error(self):
+        """Test fallback application fails when fallback version doesn't exist."""
+        rpms_info_by_arch = {
+            "x86_64": [RpmInfo("pkg1", "0:1.0-3", "checksum1", "repo1", 1000, "src1", "url1", 0, "1.0", "3")],
+            "aarch64": [RpmInfo("pkg1", "0:1.0-4", "checksum2", "repo1", 1000, "src1", "url2", 0, "1.0", "4")],
+        }
+
+        fallback_recommendations = {"pkg1": "0:1.0-2"}
+
+        with pytest.raises(ValueError, match="Fallback version 0:1.0-2 not available"):
+            self.generator._apply_fallback_versions(rpms_info_by_arch, fallback_recommendations)
+
+    def test_apply_fallback_versions_partial_architecture_coverage(self):
+        """Test fallback with package missing on some architectures."""
+        rpms_info_by_arch = {
+            "x86_64": [RpmInfo("pkg1", "0:1.0-2", "checksum1", "repo1", 1000, "src1", "url1", 0, "1.0", "2")],
+            "aarch64": [RpmInfo("pkg2", "0:2.0-1", "checksum2", "repo1", 1000, "src2", "url2", 0, "2.0", "1")],
+        }
+
+        fallback_recommendations = {"pkg1": "0:1.0-2"}
+        self.generator._apply_fallback_versions(rpms_info_by_arch, fallback_recommendations)
+
+        x86_64_pkg1 = [rpm for rpm in rpms_info_by_arch["x86_64"] if rpm.name == "pkg1"]
+        assert len(x86_64_pkg1) == 1
+        assert x86_64_pkg1[0].evr == "0:1.0-2"
+
+        aarch64_pkg1 = [rpm for rpm in rpms_info_by_arch["aarch64"] if rpm.name == "pkg1"]
+        assert len(aarch64_pkg1) == 0
+
+    def test_apply_fallback_versions_multi_arch_consistency(self):
+        """Test fallback maintains consistency across all architectures."""
+        rpms_info_by_arch = {
+            "x86_64": [RpmInfo("pkg1", "0:1.0-2", "checksum1", "repo1", 1000, "src1", "url1", 0, "1.0", "2")],
+            "aarch64": [RpmInfo("pkg1", "0:1.0-2", "checksum2", "repo1", 1000, "src1", "url2", 0, "1.0", "2")],
+            "ppc64le": [RpmInfo("pkg1", "0:1.0-2", "checksum3", "repo1", 1000, "src1", "url3", 0, "1.0", "2")],
+            "s390x": [RpmInfo("pkg1", "0:1.0-2", "checksum4", "repo1", 1000, "src1", "url4", 0, "1.0", "2")],
+        }
+
+        fallback_recommendations = {"pkg1": "0:1.0-2"}
+        self.generator._apply_fallback_versions(rpms_info_by_arch, fallback_recommendations)
+
+        for arch in rpms_info_by_arch:
+            pkg_rpms = [rpm for rpm in rpms_info_by_arch[arch] if rpm.name == "pkg1"]
+            assert len(pkg_rpms) == 1
+            assert pkg_rpms[0].evr == "0:1.0-2"
+
+    def test_apply_fallback_only_mismatched_packages_affected(self):
+        """Test that only mismatched packages are modified during fallback."""
+        rpms_info_by_arch = {
+            "x86_64": [
+                RpmInfo("pkg1", "0:1.0-2", "checksum1", "repo1", 1000, "src1", "url1", 0, "1.0", "2"),
+                RpmInfo("pkg2", "0:2.0-1", "checksum2", "repo1", 1000, "src2", "url2", 0, "2.0", "1"),
+            ],
+            "aarch64": [
+                RpmInfo("pkg1", "0:1.0-2", "checksum3", "repo1", 1000, "src1", "url3", 0, "1.0", "2"),
+                RpmInfo("pkg2", "0:2.0-1", "checksum4", "repo1", 1000, "src2", "url4", 0, "2.0", "1"),
+            ],
+        }
+
+        original_pkg2 = {arch: [rpm for rpm in rpms if rpm.name == "pkg2"] for arch, rpms in rpms_info_by_arch.items()}
+
+        fallback_recommendations = {"pkg1": "0:1.0-2"}
+        self.generator._apply_fallback_versions(rpms_info_by_arch, fallback_recommendations)
+
+        for arch in rpms_info_by_arch:
+            pkg2_rpms = [rpm for rpm in rpms_info_by_arch[arch] if rpm.name == "pkg2"]
+            assert pkg2_rpms == original_pkg2[arch]

--- a/doozer/tests/test_lockfile_validation.py
+++ b/doozer/tests/test_lockfile_validation.py
@@ -1,6 +1,6 @@
-from unittest.mock import Mock
+import asyncio
+from unittest.mock import AsyncMock, Mock
 
-import pytest
 from doozerlib.lockfile import RpmInfo, RPMLockfileGenerator
 
 
@@ -797,89 +797,78 @@ class TestRPMLockfileFallback:
 
     def test_apply_fallback_versions_case_1_success(self):
         """Test fallback application when fallback version exists in all architectures."""
-        rpms_info_by_arch = {
-            "x86_64": [
-                RpmInfo("pkg1", "0:1.0-2", "checksum1", "repo1", 1000, "src1", "url1", 0, "1.0", "2"),
-                RpmInfo("pkg1", "0:1.0-3", "checksum2", "repo1", 1000, "src1", "url2", 0, "1.0", "3"),
-            ],
-            "aarch64": [
-                RpmInfo("pkg1", "0:1.0-2", "checksum3", "repo1", 1000, "src1", "url3", 0, "1.0", "2"),
-                RpmInfo("pkg1", "0:1.0-4", "checksum4", "repo1", 1000, "src1", "url4", 0, "1.0", "4"),
-            ],
-        }
 
-        fallback_recommendations = {"pkg1": "0:1.0-2"}
-        self.generator._apply_fallback_versions(rpms_info_by_arch, fallback_recommendations)
+        async def _test():
+            rpms_info_by_arch = {
+                "x86_64": [
+                    RpmInfo("pkg1", "0:1.0-2", "checksum1", "repo1", 1000, "src1", "url1", 0, "1.0", "2"),
+                    RpmInfo("pkg1", "0:1.0-3", "checksum2", "repo1", 1000, "src1", "url2", 0, "1.0", "3"),
+                ],
+                "aarch64": [
+                    RpmInfo("pkg1", "0:1.0-2", "checksum3", "repo1", 1000, "src1", "url3", 0, "1.0", "2"),
+                    RpmInfo("pkg1", "0:1.0-4", "checksum4", "repo1", 1000, "src1", "url4", 0, "1.0", "4"),
+                ],
+            }
 
-        for arch in rpms_info_by_arch:
-            pkg_rpms = [rpm for rpm in rpms_info_by_arch[arch] if rpm.name == "pkg1"]
-            assert len(pkg_rpms) == 1
-            assert pkg_rpms[0].evr == "0:1.0-2"
+            fallback_recommendations = {"pkg1": "0:1.0-2"}
+            arches = ["x86_64", "aarch64"]
+            enabled_repos = {"repo1"}
 
-    def test_apply_fallback_versions_case_2_error(self):
-        """Test fallback application fails when fallback version doesn't exist."""
-        rpms_info_by_arch = {
-            "x86_64": [RpmInfo("pkg1", "0:1.0-3", "checksum1", "repo1", 1000, "src1", "url1", 0, "1.0", "3")],
-            "aarch64": [RpmInfo("pkg1", "0:1.0-4", "checksum2", "repo1", 1000, "src1", "url2", 0, "1.0", "4")],
-        }
+            await self.generator._apply_fallback_versions(
+                rpms_info_by_arch, fallback_recommendations, arches, enabled_repos
+            )
 
-        fallback_recommendations = {"pkg1": "0:1.0-2"}
+            for arch in rpms_info_by_arch:
+                pkg_rpms = [rpm for rpm in rpms_info_by_arch[arch] if rpm.name == "pkg1"]
+                assert len(pkg_rpms) == 1
+                assert pkg_rpms[0].evr == "0:1.0-2"
 
-        with pytest.raises(ValueError, match="Fallback version 0:1.0-2 not available"):
-            self.generator._apply_fallback_versions(rpms_info_by_arch, fallback_recommendations)
+        asyncio.run(_test())
 
-    def test_apply_fallback_versions_partial_architecture_coverage(self):
-        """Test fallback with package missing on some architectures."""
-        rpms_info_by_arch = {
-            "x86_64": [RpmInfo("pkg1", "0:1.0-2", "checksum1", "repo1", 1000, "src1", "url1", 0, "1.0", "2")],
-            "aarch64": [RpmInfo("pkg2", "0:2.0-1", "checksum2", "repo1", 1000, "src2", "url2", 0, "2.0", "1")],
-        }
+    def test_apply_fallback_versions_case_2_repository_resolution(self):
+        """Test Case 2: Repository resolution when fallback version doesn't exist in collections but available in repos."""
 
-        fallback_recommendations = {"pkg1": "0:1.0-2"}
-        self.generator._apply_fallback_versions(rpms_info_by_arch, fallback_recommendations)
+        async def _test():
+            rpms_info_by_arch = {
+                "x86_64": [RpmInfo("pkg1", "0:1.0-3", "checksum1", "repo1", 1000, "src1", "url1", 0, "1.0", "3")],
+                "aarch64": [RpmInfo("pkg1", "0:1.0-4", "checksum2", "repo1", 1000, "src1", "url2", 0, "1.0", "4")],
+            }
 
-        x86_64_pkg1 = [rpm for rpm in rpms_info_by_arch["x86_64"] if rpm.name == "pkg1"]
-        assert len(x86_64_pkg1) == 1
-        assert x86_64_pkg1[0].evr == "0:1.0-2"
+            fallback_recommendations = {"pkg1": "0:1.0-2"}
+            arches = ["x86_64", "aarch64"]
+            enabled_repos = {"repo1"}
 
-        aarch64_pkg1 = [rpm for rpm in rpms_info_by_arch["aarch64"] if rpm.name == "pkg1"]
-        assert len(aarch64_pkg1) == 0
+            # Mock successful repository resolution
+            resolved_rpm_x86 = RpmInfo(
+                "pkg1", "0:1.0-2", "resolved_checksum_x86", "repo1", 1000, "src1", "resolved_url_x86", 0, "1.0", "2"
+            )
+            resolved_rpm_aarch64 = RpmInfo(
+                "pkg1",
+                "0:1.0-2",
+                "resolved_checksum_aarch64",
+                "repo1",
+                1000,
+                "src1",
+                "resolved_url_aarch64",
+                0,
+                "1.0",
+                "2",
+            )
 
-    def test_apply_fallback_versions_multi_arch_consistency(self):
-        """Test fallback maintains consistency across all architectures."""
-        rpms_info_by_arch = {
-            "x86_64": [RpmInfo("pkg1", "0:1.0-2", "checksum1", "repo1", 1000, "src1", "url1", 0, "1.0", "2")],
-            "aarch64": [RpmInfo("pkg1", "0:1.0-2", "checksum2", "repo1", 1000, "src1", "url2", 0, "1.0", "2")],
-            "ppc64le": [RpmInfo("pkg1", "0:1.0-2", "checksum3", "repo1", 1000, "src1", "url3", 0, "1.0", "2")],
-            "s390x": [RpmInfo("pkg1", "0:1.0-2", "checksum4", "repo1", 1000, "src1", "url4", 0, "1.0", "2")],
-        }
+            self.generator.builder.fetch_rpms_info = AsyncMock()
+            self.generator.builder.fetch_rpms_info.side_effect = [
+                {"x86_64": [resolved_rpm_x86]},  # First call for x86_64
+                {"aarch64": [resolved_rpm_aarch64]},  # Second call for aarch64
+            ]
 
-        fallback_recommendations = {"pkg1": "0:1.0-2"}
-        self.generator._apply_fallback_versions(rpms_info_by_arch, fallback_recommendations)
+            await self.generator._apply_fallback_versions(
+                rpms_info_by_arch, fallback_recommendations, arches, enabled_repos
+            )
 
-        for arch in rpms_info_by_arch:
-            pkg_rpms = [rpm for rpm in rpms_info_by_arch[arch] if rpm.name == "pkg1"]
-            assert len(pkg_rpms) == 1
-            assert pkg_rpms[0].evr == "0:1.0-2"
+            # Verify fallback versions were applied after repository resolution
+            for arch in rpms_info_by_arch:
+                pkg_rpms = [rpm for rpm in rpms_info_by_arch[arch] if rpm.name == "pkg1"]
+                assert len(pkg_rpms) == 1
+                assert pkg_rpms[0].evr == "0:1.0-2"
 
-    def test_apply_fallback_only_mismatched_packages_affected(self):
-        """Test that only mismatched packages are modified during fallback."""
-        rpms_info_by_arch = {
-            "x86_64": [
-                RpmInfo("pkg1", "0:1.0-2", "checksum1", "repo1", 1000, "src1", "url1", 0, "1.0", "2"),
-                RpmInfo("pkg2", "0:2.0-1", "checksum2", "repo1", 1000, "src2", "url2", 0, "2.0", "1"),
-            ],
-            "aarch64": [
-                RpmInfo("pkg1", "0:1.0-2", "checksum3", "repo1", 1000, "src1", "url3", 0, "1.0", "2"),
-                RpmInfo("pkg2", "0:2.0-1", "checksum4", "repo1", 1000, "src2", "url4", 0, "2.0", "1"),
-            ],
-        }
-
-        original_pkg2 = {arch: [rpm for rpm in rpms if rpm.name == "pkg2"] for arch, rpms in rpms_info_by_arch.items()}
-
-        fallback_recommendations = {"pkg1": "0:1.0-2"}
-        self.generator._apply_fallback_versions(rpms_info_by_arch, fallback_recommendations)
-
-        for arch in rpms_info_by_arch:
-            pkg2_rpms = [rpm for rpm in rpms_info_by_arch[arch] if rpm.name == "pkg2"]
-            assert pkg2_rpms == original_pkg2[arch]
+        asyncio.run(_test())


### PR DESCRIPTION
…builds

Cross-architecture RPM version mismatches in lockfile generation were causing build failures when converting images to hermetic mode. This implements intelligent fallback recovery that automatically selects the lowest common version when mismatches occur, allowing builds to continue successfully.

The fallback system handles Case 1 scenarios where the target version already exists in all architecture collections, gracefully degrading to the original error behavior for Case 2 scenarios requiring repository resolution. Only mismatched packages are modified while maintaining architecture consistency.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED