### PR TITLE
Remove 12 unused constants and consolidate 4 duplicates

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -49,25 +49,6 @@ LOGGER = logging.getLogger(__name__)
 TRACER = trace.get_tracer(__name__)
 
 
-CONTAINER_YAML_HEADER = """
-# This file is managed by Doozer: https://github.com/openshift-eng/art-tools/tree/main/doozer
-# operated by the OpenShift Automated Release Tooling team (#forum-ocp-art on CoreOS Slack).
-
-# Any manual changes will be overwritten by Doozer on the next build.
-#
-# See https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/odcs_integration_with_osbs
-# for more information on maintaining this file and the format and examples
-
----
-"""
-
-
-# Doozer used to be part of OIT
-OIT_COMMENT_PREFIX = '#oit##'
-OIT_BEGIN = '##OIT_BEGIN'
-OIT_END = '##OIT_END'
-
-
 class KonfluxRebaser:
     """Rebase images to a new branch in the build source repository.
 
@@ -1117,16 +1098,16 @@ class KonfluxRebaser:
 
         # Remove any programmatic oit comments from previous management
         df_lines = dfp.content.splitlines(False)
-        df_lines = [line for line in df_lines if not line.strip().startswith(OIT_COMMENT_PREFIX)]
+        df_lines = [line for line in df_lines if not line.strip().startswith(constants.OIT_COMMENT_PREFIX)]
 
         filtered_content = []
         in_mod_block = False
         for line in df_lines:
             # Check for begin/end of mod block, skip any lines inside
-            if OIT_BEGIN in line:
+            if constants.OIT_BEGIN in line:
                 in_mod_block = True
                 continue
-            elif OIT_END in line:
+            elif constants.OIT_END in line:
                 in_mod_block = False
                 continue
 
@@ -1908,7 +1889,7 @@ class KonfluxRebaser:
         # generate yaml data with header
         content_yml = yaml.safe_dump(container_config, default_flow_style=False)
         async with aiofiles.open(dest_dir.joinpath('container.yaml'), 'w', encoding="utf-8") as rc:
-            await rc.write(CONTAINER_YAML_HEADER + content_yml)
+            await rc.write(constants.CONTAINER_YAML_HEADER + content_yml)
 
     def _generate_osbs_image_config(
         self, metadata: ImageMetadata, dest_dir: Path, source: Optional[SourceResolution], version: str

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -4,6 +4,23 @@ RC_BASE_PRIV_URL = "https://{arch}.ocp.internal.releases.ci.openshift.org"
 BREWWEB_URL = "https://brewweb.engineering.redhat.com/brew"
 DISTGIT_GIT_URL = "git+https://pkgs.devel.redhat.com/git"
 
+# Doozer used to be part of OIT
+OIT_COMMENT_PREFIX = '#oit##'
+OIT_BEGIN = '##OIT_BEGIN'
+OIT_END = '##OIT_END'
+
+CONTAINER_YAML_HEADER = """
+# This file is managed by Doozer: https://github.com/openshift-eng/art-tools/tree/main/doozer
+# operated by the OpenShift Automated Release Tooling team (#forum-ocp-art on CoreOS Slack).
+
+# Any manual changes will be overwritten by Doozer on the next build.
+#
+# See https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/odcs_integration_with_osbs
+# for more information on maintaining this file and the format and examples
+
+---
+"""
+
 # Environment variables that should be set for doozer interaction with db for storing and retrieving build records.
 # DB ENV VARS
 DB_HOST = "DOOZER_DB_HOST"
@@ -32,9 +49,6 @@ KONFLUX_REPO_CA_BUNDLE_HOST = "https://certs.corp.redhat.com/certs"
 WORKING_SUBDIR_KONFLUX_BUILD_SOURCES = "konflux_build_sources"
 WORKING_SUBDIR_KONFLUX_FBC_SOURCES = "konflux_fbc_sources"
 WORKING_SUBDIR_KONFLUX_OKD_SOURCES = "konflux_okd_sources"
-KONFLUX_DEFAULT_PIPELINERUN_SERVICE_ACCOUNT = "appstudio-pipeline"
-KONFLUX_DEFAULT_PIPELINERUN_TIMEOUT = "1h0m0s"
-KONFLUX_DEFAULT_PIPRLINE_DOCKER_BUILD_BUNDLE_PULLSPEC = "quay.io/konflux-ci/tekton-catalog/pipeline-docker-build:devel"
 KONFLUX_DEFAULT_IMAGE_REPO = (
     "quay.io/redhat-user-workloads/ocp-art-tenant/art-images"  # FIXME: If we change clusters this URL will change
 )
@@ -42,7 +56,6 @@ KONFLUX_DEFAULT_FBC_REPO = "quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc
 # Legacy constants removed - use get_art_prod_image_repo_for_version() from artcommonlib.util instead
 DELIVERY_IMAGE_REGISTRY = "registry.redhat.io"
 KONFLUX_UI_HOST = "https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com"
-KONFLUX_UI_DEFAULT_WORKSPACE = "ocp-art"  # associated with ocp-art-tenant
 KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL = "https://api.github.com/repos/openshift-priv/art-konflux-template/contents/.tekton/art-konflux-template-push.yaml?ref=main"
 KONFLUX_DEFAULT_BUNDLE_BUILD_PLR_TEMPLATE_URL = "https://api.github.com/repos/openshift-priv/art-konflux-template/contents/.tekton/art-bundle-konflux-template-push.yaml?ref=main"
 KONFLUX_DEFAULT_FBC_BUILD_PLR_TEMPLATE_URL = "https://api.github.com/repos/openshift-priv/art-konflux-template/contents/.tekton/art-fbc-konflux-template-push.yaml?ref=main"

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -48,7 +48,7 @@ from dockerfile_parse import DockerfileParser
 from tenacity import before_sleep_log, retry, retry_if_not_result, stop_after_attempt, wait_fixed
 
 import doozerlib
-from doozerlib import state, util
+from doozerlib import constants, state, util
 from doozerlib.build_info import BrewBuildRecordInspector
 from doozerlib.comment_on_pr import CommentOnPr
 from doozerlib.dblib import Record
@@ -61,23 +61,6 @@ from doozerlib.util import extract_version_fields
 if TYPE_CHECKING:
     from doozerlib.image import ImageMetadata
     from doozerlib.metadata import Metadata
-
-# doozer used to be part of OIT
-OIT_COMMENT_PREFIX = '#oit##'
-OIT_BEGIN = '##OIT_BEGIN'
-OIT_END = '##OIT_END'
-
-CONTAINER_YAML_HEADER = """
-# This file is managed by doozer: https://github.com/openshift-eng/doozer
-# operated by the OpenShift Automated Release Tooling team (#forum-ocp-art on CoreOS Slack).
-
-# Any manual changes will be overwritten by doozer on the next build.
-#
-# See https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/odcs_integration_with_osbs
-# for more information on maintaining this file and the format and examples
-
----
-"""
 
 # Always ignore these files/folders when rebasing into distgit
 # May be added to based on group/image config
@@ -564,7 +547,7 @@ class ImageDistGitRepo(DistGitRepo):
         # generate yaml data with header
         content_yml = yaml.safe_dump(container_config, default_flow_style=False)
         with self.dg_path.joinpath('container.yaml').open('w', encoding="utf-8") as rc:
-            rc.write(CONTAINER_YAML_HEADER + content_yml)
+            rc.write(constants.CONTAINER_YAML_HEADER + content_yml)
 
     def _generate_osbs_image_config(self, version: str) -> Dict:
         """
