### PR TITLE
WIP Autoselect valid olm build

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -8,6 +8,8 @@ RHCOS_RELEASES_STREAM_URL = (
 )
 BREW_HUB = "https://brewhub.engineering.redhat.com/brewhub"
 BREW_DOWNLOAD_URL = "https://download.devel.redhat.com/brewroot"
+# Brew image proxy used by OLM bundle rebasing / reference resolution
+REGISTRY_PROXY_BASE_URL = "registry-proxy.engineering.redhat.com"
 RELEASE_SCHEDULES = "https://pp.engineering.redhat.com/api/v7/releases"
 DEFAULT_PLASHET_BASE_URL = "https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets"
 

--- a/artcommon/artcommonlib/metadata.py
+++ b/artcommon/artcommonlib/metadata.py
@@ -8,7 +8,13 @@ from typing import Any
 from artcommonlib import logutil
 from artcommonlib.assembly import assembly_basis_event, assembly_metadata_config
 from artcommonlib.brew import BuildStates
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBuildRecord
+from artcommonlib.konflux.konflux_build_record import (
+    ArtifactType,
+    Engine,
+    KonfluxBuildOutcome,
+    KonfluxBuildRecord,
+)
+from artcommonlib.konflux.konflux_db import LARGE_COLUMNS
 from artcommonlib.model import Missing, Model
 from artcommonlib.util import isolate_el_version_in_brew_tag
 from artcommonlib.variants import BuildVariant
@@ -569,6 +575,111 @@ class MetadataBase(object):
             )
             return default
         return build_record
+
+    async def list_konflux_success_build_candidates(
+        self,
+        *,
+        el_target: int | str | None = None,
+        assembly: str | None = None,
+        honor_is: bool = True,
+        outcome: KonfluxBuildOutcome = KonfluxBuildOutcome.SUCCESS,
+        completed_before: datetime.datetime | None = None,
+        extra_patterns: dict | None = None,
+        exclude_large_columns: bool = False,
+        limit: int = 25,
+    ) -> list[KonfluxBuildRecord]:
+        """
+        Return up to ``limit`` successful Konflux image builds newest-first, for OLM validation / find-builds.
+
+        Honors the same query_group, el_target, assembly, and completed_before semantics as
+        :meth:`get_latest_konflux_build`. Pinned ``is:`` images return at most that single build.
+        """
+        assert self.runtime.konflux_db is not None, 'Konflux DB must be initialized with GCP credentials'
+        self.runtime.konflux_db.bind(KonfluxBuildRecord)
+
+        if self.meta_type != 'image':
+            return []
+
+        extra_patterns = extra_patterns or {}
+
+        if honor_is and self.config['is']:
+            if outcome != KonfluxBuildOutcome.SUCCESS:
+                return []
+            pinned = await self.get_pinned_konflux_build(el_target=el_target)
+            return [pinned] if pinned else []
+
+        query_group = self.runtime.group
+        is_okd = False
+        runtime_variant = getattr(self.runtime, 'variant', None)
+        if runtime_variant == BuildVariant.OKD:
+            query_group = self.runtime.group.replace('openshift-', 'okd-')
+            is_okd = True
+            self.logger.debug("Using OKD group '%s' for OKD variant scan of %s", query_group, self.distgit_key)
+        elif self.mode == 'disabled':
+            if self.config.okd is not Missing and self.config.okd.mode == 'enabled':
+                is_okd = True
+                query_group = self.runtime.group.replace('openshift-', 'okd-')
+                self.logger.debug("Using OKD group '%s' for okd-only image %s", query_group, self.distgit_key)
+
+        el_val: str | None
+        if el_target and isinstance(el_target, int):
+            el_val = f'scos{el_target}' if is_okd else f'el{el_target}'
+        elif el_target:
+            el_val = str(el_target)
+        else:
+            el_prefix = 'scos' if is_okd else 'el'
+            el_val = f'{el_prefix}{self.branch_el_target()}'
+
+        assembly = assembly if assembly else self.runtime.assembly
+        effective_assemblies: list[str | None]
+        if not assembly:
+            effective_assemblies = [None]
+        else:
+            if assembly_basis_event(self.runtime.get_releases_config(), assembly=assembly, build_system='konflux'):
+                effective_assemblies = ['stream']
+            else:
+                effective_assemblies = [assembly]
+                if assembly != 'stream':
+                    effective_assemblies.append('stream')
+
+        exclude_columns = LARGE_COLUMNS if exclude_large_columns else None
+        per_asm_limit = max(limit, 1)
+
+        merged: list[KonfluxBuildRecord] = []
+        seen: set[str] = set()
+
+        for asm in effective_assemblies:
+            where: dict = {
+                'name': self.distgit_key,
+                'group': query_group,
+                'outcome': outcome,
+                'engine': Engine(self.runtime.build_system),
+                'artifact_type': ArtifactType.IMAGE,
+                'el_target': el_val,
+            }
+            if asm is not None:
+                where['assembly'] = asm
+            count = 0
+            async for row in self.runtime.konflux_db.search_builds_by_fields(
+                end_search=completed_before,
+                where=where,
+                extra_patterns=extra_patterns or None,
+                order_by='start_time',
+                sorting='DESC',
+                limit=per_asm_limit,
+                exclude_columns=exclude_columns,
+            ):
+                if row.nvr in seen:
+                    continue
+                seen.add(row.nvr)
+                merged.append(row)
+                count += 1
+                if count >= per_asm_limit:
+                    break
+
+        epoch = datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc)
+        merged.sort(key=lambda r: r.start_time or epoch, reverse=True)
+        return merged[:limit]
 
     async def get_latest_brew_build_async(self, **kwargs):
         return await asyncio.to_thread(self.get_latest_brew_build, **kwargs)

--- a/artcommon/artcommonlib/olm/__init__.py
+++ b/artcommon/artcommonlib/olm/__init__.py
@@ -1,0 +1,11 @@
+from artcommonlib.olm.operator_image_refs import (
+    replace_olm_manifest_image_references,
+    validate_olm_bundle_dir_yaml_files,
+    validate_olm_manifest_image_references,
+)
+
+__all__ = [
+    'replace_olm_manifest_image_references',
+    'validate_olm_manifest_image_references',
+    'validate_olm_bundle_dir_yaml_files',
+]

--- a/artcommon/artcommonlib/olm/operator_image_refs.py
+++ b/artcommon/artcommonlib/olm/operator_image_refs.py
@@ -1,0 +1,227 @@
+"""
+Shared OLM operator manifest image reference handling.
+
+Used by doozer KonfluxOlmBundleRebaser and by elliott find-builds validation so behavior stays aligned.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import glob
+import logging
+import os
+import re
+from functools import lru_cache
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import yaml
+from artcommonlib.constants import REGISTRY_PROXY_BASE_URL
+from artcommonlib.konflux.konflux_build_record import Engine
+from artcommonlib.model import Missing
+from artcommonlib.util import oc_image_info_for_arch_async
+
+LOGGER = logging.getLogger(__name__)
+
+
+@lru_cache
+def get_image_reference_pattern(registry: str) -> re.Pattern:
+    """Match `registry/namespace/image:tag` style references for the given registry host."""
+    pattern = r'{}\/([^:]+):([^\'"\\\s]+)'.format(re.escape(registry))
+    return re.compile(pattern)
+
+
+def get_digest_image_pattern() -> re.Pattern:
+    """Match digest-pinned references: registry/path@sha256:hexdigest."""
+    pattern = r'([a-zA-Z0-9][-a-zA-Z0-9.]*(?::[0-9]+)?/[^@\s]+)@(sha256:[a-fA-F0-9]{64})'
+    return re.compile(pattern)
+
+
+def load_delivery_repo_override_map(data_dir: str, logger: Optional[logging.Logger] = None) -> Dict[str, str]:
+    """Short-name map for delivery_repo_name_override (same logic as KonfluxOlmBundleRebaser)."""
+    log = logger or LOGGER
+    delivery_override_map: Dict[str, str] = {}
+    for _yml_path in glob.glob(f"{data_dir}/images/*.yml") + glob.glob(f"{data_dir}/images/*.yaml"):
+        try:
+            with open(_yml_path) as _yf:
+                _img_data = yaml.safe_load(_yf)
+            if not isinstance(_img_data, dict):
+                continue
+            _delivery = _img_data.get('delivery', {}) or {}
+            if not _delivery.get('delivery_repo_name_override'):
+                continue
+            _repo_names = _delivery.get('delivery_repo_names') or []
+            if len(_repo_names) != 1:
+                raise IOError(
+                    f"delivery_repo_name_override is set in {_yml_path} but delivery_repo_names has "
+                    f"{len(_repo_names)} entries (expected exactly 1)"
+                )
+            _img_short = str(_img_data.get('name', '')).rsplit('/', 1)[-1]
+            _override_short = str(_repo_names[0]).rsplit('/', 1)[-1]
+            delivery_override_map[_img_short] = _override_short
+        except (yaml.YAMLError, OSError) as e:
+            log.debug("Failed to parse image YAML %s: %s", _yml_path, e)
+    return delivery_override_map
+
+
+def _operator_image_ref_mode(group_config: Any) -> str:
+    # Prefer Model.get (matches KonfluxOlmBundleRebaser / MagicMock tests) over bare attribute access.
+    if hasattr(group_config, 'get'):
+        mode = group_config.get('operator_image_ref_mode', Missing)
+        if mode not in (Missing, None, ''):
+            return str(mode)
+    mode = getattr(group_config, 'operator_image_ref_mode', Missing)
+    if mode not in (Missing, None, ''):
+        return str(mode)
+    return 'manifest-list'
+
+
+def _csv_namespace(group_config: Any) -> str:
+    if hasattr(group_config, 'get'):
+        ns = group_config.get('csv_namespace', 'openshift')
+        if ns not in (Missing, None, ''):
+            return str(ns)
+    ns = getattr(group_config, 'csv_namespace', Missing)
+    if ns not in (Missing, None, ''):
+        return str(ns)
+    return 'openshift'
+
+
+async def replace_olm_manifest_image_references(
+    old_registry: str,
+    content: str,
+    engine: Engine,
+    metadata: Any,
+    group_config: Any,
+    image_repo: str,
+    logger: Optional[logging.Logger] = None,
+) -> Tuple[str, Dict[str, Tuple[str, str, str]]]:
+    """
+    Replace image references in YAML-ish content the same way KonfluxOlmBundleRebaser did historically.
+
+    Returns (new_content, found_images) where found_images maps short name to
+    (old_pullspec, new_pullspec, nvr_or_external).
+    """
+    log = logger or LOGGER
+    new_content = content
+    found_images: Dict[str, Tuple[str, str, str]] = {}
+
+    pattern = get_image_reference_pattern(old_registry)
+    matches = pattern.finditer(content)
+    art_references: Dict[str, Tuple[str, str, str]] = {}
+    for match in matches:
+        pullspec = match.group(0)
+        namespace, image_short_name = match.group(1).rsplit('/', maxsplit=1)
+        image_tag = match.group(2)
+        art_references[pullspec] = (namespace, image_short_name, image_tag)
+
+    image_info_tasks: List[asyncio.Task] = []
+    for pullspec, (namespace, image_short_name, image_tag) in art_references.items():
+        if engine is Engine.KONFLUX:
+            build_pullspec = f"{image_repo}:{image_short_name}-{image_tag}"
+            image_info_tasks.append(
+                asyncio.create_task(
+                    oc_image_info_for_arch_async(
+                        build_pullspec,
+                        registry_config=os.getenv("QUAY_AUTH_FILE"),
+                    )
+                )
+            )
+        elif engine is Engine.BREW:
+            build_pullspec = f"{REGISTRY_PROXY_BASE_URL}/rh-osbs/{namespace}-{image_short_name}:{image_tag}"
+            image_info_tasks.append(
+                asyncio.create_task(
+                    oc_image_info_for_arch_async(
+                        build_pullspec,
+                    )
+                )
+            )
+        else:
+            raise ValueError(f"Unsupported engine {engine!r} for OLM image reference replacement")
+
+    image_infos = await asyncio.gather(*image_info_tasks)
+
+    csv_namespace = _csv_namespace(group_config)
+    ref_mode = _operator_image_ref_mode(group_config)
+    data_dir = metadata.runtime.data_dir
+    delivery_override_map = load_delivery_repo_override_map(data_dir, logger=log)
+
+    for pullspec, image_info in zip(art_references, image_infos):
+        image_labels = image_info['config']['config']['Labels']
+        image_version = image_labels['version']
+        image_release = image_labels['release']
+        image_component_name = image_labels['com.redhat.component']
+        image_nvr = f"{image_component_name}-{image_version}-{image_release}"
+        namespace, image_short_name, image_tag = art_references[pullspec]
+        image_sha = image_info['contentDigest'] if ref_mode == 'by-arch' else image_info['listDigest']
+        ocp_group = metadata.runtime.group
+        if not ocp_group.startswith("openshift-"):
+            new_namespace = namespace
+        else:
+            new_namespace = 'openshift4' if namespace == csv_namespace else namespace
+        delivery_image_short_name = delivery_override_map.get(image_short_name, image_short_name)
+        new_pullspec = '{}/{}@{}'.format(
+            'registry.redhat.io',
+            f'{new_namespace}/{delivery_image_short_name}',
+            image_sha,
+        )
+        new_content = new_content.replace(pullspec, new_pullspec)
+        found_images[delivery_image_short_name] = (pullspec, new_pullspec, image_nvr)
+
+    digest_pattern = get_digest_image_pattern()
+    for match in digest_pattern.finditer(new_content):
+        image_path = match.group(1)
+        digest = match.group(2)
+        pullspec = f"{image_path}@{digest}"
+        image_short_name = image_path.rsplit('/', 1)[-1]
+        if image_short_name in found_images:
+            continue
+        found_images[image_short_name] = (pullspec, pullspec, "external")
+        log.debug("Found digest-pinned external image: %s", pullspec)
+
+    return new_content, found_images
+
+
+async def validate_olm_manifest_image_references(
+    old_registry: str,
+    content: str,
+    engine: Engine,
+    metadata: Any,
+    group_config: Any,
+    image_repo: str,
+    logger: Optional[logging.Logger] = None,
+) -> Tuple[bool, Optional[str]]:
+    """
+    Return (True, None) if replace_olm_manifest_image_references would succeed for this content.
+
+    On failure return (False, human-readable reason).
+    """
+    try:
+        await replace_olm_manifest_image_references(
+            old_registry, content, engine, metadata, group_config, image_repo, logger=logger
+        )
+        return True, None
+    except (KeyError, TypeError) as e:
+        return False, f"missing image metadata field: {e}"
+    except Exception as e:  # noqa: BLE001 — surface oc failures and YAML edge cases
+        return False, str(e)
+
+
+async def validate_olm_bundle_dir_yaml_files(
+    files: Iterable[Tuple[str, str]],
+    old_registry: str,
+    engine: Engine,
+    metadata: Any,
+    group_config: Any,
+    image_repo: str,
+    logger: Optional[logging.Logger] = None,
+) -> Tuple[bool, Optional[str]]:
+    """
+    Validate each (relative_path, file_content) tuple; fail fast on first invalid file.
+    """
+    for rel_path, content in files:
+        ok, err = await validate_olm_manifest_image_references(
+            old_registry, content, engine, metadata, group_config, image_repo, logger=logger
+        )
+        if not ok:
+            return False, f"{rel_path}: {err}"
+    return True, None

--- a/artcommon/tests/test_olm_operator_image_refs.py
+++ b/artcommon/tests/test_olm_operator_image_refs.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from artcommonlib.konflux.konflux_build_record import Engine
+from artcommonlib.olm.operator_image_refs import (
+    replace_olm_manifest_image_references,
+    validate_olm_manifest_image_references,
+)
+
+
+class TestOlmOperatorImageRefs(unittest.IsolatedAsyncioTestCase):
+    @patch("artcommonlib.olm.operator_image_refs.oc_image_info_for_arch_async", new_callable=AsyncMock)
+    async def test_replace_resolves_tag_reference(self, mock_oc):
+        mock_oc.return_value = {
+            'config': {
+                'config': {
+                    'Labels': {
+                        'com.redhat.component': 'test-brew-component',
+                        'version': '1.0',
+                        'release': '1',
+                    },
+                },
+            },
+            'listDigest': 'sha256:1234567890abcdef',
+            'contentDigest': 'sha256:abcdef1234567890',
+        }
+        group_config = {'csv_namespace': 'namespace'}
+        metadata = MagicMock()
+        metadata.runtime.group = "openshift-4.19"
+        metadata.runtime.data_dir = "/tmp/nonexistent-art-data"
+
+        content = """
+        image: registry.example.com/namespace/image:tag
+        """
+        new_content, found = await replace_olm_manifest_image_references(
+            "registry.example.com",
+            content,
+            Engine.KONFLUX,
+            metadata,
+            group_config,
+            "quay.io/example/art-images",
+        )
+        self.assertIn("registry.redhat.io/openshift4/image@sha256:1234567890abcdef", new_content)
+        self.assertIn("image", found)
+
+    @patch("artcommonlib.olm.operator_image_refs.replace_olm_manifest_image_references", new_callable=AsyncMock)
+    async def test_validate_delegates_to_replace(self, mock_replace):
+        mock_replace.side_effect = ValueError("simulated oc failure")
+        ok, err = await validate_olm_manifest_image_references(
+            "r.io",
+            "x",
+            Engine.KONFLUX,
+            MagicMock(),
+            MagicMock(),
+            "quay.io/x/art-images",
+        )
+        self.assertFalse(ok)
+        self.assertIn("simulated oc failure", err or "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -2,10 +2,9 @@ import asyncio
 import glob
 import logging
 import os
-import re
 import shutil
 from datetime import datetime, timezone
-from functools import cached_property, lru_cache
+from functools import cached_property
 from pathlib import Path
 from typing import Dict, Optional, Sequence, Tuple, cast
 
@@ -23,9 +22,10 @@ from artcommonlib.konflux.konflux_build_record import (
 )
 from artcommonlib.konflux.konflux_db import Engine, KonfluxDb
 from artcommonlib.model import Model
+from artcommonlib.olm import operator_image_refs as olm_image_refs
 from artcommonlib.util import sync_to_quay
 from dockerfile_parse import DockerfileParser
-from doozerlib import constants, util
+from doozerlib import constants
 from doozerlib.backend.build_repo import BuildRepo
 from doozerlib.backend.konflux_client import KonfluxClient
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
@@ -347,25 +347,14 @@ class KonfluxOlmBundleRebaser:
         async with aiofiles.open(oit_dir / 'olm_bundle_info.yaml', 'w') as f:
             await f.write(content)
 
-    @lru_cache
     @staticmethod
     def _get_image_reference_pattern(registry: str):
-        """Get a compiled regex pattern to match image references in the format of `registry/namespace/image:tag`."""
-        pattern = r'{}\/([^:]+):([^\'"\\\s]+)'.format(re.escape(registry))
-        return re.compile(pattern)
+        """Delegate to artcommon OLM helpers (kept for tests and callers)."""
+        return olm_image_refs.get_image_reference_pattern(registry)
 
     @staticmethod
     def _get_digest_image_pattern():
-        """Get a compiled regex pattern to match digest-pinned image references.
-
-        Matches images in the format: registry/namespace/image@sha256:digest
-        Examples:
-            - registry.redhat.io/rhel9/postgresql-15@sha256:abc123...
-            - quay.io/openshift/image@sha256:def456...
-        """
-        # Match: registry/path@sha256:hexdigest
-        pattern = r'([a-zA-Z0-9][-a-zA-Z0-9.]*(?::[0-9]+)?/[^@\s]+)@(sha256:[a-fA-F0-9]{64})'
-        return re.compile(pattern)
+        return olm_image_refs.get_digest_image_pattern()
 
     async def _replace_image_references(self, old_registry: str, content: str, engine: Engine, metadata):
         """
@@ -378,121 +367,15 @@ class KonfluxOlmBundleRebaser:
         2. Digest-pinned images (e.g., registry.redhat.io/rhel9/postgresql-15@sha256:...)
            - These are already pinned and are included in found_images without modification
         """
-        new_content = content
-        found_images: Dict[str, Tuple[str, str, str]] = {}
-
-        # Step 1: Find and process ART-built images matching the registry pattern
-        pattern = KonfluxOlmBundleRebaser._get_image_reference_pattern(old_registry)
-        matches = pattern.finditer(content)
-        art_references = {}  # map of image pullspec to (namespace, image_short_name, image_tag)
-        image_info_tasks = []
-        for match in matches:
-            pullspec = match.group(0)
-            namespace, image_short_name = match.group(1).rsplit('/', maxsplit=1)
-            image_tag = match.group(2)
-            art_references[pullspec] = (namespace, image_short_name, image_tag)
-
-        # Get image infos for ART-built images
-        for pullspec, (namespace, image_short_name, image_tag) in art_references.items():
-            if engine is Engine.KONFLUX:
-                build_pullspec = f"{self.image_repo}:{image_short_name}-{image_tag}"
-                image_info_tasks.append(
-                    asyncio.create_task(
-                        util.oc_image_info_for_arch_async(
-                            build_pullspec,
-                            registry_config=os.getenv("QUAY_AUTH_FILE"),
-                        )
-                    )
-                )
-            elif engine is Engine.BREW:
-                build_pullspec = (
-                    f"{constants.REGISTRY_PROXY_BASE_URL}/rh-osbs/{namespace}-{image_short_name}:{image_tag}"
-                )
-                image_info_tasks.append(
-                    asyncio.create_task(
-                        util.oc_image_info_for_arch_async(
-                            build_pullspec,
-                        )
-                    )
-                )
-        image_infos = await asyncio.gather(*image_info_tasks)
-
-        # Replace ART-built image references in the content
-        csv_namespace = self._group_config.get('csv_namespace', 'openshift')
-        # Build a map of image short name -> delivery override short name for images that have
-        # delivery_repo_name_override set. This allows operators to reference images using a
-        # versioned internal name (e.g. ose-csi-livenessprobe-4.18-rhel9) while having them
-        # replaced with the preferred unversioned delivery repo name (e.g. ose-csi-livenessprobe-rhel9).
-        _delivery_override_map: Dict[str, str] = {}
-        _data_dir = metadata.runtime.data_dir
-        for _yml_path in glob.glob(f"{_data_dir}/images/*.yml") + glob.glob(f"{_data_dir}/images/*.yaml"):
-            try:
-                with open(_yml_path) as _yf:
-                    _img_data = yaml.safe_load(_yf)
-                if not isinstance(_img_data, dict):
-                    continue
-                _delivery = _img_data.get('delivery', {}) or {}
-                if not _delivery.get('delivery_repo_name_override'):
-                    continue
-                _repo_names = _delivery.get('delivery_repo_names') or []
-                if len(_repo_names) != 1:
-                    raise IOError(
-                        f"delivery_repo_name_override is set in {_yml_path} but delivery_repo_names has "
-                        f"{len(_repo_names)} entries (expected exactly 1)"
-                    )
-                _img_short = str(_img_data.get('name', '')).rsplit('/', 1)[-1]
-                _override_short = str(_repo_names[0]).rsplit('/', 1)[-1]
-                _delivery_override_map[_img_short] = _override_short
-            except (yaml.YAMLError, OSError) as e:
-                self._logger.debug("Failed to parse image YAML %s: %s", _yml_path, e)
-        for pullspec, image_info in zip(art_references, image_infos):
-            image_labels = image_info['config']['config']['Labels']
-            image_version = image_labels['version']
-            image_release = image_labels['release']
-            image_component_name = image_labels['com.redhat.component']
-            image_nvr = f"{image_component_name}-{image_version}-{image_release}"
-            namespace, image_short_name, image_tag = art_references[pullspec]
-            image_sha = (
-                image_info['contentDigest']
-                if self._group_config.operator_image_ref_mode == 'by-arch'
-                else image_info['listDigest']
-            )
-            if not metadata.runtime.group.startswith("openshift-"):
-                new_namespace = namespace
-            else:
-                new_namespace = 'openshift4' if namespace == csv_namespace else namespace
-            # If delivery_repo_name_override is set for this image, use the overridden short name
-            # so the final pullspec uses the preferred delivery repo name (e.g. without a version tag).
-            delivery_image_short_name = _delivery_override_map.get(image_short_name, image_short_name)
-            new_pullspec = '{}/{}@{}'.format(
-                'registry.redhat.io',  # hardcoded until appregistry is dead
-                f'{new_namespace}/{delivery_image_short_name}',
-                image_sha,
-            )
-            new_content = new_content.replace(pullspec, new_pullspec)
-            found_images[delivery_image_short_name] = (pullspec, new_pullspec, image_nvr)
-
-        # Step 2: Find digest-pinned images that are already resolved (e.g., external images)
-        # These don't need resolution but should be included in found_images for relatedImages
-        digest_pattern = KonfluxOlmBundleRebaser._get_digest_image_pattern()
-        for match in digest_pattern.finditer(new_content):
-            image_path = match.group(1)  # e.g., registry.redhat.io/rhel9/postgresql-15
-            digest = match.group(2)  # e.g., sha256:abc123...
-            pullspec = f"{image_path}@{digest}"
-
-            # Extract image short name from the path
-            image_short_name = image_path.rsplit('/', 1)[-1]
-
-            # Skip if this image was already processed as an ART-built image
-            if image_short_name in found_images:
-                continue
-
-            # Add to found_images with pullspec as both old and new (no change needed)
-            # Use "external" as NVR since we don't have version info for external images
-            found_images[image_short_name] = (pullspec, pullspec, "external")
-            self._logger.debug(f"Found digest-pinned external image: {pullspec}")
-
-        return new_content, found_images
+        return await olm_image_refs.replace_olm_manifest_image_references(
+            old_registry,
+            content,
+            engine,
+            metadata,
+            self._group_config,
+            self.image_repo,
+            logger=self._logger,
+        )
 
     @cached_property
     def _operator_index_mode(self):

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -1,3 +1,5 @@
+from artcommonlib.constants import REGISTRY_PROXY_BASE_URL
+
 RC_BASE_URL = "https://{arch}.ocp.releases.ci.openshift.org"
 RC_BASE_PRIV_URL = "https://{arch}.ocp.internal.releases.ci.openshift.org"
 
@@ -60,7 +62,6 @@ KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL = "https://api.github.com/repos/ope
 KONFLUX_DEFAULT_BUNDLE_BUILD_PLR_TEMPLATE_URL = "https://api.github.com/repos/openshift-priv/art-konflux-template/contents/.tekton/art-bundle-konflux-template-push.yaml?ref=main"
 KONFLUX_DEFAULT_FBC_BUILD_PLR_TEMPLATE_URL = "https://api.github.com/repos/openshift-priv/art-konflux-template/contents/.tekton/art-fbc-konflux-template-push.yaml?ref=main"
 ART_FBC_GIT_REPO = "https://github.com/openshift-priv/art-fbc.git"
-REGISTRY_PROXY_BASE_URL = "registry-proxy.engineering.redhat.com"
 BREW_REGISTRY_BASE_URL = "brew.registry.redhat.io"
 
 ART_BUILD_HISTORY_URL = 'https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com'

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -71,7 +71,7 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
         self.assertEqual(match.group(1), "namespace/image")
         self.assertEqual(match.group(2), "tag")
 
-    @patch("doozerlib.util.oc_image_info_for_arch_async")
+    @patch("artcommonlib.olm.operator_image_refs.oc_image_info_for_arch_async")
     async def test_replace_image_references(self, mock_oc_image_info):
         old_registry = "registry.example.com"
         content = """

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -24,6 +24,7 @@ from elliottlib.cli.common import cli, click_coroutine, find_default_advisory, u
 from elliottlib.errata_async import AsyncErrataAPI
 from elliottlib.exceptions import ElliottFatalError
 from elliottlib.imagecfg import ImageMetadata
+from elliottlib.olm_operator_build_validation import select_konflux_olm_operator_build_for_find_builds
 from elliottlib.util import (
     ensure_erratatool_auth,
     get_release_version,
@@ -749,21 +750,19 @@ async def find_builds_konflux_all_types(runtime: Runtime) -> dict[str, list]:
     - For each image, queries for the latest build.
     - Separates the results into payload and non-payload image builds.
     - For OLM operator images, fetches the related bundle build records from the database.
-    - Returns a dictionary with four categorized lists:
-        1. 'payload': Build nvrs for payload images.
-        2. 'non_payload': Build nvrs for non-payload images.
-        3. 'olm_builds': NVRs of OLM bundle builds found.
-        4. 'olm_builds_not_found': NVRs of OLM operator builds for which no bundle build was found.
+    - Returns a dictionary with categorized lists including optional OLM skip diagnostics.
 
     Args:
         runtime: The runtime object providing access to image metadata and the Konflux database.
 
     Returns:
-        dict[str, list]: A dictionary containing four lists:
+        dict[str, list]: A dictionary containing:
             - 'payload': List of build nvrs for payload images.
             - 'non_payload': List of build nvrs for non-payload images.
             - 'olm_builds': List of NVRs for OLM bundle builds found.
             - 'olm_builds_not_found': List of NVRs for OLM operator builds with no bundle build.
+            - 'olm_operator_skipped_invalid_refs': Builds skipped due to invalid manifest image refs
+              (each item: distgit_key, nvr, reason).
     """
     runtime.konflux_db.bind(KonfluxBuildRecord)
 
@@ -774,15 +773,22 @@ async def find_builds_konflux_all_types(runtime: Runtime) -> dict[str, list]:
         image_metas.append((image.is_payload, image))
 
     LOGGER.info("Fetching image NVRs from DB...")
-    # find build result (is_olm_operator, build_Record, is_payload)
-    olm_flags = []
-    payload_flags = []
-    tasks = []
-    for is_payload, image in image_metas:
-        olm_flags.append(image.is_olm_operator)
-        payload_flags.append(is_payload)
-        tasks.append(image.get_latest_build(el_target=image.branch_el_target(), exclude_large_columns=True))
-    results = await asyncio.gather(*tasks)
+
+    async def _resolve_image_build(is_payload: bool, image: ImageMetadata) -> tuple[KonfluxBuildRecord | None, list]:
+        if image.is_olm_operator:
+            record, skipped = await select_konflux_olm_operator_build_for_find_builds(runtime, image)
+            return record, skipped
+        record = await image.get_latest_build(el_target=image.branch_el_target(), exclude_large_columns=True)
+        return record, []
+
+    tasks = [_resolve_image_build(is_payload, image) for is_payload, image in image_metas]
+    resolved = await asyncio.gather(*tasks)
+    results = [r for r, _ in resolved]
+    olm_operator_skipped_invalid_refs: list[dict] = []
+    for (is_payload, image), (_, skipped) in zip(image_metas, resolved):
+        if image.is_olm_operator:
+            for row in skipped:
+                olm_operator_skipped_invalid_refs.append({'distgit_key': image.distgit_key, **row})
     images_not_found: list[str] = [image_metas[i][1].name for i, r in enumerate(results) if r is None]
     if images_not_found:
         message = f"Failed to find Konflux builds for {len(images_not_found)} images: {images_not_found}"
@@ -795,7 +801,7 @@ async def find_builds_konflux_all_types(runtime: Runtime) -> dict[str, list]:
 
     operator_builds = []
     olm_tasks = []
-    records_with_olm = [(is_olm, is_payload, r) for is_olm, is_payload, r in zip(olm_flags, payload_flags, results)]
+    records_with_olm = [(image.is_olm_operator, is_payload, r) for (is_payload, image), r in zip(image_metas, results)]
     for is_olm, is_payload, record in records_with_olm:
         if is_olm:
             operator_builds.append(record)
@@ -817,5 +823,9 @@ async def find_builds_konflux_all_types(runtime: Runtime) -> dict[str, list]:
         'non_payload': sorted([record.nvr for _, is_payload, record in records_with_olm if not is_payload]),
         'olm_builds': sorted([b.nvr for b in olm_records]),
         'olm_builds_not_found': sorted([b.nvr for b in olm_records_not_found]),
+        'olm_operator_skipped_invalid_refs': sorted(
+            olm_operator_skipped_invalid_refs,
+            key=lambda d: (d.get('distgit_key', ''), d.get('nvr', '')),
+        ),
     }
     return builds_tuple

--- a/elliott/elliottlib/metadata.py
+++ b/elliott/elliottlib/metadata.py
@@ -9,3 +9,8 @@ class Metadata(MetadataBase):
         :param data_obj - a dictionary for the metadata configuration
         """
         super().__init__(meta_type, runtime, data_obj)
+        # Fields expected by doozerlib.SourceResolver when used from Elliott (e.g. OLM manifest validation).
+        self.prevent_cloning = False
+        self.commitish = None
+        self.public_upstream_url = None
+        self.public_upstream_branch = None

--- a/elliott/elliottlib/olm_operator_build_validation.py
+++ b/elliott/elliottlib/olm_operator_build_validation.py
@@ -1,0 +1,192 @@
+"""Validate Konflux OLM operator builds the same way bundle rebasing resolves manifest image refs."""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Tuple, cast
+
+from artcommonlib import exectools
+from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildRecord
+from artcommonlib.olm import operator_image_refs as olm_image_refs
+from doozerlib import constants as doozer_constants
+from doozerlib.backend.build_repo import BuildRepo
+from doozerlib.source_resolver import SourceResolution, SourceResolver
+
+if TYPE_CHECKING:
+    from elliottlib.imagecfg import ImageMetadata
+    from elliottlib.runtime import Runtime
+
+LOGGER = logging.getLogger(__name__)
+
+OLM_FIND_BUILDS_CANDIDATE_LIMIT = 25
+
+
+def _image_has_git_source(metadata: ImageMetadata) -> bool:
+    try:
+        return bool(metadata.config.content.source.git)
+    except Exception:
+        return False
+
+
+def _source_resolver_for(runtime: Runtime) -> SourceResolver:
+    return SourceResolver(
+        sources_base_dir=str(runtime.working_dir),
+        cache_dir=getattr(runtime, 'cache_dir', None),
+        group_config=runtime.group_config,
+        local=False,
+        upcycle=False,
+        stage=False,
+    )
+
+
+def _bundle_dir_yaml_files(operator_dir: Path, update_csv: dict) -> List[Tuple[str, str]]:
+    manifests_dir = operator_dir.joinpath(str(update_csv['manifests-dir']))
+    bundle_dir = manifests_dir.joinpath(str(update_csv['bundle-dir']))
+    out: List[Tuple[str, str]] = []
+    if not bundle_dir.is_dir():
+        return out
+    for src in sorted(bundle_dir.iterdir()):
+        if src.name == 'image-references':
+            continue
+        if src.suffix.lower() not in ('.yaml', '.yml'):
+            continue
+        out.append((str(src.relative_to(operator_dir)), src.read_text(encoding='utf-8', errors='replace')))
+    return out
+
+
+async def validate_konflux_operator_build_manifest_refs(
+    runtime: Runtime,
+    image_meta: ImageMetadata,
+    operator_build: KonfluxBuildRecord,
+    *,
+    image_repo: str | None = None,
+    logger: logging.Logger | None = None,
+) -> Tuple[bool, str | None]:
+    """
+    Return (True, None) if operator manifests at this build's ref are resolvable like bundle rebasing.
+
+    Non-Konflux engine records are accepted without cloning (no validation).
+    """
+    log = logger or LOGGER
+    if operator_build.engine is not Engine.KONFLUX:
+        return True, None
+
+    if not _image_has_git_source(image_meta):
+        return False, 'no git source in image metadata'
+
+    update_csv = image_meta.config.get('update-csv')
+    if not update_csv or not update_csv.get('manifests-dir') or not update_csv.get('bundle-dir'):
+        return False, 'incomplete update-csv config (manifests-dir / bundle-dir)'
+
+    resolver = _source_resolver_for(runtime)
+    source = cast(
+        SourceResolution,
+        await exectools.to_thread(resolver.resolve_source, image_meta, no_clone=True),
+    )
+
+    tmp_root = tempfile.mkdtemp(dir=str(runtime.working_dir))
+    operator_dir = Path(tmp_root) / 'operator-checkout'
+    try:
+        repo = BuildRepo(
+            url=source.url,
+            branch=None,
+            local_dir=operator_dir,
+            logger=log,
+        )
+        await repo.ensure_source(upcycle=False)
+        refspec = operator_build.rebase_commitish
+        if not refspec:
+            return False, 'operator build has empty rebase_commitish'
+        await repo.fetch(refspec, strict=True)
+        await repo.switch('FETCH_HEAD', detach=True)
+
+        files = _bundle_dir_yaml_files(operator_dir, update_csv)
+        if not files:
+            return False, f'no YAML files under bundle-dir {update_csv.get("bundle-dir")!r}'
+
+        repo_url = image_repo or doozer_constants.KONFLUX_DEFAULT_IMAGE_REPO
+        ok, err = await olm_image_refs.validate_olm_bundle_dir_yaml_files(
+            files,
+            str(update_csv['registry']),
+            Engine.KONFLUX,
+            image_meta,
+            runtime.group_config,
+            repo_url,
+            logger=log,
+        )
+        return ok, err
+    finally:
+        shutil.rmtree(tmp_root, ignore_errors=True)
+
+
+def _konflux_completed_before(runtime: Runtime) -> datetime.datetime | None:
+    be = runtime.assembly_basis_event
+    if isinstance(be, datetime.datetime):
+        return be
+    return None
+
+
+async def select_konflux_olm_operator_build_for_find_builds(
+    runtime: Runtime,
+    image_meta: ImageMetadata,
+) -> Tuple[KonfluxBuildRecord, List[dict]]:
+    """
+    Pick the newest Konflux operator build whose bundle-dir manifests pass reference validation.
+
+    Pinned ``is:`` components are never replaced with an older build; validation failure raises.
+
+    Returns (chosen_build, skipped_invalid) where skipped_invalid entries are
+    ``{'nvr': ..., 'reason': ...}`` for logging / JSON.
+    """
+    from elliottlib.exceptions import ElliottFatalError
+
+    completed_before = _konflux_completed_before(runtime)
+    candidates = await image_meta.list_konflux_success_build_candidates(
+        el_target=image_meta.branch_el_target(),
+        exclude_large_columns=True,
+        limit=OLM_FIND_BUILDS_CANDIDATE_LIMIT,
+        completed_before=completed_before,
+    )
+    if not candidates:
+        raise ElliottFatalError(f"No Konflux builds found for OLM operator {image_meta.distgit_key}")
+
+    skipped: List[dict] = []
+    is_pinned = bool(image_meta.config.get('is'))
+
+    if is_pinned:
+        cand = candidates[0]
+        ok, err = await validate_konflux_operator_build_manifest_refs(runtime, image_meta, cand, logger=LOGGER)
+        if not ok:
+            raise ElliottFatalError(
+                f"Pinned OLM operator image {image_meta.distgit_key} build {cand.nvr} has invalid "
+                f"manifest image references: {err}"
+            )
+        return cand, skipped
+
+    for cand in candidates:
+        ok, err = await validate_konflux_operator_build_manifest_refs(runtime, image_meta, cand, logger=LOGGER)
+        if ok:
+            if skipped:
+                LOGGER.warning(
+                    "OLM operator %s: using %s after skipping %d build(s) with invalid manifest references",
+                    image_meta.distgit_key,
+                    cand.nvr,
+                    len(skipped),
+                )
+            return cand, skipped
+        skipped.append({'nvr': cand.nvr, 'reason': err or 'unknown'})
+        LOGGER.warning(
+            "Skipping OLM operator build %s for %s: %s",
+            cand.nvr,
+            image_meta.distgit_key,
+            err,
+        )
+
+    raise ElliottFatalError(
+        f"No OLM operator build with resolvable manifest references for {image_meta.distgit_key} "
+        f"within {len(candidates)} candidate(s)"
+    )

--- a/elliott/tests/test_find_builds_cli.py
+++ b/elliott/tests/test_find_builds_cli.py
@@ -104,7 +104,7 @@ class TestFindBuildsKonfluxAllTypes(IsolatedAsyncioTestCase):
         build_2 = MagicMock(nvr="image2-2.0.0-1.el9")
         image_meta_2.get_latest_build = AsyncMock(return_value=build_2)
 
-        # Mock OLM bundle search
+        # Mock OLM bundle search (operator_nvr lookup)
         build_3 = MagicMock(nvr="image2-bundle-2.0.0-1.el9")
         runtime.konflux_db.should_receive("search_builds_by_fields").and_return(iter([build_3]))
 
@@ -116,7 +116,16 @@ class TestFindBuildsKonfluxAllTypes(IsolatedAsyncioTestCase):
             except StopIteration:
                 return default
 
-        with mock.patch("elliottlib.cli.find_builds_cli.anext", side_effect=fake_anext):
+        async def fake_select_olm(_rt, _img):
+            return build_2, []
+
+        with (
+            mock.patch("elliottlib.cli.find_builds_cli.anext", side_effect=fake_anext),
+            mock.patch(
+                "elliottlib.cli.find_builds_cli.select_konflux_olm_operator_build_for_find_builds",
+                side_effect=fake_select_olm,
+            ),
+        ):
             builds_map = await find_builds_konflux_all_types(runtime)
 
         # Assertions
@@ -127,8 +136,9 @@ class TestFindBuildsKonfluxAllTypes(IsolatedAsyncioTestCase):
         self.assertEqual(len(builds_map['olm_builds']), 1)
         self.assertEqual(builds_map['olm_builds'][0], build_3.nvr)
         self.assertEqual(len(builds_map['olm_builds_not_found']), 0)
+        self.assertEqual(builds_map.get("olm_operator_skipped_invalid_refs"), [])
         image_meta_1.get_latest_build.assert_called_once_with(el_target="el8", exclude_large_columns=True)
-        image_meta_2.get_latest_build.assert_called_once_with(el_target="el9", exclude_large_columns=True)
+        image_meta_2.get_latest_build.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/elliott/tests/test_olm_operator_build_validation.py
+++ b/elliott/tests/test_olm_operator_build_validation.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord
+from elliottlib.exceptions import ElliottFatalError
+from elliottlib.olm_operator_build_validation import select_konflux_olm_operator_build_for_find_builds
+
+
+class TestSelectKonfluxOlmOperatorBuild(unittest.IsolatedAsyncioTestCase):
+    @patch(
+        "elliottlib.olm_operator_build_validation.validate_konflux_operator_build_manifest_refs", new_callable=AsyncMock
+    )
+    async def test_skips_invalid_then_returns_next(self, mock_validate):
+        bad = MagicMock(spec=KonfluxBuildRecord, nvr="op-1.0-1")
+        good = MagicMock(spec=KonfluxBuildRecord, nvr="op-1.0-0")
+        image_meta = MagicMock()
+        image_meta.distgit_key = "my-operator"
+        image_meta.config = {}
+        image_meta.list_konflux_success_build_candidates = AsyncMock(return_value=[bad, good])
+
+        mock_validate.side_effect = [(False, "bad refs"), (True, None)]
+
+        runtime = MagicMock()
+
+        chosen, skipped = await select_konflux_olm_operator_build_for_find_builds(runtime, image_meta)
+
+        self.assertEqual(chosen.nvr, good.nvr)
+        self.assertEqual(len(skipped), 1)
+        self.assertEqual(skipped[0]["nvr"], bad.nvr)
+        self.assertIn("bad refs", skipped[0]["reason"])
+
+    @patch(
+        "elliottlib.olm_operator_build_validation.validate_konflux_operator_build_manifest_refs", new_callable=AsyncMock
+    )
+    async def test_pinned_raises_on_invalid(self, mock_validate):
+        pinned = MagicMock(spec=KonfluxBuildRecord, nvr="op-pinned-1.0-1")
+        image_meta = MagicMock()
+        image_meta.distgit_key = "my-operator"
+        image_meta.config = {"is": {"nvr": "op-pinned-1.0-1"}}
+        image_meta.list_konflux_success_build_candidates = AsyncMock(return_value=[pinned])
+        mock_validate.return_value = (False, "broken")
+
+        runtime = MagicMock()
+
+        with self.assertRaises(ElliottFatalError) as ctx:
+            await select_konflux_olm_operator_build_for_find_builds(runtime, image_meta)
+        self.assertIn("Pinned", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Konflux elliott find-builds --all-image-types now picks OLM operator builds whose update-csv bundle manifests have image references that would succeed during bundle rebasing (same logic as _replace_image_references, shared via artcommonlib.olm.operator_image_refs). Newer candidates that fail oc image info / label / digest resolution are skipped with warnings; the first passing candidate is used for payload/non-payload and for operator_nvr bundle lookup. Doozer’s KonfluxOlmBundleRebaser._replace_image_references delegates to that shared module so behavior stays aligned.

Images with is: pins are not replaced by an older build: the pinned build is validated only; failure raises ElliottFatalError.

JSON adds olm_operator_skipped_invalid_refs (distgit_key, nvr, reason) for visibility in pipelines/logs.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED