### PR TITLE
Fix missing registry auth for non-layered RHCOS scan

### DIFF
--- a/doozer/doozerlib/rhcos.py
+++ b/doozer/doozerlib/rhcos.py
@@ -302,7 +302,7 @@ class RHCOSBuildInspector:
                 )
         else:
             for tag, pullspec in pullspec_for_tag.items():
-                image_build_id = get_build_id_from_rhcos_pullspec(pullspec)
+                image_build_id = get_build_id_from_rhcos_pullspec(pullspec, registry_config=self.registry_config)
                 if self.build_id and self.build_id != image_build_id:
                     raise Exception(
                         f'Found divergent RHCOS build_id for {tag} {pullspec}. {image_build_id} versus {self.build_id}'


### PR DESCRIPTION
PR #2732 added registry_config to RHCOS classes but only updated the layered RHCOS code path. This completes the fix by passing registry_config in the non-layered path, fixing 4.12 - 4.17 scan failures.

[4.12 green scan](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/44820/)