@@ -2187,16 +2170,16 @@ class ImageDistGitRepo(DistGitRepo):
 
             # Remove any programmatic oit comments from previous management
             df_lines = dfp.content.splitlines(False)
-            df_lines = [line for line in df_lines if not line.strip().startswith(OIT_COMMENT_PREFIX)]
+            df_lines = [line for line in df_lines if not line.strip().startswith(constants.OIT_COMMENT_PREFIX)]
 
             filtered_content = []
             in_mod_block = False
             for line in df_lines:
                 # Check for begin/end of mod block, skip any lines inside
-                if OIT_BEGIN in line:
+                if constants.OIT_BEGIN in line:
                     in_mod_block = True
                     continue
-                elif OIT_END in line:
+                elif constants.OIT_END in line:
                     in_mod_block = False
                     continue
 

--- a/elliott/elliottlib/constants.py
+++ b/elliott/elliottlib/constants.py
@@ -7,9 +7,7 @@ from artcommonlib.constants import BREW_DOWNLOAD_URL, BREW_HUB, RHCOS_RELEASES_B
 # JIRA configuration is now centralized in artcommonlib.jira_config
 from artcommonlib.jira_config import JIRA_API_FIELD, JIRA_SECURITY_ALLOWLIST
 
-CINCINNATI_BASE_URL = "https://api.openshift.com/api/upgrades_info/v1/graph"
 BREW_DOWNLOAD_TEMPLATE = BREW_DOWNLOAD_URL + "/packages/{name}/{version}/{release}/files/{file_path}"
-CGIT_URL = "https://pkgs.devel.redhat.com/cgit"
 RESULTSDB_API_URL = "https://resultsdb-api.engineering.redhat.com"
 
 VALID_BUG_STATES = ['NEW', 'ASSIGNED', 'POST', 'MODIFIED', 'ON_QA', 'VERIFIED', 'RELEASE_PENDING', 'CLOSED']
@@ -65,44 +63,6 @@ standard_advisory_types = [
     "bootimage",
 ]
 
-
-# Valid external test (RPMDiff) statuses defined in Errata Tool.
-# Note those status names are partially different from the status names in RPMDiff tool.
-# https://code.engineering.redhat.com/gerrit/gitweb?p=errata-rails.git;a=blob;f=app/models/external_test_run.rb;h=eb9489c24ec70a8e6b4e54cfe6b385fb51e330b8;hb=refs/heads/master
-ET_EXTERNAL_TEST_STATUSES = {
-    "PASSED",
-    "INELIGIBLE",
-    "INFO",
-    "WAIVED",
-    "NEEDS_INSPECTION",
-    "FAILED",
-    "PENDING",
-    "QUEUED_FOR_TEST",
-    "RUNNING",
-}
-
-ET_COMPLETED_EXTERNAL_TEST_STATUSES = {
-    "PASSED",
-    "INELIGIBLE",
-    "INFO",
-    "WAIVED",
-    "NEEDS_INSPECTION",
-    "FAILED",
-}
-
-# External test statuses that are considered "good" by Errata Tool:
-# https://code.engineering.redhat.com/gerrit/gitweb?p=errata-rails.git;a=blob;f=app/models/external_test_run.rb;h=eb9489c24ec70a8e6b4e54cfe6b385fb51e330b8;hb=refs/heads/master#l74
-ET_GOOD_EXTERNAL_TEST_STATUSES = {
-    "PASSED",
-    "INELIGIBLE",
-    "INFO",
-    "WAIVED",
-}
-
-ET_BAD_EXTERNAL_TEST_STATUSES = {
-    "NEEDS_INSPECTION",
-    "FAILED",
-}
 
 ADVISORY_TYPES = ('rhba', 'rhea', 'rhsa')
 

--- a/pyartcd/pyartcd/constants.py
+++ b/pyartcd/pyartcd/constants.py
@@ -11,8 +11,6 @@ SPMM_UTILS_REMOTE_HOST = "exd-ocp-buildvm-bot-prod@spmm-util"
 
 RELEASE_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-release"
 
-GIT_AUTHOR = "AOS Automation Release Team <noreply@redhat.com>"
-
 # Maps the name of a release component tag to the filename element to include
 # when creating artifacts on mirror.openshift.com.
 MIRROR_CLIENTS = {
@@ -30,8 +28,6 @@ JENKINS_SERVER_URL = 'https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.r
 # This is the URL that humans behind a VPN use to browse Jenkins UI
 # It shall be used to print clickable logs that redirect the user to the triggered job page
 JENKINS_UI_URL = 'https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com'
-
-MIRROR_BASE_URL = 'https://mirror.openshift.com'
 
 UMB_BROKERS = {
     "prod": "stomp+ssl://umb.api.redhat.com:61612",


### PR DESCRIPTION
Remove unused constants across doozer, elliott, and pyartcd that were defined but never referenced in the codebase. Consolidate duplicate OIT constants (OIT_COMMENT_PREFIX, OIT_BEGIN, OIT_END, CONTAINER_YAML_HEADER) from distgit.py and rebaser.py into doozerlib/constants.py.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED