### PR TITLE
images-health: keep Jira tickets up-to-date on each run

### DIFF
--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -154,7 +154,8 @@ class ImagesHealthPipeline:
             if (image_name, group) in ticket_index:
                 ticket = ticket_index[(image_name, group)]
                 self.jira_tickets[(image_name, group)] = ticket.key
-                _LOGGER.info("Ticket already exists for %s (%s): %s", image_name, group, ticket.key)
+                _LOGGER.info("Ticket already exists for %s (%s): %s — updating", image_name, group, ticket.key)
+                self._update_existing_ticket(ticket, concern)
                 continue
             new_ticket = self._create_failure_ticket(jira_client, concern)
             self.jira_tickets[(image_name, group)] = new_ticket.key
@@ -171,7 +172,26 @@ class ImagesHealthPipeline:
                 _LOGGER.info("Closing resolved ticket %s for %s (%s)", ticket.key, image_name, group)
                 jira_client.close_task(ticket.key)
 
-    def _create_failure_ticket(self, jira_client: JIRAClient, concern: dict):
+    @staticmethod
+    def _get_fail_count(concern: dict) -> int:
+        """Return the number of consecutive build failures from a concern."""
+        if concern['code'] == ConcernCode.FAILING_AT_LEAST_FOR.value:
+            return LIMIT_BUILD_RESULTS
+        return concern['latest_success_idx']
+
+    @staticmethod
+    def _fail_count_label(concern: dict) -> str:
+        return f"art:fail-count:{ImagesHealthPipeline._get_fail_count(concern)}"
+
+    def _update_existing_ticket(self, ticket, concern: dict):
+        """Update fail-count label and description on an existing ticket."""
+        new_label = self._fail_count_label(concern)
+        labels = [label for label in ticket.fields.labels if not label.startswith("art:fail-count:")]
+        if new_label not in labels:
+            labels.append(new_label)
+        ticket.update(fields={"labels": labels, "description": self._build_description(concern)})
+
+    def _build_description(self, concern: dict) -> str:
         image_name = concern['image_name']
         group = concern['group']
         code = concern['code']
@@ -197,18 +217,24 @@ class ImagesHealthPipeline:
         )
         if last_good_url:
             description += f"*Last successful build:* {last_good_url}\n"
+        return description
+
+    def _create_failure_ticket(self, jira_client: JIRAClient, concern: dict):
+        image_name = concern['image_name']
+        group = concern['group']
 
         labels = [
             "art:image-build-failure",
             f"art:package:{image_name}",
             f"art:group:{group}",
+            self._fail_count_label(concern),
         ]
 
         ticket = jira_client.create_issue(
             project="ART",
             issue_type="Task",
             summary=f"Image build failure: {image_name} ({group})",
-            description=description,
+            description=self._build_description(concern),
             labels=labels,
             components=["daily-ops"],
         )
@@ -424,7 +450,7 @@ class ImagesHealthPipeline:
         """
         dt = datetime.fromisoformat(concern['latest_failed_build_time'])
         formatted = dt.astimezone(timezone.utc).strftime("%a, %d %b %Y %H:%M:%S GMT")
-        logs_url = f'{ART_BUILD_HISTORY_URL}/logs?nvr={concern["latest_failed_nvr"]}&record_id={concern["latest_failed_build_record_id"]}&after={formatted}'
+        logs_url = f'{ART_BUILD_HISTORY_URL}/logs?nvr={concern["latest_failed_nvr"]}&record_id={concern["latest_failed_build_record_id"]}&after={quote(formatted)}'
         return logs_url
 
     @staticmethod

--- a/pyartcd/tests/pipelines/test_images_health.py
+++ b/pyartcd/tests/pipelines/test_images_health.py
@@ -218,12 +218,55 @@ class TestSyncJira(TestCase):
         self.assertIn("art:image-build-failure", kwargs[1]["labels"])
         self.assertIn("art:package:ironic", kwargs[1]["labels"])
         self.assertIn("art:group:openshift-5.0", kwargs[1]["labels"])
+        self.assertIn("art:fail-count:100", kwargs[1]["labels"])
         mock_jira.close_task.assert_not_called()
 
-    def test_skips_existing_ticket(self):
+    def test_creates_ticket_with_fail_count_from_latest_success_idx(self):
+        pipeline = self._make_pipeline()
+        pipeline.report = [
+            _make_concern("ironic", "openshift-5.0", ConcernCode.LATEST_ATTEMPT_FAILED.value, latest_success_idx=7),
+        ]
+
+        mock_jira = MagicMock()
+        mock_jira.search_issues.return_value = []
+        mock_jira.create_issue.return_value = MagicMock(key="ART-101")
+        pipeline.runtime.new_jira_client.return_value = mock_jira
+
+        pipeline.sync_jira()
+
+        kwargs = mock_jira.create_issue.call_args
+        self.assertIn("art:fail-count:7", kwargs[1]["labels"])
+
+    def test_updates_existing_ticket(self):
         pipeline = self._make_pipeline()
         pipeline.report = [
             _make_concern("ironic", "openshift-5.0", ConcernCode.FAILING_AT_LEAST_FOR.value),
+        ]
+
+        existing_ticket = _make_ticket(
+            "ART-99",
+            ["art:image-build-failure", "art:package:ironic", "art:group:openshift-5.0", "art:fail-count:5"],
+        )
+        mock_jira = MagicMock()
+        mock_jira.search_issues.return_value = [existing_ticket]
+        pipeline.runtime.new_jira_client.return_value = mock_jira
+
+        pipeline.sync_jira()
+
+        mock_jira.create_issue.assert_not_called()
+        mock_jira.close_task.assert_not_called()
+        existing_ticket.update.assert_called_once()
+        updated_fields = existing_ticket.update.call_args[1]["fields"]
+        updated_labels = updated_fields["labels"]
+        self.assertIn("art:fail-count:100", updated_labels)
+        self.assertNotIn("art:fail-count:5", updated_labels)
+        self.assertIn("ironic", updated_fields["description"])
+        self.assertIn("Error logs", updated_fields["description"])
+
+    def test_updates_existing_ticket_without_prior_fail_count(self):
+        pipeline = self._make_pipeline()
+        pipeline.report = [
+            _make_concern("ironic", "openshift-5.0", ConcernCode.LATEST_ATTEMPT_FAILED.value, latest_success_idx=3),
         ]
 
         existing_ticket = _make_ticket(
@@ -237,7 +280,12 @@ class TestSyncJira(TestCase):
         pipeline.sync_jira()
 
         mock_jira.create_issue.assert_not_called()
-        mock_jira.close_task.assert_not_called()
+        existing_ticket.update.assert_called_once()
+        updated_fields = existing_ticket.update.call_args[1]["fields"]
+        updated_labels = updated_fields["labels"]
+        self.assertIn("art:fail-count:3", updated_labels)
+        self.assertIn("art:image-build-failure", updated_labels)
+        self.assertIn("ironic-1.0-1", updated_fields["description"])
 
     def test_closes_resolved_ticket(self):
         pipeline = self._make_pipeline()


### PR DESCRIPTION
## Summary

- Add `art:fail-count:<N>` label to image-build-failure Jira tickets, set on creation and updated every run
- Update the ticket description on each run so the error logs link always points to the latest failure
- URL-encode the `after` parameter in error logs URLs so links render correctly in Jira

## Test plan

- [x] Unit tests pass (`pyartcd/tests/pipelines/test_images_health.py`)
- [x] Ruff lint clean


Made with [Cursor](https://cursor.com)