### PR TITLE
ART-14323: Add enterprise-contract verification after Konflux image builds

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -44,6 +44,12 @@ class KonfluxBuildOutcome(KonfluxEnum):
         return cls.PENDING
 
 
+class KonfluxECStatus(KonfluxEnum):
+    PASSED = 'passed'
+    FAILED = 'failed'
+    NOT_APPLICABLE = 'n/a'
+
+
 class ArtifactType(KonfluxEnum):
     RPM = 'rpm'
     IMAGE = 'image'
@@ -60,6 +66,7 @@ class KonfluxRecord:
         'record_id',
         'build_id',
         'nvr',
+        'ec_status',
     ]
 
     TABLE_ID = None
@@ -282,6 +289,7 @@ class KonfluxBuildRecord(KonfluxRecord):
         nvr: str = None,
         build_component: str = '',
         build_priority: int = constants.KONFLUX_DEFAULT_BUILD_PRIORITY,
+        ec_status: KonfluxECStatus = KonfluxECStatus.NOT_APPLICABLE,
     ):
         super().__init__(
             name,
@@ -316,6 +324,7 @@ class KonfluxBuildRecord(KonfluxRecord):
         self.embargoed = embargoed
         self.hermetic = hermetic
         self.artifact_type = artifact_type if isinstance(artifact_type, ArtifactType) else ArtifactType(artifact_type)
+        self.ec_status = ec_status if isinstance(ec_status, KonfluxECStatus) else KonfluxECStatus(ec_status)
         self.init_uuids(record_id, build_id, nvr)
 
 

--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -67,6 +67,7 @@ class KonfluxRecord:
         'build_id',
         'nvr',
         'ec_status',
+        'ec_pipeline_url',
     ]
 
     TABLE_ID = None
@@ -290,6 +291,7 @@ class KonfluxBuildRecord(KonfluxRecord):
         build_component: str = '',
         build_priority: int = constants.KONFLUX_DEFAULT_BUILD_PRIORITY,
         ec_status: KonfluxECStatus = KonfluxECStatus.NOT_APPLICABLE,
+        ec_pipeline_url: str = '',
     ):
         super().__init__(
             name,
@@ -325,6 +327,7 @@ class KonfluxBuildRecord(KonfluxRecord):
         self.hermetic = hermetic
         self.artifact_type = artifact_type if isinstance(artifact_type, ArtifactType) else ArtifactType(artifact_type)
         self.ec_status = ec_status if isinstance(ec_status, KonfluxECStatus) else KonfluxECStatus(ec_status)
+        self.ec_pipeline_url = ec_pipeline_url
         self.init_uuids(record_id, build_id, nvr)
 
 

--- a/artcommon/tests/test_konflux_build_record.py
+++ b/artcommon/tests/test_konflux_build_record.py
@@ -1,7 +1,7 @@
 import json
 from unittest import TestCase
 
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord, KonfluxECStatus
 
 
 class TestKonfluxBuild(TestCase):
@@ -59,3 +59,37 @@ class TestKonfluxBuild(TestCase):
 
         build.record_id = 'record_id'
         self.assertEqual(build.generate_build_id(), build_id)
+
+    def test_ec_status_default(self):
+        build = KonfluxBuildRecord()
+        self.assertEqual(build.ec_status, KonfluxECStatus.NOT_APPLICABLE)
+
+    def test_ec_status_serialization(self):
+        build = KonfluxBuildRecord(ec_status=KonfluxECStatus.PASSED)
+        d = build.to_dict()
+        self.assertEqual(d['ec_status'], 'passed')
+
+        build = KonfluxBuildRecord(ec_status=KonfluxECStatus.FAILED)
+        d = build.to_dict()
+        self.assertEqual(d['ec_status'], 'failed')
+
+        build = KonfluxBuildRecord(ec_status=KonfluxECStatus.NOT_APPLICABLE)
+        d = build.to_dict()
+        self.assertEqual(d['ec_status'], 'n/a')
+
+    def test_ec_status_excluded_from_build_id(self):
+        build_1 = KonfluxBuildRecord(ec_status=KonfluxECStatus.NOT_APPLICABLE)
+        build_2 = KonfluxBuildRecord(ec_status=KonfluxECStatus.PASSED)
+        build_3 = KonfluxBuildRecord(ec_status=KonfluxECStatus.FAILED)
+        self.assertEqual(build_1.build_id, build_2.build_id)
+        self.assertEqual(build_1.build_id, build_3.build_id)
+
+    def test_ec_status_string_to_enum_conversion(self):
+        build = KonfluxBuildRecord(ec_status='passed')
+        self.assertEqual(build.ec_status, KonfluxECStatus.PASSED)
+
+        build = KonfluxBuildRecord(ec_status='failed')
+        self.assertEqual(build.ec_status, KonfluxECStatus.FAILED)
+
+        build = KonfluxBuildRecord(ec_status='n/a')
+        self.assertEqual(build.ec_status, KonfluxECStatus.NOT_APPLICABLE)

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -658,6 +658,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             SchemaField('build_component', 'STRING', 'REQUIRED'),
             SchemaField('build_priority', 'INTEGER', 'REQUIRED'),
             SchemaField('ec_status', 'STRING', 'REQUIRED'),
+            SchemaField('ec_pipeline_url', 'STRING', 'REQUIRED'),
         ]
         self.db.bind(KonfluxBuildRecord)
         self.assertEqual(self.db.generate_build_schema(), expected_fields)

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -657,6 +657,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             SchemaField('nvr', 'STRING', 'REQUIRED'),
             SchemaField('build_component', 'STRING', 'REQUIRED'),
             SchemaField('build_priority', 'INTEGER', 'REQUIRED'),
+            SchemaField('ec_status', 'STRING', 'REQUIRED'),
         ]
         self.db.bind(KonfluxBuildRecord)
         self.assertEqual(self.db.generate_build_schema(), expected_fields)

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import hashlib
+import json
 import logging
 import os
 import random
@@ -172,11 +173,13 @@ def _clone_or_update_template_repo(git_url: str, ref: str) -> Path:
 
 
 API_VERSION = "appstudio.redhat.com/v1alpha1"
+API_VERSION_V1BETA2 = "appstudio.redhat.com/v1beta2"
 KIND_SNAPSHOT = "Snapshot"
 KIND_COMPONENT = "Component"
 KIND_APPLICATION = "Application"
 KIND_RELEASE = "Release"
 KIND_RELEASE_PLAN = "ReleasePlan"
+KIND_INTEGRATION_TEST_SCENARIO = "IntegrationTestScenario"
 
 DEFAULT_WAIT_HOURS_RELEASE = 5
 
@@ -558,6 +561,230 @@ class KonfluxClient:
     ) -> resource.ResourceInstance:
         component = self._new_component(name, application, component_name, image_repo, source_url, revision)
         return await self._create_or_replace(component)
+
+    @staticmethod
+    def _new_integration_test_scenario(
+        name: str,
+        application_name: str,
+        application_uid: str,
+        policy_configuration: str,
+        ec_pipeline_url: str = constants.KONFLUX_EC_PIPELINE_GIT_URL,
+        ec_pipeline_revision: str = constants.KONFLUX_EC_PIPELINE_REVISION,
+        ec_pipeline_path: str = constants.KONFLUX_EC_PIPELINE_PATH,
+    ) -> dict:
+        """Create an IntegrationTestScenario manifest for enterprise-contract verification.
+
+        :param name: The name of the ITS resource.
+        :param application_name: The application name.
+        :param application_uid: The UID of the Application resource (for ownerReference).
+        :param policy_configuration: The EC policy configuration (e.g. rhtap-releng-tenant/registry-ocp-art-stage).
+        :param ec_pipeline_url: The git URL for the EC pipeline.
+        :param ec_pipeline_revision: The git revision for the EC pipeline.
+        :param ec_pipeline_path: The path to the EC pipeline in the git repo.
+        :return: The ITS manifest dict.
+        """
+        return {
+            "apiVersion": API_VERSION_V1BETA2,
+            "kind": KIND_INTEGRATION_TEST_SCENARIO,
+            "metadata": {
+                "name": name,
+                "labels": {
+                    "test.appstudio.openshift.io/optional": "true",
+                },
+                "annotations": {
+                    "test.appstudio.openshift.io/kind": "enterprise-contract",
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": API_VERSION,
+                        "kind": KIND_APPLICATION,
+                        "name": application_name,
+                        "uid": application_uid,
+                    }
+                ],
+            },
+            "spec": {
+                "application": application_name,
+                "params": [
+                    {"name": "POLICY_CONFIGURATION", "value": policy_configuration},
+                    {"name": "SINGLE_COMPONENT", "value": "true"},
+                ],
+                "resolverRef": {
+                    "resolver": "git",
+                    "params": [
+                        {"name": "url", "value": ec_pipeline_url},
+                        {"name": "revision", "value": ec_pipeline_revision},
+                        {"name": "pathInRepo", "value": ec_pipeline_path},
+                    ],
+                    "resourceKind": "pipeline",
+                },
+            },
+        }
+
+    async def ensure_integration_test_scenario(
+        self,
+        name: str,
+        application_name: str,
+        policy_configuration: str,
+    ) -> resource.ResourceInstance:
+        """Ensure an IntegrationTestScenario exists for the given application.
+
+        Creates or patches the ITS resource idempotently. Safe for concurrent calls.
+
+        :param name: The name of the ITS resource.
+        :param application_name: The application name.
+        :param policy_configuration: The EC policy configuration.
+        :return: The ITS resource.
+        """
+        app = await self.get_application(application_name, strict=True)
+        application_uid = app.metadata.uid
+
+        its = self._new_integration_test_scenario(
+            name=name,
+            application_name=application_name,
+            application_uid=application_uid,
+            policy_configuration=policy_configuration,
+        )
+        return await self._create_or_patch(its)
+
+    @staticmethod
+    def _new_ec_pipelinerun(
+        generate_name: str,
+        namespace: str,
+        application_name: str,
+        component_name: str,
+        snapshot_json: str,
+        its_name: str,
+        policy_configuration: str,
+        watch_labels: dict,
+        ec_pipeline_url: str = constants.KONFLUX_EC_PIPELINE_GIT_URL,
+        ec_pipeline_revision: str = constants.KONFLUX_EC_PIPELINE_REVISION,
+        ec_pipeline_path: str = constants.KONFLUX_EC_PIPELINE_PATH,
+    ) -> dict:
+        """Create a PipelineRun manifest for enterprise-contract verification.
+
+        :param generate_name: The generateName prefix for the PipelineRun.
+        :param namespace: The namespace for the PipelineRun.
+        :param application_name: The application name.
+        :param component_name: The component name.
+        :param snapshot_json: JSON-encoded snapshot spec for the SNAPSHOT param.
+        :param its_name: The name of the IntegrationTestScenario.
+        :param policy_configuration: The EC policy configuration.
+        :param watch_labels: Labels for the KonfluxWatcher to track this PLR.
+        :param ec_pipeline_url: The git URL for the EC pipeline.
+        :param ec_pipeline_revision: The git revision for the EC pipeline.
+        :param ec_pipeline_path: The path to the EC pipeline in the git repo.
+        :return: The PipelineRun manifest dict.
+        """
+        labels = {
+            "appstudio.openshift.io/application": application_name,
+            "appstudio.openshift.io/component": component_name,
+            "test.appstudio.openshift.io/scenario": its_name,
+        }
+        labels.update(watch_labels)
+
+        return {
+            "apiVersion": "tekton.dev/v1",
+            "kind": "PipelineRun",
+            "metadata": {
+                "generateName": generate_name,
+                "namespace": namespace,
+                "labels": labels,
+                "annotations": {
+                    "test.appstudio.openshift.io/kind": "enterprise-contract",
+                    "art-jenkins-job-url": os.getenv("BUILD_URL", "n/a"),
+                },
+            },
+            "spec": {
+                "pipelineRef": {
+                    "resolver": "git",
+                    "params": [
+                        {"name": "url", "value": ec_pipeline_url},
+                        {"name": "revision", "value": ec_pipeline_revision},
+                        {"name": "pathInRepo", "value": ec_pipeline_path},
+                    ],
+                },
+                "params": [
+                    {"name": "POLICY_CONFIGURATION", "value": policy_configuration},
+                    {"name": "SINGLE_COMPONENT", "value": "true"},
+                    {"name": "SNAPSHOT", "value": snapshot_json},
+                ],
+                "taskRunTemplate": {
+                    "serviceAccountName": f"build-pipeline-{component_name}",
+                },
+                "timeouts": {
+                    "pipeline": "1h",
+                },
+            },
+        }
+
+    async def start_ec_pipeline_run(
+        self,
+        namespace: str,
+        application_name: str,
+        component_name: str,
+        image_pullspec: str,
+        source_url: str,
+        commit_sha: str,
+        its_name: str,
+        policy_configuration: str,
+    ) -> PipelineRunInfo:
+        """Start an enterprise-contract verification PipelineRun.
+
+        :param namespace: The namespace for the PipelineRun.
+        :param application_name: The application name.
+        :param component_name: The component name.
+        :param image_pullspec: The built image pullspec (repo@digest).
+        :param source_url: The source git URL.
+        :param commit_sha: The source commit SHA.
+        :param its_name: The name of the IntegrationTestScenario.
+        :param policy_configuration: The EC policy configuration.
+        :return: The PipelineRunInfo for the created EC PipelineRun.
+        """
+        snapshot_spec = {
+            "application": application_name,
+            "components": [
+                {
+                    "name": component_name,
+                    "containerImage": image_pullspec,
+                    "source": {
+                        "git": {
+                            "url": source_url,
+                            "revision": commit_sha,
+                        }
+                    },
+                }
+            ],
+        }
+        snapshot_json = json.dumps(snapshot_spec)
+
+        watch_labels = get_common_runtime_watcher_labels()
+        generate_name = f"{application_name}-ec-{component_name}-"
+        # K8s names must be <= 253 chars; generateName adds 5 random chars
+        if len(generate_name) > 248:
+            generate_name = generate_name[:248]
+
+        manifest = self._new_ec_pipelinerun(
+            generate_name=generate_name,
+            namespace=namespace,
+            application_name=application_name,
+            component_name=component_name,
+            snapshot_json=snapshot_json,
+            its_name=its_name,
+            policy_configuration=policy_configuration,
+            watch_labels=watch_labels,
+        )
+
+        if self.dry_run:
+            fake_plr = resource.ResourceInstance(self.dyn_client, manifest)
+            fake_plr.metadata.name = f"{component_name}-ec-dry-run"
+            self._logger.warning(f"[DRY RUN] Would have created EC PipelineRun: {fake_plr.metadata.name}")
+            return PipelineRunInfo(fake_plr, {})
+
+        plr = await self._create(manifest, async_req=True)
+        plr_info = PipelineRunInfo(plr, {})
+        self._logger.info(f"Created EC PipelineRun: {self.resource_url(plr.to_dict())}")
+        return plr_info
 
     @staticmethod
     @alru_cache

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -10,6 +10,7 @@ import shutil
 import tempfile
 import threading
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, Sequence, Union, cast
 from urllib.parse import parse_qs, urlparse
