### PR TITLE
Use software lifecycle phase for EC policy selection during ocp4-konflux

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -285,7 +285,10 @@ class KonfluxImageBuilder:
                     # - pre-release phase uses a more permissive policy that allows unsigned RPMs
                     # - All other phases use the default stage policy
                     lifecycle_phase = metadata.runtime.group_config.software_lifecycle.phase
-                    if lifecycle_phase is not Missing and SoftwareLifecyclePhase.from_name(lifecycle_phase) == SoftwareLifecyclePhase.PRE_RELEASE:
+                    if (
+                        lifecycle_phase is not Missing
+                        and SoftwareLifecyclePhase.from_name(lifecycle_phase) == SoftwareLifecyclePhase.PRE_RELEASE
+                    ):
                         ec_policy = constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION
                     else:
                         ec_policy = self._config.ec_policy_configuration

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -284,8 +284,8 @@ class KonfluxImageBuilder:
                     # Select EC policy based on software lifecycle phase:
                     # - pre-release phase uses a more permissive policy that allows unsigned RPMs
                     # - All other phases use the default stage policy
-                    phase = SoftwareLifecyclePhase.from_name(metadata.runtime.group_config.software_lifecycle.phase)
-                    if phase == SoftwareLifecyclePhase.PRE_RELEASE:
+                    lifecycle_phase = metadata.runtime.group_config.software_lifecycle.phase
+                    if lifecycle_phase is not Missing and SoftwareLifecyclePhase.from_name(lifecycle_phase) == SoftwareLifecyclePhase.PRE_RELEASE:
                         ec_policy = constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION
                     else:
                         ec_policy = self._config.ec_policy_configuration

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -15,7 +15,6 @@ from artcommonlib import bigquery, exectools
 from artcommonlib import constants as artlib_constants
 from artcommonlib import util as artlib_util
 from artcommonlib.arch_util import go_arch_for_brew_arch
-from artcommonlib.assembly import AssemblyTypes
 from artcommonlib.build_visibility import is_release_embargoed
 from artcommonlib.konflux.konflux_build_record import (
     ArtifactType,
@@ -282,10 +281,11 @@ class KonfluxImageBuilder:
                 if should_run_ec:
                     app_name = self.get_application_name(self._config.group_name)
 
-                    # Select EC policy based on assembly type:
-                    # - PREVIEW (preGA) assemblies use a more permissive policy that allows unsigned RPMs
-                    # - All other images use the default stage policy
-                    if metadata.runtime.assembly_type == AssemblyTypes.PREVIEW:
+                    # Select EC policy based on software lifecycle phase:
+                    # - pre-release phase uses a more permissive policy that allows unsigned RPMs
+                    # - All other phases use the default stage policy
+                    phase = SoftwareLifecyclePhase.from_name(metadata.runtime.group_config.software_lifecycle.phase)
+                    if phase == SoftwareLifecyclePhase.PRE_RELEASE:
                         ec_policy = constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION
                     else:
                         ec_policy = self._config.ec_policy_configuration

--- a/doozer/tests/backend/test_konflux_ec_verification.py
+++ b/doozer/tests/backend/test_konflux_ec_verification.py
@@ -77,7 +77,7 @@ def _make_metadata(distgit_key="test-image", for_release=True, is_base_image=Fal
     metadata.build_event = asyncio.Event()
     metadata.get_parent_members.return_value = {}
     metadata.runtime.assembly = "stream"
-    metadata.runtime.assembly_type = MagicMock()
+    metadata.runtime.group_config.software_lifecycle.phase = "release"
     metadata.runtime.konflux_db = None
     return metadata
 

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -225,3 +225,68 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
             )
 
         mock_get_installed_packages.assert_awaited_once_with("quay.io/test/image@sha256:testdigest", ["x86_64"], None)
+
+    async def test_ec_policy_selection_missing_lifecycle_phase(self):
+        """Test that default EC policy is used when lifecycle phase is Missing."""
+        from artcommonlib.model import Missing
+        from doozerlib import constants
+
+        metadata = self._metadata()
+        # Set lifecycle phase to Missing
+        metadata.runtime.group_config.software_lifecycle.phase = Missing
+
+        dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        build_repo = MagicMock()
+        build_repo.local_dir = dest_dir
+        build_repo.url = "https://github.com/test/repo.git"
+        build_repo.commit_hash = "test-commit"
+
+        initial_pipelinerun = MagicMock()
+        initial_pipelinerun.name = "test-pipelinerun"
+        initial_pipelinerun.to_dict.return_value = {"metadata": {"name": "test-pipelinerun"}}
+
+        completed_pipelinerun = MagicMock()
+        completed_pipelinerun.name = "test-pipelinerun"
+        completed_pipelinerun.find_condition.return_value = {"status": "True"}
+        completed_pipelinerun.to_dict.return_value = {
+            "metadata": {"name": "test-pipelinerun"},
+            "status": {
+                "results": [
+                    {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                    {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                ]
+            },
+        }
+        self.mock_konflux_client.wait_for_pipelinerun = AsyncMock(return_value=completed_pipelinerun)
+
+        ec_result_mock = MagicMock()
+        ec_result_mock.ec_status = "PASSED"
+        ec_result_mock.ec_pipeline_url = "https://example.com/ec-pipeline"
+        ec_result_mock.ec_failed = False
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=build_repo),
+            ),
+            patch.object(self.builder, "_parse_dockerfile", return_value=("test-uuid", "test-component", "1.0", "1")),
+            patch.object(self.builder, "_wait_for_parent_members", new=AsyncMock(return_value=[])),
+            patch.object(self.builder, "_start_build", new=AsyncMock(return_value=initial_pipelinerun)),
+            patch.object(self.builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))),
+            patch.object(self.builder, "_validate_build_attestation_and_signature", new=AsyncMock()),
+            patch.object(
+                self.builder._konflux_client, "verify_enterprise_contract", new=AsyncMock(return_value=ec_result_mock)
+            ) as mock_verify_ec,
+            patch(
+                "doozerlib.backend.konflux_image_builder.KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition",
+                return_value=KonfluxBuildOutcome.SUCCESS,
+            ),
+        ):
+            await self.builder.build(metadata)
+
+        # Verify that default EC policy was used (not the pre-GA policy)
+        mock_verify_ec.assert_awaited_once()
+        call_kwargs = mock_verify_ec.await_args[1]
+        self.assertEqual(call_kwargs['ec_policy'], constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION)

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -42,6 +42,8 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         metadata.runtime = MagicMock()
         metadata.runtime.assembly = "test-assembly"
         metadata.runtime.konflux_db = MagicMock()
+        metadata.runtime.group_config.software_lifecycle.phase = "release"
+        metadata.for_release = True
         metadata.get_latest_build = AsyncMock(return_value=None)
         metadata.get_konflux_build_attempts.return_value = 1
         metadata.get_arches.return_value = ["x86_64"]


### PR DESCRIPTION
Change EC policy selection from assembly type to software lifecycle phase. This allows groups in pre-release phase (e.g., OCP 5.0) to use the permissive EC policy that allows unsigned RPMs.

When software_lifecycle.phase is not configured in group.yml (Missing), the default EC policy is used.