### PR TITLE
Add module-aware RPM resolution to lockfile generator

### DIFF
--- a/doozer/doozerlib/lockfile.py
+++ b/doozer/doozerlib/lockfile.py
@@ -14,7 +14,7 @@ from artcommonlib.telemetry import start_as_current_span_async
 from opentelemetry import trace
 
 from doozerlib.image import ImageMetadata
-from doozerlib.repodata import Repodata, Rpm
+from doozerlib.repodata import Repodata, Rpm, RpmModule
 from doozerlib.repos import Repos
 
 TRACER = trace.get_tracer(__name__)
@@ -272,7 +272,9 @@ class RpmInfoCollector:
         self.loaded_repos.update({r.name: r for r in repodatas})
         self.logger.info(f"Finished loading repos: {', '.join(repos_to_fetch)} for arch {arch}")
 
-    def _fetch_rpms_info_per_arch(self, rpm_names: set[str], repo_names: set[str], arch: str) -> list[RpmInfo]:
+    def _fetch_rpms_info_per_arch(
+        self, rpm_names: set[str], repo_names: set[str], arch: str, enabled_modules: set[str] | None = None
+    ) -> list[RpmInfo]:
         """
         Resolve RPM metadata for a specific architecture from the given repodata names.
 
@@ -284,10 +286,17 @@ class RpmInfoCollector:
         ``sort_repos_for_lockfile_resolution`` acts as tiebreaker (RHEL upstream repos
         are preferred over rhocp plashets).
 
+        Non-modular RPMs are preferred over modular ones when both exist for the same
+        package name. This prevents the "highest EVR" logic from pulling in modular RPMs
+        that would be blocked by dnf modular filtering at build time. RPMs from modules
+        listed in ``enabled_modules`` (i.e. the image's ``modules:`` config) are exempt
+        and compete on EVR normally — the user is explicitly requesting those modules.
+
         Args:
             rpm_names (set[str]): RPM names or NVRs to resolve.
             repo_names (set[str]): Names of repodata sources to search.
             arch (str): Target architecture.
+            enabled_modules (set[str] | None): Module names from the image's ``modules:`` config.
 
         Returns:
             list[RpmInfo]: Resolved RPM package metadata.
@@ -298,7 +307,20 @@ class RpmInfoCollector:
             if is_nvr:
                 nvr_to_name[item] = pkg_name
 
+        # Build a set of ALL modular NEVRAs so we can identify modular RPMs.
+        # For non-enabled modules, non-modular versions are preferred.
+        # For enabled modules, RPMs are resolved directly from module metadata
+        # in a second pass, bypassing EVR comparison entirely.
+        enabled_module_names = {m.split(':')[0] for m in (enabled_modules or set())}
+        all_modular_nevras: set[str] = set()
+        for repo_key, repodata in self.loaded_repos.items():
+            if not repo_key.endswith(f'-{arch}'):
+                continue
+            for module in repodata.modules:
+                all_modular_nevras.update(module.rpms)
+
         best_by_name: dict[str, RpmInfo] = {}
+        best_is_modular: dict[str, bool] = {}
         pinned_by_nvr: dict[str, RpmInfo] = {}
         resolved_items: set[str] = set()
 
@@ -326,20 +348,64 @@ class RpmInfoCollector:
             baseurl = repo.baseurl(repotype="unsigned", arch=arch)
             for rpm in found_rpms:
                 info = RpmInfo.from_rpm(rpm, repoid=content_set_id, baseurl=baseurl)
+                is_modular = rpm.nevra in all_modular_nevras
 
                 for nvr_str, pkg_name in nvr_to_name.items():
                     if rpm.name == pkg_name and rpm.nvr == nvr_str and nvr_str not in pinned_by_nvr:
                         pinned_by_nvr[nvr_str] = info
 
                 existing = best_by_name.get(rpm.name)
-                if existing is None or info > existing:
+                if existing is None:
                     best_by_name[rpm.name] = info
+                    best_is_modular[rpm.name] = is_modular
+                elif best_is_modular.get(rpm.name) and not is_modular:
+                    best_by_name[rpm.name] = info
+                    best_is_modular[rpm.name] = False
+                elif not best_is_modular.get(rpm.name) and is_modular:
+                    pass  # Keep existing non-modular
+                elif info > existing:
+                    best_by_name[rpm.name] = info
+                    best_is_modular[rpm.name] = is_modular
 
         missing = rpm_names - resolved_items
         if missing:
             self.logger.warning(
                 f"Could not find {','.join(sorted(missing))} in {', '.join(repo_names)} for arch {arch}"
             )
+
+        # Fix: when get_rpms() returned a modular RPM from a non-enabled module
+        # (because it was the highest EVR in that repo), search primary_rpms
+        # directly for a non-modular alternative with a lower EVR.
+        nvr_pinned_names = set(nvr_to_name.values())
+        for pkg_name in list(best_by_name):
+            if not best_is_modular.get(pkg_name):
+                continue
+            if pkg_name in nvr_pinned_names:
+                continue
+            for repo_name in sort_repos_for_lockfile_resolution(repo_names):
+                repodata = self.loaded_repos.get(f'{repo_name}-{arch}')
+                if repodata is None:
+                    continue
+                for rpm in repodata.primary_rpms:
+                    if rpm.name == pkg_name and (rpm.arch == arch or rpm.arch == 'noarch'):
+                        if rpm.nevra not in all_modular_nevras:
+                            repo = self.repos._repos.get(repo_name)
+                            if repo is None:
+                                continue
+                            content_set_id = repo.content_set(arch) or f'{repo_name}-{arch}'
+                            baseurl = repo.baseurl(repotype="unsigned", arch=arch)
+                            best_by_name[pkg_name] = RpmInfo.from_rpm(rpm, repoid=content_set_id, baseurl=baseurl)
+                            best_is_modular[pkg_name] = False
+                            break
+                if not best_is_modular.get(pkg_name):
+                    break
+
+        # Second pass: for enabled modules, resolve RPMs directly from module
+        # metadata instead of relying on EVR comparison from primary.xml.
+        # This ensures correct module context selection and overrides any
+        # non-modular versions that dnf would filter out at build time.
+        if enabled_module_names:
+            self._resolve_enabled_module_rpms(best_by_name, enabled_modules or set(), repo_names, arch, rpm_names)
 
         results: dict[tuple[str, str], RpmInfo] = {}
         for info in best_by_name.values():
@@ -349,9 +415,141 @@ class RpmInfoCollector:
 
         return sorted(results.values())
 
+    def _resolve_enabled_module_rpms(
+        self,
+        best_by_name: dict[str, RpmInfo],
+        enabled_modules: set[str],
+        repo_names: set[str],
+        arch: str,
+        rpm_names: set[str],
+    ) -> None:
+        """
+        For enabled modules, resolve RPMs directly from module metadata.
+
+        Instead of relying on EVR comparison from primary.xml (which picks
+        wrong module contexts based on meaningless context hashes), this method:
+        1. Finds all contexts for each enabled module
+        2. Picks the context whose requirements match already-resolved packages
+        3. Force-resolves RPMs from that context, overriding first-pass results
+
+        This ensures the lockfile contains modular RPMs from a consistent context
+        that matches the base packages (e.g. perl:5.26 context when perl-interpreter
+        5.26 is resolved).
+        """
+        # Resolve bare module names to their default streams from repodata.
+        # When a stream is specified (e.g. perl:5.26), use that stream.
+        # When no stream is specified (e.g. perl), use the default stream from
+        # modulemd-defaults metadata (e.g. perl:5.26 is the default on el8).
+        enabled_streams = {m for m in enabled_modules if ':' in m}
+        bare_names = {m for m in enabled_modules if ':' not in m}
+
+        # Look up default streams for bare names
+        for repo_name in repo_names:
+            repodata = self.loaded_repos.get(f'{repo_name}-{arch}')
+            if repodata is None:
+                continue
+            for name in list(bare_names):
+                default_stream = repodata.default_streams.get(name)
+                if default_stream:
+                    enabled_streams.add(f'{name}:{default_stream}')
+                    bare_names.discard(name)
+
+        module_contexts: dict[str, list[RpmModule]] = {}
+        for repo_name in repo_names:
+            repodata = self.loaded_repos.get(f'{repo_name}-{arch}')
+            if repodata is None:
+                continue
+            for module in repodata.modules:
+                if module.name_stream in enabled_streams or module.name in bare_names:
+                    module_contexts.setdefault(module.name_stream, []).append(module)
+
+        if not module_contexts:
+            return
+
+        # Resolved versions from first pass (for context matching)
+        resolved_versions: dict[str, str] = {name: info.version for name, info in best_by_name.items()}
+
+        for name_stream, contexts in module_contexts.items():
+            matching_contexts = self._pick_matching_module_contexts(contexts, resolved_versions)
+            if not matching_contexts:
+                continue
+
+            # Collect RPMs from ALL matching contexts (same requirements).
+            # Different packages may appear in different contexts of the same stream.
+            target_nevras: set[str] = set()
+            for ctx in matching_contexts:
+                target_nevras.update(ctx.rpms)
+            overridden: set[str] = set()
+
+            for repo_name in repo_names:
+                repodata = self.loaded_repos.get(f'{repo_name}-{arch}')
+                if repodata is None:
+                    continue
+                repo = self.repos._repos.get(repo_name)
+                if repo is None:
+                    continue
+                content_set_id = repo.content_set(arch) or f'{repo_name}-{arch}'
+                baseurl = repo.baseurl(repotype="unsigned", arch=arch)
+
+                for rpm in repodata.primary_rpms:
+                    if rpm.nevra in target_nevras and rpm.name not in overridden:
+                        best_by_name[rpm.name] = RpmInfo.from_rpm(rpm, repoid=content_set_id, baseurl=baseurl)
+                        overridden.add(rpm.name)
+
+            if overridden:
+                ctx_ids = ','.join(sorted({str(c.context) for c in matching_contexts}))
+                self.logger.info(
+                    f"Resolved {len(overridden)} RPMs from module {name_stream} "
+                    f"context(s) {ctx_ids}: {','.join(sorted(overridden))}"
+                )
+
+    @staticmethod
+    def _pick_matching_module_contexts(contexts: list[RpmModule], resolved_versions: dict[str, str]) -> list[RpmModule]:
+        """
+        Pick module contexts whose requirements match already-resolved packages.
+
+        Returns ALL contexts with the best match score, since different packages
+        may appear in different contexts of the same module stream (e.g.
+        perl-Net-SSLeay in one context, perl-Mozilla-CA in another, both
+        requiring perl:5.26).
+
+        Falls back to all contexts with the highest module version if no
+        requirements match.
+        """
+        scored: list[tuple[int, RpmModule]] = []
+
+        for ctx in contexts:
+            if not ctx.requires:
+                scored.append((0, ctx))
+                continue
+            score = 0
+            for dep_module, dep_streams in ctx.requires.items():
+                for pkg_name, pkg_version in resolved_versions.items():
+                    if dep_module in pkg_name:
+                        for stream in dep_streams:
+                            if pkg_version.startswith(stream):
+                                score += 1
+                                break
+            scored.append((score, ctx))
+
+        if not scored:
+            return []
+
+        best_score = max(s for s, _ in scored)
+        if best_score > 0:
+            return [ctx for s, ctx in scored if s == best_score]
+
+        # No requirements matched — return contexts with highest module version
+        max_version = max(ctx.version for _, ctx in scored)
+        return [ctx for _, ctx in scored if ctx.version == max_version]
+
     @start_as_current_span_async(TRACER, "lockfile.fetch_rpms_info")
     async def fetch_rpms_info(
-        self, arches: list[str], repositories: set[str], rpm_names: set[str]
+        self,
+        arches: list[str],
+        repositories: set[str],
+        rpm_names: set[str],
+        enabled_modules: set[str] | None = None,
     ) -> dict[str, list[RpmInfo]]:
         """
         Resolve RPM info across multiple architectures and repositories.
