### PR TITLE
Handle None ec_status from BigQuery to prevent ValueError during rebase

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -326,7 +326,11 @@ class KonfluxBuildRecord(KonfluxRecord):
         self.embargoed = embargoed
         self.hermetic = hermetic
         self.artifact_type = artifact_type if isinstance(artifact_type, ArtifactType) else ArtifactType(artifact_type)
-        self.ec_status = ec_status if isinstance(ec_status, KonfluxECStatus) else KonfluxECStatus(ec_status)
+        self.ec_status = (
+            ec_status
+            if isinstance(ec_status, KonfluxECStatus)
+            else KonfluxECStatus(ec_status or KonfluxECStatus.NOT_APPLICABLE.value)
+        )
         self.ec_pipeline_url = ec_pipeline_url
         self.init_uuids(record_id, build_id, nvr)
 

--- a/artcommon/tests/test_konflux_build_record.py
+++ b/artcommon/tests/test_konflux_build_record.py
@@ -84,6 +84,10 @@ class TestKonfluxBuild(TestCase):
         self.assertEqual(build_1.build_id, build_2.build_id)
         self.assertEqual(build_1.build_id, build_3.build_id)
 
+    def test_ec_status_none_defaults_to_not_applicable(self):
+        build = KonfluxBuildRecord(ec_status=None)
+        self.assertEqual(build.ec_status, KonfluxECStatus.NOT_APPLICABLE)
+
     def test_ec_status_string_to_enum_conversion(self):
         build = KonfluxBuildRecord(ec_status='passed')
         self.assertEqual(build.ec_status, KonfluxECStatus.PASSED)


### PR DESCRIPTION
## Summary
- Some BigQuery rows have `NULL` for `ec_status` (likely pre-dating the column addition), causing `KonfluxECStatus(None)` to raise `ValueError` when loading build records via `from_result_row`
- This broke rebase for images like `nmstate-console-plugin`, `networking-console-plugin`, and `openshift-kubernetes-nmstate-operator` in [Jenkins build #31093](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/31093/console)
- Fix: fall back to `NOT_APPLICABLE` when `ec_status` is `None` or empty, matching the existing parameter default

## Test plan
- [x] Added unit test `test_ec_status_none_defaults_to_not_applicable` that verifies `KonfluxBuildRecord(ec_status=None)` resolves to `KonfluxECStatus.NOT_APPLICABLE`
- [x] All existing `ec_status` tests continue to pass
- [x] Lint (`ruff check` + `ruff format`) passes


Made with [Cursor](https://cursor.com)