### PR TITLE
seed-lockfile: generate fresh release suffix for Phase 2

### DIFF
--- a/pyartcd/pyartcd/pipelines/seed_lockfile.py
+++ b/pyartcd/pyartcd/pipelines/seed_lockfile.py
@@ -213,6 +213,12 @@ class SeedLockfilePipeline:
         """Phase 2: Rebase and build in the target assembly with --lockfile-seed-nvrs for lockfile generation."""
         seed_nvrs_str = ','.join(self.seed_map.values())
 
+        # Generate a fresh release suffix so Phase 2's NVR is strictly newer
+        # than any Phase 1 build (avoids NVR collision when both phases target
+        # the same assembly, or when RPM version ordering makes the stream
+        # assembly sort below the test assembly).
+        self.release = default_release_suffix()
+
         # Rebase with seeded lockfile
         LOGGER.info('Phase 2: Rebasing images in %s assembly with seed NVRs', self.assembly)
         cmd = self._doozer_base_command(assembly=self.assembly)


### PR DESCRIPTION
## Summary
- Phase 2 of the seed-lockfile pipeline reused the same release timestamp as Phase 1, causing Doozer's NVR check to reject the build as a duplicate (or lower, when `assembly.stream` sorts below `assembly.test` in RPM version comparison).
- Regenerate `self.release` via `default_release_suffix()` at the start of Phase 2 so its NVR is always strictly newer than Phase 1's build.
- Observed in [seed-lockfile build #55](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fseed-lockfile/55/); workaround was re-triggering as build #64 with `SEED_NVRS`.

## Test plan
- [x] `make test` passes (1,782 tests, lint clean)
- [ ] Trigger a seed-lockfile build without `SEED_NVRS` and verify Phase 2 gets a newer timestamp and builds successfully

Made with [Cursor](https://cursor.com)