### PR TITLE
Add group.yml toggle for EC verification failure gating

### DIFF
--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -1892,8 +1892,19 @@ class KonfluxFbcBuilder:
                         ec_status = ec_result.ec_status
                         ec_pipeline_url = ec_result.ec_pipeline_url
                         if ec_result.ec_failed:
-                            outcome = KonfluxBuildOutcome.FAILURE
-                            ec_failed = True
+                            ec_failure_is_error = metadata.runtime.group_config.get("konflux", {}).get(
+                                "ec_failure_is_error", False
+                            )
+                            if ec_failure_is_error:
+                                outcome = KonfluxBuildOutcome.FAILURE
+                                ec_failed = True
+                            else:
+                                logger.warning(
+                                    "EC verification failed for %s but ec_failure_is_error is false; "
+                                    "recording status without failing the build. PLR: %s",
+                                    metadata.distgit_key,
+                                    ec_pipeline_url,
+                                )
                     else:
                         logger.warning("Could not extract image pullspec/digest for EC verification")
                 elif outcome is KonfluxBuildOutcome.SUCCESS and self.skip_ec_verify:

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -300,9 +300,20 @@ class KonfluxImageBuilder:
                     )
                     ec_status = ec_result.ec_status
                     ec_pipeline_url = ec_result.ec_pipeline_url
-                    ec_failed = ec_result.ec_failed
-                    if ec_failed:
-                        outcome = KonfluxBuildOutcome.FAILURE
+                    ec_failure_is_error = metadata.runtime.group_config.get("konflux", {}).get(
+                        "ec_failure_is_error", False
+                    )
+                    if ec_result.ec_failed:
+                        if ec_failure_is_error:
+                            ec_failed = True
+                            outcome = KonfluxBuildOutcome.FAILURE
+                        else:
+                            logger.warning(
+                                "EC verification failed for %s but ec_failure_is_error is false; "
+                                "recording status without failing the build. PLR: %s",
+                                metadata.distgit_key,
+                                ec_pipeline_url,
+                            )
 
                 elif outcome is KonfluxBuildOutcome.SUCCESS:
                     if self._config.skip_ec_verify:

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -800,8 +800,19 @@ class KonfluxOlmBundleBuilder:
                         ec_status = ec_result.ec_status
                         ec_pipeline_url = ec_result.ec_pipeline_url
                         if ec_result.ec_failed:
-                            outcome = KonfluxBuildOutcome.FAILURE
-                            ec_failed = True
+                            ec_failure_is_error = metadata.runtime.group_config.get("konflux", {}).get(
+                                "ec_failure_is_error", False
+                            )
+                            if ec_failure_is_error:
+                                outcome = KonfluxBuildOutcome.FAILURE
+                                ec_failed = True
+                            else:
+                                logger.warning(
+                                    "EC verification failed for %s but ec_failure_is_error is false; "
+                                    "recording status without failing the build. PLR: %s",
+                                    metadata.distgit_key,
+                                    ec_pipeline_url,
+                                )
                     elif outcome is KonfluxBuildOutcome.SUCCESS:
                         if self.skip_ec_verify:
                             logger.info("Skipping EC verification for %s: skip_ec_verify is set", metadata.distgit_key)

--- a/doozer/tests/backend/test_konflux_ec_verification.py
+++ b/doozer/tests/backend/test_konflux_ec_verification.py
@@ -61,7 +61,7 @@ def _make_successful_pipelinerun_info():
     return plr_info
 
 
-def _make_metadata(distgit_key="test-image", for_release=True, is_base_image=False):
+def _make_metadata(distgit_key="test-image", for_release=True, is_base_image=False, ec_failure_is_error=False):
     """Create a mock ImageMetadata."""
     metadata = MagicMock()
     metadata.distgit_key = distgit_key
@@ -79,6 +79,7 @@ def _make_metadata(distgit_key="test-image", for_release=True, is_base_image=Fal
     metadata.runtime.assembly = "stream"
     metadata.runtime.assembly_type = MagicMock()
     metadata.runtime.konflux_db = None
+    metadata.runtime.group_config = {"konflux": {"ec_failure_is_error": ec_failure_is_error}}
     return metadata
 
 
@@ -183,10 +184,21 @@ class TestEcVerificationGating(IsolatedAsyncioTestCase):
         verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
         verify_ec.assert_not_called()
 
-    async def test_no_retry_when_ec_fails(self, mock_kc_init):
-        """When EC verification fails, the build should NOT be retried."""
+    async def test_ec_failure_does_not_fail_build_by_default(self, mock_kc_init):
+        """When ec_failure_is_error is false (default), EC failure should not fail the build."""
         config = _make_config(group_name="openshift-4.18")
-        metadata = _make_metadata(for_release=True)
+        metadata = _make_metadata(for_release=True, ec_failure_is_error=False)
+
+        verify_ec = await self._run_build_and_get_ec_calls(
+            config, metadata, mock_kc_init, ec_result=_ec_failed_result()
+        )
+        verify_ec.assert_called_once()
+        self.assertTrue(metadata.build_status)
+
+    async def test_no_retry_when_ec_fails(self, mock_kc_init):
+        """When ec_failure_is_error is true and EC verification fails, the build should NOT be retried."""
+        config = _make_config(group_name="openshift-4.18")
+        metadata = _make_metadata(for_release=True, ec_failure_is_error=True)
         metadata.get_konflux_build_attempts.return_value = 3
 
         builder = KonfluxImageBuilder(config)

--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -445,7 +445,18 @@
         "build_attempts?": {
           "$ref": "#/properties/konflux/properties/build_attempts"
         },
-        "build_attempts-": {}
+        "build_attempts-": {},
+        "ec_failure_is_error": {
+          "description": "When true, enterprise-contract verification failures will fail the build. When false (default), failures are recorded but the build succeeds.",
+          "type": "boolean"
+        },
+        "ec_failure_is_error!": {
+          "$ref": "#/properties/konflux/properties/ec_failure_is_error"
+        },
+        "ec_failure_is_error?": {
+          "$ref": "#/properties/konflux/properties/ec_failure_is_error"
+        },
+        "ec_failure_is_error-": {}
       },
       "additionalProperties": false
     },


### PR DESCRIPTION
## Summary
- Adds `konflux.ec_failure_is_error` boolean toggle to group.yml (defaults to `false`)
- When `false`: EC verification runs and results are recorded (`ec_status`, `ec_pipeline_url`) but failures do **not** break the build
- When `true`: EC failure fails the build and skips retries (original behavior from #2724)
- Updated schema, all three builders (image, FBC, bundle), and tests

## Motivation
We want to collect EC verification results across builds before enforcing failures. This toggle lets us observe without risk, then flip to `true` per-group when ready.

## Test plan
- [x] `test_ec_failure_does_not_fail_build_by_default` — EC fails, build succeeds
- [x] `test_no_retry_when_ec_fails` — with `ec_failure_is_error: true`, EC failure breaks the build
- [x] All existing EC verification tests pass
- [x] Lint clean


Made with [Cursor](https://cursor.com)