### PR TITLE
Enable EC/ITS verification for layered products after Konflux builds

### DIFF
--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -1862,8 +1862,39 @@ class KonfluxFbcBuilder:
                 succeeded_condition = pipelinerun_info.find_condition('Succeeded')
                 outcome = KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition(succeeded_condition)
 
+                ec_failed = False
                 ec_status = KonfluxECStatus.NOT_APPLICABLE
                 ec_pipeline_url = ''
+
+                has_fbc_ec_policy = self.product in constants.PRODUCT_FBC_EC_POLICY_MAP
+                if outcome is KonfluxBuildOutcome.SUCCESS and has_fbc_ec_policy:
+                    results = pipelinerun_dict.get('status', {}).get('results', [])
+                    image_pullspec = next((r['value'] for r in results if r['name'] == 'IMAGE_URL'), None)
+                    image_digest = next((r['value'] for r in results if r['name'] == 'IMAGE_DIGEST'), None)
+
+                    if image_pullspec and image_digest:
+                        app_name = self.get_application_name(self.group)
+                        component_name = self.get_component_name(self.group, metadata.distgit_key)
+                        image_with_digest = f"{image_pullspec.split(':')[0]}@{image_digest}"
+                        source_url = artlib_util.convert_remote_git_to_https(build_repo.url)
+
+                        ec_result = await self._konflux_client.verify_enterprise_contract(
+                            namespace=self.konflux_namespace,
+                            application_name=app_name,
+                            component_name=component_name,
+                            image_pullspec=image_with_digest,
+                            source_url=source_url,
+                            commit_sha=build_repo.commit_hash,
+                            ec_policy=constants.get_fbc_ec_policy_for_product(self.product),
+                            logger=logger,
+                        )
+                        ec_status = ec_result.ec_status
+                        ec_pipeline_url = ec_result.ec_pipeline_url
+                        if ec_result.ec_failed:
+                            outcome = KonfluxBuildOutcome.FAILURE
+                            ec_failed = True
+                    else:
+                        logger.warning("Could not extract image pullspec/digest for EC verification")
 
                 if self.dry_run:
                     logger.info("Dry run: Would have inserted build record in Konflux DB")
@@ -1883,6 +1914,8 @@ class KonfluxFbcBuilder:
                     error = KonfluxFbcBuildError(
                         f"Konflux image build for {metadata.distgit_key} failed", pipelinerun_name, pipelinerun_dict
                     )
+                    if ec_failed:
+                        break
                 else:
                     error = None
                     metadata.build_status = True

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -87,7 +87,6 @@ class KonfluxImageBuilderConfig:
     skip_checks: bool = False
     dry_run: bool = False
     build_priority: Optional[str] = None
-    ec_policy_configuration: str = constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION
     skip_ec_verify: bool = False
 
 
@@ -291,12 +290,12 @@ class KonfluxImageBuilder:
                         )
 
                 # Run enterprise-contract (EC) verification after a successful build
-                # TODO: Expand EC verification to layered products
                 # TODO: Expose EC failure links (ITS/PLR URLs) via Slack notification or dashboard column
-                is_ocp_group = self._config.group_name.startswith("openshift-")
+                product = metadata.runtime.product
+                has_ec_policy = product in constants.PRODUCT_EC_POLICY_MAP
                 should_run_ec = (
                     outcome is KonfluxBuildOutcome.SUCCESS
-                    and is_ocp_group
+                    and has_ec_policy
                     and not self._config.skip_ec_verify
                     and metadata.for_release
                 )
@@ -305,7 +304,7 @@ class KonfluxImageBuilder:
 
                     # Select EC policy based on software lifecycle phase:
                     # - pre-release phase uses a more permissive policy that allows unsigned RPMs
-                    # - All other phases use the default stage policy
+                    # - All other phases use the product-specific stage policy
                     lifecycle_phase = metadata.runtime.group_config.software_lifecycle.phase
                     if (
                         lifecycle_phase is not Missing
@@ -313,7 +312,7 @@ class KonfluxImageBuilder:
                     ):
                         ec_policy = constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION
                     else:
