### PR TITLE
Add ec_status and ec_pipeline_url columns to bundle and FBC build records

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -369,6 +369,8 @@ class KonfluxBundleBuildRecord(KonfluxRecord):
         nvr: str = None,
         build_component: str = '',
         build_priority: int = constants.KONFLUX_DEFAULT_BUILD_PRIORITY,
+        ec_status: KonfluxECStatus = KonfluxECStatus.NOT_APPLICABLE,
+        ec_pipeline_url: str = '',
     ):
         super().__init__(
             name,
@@ -398,6 +400,12 @@ class KonfluxBundleBuildRecord(KonfluxRecord):
         self.operator_nvr = operator_nvr
         self.bundle_package_name = bundle_package_name
         self.bundle_csv_name = bundle_csv_name
+        self.ec_status = (
+            ec_status
+            if isinstance(ec_status, KonfluxECStatus)
+            else KonfluxECStatus(ec_status or KonfluxECStatus.NOT_APPLICABLE.value)
+        )
+        self.ec_pipeline_url = ec_pipeline_url
         self.init_uuids(record_id, build_id, nvr)
 
 
@@ -433,6 +441,8 @@ class KonfluxFbcBuildRecord(KonfluxRecord):
         nvr: str = '',
         build_component: str = '',
         build_priority: int = constants.KONFLUX_DEFAULT_BUILD_PRIORITY,
+        ec_status: KonfluxECStatus = KonfluxECStatus.NOT_APPLICABLE,
+        ec_pipeline_url: str = '',
     ):
         super().__init__(
             name,
@@ -460,4 +470,10 @@ class KonfluxFbcBuildRecord(KonfluxRecord):
         )
         self.bundle_nvrs = bundle_nvrs
         self.arches = arches
+        self.ec_status = (
+            ec_status
+            if isinstance(ec_status, KonfluxECStatus)
+            else KonfluxECStatus(ec_status or KonfluxECStatus.NOT_APPLICABLE.value)
+        )
+        self.ec_pipeline_url = ec_pipeline_url
         self.init_uuids(record_id, build_id, nvr)

--- a/artcommon/tests/test_konflux_build_record.py
+++ b/artcommon/tests/test_konflux_build_record.py
@@ -1,7 +1,12 @@
 import json
 from unittest import TestCase
 
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord, KonfluxECStatus
+from artcommonlib.konflux.konflux_build_record import (
+    KonfluxBuildRecord,
+    KonfluxBundleBuildRecord,
+    KonfluxECStatus,
+    KonfluxFbcBuildRecord,
+)
 
 
 class TestKonfluxBuild(TestCase):
@@ -97,3 +102,61 @@ class TestKonfluxBuild(TestCase):
 
         build = KonfluxBuildRecord(ec_status='n/a')
         self.assertEqual(build.ec_status, KonfluxECStatus.NOT_APPLICABLE)
+
+
+class TestKonfluxBundleBuildRecordEC(TestCase):
+    def test_ec_status_default(self):
+        build = KonfluxBundleBuildRecord()
+        self.assertEqual(build.ec_status, KonfluxECStatus.NOT_APPLICABLE)
+        self.assertEqual(build.ec_pipeline_url, '')
+
+    def test_ec_status_serialization(self):
+        build = KonfluxBundleBuildRecord(ec_status=KonfluxECStatus.PASSED, ec_pipeline_url='https://example.com/plr')
+        d = build.to_dict()
+        self.assertEqual(d['ec_status'], 'passed')
+        self.assertEqual(d['ec_pipeline_url'], 'https://example.com/plr')
+
+    def test_ec_status_none_defaults_to_not_applicable(self):
+        build = KonfluxBundleBuildRecord(ec_status=None)
+        self.assertEqual(build.ec_status, KonfluxECStatus.NOT_APPLICABLE)
+
+    def test_ec_status_string_to_enum_conversion(self):
+        build = KonfluxBundleBuildRecord(ec_status='passed')
+        self.assertEqual(build.ec_status, KonfluxECStatus.PASSED)
+
+        build = KonfluxBundleBuildRecord(ec_status='failed')
+        self.assertEqual(build.ec_status, KonfluxECStatus.FAILED)
+
+    def test_ec_status_excluded_from_build_id(self):
+        build_1 = KonfluxBundleBuildRecord(ec_status=KonfluxECStatus.NOT_APPLICABLE)
+        build_2 = KonfluxBundleBuildRecord(ec_status=KonfluxECStatus.PASSED)
+        self.assertEqual(build_1.build_id, build_2.build_id)
+
+
+class TestKonfluxFbcBuildRecordEC(TestCase):
+    def test_ec_status_default(self):
+        build = KonfluxFbcBuildRecord()
+        self.assertEqual(build.ec_status, KonfluxECStatus.NOT_APPLICABLE)
+        self.assertEqual(build.ec_pipeline_url, '')
+
+    def test_ec_status_serialization(self):
+        build = KonfluxFbcBuildRecord(ec_status=KonfluxECStatus.PASSED, ec_pipeline_url='https://example.com/plr')
+        d = build.to_dict()
+        self.assertEqual(d['ec_status'], 'passed')
+        self.assertEqual(d['ec_pipeline_url'], 'https://example.com/plr')
+
+    def test_ec_status_none_defaults_to_not_applicable(self):
+        build = KonfluxFbcBuildRecord(ec_status=None)
+        self.assertEqual(build.ec_status, KonfluxECStatus.NOT_APPLICABLE)
+
+    def test_ec_status_string_to_enum_conversion(self):
+        build = KonfluxFbcBuildRecord(ec_status='passed')
+        self.assertEqual(build.ec_status, KonfluxECStatus.PASSED)
+
+        build = KonfluxFbcBuildRecord(ec_status='failed')
+        self.assertEqual(build.ec_status, KonfluxECStatus.FAILED)
+
+    def test_ec_status_excluded_from_build_id(self):
+        build_1 = KonfluxFbcBuildRecord(ec_status=KonfluxECStatus.NOT_APPLICABLE)
+        build_2 = KonfluxFbcBuildRecord(ec_status=KonfluxECStatus.PASSED)
+        self.assertEqual(build_1.build_id, build_2.build_id)

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -10,6 +10,7 @@ from artcommonlib.konflux.konflux_build_record import (
     KonfluxBuildOutcome,
     KonfluxBuildRecord,
     KonfluxBundleBuildRecord,
+    KonfluxFbcBuildRecord,
 )
 from artcommonlib.konflux.konflux_db import CacheRecordsType, KonfluxDb
 from google.cloud.bigquery import SchemaField
@@ -694,8 +695,45 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             SchemaField('nvr', 'STRING', 'REQUIRED'),
             SchemaField('build_component', 'STRING', 'REQUIRED'),
             SchemaField('build_priority', 'INTEGER', 'REQUIRED'),
+            SchemaField('ec_status', 'STRING', 'REQUIRED'),
+            SchemaField('ec_pipeline_url', 'STRING', 'REQUIRED'),
         ]
         self.db.bind(KonfluxBundleBuildRecord)
+        self.assertEqual(self.db.generate_build_schema(), expected_fields)
+
+    def test_generate_fbc_builds_schema(self):
+        expected_fields = [
+            SchemaField('name', 'STRING', 'REQUIRED'),
+            SchemaField('group', 'STRING', 'REQUIRED'),
+            SchemaField('version', 'STRING', 'REQUIRED'),
+            SchemaField('release', 'STRING', 'REQUIRED'),
+            SchemaField('assembly', 'STRING', 'REQUIRED'),
+            SchemaField('source_repo', 'STRING', 'REQUIRED'),
+            SchemaField('commitish', 'STRING', 'REQUIRED'),
+            SchemaField('rebase_repo_url', 'STRING', 'REQUIRED'),
+            SchemaField('rebase_commitish', 'STRING', 'REQUIRED'),
+            SchemaField('start_time', 'TIMESTAMP', 'REQUIRED'),
+            SchemaField('end_time', 'TIMESTAMP', 'REQUIRED'),
+            SchemaField('engine', 'STRING', 'REQUIRED'),
+            SchemaField('image_pullspec', 'STRING', 'REQUIRED'),
+            SchemaField('image_tag', 'STRING', 'REQUIRED'),
+            SchemaField('outcome', 'STRING', 'REQUIRED'),
+            SchemaField('art_job_url', 'STRING', 'REQUIRED'),
+            SchemaField('build_pipeline_url', 'STRING', 'REQUIRED'),
+            SchemaField('pipeline_commit', 'STRING', 'REQUIRED'),
+            SchemaField('schema_level', 'INTEGER', 'REQUIRED'),
+            SchemaField('ingestion_time', 'TIMESTAMP', 'REQUIRED'),
+            SchemaField('bundle_nvrs', 'STRING', 'REQUIRED', None, None, (), None),
+            SchemaField('arches', 'STRING', 'REQUIRED', None, None, (), None),
+            SchemaField('record_id', 'STRING', 'REQUIRED'),
+            SchemaField('build_id', 'STRING', 'REQUIRED'),
+            SchemaField('nvr', 'STRING', 'REQUIRED'),
+            SchemaField('build_component', 'STRING', 'REQUIRED'),
+            SchemaField('build_priority', 'INTEGER', 'REQUIRED'),
+            SchemaField('ec_status', 'STRING', 'REQUIRED'),
+            SchemaField('ec_pipeline_url', 'STRING', 'REQUIRED'),
+        ]
+        self.db.bind(KonfluxFbcBuildRecord)
         self.assertEqual(self.db.generate_build_schema(), expected_fields)
 
     @patch("artcommonlib.konflux.konflux_db.KonfluxDb.get_latest_build")

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -24,6 +24,7 @@ from artcommonlib.konflux.konflux_build_record import (
     KonfluxBuildOutcome,
     KonfluxBuildRecord,
     KonfluxBundleBuildRecord,
+    KonfluxECStatus,
     KonfluxFbcBuildRecord,
 )
 from artcommonlib.konflux.konflux_db import KonfluxDb
@@ -1863,15 +1864,10 @@ class KonfluxFbcBuilder:
                 succeeded_condition = pipelinerun_info.find_condition('Succeeded')
                 outcome = KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition(succeeded_condition)
 
-                if self.dry_run:
-                    logger.info("Dry run: Would have inserted build record in Konflux DB")
-                else:
-                    await self._update_konflux_db(
-                        metadata, build_repo, pipelinerun_info, outcome, arches, logger=logger
-                    )
-
                 # Run EC verification after a successful FBC build
                 ec_failed = False
+                ec_status = KonfluxECStatus.NOT_APPLICABLE
+                ec_pipeline_url = ''
                 if outcome is KonfluxBuildOutcome.SUCCESS and not self.skip_ec_verify:
                     results = pipelinerun_dict.get('status', {}).get('results', [])
                     image_pullspec = next((r['value'] for r in results if r['name'] == 'IMAGE_URL'), None)
@@ -1893,6 +1889,8 @@ class KonfluxFbcBuilder:
                             ec_policy=constants.KONFLUX_FBC_EC_POLICY_CONFIGURATION,
                             logger=logger,
                         )
+                        ec_status = ec_result.ec_status
+                        ec_pipeline_url = ec_result.ec_pipeline_url
                         if ec_result.ec_failed:
                             outcome = KonfluxBuildOutcome.FAILURE
                             ec_failed = True
@@ -1900,6 +1898,20 @@ class KonfluxFbcBuilder:
                         logger.warning("Could not extract image pullspec/digest for EC verification")
                 elif outcome is KonfluxBuildOutcome.SUCCESS and self.skip_ec_verify:
                     logger.info("Skipping EC verification for %s: skip_ec_verify is set", metadata.distgit_key)
+
+                if self.dry_run:
+                    logger.info("Dry run: Would have inserted build record in Konflux DB")
+                else:
+                    await self._update_konflux_db(
+                        metadata,
+                        build_repo,
+                        pipelinerun_info,
+                        outcome,
+                        arches,
+                        logger=logger,
+                        ec_status=ec_status,
+                        ec_pipeline_url=ec_pipeline_url,
+                    )
 
                 if outcome is not KonfluxBuildOutcome.SUCCESS:
                     error = KonfluxFbcBuildError(
@@ -2049,6 +2061,8 @@ class KonfluxFbcBuilder:
         outcome: KonfluxBuildOutcome,
         arches: Sequence[str],
         logger: Optional[logging.Logger] = None,
+        ec_status: KonfluxECStatus = KonfluxECStatus.NOT_APPLICABLE,
+        ec_pipeline_url: str = '',
     ):
         logger = logger or self._logger.getChild(f"[{metadata.distgit_key}]")
         db = self._db
@@ -2101,6 +2115,8 @@ class KonfluxFbcBuilder:
                 'bundle_nvrs': bundle_nvrs,
                 'arches': arches,
                 'build_component': build_component,
+                'ec_status': ec_status,
+                'ec_pipeline_url': ec_pipeline_url,
             }
 
             match outcome:

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -15,7 +15,12 @@ from artcommonlib import exectools
 from artcommonlib import util as artlib_util
 from artcommonlib.assembly import AssemblyTypes
 from artcommonlib.constants import KONFLUX_ART_IMAGES_SHARE
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBuildRecord, KonfluxBundleBuildRecord
+from artcommonlib.konflux.konflux_build_record import (
+    KonfluxBuildOutcome,
+    KonfluxBuildRecord,
+    KonfluxBundleBuildRecord,
+    KonfluxECStatus,
+)
 from artcommonlib.konflux.konflux_db import Engine, KonfluxDb
 from artcommonlib.model import Model
 from artcommonlib.util import sync_to_quay
@@ -752,6 +757,8 @@ class KonfluxOlmBundleBuilder:
                 outcome = KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition(succeeded_condition)
 
                 ec_failed = False
+                ec_status = KonfluxECStatus.NOT_APPLICABLE
+                ec_pipeline_url = ''
                 if not self.dry_run:
                     results = pipelinerun_dict.get('status', {}).get('results', [])
                     image_pullspec = next((r['value'] for r in results if r['name'] == 'IMAGE_URL'), None)
@@ -790,6 +797,8 @@ class KonfluxOlmBundleBuilder:
                             ec_policy=ec_policy,
                             logger=logger,
                         )
+                        ec_status = ec_result.ec_status
+                        ec_pipeline_url = ec_result.ec_pipeline_url
                         if ec_result.ec_failed:
                             outcome = KonfluxBuildOutcome.FAILURE
                             ec_failed = True
@@ -813,6 +822,8 @@ class KonfluxOlmBundleBuilder:
                         outcome,
                         operator_nvr,
                         operand_nvrs,
+                        ec_status=ec_status,
+                        ec_pipeline_url=ec_pipeline_url,
                     )
                 else:
                     logger.warning("Dry run: Would update Konflux DB for %s with outcome %s", pipelinerun_name, outcome)
@@ -932,6 +943,8 @@ class KonfluxOlmBundleBuilder:
         outcome: KonfluxBuildOutcome,
         operator_nvr: str,
         operand_nvrs: list[str],
+        ec_status: KonfluxECStatus = KonfluxECStatus.NOT_APPLICABLE,
+        ec_pipeline_url: str = '',
     ):
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
         db = self._db
@@ -982,6 +995,8 @@ class KonfluxOlmBundleBuilder:
                 'operator_nvr': operator_nvr,
                 'operand_nvrs': operand_nvrs,
                 'build_component': build_component,
+                'ec_status': ec_status,
+                'ec_pipeline_url': ec_pipeline_url,
             }
 
             match outcome:

--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, call, patch
 
 from artcommonlib.assembly import AssemblyTypes
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBundleBuildRecord
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBundleBuildRecord, KonfluxECStatus
 from doozerlib.backend.build_repo import BuildRepo
 from doozerlib.backend.konflux_client import KonfluxClient
 from doozerlib.backend.konflux_fbc import (
@@ -2315,6 +2315,8 @@ class TestKonfluxFbcBuilder(unittest.IsolatedAsyncioTestCase):
                     KonfluxBuildOutcome.SUCCESS,
                     all_arches,
                     logger=ANY,
+                    ec_status=KonfluxECStatus.NOT_APPLICABLE,
+                    ec_pipeline_url='',
                 ),
             ]
         )
@@ -2402,6 +2404,8 @@ class TestKonfluxFbcBuilder(unittest.IsolatedAsyncioTestCase):
                     KonfluxBuildOutcome.SUCCESS,
                     all_arches,
                     logger=ANY,
+                    ec_status=KonfluxECStatus.NOT_APPLICABLE,
+                    ec_pipeline_url='',
                 ),
             ]
         )


### PR DESCRIPTION
## Summary

* PR #2724 added EC verification for bundle and FBC builds but only persisted `ec_status` and `ec_pipeline_url` on image build records (`KonfluxBuildRecord`). The bundle and FBC builders called `verify_enterprise_contract()` and used the result to flip `outcome` to FAILURE, but never stored the EC status or pipeline URL in BigQuery.
* This PR adds `ec_status` and `ec_pipeline_url` fields to `KonfluxBundleBuildRecord` and `KonfluxFbcBuildRecord`, and wires them through the respective builders' `_update_konflux_db` methods.

### Changes

* `artcommon/artcommonlib/konflux/konflux_build_record.py`: Add `ec_status` and `ec_pipeline_url` fields to both `KonfluxBundleBuildRecord` and `KonfluxFbcBuildRecord` with the same `None`-to-`NOT_APPLICABLE` conversion logic
* `doozer/doozerlib/backend/konflux_olm_bundler.py`: Capture `ec_result.ec_status` / `ec_pipeline_url` and pass them to `_update_konflux_db`
* `doozer/doozerlib/backend/konflux_fbc.py`: Capture EC results, move the final DB write to **after** EC verification so outcome and EC status are consistent, pass EC fields to `_update_konflux_db`
* `artcommon/tests/test_konflux_db.py`: Add `ec_status`/`ec_pipeline_url` to bundle schema test, add new FBC schema test
* `artcommon/tests/test_konflux_build_record.py`: Add unit tests for `ec_status` defaults, serialization, and `build_id` exclusion on both record types

## Test plan

- [x] `ruff check` + `ruff format` pass on all changed files
- [x] All existing `ec_status` tests continue to pass (37 tests in artcommon, 28 tests in doozer backend)
- [x] New unit tests for `KonfluxBundleBuildRecord` and `KonfluxFbcBuildRecord` EC fields pass
- [x] New FBC schema test passes
- [ ] DB schema needs to be updated in BigQuery for bundles and FBCs tables (add `ec_status STRING` and `ec_pipeline_url STRING` columns)
