### PR TITLE
Skip redundant assembly consistency checks in multi-model build sync

### DIFF
--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -550,7 +550,21 @@ class GenPayloadCli:
         self.payload_entries_for_arch, self.private_payload_entries_for_arch = await self.generate_payload_entries(
             assembly_inspector
         )
-        assembly_report: Dict = await self.generate_assembly_report(assembly_inspector)
+
+        if self.multi_model:
+            # The model nightly already passed consistency checks in regular build-sync;
+            # re-running them here is expensive and can flake without adding value.
+            self.payload_permitted = True
+            assembly_report: Dict = dict(
+                non_release_images=[m.distgit_key for m in rt.get_non_release_image_metas()],
+                release_images=[m.distgit_key for m in rt.get_for_release_image_metas()],
+                missing_image_builds=[],
+                viable=True,
+                assembly_issues={},
+            )
+            self.logger.info("Multi-model mode: skipping assembly consistency checks")
+        else:
+            assembly_report: Dict = await self.generate_assembly_report(assembly_inspector)
 
         self.logger.info('\n%s', yaml.dump(assembly_report, default_flow_style=False, indent=2))
         with self.output_path.joinpath("assembly-report.yaml").open(mode="w") as report_file:


### PR DESCRIPTION
## Summary
- In the multi-model (`build-sync-multi`) path, `release:gen-payload` was running the full suite of assembly consistency checks (`generate_assembly_report`) even though:
  1. The model nightly (x86_64) already passed these checks during regular `build-sync`
  2. `emergency_ignore_issues` is hardcoded to `True` in multi-model mode, so the checks can never block anything
- These checks are expensive (Brew/Konflux RPM queries, hermetic checks, sibling matching, etc.) and can flake, causing unnecessary failures
- This change skips `generate_assembly_report()` in multi-model mode and writes a minimal report instead. The essential `generate_payload_entries()` and `sync_payloads()` flow is unchanged.

## Test plan
- [x] Existing `test_gen_payload.py` tests pass (50/50)
- [ ] Verify a `build-sync-multi` run completes successfully and produces the multi-arch nightly

Made with [Cursor](https://cursor.com)