### PR TITLE
ART-14960: Use Redis as pre-filter for images-health BigQuery queries

### DIFF
--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -71,7 +71,6 @@ class ImagesHealthPipeline:
 
     async def get_report(self, version: str) -> Optional[list]:
         doozer_working = f'{self.doozer_working}-{version}'
-        # Check if automation is frozen for current group
         if not await util.is_build_permitted(
             version,
             doozer_working=str(doozer_working),
@@ -83,8 +82,24 @@ class ImagesHealthPipeline:
 
         self.scanned_versions.append(version)
 
-        # Get doozer report for the given version
-        group_param = f'--group=openshift-{version}'
+        group = f'openshift-{version}'
+        failures = await util.get_build_failures(group=group, logger=self.runtime.logger)
+
+        # Use Redis failures to scope the image list for the BigQuery query.
+        # If an explicit image_list was provided, intersect it with failing images.
+        failing_images = set(failures.keys())
+        if self.image_list:
+            failing_images &= set(self.image_list)
+
+        if not failing_images:
+            self.runtime.logger.info('No build failures in Redis for %s; skipping BigQuery scan', group)
+            return
+
+        self.runtime.logger.info(
+            'Redis reports %d failing image(s) for %s; querying BigQuery for details', len(failing_images), group
+        )
+
+        group_param = f'--group={group}'
         if self.data_gitref:
             group_param += f'@{self.data_gitref}'
         cmd = [
@@ -92,17 +107,16 @@ class ImagesHealthPipeline:
             f'--working-dir={doozer_working}',
             f'--data-path={self.data_path}',
             group_param,
+            f'--images={",".join(sorted(failing_images))}',
+            'images:health',
         ]
-        if self.image_list:
-            cmd.append(f'--images={",".join(self.image_list)}')
-        cmd.append('images:health')
 
         if self.assembly:
             cmd.append(f'--assembly={self.assembly}')
 
         _, out, err = await exectools.cmd_gather_async(cmd, stderr=None)
         report = json.loads(out.strip())
-        self.runtime.logger.info('images:health output for openshift-%s:\n%s', version, out)
+        self.runtime.logger.info('images:health output for %s:\n%s', group, out)
         self.report.extend(report)
 
     async def get_rebase_failures(self, version: str):

--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -95,8 +95,25 @@ class ImagesHealthPipeline:
             self.runtime.logger.info('No build failures in Redis for %s; skipping BigQuery scan', group)
             return
 
+        # Filter failing_images to only include images that exist in current ocp-build-data
+        valid_images = await self._get_valid_images(version, doozer_working)
+        filtered_failing_images = failing_images & valid_images
+        skipped_images = failing_images - valid_images
+
+        if skipped_images:
+            self.runtime.logger.warning(
+                'Filtered out %d image(s) from Redis that do not exist in %s metadata: %s',
+                len(skipped_images), group, ', '.join(sorted(skipped_images))
+            )
+
+        if not filtered_failing_images:
+            self.runtime.logger.info(
+                'No valid failing images remain for %s after filtering; skipping BigQuery scan', group
+            )
+            return
+
         self.runtime.logger.info(
-            'Redis reports %d failing image(s) for %s; querying BigQuery for details', len(failing_images), group
+            'Redis reports %d failing image(s) for %s; querying BigQuery for details', len(filtered_failing_images), group
         )
 
         group_param = f'--group={group}'
@@ -107,7 +124,7 @@ class ImagesHealthPipeline:
             f'--working-dir={doozer_working}',
             f'--data-path={self.data_path}',
             group_param,
-            f'--images={",".join(sorted(failing_images))}',
+            f'--images={",".join(sorted(filtered_failing_images))}',
             'images:health',
         ]
 
@@ -123,17 +140,79 @@ class ImagesHealthPipeline:
         """
         Fetch OCP rebase failure data from Redis for a specific version.
         Checks both Brew and Konflux build systems.
+        Filters out images that don't exist in current ocp-build-data.
         Populates self.rebase_failures[version] with {image: {failure_count, url, build_system}}.
 
         Arg(s):
             version (str): OCP version (e.g., "4.18")
         """
