### PR TITLE
Fix lockfile picking older RPM from rhocp plashet over newer RHEL version

### DIFF
--- a/doozer/doozerlib/lockfile.py
+++ b/doozer/doozerlib/lockfile.py
@@ -24,19 +24,19 @@ DEFAULT_ARTIFACT_LOCKFILE_NAME = "artifacts.lock.yaml"
 
 def sort_repos_for_lockfile_resolution(repo_names: set[str]) -> list[str]:
     """
-    Order repos so OCP content (rhocp / *ose-rpms*) is preferred over plain RHEL (baseos, appstream, CRB, ...).
+    Order repos so upstream RHEL content (baseos, appstream, CRB, ...) is preferred over OCP plashets
+    (rhocp / *ose-rpms*) as a tiebreaker when the same EVR exists in multiple repos.
 
-    :meth:`RpmInfoCollector._fetch_rpms_info_per_arch` resolves each package name from the first repo in
-    iteration order that contains it. ``repo_names`` is a ``set``, so order was undefined; the same RPM
-    name can exist in both RHEL AppStream (e.g. modular ``runc`` 1.1.x) and OSE (``runc`` 1.2.x from
-    ``rhaos``). Prefer OSE so lockfiles and hermetic prefetch match ``check_external_packages`` / Brew.
+    :meth:`RpmInfoCollector._fetch_rpms_info_per_arch` always picks the highest EVR across all repos.
+    When two repos provide the same highest EVR, the first one in iteration order wins — so RHEL repos
+    are listed first to prefer the upstream/canonical source for system packages.
     """
 
     def sort_key(name: str) -> tuple[int, str]:
         lower = name.lower()
         if 'ose-rpms' in lower or 'rhocp' in lower:
-            return (0, name)
-        return (1, name)
+            return (1, name)
+        return (0, name)
 
     return sorted(repo_names, key=sort_key)
 
@@ -276,6 +276,11 @@ class RpmInfoCollector:
         """
         Resolve RPM metadata for a specific architecture from the given repodata names.
 
+        For each package, the highest version across ALL repos is selected (matching dnf
+        behaviour). When the same EVR exists in multiple repos, the repo iteration order
+        from ``sort_repos_for_lockfile_resolution`` acts as tiebreaker (RHEL upstream repos
+        are preferred over rhocp plashets).
+
         Args:
             rpm_names (set[str]): RPM names or NVRs to resolve.
             repo_names (set[str]): Names of repodata sources to search.
@@ -284,9 +289,11 @@ class RpmInfoCollector:
         Returns:
             list[RpmInfo]: Resolved RPM package metadata.
         """
-        rpm_info_list = []
-        unresolved_rpms = set(rpm_names)
-        missing_rpms = unresolved_rpms
+        # best_by_name tracks the highest-version RpmInfo seen so far per package name.
+        # Iteration order (RHEL first) ensures that when two repos carry the same EVR
+        # the upstream RHEL entry is kept.
+        best_by_name: dict[str, RpmInfo] = {}
+        resolved_items: set[str] = set()
 
         for repo_name in sort_repos_for_lockfile_resolution(repo_names):
             repodata = self.loaded_repos.get(f'{repo_name}-{arch}')
@@ -301,30 +308,28 @@ class RpmInfoCollector:
                 self.logger.error(f'repo {repo_name} not found')
                 continue
 
-            found_rpms, missing_rpms = repodata.get_rpms(unresolved_rpms, arch)
+            found_rpms, not_found = repodata.get_rpms(rpm_names, arch)
+            resolved_items |= rpm_names - set(not_found)
 
             content_set_id = repo.content_set(arch)
             if content_set_id is None:
                 self.logger.warning(f'repo {repo_name} has no content_set for {arch}, falling back to repo key')
                 content_set_id = f'{repo_name}-{arch}'
 
-            rpm_info_list.extend(
-                [
-                    RpmInfo.from_rpm(rpm, repoid=content_set_id, baseurl=repo.baseurl(repotype="unsigned", arch=arch))
-                    for rpm in found_rpms
-                ]
+            baseurl = repo.baseurl(repotype="unsigned", arch=arch)
+            for rpm in found_rpms:
+                info = RpmInfo.from_rpm(rpm, repoid=content_set_id, baseurl=baseurl)
+                existing = best_by_name.get(rpm.name)
+                if existing is None or info > existing:
+                    best_by_name[rpm.name] = info
+
+        missing = rpm_names - resolved_items
+        if missing:
+            self.logger.warning(
+                f"Could not find {','.join(sorted(missing))} in {', '.join(repo_names)} for arch {arch}"
             )
 
-            if not missing_rpms:
-                # Found all rpms, break early
-                break
-
-            unresolved_rpms = missing_rpms
-
-        if missing_rpms:
-            self.logger.warning(f"Could not find {','.join(missing_rpms)} in {', '.join(repo_names)} for arch {arch}")
-
-        return sorted(rpm_info_list)
+        return sorted(best_by_name.values())
 
     @start_as_current_span_async(TRACER, "lockfile.fetch_rpms_info")
     async def fetch_rpms_info(

--- a/doozer/tests/test_lockfile.py
+++ b/doozer/tests/test_lockfile.py
@@ -115,19 +115,20 @@ class TestModuleInfo(unittest.TestCase):
 
 
 class TestSortReposForLockfileResolution(unittest.TestCase):
-    def test_prefers_ose_and_rhocp_over_rhel(self):
+    def test_prefers_rhel_over_ose_and_rhocp(self):
         names = {
             'rhel-8-appstream-rpms',
             'rhel-8-baseos-rpms',
             'rhel-8-server-ose-rpms-embargoed',
         }
         ordered = sort_repos_for_lockfile_resolution(names)
-        self.assertEqual(ordered[0], 'rhel-8-server-ose-rpms-embargoed')
+        self.assertIn(ordered[0], {'rhel-8-appstream-rpms', 'rhel-8-baseos-rpms'})
+        self.assertEqual(ordered[-1], 'rhel-8-server-ose-rpms-embargoed')
         self.assertEqual(set(ordered), names)
 
-    def test_rhocp_before_baseos(self):
+    def test_baseos_before_rhocp(self):
         ordered = sort_repos_for_lockfile_resolution({'rhel-8-baseos-rpms', 'rhocp-4.12-for-rhel-8-x86_64-rpms'})
-        self.assertEqual(ordered[0], 'rhocp-4.12-for-rhel-8-x86_64-rpms')
+        self.assertEqual(ordered[0], 'rhel-8-baseos-rpms')
 
 
 class TestRpmInfoCollectorFetchRpms(unittest.TestCase):
@@ -303,8 +304,8 @@ class TestRpmInfoCollectorFetchRpms(unittest.TestCase):
         self.collector._fetch_rpms_info_per_arch({rpm.name, "missingpkg"}, {repo_name}, arch)
         self.collector.logger.warning.assert_called_with(f"Could not find missingpkg in {repo_name} for arch {arch}")
 
-    def test_fetch_rpms_prefers_ose_repo_when_same_name_in_appstream(self):
-        """OSE/rhocp must be scanned before RHEL repos so e.g. runc resolves to rhaos, not container-tools."""
+    def test_fetch_rpms_picks_highest_version_across_repos(self):
+        """When the same package exists in multiple repos, the highest EVR wins."""
         arches = ['x86_64']
         repo_data = {
             "rhel-8-appstream-rpms": {
@@ -361,6 +362,109 @@ class TestRpmInfoCollectorFetchRpms(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].evr, '4:1.2.9-1.rhaos4.17.el8')
         self.assertEqual(result[0].repoid, 'ose-cs')
+
+    def test_fetch_rpms_prefers_rhel_repo_when_same_evr(self):
+        """When the same EVR exists in both RHEL and rhocp repos, prefer RHEL (upstream)."""
+        arches = ['x86_64']
+        repo_data = {
+            "rhel-9-baseos-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/baseos/"}},
+                "content_set": {"default": "baseos-cs"},
+                "reposync": {"enabled": False},
+            },
+            "rhocp-4.16-for-rhel-9-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/rhocp/"}},
+                "content_set": {"default": "rhocp-cs"},
+                "reposync": {"enabled": False},
+            },
+        }
+        repos = Repos(repo_data, arches=arches)
+        collector = RpmInfoCollector(repos=repos)
+        collector.logger = MagicMock()
+
+        shared_rpm = Rpm(
+            name="systemd-udev",
+            epoch=0,
+            version="252",
+            checksum="abc",
+            size=100,
+            location="/systemd-udev.rpm",
+            sourcerpm="systemd.src.rpm",
+            release="32.el9_4",
+            arch="x86_64",
+        )
+        arch = 'x86_64'
+        for repo_name in repo_data:
+            repodata = MagicMock()
+            repodata.get_rpms.return_value = ([shared_rpm], [])
+            collector.loaded_repos[f"{repo_name}-{arch}"] = repodata
+
+        result = collector._fetch_rpms_info_per_arch(
+            {'systemd-udev'},
+            set(repo_data.keys()),
+            arch,
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].repoid, 'baseos-cs')
+
+    def test_fetch_rpms_picks_newer_from_rhel_over_older_from_rhocp(self):
+        """A newer RPM from RHEL baseos must beat an older one from a rhocp plashet."""
+        arches = ['x86_64']
+        repo_data = {
+            "rhel-9-baseos-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/baseos/"}},
+                "content_set": {"default": "baseos-cs"},
+                "reposync": {"enabled": False},
+            },
+            "rhocp-4.16-for-rhel-9-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/rhocp/"}},
+                "content_set": {"default": "rhocp-cs"},
+                "reposync": {"enabled": False},
+            },
+        }
+        repos = Repos(repo_data, arches=arches)
+        collector = RpmInfoCollector(repos=repos)
+        collector.logger = MagicMock()
+
+        old_rpm = Rpm(
+            name="systemd-udev",
+            epoch=0,
+            version="252",
+            checksum="old",
+            size=100,
+            location="/systemd-udev-old.rpm",
+            sourcerpm="systemd.src.rpm",
+            release="14.el9_2.7",
+            arch="x86_64",
+        )
+        new_rpm = Rpm(
+            name="systemd-udev",
+            epoch=0,
+            version="252",
+            checksum="new",
+            size=110,
+            location="/systemd-udev-new.rpm",
+            sourcerpm="systemd.src.rpm",
+            release="32.el9_4",
+            arch="x86_64",
+        )
+        arch = 'x86_64'
+        for repo_name in repo_data:
+            repodata = MagicMock()
+            if 'rhocp' in repo_name:
+                repodata.get_rpms.return_value = ([old_rpm], [])
+            else:
+                repodata.get_rpms.return_value = ([new_rpm], [])
+            collector.loaded_repos[f"{repo_name}-{arch}"] = repodata
+
+        result = collector._fetch_rpms_info_per_arch(
+            {'systemd-udev'},
+            set(repo_data.keys()),
+            arch,
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].evr, '0:252-32.el9_4')
+        self.assertEqual(result[0].repoid, 'baseos-cs')
 
     def test_load_repos_skips_already_loaded(self):
         # Simulate that both repos are already loaded


### PR DESCRIPTION
## Summary

- **Bug**: `_fetch_rpms_info_per_arch` stopped searching after the first repo containing a package. Combined with `sort_repos_for_lockfile_resolution` prioritising rhocp/OSE repos, this caused older RPMs from rhocp plashets (e.g. `systemd-udev-252-14.el9_2.7`) to be selected over newer versions from RHEL baseos (`252-32.el9_4`), breaking hermetic builds on unresolvable dependencies.
- **Fix**: `_fetch_rpms_info_per_arch` now scans all repos and keeps the highest EVR per package (matching `dnf` behaviour). When the same EVR exists in multiple repos, RHEL upstream is preferred as the canonical source.
- The rhocp-first priority was introduced in #2700 to ensure the ART-built `runc` (epoch 4, v1.2.x) beat the RHEL AppStream modular `runc` (epoch 1, v1.1.x). The highest-EVR strategy resolves that case equally well, since the ART-built runc has a strictly higher EVR regardless of repo ordering.

Closes: [ART-14906](https://redhat.atlassian.net/browse/ART-14906)

## Test plan

- [x] Existing lockfile tests updated and passing (37/37)
- [x] New test: highest EVR wins across repos (runc scenario)
- [x] New test: RHEL preferred on EVR tie
- [x] New test: newer RHEL baseos beats older rhocp plashet (systemd-udev scenario from [ART-14906](https://redhat.atlassian.net/browse/ART-14906))

Made with [Cursor](https://cursor.com)