### PR TITLE
feat(doozer): prefer OSE/rhocp for RPM lockfiles and hermetic cachi2 DNF options

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -388,6 +388,17 @@ class KonfluxImageBuilder:
         name = f"ose-{name[10:]}" if name.startswith("openshift-") else name
         return name
 
+    @staticmethod
+    def _repo_gets_hermetic_module_hotfixes(repo_name: str, group: str, golang_pattern: re.Pattern) -> bool:
+        """
+        art-unsigned.repo sets module_hotfixes=1 on OSE (plashet) repos so non-modular RPMs there can win over
+        modular AppStream streams (e.g. runc). Apply the same hint to cachi2 hermetic prefetch DNF repo options.
+        """
+        if not (group.startswith("openshift-") or golang_pattern.match(group)):
+            return False
+        lower = repo_name.lower()
+        return 'ose-rpms' in lower or 'rhocp' in lower
+
     def _prefetch(self, metadata: ImageMetadata, group: str, dest_dir: Optional[Path] = None) -> list:
         """
         To generate the param values for konflux's prefetch dependencies task which uses cachi2 (similar to cachito in
@@ -433,26 +444,40 @@ class KonfluxImageBuilder:
                     phase = SoftwareLifecyclePhase.from_name(metadata.runtime.group_config.software_lifecycle.phase)
                     should_disable_gpg = phase <= SoftwareLifecyclePhase.SIGNING
 
-                if should_disable_gpg:
-                    enabled_repos = metadata.get_enabled_repos()
-                    if enabled_repos:
-                        dnf_options = {}
-                        repos = metadata.runtime.repos
-                        building_arches = metadata.get_arches()
+                enabled_repos = metadata.get_enabled_repos()
+                if enabled_repos:
+                    dnf_options = {}
+                    repos = metadata.runtime.repos
+                    building_arches = metadata.get_arches()
 
-                        for repo_name in enabled_repos:
-                            repo = repos[repo_name]
-                            for arch in building_arches:
-                                content_set_id = repo.content_set(arch)
-                                if content_set_id is None:
-                                    content_set_id = f'{repo_name}-{arch}'
+                    for repo_name in enabled_repos:
+                        repo = repos[repo_name]
+                        for arch in building_arches:
+                            content_set_id = repo.content_set(arch)
+                            if content_set_id is None:
+                                content_set_id = f'{repo_name}-{arch}'
 
-                                dnf_options[content_set_id] = {"gpgcheck": "0"}
+                            opts: dict = {}
+                            if should_disable_gpg:
+                                opts["gpgcheck"] = "0"
+                            if self._repo_gets_hermetic_module_hotfixes(repo_name, group, golang_pattern):
+                                opts["module_hotfixes"] = "1"
 
+                            if opts:
+                                dnf_options[content_set_id] = opts
+
+                    if dnf_options:
                         data["options"] = {"dnf": dnf_options}
-                        logger.info(
-                            f"Adding prerelease DNF options for {len(dnf_options)} repository IDs: gpgcheck disabled"
-                        )
+                        if should_disable_gpg:
+                            logger.info(
+                                f"Adding hermetic RPM prefetch DNF options for {len(dnf_options)} repository IDs "
+                                f"(gpgcheck disabled for prerelease; module_hotfixes on OSE/rhocp where applicable)"
+                            )
+                        else:
+                            logger.info(
+                                f"Adding hermetic RPM prefetch DNF options for {len(dnf_options)} repository IDs "
+                                f"(module_hotfixes on OSE/rhocp repos, aligned with art-unsigned.repo)"
+                            )
 
             prefetch.append(data)
             logger.info(f"Adding RPM prefetch for lockfile {DEFAULT_RPM_LOCKFILE_NAME} at path: {lockfile_path}")

--- a/doozer/doozerlib/lockfile.py
+++ b/doozer/doozerlib/lockfile.py
@@ -22,6 +22,25 @@ DEFAULT_RPM_LOCKFILE_NAME = "rpms.lock.yaml"
 DEFAULT_ARTIFACT_LOCKFILE_NAME = "artifacts.lock.yaml"
 
 
+def sort_repos_for_lockfile_resolution(repo_names: set[str]) -> list[str]:
+    """
+    Order repos so OCP content (rhocp / *ose-rpms*) is preferred over plain RHEL (baseos, appstream, CRB, ...).
+
+    :meth:`RpmInfoCollector._fetch_rpms_info_per_arch` resolves each package name from the first repo in
+    iteration order that contains it. ``repo_names`` is a ``set``, so order was undefined; the same RPM
+    name can exist in both RHEL AppStream (e.g. modular ``runc`` 1.1.x) and OSE (``runc`` 1.2.x from
+    ``rhaos``). Prefer OSE so lockfiles and hermetic prefetch match ``check_external_packages`` / Brew.
+    """
+
+    def sort_key(name: str) -> tuple[int, str]:
+        lower = name.lower()
+        if 'ose-rpms' in lower or 'rhocp' in lower:
+            return (0, name)
+        return (1, name)
+
+    return sorted(repo_names, key=sort_key)
+
+
 @total_ordering
 @dataclass(frozen=True)
 class RpmInfo:
@@ -269,7 +288,7 @@ class RpmInfoCollector:
         unresolved_rpms = set(rpm_names)
         missing_rpms = unresolved_rpms
 
-        for repo_name in repo_names:
+        for repo_name in sort_repos_for_lockfile_resolution(repo_names):
             repodata = self.loaded_repos.get(f'{repo_name}-{arch}')
             if repodata is None:
                 self.logger.error(

--- a/doozer/tests/backend/test_konflux_cachi2.py
+++ b/doozer/tests/backend/test_konflux_cachi2.py
@@ -209,7 +209,7 @@ class TestKonfluxCachi2(TestCase):
 
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
     def test_prefetch_rpm_lockfile_non_prerelease_no_dnf_options(self, mock_konflux_client_init):
-        """Test that non-prerelease phase does NOT add DNF options"""
+        """Non-prerelease: no gpgcheck override; plain repos get no DNF options."""
         builder = KonfluxImageBuilder(MagicMock())
         metadata = MagicMock()
 
@@ -228,6 +228,83 @@ class TestKonfluxCachi2(TestCase):
         result = builder._prefetch(metadata=metadata, group="openshift-4.17")
 
         expected = [{'type': 'rpm', 'path': '.'}, {'type': 'gomod', 'path': '.'}]
+        self.assertEqual(result, expected)
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    def test_prefetch_rpm_lockfile_release_ose_module_hotfixes(self, mock_konflux_client_init):
+        """Release phase: OSE/rhocp repos still get module_hotfixes=1 (aligned with art-unsigned.repo)."""
+        builder = KonfluxImageBuilder(MagicMock())
+        metadata = MagicMock()
+
+        metadata.is_cachi2_enabled.return_value = True
+        metadata.is_lockfile_generation_enabled.return_value = True
+        metadata.is_artifact_lockfile_enabled.return_value = False
+        metadata.get_konflux_network_mode.return_value = "hermetic"
+        metadata.config.content.source.pkg_managers = ["gomod"]
+        metadata.config.cachito.packages = {'gomod': [{'path': '.'}]}
+        metadata.config.konflux.cachi2.lockfile.get.return_value = "."
+
+        metadata.runtime.group_config.software_lifecycle.phase = 'release'
+        metadata.get_enabled_repos.return_value = {'rhel-8-server-ose-rpms-embargoed', 'baseos'}
+        metadata.get_arches.return_value = ['x86_64']
+
+        mock_ose = MagicMock()
+        mock_ose.content_set.side_effect = lambda arch: f'ose-cs-{arch}'
+        mock_base = MagicMock()
+        mock_base.content_set.side_effect = lambda arch: f'baseos-cs-{arch}'
+        metadata.runtime.repos = {
+            'rhel-8-server-ose-rpms-embargoed': mock_ose,
+            'baseos': mock_base,
+        }
+
+        result = builder._prefetch(metadata=metadata, group="openshift-4.17")
+
+        expected_rpm_data = {
+            'type': 'rpm',
+            'path': '.',
+            'options': {
+                'dnf': {
+                    'ose-cs-x86_64': {'module_hotfixes': '1'},
+                }
+            },
+        }
+        expected = [expected_rpm_data, {'type': 'gomod', 'path': '.'}]
+        self.assertEqual(result, expected)
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    def test_prefetch_rpm_lockfile_prerelease_rhocp_module_hotfixes_and_gpg(self, mock_konflux_client_init):
+        """Prerelease: rhocp/ose repos get both gpgcheck=0 and module_hotfixes=1."""
+        builder = KonfluxImageBuilder(MagicMock())
+        metadata = MagicMock()
+
+        metadata.is_cachi2_enabled.return_value = True
+        metadata.is_lockfile_generation_enabled.return_value = True
+        metadata.is_artifact_lockfile_enabled.return_value = False
+        metadata.get_konflux_network_mode.return_value = "hermetic"
+        metadata.config.content.source.pkg_managers = ["gomod"]
+        metadata.config.cachito.packages = {'gomod': [{'path': '.'}]}
+        metadata.config.konflux.cachi2.lockfile.get.return_value = "."
+
+        metadata.runtime.group_config.software_lifecycle.phase = 'pre-release'
+        metadata.get_enabled_repos.return_value = {'rhocp-4.12'}
+        metadata.get_arches.return_value = ['x86_64']
+
+        mock_rhocp = MagicMock()
+        mock_rhocp.content_set.side_effect = lambda arch: f'rhocp-cs-{arch}'
+        metadata.runtime.repos = {'rhocp-4.12': mock_rhocp}
+
+        result = builder._prefetch(metadata=metadata, group="openshift-4.17")
+
+        expected_rpm_data = {
+            'type': 'rpm',
+            'path': '.',
+            'options': {
+                'dnf': {
+                    'rhocp-cs-x86_64': {'gpgcheck': '0', 'module_hotfixes': '1'},
+                }
+            },
+        }
+        expected = [expected_rpm_data, {'type': 'gomod', 'path': '.'}]
         self.assertEqual(result, expected)
 
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")

--- a/doozer/tests/test_lockfile.py
+++ b/doozer/tests/test_lockfile.py
@@ -10,6 +10,7 @@ from doozerlib.lockfile import (
     RpmInfo,
     RpmInfoCollector,
     RPMLockfileGenerator,
+    sort_repos_for_lockfile_resolution,
 )
 from doozerlib.repodata import Rpm, RpmModule
 from doozerlib.repos import Repos
@@ -111,6 +112,22 @@ class TestModuleInfo(unittest.TestCase):
             "size": 12345,
         }
         self.assertEqual(module_info.to_dict(), expected)
+
+
+class TestSortReposForLockfileResolution(unittest.TestCase):
+    def test_prefers_ose_and_rhocp_over_rhel(self):
+        names = {
+            'rhel-8-appstream-rpms',
+            'rhel-8-baseos-rpms',
+            'rhel-8-server-ose-rpms-embargoed',
+        }
+        ordered = sort_repos_for_lockfile_resolution(names)
+        self.assertEqual(ordered[0], 'rhel-8-server-ose-rpms-embargoed')
+        self.assertEqual(set(ordered), names)
+
+    def test_rhocp_before_baseos(self):
+        ordered = sort_repos_for_lockfile_resolution({'rhel-8-baseos-rpms', 'rhocp-4.12-for-rhel-8-x86_64-rpms'})
+        self.assertEqual(ordered[0], 'rhocp-4.12-for-rhel-8-x86_64-rpms')
 
 
 class TestRpmInfoCollectorFetchRpms(unittest.TestCase):
@@ -285,6 +302,65 @@ class TestRpmInfoCollectorFetchRpms(unittest.TestCase):
 
         self.collector._fetch_rpms_info_per_arch({rpm.name, "missingpkg"}, {repo_name}, arch)
         self.collector.logger.warning.assert_called_with(f"Could not find missingpkg in {repo_name} for arch {arch}")
+
+    def test_fetch_rpms_prefers_ose_repo_when_same_name_in_appstream(self):
+        """OSE/rhocp must be scanned before RHEL repos so e.g. runc resolves to rhaos, not container-tools."""
+        arches = ['x86_64']
+        repo_data = {
+            "rhel-8-appstream-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/appstream/"}},
+                "content_set": {"default": "appstream-cs"},
+                "reposync": {"enabled": False},
+            },
+            "rhel-8-server-ose-rpms-embargoed": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/ose/"}},
+                "content_set": {"default": "ose-cs"},
+                "reposync": {"enabled": False},
+            },
+        }
+        repos = Repos(repo_data, arches=arches)
+        collector = RpmInfoCollector(repos=repos)
+        collector.logger = MagicMock()
+
+        runc_appstream = Rpm(
+            name="runc",
+            epoch=1,
+            version="1.1.12",
+            checksum="a",
+            size=1,
+            location="/runc-old.rpm",
+            sourcerpm="runc.src.rpm",
+            release="1.module.el8",
+            arch="x86_64",
+        )
+        runc_ose = Rpm(
+            name="runc",
+            epoch=4,
+            version="1.2.9",
+            checksum="b",
+            size=2,
+            location="/runc-ose.rpm",
+            sourcerpm="runc.src.rpm",
+            release="1.rhaos4.17.el8",
+            arch="x86_64",
+        )
+        arch = 'x86_64'
+        for repo_name in repo_data:
+            repodata = MagicMock()
+            if 'ose' in repo_name:
+                repodata.get_rpms.return_value = ([runc_ose], [])
+            else:
+                repodata.get_rpms.return_value = ([runc_appstream], [])
+            collector.loaded_repos[f"{repo_name}-{arch}"] = repodata
+
+        result = collector._fetch_rpms_info_per_arch(
+            {'runc'},
+            {'rhel-8-appstream-rpms', 'rhel-8-server-ose-rpms-embargoed'},
+            arch,
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].evr, '4:1.2.9-1.rhaos4.17.el8')
+        self.assertEqual(result[0].repoid, 'ose-cs')
 
     def test_load_repos_skips_already_loaded(self):
         # Simulate that both repos are already loaded


### PR DESCRIPTION
## Summary

Two related fixes for hermetic Konflux and doozer-generated RPM lockfiles when the same package name exists in RHEL AppStream (e.g. modular runc) and OSE/rhocp (rhaos runc).

## Changes

* Lockfile resolution (lockfile.py)
Repo iteration for `_fetch_rpms_info_per_arch` used a set, so order was undefined. 
Add `sort_repos_for_lockfile_resolution()` so repos whose names contain ose-rpms or rhocp are processed before BaseOS/AppStream (and other RHEL repos).
 
* Hermetic cachi2 prefetch (konflux_image_builder.py)
For openshift/golang groups, merge per-content-set options.dnf: module_hotfixes: "1" on OSE/rhocp repos (as in art-unsigned.repo / group.yml), together with existing gpgcheck: "0" when prerelease signing applies.