-        self.rebase_failures[version] = await util.get_rebase_failures(
+        # Fetch all rebase failures from Redis
+        all_failures = await util.get_rebase_failures(
             version=version,
             branches=['rebase-failure'],
             build_systems=['brew', 'konflux'],
             logger=self.runtime.logger,
         )
+
+        # Get list of valid images for this version from metadata
+        doozer_working = f'{self.doozer_working}-{version}'
+        valid_images = await self._get_valid_images(version, doozer_working)
+
+        # Filter to only include images that exist in metadata
+        filtered_failures = {}
+        skipped_images = []
+
+        for image_name, failure_info in all_failures.items():
+            if image_name in valid_images:
+                filtered_failures[image_name] = failure_info
+            else:
+                skipped_images.append(image_name)
+
+        if skipped_images:
+            self.runtime.logger.warning(
+                'Filtered out %d rebase failure(s) from Redis that do not exist in openshift-%s metadata: %s',
+                len(skipped_images), version, ', '.join(sorted(skipped_images))
+            )
+
+        self.rebase_failures[version] = filtered_failures
+
+    async def _get_valid_images(self, version: str, doozer_working: str) -> set[str]:
+        """
+        Get the set of valid image names for a given version from ocp-build-data.
+
+        Arg(s):
+            version (str): OCP version (e.g., "4.18")
+            doozer_working (str): Doozer working directory path
+        Return Value(s):
+            set[str]: Set of valid image distgit keys
+        """
+        group_param = f'--group=openshift-{version}'
+        if self.data_gitref:
+            group_param += f'@{self.data_gitref}'
+
+        cmd = [
+            'doozer',
+            f'--working-dir={doozer_working}',
+            f'--data-path={self.data_path}',
+            group_param,
+            'images:print',
+            '--short',
+            '{name}',
+        ]
+
+        try:
+            _, out, _ = await exectools.cmd_gather_async(cmd, stderr=None)
+            # Parse the output - one image name per line
+            valid_images = {line.strip() for line in out.strip().split('\n') if line.strip()}
+            self.runtime.logger.info('Found %d valid images for openshift-%s', len(valid_images), version)
+            return valid_images
+        except Exception as e:
+            self.runtime.logger.warning(
+                'Failed to fetch valid images for openshift-%s: %s. Proceeding without filtering.',
+                version, e
+            )
+            # On failure, return empty set to fail safe (don't process any images from Redis)
+            return set()
 
     def sync_jira(self):
         jira_client = self.runtime.new_jira_client()

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -29,8 +29,10 @@ from pyartcd.util import (
     build_history_link_url,
     get_group_images,
     get_group_rpms,
+    increment_build_fail_counter,
     increment_rebase_fail_counter,
     mass_rebuild_score,
+    reset_build_fail_counter,
     reset_rebase_fail_counter,
 )
 
@@ -197,6 +199,31 @@ class KonfluxOcpPipeline:
             *[increment_rebase_fail_counter(image, self.version, 'konflux', job_url=job_url) for image in failed_images]
         )
 
+    async def update_build_fail_counters(self, built_images, failed_images, record_log):
+        if self.assembly != 'stream':
+            return
+
+        group = f'openshift-{self.version}'
+        job_url = os.getenv('BUILD_URL')
+
+        # Build a lookup of failed entries for NVR metadata
+        failed_entries = {
+            entry['name']: entry for entry in record_log.get('image_build_konflux', []) if int(entry['status'])
+        }
+
+        await asyncio.gather(*[reset_build_fail_counter(image, group) for image in built_images])
+        await asyncio.gather(
+            *[
+                increment_build_fail_counter(
+                    image,
+                    group,
+                    job_url=job_url,
+                    nvr=failed_entries.get(image, {}).get('nvrs'),
+                )
+                for image in failed_images
+            ]
+        )
+
     def building_images(self):
         """
         Returns True if images are being built, False otherwise.
@@ -346,6 +373,8 @@ class KonfluxOcpPipeline:
             jenkins.update_description(f'Failed images: {", ".join(failed_images)}<br/>')
         elif len(failed_images) > 10:
             jenkins.update_description(f'{len(failed_images)} images failed. Check record.log for details<br/>')
+
+        await self.update_build_fail_counters(built_images, failed_images, record_log)
 
         if not built_images:
             # Nothing to do, skipping build-sync

--- a/pyartcd/pyartcd/pipelines/okd.py
+++ b/pyartcd/pyartcd/pipelines/okd.py
@@ -24,7 +24,9 @@ from pyartcd.util import (
     build_history_link_url,
     default_release_suffix,
     get_group_images,
+    increment_build_fail_counter,
     increment_rebase_fail_counter,
+    reset_build_fail_counter,
     reset_rebase_fail_counter,
 )
 
@@ -396,9 +398,9 @@ class KonfluxOkdPipeline:
             pass
 
         finally:
-            self.handle_built_images()
+            await self.handle_built_images()
 
-    def handle_built_images(self):
+    async def handle_built_images(self):
         record_log = self.parse_record_log()
         if not record_log:
             self.logger.error('record.log not found!')
@@ -429,6 +431,36 @@ class KonfluxOkdPipeline:
                 jenkins.update_description(f'Build failures: {", ".join(failed_images)}<br>')
             else:
                 jenkins.update_description(f'Build failures: {len(failed_images)} images<br>')
+
+        await self.update_build_fail_counters(
+            [img['name'] for img in self.built_images],
+            failed_images,
+            record_log,
+        )
+
+    async def update_build_fail_counters(self, built_images, failed_images, record_log):
+        if self.assembly != 'stream':
+            return
+
+        group = f'okd-{self.version}'
+        job_url = os.getenv('BUILD_URL')
+
+        failed_entries = {
+            entry['name']: entry for entry in record_log.get('image_build_okd', []) if int(entry['status'])
+        }
+
+        await asyncio.gather(*[reset_build_fail_counter(image, group) for image in built_images])
+        await asyncio.gather(
+            *[
+                increment_build_fail_counter(
+                    image,
+                    group,
+                    job_url=job_url,
+                    nvr=failed_entries.get(image, {}).get('nvrs'),
+                )
+                for image in failed_images
+            ]
+        )
 
     async def detect_embargoed_builds(self):
         """

