### PR TITLE
Fix missing registry auth for RHCOS node-image scan

### DIFF
--- a/artcommon/artcommonlib/rhcos.py
+++ b/artcommon/artcommonlib/rhcos.py
@@ -131,25 +131,26 @@ def get_build_id_from_rhcos_pullspec(pullspec) -> str:
     return build_id
 
 
-def get_latest_layered_rhcos_build(container_conf: dict = None, arch: str = None):
+def get_latest_layered_rhcos_build(container_conf: Model, arch: str, registry_config: str = None):
     """
     Get the latest Layered RHCOS build ID and pullspec for the specified rhcos container configuration.
 
-    :param container_conf: RHCOS container configuration
-    :param arch: Architecture (e.g., 'x86_64', 'aarch64')
+    :param container_conf: Payload tag config Model from group.yml (exposes rhel_build_id_index, rhcos_index_tag, etc.)
+    :param arch: Brew architecture (e.g., 'x86_64', 'aarch64')
+    :param registry_config: Optional path to registry auth config file
     :return: Tuple of (build_id, pullspec)
     """
     brew_arch = go_arch_for_brew_arch(arch)
 
     # Get build_id from rhel_build_id_index
-    rhel_info_str = oc_image_info__cached(container_conf.rhel_build_id_index, f'--filter-by-os={brew_arch}')
+    rhel_info_str = oc_image_info__cached(container_conf.rhel_build_id_index, f'--filter-by-os={brew_arch}', registry_config=registry_config)
     rhel_info = json.loads(rhel_info_str)
     build_id = rhel_info['config']['config']['Labels']["org.opencontainers.image.version"]
 
     if container_conf.rhel_build_id_index == container_conf.rhcos_index_tag:
         digest = rhel_info['digest']
     else:
-        rhcos_info_str = oc_image_info__cached(container_conf.rhcos_index_tag, f'--filter-by-os={brew_arch}')
+        rhcos_info_str = oc_image_info__cached(container_conf.rhcos_index_tag, f'--filter-by-os={brew_arch}', registry_config=registry_config)
         digest = json.loads(rhcos_info_str)['digest']
 
     # NOTE: RHCOS images are always hosted in the OCP 4.x art-dev repository, even for OCP 5.x,

--- a/artcommon/artcommonlib/rhcos.py
+++ b/artcommon/artcommonlib/rhcos.py
@@ -143,14 +143,18 @@ def get_latest_layered_rhcos_build(container_conf: Model, arch: str, registry_co
     brew_arch = go_arch_for_brew_arch(arch)
 
     # Get build_id from rhel_build_id_index
-    rhel_info_str = oc_image_info__cached(container_conf.rhel_build_id_index, f'--filter-by-os={brew_arch}', registry_config=registry_config)
+    rhel_info_str = oc_image_info__cached(
+        container_conf.rhel_build_id_index, f'--filter-by-os={brew_arch}', registry_config=registry_config
+    )
     rhel_info = json.loads(rhel_info_str)
     build_id = rhel_info['config']['config']['Labels']["org.opencontainers.image.version"]
 
     if container_conf.rhel_build_id_index == container_conf.rhcos_index_tag:
         digest = rhel_info['digest']
     else:
-        rhcos_info_str = oc_image_info__cached(container_conf.rhcos_index_tag, f'--filter-by-os={brew_arch}', registry_config=registry_config)
+        rhcos_info_str = oc_image_info__cached(
+            container_conf.rhcos_index_tag, f'--filter-by-os={brew_arch}', registry_config=registry_config
+        )
         digest = json.loads(rhcos_info_str)['digest']
 
     # NOTE: RHCOS images are always hosted in the OCP 4.x art-dev repository, even for OCP 5.x,

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -1603,7 +1603,7 @@ class ConfigScanSources:
                 build_id = ""
                 for container_conf in self.runtime.group_config.rhcos.payload_tags:
                     if self.runtime.group_config.rhcos.get("layered_rhcos", False):
-                        build_id, pullspec = get_latest_layered_rhcos_build(container_conf, brew_arch)
+                        build_id, pullspec = get_latest_layered_rhcos_build(container_conf, brew_arch, registry_config=self.registry_auth_file)
                     else:
                         build_id, pullspec = rhcos.RHCOSBuildFinder(
                             self.runtime, version, brew_arch, private
@@ -1651,7 +1651,7 @@ class ConfigScanSources:
         rhcos_index = next(
             (tag.rhcos_index_tag for tag in self.runtime.group_config.rhcos.payload_tags if tag.primary), ""
         )
-        rhcos_info = util.oc_image_info_for_arch(rhcos_index, go_arch)
+        rhcos_info = util.oc_image_info_for_arch(rhcos_index, go_arch, registry_config=self.registry_auth_file)
         return rhcos_info['digest']
 
     def tagged_rhcos_id(self, container_name, version, arch, private) -> Optional[str]:

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -1603,7 +1603,9 @@ class ConfigScanSources:
                 build_id = ""
                 for container_conf in self.runtime.group_config.rhcos.payload_tags:
                     if self.runtime.group_config.rhcos.get("layered_rhcos", False):
-                        build_id, pullspec = get_latest_layered_rhcos_build(container_conf, brew_arch, registry_config=self.registry_auth_file)
+                        build_id, pullspec = get_latest_layered_rhcos_build(
+                            container_conf, brew_arch, registry_config=self.registry_auth_file
+                        )
                     else:
                         build_id, pullspec = rhcos.RHCOSBuildFinder(
                             self.runtime, version, brew_arch, private


### PR DESCRIPTION
## Summary
- The `latest_rhcos_node_shasum` method in `scan_sources_konflux.py` was calling `util.oc_image_info_for_arch()` without passing `registry_config`, causing `oc image info` to run without `--registry-config` when querying `quay.io/openshift-release-dev/ocp-v4.0-art-dev` for the RHCOS node-image tag.
- This resulted in `unauthorized: Could not find robot with username: openshift-release-dev+art_quay_dev` errors in the `ocp4-scan-konflux` job (e.g. [build #44495](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/44495/console)).
- Fix: pass `registry_config=self.registry_auth_file` so the auth file from `KONFLUX_ART_IMAGES_AUTH_FILE` is used, consistent with all other `oc image info` calls in the same class.

## Test plan
- [ ] Verify `ocp4-scan-konflux` job passes for 4.19 after this fix
