### PR TITLE
ART-14860: fix(lockfile): prevent lockfile generation for non-hermetic network modes

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1010,9 +1010,10 @@ class ImageMetadata(Metadata):
         Determines whether lockfile generation is enabled for the current image configuration.
 
         The method checks preconditions in the following order:
-        1. Cachi2 feature must be enabled
-        2. enabled_repos must be defined and not empty
-        3. Lockfile generation overrides:
+        1. Network mode must be "hermetic" (lockfiles only for hermetic builds)
+        2. Cachi2 feature must be enabled
+        3. enabled_repos must be defined and not empty
+        4. Lockfile generation overrides:
            - Image metadata configuration (`self.config.konflux.cachi2.lockfile.enabled`)
            - Group configuration (`self.runtime.group_config.konflux.cachi2.lockfile.enabled`)
         If no override is set, lockfile generation defaults to enabled.
@@ -1020,6 +1021,12 @@ class ImageMetadata(Metadata):
         Returns:
             bool: True if lockfile generation is enabled, False otherwise.
         """
+        # Early network mode check - lockfiles only for hermetic builds
+        network_mode = self.get_konflux_network_mode()
+        if network_mode != "hermetic":
+            self.logger.info(f"Lockfile generation disabled: network mode is '{network_mode}' (requires 'hermetic')")
+            return False
+
         lockfile_enabled = True
 
         # First check: cachi2 must be enabled

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -259,7 +259,10 @@ class TestImageMetadata(unittest.TestCase):
 
         metadata.runtime.group_config.konflux.cachi2.lockfile.enabled = False
 
-        with patch.object(ImageMetadata, "is_cachi2_enabled", return_value=True):
+        with (
+            patch.object(ImageMetadata, "is_cachi2_enabled", return_value=True),
+            patch.object(ImageMetadata, "get_konflux_network_mode", return_value="hermetic"),
+        ):
             result = metadata.is_lockfile_generation_enabled()
         self.assertTrue(result)
         self.logger.info.assert_any_call("Lockfile generation set from metadata config True")
@@ -290,7 +293,10 @@ class TestImageMetadata(unittest.TestCase):
 
         metadata.runtime.group_config.konflux.cachi2.lockfile.enabled = True
 
-        with patch.object(ImageMetadata, "is_cachi2_enabled", return_value=True):
+        with (
+            patch.object(ImageMetadata, "is_cachi2_enabled", return_value=True),
+            patch.object(ImageMetadata, "get_konflux_network_mode", return_value="hermetic"),
+        ):
             result = metadata.is_lockfile_generation_enabled()
         self.assertTrue(result)
         self.logger.info.assert_any_call("Lockfile generation set from group config True")
@@ -321,7 +327,10 @@ class TestImageMetadata(unittest.TestCase):
 
         metadata.runtime.group_config.konflux.cachi2.lockfile.enabled = Missing
 
-        with patch.object(ImageMetadata, "is_cachi2_enabled", return_value=True):
+        with (
+            patch.object(ImageMetadata, "is_cachi2_enabled", return_value=True),
+            patch.object(ImageMetadata, "get_konflux_network_mode", return_value="hermetic"),
+        ):
             result = metadata.is_lockfile_generation_enabled()
         self.assertTrue(result)
 
@@ -354,6 +363,48 @@ class TestImageMetadata(unittest.TestCase):
         with patch.object(ImageMetadata, "is_cachi2_enabled", return_value=Missing):
             result = metadata.is_lockfile_generation_enabled()
         self.assertFalse(result)
+
+    def test_lockfile_enabled_open_network_mode(self):
+        """Test that lockfile generation is disabled for open network mode"""
+        self.logger = MagicMock()
+        metadata = self._create_image_metadata('openshift/test_lockfile')
+
+        mock_config = MagicMock()
+        mock_config.konflux.cachi2.lockfile.enabled = True
+        metadata.config = mock_config
+        metadata.logger = self.logger
+
+        metadata.runtime.group_config.konflux.cachi2.lockfile.enabled = True
+
+        with (
+            patch.object(ImageMetadata, "is_cachi2_enabled", return_value=True),
+            patch.object(ImageMetadata, "get_konflux_network_mode", return_value="open"),
+        ):
+            result = metadata.is_lockfile_generation_enabled()
+        self.assertFalse(result)
+        self.logger.info.assert_any_call("Lockfile generation disabled: network mode is 'open' (requires 'hermetic')")
+
+    def test_lockfile_enabled_internal_only_network_mode(self):
+        """Test that lockfile generation is disabled for internal-only network mode"""
+        self.logger = MagicMock()
+        metadata = self._create_image_metadata('openshift/test_lockfile')
+
+        mock_config = MagicMock()
+        mock_config.konflux.cachi2.lockfile.enabled = True
+        metadata.config = mock_config
+        metadata.logger = self.logger
+
+        metadata.runtime.group_config.konflux.cachi2.lockfile.enabled = True
+
+        with (
+            patch.object(ImageMetadata, "is_cachi2_enabled", return_value=True),
+            patch.object(ImageMetadata, "get_konflux_network_mode", return_value="internal-only"),
+        ):
+            result = metadata.is_lockfile_generation_enabled()
+        self.assertFalse(result)
+        self.logger.info.assert_any_call(
+            "Lockfile generation disabled: network mode is 'internal-only' (requires 'hermetic')"
+        )
 
     def test_get_enabled_repos_with_repos(self):
         """Test get_enabled_repos returns repos that are both globally enabled and in image config"""


### PR DESCRIPTION
## Summary
Fixed the missing network mode awareness in lockfile generation that was causing expensive RPM resolution for non-hermetic builds, significantly improving performance for open network mode builds.

## Problem
**Before:** Lockfiles were generated regardless of network mode, causing performance issues for open builds by triggering unnecessary RPM resolution machinery.

**After:** Lockfiles are only generated for hermetic builds (network_mode == "hermetic"), with fast exit for open/internal-only network modes, eliminating expensive RPM resolution for non-hermetic builds.