### PR TITLE
Operate on ART managed CVE tracker bugs only

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -39,6 +39,10 @@ LOGGER = logging.getLogger(__name__)
 KONFLUX_LOGGER = logutil.get_logger(__name__)
 
 
+def is_ocp_delivery_repo(name: str) -> bool:
+    return name.startswith(("openshift4/", "openshift5/"))
+
+
 def get_utc_now_formatted_str(microseconds: bool = False):
     return datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S%f" if microseconds else "%Y%m%d%H%M%S")
 

--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -19,6 +19,7 @@ import requests
 from artcommonlib import logutil
 from artcommonlib.assembly import AssemblyTypes
 from artcommonlib.jira_config import JIRA_EMAIL
+from artcommonlib.util import is_ocp_delivery_repo
 from errata_tool import Erratum
 from errata_tool.bug import Bug as ErrataBug
 from errata_tool.jira_issue import JiraIssue as ErrataJira
@@ -33,7 +34,6 @@ from elliottlib.metadata import Metadata
 from elliottlib.util import (
     chunk,
     get_component_by_delivery_repo,
-    is_ocp_delivery_repo,
     isolate_timestamp_in_release,
 )
 

--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -30,7 +30,12 @@ from elliottlib import constants, errata, exceptions
 from elliottlib.cli import cli_opts
 from elliottlib.errata_async import AsyncErrataAPI
 from elliottlib.metadata import Metadata
-from elliottlib.util import chunk, get_component_by_delivery_repo, isolate_timestamp_in_release
+from elliottlib.util import (
+    chunk,
+    get_component_by_delivery_repo,
+    is_ocp_delivery_repo,
+    isolate_timestamp_in_release,
+)
 
 logger = logutil.get_logger(__name__)
 
@@ -1630,7 +1635,7 @@ def get_cve_unfixed_components(runtime, cve_alias: str) -> Dict:
 
             # is it a delivery repo?
             # if it is then we need to match the delivery repo name to component name
-            if "openshift4/" in pkg_name:
+            if is_ocp_delivery_repo(pkg_name):
                 comp_name = get_component_by_delivery_repo(runtime, pkg_name)
                 if not comp_name:
                     logger.warning(

--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -10,7 +10,7 @@ from artcommonlib import arch_util
 from artcommonlib.assembly import assembly_config_struct
 from artcommonlib.gitdata import SafeFormatter
 from artcommonlib.rpm_utils import parse_nvr
-from artcommonlib.util import new_roundtrip_yaml_handler
+from artcommonlib.util import is_ocp_delivery_repo, new_roundtrip_yaml_handler
 from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
 from errata_tool import Erratum
 
@@ -25,7 +25,6 @@ from elliottlib.shipment_utils import get_shipment_config_from_mr, set_bugzilla_
 from elliottlib.util import (
     get_advisory_boilerplate,
     get_component_by_delivery_repo,
-    is_ocp_delivery_repo,
 )
 
 YAML = new_roundtrip_yaml_handler()

--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -22,7 +22,11 @@ from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
 from elliottlib.runtime import Runtime
 from elliottlib.shipment_model import CveAssociation, ReleaseNotes
 from elliottlib.shipment_utils import get_shipment_config_from_mr, set_bugzilla_bug_ids
-from elliottlib.util import get_advisory_boilerplate, get_component_by_delivery_repo
+from elliottlib.util import (
+    get_advisory_boilerplate,
+    get_component_by_delivery_repo,
+    is_ocp_delivery_repo,
+)
 
 YAML = new_roundtrip_yaml_handler()
 
@@ -534,7 +538,7 @@ class AttachCveFlaws:
                 raise ValueError(f"Bug {tracker.id} doesn't have a valid whiteboard component.")
 
             whiteboard_component = tracker.whiteboard_component
-            if "openshift4/" in whiteboard_component:
+            if is_ocp_delivery_repo(whiteboard_component):
                 # this means the component here is the delivery repo name
                 # we need to translate it to build component name
                 new_component = get_component_by_delivery_repo(runtime, whiteboard_component)

--- a/elliott/elliottlib/cli/find_bugs_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_cli.py
@@ -41,6 +41,11 @@ type_bug_set = Set[Bug]
     help='Output in the specified format',
 )
 @click.option("--cve-only", is_flag=True, help="Only find CVE trackers")
