### PR TITLE
Use auth file from jenkins cred instead of auth.json

### DIFF
--- a/artcommon/artcommonlib/exectools.py
+++ b/artcommon/artcommonlib/exectools.py
@@ -17,7 +17,6 @@ from datetime import datetime
 from fcntl import F_GETFL, F_SETFL, fcntl
 from inspect import getframeinfo, stack
 from multiprocessing.pool import MapResult, ThreadPool
-from pathlib import Path
 from typing import Awaitable, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 from urllib.request import urlopen
 
@@ -510,18 +509,18 @@ def unpack_tuple_args(func):
 
 
 @tenacity.retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(60))
-async def manifest_tool(options, dry_run=False):
+async def manifest_tool(options, dry_run=False, auth_file: Optional[str] = None):
     auth_opt = ""
-    if os.environ.get("XDG_RUNTIME_DIR"):
-        auth_file = os.path.expandvars("${XDG_RUNTIME_DIR}/containers/auth.json")
-        if Path(auth_file).is_file():
-            auth_opt = f"--docker-cfg={auth_file}"
+    if auth_file:
+        auth_opt = f"--docker-cfg={auth_file}"
 
     if isinstance(options, str):
-        cmd = f'manifest-tool {auth_opt} {options}'
+        cmd = f'manifest-tool {auth_opt} {options}' if auth_opt else f'manifest-tool {options}'
 
     elif isinstance(options, list):
-        cmd = ['manifest-tool', auth_opt]
+        cmd = ['manifest-tool']
+        if auth_opt:
+            cmd.append(auth_opt)
         cmd.extend(options)
 
     else:

--- a/artcommon/tests/test_exectools.py
+++ b/artcommon/tests/test_exectools.py
@@ -228,6 +228,54 @@ class TestExectools(IsolatedAsyncioTestCase):
             create_subprocess_exec.assert_awaited_once_with(*cmd, cwd=fake_cwd)
             self.assertEqual(rc, 0)
 
+    @mock.patch("artcommonlib.exectools.cmd_assert_async")
+    async def test_manifest_tool_uses_explicit_auth_file(self, cmd_assert_async: mock.AsyncMock):
+        await exectools.manifest_tool(
+            ["push", "from-spec", "--", "/tmp/manifest-list.yaml"],
+            auth_file="/tmp/quay-auth.json",
+        )
+
+        cmd_assert_async.assert_awaited_once_with(
+            ["manifest-tool", "--docker-cfg=/tmp/quay-auth.json", "push", "from-spec", "--", "/tmp/manifest-list.yaml"]
+        )
+
+    @mock.patch("artcommonlib.exectools.cmd_assert_async")
+    async def test_manifest_tool_ignores_xdg_runtime_auth_file(self, cmd_assert_async: mock.AsyncMock):
+        with mock.patch.dict(exectools.os.environ, {"XDG_RUNTIME_DIR": "/run/user/984"}, clear=True):
+            await exectools.manifest_tool(["push", "from-spec", "--", "/tmp/manifest-list.yaml"])
+
+        cmd_assert_async.assert_awaited_once_with(
+            ["manifest-tool", "push", "from-spec", "--", "/tmp/manifest-list.yaml"]
+        )
+
+    @mock.patch("artcommonlib.exectools.cmd_assert_async")
+    async def test_manifest_tool_uses_explicit_auth_file_over_env(self, cmd_assert_async: mock.AsyncMock):
+        with mock.patch.dict(exectools.os.environ, {"QUAY_AUTH_FILE": "/tmp/env-auth.json"}, clear=True):
+            await exectools.manifest_tool(
+                ["push", "from-spec", "--", "/tmp/manifest-list.yaml"],
+                auth_file="/tmp/explicit-auth.json",
+            )
+
+        cmd_assert_async.assert_awaited_once_with(
+            [
+                "manifest-tool",
+                "--docker-cfg=/tmp/explicit-auth.json",
+                "push",
+                "from-spec",
+                "--",
+                "/tmp/manifest-list.yaml",
+            ]
+        )
+
+    @mock.patch("artcommonlib.exectools.cmd_assert_async")
+    async def test_manifest_tool_ignores_quay_auth_file_env(self, cmd_assert_async: mock.AsyncMock):
+        with mock.patch.dict(exectools.os.environ, {"QUAY_AUTH_FILE": "/tmp/env-auth.json"}, clear=True):
+            await exectools.manifest_tool(["push", "from-spec", "--", "/tmp/manifest-list.yaml"])
+
+        cmd_assert_async.assert_awaited_once_with(
+            ["manifest-tool", "push", "from-spec", "--", "/tmp/manifest-list.yaml"]
+        )
+
     def test_parallel_exec(self):
         items = [1, 2, 3]
         results = exectools.parallel_exec(lambda k, v: k, items, n_threads=4)

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -1960,7 +1960,7 @@ class GenPayloadCli:
         # write the manifest list to a file and push it to the registry.
         async with aiofiles.open(component_manifest_path, mode="w+") as ml:
             await ml.write(yaml.safe_dump(dict(image=output_pullspec, manifests=manifests), default_flow_style=False))
