### PR TITLE
ocp-build-data-validator: allow redhat-cne/downstream-ptp-operator-mo…

### DIFF
--- a/ocp-build-data-validator/validator/github.py
+++ b/ocp-build-data-validator/validator/github.py
@@ -141,6 +141,7 @@ def uses_ssh(data):
 def has_permitted_repo(data):
     permitted = [
         'redhat-cne/cloud-event-proxy',  # max version 4.12
+        'redhat-cne/downstream-ptp-operator-monorepo',  # max version 4.12
         'operator-framework/operator-lifecycle-manager',  # max version 4.7 3.11
         'operator-framework/operator-marketplace',  # max version 4.19
         'openshift/jenkins',  # max version 3.11


### PR DESCRIPTION
…norepo

Add the repo to the GitHub permitted list so full ocp-build-data validation passes for images sourced from that repository.

Made-with: Cursor

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED