### PR TITLE
Temporarily disable post-build SLSA attestation validation

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -686,10 +686,6 @@ async def fetch_slsa_attestation(
         LOGGER.warning(f'Failed to fetch SLSA attestation for {build_name}')
         return None
 
-    except (JSONDecodeError, Exception) as e:
-        LOGGER.warning('Failed to parse SLSA attestation for %s: %s', build_name, e)
-        return None
-
 
 async def _oc_image_mirror(cmd: list, description: str, timeout: int = 1800):
     """Run oc image mirror, streaming output and logging only summary/error lines."""

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -682,8 +682,8 @@ async def fetch_slsa_attestation(
         )
         return json.loads(base64.b64decode(json.loads(attestation)["payload"]).decode("utf-8"))
 
-    except ChildProcessError:
-        LOGGER.warning(f'Failed to fetch SLSA attestation for {build_name}')
+    except ChildProcessError as e:
+        LOGGER.warning('Failed to fetch SLSA attestation for %s: %s', build_name, e)
         return None
 
 

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -448,12 +448,27 @@ class KonfluxImageBuilder:
         :param distgit_key: The distgit key for logging purposes
         :raises: Exception if validation fails
         """
-        # Get SLA attestation from konflux. The command will error out if it cannot find it.
-        attestation = await fetch_slsa_attestation(
-            image_pullspec=image_pullspec,
-            build_name=distgit_key,
-            registry_auth_file=self._config.registry_auth_file,
-        )
+        # Attestation may not be immediately available after build completion due to
+        # signing/attestation propagation delays. Retry with wait to allow time.
+        max_attempts = 5
+        wait_seconds = 60
+        attestation = None
+
+        for attempt in range(1, max_attempts + 1):
+            attestation = await fetch_slsa_attestation(
+                image_pullspec=image_pullspec,
+                build_name=distgit_key,
+                registry_auth_file=self._config.registry_auth_file,
+            )
+            if attestation:
+                break
+            if attempt < max_attempts:
+                LOGGER.warning(
+                    "SLSA attestation not yet available for %s, retrying in %ds (attempt %d/%d)",
+                    distgit_key, wait_seconds, attempt, max_attempts,
+                )
+                await asyncio.sleep(wait_seconds)
+
         if not attestation:
             raise ValueError("SLSA attestation cannot be empty")
 

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -271,24 +271,25 @@ class KonfluxImageBuilder:
 
                     # Validate SLSA attestation and source image signature
                     # Skip for non-OCP groups (e.g., OKD) as they may not have attestations/signatures
-                    is_ocp_group = self._config.group_name.startswith("openshift-")
-                    if is_ocp_group:
-                        try:
-                            # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
-                            await self._validate_build_attestation_and_signature(
-                                definitive_image_pullspec, metadata.distgit_key
-                            )
-                        except Exception as e:
-                            logger.error(
-                                f"Failed to get SLA attestation / source signature from konflux for image {definitive_image_pullspec}, marking build as {KonfluxBuildOutcome.FAILURE}. Error: {e}"
-                            )
-                            outcome = KonfluxBuildOutcome.FAILURE
-                    else:
-                        logger.info(
-                            "Skipping SLSA attestation validation for %s: non-OCP group '%s'",
-                            metadata.distgit_key,
-                            self._config.group_name,
-                        )
+                    # TODO: Re-enable once cosign auth issues in the build environment are resolved
+                    # is_ocp_group = self._config.group_name.startswith("openshift-")
+                    # if is_ocp_group:
+                    #     try:
+                    #         # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
+                    #         await self._validate_build_attestation_and_signature(
+                    #             definitive_image_pullspec, metadata.distgit_key
+                    #         )
+                    #     except Exception as e:
+                    #         logger.error(
+                    #             f"Failed to get SLA attestation / source signature from konflux for image {definitive_image_pullspec}, marking build as {KonfluxBuildOutcome.FAILURE}. Error: {e}"
+                    #         )
+                    #         outcome = KonfluxBuildOutcome.FAILURE
+                    # else:
+                    #     logger.info(
+                    #         "Skipping SLSA attestation validation for %s: non-OCP group '%s'",
+                    #         metadata.distgit_key,
+                    #         self._config.group_name,
+                    #     )
 
                 # Run enterprise-contract (EC) verification after a successful build
                 # TODO: Expand EC verification to layered products

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -658,9 +658,13 @@ class ConfigScanSources:
         build_record = self.latest_image_build_records_map[image_meta.distgit_key]
 
         # Fetch the SLSA attestation for the latest build
-        attestation = await fetch_slsa_attestation(
-            build_record.image_pullspec, build_record.name, self.registry_auth_file
-        )
+        try:
+            attestation = await fetch_slsa_attestation(
+                build_record.image_pullspec, build_record.name, self.registry_auth_file
+            )
+        except Exception as e:
+            self.logger.warning('Failed to parse SLSA attestation for %s: %s', image_meta.distgit_key, e)
+            attestation = None
         if not attestation:
             self.logger.warning('Skipping network mode check for %s', image_meta.distgit_key)
             return
@@ -1177,9 +1181,13 @@ class ConfigScanSources:
         build_record = self.latest_image_build_records_map[image_meta.distgit_key]
 
         # Fetch SLSA attestation
-        attestation = await fetch_slsa_attestation(
-            build_record.image_pullspec, build_record.name, self.registry_auth_file
-        )
+        try:
+            attestation = await fetch_slsa_attestation(
+                build_record.image_pullspec, build_record.name, self.registry_auth_file
+            )
+        except Exception as e:
+            self.logger.warning('Failed to parse SLSA attestation for %s: %s', image_meta.distgit_key, e)
+            attestation = None
         if not attestation:
             self.logger.warning('Skipping task bundle check for %s', image_meta.distgit_key)
             return

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -109,67 +109,69 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         ):
             await self.builder.build(metadata)
 
-        mock_validate.assert_awaited_once_with("quay.io/test/image@sha256:testdigest", "test-image")
+        # TODO: Re-enable once cosign attestation validation is re-enabled
+        # mock_validate.assert_awaited_once_with("quay.io/test/image@sha256:testdigest", "test-image")
 
-    async def test_build_skips_slsa_validation_for_non_ocp_groups(self):
-        """Test that SLSA attestation validation is skipped for non-OCP groups like OKD."""
-        # Create a builder with an OKD group name
-        okd_builder = KonfluxImageBuilder(
-            KonfluxImageBuilderConfig(
-                base_dir=Path(self.temp_dir.name),
-                group_name="okd-4.17",
-                namespace="test-namespace",
-                plr_template="test-template",
-                build_priority="5",
-            )
-        )
-
-        metadata = self._metadata()
-        dest_dir = okd_builder._config.base_dir.joinpath(metadata.qualified_key)
-        dest_dir.mkdir(parents=True)
-
-        build_repo = MagicMock()
-        build_repo.local_dir = dest_dir
-        build_repo.url = "https://github.com/test/okd-repo.git"
-        build_repo.commit_hash = "test-okd-commit"
-
-        initial_pipelinerun = MagicMock()
-        initial_pipelinerun.name = "test-pipelinerun"
-        initial_pipelinerun.to_dict.return_value = {"metadata": {"name": "test-pipelinerun"}}
-
-        completed_pipelinerun = MagicMock()
-        completed_pipelinerun.name = "test-pipelinerun"
-        completed_pipelinerun.find_condition.return_value = {"status": "True"}
-        completed_pipelinerun.to_dict.return_value = {
-            "metadata": {"name": "test-pipelinerun"},
-            "status": {
-                "results": [
-                    {"name": "IMAGE_URL", "value": "quay.io/test/okd-image:test-tag"},
-                    {"name": "IMAGE_DIGEST", "value": "sha256:okddigest"},
-                ]
-            },
-        }
-        self.mock_konflux_client.wait_for_pipelinerun = AsyncMock(return_value=completed_pipelinerun)
-
-        with (
-            patch(
-                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
-                new=AsyncMock(return_value=build_repo),
-            ),
-            patch.object(okd_builder, "_parse_dockerfile", return_value=("test-uuid", "test-component", "1.0", "1")),
-            patch.object(okd_builder, "_wait_for_parent_members", new=AsyncMock(return_value=[])),
-            patch.object(okd_builder, "_start_build", new=AsyncMock(return_value=initial_pipelinerun)),
-            patch.object(okd_builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))),
-            patch.object(okd_builder, "_validate_build_attestation_and_signature", new=AsyncMock()) as mock_validate,
-            patch(
-                "doozerlib.backend.konflux_image_builder.KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition",
-                return_value=KonfluxBuildOutcome.SUCCESS,
-            ),
-        ):
-            await okd_builder.build(metadata)
-
-        # Validation should NOT be called for OKD groups
-        mock_validate.assert_not_awaited()
+    # TODO: Re-enable once cosign attestation validation is re-enabled
+    # async def test_build_skips_slsa_validation_for_non_ocp_groups(self):
+    #     """Test that SLSA attestation validation is skipped for non-OCP groups like OKD."""
+    #     # Create a builder with an OKD group name
+    #     okd_builder = KonfluxImageBuilder(
+    #         KonfluxImageBuilderConfig(
+    #             base_dir=Path(self.temp_dir.name),
+    #             group_name="okd-4.17",
+    #             namespace="test-namespace",
+    #             plr_template="test-template",
+    #             build_priority="5",
+    #         )
+    #     )
+    #
+    #     metadata = self._metadata()
+    #     dest_dir = okd_builder._config.base_dir.joinpath(metadata.qualified_key)
+    #     dest_dir.mkdir(parents=True)
+    #
+    #     build_repo = MagicMock()
+    #     build_repo.local_dir = dest_dir
+    #     build_repo.url = "https://github.com/test/okd-repo.git"
+    #     build_repo.commit_hash = "test-okd-commit"
+    #
+    #     initial_pipelinerun = MagicMock()
+    #     initial_pipelinerun.name = "test-pipelinerun"
+    #     initial_pipelinerun.to_dict.return_value = {"metadata": {"name": "test-pipelinerun"}}
+    #
+    #     completed_pipelinerun = MagicMock()
+    #     completed_pipelinerun.name = "test-pipelinerun"
+    #     completed_pipelinerun.find_condition.return_value = {"status": "True"}
+    #     completed_pipelinerun.to_dict.return_value = {
+    #         "metadata": {"name": "test-pipelinerun"},
+    #         "status": {
+    #             "results": [
+    #                 {"name": "IMAGE_URL", "value": "quay.io/test/okd-image:test-tag"},
+    #                 {"name": "IMAGE_DIGEST", "value": "sha256:okddigest"},
+    #             ]
+    #         },
+    #     }
+    #     self.mock_konflux_client.wait_for_pipelinerun = AsyncMock(return_value=completed_pipelinerun)
+    #
+    #     with (
+    #         patch(
+    #             "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+    #             new=AsyncMock(return_value=build_repo),
+    #         ),
+    #         patch.object(okd_builder, "_parse_dockerfile", return_value=("test-uuid", "test-component", "1.0", "1")),
+    #         patch.object(okd_builder, "_wait_for_parent_members", new=AsyncMock(return_value=[])),
+    #         patch.object(okd_builder, "_start_build", new=AsyncMock(return_value=initial_pipelinerun)),
+    #         patch.object(okd_builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))),
+    #         patch.object(okd_builder, "_validate_build_attestation_and_signature", new=AsyncMock()) as mock_validate,
+    #         patch(
+    #             "doozerlib.backend.konflux_image_builder.KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition",
+    #             return_value=KonfluxBuildOutcome.SUCCESS,
+    #         ),
+    #     ):
+    #         await okd_builder.build(metadata)
+    #
+    #     # Validation should NOT be called for OKD groups
+    #     mock_validate.assert_not_awaited()
 
     async def test_update_konflux_db_uses_definitive_pullspec_for_installed_packages(self):
         metadata = self._metadata()


### PR DESCRIPTION
## Summary
- Post-build SLSA attestation validation via `cosign download attestation` is consistently failing in the build environment, despite the attestation being available (verified locally)
- This is likely an auth/environment issue in the build pod, not a timing issue
- Temporarily comments out the attestation validation block to unblock builds while the root cause is investigated
- Adds retry logic (5 attempts, 60s backoff) for when the validation is re-enabled
- Improves error handling: parse errors now fail fast instead of retrying, and `ChildProcessError` logging now includes cosign stderr for debugging

## Test plan
- [x] Unit tests pass (`doozer/tests/backend/test_konflux_image_builder.py`, `doozer/tests/cli/test_scan_sources_konflux.py`)
- [ ] Verify builds complete without being marked as failure due to attestation issues
- [ ] Investigate cosign auth in build environment and re-enable validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)