### PR TITLE
images:health: report failures immediately instead of snoozing

### DIFF
--- a/doozer/doozerlib/cli/images_health.py
+++ b/doozer/doozerlib/cli/images_health.py
@@ -168,16 +168,8 @@ class ImagesHealthPipeline:
                 ),
             )
 
-        elif self.variant is not BuildVariant.OKD and latest_success_idx <= 3:
-            # The latest attempt was a failure, but there was a success within the last 3 attempts: skip notification
-            # Note: For OKD, we always notify on first failure, so this check is skipped
-            self.logger.info(
-                f'Latest attempt for {image_meta.distgit_key} failed, but the one before it succeeded, skipping notification.'
-            )
-            return
-
         else:
-            # The latest attempt was a failure, and the last success was more than 3 attempts ago: add a concern
+            # The latest attempt was a failure: add a concern
             self.add_concern(
                 Concern(
                     image_name=image_meta.distgit_key,


### PR DESCRIPTION
## Summary
- Removes the 3-attempt noise suppression logic from `doozer images:health` that was silently hiding build failures for OCP images
- Previously, if a failing image had *any* successful build within its last 3 attempts, the failure was suppressed from the report entirely
- This caused the images-health scan to report zero errors for 4.22 despite many UNSTABLE `ocp4-konflux` builds with real failures (confirmed via Jenkins logs showing dozens of "skipping notification" messages)

## Test plan
- [x] Existing unit tests pass (`doozer/tests/cli/test_images_health.py`)
- [ ] Next images-health scan for 4.22 should surface `LATEST_ATTEMPT_FAILED` concerns for currently-failing images

Made with [Cursor](https://cursor.com)