### PR TITLE
ART-15594: fix(scanner): add error handling for CVE API failures in golang bug tracker

### DIFF
--- a/elliott/elliottlib/cli/find_bugs_golang_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_golang_cli.py
@@ -567,6 +567,9 @@ class FindBugsGolangCli:
                 continue
 
             cve_data = get_cve_from_prodsec_db(cve_id)
+            if not cve_data or 'bugzilla' not in cve_data:
+                logger.warning(f"Could not fetch valid CVE data for {cve_id}. Skipping.")
+                continue
             flaw_id = cve_data['bugzilla']['id']
             title = cve_data['bugzilla']['description']
             comp_in_title = get_component_from_bug_title(title)


### PR DESCRIPTION
## Summary
Fix TypeError crash in Elliott's golang security tracker when processing CVE data from Red Hat's Product Security API. The tracker now gracefully handles API error responses instead of crashing.

## Problem
**Before:** Elliott crashes with `TypeError: string indices must be integers, not 'str'` at line 570 when `get_cve_from_prodsec_db()` returns error responses (None, error strings) instead of valid CVE dictionaries, causing Jenkins OCP4-Konflux build failures.

**After:** Elliott gracefully skips invalid CVE responses with warning logs and continues processing valid CVE data, allowing golang vulnerability tracking to complete successfully.

## Implementation Details
Added defensive checking before accessing `cve_data['bugzilla']['id']` to handle cases where the CVE API returns:
- `None` (when JSON parsing fails)
- Error dictionaries like `{"message": "Not Found"}` 
- Invalid response structures

The fix maintains existing functionality for valid CVE data while preventing crashes on API errors.

### Key Changes
- Added null/error checking for CVE API responses
- Added warning logging for skipped invalid CVEs
- Ensured processing continues for valid CVE data