### PR TITLE
fix(lockfile): preserve NVR-pinned RPMs in hermetic lockfile generation

### DIFF
--- a/doozer/doozerlib/lockfile.py
+++ b/doozer/doozerlib/lockfile.py
@@ -276,9 +276,12 @@ class RpmInfoCollector:
         """
         Resolve RPM metadata for a specific architecture from the given repodata names.
 
-        For each package, the highest version across ALL repos is selected (matching dnf
-        behaviour). When the same EVR exists in multiple repos, the repo iteration order
-        from ``sort_repos_for_lockfile_resolution`` acts as tiebreaker (RHEL upstream repos
+        For plain package names the highest version across ALL repos is selected (matching
+        dnf behaviour).  For NVR-pinned items the exact requested version is preserved in
+        the output so that hermetic builds can install a specific older version.
+
+        When the same EVR exists in multiple repos, the repo iteration order from
+        ``sort_repos_for_lockfile_resolution`` acts as tiebreaker (RHEL upstream repos
         are preferred over rhocp plashets).
 
         Args:
@@ -289,10 +292,14 @@ class RpmInfoCollector:
         Returns:
             list[RpmInfo]: Resolved RPM package metadata.
         """
-        # best_by_name tracks the highest-version RpmInfo seen so far per package name.
-        # Iteration order (RHEL first) ensures that when two repos carry the same EVR
-        # the upstream RHEL entry is kept.
+        nvr_to_name: dict[str, str] = {}
+        for item in rpm_names:
+            is_nvr, pkg_name = Repodata._detect_nvr_vs_name(item)
+            if is_nvr:
+                nvr_to_name[item] = pkg_name
+
         best_by_name: dict[str, RpmInfo] = {}
+        pinned_by_nvr: dict[str, RpmInfo] = {}
         resolved_items: set[str] = set()
 
         for repo_name in sort_repos_for_lockfile_resolution(repo_names):
@@ -319,6 +326,11 @@ class RpmInfoCollector:
             baseurl = repo.baseurl(repotype="unsigned", arch=arch)
             for rpm in found_rpms:
                 info = RpmInfo.from_rpm(rpm, repoid=content_set_id, baseurl=baseurl)
+
+                for nvr_str, pkg_name in nvr_to_name.items():
+                    if rpm.name == pkg_name and rpm.nvr == nvr_str and nvr_str not in pinned_by_nvr:
+                        pinned_by_nvr[nvr_str] = info
+
                 existing = best_by_name.get(rpm.name)
                 if existing is None or info > existing:
                     best_by_name[rpm.name] = info
@@ -329,7 +341,13 @@ class RpmInfoCollector:
                 f"Could not find {','.join(sorted(missing))} in {', '.join(repo_names)} for arch {arch}"
             )
 
