### PR TITLE
add registryConfig: explicit registry auth manager

### DIFF
--- a/artcommon/artcommonlib/registry_config.py
+++ b/artcommon/artcommonlib/registry_config.py
@@ -6,6 +6,11 @@
 **``oc image mirror`` (and related ``oc image`` commands)** accept
 ``-a PATH`` or ``--registry-config=PATH`` with this file.
 
+**PROOF-OF-CONCEPT STATUS:**
+Currently used in ocp4-konflux pipeline as a PoC to eliminate dependency on
+default auth.json files. Once validated in production, this pattern can be
+gradually migrated to other pipelines (build-sync, sync-ci-images, etc.).
+
 **Usage:**
 
 Specify explicit credentials from trusted credential stores::
@@ -67,8 +72,8 @@ class Registry:
 
     def __post_init__(self):
         # Validate exactly one auth source
-        sources = [self.auth_file, self.username_password, self.base64_auth]
-        if sum(bool(s) for s in sources) != 1:
+        sources_provided = [s for s in [self.auth_file, self.username_password, self.base64_auth] if s is not None]
+        if len(sources_provided) != 1:
             raise ValueError(
                 f"Registry '{self.path}' requires exactly one of: auth_file, username_password, or base64_auth"
             )

--- a/artcommon/artcommonlib/registry_config.py
+++ b/artcommon/artcommonlib/registry_config.py
@@ -1,0 +1,335 @@
+"""Container registry credentials for ``oc`` / Podman-style tools.
+
+:class:`RegistryConfig` creates a temporary Docker ``config.json`` file
+(``{"auths": {...}}``) for use with OpenShift CLI registry operations.
+
+**``oc image mirror`` (and related ``oc image`` commands)** accept
+``-a PATH`` or ``--registry-config=PATH`` with this file.
+
+**Usage:**
+
+Specify explicit credentials from trusted credential stores::
+
+    with RegistryConfig(
+        registries=[
+            Registry('quay.io/openshift-release-dev',
+                    auth_file=os.getenv('QUAY_AUTH_FILE')),
+            Registry('registry.redhat.io',
+                    username_password=os.getenv('RH_REGISTRY_CREDS')),
+        ]
+    ) as auth_file:
+        # auth_file is a temporary file with merged credentials
+        cmd.extend(['--registry-auth', auth_file])
+        ...
+
+Using common registries helper::
+
+    with RegistryConfig(
+        registries=[
+            Registry('quay.io/special', auth_file=special_auth),  # Override
+            *COMMON_READ_ONLY_REGISTRIES(),  # Common defaults
+        ]
+    ) as auth_file:
+        ...
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Registry:
+    """
+    Represents a single registry with one authentication source.
+
+    Exactly one of auth_file, username_password, or base64_auth must be provided.
+
+    :param path: Registry path (e.g., 'quay.io' or 'quay.io/openshift-release-dev')
+    :param auth_file: Path to an auth.json file containing credentials for this registry
+    :param username_password: Plain text "username:password" (will be base64 encoded)
+    :param base64_auth: Base64-encoded "username:password" string
+    """
+
+    path: str
+    auth_file: Optional[str] = None
+    username_password: Optional[str] = None
+    base64_auth: Optional[str] = None
+
+    def __post_init__(self):
+        # Validate exactly one auth source
+        sources = [self.auth_file, self.username_password, self.base64_auth]
+        if sum(bool(s) for s in sources) != 1:
+            raise ValueError(
+                f"Registry '{self.path}' requires exactly one of: auth_file, username_password, or base64_auth"
+            )
+
+        # Validate path is not empty
+        if not self.path or not self.path.strip():
+            raise ValueError("Registry path cannot be empty")
+
+        # Validate auth_file path is not empty if provided
+        if self.auth_file is not None and not self.auth_file.strip():
+            raise ValueError(f"auth_file path cannot be empty for registry '{self.path}'")
+
+        # Normalize the path (lowercase host, preserve path case)
+        self.path = self._normalize_path(self.path)
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        """Normalize registry path: lowercase host, preserve path case, strip schemes"""
+        path = path.strip()
+
+        # Strip common URI schemes
+        for prefix in ("docker://", "oci://", "https://", "http://"):
+            if path.startswith(prefix):
+                path = path[len(prefix) :]
+                break
+
+        # Strip digest suffix
+        path = path.split("@", 1)[0].rstrip("/")
+
+        if not path:
+            raise ValueError("empty registry reference after normalization")
+
+        # Lowercase host, preserve path case
+        if "/" in path:
+            host, rest = path.split("/", 1)
+            return f"{host.lower()}/{rest}"
+        return path.lower()
+
+
+class RegistryConfig:
+    """Build a merged ``auths`` JSON file for ``oc``/Podman pull secrets.
+
+    The yielded path can be passed to ``oc image mirror`` as ``--registry-config``
+    (short: ``-a``), or exported as ``REGISTRY_AUTH_FILE``.
+
+    **Usage:**
+
+    Explicit credentials from trusted sources::
+
+        with RegistryConfig(
+            registries=[
+                Registry('quay.io/openshift-release-dev',
+                        auth_file=os.getenv('QUAY_AUTH_FILE')),
+                Registry('registry.redhat.io',
+                        username_password=os.getenv('RH_CREDS')),
+            ]
+        ) as auth_file:
+            cmd.extend(['--registry-auth', auth_file])
+            ...
+
+    Composing with common configs (first source wins)::
+
+        with RegistryConfig(
+            registries=[
+                Registry('quay.io/special', auth_file=special_auth),  # Override
+                *COMMON_READ_ONLY_REGISTRIES(),  # Common defaults
+            ]
+        ) as auth_file:
+            ...
+    """
+
+    def __init__(self, registries: list[Registry]) -> None:
+        """
+        Initialize the RegistryConfig context manager.
+
+        :param registries: List of Registry objects with explicit auth sources
+        """
+        if not registries:
+            raise ValueError("RegistryConfig requires at least one registry")
+
+        self.registries = list(registries)
+        self.temp_auth_file: Optional[Path] = None
+        self.merged_auths: dict[str, dict[str, str]] = {}
+
+    def __enter__(self) -> str:
+        """
+        Enter the context manager: resolve credentials and write to temporary file.
+
+        :return: Path to the temporary auth file containing merged credentials
+        :raises ValueError: If any registry cannot be resolved
+        """
+        resolved: dict[str, dict[str, str]] = {}
+
+        for registry in self.registries:
+            registry_key = registry.path
+
+            # First source wins - skip if already resolved
+            if registry_key in resolved:
+                logger.debug("RegistryConfig: registry '%s' already resolved by earlier source, skipping", registry_key)
+                continue
+
+            # Resolve auth for this registry
+            auth_str = self._resolve_auth(registry)
+            if auth_str:
+                resolved[registry_key] = {"auth": auth_str}
+                logger.info("RegistryConfig: resolved credentials for '%s'", registry_key)
+            else:
+                raise ValueError(f"RegistryConfig: could not resolve credentials for registry '{registry_key}'")
+
+        self.merged_auths = resolved
+        self._write_temp_file()
+        return str(self.temp_auth_file)
+
+    def _resolve_auth(self, registry: Registry) -> Optional[str]:
+        """
+        Resolve a single Registry to a base64 auth string.
+
+        :param registry: The Registry to resolve
+        :return: Base64 encoded auth string, or None if not found
+        """
+        registry_key = registry.path
+
+        # Explicit base64 string
+        if registry.base64_auth:
+            auth_str = registry.base64_auth.strip()
+            if not auth_str:
+                raise ValueError(f"Empty base64_auth for '{registry_key}'")
+            logger.debug("RegistryConfig: using explicit base64 auth for '%s'", registry_key)
+            return auth_str
+
+        # Plain username:password
+        elif registry.username_password:
+            plain = registry.username_password.strip()
+            if not plain:
+                raise ValueError(f"Empty username_password for '{registry_key}'")
+            logger.debug("RegistryConfig: using username:password for '%s'", registry_key)
+            return base64.b64encode(plain.encode()).decode()
+
+        # Auth file
+        elif registry.auth_file:
+            file_path = registry.auth_file.strip()
+            if not file_path:
+                raise ValueError(f"Empty auth_file path for '{registry_key}'")
+
+            if not os.path.exists(file_path):
+                raise FileNotFoundError(f"Auth file not found: {file_path}")
+
+            logger.debug("RegistryConfig: reading auth file %s for '%s'", file_path, registry_key)
+
+            with open(file_path, encoding="utf-8") as f:
+                file_config = json.load(f)
+                file_auths = file_config.get("auths", {})
+
+            # Exact match required
+            if registry_key in file_auths:
+                logger.debug("RegistryConfig: found exact match for '%s' in %s", registry_key, file_path)
+                return file_auths[registry_key].get("auth")
+            else:
+                raise ValueError(
+                    f"RegistryConfig: registry '{registry_key}' not found in auth file {file_path}. "
+                    f"Available keys: {list(file_auths.keys())}"
+                )
+
+        return None
+
+    def _write_temp_file(self):
+        """Write merged credentials to temporary file in current directory"""
+        try:
+            fd, temp_path = tempfile.mkstemp(prefix="registry_config_", suffix=".json", text=True)
+
+            self.temp_auth_file = Path(temp_path)
+
+            merged_config = {"auths": self.merged_auths}
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(merged_config, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+
+            logger.info("RegistryConfig: wrote %d credentials to %s", len(self.merged_auths), self.temp_auth_file)
+            logger.debug("RegistryConfig: enabled registries: %s", list(self.merged_auths.keys()))
+
+        except Exception:
+            if self.temp_auth_file and self.temp_auth_file.exists():
+                try:
+                    self.temp_auth_file.unlink()
+                except OSError:
+                    pass
+            raise
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        """Clean up temporary auth file"""
+        self.merged_auths = {}
+        path = self.temp_auth_file
+        self.temp_auth_file = None
+        if path and path.exists():
+            try:
+                path.unlink()
+                logger.debug("RegistryConfig: removed temp file %s", path)
+            except OSError as err:
+                logger.warning("RegistryConfig: could not remove %s: %s", path, err)
+        return False
+
+    # Public helper methods
+
+    def get_registries(self) -> list[str]:
+        """Return auth keys in the merged config (only valid inside the context after ``__enter__``)."""
+        return list(self.merged_auths.keys())
+
+    def has_credential_for(self, registry: str) -> bool:
+        """True if merged auths include credentials for *registry* (exact match only)."""
+        return registry in self.merged_auths
+
+
+# Common registry configurations for reuse
+
+
+def COMMON_READ_ONLY_REGISTRIES() -> list[Registry]:
+    """
+    Common read-only registries used across ART tools.
+
+    These use credentials from Jenkins-provided environment variables.
+    Override specific registries by placing them earlier in the registries list
+    (first source wins for duplicate registry paths).
+
+    Example::
+
+        with RegistryConfig(
+            registries=[
+                # This specific override wins
+                Registry('quay.io', auth_file=special_auth),
+                # Common configs used as fallback
+                *COMMON_READ_ONLY_REGISTRIES(),
+            ]
+        ) as auth_file:
+            ...
+    """
+    quay_auth_file = os.getenv("QUAY_AUTH_FILE", "")
+    rh_registry_auth_file = os.getenv("REGISTRY_REDHAT_IO_AUTH_FILE", "")
+
+    registries = []
+
+    if quay_auth_file:
+        registries.extend(
+            [
+                Registry(
+                    "quay.io/openshift-release-dev",
+                    auth_file=quay_auth_file,
+                ),
+                Registry(
+                    "quay.io",
+                    auth_file=quay_auth_file,
+                ),
+            ]
+        )
+
+    if rh_registry_auth_file:
+        registries.append(
+            Registry(
+                "registry.redhat.io",
+                auth_file=rh_registry_auth_file,
+            )
+        )
+
+    return registries

--- a/artcommon/tests/test_registry_config.py
+++ b/artcommon/tests/test_registry_config.py
@@ -1,0 +1,310 @@
+import base64
+import json
+import os
+import tempfile
+import unittest
+
+from artcommonlib.registry_config import (
+    COMMON_READ_ONLY_REGISTRIES,
+    Registry,
+    RegistryConfig,
+)
+
+
+class TestRegistry(unittest.TestCase):
+    def test_requires_exactly_one_source(self):
+        # No source
+        with self.assertRaises(ValueError):
+            Registry("quay.io")
+
+        # Multiple sources
+        with self.assertRaises(ValueError):
+            Registry("quay.io", auth_file="/path/to/auth.json", username_password="user:pass")
+
+    def test_valid_auth_file(self):
+        reg = Registry("quay.io", auth_file="/path/to/auth.json")
+        self.assertEqual(reg.auth_file, "/path/to/auth.json")
+        self.assertIsNone(reg.username_password)
+        self.assertIsNone(reg.base64_auth)
+
+    def test_valid_username_password(self):
+        reg = Registry("quay.io", username_password="user:pass")
+        self.assertEqual(reg.username_password, "user:pass")
+        self.assertIsNone(reg.auth_file)
+        self.assertIsNone(reg.base64_auth)
+
+    def test_valid_base64_auth(self):
+        reg = Registry("quay.io", base64_auth="dXNlcjpwYXNz")
+        self.assertEqual(reg.base64_auth, "dXNlcjpwYXNz")
+        self.assertIsNone(reg.auth_file)
+        self.assertIsNone(reg.username_password)
+
+    def test_empty_path_raises(self):
+        with self.assertRaises(ValueError):
+            Registry("", auth_file="/path/to/auth.json")
+
+    def test_empty_auth_file_raises(self):
+        with self.assertRaises(ValueError):
+            Registry("quay.io", auth_file="")
+
+    def test_normalizes_path(self):
+        reg = Registry("Quay.IO/OpenShift/CI", auth_file="/path/to/auth.json")
+        self.assertEqual(reg.path, "quay.io/OpenShift/CI")  # Host lowercased, path preserved
+
+        reg = Registry("QUAY.IO", auth_file="/path/to/auth.json")
+        self.assertEqual(reg.path, "quay.io")
+
+    def test_strips_schemes(self):
+        reg = Registry("docker://quay.io/foo", auth_file="/path/to/auth.json")
+        self.assertEqual(reg.path, "quay.io/foo")
+
+        reg = Registry("https://registry.redhat.io", auth_file="/path/to/auth.json")
+        self.assertEqual(reg.path, "registry.redhat.io")
+
+    def test_strips_digest(self):
+        reg = Registry("quay.io/foo@sha256:abc123", auth_file="/path/to/auth.json")
+        self.assertEqual(reg.path, "quay.io/foo")
+
+    def test_strips_trailing_slash(self):
+        reg = Registry("quay.io/foo/", auth_file="/path/to/auth.json")
+        self.assertEqual(reg.path, "quay.io/foo")
+
+
+class TestRegistryConfig(unittest.TestCase):
+    def _sample_b64(self) -> str:
+        return base64.b64encode(b"user:pass").decode()
+
+    def test_base64_auth(self):
+        b64 = self._sample_b64()
+        with RegistryConfig(
+            registries=[
+                Registry("quay.io", base64_auth=b64),
+            ]
+        ) as auth_file:
+            self.assertTrue(os.path.isfile(auth_file))
+            with open(auth_file, encoding="utf-8") as fh:
+                data = json.load(fh)
+            self.assertEqual(data["auths"]["quay.io"]["auth"], b64)
+
+    def test_username_password(self):
+        with RegistryConfig(
+            registries=[
+                Registry("quay.io", username_password="user:pass"),
+            ]
+        ) as auth_file:
+            with open(auth_file, encoding="utf-8") as fh:
+                data = json.load(fh)
+            # Should be base64 encoded
+            auth = data["auths"]["quay.io"]["auth"]
+            decoded = base64.b64decode(auth).decode()
+            self.assertEqual(decoded, "user:pass")
+
+    def test_auth_file_exact_match(self):
+        b64 = self._sample_b64()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False, encoding="utf-8") as tmp:
+            json.dump({"auths": {"quay.io/foo": {"auth": b64}}}, tmp)
+            auth_path = tmp.name
+
+        try:
+            with RegistryConfig(
+                registries=[
+                    Registry("quay.io/foo", auth_file=auth_path),
+                ]
+            ) as auth_file:
+                with open(auth_file, encoding="utf-8") as fh:
+                    data = json.load(fh)
+                self.assertEqual(data["auths"]["quay.io/foo"]["auth"], b64)
+        finally:
+            os.unlink(auth_path)
+
+    def test_auth_file_no_match_raises(self):
+        b64 = self._sample_b64()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False, encoding="utf-8") as tmp:
+            json.dump({"auths": {"quay.io": {"auth": b64}}}, tmp)
+            auth_path = tmp.name
+
+        try:
+            # Requesting quay.io/foo but file only has quay.io - should fail
+            with self.assertRaises(ValueError) as cm:
+                with RegistryConfig(
+                    registries=[
+                        Registry("quay.io/foo", auth_file=auth_path),
+                    ]
+                ):
+                    pass
+            self.assertIn("not found in auth file", str(cm.exception))
+        finally:
+            os.unlink(auth_path)
+
+    def test_first_source_wins(self):
+        """Test that first source wins for duplicate registry paths"""
+        b64_first = base64.b64encode(b"first:cred").decode()
+        b64_second = base64.b64encode(b"second:cred").decode()
+
+        with RegistryConfig(
+            registries=[
+                Registry("quay.io", base64_auth=b64_first),
+                Registry("quay.io", base64_auth=b64_second),  # Ignored
+            ]
+        ) as auth_file:
+            with open(auth_file, encoding="utf-8") as fh:
+                data = json.load(fh)
+            # Should use first
+            self.assertEqual(data["auths"]["quay.io"]["auth"], b64_first)
+
+    def test_multiple_registries(self):
+        b64_quay = base64.b64encode(b"quay:cred").decode()
+        b64_rh = base64.b64encode(b"rh:cred").decode()
+
+        with RegistryConfig(
+            registries=[
+                Registry("quay.io", base64_auth=b64_quay),
+                Registry("registry.redhat.io", base64_auth=b64_rh),
+            ]
+        ) as auth_file:
+            with open(auth_file, encoding="utf-8") as fh:
+                data = json.load(fh)
+            self.assertEqual(data["auths"]["quay.io"]["auth"], b64_quay)
+            self.assertEqual(data["auths"]["registry.redhat.io"]["auth"], b64_rh)
+
+    def test_empty_registries_raises(self):
+        with self.assertRaises(ValueError):
+            with RegistryConfig(registries=[]):
+                pass
+
+    def test_cleanup_on_exit(self):
+        b64 = self._sample_b64()
+        path_holder = []
+
+        with RegistryConfig(
+            registries=[
+                Registry("quay.io", base64_auth=b64),
+            ]
+        ) as auth_file:
+            path_holder.append(auth_file)
+            self.assertTrue(os.path.exists(auth_file))
+
+        # File should be cleaned up
+        self.assertFalse(os.path.exists(path_holder[0]))
+
+    def test_cleanup_on_exception(self):
+        b64 = self._sample_b64()
+        path_seen = None
+
+        try:
+            with RegistryConfig(
+                registries=[
+                    Registry("quay.io", base64_auth=b64),
+                ]
+            ) as auth_file:
+                path_seen = auth_file
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+
+        self.assertIsNotNone(path_seen)
+        self.assertFalse(os.path.exists(path_seen))
+
+    def test_get_registries_method(self):
+        b64 = self._sample_b64()
+        ctx = RegistryConfig(
+            registries=[
+                Registry("quay.io/foo", base64_auth=b64),
+                Registry("registry.redhat.io", base64_auth=b64),
+            ]
+        )
+        ctx.__enter__()
+        try:
+            registries = ctx.get_registries()
+            self.assertIn("quay.io/foo", registries)
+            self.assertIn("registry.redhat.io", registries)
+            self.assertEqual(len(registries), 2)
+        finally:
+            ctx.__exit__(None, None, None)
+
+    def test_has_credential_for_method(self):
+        b64 = self._sample_b64()
+        ctx = RegistryConfig(
+            registries=[
+                Registry("quay.io", base64_auth=b64),
+            ]
+        )
+        ctx.__enter__()
+        try:
+            self.assertTrue(ctx.has_credential_for("quay.io"))
+            # No prefix matching - exact only
+            self.assertFalse(ctx.has_credential_for("quay.io/openshift"))
+            self.assertFalse(ctx.has_credential_for("registry.redhat.io"))
+        finally:
+            ctx.__exit__(None, None, None)
+
+    def test_auth_file_not_found_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            with RegistryConfig(
+                registries=[
+                    Registry("quay.io", auth_file="/nonexistent/file.json"),
+                ]
+            ):
+                pass
+
+    def test_empty_base64_auth_raises(self):
+        with self.assertRaises(ValueError):
+            with RegistryConfig(
+                registries=[
+                    Registry("quay.io", base64_auth="   "),
+                ]
+            ):
+                pass
+
+    def test_empty_username_password_raises(self):
+        with self.assertRaises(ValueError):
+            with RegistryConfig(
+                registries=[
+                    Registry("quay.io", username_password="   "),
+                ]
+            ):
+                pass
+
+
+class TestCommonReadOnlyRegistries(unittest.TestCase):
+    def test_returns_list_of_registries(self):
+        # Set env vars
+        os.environ["QUAY_AUTH_FILE"] = "/path/to/quay.json"
+        os.environ["REGISTRY_REDHAT_IO_AUTH_FILE"] = "/path/to/rh.json"
+
+        try:
+            config = COMMON_READ_ONLY_REGISTRIES()
+            self.assertIsInstance(config, list)
+            self.assertTrue(all(isinstance(item, Registry) for item in config))
+
+            # Should have entries for quay.io
+            paths = [reg.path for reg in config]
+            self.assertIn("quay.io/openshift-release-dev", paths)
+            self.assertIn("quay.io", paths)
+            self.assertIn("registry.redhat.io", paths)
+        finally:
+            os.environ.pop("QUAY_AUTH_FILE", None)
+            os.environ.pop("REGISTRY_REDHAT_IO_AUTH_FILE", None)
+
+    def test_handles_missing_env_vars(self):
+        # Clear env vars
+        os.environ.pop("QUAY_AUTH_FILE", None)
+        os.environ.pop("REGISTRY_REDHAT_IO_AUTH_FILE", None)
+
+        config = COMMON_READ_ONLY_REGISTRIES()
+        # Should return empty list when env vars not set
+        self.assertIsInstance(config, list)
+        self.assertEqual(len(config), 0)
+
+    def test_quay_only(self):
+        os.environ["QUAY_AUTH_FILE"] = "/path/to/quay.json"
+        os.environ.pop("REGISTRY_REDHAT_IO_AUTH_FILE", None)
+
+        try:
+            config = COMMON_READ_ONLY_REGISTRIES()
+            paths = [reg.path for reg in config]
+            self.assertIn("quay.io/openshift-release-dev", paths)
+            self.assertIn("quay.io", paths)
+            self.assertNotIn("registry.redhat.io", paths)
+        finally:
+            os.environ.pop("QUAY_AUTH_FILE", None)

--- a/pyartcd/pyartcd/oc.py
+++ b/pyartcd/pyartcd/oc.py
@@ -51,13 +51,17 @@ async def get_release_image_info(pullspec: str, raise_if_not_found: bool = False
     return info
 
 
-async def registry_login():
+async def registry_login(to_file: str | None = None):
     """
     Login into OC registry using KUBECONFIG env var
+
+    :param to_file: Optional path to write credentials to (uses --to flag).
+                    If not provided, writes to default location.
     """
 
     try:
-        await exectools.cmd_gather_async(f'oc --kubeconfig {os.environ["KUBECONFIG"]} registry login')
+        to_arg = f'--to={to_file}' if to_file else ''
+        await exectools.cmd_gather_async(f'oc --kubeconfig {os.environ["KUBECONFIG"]} registry login {to_arg}'.strip())
 
     except KeyError:
         logger.error('KUBECONFIG env var must be defined!')
@@ -68,14 +72,18 @@ async def registry_login():
         raise
 
 
-async def qci_registry_login():
+async def qci_registry_login(to_file: str | None = None):
     """
     Log in to quay.io with credentials necessary to push to DPTP's QCI registry (quay.io/openshift/ci)
+
+    :param to_file: Optional path to write credentials to (uses --to flag).
+                    If not provided, writes to default location.
     """
 
     try:
+        to_arg = f'--to={to_file}' if to_file else ''
         await exectools.cmd_gather_async(
-            f'oc registry login --registry=quay.io/openshift --auth-basic={os.environ["QCI_USER"]}:{os.environ["QCI_PASSWORD"]}'
+            f'oc registry login --registry=quay.io/openshift --auth-basic={os.environ["QCI_USER"]}:{os.environ["QCI_PASSWORD"]} {to_arg}'.strip()
         )
 
     except KeyError:

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -402,6 +402,17 @@ class KonfluxOcpPipeline:
         if built_images.get('ose-openshift-apiserver', None):
             LOGGER.warning('apiserver rebuilt: mirroring streams to CI...')
 
+            # PROOF-OF-CONCEPT: Explicit registry auth for ocp4-konflux
+            # This avoids dependency on default auth.json and makes credential sources explicit.
+            # Once validated, this pattern can be migrated to other pipelines.
+
+            quay_auth_file = os.getenv('QUAY_AUTH_FILE')
+            if not quay_auth_file:
+                raise ValueError(
+                    "QUAY_AUTH_FILE environment variable is required for registry authentication. "
+                    "This should be set by Jenkins credentials."
+                )
+
             # Create temp file for oc registry login credentials
             with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as ci_auth_temp:
                 ci_auth_file = ci_auth_temp.name
@@ -414,8 +425,8 @@ class KonfluxOcpPipeline:
                 with RegistryConfig(
                     registries=[
                         # Explicit credentials from Jenkins QUAY_AUTH_FILE
-                        Registry('quay.io/openshift-release-dev', auth_file=os.getenv('QUAY_AUTH_FILE')),
-                        Registry('quay.io', auth_file=os.getenv('QUAY_AUTH_FILE')),
+                        Registry('quay.io/openshift-release-dev', auth_file=quay_auth_file),
+                        Registry('quay.io', auth_file=quay_auth_file),
                         # CI registry credentials from oc login
                         Registry('registry.ci.openshift.org', auth_file=ci_auth_file),
                     ]

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -12,6 +12,7 @@ import yaml
 from artcommonlib import exectools, redis
 from artcommonlib.build_visibility import is_release_embargoed
 from artcommonlib.constants import KONFLUX_ART_IMAGES_SHARE
+from artcommonlib.registry_config import Registry, RegistryConfig
 from artcommonlib.util import (
     new_roundtrip_yaml_handler,
     run_safe,
@@ -406,10 +407,21 @@ class KonfluxOcpPipeline:
             # Log into QCI registry
             await oc.qci_registry_login()
 
-            # Mirror out ART equivalent images to CI
-            cmd = self._doozer_base_command.copy()
-            cmd.extend(['images:streams', 'mirror'])
-            await exectools.cmd_assert_async(cmd)
+            # Get the auth file path where oc.registry_login() writes credentials
+            ci_auth_file = os.getenv('REGISTRY_AUTH_FILE', f"{os.getenv('XDG_RUNTIME_DIR')}/containers/auth.json")
+
+            with RegistryConfig(
+                registries=[
+                    # Explicit credentials from Jenkins QUAY_AUTH_FILE
+                    Registry('quay.io/openshift-release-dev', auth_file=os.getenv('QUAY_AUTH_FILE')),
+                    Registry('quay.io', auth_file=os.getenv('QUAY_AUTH_FILE')),
+                    # CI registry credentials from oc login
+                    Registry('registry.ci.openshift.org', auth_file=ci_auth_file),
+                ]
+            ) as auth_file:
+                cmd = self._doozer_base_command.copy()
+                cmd.extend(['images:streams', 'mirror', '--registry-auth', auth_file])
+                await exectools.cmd_assert_async(cmd)
 
     async def sweep_bugs(self):
         """

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import shutil
+import tempfile
 from enum import Enum
 from pathlib import Path
 from typing import Optional, Tuple
@@ -401,27 +402,31 @@ class KonfluxOcpPipeline:
         if built_images.get('ose-openshift-apiserver', None):
             LOGGER.warning('apiserver rebuilt: mirroring streams to CI...')
 
-            # Make sure our api.ci token is fresh
-            await oc.registry_login()
+            # Create temp file for oc registry login credentials
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as ci_auth_temp:
+                ci_auth_file = ci_auth_temp.name
 
-            # Log into QCI registry
-            await oc.qci_registry_login()
+            try:
+                # Write oc credentials to temp file instead of default location
+                await oc.registry_login(to_file=ci_auth_file)
+                await oc.qci_registry_login(to_file=ci_auth_file)
 
-            # Get the auth file path where oc.registry_login() writes credentials
-            ci_auth_file = os.getenv('REGISTRY_AUTH_FILE', f"{os.getenv('XDG_RUNTIME_DIR')}/containers/auth.json")
-
-            with RegistryConfig(
-                registries=[
-                    # Explicit credentials from Jenkins QUAY_AUTH_FILE
-                    Registry('quay.io/openshift-release-dev', auth_file=os.getenv('QUAY_AUTH_FILE')),
-                    Registry('quay.io', auth_file=os.getenv('QUAY_AUTH_FILE')),
-                    # CI registry credentials from oc login
-                    Registry('registry.ci.openshift.org', auth_file=ci_auth_file),
-                ]
-            ) as auth_file:
-                cmd = self._doozer_base_command.copy()
-                cmd.extend(['images:streams', 'mirror', '--registry-auth', auth_file])
-                await exectools.cmd_assert_async(cmd)
+                with RegistryConfig(
+                    registries=[
+                        # Explicit credentials from Jenkins QUAY_AUTH_FILE
+                        Registry('quay.io/openshift-release-dev', auth_file=os.getenv('QUAY_AUTH_FILE')),
+                        Registry('quay.io', auth_file=os.getenv('QUAY_AUTH_FILE')),
+                        # CI registry credentials from oc login
+                        Registry('registry.ci.openshift.org', auth_file=ci_auth_file),
+                    ]
+                ) as auth_file:
+                    cmd = self._doozer_base_command.copy()
+                    cmd.extend(['images:streams', 'mirror', '--registry-auth', auth_file])
+                    await exectools.cmd_assert_async(cmd)
+            finally:
+                # Clean up temp oc auth file
+                if os.path.exists(ci_auth_file):
+                    os.unlink(ci_auth_file)
 
     async def sweep_bugs(self):
         """


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

Introduces RegistryConfig, a new context manager for explicit registry authentication that eliminates dependency on default auth.json files. Creates temporary, merged credential files from explicit sources for use with oc and container registry operations.                                                                                  
                                                                                                                                                                             Motivation                                                                                                                                                                                                                                                                                                                                              
  Current problem: Tools rely on default auth.json files (e.g., /run/user/<uid>/containers/auth.json) that may be:                                                           
  - Modified outside trusted credential stores (via podman login)
  - Shared across processes causing credential conflicts                                                                                                                     
  - Difficult to debug when authentication fails        
  - Implicitly dependent on buildvm filesystem state                                                                                                                         
                                                    
Solution: Explicit credential management where:                                                                                                                            
  - All auth sources are specified explicitly from Jenkins credentials                                                                                                       
  - Temporary auth files are created per-operation                                                                                                                           
  - No hidden dependencies on default auth.json                                                                                                                              
  - Clear audit trail of which credentials are used