+@click.option(
+    "--art-managed-trackers-only/--no-art-managed-trackers-only",
+    default=True,
+    help="Filter image component CVE trackers to ART-managed images only",
+)
 @click.pass_obj
 @click_coroutine
 async def find_bugs_cli(
@@ -49,6 +54,7 @@ async def find_bugs_cli(
     permissive,
     output,
     cve_only,
+    art_managed_trackers_only,
 ):
     """Find OCP bugs for the given group and assembly, eligible for release.
 
@@ -78,6 +84,7 @@ async def find_bugs_cli(
         output=output,
         cve_only=cve_only,
         exclude_trackers=exclude_trackers,
+        art_managed_trackers_only=art_managed_trackers_only,
     )
     await cli.run()
 
@@ -90,12 +97,14 @@ class FindBugsCli:
         output: str,
         cve_only: bool,
         exclude_trackers: bool,
+        art_managed_trackers_only: bool,
     ):
         self.runtime = runtime
         self.permissive = permissive
         self.output = output
         self.cve_only = cve_only
         self.exclude_trackers = exclude_trackers
+        self.art_managed_trackers_only = art_managed_trackers_only
         self.bug_tracker = None
 
     async def run(self):
@@ -116,7 +125,7 @@ class FindBugsCli:
         :return: A dictionary where keys are advisory kinds and values are sets of Bug objects.
         """
 
-        find_bugs_obj = FindBugsSweep(cve_only=self.cve_only)
+        find_bugs_obj = FindBugsSweep(cve_only=self.cve_only, art_managed_trackers_only=self.art_managed_trackers_only)
         statuses = sorted(find_bugs_obj.status)
         tr = self.bug_tracker.target_release()
         LOGGER.info(f"Searching {self.bug_tracker.type} for bugs with status {statuses} and target releases: {tr}\n")

--- a/elliott/elliottlib/cli/find_bugs_qe_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_qe_cli.py
@@ -38,7 +38,7 @@ def find_bugs_qe_cli(runtime: Runtime, noop, art_managed_trackers_only):
         $ elliott -g openshift-4.6 find-bugs:qe
 
     """
-    runtime.initialize()
+    runtime.initialize(mode="images")
     find_bugs_obj = FindBugsQE(art_managed_trackers_only=art_managed_trackers_only)
     exit_code = 0
     bug_tracker = runtime.get_bug_tracker('jira')

--- a/elliott/elliottlib/cli/find_bugs_qe_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_qe_cli.py
@@ -6,23 +6,29 @@ from artcommonlib import logutil
 
 from elliottlib import Runtime
 from elliottlib.cli.common import cli
-from elliottlib.cli.find_bugs_sweep_cli import FindBugsMode
+from elliottlib.cli.find_bugs_sweep_cli import FindBugsMode, filter_art_managed_jira_trackers
 
 LOGGER = logutil.get_logger(__name__)
 
 
 class FindBugsQE(FindBugsMode):
-    def __init__(self):
+    def __init__(self, art_managed_trackers_only: bool = True):
         super().__init__(
             status={'MODIFIED'},
             cve_only=False,
+            art_managed_trackers_only=art_managed_trackers_only,
         )
 
 
 @cli.command("find-bugs:qe", short_help="Change MODIFIED bugs to ON_QA and close reconciliation bugs")
 @click.option("--noop", "--dry-run", is_flag=True, default=False, help="Don't change anything")
+@click.option(
+    "--art-managed-trackers-only/--no-art-managed-trackers-only",
+    default=True,
+    help="Filter image component CVE trackers to ART-managed images only",
+)
 @click.pass_obj
-def find_bugs_qe_cli(runtime: Runtime, noop):
+def find_bugs_qe_cli(runtime: Runtime, noop, art_managed_trackers_only):
     """Find MODIFIED bugs for the target-releases, and set them to ON_QA.
         with a release comment on each bug.
 
@@ -33,7 +39,7 @@ def find_bugs_qe_cli(runtime: Runtime, noop):
 
     """
     runtime.initialize()
-    find_bugs_obj = FindBugsQE()
+    find_bugs_obj = FindBugsQE(art_managed_trackers_only=art_managed_trackers_only)
     exit_code = 0
     bug_tracker = runtime.get_bug_tracker('jira')
 
@@ -106,6 +112,8 @@ def find_bugs_qe(runtime, find_bugs_obj, noop, bug_tracker):
     LOGGER.info(f"Searching {bug_tracker.type} for bugs with status {statuses} and target releases: {tr}")
 
     bugs = find_bugs_obj.search(bug_tracker_obj=bug_tracker, verbose=runtime.debug)
+    if find_bugs_obj.art_managed_trackers_only:
+        bugs = filter_art_managed_jira_trackers(runtime, bugs, bug_tracker_type=bug_tracker.type)
     LOGGER.info(f"Found {len(bugs)} bugs: {', '.join(sorted(str(b.id) for b in bugs))}")
 
     release_comment = (

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -79,8 +79,14 @@ def filter_art_managed_jira_trackers(
         if not bug.whiteboard_component:
             raise ValueError(f"Bug {bug.id} doesn't have a valid whiteboard component.")
 
-        normalized_component = normalize_component_by_ocp_delivery_repo(runtime, bug.whiteboard_component)
-        if not normalized_component.endswith("-container"):
+        original_component = bug.whiteboard_component
+        normalized_component = normalize_component_by_ocp_delivery_repo(runtime, original_component)
+        is_image_tracker = (
+            original_component.endswith("-container")
+            or is_ocp_delivery_repo(original_component)
+            or normalized_component.endswith("-container")
+        )
+        if not is_image_tracker:
             art_trackers.append(bug)
             continue
 

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -16,7 +16,7 @@ from elliottlib.cli import common
 from elliottlib.cli.common import click_coroutine
 from elliottlib.exceptions import ElliottFatalError
 from elliottlib.shipment_utils import get_builds_from_mr
-from elliottlib.util import chunk, get_component_by_delivery_repo
+from elliottlib.util import chunk, is_ocp_delivery_repo, normalize_component_by_ocp_delivery_repo
 
 logger = logutil.get_logger(__name__)
 type_bug_list = List[Bug]
@@ -25,9 +25,10 @@ yaml = new_roundtrip_yaml_handler()
 
 
 class FindBugsMode:
-    def __init__(self, status: List, cve_only: bool = False):
+    def __init__(self, status: List, cve_only: bool = False, art_managed_trackers_only: bool = False):
         self.status = set(status)
         self.cve_only = cve_only
+        self.art_managed_trackers_only = art_managed_trackers_only
 
     def include_status(self, status: List):
         self.status |= set(status)
@@ -44,10 +45,58 @@ class FindBugsMode:
 
 
 class FindBugsSweep(FindBugsMode):
-    def __init__(self, cve_only: bool = False):
+    def __init__(self, cve_only: bool = False, art_managed_trackers_only: bool = True):
         # Policy document: https://docs.google.com/document/d/1RkyN1hp1_mUqeks0kVzPscDeZVo-RDCYCTq6VLNB9i4/edit?tab=t.0#heading=h.m52kbuqe0dss
         # Accordingly, ART only sweeps VERIFIED by default.
-        super().__init__(status={'VERIFIED'}, cve_only=cve_only)
+        super().__init__(status={'VERIFIED'}, cve_only=cve_only, art_managed_trackers_only=art_managed_trackers_only)
+
+
+def get_art_managed_image_components(runtime: Runtime) -> Set[str]:
+    image_metas = runtime.image_metas()
+    if not image_metas:
+        raise ValueError("No image metas found. Forgot to initialize runtime with mode='images' or mode='both'?")
+    return {image_meta.get_component_name() for image_meta in image_metas}
+
+
+def filter_art_managed_jira_trackers(
+    runtime: Runtime, bugs: type_bug_list, bug_tracker_type: str = "jira"
+) -> type_bug_list:
+    if bug_tracker_type != "jira" or not bugs:
+        return list(bugs)
+
+    logger.info("Validating ART-managed image tracker bugs against image metadata")
+
+    non_trackers = [bug for bug in bugs if not bug.is_tracker_bug()]
+    trackers = [bug for bug in bugs if bug.is_tracker_bug()]
+    if not trackers:
+        return list(bugs)
+
+    art_managed_image_components = get_art_managed_image_components(runtime)
+    art_trackers: type_bug_list = []
+    non_art_trackers = []
+
+    for bug in trackers:
+        if not bug.whiteboard_component:
+            raise ValueError(f"Bug {bug.id} doesn't have a valid whiteboard component.")
+
+        normalized_component = normalize_component_by_ocp_delivery_repo(runtime, bug.whiteboard_component)
+        if not normalized_component.endswith("-container"):
+            art_trackers.append(bug)
+            continue
+
+        if (
+            normalized_component == constants.GOLANG_BUILDER_CVE_COMPONENT
+            or normalized_component in art_managed_image_components
+        ):
+            art_trackers.append(bug)
+            continue
+
+        non_art_trackers.append((bug.id, bug.whiteboard_component))
+
+    if non_art_trackers:
+        logger.info("Filtered %s non-ART-managed image tracker bugs: %s", len(non_art_trackers), non_art_trackers)
+
+    return non_trackers + art_trackers
 
 
 @common.cli.command("find-bugs:sweep", short_help="Sweep qualified bugs into advisories")
@@ -87,6 +136,11 @@ class FindBugsSweep(FindBugsMode):
     '"extras" instead of the default "image", bugs filtered into "none" are not attached at all.',
 )
 @click.option("--cve-only", is_flag=True, help="Only find CVE trackers")
+@click.option(
+    "--art-managed-trackers-only/--no-art-managed-trackers-only",
+    default=True,
+    help="Filter image component CVE trackers to ART-managed images only",
+)
 @click.option("--advance-release", is_flag=True, help="If the release contains an advance advisory")
 @click.option(
     "--permissive",
@@ -108,6 +162,7 @@ async def find_bugs_sweep_cli(
     output,
     into_default_advisories,
     cve_only,
+    art_managed_trackers_only,
     advance_release,
     permissive,
     noop,
@@ -151,7 +206,7 @@ async def find_bugs_sweep_cli(
         raise click.BadParameter("Do not use find-bugs:sweep with --build-system=konflux, instead use find-bugs")
 
     runtime.initialize(mode="both")
-    find_bugs_obj = FindBugsSweep(cve_only=cve_only)
+    find_bugs_obj = FindBugsSweep(cve_only=cve_only, art_managed_trackers_only=art_managed_trackers_only)
     find_bugs_obj.include_status(include_status)
     find_bugs_obj.exclude_status(exclude_status)
 
@@ -212,6 +267,9 @@ async def get_bugs_sweep(runtime: Runtime, find_bugs_obj, bug_tracker):
             logger.debug(f"Bugs attached to other advisories: {sorted(attached_bug_ids)}")
             bugs = [b for b in bugs if b.id not in attached_bug_ids]
             logger.info(f"Filtered {len(attached_bugs)} bugs since they are attached to other advisories")
+
+        if find_bugs_obj.art_managed_trackers_only:
+            bugs = filter_art_managed_jira_trackers(runtime, bugs, bug_tracker_type=bug_tracker.type)
 
     included_bug_ids, excluded_bug_ids = get_assembly_bug_ids(runtime, bug_tracker_type=bug_tracker.type)
     if included_bug_ids & excluded_bug_ids:
@@ -509,8 +567,7 @@ def categorize_bugs_by_type(
 
         for bug in tracker_bugs:
             package_name = bug.whiteboard_component
-            if "openshift4/" in package_name:
-                package_name = get_component_by_delivery_repo(runtime, package_name)
+            package_name = normalize_component_by_ocp_delivery_repo(runtime, package_name)
             if kind == "microshift" and package_name == "microshift" and len(packages) == 0:
                 # microshift is special since it has a separate advisory, and it's build is attached
                 # after payload is promoted. So do not pre-emptively complain
@@ -541,7 +598,7 @@ def categorize_bugs_by_type(
         )
 
     def _is_image_component(component: str) -> bool:
-        return component.endswith("-container") or "openshift4/" in component
+        return component.endswith("-container") or is_ocp_delivery_repo(component)
 
     not_found = set(tracker_bugs) - found
     if not_found:

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -8,7 +8,7 @@ from artcommonlib import arch_util, logutil
 from artcommonlib.assembly import assembly_config_struct, assembly_issues_config
 from artcommonlib.format_util import green_print
 from artcommonlib.rpm_utils import parse_nvr
-from artcommonlib.util import new_roundtrip_yaml_handler
+from artcommonlib.util import is_ocp_delivery_repo, new_roundtrip_yaml_handler
 
 from elliottlib import Runtime, bzutil, constants, errata
 from elliottlib.bzutil import Bug, BugTracker, JIRABug
@@ -16,7 +16,7 @@ from elliottlib.cli import common
 from elliottlib.cli.common import click_coroutine
 from elliottlib.exceptions import ElliottFatalError
 from elliottlib.shipment_utils import get_builds_from_mr
-from elliottlib.util import chunk, is_ocp_delivery_repo, normalize_component_by_ocp_delivery_repo
+from elliottlib.util import chunk, normalize_component_by_ocp_delivery_repo
 
 logger = logutil.get_logger(__name__)
 type_bug_list = List[Bug]

--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -202,7 +202,7 @@ async def verify_bugs_cli(
     - Bug Status (--verify-bug-status): All bugs are at least in VERIFIED state
 
     """
-    runtime.initialize()
+    runtime.initialize(mode="images")
     await verify_bugs(runtime, verify_bug_status, output, no_verify_blocking_bugs, art_managed_trackers_only)
 
 

--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -14,7 +14,12 @@ from elliottlib import bzutil, constants
 from elliottlib.bzutil import Bug, get_flaws
 from elliottlib.cli.attach_cve_flaws_cli import AttachCveFlaws
 from elliottlib.cli.common import cli, click_coroutine, pass_runtime
-from elliottlib.cli.find_bugs_sweep_cli import FindBugsSweep, categorize_bugs_by_type, get_builds_by_advisory_kind
+from elliottlib.cli.find_bugs_sweep_cli import (
+    FindBugsSweep,
+    categorize_bugs_by_type,
+    filter_art_managed_jira_trackers,
+    get_builds_by_advisory_kind,
+)
 from elliottlib.errata import get_bug_ids, is_advisory_editable, sync_jira_issue
 from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
 from elliottlib.runtime import Runtime
@@ -173,9 +178,16 @@ async def verify_attached_bugs(
     default='text',
     help='Applies chosen format to command output',
 )
+@click.option(
+    "--art-managed-trackers-only/--no-art-managed-trackers-only",
+    default=True,
+    help="Filter image component CVE trackers to ART-managed images only",
+)
 @pass_runtime
 @click_coroutine
-async def verify_bugs_cli(runtime, verify_bug_status, output, no_verify_blocking_bugs: bool):
+async def verify_bugs_cli(
+    runtime, verify_bug_status, output, no_verify_blocking_bugs: bool, art_managed_trackers_only: bool
+):
     """
     Validate bugs that qualify as being part of an assembly (specified as --assembly)
     Requires group param (-g openshift-X.Y). By default runs for --assembly=stream
@@ -191,16 +203,20 @@ async def verify_bugs_cli(runtime, verify_bug_status, output, no_verify_blocking
 
     """
     runtime.initialize()
-    await verify_bugs(runtime, verify_bug_status, output, no_verify_blocking_bugs)
+    await verify_bugs(runtime, verify_bug_status, output, no_verify_blocking_bugs, art_managed_trackers_only)
 
 
-async def verify_bugs(runtime, verify_bug_status, output, no_verify_blocking_bugs):
+async def verify_bugs(
+    runtime, verify_bug_status, output, no_verify_blocking_bugs, art_managed_trackers_only: bool = True
+):
     validator = BugValidator(runtime, output)
-    find_bugs_obj = FindBugsSweep(cve_only=False)
+    find_bugs_obj = FindBugsSweep(cve_only=False, art_managed_trackers_only=art_managed_trackers_only)
     ocp_bugs = []
     logger.info(f'Using {runtime.assembly} assembly to search bugs')
     for b in [runtime.get_bug_tracker('jira'), runtime.get_bug_tracker('bugzilla')]:
         bugs = find_bugs_obj.search(bug_tracker_obj=b, verbose=runtime.debug)
+        if find_bugs_obj.art_managed_trackers_only:
+            bugs = filter_art_managed_jira_trackers(runtime, bugs, bug_tracker_type=b.type)
         logger.info(f"Found {len(bugs)} {b.type} bugs: {[b.id for b in bugs]}")
         ocp_bugs.extend(bugs)
 

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -208,6 +208,10 @@ def minor_version_tuple(bz_target):
     return int(match.groups()[0]), int(match.groups()[1])
 
 
+def is_ocp_delivery_repo(name: str) -> bool:
+    return name.startswith(("openshift4/", "openshift5/"))
+
+
 def get_component_by_delivery_repo(runtime, delivery_repo_name: str) -> Optional[str]:
     """Get the component name from the delivery repo name
     For example, "openshift4/ose-sriov-network-device-plugin-rhel9" -> "sriov-network-device-plugin-container"
@@ -223,6 +227,16 @@ def get_component_by_delivery_repo(runtime, delivery_repo_name: str) -> Optional
         if _strip(delivery_repo_name) in [_strip(r) for r in image.config.delivery.delivery_repo_names]:
             return image.get_component_name()
     return None
+
+
+def normalize_component_by_ocp_delivery_repo(runtime, component_or_delivery_repo_name: str) -> str:
+    """Translate delivery repo names to component names when possible.
+
+    Returns the original value when it doesn't look like a delivery repo or when no mapping is found.
+    """
+    if not is_ocp_delivery_repo(component_or_delivery_repo_name):
+        return component_or_delivery_repo_name
+    return get_component_by_delivery_repo(runtime, component_or_delivery_repo_name) or component_or_delivery_repo_name
 
 
 def get_golang_version_from_log(log, log_url):

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -21,7 +21,7 @@ from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord
 from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.logutil import get_logger
 from artcommonlib.oc_image_info import oc_image_info__cached_async
-from artcommonlib.util import extract_related_images_from_fbc
+from artcommonlib.util import extract_related_images_from_fbc, is_ocp_delivery_repo
 from errata_tool import Erratum
 
 from elliottlib import brew, constants
@@ -206,10 +206,6 @@ def minor_version_tuple(bz_target):
 
     match = re.match(r'^(\d+).(\d+)(.0|.z)?$', bz_target)
     return int(match.groups()[0]), int(match.groups()[1])
-
-
-def is_ocp_delivery_repo(name: str) -> bool:
-    return name.startswith(("openshift4/", "openshift5/"))
 
 
 def get_component_by_delivery_repo(runtime, delivery_repo_name: str) -> Optional[str]:

--- a/elliott/tests/test_find_bugs_qe_cli.py
+++ b/elliott/tests/test_find_bugs_qe_cli.py
@@ -1,17 +1,19 @@
 import unittest
+from unittest.mock import patch
 
+import elliottlib.cli.find_bugs_qe_cli as qe_cli
 from click.testing import CliRunner
 from elliottlib.bzutil import JIRABugTracker
 from elliottlib.cli.common import Runtime, cli
-from elliottlib.cli.find_bugs_qe_cli import FindBugsQE
+from elliottlib.cli.find_bugs_qe_cli import FindBugsQE, close_reconciliation_bugs, find_bugs_qe
 from flexmock import flexmock
 
 
 class FindBugsQETestCase(unittest.TestCase):
     def test_find_bugs_qe(self):
         runner = CliRunner()
-        jira_bug = flexmock(id='OCPBUGS-123', status="MODIFIED")
-        reconciliation_bug = flexmock(id='OCPBUGS-456', status="Verified")
+        jira_bug = flexmock(id='OCPBUGS-123', status="MODIFIED", is_tracker_bug=lambda: False, security_level=None)
+        reconciliation_bug = flexmock(id='OCPBUGS-456', status="Verified", is_tracker_bug=lambda: False)
 
         flexmock(Runtime).should_receive("initialize").and_return(None)
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
@@ -50,6 +52,59 @@ class FindBugsQETestCase(unittest.TestCase):
 
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:qe', '--noop'])
         self.assertEqual(result.exit_code, 0)
+
+    def test_find_bugs_qe_opt_out_skips_filter(self):
+        runtime = flexmock(debug=False, get_major_minor=lambda: (4, 6))
+        bug = flexmock(id='OCPBUGS-123', status="MODIFIED", is_tracker_bug=lambda: False, security_level=None)
+        bug_tracker = flexmock(type='jira')
+        find_bugs_obj = FindBugsQE(art_managed_trackers_only=False)
+        flexmock(find_bugs_obj).should_receive("search").and_return([bug]).once()
+        flexmock(bug_tracker).should_receive("target_release").and_return(["4.6.z"])
+        flexmock(bug_tracker).should_receive("update_bug_status").with_args(
+            bug,
+            'ON_QA',
+            comment=(
+                "An ART build cycle completed after this fix was made, which usually means it can be"
+                " expected in the next created 4.6 nightly and release."
+            ),
+            noop=True,
+        ).once()
+
+        with patch.object(qe_cli, "filter_art_managed_jira_trackers") as filter_mock:
+            find_bugs_qe(runtime, find_bugs_obj, True, bug_tracker)
+
+        filter_mock.assert_not_called()
+
+    def test_close_reconciliation_bugs_unchanged(self):
+        runtime = flexmock(debug=False, get_major_minor=lambda: (4, 6))
+        bug1 = flexmock(id='OCPBUGS-456', status="Verified")
+        bug2 = flexmock(id='OCPBUGS-789', status="Verified")
+        client = flexmock()
+        bug_tracker = flexmock(type='jira', _client=client)
+        flexmock(bug_tracker).should_receive("target_release").and_return(["4.6.z"])
+        flexmock(bug_tracker).should_receive("_query").with_args(
+            status=['Verified'],
+            include_labels=['art:reconciliation'],
+        ).and_return("mocked query").once()
+        flexmock(bug_tracker).should_receive("_search").with_args("mocked query", verbose=False).and_return(
+            [bug1, bug2]
+        ).once()
+        for bug in [bug1, bug2]:
+            flexmock(client).should_receive("transition_issue").with_args(
+                bug.id, 'Closed', fields={'resolution': {'name': 'Done'}}
+            ).once()
+            flexmock(bug_tracker).should_receive("add_comment").with_args(
+                bug.id,
+                "This bug has been identified as having no customer value and will be closed without shipping. "
+                "It was part of an ART reconciliation process and does not require further action.",
+                private=False,
+                noop=False,
+            ).once()
+
+        with patch.object(qe_cli, "filter_art_managed_jira_trackers") as filter_mock:
+            close_reconciliation_bugs(runtime, False, bug_tracker)
+
+        filter_mock.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/elliott/tests/test_find_bugs_qe_cli.py
+++ b/elliott/tests/test_find_bugs_qe_cli.py
@@ -15,7 +15,7 @@ class FindBugsQETestCase(unittest.TestCase):
         jira_bug = flexmock(id='OCPBUGS-123', status="MODIFIED", is_tracker_bug=lambda: False, security_level=None)
         reconciliation_bug = flexmock(id='OCPBUGS-456', status="Verified", is_tracker_bug=lambda: False)
 
-        flexmock(Runtime).should_receive("initialize").and_return(None)
+        flexmock(Runtime).should_receive("initialize").with_args(mode="images").and_return(None)
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
         flexmock(JIRABugTracker).should_receive("get_config").and_return(
             {

--- a/elliott/tests/test_find_bugs_sweep_cli.py
+++ b/elliott/tests/test_find_bugs_sweep_cli.py
@@ -1,10 +1,10 @@
 import traceback
 import unittest
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import elliottlib.cli.find_bugs_sweep_cli as sweep_cli
 from click.testing import CliRunner
-from elliottlib import errata
+from elliottlib import constants, errata
 from elliottlib.bzutil import JIRABugTracker
 from elliottlib.cli.common import Runtime, cli
 from elliottlib.cli.find_bugs_sweep_cli import (
@@ -41,6 +41,85 @@ class TestFindBugsMode(unittest.TestCase):
 
 
 class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
+    def test_filter_art_managed_jira_trackers(self):
+        runtime = MagicMock()
+        payload_image = MagicMock(is_payload=True)
+        payload_image.get_component_name.return_value = "payload-container"
+        non_payload_image = MagicMock(is_payload=False)
+        non_payload_image.get_component_name.return_value = "non-payload-container"
+        runtime.image_metas.return_value = [payload_image, non_payload_image]
+
+        non_tracker = flexmock(id="OCPBUGS-0", is_tracker_bug=lambda: False)
+        payload_tracker = flexmock(
+            id="OCPBUGS-1", is_tracker_bug=lambda: True, whiteboard_component="payload-container"
+        )
+        non_payload_tracker = flexmock(
+            id="OCPBUGS-2", is_tracker_bug=lambda: True, whiteboard_component="non-payload-container"
+        )
+        filtered_image_tracker = flexmock(
+            id="OCPBUGS-7", is_tracker_bug=lambda: True, whiteboard_component="unmanaged-container"
+        )
+        rpm_tracker = flexmock(id="OCPBUGS-3", is_tracker_bug=lambda: True, whiteboard_component="openshift-clients")
+        rhcos_tracker = flexmock(id="OCPBUGS-4", is_tracker_bug=lambda: True, whiteboard_component="rhcos")
+        builder_tracker = flexmock(
+            id="OCPBUGS-5",
+            is_tracker_bug=lambda: True,
+            whiteboard_component=constants.GOLANG_BUILDER_CVE_COMPONENT,
+        )
+        delivery_repo_tracker = flexmock(
+            id="OCPBUGS-6", is_tracker_bug=lambda: True, whiteboard_component="openshift5/payload-image-rhel9"
+        )
+
+        with patch.object(
+            sweep_cli,
+            "normalize_component_by_ocp_delivery_repo",
+            side_effect=lambda runtime, name: "payload-container" if name.startswith("openshift5/") else name,
+        ):
+            actual = sweep_cli.filter_art_managed_jira_trackers(
+                runtime,
+                [
+                    non_tracker,
+                    payload_tracker,
+                    non_payload_tracker,
+                    filtered_image_tracker,
+                    rpm_tracker,
+                    rhcos_tracker,
+                    builder_tracker,
+                    delivery_repo_tracker,
+                ],
+            )
+
+        self.assertEqual(
+            [bug.id for bug in actual],
+            ["OCPBUGS-0", "OCPBUGS-1", "OCPBUGS-2", "OCPBUGS-3", "OCPBUGS-4", "OCPBUGS-5", "OCPBUGS-6"],
+        )
+
+    def test_filter_art_managed_jira_trackers_requires_whiteboard_component(self):
+        runtime = MagicMock()
+        image_meta = MagicMock()
+        image_meta.get_component_name.return_value = "payload-container"
+        runtime.image_metas.return_value = [image_meta]
+        bug = flexmock(id="OCPBUGS-1", is_tracker_bug=lambda: True, whiteboard_component=None)
+
+        with self.assertRaisesRegex(ValueError, "doesn't have a valid whiteboard component"):
+            sweep_cli.filter_art_managed_jira_trackers(runtime, [bug])
+
+    @patch("elliottlib.cli.find_bugs_sweep_cli.get_assembly_bug_ids", return_value=(set(), set()))
+    @patch("elliottlib.cli.find_bugs_sweep_cli.get_sweep_cutoff_timestamp", new_callable=AsyncMock, return_value=0)
+    async def test_get_bugs_sweep_opt_out_skips_art_managed_filter(self, *_):
+        runtime = MagicMock(debug=False)
+        bug = flexmock(id="OCPBUGS-1")
+        find_bugs_obj = sweep_cli.FindBugsSweep(art_managed_trackers_only=False)
+        find_bugs_obj.search = Mock(return_value=[bug])
+        bug_tracker = MagicMock(type="jira")
+        bug_tracker.filter_attached_bugs = AsyncMock(return_value=[])
+
+        with patch.object(sweep_cli, "filter_art_managed_jira_trackers") as filter_mock:
+            actual = await sweep_cli.get_bugs_sweep(runtime, find_bugs_obj, bug_tracker)
+
+        self.assertEqual(actual, [bug])
+        filter_mock.assert_not_called()
+
     @patch('elliottlib.bzutil.JIRABugTracker.filter_attached_bugs')
     @patch('elliottlib.cli.find_bugs_sweep_cli.FindBugsSweep.search')
     def test_find_bugs_sweep_report_jira(self, search_mock, jira_filter_mock):
@@ -70,7 +149,9 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         search_mock.return_value = [jira_bug]
         jira_filter_mock.return_value = []
 
-        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:sweep', '--report'])
+        result = runner.invoke(
+            cli, ['-g', 'openshift-4.6', 'find-bugs:sweep', '--no-art-managed-trackers-only', '--report']
+        )
         if result.exit_code != 0:
             exc_type, exc_value, exc_traceback = result.exc_info
             t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
@@ -97,7 +178,10 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
         flexmock(Runtime).should_receive("get_default_advisories").and_return({})
 
-        result = runner.invoke(cli, ['-g', 'openshift-4.6', '--assembly', '4.6.52', 'find-bugs:sweep'])
+        result = runner.invoke(
+            cli,
+            ['-g', 'openshift-4.6', '--assembly', '4.6.52', 'find-bugs:sweep', '--no-art-managed-trackers-only'],
+        )
         if result.exit_code != 0:
             exc_type, exc_value, exc_traceback = result.exc_info
             t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
@@ -134,7 +218,10 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         )
         jira_filter_mock.return_value = []
 
-        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:sweep', '--add', str(advisory_id)])
+        result = runner.invoke(
+            cli,
+            ['-g', 'openshift-4.6', 'find-bugs:sweep', '--no-art-managed-trackers-only', '--add', str(advisory_id)],
+        )
         if result.exit_code != 0:
             exc_type, exc_value, exc_traceback = result.exc_info
             t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
@@ -165,7 +252,17 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
             [b.id for b in bugs], advisory_id=123, noop=False, verbose=False
         )
 
-        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:sweep', '--use-default-advisory', 'image'])
+        result = runner.invoke(
+            cli,
+            [
+                '-g',
+                'openshift-4.6',
+                'find-bugs:sweep',
+                '--no-art-managed-trackers-only',
+                '--use-default-advisory',
+                'image',
+            ],
+        )
         if result.exit_code != 0:
             exc_type, exc_value, exc_traceback = result.exc_info
             t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
@@ -204,7 +301,16 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         flexmock(JIRABugTracker).should_receive("attach_bugs").times(3).and_return()
         jira_filter_mock.return_value = []
 
-        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:sweep', '--into-default-advisories'])
+        result = runner.invoke(
+            cli,
+            [
+                '-g',
+                'openshift-4.6',
+                'find-bugs:sweep',
+                '--no-art-managed-trackers-only',
+                '--into-default-advisories',
+            ],
+        )
         if result.exit_code != 0:
             exc_type, exc_value, exc_traceback = result.exc_info
             t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))

--- a/elliott/tests/test_find_bugs_sweep_cli.py
+++ b/elliott/tests/test_find_bugs_sweep_cli.py
@@ -104,6 +104,27 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         with self.assertRaisesRegex(ValueError, "doesn't have a valid whiteboard component"):
             sweep_cli.filter_art_managed_jira_trackers(runtime, [bug])
 
+    def test_filter_art_managed_jira_trackers_filters_unmapped_delivery_repo(self):
+        runtime = MagicMock()
+        payload_image = MagicMock()
+        payload_image.get_component_name.return_value = "payload-container"
+        runtime.image_metas.return_value = [payload_image]
+
+        tracker = flexmock(
+            id="OCPBUGS-8",
+            is_tracker_bug=lambda: True,
+            whiteboard_component="openshift5/unmapped-image-rhel9",
+        )
+
+        with patch.object(
+            sweep_cli,
+            "normalize_component_by_ocp_delivery_repo",
+            side_effect=lambda runtime, name: name,
+        ):
+            actual = sweep_cli.filter_art_managed_jira_trackers(runtime, [tracker])
+
+        self.assertEqual(actual, [])
+
     @patch("elliottlib.cli.find_bugs_sweep_cli.get_assembly_bug_ids", return_value=(set(), set()))
     @patch("elliottlib.cli.find_bugs_sweep_cli.get_sweep_cutoff_timestamp", new_callable=AsyncMock, return_value=0)
     async def test_get_bugs_sweep_opt_out_skips_art_managed_filter(self, *_):

--- a/elliott/tests/test_verify_attached_bugs_cli.py
+++ b/elliott/tests/test_verify_attached_bugs_cli.py
@@ -25,7 +25,7 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
 
     def test_verify_bugs_skip_blocking_bugs_for_prerelease(self):
         runner = CliRunner()
-        flexmock(Runtime).should_receive("initialize")
+        flexmock(Runtime).should_receive("initialize").with_args(mode="images")
         flexmock(Runtime).should_receive("get_errata_config").and_return({})
         flexmock(Runtime).should_receive("get_major_minor").and_return((4, 6))
         flexmock(Runtime).should_receive("is_version_in_lifecycle_phase").and_return(False)
@@ -66,7 +66,7 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
     @patch('elliottlib.cli.verify_attached_bugs_cli.is_release_next_week', return_value=True)
     def test_verify_bugs_with_sweep_cli(self, *_):
         runner = CliRunner()
-        flexmock(Runtime).should_receive("initialize")
+        flexmock(Runtime).should_receive("initialize").with_args(mode="images")
         flexmock(Runtime).should_receive("get_errata_config").and_return({})
         flexmock(Runtime).should_receive("get_major_minor").and_return((4, 6))
         flexmock(Runtime).should_receive("is_version_in_lifecycle_phase").and_return(True)
@@ -136,7 +136,7 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
     @patch('elliottlib.cli.verify_attached_bugs_cli.is_release_next_week', return_value=True)
     def test_verify_attached_bugs_cli_fail(self, *_):
         runner = CliRunner()
-        flexmock(Runtime).should_receive("initialize")
+        flexmock(Runtime).should_receive("initialize").with_args(mode="images")
         flexmock(Runtime).should_receive("get_errata_config").and_return({})
         flexmock(Runtime).should_receive("get_major_minor").and_return((4, 6))
         flexmock(Runtime).should_receive("is_version_in_lifecycle_phase").and_return(True)
@@ -219,7 +219,7 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
     @patch('elliottlib.errata_async.AsyncErrataAPI._generate_auth_header')
     def test_verify_attached_bugs_cli_fail_on_type(self, *_):
         runner = CliRunner()
-        flexmock(Runtime).should_receive("initialize")
+        flexmock(Runtime).should_receive("initialize").with_args(mode="images")
         flexmock(Runtime).should_receive("get_errata_config").and_return({})
         flexmock(Runtime).should_receive("get_major_minor").and_return((4, 6))
         flexmock(JIRABugTracker).should_receive("get_config").and_return(


### PR DESCRIPTION
The motivation for this change is to eliminate "build not found for tracker" 
errors we see when preparing weekly releases.
By default ART operates on all OCPBUGS, with some jira component filters we have in bug.yml.
But this filter is manually maintained and often lags behind changes - 
for example when we remove an image from a version.
Tracker bugs give us the ability to know if they belong to ART or not, 
since they always include a component value. We want to use that to filter out non-ART trackers 
and not operate on them at all.

## Summary

This change adds a tracker-only ART-managed filter to the shared `elliott` find-bugs flows without affecting non-tracker bugs.

It introduces a shared Jira tracker filter in `find_bugs_sweep_cli.py` that:
- inspects only tracker bugs
- normalizes OCP delivery repo values consistently, including both `openshift4/` and `openshift5/`
- treats image trackers as ART-managed only when they resolve to ART-managed image metadata
- keeps non-image trackers unchanged
- preserves the special handling for `openshift-golang-builder-container`

The default is now wired into the shared sweep-style Jira paths, with an explicit opt-out flag:
- `find-bugs`
- `find-bugs:sweep`
- `find-bugs:qe`

## Test plan
- `make test`
- [x] Test elliott commands touched

```
$ op run -- uv run elliott -g openshift-4.21 --assembly stream find-bugs -o json --permissive

2026-04-22 16:23:01,965 artcommonlib INFO Konflux DB initialized
2026-04-22 16:24:20,742 artcommonlib INFO On commit: a146b5fc4099ab6766b87885b37dd23c055fec17 (openshift-4.21)
2026-04-22 16:24:20,978 artcommonlib INFO Using branch from group.yml: rhaos-4.21-rhel-9
2026-04-22 16:24:23,184 art_tools.elliottlib.cli.find_bugs_cli INFO Searching jira for bugs with status ['VERIFIED'] and target releases: ['4.21.0', '4.21.z', '4.21']

2026-04-22 16:24:24,483 art_tools.elliottlib.bzutil INFO Found 70 target versions in JIRA project OCPBUGS
2026-04-22 16:24:26,519 art_tools.elliottlib.cli.find_bugs_sweep_cli INFO Filtering bugs that haven't been attached to any advisories...
2026-04-22 16:24:27,788 art_tools.elliottlib.cli.find_bugs_sweep_cli INFO Validating ART-managed image tracker bugs against image metadata
2026-04-22 16:24:27,791 art_tools.elliottlib.cli.find_bugs_sweep_cli WARNING Bug(s) [...] look like CVE trackers, but really are not. Ignoring them.
2026-04-22 16:24:27,791 art_tools.elliottlib.cli.find_bugs_cli INFO rpm bugs: []
2026-04-22 16:24:27,792 art_tools.elliottlib.cli.find_bugs_cli INFO image bugs: [...]
2026-04-22 16:24:27,792 art_tools.elliottlib.cli.find_bugs_cli INFO extras bugs: [...]
2026-04-22 16:24:27,792 art_tools.elliottlib.cli.find_bugs_cli INFO metadata bugs: []
2026-04-22 16:24:27,792 art_tools.elliottlib.cli.find_bugs_cli INFO microshift bugs: []
{
    "rpm": [],
    "image": [
        ...
    ],
    "extras": [
        ...
    ],
    "metadata": [],
    "microshift": []
}
```

```
op run -- uv run elliott -g openshift-4.21 --assembly stream find-bugs:qe --dry-run
2026-04-22 16:43:05,979 artcommonlib INFO On commit: a146b5fc4099ab6766b87885b37dd23c055fec17 (openshift-4.21)
2026-04-22 16:43:06,230 artcommonlib INFO Using branch from group.yml: rhaos-4.21-rhel-9
2026-04-22 16:43:07,824 art_tools.elliottlib.cli.find_bugs_qe_cli INFO Searching jira for bugs with status ['MODIFIED'] and target releases: ['4.21.0', '4.21.z', '4.21']
2026-04-22 16:43:08,550 art_tools.elliottlib.bzutil INFO Found 70 target versions in JIRA project OCPBUGS
2026-04-22 16:43:09,370 art_tools.elliottlib.cli.find_bugs_sweep_cli INFO Validating ART-managed image tracker bugs against image metadata
...
```

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED