### PR TITLE
ART-14907 ART-14721: seed-lockfile: improve Jenkins build description for automated remediation

### DIFF
--- a/pyartcd/pyartcd/pipelines/seed_lockfile.py
+++ b/pyartcd/pyartcd/pipelines/seed_lockfile.py
@@ -1,7 +1,10 @@
+import html as html_mod
 import logging
 import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional, Tuple
+from urllib.parse import quote
 
 import click
 from artcommonlib import exectools
@@ -49,6 +52,7 @@ class SeedLockfilePipeline:
         plr_template: str = '',
         build_priority: str = 'auto',
         seed_nvrs: Optional[str] = None,
+        jira_key: Optional[str] = None,
     ):
         self.runtime = runtime
         self.version = version
@@ -74,6 +78,8 @@ class SeedLockfilePipeline:
                     raise click.BadParameter(f"Invalid seed-nvrs entry '{entry}': expected format name@NVR")
                 name, nvr = entry.split('@', 1)
                 self.seed_map[name.strip()] = nvr.strip()
+
+        self.jira_key = jira_key or ''
 
         self.test_results: dict[str, dict] = {}
         self.stream_results: dict[str, dict] = {}
@@ -272,6 +278,16 @@ class SeedLockfilePipeline:
             return f'{ART_BUILD_HISTORY_URL}/?nvr={nvr}&group={group}&engine=konflux'
         return ''
 
+    @staticmethod
+    def _search_url(image_name: str, group: str) -> str:
+        """Build a search page URL for a component in art-build-history (fallback when no NVR is available)."""
+        start_date = (datetime.now(timezone.utc) - timedelta(days=2)).strftime('%Y-%m-%d')
+        end_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+        return (
+            f'{ART_BUILD_HISTORY_URL}/?name=^{image_name}$&group={group}'
+            f'&engine=konflux&dateRange={start_date}+to+{end_date}&outcome=success&outcome=failure'
+        )
+
     def _categorize_results(self) -> tuple[list[str], list[str], list[str]]:
         test_failed: list[str] = []
         solved: list[str] = []
@@ -291,11 +307,14 @@ class SeedLockfilePipeline:
 
         return test_failed, solved, stream_failed
 
-    def _link(self, name: str, phase: str, group: str) -> str:
+    def _link(self, name: str, phase: str, group: str, fallback_search: bool = False) -> str:
         """Return an art-build-history URL for a build, or empty string if unavailable."""
         results = self.test_results if phase == 'test' else self.stream_results
         entry = results.get(name, {})
-        return self._build_url(group, entry) if entry else ''
+        url = self._build_url(group, entry) if entry else ''
+        if not url and fallback_search:
+            return self._search_url(name, group)
+        return url
 
     def _build_slack_report(self, test_failed: list[str], solved: list[str], stream_failed: list[str]) -> str:
         group = f'openshift-{self.version}'
@@ -317,7 +336,8 @@ class SeedLockfilePipeline:
                     lines.append(f'  - `{name}`')
 
         if solved:
-            lines.append('\n*Solved:*')
+            label = 'Solved' if self.assembly == 'stream' else 'Succeeded'
+            lines.append(f'\n*{label}:*')
             for name in solved:
                 url = self._link(name, 'stream', group)
                 if url:
@@ -326,10 +346,11 @@ class SeedLockfilePipeline:
                     lines.append(f'  - `{name}`')
 
         if stream_failed:
-            lines.append('\n*Stream build failed after successful test build:*')
+            phase2_label = 'Stream' if self.assembly == 'stream' else f'{self.assembly} assembly'
+            lines.append(f'\n*{phase2_label} build failed after successful test build:*')
             for name in stream_failed:
                 test_url = self._link(name, 'test', group)
-                stream_url = self._link(name, 'stream', group)
+                stream_url = self._link(name, 'stream', group, fallback_search=True)
                 parts = [f'`{name}`']
                 if test_url:
                     parts.append(f'<{test_url}|test>')
@@ -351,27 +372,29 @@ class SeedLockfilePipeline:
             for name in test_failed:
                 url = self._link(name, 'test', group)
                 if url:
-                    lines.append(f'<li><a href="{url}">{name}</a></li>')
+                    lines.append(f'<li><a href="{url}">{html_mod.escape(name)}</a></li>')
                 else:
-                    lines.append(f'<li>{name}</li>')
+                    lines.append(f'<li>{html_mod.escape(name)}</li>')
             lines.append('</ul>')
 
         if solved:
