### PR TITLE
Log git stderr when build_repo push fails during rebase

### DIFF
--- a/doozer/doozerlib/backend/build_repo.py
+++ b/doozer/doozerlib/backend/build_repo.py
@@ -305,7 +305,9 @@ class BuildRepo:
             self._logger.info("Using force push for branch %s", self.branch)
         rc, stdout, stderr = await git_helper.gather_git_async(push_cmd, check=False, github_url=self.url)
         if rc != 0:
-            self._logger.error("git push failed (rc=%s) for %s: stdout=%s stderr=%s", rc, self.url, stdout.strip(), stderr.strip())
+            self._logger.error(
+                "git push failed (rc=%s) for %s: stdout=%s stderr=%s", rc, self.url, stdout.strip(), stderr.strip()
+            )
             raise ChildProcessError(f"git push to {self.url} failed (rc={rc}): {stderr.strip()}")
         try:
             await git_helper.run_git_async(["-C", local_dir, "push", "origin", "--tags"], github_url=self.url)

--- a/doozer/doozerlib/backend/build_repo.py
+++ b/doozer/doozerlib/backend/build_repo.py
@@ -303,11 +303,13 @@ class BuildRepo:
         if force:
             push_cmd.append("--force")
             self._logger.info("Using force push for branch %s", self.branch)
-        await git_helper.run_git_async(push_cmd, github_url=self.url)
+        rc, stdout, stderr = await git_helper.gather_git_async(push_cmd, check=False, github_url=self.url)
+        if rc != 0:
+            self._logger.error("git push failed (rc=%s) for %s: stdout=%s stderr=%s", rc, self.url, stdout.strip(), stderr.strip())
+            raise ChildProcessError(f"git push to {self.url} failed (rc={rc}): {stderr.strip()}")
         try:
             await git_helper.run_git_async(["-C", local_dir, "push", "origin", "--tags"], github_url=self.url)
         except Exception as e:
-            # Rebase should not fail if the tags are not pushed successfully
             self._logger.warning(e)
 
     @staticmethod

--- a/doozer/tests/backend/test_build_repo.py
+++ b/doozer/tests/backend/test_build_repo.py
@@ -43,15 +43,21 @@ class TestBuildRepo(IsolatedAsyncioTestCase):
         self.assertEqual(self.repo.commit_hash, "deadbeef")
 
     @patch("artcommonlib.git_helper.run_git_async", return_value=0)
-    async def test_push(self, run_git: AsyncMock):
+    @patch("artcommonlib.git_helper.gather_git_async", return_value=(0, "", ""))
+    async def test_push(self, gather_git: AsyncMock, run_git: AsyncMock):
         await self.repo.push()
-        run_git.assert_any_await(["-C", "/path/to/repo", "push", "origin", "HEAD"], github_url=self.repo.url)
+        gather_git.assert_awaited_once_with(
+            ["-C", "/path/to/repo", "push", "origin", "HEAD"], check=False, github_url=self.repo.url
+        )
         run_git.assert_any_await(["-C", "/path/to/repo", "push", "origin", "--tags"], github_url=self.repo.url)
 
     @patch("artcommonlib.git_helper.run_git_async", return_value=0)
-    async def test_push_force(self, run_git: AsyncMock):
+    @patch("artcommonlib.git_helper.gather_git_async", return_value=(0, "", ""))
+    async def test_push_force(self, gather_git: AsyncMock, run_git: AsyncMock):
         await self.repo.push(force=True)
-        run_git.assert_any_await(["-C", "/path/to/repo", "push", "origin", "HEAD", "--force"], github_url=self.repo.url)
+        gather_git.assert_awaited_once_with(
+            ["-C", "/path/to/repo", "push", "origin", "HEAD", "--force"], check=False, github_url=self.repo.url
+        )
         run_git.assert_any_await(["-C", "/path/to/repo", "push", "origin", "--tags"], github_url=self.repo.url)
 
     @patch("pathlib.Path.exists", return_value=True)
@@ -320,7 +326,8 @@ class TestBuildRepo(IsolatedAsyncioTestCase):
             mock_set_remote.assert_called_once_with("https://example.com/new-pull.git", "pull")
 
     @patch("artcommonlib.git_helper.run_git_async", return_value=0)
-    async def test_push_always_uses_origin(self, run_git: Mock):
+    @patch("artcommonlib.git_helper.gather_git_async", return_value=(0, "", ""))
+    async def test_push_always_uses_origin(self, gather_git: AsyncMock, run_git: AsyncMock):
         """Test push operation always uses origin remote regardless of pull URL."""
         push_url = "https://git.example.com/push-repo.git"
         pull_url = "https://git.example.com/pull-repo.git"
@@ -334,8 +341,10 @@ class TestBuildRepo(IsolatedAsyncioTestCase):
         await repo.push()
 
         # Verify push uses origin remote (push URL) with push URL for auth
-        run_git.assert_any_call(["-C", "/path/to/repo", "push", "origin", "HEAD"], github_url=push_url)
-        run_git.assert_any_call(["-C", "/path/to/repo", "push", "origin", "--tags"], github_url=push_url)
+        gather_git.assert_awaited_once_with(
+            ["-C", "/path/to/repo", "push", "origin", "HEAD"], check=False, github_url=push_url
+        )
+        run_git.assert_any_await(["-C", "/path/to/repo", "push", "origin", "--tags"], github_url=push_url)
 
     @patch("doozerlib.backend.build_repo.BuildRepo._get_commit_hash", return_value="deadbeef")
     @patch("doozerlib.backend.build_repo.Path")


### PR DESCRIPTION
## Summary
- The `push` method in `build_repo.py` used `run_git_async` which discards stderr, so push failures only showed "exited with code 1" with no details
- Switch to `gather_git_async` to capture stdout/stderr and log them on failure
- Makes it possible to diagnose issues like missing branches in openshift-priv or permission errors

## Test plan
- Trigger a build where `git push` to openshift-priv fails (e.g. missing branch)
- Verify Jenkins log now shows the actual git error message instead of just the exit code