### PR TITLE
Prefer KONFLUX_ART_IMAGES_AUTH_FILE for manifest-tool registry auth

### DIFF
--- a/artcommon/artcommonlib/exectools.py
+++ b/artcommon/artcommonlib/exectools.py
@@ -512,7 +512,10 @@ def unpack_tuple_args(func):
 @tenacity.retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(60))
 async def manifest_tool(options, dry_run=False):
     auth_opt = ""
-    if os.environ.get("XDG_RUNTIME_DIR"):
+    konflux_auth = os.environ.get("KONFLUX_ART_IMAGES_AUTH_FILE")
+    if konflux_auth and Path(konflux_auth).is_file():
+        auth_opt = f"--docker-cfg={konflux_auth}"
+    elif os.environ.get("XDG_RUNTIME_DIR"):
         auth_file = os.path.expandvars("${XDG_RUNTIME_DIR}/containers/auth.json")
         if Path(auth_file).is_file():
             auth_opt = f"--docker-cfg={auth_file}"


### PR DESCRIPTION
## Summary
- The `manifest_tool` function in `artcommon/artcommonlib/exectools.py` uses `XDG_RUNTIME_DIR/containers/auth.json` for `--docker-cfg`, which lacks the Quay robot account credentials in Konflux jobs (e.g. `build-sync-multi`)
- Prioritize `KONFLUX_ART_IMAGES_AUTH_FILE` when the env var is set and points to an existing file, falling back to the existing `XDG_RUNTIME_DIR` logic for non-Konflux environments (e.g. `promote-assembly`)

## Test plan
- [x] `make test` passes (5 pre-existing macOS `/var` vs `/private/var` failures unrelated to this change)
- [ ] Verify `build-sync-multi` job no longer fails with `manifest-tool` 401 Unauthorized

Made with [Cursor](https://cursor.com)