### PR TITLE
ART-14867 Deprecate @release-artists handle

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -968,7 +968,7 @@ with the images referenced in this component's github repository.
 
 Differences in upstream and downstream builds impact the fidelity of your CI signal.
 
-If you disagree with the content of this PR, please contact @release-artists
+If you disagree with the content of this PR, please contact @automated-tooling-triage
 in #forum-ocp-art to discuss the discrepancy.
 
 Closing this issue without addressing the difference will cause the issue to
@@ -986,7 +986,7 @@ improve.
 Important: ART has recorded in their product data that bugs for
 this component should be opened against Jira project "{potential_project}" and
 component "{potential_component}". This project or component does not exist. Jira
-should either be updated to include this component or @release-artists should be
+should either be updated to include this component or @automated-tooling-triage should be
 notified of the proper mapping in the #forum-ocp-art Slack channel.
 
 Component name: {image_meta.get_component_name()} .
@@ -998,7 +998,7 @@ Jira mapping: https://github.com/openshift-eng/ocp-build-data/blob/main/product.
 Important: ART maintains a mapping of OpenShift software components to
 Jira components. This component does not currently have an entry defined
 within that data.
-Contact @release-artists in the #forum-ocp-art Slack channel to inform them of
+Contact @automated-tooling-triage in the #forum-ocp-art Slack channel to inform them of
 the Jira project and component to use for this image.
 
 Until this is done, ART issues against this component will be opened
@@ -1606,7 +1606,7 @@ communicated to the ART team.
 
 __Roles & Responsibilities__:
 - Component owners are responsible for ensuring these alignment PRs merge with passing
-  tests OR that necessary metadata changes are reported to the ART team: `@release-artists`
+  tests OR that necessary metadata changes are reported to the ART team: `@automated-tooling-triage`
   in `#forum-ocp-art` on Slack. If necessary, the changes required by this pull request can be
   introduced with a separate PR opened by the component team. Once the repository is aligned,
   this PR will be closed automatically.
@@ -1637,7 +1637,7 @@ __Change behavior of future PRs__:
 * You can set a commit prefix, like `UPSTREAM: <carry>: `. [An example](https://github.com/openshift-eng/ocp-build-data/blob/6831b59dddc5b63282076d3abe04593ad1945148/images/ose-cluster-api.yml#L11).
 """
             pr_body += """
-If you have any questions about this pull request, please reach out to `@release-artists` in the `#forum-ocp-art` coreos slack channel.
+If you have any questions about this pull request, please reach out to `@automated-tooling-triage` in the `#forum-ocp-art` coreos slack channel.
 """
 
             parent_pr_urls = None

--- a/doozer/doozerlib/cli/scan_osh.py
+++ b/doozer/doozerlib/cli/scan_osh.py
@@ -31,7 +31,7 @@ Once these issues are addressed, the Bug can be closed. But a new one will be op
 
 For information on triaging these issues and dispositioning this ticket, please review the [policy document for SAST Scanning Jira Tickets|https://docs.google.com/document/d/1GsT3tvw5qf3sOSAkTSVWnMIO6vzIuirhsVhhsbK_qf0].
 
-For other questions please reach out to @release-artists in #forum-ocp-art.
+For other questions please reach out to @automated-tooling-triage in #forum-ocp-art.
 
 _(Ticket title and description are maintained by the bot. Please do not modify)_
 """

--- a/pyartcd/pyartcd/pipelines/art_notify.py
+++ b/pyartcd/pyartcd/pipelines/art_notify.py
@@ -17,7 +17,7 @@ from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.runtime import Runtime
 
 SEARCH_WINDOW_HOURS = 8  # Window of last X hours that we consider for our failed builds search
-RELEASE_ARTIST_HANDLE = 'release-artists'
+ART_TRIAGE_HANDLE = 'automated-tooling-triage'
 ART_KONFLUX_TEMPLATE_REPO = 'openshift-priv/art-konflux-template'
 ART_DOCS_TASK_BUNDLES_URL = 'https://art-docs.engineering.redhat.com/konflux/update-konflux-task-bundles/'
 
@@ -308,7 +308,7 @@ class ArtNotifyPipeline:
 
         header_block = [
             {"type": "header", "text": {"type": "plain_text", "text": f"{header_text} ({n_threads})", "emoji": True}},
-            {"type": "section", "text": {"type": "mrkdwn", "text": f"Attention @{RELEASE_ARTIST_HANDLE}"}},
+            {"type": "section", "text": {"type": "mrkdwn", "text": f"Attention @{ART_TRIAGE_HANDLE}"}},
         ]
 
         if self.runtime.dry_run:
@@ -330,7 +330,7 @@ class ArtNotifyPipeline:
             # https://api.slack.com/methods/chat.postMessage#examples
             response = self.app.client.chat_postMessage(
                 channel=self.channel,
-                text=f'@{RELEASE_ARTIST_HANDLE} - {fallback_text}',
+                text=f'@{ART_TRIAGE_HANDLE} - {fallback_text}',
                 blocks=header_block,
                 unfurl_links=False,
             )

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -351,7 +351,7 @@ class BuildMicroShiftPipeline:
         except Exception as err:
             self._logger.error("Failed to trigger microshift_sync job: %s", err)
             message = (
-                f"@release-artists Please start <{constants.JENKINS_UI_URL}"
+                f"@automated-tooling-triage Please start <{constants.JENKINS_UI_URL}"
                 "/job/aos-cd-builds/job/build%252Fmicroshift_sync|microshift sync> manually."
             )
             await self.slack_client.say_in_thread(message)
@@ -376,7 +376,7 @@ class BuildMicroShiftPipeline:
         except Exception as err:
             self._logger.error("Failed to trigger build-microshift-bootc job: %s", err)
             message = (
-                f"@release-artists Please start <{constants.JENKINS_UI_URL}"
+                f"@automated-tooling-triage Please start <{constants.JENKINS_UI_URL}"
                 "/job/aos-cd-builds/job/build%252Fbuild-microshift-bootc|build-microshift-bootc> manually."
             )
             await self.slack_client.say_in_thread(message)
@@ -675,7 +675,7 @@ class BuildMicroShiftPipeline:
         slack_client = self.runtime.new_slack_client()
         slack_client.channel = "C0310LGMQQY"  # microshift-alerts
         message = f":alert: @here ART build failure: microshift-{version_release}."
-        message += "\nPing @ release-artists if you need help."
+        message += "\nPing @ automated-tooling-triage if you need help."
         slack_response = await slack_client.say(message)
         slack_thread = slack_response["message"]["ts"]
         if doozer_log_file.exists():

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -225,7 +225,7 @@ class BuildSyncPipeline:
             # Comment on the PR that the job succeeded
             await self.comment_on_assembly_pr(f"Build sync job [run]({self.job_run}) succeeded!")
             await self.slack_client.say(
-                f"@release-artists `{self.build_system.capitalize()}` <{self.job_run}|build-sync> "
+                f"`{self.build_system.capitalize()}` <{self.job_run}|build-sync> "
                 f"for assembly `{self.assembly}` succeeded!"
             )
 
@@ -571,7 +571,7 @@ class BuildSyncPipeline:
         if self.assembly != 'stream':
             await self.comment_on_assembly_pr(f"Build sync job [run]({self.job_run}) failed!")
             await self.slack_client.say(
-                f"@release-artists `{self.build_system.capitalize()}` <{self.job_run}|build sync> "
+                f"`{self.build_system.capitalize()}` <{self.job_run}|build sync> "
                 f"for assembly {self.assembly} failed!"
             )
 

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -571,8 +571,7 @@ class BuildSyncPipeline:
         if self.assembly != 'stream':
             await self.comment_on_assembly_pr(f"Build sync job [run]({self.job_run}) failed!")
             await self.slack_client.say(
-                f"`{self.build_system.capitalize()}` <{self.job_run}|build sync> "
-                f"for assembly {self.assembly} failed!"
+                f"`{self.build_system.capitalize()}` <{self.job_run}|build sync> for assembly {self.assembly} failed!"
             )
 
         # Increment failure count

--- a/pyartcd/pyartcd/pipelines/build_sync_multi.py
+++ b/pyartcd/pyartcd/pipelines/build_sync_multi.py
@@ -163,7 +163,7 @@ class BuildSyncMultiPipeline:
             # Comment on the PR that the job succeeded
             await self.comment_on_assembly_pr(f"Multi-model build sync job [run]({self.job_run}) succeeded!")
             await self.slack_client.say(
-                f"@release-artists Multi-model <{self.job_run}|build-sync> for assembly `{self.assembly}` succeeded!"
+                f"Multi-model <{self.job_run}|build-sync> for assembly `{self.assembly}` succeeded!"
             )
 
         #  All good: delete fail counter
@@ -253,7 +253,7 @@ class BuildSyncMultiPipeline:
         if self.assembly != 'stream':
             await self.comment_on_assembly_pr(f"Multi-model build sync job [run]({self.job_run}) failed!")
             await self.slack_client.say(
-                f"@release-artists Multi-model <{self.job_run}|build-sync> for assembly {self.assembly} failed!"
+                f"Multi-model <{self.job_run}|build-sync> for assembly {self.assembly} failed!"
             )
 
         # Increment failure count

--- a/pyartcd/pyartcd/pipelines/build_sync_multi.py
+++ b/pyartcd/pyartcd/pipelines/build_sync_multi.py
@@ -252,9 +252,7 @@ class BuildSyncMultiPipeline:
 
         if self.assembly != 'stream':
             await self.comment_on_assembly_pr(f"Multi-model build sync job [run]({self.job_run}) failed!")
-            await self.slack_client.say(
-                f"Multi-model <{self.job_run}|build-sync> for assembly {self.assembly} failed!"
-            )
+            await self.slack_client.say(f"Multi-model <{self.job_run}|build-sync> for assembly {self.assembly} failed!")
 
         # Increment failure count
         current_count = await redis.get_value(self.fail_count_name)

--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -240,7 +240,7 @@ class GenAssemblyPipeline:
 
             # Sends a slack message
             message = (
-                f"Hi @release-artists, please review assembly definition for {self.assembly}: {pr.html_url}\n\n"
+                f"Hi @automated-tooling-triage, please review assembly definition for {self.assembly}: {pr.html_url}\n\n"
                 f"The inflight release is {self.in_flight}"
             )
             if not self.skip_get_nightlies:

--- a/pyartcd/pyartcd/pipelines/ocp.py
+++ b/pyartcd/pyartcd/pipelines/ocp.py
@@ -763,7 +763,7 @@ class OcpPipeline:
         # add yourself to the queue
         # if queue does not exist, it will be created with the value
         # nx=True to only create new elements and not to update scores for elements that already exist.
-        # This is so that release-artists can manually add versions with scores to set mass rebuild order
+        # This is so that the ART team can manually add versions with scores to set mass rebuild order
         # and they will not be overwritten
         await redis.call('zadd', queue, mapping, nx=True)
         self.runtime.logger.info('Queued in for mass rebuild lock')

--- a/pyartcd/pyartcd/pipelines/ocp4_scan.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan.py
@@ -171,7 +171,8 @@ class Ocp4ScanPipeline:
         slack_client = self.runtime.new_slack_client()
         slack_client.bind_channel(self.version)
         message = (
-            f':warning: @release-artists, some issues have arisen during scan-sources for *{self.version}* :warning:'
+            f":warning: @automated-tooling-triage, some issues have arisen during "
+            f"scan-sources for *{self.version}* :warning:"
         )
         slack_response = await slack_client.say(message)
 

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -249,7 +249,7 @@ class PromotePipeline:
         logger.info("Release name: %s", release_name)
 
         self._slack_client.bind_channel(release_name)
-        await self._slack_client.say_in_thread(f"Promoting release `{release_name}` @release-artists")
+        await self._slack_client.say_in_thread(f"Promoting release `{release_name}` @automated-tooling-triage")
 
         justifications = []
         try:

--- a/pyartcd/pyartcd/pipelines/tag_rpms.py
+++ b/pyartcd/pyartcd/pipelines/tag_rpms.py
@@ -56,7 +56,7 @@ class TagRPMsPipeline:
                 if untagged:
                     message += "Builds were untagged because they were tagged into the stop-ship tags. Notify ota-monitor on Slack channel #forum-release if a release contains this build is already promoted.\n"
                     message += "May need to manually trigger builds of kernel carryin images like `driver-toolkit` and `ironic-rhcos-downloader`.\n\n"
-                    await self.slack_client.say(f":alert-siren: Hi @release-artists ,\n{message}")
+                    await self.slack_client.say(f":alert-siren: Hi,\n{message}")
             if report["tagged"]:
                 for tag, nvrs in report["tagged"].items():
                     if not nvrs:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ART-14867

## Summary
- Replace `@release-artists` Slack handle references with `@automated-tooling-triage` across pipeline code and tooling
- Rename `RELEASE_ARTIST_HANDLE` constant to `ART_TRIAGE_HANDLE` in `art_notify.py`
- Remove unnecessary pings from build-sync and build-sync-multi success/failure messages (monitored via nightly dash)
- Remove tag from tag_rpms alert (not urgent)
- Keep microshift-alerts message as plaintext (no ping to ART)
- Update generic team references to "ART team" where appropriate

## Files Changed
- `doozer/doozerlib/cli/images_streams.py` (5 occurrences)
- `doozer/doozerlib/cli/scan_osh.py` (1 occurrence)
- `pyartcd/pyartcd/pipelines/art_notify.py` (constant rename + 2 usages)
- `pyartcd/pyartcd/pipelines/build_microshift.py` (3 occurrences, kept plaintext in microshift-alerts)
- `pyartcd/pyartcd/pipelines/build_sync.py` (removed pings on success/failure)
- `pyartcd/pyartcd/pipelines/build_sync_multi.py` (removed pings on success/failure)
- `pyartcd/pyartcd/pipelines/gen_assembly.py` (1 occurrence)
- `pyartcd/pyartcd/pipelines/ocp4_scan.py` (1 occurrence, fixed ruff formatting)
- `pyartcd/pyartcd/pipelines/promote.py` (1 occurrence)
- `pyartcd/pyartcd/pipelines/tag_rpms.py` (removed tag, not urgent)
- `pyartcd/pyartcd/pipelines/ocp.py` (1 generic reference)

## Test plan
- [x] Verify no remaining references to `release-artists` in changed files
- [x] Verify `ART_TRIAGE_HANDLE` constant is correctly used in `art_notify.py`
- [x] `ruff format --check` passes on all changed files
- [x] `ruff check` passes on all changed files