### PR TITLE
Skip EC/ITS verification for base images in OCP builds

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -268,18 +268,15 @@ class KonfluxImageBuilder:
                     outcome is KonfluxBuildOutcome.SUCCESS
                     and is_ocp_group
                     and not self._config.skip_ec_verify
-                    and (metadata.for_release or metadata.is_base_image())
+                    and metadata.for_release
                 )
                 if should_run_ec:
                     app_name = self.get_application_name(self._config.group_name)
 
-                    # Select EC policy based on image type and assembly type:
-                    # - Base images always use the dedicated base-prod policy
+                    # Select EC policy based on assembly type:
                     # - PREVIEW (preGA) assemblies use a more permissive policy that allows unsigned RPMs
                     # - All other images use the default stage policy
-                    if metadata.is_base_image():
-                        ec_policy = constants.KONFLUX_BASE_IMAGE_EC_POLICY_CONFIGURATION
-                    elif metadata.runtime.assembly_type == AssemblyTypes.PREVIEW:
+                    if metadata.runtime.assembly_type == AssemblyTypes.PREVIEW:
                         ec_policy = constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION
                     else:
                         ec_policy = self._config.ec_policy_configuration
@@ -315,9 +312,9 @@ class KonfluxImageBuilder:
                             metadata.distgit_key,
                             self._config.group_name,
                         )
-                    elif not metadata.for_release and not metadata.is_base_image():
+                    elif not metadata.for_release:
                         logger.info(
-                            "Skipping EC verification for %s: image is not for_release and not a base image",
+                            "Skipping EC verification for %s: image is not for_release",
                             metadata.distgit_key,
                         )
 

--- a/doozer/tests/backend/test_konflux_ec_verification.py
+++ b/doozer/tests/backend/test_konflux_ec_verification.py
@@ -1,7 +1,7 @@
 """Tests for EC verification gating logic in KonfluxImageBuilder.build().
 
 Verifies that enterprise-contract verification is only triggered for images
-that are for_release=True (or base images), in an OCP group, and not skipped via --skip-ec-verify.
+that are for_release=True, in an OCP group, and not skipped via --skip-ec-verify.
 """
 
 import asyncio
@@ -149,18 +149,16 @@ class TestEcVerificationGating(IsolatedAsyncioTestCase):
         verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
         verify_ec.assert_called_once()
 
-    async def test_ec_runs_for_base_image(self, mock_kc_init):
-        """EC verification should run for base images using the base image policy."""
+    async def test_ec_skipped_for_base_image(self, mock_kc_init):
+        """EC verification should be skipped for base images (not for_release)."""
         config = _make_config(group_name="openshift-4.18")
         metadata = _make_metadata(for_release=False, is_base_image=True)
 
         verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
-        verify_ec.assert_called_once()
-        call_kwargs = verify_ec.call_args[1]
-        self.assertEqual(call_kwargs["ec_policy"], "rhtap-releng-tenant/registry-ocp-art-base-prod")
+        verify_ec.assert_not_called()
 
-    async def test_ec_skipped_for_non_release_non_base_image(self, mock_kc_init):
-        """EC verification should be skipped for non-release, non-base images."""
+    async def test_ec_skipped_for_non_release_image(self, mock_kc_init):
+        """EC verification should be skipped for non-release images."""
         config = _make_config(group_name="openshift-4.18")
         metadata = _make_metadata(for_release=False, is_base_image=False)
 


### PR DESCRIPTION
## Summary
- For OCP groups, only run enterprise-contract (EC/ITS) verification for `for_release: true` images
- Base images (`base_only: true`) are now skipped since they are not part of the release payload
- Simplifies EC policy selection by removing the base-image-specific policy branch

## Test plan
- [x] `make test` passes (5 pre-existing failures in `test_util.py` unrelated to this change)
- [x] `test_ec_skipped_for_base_image` confirms EC is no longer triggered for base images
- [x] `test_ec_runs_for_release_ocp_image` confirms EC still runs for `for_release=True` images

Made with [Cursor](https://cursor.com)