@@ -52,6 +53,15 @@ def get_common_runtime_watcher_labels() -> Dict[str, str]:
             # Use nanoseconds since epoch for uniqueness
             _COMMON_RUNTIME_LABEL_VALUE = str(time.time_ns())
         return {_COMMON_RUNTIME_LABEL_KEY: _COMMON_RUNTIME_LABEL_VALUE}
+
+
+@dataclass
+class ECVerificationResult:
+    """Result of an enterprise-contract verification run."""
+
+    ec_status: object  # KonfluxECStatus (imported lazily to avoid circular imports)
+    ec_pipeline_url: str
+    ec_failed: bool
 
 
 class GitHubApiUrlInfo(NamedTuple):
@@ -786,6 +796,74 @@ class KonfluxClient:
         plr_info = PipelineRunInfo(plr, {})
         self._logger.info(f"Created EC PipelineRun: {self.resource_url(plr.to_dict())}")
         return plr_info
+
+    async def verify_enterprise_contract(
+        self,
+        namespace: str,
+        application_name: str,
+        component_name: str,
+        image_pullspec: str,
+        source_url: str,
+        commit_sha: str,
+        ec_policy: str,
+        logger: logging.Logger,
+    ) -> ECVerificationResult:
+        """Run enterprise-contract verification for a built image.
+
+        Ensures an IntegrationTestScenario exists, starts an EC PipelineRun,
+        waits for completion, and returns the result. This is the shared entry
+        point used by image, FBC, and bundle builders.
+        """
+        from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxECStatus
+
+        ec_status = KonfluxECStatus.NOT_APPLICABLE
+        ec_pipeline_url = ''
+        ec_failed = False
+
+        try:
+            policy_suffix = ec_policy.split('/')[-1]
+            its_name = f"{application_name}-ec-{policy_suffix}"
+
+            logger.info("Ensuring IntegrationTestScenario %s exists...", its_name)
+            await self.ensure_integration_test_scenario(
+                name=its_name,
+                application_name=application_name,
+                policy_configuration=ec_policy,
+            )
+
+            logger.info("Starting EC verification PipelineRun...")
+            ec_plr_info = await self.start_ec_pipeline_run(
+                namespace=namespace,
+                application_name=application_name,
+                component_name=component_name,
+                image_pullspec=image_pullspec,
+                source_url=source_url,
+                commit_sha=commit_sha,
+                its_name=its_name,
+                policy_configuration=ec_policy,
+            )
+            ec_plr_name = ec_plr_info.name
+
+            logger.info("Waiting for EC PipelineRun %s to complete...", ec_plr_name)
+            ec_plr_info = await self.wait_for_pipelinerun(ec_plr_name, namespace=namespace)
+
+            ec_pipeline_url = self.resource_url(ec_plr_info.to_dict())
+            ec_condition = ec_plr_info.find_condition('Succeeded')
+            ec_outcome = KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition(ec_condition)
+            if ec_outcome is not KonfluxBuildOutcome.SUCCESS:
+                logger.error("EC verification failed. PLR: %s", ec_pipeline_url)
+                ec_status = KonfluxECStatus.FAILED
+                ec_failed = True
+            else:
+                logger.info("EC verification passed. PLR: %s", ec_pipeline_url)
+                ec_status = KonfluxECStatus.PASSED
+
+        except Exception:
+            logger.exception("EC verification error")
+            ec_status = KonfluxECStatus.FAILED
+            ec_failed = True
+
+        return ECVerificationResult(ec_status=ec_status, ec_pipeline_url=ec_pipeline_url, ec_failed=ec_failed)
 
     @staticmethod
     @alru_cache

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -680,6 +680,7 @@ class KonfluxClient:
             "appstudio.openshift.io/application": application_name,
             "appstudio.openshift.io/component": component_name,
             "test.appstudio.openshift.io/scenario": its_name,
+            "kueue.x-k8s.io/priority-class": "build-priority-2",
         }
         labels.update(watch_labels)
 

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -1590,6 +1590,7 @@ class KonfluxFbcBuilder:
         pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_FBC_BUILD_PLR_TEMPLATE_URL,
         dry_run: bool = False,
         major_minor_override: Optional[Tuple[int, int]] = None,
+        skip_ec_verify: bool = False,
         record_logger: Optional[RecordLogger] = None,
         logger: logging.Logger = LOGGER,
     ):
@@ -1607,6 +1608,7 @@ class KonfluxFbcBuilder:
         self.pipelinerun_template_url = pipelinerun_template_url
         self.dry_run = dry_run
         self.major_minor_override = major_minor_override
+        self.skip_ec_verify = skip_ec_verify
         self.source_git_commits = []
         self._record_logger = record_logger
         self._logger = logger.getChild(self.__class__.__name__)
@@ -1861,10 +1863,43 @@ class KonfluxFbcBuilder:
                         metadata, build_repo, pipelinerun_info, outcome, arches, logger=logger
                     )
 
+                # Run EC verification after a successful FBC build
+                ec_failed = False
+                if outcome is KonfluxBuildOutcome.SUCCESS and not self.skip_ec_verify:
+                    results = pipelinerun_dict.get('status', {}).get('results', [])
+                    image_pullspec = next((r['value'] for r in results if r['name'] == 'IMAGE_URL'), None)
+                    image_digest = next((r['value'] for r in results if r['name'] == 'IMAGE_DIGEST'), None)
+
+                    if image_pullspec and image_digest:
+                        app_name = self.get_application_name(self.group)
+                        component_name = self.get_component_name(self.group, metadata.distgit_key)
+                        image_with_digest = f"{image_pullspec.split(':')[0]}@{image_digest}"
+                        source_url = artlib_util.convert_remote_git_to_https(build_repo.url)
+
+                        ec_result = await self._konflux_client.verify_enterprise_contract(
+                            namespace=self.konflux_namespace,
+                            application_name=app_name,
+                            component_name=component_name,
+                            image_pullspec=image_with_digest,
+                            source_url=source_url,
+                            commit_sha=build_repo.commit_hash,
+                            ec_policy=constants.KONFLUX_FBC_EC_POLICY_CONFIGURATION,
+                            logger=logger,
+                        )
+                        if ec_result.ec_failed:
+                            outcome = KonfluxBuildOutcome.FAILURE
+                            ec_failed = True
+                    else:
+                        logger.warning("Could not extract image pullspec/digest for EC verification")
+                elif outcome is KonfluxBuildOutcome.SUCCESS and self.skip_ec_verify:
+                    logger.info("Skipping EC verification for %s: skip_ec_verify is set", metadata.distgit_key)
+
                 if outcome is not KonfluxBuildOutcome.SUCCESS:
                     error = KonfluxFbcBuildError(
                         f"Konflux image build for {metadata.distgit_key} failed", pipelinerun_name, pipelinerun_dict
                     )
+                    if ec_failed:
+                        break
                 else:
                     error = None
                     metadata.build_status = True

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -17,7 +17,13 @@ from artcommonlib import util as artlib_util
 from artcommonlib.arch_util import go_arch_for_brew_arch
 from artcommonlib.assembly import AssemblyTypes
 from artcommonlib.build_visibility import is_release_embargoed
-from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
+from artcommonlib.konflux.konflux_build_record import (
+    ArtifactType,
+    Engine,
+    KonfluxBuildOutcome,
+    KonfluxBuildRecord,
+    KonfluxECStatus,
+)
 from artcommonlib.model import Missing
 from artcommonlib.oc_image_info import oc_image_info__cached_async
 from artcommonlib.release_util import SoftwareLifecyclePhase, isolate_el_version_in_release, split_el_suffix_in_release
@@ -183,6 +189,7 @@ class KonfluxImageBuilder:
             logger.info(f"Building for arches: {building_arches}")
             error = None
             ec_failed = False
+            ec_status = KonfluxECStatus.NOT_APPLICABLE
             # Resolve build priority based on precedence rules
             if self._config.build_priority == "auto":
                 build_priority = util.get_konflux_build_priority(metadata=metadata, group=self._config.group_name)
@@ -214,6 +221,7 @@ class KonfluxImageBuilder:
                     KonfluxBuildOutcome.PENDING,
                     building_arches,
                     build_priority,
+                    ec_status=KonfluxECStatus.NOT_APPLICABLE,
                 )
 
                 logger.info("Waiting for PipelineRun %s to complete...", pipelinerun_name)
@@ -309,17 +317,20 @@ class KonfluxImageBuilder:
                             )
                             outcome = KonfluxBuildOutcome.FAILURE
                             ec_failed = True
+                            ec_status = KonfluxECStatus.FAILED
                         else:
                             logger.info(
                                 "EC verification passed for %s. PLR: %s",
                                 metadata.distgit_key,
                                 self._konflux_client.resource_url(ec_plr_info.to_dict()),
                             )
+                            ec_status = KonfluxECStatus.PASSED
 
                     except Exception:
                         logger.exception("EC verification error for %s", metadata.distgit_key)
                         outcome = KonfluxBuildOutcome.FAILURE
                         ec_failed = True
+                        ec_status = KonfluxECStatus.FAILED
 
                 elif outcome is KonfluxBuildOutcome.SUCCESS:
                     if self._config.skip_ec_verify:
@@ -344,7 +355,13 @@ class KonfluxImageBuilder:
                 else:
                     # Create a build record after every attempt (both success and failure)
                     build_record = await self.update_konflux_db(
-                        metadata, build_repo, pipelinerun_info, outcome, building_arches, build_priority
+                        metadata,
+                        build_repo,
+                        pipelinerun_info,
+                        outcome,
+                        building_arches,
+                        build_priority,
+                        ec_status=ec_status,
                     )
                     if build_record:
                         record["record_id"] = build_record.record_id
@@ -826,6 +843,7 @@ class KonfluxImageBuilder:
         outcome,
         building_arches,
         build_priority,
+        ec_status=KonfluxECStatus.NOT_APPLICABLE,
     ) -> Optional[KonfluxBuildRecord]:
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
         if not metadata.runtime.konflux_db:
@@ -890,6 +908,7 @@ class KonfluxImageBuilder:
             'pipeline_commit': 'n/a',  # TODO: populate this
             'build_component': build_component,
             'build_priority': int(build_priority),
+            'ec_status': ec_status,
         }
 
         if outcome == KonfluxBuildOutcome.SUCCESS:

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -249,7 +249,12 @@ class KonfluxImageBuilder:
                 # TODO: Expand EC verification to layered products
                 # TODO: Expose EC failure links (ITS/PLR URLs) via Slack notification or dashboard column
                 is_ocp_group = self._config.group_name.startswith("openshift-")
-                if outcome is KonfluxBuildOutcome.SUCCESS and is_ocp_group and not self._config.skip_ec_verify:
+                if (
+                    outcome is KonfluxBuildOutcome.SUCCESS
+                    and is_ocp_group
+                    and not self._config.skip_ec_verify
+                    and metadata.for_release
+                ):
                     try:
                         app_name = self.get_application_name(self._config.group_name)
 
@@ -312,6 +317,23 @@ class KonfluxImageBuilder:
                     except Exception:
                         logger.exception("EC verification error for %s", metadata.distgit_key)
                         outcome = KonfluxBuildOutcome.FAILURE
+
+                elif outcome is KonfluxBuildOutcome.SUCCESS:
+                    if self._config.skip_ec_verify:
+                        logger.info(
+                            "Skipping EC verification for %s: --skip-ec-verify flag is set", metadata.distgit_key
+                        )
+                    elif not is_ocp_group:
+                        logger.info(
+                            "Skipping EC verification for %s: non-OCP group '%s'",
+                            metadata.distgit_key,
+                            self._config.group_name,
+                        )
+                    elif not metadata.for_release:
+                        logger.info(
+                            "Skipping EC verification for %s: image is not for_release (base image or non-release)",
+                            metadata.distgit_key,
+                        )
 
                 if self._config.dry_run:
                     logger.info("Dry run: Would have inserted build record in Konflux DB")

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -62,6 +62,8 @@ class KonfluxImageBuilderConfig:
     skip_checks: bool = False
     dry_run: bool = False
     build_priority: Optional[str] = None
+    ec_policy_configuration: str = constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION
+    skip_ec_verify: bool = False
 
 
 class KonfluxImageBuilder:
@@ -240,6 +242,62 @@ class KonfluxImageBuilder:
                         logger.error(
                             f"Failed to get SLA attestation / source signature from konflux for image {image_pullspec}, marking build as {KonfluxBuildOutcome.FAILURE}. Error: {e}"
                         )
+                        outcome = KonfluxBuildOutcome.FAILURE
+
+                # Run enterprise-contract (EC) verification after a successful build
+                # TODO: Expand EC verification to layered products
+                if outcome is KonfluxBuildOutcome.SUCCESS and not self._config.skip_ec_verify:
+                    try:
+                        app_name = self.get_application_name(self._config.group_name)
+                        its_name = f"{app_name}-ec-registry-ocp-art-stage"
+
+                        logger.info("Ensuring IntegrationTestScenario %s exists...", its_name)
+                        await self._konflux_client.ensure_integration_test_scenario(
+                            name=its_name,
+                            application_name=app_name,
+                            policy_configuration=self._config.ec_policy_configuration,
+                        )
+
+                        image_with_digest = f"{image_pullspec.split(':')[0]}@{image_digest}"
+                        source_url = artlib_util.convert_remote_git_to_https(build_repo.url)
+                        konflux_component_name = self.get_component_name(app_name, metadata.distgit_key)
+
+                        logger.info("Starting EC verification PipelineRun for %s...", metadata.distgit_key)
+                        ec_plr_info = await self._konflux_client.start_ec_pipeline_run(
+                            namespace=self._config.namespace,
+                            application_name=app_name,
+                            component_name=konflux_component_name,
+                            image_pullspec=image_with_digest,
+                            source_url=source_url,
+                            commit_sha=build_repo.commit_hash,
+                            its_name=its_name,
+                            policy_configuration=self._config.ec_policy_configuration,
+                        )
+                        ec_plr_name = ec_plr_info.name
+
+                        logger.info("Waiting for EC PipelineRun %s to complete...", ec_plr_name)
+                        ec_plr_info = await self._konflux_client.wait_for_pipelinerun(
+                            ec_plr_name, namespace=self._config.namespace
+                        )
+
+                        ec_condition = ec_plr_info.find_condition('Succeeded')
+                        ec_outcome = KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition(ec_condition)
+                        if ec_outcome is not KonfluxBuildOutcome.SUCCESS:
+                            logger.error(
+                                "EC verification failed for %s. PLR: %s",
+                                metadata.distgit_key,
+                                self._konflux_client.resource_url(ec_plr_info.to_dict()),
+                            )
+                            outcome = KonfluxBuildOutcome.FAILURE
+                        else:
+                            logger.info(
+                                "EC verification passed for %s. PLR: %s",
+                                metadata.distgit_key,
+                                self._konflux_client.resource_url(ec_plr_info.to_dict()),
+                            )
+
+                    except Exception as e:
+                        logger.error("EC verification error for %s: %s", metadata.distgit_key, e)
                         outcome = KonfluxBuildOutcome.FAILURE
 
                 if self._config.dry_run:

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -190,6 +190,7 @@ class KonfluxImageBuilder:
             error = None
             ec_failed = False
             ec_status = KonfluxECStatus.NOT_APPLICABLE
+            ec_pipeline_url = ''
             # Resolve build priority based on precedence rules
             if self._config.build_priority == "auto":
                 build_priority = util.get_konflux_build_priority(metadata=metadata, group=self._config.group_name)
@@ -307,13 +308,14 @@ class KonfluxImageBuilder:
                             ec_plr_name, namespace=self._config.namespace
                         )
 
+                        ec_pipeline_url = self._konflux_client.resource_url(ec_plr_info.to_dict())
                         ec_condition = ec_plr_info.find_condition('Succeeded')
                         ec_outcome = KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition(ec_condition)
                         if ec_outcome is not KonfluxBuildOutcome.SUCCESS:
                             logger.error(
                                 "EC verification failed for %s. PLR: %s",
                                 metadata.distgit_key,
-                                self._konflux_client.resource_url(ec_plr_info.to_dict()),
+                                ec_pipeline_url,
                             )
                             outcome = KonfluxBuildOutcome.FAILURE
                             ec_failed = True
@@ -322,7 +324,7 @@ class KonfluxImageBuilder:
                             logger.info(
                                 "EC verification passed for %s. PLR: %s",
                                 metadata.distgit_key,
-                                self._konflux_client.resource_url(ec_plr_info.to_dict()),
+                                ec_pipeline_url,
                             )
                             ec_status = KonfluxECStatus.PASSED
 
@@ -362,6 +364,7 @@ class KonfluxImageBuilder:
                         building_arches,
                         build_priority,
                         ec_status=ec_status,
+                        ec_pipeline_url=ec_pipeline_url,
                     )
                     if build_record:
                         record["record_id"] = build_record.record_id
@@ -844,6 +847,7 @@ class KonfluxImageBuilder:
         building_arches,
         build_priority,
         ec_status=KonfluxECStatus.NOT_APPLICABLE,
+        ec_pipeline_url='',
     ) -> Optional[KonfluxBuildRecord]:
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
         if not metadata.runtime.konflux_db:
@@ -909,6 +913,7 @@ class KonfluxImageBuilder:
             'build_component': build_component,
             'build_priority': int(build_priority),
             'ec_status': ec_status,
+            'ec_pipeline_url': ec_pipeline_url,
         }
 
         if outcome == KonfluxBuildOutcome.SUCCESS:

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -182,6 +182,7 @@ class KonfluxImageBuilder:
             building_arches = metadata.get_arches()
             logger.info(f"Building for arches: {building_arches}")
             error = None
+            ec_failed = False
             # Resolve build priority based on precedence rules
             if self._config.build_priority == "auto":
                 build_priority = util.get_konflux_build_priority(metadata=metadata, group=self._config.group_name)
@@ -307,6 +308,7 @@ class KonfluxImageBuilder:
                                 self._konflux_client.resource_url(ec_plr_info.to_dict()),
                             )
                             outcome = KonfluxBuildOutcome.FAILURE
+                            ec_failed = True
                         else:
                             logger.info(
                                 "EC verification passed for %s. PLR: %s",
@@ -317,6 +319,7 @@ class KonfluxImageBuilder:
                     except Exception:
                         logger.exception("EC verification error for %s", metadata.distgit_key)
                         outcome = KonfluxBuildOutcome.FAILURE
+                        ec_failed = True
 
                 elif outcome is KonfluxBuildOutcome.SUCCESS:
                     if self._config.skip_ec_verify:
@@ -361,6 +364,11 @@ class KonfluxImageBuilder:
                         pipelinerun_name,
                         pipelinerun_info.to_dict(),
                     )
+                    if ec_failed:
+                        # EC policy failures are not recoverable by rebuilding -- the image
+                        # artifact is valid but violates policy. Retrying would just rebuild
+                        # the same image and fail EC again, wasting cluster resources.
+                        break
                 else:
                     metadata.build_status = True
                     record["message"] = "Success"

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -259,80 +259,45 @@ class KonfluxImageBuilder:
                 # TODO: Expand EC verification to layered products
                 # TODO: Expose EC failure links (ITS/PLR URLs) via Slack notification or dashboard column
                 is_ocp_group = self._config.group_name.startswith("openshift-")
-                if (
+                should_run_ec = (
                     outcome is KonfluxBuildOutcome.SUCCESS
                     and is_ocp_group
                     and not self._config.skip_ec_verify
-                    and metadata.for_release
-                ):
-                    try:
-                        app_name = self.get_application_name(self._config.group_name)
+                    and (metadata.for_release or metadata.is_base_image())
+                )
+                if should_run_ec:
+                    app_name = self.get_application_name(self._config.group_name)
 
-                        # Select EC policy based on assembly type:
-                        # PREVIEW (preGA) assemblies use a more permissive policy that allows unsigned RPMs.
-                        # Mirrors the logic in prepare_release_konflux.py check_advisory_stage_policy().
-                        if metadata.runtime.assembly_type == AssemblyTypes.PREVIEW:
-                            ec_policy = constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION
-                        else:
-                            ec_policy = self._config.ec_policy_configuration
+                    # Select EC policy based on image type and assembly type:
+                    # - Base images always use the dedicated base-prod policy
+                    # - PREVIEW (preGA) assemblies use a more permissive policy that allows unsigned RPMs
+                    # - All other images use the default stage policy
+                    if metadata.is_base_image():
+                        ec_policy = constants.KONFLUX_BASE_IMAGE_EC_POLICY_CONFIGURATION
+                    elif metadata.runtime.assembly_type == AssemblyTypes.PREVIEW:
+                        ec_policy = constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION
+                    else:
+                        ec_policy = self._config.ec_policy_configuration
 
-                        policy_suffix = ec_policy.split('/')[-1]
-                        its_name = f"{app_name}-ec-{policy_suffix}"
+                    image_with_digest = f"{image_pullspec.split(':')[0]}@{image_digest}"
+                    source_url = artlib_util.convert_remote_git_to_https(build_repo.url)
+                    konflux_component_name = self.get_component_name(app_name, metadata.distgit_key)
 
-                        logger.info("Ensuring IntegrationTestScenario %s exists...", its_name)
-                        await self._konflux_client.ensure_integration_test_scenario(
-                            name=its_name,
-                            application_name=app_name,
-                            policy_configuration=ec_policy,
-                        )
-
-                        image_with_digest = f"{image_pullspec.split(':')[0]}@{image_digest}"
-                        source_url = artlib_util.convert_remote_git_to_https(build_repo.url)
-                        konflux_component_name = self.get_component_name(app_name, metadata.distgit_key)
-
-                        logger.info("Starting EC verification PipelineRun for %s...", metadata.distgit_key)
-                        ec_plr_info = await self._konflux_client.start_ec_pipeline_run(
-                            namespace=self._config.namespace,
-                            application_name=app_name,
-                            component_name=konflux_component_name,
-                            image_pullspec=image_with_digest,
-                            source_url=source_url,
-                            commit_sha=build_repo.commit_hash,
-                            its_name=its_name,
-                            policy_configuration=ec_policy,
-                        )
-                        ec_plr_name = ec_plr_info.name
-
-                        logger.info("Waiting for EC PipelineRun %s to complete...", ec_plr_name)
-                        ec_plr_info = await self._konflux_client.wait_for_pipelinerun(
-                            ec_plr_name, namespace=self._config.namespace
-                        )
-
-                        ec_pipeline_url = self._konflux_client.resource_url(ec_plr_info.to_dict())
-                        ec_condition = ec_plr_info.find_condition('Succeeded')
-                        ec_outcome = KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition(ec_condition)
-                        if ec_outcome is not KonfluxBuildOutcome.SUCCESS:
-                            logger.error(
-                                "EC verification failed for %s. PLR: %s",
-                                metadata.distgit_key,
-                                ec_pipeline_url,
-                            )
-                            outcome = KonfluxBuildOutcome.FAILURE
-                            ec_failed = True
-                            ec_status = KonfluxECStatus.FAILED
-                        else:
-                            logger.info(
-                                "EC verification passed for %s. PLR: %s",
-                                metadata.distgit_key,
-                                ec_pipeline_url,
-                            )
-                            ec_status = KonfluxECStatus.PASSED
-
-                    except Exception:
-                        logger.exception("EC verification error for %s", metadata.distgit_key)
+                    ec_result = await self._konflux_client.verify_enterprise_contract(
+                        namespace=self._config.namespace,
+                        application_name=app_name,
+                        component_name=konflux_component_name,
+                        image_pullspec=image_with_digest,
+                        source_url=source_url,
+                        commit_sha=build_repo.commit_hash,
+                        ec_policy=ec_policy,
+                        logger=logger,
+                    )
+                    ec_status = ec_result.ec_status
+                    ec_pipeline_url = ec_result.ec_pipeline_url
+                    ec_failed = ec_result.ec_failed
+                    if ec_failed:
                         outcome = KonfluxBuildOutcome.FAILURE
