### PR TITLE
Add --serial flag to schedule-ocp4-scan-konflux

### DIFF
--- a/pyartcd/pyartcd/pipelines/scheduled/schedule_ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/scheduled/schedule_ocp4_scan_konflux.py
@@ -9,7 +9,7 @@ from pyartcd.locks import Lock, LockManager
 from pyartcd.runtime import Runtime
 
 
-async def run_for(version: str, runtime: Runtime, lock_manager: LockManager):
+async def run_for(version: str, runtime: Runtime, lock_manager: LockManager, serial: bool = False):
     # Skip if locked on scan
     scan_lock_name = Lock.SCAN_KONFLUX.value.format(version=version)
     if await lock_manager.is_locked(scan_lock_name):
@@ -30,18 +30,34 @@ async def run_for(version: str, runtime: Runtime, lock_manager: LockManager):
         return
 
     # Schedule scan
-    runtime.logger.info('[%s] Scheduling ocp4-scan-konflux', version)
-    jenkins.start_ocp4_scan_konflux(version=version, block_until_building=False)
+    if serial:
+        runtime.logger.info('[%s] Scheduling ocp4-scan-konflux (serial: waiting for completion)', version)
+        try:
+            result = jenkins.start_ocp4_scan_konflux(
+                version=version, block_until_building=True, block_until_complete=True
+            )
+            runtime.logger.info('[%s] Scan completed with result: %s', version, result)
+        except Exception:
+            runtime.logger.warning('[%s] Scan failed, continuing with remaining versions', version, exc_info=True)
+    else:
+        runtime.logger.info('[%s] Scheduling ocp4-scan-konflux', version)
+        jenkins.start_ocp4_scan_konflux(version=version, block_until_building=False)
 
 
 @cli.command('schedule-ocp4-scan-konflux')
 @click.option('--version', '-v', required=True, help='OCP version to scan', multiple=True)
+@click.option('--serial', is_flag=True, default=False, help='Run scans sequentially, waiting for each to complete')
 @pass_runtime
 @click_coroutine
-async def ocp4_scan_konflux(runtime: Runtime, version: tuple):
+async def ocp4_scan_konflux(runtime: Runtime, version: tuple, serial: bool):
     jenkins.init_jenkins()
     lock_manager = LockManager([redis.redis_url()])
     try:
-        await asyncio.gather(*[run_for(v, runtime, lock_manager) for v in version])
+        if serial:
+            runtime.logger.info('Running scans serially for versions: %s', ', '.join(version))
+            for v in version:
+                await run_for(v, runtime, lock_manager, serial=True)
+        else:
+            await asyncio.gather(*[run_for(v, runtime, lock_manager) for v in version])
     finally:
         await lock_manager.destroy()


### PR DESCRIPTION
## Summary
- Add a `--serial` flag to `artcd schedule-ocp4-scan-konflux` so scan jobs can be triggered sequentially, each polled to completion before the next starts
- Prevents thundering herd of PipelineRuns that overwhelmed the Konflux cluster (etcd full)
- Companion PR for aos-cd-jobs passes `--serial` in the low-priority scheduler

[ART-15917](https://issues.redhat.com/browse/ART-15917)

## Test plan
- [ ] Run `artcd schedule-ocp4-scan-konflux --version=4.14 --version=4.15 --serial` and verify scans run one at a time
- [ ] Run without `--serial` and verify existing parallel behavior is unchanged

Made with [Cursor](https://cursor.com)