### PR TITLE
Thread registry_config through inspect_stream and AssemblyInspector

### DIFF
--- a/doozer/doozerlib/assembly_inspector.py
+++ b/doozer/doozerlib/assembly_inspector.py
@@ -601,7 +601,9 @@ class AssemblyInspector:
                 cache[tag] = component_builds
         return cache
 
-    def get_rhcos_build(self, arch: str, private: bool = False, custom: bool = False) -> RHCOSBuildInspector:
+    def get_rhcos_build(
+        self, arch: str, private: bool = False, custom: bool = False, registry_config: str = None
+    ) -> RHCOSBuildInspector:
         """
         :param arch: The CPU architecture of the build to retrieve.
         :param private: If this should be a private build (NOT CURRENTLY SUPPORTED)
@@ -638,7 +640,12 @@ class AssemblyInspector:
             try:
                 version = self.runtime.get_minor_version()
                 build_id, pullspec = RHCOSBuildFinder(
-                    runtime, version, brew_arch, private, custom=custom
+                    runtime,
+                    version,
+                    brew_arch,
+                    private,
+                    custom=custom,
+                    registry_config=registry_config,
                 ).latest_container(container_conf)
                 if not pullspec:
                     raise IOError(f"No RHCOS latest found for {version} / {brew_arch}")
@@ -649,4 +656,4 @@ class AssemblyInspector:
                     # their absence will be noted when generating payloads anyway.
                     raise
 
-        return RHCOSBuildInspector(runtime, pullspec_for_tag, brew_arch, build_id)
+        return RHCOSBuildInspector(runtime, pullspec_for_tag, brew_arch, build_id, registry_config=registry_config)

--- a/doozer/doozerlib/cli/inspect_stream.py
+++ b/doozer/doozerlib/cli/inspect_stream.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pprint import pprint
 
 import click
@@ -32,8 +33,12 @@ async def inspect_stream(runtime: Runtime, code: AssemblyIssueCode, strict: bool
         await assembly_inspector.initialize(lookup_mode=None)
         package_rpm_finder = PackageRpmFinder(runtime)
         payload_generator = PayloadGenerator(runtime, package_rpm_finder)
+        registry_config = os.getenv("KONFLUX_ART_IMAGES_AUTH_FILE")
         rhcos_builds, rhcos_inconsistencies = _check_inconsistent_rhcos_rpms(
-            runtime, assembly_inspector, payload_generator
+            runtime,
+            assembly_inspector,
+            payload_generator,
+            registry_config=registry_config,
         )
         if rhcos_inconsistencies:
             msg = f'Found RHCOS inconsistencies in builds {rhcos_builds}'
@@ -60,8 +65,13 @@ async def inspect_stream(runtime: Runtime, code: AssemblyIssueCode, strict: bool
         await assembly_inspector.initialize(lookup_mode="images")
         package_rpm_finder = PackageRpmFinder(runtime)
         payload_generator = PayloadGenerator(runtime, package_rpm_finder)
+        registry_config = os.getenv("KONFLUX_ART_IMAGES_AUTH_FILE")
         issues = _check_cross_payload_consistency_requirements(
-            runtime, assembly_inspector, payload_generator, requirements
+            runtime,
+            assembly_inspector,
+            payload_generator,
+            requirements,
+            registry_config=registry_config,
         )
         if issues:
             LOGGER.info('Payload contents consistency requirements not satisfied')
@@ -77,11 +87,14 @@ async def inspect_stream(runtime: Runtime, code: AssemblyIssueCode, strict: bool
 
 
 def _check_inconsistent_rhcos_rpms(
-    runtime: Runtime, assembly_inspector: AssemblyInspector, payload_generator: PayloadGenerator
+    runtime: Runtime,
+    assembly_inspector: AssemblyInspector,
+    payload_generator: PayloadGenerator,
+    registry_config: str = None,
 ):
     rhcos_builds = []
     for arch in runtime.group_config.arches:
-        build_inspector = assembly_inspector.get_rhcos_build(arch)
+        build_inspector = assembly_inspector.get_rhcos_build(arch, registry_config=registry_config)
         rhcos_builds.append(build_inspector)
     runtime.logger.info(f"Checking following builds for inconsistency: {rhcos_builds}")
     rhcos_inconsistencies = payload_generator.find_rhcos_build_rpm_inconsistencies(rhcos_builds)
@@ -89,13 +102,17 @@ def _check_inconsistent_rhcos_rpms(
 
 
 def _check_cross_payload_consistency_requirements(
-    runtime: Runtime, assembly_inspector: AssemblyInspector, payload_generator: PayloadGenerator, requirements: dict
+    runtime: Runtime,
+    assembly_inspector: AssemblyInspector,
+    payload_generator: PayloadGenerator,
+    requirements: dict,
+    registry_config: str = None,
 ):
     issues = []
     for arch in runtime.group_config.arches:
         issues.extend(
             payload_generator.find_rhcos_payload_rpm_inconsistencies(
-                assembly_inspector.get_rhcos_build(arch),
+                assembly_inspector.get_rhcos_build(arch, registry_config=registry_config),
                 assembly_inspector.get_group_release_images(),
                 requirements,
             )


### PR DESCRIPTION
## Summary
- Adds `registry_config` parameter to `AssemblyInspector.get_rhcos_build()` and threads it through to `RHCOSBuildFinder` and `RHCOSBuildInspector`.
- Updates `inspect_stream.py` to read `KONFLUX_ART_IMAGES_AUTH_FILE` from the environment and pass it to `get_rhcos_build()` for both `INCONSISTENT_RHCOS_RPMS` and `FAILED_CONSISTENCY_REQUIREMENT` checks.
- Fixes the `unauthorized: Could not find robot with username: openshift-release-dev+art_quay_dev` error in the `doozer inspect:stream INCONSISTENT_RHCOS_RPMS` subprocess invoked by `ocp4-scan-konflux`.

## Context
PR #2732 threaded `registry_config` through `RHCOSBuildFinder`, `RHCOSBuildInspector`, and `get_build_id_from_rhcos_pullspec`. However, the `inspect:stream` command runs as a separate doozer subprocess and reaches these classes through `AssemblyInspector.get_rhcos_build()`, which was not updated to pass `registry_config`. This PR closes that gap.

## Test plan
- [x] `make lint` passes (ruff check + format)
- [x] `make unit` passes (809 passed, 5 pre-existing failures unrelated — macOS `/var` vs `/private/var` symlink issue in `TestFindGoMainPackages`)
- [ ] Verify `ocp4-scan-konflux` Jenkins job succeeds after merge


Made with [Cursor](https://cursor.com)