-        await manifest_tool(f'push from-spec {str(component_manifest_path)}')
+        await manifest_tool(f'push from-spec {str(component_manifest_path)}', auth_file=os.getenv("QUAY_AUTH_FILE"))
 
         # we are pushing a new manifest list, so return its sha256 based pullspec
         sha = await find_manifest_list_sha(output_pullspec, registry_config=os.getenv("QUAY_AUTH_FILE"))
@@ -2059,7 +2059,7 @@ class GenPayloadCli:
         async with aiofiles.open(release_payload_ml_path, mode="w+") as ml:
             await ml.write(yaml.safe_dump(ml_dict, default_flow_style=False))
 
-        await manifest_tool(f'push from-spec {str(release_payload_ml_path)}')
+        await manifest_tool(f'push from-spec {str(release_payload_ml_path)}', auth_file=os.getenv("QUAY_AUTH_FILE"))
 
         # if we are actually pushing a manifest list, then we should derive a sha256 based pullspec
         sha = await find_manifest_list_sha(multi_release_dest, registry_config=os.getenv("QUAY_AUTH_FILE"))

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -867,29 +867,33 @@ spec:
     @patch("artcommonlib.exectools.cmd_assert_async")
     @patch("aiofiles.open")
     async def test_create_multi_manifest_list(self, open_mock, exec_mock, fmlsha_mock):
-        os.environ['XDG_RUNTIME_DIR'] = 'fake'
-        runtime = MagicMock(uuid="uuid")
-        gpcli = rgp_cli.GenPayloadCli(runtime, output_dir="/tmp", organization="org", repository="repo")
+        with patch.dict(os.environ, {"QUAY_AUTH_FILE": "/tmp/quay-auth.json"}, clear=True):
+            runtime = MagicMock(uuid="uuid")
+            gpcli = rgp_cli.GenPayloadCli(runtime, output_dir="/tmp", organization="org", repository="repo")
 
-        buffer = io.StringIO()
-        open_mock.return_value.__aenter__.return_value.write = AsyncMock(side_effect=lambda s: buffer.write(s))
-        exec_mock.return_value = None  # do not actually run the command
-        fmlsha_mock.return_value = "sha256:abcdef"
+            buffer = io.StringIO()
+            open_mock.return_value.__aenter__.return_value.write = AsyncMock(side_effect=lambda s: buffer.write(s))
+            exec_mock.return_value = None  # do not actually run the command
+            fmlsha_mock.return_value = "sha256:abcdef"
 
