### PR TITLE
Fix lockfile generation using wrong assembly's installed_rpms

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1150,6 +1150,7 @@ class ImageMetadata(Metadata):
                     'outcome': "success",
                     'engine': self.runtime.build_system,
                     'name': self.distgit_key,
+                    'assembly': self.runtime.assembly,
                 }
                 build = await self.runtime.konflux_db.get_latest_build(**base_search_params)
 


### PR DESCRIPTION
## Problem

When generating lockfiles, `fetch_rpms_from_build()` queries the database for the latest successful build to get `installed_rpms`. However, it was **not filtering by assembly**, causing it to return builds from the wrong assembly.

### Failure Scenario

1. Latest successful **test assembly** build exists for `ose-ovn-kubernetes`
2. Trying to build **stream assembly**
3. `fetch_rpms_from_build()` finds test assembly build (no assembly filter!)
4. Lockfile generation gets test assembly's `installed_rpms`:
   ```
   openshift-clients-4.18.0-...-assembly.test.el9
   ```
5. Tries to find this NVR in stream assembly plashets
6. Not found → package dropped (due to PR #2717) → hermetic build fails:
   ```
   Error: Unable to find a match: openshift-clients
   ```

### Example Failure

https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/31541/

## Relationship to PR #2717

PR #2717 made `_filter_nvr_versions()` return `[]` when an NVR isn't found in repos (to prevent cross-arch version mismatches). This exposed the latent bug where we were querying the wrong assembly:

- **Before PR #2717:** Wrong assembly NVRs → fallback to latest → worked by accident
- **After PR #2717:** Wrong assembly NVRs → dropped → explicit failure