### PR TITLE
Fetch exact rpm NVR if pinned in ocp-build-data

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1228,6 +1228,58 @@ class ImageMetadata(Metadata):
 
         return modules_from_config
 
+    def get_pinned_nvrs(self) -> dict[str, str]:
+        """
+        Extract explicitly pinned NVRs from lockfile configuration.
+
+        Parses konflux.cachi2.lockfile.rpms and identifies entries that are full NVRs
+        (name-version-release) rather than just package names. Returns a mapping of
+        package name to version-release string for pinned versions.
+
+        Returns:
+            dict[str, str]: Mapping of package name to version-release for pinned NVRs.
+                           Example: {"foo": "1.0-1.el9", "bar": "2.3-4.el9"}
+        """
+        pinned_versions = {}
+        lockfile_rpms = self.config.konflux.cachi2.lockfile.get('rpms', [])
+
+        if lockfile_rpms in [Missing, None]:
+            return pinned_versions
+
+        for rpm in lockfile_rpms:
+            try:
+                parsed = parse_nvr(rpm)
+                name = parsed.get('name')
+                version = parsed.get('version')
+                release = parsed.get('release')
+
+                # Validate it's a real NVR (not just something with dashes like "kernel-rt-core")
+                # Version should contain digits or dots, release should contain at least one digit
+                if name and version and release:
+                    if re.search(r'[\d.]', version) and re.search(r'\d', release):
+                        pinned_versions[name] = f"{version}-{release}"
+                    else:
+                        self.logger.warning(
+                            f'{self.distgit_key} skipping invalid NVR "{rpm}" in lockfile config: '
+                            f'version or release does not match expected RPM format'
+                        )
+            except ValueError as e:
+                # Not a valid NVR format (just a package name like "foo")
+                # Only log if it looks like it was intended to be an NVR (has multiple dashes)
+                if rpm.count('-') >= 2:
+                    self.logger.warning(
+                        f'{self.distgit_key} failed to parse "{rpm}" as NVR in lockfile config: {e}'
+                    )
+                # Otherwise it's just a package name, silently skip
+
+        if pinned_versions:
+            self.logger.info(
+                f'{self.distgit_key} found {len(pinned_versions)} pinned NVRs in lockfile config: '
+                f'{list(pinned_versions.keys())}'
+            )
+
+        return pinned_versions
+
     def get_enabled_repos(self) -> set[str]:
         """
         Get enabled repositories for lockfile generation.

--- a/doozer/doozerlib/lockfile.py
+++ b/doozer/doozerlib/lockfile.py
@@ -272,7 +272,9 @@ class RpmInfoCollector:
         self.loaded_repos.update({r.name: r for r in repodatas})
         self.logger.info(f"Finished loading repos: {', '.join(repos_to_fetch)} for arch {arch}")
 
-    def _fetch_rpms_info_per_arch(self, rpm_names: set[str], repo_names: set[str], arch: str) -> list[RpmInfo]:
+    def _fetch_rpms_info_per_arch(
+        self, rpm_names: set[str], repo_names: set[str], arch: str, pinned_nvrs: dict[str, str] = None
+    ) -> list[RpmInfo]:
         """
         Resolve RPM metadata for a specific architecture from the given repodata names.
 
@@ -281,10 +283,16 @@ class RpmInfoCollector:
         from ``sort_repos_for_lockfile_resolution`` acts as tiebreaker (RHEL upstream repos
         are preferred over rhocp plashets).
 
+        Packages with explicitly pinned versions (via pinned_nvrs) are preserved at their
+        pinned version instead of being upgraded to the latest.
+
         Args:
             rpm_names (set[str]): RPM names or NVRs to resolve.
             repo_names (set[str]): Names of repodata sources to search.
             arch (str): Target architecture.
+            pinned_nvrs (dict[str, str]): Optional mapping of package name to version-release
+                                         for explicitly pinned RPMs from YAML config.
+                                         Example: {"foo": "1.0-1.el9"}
 
         Returns:
             list[RpmInfo]: Resolved RPM package metadata.
@@ -294,6 +302,7 @@ class RpmInfoCollector:
         # the upstream RHEL entry is kept.
         best_by_name: dict[str, RpmInfo] = {}
         resolved_items: set[str] = set()
+        pinned_nvrs = pinned_nvrs or {}
 
         for repo_name in sort_repos_for_lockfile_resolution(repo_names):
             repodata = self.loaded_repos.get(f'{repo_name}-{arch}')
@@ -319,9 +328,19 @@ class RpmInfoCollector:
             baseurl = repo.baseurl(repotype="unsigned", arch=arch)
             for rpm in found_rpms:
                 info = RpmInfo.from_rpm(rpm, repoid=content_set_id, baseurl=baseurl)
-                existing = best_by_name.get(rpm.name)
-                if existing is None or info > existing:
-                    best_by_name[rpm.name] = info
+                rpm_ver = f"{rpm.version}-{rpm.release}"
+
+                # Check if this package has a pinned version in the config
+                if rpm.name in pinned_nvrs:
+                    # For pinned packages: only add if version matches AND not already added
+                    # (use first repo with pinned version - RHEL preferred over rhocp)
+                    if rpm_ver == pinned_nvrs[rpm.name] and rpm.name not in best_by_name:
+                        best_by_name[rpm.name] = info
+                else:
+                    # For non-pinned packages: keep highest version
+                    existing = best_by_name.get(rpm.name)
+                    if existing is None or info > existing:
+                        best_by_name[rpm.name] = info
 
         missing = rpm_names - resolved_items
         if missing:
@@ -333,7 +352,7 @@ class RpmInfoCollector:
 
     @start_as_current_span_async(TRACER, "lockfile.fetch_rpms_info")
     async def fetch_rpms_info(
-        self, arches: list[str], repositories: set[str], rpm_names: set[str]
+        self, arches: list[str], repositories: set[str], rpm_names: set[str], pinned_nvrs: dict[str, str] = None
     ) -> dict[str, list[RpmInfo]]:
         """
         Resolve RPM info across multiple architectures and repositories.
@@ -344,6 +363,8 @@ class RpmInfoCollector:
             arches (list[str]): Target architectures.
             repositories (set[str]): Names of repositories to search.
             rpm_names (set[str]): Names or NVRs of RPMs to resolve.
+            pinned_nvrs (dict[str, str]): Optional mapping of package name to version-release
+                                         for explicitly pinned RPMs from YAML config.
 
         Returns:
             dict[str, list[RpmInfo]]: Mapping of architecture to resolved RPM metadata.
@@ -357,7 +378,7 @@ class RpmInfoCollector:
         results = await asyncio.gather(
             *[
                 asyncio.get_running_loop().run_in_executor(
-                    None, self._fetch_rpms_info_per_arch, rpm_names, repositories, arch
+                    None, self._fetch_rpms_info_per_arch, rpm_names, repositories, arch, pinned_nvrs
                 )
                 for arch in arches
             ]
@@ -695,9 +716,10 @@ class RPMLockfileGenerator:
         }
 
         modules_to_install = image_meta.get_lockfile_modules_to_install()
+        pinned_nvrs = image_meta.get_pinned_nvrs()
 
         rpms_info_by_arch, modules_info_by_arch = await asyncio.gather(
-            self.builder.fetch_rpms_info(arches, enabled_repos, rpms_to_install),
+            self.builder.fetch_rpms_info(arches, enabled_repos, rpms_to_install, pinned_nvrs),
             self.builder.fetch_modules_info(arches, enabled_repos, modules_to_install),
         )
 


### PR DESCRIPTION
## Summary

This PR modifies the lockfile generation logic to respect explicitly pinned RPM versions specified in the ocp-build-data image configuration.

## Problem

Currently, when generating lockfiles for hermetic builds, the system always selects the latest available RPM version for each package, even if a specific version is pinned in the image's `konflux.cachi2.lockfile.rpms` configuration. This causes hermetic builds to fail when a Dockerfile explicitly pins a specific RPM version but a newer version exists in the repos.

## Solution

- Added `get_pinned_nvrs()` method to `ImageMetadata` that extracts explicitly pinned NVRs from the YAML config
- Modified `_fetch_rpms_info_per_arch()` to check if a package is pinned and only include the pinned version (ignoring newer versions)
- For pinned packages, uses the first repo that provides the pinned version (RHEL preferred over rhocp)
- For non-pinned packages, continues to use the existing `best_by_name` logic (keeps highest version)

## Behavior

**Without pin in YAML:**
```yaml
konflux.cachi2.lockfile.rpms:
  - foo  # Just package name
```
Result: Lockfile gets latest version (e.g., `foo-2.0-1.el9`)

**With pin in YAML:**
```yaml
konflux.cachi2.lockfile.rpms:
  - foo-1.0-1.el9  # Specific NVR
```
Result: Lockfile gets pinned version (`foo-1.0-1.el9`), ignoring newer versions

## Testing

- [ ] Manual testing with pinned RPM versions
- [ ] Verify existing lockfile generation still works for non-pinned packages
- [ ] Verify warnings are logged for invalid NVR formats

Made with [Claude Code](https://claude.com/claude-code)