### PR TITLE
ART-14734 Make ocp4-scan-konflux/scan-sources individual image failure resilient and report at end

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -407,82 +407,87 @@ class ConfigScanSources:
         ).get()
 
         for metadata, public_upstream in upstream_mappings:
-            # Skip rebase for disabled components
-            if metadata.meta_type == 'image':
-                # For images: use OKD-aware enabled check
-                if not self._is_image_enabled(metadata):
+            try:
+                # Skip rebase for disabled components
+                if metadata.meta_type == 'image':
+                    # For images: use OKD-aware enabled check
+                    if not self._is_image_enabled(metadata):
+                        self.logger.warning('%s is disabled: skipping rebase', metadata.name)
+                        continue
+                elif not metadata.enabled:
+                    # For RPMs, use standard enabled check
                     self.logger.warning('%s is disabled: skipping rebase', metadata.name)
                     continue
-            elif not metadata.enabled:
-                # For RPMs, use standard enabled check
-                self.logger.warning('%s is disabled: skipping rebase', metadata.name)
-                continue
 
-            if metadata.config.content is Missing:
-                self.logger.warning(
-                    '%s %s is a distgit-only component: skipping openshift-priv rebase',
-                    metadata.meta_type,
-                    metadata.name,
-                )
-                continue
+                if metadata.config.content is Missing:
+                    self.logger.warning(
+                        '%s %s is a distgit-only component: skipping openshift-priv rebase',
+                        metadata.meta_type,
+                        metadata.name,
+                    )
+                    continue
 
-            public_url, public_branch_name, has_public_upstream = public_upstream
+                public_url, public_branch_name, has_public_upstream = public_upstream
 
-            # If no public upstream exists, skip the rebase
-            if not has_public_upstream:
-                self.logger.warning(
-                    '%s %s does not have a public upstream: skipping openshift-priv rebase',
-                    metadata.meta_type,
-                    metadata.name,
-                )
-                continue
+                # If no public upstream exists, skip the rebase
+                if not has_public_upstream:
+                    self.logger.warning(
+                        '%s %s does not have a public upstream: skipping openshift-priv rebase',
+                        metadata.meta_type,
+                        metadata.name,
+                    )
+                    continue
 
-            priv_url = artcommonlib.util.ensure_github_https_url(metadata.config.content.source.git.url)
-            priv_branch_name = metadata.config.content.source.git.branch.target
+                priv_url = artcommonlib.util.ensure_github_https_url(metadata.config.content.source.git.url)
+                priv_branch_name = metadata.config.content.source.git.branch.target
 
-            # If a git commit hash was declared as the upstream source, skip the rebase
-            try:
-                _ = int(priv_branch_name, 16)
-                # target branch is a sha: skip rebase for this component
-                self.logger.warning('Target branch for %s is a SHA: skipping rebase', metadata.name)
-                continue
+                # If a git commit hash was declared as the upstream source, skip the rebase
+                try:
+                    _ = int(priv_branch_name, 16)
+                    # target branch is a sha: skip rebase for this component
+                    self.logger.warning('Target branch for %s is a SHA: skipping rebase', metadata.name)
+                    continue
 
-            except ValueError:
-                # target branch is a normal branch name
-                pass
+                except ValueError:
+                    # target branch is a normal branch name
+                    pass
 
-            # If no public_upstreams field exists, public_branch_name will be None
-            public_branch_name = public_branch_name or priv_branch_name
+                # If no public_upstreams field exists, public_branch_name will be None
+                public_branch_name = public_branch_name or priv_branch_name
 
-            if priv_url == public_url:
-                # Upstream repo does not have a public counterpart: no need to rebase
-                self.logger.warning(
-                    '%s %s does not have a public upstream: skipping openshift-priv rebase',
-                    metadata.meta_type,
-                    metadata.name,
-                )
-                continue
+                if priv_url == public_url:
+                    # Upstream repo does not have a public counterpart: no need to rebase
+                    self.logger.warning(
+                        '%s %s does not have a public upstream: skipping openshift-priv rebase',
+                        metadata.meta_type,
+                        metadata.name,
+                    )
+                    continue
 
-            # First, quick check: if SHAs match across remotes, repo is synced and we can avoid cloning it
-            _, public_org, public_repo_name = artcommonlib.util.split_git_url(public_url)
-            _, priv_org, priv_repo_name = artcommonlib.util.split_git_url(priv_url)
+                # First, quick check: if SHAs match across remotes, repo is synced and we can avoid cloning it
+                _, public_org, public_repo_name = artcommonlib.util.split_git_url(public_url)
+                _, priv_org, priv_repo_name = artcommonlib.util.split_git_url(priv_url)
 
-            if self._do_shas_match(public_url, public_branch_name, priv_url, priv_branch_name):
-                # If they match, do nothing
-                continue
+                if self._do_shas_match(
+                    public_url, public_branch_name, metadata.config.content.source.git.url, priv_branch_name
+                ):
+                    # If they match, do nothing
+                    continue
 
-            # If they don't, clone source repo
-            path = self.runtime.source_resolver.resolve_source(metadata).source_path
+                # If they don't, clone source repo
+                path = self.runtime.source_resolver.resolve_source(metadata).source_path
 
-            # SHAs might differ because of previous rebase; let's check the actual content across upstreams
-            if self._is_pub_ancestor_of_priv(path, public_branch_name, priv_branch_name, priv_repo_name):
-                # Private upstream is ahead of public: no need to rebase
-                continue
+                # SHAs might differ because of previous rebase; let's check the actual content across upstreams
+                if self._is_pub_ancestor_of_priv(path, public_branch_name, priv_branch_name, priv_repo_name):
+                    # Private upstream is ahead of public: no need to rebase
+                    continue
 
-            with Dir(path):
-                self._try_reconciliation(
-                    metadata, priv_repo_name, public_branch_name, priv_branch_name, priv_url=priv_url
-                )
+                with Dir(path):
+                    self._try_reconciliation(metadata, priv_repo_name, public_branch_name, priv_branch_name, priv_url=priv_url)
+
+            except Exception as e:
+                self.logger.exception('Failed rebasing %s into openshift-priv', metadata.distgit_key)
+                self.issues.append({'name': metadata.distgit_key, 'issue': f'Failed rebasing into -priv: {e}'})
 
     def generate_dependency_tree(self, tree, level=1, levels_dict=None):
         if not levels_dict:
@@ -584,46 +589,63 @@ class ConfigScanSources:
 
     @skip_check_if_changing
     async def scan_image(self, image_meta: ImageMetadata):
-        self.logger.info(f'Scanning {image_meta.distgit_key} for changes')
-        if image_meta.config.konflux is not Missing:
-            image_meta.config = Model(deep_merge(image_meta.config.primitive(), image_meta.config.konflux.primitive()))
+        stage = 'initialization'
+        try:
+            self.logger.info(f'Scanning {image_meta.distgit_key} for changes')
+            if image_meta.config.konflux is not Missing:
+                image_meta.config = Model(
+                    deep_merge(image_meta.config.primitive(), image_meta.config.konflux.primitive())
+                )
 
-        # Check if the component has ever been built
-        latest_build_record = self.latest_image_build_records_map.get(image_meta.distgit_key, None)
-        if not latest_build_record:
-            self.add_image_meta_change(
-                image_meta,
-                RebuildHint(
-                    code=RebuildHintCode.NO_LATEST_BUILD,
-                    reason=f'Component {image_meta.distgit_key} has no latest build '
-                    f'for assembly {self.runtime.assembly}',
-                ),
-            )
-            return
+            # Check if the component has ever been built
+            latest_build_record = self.latest_image_build_records_map.get(image_meta.distgit_key, None)
+            if not latest_build_record:
+                self.add_image_meta_change(
+                    image_meta,
+                    RebuildHint(
+                        code=RebuildHintCode.NO_LATEST_BUILD,
+                        reason=f'Component {image_meta.distgit_key} has no latest build '
+                        f'for assembly {self.runtime.assembly}',
+                    ),
+                )
+                return
 
-        # Check if there's already a build from upstream latest commit
-        await self.scan_for_upstream_changes(image_meta)
+            # Check if there's already a build from upstream latest commit
+            stage = 'upstream commit checks'
+            await self.scan_for_upstream_changes(image_meta)
 
-        # Check for dependency changes
-        await self.scan_dependency_changes(image_meta)
+            # Check for dependency changes
+            stage = 'dependency checks'
+            await self.scan_dependency_changes(image_meta)
 
-        # Check for changes in builders
-        await self.scan_builders_changes(image_meta)
+            # Check for changes in builders
+            stage = 'builder checks'
+            await self.scan_builders_changes(image_meta)
 
-        # For OCP variant, perform additional checks that don't apply to OKD
-        if self.variant != BuildVariant.OKD:
-            # Check for changes in image arches (skip for OKD - arch changes don't trigger OKD rebuilds)
-            await self.scan_arch_changes(image_meta)
-            # Check for changes in the network mode (skip for OKD - it always uses open network)
-            await self.scan_network_mode_changes(image_meta)
-            # Check if there has been a config change since last build
-            await self.scan_for_config_changes(image_meta)
-            # Check for RPM changes
-            await self.scan_rpm_changes(image_meta)
-            # Check for changes in extra packages
-            await self.scan_extra_packages(image_meta)
-            # Check for outdated task bundles
-            await self.scan_task_bundle_changes(image_meta)
+            # For OCP variant, perform additional checks that don't apply to OKD
+            if self.variant != BuildVariant.OKD:
+                # Check for changes in image arches (skip for OKD - arch changes don't trigger OKD rebuilds)
+                stage = 'arch checks'
+                await self.scan_arch_changes(image_meta)
+                # Check for changes in the network mode (skip for OKD - it always uses open network)
+                stage = 'network mode checks'
+                await self.scan_network_mode_changes(image_meta)
+                # Check if there has been a config change since last build
+                stage = 'config digest checks'
+                await self.scan_for_config_changes(image_meta)
+                # Check for RPM changes
+                stage = 'rpm checks'
+                await self.scan_rpm_changes(image_meta)
+                # Check for changes in extra packages
+                stage = 'extra package checks'
+                await self.scan_extra_packages(image_meta)
+                # Check for outdated task bundles
+                stage = 'task bundle checks'
+                await self.scan_task_bundle_changes(image_meta)
+
+        except Exception as e:
+            self.logger.exception('Failed scanning image %s during %s', image_meta.distgit_key, stage)
+            self.issues.append({'name': image_meta.distgit_key, 'issue': f'Failed scanning image during {stage}: {e}'})
 
     def find_upstream_commit_hash(self, meta: Metadata):
         """

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -480,7 +480,9 @@ class ConfigScanSources:
                 return
 
             with Dir(path):
-                self._try_reconciliation(metadata, priv_repo_name, public_branch_name, priv_branch_name)
+                self._try_reconciliation(
+                    metadata, priv_repo_name, public_branch_name, priv_branch_name, priv_url=priv_url
+                )
 
         for metadata, public_upstream in upstream_mappings:
             try:

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -406,85 +406,87 @@ class ConfigScanSources:
             n_threads=20,
         ).get()
 
+        def _rebase_into_priv(metadata, public_upstream):
+            # Skip rebase for disabled components
+            if metadata.meta_type == 'image':
+                # For images: use OKD-aware enabled check
+                if not self._is_image_enabled(metadata):
+                    self.logger.warning('%s is disabled: skipping rebase', metadata.name)
+                    return
+            elif not metadata.enabled:
+                # For RPMs, use standard enabled check
+                self.logger.warning('%s is disabled: skipping rebase', metadata.name)
+                return
+
+            if metadata.config.content is Missing:
+                self.logger.warning(
+                    '%s %s is a distgit-only component: skipping openshift-priv rebase',
+                    metadata.meta_type,
+                    metadata.name,
+                )
+                return
+
+            public_url, public_branch_name, has_public_upstream = public_upstream
+
+            # If no public upstream exists, skip the rebase
+            if not has_public_upstream:
+                self.logger.warning(
+                    '%s %s does not have a public upstream: skipping openshift-priv rebase',
+                    metadata.meta_type,
+                    metadata.name,
+                )
+                return
+
+            priv_url = artcommonlib.util.ensure_github_https_url(metadata.config.content.source.git.url)
+            priv_branch_name = metadata.config.content.source.git.branch.target
+
+            # If a git commit hash was declared as the upstream source, skip the rebase
+            try:
+                _ = int(priv_branch_name, 16)
+                # target branch is a sha: skip rebase for this component
+                self.logger.warning('Target branch for %s is a SHA: skipping rebase', metadata.name)
+                return
+
+            except ValueError:
+                # target branch is a normal branch name
+                pass
+
+            # If no public_upstreams field exists, public_branch_name will be None
+            public_branch_name = public_branch_name or priv_branch_name
+
+            if priv_url == public_url:
+                # Upstream repo does not have a public counterpart: no need to rebase
+                self.logger.warning(
+                    '%s %s does not have a public upstream: skipping openshift-priv rebase',
+                    metadata.meta_type,
+                    metadata.name,
+                )
+                return
+
+            # First, quick check: if SHAs match across remotes, repo is synced and we can avoid cloning it
+            _, public_org, public_repo_name = artcommonlib.util.split_git_url(public_url)
+            _, priv_org, priv_repo_name = artcommonlib.util.split_git_url(priv_url)
+
+            if self._do_shas_match(
+                public_url, public_branch_name, metadata.config.content.source.git.url, priv_branch_name
+            ):
+                # If they match, do nothing
+                return
+
+            # If they don't, clone source repo
+            path = self.runtime.source_resolver.resolve_source(metadata).source_path
+
+            # SHAs might differ because of previous rebase; let's check the actual content across upstreams
+            if self._is_pub_ancestor_of_priv(path, public_branch_name, priv_branch_name, priv_repo_name):
+                # Private upstream is ahead of public: no need to rebase
+                return
+
+            with Dir(path):
+                self._try_reconciliation(metadata, priv_repo_name, public_branch_name, priv_branch_name)
+
         for metadata, public_upstream in upstream_mappings:
             try:
-                # Skip rebase for disabled components
-                if metadata.meta_type == 'image':
-                    # For images: use OKD-aware enabled check
-                    if not self._is_image_enabled(metadata):
-                        self.logger.warning('%s is disabled: skipping rebase', metadata.name)
-                        continue
-                elif not metadata.enabled:
-                    # For RPMs, use standard enabled check
-                    self.logger.warning('%s is disabled: skipping rebase', metadata.name)
-                    continue
-
-                if metadata.config.content is Missing:
-                    self.logger.warning(
-                        '%s %s is a distgit-only component: skipping openshift-priv rebase',
-                        metadata.meta_type,
-                        metadata.name,
-                    )
-                    continue
-
-                public_url, public_branch_name, has_public_upstream = public_upstream
-
-                # If no public upstream exists, skip the rebase
-                if not has_public_upstream:
-                    self.logger.warning(
-                        '%s %s does not have a public upstream: skipping openshift-priv rebase',
-                        metadata.meta_type,
-                        metadata.name,
-                    )
-                    continue
-
-                priv_url = artcommonlib.util.ensure_github_https_url(metadata.config.content.source.git.url)
-                priv_branch_name = metadata.config.content.source.git.branch.target
-
-                # If a git commit hash was declared as the upstream source, skip the rebase
-                try:
-                    _ = int(priv_branch_name, 16)
-                    # target branch is a sha: skip rebase for this component
-                    self.logger.warning('Target branch for %s is a SHA: skipping rebase', metadata.name)
-                    continue
-
-                except ValueError:
-                    # target branch is a normal branch name
-                    pass
-
-                # If no public_upstreams field exists, public_branch_name will be None
-                public_branch_name = public_branch_name or priv_branch_name
-
-                if priv_url == public_url:
-                    # Upstream repo does not have a public counterpart: no need to rebase
-                    self.logger.warning(
-                        '%s %s does not have a public upstream: skipping openshift-priv rebase',
-                        metadata.meta_type,
-                        metadata.name,
-                    )
-                    continue
-
-                # First, quick check: if SHAs match across remotes, repo is synced and we can avoid cloning it
-                _, public_org, public_repo_name = artcommonlib.util.split_git_url(public_url)
-                _, priv_org, priv_repo_name = artcommonlib.util.split_git_url(priv_url)
-
-                if self._do_shas_match(
-                    public_url, public_branch_name, metadata.config.content.source.git.url, priv_branch_name
-                ):
-                    # If they match, do nothing
-                    continue
-
-                # If they don't, clone source repo
-                path = self.runtime.source_resolver.resolve_source(metadata).source_path
-
-                # SHAs might differ because of previous rebase; let's check the actual content across upstreams
-                if self._is_pub_ancestor_of_priv(path, public_branch_name, priv_branch_name, priv_repo_name):
-                    # Private upstream is ahead of public: no need to rebase
-                    continue
-
-                with Dir(path):
-                    self._try_reconciliation(metadata, priv_repo_name, public_branch_name, priv_branch_name, priv_url=priv_url)
-
+                _rebase_into_priv(metadata, public_upstream)
             except Exception as e:
                 self.logger.exception('Failed rebasing %s into openshift-priv', metadata.distgit_key)
                 self.issues.append({'name': metadata.distgit_key, 'issue': f'Failed rebasing into -priv: {e}'})

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -467,9 +467,7 @@ class ConfigScanSources:
             _, public_org, public_repo_name = artcommonlib.util.split_git_url(public_url)
             _, priv_org, priv_repo_name = artcommonlib.util.split_git_url(priv_url)
 
-            if self._do_shas_match(
-                public_url, public_branch_name, metadata.config.content.source.git.url, priv_branch_name
-            ):
+            if self._do_shas_match(public_url, public_branch_name, priv_url, priv_branch_name):
                 # If they match, do nothing
                 return
 

--- a/doozer/tests/cli/test_scan_sources_konflux.py
+++ b/doozer/tests/cli/test_scan_sources_konflux.py
@@ -65,6 +65,77 @@ class TestScanSourcesKonflux(IsolatedAsyncioTestCase):
         super().tearDown()
 
 
+class TestMinimalCrashIsolation(TestScanSourcesKonflux):
+    async def test_scan_image_records_issue_instead_of_raising(self):
+        self.image_meta.config.konflux = Missing
+
+        with (
+            patch.object(self.scanner, 'scan_for_upstream_changes', AsyncMock(side_effect=RuntimeError('boom'))),
+            patch.object(self.scanner, 'scan_dependency_changes', AsyncMock()),
+            patch.object(self.scanner, 'scan_builders_changes', AsyncMock()),
+            patch.object(self.scanner, 'scan_arch_changes', AsyncMock()),
+            patch.object(self.scanner, 'scan_network_mode_changes', AsyncMock()),
+            patch.object(self.scanner, 'scan_for_config_changes', AsyncMock()),
+            patch.object(self.scanner, 'scan_rpm_changes', AsyncMock()),
+            patch.object(self.scanner, 'scan_extra_packages', AsyncMock()),
+            patch.object(self.scanner, 'scan_task_bundle_changes', AsyncMock()),
+        ):
+            await self.scanner.scan_image(self.image_meta)
+
+        self.assertEqual(
+            self.scanner.issues,
+            [{'name': 'test-image', 'issue': 'Failed scanning image during upstream commit checks: boom'}],
+        )
+
+    @patch('doozerlib.cli.scan_sources_konflux.Dir')
+    @patch('doozerlib.cli.scan_sources_konflux.exectools.parallel_exec')
+    def test_rebase_into_priv_records_issue_and_continues(self, mock_parallel_exec, mock_dir):
+        broken_meta = MagicMock()
+        broken_meta.meta_type = 'image'
+        broken_meta.enabled = True
+        broken_meta.name = 'broken-image'
+        broken_meta.distgit_key = 'broken-image'
+        broken_meta.config.content = MagicMock()
+        broken_meta.config.content.source.git.url = 'https://example.com/org/broken.git'
+        broken_meta.config.content.source.git.branch.target = 'main'
+
+        good_meta = MagicMock()
+        good_meta.meta_type = 'image'
+        good_meta.enabled = True
+        good_meta.name = 'good-image'
+        good_meta.distgit_key = 'good-image'
+        good_meta.config.content = MagicMock()
+        good_meta.config.content.source.git.url = 'https://example.com/org/good.git'
+        good_meta.config.content.source.git.branch.target = 'main'
+
+        mock_parallel_exec.return_value.get.return_value = [
+            (broken_meta, ('https://example.com/public-org/broken.git', 'main', True)),
+            (good_meta, ('https://example.com/public-org/good.git', 'main', True)),
+        ]
+        mock_dir.return_value.__enter__.return_value = None
+        mock_dir.return_value.__exit__.return_value = None
+
+        self.runtime.source_resolver = MagicMock()
+        self.runtime.source_resolver.resolve_source.side_effect = [
+            MagicMock(source_path='/tmp/broken'),
+            MagicMock(source_path='/tmp/good'),
+        ]
+
+        with (
+            patch.object(self.scanner, '_is_image_enabled', return_value=True),
+            patch.object(self.scanner, '_do_shas_match', return_value=False),
+            patch.object(self.scanner, '_is_pub_ancestor_of_priv', side_effect=[RuntimeError('bad repo'), False]),
+            patch.object(self.scanner, '_try_reconciliation') as mock_try_reconciliation,
+        ):
+            self.scanner.rebase_into_priv()
+
+        self.assertEqual(
+            self.scanner.issues,
+            [{'name': 'broken-image', 'issue': 'Failed rebasing into -priv: bad repo'}],
+        )
+        mock_try_reconciliation.assert_called_once_with(good_meta, 'good', 'main', 'main')
+
+
 class TestScanTaskBundleChanges(TestScanSourcesKonflux):
     """Test the scan_task_bundle_changes method."""
 

--- a/doozer/tests/cli/test_scan_sources_konflux.py
+++ b/doozer/tests/cli/test_scan_sources_konflux.py
@@ -133,7 +133,9 @@ class TestMinimalCrashIsolation(TestScanSourcesKonflux):
             self.scanner.issues,
             [{'name': 'broken-image', 'issue': 'Failed rebasing into -priv: bad repo'}],
         )
-        mock_try_reconciliation.assert_called_once_with(good_meta, 'good', 'main', 'main')
+        mock_try_reconciliation.assert_called_once_with(
+            good_meta, 'good', 'main', 'main', priv_url='https://example.com/org/good.git'
+        )
 
 
 class TestScanTaskBundleChanges(TestScanSourcesKonflux):

--- a/doozer/tests/cli/test_scan_sources_konflux.py
+++ b/doozer/tests/cli/test_scan_sources_konflux.py
@@ -2,7 +2,7 @@ import base64
 import json
 from datetime import datetime, timezone
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import yaml

--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 
 import click
 import yaml
@@ -25,6 +26,9 @@ class Ocp4ScanPipeline:
         self._doozer_working = self.runtime.working_dir / "doozer_working"
         self.changes = {}
         self.report = {}
+        self.issues = []
+        self.command_failed = False
+        self.command_failure_message = ''
 
         self.rhcos_updated = False
         self.rhcos_outdated = False
@@ -66,6 +70,9 @@ class Ocp4ScanPipeline:
         # Handle RHCOS changes or inconsistencies
         await self.handle_rhcos_changes()
 
+        self._report_issues()
+        self._finalize()
+
     def check_params(self):
         """
         Make sure non-stream assemblies, custom forks and branches are only used with dry run mode
@@ -98,10 +105,19 @@ class Ocp4ScanPipeline:
         if self.runtime.dry_run:
             cmd.append('--dry-run')
 
-        _, out, _ = await exectools.cmd_gather_async(cmd, stderr=None)
+        rc, out, _ = await exectools.cmd_gather_async(cmd, stderr=None, check=False)
         self.logger.info('scan-sources output for openshift-%s:\n%s', self.version, out)
 
-        self.report = yaml.safe_load(out)
+        self.command_failed = rc != 0
+        if self.command_failed:
+            self.command_failure_message = f'scan-sources command failed with exit code {rc}'
+            self.logger.error(self.command_failure_message)
+
+        self.report = yaml.safe_load(out) or {}
+        if not isinstance(self.report, dict):
+            raise ValueError('scan-sources output did not contain a YAML mapping')
+
+        self.issues = self.report.get('issues', [])
         self.changes = util.get_changes(self.report)
         if self.changes:
             self.logger.info('Detected source changes:\n%s', yaml.safe_dump(self.changes))
@@ -115,6 +131,32 @@ class Ocp4ScanPipeline:
                     self.rhcos_updated = True
                 if rhcos_change['reason'].get('outdated', None):
                     self.rhcos_outdated = True
+
+    def _report_issues(self):
+        if not self.issues:
+            return
+
+        image_names = sorted({issue.get('name') for issue in self.issues if issue.get('name')})
+
+        if 1 <= len(image_names) <= 10:
+            jenkins.update_description(f'Scan failures: {", ".join(image_names)}<br/>')
+        elif image_names:
+            jenkins.update_description(f'{len(image_names)} images had scan failures. Check scan-sources output<br/>')
+        else:
+            jenkins.update_description('Scan failures detected. Check scan-sources output<br/>')
+
+    def _finalize(self):
+        if self.command_failed:
+            raise RuntimeError(self.command_failure_message)
+
+        if not self.issues:
+            return
+
+        if self.changes:
+            self.logger.warning('scan-sources reported issues but also found valid changes; marking job unstable')
+            sys.exit(2)
+
+        raise RuntimeError('scan-sources reported issues but found no valid changes')
 
     async def get_rhcos_inconsistencies(self):
         """

--- a/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
+++ b/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+import os
+import unittest
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import yaml
+from pyartcd.pipelines.ocp4_scan_konflux import Ocp4ScanPipeline
+from pyartcd.runtime import Runtime
+
+
+class TestOcp4ScanKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.runtime = MagicMock(spec=Runtime)
+        self.runtime.dry_run = True
+        self.runtime.working_dir = MagicMock()
+        self.runtime.working_dir.__truediv__ = lambda self, x: MagicMock()
+
+    def _make_pipeline(self):
+        return Ocp4ScanPipeline(
+            runtime=self.runtime,
+            version='4.21',
+            data_path='https://github.com/openshift-eng/ocp-build-data',
+            assembly='stream',
+            data_gitref='',
+            image_list='',
+        )
+
+    @patch.dict(os.environ, {'KUBECONFIG': '/path/to/kubeconfig'})
+    @patch('pyartcd.pipelines.ocp4_scan_konflux.exectools.cmd_gather_async')
+    async def test_get_changes_captures_issues_and_command_failure(self, mock_cmd_gather):
+        scan_output = yaml.dump(
+            {
+                'images': [{'name': 'test-image', 'changed': True}],
+                'issues': [
+                    {'name': 'test-image', 'issue': 'Failed scanning image during upstream commit checks: boom'}
+                ],
+            }
+        )
+        mock_cmd_gather.return_value = (1, scan_output, '')
+
+        pipeline = self._make_pipeline()
+
+        await pipeline.get_changes()
+
+        self.assertTrue(pipeline.command_failed)
+        self.assertEqual(pipeline.command_failure_message, 'scan-sources command failed with exit code 1')
+        self.assertEqual(
+            pipeline.issues,
+            [{'name': 'test-image', 'issue': 'Failed scanning image during upstream commit checks: boom'}],
+        )
+        self.assertEqual(pipeline.changes, {'images': ['test-image']})
+
+    @patch.dict(os.environ, {'KUBECONFIG': '/path/to/kubeconfig'})
+    @patch('pyartcd.pipelines.ocp4_scan_konflux.jenkins')
+    async def test_run_marks_job_unstable_when_changes_and_issues_found(self, mock_jenkins):
+        pipeline = self._make_pipeline()
+
+        async def fake_get_changes():
+            pipeline.changes = {'images': ['test-image']}
+            pipeline.issues = [
+                {'name': 'test-image', 'issue': 'Failed scanning image during upstream commit checks: boom'}
+            ]
+            pipeline.command_failed = False
+            pipeline.report = {'images': [{'name': 'test-image', 'changed': True}]}
+
+        pipeline.get_changes = AsyncMock(side_effect=fake_get_changes)
+        pipeline.get_rhcos_inconsistencies = AsyncMock()
+        pipeline.handle_source_changes = Mock()
+        pipeline.handle_rhcos_changes = AsyncMock()
+
+        with self.assertRaises(SystemExit) as ctx:
+            await pipeline.run()
+
+        self.assertEqual(ctx.exception.code, 2)
+        pipeline.handle_source_changes.assert_called_once()
+        pipeline.handle_rhcos_changes.assert_awaited_once()
+        mock_jenkins.update_description.assert_called_with('Scan failures: test-image<br/>')
+
+    @patch.dict(os.environ, {'KUBECONFIG': '/path/to/kubeconfig'})
+    @patch('pyartcd.pipelines.ocp4_scan_konflux.jenkins')
+    async def test_run_fails_when_issues_found_without_changes(self, mock_jenkins):
+        pipeline = self._make_pipeline()
+
+        async def fake_get_changes():
+            pipeline.changes = {}
+            pipeline.issues = [
+                {'name': 'test-image', 'issue': 'Could not rebase into -priv as it needs manual reconciliation'}
+            ]
+            pipeline.command_failed = False
+            pipeline.report = {'images': []}
+
+        pipeline.get_changes = AsyncMock(side_effect=fake_get_changes)
+        pipeline.get_rhcos_inconsistencies = AsyncMock()
+        pipeline.handle_source_changes = Mock()
+        pipeline.handle_rhcos_changes = AsyncMock()
+
+        with self.assertRaises(RuntimeError) as ctx:
+            await pipeline.run()
+
+        self.assertIn('scan-sources reported issues but found no valid changes', str(ctx.exception))
+        pipeline.handle_source_changes.assert_called_once()
+        pipeline.handle_rhcos_changes.assert_awaited_once()
+        mock_jenkins.update_description.assert_called_with('Scan failures: test-image<br/>')
+
+    @patch.dict(os.environ, {'KUBECONFIG': '/path/to/kubeconfig'})
+    @patch('pyartcd.pipelines.ocp4_scan_konflux.jenkins')
+    async def test_run_fails_when_scan_command_failed(self, mock_jenkins):
+        pipeline = self._make_pipeline()
+
+        async def fake_get_changes():
+            pipeline.changes = {'images': ['test-image']}
+            pipeline.issues = [
+                {'name': 'test-image', 'issue': 'Failed scanning image during upstream commit checks: boom'}
+            ]
+            pipeline.command_failed = True
+            pipeline.command_failure_message = 'scan-sources command failed with exit code 1'
+            pipeline.report = {'images': [{'name': 'test-image', 'changed': True}]}
+
+        pipeline.get_changes = AsyncMock(side_effect=fake_get_changes)
+        pipeline.get_rhcos_inconsistencies = AsyncMock()
+        pipeline.handle_source_changes = Mock()
+        pipeline.handle_rhcos_changes = AsyncMock()
+
+        with self.assertRaises(RuntimeError) as ctx:
+            await pipeline.run()
+
+        self.assertEqual(str(ctx.exception), 'scan-sources command failed with exit code 1')
+        pipeline.handle_source_changes.assert_called_once()
+        pipeline.handle_rhcos_changes.assert_awaited_once()
+        mock_jenkins.update_description.assert_called_with('Scan failures: test-image<br/>')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Make Konflux scan-sources resilient to per-image and per-repo failures by catching exceptions in doozer, recording affected image names in issues, and continuing the rest of the scan.
- Update ocp4_scan_konflux to consume reported issues, surface failed image names in Jenkins, and defer failure handling until the end: mark the job unstable when valid changes were still found, and fail when the scan command failed or only issues were produced.
- Add focused unit coverage for both the new doozer isolation behavior and the scan pipeline’s end-of-run reporting/failure paths.

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/44247/console