### PR TITLE
ART-16005: Add disabled context to IntegrationTestScenario manifests

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -786,6 +786,13 @@ class KonfluxClient:
             },
             "spec": {
                 "application": application_name,
+                "contexts": [
+                    {
+                        "name": "disabled",
+                        "description": "disables the execution of the given integration test "
+                        "if it's the only context that's defined",
+                    },
+                ],
                 "params": [
                     {"name": "POLICY_CONFIGURATION", "value": policy_configuration},
                     {"name": "SINGLE_COMPONENT", "value": "true"},

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -125,7 +125,10 @@ class TestNewIntegrationTestScenario(TestCase):
         self.assertEqual(owner_refs[0]["name"], "openshift-4-21")
         self.assertEqual(owner_refs[0]["uid"], "test-uid-1234")
 
-        # spec
+        # spec - contexts must include disabled to prevent automatic EC runs
+        self.assertEqual(len(manifest["spec"]["contexts"]), 1)
+        self.assertEqual(manifest["spec"]["contexts"][0]["name"], "disabled")
+
         self.assertEqual(manifest["spec"]["application"], "openshift-4-21")
         params = {p["name"]: p["value"] for p in manifest["spec"]["params"]}
         self.assertEqual(params["POLICY_CONFIGURATION"], "rhtap-releng-tenant/registry-ocp-art-stage")


### PR DESCRIPTION
## Summary
- Add `contexts: [{name: disabled}]` to IntegrationTestScenario (ITS) manifests in `_new_integration_test_scenario()`
- Without this, Konflux runs EC checks automatically on every new build, adding unnecessary load to the cluster
- The disabled context prevents automatic execution when it is the only context defined

## Changes
- `doozer/doozerlib/backend/konflux_client.py` — add `contexts` field to ITS manifest
- `doozer/tests/backend/test_konflux_client.py` — add test verifying the disabled context is present

## Test plan
- [x] All 22 konflux_client tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)