-                        ec_failed = True
-                        ec_status = KonfluxECStatus.FAILED
 
                 elif outcome is KonfluxBuildOutcome.SUCCESS:
                     if self._config.skip_ec_verify:
@@ -345,9 +310,9 @@ class KonfluxImageBuilder:
                             metadata.distgit_key,
                             self._config.group_name,
                         )
-                    elif not metadata.for_release:
+                    elif not metadata.for_release and not metadata.is_base_image():
                         logger.info(
-                            "Skipping EC verification for %s: image is not for_release (base image or non-release)",
+                            "Skipping EC verification for %s: image is not for_release and not a base image",
                             metadata.distgit_key,
                         )
 

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -15,6 +15,7 @@ from artcommonlib import bigquery, exectools
 from artcommonlib import constants as artlib_constants
 from artcommonlib import util as artlib_util
 from artcommonlib.arch_util import go_arch_for_brew_arch
+from artcommonlib.assembly import AssemblyTypes
 from artcommonlib.build_visibility import is_release_embargoed
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.model import Missing
@@ -246,17 +247,28 @@ class KonfluxImageBuilder:
 
                 # Run enterprise-contract (EC) verification after a successful build
                 # TODO: Expand EC verification to layered products
+                # TODO: Expose EC failure links (ITS/PLR URLs) via Slack notification or dashboard column
                 is_ocp_group = self._config.group_name.startswith("openshift-")
                 if outcome is KonfluxBuildOutcome.SUCCESS and is_ocp_group and not self._config.skip_ec_verify:
                     try:
                         app_name = self.get_application_name(self._config.group_name)
-                        its_name = f"{app_name}-ec-registry-ocp-art-stage"
+
+                        # Select EC policy based on assembly type:
+                        # PREVIEW (preGA) assemblies use a more permissive policy that allows unsigned RPMs.
+                        # Mirrors the logic in prepare_release_konflux.py check_advisory_stage_policy().
+                        if metadata.runtime.assembly_type == AssemblyTypes.PREVIEW:
+                            ec_policy = constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION
+                        else:
+                            ec_policy = self._config.ec_policy_configuration
+
+                        policy_suffix = ec_policy.split('/')[-1]
+                        its_name = f"{app_name}-ec-{policy_suffix}"
 
                         logger.info("Ensuring IntegrationTestScenario %s exists...", its_name)
                         await self._konflux_client.ensure_integration_test_scenario(
                             name=its_name,
                             application_name=app_name,
-                            policy_configuration=self._config.ec_policy_configuration,
+                            policy_configuration=ec_policy,
                         )
 
                         image_with_digest = f"{image_pullspec.split(':')[0]}@{image_digest}"
@@ -272,7 +284,7 @@ class KonfluxImageBuilder:
                             source_url=source_url,
                             commit_sha=build_repo.commit_hash,
                             its_name=its_name,
-                            policy_configuration=self._config.ec_policy_configuration,
+                            policy_configuration=ec_policy,
                         )
                         ec_plr_name = ec_plr_info.name
 

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -246,7 +246,8 @@ class KonfluxImageBuilder:
 
                 # Run enterprise-contract (EC) verification after a successful build
                 # TODO: Expand EC verification to layered products
-                if outcome is KonfluxBuildOutcome.SUCCESS and not self._config.skip_ec_verify:
+                is_ocp_group = self._config.group_name.startswith("openshift-")
+                if outcome is KonfluxBuildOutcome.SUCCESS and is_ocp_group and not self._config.skip_ec_verify:
                     try:
                         app_name = self.get_application_name(self._config.group_name)
                         its_name = f"{app_name}-ec-registry-ocp-art-stage"
@@ -296,8 +297,8 @@ class KonfluxImageBuilder:
                                 self._konflux_client.resource_url(ec_plr_info.to_dict()),
                             )
 
-                    except Exception as e:
-                        logger.error("EC verification error for %s: %s", metadata.distgit_key, e)
+                    except Exception:
+                        logger.exception("EC verification error for %s", metadata.distgit_key)
                         outcome = KonfluxBuildOutcome.FAILURE
 
                 if self._config.dry_run:

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -12,6 +12,8 @@ from typing import Dict, Optional, Sequence, Tuple, cast
 import aiofiles
 import yaml
 from artcommonlib import exectools
+from artcommonlib import util as artlib_util
+from artcommonlib.assembly import AssemblyTypes
 from artcommonlib.constants import KONFLUX_ART_IMAGES_SHARE
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBuildRecord, KonfluxBundleBuildRecord
 from artcommonlib.konflux.konflux_db import Engine, KonfluxDb
@@ -602,6 +604,8 @@ class KonfluxOlmBundleBuilder:
         skip_checks: bool = False,
         pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_BUNDLE_BUILD_PLR_TEMPLATE_URL,
         dry_run: bool = False,
+        skip_ec_verify: bool = False,
+        assembly_type: Optional[AssemblyTypes] = None,
         record_logger: Optional[RecordLogger] = None,
         logger: logging.Logger = _LOGGER,
     ) -> None:
@@ -617,6 +621,8 @@ class KonfluxOlmBundleBuilder:
         self.skip_checks = skip_checks
         self.pipelinerun_template_url = pipelinerun_template_url
         self.dry_run = dry_run
+        self.skip_ec_verify = skip_ec_verify
+        self.assembly_type = assembly_type
         self._record_logger = record_logger
         self._logger = logger
         self._konflux_client = KonfluxClient.from_kubeconfig(
@@ -740,6 +746,7 @@ class KonfluxOlmBundleBuilder:
                 succeeded_condition = pipelinerun_info.find_condition('Succeeded')
                 outcome = KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition(succeeded_condition)
 
+                ec_failed = False
                 if not self.dry_run:
                     results = pipelinerun_dict.get('status', {}).get('results', [])
                     image_pullspec = next((r['value'] for r in results if r['name'] == 'IMAGE_URL'), None)
@@ -753,6 +760,43 @@ class KonfluxOlmBundleBuilder:
 
                     # Sync the bundle to art-images-share
                     await sync_to_quay(f"{image_pullspec.split(':')[0]}@{image_digest}", KONFLUX_ART_IMAGES_SHARE)
+
+                    # Run EC verification after a successful bundle build
+                    is_ocp_group = self.group.startswith("openshift-")
+                    if outcome is KonfluxBuildOutcome.SUCCESS and is_ocp_group and not self.skip_ec_verify:
+                        app_name = self.get_application_name(metadata.runtime.group)
+                        bundle_name = metadata.get_olm_bundle_short_name()
+                        component_name = self.get_component_name(app_name, bundle_name)
+                        image_with_digest = f"{image_pullspec.split(':')[0]}@{image_digest}"
+                        source_url = artlib_util.convert_remote_git_to_https(bundle_build_repo.url)
+
+                        if self.assembly_type == AssemblyTypes.PREVIEW:
+                            ec_policy = constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION
+                        else:
+                            ec_policy = constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION
+
+                        ec_result = await konflux_client.verify_enterprise_contract(
+                            namespace=self.konflux_namespace,
+                            application_name=app_name,
+                            component_name=component_name,
+                            image_pullspec=image_with_digest,
+                            source_url=source_url,
+                            commit_sha=bundle_build_repo.commit_hash,
+                            ec_policy=ec_policy,
+                            logger=logger,
+                        )
+                        if ec_result.ec_failed:
+                            outcome = KonfluxBuildOutcome.FAILURE
+                            ec_failed = True
+                    elif outcome is KonfluxBuildOutcome.SUCCESS:
+                        if self.skip_ec_verify:
+                            logger.info("Skipping EC verification for %s: skip_ec_verify is set", metadata.distgit_key)
+                        elif not is_ocp_group:
+                            logger.info(
+                                "Skipping EC verification for %s: non-OCP group '%s'",
+                                metadata.distgit_key,
+                                self.group,
+                            )
 
                     # Update the Konflux DB with the final outcome
                     await self._update_konflux_db(
@@ -774,6 +818,8 @@ class KonfluxOlmBundleBuilder:
                         pipelinerun_dict,
                     )
                     logger.error(f"{error}: {url}")
+                    if ec_failed:
+                        break
                 else:
                     error = None
                     record["message"] = "Success"

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -219,6 +219,7 @@ class KonfluxBuildCli:
         dry_run: bool,
         plr_template: str,
         build_priority: Optional[str],
+        skip_ec_verify: bool = False,
     ):
         self.runtime = runtime
         self.konflux_kubeconfig = konflux_kubeconfig
@@ -230,6 +231,7 @@ class KonfluxBuildCli:
         self.dry_run = dry_run
         self.plr_template = plr_template
         self.build_priority = build_priority
+        self.skip_ec_verify = skip_ec_verify
 
         validate_build_priority(self.build_priority)
 
@@ -267,6 +269,7 @@ class KonfluxBuildCli:
             dry_run=self.dry_run,
             plr_template=self.plr_template,
             build_priority=self.build_priority,
+            skip_ec_verify=self.skip_ec_verify,
         )
         builder = KonfluxImageBuilder(config=config, record_logger=runtime.record_logger)
         tasks = []
@@ -322,6 +325,12 @@ class KonfluxBuildCli:
     type=click.Choice(['hermetic', 'internal-only', 'open']),
     help='Override network mode for Konflux builds. Takes precedence over image and group config settings.',
 )
+@click.option(
+    '--skip-ec-verify',
+    default=False,
+    is_flag=True,
+    help='Skip enterprise-contract verification after builds.',
+)
 @pass_runtime
 @click_coroutine
 async def images_konflux_build(
@@ -335,6 +344,7 @@ async def images_konflux_build(
     plr_template: str,
     build_priority: Optional[str],
     network_mode: Optional[str],
+    skip_ec_verify: bool,
 ):
     if network_mode:
         runtime.network_mode_override = network_mode
@@ -350,6 +360,7 @@ async def images_konflux_build(
         dry_run=dry_run,
         plr_template=plr_template,
         build_priority=build_priority,
+        skip_ec_verify=skip_ec_verify,
     )
     await cli.run()
 

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -540,6 +540,7 @@ class KonfluxBundleCli:
             skip_checks=self.skip_checks,
             pipelinerun_template_url=self.plr_template,
             dry_run=self.dry_run,
+            assembly_type=runtime.assembly_type,
             record_logger=runtime.record_logger,
         )
 

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -62,3 +62,8 @@ KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-
 # PreGA (PREVIEW assembly) EC policy: same as stage but allows unsigned RPMs
 # https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/kflux-ocp-p01.7ayg.p1/product/EnterpriseContractPolicy/registry-ocp-art-ec-stage.yaml
 KONFLUX_PREGA_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-ec-stage"
+# Base image EC policy (base_only images use a dedicated prod policy for all assembly types)
+# https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/kflux-ocp-p01.7ayg.p1/product/EnterpriseContractPolicy/registry-ocp-art-base-prod.yaml
+KONFLUX_BASE_IMAGE_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-base-prod"
+# FBC (File-Based Catalog) EC policy
+KONFLUX_FBC_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/fbc-ocp-art-stage"

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -51,3 +51,11 @@ REGISTRY_PROXY_BASE_URL = "registry-proxy.engineering.redhat.com"
 BREW_REGISTRY_BASE_URL = "brew.registry.redhat.io"
 
 ART_BUILD_HISTORY_URL = 'https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com'