--- a/pyartcd/pyartcd/pipelines/okd_images_health.py
+++ b/pyartcd/pyartcd/pipelines/okd_images_health.py
@@ -57,7 +57,22 @@ class ImagesHealthPipeline:
             await self.notify_okd_channel()
 
     async def get_report(self, version: str) -> Optional[list]:
-        # Get doozer report for the given version
+        group = OKD_GROUP_TEMPLATE.format(version)
+        failures = await util.get_build_failures(group=group, logger=self.runtime.logger)
+
+        failing_images = set(failures.keys())
+        if self.image_list:
+            failing_images &= set(self.image_list)
+
+        if not failing_images:
+            self.runtime.logger.info('No build failures in Redis for %s; skipping BigQuery scan', group)
+            self.scanned_versions.append(version)
+            return
+
+        self.runtime.logger.info(
+            'Redis reports %d failing image(s) for %s; querying BigQuery for details', len(failing_images), group
+        )
+
         doozer_working = f'{self.doozer_working}-{version}'
         group_param = f'--group=openshift-{version}'
         if self.data_gitref:
@@ -69,12 +84,10 @@ class ImagesHealthPipeline:
             f'--data-path={self.data_path}',
             '--variant=okd',
             group_param,
+            f'--images={",".join(sorted(failing_images))}',
+            'images:health',
+            f'--group={group}',
         ]
-
-        if self.image_list:
-            cmd.append(f'--images={",".join(self.image_list)}')
-
-        cmd.extend(['images:health', f'--group={OKD_GROUP_TEMPLATE.format(version)}'])
 
         if self.assembly:
             cmd.append(f'--assembly={self.assembly}')
@@ -82,7 +95,7 @@ class ImagesHealthPipeline:
         _, out, err = await exectools.cmd_gather_async(cmd, stderr=None)
         report = json.loads(out.strip())
 
-        self.runtime.logger.info('images:health output for openshift-%s:\n%s', version, out)
+        self.runtime.logger.info('images:health output for %s:\n%s', group, out)
         self.report.extend(report)
         self.scanned_versions.append(version)
 

--- a/pyartcd/pyartcd/pipelines/okd_images_health.py
+++ b/pyartcd/pyartcd/pipelines/okd_images_health.py
@@ -69,11 +69,29 @@ class ImagesHealthPipeline:
             self.scanned_versions.append(version)
             return
 
