### PR TITLE
doozer: fix TestFindGoMainPackages on macOS temp paths

### DIFF
--- a/doozer/tests/test_util.py
+++ b/doozer/tests/test_util.py
@@ -327,7 +327,7 @@ class TestFindGoMainPackages(unittest.TestCase):
 
     def test_finds_simple_main_package(self):
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             cmd_dir = root / 'cmd' / 'myapp'
             self._write(cmd_dir, 'main.go', 'package main\n\nfunc main() {}\n')
             result = util.find_go_main_packages(root)
@@ -335,14 +335,14 @@ class TestFindGoMainPackages(unittest.TestCase):
 
     def test_skips_vendor_dirs(self):
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             self._write(root / 'vendor' / 'pkg', 'main.go', 'package main\n')
             result = util.find_go_main_packages(root)
             self.assertEqual(result, [])
 
     def test_skips_test_files(self):
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             # Directory with only a test file declaring package main
             self._write(root / 'pkg', 'main_test.go', 'package main\n')
             result = util.find_go_main_packages(root)
@@ -351,7 +351,7 @@ class TestFindGoMainPackages(unittest.TestCase):
     def test_skips_build_ignored_main(self):
         """A directory with only ``//go:build ignore`` main files should be skipped."""
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             plugins_dir = root / 'plugins'
             self._write(plugins_dir, 'example.go', '//go:build ignore\n\npackage main\n\nfunc main() {}\n')
             self._write(plugins_dir, 'minimum.go', 'package plugins\n')
@@ -364,7 +364,7 @@ class TestFindGoMainPackages(unittest.TestCase):
         check) should be skipped.
         """
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             mixed_dir = root / 'mixed'
             self._write(mixed_dir, 'main.go', 'package main\n\nfunc main() {}\n')
             self._write(mixed_dir, 'lib.go', 'package mixed\n')
@@ -377,7 +377,7 @@ class TestFindGoMainPackages(unittest.TestCase):
         ``//go:build ignore`` file with ``package main``.
         """
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             plugins_dir = root / 'plugins'
             self._write(plugins_dir, 'minimum.go', 'package plugins\n\nvar _ = 1\n')
             self._write(
@@ -400,7 +400,7 @@ class TestFindGoMainPackages(unittest.TestCase):
 
     def test_multiple_main_packages(self):
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             cmd1 = root / 'cmd' / 'app1'
             cmd2 = root / 'cmd' / 'app2'
             self._write(cmd1, 'main.go', 'package main\n\nfunc main() {}\n')
@@ -414,7 +414,7 @@ class TestFindGoMainPackages(unittest.TestCase):
         that ``go mod vendor`` does not copy injected files into vendor/.
         """
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             # Root module
             self._write(root, 'go.mod', 'module example.com/myproject\n')
             root_cmd = root / 'cmd' / 'myapp'
@@ -436,7 +436,7 @@ class TestFindGoMainPackages(unittest.TestCase):
         vendor/.
         """
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             self._write(root, 'go.mod', 'module example.com/olm\n')
             # Root cmd directories
             cmd_a = root / 'cmd' / 'collect-profiles'


### PR DESCRIPTION
## Summary
`TestFindGoMainPackages` (and related assertions) failed on macOS because `tempfile` paths use `/var/...` while `find_go_main_packages()` canonicalizes with `pathlib.Path.resolve()`, producing `/private/var/...`.

## Change
Use `pathlib.Path(td).resolve()` for the test temp root in `TestFindGoMainPackages` so expected paths match the implementation on all platforms.

## Testing
`uv run pytest doozer/tests/test_util.py -q` (49 passed).

Made with [Cursor](https://cursor.com)