### PR TITLE
Add --release-jira option to release-from-fbc pipeline

### DIFF
--- a/pyartcd/pyartcd/jira_client.py
+++ b/pyartcd/pyartcd/jira_client.py
@@ -25,6 +25,15 @@ class JIRAClient:
     def add_comment(self, key, comment):
         self._client.add_comment(key, comment, visibility={'type': 'group', 'value': 'Red Hat Employee'})
 
+    def add_remote_link(self, issue_key: str, link_object: dict):
+        """Add a remote web link to a JIRA issue.
+
+        Args:
+            issue_key: The JIRA issue key (e.g. "OADP-1234")
+            link_object: Dict with "title" and "url" keys
+        """
+        self._client.add_remote_link(issue_key, {"object": link_object})
+
     def assign_to_me(self, key):
         self._client.assign_issue(key, 'openshift-art-jira-bot')
 

--- a/pyartcd/pyartcd/jira_client.py
+++ b/pyartcd/pyartcd/jira_client.py
@@ -41,6 +41,15 @@ class JIRAClient:
     def add_comment(self, key, comment):
         self._client.add_comment(key, comment, visibility={'type': 'group', 'value': 'Red Hat Employee'})
 
+    def add_remote_link(self, issue_key: str, link_object: dict):
+        """Add a remote web link to a JIRA issue.
+
+        Args:
+            issue_key: The JIRA issue key (e.g. "OADP-1234")
+            link_object: Dict with "title" and "url" keys
+        """
+        self._client.add_remote_link(issue_key, {"object": link_object})
+
     def assign_to_me(self, key):
         self._client.assign_issue(key, 'openshift-art-jira-bot')
 

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -76,6 +76,7 @@ class ReleaseFromFbcPipeline:
         jira_bugs: Optional[List[str]] = None,
         target_release_date: Optional[str] = None,
         extra_image_nvrs: Optional[List[str]] = None,
+        release_jira: Optional[str] = None,
     ) -> None:
         self.logger = logging.getLogger(__name__)
         self.runtime = runtime
@@ -115,6 +116,7 @@ class ReleaseFromFbcPipeline:
 
         self.jira_bugs = jira_bugs
         self.target_release_date = target_release_date
+        self.release_jira = release_jira
 
         # Base elliott command template
         self._elliott_base_command = [
@@ -606,6 +608,8 @@ class ReleaseFromFbcPipeline:
             mr_title = f"Draft: Shipment for {self.product} {self.assembly}"
         mr_description = f"Created by job: {self.job_url}\n\n" if self.job_url else ""
         mr_description += f"Shipment files created for {self.assembly} using release-from-fbc command"
+        if self.release_jira:
+            mr_description += f"\n\nRelease JIRA: {self.release_jira}"
 
         if self.dry_run:
             self.logger.info("[DRY-RUN] Would have created MR with title: %s", mr_title)
@@ -638,6 +642,39 @@ class ReleaseFromFbcPipeline:
         # Store the MR URL for later use
         self.shipment_mr_url = mr_url
         return mr_url
+
+    @staticmethod
+    def _parse_jira_key(jira_url: str) -> str:
+        """Extract the JIRA issue key from a browse URL.
+
+        E.g. "https://redhat.atlassian.net/browse/OADP-1234" -> "OADP-1234"
+        """
+        path = urlparse(jira_url).path.rstrip('/')
+        return path.split('/')[-1]
+
+    def _update_jira_with_mr_link(self, mr_url: str):
+        """Add a remote web link on the release JIRA ticket pointing to the shipment MR.
+
+        This is best-effort; failures are logged but do not raise.
+        """
+        if not self.release_jira:
+            return
+
+        issue_key = self._parse_jira_key(self.release_jira)
+        if not issue_key:
+            self.logger.warning("Could not extract JIRA issue key from URL: %s", self.release_jira)
+            return
+
+        if self.dry_run:
+            self.logger.info("[DRY-RUN] Would add remote link on %s pointing to %s", issue_key, mr_url)
+            return
+
+        try:
+            jira_client = self.runtime.new_jira_client()
+            jira_client.add_remote_link(issue_key, {"title": "Shipment MR", "url": mr_url})
+            self.logger.info("Added shipment MR link to JIRA ticket %s", issue_key)
+        except Exception as e:
+            self.logger.warning("Failed to update JIRA ticket %s with MR link: %s", issue_key, e)
 
     async def update_shipment_data(
         self, shipments_by_kind: Dict[str, ShipmentConfig], env: str, commit_message: str, branch: str
@@ -922,6 +959,7 @@ class ReleaseFromFbcPipeline:
                 mr_url = await self.create_shipment_mr(shipments_by_kind, env="prod")
                 if mr_url:
                     self.logger.info(f"Created shipment MR: {mr_url}")
+                    self._update_jira_with_mr_link(mr_url)
             except Exception as e:
                 self.logger.exception(f"Failed to create MR: {e}")
                 if not self.dry_run:
@@ -988,6 +1026,13 @@ class ReleaseFromFbcPipeline:
     help='Target ship date for the release (e.g., 2026-Mar-31 or 2026-03-31). '
     'When provided, the date is included in the shipment MR title.',
 )
+@click.option(
+    '--release-jira',
+    default=None,
+    help='Optional JIRA ticket URL for the release request (e.g. https://redhat.atlassian.net/browse/OADP-1234). '
+    'When provided, the ticket is referenced in the shipment MR description, and a web link '
+    'to the MR is added back to the JIRA ticket.',
+)
 @pass_runtime
 @click_coroutine
 async def release_from_fbc(
@@ -1001,6 +1046,7 @@ async def release_from_fbc(
     shipment_path: Optional[str],
     jira_bugs: Optional[str],
     target_release_date: Optional[str],
+    release_jira: Optional[str],
 ):
     """
     Create shipment files from an FBC image for non-OpenShift products.
@@ -1073,6 +1119,7 @@ async def release_from_fbc(
         jira_bugs=jira_bugs_list,
         target_release_date=normalized_date,
         extra_image_nvrs=extra_image_nvrs_list,
+        release_jira=release_jira,
     )
 
     await pipeline.run()

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -91,6 +91,7 @@ class ReleaseFromFbcPipeline:
         extra_image_nvrs: Optional[List[str]] = None,
         ocp_optional: bool = False,
         exclude_nvr_components: Optional[List[str]] = None,
+        release_jira: Optional[str] = None,
     ) -> None:
         self.logger = logging.getLogger(__name__)
         self.runtime = runtime
@@ -139,6 +140,7 @@ class ReleaseFromFbcPipeline:
 
         self.jira_bugs = jira_bugs
         self.target_release_date = target_release_date
+        self.release_jira = release_jira
 
         # Base elliott command template
         self._elliott_base_command = [
@@ -864,6 +866,8 @@ class ReleaseFromFbcPipeline:
             mr_title = f"Draft: Shipment for {self.product} {self.assembly}"
         mr_description = f"Created by job: {self.job_url}\n\n" if self.job_url else ""
         mr_description += f"Shipment files created for {self.assembly} using release-from-fbc command"
+        if self.release_jira:
+            mr_description += f"\n\nRelease JIRA: {self.release_jira}"
 
         if self.dry_run:
             self.logger.info("[DRY-RUN] Would have created MR with title: %s", mr_title)
@@ -940,6 +944,39 @@ class ReleaseFromFbcPipeline:
                 blocking_mr_url,
                 e,
             )
+
+    @staticmethod
+    def _parse_jira_key(jira_url: str) -> str:
+        """Extract the JIRA issue key from a browse URL.
+
+        E.g. "https://redhat.atlassian.net/browse/OADP-1234" -> "OADP-1234"
+        """
+        path = urlparse(jira_url).path.rstrip('/')
+        return path.split('/')[-1]
+
+    def _update_jira_with_mr_link(self, mr_url: str):
+        """Add a remote web link on the release JIRA ticket pointing to the shipment MR.
+
+        This is best-effort; failures are logged but do not raise.
+        """
+        if not self.release_jira:
+            return
+
+        issue_key = self._parse_jira_key(self.release_jira)
+        if not issue_key:
+            self.logger.warning("Could not extract JIRA issue key from URL: %s", self.release_jira)
+            return
+
+        if self.dry_run:
+            self.logger.info("[DRY-RUN] Would add remote link on %s pointing to %s", issue_key, mr_url)
+            return
+
+        try:
+            jira_client = self.runtime.new_jira_client()
+            jira_client.add_remote_link(issue_key, {"title": "Shipment MR", "url": mr_url})
+            self.logger.info("Added shipment MR link to JIRA ticket %s", issue_key)
+        except Exception as e:
+            self.logger.warning("Failed to update JIRA ticket %s with MR link: %s", issue_key, e)
 
     async def update_shipment_data(
         self, shipments_by_kind: Dict[str, ShipmentConfig], env: str, commit_message: str, branch: str
@@ -1194,6 +1231,7 @@ class ReleaseFromFbcPipeline:
                         if main_ocp_mr_url:
                             await self._set_shipment_mr_dependency(main_ocp_mr_url)
 
+                    self._update_jira_with_mr_link(mr_url)
                     await self.set_shipment_mr_ready()
             except Exception as e:
                 self.logger.exception(f"Failed to create MR: {e}")
@@ -1280,6 +1318,13 @@ class ReleaseFromFbcPipeline:
     help='Comma-separated NVR component names to explicitly exclude from the shipment '
     '(e.g., kube-rbac-proxy-container). Only needed in edge cases with --ocp-optional.',
 )
+@click.option(
+    '--release-jira',
+    default=None,
+    help='Optional JIRA ticket URL for the release request (e.g. https://redhat.atlassian.net/browse/OADP-1234). '
+    'When provided, the ticket is referenced in the shipment MR description, and a web link '
+    'to the MR is added back to the JIRA ticket.',
+)
 @pass_runtime
 @click_coroutine
 async def release_from_fbc(
@@ -1295,6 +1340,7 @@ async def release_from_fbc(
     target_release_date: Optional[str],
     ocp_optional: bool,
     exclude_nvr_components: Optional[str],
+    release_jira: Optional[str],
 ):
     """
     Create shipment files from an FBC image.
@@ -1380,6 +1426,7 @@ async def release_from_fbc(
         extra_image_nvrs=extra_image_nvrs_list,
         ocp_optional=ocp_optional,
         exclude_nvr_components=exclude_nvr_components_list,
+        release_jira=release_jira,
     )
 
     await pipeline.run()

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -986,7 +986,7 @@ class ReleaseFromFbcPipeline:
             return
 
         if self.dry_run:
-            self.logger.info("[DRY-RUN] Would add remote link on %s pointing to %s", issue_key, mr_url)
+            self.logger.info("[DRY-RUN] Would add remote link on %s pointing to the shipment MR", issue_key)
             return
 
         try:

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -974,7 +974,7 @@ class ReleaseFromFbcPipeline:
 
         issue_key = self._parse_jira_key(self.release_jira)
         if not issue_key:
-            self.logger.warning("Could not extract JIRA issue key from URL: %s", self.release_jira)
+            self.logger.warning("Could not extract a valid JIRA issue key from the provided --release-jira URL")
             return
 
         if self.dry_run:

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -80,6 +80,7 @@ class ReleaseFromFbcPipeline:
 
     _JIRA_KEY_RE = re.compile(r"^[A-Z][A-Z0-9]+-\d+$")
     _JIRA_HOSTS = {"redhat.atlassian.net"}
+    _JIRA_BROWSE_URL = "https://redhat.atlassian.net/browse"
 
     def __init__(
         self,
@@ -871,7 +872,9 @@ class ReleaseFromFbcPipeline:
         mr_description = f"Created by job: {self.job_url}\n\n" if self.job_url else ""
         mr_description += f"Shipment files created for {self.assembly} using release-from-fbc command"
         if self.release_jira:
-            mr_description += f"\n\nRelease JIRA: {self.release_jira}"
+            issue_key = self._parse_jira_key(self.release_jira)
+            jira_url = f"{self._JIRA_BROWSE_URL}/{issue_key}" if issue_key else self.release_jira
+            mr_description += f"\n\nRelease JIRA: {jira_url}"
 
         if self.dry_run:
             self.logger.info("[DRY-RUN] Would have created MR with title: %s", mr_title)
@@ -949,15 +952,19 @@ class ReleaseFromFbcPipeline:
                 e,
             )
 
-
     @staticmethod
-    def _parse_jira_key(jira_url: str) -> str:
-        """Extract and validate a JIRA issue key from a browse URL.
+    def _parse_jira_key(jira_ref: str) -> str:
+        """Extract and validate a JIRA issue key from a URL or bare key.
 
-        Accepts URLs like "https://redhat.atlassian.net/browse/OADP-1234".
-        Returns the issue key (e.g. "OADP-1234") or empty string if invalid.
+        Accepts:
+          - "OADP-1234" (bare key)
+          - "https://redhat.atlassian.net/browse/OADP-1234" (full URL)
+        Returns the issue key or empty string if invalid.
         """
-        parsed = urlparse(jira_url.strip())
+        value = jira_ref.strip()
+        if ReleaseFromFbcPipeline._JIRA_KEY_RE.match(value):
+            return value
+        parsed = urlparse(value)
         if parsed.hostname not in ReleaseFromFbcPipeline._JIRA_HOSTS:
             return ""
         key = parsed.path.rstrip("/").split("/")[-1]
@@ -975,7 +982,7 @@ class ReleaseFromFbcPipeline:
 
         issue_key = self._parse_jira_key(self.release_jira)
         if not issue_key:
-            self.logger.warning("Could not extract a valid JIRA issue key from the provided --release-jira URL")
+            self.logger.warning("Could not extract a valid JIRA issue key from the provided --release-jira value")
             return
 
         if self.dry_run:
@@ -1332,7 +1339,8 @@ class ReleaseFromFbcPipeline:
 @click.option(
     '--release-jira',
     default=None,
-    help='Optional JIRA ticket URL for the release request (e.g. https://redhat.atlassian.net/browse/OADP-1234). '
+    help='Optional JIRA ticket key or URL for the release request '
+    '(e.g. OADP-1234 or https://redhat.atlassian.net/browse/OADP-1234). '
     'When provided, the ticket is referenced in the shipment MR description, and a web link '
     'to the MR is added back to the JIRA ticket.',
 )

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import shutil
 import tempfile
 from datetime import datetime, timezone
@@ -945,14 +946,23 @@ class ReleaseFromFbcPipeline:
                 e,
             )
 
+    _JIRA_KEY_RE = re.compile(r"^[A-Z][A-Z0-9]+-\d+$")
+    _JIRA_HOSTS = {"redhat.atlassian.net", "issues.redhat.com"}
+
     @staticmethod
     def _parse_jira_key(jira_url: str) -> str:
-        """Extract the JIRA issue key from a browse URL.
+        """Extract and validate a JIRA issue key from a browse URL.
 
-        E.g. "https://redhat.atlassian.net/browse/OADP-1234" -> "OADP-1234"
+        Accepts URLs like "https://redhat.atlassian.net/browse/OADP-1234".
+        Returns the issue key (e.g. "OADP-1234") or empty string if invalid.
         """
-        path = urlparse(jira_url).path.rstrip('/')
-        return path.split('/')[-1]
+        parsed = urlparse(jira_url.strip())
+        if parsed.hostname not in ReleaseFromFbcPipeline._JIRA_HOSTS:
+            return ""
+        key = parsed.path.rstrip("/").split("/")[-1]
+        if not ReleaseFromFbcPipeline._JIRA_KEY_RE.match(key):
+            return ""
+        return key
 
     def _update_jira_with_mr_link(self, mr_url: str):
         """Add a remote web link on the release JIRA ticket pointing to the shipment MR.
@@ -975,7 +985,7 @@ class ReleaseFromFbcPipeline:
             jira_client = self.runtime.new_jira_client()
             jira_client.add_remote_link(issue_key, {"title": "Shipment MR", "url": mr_url})
             self.logger.info("Added shipment MR link to JIRA ticket %s", issue_key)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — best-effort; JIRA failures must not block the release
             self.logger.warning("Failed to update JIRA ticket %s with MR link: %s", issue_key, e)
 
     async def update_shipment_data(

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -78,6 +78,9 @@ class ReleaseFromFbcPipeline:
     that were excluded from the main release due to dependency version conflicts.
     """
 
+    _JIRA_KEY_RE = re.compile(r"^[A-Z][A-Z0-9]+-\d+$")
+    _JIRA_HOSTS = {"redhat.atlassian.net"}
+
     def __init__(
         self,
         runtime: Runtime,
@@ -946,8 +949,6 @@ class ReleaseFromFbcPipeline:
                 e,
             )
 
-    _JIRA_KEY_RE = re.compile(r"^[A-Z][A-Z0-9]+-\d+$")
-    _JIRA_HOSTS = {"redhat.atlassian.net", "issues.redhat.com"}
 
     @staticmethod
     def _parse_jira_key(jira_url: str) -> str:

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -621,9 +621,7 @@ class TestReleaseJira(unittest.TestCase):
     @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
     def test_mr_description_includes_jira_when_set(self, mock_cmd):
         mock_cmd.return_value = (0, "None", "")
-        pipeline = self._make_pipeline(
-            dry_run=False, release_jira="https://redhat.atlassian.net/browse/OADP-1234"
-        )
+        pipeline = self._make_pipeline(dry_run=False, release_jira="https://redhat.atlassian.net/browse/OADP-1234")
         pipeline.update_shipment_data = AsyncMock(return_value=True)
 
         mock_source_project = MagicMock()
@@ -665,9 +663,7 @@ class TestReleaseJira(unittest.TestCase):
         self.assertEqual(key, "MTA-999")
 
     def test_update_jira_adds_remote_link(self):
-        pipeline = self._make_pipeline(
-            dry_run=False, release_jira="https://redhat.atlassian.net/browse/OADP-5678"
-        )
+        pipeline = self._make_pipeline(dry_run=False, release_jira="https://redhat.atlassian.net/browse/OADP-5678")
         mock_jira = MagicMock()
         pipeline.runtime.new_jira_client.return_value = mock_jira
 
@@ -679,9 +675,7 @@ class TestReleaseJira(unittest.TestCase):
         )
 
     def test_update_jira_dry_run_skips(self):
-        pipeline = self._make_pipeline(
-            dry_run=True, release_jira="https://redhat.atlassian.net/browse/OADP-5678"
-        )
+        pipeline = self._make_pipeline(dry_run=True, release_jira="https://redhat.atlassian.net/browse/OADP-5678")
 
         pipeline._update_jira_with_mr_link("https://gitlab.example.com/org/repo/-/merge_requests/10")
 
@@ -695,9 +689,7 @@ class TestReleaseJira(unittest.TestCase):
         pipeline.runtime.new_jira_client.assert_not_called()
 
     def test_update_jira_failure_is_nonfatal(self):
-        pipeline = self._make_pipeline(
-            dry_run=False, release_jira="https://redhat.atlassian.net/browse/OADP-5678"
-        )
+        pipeline = self._make_pipeline(dry_run=False, release_jira="https://redhat.atlassian.net/browse/OADP-5678")
         pipeline.runtime.new_jira_client.side_effect = RuntimeError("auth failed")
 
         pipeline._update_jira_with_mr_link("https://gitlab.example.com/org/repo/-/merge_requests/10")

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -586,6 +586,123 @@ class TestExtraImageNvrsValidation(unittest.TestCase):
             self.assertNotIn("FBC builds", str(e))
 
 
+class TestReleaseJira(unittest.TestCase):
+    """Tests for the --release-jira feature: MR description and JIRA link update."""
+
+    def _make_pipeline(self, dry_run=False, release_jira=None):
+        runtime = MagicMock()
+        runtime.dry_run = dry_run
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        runtime.config = {"gitlab_url": "https://gitlab.example.com"}
+
+        pipeline = ReleaseFromFbcPipeline(
+            runtime=runtime,
+            group="oadp-1.4",
+            assembly="1.4.8",
+            fbc_pullspecs=["quay.io/test/fbc:latest"],
+            create_mr=True,
+            release_jira=release_jira,
+        )
+        pipeline.product = "oadp"
+        pipeline.shipment_data_repo = AsyncMock()
+        pipeline.shipment_data_repo_push_url = "https://gitlab.example.com/user/ocp-shipment-data.git"
+        pipeline.shipment_data_repo_pull_url = "https://gitlab.example.com/org/ocp-shipment-data.git"
+        return pipeline
+
+    def test_release_jira_stored(self):
+        pipeline = self._make_pipeline(release_jira="https://redhat.atlassian.net/browse/OADP-1234")
+        self.assertEqual(pipeline.release_jira, "https://redhat.atlassian.net/browse/OADP-1234")
+
+    def test_release_jira_default_none(self):
+        pipeline = self._make_pipeline()
+        self.assertIsNone(pipeline.release_jira)
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_mr_description_includes_jira_when_set(self, mock_cmd):
+        mock_cmd.return_value = (0, "None", "")
+        pipeline = self._make_pipeline(
+            dry_run=False, release_jira="https://redhat.atlassian.net/browse/OADP-1234"
+        )
+        pipeline.update_shipment_data = AsyncMock(return_value=True)
+
+        mock_source_project = MagicMock()
+        mock_mr = MagicMock()
+        mock_mr.web_url = "https://gitlab.example.com/org/repo/-/merge_requests/42"
+        mock_source_project.mergerequests.create.return_value = mock_mr
+        pipeline._get_gitlab_project = MagicMock(return_value=mock_source_project)
+        pipeline.__dict__["_gitlab"] = MagicMock()
+
+        asyncio.run(pipeline.create_shipment_mr({}, env="prod"))
+
+        create_call = mock_source_project.mergerequests.create.call_args[0][0]
+        self.assertIn("Release JIRA: https://redhat.atlassian.net/browse/OADP-1234", create_call["description"])
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_mr_description_excludes_jira_when_none(self, mock_cmd):
+        mock_cmd.return_value = (0, "None", "")
+        pipeline = self._make_pipeline(dry_run=False, release_jira=None)
+        pipeline.update_shipment_data = AsyncMock(return_value=True)
+
+        mock_source_project = MagicMock()
+        mock_mr = MagicMock()
+        mock_mr.web_url = "https://gitlab.example.com/org/repo/-/merge_requests/42"
+        mock_source_project.mergerequests.create.return_value = mock_mr
+        pipeline._get_gitlab_project = MagicMock(return_value=mock_source_project)
+        pipeline.__dict__["_gitlab"] = MagicMock()
+
+        asyncio.run(pipeline.create_shipment_mr({}, env="prod"))
+
+        create_call = mock_source_project.mergerequests.create.call_args[0][0]
+        self.assertNotIn("Release JIRA", create_call["description"])
+
+    def test_parse_jira_key_from_url(self):
+        key = ReleaseFromFbcPipeline._parse_jira_key("https://redhat.atlassian.net/browse/OADP-1234")
+        self.assertEqual(key, "OADP-1234")
+
+    def test_parse_jira_key_trailing_slash(self):
+        key = ReleaseFromFbcPipeline._parse_jira_key("https://redhat.atlassian.net/browse/MTA-999/")
+        self.assertEqual(key, "MTA-999")
+
+    def test_update_jira_adds_remote_link(self):
+        pipeline = self._make_pipeline(
+            dry_run=False, release_jira="https://redhat.atlassian.net/browse/OADP-5678"
+        )
+        mock_jira = MagicMock()
+        pipeline.runtime.new_jira_client.return_value = mock_jira
+
+        pipeline._update_jira_with_mr_link("https://gitlab.example.com/org/repo/-/merge_requests/10")
+
+        mock_jira.add_remote_link.assert_called_once_with(
+            "OADP-5678",
+            {"title": "Shipment MR", "url": "https://gitlab.example.com/org/repo/-/merge_requests/10"},
+        )
+
+    def test_update_jira_dry_run_skips(self):
+        pipeline = self._make_pipeline(
+            dry_run=True, release_jira="https://redhat.atlassian.net/browse/OADP-5678"
+        )
+
+        pipeline._update_jira_with_mr_link("https://gitlab.example.com/org/repo/-/merge_requests/10")
+
+        pipeline.runtime.new_jira_client.assert_not_called()
+
+    def test_update_jira_no_release_jira_skips(self):
+        pipeline = self._make_pipeline(dry_run=False, release_jira=None)
+
+        pipeline._update_jira_with_mr_link("https://gitlab.example.com/org/repo/-/merge_requests/10")
+
+        pipeline.runtime.new_jira_client.assert_not_called()
+
+    def test_update_jira_failure_is_nonfatal(self):
+        pipeline = self._make_pipeline(
+            dry_run=False, release_jira="https://redhat.atlassian.net/browse/OADP-5678"
+        )
+        pipeline.runtime.new_jira_client.side_effect = RuntimeError("auth failed")
+
+        pipeline._update_jira_with_mr_link("https://gitlab.example.com/org/repo/-/merge_requests/10")
+
+
 class TestCliValidation(unittest.TestCase):
     """Test CLI argument validation via CliRunner against the real Click command."""
 

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -588,107 +588,6 @@ class TestExtraImageNvrsValidation(unittest.TestCase):
             self.assertNotIn("FBC builds", str(e))
 
 
-class TestEmbargoedNvrDefensiveCheck(unittest.TestCase):
-    """run() must refuse to release if any embargoed (private-fix) NVR is found, whether it came
-    from an FBC pullspec or from a manual --extra-image-nvrs override."""
-
-    def _make_pipeline(self, extra_image_nvrs=None, fbc_pullspecs=None):
-        runtime = MagicMock()
-        runtime.config = {}
-        runtime.dry_run = False
-        runtime.working_dir = MagicMock()
-        runtime.working_dir.absolute.return_value = MagicMock()
-        pipeline = ReleaseFromFbcPipeline(
-            runtime=runtime,
-            group="oadp-1.5",
-            assembly="1.5.3",
-            fbc_pullspecs=fbc_pullspecs or [],
-            extra_image_nvrs=extra_image_nvrs,
-        )
-        pipeline.check_env_vars = MagicMock()
-        pipeline.setup_working_dir = MagicMock()
-        pipeline._load_product_from_group_config = AsyncMock(return_value="oadp")
-        return pipeline
-
-    def test_embargoed_fbc_nvr_alone_does_not_raise(self):
-        """The FBC (catalog) image's own NVR is excluded from the embargo check: it's just a
-        catalog wrapper and, by construction, never carries a p-flag at all (see build_fbc.py,
-        which tags it with a bare timestamp, e.g.
-        'openshift-migration-operator-fbc-1.8.16-20260715174111.ocp4.19'). Since is_nvr_embargoed()
-        defaults to treating an NVR with no p-flag as embargoed, checking the FBC's own NVR would
-        make this defensive check fail unconditionally on every run - confirm it's excluded."""
-        pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/example/fbc:v1"])
-        pipeline.validate_fbc_related_images = AsyncMock(return_value=[])
-        pipeline.extract_fbc_nvr = MagicMock(return_value="oadp-operator-fbc-1.5.3-20260715174111.ocp4.19")
-        pipeline.create_snapshot = AsyncMock(return_value=MagicMock())
-        pipeline.create_shipment_config = MagicMock(return_value=MagicMock())
-        pipeline.write_shipment_files_locally = AsyncMock()
-
-        asyncio.run(pipeline.run())
-
-    def test_embargoed_related_nvr_raises(self):
-        """An embargoed NVR among the FBC's related images (the actual bundle/operand images
-        referenced inside the catalog) must fail the release."""
-        embargoed_nvr = "oadp-velero-container-1.5.3-202607151200.p3.g172d0b2.assembly.stream.el9"
-        pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/example/fbc:v1"])
-        pipeline.validate_fbc_related_images = AsyncMock(return_value=[embargoed_nvr])
-        pipeline.extract_fbc_nvr = MagicMock(return_value="oadp-operator-fbc-1.5.3-20260715174111.ocp4.19")
-
-        with self.assertRaises(RuntimeError) as ctx:
-            asyncio.run(pipeline.run())
-        self.assertIn("embargoed", str(ctx.exception))
-        self.assertIn(embargoed_nvr, str(ctx.exception))
-
-    def test_ambiguous_nvr_raises(self):
-        """An NVR whose embargo status is ambiguous (matches more than one visibility suffix)
-        must fail the release rather than have is_nvr_embargoed() guess which one applies."""
-        ambiguous_nvr = "oadp-velero-container-1.5.3-202607151200.p2.g172d0b2.assembly.stream.el9.p3"
-        pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/example/fbc:v1"])
-        pipeline.validate_fbc_related_images = AsyncMock(return_value=[ambiguous_nvr])
-        pipeline.extract_fbc_nvr = MagicMock(return_value="oadp-operator-fbc-1.5.3-20260715174111.ocp4.19")
-
-        with self.assertRaises(RuntimeError) as ctx:
-            asyncio.run(pipeline.run())
-        self.assertIn("embargo status", str(ctx.exception))
-
-    def test_embargoed_extra_image_nvr_raises(self):
-        """An embargoed NVR passed via --extra-image-nvrs must fail the release."""
-        embargoed_nvr = "oadp-velero-container-1.5.3-202607151200.p3.g172d0b2.assembly.stream.el9"
-        pipeline = self._make_pipeline(extra_image_nvrs=[embargoed_nvr])
-
-        with self.assertRaises(RuntimeError) as ctx:
-            asyncio.run(pipeline.run())
-        self.assertIn("embargoed", str(ctx.exception))
-        self.assertIn(embargoed_nvr, str(ctx.exception))
-
-    def test_non_embargoed_nvrs_do_not_raise_embargo_error(self):
-        """Public (non-embargoed) NVRs should not trigger the embargo defensive check. The
-        mocked workflow should complete normally, so require the run to fully succeed rather
-        than suppressing any RuntimeError (which would mask unrelated regressions)."""
-        pipeline = self._make_pipeline(
-            extra_image_nvrs=["oadp-velero-container-1.5.3-202607151200.p2.g172d0b2.assembly.stream.el9"]
-        )
-        pipeline.create_snapshot = AsyncMock(return_value=MagicMock())
-        pipeline.create_shipment_config = MagicMock(return_value=MagicMock())
-        pipeline.write_shipment_files_locally = AsyncMock()
-
-        asyncio.run(pipeline.run())
-
-    def test_external_nvrs_skipped_from_embargo_check(self):
-        """External image NVRs (from the prod registry, e.g. postgresql) don't carry p-flags.
-        They must be excluded from the embargo check — is_nvr_embargoed() defaults to True
-        for NVRs without p-flags, which would incorrectly block the release."""
-        external_nvr = "postgresql-15-container-15.14-1.1733837256"
-        pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/example/fbc:v1"])
-        pipeline.validate_fbc_related_images = AsyncMock(return_value=[external_nvr])
-        pipeline.extract_fbc_nvr = MagicMock(return_value="oadp-operator-fbc-1.5.3-20260715174111.ocp4.19")
-        pipeline.create_snapshot = AsyncMock(return_value=MagicMock())
-        pipeline.create_shipment_config = MagicMock(return_value=MagicMock())
-        pipeline.write_shipment_files_locally = AsyncMock()
-
-        asyncio.run(pipeline.run())
-
-
 class TestSetShipmentMrReady(unittest.TestCase):
     """Tests for ReleaseFromFbcPipeline.set_shipment_mr_ready()."""
 
@@ -777,6 +676,115 @@ class TestSetShipmentMrReady(unittest.TestCase):
         mock_gitlab.set_mr_ready.assert_awaited_once_with(pipeline.shipment_mr_url)
         mock_sleep.assert_not_awaited()
         mock_gitlab.trigger_ci_pipeline.assert_not_awaited()
+
+
+class TestReleaseJira(unittest.TestCase):
+    """Tests for the --release-jira feature: MR description and JIRA link update."""
+
+    def _make_pipeline(self, dry_run=False, release_jira=None):
+        runtime = MagicMock()
+        runtime.dry_run = dry_run
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        runtime.config = {"gitlab_url": "https://gitlab.example.com"}
+
+        pipeline = ReleaseFromFbcPipeline(
+            runtime=runtime,
+            group="oadp-1.4",
+            assembly="1.4.8",
+            fbc_pullspecs=["quay.io/test/fbc:latest"],
+            create_mr=True,
+            release_jira=release_jira,
+        )
+        pipeline.product = "oadp"
+        pipeline.shipment_data_repo = AsyncMock()
+        pipeline.shipment_data_repo_push_url = "https://gitlab.example.com/user/ocp-shipment-data.git"
+        pipeline.shipment_data_repo_pull_url = "https://gitlab.example.com/org/ocp-shipment-data.git"
+        return pipeline
+
+    def test_release_jira_stored(self):
+        pipeline = self._make_pipeline(release_jira="https://redhat.atlassian.net/browse/OADP-1234")
+        self.assertEqual(pipeline.release_jira, "https://redhat.atlassian.net/browse/OADP-1234")
+
+    def test_release_jira_default_none(self):
+        pipeline = self._make_pipeline()
+        self.assertIsNone(pipeline.release_jira)
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_mr_description_includes_jira_when_set(self, mock_cmd):
+        mock_cmd.return_value = (0, "None", "")
+        pipeline = self._make_pipeline(dry_run=False, release_jira="https://redhat.atlassian.net/browse/OADP-1234")
+        pipeline.update_shipment_data = AsyncMock(return_value=True)
+
+        mock_source_project = MagicMock()
+        mock_mr = MagicMock()
+        mock_mr.web_url = "https://gitlab.example.com/org/repo/-/merge_requests/42"
+        mock_source_project.mergerequests.create.return_value = mock_mr
+        pipeline._get_gitlab_project = MagicMock(return_value=mock_source_project)
+        pipeline.__dict__["_gitlab"] = MagicMock()
+
+        asyncio.run(pipeline.create_shipment_mr({}, env="prod"))
+
+        create_call = mock_source_project.mergerequests.create.call_args[0][0]
+        self.assertIn("Release JIRA: https://redhat.atlassian.net/browse/OADP-1234", create_call["description"])
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_mr_description_excludes_jira_when_none(self, mock_cmd):
+        mock_cmd.return_value = (0, "None", "")
+        pipeline = self._make_pipeline(dry_run=False, release_jira=None)
+        pipeline.update_shipment_data = AsyncMock(return_value=True)
+
+        mock_source_project = MagicMock()
+        mock_mr = MagicMock()
+        mock_mr.web_url = "https://gitlab.example.com/org/repo/-/merge_requests/42"
+        mock_source_project.mergerequests.create.return_value = mock_mr
+        pipeline._get_gitlab_project = MagicMock(return_value=mock_source_project)
+        pipeline.__dict__["_gitlab"] = MagicMock()
+
+        asyncio.run(pipeline.create_shipment_mr({}, env="prod"))
+
+        create_call = mock_source_project.mergerequests.create.call_args[0][0]
+        self.assertNotIn("Release JIRA", create_call["description"])
+
+    def test_parse_jira_key_from_url(self):
+        key = ReleaseFromFbcPipeline._parse_jira_key("https://redhat.atlassian.net/browse/OADP-1234")
+        self.assertEqual(key, "OADP-1234")
+
+    def test_parse_jira_key_trailing_slash(self):
+        key = ReleaseFromFbcPipeline._parse_jira_key("https://redhat.atlassian.net/browse/MTA-999/")
+        self.assertEqual(key, "MTA-999")
+
+    def test_update_jira_adds_remote_link(self):
+        pipeline = self._make_pipeline(dry_run=False, release_jira="https://redhat.atlassian.net/browse/OADP-5678")
+        mock_jira = MagicMock()
+        pipeline.runtime.new_jira_client.return_value = mock_jira
+
+        pipeline._update_jira_with_mr_link("https://gitlab.example.com/org/repo/-/merge_requests/10")
+
+        mock_jira.add_remote_link.assert_called_once_with(
+            "OADP-5678",
+            {"title": "Shipment MR", "url": "https://gitlab.example.com/org/repo/-/merge_requests/10"},
+        )
+
+    def test_update_jira_dry_run_skips(self):
+        pipeline = self._make_pipeline(dry_run=True, release_jira="https://redhat.atlassian.net/browse/OADP-5678")
+
+        pipeline._update_jira_with_mr_link("https://gitlab.example.com/org/repo/-/merge_requests/10")
+
+        pipeline.runtime.new_jira_client.assert_not_called()
+
+    def test_update_jira_no_release_jira_skips(self):
+        pipeline = self._make_pipeline(dry_run=False, release_jira=None)
+
+        pipeline._update_jira_with_mr_link("https://gitlab.example.com/org/repo/-/merge_requests/10")
+
+        pipeline.runtime.new_jira_client.assert_not_called()
+
+    def test_update_jira_failure_is_nonfatal(self):
+        pipeline = self._make_pipeline(dry_run=False, release_jira="https://redhat.atlassian.net/browse/OADP-5678")
+        pipeline.runtime.new_jira_client.side_effect = RuntimeError("auth failed")
+
+        pipeline._update_jira_with_mr_link("https://gitlab.example.com/org/repo/-/merge_requests/10")
 
 
 class TestCliValidation(unittest.TestCase):

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -754,6 +754,30 @@ class TestReleaseJira(unittest.TestCase):
         key = ReleaseFromFbcPipeline._parse_jira_key("https://redhat.atlassian.net/browse/MTA-999/")
         self.assertEqual(key, "MTA-999")
 
+    def test_parse_jira_key_rejects_unsupported_host(self):
+        key = ReleaseFromFbcPipeline._parse_jira_key("https://evil.example.com/browse/OADP-1234")
+        self.assertEqual(key, "")
+
+    def test_parse_jira_key_rejects_malformed_key(self):
+        key = ReleaseFromFbcPipeline._parse_jira_key("https://redhat.atlassian.net/browse/not-a-key")
+        self.assertEqual(key, "")
+
+    def test_parse_jira_key_rejects_empty_path(self):
+        key = ReleaseFromFbcPipeline._parse_jira_key("https://redhat.atlassian.net/browse/")
+        self.assertEqual(key, "")
+
+    def test_parse_jira_key_rejects_relative_url(self):
+        key = ReleaseFromFbcPipeline._parse_jira_key("/browse/OADP-1234")
+        self.assertEqual(key, "")
+
+    def test_parse_jira_key_handles_whitespace(self):
+        key = ReleaseFromFbcPipeline._parse_jira_key("  https://redhat.atlassian.net/browse/OADP-1234  ")
+        self.assertEqual(key, "OADP-1234")
+
+    def test_parse_jira_key_issues_redhat_com(self):
+        key = ReleaseFromFbcPipeline._parse_jira_key("https://issues.redhat.com/browse/OADP-5678")
+        self.assertEqual(key, "OADP-5678")
+
     def test_update_jira_adds_remote_link(self):
         pipeline = self._make_pipeline(dry_run=False, release_jira="https://redhat.atlassian.net/browse/OADP-5678")
         mock_jira = MagicMock()

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -776,7 +776,7 @@ class TestReleaseJira(unittest.TestCase):
 
     def test_parse_jira_key_issues_redhat_com(self):
         key = ReleaseFromFbcPipeline._parse_jira_key("https://issues.redhat.com/browse/OADP-5678")
-        self.assertEqual(key, "OADP-5678")
+        self.assertEqual(key, "")
 
     def test_update_jira_adds_remote_link(self):
         pipeline = self._make_pipeline(dry_run=False, release_jira="https://redhat.atlassian.net/browse/OADP-5678")

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -778,8 +778,32 @@ class TestReleaseJira(unittest.TestCase):
         key = ReleaseFromFbcPipeline._parse_jira_key("https://issues.redhat.com/browse/OADP-5678")
         self.assertEqual(key, "")
 
+    def test_parse_jira_key_bare_key(self):
+        key = ReleaseFromFbcPipeline._parse_jira_key("OADP-1234")
+        self.assertEqual(key, "OADP-1234")
+
+    def test_parse_jira_key_bare_key_with_whitespace(self):
+        key = ReleaseFromFbcPipeline._parse_jira_key("  MTA-567  ")
+        self.assertEqual(key, "MTA-567")
+
+    def test_parse_jira_key_bare_key_invalid(self):
+        key = ReleaseFromFbcPipeline._parse_jira_key("not-a-key")
+        self.assertEqual(key, "")
+
     def test_update_jira_adds_remote_link(self):
         pipeline = self._make_pipeline(dry_run=False, release_jira="https://redhat.atlassian.net/browse/OADP-5678")
+        mock_jira = MagicMock()
+        pipeline.runtime.new_jira_client.return_value = mock_jira
+
+        pipeline._update_jira_with_mr_link("https://gitlab.example.com/org/repo/-/merge_requests/10")
+
+        mock_jira.add_remote_link.assert_called_once_with(
+            "OADP-5678",
+            {"title": "Shipment MR", "url": "https://gitlab.example.com/org/repo/-/merge_requests/10"},
+        )
+
+    def test_update_jira_adds_remote_link_bare_key(self):
+        pipeline = self._make_pipeline(dry_run=False, release_jira="OADP-5678")
         mock_jira = MagicMock()
         pipeline.runtime.new_jira_client.return_value = mock_jira
 

--- a/pyartcd/tests/test_jira_client.py
+++ b/pyartcd/tests/test_jira_client.py
@@ -29,6 +29,14 @@ class TestJIRAClient(TestCase):
             }
         )
 
+    def test_add_remote_link(self):
+        client = JIRAClient(mock.MagicMock())
+        client.add_remote_link("OADP-1234", {"title": "Shipment MR", "url": "https://gitlab.example.com/mr/1"})
+        client._client.add_remote_link.assert_called_once_with(
+            "OADP-1234",
+            {"object": {"title": "Shipment MR", "url": "https://gitlab.example.com/mr/1"}},
+        )
+
     def test_clone_issue(self):
         source_issue = mock.MagicMock(
             key="FOO-1",

--- a/pyartcd/tests/test_jira_client.py
+++ b/pyartcd/tests/test_jira_client.py
@@ -34,6 +34,14 @@ class TestJIRAClient(TestCase):
             }
         )
 
+    def test_add_remote_link(self):
+        client = JIRAClient(mock.MagicMock())
+        client.add_remote_link("OADP-1234", {"title": "Shipment MR", "url": "https://gitlab.example.com/mr/1"})
+        client._client.add_remote_link.assert_called_once_with(
+            "OADP-1234",
+            {"object": {"title": "Shipment MR", "url": "https://gitlab.example.com/mr/1"}},
+        )
+
     def test_clone_issue(self):
         source_issue = mock.MagicMock(
             key="FOO-1",


### PR DESCRIPTION
Allow associating a JIRA release request ticket with the release-from-fbc job. When provided, the JIRA reference is included in the shipment MR description and a remote web link pointing to the MR is added back to the JIRA ticket.

The `--release-jira` option accepts either a bare JIRA key (e.g. `OADP-1234`) or a full browse URL (e.g. `https://redhat.atlassian.net/browse/OADP-1234`). The MR description always renders a full URL regardless of input format.

- Add `--release-jira` CLI option and thread through pipeline constructor
- Include JIRA reference in shipment MR description
- Add `_update_jira_with_mr_link()` best-effort helper (non-fatal on failure)
- Add `_parse_jira_key()` with strict URL/key validation (host allow-list + regex)
- Add `add_remote_link()` method to JIRAClient
- Add unit tests for all new behavior (20 tests)

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional JIRA issue references to release-from-FBC workflows.
  * Supports bare JIRA issue keys and JIRA browse URLs.
  * Shipment merge request descriptions include canonical JIRA links.
  * Successfully created shipment merge requests are linked to the associated JIRA issue.
  * Added dry-run support for JIRA linking.

* **Bug Fixes**
  * Improved handling of invalid, missing, or unavailable JIRA references without interrupting releases.

* **Tests**
  * Added coverage for JIRA configuration, link creation, parsing, dry runs, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->