### PR TITLE
Instrument ocp4_konflux

### DIFF
--- a/pyartcd/pyartcd/cli.py
+++ b/pyartcd/pyartcd/cli.py
@@ -11,7 +11,7 @@ from artcommonlib import logutil
 
 from pyartcd import __version__
 from pyartcd.runtime import Runtime
-from pyartcd.telemetry import initialize_telemetry
+from pyartcd.telemetry import initialize_telemetry, shutdown_telemetry
 
 pass_runtime = click.make_pass_decorator(Runtime)
 
@@ -23,7 +23,10 @@ def click_coroutine(f):
 
     def wrapper(*args, **kwargs):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(f(*args, **kwargs))
+        try:
+            return loop.run_until_complete(f(*args, **kwargs))
+        finally:
+            shutdown_telemetry()
 
     return update_wrapper(wrapper, f)
 

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -1,9 +1,12 @@
 import asyncio
+import inspect
 import json
 import logging
 import os
 import shutil
+import time
 from enum import Enum
+from functools import wraps
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -19,6 +22,8 @@ from artcommonlib.util import (
     uses_konflux_imagestream_override,
     validate_build_priority,
 )
+from opentelemetry import metrics, trace
+from opentelemetry.trace import Status, StatusCode
 
 from pyartcd import constants, jenkins, locks, oc, util
 from pyartcd import record as record_util
@@ -35,6 +40,59 @@ from pyartcd.util import (
 )
 
 LOGGER = logging.getLogger(__name__)
+TRACER = trace.get_tracer(__name__)
+METER = metrics.get_meter(__name__)
+STAGE_RUN_COUNTER = METER.create_counter(
+    "pyartcd.ocp4_konflux.stage_runs",
+    unit="1",
+    description="Completed ocp4_konflux pipeline stages by result.",
+)
+STAGE_FAILURE_COUNTER = METER.create_counter(
+    "pyartcd.ocp4_konflux.stage_failures",
+    unit="1",
+    description="Failed ocp4_konflux pipeline stages.",
+)
+STAGE_DURATION_HISTOGRAM = METER.create_histogram(
+    "pyartcd.ocp4_konflux.stage_duration_seconds",
+    unit="s",
+    description="Duration of ocp4_konflux pipeline stages.",
+)
+
+
+def instrument_stage(stage_name: str):
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(self, *args, **kwargs):
+            attributes = self._stage_attributes(stage_name)
+            start_time = time.monotonic()
+            with TRACER.start_as_current_span(f"ocp4-konflux.{stage_name}") as span:
+                for key, value in attributes.items():
+                    span.set_attribute(f"ocp4-konflux.{key}", value)
+                try:
+                    result = func(self, *args, **kwargs)
+                    if inspect.isawaitable(result):
+                        result = await result
+                except Exception as exc:
+                    span.record_exception(exc)
+                    span.set_status(Status(StatusCode.ERROR, str(exc)))
+                    STAGE_RUN_COUNTER.add(1, {**attributes, "result": "failure"})
+                    STAGE_FAILURE_COUNTER.add(1, attributes)
+                    STAGE_DURATION_HISTOGRAM.record(
+                        time.monotonic() - start_time,
+                        {**attributes, "result": "failure"},
+                    )
+                    raise
+
+                STAGE_RUN_COUNTER.add(1, {**attributes, "result": "success"})
+                STAGE_DURATION_HISTOGRAM.record(
+                    time.monotonic() - start_time,
+                    {**attributes, "result": "success"},
+                )
+                return result
+
+        return wrapper
+
+    return decorator
 
 
 class BuildStrategy(Enum):
@@ -166,6 +224,15 @@ class KonfluxOcpPipeline:
         elif build_strategy == BuildStrategy.EXCEPT:
             return [f'--{kind}=', f'--exclude={",".join(excludes)}']
 
+    def _stage_attributes(self, stage_name: str) -> dict[str, str | bool]:
+        return {
+            "pipeline": "ocp4_konflux",
+            "stage": stage_name,
+            "assembly": self.assembly,
+            "version": self.version,
+            "dry_run": self.runtime.dry_run,
+        }
+
     async def update_rebase_fail_counters(self, failed_images):
         if self.assembly != 'stream':
             # Only update fail counters for stream assembly
@@ -214,6 +281,7 @@ class KonfluxOcpPipeline:
         # or if the build strategy is ALL, all images will be built
         return True
 
+    @instrument_stage("rebase_images")
     async def rebase_images(self, version: str, input_release: str):
         # Skip rebase if the flag is set
         if self.skip_rebase:
@@ -279,6 +347,7 @@ class KonfluxOcpPipeline:
             # Track rebase failures for later steps
             self.rebase_failures = failed_images
 
+    @instrument_stage("build_images")
     async def build_images(self):
         if not self.building_images():
             LOGGER.warning('No images will be built')
@@ -322,6 +391,7 @@ class KonfluxOcpPipeline:
 
         LOGGER.info("All builds completed successfully")
 
+    @instrument_stage("sync_images")
     async def sync_images(self):
         if not self.building_images():
             LOGGER.warning('No images will be synced')
@@ -411,6 +481,7 @@ class KonfluxOcpPipeline:
             cmd.extend(['images:streams', 'mirror'])
             await exectools.cmd_assert_async(cmd)
 
+    @instrument_stage("sweep_bugs")
     async def sweep_bugs(self):
         """
         Find MODIFIED bugs for the target-releases, and set them to ON_QA
@@ -438,6 +509,7 @@ class KonfluxOcpPipeline:
             self.slack_client.bind_channel(f'openshift-{self.version}')
             await self.slack_client.say(f'Bug sweep failed for {self.version}. Please investigate')
 
+    @instrument_stage("sweep_golang_bugs")
     async def sweep_golang_bugs(self):
         # find-bugs:golang only modifies bug state after verifying
         # that the bug is fixed in the builds found in latest nightly / rpms in candidate tag
@@ -592,11 +664,13 @@ class KonfluxOcpPipeline:
             else:
                 jenkins.update_description(f'RPMs: building {n_rpms} RPMs.<br/>')
 
+    @instrument_stage("initialize")
     async def initialize(self):
         jenkins.init_jenkins()
         jenkins.update_title(f' - {self.version} [{self.assembly}] ')
         await self.init_build_plan()
 
+    @instrument_stage("clean_up")
     async def clean_up(self):
         LOGGER.info('Cleaning up Doozer source dirs')
         await asyncio.gather(
@@ -646,6 +720,7 @@ class KonfluxOcpPipeline:
             record_log: dict = record_util.parse_record_log(file)
             return record_log
 
+    @instrument_stage("request_mass_rebuild")
     async def request_mass_rebuild(self):
         await self.slack_client.say(
             f':konflux: :loading-correct: Enqueuing mass rebuild for {self.version} :loading-correct:'
@@ -788,6 +863,7 @@ class KonfluxOcpPipeline:
                 failed_ops = ", ".join(f"{name}: {err}" for name, err in critical_failures)
                 raise RuntimeError(f"Critical operations failed in finally block: {failed_ops}")
 
+    @instrument_stage("rebase_and_build_rpms")
     async def rebase_and_build_rpms(self, input_release: str):
         if (
             self.build_plan.rpm_build_strategy == BuildStrategy.ONLY and not self.build_plan.rpms_included

--- a/pyartcd/pyartcd/telemetry.py
+++ b/pyartcd/pyartcd/telemetry.py
@@ -2,8 +2,11 @@ import os
 import sys
 
 from artcommonlib import constants
-from opentelemetry import context, trace
+from opentelemetry import context, metrics, trace
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter
@@ -23,6 +26,12 @@ def new_tracker_provider(resource: Resource, exporter: SpanExporter):
     return provider
 
 
+def new_meter_provider(resource: Resource, exporter: OTLPMetricExporter):
+    """Creates and initialize a MeterProvider for pyartcd metrics."""
+    reader = PeriodicExportingMetricReader(exporter)
+    return MeterProvider(resource=resource, metric_readers=[reader])
+
+
 def initialize_telemetry():
     # Initialize resource attributes;
     # Additional attributes can be specified in OTEL_RESOURCE_ATTRIBUTES env var
@@ -36,10 +45,13 @@ def initialize_telemetry():
     otel_exporter_otlp_endpoint = os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT', constants.OTEL_EXPORTER_OTLP_ENDPOINT)
     otel_exporter_otlp_headers = os.environ.get('OTEL_EXPORTER_OTLP_HEADERS')
 
-    exporter = OTLPSpanExporter(endpoint=otel_exporter_otlp_endpoint, headers=otel_exporter_otlp_headers)
+    trace_exporter = OTLPSpanExporter(endpoint=otel_exporter_otlp_endpoint, headers=otel_exporter_otlp_headers)
+    metric_exporter = OTLPMetricExporter(endpoint=otel_exporter_otlp_endpoint, headers=otel_exporter_otlp_headers)
 
-    tp = new_tracker_provider(resource, exporter)
+    tp = new_tracker_provider(resource, trace_exporter)
+    mp = new_meter_provider(resource, metric_exporter)
     trace.set_tracer_provider(tp)
+    metrics.set_meter_provider(mp)
     # TRACEPARENT env var is used to propagate trace context
     traceparent = os.environ.get('TRACEPARENT')
     if traceparent:

--- a/pyartcd/pyartcd/telemetry.py
+++ b/pyartcd/pyartcd/telemetry.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 
@@ -14,6 +15,10 @@ from opentelemetry.semconv.resource import ResourceAttributes
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from pyartcd import __version__
+
+LOGGER = logging.getLogger(__name__)
+_TRACER_PROVIDER: TracerProvider | None = None
+_METER_PROVIDER: MeterProvider | None = None
 
 
 def new_tracker_provider(resource: Resource, exporter: SpanExporter):
@@ -33,6 +38,10 @@ def new_meter_provider(resource: Resource, exporter: OTLPMetricExporter):
 
 
 def initialize_telemetry():
+    global _TRACER_PROVIDER, _METER_PROVIDER
+    if _TRACER_PROVIDER is not None or _METER_PROVIDER is not None:
+        return
+
     # Initialize resource attributes;
     # Additional attributes can be specified in OTEL_RESOURCE_ATTRIBUTES env var
     resource = Resource.create(
@@ -48,10 +57,10 @@ def initialize_telemetry():
     trace_exporter = OTLPSpanExporter(endpoint=otel_exporter_otlp_endpoint, headers=otel_exporter_otlp_headers)
     metric_exporter = OTLPMetricExporter(endpoint=otel_exporter_otlp_endpoint, headers=otel_exporter_otlp_headers)
 
-    tp = new_tracker_provider(resource, trace_exporter)
-    mp = new_meter_provider(resource, metric_exporter)
-    trace.set_tracer_provider(tp)
-    metrics.set_meter_provider(mp)
+    _TRACER_PROVIDER = new_tracker_provider(resource, trace_exporter)
+    _METER_PROVIDER = new_meter_provider(resource, metric_exporter)
+    trace.set_tracer_provider(_TRACER_PROVIDER)
+    metrics.set_meter_provider(_METER_PROVIDER)
     # TRACEPARENT env var is used to propagate trace context
     traceparent = os.environ.get('TRACEPARENT')
     if traceparent:
@@ -59,3 +68,32 @@ def initialize_telemetry():
         ctx = TraceContextTextMapPropagator().extract(carrier=carrier)
         context.attach(ctx)
         print(f"Use TRACEPARENT {traceparent} for telemetry", file=sys.stderr)
+
+
+def shutdown_telemetry():
+    global _TRACER_PROVIDER, _METER_PROVIDER
+
+    meter_provider = _METER_PROVIDER
+    tracer_provider = _TRACER_PROVIDER
+    _METER_PROVIDER = None
+    _TRACER_PROVIDER = None
+
+    if meter_provider is not None:
+        try:
+            meter_provider.force_flush()
+        except Exception:
+            LOGGER.warning("Failed to flush OpenTelemetry metrics", exc_info=True)
+        try:
+            meter_provider.shutdown()
+        except Exception:
+            LOGGER.warning("Failed to shut down OpenTelemetry metrics", exc_info=True)
+
+    if tracer_provider is not None:
+        try:
+            tracer_provider.force_flush()
+        except Exception:
+            LOGGER.warning("Failed to flush OpenTelemetry traces", exc_info=True)
+        try:
+            tracer_provider.shutdown()
+        except Exception:
+            LOGGER.warning("Failed to shut down OpenTelemetry traces", exc_info=True)

--- a/pyartcd/tests/pipelines/test_ocp.py
+++ b/pyartcd/tests/pipelines/test_ocp.py
@@ -839,15 +839,15 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
 
 
 class TestKonfluxOcpPipeline(unittest.IsolatedAsyncioTestCase):
-    @patch('pyartcd.pipelines.ocp4_konflux.exectools.cmd_assert_async')
-    async def test_konflux_pipeline_network_mode_parameter_flow(self, mock_cmd):
-        """Test pipeline passes network-mode to both doozer commands."""
+    @staticmethod
+    def _default_konflux_pipeline():
         from pyartcd.pipelines.ocp4_konflux import KonfluxOcpPipeline
 
         runtime = MagicMock()
         runtime.dry_run = False
+        runtime.doozer_working = "doozer-working"
 
-        pipeline = KonfluxOcpPipeline(
+        return KonfluxOcpPipeline(
             runtime=runtime,
             assembly='stream',
             version='4.14',
@@ -869,6 +869,11 @@ class TestKonfluxOcpPipeline(unittest.IsolatedAsyncioTestCase):
             network_mode='open',
         )
 
+    @patch('pyartcd.pipelines.ocp4_konflux.exectools.cmd_assert_async')
+    async def test_konflux_pipeline_network_mode_parameter_flow(self, mock_cmd):
+        """Test pipeline passes network-mode to both doozer commands."""
+        pipeline = self._default_konflux_pipeline()
+
         await pipeline.rebase_images('4.14.0', '1')
         await pipeline.build_images()
 
@@ -881,3 +886,56 @@ class TestKonfluxOcpPipeline(unittest.IsolatedAsyncioTestCase):
         self.assertIn('open', rebase_call)
         self.assertIn('--network-mode', build_call)
         self.assertIn('open', build_call)
+
+    @patch('pyartcd.pipelines.ocp4_konflux.STAGE_DURATION_HISTOGRAM')
+    @patch('pyartcd.pipelines.ocp4_konflux.STAGE_FAILURE_COUNTER')
+    @patch('pyartcd.pipelines.ocp4_konflux.STAGE_RUN_COUNTER')
+    @patch('pyartcd.pipelines.ocp4_konflux.jenkins.update_title')
+    @patch('pyartcd.pipelines.ocp4_konflux.jenkins.init_jenkins')
+    async def test_initialize_records_success_metrics(
+        self,
+        _mock_init_jenkins,
+        _mock_update_title,
+        mock_run_counter,
+        mock_failure_counter,
+        mock_duration,
+    ):
+        pipeline = self._default_konflux_pipeline()
+        pipeline.init_build_plan = AsyncMock()
+
+        await pipeline.initialize()
+
+        expected_attributes = {
+            'pipeline': 'ocp4_konflux',
+            'stage': 'initialize',
+            'assembly': 'stream',
+            'version': '4.14',
+            'dry_run': False,
+            'result': 'success',
+        }
+        mock_run_counter.add.assert_called_once_with(1, expected_attributes)
+        mock_failure_counter.add.assert_not_called()
+        mock_duration.record.assert_called_once()
+        self.assertEqual(mock_duration.record.call_args.args[1], expected_attributes)
+
+    @patch('pyartcd.pipelines.ocp4_konflux.STAGE_DURATION_HISTOGRAM')
+    @patch('pyartcd.pipelines.ocp4_konflux.STAGE_FAILURE_COUNTER')
+    @patch('pyartcd.pipelines.ocp4_konflux.STAGE_RUN_COUNTER')
+    async def test_clean_up_records_failure_metrics(self, mock_run_counter, mock_failure_counter, mock_duration):
+        pipeline = self._default_konflux_pipeline()
+        pipeline.rebase_failures = ['image-a']
+        pipeline.runtime.cleanup_sources = AsyncMock()
+
+        with self.assertRaisesRegex(RuntimeError, 'Following images failed to rebase: image-a'):
+            await pipeline.clean_up()
+
+        base_attributes = {
+            'pipeline': 'ocp4_konflux',
+            'stage': 'clean_up',
+            'assembly': 'stream',
+            'version': '4.14',
+            'dry_run': False,
+        }
+        mock_run_counter.add.assert_called_once_with(1, {**base_attributes, 'result': 'failure'})
+        mock_failure_counter.add.assert_called_once_with(1, base_attributes)
+        mock_duration.record.assert_called_once()

--- a/pyartcd/tests/test_telemetry.py
+++ b/pyartcd/tests/test_telemetry.py
@@ -1,0 +1,52 @@
+import unittest
+from unittest.mock import patch, sentinel
+
+from pyartcd import telemetry
+
+
+class TestTelemetry(unittest.TestCase):
+    @patch("pyartcd.telemetry.context.attach")
+    @patch("pyartcd.telemetry.metrics.set_meter_provider")
+    @patch("pyartcd.telemetry.trace.set_tracer_provider")
+    @patch("pyartcd.telemetry.new_meter_provider")
+    @patch("pyartcd.telemetry.new_tracker_provider")
+    @patch("pyartcd.telemetry.OTLPMetricExporter")
+    @patch("pyartcd.telemetry.OTLPSpanExporter")
+    def test_initialize_telemetry_initializes_trace_and_metric_providers(
+        self,
+        mock_span_exporter,
+        mock_metric_exporter,
+        mock_new_tracker_provider,
+        mock_new_meter_provider,
+        mock_set_tracer_provider,
+        mock_set_meter_provider,
+        mock_context_attach,
+    ):
+        mock_span_exporter.return_value = sentinel.trace_exporter
+        mock_metric_exporter.return_value = sentinel.metric_exporter
+        mock_new_tracker_provider.return_value = sentinel.tracer_provider
+        mock_new_meter_provider.return_value = sentinel.meter_provider
+
+        with patch.dict(
+            "os.environ",
+            {
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "https://otel.example:4317",
+                "OTEL_EXPORTER_OTLP_HEADERS": "authorization=Bearer test",
+            },
+            clear=False,
+        ):
+            telemetry.initialize_telemetry()
+
+        mock_span_exporter.assert_called_once_with(
+            endpoint="https://otel.example:4317",
+            headers="authorization=Bearer test",
+        )
+        mock_metric_exporter.assert_called_once_with(
+            endpoint="https://otel.example:4317",
+            headers="authorization=Bearer test",
+        )
+        mock_new_tracker_provider.assert_called_once()
+        mock_new_meter_provider.assert_called_once()
+        mock_set_tracer_provider.assert_called_once_with(sentinel.tracer_provider)
+        mock_set_meter_provider.assert_called_once_with(sentinel.meter_provider)
+        mock_context_attach.assert_not_called()

--- a/pyartcd/tests/test_telemetry.py
+++ b/pyartcd/tests/test_telemetry.py
@@ -5,6 +5,10 @@ from pyartcd import telemetry
 
 
 class TestTelemetry(unittest.TestCase):
+    def tearDown(self):
+        telemetry._TRACER_PROVIDER = None
+        telemetry._METER_PROVIDER = None
+
     @patch("pyartcd.telemetry.context.attach")
     @patch("pyartcd.telemetry.metrics.set_meter_provider")
     @patch("pyartcd.telemetry.trace.set_tracer_provider")
@@ -50,3 +54,63 @@ class TestTelemetry(unittest.TestCase):
         mock_set_tracer_provider.assert_called_once_with(sentinel.tracer_provider)
         mock_set_meter_provider.assert_called_once_with(sentinel.meter_provider)
         mock_context_attach.assert_not_called()
+        self.assertIs(telemetry._TRACER_PROVIDER, sentinel.tracer_provider)
+        self.assertIs(telemetry._METER_PROVIDER, sentinel.meter_provider)
+
+    @patch("pyartcd.telemetry.metrics.set_meter_provider")
+    @patch("pyartcd.telemetry.trace.set_tracer_provider")
+    @patch("pyartcd.telemetry.new_meter_provider")
+    @patch("pyartcd.telemetry.new_tracker_provider")
+    @patch("pyartcd.telemetry.OTLPMetricExporter")
+    @patch("pyartcd.telemetry.OTLPSpanExporter")
+    def test_initialize_telemetry_is_idempotent(
+        self,
+        mock_span_exporter,
+        mock_metric_exporter,
+        mock_new_tracker_provider,
+        mock_new_meter_provider,
+        mock_set_tracer_provider,
+        mock_set_meter_provider,
+    ):
+        mock_new_tracker_provider.return_value = sentinel.tracer_provider
+        mock_new_meter_provider.return_value = sentinel.meter_provider
+
+        telemetry.initialize_telemetry()
+        telemetry.initialize_telemetry()
+
+        mock_span_exporter.assert_called_once()
+        mock_metric_exporter.assert_called_once()
+        mock_new_tracker_provider.assert_called_once()
+        mock_new_meter_provider.assert_called_once()
+        mock_set_tracer_provider.assert_called_once_with(sentinel.tracer_provider)
+        mock_set_meter_provider.assert_called_once_with(sentinel.meter_provider)
+
+    @patch("pyartcd.telemetry.LOGGER")
+    def test_shutdown_telemetry_flushes_and_shuts_down_providers(self, mock_logger):
+        telemetry._TRACER_PROVIDER = tracer_provider = unittest.mock.Mock()
+        telemetry._METER_PROVIDER = meter_provider = unittest.mock.Mock()
+
+        telemetry.shutdown_telemetry()
+
+        meter_provider.force_flush.assert_called_once_with()
+        meter_provider.shutdown.assert_called_once_with()
+        tracer_provider.force_flush.assert_called_once_with()
+        tracer_provider.shutdown.assert_called_once_with()
+        mock_logger.warning.assert_not_called()
+        self.assertIsNone(telemetry._TRACER_PROVIDER)
+        self.assertIsNone(telemetry._METER_PROVIDER)
+
+    @patch("pyartcd.telemetry.LOGGER")
+    def test_shutdown_telemetry_swallows_provider_errors(self, mock_logger):
+        telemetry._TRACER_PROVIDER = tracer_provider = unittest.mock.Mock()
+        telemetry._METER_PROVIDER = meter_provider = unittest.mock.Mock()
+        meter_provider.force_flush.side_effect = RuntimeError("metrics flush")
+        meter_provider.shutdown.side_effect = RuntimeError("metrics shutdown")
+        tracer_provider.force_flush.side_effect = RuntimeError("traces flush")
+        tracer_provider.shutdown.side_effect = RuntimeError("traces shutdown")
+
+        telemetry.shutdown_telemetry()
+
+        self.assertEqual(mock_logger.warning.call_count, 4)
+        self.assertIsNone(telemetry._TRACER_PROVIDER)
+        self.assertIsNone(telemetry._METER_PROVIDER)


### PR DESCRIPTION
## Summary
- Add OTLP metric export to pyartcd telemetry setup so pipeline metrics are emitted alongside traces.
- Instrument clean async stages in ocp4_konflux with a local decorator that records per-stage success/failure counters, duration, and trace error status.
- Add/update focused tests for telemetry initialization and ocp4_konflux stage metrics behavior.

## Validate
- [X] https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/31228/console
- [ ] https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/31234/console
- [X] Traces are viewable in ART's signoz instance
- [ ] Metrics are viewable in ART's signoz instance

<img width="1903" height="957" alt="Screenshot From 2026-04-14 18-16-28" src="https://github.com/user-attachments/assets/abd7dd61-ab45-48ed-b71b-2b72e56784a3" />

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED