### PR TITLE
fix validator cpu_count

### DIFF
--- a/ocp-build-data-validator/validator/__main__.py
+++ b/ocp-build-data-validator/validator/__main__.py
@@ -92,7 +92,7 @@ def main():
     else:
         try:
             rc = 0
-            pool = Pool(cpu_count(), initializer=global_session.set_global_session)
+            pool = Pool(min(cpu_count(), len(args.files)), initializer=global_session.set_global_session)
             atexit.register(pool.close)
             pool.starmap(validate, [(f, args.schema_only, args.images_dir) for f in args.files])
         except exceptions.ValidationFailedWIP as e:


### PR DESCRIPTION
  ## Summary                                                                                                                                                                             
   
  - Cap multiprocessing pool size to the number of files being validated instead of using all available CPUs                                                                             
                                      
  ## Problem                                                                                                                                                                             
                                      
  `validate-ocp-build-data` creates a multiprocessing `Pool(cpu_count())`, spawning as many worker processes as there are CPUs on the host. In Kubernetes pods, `cpu_count()` returns the **node's** CPU count (often 32-64), not the pod's CPU limit. When validating a small number of files (e.g., 4 shipment files), this spawns dozens of idle processes that waste memory and can trigger OOM kills.                                                                                                                                                             
                                      
  This was observed in the [ocp-shipment-data CI pipeline](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/470) where the validator was killed by the kernel while validating 4 files for the 4.18.38 shipment:
                                                                                                                                                                                         
  line 339:   657 Killed    validate-ocp-build-data $CHANGED_SHIPMENT_FILES                                                                                                              
                                         
  ## Fix                                                                                                                                                                                 
                                                                                                                                                                                         
  Cap the pool size to `min(cpu_count(), len(files))` so we never spawn more workers than files to validate.                                                                             
                                                                                                                                                                                         
  ## Test plan                                                                                                                                                                           
                                         
  - [ ] Existing unit tests pass                                                                                                                                                         
  - [ ] Validate a small number of files (e.g., 4) and confirm only 4 worker processes are spawned
  - [ ] Validate a large number of files and confirm pool size still scales up to `cpu_count()` 