+
+# Enterprise Contract (EC) verification pipeline constants
+# TODO: Expand EC verification to layered products (logging, oadp, mta, rhmtc, quay, cert-manager, etc.)
+# Currently scoped to OCP only.
+KONFLUX_EC_PIPELINE_GIT_URL = "https://github.com/konflux-ci/build-definitions"
+KONFLUX_EC_PIPELINE_REVISION = "main"
+KONFLUX_EC_PIPELINE_PATH = "pipelines/enterprise-contract.yaml"
+KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-stage"

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -59,3 +59,6 @@ KONFLUX_EC_PIPELINE_GIT_URL = "https://github.com/konflux-ci/build-definitions"
 KONFLUX_EC_PIPELINE_REVISION = "main"
 KONFLUX_EC_PIPELINE_PATH = "pipelines/enterprise-contract.yaml"
 KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-stage"
+# PreGA (PREVIEW assembly) EC policy: same as stage but allows unsigned RPMs
+# https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/kflux-ocp-p01.7ayg.p1/product/EnterpriseContractPolicy/registry-ocp-art-ec-stage.yaml
+KONFLUX_PREGA_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-ec-stage"

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -174,6 +174,7 @@ class TestNewEcPipelinerun(TestCase):
         self.assertEqual(labels["appstudio.openshift.io/application"], "openshift-4-21")
         self.assertEqual(labels["appstudio.openshift.io/component"], "ose-4-21-openshift-apiserver")
         self.assertEqual(labels["test.appstudio.openshift.io/scenario"], "openshift-4-21-ec-registry-ocp-art-stage")
+        self.assertEqual(labels["kueue.x-k8s.io/priority-class"], "build-priority-2")
         self.assertEqual(labels["doozer-watch-id"], "12345")
 
         # annotations

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -138,6 +138,22 @@ class TestNewIntegrationTestScenario(TestCase):
         self.assertEqual(resolver_params["pathInRepo"], "pipelines/enterprise-contract.yaml")
 
 
