### PR TITLE
Thread registry_config through release_gen_assembly for build-sync-multi auth

### DIFF
--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import re
 import sys
 from datetime import datetime
@@ -167,6 +168,7 @@ async def gen_assembly_from_releases(
         suggestions_url=suggestions_url,
         gen_microshift=gen_microshift,
         release_date=date,
+        registry_config=os.getenv("KONFLUX_ART_IMAGES_AUTH_FILE"),
     ).run()
 
     # ruamel.yaml configuration
@@ -205,8 +207,10 @@ class GenAssemblyCli:
         suggestions_url: Optional[str] = None,
         gen_microshift: bool = False,
         release_date: Optional[str] = None,
+        registry_config: str = None,
     ):
         self.runtime = runtime
+        self.registry_config = registry_config
         # The name of the assembly we are going to output
         self.gen_assembly_name = gen_assembly_name
         self.nightlies = nightlies
@@ -356,7 +360,9 @@ class GenAssemblyCli:
             payload_tag_name = component_tag.name  # e.g. "aws-ebs-csi-driver"
             payload_tag_pullspec = component_tag['from'].name  # quay pullspec
             image_info = await util.oc_image_info_for_arch_async(
-                payload_tag_pullspec, go_arch_for_brew_arch(brew_cpu_arch)
+                payload_tag_pullspec,
+                go_arch_for_brew_arch(brew_cpu_arch),
+                registry_config=self.registry_config,
             )
             if payload_tag_name in rhcos_tag_names:
                 self.runtime.logger.info(f'Record rhcos tag name {payload_tag_name}')
@@ -370,7 +376,9 @@ class GenAssemblyCli:
                 continue
 
             # Use shared utility to extract NVR and get build inspector
-            name, version, release_ver = await release_inspector.extract_nvr_from_pullspec(payload_tag_pullspec)
+            name, version, release_ver = await release_inspector.extract_nvr_from_pullspec(
+                payload_tag_pullspec, registry_config=self.registry_config
+            )
             package_name = name
             build_nvr = f"{name}-{version}-{release_ver}"
 
@@ -605,7 +613,11 @@ class GenAssemblyCli:
                             self._exit_with_error(
                                 f"Did not find RHCOS {tag.name} image for architecture: x86_64 in any nightly"
                             )
-                        amd64_rhcos_info = util.oc_image_info_for_arch(self.rhcos_by_tag[tag.name]["x86_64"], "amd64")
+                        amd64_rhcos_info = util.oc_image_info_for_arch(
+                            self.rhcos_by_tag[tag.name]["x86_64"],
+                            "amd64",
+                            registry_config=self.registry_config,
+                        )
                         # NOTE: RHCOS images are currently always in ocp-v4.0-art-dev, even for OCP 5.x.
                         # When RHCOS 5.x images exist in their own repository, this should be updated to
                         # use the actual OCP major version: get_art_prod_image_repo_for_version(major, "dev")
@@ -613,6 +625,7 @@ class GenAssemblyCli:
                         rhcos_info = util.oc_image_info_for_arch(
                             f"{art_repo}:{amd64_rhcos_info['config']['config']['Labels']['coreos.build.manifest-list-tag']}",
                             go_arch_for_brew_arch(arch),
+                            registry_config=self.registry_config,
                         )
                         self.rhcos_by_tag[tag.name][arch] = f"{art_repo}@{rhcos_info['digest']}"
                         self.logger.info(f'Find RHCOS image {tag.name} for {arch}: {self.rhcos_by_tag[tag.name][arch]}')

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -614,6 +614,7 @@ class GenPayloadCli:
             suggestions_url=None,
             gen_microshift=False,
             release_date=dummy_release_date,  # Prevent release schedule lookup
+            registry_config=os.getenv("KONFLUX_ART_IMAGES_AUTH_FILE"),
         )
 
         # Run gen-assembly logic to create the assembly definition

--- a/doozer/doozerlib/release_inspector.py
+++ b/doozer/doozerlib/release_inspector.py
@@ -65,19 +65,22 @@ async def introspect_release(pullspec: str) -> Model:
     return release_info
 
 
-async def extract_nvr_from_pullspec(pullspec: str, arch: str = None) -> Tuple[str, str, str]:
+async def extract_nvr_from_pullspec(
+    pullspec: str, arch: str = None, registry_config: str = None
+) -> Tuple[str, str, str]:
     """
     Extract NVR (name, version, release) from an image pullspec by reading labels.
 
     :param pullspec: Image pullspec
     :param arch: Optional go architecture to filter by
+    :param registry_config: Optional path to registry auth config file
     :return: Tuple of (name, version, release)
     """
     options = []
     if arch:
         options.append(f"--filter-by-os={arch}")
     try:
-        stdout = await oc_image_info__cached_async(pullspec, *options)
+        stdout = await oc_image_info__cached_async(pullspec, *options, registry_config=registry_config)
     except ChildProcessError as e:
         raise IOError(f"Failed to get image info for {pullspec}: {e}") from e
 
@@ -117,15 +120,18 @@ async def get_build_inspector_from_nvr(runtime: Runtime, nvr: str, pullspec: str
         return KonfluxBuildRecordInspector(runtime, build_record)
 
 
-async def get_build_inspector_from_pullspec(runtime: Runtime, pullspec: str, arch: str = None) -> BuildRecordInspector:
+async def get_build_inspector_from_pullspec(
+    runtime: Runtime, pullspec: str, arch: str = None, registry_config: str = None
+) -> BuildRecordInspector:
     """
     Extract NVR from a pullspec and query build system to get build inspector.
 
     :param runtime: Doozer runtime
     :param pullspec: Image pullspec
     :param arch: Optional go architecture to filter by
+    :param registry_config: Optional path to registry auth config file
     :return: BuildRecordInspector for the build
     """
-    name, version, release = await extract_nvr_from_pullspec(pullspec, arch)
+    name, version, release = await extract_nvr_from_pullspec(pullspec, arch, registry_config=registry_config)
     nvr = f"{name}-{version}-{release}"
     return await get_build_inspector_from_nvr(runtime, nvr, pullspec=pullspec)


### PR DESCRIPTION
## Summary
- Adds `registry_config` parameter to `GenAssemblyCli.__init__` and stores it as `self.registry_config`.
- Passes `registry_config` to `oc_image_info_for_arch_async` in `_process_release()` (nightly payload image introspection).
- Passes `registry_config` to both `oc_image_info_for_arch` calls in the layered RHCOS resolution path.
- Reads `KONFLUX_ART_IMAGES_AUTH_FILE` from the environment at both entry points: the `gen_assembly_from_releases` CLI command and the `_create_assembly_from_model` caller in `release_gen_payload.py`.

## Context
PRs #2730, #2732, #2733, and #2734 threaded `registry_config` through the RHCOS classes, `inspect_stream`, `scan_sources_konflux`, and `release_gen_payload` paths. This PR closes the gap in the `release_gen_assembly` path used by `build-sync-multi`, where `GenAssemblyCli._process_release()` was calling `oc_image_info_for_arch_async` without auth when introspecting nightly payload images from `quay.io/openshift-release-dev/ocp-v4.0-art-dev`.

## Test plan
- [x] `make lint` passes (ruff check + format)
- [x] `make unit` passes (809 passed, 5 pre-existing failures unrelated — macOS `/var` vs `/private/var` symlink issue in `TestFindGoMainPackages`)
- [ ] Verify `build-sync-multi` Jenkins job succeeds after merge


Made with [Cursor](https://cursor.com)