### PR TITLE
Thread registry_config through find_manifest_list_sha for build-sync-multi auth

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -1949,7 +1949,7 @@ class GenPayloadCli:
         await manifest_tool(f'push from-spec {str(component_manifest_path)}')
 
         # we are pushing a new manifest list, so return its sha256 based pullspec
-        sha = await find_manifest_list_sha(output_pullspec)
+        sha = await find_manifest_list_sha(output_pullspec, registry_config=os.getenv("KONFLUX_ART_IMAGES_AUTH_FILE"))
         return exchange_pullspec_tag_for_shasum(output_pullspec, sha)
 
     async def create_multi_release_image(
@@ -2046,7 +2046,9 @@ class GenPayloadCli:
         await manifest_tool(f'push from-spec {str(release_payload_ml_path)}')
 
         # if we are actually pushing a manifest list, then we should derive a sha256 based pullspec
-        sha = await find_manifest_list_sha(multi_release_dest)
+        sha = await find_manifest_list_sha(
+            multi_release_dest, registry_config=os.getenv("KONFLUX_ART_IMAGES_AUTH_FILE")
+        )
         return exchange_pullspec_tag_for_shasum(multi_release_dest, sha)
 
     async def apply_multi_imagestream_update(

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -544,8 +544,8 @@ def get_release_calc_previous(
     return sort_semver(list(upgrade_from))
 
 
-async def find_manifest_list_sha(pullspec):
-    image_data = await oc_image_info_for_arch_async(pullspec)
+async def find_manifest_list_sha(pullspec, registry_config: str = None):
+    image_data = await oc_image_info_for_arch_async(pullspec, registry_config=registry_config)
     if 'listDigest' not in image_data:
         raise ValueError('Specified image is not a manifest-list.')
     return image_data['listDigest']


### PR DESCRIPTION
## Summary
- `find_manifest_list_sha` in `doozer/doozerlib/util.py` calls `oc_image_info_for_arch_async` without `registry_config`, causing 401 Unauthorized when querying manifest list digests on `quay.io`
- Added `registry_config` parameter to `find_manifest_list_sha` and pass `KONFLUX_ART_IMAGES_AUTH_FILE` from both callers in `release_gen_payload.py` (`create_multi_manifest_list` and `create_multi_release_image`)

## Test plan
- [x] `make test` passes (5 pre-existing macOS `/var` vs `/private/var` failures unrelated to this change)
- [ ] Verify `build-sync-multi` job no longer fails with `oc image info` 401 Unauthorized on manifest list SHA lookup

Made with [Cursor](https://cursor.com)