### PR TITLE
Use image digest when using cosign download

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -229,7 +229,8 @@ class KonfluxImageBuilder:
                     image_pullspec = next((r['value'] for r in results if r['name'] == 'IMAGE_URL'), None)
                     image_digest = next((r['value'] for r in results if r['name'] == 'IMAGE_DIGEST'), None)
 
-                    record["image_pullspec"] = f"{image_pullspec.split(':')[0]}@{image_digest}"
+                    definitive_image_pullspec = f"{image_pullspec.split(':')[0]}@{image_digest}"
+                    record["image_pullspec"] = definitive_image_pullspec
 
                     image_tag = image_pullspec.split(':')[-1]
                     record["image_tag"] = image_tag
@@ -237,10 +238,12 @@ class KonfluxImageBuilder:
                     # Validate SLSA attestation and source image signature
                     try:
                         # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
-                        await self._validate_build_attestation_and_signature(image_digest, metadata.distgit_key)
+                        await self._validate_build_attestation_and_signature(
+                            definitive_image_pullspec, metadata.distgit_key
+                        )
                     except Exception as e:
                         logger.error(
-                            f"Failed to get SLA attestation / source signature from konflux for image {image_pullspec}, marking build as {KonfluxBuildOutcome.FAILURE}. Error: {e}"
+                            f"Failed to get SLA attestation / source signature from konflux for image {definitive_image_pullspec}, marking build as {KonfluxBuildOutcome.FAILURE}. Error: {e}"
                         )
                         outcome = KonfluxBuildOutcome.FAILURE
 
@@ -814,14 +817,16 @@ class KonfluxImageBuilder:
                     f"pipelinerun {pipelinerun_name}"
                 )
 
+            definitive_image_pullspec = f"{image_pullspec.split(':')[0]}@{image_digest}"
+
             # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
             package_nvrs, source_rpms = await self.get_installed_packages(
-                image_digest, building_arches, self._config.registry_auth_file
+                definitive_image_pullspec, building_arches, self._config.registry_auth_file
             )
 
             build_record_params.update(
                 {
-                    'image_pullspec': f"{image_pullspec.split(':')[0]}@{image_digest}",
+                    'image_pullspec': definitive_image_pullspec,
                     'installed_packages': sorted(source_rpms),
                     'installed_rpms': sorted(package_nvrs),
                     'image_tag': image_pullspec.split(':')[-1],

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -236,7 +236,8 @@ class KonfluxImageBuilder:
 
                     # Validate SLSA attestation and source image signature
                     try:
-                        await self._validate_build_attestation_and_signature(image_pullspec, metadata.distgit_key)
+                        # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
+                        await self._validate_build_attestation_and_signature(image_digest, metadata.distgit_key)
                     except Exception as e:
                         logger.error(
                             f"Failed to get SLA attestation / source signature from konflux for image {image_pullspec}, marking build as {KonfluxBuildOutcome.FAILURE}. Error: {e}"
@@ -813,8 +814,9 @@ class KonfluxImageBuilder:
                     f"pipelinerun {pipelinerun_name}"
                 )
 
+            # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
             package_nvrs, source_rpms = await self.get_installed_packages(
-                image_pullspec, building_arches, self._config.registry_auth_file
+                image_digest, building_arches, self._config.registry_auth_file
             )
 
             build_record_params.update(

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -1,0 +1,154 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
+from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder, KonfluxImageBuilderConfig
+from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
+
+
+class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+
+        self.konflux_client_patcher = patch("doozerlib.backend.konflux_image_builder.KonfluxClient.from_kubeconfig")
+        self.mock_konflux_client_factory = self.konflux_client_patcher.start()
+        self.addCleanup(self.konflux_client_patcher.stop)
+
+        self.mock_konflux_client = MagicMock()
+        self.mock_konflux_client_factory.return_value = self.mock_konflux_client
+        self.mock_konflux_client.resource_url.return_value = "https://example.com/pipelinerun"
+
+        self.builder = KonfluxImageBuilder(
+            KonfluxImageBuilderConfig(
+                base_dir=Path(self.temp_dir.name),
+                group_name="test-group",
+                namespace="test-namespace",
+                plr_template="test-template",
+                build_priority="5",
+            )
+        )
+
+    def _metadata(self):
+        metadata = MagicMock()
+        metadata.distgit_key = "test-image"
+        metadata.qualified_key = "containers/test-image"
+        metadata.image_name_short = "test-image"
+        metadata.is_olm_operator = False
+        metadata.build_status = False
+        metadata.build_event = MagicMock()
+        metadata.runtime = MagicMock()
+        metadata.runtime.assembly = "test-assembly"
+        metadata.runtime.konflux_db = MagicMock()
+        metadata.get_latest_build = AsyncMock(return_value=None)
+        metadata.get_konflux_build_attempts.return_value = 1
+        metadata.get_arches.return_value = ["x86_64"]
+        metadata.get_konflux_network_mode.return_value = "open"
+        metadata.is_base_image.return_value = False
+        return metadata
+
+    async def test_build_uses_image_digest_for_attestation_validation(self):
+        metadata = self._metadata()
+        dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        build_repo = MagicMock()
+        build_repo.local_dir = dest_dir
+
+        initial_pipelinerun = MagicMock()
+        initial_pipelinerun.name = "test-pipelinerun"
+        initial_pipelinerun.to_dict.return_value = {"metadata": {"name": "test-pipelinerun"}}
+
+        completed_pipelinerun = MagicMock()
+        completed_pipelinerun.name = "test-pipelinerun"
+        completed_pipelinerun.find_condition.return_value = {"status": "True"}
+        completed_pipelinerun.to_dict.return_value = {
+            "metadata": {"name": "test-pipelinerun"},
+            "status": {
+                "results": [
+                    {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                    {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                ]
+            },
+        }
+        self.mock_konflux_client.wait_for_pipelinerun = AsyncMock(return_value=completed_pipelinerun)
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=build_repo),
+            ),
+            patch.object(self.builder, "_parse_dockerfile", return_value=("test-uuid", "test-component", "1.0", "1")),
+            patch.object(self.builder, "_wait_for_parent_members", new=AsyncMock(return_value=[])),
+            patch.object(self.builder, "_start_build", new=AsyncMock(return_value=initial_pipelinerun)),
+            patch.object(self.builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))),
+            patch.object(self.builder, "_validate_build_attestation_and_signature", new=AsyncMock()) as mock_validate,
+            patch(
+                "doozerlib.backend.konflux_image_builder.KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition",
+                return_value=KonfluxBuildOutcome.SUCCESS,
+            ),
+        ):
+            await self.builder.build(metadata)
+
+        mock_validate.assert_awaited_once_with("sha256:testdigest", "test-image")
+
+    async def test_update_konflux_db_uses_image_digest_for_installed_packages(self):
+        metadata = self._metadata()
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "test-commit-hash"
+        build_repo.local_dir = Path(self.temp_dir.name)
+
+        pipelinerun = PipelineRunInfo(
+            {
+                "metadata": {
+                    "name": "test-pipelinerun",
+                    "uid": "test-uid",
+                    "labels": {"appstudio.openshift.io/component": "test-component"},
+                },
+                "status": {
+                    "results": [
+                        {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                        {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                    ],
+                    "startTime": "2023-10-01T12:00:00Z",
+                    "completionTime": "2023-10-01T12:30:00Z",
+                },
+            },
+            {},
+        )
+
+        with (
+            patch("doozerlib.backend.konflux_image_builder.DockerfileParser") as mock_dockerfile_parser,
+            patch.object(self.builder, "extract_parent_image_nvrs", new=AsyncMock(return_value=[])),
+            patch.object(
+                self.builder,
+                "get_installed_packages",
+                new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
+            ) as mock_get_installed_packages,
+            patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
+        ):
+            mock_dockerfile = MagicMock()
+            mock_dockerfile.labels = {
+                "io.openshift.build.source-location": "https://example.com/source-repo.git",
+                "io.openshift.build.commit.id": "source-commit-id",
+                "com.redhat.component": "test-component",
+                "version": "1.0",
+                "release": "1.el9",
+            }
+            mock_dockerfile.parent_images = []
+            mock_dockerfile_parser.return_value = mock_dockerfile
+            mock_bigquery_client.return_value.client.insert_rows_json.return_value = None
+
+            await self.builder.update_konflux_db(
+                metadata,
+                build_repo,
+                pipelinerun,
+                KonfluxBuildOutcome.SUCCESS,
+                ["x86_64"],
+                "5",
+            )
+
+        mock_get_installed_packages.assert_awaited_once_with("sha256:testdigest", ["x86_64"], None)

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -49,7 +49,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         metadata.is_base_image.return_value = False
         return metadata
 
-    async def test_build_uses_image_digest_for_attestation_validation(self):
+    async def test_build_uses_definitive_pullspec_for_attestation_validation(self):
         metadata = self._metadata()
         dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
         dest_dir.mkdir(parents=True)
@@ -92,9 +92,9 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         ):
             await self.builder.build(metadata)
 
-        mock_validate.assert_awaited_once_with("sha256:testdigest", "test-image")
+        mock_validate.assert_awaited_once_with("quay.io/test/image@sha256:testdigest", "test-image")
 
-    async def test_update_konflux_db_uses_image_digest_for_installed_packages(self):
+    async def test_update_konflux_db_uses_definitive_pullspec_for_installed_packages(self):
         metadata = self._metadata()
         build_repo = MagicMock()
         build_repo.https_url = "https://example.com/repo.git"
@@ -151,4 +151,4 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 "5",
             )
 
-        mock_get_installed_packages.assert_awaited_once_with("sha256:testdigest", ["x86_64"], None)
+        mock_get_installed_packages.assert_awaited_once_with("quay.io/test/image@sha256:testdigest", ["x86_64"], None)


### PR DESCRIPTION
Seen at https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgolang-builder/381/console

This command is run for both the image variants.

```
cosign download sbom quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.20.12-20260410.110116 --platform linux/amd64
```

uuid tag for golang builder image can collide for rhel8 and rhel9 builders. So instead use image digest

for more context: this is because our images use openshift-golang-builder.yml in all branches. In future including rhel info in the image name would be the way to go.