+class TestNewIntegrationTestScenarioPreGA(TestCase):
+    """Test that preGA (PREVIEW) assemblies use the ec-stage policy."""
+
+    def test_prega_policy_manifest(self):
+        manifest = KonfluxClient._new_integration_test_scenario(
+            name="openshift-4-22-ec-registry-ocp-art-ec-stage",
+            application_name="openshift-4-22",
+            application_uid="test-uid-prega",
+            policy_configuration="rhtap-releng-tenant/registry-ocp-art-ec-stage",
+        )
+
+        self.assertEqual(manifest["metadata"]["name"], "openshift-4-22-ec-registry-ocp-art-ec-stage")
+        params = {p["name"]: p["value"] for p in manifest["spec"]["params"]}
+        self.assertEqual(params["POLICY_CONFIGURATION"], "rhtap-releng-tenant/registry-ocp-art-ec-stage")
+
+
 class TestNewEcPipelinerun(TestCase):
     def test_manifest_structure(self):
         snapshot_spec = {

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -1,12 +1,15 @@
 import json
+import logging
 from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from artcommonlib.konflux.konflux_build_record import KonfluxECStatus
 from doozerlib.backend.konflux_client import (
     API_VERSION,
     API_VERSION_V1BETA2,
     KIND_APPLICATION,
     KIND_INTEGRATION_TEST_SCENARIO,
+    ECVerificationResult,
     GitHubApiUrlInfo,
     KonfluxClient,
     parse_github_api_url,
@@ -395,3 +398,135 @@ class TestEnsureIntegrationTestScenarioNotFound(IsolatedAsyncioTestCase):
                 application_name="nonexistent-app",
                 policy_configuration="test-policy",
             )
+
+
+class TestVerifyEnterpriseContract(IsolatedAsyncioTestCase):
+    def _make_client_with_ec_result(self, is_success: bool):
+        """Create a mocked KonfluxClient that returns the given EC outcome."""
+        from artcommonlib.util import KubeCondition
+
+        client = MagicMock(spec=KonfluxClient)
+        client.ensure_integration_test_scenario = AsyncMock()
+
+        ec_plr_mock = MagicMock()
+        ec_plr_mock.name = "test-ec-plr"
+        client.start_ec_pipeline_run = AsyncMock(return_value=ec_plr_mock)
+
+        condition = KubeCondition(
+            {
+                'type': 'Succeeded',
+                'status': 'True' if is_success else 'False',
+                'reason': 'Succeeded' if is_success else 'Failed',
+                'message': '',
+            }
+        )
+        waited_plr = MagicMock()
+        waited_plr.find_condition.return_value = condition
+        waited_plr.to_dict.return_value = {"metadata": {"name": "test-ec-plr"}}
+        client.wait_for_pipelinerun = AsyncMock(return_value=waited_plr)
+        client.resource_url = MagicMock(return_value="https://example.com/plr/test")
+        return client
+
+    async def test_ec_passed(self):
+        client = self._make_client_with_ec_result(is_success=True)
+
+        result = await KonfluxClient.verify_enterprise_contract(
+            client,
+            namespace="ocp-art-tenant",
+            application_name="openshift-4-21",
+            component_name="ose-4-21-openshift-apiserver",
+            image_pullspec="quay.io/repo@sha256:abc123",
+            source_url="https://github.com/org/repo",
+            commit_sha="deadbeef",
+            ec_policy="rhtap-releng-tenant/registry-ocp-art-stage",
+            logger=logging.getLogger("test"),
+        )
+
+        self.assertIsInstance(result, ECVerificationResult)
+        self.assertEqual(result.ec_status, KonfluxECStatus.PASSED)
+        self.assertFalse(result.ec_failed)
+        self.assertEqual(result.ec_pipeline_url, "https://example.com/plr/test")
+        client.ensure_integration_test_scenario.assert_called_once_with(
+            name="openshift-4-21-ec-registry-ocp-art-stage",
+            application_name="openshift-4-21",
+            policy_configuration="rhtap-releng-tenant/registry-ocp-art-stage",
+        )
+
+    async def test_ec_failed(self):
+        client = self._make_client_with_ec_result(is_success=False)
+
+        result = await KonfluxClient.verify_enterprise_contract(
+            client,
+            namespace="ocp-art-tenant",
+            application_name="openshift-4-21",
+            component_name="ose-4-21-openshift-apiserver",
+            image_pullspec="quay.io/repo@sha256:abc123",
+            source_url="https://github.com/org/repo",
+            commit_sha="deadbeef",
+            ec_policy="rhtap-releng-tenant/registry-ocp-art-stage",
+            logger=logging.getLogger("test"),
+        )
+
+        self.assertEqual(result.ec_status, KonfluxECStatus.FAILED)
+        self.assertTrue(result.ec_failed)
+
+    async def test_ec_exception_returns_failed(self):
+        client = MagicMock(spec=KonfluxClient)
+        client.ensure_integration_test_scenario = AsyncMock(side_effect=RuntimeError("connection error"))
+
+        result = await KonfluxClient.verify_enterprise_contract(
+            client,
+            namespace="ocp-art-tenant",
+            application_name="openshift-4-21",
+            component_name="ose-4-21-openshift-apiserver",
+            image_pullspec="quay.io/repo@sha256:abc123",
+            source_url="https://github.com/org/repo",
+            commit_sha="deadbeef",
+            ec_policy="rhtap-releng-tenant/registry-ocp-art-stage",
+            logger=logging.getLogger("test"),
+        )
+
+        self.assertEqual(result.ec_status, KonfluxECStatus.FAILED)
+        self.assertTrue(result.ec_failed)
+
+    async def test_its_name_derived_from_fbc_policy(self):
+        client = self._make_client_with_ec_result(is_success=True)
+
+        await KonfluxClient.verify_enterprise_contract(
+            client,
+            namespace="ns",
+            application_name="fbc-openshift-4-21",
+            component_name="comp",
+            image_pullspec="quay.io/repo@sha256:abc",
+            source_url="https://github.com/org/repo",
+            commit_sha="abc",
+            ec_policy="rhtap-releng-tenant/fbc-ocp-art-stage",
+            logger=logging.getLogger("test"),
+        )
+
+        client.ensure_integration_test_scenario.assert_called_once_with(
+            name="fbc-openshift-4-21-ec-fbc-ocp-art-stage",
+            application_name="fbc-openshift-4-21",
+            policy_configuration="rhtap-releng-tenant/fbc-ocp-art-stage",
+        )
+
+    async def test_its_name_derived_from_base_image_policy(self):
+        client = self._make_client_with_ec_result(is_success=True)
+
+        await KonfluxClient.verify_enterprise_contract(
+            client,
+            namespace="ns",
+            application_name="openshift-4-21",
+            component_name="comp",
+            image_pullspec="quay.io/repo@sha256:abc",
+            source_url="https://github.com/org/repo",
+            commit_sha="abc",
+            ec_policy="rhtap-releng-tenant/registry-ocp-art-base-prod",
+            logger=logging.getLogger("test"),
+        )
+
+        client.ensure_integration_test_scenario.assert_called_once_with(
+            name="openshift-4-21-ec-registry-ocp-art-base-prod",
+            application_name="openshift-4-21",
+            policy_configuration="rhtap-releng-tenant/registry-ocp-art-base-prod",
+        )

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -1,7 +1,16 @@
-from unittest import TestCase
-from unittest.mock import patch
+import json
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from doozerlib.backend.konflux_client import GitHubApiUrlInfo, KonfluxClient, parse_github_api_url
+from doozerlib.backend.konflux_client import (
+    API_VERSION,
+    API_VERSION_V1BETA2,
+    KIND_APPLICATION,
+    KIND_INTEGRATION_TEST_SCENARIO,
+    GitHubApiUrlInfo,
+    KonfluxClient,
+    parse_github_api_url,
+)
 
 
 class TestResourceUrl(TestCase):
@@ -88,3 +97,284 @@ class TestParseGitHubApiUrl(TestCase):
         self.assertEqual(result[1], "repo")  # repo
         self.assertEqual(result[2], "file.yaml")  # file_path
         self.assertEqual(result[3], "main")  # ref
+
+
+class TestNewIntegrationTestScenario(TestCase):
+    def test_manifest_structure(self):
+        manifest = KonfluxClient._new_integration_test_scenario(
+            name="openshift-4-21-ec-registry-ocp-art-stage",
+            application_name="openshift-4-21",
+            application_uid="test-uid-1234",
+            policy_configuration="rhtap-releng-tenant/registry-ocp-art-stage",
+        )
+
+        self.assertEqual(manifest["apiVersion"], API_VERSION_V1BETA2)
+        self.assertEqual(manifest["kind"], KIND_INTEGRATION_TEST_SCENARIO)
+        self.assertEqual(manifest["metadata"]["name"], "openshift-4-21-ec-registry-ocp-art-stage")
+        self.assertEqual(manifest["metadata"]["labels"]["test.appstudio.openshift.io/optional"], "true")
+        self.assertEqual(manifest["metadata"]["annotations"]["test.appstudio.openshift.io/kind"], "enterprise-contract")
+
+        # ownerReferences
+        owner_refs = manifest["metadata"]["ownerReferences"]
+        self.assertEqual(len(owner_refs), 1)
+        self.assertEqual(owner_refs[0]["apiVersion"], API_VERSION)
+        self.assertEqual(owner_refs[0]["kind"], KIND_APPLICATION)
+        self.assertEqual(owner_refs[0]["name"], "openshift-4-21")
+        self.assertEqual(owner_refs[0]["uid"], "test-uid-1234")
+
+        # spec
+        self.assertEqual(manifest["spec"]["application"], "openshift-4-21")
+        params = {p["name"]: p["value"] for p in manifest["spec"]["params"]}
+        self.assertEqual(params["POLICY_CONFIGURATION"], "rhtap-releng-tenant/registry-ocp-art-stage")
+        self.assertEqual(params["SINGLE_COMPONENT"], "true")
+
+        # resolverRef
+        resolver_ref = manifest["spec"]["resolverRef"]
+        self.assertEqual(resolver_ref["resolver"], "git")
+        self.assertEqual(resolver_ref["resourceKind"], "pipeline")
+        resolver_params = {p["name"]: p["value"] for p in resolver_ref["params"]}
+        self.assertEqual(resolver_params["url"], "https://github.com/konflux-ci/build-definitions")
+        self.assertEqual(resolver_params["revision"], "main")
+        self.assertEqual(resolver_params["pathInRepo"], "pipelines/enterprise-contract.yaml")
+
+
+class TestNewEcPipelinerun(TestCase):
+    def test_manifest_structure(self):
+        snapshot_spec = {
+            "application": "openshift-4-21",
+            "components": [
+                {
+                    "name": "ose-4-21-openshift-apiserver",
+                    "containerImage": "quay.io/repo@sha256:abc123",
+                    "source": {"git": {"url": "https://github.com/org/repo", "revision": "deadbeef"}},
+                }
+            ],
+        }
+        snapshot_json = json.dumps(snapshot_spec)
+        watch_labels = {"doozer-watch-id": "12345"}
+
+        manifest = KonfluxClient._new_ec_pipelinerun(
+            generate_name="openshift-4-21-ec-ose-4-21-openshift-apiserver-",
+            namespace="ocp-art-tenant",
+            application_name="openshift-4-21",
+            component_name="ose-4-21-openshift-apiserver",
+            snapshot_json=snapshot_json,
+            its_name="openshift-4-21-ec-registry-ocp-art-stage",
+            policy_configuration="rhtap-releng-tenant/registry-ocp-art-stage",
+            watch_labels=watch_labels,
+        )
+
+        self.assertEqual(manifest["apiVersion"], "tekton.dev/v1")
+        self.assertEqual(manifest["kind"], "PipelineRun")
+        self.assertEqual(manifest["metadata"]["generateName"], "openshift-4-21-ec-ose-4-21-openshift-apiserver-")
+        self.assertEqual(manifest["metadata"]["namespace"], "ocp-art-tenant")
+
+        # labels
+        labels = manifest["metadata"]["labels"]
+        self.assertEqual(labels["appstudio.openshift.io/application"], "openshift-4-21")
+        self.assertEqual(labels["appstudio.openshift.io/component"], "ose-4-21-openshift-apiserver")
+        self.assertEqual(labels["test.appstudio.openshift.io/scenario"], "openshift-4-21-ec-registry-ocp-art-stage")
+        self.assertEqual(labels["doozer-watch-id"], "12345")
+
+        # annotations
+        self.assertEqual(manifest["metadata"]["annotations"]["test.appstudio.openshift.io/kind"], "enterprise-contract")
+        self.assertIn("art-jenkins-job-url", manifest["metadata"]["annotations"])
+
+        # pipelineRef
+        pipeline_ref = manifest["spec"]["pipelineRef"]
+        self.assertEqual(pipeline_ref["resolver"], "git")
+        ref_params = {p["name"]: p["value"] for p in pipeline_ref["params"]}
+        self.assertEqual(ref_params["url"], "https://github.com/konflux-ci/build-definitions")
+        self.assertEqual(ref_params["pathInRepo"], "pipelines/enterprise-contract.yaml")
+
+        # params
+        params = {p["name"]: p["value"] for p in manifest["spec"]["params"]}
+        self.assertEqual(params["POLICY_CONFIGURATION"], "rhtap-releng-tenant/registry-ocp-art-stage")
+        self.assertEqual(params["SINGLE_COMPONENT"], "true")
+        parsed_snapshot = json.loads(params["SNAPSHOT"])
+        self.assertEqual(parsed_snapshot["application"], "openshift-4-21")
+        self.assertEqual(len(parsed_snapshot["components"]), 1)
+        self.assertEqual(parsed_snapshot["components"][0]["name"], "ose-4-21-openshift-apiserver")
+
+        # timeouts
+        self.assertEqual(manifest["spec"]["timeouts"]["pipeline"], "1h")
+
+
+class TestEnsureIntegrationTestScenario(IsolatedAsyncioTestCase):
+    async def test_creates_its_with_application_uid(self):
+        client = MagicMock(spec=KonfluxClient)
+        client.get_application = AsyncMock()
+        client.get_application.return_value = MagicMock()
+        client.get_application.return_value.metadata.uid = "app-uid-5678"
+        client._create_or_patch = AsyncMock()
+        client._create_or_patch.return_value = MagicMock()
+        # Ensure the static method is not mocked away
+        client._new_integration_test_scenario = KonfluxClient._new_integration_test_scenario
+
+        # Call the real method with mocked self
+        await KonfluxClient.ensure_integration_test_scenario(
+            client,
+            name="openshift-4-21-ec-registry-ocp-art-stage",
+            application_name="openshift-4-21",
+            policy_configuration="rhtap-releng-tenant/registry-ocp-art-stage",
+        )
+
+        client.get_application.assert_called_once_with("openshift-4-21", strict=True)
+        client._create_or_patch.assert_called_once()
+        manifest = client._create_or_patch.call_args[0][0]
+        self.assertEqual(manifest["metadata"]["ownerReferences"][0]["uid"], "app-uid-5678")
+        self.assertEqual(manifest["spec"]["application"], "openshift-4-21")
+
+
+class TestStartEcPipelineRun(IsolatedAsyncioTestCase):
+    @patch("doozerlib.backend.konflux_client.get_common_runtime_watcher_labels", return_value={"doozer-watch-id": "99"})
+    async def test_dry_run_returns_fake_plr(self, _mock_labels):
+        client = MagicMock(spec=KonfluxClient)
+        client.dry_run = True
+        client.dyn_client = MagicMock()
+        client._logger = MagicMock()
+        # Ensure the static method is not mocked away
+        client._new_ec_pipelinerun = KonfluxClient._new_ec_pipelinerun
+
+        result = await KonfluxClient.start_ec_pipeline_run(
+            client,
+            namespace="ocp-art-tenant",
+            application_name="openshift-4-21",
+            component_name="ose-4-21-openshift-apiserver",
+            image_pullspec="quay.io/repo@sha256:abc123",
+            source_url="https://github.com/org/repo",
+            commit_sha="deadbeef",
+            its_name="openshift-4-21-ec-registry-ocp-art-stage",
+            policy_configuration="rhtap-releng-tenant/registry-ocp-art-stage",
+        )
+
+        self.assertEqual(result.name, "ose-4-21-openshift-apiserver-ec-dry-run")
+
+    @patch("doozerlib.backend.konflux_client.get_common_runtime_watcher_labels", return_value={"doozer-watch-id": "99"})
+    async def test_non_dry_run_creates_plr(self, _mock_labels):
+        client = MagicMock(spec=KonfluxClient)
+        client.dry_run = False
+        client._logger = MagicMock()
+        client._new_ec_pipelinerun = KonfluxClient._new_ec_pipelinerun
+
+        mock_plr = MagicMock()
+        mock_plr.to_dict.return_value = {
+            "kind": "PipelineRun",
+            "metadata": {
+                "name": "openshift-4-21-ec-ose-4-21-openshift-apiserver-abc12",
+                "namespace": "ocp-art-tenant",
+                "labels": {"appstudio.openshift.io/application": "openshift-4-21"},
+            },
+        }
+        client._create = AsyncMock(return_value=mock_plr)
+        client.resource_url = KonfluxClient.resource_url
+
+        result = await KonfluxClient.start_ec_pipeline_run(
+            client,
+            namespace="ocp-art-tenant",
+            application_name="openshift-4-21",
+            component_name="ose-4-21-openshift-apiserver",
+            image_pullspec="quay.io/repo@sha256:abc123",
+            source_url="https://github.com/org/repo",
+            commit_sha="deadbeef",
+            its_name="openshift-4-21-ec-registry-ocp-art-stage",
+            policy_configuration="rhtap-releng-tenant/registry-ocp-art-stage",
+        )
+
+        client._create.assert_called_once()
+        self.assertEqual(result.name, "openshift-4-21-ec-ose-4-21-openshift-apiserver-abc12")
+
+        # Verify the manifest includes the correct serviceAccountName
+        manifest = client._create.call_args[0][0]
+        self.assertEqual(
+            manifest["spec"]["taskRunTemplate"]["serviceAccountName"],
+            "build-pipeline-ose-4-21-openshift-apiserver",
+        )
+
+    @patch("doozerlib.backend.konflux_client.get_common_runtime_watcher_labels", return_value={"doozer-watch-id": "99"})
+    async def test_generate_name_truncation(self, _mock_labels):
+        client = MagicMock(spec=KonfluxClient)
+        client.dry_run = True
+        client.dyn_client = MagicMock()
+        client._logger = MagicMock()
+
+        captured_kwargs = {}
+        real_method = KonfluxClient._new_ec_pipelinerun
+
+        def spy_new_ec_pipelinerun(**kwargs):
+            captured_kwargs.update(kwargs)
+            return real_method(**kwargs)
+
+        client._new_ec_pipelinerun = spy_new_ec_pipelinerun
+
+        long_app_name = "a" * 150
+        long_component_name = "b" * 150
+
+        await KonfluxClient.start_ec_pipeline_run(
+            client,
+            namespace="ocp-art-tenant",
+            application_name=long_app_name,
+            component_name=long_component_name,
+            image_pullspec="quay.io/repo@sha256:abc123",
+            source_url="https://github.com/org/repo",
+            commit_sha="deadbeef",
+            its_name="test-its",
+            policy_configuration="test-policy",
+        )
+
+        self.assertLessEqual(len(captured_kwargs["generate_name"]), 248)
+
+    @patch("doozerlib.backend.konflux_client.get_common_runtime_watcher_labels", return_value={"doozer-watch-id": "99"})
+    async def test_snapshot_json_structure(self, _mock_labels):
+        client = MagicMock(spec=KonfluxClient)
+        client.dry_run = True
+        client.dyn_client = MagicMock()
+        client._logger = MagicMock()
+
+        captured_kwargs = {}
+        real_method = KonfluxClient._new_ec_pipelinerun
+
+        def spy_new_ec_pipelinerun(**kwargs):
+            captured_kwargs.update(kwargs)
+            return real_method(**kwargs)
+
+        client._new_ec_pipelinerun = spy_new_ec_pipelinerun
+
+        await KonfluxClient.start_ec_pipeline_run(
+            client,
+            namespace="ocp-art-tenant",
+            application_name="openshift-4-21",
+            component_name="ose-4-21-openshift-apiserver",
+            image_pullspec="quay.io/repo@sha256:abc123",
+            source_url="https://github.com/org/repo",
+            commit_sha="deadbeef",
+            its_name="openshift-4-21-ec-registry-ocp-art-stage",
+            policy_configuration="rhtap-releng-tenant/registry-ocp-art-stage",
+        )
+
+        snapshot = json.loads(captured_kwargs["snapshot_json"])
+
+        self.assertEqual(snapshot["application"], "openshift-4-21")
+        self.assertEqual(len(snapshot["components"]), 1)
+        component = snapshot["components"][0]
+        self.assertEqual(component["name"], "ose-4-21-openshift-apiserver")
+        self.assertEqual(component["containerImage"], "quay.io/repo@sha256:abc123")
+        self.assertEqual(component["source"]["git"]["url"], "https://github.com/org/repo")
+        self.assertEqual(component["source"]["git"]["revision"], "deadbeef")
+
+
+class TestEnsureIntegrationTestScenarioNotFound(IsolatedAsyncioTestCase):
+    async def test_application_not_found_propagates(self):
+        from kubernetes.dynamic import exceptions as dyn_exceptions
+
+        client = MagicMock(spec=KonfluxClient)
+        client.get_application = AsyncMock(side_effect=dyn_exceptions.NotFoundError(MagicMock(status=404)))
+        client._new_integration_test_scenario = KonfluxClient._new_integration_test_scenario
+
+        with self.assertRaises(dyn_exceptions.NotFoundError):
+            await KonfluxClient.ensure_integration_test_scenario(
+                client,
+                name="openshift-4-21-ec-test",
+                application_name="nonexistent-app",
+                policy_configuration="test-policy",
+            )

--- a/doozer/tests/backend/test_konflux_ec_verification.py
+++ b/doozer/tests/backend/test_konflux_ec_verification.py
@@ -1,7 +1,7 @@
 """Tests for EC verification gating logic in KonfluxImageBuilder.build().
 
 Verifies that enterprise-contract verification is only triggered for images
-that are for_release=True, in an OCP group, and not skipped via --skip-ec-verify.
+that are for_release=True (or base images), in an OCP group, and not skipped via --skip-ec-verify.
 """
 
 import asyncio
@@ -9,7 +9,8 @@ from pathlib import Path
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxECStatus
+from doozerlib.backend.konflux_client import ECVerificationResult
 from doozerlib.backend.konflux_image_builder import (
     KonfluxImageBuilder,
     KonfluxImageBuilderConfig,
@@ -60,7 +61,7 @@ def _make_successful_pipelinerun_info():
     return plr_info
 
 
-def _make_metadata(distgit_key="test-image", for_release=True):
+def _make_metadata(distgit_key="test-image", for_release=True, is_base_image=False):
     """Create a mock ImageMetadata."""
     metadata = MagicMock()
     metadata.distgit_key = distgit_key
@@ -68,6 +69,7 @@ def _make_metadata(distgit_key="test-image", for_release=True):
     metadata.image_name_short = distgit_key
     metadata.is_olm_operator = False
     metadata.for_release = for_release
+    metadata.is_base_image.return_value = is_base_image
     metadata.has_source.return_value = True
     metadata.get_konflux_build_attempts.return_value = 1
     metadata.get_arches.return_value = ["x86_64"]
@@ -80,12 +82,27 @@ def _make_metadata(distgit_key="test-image", for_release=True):
     return metadata
 
 
+def _ec_passed_result():
+    return ECVerificationResult(
+        ec_status=KonfluxECStatus.PASSED, ec_pipeline_url="https://example.com/ec-plr", ec_failed=False
+    )
+
+
+def _ec_failed_result():
+    return ECVerificationResult(
+        ec_status=KonfluxECStatus.FAILED, ec_pipeline_url="https://example.com/ec-plr", ec_failed=True
+    )
+
+
 @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
 class TestEcVerificationGating(IsolatedAsyncioTestCase):
     """Test that EC verification is only triggered under the correct conditions."""
 
-    async def _run_build_and_get_ec_calls(self, config, metadata, mock_kc_init):
-        """Helper: run build() with all heavy methods mocked, return EC-related call info."""
+    async def _run_build_and_get_ec_calls(self, config, metadata, mock_kc_init, ec_result=None):
+        """Helper: run build() with all heavy methods mocked, return verify_enterprise_contract mock."""
+        if ec_result is None:
+            ec_result = _ec_passed_result()
+
         builder = KonfluxImageBuilder(config)
 
         plr_info = _make_successful_pipelinerun_info()
@@ -98,7 +115,6 @@ class TestEcVerificationGating(IsolatedAsyncioTestCase):
             return_value=("uuid-tag", "test-component", "v4.18.0", "202604100000.p0.el9")
         )
 
-        # Make dest_dir.exists() return True so we skip cloning
         with patch.object(Path, "exists", return_value=True):
             with patch(
                 "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
@@ -110,29 +126,11 @@ class TestEcVerificationGating(IsolatedAsyncioTestCase):
                 mock_repo.branch = "art-openshift-4.18-assembly-stream-dgk-test-image"
                 mock_build_repo.return_value = mock_repo
 
-                # Mock wait_for_pipelinerun to return a successful PLR
                 wait_plr_info = _make_successful_pipelinerun_info()
                 builder._konflux_client.wait_for_pipelinerun = AsyncMock(return_value=wait_plr_info)
                 builder._konflux_client.resource_url = MagicMock(return_value="https://example.com/plr")
 
-                # Mock EC methods
-                builder._konflux_client.ensure_integration_test_scenario = AsyncMock()
-                ec_plr_info = MagicMock()
-                ec_plr_info.name = "test-ec-plr"
-                ec_plr_info.to_dict.return_value = {
-                    "kind": "PipelineRun",
-                    "metadata": {
-                        "name": "test-ec-plr",
-                        "namespace": "ocp-art-tenant",
-                        "labels": {"appstudio.openshift.io/application": "openshift-4-18"},
-                    },
-                }
-                ec_succeeded = MagicMock()
-                ec_plr_info.find_condition.return_value = ec_succeeded
-                builder._konflux_client.start_ec_pipeline_run = AsyncMock(return_value=ec_plr_info)
-
-                # Make the second wait_for_pipelinerun call (for EC) also return success
-                builder._konflux_client.wait_for_pipelinerun = AsyncMock(side_effect=[wait_plr_info, ec_plr_info])
+                builder._konflux_client.verify_enterprise_contract = AsyncMock(return_value=ec_result)
 
                 with patch.object(
                     KonfluxBuildOutcome,
@@ -141,47 +139,49 @@ class TestEcVerificationGating(IsolatedAsyncioTestCase):
                 ):
                     await builder.build(metadata)
 
-        return builder._konflux_client.ensure_integration_test_scenario, builder._konflux_client.start_ec_pipeline_run
+        return builder._konflux_client.verify_enterprise_contract
 
     async def test_ec_runs_for_release_ocp_image(self, mock_kc_init):
         """EC verification should run for a for_release=True OCP image."""
         config = _make_config(group_name="openshift-4.18")
         metadata = _make_metadata(for_release=True)
 
-        ensure_its, start_ec_plr = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+        verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+        verify_ec.assert_called_once()
 
-        ensure_its.assert_called_once()
-        start_ec_plr.assert_called_once()
-
-    async def test_ec_skipped_for_non_release_image(self, mock_kc_init):
-        """EC verification should be skipped for base images (for_release=False)."""
+    async def test_ec_runs_for_base_image(self, mock_kc_init):
+        """EC verification should run for base images using the base image policy."""
         config = _make_config(group_name="openshift-4.18")
-        metadata = _make_metadata(for_release=False)
+        metadata = _make_metadata(for_release=False, is_base_image=True)
 
-        ensure_its, start_ec_plr = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+        verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+        verify_ec.assert_called_once()
+        call_kwargs = verify_ec.call_args[1]
+        self.assertEqual(call_kwargs["ec_policy"], "rhtap-releng-tenant/registry-ocp-art-base-prod")
 
-        ensure_its.assert_not_called()
-        start_ec_plr.assert_not_called()
+    async def test_ec_skipped_for_non_release_non_base_image(self, mock_kc_init):
+        """EC verification should be skipped for non-release, non-base images."""
+        config = _make_config(group_name="openshift-4.18")
+        metadata = _make_metadata(for_release=False, is_base_image=False)
+
+        verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+        verify_ec.assert_not_called()
 
     async def test_ec_skipped_when_skip_flag_set(self, mock_kc_init):
         """EC verification should be skipped when --skip-ec-verify is set."""
         config = _make_config(group_name="openshift-4.18", skip_ec_verify=True)
         metadata = _make_metadata(for_release=True)
 
-        ensure_its, start_ec_plr = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
-
-        ensure_its.assert_not_called()
-        start_ec_plr.assert_not_called()
+        verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+        verify_ec.assert_not_called()
 
     async def test_ec_skipped_for_non_ocp_group(self, mock_kc_init):
         """EC verification should be skipped for non-OCP groups (e.g. logging)."""
         config = _make_config(group_name="logging-6.2")
         metadata = _make_metadata(for_release=True)
 
-        ensure_its, start_ec_plr = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
-
-        ensure_its.assert_not_called()
-        start_ec_plr.assert_not_called()
+        verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+        verify_ec.assert_not_called()
 
     async def test_no_retry_when_ec_fails(self, mock_kc_init):
         """When EC verification fails, the build should NOT be retried."""
@@ -212,28 +212,14 @@ class TestEcVerificationGating(IsolatedAsyncioTestCase):
                 mock_build_repo.return_value = mock_repo
 
                 wait_plr_info = _make_successful_pipelinerun_info()
-                ec_plr_info = MagicMock()
-                ec_plr_info.name = "test-ec-plr"
-                ec_plr_info.to_dict.return_value = {
-                    "kind": "PipelineRun",
-                    "metadata": {
-                        "name": "test-ec-plr",
-                        "namespace": "ocp-art-tenant",
-                        "labels": {"appstudio.openshift.io/application": "openshift-4-18"},
-                    },
-                }
-                ec_plr_info.find_condition.return_value = MagicMock()
-
-                builder._konflux_client.wait_for_pipelinerun = AsyncMock(side_effect=[wait_plr_info, ec_plr_info])
+                builder._konflux_client.wait_for_pipelinerun = AsyncMock(return_value=wait_plr_info)
                 builder._konflux_client.resource_url = MagicMock(return_value="https://example.com/plr")
-                builder._konflux_client.ensure_integration_test_scenario = AsyncMock()
-                builder._konflux_client.start_ec_pipeline_run = AsyncMock(return_value=ec_plr_info)
+                builder._konflux_client.verify_enterprise_contract = AsyncMock(return_value=_ec_failed_result())
 
-                # Build PLR succeeds, EC PLR fails
                 with patch.object(
                     KonfluxBuildOutcome,
                     "extract_from_pipelinerun_succeeded_condition",
-                    side_effect=[KonfluxBuildOutcome.SUCCESS, KonfluxBuildOutcome.FAILURE],
+                    return_value=KonfluxBuildOutcome.SUCCESS,
                 ):
                     with self.assertRaises(KonfluxImageBuildError):
                         await builder.build(metadata)

--- a/doozer/tests/backend/test_konflux_ec_verification.py
+++ b/doozer/tests/backend/test_konflux_ec_verification.py
@@ -10,7 +10,11 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
-from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder, KonfluxImageBuilderConfig
+from doozerlib.backend.konflux_image_builder import (
+    KonfluxImageBuilder,
+    KonfluxImageBuilderConfig,
+    KonfluxImageBuildError,
+)
 
 
 def _make_config(**overrides) -> KonfluxImageBuilderConfig:
@@ -178,3 +182,60 @@ class TestEcVerificationGating(IsolatedAsyncioTestCase):
 
         ensure_its.assert_not_called()
         start_ec_plr.assert_not_called()
+
+    async def test_no_retry_when_ec_fails(self, mock_kc_init):
+        """When EC verification fails, the build should NOT be retried."""
+        config = _make_config(group_name="openshift-4.18")
+        metadata = _make_metadata(for_release=True)
+        metadata.get_konflux_build_attempts.return_value = 3
+
+        builder = KonfluxImageBuilder(config)
+
+        plr_info = _make_successful_pipelinerun_info()
+        builder._start_build = AsyncMock(return_value=plr_info)
+        builder._validate_build_attestation_and_signature = AsyncMock()
+        builder._wait_for_parent_members = AsyncMock(return_value=[])
+        builder.update_konflux_db = AsyncMock(return_value=None)
+        builder._parse_dockerfile = MagicMock(
+            return_value=("uuid-tag", "test-component", "v4.18.0", "202604100000.p0.el9")
+        )
+
+        with patch.object(Path, "exists", return_value=True):
+            with patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new_callable=AsyncMock,
+            ) as mock_build_repo:
+                mock_repo = MagicMock()
+                mock_repo.url = "https://github.com/openshift/test-repo"
+                mock_repo.commit_hash = "deadbeef"
+                mock_repo.branch = "art-openshift-4.18-assembly-stream-dgk-test-image"
+                mock_build_repo.return_value = mock_repo
+
+                wait_plr_info = _make_successful_pipelinerun_info()
+                ec_plr_info = MagicMock()
+                ec_plr_info.name = "test-ec-plr"
+                ec_plr_info.to_dict.return_value = {
+                    "kind": "PipelineRun",
+                    "metadata": {
+                        "name": "test-ec-plr",
+                        "namespace": "ocp-art-tenant",
+                        "labels": {"appstudio.openshift.io/application": "openshift-4-18"},
+                    },
+                }
+                ec_plr_info.find_condition.return_value = MagicMock()
+
+                builder._konflux_client.wait_for_pipelinerun = AsyncMock(side_effect=[wait_plr_info, ec_plr_info])
+                builder._konflux_client.resource_url = MagicMock(return_value="https://example.com/plr")
+                builder._konflux_client.ensure_integration_test_scenario = AsyncMock()
+                builder._konflux_client.start_ec_pipeline_run = AsyncMock(return_value=ec_plr_info)
+
+                # Build PLR succeeds, EC PLR fails
+                with patch.object(
+                    KonfluxBuildOutcome,
+                    "extract_from_pipelinerun_succeeded_condition",
+                    side_effect=[KonfluxBuildOutcome.SUCCESS, KonfluxBuildOutcome.FAILURE],
+                ):
+                    with self.assertRaises(KonfluxImageBuildError):
+                        await builder.build(metadata)
+
+        builder._start_build.assert_called_once()

--- a/doozer/tests/backend/test_konflux_ec_verification.py
+++ b/doozer/tests/backend/test_konflux_ec_verification.py
@@ -1,0 +1,180 @@
+"""Tests for EC verification gating logic in KonfluxImageBuilder.build().
+
+Verifies that enterprise-contract verification is only triggered for images
+that are for_release=True, in an OCP group, and not skipped via --skip-ec-verify.
+"""
+
+import asyncio
+from pathlib import Path
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
+from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder, KonfluxImageBuilderConfig
+
+
+def _make_config(**overrides) -> KonfluxImageBuilderConfig:
+    defaults = dict(
+        base_dir=Path("/tmp/test-builds"),
+        group_name="openshift-4.18",
+        namespace="ocp-art-tenant",
+        plr_template="https://example.com/template",
+        dry_run=True,
+        build_priority="5",
+        skip_ec_verify=False,
+    )
+    defaults.update(overrides)
+    return KonfluxImageBuilderConfig(**defaults)
+
+
+def _make_successful_pipelinerun_info():
+    """Create a mock PipelineRunInfo that represents a successful build."""
+    plr_info = MagicMock()
+    plr_info.name = "test-plr-abc12"
+    plr_info.to_dict.return_value = {
+        "kind": "PipelineRun",
+        "metadata": {
+            "name": "test-plr-abc12",
+            "namespace": "ocp-art-tenant",
+            "uid": "fake-uid",
+            "labels": {
+                "appstudio.openshift.io/application": "openshift-4-18",
+                "appstudio.openshift.io/component": "ose-4-18-test-image",
+            },
+        },
+        "status": {
+            "results": [
+                {"name": "IMAGE_URL", "value": "quay.io/openshift-release-dev/ocp-v4.0-art-dev-test:tag123"},
+                {"name": "IMAGE_DIGEST", "value": "sha256:abc123def456"},
+            ],
+            "startTime": "2026-04-10T00:00:00Z",
+            "completionTime": "2026-04-10T00:30:00Z",
+        },
+    }
+    succeeded_condition = MagicMock()
+    plr_info.find_condition.return_value = succeeded_condition
+    return plr_info
+
+
+def _make_metadata(distgit_key="test-image", for_release=True):
+    """Create a mock ImageMetadata."""
+    metadata = MagicMock()
+    metadata.distgit_key = distgit_key
+    metadata.qualified_key = f"containers/{distgit_key}"
+    metadata.image_name_short = distgit_key
+    metadata.is_olm_operator = False
+    metadata.for_release = for_release
+    metadata.has_source.return_value = True
+    metadata.get_konflux_build_attempts.return_value = 1
+    metadata.get_arches.return_value = ["x86_64"]
+    metadata.get_latest_build = AsyncMock(return_value=None)
+    metadata.build_event = asyncio.Event()
+    metadata.get_parent_members.return_value = {}
+    metadata.runtime.assembly = "stream"
+    metadata.runtime.assembly_type = MagicMock()
+    metadata.runtime.konflux_db = None
+    return metadata
+
+
+@patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+class TestEcVerificationGating(IsolatedAsyncioTestCase):
+    """Test that EC verification is only triggered under the correct conditions."""
+
+    async def _run_build_and_get_ec_calls(self, config, metadata, mock_kc_init):
+        """Helper: run build() with all heavy methods mocked, return EC-related call info."""
+        builder = KonfluxImageBuilder(config)
+
+        plr_info = _make_successful_pipelinerun_info()
+
+        builder._start_build = AsyncMock(return_value=plr_info)
+        builder._validate_build_attestation_and_signature = AsyncMock()
+        builder._wait_for_parent_members = AsyncMock(return_value=[])
+        builder.update_konflux_db = AsyncMock(return_value=None)
+        builder._parse_dockerfile = MagicMock(
+            return_value=("uuid-tag", "test-component", "v4.18.0", "202604100000.p0.el9")
+        )
+
+        # Make dest_dir.exists() return True so we skip cloning
+        with patch.object(Path, "exists", return_value=True):
+            with patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new_callable=AsyncMock,
+            ) as mock_build_repo:
+                mock_repo = MagicMock()
+                mock_repo.url = "https://github.com/openshift/test-repo"
+                mock_repo.commit_hash = "deadbeef"
+                mock_repo.branch = "art-openshift-4.18-assembly-stream-dgk-test-image"
+                mock_build_repo.return_value = mock_repo
+
+                # Mock wait_for_pipelinerun to return a successful PLR
+                wait_plr_info = _make_successful_pipelinerun_info()
+                builder._konflux_client.wait_for_pipelinerun = AsyncMock(return_value=wait_plr_info)
+                builder._konflux_client.resource_url = MagicMock(return_value="https://example.com/plr")
+
+                # Mock EC methods
+                builder._konflux_client.ensure_integration_test_scenario = AsyncMock()
+                ec_plr_info = MagicMock()
+                ec_plr_info.name = "test-ec-plr"
+                ec_plr_info.to_dict.return_value = {
+                    "kind": "PipelineRun",
+                    "metadata": {
+                        "name": "test-ec-plr",
+                        "namespace": "ocp-art-tenant",
+                        "labels": {"appstudio.openshift.io/application": "openshift-4-18"},
+                    },
+                }
+                ec_succeeded = MagicMock()
+                ec_plr_info.find_condition.return_value = ec_succeeded
+                builder._konflux_client.start_ec_pipeline_run = AsyncMock(return_value=ec_plr_info)
+
+                # Make the second wait_for_pipelinerun call (for EC) also return success
+                builder._konflux_client.wait_for_pipelinerun = AsyncMock(side_effect=[wait_plr_info, ec_plr_info])
+
+                with patch.object(
+                    KonfluxBuildOutcome,
+                    "extract_from_pipelinerun_succeeded_condition",
+                    return_value=KonfluxBuildOutcome.SUCCESS,
+                ):
+                    await builder.build(metadata)
+
+        return builder._konflux_client.ensure_integration_test_scenario, builder._konflux_client.start_ec_pipeline_run
+
+    async def test_ec_runs_for_release_ocp_image(self, mock_kc_init):
+        """EC verification should run for a for_release=True OCP image."""
+        config = _make_config(group_name="openshift-4.18")
+        metadata = _make_metadata(for_release=True)
+
+        ensure_its, start_ec_plr = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+
+        ensure_its.assert_called_once()
+        start_ec_plr.assert_called_once()
+
+    async def test_ec_skipped_for_non_release_image(self, mock_kc_init):
+        """EC verification should be skipped for base images (for_release=False)."""
+        config = _make_config(group_name="openshift-4.18")
+        metadata = _make_metadata(for_release=False)
+
+        ensure_its, start_ec_plr = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+
+        ensure_its.assert_not_called()
+        start_ec_plr.assert_not_called()
+
+    async def test_ec_skipped_when_skip_flag_set(self, mock_kc_init):
+        """EC verification should be skipped when --skip-ec-verify is set."""
+        config = _make_config(group_name="openshift-4.18", skip_ec_verify=True)
+        metadata = _make_metadata(for_release=True)
+
+        ensure_its, start_ec_plr = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+
+        ensure_its.assert_not_called()
+        start_ec_plr.assert_not_called()
+
+    async def test_ec_skipped_for_non_ocp_group(self, mock_kc_init):
+        """EC verification should be skipped for non-OCP groups (e.g. logging)."""
+        config = _make_config(group_name="logging-6.2")
+        metadata = _make_metadata(for_release=True)
+
+        ensure_its, start_ec_plr = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+
+        ensure_its.assert_not_called()
+        start_ec_plr.assert_not_called()

