### PR TITLE
Match rpm exactly

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -467,16 +467,17 @@ class UpdateGolangPipeline:
                 _LOGGER,
                 exact=True,
             )
-            builder_nvr = list(list(go_nvr_map.values())[0])[0]
-            actual_go_nvr = list(go_nvr_map.keys())[0]
+            actual_go_nvr, _ = next(iter(go_nvr_map.items()))
             expected_go_nvr = el_nvr_map[el_v]
             if actual_go_nvr != expected_go_nvr:
                 _LOGGER.warning(
-                    f"Installed golang rpm for {el_v} is different from the expected one: {actual_go_nvr} != {expected_go_nvr}"
+                    f"Installed golang rpm in {build_record.nvr} is different from the expected one: {actual_go_nvr} != {expected_go_nvr}"
                 )
             else:
-                _LOGGER.info(f"Found existing builder image in Konflux: {builder_nvr} built with {expected_go_nvr}")
-                builder_nvrs[el_v] = builder_nvr
+                _LOGGER.info(
+                    f"Found existing builder image in Konflux: {build_record.nvr} built with {expected_go_nvr}"
+                )
+                builder_nvrs[el_v] = build_record.nvr
         return builder_nvrs
 
     def _get_builder_pullspec(self, parsed_nvr, build_system: str):

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -457,18 +457,26 @@ class UpdateGolangPipeline:
             for el_v, build_record in zip(el_nvr_map, build_records)
             if build_record
         }
-        go_nvr_map = elliottutil.get_golang_container_nvrs_for_konflux_record(found_records.values(), _LOGGER)
-        for builder_go_vr, nvrs in go_nvr_map.items():
-            for el_v, go_nvr in el_nvr_map.items():
-                # Strip RHEL minor version suffix (e.g. el9_5 -> el9) from both sides,
-                # since installed RPMs may have a more specific dist tag than the input NVR
-                normalized_builder = re.sub(r'\.el(\d+)_\d+$', r'.el\1', builder_go_vr)
-                normalized_input = re.sub(r'\.el(\d+)_\d+$', r'.el\1', go_nvr)
-                if normalized_builder in normalized_input:
-                    for nvr in nvrs:
-                        nvr_str = f"{nvr[0]}-{nvr[1]}-{nvr[2]}"
-                        _LOGGER.info(f"Found existing builder image in Konflux: {nvr_str} built with {go_nvr}")
-                        builder_nvrs[el_v] = nvr_str
+
+        # The found builder records until this point, their NVRs contain the go version substring that we are looking for
+        # Sometimes due to misconfiguration, installed golang rpm may be different/incorrect
+        # So ensure that the installed rpm is exactly the one we want
+        for el_v, build_record in found_records.items():
+            go_nvr_map = elliottutil.get_golang_container_nvrs_for_konflux_record(
+                [build_record],
+                _LOGGER,
+                exact=True,
+            )
+            builder_nvr = list(go_nvr_map.values())[0][0]
+            actual_go_nvr = go_nvr_map.keys()[0]
+            expected_go_nvr = el_nvr_map[el_v]
+            if actual_go_nvr != expected_go_nvr:
+                _LOGGER.warning(
+                    f"Installed golang rpm for {el_v} is different from the expected one: {actual_go_nvr} != {expected_go_nvr}"
+                )
+            else:
+                _LOGGER.info(f"Found existing builder image in Konflux: {builder_nvr} built with {expected_go_nvr}")
+                builder_nvrs[el_v] = builder_nvr
         return builder_nvrs
 
     def _get_builder_pullspec(self, parsed_nvr, build_system: str):

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -468,7 +468,7 @@ class UpdateGolangPipeline:
                 exact=True,
             )
             builder_nvr = list(list(go_nvr_map.values())[0])[0]
-            actual_go_nvr = go_nvr_map.keys()[0]
+            actual_go_nvr = list(go_nvr_map.keys())[0]
             expected_go_nvr = el_nvr_map[el_v]
             if actual_go_nvr != expected_go_nvr:
                 _LOGGER.warning(

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -467,7 +467,7 @@ class UpdateGolangPipeline:
                 _LOGGER,
                 exact=True,
             )
-            builder_nvr = list(go_nvr_map.values())[0][0]
+            builder_nvr = list(list(go_nvr_map.values())[0])[0]
             actual_go_nvr = go_nvr_map.keys()[0]
             expected_go_nvr = el_nvr_map[el_v]
             if actual_go_nvr != expected_go_nvr:

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -698,7 +698,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("pyartcd.pipelines.update_golang.elliottutil.get_golang_container_nvrs_for_konflux_record")
     async def test_get_existing_builders_konflux(self, mock_get_golang_nvrs, mock_konflux_db_class):
-        """Test get_existing_builders_konflux for Konflux"""
+        """Test Konflux builder lookup returns the build record NVR on exact RPM match"""
         mock_runtime = Mock(
             dry_run=False,
             working_dir=Path("/tmp/working"),
@@ -720,28 +720,30 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             build_system="konflux",
         )
 
-        # Mock the build record
         mock_build_record = Mock(spec=KonfluxBuildRecord)
+        mock_build_record.nvr = "openshift-golang-builder-v1.20.12-202403212137.el8.g144a3f8"
 
-        # Mock the async generator
         async def mock_search_builds(*_args, **_kwargs):
             yield mock_build_record
 
         mock_db_instance.search_builds_by_fields = Mock(side_effect=mock_search_builds)
 
         mock_get_golang_nvrs.return_value = {
-            "1.20.12-2.el8": [("openshift-golang-builder", "v1.20.12", "202403212137.el8.g144a3f8")]
+            "golang-1.20.12-2.el8": {("ignored-builder", "ignored-version", "ignored-release")}
         }
 
         el_nvr_map = {8: "golang-1.20.12-2.el8"}
         builder_nvrs = await pipeline.get_existing_builders_konflux(el_nvr_map, "1.20.12")
 
-        self.assertEqual(builder_nvrs, {8: "openshift-golang-builder-v1.20.12-202403212137.el8.g144a3f8"})
+        self.assertEqual(builder_nvrs, {8: mock_build_record.nvr})
+        mock_get_golang_nvrs.assert_called_once()
+        self.assertEqual(mock_get_golang_nvrs.call_args.args[0], [mock_build_record])
+        self.assertEqual(mock_get_golang_nvrs.call_args.kwargs, {"exact": True})
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("pyartcd.pipelines.update_golang.elliottutil.get_golang_container_nvrs_for_konflux_record")
     async def test_get_existing_builders_konflux_el_suffix(self, mock_get_golang_nvrs, mock_konflux_db_class):
-        """Test that el9_5 installed RPM matches el9 input NVR"""
+        """Test Konflux builder lookup rejects an installed RPM that differs from the expected NVR"""
         mock_runtime = Mock(
             dry_run=False,
             working_dir=Path("/tmp/working"),
@@ -763,21 +765,21 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         )
 
         mock_build_record = Mock(spec=KonfluxBuildRecord)
+        mock_build_record.nvr = "openshift-golang-builder-v1.25.7-202602170955.g5015a16.el9"
 
         async def mock_search_builds(*_args, **_kwargs):
             yield mock_build_record
 
         mock_db_instance.search_builds_by_fields = Mock(side_effect=mock_search_builds)
 
-        # Installed RPM has el9_5 suffix while input NVR has just el9
         mock_get_golang_nvrs.return_value = {
-            "1.25.7-1.el9_5": [("openshift-golang-builder", "v1.25.7", "202602170955.g5015a16.el9")]
+            "golang-1.25.7-1.el9_5": {("openshift-golang-builder", "v1.25.7", "202602170955.g5015a16.el9")}
         }
 
         el_nvr_map = {9: "golang-1.25.7-1.el9"}
         builder_nvrs = await pipeline.get_existing_builders_konflux(el_nvr_map, "1.25.7")
 
-        self.assertEqual(builder_nvrs, {9: "openshift-golang-builder-v1.25.7-202602170955.g5015a16.el9"})
+        self.assertEqual(builder_nvrs, {})
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_assert_async")


### PR DESCRIPTION
Right now we're doing string matching to match go version, instead do an exact match.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED