### PR TITLE
ART-16001: Refresh transient git-auth token for long-queued Konflux builds

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -269,8 +269,10 @@ class KonfluxClient:
 
         namespace = namespace or self.default_namespace
 
-        # Mint a short-lived installation token (valid ~1 hour, but only the
-        # git-clone + prefetch tasks need it — those run in the first few minutes).
+        # Mint a short-lived installation token (valid ~1 hour).
+        # A background refresh loop (token_refresh_loop) keeps the secret
+        # up-to-date for PipelineRuns that sit in the Kueue queue longer than
+        # the token's lifetime.
         token = await exectools.to_thread(get_github_app_token_for_org, org)
 
         # Nanosecond epoch avoids name collisions when multiple doozer
@@ -353,6 +355,81 @@ class KonfluxClient:
                     self._logger.warning(f"Failed to delete git-auth Secret {secret_name}: {e}")
 
         self._git_auth_secret_name = None
+
+    async def refresh_git_auth_secret(self, namespace: Optional[str] = None, org: str = "openshift-priv") -> None:
+        """Re-mint the GitHub App installation token and update the existing
+        Kubernetes Secret in-place.
+
+        This keeps the token valid for PipelineRuns that have been queued
+        longer than the token's 1-hour lifetime. Tekton reads Secret data
+        when the Pod is actually scheduled, so updating the Secret while a
+        PipelineRun is Pending ensures the git-clone task gets a valid token.
+
+        No-op when:
+        - No transient secret was created (static fallback)
+        - Running in dry-run mode
+
+        :param namespace: Target namespace. Defaults to self.default_namespace.
+        :param org: GitHub org whose installation token to mint.
+        """
+        secret_name = self._git_auth_secret_name
+        if not secret_name or not secret_name.startswith(_GIT_AUTH_SECRET_PREFIX):
+            return
+
+        if self.dry_run:
+            self._logger.warning(f"[DRY RUN] Would have refreshed git-auth Secret {secret_name}")
+            return
+
+        namespace = namespace or self.default_namespace
+
+        token = await exectools.to_thread(get_github_app_token_for_org, org)
+        now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+        try:
+            existing = await exectools.to_thread(
+                self.corev1_client.read_namespaced_secret,
+                name=secret_name,
+                namespace=namespace,
+                _request_timeout=self.request_timeout,
+            )
+            existing.data["password"] = base64.b64encode(token.encode()).decode()
+            existing.metadata.annotations["art.openshift.io/created-at"] = now
+            await exectools.to_thread(
+                self.corev1_client.replace_namespaced_secret,
+                name=secret_name,
+                namespace=namespace,
+                body=existing,
+                _request_timeout=self.request_timeout,
+            )
+            self._logger.info(f"Refreshed git-auth Secret {namespace}/{secret_name}")
+        except ApiException as e:
+            if e.status == 404:
+                self._logger.debug(f"Secret {secret_name} already deleted; skipping refresh")
+            else:
+                raise
+
+    async def token_refresh_loop(
+        self,
+        namespace: Optional[str] = None,
+        org: str = "openshift-priv",
+        interval_seconds: int = 45 * 60,
+    ) -> None:
+        """Periodically refresh the transient git-auth secret.
+
+        Runs until cancelled. Intended to be launched as an asyncio task
+        alongside PipelineRun build tasks so that the token stays valid
+        for jobs queued longer than the 1-hour token lifetime.
+
+        :param namespace: Target namespace. Defaults to self.default_namespace.
+        :param org: GitHub org whose installation token to mint.
+        :param interval_seconds: Seconds between refreshes (default 45 min).
+        """
+        while True:
+            await asyncio.sleep(interval_seconds)
+            try:
+                await self.refresh_git_auth_secret(namespace=namespace, org=org)
+            except Exception as exc:
+                self._logger.warning(f"Failed to refresh git-auth secret (will retry next cycle): {exc}")
 
     async def cleanup_stale_git_auth_secrets(self, namespace: Optional[str] = None, max_age_hours: int = 24) -> None:
         """Delete transient git-auth secrets older than *max_age_hours*.

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -405,6 +405,7 @@ class KonfluxClient:
         except ApiException as e:
             if e.status == 404:
                 self._logger.debug(f"Secret {secret_name} already deleted; skipping refresh")
+                self._git_auth_secret_name = None
             else:
                 raise
 

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -333,9 +333,17 @@ class FbcMergeCli:
         git_auth_secret = await merger._konflux_client.ensure_git_auth_secret(
             namespace=self.konflux_namespace,
         )
+        refresh_task = asyncio.create_task(
+            merger._konflux_client.token_refresh_loop(namespace=self.konflux_namespace)
+        )
         try:
             await merger.run(fragments, target_index, git_auth_secret=git_auth_secret)
         finally:
+            refresh_task.cancel()
+            try:
+                await refresh_task
+            except asyncio.CancelledError:
+                pass
             try:
                 await merger._konflux_client.delete_git_auth_secret(
                     namespace=self.konflux_namespace,
@@ -749,6 +757,9 @@ class FbcRebaseAndBuildCli:
         git_auth_secret = await builder._konflux_client.ensure_git_auth_secret(
             namespace=self.konflux_namespace,
         )
+        refresh_task = asyncio.create_task(
+            builder._konflux_client.token_refresh_loop(namespace=self.konflux_namespace)
+        )
 
         tasks = [
             self._rebase_and_build(
@@ -785,6 +796,11 @@ class FbcRebaseAndBuildCli:
                 else:
                     successful_nvrs.append(result)
         finally:
+            refresh_task.cancel()
+            try:
+                await refresh_task
+            except asyncio.CancelledError:
+                pass
             try:
                 await builder._konflux_client.delete_git_auth_secret(
                     namespace=self.konflux_namespace,

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -333,9 +333,7 @@ class FbcMergeCli:
         git_auth_secret = await merger._konflux_client.ensure_git_auth_secret(
             namespace=self.konflux_namespace,
         )
-        refresh_task = asyncio.create_task(
-            merger._konflux_client.token_refresh_loop(namespace=self.konflux_namespace)
-        )
+        refresh_task = asyncio.create_task(merger._konflux_client.token_refresh_loop(namespace=self.konflux_namespace))
         try:
             await merger.run(fragments, target_index, git_auth_secret=git_auth_secret)
         finally:
@@ -757,9 +755,7 @@ class FbcRebaseAndBuildCli:
         git_auth_secret = await builder._konflux_client.ensure_git_auth_secret(
             namespace=self.konflux_namespace,
         )
-        refresh_task = asyncio.create_task(
-            builder._konflux_client.token_refresh_loop(namespace=self.konflux_namespace)
-        )
+        refresh_task = asyncio.create_task(builder._konflux_client.token_refresh_loop(namespace=self.konflux_namespace))
 
         tasks = [
             self._rebase_and_build(

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -311,6 +311,9 @@ class KonfluxBuildCli:
         git_auth_secret = await builder._konflux_client.ensure_git_auth_secret(
             namespace=self.konflux_namespace,
         )
+        refresh_task = asyncio.create_task(
+            builder._konflux_client.token_refresh_loop(namespace=self.konflux_namespace)
+        )
 
         tasks = []
         for image_meta in metas:
@@ -325,6 +328,11 @@ class KonfluxBuildCli:
                     stack_trace = ''.join(traceback.TracebackException.from_exception(result).format())
                     LOGGER.error(f"Failed to build {image_name}: {result}; {stack_trace}")
         finally:
+            refresh_task.cancel()
+            try:
+                await refresh_task
+            except asyncio.CancelledError:
+                pass
             try:
                 await builder._konflux_client.delete_git_auth_secret(
                     namespace=self.konflux_namespace,
@@ -601,6 +609,9 @@ class KonfluxBundleCli:
         git_auth_secret = await builder._konflux_client.ensure_git_auth_secret(
             namespace=self.konflux_namespace,
         )
+        refresh_task = asyncio.create_task(
+            builder._konflux_client.token_refresh_loop(namespace=self.konflux_namespace)
+        )
 
         tasks = []
         for dgk, record in dgk_records.items():
@@ -633,6 +644,11 @@ class KonfluxBundleCli:
                 else:
                     successful_nvrs.append(result)
         finally:
+            refresh_task.cancel()
+            try:
+                await refresh_task
+            except asyncio.CancelledError:
+                pass
             try:
                 await builder._konflux_client.delete_git_auth_secret(
                     namespace=self.konflux_namespace,

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -311,9 +311,7 @@ class KonfluxBuildCli:
         git_auth_secret = await builder._konflux_client.ensure_git_auth_secret(
             namespace=self.konflux_namespace,
         )
-        refresh_task = asyncio.create_task(
-            builder._konflux_client.token_refresh_loop(namespace=self.konflux_namespace)
-        )
+        refresh_task = asyncio.create_task(builder._konflux_client.token_refresh_loop(namespace=self.konflux_namespace))
 
         tasks = []
         for image_meta in metas:
@@ -609,9 +607,7 @@ class KonfluxBundleCli:
         git_auth_secret = await builder._konflux_client.ensure_git_auth_secret(
             namespace=self.konflux_namespace,
         )
-        refresh_task = asyncio.create_task(
-            builder._konflux_client.token_refresh_loop(namespace=self.konflux_namespace)
-        )
+        refresh_task = asyncio.create_task(builder._konflux_client.token_refresh_loop(namespace=self.konflux_namespace))
 
         tasks = []
         for dgk, record in dgk_records.items():

--- a/doozer/tests/backend/test_konflux_client_git_auth.py
+++ b/doozer/tests/backend/test_konflux_client_git_auth.py
@@ -235,3 +235,67 @@ class TestDeleteGitAuthSecret(TestCase):
 
         client.corev1_client.delete_namespaced_secret.assert_not_called()
         self.assertIsNone(client._git_auth_secret_name)
+
+
+class TestRefreshGitAuthSecret(TestCase):
+    @patch("doozerlib.backend.konflux_client.get_github_app_token_for_org", return_value="ghp_refreshed_token")
+    def test_refreshes_secret_with_new_token(self, mock_token_fn):
+        client = _make_client()
+        secret_name = f"{_GIT_AUTH_SECRET_PREFIX}1700000000000000000"
+        client._git_auth_secret_name = secret_name
+
+        existing_secret = MagicMock()
+        existing_secret.data = {"username": base64.b64encode(b"x-access-token").decode(), "password": "old"}
+        existing_secret.metadata.annotations = {"art.openshift.io/created-at": "old-time"}
+        client.corev1_client.read_namespaced_secret.return_value = existing_secret
+
+        _run(client.refresh_git_auth_secret(namespace="test-ns"))
+
+        client.corev1_client.read_namespaced_secret.assert_called_once_with(
+            name=secret_name,
+            namespace="test-ns",
+            _request_timeout=client.request_timeout,
+        )
+        client.corev1_client.replace_namespaced_secret.assert_called_once()
+        call_kwargs = client.corev1_client.replace_namespaced_secret.call_args
+        body = call_kwargs.kwargs.get("body") or call_kwargs[1].get("body")
+        self.assertEqual(
+            base64.b64decode(body.data["password"]).decode(),
+            "ghp_refreshed_token",
+        )
+
+    def test_noop_when_no_secret(self):
+        client = _make_client()
+        self.assertIsNone(client._git_auth_secret_name)
+
+        _run(client.refresh_git_auth_secret(namespace="test-ns"))
+
+        client.corev1_client.read_namespaced_secret.assert_not_called()
+
+    def test_noop_for_static_fallback(self):
+        client = _make_client()
+        client._git_auth_secret_name = "pipelines-as-code-secret"
+
+        _run(client.refresh_git_auth_secret(namespace="test-ns"))
+
+        client.corev1_client.read_namespaced_secret.assert_not_called()
+
+    @patch("doozerlib.backend.konflux_client.get_github_app_token_for_org", return_value="ghp_refreshed_token")
+    def test_handles_404(self, mock_token_fn):
+        client = _make_client()
+        client._git_auth_secret_name = f"{_GIT_AUTH_SECRET_PREFIX}1700000000000000000"
+        client.corev1_client.read_namespaced_secret.side_effect = ApiException(status=404, reason="Not Found")
+
+        # Should not raise
+        _run(client.refresh_git_auth_secret(namespace="test-ns"))
+
+        client.corev1_client.replace_namespaced_secret.assert_not_called()
+
+    def test_dry_run_skips_refresh(self):
+        client = _make_client(dry_run=True)
+        client._git_auth_secret_name = f"{_GIT_AUTH_SECRET_PREFIX}1700000000000000000"
+
+        _run(client.refresh_git_auth_secret(namespace="test-ns"))
+
+        client.corev1_client.read_namespaced_secret.assert_not_called()
+        client.corev1_client.replace_namespaced_secret.assert_not_called()

--- a/doozer/tests/backend/test_konflux_client_git_auth.py
+++ b/doozer/tests/backend/test_konflux_client_git_auth.py
@@ -290,6 +290,7 @@ class TestRefreshGitAuthSecret(TestCase):
         _run(client.refresh_git_auth_secret(namespace="test-ns"))
 
         client.corev1_client.replace_namespaced_secret.assert_not_called()
+        self.assertIsNone(client._git_auth_secret_name)
 
     def test_dry_run_skips_refresh(self):
         client = _make_client(dry_run=True)

--- a/doozer/tests/cli/test_images_konflux.py
+++ b/doozer/tests/cli/test_images_konflux.py
@@ -80,6 +80,7 @@ class TestKonfluxBundleCli(unittest.IsolatedAsyncioTestCase):
         mock_rebaser_class.return_value = mock.Mock()
         mock_builder = mock.Mock()
         mock_builder._konflux_client.ensure_git_auth_secret = mock.AsyncMock(return_value="test-secret")
+        mock_builder._konflux_client.token_refresh_loop = mock.AsyncMock()
         mock_builder._konflux_client.delete_git_auth_secret = mock.AsyncMock()
         mock_builder._konflux_client.cleanup_stale_git_auth_secrets = mock.AsyncMock()
         mock_builder_class.return_value = mock_builder
@@ -107,6 +108,7 @@ class TestKonfluxBundleCli(unittest.IsolatedAsyncioTestCase):
         mock_rebaser_class.return_value = mock.Mock()
         mock_builder = mock.Mock()
         mock_builder._konflux_client.ensure_git_auth_secret = mock.AsyncMock(return_value="test-secret")
+        mock_builder._konflux_client.token_refresh_loop = mock.AsyncMock()
         mock_builder._konflux_client.delete_git_auth_secret = mock.AsyncMock()
         mock_builder._konflux_client.cleanup_stale_git_auth_secrets = mock.AsyncMock()
         mock_builder_class.return_value = mock_builder


### PR DESCRIPTION
## Summary
- GitHub App installation tokens expire after 1 hour, but Konflux PipelineRuns can sit in the Kueue queue longer than that, causing git-clone auth failures
- Adds a background asyncio refresh loop that re-mints the token and updates the K8s Secret in-place every 45 minutes
- Tekton reads Secret data at pod scheduling time, so all pending PipelineRuns automatically pick up the refreshed token
- Wired into all 4 call sites: image builds, OLM bundle builds, FBC merge, and FBC builds

## Test plan
- [x] Unit tests added for `refresh_git_auth_secret` (5 new tests covering refresh, no-op cases, 404 handling, dry-run)
- [x] All 18 git-auth tests pass
- [x] Lint passes
- [ ] Integration: trigger a Konflux build and verify refresh loop logs appear at 45-min intervals
- [ ] Verify builds queued >1 hour succeed with git-clone auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)