-                        ec_policy = self._config.ec_policy_configuration
+                        ec_policy = constants.get_ec_policy_for_product(product)
 
                     image_with_digest = f"{image_pullspec.split(':')[0]}@{image_digest}"
                     source_url = artlib_util.convert_remote_git_to_https(build_repo.url)
@@ -340,11 +339,11 @@ class KonfluxImageBuilder:
                         logger.info(
                             "Skipping EC verification for %s: --skip-ec-verify flag is set", metadata.distgit_key
                         )
-                    elif not is_ocp_group:
+                    elif not has_ec_policy:
                         logger.info(
-                            "Skipping EC verification for %s: non-OCP group '%s'",
+                            "Skipping EC verification for %s: product '%s' not configured for EC verification",
                             metadata.distgit_key,
-                            self._config.group_name,
+                            product,
                         )
                     elif not metadata.for_release:
                         logger.info(

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -774,8 +774,9 @@ class KonfluxOlmBundleBuilder:
                     await sync_to_quay(f"{image_pullspec.split(':')[0]}@{image_digest}", KONFLUX_ART_IMAGES_SHARE)
 
                     # Run EC verification after a successful bundle build
-                    is_ocp_group = self.group.startswith("openshift-")
-                    if outcome is KonfluxBuildOutcome.SUCCESS and is_ocp_group and not self.skip_ec_verify:
+                    product = metadata.runtime.product
+                    has_ec_policy = product in constants.PRODUCT_EC_POLICY_MAP
+                    if outcome is KonfluxBuildOutcome.SUCCESS and has_ec_policy and not self.skip_ec_verify:
                         app_name = self.get_application_name(metadata.runtime.group)
                         bundle_name = metadata.get_olm_bundle_short_name()
                         component_name = self.get_component_name(app_name, bundle_name)
@@ -785,7 +786,7 @@ class KonfluxOlmBundleBuilder:
                         if self.assembly_type == AssemblyTypes.PREVIEW:
                             ec_policy = constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION
                         else:
-                            ec_policy = constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION
+                            ec_policy = constants.get_ec_policy_for_product(product)
 
                         ec_result = await konflux_client.verify_enterprise_contract(
                             namespace=self.konflux_namespace,
@@ -805,11 +806,11 @@ class KonfluxOlmBundleBuilder:
                     elif outcome is KonfluxBuildOutcome.SUCCESS:
                         if self.skip_ec_verify:
                             logger.info("Skipping EC verification for %s: skip_ec_verify is set", metadata.distgit_key)
-                        elif not is_ocp_group:
+                        elif not has_ec_policy:
                             logger.info(
-                                "Skipping EC verification for %s: non-OCP group '%s'",
+                                "Skipping EC verification for %s: product '%s' not configured for EC verification",
                                 metadata.distgit_key,
-                                self.group,
+                                product,
                             )
 
                     # Update the Konflux DB with the final outcome

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -53,15 +53,54 @@ BREW_REGISTRY_BASE_URL = "brew.registry.redhat.io"
 ART_BUILD_HISTORY_URL = 'https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com'
 
 # Enterprise Contract (EC) verification pipeline constants
-# TODO: Expand EC verification to layered products (logging, oadp, mta, rhmtc, quay, cert-manager, etc.)
-# Currently scoped to OCP only.
 KONFLUX_EC_PIPELINE_GIT_URL = "https://github.com/konflux-ci/build-definitions"
 KONFLUX_EC_PIPELINE_REVISION = "main"
 KONFLUX_EC_PIPELINE_PATH = "pipelines/enterprise-contract.yaml"
-KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-stage"
+
+# Shared namespace for all EC policies in konflux-release-data
+KONFLUX_EC_POLICY_NAMESPACE = "rhtap-releng-tenant"
+
+# Product-to-EC-policy mappings (bare policy names; prepend KONFLUX_EC_POLICY_NAMESPACE at lookup time).
+# Policy YAMLs live in konflux-release-data under config/kflux-ocp-p01.7ayg.p1/product/EnterpriseContractPolicy/.
+PRODUCT_EC_POLICY_MAP = {
+    "ocp": "registry-ocp-art-stage",
+    "logging": "registry-art-logging-stage",
+    "mta": "registry-art-mta-stage",
+    "rhmtc": "registry-art-mtc-stage",
+    "oadp": "registry-art-oadp-stage",
+}
+
+PRODUCT_FBC_EC_POLICY_MAP = {
+    "logging": "fbc-ocp-art-stage",
+    "mta": "fbc-ocp-art-stage",
+    "rhmtc": "fbc-ocp-art-stage",
+    "oadp": "fbc-art-oadp-stage",
+}
+
+KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION = f"{KONFLUX_EC_POLICY_NAMESPACE}/registry-ocp-art-stage"
 # PreGA (PREVIEW assembly) EC policy: same as stage but allows unsigned RPMs
 # https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/kflux-ocp-p01.7ayg.p1/product/EnterpriseContractPolicy/registry-ocp-art-ec-stage.yaml
-KONFLUX_PREGA_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-ec-stage"
+KONFLUX_PREGA_EC_POLICY_CONFIGURATION = f"{KONFLUX_EC_POLICY_NAMESPACE}/registry-ocp-art-ec-stage"
 # Base image EC policy (base_only images use a dedicated prod policy for all assembly types)
 # https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/kflux-ocp-p01.7ayg.p1/product/EnterpriseContractPolicy/registry-ocp-art-base-prod.yaml
-KONFLUX_BASE_IMAGE_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-base-prod"
+KONFLUX_BASE_IMAGE_EC_POLICY_CONFIGURATION = f"{KONFLUX_EC_POLICY_NAMESPACE}/registry-ocp-art-base-prod"
+
+
+def get_ec_policy_for_product(product: str) -> str:
+    """Resolve the registry EC policy for a given product, falling back to OCP default."""
+    policy_name = PRODUCT_EC_POLICY_MAP.get(product)
+    if policy_name:
+        return f"{KONFLUX_EC_POLICY_NAMESPACE}/{policy_name}"
+    return KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION
+
+
+def get_fbc_ec_policy_for_product(product: str) -> str:
+    """Resolve the FBC EC policy for a given product.
+
+    Only products in PRODUCT_FBC_EC_POLICY_MAP should call this; callers gate
+    on map membership first. The fallback is purely defensive.
+    """
+    policy_name = PRODUCT_FBC_EC_POLICY_MAP.get(product)
+    if policy_name:
+        return f"{KONFLUX_EC_POLICY_NAMESPACE}/{policy_name}"
+    return KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -87,7 +87,11 @@ KONFLUX_BASE_IMAGE_EC_POLICY_CONFIGURATION = f"{KONFLUX_EC_POLICY_NAMESPACE}/reg
 
 
 def get_ec_policy_for_product(product: str) -> str:
-    """Resolve the registry EC policy for a given product, falling back to OCP default."""
+    """Resolve the registry EC policy for a given product.
+
+    Only products in PRODUCT_EC_POLICY_MAP should call this; callers gate
+    on map membership first. The fallback is purely defensive.
+    """
     policy_name = PRODUCT_EC_POLICY_MAP.get(product)
     if policy_name:
         return f"{KONFLUX_EC_POLICY_NAMESPACE}/{policy_name}"

--- a/doozer/tests/backend/test_konflux_ec_verification.py
+++ b/doozer/tests/backend/test_konflux_ec_verification.py
@@ -1,15 +1,17 @@
 """Tests for EC verification gating logic in KonfluxImageBuilder.build().
 
 Verifies that enterprise-contract verification is only triggered for images
-that are for_release=True, in an OCP group, and not skipped via --skip-ec-verify.
+that are for_release=True, with a product configured in PRODUCT_EC_POLICY_MAP,
+and not skipped via --skip-ec-verify.
 """
 
 import asyncio
 from pathlib import Path
-from unittest import IsolatedAsyncioTestCase
+from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxECStatus
+from doozerlib import constants
 from doozerlib.backend.konflux_client import ECVerificationResult
 from doozerlib.backend.konflux_image_builder import (
     KonfluxImageBuilder,
@@ -61,7 +63,7 @@ def _make_successful_pipelinerun_info():
     return plr_info
 
 
-def _make_metadata(distgit_key="test-image", for_release=True, is_base_image=False):
+def _make_metadata(distgit_key="test-image", for_release=True, is_base_image=False, product="ocp"):
     """Create a mock ImageMetadata."""
     metadata = MagicMock()
     metadata.distgit_key = distgit_key
@@ -79,6 +81,7 @@ def _make_metadata(distgit_key="test-image", for_release=True, is_base_image=Fal
     metadata.runtime.assembly = "stream"
     metadata.runtime.group_config.software_lifecycle.phase = "release"
     metadata.runtime.konflux_db = None
+    metadata.runtime.product = product
     return metadata
 
 
@@ -173,10 +176,30 @@ class TestEcVerificationGating(IsolatedAsyncioTestCase):
         verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
         verify_ec.assert_not_called()
 
-    async def test_ec_skipped_for_non_ocp_group(self, mock_kc_init):
-        """EC verification should be skipped for non-OCP groups (e.g. logging)."""
+    async def test_ec_runs_for_layered_product(self, mock_kc_init):
+        """EC verification should run for layered products with a configured EC policy."""
         config = _make_config(group_name="logging-6.2")
-        metadata = _make_metadata(for_release=True)
+        metadata = _make_metadata(for_release=True, product="logging")
+
+        verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+        verify_ec.assert_called_once()
+        call_kwargs = verify_ec.call_args.kwargs
+        self.assertEqual(call_kwargs["ec_policy"], "rhtap-releng-tenant/registry-art-logging-stage")
+
+    async def test_ec_runs_for_oadp_with_correct_policy(self, mock_kc_init):
+        """EC verification should use the OADP-specific policy for OADP builds."""
+        config = _make_config(group_name="oadp-1.5")
+        metadata = _make_metadata(for_release=True, product="oadp")
+
+        verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+        verify_ec.assert_called_once()
+        call_kwargs = verify_ec.call_args.kwargs
+        self.assertEqual(call_kwargs["ec_policy"], "rhtap-releng-tenant/registry-art-oadp-stage")
+
+    async def test_ec_skipped_for_unknown_product(self, mock_kc_init):
+        """EC verification should be skipped for products not in PRODUCT_EC_POLICY_MAP."""
+        config = _make_config(group_name="unknown-1.0")
+        metadata = _make_metadata(for_release=True, product="unknown")
 
         verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
         verify_ec.assert_not_called()
@@ -223,3 +246,69 @@ class TestEcVerificationGating(IsolatedAsyncioTestCase):
                         await builder.build(metadata)
 
         builder._start_build.assert_called_once()
+
+
+class TestEcPolicyHelpers(TestCase):
+    """Test the product-to-EC-policy resolution helpers."""
+
+    def test_ocp_registry_policy(self):
+        self.assertEqual(
+            constants.get_ec_policy_for_product("ocp"),
+            "rhtap-releng-tenant/registry-ocp-art-stage",
+        )
+
+    def test_logging_registry_policy(self):
+        self.assertEqual(
+            constants.get_ec_policy_for_product("logging"),
+            "rhtap-releng-tenant/registry-art-logging-stage",
+        )
+
+    def test_oadp_registry_policy(self):
+        self.assertEqual(
+            constants.get_ec_policy_for_product("oadp"),
+            "rhtap-releng-tenant/registry-art-oadp-stage",
+        )
+
+    def test_mta_registry_policy(self):
+        self.assertEqual(
+            constants.get_ec_policy_for_product("mta"),
+            "rhtap-releng-tenant/registry-art-mta-stage",
+        )
+
+    def test_rhmtc_registry_policy(self):
+        self.assertEqual(
+            constants.get_ec_policy_for_product("rhmtc"),
+            "rhtap-releng-tenant/registry-art-mtc-stage",
+        )
+
+    def test_unknown_product_falls_back_to_default(self):
+        self.assertEqual(
+            constants.get_ec_policy_for_product("unknown"),
+            constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION,
+        )
+
+    def test_oadp_fbc_policy(self):
+        self.assertEqual(
+            constants.get_fbc_ec_policy_for_product("oadp"),
+            "rhtap-releng-tenant/fbc-art-oadp-stage",
+        )
+
+    def test_logging_fbc_policy(self):
+        self.assertEqual(
+            constants.get_fbc_ec_policy_for_product("logging"),
+            "rhtap-releng-tenant/fbc-ocp-art-stage",
+        )
+
+    def test_ocp_not_in_fbc_policy_map(self):
+        """OCP FBC EC was removed (verified at release time); should fall back to default."""
+        self.assertNotIn("ocp", constants.PRODUCT_FBC_EC_POLICY_MAP)
+        self.assertEqual(
+            constants.get_fbc_ec_policy_for_product("ocp"),
+            constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION,
+        )
+
+    def test_unknown_product_fbc_falls_back_to_default(self):
+        self.assertEqual(
+            constants.get_fbc_ec_policy_for_product("unknown"),
+            constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION,
+        )

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -47,6 +47,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         metadata.runtime.assembly = "test-assembly"
         metadata.runtime.konflux_db = MagicMock()
         metadata.runtime.group_config.software_lifecycle.phase = "release"
+        metadata.runtime.product = "ocp"
         metadata.for_release = True
         metadata.get_latest_build = AsyncMock(return_value=None)
         metadata.get_konflux_build_attempts.return_value = 1
@@ -125,6 +126,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         )
 
         metadata = self._metadata()
+        metadata.runtime.product = "okd"
         dest_dir = okd_builder._config.base_dir.joinpath(metadata.qualified_key)
         dest_dir.mkdir(parents=True)
 


### PR DESCRIPTION
## Summary

- Expand EC (Enterprise Contract) verification via ITS (IntegrationTestScenario) from OCP-only to layered products (logging, mta, rhmtc, oadp)
- Replace `group_name.startswith("openshift-")` gates with product-based lookup against `PRODUCT_EC_POLICY_MAP` in all three builders (image, OLM bundle, FBC)
- Each product resolves to its own `EnterpriseContractPolicy` from `konflux-release-data` (e.g. `registry-art-logging-stage` for logging, `fbc-art-oadp-stage` for OADP FBC). Unknown products gracefully skip EC with an info log.

## Changes

- `doozer/doozerlib/constants.py`: Add `PRODUCT_EC_POLICY_MAP`, `PRODUCT_FBC_EC_POLICY_MAP`, `get_ec_policy_for_product()`, `get_fbc_ec_policy_for_product()`
- `doozer/doozerlib/backend/konflux_image_builder.py`: Replace `is_ocp_group` with product-based check; remove unused `ec_policy_configuration` config field
- `doozer/doozerlib/backend/konflux_olm_bundler.py`: Replace `is_ocp_group` with product-based check
- `doozer/doozerlib/backend/konflux_fbc.py`: Use `get_fbc_ec_policy_for_product(self.product)` instead of hardcoded OCP FBC policy
- `doozer/tests/backend/test_konflux_ec_verification.py`: Add tests for layered product EC (logging, oadp), unknown product skip, and policy helper functions

## Test plan

- [x] All 18 EC verification tests pass (8 gating + 10 policy helper)
- [x] All 24 related backend tests pass (konflux_client + image_builder)
- [x] `make lint` passes
- [ ] Verify in staging that layered product builds (e.g. logging-6.x) trigger EC with correct policy

Made with [Cursor](https://cursor.com)