--- a/doozer/tests/cli/test_images_konflux.py
+++ b/doozer/tests/cli/test_images_konflux.py
@@ -19,6 +19,7 @@ class TestKonfluxBundleCli(unittest.IsolatedAsyncioTestCase):
         self.runtime.assembly = "test-assembly"
         self.runtime.images = []
         self.runtime.upcycle = False
+        self.runtime.assembly_type = None
         self.runtime.source_resolver = mock.Mock(spec=SourceResolver)
         self.runtime.konflux_db = mock.Mock()
         self.runtime.konflux_db.bind = mock.Mock()

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -758,6 +758,7 @@ class UpdateGolangPipeline:
                 branch,
                 "beta:images:konflux:build",
                 f"--konflux-namespace={konflux_namespace}",
+                "--skip-ec-verify",
             ]
         )
         if self.kubeconfig:


### PR DESCRIPTION
## Summary
- After a successful Konflux image build + SLSA attestation validation, runs an enterprise-contract (EC) policy check
- Ensures an `IntegrationTestScenario` (ITS) exists for the application, then creates an EC PipelineRun to verify the built image against the stage EC policy
- EC policy is selected based on assembly type and image type:
  - **Base images** (`base_only=true`): use [`registry-ocp-art-base-prod`](https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/kflux-ocp-p01.7ayg.p1/product/EnterpriseContractPolicy/registry-ocp-art-base-prod.yaml) (no preGA variant)
  - **FBC builds**: use `rhtap-releng-tenant/fbc-ocp-art-stage` (no preGA variant)
  - **Bundle builds**: same logic as regular images — `registry-ocp-art-stage` (default) or `registry-ocp-art-ec-stage` (preGA/PREVIEW assemblies)
  - **Regular images**: **PREVIEW** (preGA) assemblies use [`registry-ocp-art-ec-stage`](https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/kflux-ocp-p01.7ayg.p1/product/EnterpriseContractPolicy/registry-ocp-art-ec-stage.yaml) (allows unsigned RPMs), all others use `registry-ocp-art-stage`
