### PR TITLE
Remove build-time EC verification from FBC builds

### DIFF
--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -1595,7 +1595,6 @@ class KonfluxFbcBuilder:
         pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_FBC_BUILD_PLR_TEMPLATE_URL,
         dry_run: bool = False,
         major_minor_override: Optional[Tuple[int, int]] = None,
-        skip_ec_verify: bool = False,
         record_logger: Optional[RecordLogger] = None,
         logger: logging.Logger = LOGGER,
     ):
@@ -1613,7 +1612,6 @@ class KonfluxFbcBuilder:
         self.pipelinerun_template_url = pipelinerun_template_url
         self.dry_run = dry_run
         self.major_minor_override = major_minor_override
-        self.skip_ec_verify = skip_ec_verify
         self.source_git_commits = []
         self._record_logger = record_logger
         self._logger = logger.getChild(self.__class__.__name__)
@@ -1864,40 +1862,8 @@ class KonfluxFbcBuilder:
                 succeeded_condition = pipelinerun_info.find_condition('Succeeded')
                 outcome = KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition(succeeded_condition)
 
-                # Run EC verification after a successful FBC build
-                ec_failed = False
                 ec_status = KonfluxECStatus.NOT_APPLICABLE
                 ec_pipeline_url = ''
-                if outcome is KonfluxBuildOutcome.SUCCESS and not self.skip_ec_verify:
-                    results = pipelinerun_dict.get('status', {}).get('results', [])
-                    image_pullspec = next((r['value'] for r in results if r['name'] == 'IMAGE_URL'), None)
-                    image_digest = next((r['value'] for r in results if r['name'] == 'IMAGE_DIGEST'), None)
-
-                    if image_pullspec and image_digest:
-                        app_name = self.get_application_name(self.group)
-                        component_name = self.get_component_name(self.group, metadata.distgit_key)
-                        image_with_digest = f"{image_pullspec.split(':')[0]}@{image_digest}"
-                        source_url = artlib_util.convert_remote_git_to_https(build_repo.url)
-
-                        ec_result = await self._konflux_client.verify_enterprise_contract(
-                            namespace=self.konflux_namespace,
-                            application_name=app_name,
-                            component_name=component_name,
-                            image_pullspec=image_with_digest,
-                            source_url=source_url,
-                            commit_sha=build_repo.commit_hash,
-                            ec_policy=constants.KONFLUX_FBC_EC_POLICY_CONFIGURATION,
-                            logger=logger,
-                        )
-                        ec_status = ec_result.ec_status
-                        ec_pipeline_url = ec_result.ec_pipeline_url
-                        if ec_result.ec_failed:
-                            outcome = KonfluxBuildOutcome.FAILURE
-                            ec_failed = True
-                    else:
-                        logger.warning("Could not extract image pullspec/digest for EC verification")
-                elif outcome is KonfluxBuildOutcome.SUCCESS and self.skip_ec_verify:
-                    logger.info("Skipping EC verification for %s: skip_ec_verify is set", metadata.distgit_key)
 
                 if self.dry_run:
                     logger.info("Dry run: Would have inserted build record in Konflux DB")
@@ -1917,8 +1883,6 @@ class KonfluxFbcBuilder:
                     error = KonfluxFbcBuildError(
                         f"Konflux image build for {metadata.distgit_key} failed", pipelinerun_name, pipelinerun_dict
                     )
-                    if ec_failed:
-                        break
                 else:
                     error = None
                     metadata.build_status = True

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -65,5 +65,3 @@ KONFLUX_PREGA_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-ec
 # Base image EC policy (base_only images use a dedicated prod policy for all assembly types)
 # https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/kflux-ocp-p01.7ayg.p1/product/EnterpriseContractPolicy/registry-ocp-art-base-prod.yaml
 KONFLUX_BASE_IMAGE_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-base-prod"
-# FBC (File-Based Catalog) EC policy
-KONFLUX_FBC_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/fbc-ocp-art-stage"


### PR DESCRIPTION
## Summary

- Remove the build-time Enterprise Contract (EC) verification from `KonfluxFbcBuilder` for FBC builds
- The FBC EC policy (`fbc-ocp-art-stage`) is OCP-specific, and OCP FBC images are already verified by the release-time EC (`fbc-ocp-art-prod`) via the `ReleasePlanAdmission` before anything ships
- Since `prepare-release-konflux` always triggers fresh FBC builds for each release assembly (the existing-build check filters by assembly name, which is unique per release), the build-time EC is redundant

## Changes

- Removed the EC verification block from `KonfluxFbcBuilder.build()` in `konflux_fbc.py`
- Removed the `skip_ec_verify` parameter from `KonfluxFbcBuilder`
- Removed the `KONFLUX_FBC_EC_POLICY_CONFIGURATION` constant from `constants.py`
- Removed the `ec_failed` early-break logic (dead code without EC)

## Test plan

- [x] `make test` passes (854 passed; 5 pre-existing failures in `TestFindGoMainPackages` unrelated to this change)
- [x] Existing FBC builder tests (`test_konflux_fbc.py`) pass unchanged -- they already assert `ec_status=NOT_APPLICABLE` and `ec_pipeline_url=''`
- [x] EC verification tests for images and bundles (`test_konflux_ec_verification.py`) unaffected

Made with [Cursor](https://cursor.com)