### PR TITLE
Skip SLSA attestation check for OKD builds

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -249,16 +249,25 @@ class KonfluxImageBuilder:
                     record["image_tag"] = image_tag
 
                     # Validate SLSA attestation and source image signature
-                    try:
-                        # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
-                        await self._validate_build_attestation_and_signature(
-                            definitive_image_pullspec, metadata.distgit_key
+                    # Skip for non-OCP groups (e.g., OKD) as they may not have attestations/signatures
+                    is_ocp_group = self._config.group_name.startswith("openshift-")
+                    if is_ocp_group:
+                        try:
+                            # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
+                            await self._validate_build_attestation_and_signature(
+                                definitive_image_pullspec, metadata.distgit_key
+                            )
+                        except Exception as e:
+                            logger.error(
+                                f"Failed to get SLA attestation / source signature from konflux for image {definitive_image_pullspec}, marking build as {KonfluxBuildOutcome.FAILURE}. Error: {e}"
+                            )
+                            outcome = KonfluxBuildOutcome.FAILURE
+                    else:
+                        logger.info(
+                            "Skipping SLSA attestation validation for %s: non-OCP group '%s'",
+                            metadata.distgit_key,
+                            self._config.group_name,
                         )
-                    except Exception as e:
-                        logger.error(
-                            f"Failed to get SLA attestation / source signature from konflux for image {definitive_image_pullspec}, marking build as {KonfluxBuildOutcome.FAILURE}. Error: {e}"
-                        )
-                        outcome = KonfluxBuildOutcome.FAILURE
 
                 # Run enterprise-contract (EC) verification after a successful build
                 # TODO: Expand EC verification to layered products

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -24,7 +24,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         self.builder = KonfluxImageBuilder(
             KonfluxImageBuilderConfig(
                 base_dir=Path(self.temp_dir.name),
-                group_name="test-group",
+                group_name="openshift-4.17",
                 namespace="test-namespace",
                 plr_template="test-template",
                 build_priority="5",
@@ -56,6 +56,8 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
 
         build_repo = MagicMock()
         build_repo.local_dir = dest_dir
+        build_repo.url = "https://github.com/test/repo.git"
+        build_repo.commit_hash = "test-commit"
 
         initial_pipelinerun = MagicMock()
         initial_pipelinerun.name = "test-pipelinerun"
@@ -75,6 +77,12 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         }
         self.mock_konflux_client.wait_for_pipelinerun = AsyncMock(return_value=completed_pipelinerun)
 
+        # Mock EC verification result
+        ec_result_mock = MagicMock()
+        ec_result_mock.ec_status = "PASSED"
+        ec_result_mock.ec_pipeline_url = "https://example.com/ec-pipeline"
+        ec_result_mock.ec_failed = False
+
         with (
             patch(
                 "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
@@ -85,6 +93,9 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
             patch.object(self.builder, "_start_build", new=AsyncMock(return_value=initial_pipelinerun)),
             patch.object(self.builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))),
             patch.object(self.builder, "_validate_build_attestation_and_signature", new=AsyncMock()) as mock_validate,
+            patch.object(
+                self.builder._konflux_client, "verify_enterprise_contract", new=AsyncMock(return_value=ec_result_mock)
+            ),
             patch(
                 "doozerlib.backend.konflux_image_builder.KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition",
                 return_value=KonfluxBuildOutcome.SUCCESS,
@@ -93,6 +104,66 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
             await self.builder.build(metadata)
 
         mock_validate.assert_awaited_once_with("quay.io/test/image@sha256:testdigest", "test-image")
+
+    async def test_build_skips_slsa_validation_for_non_ocp_groups(self):
+        """Test that SLSA attestation validation is skipped for non-OCP groups like OKD."""
+        # Create a builder with an OKD group name
+        okd_builder = KonfluxImageBuilder(
+            KonfluxImageBuilderConfig(
+                base_dir=Path(self.temp_dir.name),
+                group_name="okd-4.17",
+                namespace="test-namespace",
+                plr_template="test-template",
+                build_priority="5",
+            )
+        )
+
+        metadata = self._metadata()
+        dest_dir = okd_builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        build_repo = MagicMock()
+        build_repo.local_dir = dest_dir
+        build_repo.url = "https://github.com/test/okd-repo.git"
+        build_repo.commit_hash = "test-okd-commit"
+
+        initial_pipelinerun = MagicMock()
+        initial_pipelinerun.name = "test-pipelinerun"
+        initial_pipelinerun.to_dict.return_value = {"metadata": {"name": "test-pipelinerun"}}
+
+        completed_pipelinerun = MagicMock()
+        completed_pipelinerun.name = "test-pipelinerun"
+        completed_pipelinerun.find_condition.return_value = {"status": "True"}
+        completed_pipelinerun.to_dict.return_value = {
+            "metadata": {"name": "test-pipelinerun"},
+            "status": {
+                "results": [
+                    {"name": "IMAGE_URL", "value": "quay.io/test/okd-image:test-tag"},
+                    {"name": "IMAGE_DIGEST", "value": "sha256:okddigest"},
+                ]
+            },
+        }
+        self.mock_konflux_client.wait_for_pipelinerun = AsyncMock(return_value=completed_pipelinerun)
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=build_repo),
+            ),
+            patch.object(okd_builder, "_parse_dockerfile", return_value=("test-uuid", "test-component", "1.0", "1")),
+            patch.object(okd_builder, "_wait_for_parent_members", new=AsyncMock(return_value=[])),
+            patch.object(okd_builder, "_start_build", new=AsyncMock(return_value=initial_pipelinerun)),
+            patch.object(okd_builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))),
+            patch.object(okd_builder, "_validate_build_attestation_and_signature", new=AsyncMock()) as mock_validate,
+            patch(
+                "doozerlib.backend.konflux_image_builder.KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition",
+                return_value=KonfluxBuildOutcome.SUCCESS,
+            ),
+        ):
+            await okd_builder.build(metadata)
+
+        # Validation should NOT be called for OKD groups
+        mock_validate.assert_not_awaited()
 
     async def test_update_konflux_db_uses_definitive_pullspec_for_installed_packages(self):
         metadata = self._metadata()


### PR DESCRIPTION
# Fix: Skip SLSA attestation validation for non-OCP groups (OKD)

## Problem

OKD builds were being marked as failed despite successful PipelineRuns. Build #841 showed "Build failures: 40 images" when all PLRs actually succeeded. The build records in BigQuery showed `status=-1` (failure) even though `image_pullspec` was populated successfully.

## Root Cause

OKD builds from public repositories (github.com/openshift) don't have SLSA attestations/signatures, causing the validation to fail and mark otherwise successful builds as failures.

## Solution

Skip SLSA attestation validation for non-OCP groups by checking `group_name.startswith("openshift-")`, mirroring the existing Enterprise Contract (EC) verification pattern which already has this OCP-only check.
