### PR TITLE
Pass --registry-config to oc adm release new for quay.io auth

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -1976,22 +1976,24 @@ class GenPayloadCli:
 
         @retry(reraise=True, stop=stop_after_attempt(10), wait=wait_fixed(60))
         async def _run(to_image, to_image_base):
-            return await exectools.cmd_assert_async(
-                [
-                    "oc",
-                    "adm",
-                    "release",
-                    "new",
-                    f"--name={multi_release_name}",
-                    "--reference-mode=source",
-                    "--keep-manifest-list",
-                    f"--from-image-stream-file={str(multi_release_is_path)}",
-                    f"--to-image-base={to_image_base}",
-                    f"--to-image={to_image}",
-                    "--metadata",
-                    json.dumps({"release.openshift.io/architecture": "multi"}),
-                ]
-            )
+            cmd = [
+                "oc",
+                "adm",
+                "release",
+                "new",
+                f"--name={multi_release_name}",
+                "--reference-mode=source",
+                "--keep-manifest-list",
+                f"--from-image-stream-file={str(multi_release_is_path)}",
+                f"--to-image-base={to_image_base}",
+                f"--to-image={to_image}",
+                "--metadata",
+                json.dumps({"release.openshift.io/architecture": "multi"}),
+            ]
+            registry_config = os.getenv("KONFLUX_ART_IMAGES_AUTH_FILE")
+            if registry_config:
+                cmd.append(f"--registry-config={registry_config}")
+            return await exectools.cmd_assert_async(cmd)
 
         # This will map arch names to a release payload pullspec we create for that arch
         # (i.e. based on the arch's CVO image)


### PR DESCRIPTION
## Summary

- After the quay.io token rotation, `oc adm release new` in `create_multi_release_image` fails with 401 Unauthorized because it does not pass `--registry-config` and falls back to the default Docker config (which has stale creds)
- All other quay-facing commands in the build-sync-multi flow already pass `KONFLUX_ART_IMAGES_AUTH_FILE` (via `--registry-config` or `--docker-cfg`). This was the last remaining gap.
- Conditionally appends `--registry-config` only when `KONFLUX_ART_IMAGES_AUTH_FILE` is set, maintaining backward compatibility

## Test plan

- [ ] Verify build-sync-multi job no longer fails with 401 on the `oc adm release new` step
- [ ] Verify non-Konflux environments (where `KONFLUX_ART_IMAGES_AUTH_FILE` is unset) are unaffected


Made with [Cursor](https://cursor.com)