+        # Filter failing_images to only include images that exist in current ocp-build-data
+        doozer_working = f'{self.doozer_working}-{version}'
+        valid_images = await self._get_valid_images(version, doozer_working)
+        filtered_failing_images = failing_images & valid_images
+        skipped_images = failing_images - valid_images
+
+        if skipped_images:
+            self.runtime.logger.warning(
+                'Filtered out %d image(s) from Redis that do not exist in %s metadata: %s',
+                len(skipped_images), group, ', '.join(sorted(skipped_images))
+            )
+
+        if not filtered_failing_images:
+            self.runtime.logger.info(
+                'No valid failing images remain for %s after filtering; skipping BigQuery scan', group
+            )
+            self.scanned_versions.append(version)
+            return
+
         self.runtime.logger.info(
-            'Redis reports %d failing image(s) for %s; querying BigQuery for details', len(failing_images), group
+            'Redis reports %d failing image(s) for %s; querying BigQuery for details', len(filtered_failing_images), group
         )
 
-        doozer_working = f'{self.doozer_working}-{version}'
         group_param = f'--group=openshift-{version}'
         if self.data_gitref:
             group_param += f'@{self.data_gitref}'
@@ -84,7 +102,7 @@ class ImagesHealthPipeline:
             f'--data-path={self.data_path}',
             '--variant=okd',
             group_param,
-            f'--images={",".join(sorted(failing_images))}',
+            f'--images={",".join(sorted(filtered_failing_images))}',
             'images:health',
             f'--group={group}',
         ]
@@ -102,17 +120,80 @@ class ImagesHealthPipeline:
     async def get_rebase_failures(self, version: str):
         """
         Fetch OKD rebase failure data from Redis for a specific version.
+        Filters out images that don't exist in current ocp-build-data.
         Populates self.rebase_failures[version] with {image: {failure_count, url}}.
 
         Arg(s):
             version (str): OKD version (e.g., "4.21")
         """
-        self.rebase_failures[version] = await util.get_rebase_failures(
+        # Fetch all rebase failures from Redis
+        all_failures = await util.get_rebase_failures(
             version=version,
             branches=['okd-rebase-failure'],
             build_systems=['konflux'],
             logger=self.runtime.logger,
         )
+
+        # Get list of valid images for this version from metadata
+        doozer_working = f'{self.doozer_working}-{version}'
+        valid_images = await self._get_valid_images(version, doozer_working)
+
+        # Filter to only include images that exist in metadata
+        filtered_failures = {}
+        skipped_images = []
+
+        for image_name, failure_info in all_failures.items():
+            if image_name in valid_images:
+                filtered_failures[image_name] = failure_info
+            else:
+                skipped_images.append(image_name)
+
+        if skipped_images:
+            self.runtime.logger.warning(
+                'Filtered out %d rebase failure(s) from Redis that do not exist in okd-%s metadata: %s',
+                len(skipped_images), version, ', '.join(sorted(skipped_images))
+            )
+
+        self.rebase_failures[version] = filtered_failures
+
+    async def _get_valid_images(self, version: str, doozer_working: str) -> set[str]:
+        """
+        Get the set of valid image names for a given OKD version from ocp-build-data.
+
+        Arg(s):
+            version (str): OKD version (e.g., "4.21")
+            doozer_working (str): Doozer working directory path
+        Return Value(s):
+            set[str]: Set of valid image distgit keys
+        """
+        group_param = f'--group=openshift-{version}'
+        if self.data_gitref:
+            group_param += f'@{self.data_gitref}'
+
+        cmd = [
+            'doozer',
+            f'--working-dir={doozer_working}',
+            f'--data-path={self.data_path}',
+            '--variant=okd',
+            group_param,
+            'images:print',
+            '--short',
+            '{name}',
+        ]
+
+        try:
+            _, out, _ = await exectools.cmd_gather_async(cmd, stderr=None)
+            # Parse the output - one image name per line
+            valid_images = {line.strip() for line in out.strip().split('\n') if line.strip()}
+            self.runtime.logger.info('Found %d valid OKD images for openshift-%s', len(valid_images), version)
+            return valid_images
+        except Exception as e:
+            self.runtime.logger.warning(
+                'Failed to fetch valid OKD images for openshift-%s: %s. Proceeding without filtering.',
+                version, e
+            )
+            # On failure, return empty set to fail safe (don't process any images from Redis)
+            return set()
 
     async def notify_release_channel(self, version):
         """

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -1008,6 +1008,102 @@ async def get_group_rpms(
     return out.splitlines()
 
 
+async def increment_build_fail_counter(image, group, build_system='konflux', job_url=None, nvr=None):
+    """
+    Increment the build fail counter for a given image in Redis.
+    Optionally store the job URL and NVR of the failed build.
+
+    Key format: count:build-failure:{build_system}:{group}:{image}:{field}
+    Consistent with the rebase failure key pattern.
+
+    Arg(s):
+        image (str): Image name (distgit key)
+        group (str): Group name (e.g., 'openshift-4.17', 'okd-4.21')
+        build_system (str): Build system (default: 'konflux')
+        job_url (str): Optional job URL where the failure occurred
+        nvr (str): Optional NVR of the failed build
+    """
+    redis_branch = f'count:build-failure:{build_system}:{group}:{image}'
+    failure_key = f'{redis_branch}:failure'
+    fail_count = await redis.get_value(failure_key)
+    fail_count = int(fail_count) if fail_count else 0
+    await redis.set_value(key=failure_key, value=fail_count + 1)
+
+    if job_url:
+        await redis.set_value(key=f'{redis_branch}:url', value=job_url)
+    if nvr:
+        await redis.set_value(key=f'{redis_branch}:nvr', value=nvr)
+
+
+@limit_concurrency(50)
+async def reset_build_fail_counter(image, group, build_system='konflux'):
+    """
+    Reset the build fail counter for a given image in Redis.
+    Limit concurrency as we might have a lot of images to reset.
+
+    Arg(s):
+        image (str): Image name (distgit key)
+        group (str): Group name (e.g., 'openshift-4.17', 'okd-4.21')
+        build_system (str): Build system (default: 'konflux')
+    """
+    redis_branch = f'count:build-failure:{build_system}:{group}:{image}:*'
+    await redis.delete_keys_by_pattern(redis_branch)
+
+
+async def get_build_failures(group: str, build_system: str = 'konflux', logger=None):
+    """
+    Fetch build failure data from Redis for a specific group.
+
+    Arg(s):
+        group (str): Group name (e.g., 'openshift-4.18', 'okd-4.21')
+        build_system (str): Build system (default: 'konflux')
+        logger (Logger): Optional logger for debugging
+    Return Value(s):
+        dict: {image_name: {failure_count, url, nvr}}
+    """
+    failures = {}
+
+    try:
+        pattern = f'count:build-failure:{build_system}:{group}:*:failure'
+        failure_keys = await redis.get_keys(pattern)
+
+        if not failure_keys:
+            if logger:
+                logger.info('No %s build failures found for group %s', build_system, group)
+            return failures
+
+        if logger:
+            logger.info('Found %d %s build failure keys for group %s', len(failure_keys), build_system, group)
+
+        # Key format: count:build-failure:{build_system}:{group}:{image}:failure
+        for failure_key in failure_keys:
+            parts = failure_key.split(':')
+            if len(parts) >= 6:
+                image_name = parts[4]
+                base_key = f'count:build-failure:{build_system}:{group}:{image_name}'
+
+                failure_count = await redis.get_value(failure_key)
+                job_url = await redis.get_value(f'{base_key}:url')
+                nvr = await redis.get_value(f'{base_key}:nvr')
+
+                failures[image_name] = {
+                    'failure_count': int(failure_count) if failure_count else 0,
+                    'url': job_url or '',
+                    'nvr': nvr or '',
+                }
+
+        if logger and failures:
+            import json
+
+            logger.info('Build failures for group %s: %s', group, json.dumps(failures, indent=2))
+
+    except Exception as e:
+        if logger:
+            logger.warning('Failed to fetch build failures from Redis for group %s: %s', group, e)
+
+    return failures
+
+
 async def increment_rebase_fail_counter(image, version, build_system, branch='rebase-failure', job_url=None):
     """
     Increment the fail counter for a given image in Redis.

--- a/pyartcd/tests/pipelines/test_images_health.py
+++ b/pyartcd/tests/pipelines/test_images_health.py
@@ -1,3 +1,4 @@
+import json
 from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -176,6 +177,95 @@ class TestImagesHealthPipeline(IsolatedAsyncioTestCase):
         mock_slack_client.say.assert_called_once_with(
             ":white_check_mark: All images are healthy for all monitored releases"
         )
+
+
+class TestGetReport(IsolatedAsyncioTestCase):
+    def _make_pipeline(self, versions="4.18", image_list=""):
+        runtime = MagicMock()
+        runtime.working_dir = MagicMock()
+        runtime.logger = MagicMock()
+        runtime.new_slack_client.return_value = MagicMock()
+        return ImagesHealthPipeline(
+            runtime=runtime,
+            versions=versions,
+            send_to_release_channel=False,
+            send_to_forum_ocp_art=False,
+            data_path=DATA_PATH,
+            data_gitref="",
+            image_list=image_list,
+            assembly="stream",
+        )
+
+    @patch("pyartcd.pipelines.images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.images_health.util.is_build_permitted", new_callable=AsyncMock, return_value=True)
+    @patch("pyartcd.pipelines.images_health.util.get_build_failures", new_callable=AsyncMock)
+    async def test_redis_pre_filters_doozer_call(self, mock_get_failures, _mock_permitted, mock_cmd):
+        """Redis failures scope the --images flag on the doozer subprocess."""
+        mock_get_failures.return_value = {
+            'ironic': {'failure_count': 3, 'url': '', 'nvr': ''},
+            'hypershift': {'failure_count': 5, 'url': '', 'nvr': ''},
+        }
+        doozer_report = [
+            _make_concern("ironic", "openshift-4.18", ConcernCode.LATEST_ATTEMPT_FAILED.value, latest_success_idx=3),
+            _make_concern(
+                "hypershift", "openshift-4.18", ConcernCode.LATEST_ATTEMPT_FAILED.value, latest_success_idx=5
+            ),
+        ]
+        mock_cmd.return_value = (0, json.dumps(doozer_report), '')
+
+        pipeline = self._make_pipeline()
+        await pipeline.get_report('4.18')
+
+        mock_get_failures.assert_called_once_with(group='openshift-4.18', logger=pipeline.runtime.logger)
+        mock_cmd.assert_called_once()
+        cmd = mock_cmd.call_args[0][0]
+        images_arg = next(a for a in cmd if a.startswith('--images='))
+        self.assertIn('ironic', images_arg)
+        self.assertIn('hypershift', images_arg)
+        self.assertEqual(len(pipeline.report), 2)
+
+    @patch("pyartcd.pipelines.images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.images_health.util.is_build_permitted", new_callable=AsyncMock, return_value=True)
+    @patch("pyartcd.pipelines.images_health.util.get_build_failures", new_callable=AsyncMock)
+    async def test_image_list_intersects_with_redis(self, mock_get_failures, _mock_permitted, mock_cmd):
+        """When --image-list is provided, only images in BOTH lists are queried."""
+        mock_get_failures.return_value = {
+            'ironic': {'failure_count': 3, 'url': '', 'nvr': ''},
+            'hypershift': {'failure_count': 5, 'url': '', 'nvr': ''},
+        }
+        doozer_report = [
+            _make_concern("ironic", "openshift-4.18", ConcernCode.LATEST_ATTEMPT_FAILED.value, latest_success_idx=3),
+        ]
+        mock_cmd.return_value = (0, json.dumps(doozer_report), '')
+
+        pipeline = self._make_pipeline(image_list="ironic")
+        await pipeline.get_report('4.18')
+
+        cmd = mock_cmd.call_args[0][0]
+        images_arg = next(a for a in cmd if a.startswith('--images='))
+        self.assertEqual(images_arg, '--images=ironic')
+
+    @patch("pyartcd.pipelines.images_health.util.is_build_permitted", new_callable=AsyncMock, return_value=False)
+    async def test_skips_frozen_group(self, _mock_permitted):
+        pipeline = self._make_pipeline()
+
+        await pipeline.get_report('4.18')
+
+        self.assertEqual(len(pipeline.report), 0)
+        self.assertNotIn('4.18', pipeline.scanned_versions)
+
+    @patch("pyartcd.pipelines.images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.images_health.util.is_build_permitted", new_callable=AsyncMock, return_value=True)
+    @patch("pyartcd.pipelines.images_health.util.get_build_failures", new_callable=AsyncMock, return_value={})
+    async def test_skips_bigquery_when_no_redis_failures(self, _mock_get_failures, _mock_permitted, mock_cmd):
+        """When Redis reports no failures, doozer images:health is not called at all."""
+        pipeline = self._make_pipeline()
+
+        await pipeline.get_report('4.18')
+
+        mock_cmd.assert_not_called()
+        self.assertEqual(len(pipeline.report), 0)
+        self.assertIn('4.18', pipeline.scanned_versions)
 
 
 class TestSyncJira(TestCase):

--- a/pyartcd/tests/pipelines/test_okd_images_health.py
+++ b/pyartcd/tests/pipelines/test_okd_images_health.py
@@ -1,0 +1,96 @@
+import json
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from doozerlib.cli.images_health import ConcernCode
+from pyartcd.pipelines.okd_images_health import ImagesHealthPipeline
+
+DATA_PATH = "https://github.com/openshift-eng/ocp-build-data"
+
+
+def _make_concern(image_name, group, code, **kwargs):
+    concern = {
+        "image_name": image_name,
+        "group": group,
+        "code": code,
+        "latest_failed_build_time": "2025-12-17T10:00:00+00:00",
+        "latest_failed_nvr": f"{image_name}-1.0-1",
+        "latest_failed_build_record_id": "12345",
+    }
+    concern.update(kwargs)
+    return concern
+
+
+class TestGetReport(IsolatedAsyncioTestCase):
+    def _make_pipeline(self, versions="4.21", image_list=""):
+        runtime = MagicMock()
+        runtime.working_dir = MagicMock()
+        runtime.logger = MagicMock()
+        runtime.new_slack_client.return_value = MagicMock()
+        return ImagesHealthPipeline(
+            runtime=runtime,
+            versions=versions,
+            send_to_release_channel=False,
+            send_to_okd_channel=False,
+            data_path=DATA_PATH,
+            data_gitref="",
+            image_list=image_list,
+            assembly="stream",
+        )
+
+    @patch("pyartcd.pipelines.okd_images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.okd_images_health.util.get_build_failures", new_callable=AsyncMock)
+    async def test_redis_pre_filters_doozer_call(self, mock_get_failures, mock_cmd):
+        """Redis failures scope the --images flag on the doozer subprocess."""
+        mock_get_failures.return_value = {
+            'okd-machine-os': {'failure_count': 2, 'url': '', 'nvr': ''},
+        }
+        doozer_report = [
+            _make_concern(
+                "okd-machine-os", "openshift-4.21", ConcernCode.LATEST_ATTEMPT_FAILED.value, latest_success_idx=2
+            ),
+        ]
+        mock_cmd.return_value = (0, json.dumps(doozer_report), '')
+
+        pipeline = self._make_pipeline()
+        await pipeline.get_report('4.21')
+
+        mock_get_failures.assert_called_once_with(group='okd-4.21', logger=pipeline.runtime.logger)
+        mock_cmd.assert_called_once()
+        cmd = mock_cmd.call_args[0][0]
+        images_arg = next(a for a in cmd if a.startswith('--images='))
+        self.assertIn('okd-machine-os', images_arg)
+        self.assertEqual(len(pipeline.report), 1)
+        self.assertIn('4.21', pipeline.scanned_versions)
+
+    @patch("pyartcd.pipelines.okd_images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.okd_images_health.util.get_build_failures", new_callable=AsyncMock)
+    async def test_image_list_intersects_with_redis(self, mock_get_failures, mock_cmd):
+        mock_get_failures.return_value = {
+            'okd-machine-os': {'failure_count': 2, 'url': '', 'nvr': ''},
+            'other-image': {'failure_count': 5, 'url': '', 'nvr': ''},
+        }
+        doozer_report = [
+            _make_concern(
+                "okd-machine-os", "openshift-4.21", ConcernCode.LATEST_ATTEMPT_FAILED.value, latest_success_idx=2
+            ),
+        ]
+        mock_cmd.return_value = (0, json.dumps(doozer_report), '')
+
+        pipeline = self._make_pipeline(image_list="okd-machine-os")
+        await pipeline.get_report('4.21')
+
+        cmd = mock_cmd.call_args[0][0]
+        images_arg = next(a for a in cmd if a.startswith('--images='))
+        self.assertEqual(images_arg, '--images=okd-machine-os')
+
+    @patch("pyartcd.pipelines.okd_images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.okd_images_health.util.get_build_failures", new_callable=AsyncMock, return_value={})
+    async def test_skips_bigquery_when_no_redis_failures(self, _mock_get_failures, mock_cmd):
+        pipeline = self._make_pipeline()
+
+        await pipeline.get_report('4.21')
+
+        mock_cmd.assert_not_called()
+        self.assertEqual(len(pipeline.report), 0)
+        self.assertIn('4.21', pipeline.scanned_versions)

--- a/pyartcd/tests/test_util.py
+++ b/pyartcd/tests/test_util.py
@@ -1,5 +1,5 @@
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from pyartcd import util
 
@@ -223,3 +223,57 @@ class TestUtil(IsolatedAsyncioTestCase):
         self.assertEqual(util.get_rpm_if_pinned_directly(releases_config, '4.11.0', 'foo'), rpms)
         self.assertEqual(util.get_rpm_if_pinned_directly(releases_config, '4.11.1', 'foo'), dict())
         self.assertEqual(util.get_rpm_if_pinned_directly(releases_config, '4.11.0', 'bar'), dict())
+
+    @patch("artcommonlib.redis.set_value", new_callable=AsyncMock)
+    @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
+    async def test_increment_build_fail_counter_new(self, mock_get, mock_set):
+        mock_get.return_value = None
+        await util.increment_build_fail_counter('ironic', 'openshift-4.21', job_url='http://j/1', nvr='ironic-1.0-1')
+        mock_set.assert_any_call(key='count:build-failure:konflux:openshift-4.21:ironic:failure', value=1)
+        mock_set.assert_any_call(key='count:build-failure:konflux:openshift-4.21:ironic:url', value='http://j/1')
+        mock_set.assert_any_call(key='count:build-failure:konflux:openshift-4.21:ironic:nvr', value='ironic-1.0-1')
+
+    @patch("artcommonlib.redis.set_value", new_callable=AsyncMock)
+    @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
+    async def test_increment_build_fail_counter_existing(self, mock_get, mock_set):
+        mock_get.return_value = '3'
+        await util.increment_build_fail_counter('ironic', 'openshift-4.21')
+        mock_set.assert_any_call(key='count:build-failure:konflux:openshift-4.21:ironic:failure', value=4)
+
+    @patch("artcommonlib.redis.delete_keys_by_pattern", new_callable=AsyncMock)
+    async def test_reset_build_fail_counter(self, mock_delete):
+        await util.reset_build_fail_counter('ironic', 'openshift-4.21')
+        mock_delete.assert_called_once_with('count:build-failure:konflux:openshift-4.21:ironic:*')
+
+    @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
+    @patch("artcommonlib.redis.get_keys", new_callable=AsyncMock)
+    async def test_get_build_failures(self, mock_get_keys, mock_get_value):
+        mock_get_keys.return_value = [
+            'count:build-failure:konflux:openshift-4.21:ironic:failure',
+            'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:failure',
+        ]
+        mock_get_value.side_effect = lambda key: {
+            'count:build-failure:konflux:openshift-4.21:ironic:failure': '5',
+            'count:build-failure:konflux:openshift-4.21:ironic:url': 'http://j/1',
+            'count:build-failure:konflux:openshift-4.21:ironic:nvr': 'ironic-1.0-1',
+            'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:failure': '2',
+            'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:url': '',
+            'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:nvr': None,
+        }.get(key)
+        result = await util.get_build_failures('openshift-4.21')
+        self.assertEqual(result['ironic']['failure_count'], 5)
+        self.assertEqual(result['ironic']['url'], 'http://j/1')
+        self.assertEqual(result['ironic']['nvr'], 'ironic-1.0-1')
+        self.assertEqual(result['ovn-kubernetes']['failure_count'], 2)
+
+    @patch("artcommonlib.redis.get_keys", new_callable=AsyncMock)
+    async def test_get_build_failures_empty(self, mock_get_keys):
+        mock_get_keys.return_value = []
+        result = await util.get_build_failures('openshift-4.21')
+        self.assertEqual(result, {})
+
+    @patch("artcommonlib.redis.get_keys", new_callable=AsyncMock)
+    async def test_get_build_failures_redis_error(self, mock_get_keys):
+        mock_get_keys.side_effect = Exception("Redis connection refused")
+        result = await util.get_build_failures('openshift-4.21', logger=MagicMock())
+        self.assertEqual(result, {})


### PR DESCRIPTION
## Summary
- Read build failure keys from Redis to determine which images are currently failing
- Pass only those images to `doozer images:health` via `--images`, drastically reducing BigQuery queries
- When Redis reports no failures, the BigQuery scan is skipped entirely
- Full build metadata (logs URLs, record IDs, build times) is preserved for failing images

Phase 2 of [ART-14960](https://redhat.atlassian.net/browse/ART-14960). Depends on #2782 (Phase 1: writing to Redis).

**On hold** until Phase 1 is deployed and populating Redis data.

## Test plan
- [x] Unit tests for Redis pre-filter in both OCP and OKD images-health pipelines
- [x] All existing tests pass (`make test`)


Made with [Cursor](https://cursor.com)