@@ -362,6 +560,7 @@ class RpmInfoCollector:
             arches (list[str]): Target architectures.
             repositories (set[str]): Names of repositories to search.
             rpm_names (set[str]): Names or NVRs of RPMs to resolve.
+            enabled_modules (set[str] | None): Module names from the image's ``modules:`` config.
 
         Returns:
             dict[str, list[RpmInfo]]: Mapping of architecture to resolved RPM metadata.
@@ -375,7 +574,7 @@ class RpmInfoCollector:
         results = await asyncio.gather(
             *[
                 asyncio.get_running_loop().run_in_executor(
-                    None, self._fetch_rpms_info_per_arch, rpm_names, repositories, arch
+                    None, self._fetch_rpms_info_per_arch, rpm_names, repositories, arch, enabled_modules
                 )
                 for arch in arches
             ]
@@ -715,7 +914,7 @@ class RPMLockfileGenerator:
         modules_to_install = image_meta.get_lockfile_modules_to_install()
 
         rpms_info_by_arch, modules_info_by_arch = await asyncio.gather(
-            self.builder.fetch_rpms_info(arches, enabled_repos, rpms_to_install),
+            self.builder.fetch_rpms_info(arches, enabled_repos, rpms_to_install, enabled_modules=modules_to_install),
             self.builder.fetch_modules_info(arches, enabled_repos, modules_to_install),
         )
 

--- a/doozer/doozerlib/repodata.py
+++ b/doozer/doozerlib/repodata.py
@@ -140,6 +140,7 @@ class RpmModule:
     context: str
     arch: str
     rpms: Set[str] = field(default_factory=set)
+    requires: Dict[str, List[str]] = field(default_factory=dict)
 
     @property
     def name_stream(self):
@@ -160,13 +161,16 @@ class RpmModule:
     @staticmethod
     def from_metadata(metadata: Dict[str, Any]):
         rpms = metadata["data"].get("artifacts", {}).get("rpms", [])
+        deps = metadata["data"].get("dependencies", [])
+        requires = deps[0].get("requires", {}) if deps else {}
         return RpmModule(
             name=metadata["data"]["name"],
             stream=str(metadata["data"]["stream"]),
             version=metadata["data"]["version"],
-            context=metadata["data"]["context"],
+            context=str(metadata["data"]["context"]),
             arch=metadata["data"]["arch"],
             rpms=set(rpms),
+            requires={k: [str(s) for s in v] for k, v in requires.items()},
         )
 
 
@@ -175,6 +179,7 @@ class Repodata:
     name: str
     primary_rpms: List[Rpm] = field(default_factory=list)
     modules: List[RpmModule] = field(default_factory=list)
+    default_streams: Dict[str, str] = field(default_factory=dict)
     modules_checksum: Optional[str] = None
     modules_size: Optional[int] = None
     modules_url: Optional[str] = None
@@ -367,10 +372,18 @@ class Repodata:
             Rpm.from_metadata(metadata) for metadata in primary.findall("common:package[@type='rpm']", NAMESPACES)
         ]
         modules = [RpmModule.from_metadata(metadata) for metadata in modules_yaml if metadata['document'] == 'modulemd']
+        default_streams: Dict[str, str] = {}
+        for metadata in modules_yaml:
+            if metadata.get('document') == 'modulemd-defaults':
+                mod_name = metadata['data'].get('module')
+                stream = metadata['data'].get('stream')
+                if mod_name and stream:
+                    default_streams[mod_name] = str(stream)
         repodata = Repodata(
             name=name,
             primary_rpms=primary_rpms,
             modules=modules,
+            default_streams=default_streams,
             modules_checksum=modules_checksum,
             modules_size=modules_size,
             modules_url=modules_url,

--- a/doozer/tests/test_lockfile.py
+++ b/doozer/tests/test_lockfile.py
@@ -466,6 +466,346 @@ class TestRpmInfoCollectorFetchRpms(unittest.TestCase):
         self.assertEqual(result[0].evr, '0:252-32.el9_4')
         self.assertEqual(result[0].repoid, 'baseos-cs')
 
+    def test_fetch_rpms_prefers_non_modular_over_higher_modular(self):
+        """Non-modular RPM should win over a higher-EVR modular RPM."""
+        arches = ['x86_64']
+        repo_data = {
+            "rhel-8-baseos-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/baseos/"}},
+                "content_set": {"default": "baseos-cs"},
+                "reposync": {"enabled": False},
+            },
+            "rhel-8-appstream-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/appstream/"}},
+                "content_set": {"default": "appstream-cs"},
+                "reposync": {"enabled": False},
+            },
+        }
+        repos = Repos(repo_data, arches=arches)
+        collector = RpmInfoCollector(repos=repos)
+        collector.logger = MagicMock()
+
+        non_modular_rpm = Rpm(
+            name="perl-interpreter",
+            epoch=4,
+            version="5.26.3",
+            checksum="abc",
+            size=6000000,
+            location="/perl-interpreter-5.26.3-423.el8_10.x86_64.rpm",
+            sourcerpm="perl-5.26.3-423.el8_10.src.rpm",
+            release="423.el8_10",
+            arch="x86_64",
+        )
+        modular_rpm = Rpm(
+            name="perl-interpreter",
+            epoch=4,
+            version="5.32.1",
+            checksum="def",
+            size=150000,
+            location="/perl-interpreter-5.32.1-474.module+el8.10.0.x86_64.rpm",
+            sourcerpm="perl-5.32.1-474.module+el8.10.0.src.rpm",
+            release="474.module+el8.10.0+24099+8aa2f756",
+            arch="x86_64",
+        )
+        perl_module = RpmModule(
+            name="perl",
+            stream="5.32",
+            version=8100020240612,
+            context="rhel8",
+            arch="x86_64",
+            rpms={modular_rpm.nevra},
+        )
+
+        arch = 'x86_64'
+        baseos_repodata = MagicMock()
+        baseos_repodata.get_rpms.return_value = ([non_modular_rpm], [])
+        baseos_repodata.modules = []
+        baseos_repodata.default_streams = {}
+        collector.loaded_repos[f"rhel-8-baseos-rpms-{arch}"] = baseos_repodata
+
+        appstream_repodata = MagicMock()
+        appstream_repodata.get_rpms.return_value = ([modular_rpm], [])
+        appstream_repodata.modules = [perl_module]
+        appstream_repodata.default_streams = {}
+        collector.loaded_repos[f"rhel-8-appstream-rpms-{arch}"] = appstream_repodata
+
+        # Non-modular 5.26 should win even though modular 5.32 has higher EVR
+        result = collector._fetch_rpms_info_per_arch(
+            {'perl-interpreter'},
+            set(repo_data.keys()),
+            arch,
+        )
+        self.assertEqual(len(result), 1)
+        self.assertIn('5.26.3', result[0].evr)
+        self.assertEqual(result[0].repoid, 'baseos-cs')
+
+    def test_fetch_rpms_allows_modular_when_module_enabled(self):
+        """When a module is in the image's modules: config, its higher-EVR modular RPMs should win."""
+        arches = ['x86_64']
+        repo_data = {
+            "rhel-8-baseos-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/baseos/"}},
+                "content_set": {"default": "baseos-cs"},
+                "reposync": {"enabled": False},
+            },
+            "rhel-8-appstream-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/appstream/"}},
+                "content_set": {"default": "appstream-cs"},
+                "reposync": {"enabled": False},
+            },
+        }
+        repos = Repos(repo_data, arches=arches)
+        collector = RpmInfoCollector(repos=repos)
+        collector.logger = MagicMock()
+
+        non_modular_rpm = Rpm(
+            name="perl-interpreter",
+            epoch=4,
+            version="5.26.3",
+            checksum="abc",
+            size=6000000,
+            location="/perl-interpreter-5.26.3-423.el8_10.x86_64.rpm",
+            sourcerpm="perl-5.26.3-423.el8_10.src.rpm",
+            release="423.el8_10",
+            arch="x86_64",
+        )
+        modular_rpm = Rpm(
+            name="perl-interpreter",
+            epoch=4,
+            version="5.32.1",
+            checksum="def",
+            size=150000,
+            location="/perl-interpreter-5.32.1-474.module+el8.10.0.x86_64.rpm",
+            sourcerpm="perl-5.32.1-474.module+el8.10.0.src.rpm",
+            release="474.module+el8.10.0+24099+8aa2f756",
+            arch="x86_64",
+        )
+        perl_module = RpmModule(
+            name="perl",
+            stream="5.32",
+            version=8100020240612,
+            context="rhel8",
+            arch="x86_64",
+            rpms={modular_rpm.nevra},
+        )
+
+        arch = 'x86_64'
+        baseos_repodata = MagicMock()
+        baseos_repodata.get_rpms.return_value = ([non_modular_rpm], [])
+        baseos_repodata.modules = []
+        baseos_repodata.default_streams = {}
+        baseos_repodata.primary_rpms = [non_modular_rpm]
+        collector.loaded_repos[f"rhel-8-baseos-rpms-{arch}"] = baseos_repodata
+
+        appstream_repodata = MagicMock()
+        appstream_repodata.get_rpms.return_value = ([modular_rpm], [])
+        appstream_repodata.modules = [perl_module]
+        appstream_repodata.default_streams = {"perl": "5.32"}
+        appstream_repodata.primary_rpms = [modular_rpm]
+        collector.loaded_repos[f"rhel-8-appstream-rpms-{arch}"] = appstream_repodata
+
+        # With perl in enabled_modules, default stream 5.32 is resolved from
+        # modulemd-defaults metadata — modular 5.32 should win
+        result = collector._fetch_rpms_info_per_arch(
+            {'perl-interpreter'},
+            set(repo_data.keys()),
+            arch,
+            enabled_modules={'perl'},
+        )
+        self.assertEqual(len(result), 1)
+        self.assertIn('5.32.1', result[0].evr)
+        self.assertEqual(result[0].repoid, 'appstream-cs')
+
+    def test_fetch_rpms_uses_modular_when_no_non_modular_exists(self):
+        """When a package only exists in modular form, use it regardless."""
+        arches = ['x86_64']
+        repo_data = {
+            "rhel-8-appstream-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/appstream/"}},
+                "content_set": {"default": "appstream-cs"},
+                "reposync": {"enabled": False},
+            },
+        }
+        repos = Repos(repo_data, arches=arches)
+        collector = RpmInfoCollector(repos=repos)
+        collector.logger = MagicMock()
+
+        modular_rpm = Rpm(
+            name="perl-IO-Socket-SSL",
+            epoch=0,
+            version="2.075",
+            checksum="def",
+            size=250000,
+            location="/perl-IO-Socket-SSL-2.075.rpm",
+            sourcerpm="perl-IO-Socket-SSL-2.075.src.rpm",
+            release="1.module+el8.10.0+24099+8aa2f756",
+            arch="noarch",
+        )
+        perl_ssl_module = RpmModule(
+            name="perl-IO-Socket-SSL",
+            stream="2.066",
+            version=8100020240612,
+            context="rhel8",
+            arch="x86_64",
+            rpms={modular_rpm.nevra},
+        )
+
+        arch = 'x86_64'
+        appstream_repodata = MagicMock()
+        appstream_repodata.get_rpms.return_value = ([modular_rpm], [])
+        appstream_repodata.modules = [perl_ssl_module]
+        appstream_repodata.default_streams = {}
+        collector.loaded_repos[f"rhel-8-appstream-rpms-{arch}"] = appstream_repodata
+
+        result = collector._fetch_rpms_info_per_arch(
+            {'perl-IO-Socket-SSL'},
+            set(repo_data.keys()),
+            arch,
+        )
+        self.assertEqual(len(result), 1)
+        self.assertIn('2.075', result[0].evr)
+
+    def test_fetch_rpms_resolves_enabled_module_rpms_from_correct_context(self):
+        """Enabled module RPMs should come from the context matching resolved dependencies."""
+        arches = ['x86_64']
+        repo_data = {
+            "rhel-8-baseos-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/baseos/"}},
+                "content_set": {"default": "baseos-cs"},
+                "reposync": {"enabled": False},
+            },
+            "rhel-8-appstream-rpms": {
+                "conf": {"baseurl": {"x86_64": "https://example.com/appstream/"}},
+                "content_set": {"default": "appstream-cs"},
+                "reposync": {"enabled": False},
+            },
+        }
+        repos = Repos(repo_data, arches=arches)
+        collector = RpmInfoCollector(repos=repos)
+        collector.logger = MagicMock()
+
+        # Non-modular perl-interpreter 5.26 from baseos
+        perl_interpreter = Rpm(
+            name="perl-interpreter",
+            epoch=4,
+            version="5.26.3",
+            checksum="abc",
+            size=6000000,
+            location="/perl-interpreter-5.26.3-423.el8_10.x86_64.rpm",
+            sourcerpm="perl-5.26.3-423.el8_10.src.rpm",
+            release="423.el8_10",
+            arch="x86_64",
+        )
+        # Non-modular perl-Mozilla-CA from baseos (would be filtered by dnf)
+        mozilla_ca_nonmod = Rpm(
+            name="perl-Mozilla-CA",
+            epoch=0,
+            version="20160104",
+            checksum="nonmod",
+            size=12000,
+            location="/perl-Mozilla-CA-20160104-7.el8.noarch.rpm",
+            sourcerpm="perl-Mozilla-CA.src.rpm",
+            release="7.el8",
+            arch="noarch",
+        )
+
+        # perl-Net-SSLeay from perl:5.24 context (wrong — hash sorts higher)
+        net_ssleay_524 = Rpm(
+            name="perl-Net-SSLeay",
+            epoch=0,
+            version="1.88",
+            checksum="wrong",
+            size=388000,
+            location="/perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+30f09725.x86_64.rpm",
+            sourcerpm="perl-Net-SSLeay.src.rpm",
+            release="2.module+el8.6.0+13392+30f09725",
+            arch="x86_64",
+        )
+        # perl-Net-SSLeay from perl:5.26 context (correct)
+        net_ssleay_526 = Rpm(
+            name="perl-Net-SSLeay",
+            epoch=0,
+            version="1.88",
+            checksum="right",
+            size=388000,
+            location="/perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+f0897f98.x86_64.rpm",
+            sourcerpm="perl-Net-SSLeay.src.rpm",
+            release="2.module+el8.6.0+13392+f0897f98",
+            arch="x86_64",
+        )
+        # perl-Mozilla-CA modular from perl:5.26 context
+        mozilla_ca_526 = Rpm(
+            name="perl-Mozilla-CA",
+            epoch=0,
+            version="20160104",
+            checksum="modular",
+            size=12000,
+            location="/perl-Mozilla-CA-20160104-7.module+el8.3.0+6498+9eecfe51.noarch.rpm",
+            sourcerpm="perl-Mozilla-CA.src.rpm",
+            release="7.module+el8.3.0+6498+9eecfe51",
+            arch="noarch",
+        )
+
+        # Module contexts
+        ssl_module_524 = RpmModule(
+            name="perl-IO-Socket-SSL",
+            stream="2.066",
+            version=8060020220623,
+            context="30f09725",
+            arch="x86_64",
+            rpms={net_ssleay_524.nevra},
+            requires={"perl": ["5.24"], "platform": ["el8"]},
+        )
+        ssl_module_526 = RpmModule(
+            name="perl-IO-Socket-SSL",
+            stream="2.066",
+            version=8060020220623,
+            context="f0897f98",
+            arch="x86_64",
+            rpms={net_ssleay_526.nevra, mozilla_ca_526.nevra},
+            requires={"perl": ["5.26"], "platform": ["el8"]},
+        )
+        # perl module (not enabled) also claims perl-Mozilla-CA
+        perl_module = RpmModule(
+            name="perl",
+            stream="5.26",
+            version=8100020240612,
+            context="rhel8",
+            arch="x86_64",
+            rpms={mozilla_ca_526.nevra},
+            requires={"platform": ["el8"]},
+        )
+
+        arch = 'x86_64'
+        baseos_repodata = MagicMock()
+        baseos_repodata.get_rpms.return_value = ([perl_interpreter, mozilla_ca_nonmod], [])
+        baseos_repodata.modules = []
+        baseos_repodata.default_streams = {}
+        baseos_repodata.primary_rpms = [perl_interpreter, mozilla_ca_nonmod]
+        collector.loaded_repos[f"rhel-8-baseos-rpms-{arch}"] = baseos_repodata
+
+        appstream_repodata = MagicMock()
+        appstream_repodata.get_rpms.return_value = ([net_ssleay_524], [])
+        appstream_repodata.modules = [ssl_module_524, ssl_module_526, perl_module]
+        appstream_repodata.default_streams = {"perl-IO-Socket-SSL": "2.066"}
+        appstream_repodata.primary_rpms = [net_ssleay_524, net_ssleay_526, mozilla_ca_526]
+        collector.loaded_repos[f"rhel-8-appstream-rpms-{arch}"] = appstream_repodata
+
+        result = collector._fetch_rpms_info_per_arch(
+            {'perl-interpreter', 'perl-Net-SSLeay', 'perl-Mozilla-CA'},
+            set(repo_data.keys()),
+            arch,
+            enabled_modules={'perl-IO-Socket-SSL'},
+        )
+
+        result_by_name = {r.name: r for r in result}
+        # perl-interpreter: non-modular 5.26 (perl module not enabled)
+        self.assertIn('5.26.3', result_by_name['perl-interpreter'].evr)
+        # perl-Net-SSLeay: from perl:5.26 context (correct context)
+        self.assertIn('f0897f98', result_by_name['perl-Net-SSLeay'].evr)
+        # perl-Mozilla-CA: modular from perl:5.26 context (overrides non-modular)
+        self.assertIn('module+', result_by_name['perl-Mozilla-CA'].evr)
+
     def test_fetch_rpms_preserves_nvr_pin_alongside_latest(self):
         """When both a plain name and a pinned NVR are requested, the lockfile must contain both versions."""
         arches = ['x86_64']

--- a/doozer/tests/test_repodata.py
+++ b/doozer/tests/test_repodata.py
@@ -189,6 +189,34 @@ class TestRpmModule(TestCase):
         metadata = YAML(typ="safe").load(StringIO(yaml_str))
         module = RpmModule.from_metadata(metadata)
         self.assertEqual(module.nsvca, "container-tools:rhel8:8030020201124131330:830d479e:x86_64")
+        self.assertEqual(module.requires, {})
+
+    def test_from_metadata_with_dependencies(self):
+        yaml_str = """
+        document: modulemd
+        version: 2
+        data:
+            name: perl-IO-Socket-SSL
+            stream: "2.066"
+            version: 8060020220623
+            context: 6b8485cb
+            arch: x86_64
+            dependencies:
+                - buildrequires:
+                    perl: [5.32]
+                    platform: [el8.6.0]
+                  requires:
+                    perl: [5.32]
+                    platform: [el8]
+            artifacts:
+                rpms:
+                    - perl-IO-Socket-SSL-0:2.066-4.module+el8.6.0+13392+6b8485cb.noarch
+                    - perl-Net-SSLeay-0:1.88-2.module+el8.6.0+13392+30f09725.x86_64
+        """
+        metadata = YAML(typ="safe").load(StringIO(yaml_str))
+        module = RpmModule.from_metadata(metadata)
+        self.assertEqual(module.requires, {"perl": ["5.32"], "platform": ["el8"]})
+        self.assertEqual(len(module.rpms), 2)
 
 
 class TestRepodata(TestCase):


### PR DESCRIPTION
## Summary

PR #2746 changed lockfile RPM resolution to pick the highest EVR across all repos. This caused two regressions:

1. **Modular RPMs win over non-modular** — e.g., modular `perl-interpreter` 5.32 beats non-modular 5.26 because it has a higher EVR. At build time, dnf modular filtering blocks these packages.

2. **Wrong module context selection** — when a module has multiple build contexts (e.g., `perl-IO-Socket-SSL` built for perl:5.24 vs perl:5.26), EVR comparison picks based on a meaningless context hash, selecting the wrong context.

The resolver now works in three phases:

- **Phase 1 (main loop)**: Prefer non-modular over modular when both exist for the same package, regardless of EVR.
- **Phase 2 (same-repo fallback)**: When `get_rpms()` returns only a modular RPM (highest EVR in that repo), search `primary_rpms` for a non-modular alternative that `get_rpms()` skipped. Skips NVR-pinned packages from `installed_rpms` — these came from a previous successful build and should not be replaced with potentially inconsistent non-modular versions from different repos/arches.
- **Phase 3 (enabled module override)**: For modules listed in the image's `modules:` config, resolve ALL RPMs from the module's selected stream directly from module metadata. This includes packages not listed in `rpms:` — when a user requests a module, all its RPMs should be available in the lockfile. The correct stream and context are selected using `modulemd-defaults` metadata and dependency requirements.

Supporting changes:
- `RpmModule` now parses dependency requirements and default streams from `modules.yaml`
- `Repodata` now parses `modulemd-defaults` documents for default stream resolution
- Stream-aware filtering: `modules: [perl:5.32]` resolves only that stream; `modules: [perl]` resolves the default stream from `modulemd-defaults` metadata

## `modules:` config usage

The `modules:` field controls which module RPMs are included in the lockfile. When a module is listed, **all RPMs from that module stream are included** in the lockfile — they don't need to be separately listed in `rpms:`. The `rpms:` list is for builder/intermediate stage packages that can be part or not part of a specific module.

It supports two formats:

### Bare module name — uses default stream
```yaml
modules:
  - perl                    # resolves to perl:5.26 (default stream from modulemd-defaults)
  - perl-IO-Socket-SSL      # resolves to perl-IO-Socket-SSL:2.066 (only stream available)
```
- Default streams auto-enable at build time — no `dnf module enable` needed in Dockerfile
- All RPMs from the module are resolved from the correct context matching already-resolved packages

### Module with explicit stream — uses specified stream
```yaml
modules:
  - perl:5.32               # resolves to perl:5.32 specifically
  - perl-IO-Socket-SSL      # resolves to perl-IO-Socket-SSL:2.066
```
- **Non-default streams require explicit `dnf module enable` in the Dockerfile** (e.g., via ocp-build-data modification: `dnf module enable -y perl:5.32`)
- Default and single-stream modules auto-enable without Dockerfile changes

