### PR TITLE
ART-14700: Migrate Konflux PipelineRun git-clone auth from static PAT to GitHub App tokens

### DIFF
--- a/artcommon/artcommonlib/github_auth.py
+++ b/artcommon/artcommonlib/github_auth.py
@@ -117,6 +117,26 @@ def get_github_app_token_from_env() -> str:
     return get_github_app_token(app_id, private_key, installation_id)
 
 
+def get_github_app_token_for_org(org: str) -> str:
+    """
+    Generate a short-lived GitHub installation access token for a specific org.
+
+    Like get_github_app_token_from_env() but resolves the installation ID
+    from the org name instead of requiring exactly one installation.
+    If GITHUB_APP_INSTALLATION_ID is set it takes precedence over org-based
+    resolution.
+
+    :param org: GitHub organisation name (e.g. "openshift-priv")
+    :return: Installation access token string
+    :raises EnvironmentError: If required environment variables are missing
+    :raises ValueError: If no installation matches the org
+    """
+    app_id, private_key, installation_id = _read_env_credentials()
+    if not installation_id:
+        installation_id = _resolve_installation_id(org, app_id, private_key)
+    return get_github_app_token(app_id, private_key, installation_id)
+
+
 _askpass_script_path: str | None = None
 
 _git_token_cache: dict[str | None, tuple[str, float]] = {}

--- a/artcommon/tests/test_github_auth.py
+++ b/artcommon/tests/test_github_auth.py
@@ -6,6 +6,7 @@ import pytest
 from artcommonlib.github_auth import (
     _extract_org_from_github_url,
     get_github_app_token,
+    get_github_app_token_for_org,
     get_github_app_token_from_env,
     get_github_client_for_org,
     get_github_git_auth_env,
@@ -103,6 +104,46 @@ class TestGetGithubAppTokenFromEnv:
 
         with pytest.raises(EnvironmentError, match="GITHUB_APP_PRIVATE_KEY"):
             get_github_app_token_from_env()
+
+
+class TestGetGithubAppTokenForOrg:
+    """Tests for the org-aware token generation function."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_caches(self):
+        gh_auth._installation_map.clear()
+        yield
+        gh_auth._installation_map.clear()
+
+    @patch("artcommonlib.github_auth.get_github_app_token", return_value="ghs_org_token")
+    @patch("artcommonlib.github_auth._resolve_installation_id", return_value=42)
+    def test_resolves_org_when_no_explicit_id(self, mock_resolve, mock_token, monkeypatch):
+        monkeypatch.setenv("GITHUB_APP_ID", "100")
+        monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", FAKE_PEM)
+        monkeypatch.delenv("GITHUB_APP_INSTALLATION_ID", raising=False)
+
+        result = get_github_app_token_for_org("openshift-priv")
+
+        mock_resolve.assert_called_once_with("openshift-priv", 100, FAKE_PEM)
+        mock_token.assert_called_once_with(100, FAKE_PEM, 42)
+        assert result == "ghs_org_token"
+
+    @patch("artcommonlib.github_auth.get_github_app_token", return_value="ghs_explicit_token")
+    def test_explicit_installation_id_takes_precedence(self, mock_token, monkeypatch):
+        monkeypatch.setenv("GITHUB_APP_ID", "100")
+        monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", FAKE_PEM)
+        monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "777")
+
+        result = get_github_app_token_for_org("openshift-priv")
+
+        mock_token.assert_called_once_with(100, FAKE_PEM, 777)
+        assert result == "ghs_explicit_token"
+
+    def test_missing_credentials_raises(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_APP_ID", raising=False)
+
+        with pytest.raises(EnvironmentError, match="GITHUB_APP_ID"):
+            get_github_app_token_for_org("openshift-priv")
 
 
 def _make_installation(org_login: str, install_id: int) -> MagicMock:

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -37,6 +37,8 @@ LOGGER = logging.getLogger(__name__)
 _GIT_AUTH_SECRET_PREFIX = "art-transient-pipeline-auth-"
 _GIT_AUTH_SECRET_LABEL_KEY = "art.openshift.io/git-auth"
 _GIT_AUTH_SECRET_LABEL_VALUE = "true"
+_GIT_AUTH_GENERATED_BY_LABEL_KEY = "art.openshift.io/generated-by"
+_GIT_AUTH_GENERATED_BY_LABEL_VALUE = "art-automation"
 
 # Label key used to filter PipelineRuns for this process
 _COMMON_RUNTIME_LABEL_KEY = "doozer-watch-id"
@@ -275,8 +277,14 @@ class KonfluxClient:
             metadata=V1ObjectMeta(
                 name=secret_name,
                 namespace=namespace,
-                labels={_GIT_AUTH_SECRET_LABEL_KEY: _GIT_AUTH_SECRET_LABEL_VALUE},
-                annotations={"art.openshift.io/created-at": now},
+                labels={
+                    _GIT_AUTH_SECRET_LABEL_KEY: _GIT_AUTH_SECRET_LABEL_VALUE,
+                    _GIT_AUTH_GENERATED_BY_LABEL_KEY: _GIT_AUTH_GENERATED_BY_LABEL_VALUE,
+                },
+                annotations={
+                    "art.openshift.io/created-at": now,
+                    "art-jenkins-job-url": os.getenv("BUILD_URL", "n/a"),
+                },
             ),
             # basic-auth secrets expect "username" and "password" keys
             data={
@@ -343,7 +351,10 @@ class KonfluxClient:
         :param max_age_hours: Secrets older than this are deleted.
         """
         namespace = namespace or self.default_namespace
-        label_selector = f"{_GIT_AUTH_SECRET_LABEL_KEY}={_GIT_AUTH_SECRET_LABEL_VALUE}"
+        label_selector = (
+            f"{_GIT_AUTH_SECRET_LABEL_KEY}={_GIT_AUTH_SECRET_LABEL_VALUE},"
+            f"{_GIT_AUTH_GENERATED_BY_LABEL_KEY}={_GIT_AUTH_GENERATED_BY_LABEL_VALUE}"
+        )
 
         secrets = await exectools.to_thread(
             self.corev1_client.list_namespaced_secret,

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -258,6 +258,12 @@ class KonfluxClient:
         # git-clone + prefetch tasks need it — those run in the first few minutes).
         token = await exectools.to_thread(get_github_app_token_for_org, org)
 
+        # Nanosecond epoch avoids name collisions when multiple doozer
+        # invocations start within the same second.  A human-readable
+        # timestamp would need sanitising for k8s naming rules and still
+        # risk collisions at second granularity, so raw nanoseconds are
+        # the safest choice.  Use the helper below to decode:
+        #   python3 -c "import datetime as d; print(d.datetime.fromtimestamp(<ns>/1e9, d.timezone.utc))"
         epoch_ns = time.time_ns()
         secret_name = f"{_GIT_AUTH_SECRET_PREFIX}{epoch_ns}"
         now = datetime.datetime.now(datetime.timezone.utc).isoformat()

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -293,6 +293,40 @@ class KonfluxClient:
         self._git_auth_secret_name = secret_name
         return secret_name
 
+    async def delete_git_auth_secret(self, namespace: Optional[str] = None) -> None:
+        """Delete the transient git-auth secret created by this invocation.
+
+        No-op when no transient secret was created (e.g. fallback to the static
+        pipelines-as-code-secret).  A 404 from the API is silently ignored so
+        that concurrent or repeated calls are safe.
+
+        :param namespace: Target namespace. Defaults to self.default_namespace.
+        """
+        secret_name = self._git_auth_secret_name
+        if not secret_name or not secret_name.startswith(_GIT_AUTH_SECRET_PREFIX):
+            return
+
+        namespace = namespace or self.default_namespace
+
+        if self.dry_run:
+            self._logger.warning(f"[DRY RUN] Would have deleted git-auth Secret {namespace}/{secret_name}")
+        else:
+            try:
+                await exectools.to_thread(
+                    self.corev1_client.delete_namespaced_secret,
+                    name=secret_name,
+                    namespace=namespace,
+                    _request_timeout=self.request_timeout,
+                )
+                self._logger.info(f"Deleted git-auth Secret {namespace}/{secret_name}")
+            except ApiException as e:
+                if e.status == 404:
+                    self._logger.debug(f"Secret {secret_name} already deleted by another process")
+                else:
+                    self._logger.warning(f"Failed to delete git-auth Secret {secret_name}: {e}")
+
+        self._git_auth_secret_name = None
+
     async def cleanup_stale_git_auth_secrets(self, namespace: Optional[str] = None, max_age_hours: int = 24) -> None:
         """Delete transient git-auth secrets older than *max_age_hours*.
 

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import datetime
 import hashlib
 import logging
@@ -17,17 +18,25 @@ import jinja2
 from artcommonlib import exectools
 from artcommonlib import util as art_util
 from artcommonlib.constants import KONFLUX_DEFAULT_NAMESPACE
+from artcommonlib.github_auth import get_github_app_token_from_env
 from async_lru import alru_cache
 from doozerlib import constants
 from doozerlib.backend.konflux_watcher import KonfluxWatcher
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
 from kubernetes import config, watch
-from kubernetes.client import ApiClient, Configuration, CoreV1Api
+from kubernetes.client import ApiClient, ApiException, Configuration, CoreV1Api, V1ObjectMeta, V1Secret
 from kubernetes.dynamic import DynamicClient, exceptions, resource
 from ruamel.yaml import YAML
 
 yaml = YAML(typ="safe")
 LOGGER = logging.getLogger(__name__)
+
+# Prefix and label for transient git-auth secrets created per doozer invocation.
+# Each invocation mints a GitHub App installation token and stores it in a
+# uniquely-named Secret so concurrent builds never contend on the same object.
+_GIT_AUTH_SECRET_PREFIX = "art-transient-pipeline-auth-"
+_GIT_AUTH_SECRET_LABEL_KEY = "art.openshift.io/git-auth"
+_GIT_AUTH_SECRET_LABEL_VALUE = "true"
 
 # Label key used to filter PipelineRuns for this process
 _COMMON_RUNTIME_LABEL_KEY = "doozer-watch-id"
@@ -209,6 +218,8 @@ class KonfluxClient:
         # This is a workaround to set a timeout for the requests.
         # https://github.com/kubernetes-client/python/blob/master/examples/watch/timeout-settings.md
         self.request_timeout = 60 * 5  # 5 minutes
+        # Cached per-invocation git-auth secret name (created once, reused for all PLRs)
+        self._git_auth_secret_name: Optional[str] = None
 
     def verify_connection(self):
         try:
@@ -217,6 +228,113 @@ class KonfluxClient:
         except Exception as e:
             self._logger.error(f"Failed to authenticate to the Kubernetes cluster: {e}")
             raise
+
+    async def ensure_git_auth_secret(self, namespace: Optional[str] = None) -> str:
+        """Mint a GitHub App installation token and store it in a per-invocation
+        Kubernetes Secret for use as a git-clone basic-auth credential.
+
+        The secret is created once per KonfluxClient instance and reused for all
+        PipelineRuns in the same doozer invocation — no contention between
+        concurrent builds.
+
+        Falls back to the static "pipelines-as-code-secret" when GitHub App
+        credentials are not configured (GITHUB_APP_ID unset).
+
+        :param namespace: Target namespace. Defaults to self.default_namespace.
+        :return: The secret name to wire into PipelineRun workspaces.
+        """
+        if self._git_auth_secret_name:
+            return self._git_auth_secret_name
+
+        if not os.environ.get("GITHUB_APP_ID"):
+            self._logger.info("GITHUB_APP_ID not set; falling back to static pipelines-as-code-secret")
+            return "pipelines-as-code-secret"
+
+        namespace = namespace or self.default_namespace
+
+        # Mint a short-lived installation token (valid ~1 hour, but only the
+        # git-clone + prefetch tasks need it — those run in the first few minutes).
+        token = await exectools.to_thread(get_github_app_token_from_env)
+
+        epoch_ns = time.time_ns()
+        secret_name = f"{_GIT_AUTH_SECRET_PREFIX}{epoch_ns}"
+        now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+        secret = V1Secret(
+            api_version="v1",
+            kind="Secret",
+            type="kubernetes.io/basic-auth",
+            metadata=V1ObjectMeta(
+                name=secret_name,
+                namespace=namespace,
+                labels={_GIT_AUTH_SECRET_LABEL_KEY: _GIT_AUTH_SECRET_LABEL_VALUE},
+                annotations={"art.openshift.io/created-at": now},
+            ),
+            # basic-auth secrets expect "username" and "password" keys
+            data={
+                "username": base64.b64encode(b"x-access-token").decode(),
+                "password": base64.b64encode(token.encode()).decode(),
+            },
+        )
+
+        if self.dry_run:
+            self._logger.warning(f"[DRY RUN] Would have created git-auth Secret {namespace}/{secret_name}")
+        else:
+            await exectools.to_thread(
+                self.corev1_client.create_namespaced_secret,
+                namespace=namespace,
+                body=secret,
+                _request_timeout=self.request_timeout,
+            )
+            self._logger.info(f"Created git-auth Secret {namespace}/{secret_name}")
+
+        self._git_auth_secret_name = secret_name
+        return secret_name
+
+    async def cleanup_stale_git_auth_secrets(self, namespace: Optional[str] = None, max_age_hours: int = 24) -> None:
+        """Delete transient git-auth secrets older than *max_age_hours*.
+
+        Safe to call from concurrent doozer invocations: if two jobs race to
+        delete the same secret the loser simply gets a 404, which is ignored.
+
+        :param namespace: Target namespace. Defaults to self.default_namespace.
+        :param max_age_hours: Secrets older than this are deleted.
+        """
+        namespace = namespace or self.default_namespace
+        label_selector = f"{_GIT_AUTH_SECRET_LABEL_KEY}={_GIT_AUTH_SECRET_LABEL_VALUE}"
+
+        secrets = await exectools.to_thread(
+            self.corev1_client.list_namespaced_secret,
+            namespace=namespace,
+            label_selector=label_selector,
+            _request_timeout=self.request_timeout,
+        )
+
+        cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=max_age_hours)
+
+        for secret in secrets.items:
+            created = secret.metadata.creation_timestamp
+            if created and created >= cutoff:
+                continue
+
+            if self.dry_run:
+                self._logger.warning(f"[DRY RUN] Would have deleted stale git-auth Secret {secret.metadata.name}")
+                continue
+
+            try:
+                await exectools.to_thread(
+                    self.corev1_client.delete_namespaced_secret,
+                    name=secret.metadata.name,
+                    namespace=namespace,
+                    _request_timeout=self.request_timeout,
+                )
+                self._logger.info(f"Deleted stale git-auth Secret {secret.metadata.name}")
+            except ApiException as e:
+                # Another concurrent invocation may have already deleted it
+                if e.status == 404:
+                    self._logger.debug(f"Secret {secret.metadata.name} already deleted by another process")
+                else:
+                    self._logger.warning(f"Failed to delete stale Secret {secret.metadata.name}: {e}")
 
     @staticmethod
     def from_kubeconfig(

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -18,7 +18,7 @@ import jinja2
 from artcommonlib import exectools
 from artcommonlib import util as art_util
 from artcommonlib.constants import KONFLUX_DEFAULT_NAMESPACE
-from artcommonlib.github_auth import get_github_app_token_from_env
+from artcommonlib.github_auth import get_github_app_token_for_org
 from async_lru import alru_cache
 from doozerlib import constants
 from doozerlib.backend.konflux_watcher import KonfluxWatcher
@@ -229,7 +229,7 @@ class KonfluxClient:
             self._logger.error(f"Failed to authenticate to the Kubernetes cluster: {e}")
             raise
 
-    async def ensure_git_auth_secret(self, namespace: Optional[str] = None) -> str:
+    async def ensure_git_auth_secret(self, namespace: Optional[str] = None, org: str = "openshift-priv") -> str:
         """Mint a GitHub App installation token and store it in a per-invocation
         Kubernetes Secret for use as a git-clone basic-auth credential.
 
@@ -241,6 +241,8 @@ class KonfluxClient:
         credentials are not configured (GITHUB_APP_ID unset).
 
         :param namespace: Target namespace. Defaults to self.default_namespace.
+        :param org: GitHub org whose installation token to mint.
+                    Defaults to "openshift-priv" (where Konflux build sources live).
         :return: The secret name to wire into PipelineRun workspaces.
         """
         if self._git_auth_secret_name:
@@ -254,7 +256,7 @@ class KonfluxClient:
 
         # Mint a short-lived installation token (valid ~1 hour, but only the
         # git-clone + prefetch tasks need it — those run in the first few minutes).
-        token = await exectools.to_thread(get_github_app_token_from_env)
+        token = await exectools.to_thread(get_github_app_token_for_org, org)
 
         epoch_ns = time.time_ns()
         secret_name = f"{_GIT_AUTH_SECRET_PREFIX}{epoch_ns}"

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -1721,7 +1721,9 @@ class KonfluxFbcBuilder:
         except Exception:
             logger.exception("Error while syncing FBC related images to art-images-share")
 
-    async def build(self, metadata: ImageMetadata, operator_nvr: Optional[str] = None, git_auth_secret: Optional[str] = None):
+    async def build(
+        self, metadata: ImageMetadata, operator_nvr: Optional[str] = None, git_auth_secret: Optional[str] = None
+    ):
         bundle_short_name = metadata.get_olm_bundle_short_name()
         logger = self._logger.getChild(f"[{bundle_short_name}]")
         logger.info("Building FBC for %s", metadata.distgit_key)

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -401,7 +401,7 @@ class KonfluxFbcFragmentMerger:
             logger=logger,
         )
 
-    async def run(self, fragments: Collection[str], target_index: str):
+    async def run(self, fragments: Collection[str], target_index: str, git_auth_secret: Optional[str] = None):
         if not fragments:
             raise ValueError("At least one fragment must be provided.")
         if not target_index:
@@ -494,6 +494,7 @@ class KonfluxFbcFragmentMerger:
             created_plr = await self._start_build(
                 build_repo=build_repo,
                 output_image=target_index,
+                git_auth_secret=git_auth_secret,
             )
             plr_name = created_plr.name
             plr_url = konflux_client.resource_url(created_plr.to_dict())
@@ -599,7 +600,7 @@ class KonfluxFbcFragmentMerger:
         }
         return target_idms
 
-    async def _start_build(self, build_repo: BuildRepo, output_image: str):
+    async def _start_build(self, build_repo: BuildRepo, output_image: str, git_auth_secret: Optional[str] = None):
         logger = self._logger
         konflux_client = self._konflux_client
         commit_sha = build_repo.commit_hash
@@ -630,7 +631,7 @@ class KonfluxFbcFragmentMerger:
 
         arches = self.group_config.get("arches", list(KonfluxClient.SUPPORTED_ARCHES.keys()))
 
-        created_plr = await konflux_client.start_pipeline_run_for_image_build(
+        build_kwargs = dict(
             generate_name=f"{comp_name}-",
             namespace=self.konflux_namespace,
             application_name=app_name,
@@ -641,14 +642,17 @@ class KonfluxFbcFragmentMerger:
             output_image=f"{output_image_repo}:{output_image_tag}",
             additional_tags=[],
             vm_override={},
-            building_arches=arches,  # FBC should be built for all supported arches
-            hermetic=True,  # FBC should be built in hermetic mode
+            building_arches=arches,
+            hermetic=True,
             dockerfile="catalog.Dockerfile",
             skip_checks=self.skip_checks,
             skip_fips_check=self.skip_fips_check,
             pipelinerun_template_url=self.plr_template,
             build_priority=FBC_BUILD_PRIORITY,
         )
+        if git_auth_secret:
+            build_kwargs["git_auth_secret"] = git_auth_secret
+        created_plr = await konflux_client.start_pipeline_run_for_image_build(**build_kwargs)
         return created_plr
 
 
@@ -1717,7 +1721,7 @@ class KonfluxFbcBuilder:
         except Exception:
             logger.exception("Error while syncing FBC related images to art-images-share")
 
-    async def build(self, metadata: ImageMetadata, operator_nvr: Optional[str] = None):
+    async def build(self, metadata: ImageMetadata, operator_nvr: Optional[str] = None, git_auth_secret: Optional[str] = None):
         bundle_short_name = metadata.get_olm_bundle_short_name()
         logger = self._logger.getChild(f"[{bundle_short_name}]")
         logger.info("Building FBC for %s", metadata.distgit_key)
@@ -1833,6 +1837,7 @@ class KonfluxFbcBuilder:
                     arches=arches,
                     logger=logger,
                     operator_nvr=operator_nvr,
+                    git_auth_secret=git_auth_secret,
                 )
                 pipelinerun_name = pipelinerun_info.name
                 record["task_id"] = pipelinerun_name
@@ -1913,6 +1918,7 @@ class KonfluxFbcBuilder:
         arches: Sequence[str],
         logger: logging.Logger,
         operator_nvr: Optional[str] = None,
+        git_auth_secret: Optional[str] = None,
     ) -> Tuple[PipelineRunInfo, str]:
         """Start a build with Konflux."""
         if not build_repo.commit_hash:
@@ -1973,7 +1979,7 @@ class KonfluxFbcBuilder:
         else:
             logger.info("No additional tags to be added")
 
-        pipelinerun_info = await konflux_client.start_pipeline_run_for_image_build(
+        build_kwargs = dict(
             generate_name=f"{component_name}-",
             namespace=self.konflux_namespace,
             application_name=app_name,
@@ -1983,7 +1989,7 @@ class KonfluxFbcBuilder:
             target_branch=build_repo.branch or build_repo.commit_hash,
             output_image=output_image,
             vm_override={},
-            building_arches=arches,  # FBC should be built for all supported arches
+            building_arches=arches,
             additional_tags=list(additional_tags),
             skip_checks=self.skip_checks,
             hermetic=True,
@@ -1991,6 +1997,9 @@ class KonfluxFbcBuilder:
             pipelinerun_template_url=self.pipelinerun_template_url,
             build_priority=FBC_BUILD_PRIORITY,
         )
+        if git_auth_secret:
+            build_kwargs["git_auth_secret"] = git_auth_secret
+        pipelinerun_info = await konflux_client.start_pipeline_run_for_image_build(**build_kwargs)
         url = konflux_client.resource_url(pipelinerun_info.to_dict())
         logger.info(f"PipelineRun {pipelinerun_info.name} created: {url}")
         return pipelinerun_info, url

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -89,7 +89,7 @@ class KonfluxImageBuilder:
             dry_run=config.dry_run,
         )
 
-    async def build(self, metadata: ImageMetadata):
+    async def build(self, metadata: ImageMetadata, git_auth_secret: Optional[str] = None):
         """Build a container image with Konflux."""
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
         metadata.build_status = False
@@ -199,6 +199,7 @@ class KonfluxImageBuilder:
                     nvr=nvr,
                     build_priority=build_priority,
                     dest_dir=dest_dir,
+                    git_auth_secret=git_auth_secret,
                 )
                 pipelinerun_name = pipelinerun_info.name
                 record["task_id"] = pipelinerun_name
@@ -543,6 +544,7 @@ class KonfluxImageBuilder:
         nvr: str,
         build_priority: str,
         dest_dir: Optional[Path] = None,
+        git_auth_secret: Optional[str] = None,
     ) -> PipelineRunInfo:
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
         if not build_repo.commit_hash:
@@ -596,7 +598,7 @@ class KonfluxImageBuilder:
             annotations["art-overall-timeout-minutes"] = str(build_timeout_minutes)
             logger.info(f"Setting custom build timeout: {build_timeout_minutes} minutes")
 
-        pipelinerun_info = await self._konflux_client.start_pipeline_run_for_image_build(
+        build_kwargs = dict(
             generate_name=f"{component_name}-",
             namespace=self._config.namespace,
             application_name=app_name,
@@ -616,6 +618,9 @@ class KonfluxImageBuilder:
             annotations=annotations,
             build_priority=build_priority,
         )
+        if git_auth_secret:
+            build_kwargs["git_auth_secret"] = git_auth_secret
+        pipelinerun_info = await self._konflux_client.start_pipeline_run_for_image_build(**build_kwargs)
 
         logger.info(f"Created PipelineRun: {self._konflux_client.resource_url(pipelinerun_info.to_dict())}")
         return pipelinerun_info

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -710,7 +710,11 @@ class KonfluxOlmBundleBuilder:
             for attempt in range(build_attempts):
                 logger.info("Build attempt %d/%d", attempt + 1, build_attempts)
                 pipelinerun_info, url = await self._start_build(
-                    metadata, bundle_build_repo, output_image, self.konflux_namespace, self.skip_checks,
+                    metadata,
+                    bundle_build_repo,
+                    output_image,
+                    self.konflux_namespace,
+                    self.skip_checks,
                     git_auth_secret=git_auth_secret,
                 )
                 pipelinerun_name = pipelinerun_info.name

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -626,7 +626,7 @@ class KonfluxOlmBundleBuilder:
             dry_run=self.dry_run,
         )
 
-    async def build(self, metadata: ImageMetadata):
+    async def build(self, metadata: ImageMetadata, git_auth_secret: Optional[str] = None):
         """Build a bundle with Konflux."""
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
         konflux_client = self._konflux_client
@@ -710,7 +710,8 @@ class KonfluxOlmBundleBuilder:
             for attempt in range(build_attempts):
                 logger.info("Build attempt %d/%d", attempt + 1, build_attempts)
                 pipelinerun_info, url = await self._start_build(
-                    metadata, bundle_build_repo, output_image, self.konflux_namespace, self.skip_checks
+                    metadata, bundle_build_repo, output_image, self.konflux_namespace, self.skip_checks,
+                    git_auth_secret=git_auth_secret,
                 )
                 pipelinerun_name = pipelinerun_info.name
                 record["task_id"] = pipelinerun_name
@@ -816,6 +817,7 @@ class KonfluxOlmBundleBuilder:
         namespace: str,
         skip_checks: bool = False,
         additional_tags: Optional[Sequence[str]] = None,
+        git_auth_secret: Optional[str] = None,
     ) -> Tuple[PipelineRunInfo, str]:
         """Start a build with Konflux."""
         if not bundle_build_repo.commit_hash:
@@ -845,7 +847,7 @@ class KonfluxOlmBundleBuilder:
         )
         logger.info(f"Konflux component {component_name} created")
         # Start a PipelineRun
-        pipelinerun_info = await konflux_client.start_pipeline_run_for_image_build(
+        build_kwargs = dict(
             generate_name=f"{component_name}-",
             namespace=namespace,
             application_name=app_name,
@@ -855,7 +857,7 @@ class KonfluxOlmBundleBuilder:
             target_branch=target_branch,
             output_image=output_image,
             vm_override={},
-            building_arches=["x86_64"],  # We always build bundles on x86_64
+            building_arches=["x86_64"],
             additional_tags=list(additional_tags),
             skip_checks=skip_checks,
             hermetic=True,
@@ -863,6 +865,9 @@ class KonfluxOlmBundleBuilder:
             artifact_type="operatorbundle",
             build_priority=BUNDLE_BUILD_PRIORITY,
         )
+        if git_auth_secret:
+            build_kwargs["git_auth_secret"] = git_auth_secret
+        pipelinerun_info = await konflux_client.start_pipeline_run_for_image_build(**build_kwargs)
         url = konflux_client.resource_url(pipelinerun_info.to_dict())
         logger.info(f"PipelineRun {pipelinerun_info.name} created: {url}")
         return pipelinerun_info, url

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -749,7 +749,11 @@ class FbcRebaseAndBuildCli:
 
         tasks = [
             self._rebase_and_build(
-                importer, rebaser, builder, self.runtime.image_map[dgk], bundle_build,
+                importer,
+                rebaser,
+                builder,
+                self.runtime.image_map[dgk],
+                bundle_build,
                 git_auth_secret=git_auth_secret,
             )
             for dgk, bundle_build in dgk_bundle_builds.items()

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -329,7 +329,19 @@ class FbcMergeCli:
             plr_template=self.plr_template,
             major_minor_override=(major, minor) if self.major_minor else None,
         )
-        await merger.run(fragments, target_index)
+        # Mint a per-invocation GitHub App token for git-clone auth
+        git_auth_secret = await merger._konflux_client.ensure_git_auth_secret(
+            namespace=self.konflux_namespace,
+        )
+        try:
+            await merger.run(fragments, target_index, git_auth_secret=git_auth_secret)
+        finally:
+            try:
+                await merger._konflux_client.cleanup_stale_git_auth_secrets(
+                    namespace=self.konflux_namespace,
+                )
+            except Exception as e:
+                LOGGER.warning("Failed to cleanup stale git-auth secrets: %s", e)
 
 
 @cli.command("beta:fbc:merge", short_help="Merge FBC fragments from multiple index images into a single FBC repository")
@@ -614,6 +626,7 @@ class FbcRebaseAndBuildCli:
         builder: KonfluxFbcBuilder,
         operator_meta: ImageMetadata,
         bundle_build: KonfluxBundleBuildRecord,
+        git_auth_secret: Optional[str] = None,
     ) -> str:
         """Rebase and build FBC for the given operator and bundle build.
 
@@ -621,6 +634,7 @@ class FbcRebaseAndBuildCli:
         :param builder: FBC builder instance
         :param operator_meta: Operator metadata
         :param bundle_build: Bundle build record
+        :param git_auth_secret: Name of the transient git-auth Secret for PipelineRuns
         :return: NVR of the FBC build
         """
         existing_fbc_build = await self._check_existing_fbc_build(operator_meta, bundle_build)
@@ -637,7 +651,7 @@ class FbcRebaseAndBuildCli:
         self._logger.info(f"Rebasing fbc for {operator_meta.name}...")
         nvr = await rebaser.rebase(operator_meta, bundle_build, self.version, self.release)
         self._logger.info(f"Building fbc for {operator_meta.name}...")
-        await builder.build(operator_meta, operator_nvr=bundle_build.operator_nvr)
+        await builder.build(operator_meta, operator_nvr=bundle_build.operator_nvr, git_auth_secret=git_auth_secret)
         return nvr
 
     async def run(self):
@@ -728,32 +742,48 @@ class FbcRebaseAndBuildCli:
             record_logger=runtime.record_logger,
         )
 
+        # Mint a per-invocation GitHub App token for git-clone auth
+        git_auth_secret = await builder._konflux_client.ensure_git_auth_secret(
+            namespace=self.konflux_namespace,
+        )
+
         tasks = [
-            self._rebase_and_build(importer, rebaser, builder, self.runtime.image_map[dgk], bundle_build)
+            self._rebase_and_build(
+                importer, rebaser, builder, self.runtime.image_map[dgk], bundle_build,
+                git_auth_secret=git_auth_secret,
+            )
             for dgk, bundle_build in dgk_bundle_builds.items()
         ]
 
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-        successful_nvrs = []
-        failed_tasks = []
-        errors = []
+        try:
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            successful_nvrs = []
+            failed_tasks = []
+            errors = []
 
-        for dgk, result in zip(dgk_bundle_builds, results):
-            if isinstance(result, Exception):
-                failed_tasks.append(dgk)
-                stack_trace = ''.join(traceback.TracebackException.from_exception(result).format())
-                error_msg = f"Failed to rebase/build FBC for {dgk}: {result}"
-                error_details = {
-                    "operator": dgk,
-                    "operator_nvr": dgk_operator_builds[dgk].nvr,
-                    "bundle_nvr": dgk_bundle_builds[dgk].nvr,
-                    "error": str(result),
-                    "traceback": stack_trace,
-                }
-                errors.append(error_details)
-                LOGGER.error(f"{error_msg}; {stack_trace}")
-            else:
-                successful_nvrs.append(result)
+            for dgk, result in zip(dgk_bundle_builds, results):
+                if isinstance(result, Exception):
+                    failed_tasks.append(dgk)
+                    stack_trace = ''.join(traceback.TracebackException.from_exception(result).format())
+                    error_msg = f"Failed to rebase/build FBC for {dgk}: {result}"
+                    error_details = {
+                        "operator": dgk,
+                        "operator_nvr": dgk_operator_builds[dgk].nvr,
+                        "bundle_nvr": dgk_bundle_builds[dgk].nvr,
+                        "error": str(result),
+                        "traceback": stack_trace,
+                    }
+                    errors.append(error_details)
+                    LOGGER.error(f"{error_msg}; {stack_trace}")
+                else:
+                    successful_nvrs.append(result)
+        finally:
+            try:
+                await builder._konflux_client.cleanup_stale_git_auth_secrets(
+                    namespace=self.konflux_namespace,
+                )
+            except Exception as e:
+                LOGGER.warning("Failed to cleanup stale git-auth secrets: %s", e)
 
         if self.output == 'json':
             output_data = {

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -337,11 +337,14 @@ class FbcMergeCli:
             await merger.run(fragments, target_index, git_auth_secret=git_auth_secret)
         finally:
             try:
+                await merger._konflux_client.delete_git_auth_secret(
+                    namespace=self.konflux_namespace,
+                )
                 await merger._konflux_client.cleanup_stale_git_auth_secrets(
                     namespace=self.konflux_namespace,
                 )
             except Exception as e:
-                LOGGER.warning("Failed to cleanup stale git-auth secrets: %s", e)
+                LOGGER.warning("Failed to cleanup git-auth secrets: %s", e)
 
 
 @cli.command("beta:fbc:merge", short_help="Merge FBC fragments from multiple index images into a single FBC repository")
@@ -783,11 +786,14 @@ class FbcRebaseAndBuildCli:
                     successful_nvrs.append(result)
         finally:
             try:
+                await builder._konflux_client.delete_git_auth_secret(
+                    namespace=self.konflux_namespace,
+                )
                 await builder._konflux_client.cleanup_stale_git_auth_secrets(
                     namespace=self.konflux_namespace,
                 )
             except Exception as e:
-                LOGGER.warning("Failed to cleanup stale git-auth secrets: %s", e)
+                LOGGER.warning("Failed to cleanup git-auth secrets: %s", e)
 
         if self.output == 'json':
             output_data = {

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -557,9 +557,11 @@ class KonfluxBundleCli:
         tasks = []
         for dgk, record in dgk_records.items():
             image_meta = runtime.image_map[dgk]
-            tasks.append(asyncio.create_task(
-                self._rebase_and_build(rebaser, builder, image_meta, record, git_auth_secret=git_auth_secret)
-            ))
+            tasks.append(
+                asyncio.create_task(
+                    self._rebase_and_build(rebaser, builder, image_meta, record, git_auth_secret=git_auth_secret)
+                )
+            )
 
         try:
             results = await asyncio.gather(*tasks, return_exceptions=True)

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -290,11 +290,14 @@ class KonfluxBuildCli:
                     LOGGER.error(f"Failed to build {image_name}: {result}; {stack_trace}")
         finally:
             try:
+                await builder._konflux_client.delete_git_auth_secret(
+                    namespace=self.konflux_namespace,
+                )
                 await builder._konflux_client.cleanup_stale_git_auth_secrets(
                     namespace=self.konflux_namespace,
                 )
             except Exception as e:
-                LOGGER.warning("Failed to cleanup stale git-auth secrets: %s", e)
+                LOGGER.warning("Failed to cleanup git-auth secrets: %s", e)
 
         if failed_images:
             raise DoozerFatalError(f"Failed to build images: {failed_images}")
@@ -586,11 +589,14 @@ class KonfluxBundleCli:
                     successful_nvrs.append(result)
         finally:
             try:
+                await builder._konflux_client.delete_git_auth_secret(
+                    namespace=self.konflux_namespace,
+                )
                 await builder._konflux_client.cleanup_stale_git_auth_secrets(
                     namespace=self.konflux_namespace,
                 )
             except Exception as e:
-                LOGGER.warning("Failed to cleanup stale git-auth secrets: %s", e)
+                LOGGER.warning("Failed to cleanup git-auth secrets: %s", e)
 
         if self.output == 'json':
             output_data = {

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -269,17 +269,33 @@ class KonfluxBuildCli:
             build_priority=self.build_priority,
         )
         builder = KonfluxImageBuilder(config=config, record_logger=runtime.record_logger)
+
+        # Mint a per-invocation GitHub App token and create a transient Secret.
+        # All PipelineRuns in this batch share the same secret — no contention.
+        git_auth_secret = await builder._konflux_client.ensure_git_auth_secret(
+            namespace=self.konflux_namespace,
+        )
+
         tasks = []
         for image_meta in metas:
-            tasks.append(asyncio.create_task(builder.build(image_meta)))
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-        failed_images = []
-        for index, result in enumerate(results):
-            if isinstance(result, Exception):
-                image_name = metas[index].distgit_key
-                failed_images.append(image_name)
-                stack_trace = ''.join(traceback.TracebackException.from_exception(result).format())
-                LOGGER.error(f"Failed to build {image_name}: {result}; {stack_trace}")
+            tasks.append(asyncio.create_task(builder.build(image_meta, git_auth_secret=git_auth_secret)))
+        try:
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            failed_images = []
+            for index, result in enumerate(results):
+                if isinstance(result, Exception):
+                    image_name = metas[index].distgit_key
+                    failed_images.append(image_name)
+                    stack_trace = ''.join(traceback.TracebackException.from_exception(result).format())
+                    LOGGER.error(f"Failed to build {image_name}: {result}; {stack_trace}")
+        finally:
+            try:
+                await builder._konflux_client.cleanup_stale_git_auth_secrets(
+                    namespace=self.konflux_namespace,
+                )
+            except Exception as e:
+                LOGGER.warning("Failed to cleanup stale git-auth secrets: %s", e)
+
         if failed_images:
             raise DoozerFatalError(f"Failed to build images: {failed_images}")
         LOGGER.info("Build complete")
@@ -457,6 +473,7 @@ class KonfluxBundleCli:
         builder: KonfluxOlmBundleBuilder,
         image_meta: ImageMetadata,
         operator_build: KonfluxBuildRecord,
+        git_auth_secret: Optional[str] = None,
     ) -> str:
         logger = LOGGER.getChild(f"[{image_meta.distgit_key}]")
         input_release = self.release
@@ -480,7 +497,7 @@ class KonfluxBundleCli:
         logger.info("Rebasing OLM bundle...")
         nvr = await rebaser.rebase(image_meta, operator_build, input_release)
         logger.info("Building OLM bundle...")
-        await builder.build(image_meta)
+        await builder.build(image_meta, git_auth_secret=git_auth_secret)
         logger.info("Bundle build complete")
         return nvr
 
@@ -532,31 +549,47 @@ class KonfluxBundleCli:
             record_logger=runtime.record_logger,
         )
 
+        # Mint a per-invocation GitHub App token for git-clone auth
+        git_auth_secret = await builder._konflux_client.ensure_git_auth_secret(
+            namespace=self.konflux_namespace,
+        )
+
         tasks = []
         for dgk, record in dgk_records.items():
             image_meta = runtime.image_map[dgk]
-            tasks.append(asyncio.create_task(self._rebase_and_build(rebaser, builder, image_meta, record)))
+            tasks.append(asyncio.create_task(
+                self._rebase_and_build(rebaser, builder, image_meta, record, git_auth_secret=git_auth_secret)
+            ))
 
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-        successful_nvrs = []
-        failed_tasks = []
-        errors = []
-        for dgk, result in zip(dgk_records, results):
-            if isinstance(result, Exception):
-                failed_tasks.append(dgk)
-                stack_trace = ''.join(traceback.TracebackException.from_exception(result).format())
-                errors.append(
-                    {
-                        "operator": dgk,
-                        "operator_nvr": dgk_records[dgk].nvr,
-                        "bundle_nvr": None,
-                        "error": str(result),
-                        "traceback": stack_trace,
-                    }
+        try:
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            successful_nvrs = []
+            failed_tasks = []
+            errors = []
+            for dgk, result in zip(dgk_records, results):
+                if isinstance(result, Exception):
+                    failed_tasks.append(dgk)
+                    stack_trace = ''.join(traceback.TracebackException.from_exception(result).format())
+                    errors.append(
+                        {
+                            "operator": dgk,
+                            "operator_nvr": dgk_records[dgk].nvr,
+                            "bundle_nvr": None,
+                            "error": str(result),
+                            "traceback": stack_trace,
+                        }
+                    )
+                    LOGGER.error(f"Failed to rebase/build OLM bundle for {dgk}: {result}; {stack_trace}")
+                else:
+                    successful_nvrs.append(result)
+        finally:
+            try:
+                await builder._konflux_client.cleanup_stale_git_auth_secrets(
+                    namespace=self.konflux_namespace,
                 )
-                LOGGER.error(f"Failed to rebase/build OLM bundle for {dgk}: {result}; {stack_trace}")
-            else:
-                successful_nvrs.append(result)
+            except Exception as e:
+                LOGGER.warning("Failed to cleanup stale git-auth secrets: %s", e)
+
         if self.output == 'json':
             output_data = {
                 "nvrs": successful_nvrs,

--- a/doozer/tests/backend/test_konflux_client_git_auth.py
+++ b/doozer/tests/backend/test_konflux_client_git_auth.py
@@ -1,0 +1,174 @@
+import asyncio
+import base64
+import datetime
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from kubernetes.client import ApiException
+
+from doozerlib.backend.konflux_client import (
+    KonfluxClient,
+    _GIT_AUTH_SECRET_LABEL_KEY,
+    _GIT_AUTH_SECRET_LABEL_VALUE,
+    _GIT_AUTH_SECRET_PREFIX,
+)
+
+
+def _make_client(dry_run=False) -> KonfluxClient:
+    """Build a KonfluxClient with mocked Kubernetes plumbing."""
+    config = MagicMock()
+    with patch("doozerlib.backend.konflux_client.ApiClient"), \
+         patch("doozerlib.backend.konflux_client.DynamicClient"), \
+         patch("doozerlib.backend.konflux_client.CoreV1Api"):
+        client = KonfluxClient(
+            default_namespace="test-ns",
+            config=config,
+            dry_run=dry_run,
+        )
+    return client
+
+
+def _run(coro):
+    """Helper to run async code in sync tests."""
+    return asyncio.run(coro)
+
+
+class TestEnsureGitAuthSecret(TestCase):
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_fallback_when_no_github_app_id(self):
+        """Without GITHUB_APP_ID the static PAT secret name is returned."""
+        client = _make_client()
+        name = _run(client.ensure_git_auth_secret())
+        self.assertEqual(name, "pipelines-as-code-secret")
+
+    @patch.dict("os.environ", {"GITHUB_APP_ID": "12345"})
+    @patch("doozerlib.backend.konflux_client.get_github_app_token_from_env", return_value="ghp_fake_token")
+    @patch("doozerlib.backend.konflux_client.time")
+    def test_creates_secret_with_correct_shape(self, mock_time, mock_token_fn):
+        mock_time.time_ns.return_value = 1700000000000000000
+        client = _make_client()
+
+        name = _run(client.ensure_git_auth_secret(namespace="my-ns"))
+
+        self.assertEqual(name, f"{_GIT_AUTH_SECRET_PREFIX}1700000000000000000")
+        client.corev1_client.create_namespaced_secret.assert_called_once()
+        call_kwargs = client.corev1_client.create_namespaced_secret.call_args
+        body = call_kwargs.kwargs.get("body") or call_kwargs[1].get("body")
+        self.assertEqual(body.type, "kubernetes.io/basic-auth")
+        self.assertEqual(body.metadata.namespace, "my-ns")
+        self.assertEqual(
+            body.metadata.labels[_GIT_AUTH_SECRET_LABEL_KEY],
+            _GIT_AUTH_SECRET_LABEL_VALUE,
+        )
+        self.assertEqual(
+            base64.b64decode(body.data["username"]).decode(), "x-access-token",
+        )
+        self.assertEqual(
+            base64.b64decode(body.data["password"]).decode(), "ghp_fake_token",
+        )
+
+    @patch.dict("os.environ", {"GITHUB_APP_ID": "12345"})
+    @patch("doozerlib.backend.konflux_client.get_github_app_token_from_env", return_value="ghp_fake_token")
+    @patch("doozerlib.backend.konflux_client.time")
+    def test_caches_secret_name(self, mock_time, mock_token_fn):
+        mock_time.time_ns.return_value = 1700000000000000000
+        client = _make_client()
+
+        name1 = _run(client.ensure_git_auth_secret())
+        name2 = _run(client.ensure_git_auth_secret())
+
+        self.assertEqual(name1, name2)
+        # create_namespaced_secret should only be called once
+        self.assertEqual(client.corev1_client.create_namespaced_secret.call_count, 1)
+
+    @patch.dict("os.environ", {"GITHUB_APP_ID": "12345"})
+    @patch("doozerlib.backend.konflux_client.get_github_app_token_from_env", return_value="ghp_fake_token")
+    @patch("doozerlib.backend.konflux_client.time")
+    def test_dry_run_does_not_create(self, mock_time, mock_token_fn):
+        mock_time.time_ns.return_value = 1700000000000000000
+        client = _make_client(dry_run=True)
+
+        name = _run(client.ensure_git_auth_secret())
+
+        self.assertTrue(name.startswith(_GIT_AUTH_SECRET_PREFIX))
+        client.corev1_client.create_namespaced_secret.assert_not_called()
+
+
+class TestCleanupStaleGitAuthSecrets(TestCase):
+
+    def _make_secret(self, name: str, created: datetime.datetime):
+        secret = MagicMock()
+        secret.metadata.name = name
+        secret.metadata.creation_timestamp = created
+        return secret
+
+    def test_deletes_old_secrets(self):
+        client = _make_client()
+        now = datetime.datetime.now(datetime.timezone.utc)
+        old = now - datetime.timedelta(hours=48)
+        recent = now - datetime.timedelta(hours=1)
+
+        old_secret = self._make_secret("art-transient-pipeline-auth-100", old)
+        recent_secret = self._make_secret("art-transient-pipeline-auth-200", recent)
+
+        mock_list = MagicMock()
+        mock_list.items = [old_secret, recent_secret]
+        client.corev1_client.list_namespaced_secret.return_value = mock_list
+
+        _run(client.cleanup_stale_git_auth_secrets(namespace="test-ns"))
+
+        # Verify that list was scoped to the transient-secret label
+        list_kwargs = client.corev1_client.list_namespaced_secret.call_args.kwargs
+        self.assertEqual(list_kwargs["namespace"], "test-ns")
+        self.assertEqual(
+            list_kwargs["label_selector"],
+            f"{_GIT_AUTH_SECRET_LABEL_KEY}={_GIT_AUTH_SECRET_LABEL_VALUE}",
+        )
+
+        # Only the old secret should be deleted
+        client.corev1_client.delete_namespaced_secret.assert_called_once_with(
+            name="art-transient-pipeline-auth-100",
+            namespace="test-ns",
+            _request_timeout=client.request_timeout,
+        )
+
+    def test_ignores_404_on_delete(self):
+        """If another process already deleted the secret, the 404 should be silently ignored."""
+        client = _make_client()
+        old = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=48)
+        old_secret = self._make_secret("art-transient-pipeline-auth-100", old)
+
+        mock_list = MagicMock()
+        mock_list.items = [old_secret]
+        client.corev1_client.list_namespaced_secret.return_value = mock_list
+        client.corev1_client.delete_namespaced_secret.side_effect = ApiException(status=404, reason="Not Found")
+
+        # Should not raise
+        _run(client.cleanup_stale_git_auth_secrets(namespace="test-ns"))
+
+    def test_does_not_delete_recent_secrets(self):
+        client = _make_client()
+        recent = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
+        recent_secret = self._make_secret("art-transient-pipeline-auth-200", recent)
+
+        mock_list = MagicMock()
+        mock_list.items = [recent_secret]
+        client.corev1_client.list_namespaced_secret.return_value = mock_list
+
+        _run(client.cleanup_stale_git_auth_secrets(namespace="test-ns"))
+
+        client.corev1_client.delete_namespaced_secret.assert_not_called()
+
+    def test_dry_run_does_not_delete(self):
+        client = _make_client(dry_run=True)
+        old = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=48)
+        old_secret = self._make_secret("art-transient-pipeline-auth-100", old)
+
+        mock_list = MagicMock()
+        mock_list.items = [old_secret]
+        client.corev1_client.list_namespaced_secret.return_value = mock_list
+
+        _run(client.cleanup_stale_git_auth_secrets(namespace="test-ns"))
+
+        client.corev1_client.delete_namespaced_secret.assert_not_called()

--- a/doozer/tests/backend/test_konflux_client_git_auth.py
+++ b/doozer/tests/backend/test_konflux_client_git_auth.py
@@ -4,22 +4,23 @@ import datetime
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from kubernetes.client import ApiException
-
 from doozerlib.backend.konflux_client import (
-    KonfluxClient,
     _GIT_AUTH_SECRET_LABEL_KEY,
     _GIT_AUTH_SECRET_LABEL_VALUE,
     _GIT_AUTH_SECRET_PREFIX,
+    KonfluxClient,
 )
+from kubernetes.client import ApiException
 
 
 def _make_client(dry_run=False) -> KonfluxClient:
     """Build a KonfluxClient with mocked Kubernetes plumbing."""
     config = MagicMock()
-    with patch("doozerlib.backend.konflux_client.ApiClient"), \
-         patch("doozerlib.backend.konflux_client.DynamicClient"), \
-         patch("doozerlib.backend.konflux_client.CoreV1Api"):
+    with (
+        patch("doozerlib.backend.konflux_client.ApiClient"),
+        patch("doozerlib.backend.konflux_client.DynamicClient"),
+        patch("doozerlib.backend.konflux_client.CoreV1Api"),
+    ):
         client = KonfluxClient(
             default_namespace="test-ns",
             config=config,
@@ -34,7 +35,6 @@ def _run(coro):
 
 
 class TestEnsureGitAuthSecret(TestCase):
-
     @patch.dict("os.environ", {}, clear=True)
     def test_fallback_when_no_github_app_id(self):
         """Without GITHUB_APP_ID the static PAT secret name is returned."""
@@ -62,10 +62,12 @@ class TestEnsureGitAuthSecret(TestCase):
             _GIT_AUTH_SECRET_LABEL_VALUE,
         )
         self.assertEqual(
-            base64.b64decode(body.data["username"]).decode(), "x-access-token",
+            base64.b64decode(body.data["username"]).decode(),
+            "x-access-token",
         )
         self.assertEqual(
-            base64.b64decode(body.data["password"]).decode(), "ghp_fake_token",
+            base64.b64decode(body.data["password"]).decode(),
+            "ghp_fake_token",
         )
 
     @patch.dict("os.environ", {"GITHUB_APP_ID": "12345"})
@@ -96,7 +98,6 @@ class TestEnsureGitAuthSecret(TestCase):
 
 
 class TestCleanupStaleGitAuthSecrets(TestCase):
-
     def _make_secret(self, name: str, created: datetime.datetime):
         secret = MagicMock()
         secret.metadata.name = name

--- a/doozer/tests/backend/test_konflux_client_git_auth.py
+++ b/doozer/tests/backend/test_konflux_client_git_auth.py
@@ -43,7 +43,7 @@ class TestEnsureGitAuthSecret(TestCase):
         self.assertEqual(name, "pipelines-as-code-secret")
 
     @patch.dict("os.environ", {"GITHUB_APP_ID": "12345"})
-    @patch("doozerlib.backend.konflux_client.get_github_app_token_from_env", return_value="ghp_fake_token")
+    @patch("doozerlib.backend.konflux_client.get_github_app_token_for_org", return_value="ghp_fake_token")
     @patch("doozerlib.backend.konflux_client.time")
     def test_creates_secret_with_correct_shape(self, mock_time, mock_token_fn):
         mock_time.time_ns.return_value = 1700000000000000000
@@ -71,7 +71,7 @@ class TestEnsureGitAuthSecret(TestCase):
         )
 
     @patch.dict("os.environ", {"GITHUB_APP_ID": "12345"})
-    @patch("doozerlib.backend.konflux_client.get_github_app_token_from_env", return_value="ghp_fake_token")
+    @patch("doozerlib.backend.konflux_client.get_github_app_token_for_org", return_value="ghp_fake_token")
     @patch("doozerlib.backend.konflux_client.time")
     def test_caches_secret_name(self, mock_time, mock_token_fn):
         mock_time.time_ns.return_value = 1700000000000000000
@@ -85,7 +85,7 @@ class TestEnsureGitAuthSecret(TestCase):
         self.assertEqual(client.corev1_client.create_namespaced_secret.call_count, 1)
 
     @patch.dict("os.environ", {"GITHUB_APP_ID": "12345"})
-    @patch("doozerlib.backend.konflux_client.get_github_app_token_from_env", return_value="ghp_fake_token")
+    @patch("doozerlib.backend.konflux_client.get_github_app_token_for_org", return_value="ghp_fake_token")
     @patch("doozerlib.backend.konflux_client.time")
     def test_dry_run_does_not_create(self, mock_time, mock_token_fn):
         mock_time.time_ns.return_value = 1700000000000000000
@@ -173,3 +173,54 @@ class TestCleanupStaleGitAuthSecrets(TestCase):
         _run(client.cleanup_stale_git_auth_secrets(namespace="test-ns"))
 
         client.corev1_client.delete_namespaced_secret.assert_not_called()
+
+
+class TestDeleteGitAuthSecret(TestCase):
+    def test_deletes_own_secret_and_resets_cache(self):
+        client = _make_client()
+        client._git_auth_secret_name = f"{_GIT_AUTH_SECRET_PREFIX}1700000000000000000"
+
+        _run(client.delete_git_auth_secret(namespace="test-ns"))
+
+        client.corev1_client.delete_namespaced_secret.assert_called_once_with(
+            name=f"{_GIT_AUTH_SECRET_PREFIX}1700000000000000000",
+            namespace="test-ns",
+            _request_timeout=client.request_timeout,
+        )
+        self.assertIsNone(client._git_auth_secret_name)
+
+    def test_noop_when_no_secret_created(self):
+        client = _make_client()
+        self.assertIsNone(client._git_auth_secret_name)
+
+        _run(client.delete_git_auth_secret(namespace="test-ns"))
+
+        client.corev1_client.delete_namespaced_secret.assert_not_called()
+
+    def test_noop_for_static_fallback(self):
+        """When the fallback pipelines-as-code-secret was used, nothing is deleted."""
+        client = _make_client()
+        client._git_auth_secret_name = "pipelines-as-code-secret"
+
+        _run(client.delete_git_auth_secret(namespace="test-ns"))
+
+        client.corev1_client.delete_namespaced_secret.assert_not_called()
+        self.assertEqual(client._git_auth_secret_name, "pipelines-as-code-secret")
+
+    def test_ignores_404(self):
+        client = _make_client()
+        client._git_auth_secret_name = f"{_GIT_AUTH_SECRET_PREFIX}1700000000000000000"
+        client.corev1_client.delete_namespaced_secret.side_effect = ApiException(status=404, reason="Not Found")
+
+        _run(client.delete_git_auth_secret(namespace="test-ns"))
+
+        self.assertIsNone(client._git_auth_secret_name)
+
+    def test_dry_run_skips_deletion(self):
+        client = _make_client(dry_run=True)
+        client._git_auth_secret_name = f"{_GIT_AUTH_SECRET_PREFIX}1700000000000000000"
+
+        _run(client.delete_git_auth_secret(namespace="test-ns"))
+
+        client.corev1_client.delete_namespaced_secret.assert_not_called()
+        self.assertIsNone(client._git_auth_secret_name)

--- a/doozer/tests/backend/test_konflux_client_git_auth.py
+++ b/doozer/tests/backend/test_konflux_client_git_auth.py
@@ -5,6 +5,8 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from doozerlib.backend.konflux_client import (
+    _GIT_AUTH_GENERATED_BY_LABEL_KEY,
+    _GIT_AUTH_GENERATED_BY_LABEL_VALUE,
     _GIT_AUTH_SECRET_LABEL_KEY,
     _GIT_AUTH_SECRET_LABEL_VALUE,
     _GIT_AUTH_SECRET_PREFIX,
@@ -42,7 +44,7 @@ class TestEnsureGitAuthSecret(TestCase):
         name = _run(client.ensure_git_auth_secret())
         self.assertEqual(name, "pipelines-as-code-secret")
 
-    @patch.dict("os.environ", {"GITHUB_APP_ID": "12345"})
+    @patch.dict("os.environ", {"GITHUB_APP_ID": "12345", "BUILD_URL": "https://jenkins.example.com/job/test/42/"})
     @patch("doozerlib.backend.konflux_client.get_github_app_token_for_org", return_value="ghp_fake_token")
     @patch("doozerlib.backend.konflux_client.time")
     def test_creates_secret_with_correct_shape(self, mock_time, mock_token_fn):
@@ -60,6 +62,14 @@ class TestEnsureGitAuthSecret(TestCase):
         self.assertEqual(
             body.metadata.labels[_GIT_AUTH_SECRET_LABEL_KEY],
             _GIT_AUTH_SECRET_LABEL_VALUE,
+        )
+        self.assertEqual(
+            body.metadata.labels[_GIT_AUTH_GENERATED_BY_LABEL_KEY],
+            _GIT_AUTH_GENERATED_BY_LABEL_VALUE,
+        )
+        self.assertEqual(
+            body.metadata.annotations["art-jenkins-job-url"],
+            "https://jenkins.example.com/job/test/42/",
         )
         self.assertEqual(
             base64.b64decode(body.data["username"]).decode(),
@@ -124,7 +134,8 @@ class TestCleanupStaleGitAuthSecrets(TestCase):
         self.assertEqual(list_kwargs["namespace"], "test-ns")
         self.assertEqual(
             list_kwargs["label_selector"],
-            f"{_GIT_AUTH_SECRET_LABEL_KEY}={_GIT_AUTH_SECRET_LABEL_VALUE}",
+            f"{_GIT_AUTH_SECRET_LABEL_KEY}={_GIT_AUTH_SECRET_LABEL_VALUE},"
+            f"{_GIT_AUTH_GENERATED_BY_LABEL_KEY}={_GIT_AUTH_GENERATED_BY_LABEL_VALUE}",
         )
 
         # Only the old secret should be deleted

--- a/doozer/tests/cli/test_images_konflux.py
+++ b/doozer/tests/cli/test_images_konflux.py
@@ -70,14 +70,18 @@ class TestKonfluxBundleCli(unittest.IsolatedAsyncioTestCase):
             }
         )
 
-        async def rebase_and_build_side_effect(_rebaser, _builder, image_meta, _operator_build):
+        async def rebase_and_build_side_effect(_rebaser, _builder, image_meta, _operator_build, **kwargs):
             if image_meta.distgit_key == "test-operator-b":
                 raise RuntimeError("bundle build failed")
             return "test-operator-a-bundle-1.0.0-1"
 
         self.bundle_cli._rebase_and_build = mock.AsyncMock(side_effect=rebase_and_build_side_effect)
         mock_rebaser_class.return_value = mock.Mock()
-        mock_builder_class.return_value = mock.Mock()
+        mock_builder = mock.Mock()
+        mock_builder._konflux_client.ensure_git_auth_secret = mock.AsyncMock(return_value="test-secret")
+        mock_builder._konflux_client.delete_git_auth_secret = mock.AsyncMock()
+        mock_builder._konflux_client.cleanup_stale_git_auth_secrets = mock.AsyncMock()
+        mock_builder_class.return_value = mock_builder
 
         with self.assertRaises(SystemExit):
             await self.bundle_cli.run()
@@ -100,7 +104,11 @@ class TestKonfluxBundleCli(unittest.IsolatedAsyncioTestCase):
         self.bundle_cli.get_operator_builds = mock.AsyncMock(return_value={"test-operator": operator_build})
         self.bundle_cli._rebase_and_build = mock.AsyncMock(side_effect=RuntimeError("bundle build failed"))
         mock_rebaser_class.return_value = mock.Mock()
-        mock_builder_class.return_value = mock.Mock()
+        mock_builder = mock.Mock()
+        mock_builder._konflux_client.ensure_git_auth_secret = mock.AsyncMock(return_value="test-secret")
+        mock_builder._konflux_client.delete_git_auth_secret = mock.AsyncMock()
+        mock_builder._konflux_client.cleanup_stale_git_auth_secrets = mock.AsyncMock()
+        mock_builder_class.return_value = mock_builder
 
         with self.assertRaises(DoozerFatalError):
             await self.bundle_cli.run()


### PR DESCRIPTION
## Summary

Migrates Konflux PipelineRun `git-clone` authentication from a static Personal Access Token (`pipelines-as-code-secret`) to short-lived GitHub App installation tokens, improving security and auditability.

### Key changes

- **Per-invocation transient secrets**: Each doozer/artcd build run mints a fresh GitHub App installation token and creates a unique `art-transient-pipeline-auth-<epoch_ns>` Kubernetes secret, avoiding contention between concurrent builds.
- **Immediate cleanup + stale sweep**: The current run secret is deleted in `finally` blocks immediately after the build completes. A secondary sweep removes any leftover transient secrets older than 24 hours (idempotent; 404 responses are silently ignored).
- **Graceful fallback**: If `GITHUB_APP_ID` is not set, the code falls back to the existing static `pipelines-as-code-secret` with no behavior change.
- **Multi-installation support**: Uses `get_github_app_token_for_org()` to correctly resolve the installation when the GitHub App is installed on multiple orgs.
- **Provenance labels and annotations**: Each transient secret carries:
  - `art.openshift.io/git-auth: "true"` -- identifies it as a git-auth secret
  - `art.openshift.io/generated-by: "art-automation"` -- marks it as machine-generated (also used in cleanup selector)
  - `art.openshift.io/created-at` annotation -- UTC ISO timestamp
  - `art-jenkins-job-url` annotation -- links back to the Jenkins build that created it

### Files changed

| File | Change |
|------|--------|
| `doozer/doozerlib/backend/konflux_client.py` | `ensure_git_auth_secret()`, `delete_git_auth_secret()`, `cleanup_stale_git_auth_secrets()` |
| `doozer/doozerlib/cli/images_konflux.py` | `finally` blocks call delete + cleanup |
| `doozer/doozerlib/cli/fbc.py` | `finally` blocks call delete + cleanup |
| `doozer/tests/backend/test_konflux_client_git_auth.py` | Unit tests for all three methods |
| `doozer/tests/cli/test_images_konflux.py` | Updated mocks for new async methods |

## Test plan

- [x] `make test` passes (5 pre-existing macOS-only symlink failures in `test_util.py` unrelated)
- [x] All 15 tests in `test_konflux_client_git_auth.py` pass
- [x] All 2 tests in `test_images_konflux.py` pass
- [ ] Verified in staging Jenkins job that transient secret is created, used, and deleted