-            lines.append('<b>Solved:</b><ul>')
+            label = 'Solved' if self.assembly == 'stream' else 'Succeeded'
+            lines.append(f'<b>{label}:</b><ul>')
             for name in solved:
                 url = self._link(name, 'stream', group)
                 if url:
-                    lines.append(f'<li><a href="{url}">{name}</a></li>')
+                    lines.append(f'<li><a href="{url}">{html_mod.escape(name)}</a></li>')
                 else:
-                    lines.append(f'<li>{name}</li>')
+                    lines.append(f'<li>{html_mod.escape(name)}</li>')
             lines.append('</ul>')
 
         if stream_failed:
-            lines.append('<b>Stream build failed after successful test build:</b><ul>')
+            phase2_label = 'Stream' if self.assembly == 'stream' else f'{self.assembly} assembly'
+            lines.append(f'<b>{phase2_label} build failed after successful test build:</b><ul>')
             for name in stream_failed:
                 test_url = self._link(name, 'test', group)
-                stream_url = self._link(name, 'stream', group)
-                parts = [name]
+                stream_url = self._link(name, 'stream', group, fallback_search=True)
+                parts = [html_mod.escape(name)]
                 if test_url:
                     parts.append(f'<a href="{test_url}">test</a>')
                 if stream_url:
@@ -381,6 +404,19 @@ class SeedLockfilePipeline:
 
         if not lines:
             lines.append('No build results recorded.')
+
+        if self.seed_map:
+            lines.append('<b>Seed NVRs:</b><ul>')
+            for name, nvr in sorted(self.seed_map.items()):
+                lines.append(f'<li>{html_mod.escape(name)}: <code>{html_mod.escape(nvr)}</code></li>')
+            lines.append('</ul>')
+
+        if self.data_gitref:
+            data_url = f'{self.data_path.rstrip("/")}/tree/{quote(self.data_gitref, safe="")}'
+            lines.append(
+                f'<b>Data:</b> <a href="{html_mod.escape(data_url, quote=True)}">'
+                f'{html_mod.escape(self.data_gitref)}</a><br/>'
+            )
 
         return '\n'.join(lines)
 
@@ -402,8 +438,15 @@ class SeedLockfilePipeline:
             )
             jenkins.update_description(f'<a href="{build_history_url}">View build history</a><br/>')
 
-            if solved:
-                jenkins.update_title(f' | solved: {", ".join(solved)}')
+            title_parts: list[str] = []
+            if self.assembly != 'stream':
+                title_parts.append(f'[{self.assembly}]')
+            if self.jira_key:
+                title_parts.append(self.jira_key)
+            if solved and self.assembly == 'stream':
+                title_parts.append(f'solved: {", ".join(solved)}')
+            if title_parts:
+                jenkins.update_title(f' | {" ".join(title_parts)}')
         except Exception:
             LOGGER.warning('Could not update Jenkins build description/title', exc_info=True)
 
@@ -447,6 +490,12 @@ class SeedLockfilePipeline:
     default='auto',
     help='Kueue build priority (1-10 or "auto")',
 )