-        arch_to_payload_entry = dict(
-            s390x=rgp_cli.PayloadEntry(
-                issues=[],
-                dest_pullspec="quay.io/org/repo:eggs-s390x",
-            ),
-            ppc64le=rgp_cli.PayloadEntry(
-                issues=[],
-                dest_pullspec="quay.io/org/repo:eggs-ppc64le",
-            ),
-        )
-        await gpcli.create_multi_manifest_list("spam", arch_to_payload_entry, "ocp-multi")
+            arch_to_payload_entry = dict(
+                s390x=rgp_cli.PayloadEntry(
+                    issues=[],
+                    dest_pullspec="quay.io/org/repo:eggs-s390x",
+                ),
+                ppc64le=rgp_cli.PayloadEntry(
+                    issues=[],
+                    dest_pullspec="quay.io/org/repo:eggs-ppc64le",
+                ),
+            )
+            await gpcli.create_multi_manifest_list("spam", arch_to_payload_entry, "ocp-multi")
+
         self.assertEqual(
-            exec_mock.call_args[0][0], "manifest-tool  push from-spec /tmp/ocp-multi.spam.manifest-list.yaml"
+            exec_mock.call_args[0][0],
+            "manifest-tool --docker-cfg=/tmp/quay-auth.json push from-spec /tmp/ocp-multi.spam.manifest-list.yaml",
         )
+        fmlsha_mock.assert_awaited_once()
+        self.assertEqual(fmlsha_mock.await_args.kwargs["registry_config"], "/tmp/quay-auth.json")
         ml = yaml.safe_load(buffer.getvalue())
         self.assertRegex(ml["image"], r"^quay.io/org/repo:sha256-")
         self.assertEqual(len(ml["manifests"]), 2)
@@ -927,21 +931,26 @@ spec:
     async def test_create_multi_release_manifest_list(
         self, open_mock, exec_mock, mirror_payload_content_mock, fmlsha_mock
     ):
-        os.environ['XDG_RUNTIME_DIR'] = 'fake'
-        gpcli = rgp_cli.GenPayloadCli(output_dir="/tmp")
+        with patch.dict(os.environ, {"QUAY_AUTH_FILE": "/tmp/quay-auth.json"}, clear=True):
+            gpcli = rgp_cli.GenPayloadCli(output_dir="/tmp")
 
-        exec_mock.return_value = None  # do not actually execute command
-        buffer = io.StringIO()
-        open_mock.return_value.__aenter__.return_value.write = AsyncMock(side_effect=lambda s: buffer.write(s))
-        fmlsha_mock.return_value = "sha256:abcdef"
+            exec_mock.return_value = None  # do not actually execute command
+            buffer = io.StringIO()
+            open_mock.return_value.__aenter__.return_value.write = AsyncMock(side_effect=lambda s: buffer.write(s))
+            fmlsha_mock.return_value = "sha256:abcdef"
 
-        pullspec = await gpcli.create_multi_release_manifest_list(
-            arch_release_dests=dict(x86_64="pullspec:x86"),
-            imagestream_name="isname",
-            multi_release_dest="quay.io/org/repo:spam",
-        )
+            pullspec = await gpcli.create_multi_release_manifest_list(
+                arch_release_dests=dict(x86_64="pullspec:x86"),
+                imagestream_name="isname",
+                multi_release_dest="quay.io/org/repo:spam",
+            )
         self.assertEqual(pullspec, "quay.io/org/repo@sha256:abcdef")
