### PR TITLE
fix(doozer): recognize golang builders as base images for snapshot releases

### DIFF
--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -99,8 +99,8 @@ class BaseImageHandler:
                     critical_errors.append(f"Could not resolve metadata for component {build_record.name} from {nvr}")
                     continue
 
-                if not metadata.is_base_image():
-                    self.logger.warning(f"Image {nvr} is not marked as base image, skipping")
+                if not metadata.should_trigger_base_image_release():
+                    self.logger.warning(f"Image {nvr} does not qualify for base image release workflow, skipping")
                     continue
 
                 if not metadata.is_snapshot_release_enabled():

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -254,7 +254,7 @@ class KonfluxImageBuilder:
                         record["record_id"] = build_record.record_id
 
                     # Check base image release AFTER saving to database
-                    if outcome is KonfluxBuildOutcome.SUCCESS and metadata.is_base_image():
+                    if outcome is KonfluxBuildOutcome.SUCCESS and metadata.should_trigger_base_image_release():
                         base_image_release_success = await self._trigger_base_image_release(metadata, nvr)
                         if not base_image_release_success:
                             logger.error(

--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -1472,7 +1472,7 @@ def release_to_base_repo(runtime, nvrs):
     4. Waits for release completion
     
     This is intended to be called as a separate job after base image builds complete.
-    Only processes images configured with base_only: true and snapshot_release: true.
+    Only processes base images (base_only: true) and golang builders with snapshot_release: true.
     
     Examples:
     

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1287,23 +1287,45 @@ class ImageMetadata(Metadata):
         """
         Determines whether this image is configured as a base image.
 
-        Base images are identified by the base_only: true configuration field
-        or by being a golang builder image. These images require special
-        snapshot-to-release workflow processing to generate dual URLs for
-        streams.yml updates.
+        Base images are identified by the base_only: true configuration field.
+        These images require special snapshot-to-release workflow processing
+        to generate dual URLs for streams.yml updates.
 
         Returns:
-            bool: True if this is a base image (base_only: true) or golang builder, False otherwise
+            bool: True if this is a base image (base_only: true), False otherwise
         """
         base_only_config = getattr(self.config, 'base_only', Missing)
         if base_only_config not in [Missing, None]:
             return bool(base_only_config)
-
-        # Golang builders also need snapshot-to-release workflow
-        if hasattr(self.config, 'name') and self.config.name == GOLANG_BUILDER_IMAGE_NAME:
-            return True
-
         return False
+
+    def is_golang_builder(self) -> bool:
+        """
+        Determines whether this image is a golang builder image.
+
+        Golang builders are identified by having a name that matches
+        the GOLANG_BUILDER_IMAGE_NAME constant.
+
+        Returns:
+            bool: True if this is a golang builder image, False otherwise
+        """
+        return hasattr(self.config, 'name') and self.config.name == GOLANG_BUILDER_IMAGE_NAME
+
+    def should_trigger_base_image_release(self) -> bool:
+        """
+        Determines whether this image should trigger the base image release workflow.
+
+        The base image release workflow should be triggered for both:
+        - Base images (base_only: true)
+        - Golang builder images
+
+        These image types require special snapshot-to-release workflow processing
+        to generate dual URLs for streams.yml updates.
+
+        Returns:
+            bool: True if base image release workflow should be triggered, False otherwise
+        """
+        return self.is_base_image() or self.is_golang_builder()
 
     def is_snapshot_release_enabled(self) -> bool:
         """

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -10,6 +10,7 @@ from multiprocessing import Event
 from typing import Any, Dict, List, Optional, Set, Tuple, cast
 
 from artcommonlib import util as artlib_util
+from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.model import Missing, Model
 from artcommonlib.pushd import Dir
@@ -1286,16 +1287,22 @@ class ImageMetadata(Metadata):
         """
         Determines whether this image is configured as a base image.
 
-        Base images are identified by the base_only: true configuration field.
-        These images require special snapshot-to-release workflow processing
-        to generate dual URLs for streams.yml updates.
+        Base images are identified by the base_only: true configuration field
+        or by being a golang builder image. These images require special
+        snapshot-to-release workflow processing to generate dual URLs for
+        streams.yml updates.
 
         Returns:
-            bool: True if this is a base image (base_only: true), False otherwise
+            bool: True if this is a base image (base_only: true) or golang builder, False otherwise
         """
         base_only_config = getattr(self.config, 'base_only', Missing)
         if base_only_config not in [Missing, None]:
             return bool(base_only_config)
+
+        # Golang builders also need snapshot-to-release workflow
+        if hasattr(self.config, 'name') and self.config.name == GOLANG_BUILDER_IMAGE_NAME:
+            return True
+
         return False
 
     def is_snapshot_release_enabled(self) -> bool:

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -206,3 +206,52 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         error_message = str(context.exception)
         self.assertIn("No component name found", error_message)
         self.assertIn(missing_name_nvr, error_message)
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_process_base_image_completion_golang_builder_success(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        """Test that golang builders can successfully go through base image workflow."""
+        from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
+
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+
+        konflux_client = AsyncMock()
+        mock_konflux_client_init.return_value = konflux_client
+
+        # Create golang builder metadata
+        golang_builder_model = Model(
+            {
+                "name": GOLANG_BUILDER_IMAGE_NAME,
+                "snapshot_release": True,
+                "distgit": {"component": "ose-golang-builder-container"},
+            }
+        )
+        golang_data = Model({"key": "golang-builder", "data": golang_builder_model, "filename": "golang-builder.yaml"})
+        golang_metadata = ImageMetadata(self.runtime, golang_data)
+        golang_metadata.distgit_key = "golang-builder"
+
+        golang_nvr = "golang-builder-container-v1.0.0-1.el9"
+        handler = BaseImageHandler(self.runtime, [golang_nvr], dry_run=True)
+
+        # Mock the build record for golang builder
+        golang_build_record = MagicMock()
+        golang_build_record.name = "golang-builder"
+        golang_build_record.image_pullspec = "quay.io/test/golang-builder:latest"
+        golang_build_record.rebase_repo_url = "https://example.com/golang-builder.git"
+        golang_build_record.rebase_commitish = "def456"
+
+        self.runtime.image_map = {"golang-builder": golang_metadata}
+
+        with patch.object(handler, "_fetch_build_records", return_value={golang_nvr: golang_build_record}):
+            with patch.object(handler, "_create_snapshot", return_value="golang-snapshot"):
+                with patch.object(handler, "_create_release_from_snapshot", return_value="golang-release"):
+                    with patch.object(handler, "_wait_for_release_completion", return_value=True):
+                        result = await handler.process_base_image_completion()
+
+        # Golang builder should successfully complete the workflow
+        self.assertIsNotNone(result)
+        self.assertEqual(result, ("golang-release", "golang-snapshot"))

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1392,6 +1392,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         self.assertEqual(result, [])
 
     def test_is_base_image(self):
+        from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
         from artcommonlib.model import Model
 
         runtime = MagicMock()
@@ -1407,6 +1408,11 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         regular_data = Model({'key': 'test-regular', 'data': regular_image, 'filename': 'test-regular.yaml'})
         regular_metadata = ImageMetadata(runtime, regular_data)
         self.assertFalse(regular_metadata.is_base_image())
+
+        golang_builder = Model({'name': GOLANG_BUILDER_IMAGE_NAME})
+        golang_data = Model({'key': 'golang-builder', 'data': golang_builder, 'filename': 'golang-builder.yaml'})
+        golang_metadata = ImageMetadata(runtime, golang_data)
+        self.assertTrue(golang_metadata.is_base_image())
 
     def test_is_snapshot_release_enabled(self):
         from artcommonlib.model import Model

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1399,20 +1399,75 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         runtime.logger = logging.getLogger('test_runtime')
         runtime.variant = BuildVariant.OCP
 
+        # Test base image with base_only: true
         base_image = Model({'name': 'test-base', 'base_only': True})
         base_data = Model({'key': 'test-base', 'data': base_image, 'filename': 'test-base.yaml'})
         base_metadata = ImageMetadata(runtime, base_data)
         self.assertTrue(base_metadata.is_base_image())
 
+        # Test regular image (not base)
         regular_image = Model({'name': 'test-regular'})
         regular_data = Model({'key': 'test-regular', 'data': regular_image, 'filename': 'test-regular.yaml'})
         regular_metadata = ImageMetadata(runtime, regular_data)
         self.assertFalse(regular_metadata.is_base_image())
 
+        # Test golang builder - should NOT be considered base image
         golang_builder = Model({'name': GOLANG_BUILDER_IMAGE_NAME})
         golang_data = Model({'key': 'golang-builder', 'data': golang_builder, 'filename': 'golang-builder.yaml'})
         golang_metadata = ImageMetadata(runtime, golang_data)
-        self.assertTrue(golang_metadata.is_base_image())
+        self.assertFalse(golang_metadata.is_base_image())
+
+    def test_is_golang_builder(self):
+        from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
+        from artcommonlib.model import Model
+
+        runtime = MagicMock()
+        runtime.logger = logging.getLogger('test_runtime')
+        runtime.variant = BuildVariant.OCP
+
+        # Test golang builder image
+        golang_builder = Model({'name': GOLANG_BUILDER_IMAGE_NAME})
+        golang_data = Model({'key': 'golang-builder', 'data': golang_builder, 'filename': 'golang-builder.yaml'})
+        golang_metadata = ImageMetadata(runtime, golang_data)
+        self.assertTrue(golang_metadata.is_golang_builder())
+
+        # Test regular image (not golang builder)
+        regular_image = Model({'name': 'test-regular'})
+        regular_data = Model({'key': 'test-regular', 'data': regular_image, 'filename': 'test-regular.yaml'})
+        regular_metadata = ImageMetadata(runtime, regular_data)
+        self.assertFalse(regular_metadata.is_golang_builder())
+
+        # Test base image (not golang builder)
+        base_image = Model({'name': 'test-base', 'base_only': True})
+        base_data = Model({'key': 'test-base', 'data': base_image, 'filename': 'test-base.yaml'})
+        base_metadata = ImageMetadata(runtime, base_data)
+        self.assertFalse(base_metadata.is_golang_builder())
+
+    def test_should_trigger_base_image_release(self):
+        from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
+        from artcommonlib.model import Model
+
+        runtime = MagicMock()
+        runtime.logger = logging.getLogger('test_runtime')
+        runtime.variant = BuildVariant.OCP
+
+        # Test base image - should trigger workflow
+        base_image = Model({'name': 'test-base', 'base_only': True})
+        base_data = Model({'key': 'test-base', 'data': base_image, 'filename': 'test-base.yaml'})
+        base_metadata = ImageMetadata(runtime, base_data)
+        self.assertTrue(base_metadata.should_trigger_base_image_release())
+
+        # Test golang builder - should trigger workflow
+        golang_builder = Model({'name': GOLANG_BUILDER_IMAGE_NAME})
+        golang_data = Model({'key': 'golang-builder', 'data': golang_builder, 'filename': 'golang-builder.yaml'})
+        golang_metadata = ImageMetadata(runtime, golang_data)
+        self.assertTrue(golang_metadata.should_trigger_base_image_release())
+
+        # Test regular image - should NOT trigger workflow
+        regular_image = Model({'name': 'test-regular'})
+        regular_data = Model({'key': 'test-regular', 'data': regular_image, 'filename': 'test-regular.yaml'})
+        regular_metadata = ImageMetadata(runtime, regular_data)
+        self.assertFalse(regular_metadata.should_trigger_base_image_release())
 
     def test_is_snapshot_release_enabled(self):
         from artcommonlib.model import Model


### PR DESCRIPTION
## Summary
fix(doozer): recognize golang builders as base images for snapshot releases

## Changes
The is_base_image() function was only checking for base_only: true configuration,
excluding golang builder images from snapshot-to-release workflow. This caused
golang builders to skip the snapshot release process after successful Konflux builds.

Changes:
- Update is_base_image() to return True for openshift-golang-builder images
- Add test coverage for golang builder base image detection

This ensures golang builders get the same snapshot-to-release workflow as other
base images, fixing missing snapshot releases in the build pipeline.