### PR TITLE
Pass registry_config when checking Konflux task bundle age

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -1351,7 +1351,7 @@ class ConfigScanSources:
         pullspec = f"quay.io/konflux-ci/tekton-catalog/{task_name}@sha256:{sha}"
         self.logger.info(f'Getting age for task bundle {task_name} using pullspec {pullspec}')
         try:
-            out = await oc_image_info__cached_async(pullspec)
+            out = await oc_image_info__cached_async(pullspec, registry_config=self.registry_auth_file)
             image_info = json.loads(out)
             created_str = image_info.get('config', {}).get('created', '')
             if not created_str:

--- a/doozer/tests/cli/test_scan_sources_konflux.py
+++ b/doozer/tests/cli/test_scan_sources_konflux.py
@@ -498,9 +498,9 @@ class TestGetTaskBundleAgeDays(TestScanSourcesKonflux):
 
         self.assertEqual(result, 35)
 
-        # Verify correct pullspec was queried
+        # Verify correct pullspec was queried with registry_config
         expected_pullspec = "quay.io/konflux-ci/tekton-catalog/test-task@sha256:abc123"
-        mock_oc_image_info.assert_called_once_with(expected_pullspec)
+        mock_oc_image_info.assert_called_once_with(expected_pullspec, registry_config=None)
 
     @patch('doozerlib.cli.scan_sources_konflux.oc_image_info__cached_async')
     async def test_get_task_bundle_age_days_missing_created_field(self, mock_oc_image_info):


### PR DESCRIPTION
Fix ocp4-scan-konflux issues like `WARNING Failed to get age for task bundle task-clair-scan ... oc image info failed (rc=1): error: unable to read image quay.io/konflux-ci/tekton-catalog/task-build-image-index@sha256:... `

[Succcessful dry-run scan](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/44842/consoleFull)