### PR TITLE
ART-14961: add RegistryConfig for explicit credential control

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -50,7 +50,16 @@ REDIS_PORT = '6379'
 # Telemetry
 OTEL_EXPORTER_OTLP_ENDPOINT = "http://otel-collector-psi-rhv.hosts.prod.psi.rdu2.redhat.com:4317"
 
+# Registry paths for authentication and image operations
+REGISTRY_QUAY_OCP_RELEASE_DEV = "quay.io/openshift-release-dev"
+REGISTRY_QUAY_OPENSHIFT = "quay.io/openshift"
+REGISTRY_QUAY_CI = "quay.io/openshift/ci"
+REGISTRY_CI_OPENSHIFT = "registry.ci.openshift.org"
+REGISTRY_REDHAT_IO = "registry.redhat.io"
+REGISTRY_BREW = "brew.registry.redhat.io"
+KONFLUX_ART_IMAGES = "quay.io/redhat-user-workloads/ocp-art-tenant/art-images"
 KONFLUX_ART_IMAGES_SHARE = "quay.io/redhat-user-workloads/ocp-art-tenant/art-images-share"
+KONFLUX_ART_FBC = "quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc"
 
 KONFLUX_DEFAULT_BUILD_PRIORITY = 5
 

--- a/artcommon/artcommonlib/registry_config.py
+++ b/artcommon/artcommonlib/registry_config.py
@@ -1,0 +1,377 @@
+"""
+Container registry credential manager for oc / Podman-style tools.
+
+RegistryConfig creates a temporary Docker config.json file containing only
+the specified registry credentials, built by cherry-picking entries from
+source auth files and/or providing explicit username:password pairs.
+
+Usage examples:
+
+    # Extract specific registries from a source auth file
+    with RegistryConfig(
+        source_files=['/path/to/auth.json'],
+        registries=['registry.redhat.io', 'quay.io/openshift-release-dev'],
+    ) as auth_file:
+        cmd.extend(['--registry-config', auth_file])
+
+    # Combine source file extraction with explicit credentials
+    with RegistryConfig(
+        source_files=['/path/to/auth.json'],
+        registries=['registry.redhat.io'],
+        credentials=[
+            RegistryCredential('quay.io/qci', 'user', 'password'),
+        ],
+    ) as auth_file:
+        cmd.extend(['--registry-config', auth_file])
+
+    # Credentials only (no source files needed)
+    with RegistryConfig(
+        credentials=[
+            RegistryCredential('quay.io/qci', 'user', 'password'),
+        ],
+    ) as auth_file:
+        cmd.extend(['--registry-config', auth_file])
+
+The auth_file can be passed to:
+    - oc image mirror --registry-config=<auth_file>
+    - oc image mirror -a <auth_file>
+    - REGISTRY_AUTH_FILE=<auth_file>
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_registry_path(path: str) -> str:
+    """
+    Normalize a registry path for consistent matching.
+
+    Strips URI schemes, digest suffixes, and trailing slashes.
+    Lowercases the host portion while preserving path case.
+
+    Arg(s):
+        path (str): Raw registry path.
+
+    Return Value(s):
+        str: Normalized registry path.
+
+    Raises:
+        ValueError: If path is empty after normalization.
+    """
+    path = path.strip()
+
+    # Strip common URI schemes
+    for prefix in ("docker://", "oci://", "https://", "http://"):
+        if path.startswith(prefix):
+            path = path[len(prefix) :]
+            break
+
+    # Strip digest suffix
+    path = path.split("@", 1)[0].rstrip("/")
+
+    if not path:
+        raise ValueError("empty registry reference after normalization")
+
+    # Lowercase host, preserve path case
+    if "/" in path:
+        host, rest = path.split("/", 1)
+        return f"{host.lower()}/{rest}"
+    return path.lower()
+
+
+@dataclass
+class RegistryCredential:
+    """
+    Explicit username/password credentials for a single registry.
+
+    Arg(s):
+        registry (str): Registry path (e.g., 'quay.io/openshift/ci').
+        username (str): Username for authentication.
+        password (str): Password for authentication.
+    """
+
+    registry: str
+    username: str
+    password: str
+
+    def __post_init__(self):
+        if not self.registry or not self.registry.strip():
+            raise ValueError("RegistryCredential registry cannot be empty")
+        if not self.username or not self.username.strip():
+            raise ValueError(f"RegistryCredential username cannot be empty for registry '{self.registry}'")
+        if not self.password:
+            raise ValueError(f"RegistryCredential password cannot be empty for registry '{self.registry}'")
+        self.registry = _normalize_registry_path(self.registry)
+
+
+class RegistryConfig:
+    """
+    Context manager that builds a temporary Docker auth config.json.
+
+    Constructs a minimal auth file containing only the requested registries,
+    sourced from existing auth files and/or explicit credentials.
+
+    When a registry appears in both source files and credentials, the
+    explicit credential takes precedence.  When a registry appears in
+    multiple source files, the first file wins.
+
+    Arg(s):
+        source_files (list[str] | None): Paths to existing auth.json files to extract from.
+        registries (list[str] | None): Registry paths to cherry-pick from source_files.
+        credentials (list[RegistryCredential] | None): Explicit username/password credentials.
+    """
+
+    def __init__(
+        self,
+        source_files: Optional[list[str]] = None,
+        registries: Optional[list[str]] = None,
+        credentials: Optional[list[RegistryCredential]] = None,
+    ) -> None:
+        """
+        Initialize the RegistryConfig context manager.
+
+        Arg(s):
+            source_files (list[str] | None): Paths to existing auth.json files.
+            registries (list[str] | None): Registry paths to extract from source_files.
+            credentials (list[RegistryCredential] | None): Explicit credentials.
+
+        Raises:
+            ValueError: If no registries or credentials are provided, or if
+                        registries are specified without source_files.
+        """
+        self._source_files = list(source_files) if source_files else []
+        self._registries = [_normalize_registry_path(r) for r in registries] if registries else []
+        self._credentials = list(credentials) if credentials else []
+        self._temp_auth_file: Optional[Path] = None
+        self._merged_auths: dict[str, dict[str, str]] = {}
+
+        # Must have at least one registry or credential
+        if not self._registries and not self._credentials:
+            raise ValueError("RegistryConfig requires at least one registry or credential")
+
+        # Can't extract registries without source files
+        if self._registries and not self._source_files:
+            raise ValueError("source_files must be provided when registries are specified")
+
+    def __enter__(self) -> str:
+        """
+        Enter the context: resolve credentials and write a temporary auth file.
+
+        Return Value(s):
+            str: Path to the temporary auth file containing merged credentials.
+
+        Raises:
+            ValueError: If a requested registry is not found in any source file.
+            FileNotFoundError: If a source file does not exist.
+        """
+        merged: dict[str, dict[str, str]] = {}
+
+        # Registry aliases: registries that share authentication realms
+        # When the requested registry is not found, try these fallbacks
+        registry_aliases = {
+            'brew.registry.redhat.io': 'registry.redhat.io',
+        }
+
+        # Step 1: resolve registries from source files
+        source_auths = self._load_source_files()
+        for registry in self._registries:
+            if registry in merged:
+                logger.debug("Registry '%s' already resolved, skipping duplicate", registry)
+                continue
+
+            auth_value = self._find_in_sources(registry, source_auths)
+
+            # If not found, try fallback for known aliases
+            if auth_value is None and registry in registry_aliases:
+                fallback_registry = registry_aliases[registry]
+                auth_value = self._find_in_sources(fallback_registry, source_auths)
+                if auth_value:
+                    logger.info(
+                        "Registry '%s' not found, using credentials from '%s' (shared auth realm)",
+                        registry,
+                        fallback_registry,
+                    )
+
+            if auth_value is None:
+                available_keys: list[str] = []
+                for file_auths in source_auths.values():
+                    available_keys.extend(file_auths.keys())
+                raise ValueError(
+                    f"Registry '{registry}' not found in any source file. "
+                    f"Available registries: {sorted(set(available_keys))}"
+                )
+
+            merged[registry] = {"auth": auth_value}
+            logger.info("Resolved credentials for '%s' from source file", registry)
+
+        # Step 2: add/override with explicit credentials (first credential wins
+        # for duplicates; credentials override source-file entries)
+        seen_cred_registries: set[str] = set()
+        for cred in self._credentials:
+            if cred.registry in seen_cred_registries:
+                logger.debug("Duplicate credential for '%s', skipping", cred.registry)
+                continue
+            seen_cred_registries.add(cred.registry)
+
+            if cred.registry in merged:
+                logger.debug(
+                    "Credential for '%s' overrides source file entry",
+                    cred.registry,
+                )
+
+            auth_str = base64.b64encode(f"{cred.username}:{cred.password}".encode()).decode()
+            merged[cred.registry] = {"auth": auth_str}
+            logger.info(
+                "Resolved credentials for '%s' from explicit credential",
+                cred.registry,
+            )
+
+        self._merged_auths = merged
+        self._write_temp_file()
+        return str(self._temp_auth_file)
+
+    def _load_source_files(self) -> dict[str, dict[str, dict]]:
+        """
+        Load all source auth files and return their "auths" sections.
+
+        Return Value(s):
+            dict: Mapping of file path to its auths dict.
+
+        Raises:
+            FileNotFoundError: If a source file does not exist.
+            ValueError: If a source file has invalid JSON or format.
+        """
+        result: dict[str, dict] = {}
+        for file_path in self._source_files:
+            if not os.path.exists(file_path):
+                raise FileNotFoundError(f"Source auth file not found: {file_path}")
+
+            with open(file_path, encoding="utf-8") as f:
+                try:
+                    data = json.load(f)
+                except json.JSONDecodeError as e:
+                    raise ValueError(f"Invalid JSON in source file {file_path}: {e}") from e
+
+            if not isinstance(data, dict) or "auths" not in data:
+                raise ValueError(f"Source file {file_path} missing 'auths' key. Expected Docker config.json format.")
+
+            result[file_path] = data["auths"]
+            logger.debug(
+                "Loaded %d registry entries from %s",
+                len(data["auths"]),
+                file_path,
+            )
+
+        return result
+
+    def _find_in_sources(self, registry: str, source_auths: dict[str, dict]) -> Optional[str]:
+        """
+        Find a registry's auth value across the loaded source files.
+
+        Source files are searched in order; first match wins.  Keys in each
+        source file are normalized before comparison so that host casing and
+        URI-scheme differences do not prevent a match.
+
+        Arg(s):
+            registry (str): Normalized registry path to look up.
+            source_auths (dict): Loaded source file auths (file path -> auths dict).
+
+        Return Value(s):
+            str | None: Base64 auth string if found, None otherwise.
+        """
+        for file_path, auths in source_auths.items():
+            for key, value in auths.items():
+                try:
+                    normalized_key = _normalize_registry_path(key)
+                except ValueError:
+                    continue
+                if normalized_key == registry:
+                    auth = value.get("auth")
+                    if auth:
+                        logger.debug(
+                            "Found '%s' (as '%s') in %s",
+                            registry,
+                            key,
+                            file_path,
+                        )
+                        return auth
+        return None
+
+    def _write_temp_file(self) -> None:
+        """
+        Write merged credentials to a temporary file.
+
+        The file is created with restrictive permissions (0600) via mkstemp.
+        """
+        try:
+            fd, temp_path = tempfile.mkstemp(prefix="registry_config_", suffix=".json", text=True)
+            self._temp_auth_file = Path(temp_path)
+
+            merged_config = {"auths": self._merged_auths}
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(merged_config, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+
+            logger.info(
+                "Wrote %d credentials to %s",
+                len(self._merged_auths),
+                self._temp_auth_file,
+            )
+        except Exception:
+            if self._temp_auth_file and self._temp_auth_file.exists():
+                try:
+                    self._temp_auth_file.unlink()
+                except OSError:
+                    pass
+            raise
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        """
+        Clean up the temporary auth file.
+        """
+        self._merged_auths = {}
+        path = self._temp_auth_file
+        self._temp_auth_file = None
+        if path and path.exists():
+            try:
+                path.unlink()
+                logger.debug("Removed temp file %s", path)
+            except OSError as err:
+                logger.warning("Could not remove %s: %s", path, err)
+        return False
+
+    def get_registries(self) -> list[str]:
+        """
+        Return the list of registries in the merged config.
+
+        Only valid inside the context (after __enter__).
+
+        Return Value(s):
+            list[str]: Registry paths with resolved credentials.
+        """
+        return list(self._merged_auths.keys())
+
+    def has_credential_for(self, registry: str) -> bool:
+        """
+        Check if the merged config has credentials for a registry (exact match).
+
+        Only valid inside the context (after __enter__).
+
+        Arg(s):
+            registry (str): Registry path to check.
+
+        Return Value(s):
+            bool: True if credentials exist for the registry.
+        """
+        return registry in self._merged_auths

--- a/artcommon/tests/test_registry_config.py
+++ b/artcommon/tests/test_registry_config.py
@@ -1,0 +1,1013 @@
+import base64
+import json
+import os
+import stat
+import tempfile
+import unittest
+
+from artcommonlib.registry_config import (
+    RegistryConfig,
+    RegistryCredential,
+    _normalize_registry_path,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_auth_file(auths: dict[str, dict]) -> str:
+    """
+    Write a temporary auth.json file and return its path.
+
+    The caller is responsible for cleaning up the file.
+    """
+    fd, path = tempfile.mkstemp(suffix=".json", text=True)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        json.dump({"auths": auths}, f)
+    return path
+
+
+def _b64(username: str, password: str) -> str:
+    """
+    Return the base64-encoded "username:password" string.
+    """
+    return base64.b64encode(f"{username}:{password}".encode()).decode()
+
+
+def _read_auth_file(path: str) -> dict:
+    """
+    Read and parse a Docker auth config.json file.
+    """
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_registry_path
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeRegistryPath(unittest.TestCase):
+    def test_lowercase_host(self):
+        self.assertEqual(_normalize_registry_path("QUAY.IO"), "quay.io")
+
+    def test_preserves_path_case(self):
+        self.assertEqual(
+            _normalize_registry_path("Quay.IO/OpenShift/CI"),
+            "quay.io/OpenShift/CI",
+        )
+
+    def test_strips_docker_scheme(self):
+        self.assertEqual(
+            _normalize_registry_path("docker://quay.io/foo"),
+            "quay.io/foo",
+        )
+
+    def test_strips_https_scheme(self):
+        self.assertEqual(
+            _normalize_registry_path("https://registry.redhat.io"),
+            "registry.redhat.io",
+        )
+
+    def test_strips_http_scheme(self):
+        self.assertEqual(
+            _normalize_registry_path("http://localhost:5000/repo"),
+            "localhost:5000/repo",
+        )
+
+    def test_strips_oci_scheme(self):
+        self.assertEqual(
+            _normalize_registry_path("oci://quay.io/foo"),
+            "quay.io/foo",
+        )
+
+    def test_strips_digest(self):
+        self.assertEqual(
+            _normalize_registry_path("quay.io/foo@sha256:abc123"),
+            "quay.io/foo",
+        )
+
+    def test_strips_trailing_slash(self):
+        self.assertEqual(
+            _normalize_registry_path("quay.io/foo/"),
+            "quay.io/foo",
+        )
+
+    def test_combined_normalization(self):
+        """Scheme + uppercase host + trailing slash + digest all at once."""
+        self.assertEqual(
+            _normalize_registry_path("https://QUAY.IO/Foo/@sha256:abc"),
+            "quay.io/Foo",
+        )
+
+    def test_host_only(self):
+        self.assertEqual(_normalize_registry_path("quay.io"), "quay.io")
+
+    def test_host_with_port(self):
+        self.assertEqual(
+            _normalize_registry_path("Localhost:5000"),
+            "localhost:5000",
+        )
+
+    def test_empty_string_raises(self):
+        with self.assertRaises(ValueError):
+            _normalize_registry_path("")
+
+    def test_whitespace_only_raises(self):
+        with self.assertRaises(ValueError):
+            _normalize_registry_path("   ")
+
+    def test_scheme_only_raises(self):
+        with self.assertRaises(ValueError):
+            _normalize_registry_path("https://")
+
+    def test_strips_leading_trailing_whitespace(self):
+        self.assertEqual(
+            _normalize_registry_path("  quay.io/foo  "),
+            "quay.io/foo",
+        )
+
+
+# ---------------------------------------------------------------------------
+# RegistryCredential
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryCredential(unittest.TestCase):
+    def test_valid_credential(self):
+        cred = RegistryCredential("quay.io/qci", "user", "password")
+        self.assertEqual(cred.registry, "quay.io/qci")
+        self.assertEqual(cred.username, "user")
+        self.assertEqual(cred.password, "password")
+
+    def test_normalizes_registry(self):
+        cred = RegistryCredential("QUAY.IO/Foo", "user", "pass")
+        self.assertEqual(cred.registry, "quay.io/Foo")
+
+    def test_strips_scheme_from_registry(self):
+        cred = RegistryCredential("docker://quay.io/foo", "u", "p")
+        self.assertEqual(cred.registry, "quay.io/foo")
+
+    def test_empty_registry_raises(self):
+        with self.assertRaises(ValueError):
+            RegistryCredential("", "user", "pass")
+
+    def test_whitespace_registry_raises(self):
+        with self.assertRaises(ValueError):
+            RegistryCredential("   ", "user", "pass")
+
+    def test_empty_username_raises(self):
+        with self.assertRaises(ValueError):
+            RegistryCredential("quay.io", "", "pass")
+
+    def test_whitespace_username_raises(self):
+        with self.assertRaises(ValueError):
+            RegistryCredential("quay.io", "   ", "pass")
+
+    def test_empty_password_raises(self):
+        with self.assertRaises(ValueError):
+            RegistryCredential("quay.io", "user", "")
+
+    def test_none_registry_raises(self):
+        with self.assertRaises(ValueError):
+            RegistryCredential(None, "user", "pass")
+
+    def test_none_username_raises(self):
+        with self.assertRaises(ValueError):
+            RegistryCredential("quay.io", None, "pass")
+
+    def test_none_password_raises(self):
+        with self.assertRaises(ValueError):
+            RegistryCredential("quay.io", "user", None)
+
+
+# ---------------------------------------------------------------------------
+# RegistryConfig — source files only
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryConfigSourceFilesOnly(unittest.TestCase):
+    def test_single_file_single_registry(self):
+        auth_path = _write_auth_file(
+            {
+                "quay.io": {"auth": _b64("u", "p")},
+                "registry.redhat.io": {"auth": _b64("r", "s")},
+            }
+        )
+        try:
+            with RegistryConfig(
+                source_files=[auth_path],
+                registries=["quay.io"],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                self.assertIn("quay.io", data["auths"])
+                self.assertEqual(len(data["auths"]), 1)
+        finally:
+            os.unlink(auth_path)
+
+    def test_single_file_multiple_registries(self):
+        auth_path = _write_auth_file(
+            {
+                "quay.io": {"auth": _b64("u", "p")},
+                "registry.redhat.io": {"auth": _b64("r", "s")},
+                "gcr.io": {"auth": _b64("g", "h")},
+            }
+        )
+        try:
+            with RegistryConfig(
+                source_files=[auth_path],
+                registries=["quay.io", "registry.redhat.io"],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                self.assertEqual(len(data["auths"]), 2)
+                self.assertIn("quay.io", data["auths"])
+                self.assertIn("registry.redhat.io", data["auths"])
+                # gcr.io should NOT be included
+                self.assertNotIn("gcr.io", data["auths"])
+        finally:
+            os.unlink(auth_path)
+
+    def test_cherry_pick_subset(self):
+        """Only the requested registries are included, not the entire source."""
+        auth_path = _write_auth_file(
+            {
+                "quay.io/openshift-release-dev": {"auth": _b64("a", "b")},
+                "quay.io/redhat-user-workloads/ocp-art-tenant/art-images": {"auth": _b64("c", "d")},
+                "quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc": {"auth": _b64("e", "f")},
+                "registry.redhat.io": {"auth": _b64("g", "h")},
+            }
+        )
+        try:
+            with RegistryConfig(
+                source_files=[auth_path],
+                registries=[
+                    "registry.redhat.io",
+                    "quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc",
+                ],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                self.assertEqual(len(data["auths"]), 2)
+                self.assertIn("registry.redhat.io", data["auths"])
+                self.assertIn(
+                    "quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc",
+                    data["auths"],
+                )
+        finally:
+            os.unlink(auth_path)
+
+    def test_multiple_files_registry_in_first(self):
+        path1 = _write_auth_file({"quay.io": {"auth": _b64("first", "cred")}})
+        path2 = _write_auth_file({"registry.redhat.io": {"auth": _b64("r", "s")}})
+        try:
+            with RegistryConfig(
+                source_files=[path1, path2],
+                registries=["quay.io"],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                decoded = base64.b64decode(data["auths"]["quay.io"]["auth"]).decode()
+                self.assertEqual(decoded, "first:cred")
+        finally:
+            os.unlink(path1)
+            os.unlink(path2)
+
+    def test_multiple_files_registry_in_second(self):
+        path1 = _write_auth_file({"quay.io": {"auth": _b64("q", "p")}})
+        path2 = _write_auth_file({"registry.redhat.io": {"auth": _b64("rh", "pw")}})
+        try:
+            with RegistryConfig(
+                source_files=[path1, path2],
+                registries=["registry.redhat.io"],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                decoded = base64.b64decode(data["auths"]["registry.redhat.io"]["auth"]).decode()
+                self.assertEqual(decoded, "rh:pw")
+        finally:
+            os.unlink(path1)
+            os.unlink(path2)
+
+    def test_multiple_files_first_file_wins(self):
+        path1 = _write_auth_file({"quay.io": {"auth": _b64("first", "cred")}})
+        path2 = _write_auth_file({"quay.io": {"auth": _b64("second", "cred")}})
+        try:
+            with RegistryConfig(
+                source_files=[path1, path2],
+                registries=["quay.io"],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                decoded = base64.b64decode(data["auths"]["quay.io"]["auth"]).decode()
+                self.assertEqual(decoded, "first:cred")
+        finally:
+            os.unlink(path1)
+            os.unlink(path2)
+
+    def test_registries_from_different_files(self):
+        """Each requested registry can come from a different source file."""
+        path1 = _write_auth_file({"quay.io": {"auth": _b64("q", "p")}})
+        path2 = _write_auth_file({"registry.redhat.io": {"auth": _b64("r", "s")}})
+        try:
+            with RegistryConfig(
+                source_files=[path1, path2],
+                registries=["quay.io", "registry.redhat.io"],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                self.assertEqual(len(data["auths"]), 2)
+                self.assertIn("quay.io", data["auths"])
+                self.assertIn("registry.redhat.io", data["auths"])
+        finally:
+            os.unlink(path1)
+            os.unlink(path2)
+
+    def test_duplicate_registries_in_list_deduplicated(self):
+        auth_path = _write_auth_file({"quay.io": {"auth": _b64("u", "p")}})
+        try:
+            with RegistryConfig(
+                source_files=[auth_path],
+                registries=["quay.io", "quay.io"],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                # Should only have one entry, not fail
+                self.assertEqual(len(data["auths"]), 1)
+        finally:
+            os.unlink(auth_path)
+
+    def test_registry_not_found_raises(self):
+        auth_path = _write_auth_file({"quay.io": {"auth": _b64("u", "p")}})
+        try:
+            with self.assertRaises(ValueError) as cm:
+                with RegistryConfig(
+                    source_files=[auth_path],
+                    registries=["registry.redhat.io"],
+                ):
+                    pass
+            self.assertIn("not found in any source file", str(cm.exception))
+            self.assertIn("quay.io", str(cm.exception))  # lists available keys
+        finally:
+            os.unlink(auth_path)
+
+    def test_normalizes_source_file_keys_for_matching(self):
+        """Source file keys are normalized before matching."""
+        auth_path = _write_auth_file(
+            {
+                "QUAY.IO/Foo": {"auth": _b64("u", "p")},
+            }
+        )
+        try:
+            with RegistryConfig(
+                source_files=[auth_path],
+                registries=["quay.io/Foo"],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                self.assertIn("quay.io/Foo", data["auths"])
+        finally:
+            os.unlink(auth_path)
+
+    def test_preserves_auth_value_from_source(self):
+        """The auth value from the source file is preserved exactly."""
+        original_auth = _b64("myuser", "mypass")
+        auth_path = _write_auth_file({"quay.io": {"auth": original_auth}})
+        try:
+            with RegistryConfig(
+                source_files=[auth_path],
+                registries=["quay.io"],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                self.assertEqual(data["auths"]["quay.io"]["auth"], original_auth)
+        finally:
+            os.unlink(auth_path)
+
+
+# ---------------------------------------------------------------------------
+# RegistryConfig — credentials only
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryConfigCredentialsOnly(unittest.TestCase):
+    def test_single_credential(self):
+        with RegistryConfig(
+            credentials=[RegistryCredential("quay.io/qci", "user", "pass")],
+        ) as auth_file:
+            data = _read_auth_file(auth_file)
+            self.assertEqual(len(data["auths"]), 1)
+            decoded = base64.b64decode(data["auths"]["quay.io/qci"]["auth"]).decode()
+            self.assertEqual(decoded, "user:pass")
+
+    def test_multiple_credentials(self):
+        with RegistryConfig(
+            credentials=[
+                RegistryCredential("quay.io", "u1", "p1"),
+                RegistryCredential("registry.redhat.io", "u2", "p2"),
+            ],
+        ) as auth_file:
+            data = _read_auth_file(auth_file)
+            self.assertEqual(len(data["auths"]), 2)
+            self.assertIn("quay.io", data["auths"])
+            self.assertIn("registry.redhat.io", data["auths"])
+
+    def test_credential_is_base64_encoded(self):
+        with RegistryConfig(
+            credentials=[RegistryCredential("quay.io", "user", "pass")],
+        ) as auth_file:
+            data = _read_auth_file(auth_file)
+            auth_value = data["auths"]["quay.io"]["auth"]
+            decoded = base64.b64decode(auth_value).decode()
+            self.assertEqual(decoded, "user:pass")
+
+    def test_credential_with_special_characters(self):
+        """Passwords with colons, spaces, and special chars are handled."""
+        with RegistryConfig(
+            credentials=[
+                RegistryCredential("quay.io", "user", "p@ss:w0rd with spaces!"),
+            ],
+        ) as auth_file:
+            data = _read_auth_file(auth_file)
+            decoded = base64.b64decode(data["auths"]["quay.io"]["auth"]).decode()
+            self.assertEqual(decoded, "user:p@ss:w0rd with spaces!")
+
+    def test_duplicate_credentials_first_wins(self):
+        with RegistryConfig(
+            credentials=[
+                RegistryCredential("quay.io", "first", "cred"),
+                RegistryCredential("quay.io", "second", "cred"),
+            ],
+        ) as auth_file:
+            data = _read_auth_file(auth_file)
+            decoded = base64.b64decode(data["auths"]["quay.io"]["auth"]).decode()
+            self.assertEqual(decoded, "first:cred")
+
+    def test_no_source_files_needed(self):
+        """Credentials-only mode does not require source_files."""
+        with RegistryConfig(
+            credentials=[RegistryCredential("quay.io", "u", "p")],
+        ) as auth_file:
+            self.assertTrue(os.path.isfile(auth_file))
+
+
+# ---------------------------------------------------------------------------
+# RegistryConfig — combined (source files + credentials)
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryConfigCombined(unittest.TestCase):
+    def test_different_registries_merged(self):
+        auth_path = _write_auth_file(
+            {
+                "registry.redhat.io": {"auth": _b64("rh", "pw")},
+            }
+        )
+        try:
+            with RegistryConfig(
+                source_files=[auth_path],
+                registries=["registry.redhat.io"],
+                credentials=[RegistryCredential("quay.io/qci", "qci", "pass")],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                self.assertEqual(len(data["auths"]), 2)
+                self.assertIn("registry.redhat.io", data["auths"])
+                self.assertIn("quay.io/qci", data["auths"])
+        finally:
+            os.unlink(auth_path)
+
+    def test_credential_overrides_source_entry(self):
+        """When a registry appears in both source and credentials, credential wins."""
+        auth_path = _write_auth_file(
+            {
+                "quay.io": {"auth": _b64("source-user", "source-pass")},
+            }
+        )
+        try:
+            with RegistryConfig(
+                source_files=[auth_path],
+                registries=["quay.io"],
+                credentials=[RegistryCredential("quay.io", "cred-user", "cred-pass")],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                decoded = base64.b64decode(data["auths"]["quay.io"]["auth"]).decode()
+                # Credential should override the source file
+                self.assertEqual(decoded, "cred-user:cred-pass")
+        finally:
+            os.unlink(auth_path)
+
+    def test_mixed_sources_and_credentials(self):
+        """Real-world scenario: multiple source files + explicit credentials."""
+        path1 = _write_auth_file(
+            {
+                "quay.io/openshift-release-dev": {"auth": _b64("q1", "p1")},
+                "quay.io": {"auth": _b64("q2", "p2")},
+            }
+        )
+        path2 = _write_auth_file(
+            {
+                "registry.ci.openshift.org": {"auth": _b64("ci", "pw")},
+                "quay.io/openshift": {"auth": _b64("qo", "pw")},
+            }
+        )
+        try:
+            with RegistryConfig(
+                source_files=[path1, path2],
+                registries=[
+                    "quay.io/openshift-release-dev",
+                    "quay.io",
+                    "registry.ci.openshift.org",
+                    "quay.io/openshift",
+                ],
+                credentials=[
+                    RegistryCredential("quay.io/special", "sp", "pw"),
+                ],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                self.assertEqual(len(data["auths"]), 5)
+                self.assertIn("quay.io/openshift-release-dev", data["auths"])
+                self.assertIn("quay.io", data["auths"])
+                self.assertIn("registry.ci.openshift.org", data["auths"])
+                self.assertIn("quay.io/openshift", data["auths"])
+                self.assertIn("quay.io/special", data["auths"])
+        finally:
+            os.unlink(path1)
+            os.unlink(path2)
+
+    def test_source_files_not_required_when_only_credentials(self):
+        """source_files can be omitted when only credentials are used."""
+        with RegistryConfig(
+            credentials=[
+                RegistryCredential("quay.io", "u", "p"),
+                RegistryCredential("registry.redhat.io", "r", "s"),
+            ],
+        ) as auth_file:
+            data = _read_auth_file(auth_file)
+            self.assertEqual(len(data["auths"]), 2)
+
+    def test_credential_for_registry_not_in_sources(self):
+        """A credential can add a registry that does not appear in any source file."""
+        auth_path = _write_auth_file(
+            {
+                "quay.io": {"auth": _b64("u", "p")},
+            }
+        )
+        try:
+            with RegistryConfig(
+                source_files=[auth_path],
+                registries=["quay.io"],
+                credentials=[
+                    RegistryCredential("registry.redhat.io", "rh", "pw"),
+                ],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                self.assertEqual(len(data["auths"]), 2)
+                self.assertIn("quay.io", data["auths"])
+                self.assertIn("registry.redhat.io", data["auths"])
+        finally:
+            os.unlink(auth_path)
+
+
+# ---------------------------------------------------------------------------
+# RegistryConfig — validation and error cases
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryConfigValidation(unittest.TestCase):
+    def test_no_registries_no_credentials_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            RegistryConfig()
+        self.assertIn("at least one", str(cm.exception))
+
+    def test_empty_registries_no_credentials_raises(self):
+        with self.assertRaises(ValueError):
+            RegistryConfig(registries=[])
+
+    def test_registries_without_source_files_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            RegistryConfig(registries=["quay.io"])
+        self.assertIn("source_files must be provided", str(cm.exception))
+
+    def test_registries_with_empty_source_files_raises(self):
+        with self.assertRaises(ValueError):
+            RegistryConfig(source_files=[], registries=["quay.io"])
+
+    def test_source_file_not_found_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            with RegistryConfig(
+                source_files=["/nonexistent/auth.json"],
+                registries=["quay.io"],
+            ):
+                pass
+
+    def test_source_file_invalid_json_raises(self):
+        fd, path = tempfile.mkstemp(suffix=".json", text=True)
+        with os.fdopen(fd, "w") as f:
+            f.write("not valid json{{{")
+        try:
+            with self.assertRaises(ValueError) as cm:
+                with RegistryConfig(
+                    source_files=[path],
+                    registries=["quay.io"],
+                ):
+                    pass
+            self.assertIn("Invalid JSON", str(cm.exception))
+        finally:
+            os.unlink(path)
+
+    def test_source_file_missing_auths_key_raises(self):
+        fd, path = tempfile.mkstemp(suffix=".json", text=True)
+        with os.fdopen(fd, "w") as f:
+            json.dump({"something_else": {}}, f)
+        try:
+            with self.assertRaises(ValueError) as cm:
+                with RegistryConfig(
+                    source_files=[path],
+                    registries=["quay.io"],
+                ):
+                    pass
+            self.assertIn("missing 'auths' key", str(cm.exception))
+        finally:
+            os.unlink(path)
+
+    def test_source_file_is_array_raises(self):
+        """A source file whose root is a JSON array is not valid."""
+        fd, path = tempfile.mkstemp(suffix=".json", text=True)
+        with os.fdopen(fd, "w") as f:
+            json.dump([{"auths": {}}], f)
+        try:
+            with self.assertRaises(ValueError):
+                with RegistryConfig(
+                    source_files=[path],
+                    registries=["quay.io"],
+                ):
+                    pass
+        finally:
+            os.unlink(path)
+
+    def test_empty_registry_in_list_raises(self):
+        auth_path = _write_auth_file({"quay.io": {"auth": _b64("u", "p")}})
+        try:
+            with self.assertRaises(ValueError):
+                RegistryConfig(
+                    source_files=[auth_path],
+                    registries=[""],
+                )
+        finally:
+            os.unlink(auth_path)
+
+    def test_whitespace_registry_in_list_raises(self):
+        auth_path = _write_auth_file({"quay.io": {"auth": _b64("u", "p")}})
+        try:
+            with self.assertRaises(ValueError):
+                RegistryConfig(
+                    source_files=[auth_path],
+                    registries=["   "],
+                )
+        finally:
+            os.unlink(auth_path)
+
+    def test_source_file_with_empty_auth_value_skipped(self):
+        """A source entry with an empty auth value is treated as not found."""
+        auth_path = _write_auth_file({"quay.io": {"auth": ""}})
+        try:
+            with self.assertRaises(ValueError) as cm:
+                with RegistryConfig(
+                    source_files=[auth_path],
+                    registries=["quay.io"],
+                ):
+                    pass
+            self.assertIn("not found", str(cm.exception))
+        finally:
+            os.unlink(auth_path)
+
+    def test_source_file_with_missing_auth_key_skipped(self):
+        """A source entry without an 'auth' key is treated as not found."""
+        auth_path = _write_auth_file({"quay.io": {"email": "foo@bar.com"}})
+        try:
+            with self.assertRaises(ValueError) as cm:
+                with RegistryConfig(
+                    source_files=[auth_path],
+                    registries=["quay.io"],
+                ):
+                    pass
+            self.assertIn("not found", str(cm.exception))
+        finally:
+            os.unlink(auth_path)
+
+
+# ---------------------------------------------------------------------------
+# RegistryConfig — context manager lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryConfigContextManager(unittest.TestCase):
+    def test_file_exists_during_context(self):
+        with RegistryConfig(
+            credentials=[RegistryCredential("quay.io", "u", "p")],
+        ) as auth_file:
+            self.assertTrue(os.path.isfile(auth_file))
+
+    def test_file_cleaned_up_after_exit(self):
+        path_holder = []
+        with RegistryConfig(
+            credentials=[RegistryCredential("quay.io", "u", "p")],
+        ) as auth_file:
+            path_holder.append(auth_file)
+            self.assertTrue(os.path.exists(auth_file))
+        self.assertFalse(os.path.exists(path_holder[0]))
+
+    def test_file_cleaned_up_after_exception(self):
+        path_seen = None
+        try:
+            with RegistryConfig(
+                credentials=[RegistryCredential("quay.io", "u", "p")],
+            ) as auth_file:
+                path_seen = auth_file
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+        self.assertIsNotNone(path_seen)
+        self.assertFalse(os.path.exists(path_seen))
+
+    def test_output_json_structure(self):
+        """Output file has the standard Docker config.json structure."""
+        with RegistryConfig(
+            credentials=[RegistryCredential("quay.io", "u", "p")],
+        ) as auth_file:
+            data = _read_auth_file(auth_file)
+            self.assertIn("auths", data)
+            self.assertIsInstance(data["auths"], dict)
+            for key, value in data["auths"].items():
+                self.assertIn("auth", value)
+
+    def test_file_permissions_restrictive(self):
+        """Temp file should be created with restrictive permissions (0600)."""
+        with RegistryConfig(
+            credentials=[RegistryCredential("quay.io", "u", "p")],
+        ) as auth_file:
+            mode = os.stat(auth_file).st_mode
+            # Check that group and others have no permissions
+            self.assertEqual(mode & stat.S_IRWXG, 0)
+            self.assertEqual(mode & stat.S_IRWXO, 0)
+
+    def test_get_registries_inside_context(self):
+        ctx = RegistryConfig(
+            credentials=[
+                RegistryCredential("quay.io", "u1", "p1"),
+                RegistryCredential("registry.redhat.io", "u2", "p2"),
+            ],
+        )
+        ctx.__enter__()
+        try:
+            registries = ctx.get_registries()
+            self.assertIn("quay.io", registries)
+            self.assertIn("registry.redhat.io", registries)
+            self.assertEqual(len(registries), 2)
+        finally:
+            ctx.__exit__(None, None, None)
+
+    def test_get_registries_outside_context_empty(self):
+        ctx = RegistryConfig(
+            credentials=[RegistryCredential("quay.io", "u", "p")],
+        )
+        # Before entering context
+        self.assertEqual(ctx.get_registries(), [])
+
+    def test_has_credential_for_exact_match_only(self):
+        with RegistryConfig(
+            credentials=[RegistryCredential("quay.io/openshift", "u", "p")],
+        ) as auth_file:
+            ctx = RegistryConfig.__new__(RegistryConfig)
+            ctx._merged_auths = _read_auth_file(auth_file)["auths"]
+            # Re-enter properly for a clean test
+        ctx2 = RegistryConfig(
+            credentials=[RegistryCredential("quay.io/openshift", "u", "p")],
+        )
+        ctx2.__enter__()
+        try:
+            self.assertTrue(ctx2.has_credential_for("quay.io/openshift"))
+            # No prefix/parent matching
+            self.assertFalse(ctx2.has_credential_for("quay.io"))
+            self.assertFalse(ctx2.has_credential_for("quay.io/openshift/ci"))
+            self.assertFalse(ctx2.has_credential_for("registry.redhat.io"))
+        finally:
+            ctx2.__exit__(None, None, None)
+
+    def test_get_registries_cleared_after_exit(self):
+        ctx = RegistryConfig(
+            credentials=[RegistryCredential("quay.io", "u", "p")],
+        )
+        ctx.__enter__()
+        self.assertEqual(len(ctx.get_registries()), 1)
+        ctx.__exit__(None, None, None)
+        self.assertEqual(ctx.get_registries(), [])
+
+
+# ---------------------------------------------------------------------------
+# RegistryConfig — real-world scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryConfigAliases(unittest.TestCase):
+    """Test registry alias functionality for shared authentication realms."""
+
+    def test_brew_registry_uses_redhat_registry_credentials(self):
+        """Test that brew.registry.redhat.io automatically uses registry.redhat.io credentials."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            source_file = f.name
+            json.dump(
+                {
+                    "auths": {
+                        "registry.redhat.io": {"auth": "cmVkaGF0OnBhc3N3b3Jk"}  # redhat:password
+                    }
+                },
+                f,
+            )
+
+        try:
+            with RegistryConfig(
+                source_files=[source_file],
+                registries=['brew.registry.redhat.io'],  # Request brew, but only registry.redhat.io is in source
+            ) as auth_file:
+                with open(auth_file) as f:
+                    result = json.load(f)
+
+                # Should have brew.registry.redhat.io entry using registry.redhat.io credentials
+                self.assertIn('brew.registry.redhat.io', result['auths'])
+                self.assertEqual(result['auths']['brew.registry.redhat.io']['auth'], 'cmVkaGF0OnBhc3N3b3Jk')
+        finally:
+            os.unlink(source_file)
+
+    def test_both_brew_and_redhat_registry_requested(self):
+        """Test requesting both brew.registry.redhat.io and registry.redhat.io."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            source_file = f.name
+            json.dump({"auths": {"registry.redhat.io": {"auth": "cmVkaGF0OnBhc3N3b3Jk"}}}, f)
+
+        try:
+            with RegistryConfig(
+                source_files=[source_file],
+                registries=['registry.redhat.io', 'brew.registry.redhat.io'],
+            ) as auth_file:
+                with open(auth_file) as f:
+                    result = json.load(f)
+
+                # Both should be present with the same credentials
+                self.assertIn('registry.redhat.io', result['auths'])
+                self.assertIn('brew.registry.redhat.io', result['auths'])
+                self.assertEqual(
+                    result['auths']['registry.redhat.io']['auth'], result['auths']['brew.registry.redhat.io']['auth']
+                )
+        finally:
+            os.unlink(source_file)
+
+    def test_brew_registry_not_found_without_fallback_raises(self):
+        """Test that requesting brew.registry.redhat.io fails if registry.redhat.io is also missing."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            source_file = f.name
+            json.dump({"auths": {"quay.io": {"auth": "cXVheTpwYXNzd29yZA=="}}}, f)
+
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                with RegistryConfig(
+                    source_files=[source_file],
+                    registries=['brew.registry.redhat.io'],
+                ):
+                    pass
+
+            self.assertIn('brew.registry.redhat.io', str(ctx.exception))
+            self.assertIn('not found', str(ctx.exception))
+        finally:
+            os.unlink(source_file)
+
+
+class TestRegistryConfigRealWorldScenarios(unittest.TestCase):
+    def test_art_pipeline_scenario(self):
+        """
+        Simulates the ocp4-konflux mirror_streams_to_ci use case:
+        - Source files: QUAY_AUTH_FILE + oc-login temp file
+        - Registries: quay.io/openshift-release-dev, quay.io, registry.ci, quay.io/openshift
+        """
+        quay_auth = _write_auth_file(
+            {
+                "quay.io/openshift-release-dev": {"auth": _b64("quay-dev", "pw")},
+                "quay.io": {"auth": _b64("quay-general", "pw")},
+                "quay.io/redhat-user-workloads/ocp-art-tenant/art-images": {"auth": _b64("art", "pw")},
+            }
+        )
+        ci_auth = _write_auth_file(
+            {
+                "registry.ci.openshift.org": {"auth": _b64("ci-user", "ci-pw")},
+                "quay.io/openshift": {"auth": _b64("qci-user", "qci-pw")},
+            }
+        )
+        try:
+            with RegistryConfig(
+                source_files=[quay_auth, ci_auth],
+                registries=[
+                    "quay.io/openshift-release-dev",
+                    "quay.io",
+                    "registry.ci.openshift.org",
+                    "quay.io/openshift",
+                ],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                self.assertEqual(len(data["auths"]), 4)
+
+                # Verify each credential came from the correct file
+                self.assertEqual(
+                    base64.b64decode(data["auths"]["quay.io/openshift-release-dev"]["auth"]).decode(),
+                    "quay-dev:pw",
+                )
+                self.assertEqual(
+                    base64.b64decode(data["auths"]["quay.io"]["auth"]).decode(),
+                    "quay-general:pw",
+                )
+                self.assertEqual(
+                    base64.b64decode(data["auths"]["registry.ci.openshift.org"]["auth"]).decode(),
+                    "ci-user:ci-pw",
+                )
+                self.assertEqual(
+                    base64.b64decode(data["auths"]["quay.io/openshift"]["auth"]).decode(),
+                    "qci-user:qci-pw",
+                )
+
+                # art-images should NOT be in the output
+                self.assertNotIn(
+                    "quay.io/redhat-user-workloads/ocp-art-tenant/art-images",
+                    data["auths"],
+                )
+        finally:
+            os.unlink(quay_auth)
+            os.unlink(ci_auth)
+
+    def test_credential_plus_source_files_scenario(self):
+        """
+        Simulates: extract from auth file + add QCI creds explicitly.
+        """
+        quay_auth = _write_auth_file(
+            {
+                "quay.io/openshift-release-dev": {"auth": _b64("dev", "pw")},
+                "quay.io": {"auth": _b64("quay", "pw")},
+            }
+        )
+        try:
+            with RegistryConfig(
+                source_files=[quay_auth],
+                registries=["quay.io/openshift-release-dev", "quay.io"],
+                credentials=[
+                    RegistryCredential("quay.io/openshift", "qci-user", "qci-pw"),
+                    RegistryCredential("registry.ci.openshift.org", "ci", "pw"),
+                ],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                self.assertEqual(len(data["auths"]), 4)
+
+                # From source
+                self.assertEqual(
+                    base64.b64decode(data["auths"]["quay.io/openshift-release-dev"]["auth"]).decode(),
+                    "dev:pw",
+                )
+                # From credential
+                self.assertEqual(
+                    base64.b64decode(data["auths"]["quay.io/openshift"]["auth"]).decode(),
+                    "qci-user:qci-pw",
+                )
+        finally:
+            os.unlink(quay_auth)
+
+    def test_override_source_with_credential_scenario(self):
+        """
+        Source file has general quay.io creds, but we override with
+        specific push credentials.
+        """
+        quay_auth = _write_auth_file(
+            {
+                "quay.io": {"auth": _b64("readonly", "pw")},
+            }
+        )
+        try:
+            with RegistryConfig(
+                source_files=[quay_auth],
+                registries=["quay.io"],
+                credentials=[
+                    RegistryCredential("quay.io", "push-user", "push-pw"),
+                ],
+            ) as auth_file:
+                data = _read_auth_file(auth_file)
+                decoded = base64.b64decode(data["auths"]["quay.io"]["auth"]).decode()
+                # Credential should override the source
+                self.assertEqual(decoded, "push-user:push-pw")
+        finally:
+            os.unlink(quay_auth)
+
+    def test_empty_source_file_with_credentials_only(self):
+        """
+        source_files can be omitted entirely when only credentials are used.
+        """
+        with RegistryConfig(
+            credentials=[
+                RegistryCredential("quay.io/openshift-release-dev", "dev", "pw"),
+                RegistryCredential("registry.redhat.io", "rh", "pw"),
+                RegistryCredential("quay.io/qci", "qci", "pw"),
+            ],
+        ) as auth_file:
+            data = _read_auth_file(auth_file)
+            self.assertEqual(len(data["auths"]), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyartcd/pyartcd/oc.py
+++ b/pyartcd/pyartcd/oc.py
@@ -59,13 +59,18 @@ async def get_release_image_info(
     return info
 
 
-async def registry_login():
+async def registry_login(to_file: str | None = None):
     """
-    Login into OC registry using KUBECONFIG env var
+    Login into OC registry using KUBECONFIG env var.
+
+    Arg(s):
+        to_file (str | None): Optional path to write credentials to (uses --to flag).
+                               If not provided, writes to default location.
     """
 
     try:
-        await exectools.cmd_gather_async(f'oc --kubeconfig {os.environ["KUBECONFIG"]} registry login')
+        to_arg = f'--to={to_file}' if to_file else ''
+        await exectools.cmd_gather_async(f'oc --kubeconfig {os.environ["KUBECONFIG"]} registry login {to_arg}'.strip())
 
     except KeyError:
         logger.error('KUBECONFIG env var must be defined!')
@@ -76,14 +81,20 @@ async def registry_login():
         raise
 
 
-async def qci_registry_login():
+async def qci_registry_login(to_file: str | None = None):
     """
-    Log in to quay.io with credentials necessary to push to DPTP's QCI registry (quay.io/openshift/ci)
+    Log in to quay.io with credentials necessary to push to DPTP's QCI registry (quay.io/openshift/ci).
+
+    Arg(s):
+        to_file (str | None): Optional path to write credentials to (uses --to flag).
+                               If not provided, writes to default location.
     """
 
     try:
+        to_arg = f'--to={to_file}' if to_file else ''
         await exectools.cmd_gather_async(
-            f'oc registry login --registry=quay.io/openshift --auth-basic={os.environ["QCI_USER"]}:{os.environ["QCI_PASSWORD"]}'
+            f'oc registry login --registry=quay.io/openshift '
+            f'--auth-basic={os.environ["QCI_USER"]}:{os.environ["QCI_PASSWORD"]} {to_arg}'.strip()
         )
 
     except KeyError:
@@ -126,8 +137,11 @@ def common_oc_wrapper(
 
 def get_release_image_info_from_pullspec(pullspec: str, registry_config: Optional[str] = None) -> (int, str):
     # oc image info --output=json <pullspec>
-    cmd_args = ['info', "--output=json", pullspec]
-    res, out = common_oc_wrapper("single_image_info", "image", cmd_args, True, True, registry_config=registry_config)
+    cmd_args = ['info', "--output=json"]
+    if registry_config:
+        cmd_args.append(f"--registry-config={registry_config}")
+    cmd_args.append(pullspec)
+    res, out = common_oc_wrapper("single_image_info", "image", cmd_args, True, True)
     return res, json.loads(out)
 
 
@@ -135,24 +149,29 @@ def extract_release_binary(
     image_pullspec: str, path_args: List[str], registry_config: Optional[str] = None
 ) -> (int, str):
     # oc image extract --confirm --only-files --path=/usr/bin/..:<workdir> <pullspec>
-    cmd_args = ['extract', '--confirm', '--only-files'] + path_args + [image_pullspec]
-    return common_oc_wrapper("extract_image", "image", cmd_args, True, True, registry_config=registry_config)
+    cmd_args = ['extract', '--confirm', '--only-files']
+    if registry_config:
+        cmd_args.append(f"--registry-config={registry_config}")
+    cmd_args.extend(path_args + [image_pullspec])
+    return common_oc_wrapper("extract_image", "image", cmd_args, True, True)
 
 
 def get_release_image_pullspec(release_pullspec: str, image: str, registry_config: Optional[str] = None) -> (int, str):
     # oc adm release info --image-for=<image> <pullspec>
-    cmd_args = ['release', 'info', f'--image-for={image}', release_pullspec]
-    return common_oc_wrapper("image_info_in_release", "adm", cmd_args, True, True, registry_config=registry_config)
+    cmd_args = ['release', 'info', f'--image-for={image}']
+    if registry_config:
+        cmd_args.append(f"--registry-config={registry_config}")
+    cmd_args.append(release_pullspec)
+    return common_oc_wrapper("image_info_in_release", "adm", cmd_args, True, True)
 
 
 def extract_release_client_tools(
-    release_pullspec: str,
-    path_arg: str,
-    single_arch: Optional[str] = None,
-    registry_config: Optional[str] = None,
+    release_pullspec: str, path_arg: str, single_arch: Optional[str] = None, registry_config: Optional[str] = None
 ) -> (int, str):
     # oc adm release extract --tools --command-os=* -n ocp --to=<workdir> --filter-by-os=<arch> --from <pullspec> --to <path>
     args = ["release", "extract", "--tools", "--command-os=*", "-n=ocp"]
+    if registry_config:
+        args.append(f"--registry-config={registry_config}")
     if single_arch:
         args += [f"--filter-by-os={single_arch}"]
     args += [f"--from={release_pullspec}", path_arg]
@@ -171,6 +190,7 @@ def extract_baremetal_installer(
     :param release_pullspec: e.g. quay.io/openshift-release-dev/ocp-release:4.14.0-ec.2-x86_64
     :param path: e.g. /path/to/extracted/binary
     :param arch: "amd64", "s390x", "ppc64le", "arm64"
+    :param registry_config: optional path to a Docker config.json for registry auth
     """
 
     cmd_os = f'linux/{arch}'
@@ -188,6 +208,8 @@ def extract_baremetal_installer(
         cmd_os,
         f'--to={path}',
     ]
+    if registry_config:
+        args.append(f"--registry-config={registry_config}")
     return common_oc_wrapper(
         cmd_result_name='extract_baremetal',
         cli_verb='adm',

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -1,8 +1,10 @@
 import asyncio
 import copy
 import io
+import json
 import logging
 import os
+import tempfile
 import traceback
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
@@ -11,9 +13,14 @@ import click
 from artcommonlib import exectools
 from artcommonlib.arch_util import brew_arch_for_go_arch
 from artcommonlib.assembly import AssemblyTypes, assembly_config_struct
+from artcommonlib.constants import (
+    REGISTRY_CI_OPENSHIFT,
+    REGISTRY_QUAY_OCP_RELEASE_DEV,
+)
 from artcommonlib.gitdata import SafeFormatter
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.model import Model
+from artcommonlib.registry_config import RegistryConfig
 from artcommonlib.util import get_ocp_version_from_group, new_roundtrip_yaml_handler
 from doozerlib.util import get_nightly_pullspec
 from elliottlib.errata import push_cdn_stage
@@ -63,10 +70,13 @@ class BuildMicroShiftPipeline:
         skip_prepare_advisory: bool,
         data_path: str,
         slack_client,
+        data_gitref: str | None = None,
         logger: Optional[logging.Logger] = None,
     ):
         self.runtime = runtime
         self.group = group
+        self.data_gitref = data_gitref or ""
+        self.doozer_group = f"{self.group}@{self.data_gitref}" if self.data_gitref else self.group
         self.assembly = assembly
         self.assembly_type = AssemblyTypes.STREAM
         self.payloads = payloads
@@ -94,13 +104,51 @@ class BuildMicroShiftPipeline:
             self._elliott_env_vars["ELLIOTT_DATA_PATH"] = data_path
 
     async def run(self):
-        # Make sure our api.ci token is fresh
-        await oc.registry_login()
+        # Get Jenkins credentials for Quay
+        quay_auth_file = os.getenv('QUAY_AUTH_FILE')
+        if not quay_auth_file:
+            raise ValueError(
+                "QUAY_AUTH_FILE environment variable is required. This should be set via Jenkins credentials binding."
+            )
 
-        group_config = await load_group_config(self.group, self.assembly, env=self._doozer_env_vars)
+        # Create temp file for CI registry credentials
+        fd, ci_auth_file = tempfile.mkstemp(suffix='.json', text=True)
+        with os.fdopen(fd, 'w') as f:
+            json.dump({"auths": {}}, f)
+
+        try:
+            # Login to CI registry (requires KUBECONFIG from buildlib.withAppCiAsArtPublish)
+            await oc.registry_login(to_file=ci_auth_file)
+
+            # Build source files list
+            source_files = [quay_auth_file, ci_auth_file]
+
+            # Global registry config for pipeline operations
+            with RegistryConfig(
+                source_files=source_files,
+                registries=[
+                    REGISTRY_QUAY_OCP_RELEASE_DEV,
+                    REGISTRY_CI_OPENSHIFT,
+                ],
+            ) as global_auth_file:
+                await self._run_with_auth(global_auth_file)
+        finally:
+            if os.path.exists(ci_auth_file):
+                os.unlink(ci_auth_file)
+
+    async def _run_with_auth(self, registry_config_file: str):
+        """Core pipeline logic with registry authentication."""
+        # Override QUAY_AUTH_FILE in doozer/elliott env to use the merged auth file
+        # This ensures doozer's microshift-rebase script can access both Quay and CI registries
+        self._doozer_env_vars["QUAY_AUTH_FILE"] = registry_config_file
+        self._elliott_env_vars["QUAY_AUTH_FILE"] = registry_config_file
+
+        group_config = await load_group_config(
+            self.group, self.assembly, env=self._doozer_env_vars, doozer_data_gitref=self.data_gitref
+        )
         advisories = group_config.get("advisories", {})
         self.releases_config = await load_releases_config(
-            group=self.group,
+            group=self.doozer_group,
             data_path=self._doozer_env_vars.get("DOOZER_DATA_PATH", None) or constants.OCP_BUILD_DATA_URL,
         )
         self.assembly_type = get_assembly_type(self.releases_config, self.assembly)
@@ -110,7 +158,7 @@ class BuildMicroShiftPipeline:
             )
 
         if self.assembly_type is AssemblyTypes.STREAM:
-            await self._rebase_and_build_for_stream()
+            await self._rebase_and_build_for_stream(registry_config_file)
         else:
             # Check if microshift advisory is defined in assembly
             if ('microshift' not in advisories or advisories.get("microshift") <= 0) and not self.skip_prepare_advisory:
@@ -121,7 +169,7 @@ class BuildMicroShiftPipeline:
                 await self.slack_client.say_in_thread(
                     f"Microshift advisory {self.advisory_num} saved to assembly: {pr_url}"
                 )
-            await self._rebase_and_build_for_named_assembly()
+            await self._rebase_and_build_for_named_assembly(registry_config_file)
             await self._trigger_microshift_sync()
             await self._trigger_build_microshift_bootc()
             if not self.skip_prepare_advisory:
@@ -206,7 +254,7 @@ class BuildMicroShiftPipeline:
             await errata_api.close()
         return advisory_id
 
-    async def _rebase_and_build_for_stream(self):
+    async def _rebase_and_build_for_stream(self, registry_config_file: str):
         # Do a sanity check
         if self.assembly_type != AssemblyTypes.STREAM:
             raise ValueError(f"Cannot process assembly type {self.assembly_type.value}")
@@ -221,7 +269,7 @@ class BuildMicroShiftPipeline:
         if not self.payloads:
             raise ValueError("Release payloads must be specified to rebase against assembly stream.")
 
-        payload_infos = await self.parse_release_payloads(self.payloads)
+        payload_infos = await self.parse_release_payloads(self.payloads, registry_config_file)
         if "x86_64" not in payload_infos or "aarch64" not in payload_infos:
             raise ValueError("x86_64 payload and aarch64 payload are required for rebasing microshift.")
 
@@ -247,7 +295,7 @@ class BuildMicroShiftPipeline:
             await self._notify_microshift_alerts(f"{version}-{release}")
             raise
 
-    async def _rebase_and_build_for_named_assembly(self):
+    async def _rebase_and_build_for_named_assembly(self, registry_config_file: str):
         # Do a sanity check
         if self.assembly_type == AssemblyTypes.STREAM:
             raise ValueError(f"Cannot process assembly type {self.assembly_type.value}")
@@ -443,7 +491,7 @@ class BuildMicroShiftPipeline:
             self._logger.info(f"Changed {advisory_id} to QE")
             push_cdn_stage(advisory_id)
 
-    async def parse_release_payloads(self, payloads: Iterable[str]):
+    async def parse_release_payloads(self, payloads: Iterable[str], registry_config: Optional[str] = None):
         result = {}
         pullspecs = []
         for payload in payloads:
@@ -453,7 +501,9 @@ class BuildMicroShiftPipeline:
             else:
                 # payload is a pullspec
                 pullspecs.append(payload)
-        payload_infos = await asyncio.gather(*(oc.get_release_image_info(pullspec) for pullspec in pullspecs))
+        payload_infos = await asyncio.gather(
+            *(oc.get_release_image_info(pullspec, registry_config=registry_config) for pullspec in pullspecs)
+        )
         for info in payload_infos:
             arch = info["config"]["architecture"]
             brew_arch = brew_arch_for_go_arch(arch)
@@ -691,6 +741,12 @@ class BuildMicroShiftPipeline:
     is_flag=True,
     help="(For named assemblies) Skip create advisory and prepare advisory logic",
 )
+@click.option(
+    "--data-gitref",
+    required=False,
+    default="",
+    help="Doozer data path git [branch / tag / sha] to use",
+)
 @pass_runtime
 @click_coroutine
 async def build_microshift(
@@ -702,6 +758,7 @@ async def build_microshift(
     no_rebase: bool,
     force: bool,
     skip_prepare_advisory: bool,
+    data_gitref: str | None = None,
 ):
     # slack client is dry-run aware and will not send messages if dry-run is enabled
     slack_client = runtime.new_slack_client()
@@ -717,6 +774,7 @@ async def build_microshift(
             skip_prepare_advisory=skip_prepare_advisory,
             data_path=data_path,
             slack_client=slack_client,
+            data_gitref=data_gitref,
         )
         await pipeline.run()
     except Exception as err:

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -3,23 +3,31 @@ import glob
 import json
 import os
 import re
+import shutil
+import tempfile
 
 import click
 import yaml
 from artcommonlib import exectools, redis, rhcos
 from artcommonlib.arch_util import go_arch_for_brew_arch, go_suffix_for_arch
+from artcommonlib.constants import (
+    KONFLUX_ART_IMAGES,
+    KONFLUX_ART_IMAGES_SHARE,
+    REGISTRY_CI_OPENSHIFT,
+    REGISTRY_QUAY_OCP_RELEASE_DEV,
+)
 from artcommonlib.exectools import limit_concurrency
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.redis import RedisError
+from artcommonlib.registry_config import RegistryConfig
 from artcommonlib.release_util import SoftwareLifecyclePhase
 from artcommonlib.telemetry import start_as_current_span_async
 from artcommonlib.util import split_git_url, uses_konflux_imagestream_override
 from opentelemetry import trace
 
-from pyartcd import constants, jenkins, locks
+from pyartcd import constants, jenkins, locks, oc
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.jenkins import get_build_url
-from pyartcd.oc import registry_login
 from pyartcd.runtime import GroupRuntime, Runtime
 from pyartcd.util import branch_arches
 
@@ -143,6 +151,85 @@ class BuildSyncPipeline:
 
     @start_as_current_span_async(TRACER, "build-sync.run")
     async def run(self):
+        # Unset XDG_RUNTIME_DIR to prevent use of default registry auth
+        if 'XDG_RUNTIME_DIR' in os.environ:
+            self.logger.info('Unsetting XDG_RUNTIME_DIR to prevent use of default registry auth')
+            del os.environ['XDG_RUNTIME_DIR']
+
+        # Get Jenkins credentials
+        quay_auth_file = os.getenv('QUAY_AUTH_FILE')
+        if not quay_auth_file:
+            raise ValueError(
+                "QUAY_AUTH_FILE environment variable is required. This should be set via Jenkins credentials binding."
+            )
+
+        # Create temp file for CI registry credentials with valid JSON structure
+        fd, ci_auth_file = tempfile.mkstemp(suffix='.json', text=True)
+        with os.fdopen(fd, 'w') as f:
+            json.dump({"auths": {}}, f)
+
+        try:
+            # Login to CI registry (requires KUBECONFIG from buildlib.withAppCiAsArtPublish)
+            await oc.registry_login(to_file=ci_auth_file)
+
+            # Build source files list
+            source_files = [quay_auth_file, ci_auth_file]
+
+            # Global registry config for ALL pipeline operations
+            with RegistryConfig(
+                source_files=source_files,
+                registries=[
+                    REGISTRY_QUAY_OCP_RELEASE_DEV,
+                    KONFLUX_ART_IMAGES,
+                    KONFLUX_ART_IMAGES_SHARE,
+                    REGISTRY_CI_OPENSHIFT,
+                ],
+            ) as global_auth_file:
+                # Create temp directory for Docker config (cosign needs $DOCKER_CONFIG/config.json)
+                docker_config_dir = tempfile.mkdtemp(prefix='docker_config_')
+                docker_config_file = os.path.join(docker_config_dir, 'config.json')
+
+                try:
+                    shutil.copy2(global_auth_file, docker_config_file)
+
+                    # Save original environment variables
+                    original_registry_auth = os.environ.get('REGISTRY_AUTH_FILE')
+                    original_quay_auth = os.environ.get('QUAY_AUTH_FILE')
+                    original_docker_config = os.environ.get('DOCKER_CONFIG')
+
+                    # Set global auth file for all registry operations
+                    os.environ['REGISTRY_AUTH_FILE'] = global_auth_file
+                    os.environ['QUAY_AUTH_FILE'] = global_auth_file
+                    os.environ['DOCKER_CONFIG'] = docker_config_dir
+
+                    try:
+                        await self._run_pipeline()
+                    finally:
+                        # Restore original environment variables
+                        if original_registry_auth:
+                            os.environ['REGISTRY_AUTH_FILE'] = original_registry_auth
+                        elif 'REGISTRY_AUTH_FILE' in os.environ:
+                            del os.environ['REGISTRY_AUTH_FILE']
+
+                        if original_quay_auth:
+                            os.environ['QUAY_AUTH_FILE'] = original_quay_auth
+                        elif 'QUAY_AUTH_FILE' in os.environ:
+                            del os.environ['QUAY_AUTH_FILE']
+
+                        if original_docker_config:
+                            os.environ['DOCKER_CONFIG'] = original_docker_config
+                        elif 'DOCKER_CONFIG' in os.environ:
+                            del os.environ['DOCKER_CONFIG']
+                finally:
+                    if os.path.exists(docker_config_dir):
+                        shutil.rmtree(docker_config_dir)
+        finally:
+            if os.path.exists(ci_auth_file):
+                os.unlink(ci_auth_file)
+
+    @start_as_current_span_async(TRACER, "build-sync._run_pipeline")
+    async def _run_pipeline(self):
+        """Core pipeline logic wrapped by global registry auth config."""
         current_span = trace.get_current_span()
         current_span.set_attribute("build-sync.version", self.version)
         current_span.set_attribute("build-sync.assembly", self.assembly)
@@ -165,9 +252,6 @@ class BuildSyncPipeline:
             # Comment on PR if triggered from gen assembly
             text_body = f"Build sync job [run]({self.job_run}) has been triggered"
             await self.comment_on_assembly_pr(text_body)
-
-        # Make sure we're logged into the OC registry
-        await registry_login()
 
         # Should we retrigger current nightly?
         if self.retrigger_current_nightly:

--- a/pyartcd/pyartcd/pipelines/build_sync_multi.py
+++ b/pyartcd/pyartcd/pipelines/build_sync_multi.py
@@ -1,20 +1,29 @@
+import json
 import os
 import re
+import shutil
+import tempfile
 
 import click
 import yaml
 from artcommonlib import exectools, redis
+from artcommonlib.constants import (
+    KONFLUX_ART_IMAGES,
+    KONFLUX_ART_IMAGES_SHARE,
+    REGISTRY_CI_OPENSHIFT,
+    REGISTRY_QUAY_OCP_RELEASE_DEV,
+)
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.redis import RedisError
+from artcommonlib.registry_config import RegistryConfig
 from artcommonlib.release_util import SoftwareLifecyclePhase
 from artcommonlib.telemetry import start_as_current_span_async
 from artcommonlib.util import split_git_url
 from opentelemetry import trace
 
-from pyartcd import constants, jenkins, locks
+from pyartcd import constants, jenkins, locks, oc
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.jenkins import get_build_url
-from pyartcd.oc import registry_login
 from pyartcd.runtime import GroupRuntime, Runtime
 from pyartcd.util import branch_arches
 
@@ -124,6 +133,85 @@ class BuildSyncMultiPipeline:
 
     @start_as_current_span_async(TRACER, "build-sync-multi.run")
     async def run(self):
+        # Unset XDG_RUNTIME_DIR to prevent use of default registry auth
+        if 'XDG_RUNTIME_DIR' in os.environ:
+            self.logger.info('Unsetting XDG_RUNTIME_DIR to prevent use of default registry auth')
+            del os.environ['XDG_RUNTIME_DIR']
+
+        # Get Jenkins credentials
+        quay_auth_file = os.getenv('QUAY_AUTH_FILE')
+        if not quay_auth_file:
+            raise ValueError(
+                "QUAY_AUTH_FILE environment variable is required. This should be set via Jenkins credentials binding."
+            )
+
+        # Create temp file for CI registry credentials with valid JSON structure
+        fd, ci_auth_file = tempfile.mkstemp(suffix='.json', text=True)
+        with os.fdopen(fd, 'w') as f:
+            json.dump({"auths": {}}, f)
+
+        try:
+            # Login to CI registry (requires KUBECONFIG from buildlib.withAppCiAsArtPublish)
+            await oc.registry_login(to_file=ci_auth_file)
+
+            # Build source files list
+            source_files = [quay_auth_file, ci_auth_file]
+
+            # Global registry config for ALL pipeline operations
+            with RegistryConfig(
+                source_files=source_files,
+                registries=[
+                    REGISTRY_QUAY_OCP_RELEASE_DEV,
+                    KONFLUX_ART_IMAGES,
+                    KONFLUX_ART_IMAGES_SHARE,
+                    REGISTRY_CI_OPENSHIFT,
+                ],
+            ) as global_auth_file:
+                # Create temp directory for Docker config (cosign needs $DOCKER_CONFIG/config.json)
+                docker_config_dir = tempfile.mkdtemp(prefix='docker_config_')
+                docker_config_file = os.path.join(docker_config_dir, 'config.json')
+
+                try:
+                    shutil.copy2(global_auth_file, docker_config_file)
+
+                    # Save original environment variables
+                    original_registry_auth = os.environ.get('REGISTRY_AUTH_FILE')
+                    original_quay_auth = os.environ.get('QUAY_AUTH_FILE')
+                    original_docker_config = os.environ.get('DOCKER_CONFIG')
+
+                    # Set global auth file for all registry operations
+                    os.environ['REGISTRY_AUTH_FILE'] = global_auth_file
+                    os.environ['QUAY_AUTH_FILE'] = global_auth_file
+                    os.environ['DOCKER_CONFIG'] = docker_config_dir
+
+                    try:
+                        await self._run_pipeline()
+                    finally:
+                        # Restore original environment variables
+                        if original_registry_auth:
+                            os.environ['REGISTRY_AUTH_FILE'] = original_registry_auth
+                        elif 'REGISTRY_AUTH_FILE' in os.environ:
+                            del os.environ['REGISTRY_AUTH_FILE']
+
+                        if original_quay_auth:
+                            os.environ['QUAY_AUTH_FILE'] = original_quay_auth
+                        elif 'QUAY_AUTH_FILE' in os.environ:
+                            del os.environ['QUAY_AUTH_FILE']
+
+                        if original_docker_config:
+                            os.environ['DOCKER_CONFIG'] = original_docker_config
+                        elif 'DOCKER_CONFIG' in os.environ:
+                            del os.environ['DOCKER_CONFIG']
+                finally:
+                    if os.path.exists(docker_config_dir):
+                        shutil.rmtree(docker_config_dir)
+        finally:
+            if os.path.exists(ci_auth_file):
+                os.unlink(ci_auth_file)
+
+    @start_as_current_span_async(TRACER, "build-sync-multi._run_pipeline")
+    async def _run_pipeline(self):
+        """Core pipeline logic wrapped by global registry auth config."""
         current_span = trace.get_current_span()
         current_span.set_attribute("build-sync-multi.version", self.version)
         current_span.set_attribute("build-sync-multi.assembly", self.assembly)
@@ -146,9 +234,6 @@ class BuildSyncMultiPipeline:
             # Comment on PR if triggered from gen assembly
             text_body = f"Multi-model build sync job [run]({self.job_run}) has been triggered"
             await self.comment_on_assembly_pr(text_body)
-
-        # Make sure we're logged into the OC registry
-        await registry_login()
 
         # Generate multi-model nightly imagestream
         self.logger.info('Generate multi-model nightly imagestream...')

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import shutil
+import tempfile
 from enum import Enum
 from pathlib import Path
 from typing import Optional, Tuple
@@ -11,7 +12,16 @@ import click
 import yaml
 from artcommonlib import exectools, redis
 from artcommonlib.build_visibility import is_release_embargoed
-from artcommonlib.constants import KONFLUX_ART_IMAGES_SHARE
+from artcommonlib.constants import (
+    KONFLUX_ART_IMAGES,
+    KONFLUX_ART_IMAGES_SHARE,
+    REGISTRY_BREW,
+    REGISTRY_CI_OPENSHIFT,
+    REGISTRY_QUAY_OCP_RELEASE_DEV,
+    REGISTRY_QUAY_OPENSHIFT,
+    REGISTRY_REDHAT_IO,
+)
+from artcommonlib.registry_config import RegistryConfig
 from artcommonlib.util import (
     new_roundtrip_yaml_handler,
     run_safe,
@@ -434,15 +444,17 @@ class KonfluxOcpPipeline:
         if built_images.get('ose-openshift-apiserver', None):
             LOGGER.warning('apiserver rebuilt: mirroring streams to CI...')
 
-            # Make sure our api.ci token is fresh
-            await oc.registry_login()
+            # Use the global QUAY_AUTH_FILE set by run() wrapper
+            # It already contains all necessary registry credentials
+            quay_auth_file = os.getenv('QUAY_AUTH_FILE')
+            if not quay_auth_file:
+                raise ValueError(
+                    "QUAY_AUTH_FILE environment variable is required for registry authentication. "
+                    "This should be set by the global registry auth wrapper in run()."
+                )
 
-            # Log into QCI registry
-            await oc.qci_registry_login()
-
-            # Mirror out ART equivalent images to CI
             cmd = self._doozer_base_command.copy()
-            cmd.extend(['images:streams', 'mirror'])
+            cmd.extend(['images:streams', 'mirror', '--registry-auth', quay_auth_file])
             await exectools.cmd_assert_async(cmd)
 
     async def sweep_bugs(self):
@@ -783,6 +795,108 @@ class KonfluxOcpPipeline:
         await asyncio.gather(*[sync_build(build) for build in builds_to_mirror])
 
     async def run(self):
+        # Unset XDG_RUNTIME_DIR to ensure we don't use default auth.json
+        # All registry auth must come from explicit Jenkins credentials or oc login to temp files
+        if 'XDG_RUNTIME_DIR' in os.environ:
+            LOGGER.info('Unsetting XDG_RUNTIME_DIR to prevent use of default registry auth')
+            del os.environ['XDG_RUNTIME_DIR']
+
+        # Get Jenkins credentials
+        quay_auth_file = os.getenv('QUAY_AUTH_FILE')
+        redhat_registry_auth_file = os.getenv('KONFLUX_OPERATOR_INDEX_AUTH_FILE')
+
+        if not quay_auth_file:
+            raise ValueError(
+                "QUAY_AUTH_FILE environment variable is required but not set. "
+                "Ensure Jenkins credentials are properly bound."
+            )
+
+        # Create temp file for CI registry credentials with valid JSON structure
+        # oc registry login --to=file reads the existing file to merge credentials
+        fd, ci_auth_file = tempfile.mkstemp(suffix='.json', text=True)
+        with os.fdopen(fd, 'w') as f:
+            json.dump({"auths": {}}, f)
+
+        try:
+            # Login to cluster registry and QCI to create CI auth file
+            await oc.registry_login(to_file=ci_auth_file)
+            await oc.qci_registry_login(to_file=ci_auth_file)
+
+            # Build source files list
+            source_files = [quay_auth_file]
+            if redhat_registry_auth_file:
+                source_files.append(redhat_registry_auth_file)
+            source_files.append(ci_auth_file)
+
+            # Global registry config for ALL pipeline operations
+            # This ensures all oc commands (including doozer's internal calls) use explicit credentials
+            with RegistryConfig(
+                source_files=source_files,
+                registries=[
+                    REGISTRY_QUAY_OCP_RELEASE_DEV,  # For: ART release images
+                    REGISTRY_QUAY_OPENSHIFT,  # For: QCI push (DPTP's CI registry)
+                    KONFLUX_ART_IMAGES,  # For: Konflux builds (cosign attestations)
+                    KONFLUX_ART_IMAGES_SHARE,  # For: Konflux image sharing (sync_images)
+                    REGISTRY_REDHAT_IO,  # For: RHEL base images
+                    REGISTRY_BREW,  # For: parent images (uses registry.redhat.io creds via alias)
+                    REGISTRY_CI_OPENSHIFT,  # For: CI operations
+                ],
+            ) as global_auth_file:
+                # Create a temp directory for Docker config (cosign needs $DOCKER_CONFIG/config.json)
+                docker_config_dir = tempfile.mkdtemp(prefix='docker_config_')
+                docker_config_file = os.path.join(docker_config_dir, 'config.json')
+
+                try:
+                    # Copy the merged auth file to Docker config location for cosign
+                    shutil.copy2(global_auth_file, docker_config_file)
+
+                    # Save original environment variables
+                    original_registry_auth = os.environ.get('REGISTRY_AUTH_FILE')
+                    original_quay_auth = os.environ.get('QUAY_AUTH_FILE')
+                    original_docker_config = os.environ.get('DOCKER_CONFIG')
+
+                    # Set global auth file for all registry operations
+                    # REGISTRY_AUTH_FILE: Used by oc/podman commands
+                    # QUAY_AUTH_FILE: Used by doozer when passing --registry-auth or calling oc
+                    # DOCKER_CONFIG: Used by cosign for attestation downloads
+                    os.environ['REGISTRY_AUTH_FILE'] = global_auth_file
+                    os.environ['QUAY_AUTH_FILE'] = global_auth_file
+                    os.environ['DOCKER_CONFIG'] = docker_config_dir
+
+                    LOGGER.info(
+                        f'Set global registry auth file={global_auth_file} for all pipeline operations '
+                        f'(cherry-picked from {len(source_files)} source file(s))'
+                    )
+
+                    try:
+                        await self._run_pipeline()
+                    finally:
+                        # Restore original environment variables
+                        if original_registry_auth:
+                            os.environ['REGISTRY_AUTH_FILE'] = original_registry_auth
+                        elif 'REGISTRY_AUTH_FILE' in os.environ:
+                            del os.environ['REGISTRY_AUTH_FILE']
+
+                        if original_quay_auth:
+                            os.environ['QUAY_AUTH_FILE'] = original_quay_auth
+                        elif 'QUAY_AUTH_FILE' in os.environ:
+                            del os.environ['QUAY_AUTH_FILE']
+
+                        if original_docker_config:
+                            os.environ['DOCKER_CONFIG'] = original_docker_config
+                        elif 'DOCKER_CONFIG' in os.environ:
+                            del os.environ['DOCKER_CONFIG']
+                finally:
+                    # Clean up Docker config directory
+                    if os.path.exists(docker_config_dir):
+                        shutil.rmtree(docker_config_dir)
+        finally:
+            # Clean up temp CI auth file
+            if os.path.exists(ci_auth_file):
+                os.unlink(ci_auth_file)
+
+    async def _run_pipeline(self):
+        """Core pipeline logic wrapped by global registry auth config."""
         await self.initialize()
 
         # Rebase and build RPMs

--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -1,11 +1,21 @@
+import json
 import logging
 import os
+import shutil
+import tempfile
 
 import click
 import yaml
 from artcommonlib import exectools
+from artcommonlib.constants import (
+    KONFLUX_ART_IMAGES,
+    KONFLUX_ART_IMAGES_SHARE,
+    REGISTRY_CI_OPENSHIFT,
+    REGISTRY_QUAY_OCP_RELEASE_DEV,
+)
+from artcommonlib.registry_config import RegistryConfig
 
-from pyartcd import constants, jenkins, locks, util
+from pyartcd import constants, jenkins, locks, oc, util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.locks import Lock
 from pyartcd.runtime import Runtime
@@ -46,6 +56,89 @@ class Ocp4ScanPipeline:
         ]
 
     async def run(self):
+        # Unset XDG_RUNTIME_DIR to prevent use of default registry auth
+        if 'XDG_RUNTIME_DIR' in os.environ:
+            self.logger.info('Unsetting XDG_RUNTIME_DIR to prevent use of default registry auth')
+            del os.environ['XDG_RUNTIME_DIR']
+
+        # Get Jenkins credentials
+        quay_auth_file = os.getenv('QUAY_AUTH_FILE')
+        redhat_registry_auth_file = os.getenv('KONFLUX_OPERATOR_INDEX_AUTH_FILE')
+
+        if not quay_auth_file:
+            raise ValueError(
+                "QUAY_AUTH_FILE environment variable is required. This should be set via Jenkins credentials binding."
+            )
+
+        # Create temp file for CI registry credentials with valid JSON structure
+        fd, ci_auth_file = tempfile.mkstemp(suffix='.json', text=True)
+        with os.fdopen(fd, 'w') as f:
+            json.dump({"auths": {}}, f)
+
+        try:
+            # Login to CI registry (requires KUBECONFIG from buildlib.withAppCiAsArtPublish)
+            await oc.registry_login(to_file=ci_auth_file)
+
+            # Build source files list
+            source_files = [quay_auth_file]
+            if redhat_registry_auth_file:
+                source_files.append(redhat_registry_auth_file)
+            source_files.append(ci_auth_file)
+
+            # Global registry config for ALL scan operations
+            with RegistryConfig(
+                source_files=source_files,
+                registries=[
+                    REGISTRY_QUAY_OCP_RELEASE_DEV,
+                    KONFLUX_ART_IMAGES,
+                    KONFLUX_ART_IMAGES_SHARE,
+                    REGISTRY_CI_OPENSHIFT,
+                ],
+            ) as global_auth_file:
+                # Create temp directory for Docker config
+                docker_config_dir = tempfile.mkdtemp(prefix='docker_config_')
+                docker_config_file = os.path.join(docker_config_dir, 'config.json')
+
+                try:
+                    shutil.copy2(global_auth_file, docker_config_file)
+
+                    # Save original environment variables
+                    original_registry_auth = os.environ.get('REGISTRY_AUTH_FILE')
+                    original_quay_auth = os.environ.get('QUAY_AUTH_FILE')
+                    original_docker_config = os.environ.get('DOCKER_CONFIG')
+
+                    # Set global auth file for all registry operations
+                    os.environ['REGISTRY_AUTH_FILE'] = global_auth_file
+                    os.environ['QUAY_AUTH_FILE'] = global_auth_file
+                    os.environ['DOCKER_CONFIG'] = docker_config_dir
+
+                    try:
+                        await self._run_scan()
+                    finally:
+                        # Restore original environment variables
+                        if original_registry_auth:
+                            os.environ['REGISTRY_AUTH_FILE'] = original_registry_auth
+                        elif 'REGISTRY_AUTH_FILE' in os.environ:
+                            del os.environ['REGISTRY_AUTH_FILE']
+
+                        if original_quay_auth:
+                            os.environ['QUAY_AUTH_FILE'] = original_quay_auth
+                        elif 'QUAY_AUTH_FILE' in os.environ:
+                            del os.environ['QUAY_AUTH_FILE']
+
+                        if original_docker_config:
+                            os.environ['DOCKER_CONFIG'] = original_docker_config
+                        elif 'DOCKER_CONFIG' in os.environ:
+                            del os.environ['DOCKER_CONFIG']
+                finally:
+                    if os.path.exists(docker_config_dir):
+                        shutil.rmtree(docker_config_dir)
+        finally:
+            if os.path.exists(ci_auth_file):
+                os.unlink(ci_auth_file)
+
+    async def _run_scan(self):
+        """Core scan logic wrapped by global registry auth config."""
         # If we get here, lock could be acquired
         self.skipped = False
         scan_info = f'Scanning version {self.version}, assembly {self.assembly}, data path {self.data_path}'


### PR DESCRIPTION
feat(registry-auth): add RegistryAuthManager for explicit credential control

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

Replace dependency on default buildvm auth.json files with explicit Jenkins credentials. Supports both file-based auth (QUAY_AUTH_FILE) and username/password credentials

Key changes:
  - Add RegistryAuthManager context manager in artcommonlib
  - Merge multiple auth sources into temporary file for oc commands
  - Update oc.registry_login() and oc.qci_registry_login() calls to update in a temp file.

  Benefits:
  - Transparency: clear visibility into which credentials are used
  - No hidden dependencies on buildvm default files
  - Automatic temp file cleanup
  - Support for both file and username/password auth formats
  
 Jenkins test jobs:
 [https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift/3780/](url)
 [https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/31967/console](url)