### PR TITLE
Use PAT token for pushing to openshift-priv protected branches

### DIFF
--- a/artcommon/artcommonlib/github_auth.py
+++ b/artcommon/artcommonlib/github_auth.py
@@ -201,6 +201,30 @@ def get_github_git_auth_env(url: str | None = None, force_refresh: bool = False)
     }
 
 
+def get_github_git_pat_env() -> dict[str, str]:
+    """
+    Return GIT_ASKPASS environment variables using only the GITHUB_TOKEN PAT,
+    bypassing GitHub App credentials entirely.
+
+    This is needed for operations like pushing to protected branches on
+    openshift-priv, where the GitHub App lacks permission to bypass branch
+    protection rules but the PAT does.
+
+    :return: Dict with GIT_ASKPASS, GIT_PASSWORD, GIT_TERMINAL_PROMPT; or {}
+    """
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        LOGGER.warning("GITHUB_TOKEN is not set; cannot provide PAT-based git auth")
+        return {}
+    LOGGER.info("Using GITHUB_TOKEN (PAT) for git CLI auth (App credentials bypassed)")
+    script = _ensure_askpass_script()
+    return {
+        "GIT_ASKPASS": script,
+        "GIT_PASSWORD": token,
+        "GIT_TERMINAL_PROMPT": "0",
+    }
+
+
 def _generate_app_token_for_url(url: str | None) -> str:
     """Generate an App installation token, using the URL's org when available."""
     app_id, private_key, installation_id = _read_env_credentials()

--- a/artcommon/tests/test_github_auth.py
+++ b/artcommon/tests/test_github_auth.py
@@ -10,6 +10,7 @@ from artcommonlib.github_auth import (
     get_github_app_token_from_env,
     get_github_client_for_org,
     get_github_git_auth_env,
+    get_github_git_pat_env,
 )
 
 FAKE_PEM = "-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----"
@@ -456,3 +457,39 @@ class TestGetGithubGitAuthEnv:
 
         mock_token.assert_called_once_with(100, FAKE_PEM, 777)
         assert result["GIT_PASSWORD"] == "ghs_explicit"
+
+
+class TestGetGithubGitPatEnv:
+    """Tests for the PAT-only GIT_ASKPASS auth helper."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_askpass_cache(self):
+        gh_auth._askpass_script_path = None
+        yield
+        if gh_auth._askpass_script_path and os.path.exists(gh_auth._askpass_script_path):
+            os.unlink(gh_auth._askpass_script_path)
+        gh_auth._askpass_script_path = None
+
+    def test_returns_pat_env(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_my_pat")
+
+        result = get_github_git_pat_env()
+
+        assert "GIT_ASKPASS" in result
+        assert result["GIT_PASSWORD"] == "ghp_my_pat"
+        assert result["GIT_TERMINAL_PROMPT"] == "0"
+
+    def test_ignores_app_credentials(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_APP_ID", "12345")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_pat_only")
+
+        result = get_github_git_pat_env()
+
+        assert result["GIT_PASSWORD"] == "ghp_pat_only"
+
+    def test_returns_empty_when_no_pat(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        result = get_github_git_pat_env()
+
+        assert result == {}

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -304,9 +304,15 @@ class ConfigScanSources:
             self.logger.info('Would have tried reconciliation for %s/%s', repo_name, priv_branch_name)
             return
 
-        # Try to push to openshift-priv using the PAT token instead of the GitHub App token,
+        # Push to openshift-priv using the PAT token instead of the GitHub App token,
         # because the App does not have permission to push to protected branches (GH006)
-        git_pat_env = get_github_git_pat_env() or git_auth_env
+        git_pat_env = get_github_git_pat_env()
+        if not git_pat_env:
+            raise RuntimeError(
+                f'GITHUB_TOKEN (PAT) is not set; cannot push to protected branch {priv_branch_name} '
+                f'on openshift-priv for {metadata.name}. The GitHub App token lacks permission to '
+                f'bypass branch protection (GH006).'
+            )
         try:
             exectools.cmd_assert(cmd=['git', 'push', 'origin', priv_branch_name], retries=3, set_env=git_pat_env)
             self.logger.info('Successfully reconciled %s with public upstream', metadata.name)

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -18,7 +18,7 @@ import yaml
 from artcommonlib import exectools
 from artcommonlib.arch_util import brew_arch_for_go_arch, go_arch_for_brew_arch
 from artcommonlib.exectools import cmd_gather_async
-from artcommonlib.github_auth import get_github_client_for_org, get_github_git_auth_env
+from artcommonlib.github_auth import get_github_client_for_org, get_github_git_auth_env, get_github_git_pat_env
 from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.konflux.package_rpm_finder import PackageRpmFinder
 from artcommonlib.model import Missing, Model
@@ -304,9 +304,11 @@ class ConfigScanSources:
             self.logger.info('Would have tried reconciliation for %s/%s', repo_name, priv_branch_name)
             return
 
-        # Try to push to openshift-priv
+        # Try to push to openshift-priv using the PAT token instead of the GitHub App token,
+        # because the App does not have permission to push to protected branches (GH006)
+        git_pat_env = get_github_git_pat_env() or git_auth_env
         try:
-            exectools.cmd_assert(cmd=['git', 'push', 'origin', priv_branch_name], retries=3, set_env=git_auth_env)
+            exectools.cmd_assert(cmd=['git', 'push', 'origin', priv_branch_name], retries=3, set_env=git_pat_env)
             self.logger.info('Successfully reconciled %s with public upstream', metadata.name)
 
         except ChildProcessError as exc:


### PR DESCRIPTION
The GitHub App does not have permission to push to protected branches on openshift-priv repos (GH006). Switch the git push in _try_reconciliation to use the GITHUB_TOKEN PAT instead, while keeping GitHub App credentials for all other git operations.