+@click.option(
+    '--jira-key',
+    required=False,
+    default='',
+    help='(Optional) Jira ticket key to include in Jenkins build title (e.g. ART-14902)',
+)
 @pass_runtime
 @click_coroutine
 async def seed_lockfile(
@@ -461,6 +510,7 @@ async def seed_lockfile(
     arches: Tuple[str, ...],
     plr_template: str,
     build_priority: str,
+    jira_key: str,
 ):
     if not kubeconfig:
         kubeconfig = os.environ.get('KONFLUX_SA_KUBECONFIG')
@@ -477,5 +527,6 @@ async def seed_lockfile(
         arches=arches,
         plr_template=plr_template,
         build_priority=build_priority,
+        jira_key=jira_key,
     )
     await pipeline.run()

--- a/pyartcd/tests/pipelines/test_seed_lockfile.py
+++ b/pyartcd/tests/pipelines/test_seed_lockfile.py
@@ -204,10 +204,11 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(RuntimeError):
                 await pipeline.run()
 
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.init_jenkins')
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_title')
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_description')
     @patch('pyartcd.pipelines.seed_lockfile.exectools.cmd_assert_async', new_callable=AsyncMock)
-    async def test_dry_run_skips_push(self, mock_cmd, _desc, _title):
+    async def test_dry_run_skips_push(self, mock_cmd, _desc, _title, _init):
         """In dry run, --push is not added to rebase and --dry-run is added to build."""
         pipeline = self._create_pipeline(
             runtime=MagicMock(dry_run=True, doozer_working='/tmp/doozer-working'),
@@ -272,6 +273,27 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
         url = SeedLockfilePipeline._build_url('openshift-4.22', {'nvrs': 'n/a', 'status': '-1'})
         self.assertEqual(url, '')
 
+    def test_search_url_contains_image_and_group(self):
+        url = SeedLockfilePipeline._search_url('ironic', 'openshift-4.22')
+        self.assertIn('name=^ironic$', url)
+        self.assertIn('group=openshift-4.22', url)
+        self.assertIn('engine=konflux', url)
+
+    def test_link_fallback_search(self):
+        """_link returns a search URL when _build_url returns empty and fallback_search is True."""
+        pipeline = self._create_pipeline(image_list='ironic')
+        pipeline.stream_results = {'ironic': {'name': 'ironic', 'nvrs': 'n/a', 'status': '-1'}}
+        url = pipeline._link('ironic', 'stream', 'openshift-4.22', fallback_search=True)
+        self.assertIn('name=^ironic$', url)
+        self.assertIn('group=openshift-4.22', url)
+
+    def test_link_no_fallback_returns_empty(self):
+        """_link returns empty when _build_url returns empty and fallback_search is False."""
+        pipeline = self._create_pipeline(image_list='ironic')
+        pipeline.stream_results = {'ironic': {'name': 'ironic', 'nvrs': 'n/a', 'status': '-1'}}
+        url = pipeline._link('ironic', 'stream', 'openshift-4.22', fallback_search=False)
+        self.assertEqual(url, '')
+
     def test_slack_report_content(self):
         """Slack report contains expected sections."""
         pipeline = self._create_pipeline(image_list='img-a,img-b,img-c')
@@ -283,6 +305,13 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
         self.assertIn('Stream build failed', report)
         self.assertIn('img-c', report)
 
+    def test_slack_report_uses_succeeded_for_test_assembly(self):
+        """Slack report shows 'Succeeded' instead of 'Solved' for non-stream assembly."""
+        pipeline = self._create_pipeline(image_list='img-a', assembly='test')
+        report = pipeline._build_slack_report(test_failed=[], solved=['img-a'], stream_failed=[])
+        self.assertIn('Succeeded', report)
+        self.assertNotIn('Solved', report)
+
     def test_jenkins_description_content(self):
         """Jenkins HTML description contains expected sections."""
         pipeline = self._create_pipeline(image_list='img-a,img-b,img-c')
@@ -293,6 +322,50 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
         self.assertIn('img-b', html)
         self.assertIn('Stream build failed', html)
         self.assertIn('img-c', html)
+
+    def test_jenkins_description_uses_succeeded_for_test_assembly(self):
+        """Jenkins description shows 'Succeeded' instead of 'Solved' for non-stream assembly."""
+        pipeline = self._create_pipeline(image_list='img-a', assembly='test')
+        html = pipeline._build_jenkins_description(test_failed=[], solved=['img-a'], stream_failed=[])
+        self.assertIn('Succeeded', html)
+        self.assertNotIn('Solved', html)
+
+    def test_jenkins_description_includes_seed_nvrs(self):
+        """Jenkins description includes seed NVR section."""
+        pipeline = self._create_pipeline(
+            image_list='ironic',
+            seed_nvrs='ironic@ironic-container-v4.22.0-assembly.test',
+        )
+        pipeline.stream_results = {'ironic': {'name': 'ironic', 'status': '0', 'nvrs': 'ironic-nvr', 'record_id': 'r1'}}
+        html = pipeline._build_jenkins_description(test_failed=[], solved=['ironic'], stream_failed=[])
+        self.assertIn('Seed NVRs', html)
+        self.assertIn('ironic-container-v4.22.0-assembly.test', html)
+
+    def test_jenkins_description_includes_data_link(self):
+        """Jenkins description includes ocp-build-data branch link when data_gitref is set."""
+        pipeline = self._create_pipeline(
+            image_list='ironic',
+            data_path='https://github.com/joepvd/ocp-build-data',
+            data_gitref='ART-14902-4.22-ose-frr',
+        )
+        html = pipeline._build_jenkins_description(test_failed=[], solved=[], stream_failed=[])
+        self.assertIn('https://github.com/joepvd/ocp-build-data/tree/ART-14902-4.22-ose-frr', html)
+        self.assertIn('Data:', html)
+
+    def test_jenkins_description_no_data_link_without_gitref(self):
+        """Jenkins description omits data link when data_gitref is not set."""
+        pipeline = self._create_pipeline(image_list='ironic')
+        html = pipeline._build_jenkins_description(test_failed=[], solved=[], stream_failed=[])
+        self.assertNotIn('Data:', html)
+
+    def test_jenkins_description_stream_failed_has_fallback_link(self):
+        """stream_failed entries get a fallback search URL when build URL is unavailable."""
+        pipeline = self._create_pipeline(image_list='img-c')
+        pipeline.stream_results = {'img-c': {'name': 'img-c', 'nvrs': 'n/a', 'status': '-1'}}
+        pipeline.test_results = {'img-c': {'name': 'img-c', 'nvrs': 'img-c-nvr', 'status': '0', 'record_id': 'r1'}}
+        html = pipeline._build_jenkins_description(test_failed=[], solved=[], stream_failed=['img-c'])
+        self.assertIn('stream', html)
+        self.assertIn('name=^img-c$', html)
 
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_title')
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_description')
@@ -306,4 +379,56 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
 
         pipeline.slack_client.say.assert_awaited_once()
         mock_title.assert_called_once()
+        self.assertIn('solved', mock_title.call_args[0][0])
         self.assertIn('ironic', mock_title.call_args[0][0])
+
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_title')
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_description')
+    async def test_post_report_no_solved_in_title_for_test_assembly(self, mock_desc, mock_title):
+        """_post_report does not add 'solved' to title when assembly is not stream."""
+        pipeline = self._create_pipeline(image_list='ironic', assembly='test')
+        pipeline.stream_results = {'ironic': {'name': 'ironic', 'status': '0'}}
+        pipeline.slack_client.say = AsyncMock()
+
+        await pipeline._post_report()
+
+        mock_title.assert_called_once()
+        title_arg = mock_title.call_args[0][0]
+        self.assertIn('[test]', title_arg)
+        self.assertNotIn('solved', title_arg)
+
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_title')
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_description')
+    async def test_post_report_includes_jira_key_in_title(self, mock_desc, mock_title):
+        """_post_report includes jira_key in the Jenkins title."""
+        pipeline = self._create_pipeline(image_list='ironic', assembly='test', jira_key='ART-14902')
+        pipeline.stream_results = {'ironic': {'name': 'ironic', 'status': '0'}}
+        pipeline.slack_client.say = AsyncMock()
+
+        await pipeline._post_report()
+
+        mock_title.assert_called_once()
+        title_arg = mock_title.call_args[0][0]
+        self.assertIn('ART-14902', title_arg)
+        self.assertIn('[test]', title_arg)
+
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_title')
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_description')
+    async def test_post_report_no_title_update_for_stream_no_solved(self, mock_desc, mock_title):
+        """_post_report does not update title when assembly is stream and nothing solved."""
+        pipeline = self._create_pipeline(image_list='ironic')
+        pipeline.stream_results = {'ironic': {'name': 'ironic', 'status': '-1'}}
+        pipeline.test_results = {'ironic': {'name': 'ironic', 'status': '0'}}
+        pipeline.slack_client.say = AsyncMock()
+
+        await pipeline._post_report()
+
+        mock_title.assert_not_called()
+
+    def test_init_stores_jira_key(self):
+        pipeline = self._create_pipeline(jira_key='ART-12345')
+        self.assertEqual(pipeline.jira_key, 'ART-12345')
+
+    def test_init_jira_key_defaults_to_empty(self):
+        pipeline = self._create_pipeline()
+        self.assertEqual(pipeline.jira_key, '')


### PR DESCRIPTION
## Summary

- Add fallback search URL for `stream_failed` entries when build URL is unavailable (NVR is `n/a`)
- Include seed NVRs in Jenkins description
- Show assembly name in title when not `stream` (e.g. `[test]`)
- Use "Succeeded" instead of "Solved" for non-stream assemblies
- Include ocp-build-data branch link in description when `data_gitref` is set
- Add `--jira-key` CLI option to include Jira ticket key in build title

Companion PR: https://github.com/openshift-eng/aos-cd-jobs/pull/4646 (adds `JIRA_KEY` Jenkins parameter)

## Test plan

- [x] All 36 unit tests pass
- [ ] Trigger a test-assembly seed-lockfile build and verify title shows `[test]` and description includes seed NVRs, data link
- [ ] Trigger with `--jira-key ART-XXXXX` and verify title includes the key
- [ ] Verify stream_failed entries always show a stream link (fallback to search URL)