- EC verification is **blocking** — build fails if EC check fails
- Adds `--skip-ec-verify` flag to `beta:images:konflux:build` to opt out
- Currently scoped to **OCP only**; layered products (logging, oadp, mta, etc.) to be expanded later
- Golang builder builds skip EC verification (`--skip-ec-verify`) since they use non-standard assembly conventions

## Changes
- `doozer/doozerlib/constants.py`: EC pipeline URL, policy constants, preGA policy constant, **new** `KONFLUX_BASE_IMAGE_EC_POLICY_CONFIGURATION` and `KONFLUX_FBC_EC_POLICY_CONFIGURATION` constants
- `doozer/doozerlib/backend/konflux_client.py`: New `IntegrationTestScenario` and EC `PipelineRun` manifest builders + orchestration methods; **new** shared `verify_enterprise_contract()` helper and `ECVerificationResult` dataclass to avoid duplicating ITS+PLR+wait logic across builders
- `doozer/doozerlib/backend/konflux_image_builder.py`: EC verification integrated into `build()` after SLSA attestation check; selects EC policy based on assembly type (PREVIEW vs others) and image type (base image vs regular); **now uses shared `verify_enterprise_contract()` helper**; base images (`base_only=true`) now run EC instead of being skipped
- `doozer/doozerlib/backend/konflux_fbc.py`: **New** EC verification after successful FBC build using `fbc-ocp-art-stage` policy; `skip_ec_verify` parameter support
- `doozer/doozerlib/backend/konflux_olm_bundler.py`: **New** EC verification after successful bundle build using same preGA/non-preGA policies as regular images; `skip_ec_verify` and `assembly_type` parameter support
- `doozer/doozerlib/cli/images_konflux.py`: `--skip-ec-verify` CLI flag; passes `assembly_type` to bundle builder
- `doozer/tests/backend/test_konflux_client.py`: Tests for ITS/EC PLR manifest construction, idempotent ITS creation, dry-run mode, preGA policy, **and new `verify_enterprise_contract()` helper tests**
- `doozer/tests/backend/test_konflux_ec_verification.py`: **Updated** tests for base image EC gating and non-release/non-base-image skip logic
- `doozer/tests/cli/test_images_konflux.py`: **Updated** mock setup for `assembly_type`
- `pyartcd/pyartcd/pipelines/update_golang.py`: Skip EC verification for golang builder builds

## Test plan
- [x] Unit tests pass (`uv run pytest doozer/tests/backend/test_konflux_client.py`)
- [x] Lint passes (`make lint`)
- [x] Dry-run build to verify EC flow is wired up
- [x] Live single-image build to verify ITS creation and EC PLR execution
- [ ] Dry-run EC verification against 4.22 stream builds to quantify preGA failure count
- [ ] Test FBC build with EC verification
- [ ] Test bundle build with EC verification
- [ ] Test base image build with `registry-ocp-art-base-prod` policy

Test build stored as failure when ETS fails: [jenkins job ](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/ashwin-aos-cd-jobs/job/build%252Focp4-konflux/157/) --> [ITS](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-20/pipelineruns/openshift-4-20-ec-openshift-enterprise-base-rhel9-containe99vb2) --> [failed build](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=&group=&assembly=test&outcome=success&outcome=failure&engine=konflux&dateRange=2026-04-02+to+2026-04-09&nvr=openshift-enterprise-base-rhel9-container-v4.20.0-202604090324.p2.gbb4535b.assembly.test.el9&record_id=&image_sha_tag=&source_repo=&commitish=&art-job-url=)

Test build stored as success when ETS passes: [jenkins job](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/ashwin-aos-cd-jobs/job/build%252Focp4-konflux/158/console) -> [ITS](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-20/pipelineruns/openshift-4-20-ec-ose-4-20-openshift-enterprise-base-rhel986v86) -> [green build](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=&group=&assembly=test&outcome=success&outcome=failure&engine=konflux&dateRange=2026-04-02+to+2026-04-09&nvr=openshift-enterprise-base-rhel9-container-v4.20.0-202604091846.p2.gbb4535b.assembly.test.el9&record_id=&image_sha_tag=&source_repo=&commitish=&art-job-url=)