-        return sorted(best_by_name.values())
+        results: dict[tuple[str, str], RpmInfo] = {}
+        for info in best_by_name.values():
+            results[(info.name, info.evr)] = info
+        for info in pinned_by_nvr.values():
+            results[(info.name, info.evr)] = info
+
+        return sorted(results.values())
 
     @start_as_current_span_async(TRACER, "lockfile.fetch_rpms_info")
     async def fetch_rpms_info(

--- a/doozer/doozerlib/repodata.py
+++ b/doozer/doozerlib/repodata.py
@@ -228,7 +228,8 @@ class Repodata:
 
         return found_rpms, sorted(not_found)
 
-    def _detect_nvr_vs_name(self, item: str) -> Tuple[bool, str]:
+    @staticmethod
+    def _detect_nvr_vs_name(item: str) -> Tuple[bool, str]:
         """
         Detect if input item is an NVR or a package name.
 

--- a/doozer/tests/test_lockfile.py
+++ b/doozer/tests/test_lockfile.py
@@ -466,6 +466,207 @@ class TestRpmInfoCollectorFetchRpms(unittest.TestCase):
         self.assertEqual(result[0].evr, '0:252-32.el9_4')
         self.assertEqual(result[0].repoid, 'baseos-cs')
 
+    def test_fetch_rpms_preserves_nvr_pin_alongside_latest(self):
+        """When both a plain name and a pinned NVR are requested, the lockfile must contain both versions."""
+        arches = ['x86_64']
+        repo_data = {
+            "rhel-9-appstream-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/appstream/"}},
+                "content_set": {"default": "appstream-cs"},
+                "reposync": {"enabled": False},
+            },
+        }
+        repos = Repos(repo_data, arches=arches)
+        collector = RpmInfoCollector(repos=repos)
+        collector.logger = MagicMock()
+
+        pinned_rpm = Rpm(
+            name="rust-toolset",
+            epoch=0,
+            version="1.84.1",
+            checksum="pinned",
+            size=100,
+            location="/rust-toolset-1.84.1.rpm",
+            sourcerpm="rust-toolset.src.rpm",
+            release="1.el9",
+            arch="x86_64",
+        )
+        latest_rpm = Rpm(
+            name="rust-toolset",
+            epoch=0,
+            version="1.85.0",
+            checksum="latest",
+            size=110,
+            location="/rust-toolset-1.85.0.rpm",
+            sourcerpm="rust-toolset.src.rpm",
+            release="1.el9",
+            arch="x86_64",
+        )
+        arch = 'x86_64'
+        repodata = MagicMock()
+        repodata.get_rpms.return_value = ([pinned_rpm, latest_rpm], [])
+        collector.loaded_repos[f"rhel-9-appstream-rpms-{arch}"] = repodata
+
+        result = collector._fetch_rpms_info_per_arch(
+            {'rust-toolset', 'rust-toolset-1.84.1-1.el9'},
+            set(repo_data.keys()),
+            arch,
+        )
+        result_evrs = {r.evr for r in result}
+        self.assertIn('0:1.84.1-1.el9', result_evrs)
+        self.assertIn('0:1.85.0-1.el9', result_evrs)
+        self.assertEqual(len(result), 2)
+
+    def test_fetch_rpms_preserves_nvr_pin_across_repos(self):
+        """Pinned NVR from rhocp and latest from RHEL must both appear in the lockfile."""
+        arches = ['x86_64']
+        repo_data = {
+            "rhel-9-appstream-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/appstream/"}},
+                "content_set": {"default": "appstream-cs"},
+                "reposync": {"enabled": False},
+            },
+            "rhocp-4.16-for-rhel-9-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/rhocp/"}},
+                "content_set": {"default": "rhocp-cs"},
+                "reposync": {"enabled": False},
+            },
+        }
+        repos = Repos(repo_data, arches=arches)
+        collector = RpmInfoCollector(repos=repos)
+        collector.logger = MagicMock()
+
+        pinned_rpm = Rpm(
+            name="rust-toolset",
+            epoch=0,
+            version="1.84.1",
+            checksum="pinned",
+            size=100,
+            location="/rust-toolset-1.84.1.rpm",
+            sourcerpm="rust-toolset.src.rpm",
+            release="1.el9",
+            arch="x86_64",
+        )
+        latest_rpm = Rpm(
+            name="rust-toolset",
+            epoch=0,
+            version="1.85.0",
+            checksum="latest",
+            size=110,
+            location="/rust-toolset-1.85.0.rpm",
+            sourcerpm="rust-toolset.src.rpm",
+            release="1.el9",
+            arch="x86_64",
+        )
+        arch = 'x86_64'
+
+        appstream_repodata = MagicMock()
+        appstream_repodata.get_rpms.return_value = ([latest_rpm], ['rust-toolset-1.84.1-1.el9'])
+
+        rhocp_repodata = MagicMock()
+        rhocp_repodata.get_rpms.return_value = ([pinned_rpm, latest_rpm], [])
+
+        collector.loaded_repos[f"rhel-9-appstream-rpms-{arch}"] = appstream_repodata
+        collector.loaded_repos[f"rhocp-4.16-for-rhel-9-rpms-{arch}"] = rhocp_repodata
+
+        result = collector._fetch_rpms_info_per_arch(
+            {'rust-toolset', 'rust-toolset-1.84.1-1.el9'},
+            set(repo_data.keys()),
+            arch,
+        )
+        result_evrs = {r.evr for r in result}
+        self.assertIn('0:1.84.1-1.el9', result_evrs)
+        self.assertIn('0:1.85.0-1.el9', result_evrs)
+        self.assertEqual(len(result), 2)
+
+    def test_fetch_rpms_solo_nvr_pin_preserved(self):
+        """A sole NVR pin (no plain name counterpart) must appear even when a newer version exists."""
+        arches = ['x86_64']
+        repo_data = {
+            "rhel-9-appstream-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/appstream/"}},
+                "content_set": {"default": "appstream-cs"},
+                "reposync": {"enabled": False},
+            },
+        }
+        repos = Repos(repo_data, arches=arches)
+        collector = RpmInfoCollector(repos=repos)
+        collector.logger = MagicMock()
+
+        pinned_rpm = Rpm(
+            name="rust-toolset",
+            epoch=0,
+            version="1.84.1",
+            checksum="pinned",
+            size=100,
+            location="/rust-toolset-1.84.1.rpm",
+            sourcerpm="rust-toolset.src.rpm",
+            release="1.el9",
+            arch="x86_64",
+        )
+        latest_rpm = Rpm(
+            name="rust-toolset",
+            epoch=0,
+            version="1.85.0",
+            checksum="latest",
+            size=110,
+            location="/rust-toolset-1.85.0.rpm",
+            sourcerpm="rust-toolset.src.rpm",
+            release="1.el9",
+            arch="x86_64",
+        )
+        arch = 'x86_64'
+        repodata = MagicMock()
+        repodata.get_rpms.return_value = ([pinned_rpm, latest_rpm], [])
+        collector.loaded_repos[f"rhel-9-appstream-rpms-{arch}"] = repodata
+
+        result = collector._fetch_rpms_info_per_arch(
+            {'rust-toolset-1.84.1-1.el9'},
+            set(repo_data.keys()),
+            arch,
+        )
+        result_evrs = {r.evr for r in result}
+        self.assertIn('0:1.84.1-1.el9', result_evrs)
+        self.assertEqual(len(result), 2)
+
+    def test_fetch_rpms_nvr_pin_deduplicates_when_pinned_is_latest(self):
+        """When the pinned NVR IS the latest version, only one entry should appear (no duplicate)."""
+        arches = ['x86_64']
+        repo_data = {
+            "rhel-9-appstream-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/appstream/"}},
+                "content_set": {"default": "appstream-cs"},
+                "reposync": {"enabled": False},
+            },
+        }
+        repos = Repos(repo_data, arches=arches)
+        collector = RpmInfoCollector(repos=repos)
+        collector.logger = MagicMock()
+
+        the_rpm = Rpm(
+            name="rust-toolset",
+            epoch=0,
+            version="1.84.1",
+            checksum="only",
+            size=100,
+            location="/rust-toolset-1.84.1.rpm",
+            sourcerpm="rust-toolset.src.rpm",
+            release="1.el9",
+            arch="x86_64",
+        )
+        arch = 'x86_64'
+        repodata = MagicMock()
+        repodata.get_rpms.return_value = ([the_rpm], [])
+        collector.loaded_repos[f"rhel-9-appstream-rpms-{arch}"] = repodata
+
+        result = collector._fetch_rpms_info_per_arch(
+            {'rust-toolset', 'rust-toolset-1.84.1-1.el9'},
+            set(repo_data.keys()),
+            arch,
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].evr, '0:1.84.1-1.el9')
+
     def test_load_repos_skips_already_loaded(self):
         # Simulate that both repos are already loaded
         already_loaded = {f"{name}-x86_64" for name in self.repo_names}


### PR DESCRIPTION
PR #2746 introduced a highest-EVR-per-package-name strategy in _fetch_rpms_info_per_arch that silently discarded NVR-pinned RPMs (e.g. rust-toolset-1.84.1-1.el9) when a newer version existed, causing hermetic builds to fail for images like logging vector that pin specific toolchain versions.

Add a second tracking dict (pinned_by_nvr) alongside best_by_name so that explicitly pinned NVR entries are always included in the lockfile output. Plain package names still resolve to the highest EVR across all repos (preserving the runc/systemd-udev fix from #2746). The two dicts are merged with (name, evr) deduplication to avoid duplicates when the pinned version happens to also be the latest.

Also convert Repodata._detect_nvr_vs_name to @staticmethod so lockfile.py can call it without a Repodata instance.

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED