### PR TITLE
Pass QUAY_AUTH_FILE to oc image info for RHCOS pullspec lookups

### DIFF
--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import re
 import sys
 
@@ -356,7 +357,8 @@ def get_rhcos_nvrs_from_assembly(runtime: Runtime, brew_session: koji.ClientSess
             continue
 
         for arch, pullspec in config['images'].items():
-            build_id = get_build_id_from_rhcos_pullspec(pullspec)
+            registry_config = os.getenv("QUAY_AUTH_FILE")
+            build_id = get_build_id_from_rhcos_pullspec(pullspec, registry_config=registry_config)
             if arch not in build_ids_by_arch:
                 build_ids_by_arch[arch] = set()
             build_ids_by_arch[arch].add(build_id)


### PR DESCRIPTION
The elliott find-builds --only-rhcos command calls oc image info without registry credentials, causing auth failures when the default credentials on the Jenkins node are stale. Read QUAY_AUTH_FILE from the environment (already provided by Jenkins withCredentials) and pass it through to get_build_id_from_rhcos_pullspec(), matching the existing pattern in elliottlib/util.py.