### PR TITLE
Fix manifest-tool --docker-cfg to pass directory instead of file path

### DIFF
--- a/artcommon/artcommonlib/exectools.py
+++ b/artcommon/artcommonlib/exectools.py
@@ -515,7 +515,8 @@ async def manifest_tool(options, dry_run=False):
     if os.environ.get("XDG_RUNTIME_DIR"):
         auth_file = os.path.expandvars("${XDG_RUNTIME_DIR}/containers/auth.json")
         if Path(auth_file).is_file():
-            auth_opt = f"--docker-cfg={auth_file}"
+            # manifest-tool expects --docker-cfg to be a directory containing config.json, not a file path
+            auth_opt = f"--docker-cfg={Path(auth_file).parent}"
 
     if isinstance(options, str):
         cmd = f'manifest-tool {auth_opt} {options}'


### PR DESCRIPTION
## Problem

Jenkins job `build-sync-multi` fails with **401 Unauthorized** when `manifest-tool` tries to push multi-arch manifests to Quay after secret rotation on April 11, 2026.

The auth file `/run/user/984/containers/auth.json` contains **correct credentials** (verified), but manifest-tool cannot find them.

## Root Cause

`artcommon/artcommonlib/exectools.py:518` passes a **file path** to `manifest-tool --docker-cfg`:

```python
auth_opt = f"--docker-cfg={auth_file}"  # /run/user/984/containers/auth.json
```

manifest-tool expects `--docker-cfg` to be a **directory** containing `config.json` (Docker's convention), not a direct file path. When given a file path, it looks for the impossible path `/run/user/984/containers/auth.json/config.json`, doesn't find it, and proceeds **without authentication** → 401 Unauthorized.

## Solution

Pass the **parent directory** instead of the file path:

```python
auth_opt = f"--docker-cfg={Path(auth_file).parent}"  # /run/user/984/containers/
```

This assumes `config.json` exists in `/run/user/984/containers/` (symlink or copy of `auth.json`), which is the case in the Jenkins environment.

## Testing

- Verified auth.json has correct Quay credentials
- Checked Jenkins environment has config.json in place
- Minimal one-line change to fix the path issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