-        self.assertEqual(exec_mock.call_args[0][0], "manifest-tool  push from-spec /tmp/isname.manifest-list.yaml")
+        self.assertEqual(
+            exec_mock.call_args[0][0],
+            "manifest-tool --docker-cfg=/tmp/quay-auth.json push from-spec /tmp/isname.manifest-list.yaml",
+        )
+        fmlsha_mock.assert_awaited_once()
+        self.assertEqual(fmlsha_mock.await_args.kwargs["registry_config"], "/tmp/quay-auth.json")
         self.assertEqual(
             buffer.getvalue().strip(),
             """

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1753,21 +1753,27 @@ class PromotePipeline:
         with dest_manifest_list_path.open("w") as ml:
             yaml.dump(dest_manifest_list, ml)
 
-        await manifest_tool(["push", "from-spec", "--", f"{dest_manifest_list_path}"], self.runtime.dry_run)
+        auth_file = os.environ.get("QUAY_AUTH_FILE")
+        await manifest_tool(
+            ["push", "from-spec", "--", f"{dest_manifest_list_path}"],
+            self.runtime.dry_run,
+            auth_file=auth_file,
+        )
         auth_opt = ""
-        if os.environ.get("XDG_RUNTIME_DIR"):
-            auth_file = os.path.expandvars("${XDG_RUNTIME_DIR}/containers/auth.json")
-            if Path(auth_file).is_file():
-                auth_opt = f"--docker-cfg={auth_file}"
+        if auth_file:
+            auth_opt = f"--docker-cfg={auth_file}"
 
-        cmd = [
-            "manifest-tool",
-            auth_opt,
-            "push",
-            "from-spec",
-            "--",
-            f"{dest_manifest_list_path}",
-        ]
+        cmd = ["manifest-tool"]
+        if auth_opt:
+            cmd.append(auth_opt)
+        cmd.extend(
+            [
+                "push",
+                "from-spec",
+                "--",
+                f"{dest_manifest_list_path}",
+            ]
+        )
 
         if self.runtime.dry_run:
             self._logger.warning("[DRY RUN] Would have run %s", cmd)

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -2056,3 +2056,51 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
                 }
             },
         )
+
+    @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
+    @patch("pyartcd.pipelines.promote.exectools.cmd_assert_async")
+    @patch("pyartcd.pipelines.promote.manifest_tool")
+    async def test_push_manifest_list_uses_quay_auth_file(
+        self, manifest_tool: AsyncMock, cmd_assert_async: AsyncMock, _
+    ):
+        runtime = MagicMock(
+            config={
+                "build_config": {
+                    "ocp_build_data_url": "https://example.com/ocp-build-data.git",
+                },
+                "jira": {
+                    "url": JIRA_SERVER_URL,
+                },
+            },
+            dry_run=False,
+            logger=MagicMock(),
+            new_slack_client=MagicMock(return_value=AsyncMock()),
+            new_mail_client=MagicMock(),
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime.working_dir = Path(temp_dir)
+            pipeline = PromotePipeline(runtime, group="openshift-4.10", assembly="4.10.99", signing_env="prod")
+            with patch.dict(os.environ, {"QUAY_AUTH_FILE": "/tmp/quay-auth.json", "XDG_RUNTIME_DIR": "/run/user/984"}):
+                await pipeline.push_manifest_list("4.10.99", {"schemaVersion": 2})
+
+            manifest_tool.assert_awaited_once_with(
+                ["push", "from-spec", "--", str(Path(temp_dir) / "4.10.99.manifest-list.yaml")],
+                False,
+                auth_file="/tmp/quay-auth.json",
+            )
+            cmd_assert_async.assert_awaited_once()
+            self.assertEqual(
+                cmd_assert_async.await_args.kwargs["env"]["QUAY_AUTH_FILE"],
+                "/tmp/quay-auth.json",
+            )
+            self.assertEqual(
+                cmd_assert_async.await_args.args[0],
+                [
+                    "manifest-tool",
+                    "--docker-cfg=/tmp/quay-auth.json",
+                    "push",
+                    "from-spec",
+                    "--",
+                    str(Path(temp_dir) / "4.10.99.manifest-list.yaml"),
+                ],
+            )


### PR DESCRIPTION
Changed manifest_tool to require an explicit auth_file parameter instead of discovering auth from the environment or ${XDG_RUNTIME_DIR}/containers/auth.json.

Updated the only real call sites to pass the auth file explicitly:
- doozer release_gen_payload manifest-list pushes now pass os.getenv("QUAY_AUTH_FILE")
- pyartcd promote manifest-list push now passes QUAY_AUTH_FILE

Fixed jenkins wiring: https://github.com/openshift-eng/aos-cd-jobs/pull/4654

Also updated tests in artcommon, pyartcd, and doozer to cover the explicit auth-file flow and removal of the old fallback behavior.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED