### PR TITLE
ART-14453: Support dockerfile stage references

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -430,7 +430,7 @@ class KonfluxRebaser:
 
                 # Check if this FROM references a previously defined stage
                 # Extract the base image name (first token in FROM clause)
-                base_image = from_clause.split()[0]
+                base_image = from_clause.split()[0].lower()
                 is_stage_ref.append(base_image in stage_names)
 
                 # Extract stage name if this FROM defines a new stage (has "AS stagename")
@@ -439,7 +439,7 @@ class KonfluxRebaser:
                     tokens = from_clause.split()
                     as_index = next(i for i, t in enumerate(tokens) if t.upper() == 'AS')
                     if as_index + 1 < len(tokens):
-                        stage_name = tokens[as_index + 1]
+                        stage_name = tokens[as_index + 1].lower()
                         stage_names.add(stage_name)
 
         return is_stage_ref

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -405,20 +405,82 @@ class KonfluxRebaser:
                 await file.write("\n!/.oit/**\n")
                 await file.write("\n!labels.json\n")
 
+    @staticmethod
+    def _identify_stage_references(dfp: DockerfileParser) -> List[bool]:
+        """
+        Identify which FROM directives are stage references vs actual base image pulls.
+
+        Returns a boolean list where:
+        - True = this FROM directive references a build stage defined earlier
+        - False = this FROM directive pulls an external base image
+
+        Example Dockerfile:
+            FROM registry.io/base:latest AS build   # False (base image)
+            FROM build AS metadata                   # True (stage reference)
+            FROM build                               # True (stage reference)
+
+        Returns: [False, True, True]
+        """
+        stage_names = set()
+        is_stage_ref = []
+
+        for line in json.loads(dfp.json):
+            if 'FROM' in line:
+                from_clause = line['FROM']
+
+                # Check if this FROM references a previously defined stage
+                # Extract the base image name (first token in FROM clause)
+                base_image = from_clause.split()[0]
+                is_stage_ref.append(base_image in stage_names)
+
+                # Extract stage name if this FROM defines a new stage (has "AS stagename")
+                if ' AS ' in from_clause.upper():
+                    # Stage name is the last token after AS
+                    tokens = from_clause.split()
+                    as_index = next(i for i, t in enumerate(tokens) if t.upper() == 'AS')
+                    if as_index + 1 < len(tokens):
+                        stage_name = tokens[as_index + 1]
+                        stage_names.add(stage_name)
+
+        return is_stage_ref
+
     @start_as_current_span_async(TRACER, "rebase.resolve_parents")
     async def _resolve_parents(self, metadata: ImageMetadata, dfp: DockerfileParser):
-        """Resolve the parent images for the given image metadata."""
+        """
+        Resolve the parent images for the given image metadata.
+
+        This method handles multi-stage Dockerfiles where some FROM directives may reference
+        earlier build stages (e.g., "FROM build") rather than external base images.
+        Stage references are preserved as-is, while external base images are resolved
+        according to the metadata configuration.
+        """
+        # Detect which FROM directives are stage references vs external base images
+        is_stage_ref = self._identify_stage_references(dfp)
+
+        # Filter to only actual base images (not stage references)
+        actual_base_images = [img for img, is_ref in zip(dfp.parent_images, is_stage_ref) if not is_ref]
+
+        # Get parent image configuration from metadata
         image_from = metadata.config.get('from', {})
         parents = image_from.get("builder", []).copy()
-        parents.append(image_from)
 
-        if len(parents) != len(dfp.parent_images):
+        # Only append image_from as a final parent if it specifies one
+        # (i.e., it has member, stream, or image key directly)
+        if any(key in image_from for key in ["member", "stream", "image"]):
+            parents.append(image_from)
+
+        # Validate: metadata should specify one entry per actual base image (not per stage reference)
+        num_stage_refs = sum(is_stage_ref)
+        if len(parents) != len(actual_base_images):
             raise ValueError(
-                f"Build metadata for {metadata.distgit_key} expected {len(parents)} parent images, but found {len(dfp.parent_images)} in Dockerfile"
+                f"Build metadata for {metadata.distgit_key} expected {len(parents)} parent images, "
+                f"but found {len(actual_base_images)} in Dockerfile "
+                f"({len(dfp.parent_images)} total FROM directives, {num_stage_refs} are stage references)"
             )
 
+        # Resolve only the actual base images according to metadata config
         mapped_images: List[Tuple[str, bool]] = []
-        for parent, original_parent in zip(parents, dfp.parent_images):
+        for parent, original_parent in zip(parents, actual_base_images):
             if "member" in parent:
                 mapped_images.append(await self._resolve_member_parent(parent["member"], original_parent))
             elif "image" in parent:
@@ -430,7 +492,18 @@ class KonfluxRebaser:
             else:
                 raise ValueError(f"Image in 'from' for [{metadata.distgit_key}] is missing its definition.")
 
-        downstream_parents = [pullspec for pullspec, _ in mapped_images]
+        # Build final parent list: resolved images for base pulls, original stage names for references
+        downstream_parents = []
+        resolved_idx = 0
+        for i, is_ref in enumerate(is_stage_ref):
+            if is_ref:
+                # This is a stage reference - preserve it as-is
+                downstream_parents.append(dfp.parent_images[i])
+            else:
+                # This is an actual base image - use the resolved pullspec
+                downstream_parents.append(mapped_images[resolved_idx][0])
+                resolved_idx += 1
+
         private_fix = any(private_fix for _, private_fix in mapped_images)
         return downstream_parents, private_fix
 

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -1020,3 +1020,110 @@ USER 3000
 
         # Should fall back to metadata.branch_el_target (9)
         self.assertIn(".scos9", result)
+
+    def test_identify_stage_references_simple(self):
+        """Test stage reference detection with simple multi-stage build"""
+        dfp = DockerfileParser(path=self.directory.name)
+        dfp.content = """
+            FROM registry.io/base:latest AS build
+            RUN echo "building"
+
+            FROM build AS metadata
+            RUN echo "metadata"
+
+            FROM build
+            COPY --from=metadata /data /data
+        """
+
+        result = KonfluxRebaser._identify_stage_references(dfp)
+
+        # Expected: [False, True, True]
+        # - First FROM is an external image (base image)
+        # - Second FROM references "build" stage
+        # - Third FROM references "build" stage
+        self.assertEqual(result, [False, True, True])
+        self.assertEqual(len(result), 3)
+
+    def test_identify_stage_references_no_stage_refs(self):
+        """Test with Dockerfile that has no stage references"""
+        dfp = DockerfileParser(path=self.directory.name)
+        dfp.content = """
+            FROM registry.io/base1:latest
+            RUN echo "step1"
+
+            FROM registry.io/base2:latest
+            RUN echo "step2"
+        """
+
+        result = KonfluxRebaser._identify_stage_references(dfp)
+
+        # Expected: [False, False]
+        # - Both FROM directives are external images
+        self.assertEqual(result, [False, False])
+
+    def test_identify_stage_references_all_stage_refs(self):
+        """Test with Dockerfile where all but first FROM are stage references"""
+        dfp = DockerfileParser(path=self.directory.name)
+        dfp.content = """
+            FROM registry.io/base:v1 AS stage1
+            RUN echo "stage1"
+
+            FROM stage1 AS stage2
+            RUN echo "stage2"
+
+            FROM stage2 AS stage3
+            RUN echo "stage3"
+
+            FROM stage3
+            RUN echo "final"
+        """
+
+        result = KonfluxRebaser._identify_stage_references(dfp)
+
+        # Expected: [False, True, True, True]
+        self.assertEqual(result, [False, True, True, True])
+
+    def test_identify_stage_references_mixed(self):
+        """Test with Dockerfile mixing external images and stage references"""
+        dfp = DockerfileParser(path=self.directory.name)
+        dfp.content = """
+            FROM registry.io/base:v1 AS builder
+            RUN echo "building"
+
+            FROM registry.io/tools:latest AS tools
+            RUN echo "tools"
+
+            FROM builder
+            COPY --from=tools /bin/tool /bin/tool
+        """
+
+        result = KonfluxRebaser._identify_stage_references(dfp)
+
+        # Expected: [False, False, True]
+        # - First FROM: external (base image)
+        # - Second FROM: external (tools image)
+        # - Third FROM: references "builder" stage
+        self.assertEqual(result, [False, False, True])
+
+    def test_identify_stage_references_rhcos_node_image(self):
+        """Test with actual rhcos-node-image Dockerfile pattern"""
+        dfp = DockerfileParser(path=self.directory.name)
+        dfp.content = """
+            FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev:c9s-coreos AS build
+            ARG OPENSHIFT_CI=0
+            RUN --mount=type=bind,target=/run/src /run/src/build-node-image.sh
+
+            FROM build AS metadata
+            RUN --mount=type=bind,target=/run/src /run/src/scripts/generate-metadata
+
+            FROM build
+            COPY --from=metadata /usr/share/openshift /usr/share/openshift
+            LABEL io.openshift.metalayer=true
+        """
+
+        result = KonfluxRebaser._identify_stage_references(dfp)
+
+        # Expected: [False, True, True]
+        # This is the exact pattern from rhcos-node-image
+        self.assertEqual(result, [False, True, True])
+        self.assertEqual(len(result), 3)

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -1127,3 +1127,27 @@ USER 3000
         # This is the exact pattern from rhcos-node-image
         self.assertEqual(result, [False, True, True])
         self.assertEqual(len(result), 3)
+
+    def test_identify_stage_references_case_insensitive(self):
+        """Test that stage name references are case-insensitive (Docker behavior)"""
+        dfp = DockerfileParser(path=self.directory.name)
+        dfp.content = """
+            FROM registry.io/base:latest AS Build
+            RUN echo "building"
+
+            FROM build AS METADATA
+            RUN echo "metadata"
+
+            FROM BUILD
+            COPY --from=metadata /data /data
+        """
+
+        result = KonfluxRebaser._identify_stage_references(dfp)
+
+        # Expected: [False, True, True]
+        # - First FROM: external image (base)
+        # - Second FROM: references "Build" stage (case-insensitive: "build")
+        # - Third FROM: references "Build" stage (case-insensitive: "BUILD" -> "build")
+        # Note: COPY --from=metadata is not a FROM directive, so not counted
+        self.assertEqual(result, [False, True, True])
+        self.assertEqual(len(result), 3)


### PR DESCRIPTION
# Support Dockerfile Stage References in Multi-Stage Builds

## Problem

Doozer's rebase logic treated all `FROM` directives as external base image pulls and required a metadata config entry for each one. This prevented support for Dockerfiles that use stage references in multi-stage builds (e.g., `FROM build`).

**Affected Dockerfile:** [openshift/os Containerfile](https://github.com/openshift/os/blob/release-4.23/Containerfile)

Example failure:
```dockerfile
FROM base:latest AS build
FROM build AS metadata    # Stage reference - not an external image
FROM build                # Stage reference - not an external image
```

Previous error: `Build metadata expected 2 parent images, but found 3 in Dockerfile`

## Changes

### Core Logic
- **`_identify_stage_references()`**: Detects which `FROM` directives are stage references vs external base images
- **`_resolve_parents()`**: 
  - Only counts and resolves external base images
  - Preserves stage references as-is in rebased Dockerfiles
  - Improved error messages showing stage reference counts
  - Handles images with no final stage parent (when final stage uses a stage reference)