### No modules listed
```yaml
# no modules: field, or modules: []
```
- All packages resolve as non-modular (safe default)
- Module metadata is not included in the lockfile

### Interaction with `rpms:` list
- Packages listed in both `rpms:` and a module's artifacts: the module version overrides the first-pass resolution
- Packages only in `rpms:` (not in any module): resolved normally (non-modular preferred)
- Packages only in a module (not in `rpms:`): added to the lockfile from the module's artifacts

## Evidence

Verified with Jenkins test builds across seven products (el8 and el9), all at commit `a8350661`:

### MTC 1.8 (el8, openshift-migration-openvpn + openshift-migration-operator)

| Build | Config | Result |
|---|---|---|
| [#2859](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Flayered-products/2859/) | Upstream ocp-build-data, art-tools fix only, 2 components | **SUCCESS** |

Lockfile verified: `perl-interpreter` 5.26 non-modular, `perl-IO-Socket-SSL`/`perl-Net-SSLeay`/`perl-Mozilla-CA` modular from correct contexts. Konflux build log confirmed all module streams auto-enabled (`perl:5.26`, `perl-IO-Socket-SSL:2.066`, `perl-libwww-perl:6.34`).

### OADP 1.5 (el9, 11 components)

| Build | Config | Result |
|---|---|---|
| [#2864](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Flayered-products/2864/) | Upstream ocp-build-data, art-tools fix only, all 11 components | **SUCCESS** |

### MTA 8.1 (el9, 16 components)

| Build | Config | Result |
|---|---|---|
| [#2861](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Flayered-products/2861/) | Upstream ocp-build-data, art-tools fix only, all 16 components | **SUCCESS** |

MTA uses `modules: [maven:3.9]` (jdtls-server-base) and `modules: [postgresql:15]` (mta-operator). Both resolved correctly.

### OCP 5.0 (el9, ose-agent-installer-api-server, 4 arches)

| Build | Config | Result |
|---|---|---|
| [#33356](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/33356/) | Art-tools fix + glibc-gconv-extra ocp-build-data fix, all 4 arches | **UNSTABLE** (lockfile clean, Konflux build infra failure) |

Lockfile generation verified: `modules: [postgresql:16]` resolved 24 RPMs on all 4 arches, zero cross-arch mismatches, `dnf module enable postgresql:16` configured. Build-images pods failed due to stale `openshift-clients` NVR in Konflux DB — unrelated to this PR.

### OCP 4.21 (el9, nginx:1.26 module, 3 components, 4 arches)

| Build | Config | Result |
|---|---|---|
| [#33347](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/33347/) | Art-tools fix only, upstream ocp-build-data, 3 nginx images, all 4 arches | **SUCCESS** |

Validates `nginx:1.26` module resolution with numeric context (context `9`). Resolved 10 RPMs from module on all arches. Also validates `str()` cast fix for YAML integer context parsing.

### Logging 6.5 (el9, vector)

| Build | Config | Result |
|---|---|---|
| [#2862](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Flayered-products/2862/) | Upstream ocp-build-data, art-tools fix only | **SUCCESS** |

No modules used — validates non-modular resolution path is unaffected by the changes.

### OCP 4.14 (el8, ose-egress-http-proxy, 4 arches)

| Build | Config | Result |
|---|---|---|
| [#33348](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/33348/) | Upstream ocp-build-data, art-tools fix only, `modules: [perl, squid]` | **SUCCESS** |

Validates phase 2 NVR-skip fix: `perl-DBI` (modular-only package from `installed_rpms`) is no longer replaced with an inconsistent non-modular version from baseos. Zero cross-arch mismatches. `squid:4` module resolved correctly via phase 3.

## Backwards compatibility

This change does not alter behavior for images that don't use modular packages. The `modules:` config field (existing, unchanged) controls which modules' RPMs are included in the lockfile — all other modular RPMs are deprioritised in favor of non-modular versions.

For images that already list module RPMs in `rpms:`, behavior is unchanged — phase 3 overrides the first-pass resolution with the correct module version regardless.

## Test plan

- [x] All doozer tests pass (45 lockfile + 11 validation passed)
- [x] New test: `test_fetch_rpms_prefers_non_modular_over_higher_modular` — phase 1
- [x] New test: `test_fetch_rpms_allows_modular_when_module_enabled` — phase 3 with default stream
- [x] New test: `test_fetch_rpms_uses_modular_when_no_non_modular_exists` — modular-only fallback
- [x] New test: `test_fetch_rpms_resolves_enabled_module_rpms_from_correct_context` — phase 3 context + cross-module
- [x] New test: `test_from_metadata_with_dependencies` — RpmModule dependency parsing
- [x] Lint clean
- [x] MTC 1.8 (el8) — green, 2 components (perl modules)
- [x] OADP 1.5 (el9) — green, all 11 components
- [x] MTA 8.1 (el9) — green, all 16 components (maven:3.9 + postgresql:15 modules)
- [x] OCP 5.0 (el9) — lockfile clean, all 4 arches (postgresql:16 module); Konflux build infra failure (unrelated)
- [x] OCP 4.21 (el9) — green, 3 nginx images, all 4 arches (nginx:1.26 module, numeric context handling)
- [x] Logging 6.5 (el9) — green (no modules, validates non-modular path)
- [x] OCP 4.14 (el8) — green, ose-egress-http-proxy, all 4 arches (perl + squid modules, phase 2 NVR-skip fix verified)

