### PR TITLE
Konflux rebase: do not count child images as rebase failures when parent failed

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -26,6 +26,7 @@ from artcommonlib.variants import BuildVariant
 from dockerfile_parse import DockerfileParser
 from doozerlib import constants, util
 from doozerlib.backend.build_repo import BuildRepo
+from doozerlib.exceptions import ParentRebaseFailedError
 from doozerlib.image import ImageMetadata, extract_builder_info_from_pullspec
 from doozerlib.lockfile import ArtifactLockfileGenerator, RPMLockfileGenerator
 from doozerlib.record_logger import RecordLogger
@@ -309,9 +310,7 @@ class KonfluxRebaser:
                 parent.distgit_key for parent in parent_members if parent is not None and not parent.rebase_status
             ]
             if failed_parents:
-                raise IOError(
-                    f"Couldn't rebase {metadata.distgit_key} because the following parent images failed to rebase: {', '.join(failed_parents)}"
-                )
+                raise ParentRebaseFailedError(metadata.distgit_key, failed_parents)
             downstream_parents, parent_private_fix = await self._resolve_parents(metadata, dfp)
             # If any of the parent images are private, this image is private
             if parent_private_fix:

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -33,7 +33,7 @@ from doozerlib.cli import (
     validate_semver_major_minor,
     validate_semver_major_minor_patch,
 )
-from doozerlib.exceptions import DoozerFatalError
+from doozerlib.exceptions import DoozerFatalError, ParentRebaseFailedError
 from doozerlib.image import ImageMetadata
 from doozerlib.runtime import Runtime
 
@@ -126,16 +126,25 @@ class KonfluxRebaseCli:
             )
         results = await asyncio.gather(*tasks, return_exceptions=True)
         failed_images = []
+        skipped_due_to_parent = []
         for index, result in enumerate(results):
             if isinstance(result, Exception):
                 image_name = metas[index].distgit_key
-                failed_images.append(image_name)
-                LOGGER.error(f"Failed to rebase {image_name}: {result}")
-                LOGGER.error(f"Stack trace for {image_name}:")
-                LOGGER.error(''.join(traceback.format_exception(type(result), result, result.__traceback__)))
-        if failed_images:
-            runtime.state['images:konflux:rebase'] = {'failed-images': failed_images}
-            raise DoozerFatalError(f"Failed to rebase images: {failed_images}")
+                if isinstance(result, ParentRebaseFailedError):
+                    skipped_due_to_parent.append(image_name)
+                    LOGGER.warning("Skipping rebase for %s: parent rebase(s) failed: %s", image_name, result.failed_parents)
+                else:
+                    failed_images.append(image_name)
+                    LOGGER.error(f"Failed to rebase {image_name}: {result}")
+                    LOGGER.error(f"Stack trace for {image_name}:")
+                    LOGGER.error(''.join(traceback.format_exception(type(result), result, result.__traceback__)))
+        if failed_images or skipped_due_to_parent:
+            payload = {'failed-images': failed_images}
+            if skipped_due_to_parent:
+                payload['skipped-due-to-parent-rebase-failure'] = skipped_due_to_parent
+            runtime.state['images:konflux:rebase'] = payload
+            summary = failed_images + [f"{k} (parent failure)" for k in skipped_due_to_parent]
+            raise DoozerFatalError(f"Failed to rebase images: {summary}")
         LOGGER.info("Rebase complete")
 
 

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -132,7 +132,9 @@ class KonfluxRebaseCli:
                 image_name = metas[index].distgit_key
                 if isinstance(result, ParentRebaseFailedError):
                     skipped_due_to_parent.append(image_name)
-                    LOGGER.warning("Skipping rebase for %s: parent rebase(s) failed: %s", image_name, result.failed_parents)
+                    LOGGER.warning(
+                        "Skipping rebase for %s: parent rebase(s) failed: %s", image_name, result.failed_parents
+                    )
                 else:
                     failed_images.append(image_name)
                     LOGGER.error(f"Failed to rebase {image_name}: {result}")

--- a/doozer/doozerlib/exceptions.py
+++ b/doozer/doozerlib/exceptions.py
@@ -7,3 +7,15 @@ class DoozerFatalError(Exception):
     """A broad exception for errors during Brew CRUD operations"""
 
     pass
+
+
+class ParentRebaseFailedError(Exception):
+    """Raised when a child image cannot be rebased because a group-member parent image failed first."""
+
+    def __init__(self, distgit_key: str, failed_parents: list[str]):
+        self.distgit_key = distgit_key
+        self.failed_parents = failed_parents
+        super().__init__(
+            f"Couldn't rebase {distgit_key} because the following parent images failed to rebase: "
+            f"{', '.join(failed_parents)}"
+        )

--- a/doozer/tests/cli/test_images_konflux.py
+++ b/doozer/tests/cli/test_images_konflux.py
@@ -4,8 +4,8 @@ from unittest import mock
 
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord
 from artcommonlib.model import Model
-from doozerlib.cli.images_konflux import KonfluxBundleCli
-from doozerlib.exceptions import DoozerFatalError
+from doozerlib.cli.images_konflux import KonfluxBundleCli, KonfluxRebaseCli
+from doozerlib.exceptions import DoozerFatalError, ParentRebaseFailedError
 from doozerlib.runtime import Runtime
 from doozerlib.source_resolver import SourceResolver
 
@@ -113,3 +113,59 @@ class TestKonfluxBundleCli(unittest.IsolatedAsyncioTestCase):
 
         with self.assertRaises(DoozerFatalError):
             await self.bundle_cli.run()
+
+
+class TestKonfluxRebaseCli(unittest.IsolatedAsyncioTestCase):
+    """Tests for beta:images:konflux:rebase state recording."""
+
+    @mock.patch("doozerlib.cli.images_konflux.trace.get_current_span")
+    @mock.patch("doozerlib.cli.images_konflux.KonfluxRebaser")
+    async def test_run_records_direct_failures_separately_from_skipped_due_to_parent(
+        self, mock_rebaser_cls, mock_get_span
+    ):
+        """Direct rebase failures go to failed-images; cascade failures use skipped-due-to-parent-rebase-failure."""
+        mock_get_span.return_value = mock.Mock()
+
+        parent = mock.Mock()
+        parent.distgit_key = "parent-img"
+        child = mock.Mock()
+        child.distgit_key = "child-img"
+
+        runtime = mock.Mock(spec=Runtime)
+        runtime.working_dir = "/tmp"
+        runtime.upcycle = False
+        runtime.initialize = mock.Mock()
+        runtime.source_resolver = mock.Mock(spec=SourceResolver)
+        runtime.ordered_image_metas = mock.Mock(return_value=[parent, child])
+        runtime.state = {}
+
+        mock_rebaser = mock_rebaser_cls.return_value
+        mock_rebaser.rpm_lockfile_generator.ensure_repositories_loaded = mock.AsyncMock()
+
+        async def rebase_to_side_effect(meta, *_args, **_kwargs):
+            if meta.distgit_key == "parent-img":
+                raise RuntimeError("upstream merge conflict")
+            raise ParentRebaseFailedError(meta.distgit_key, ["parent-img"])
+
+        mock_rebaser.rebase_to = mock.AsyncMock(side_effect=rebase_to_side_effect)
+
+        cli = KonfluxRebaseCli(
+            runtime=runtime,
+            version="4.14.0",
+            release="1",
+            embargoed=False,
+            force_yum_updates=False,
+            repo_type="unsigned",
+            image_repo="test-repo",
+            message="test",
+            push=False,
+        )
+
+        with self.assertRaises(DoozerFatalError):
+            await cli.run()
+
+        self.assertEqual(runtime.state["images:konflux:rebase"]["failed-images"], ["parent-img"])
+        self.assertEqual(
+            runtime.state["images:konflux:rebase"]["skipped-due-to-parent-rebase-failure"],
+            ["child-img"],
+        )

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -199,17 +199,26 @@ class BuildLayeredProductsPipeline:
 
             with state_path.open('r') as f:
                 state = yaml.safe_load(f)
-            failed_images = state.get('images:konflux:rebase', {}).get('failed-images', [])
-            if not failed_images:
+            konflux_rebase = state.get('images:konflux:rebase', {})
+            failed_images = konflux_rebase.get('failed-images', [])
+            skipped_due_to_parent = konflux_rebase.get('skipped-due-to-parent-rebase-failure', [])
+            excluded = list(dict.fromkeys(failed_images + skipped_due_to_parent))
+            if not excluded:
                 raise
 
-            self._logger.warning(
-                'Following images failed to rebase and will be excluded from build: %s',
-                ','.join(failed_images),
-            )
+            if failed_images:
+                self._logger.warning(
+                    'Following images failed to rebase and will be excluded from build: %s',
+                    ','.join(failed_images),
+                )
+            if skipped_due_to_parent:
+                self._logger.warning(
+                    'Following images were skipped because a parent failed to rebase and will be excluded from build: %s',
+                    ','.join(skipped_due_to_parent),
+                )
 
             requested = [img.strip() for img in image_list.split(',') if img.strip()]
-            remaining = [img for img in requested if img not in failed_images]
+            remaining = [img for img in requested if img not in excluded]
             return ','.join(remaining)
 
     async def _build(self, image_list: str, product: str):

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -167,23 +167,47 @@ class KonfluxOcpPipeline:
         elif build_strategy == BuildStrategy.EXCEPT:
             return [f'--{kind}=', f'--exclude={",".join(excludes)}']
 
-    async def update_rebase_fail_counters(self, failed_images):
+    async def update_rebase_fail_counters(
+        self,
+        failed_images: list[str],
+        skipped_due_to_parent: Optional[list[str]] = None,
+    ):
+        """
+        Adjust Redis rebase-fail counters after a Konflux rebase run.
+
+        - Images that rebased successfully: reset counter.
+        - Images that failed rebase directly: increment counter.
+        - Images skipped because a parent failed first: no change (rebase was not meaningfully attempted).
+        """
         if self.assembly != 'stream':
             # Only update fail counters for stream assembly
             return
 
-        # Reset fail counters for images that were rebased successfully
+        failed_set = set(failed_images)
+        skipped_set = set(skipped_due_to_parent or [])
+
+        # Reset fail counters only for images that actually rebased successfully
         match self.build_plan.image_build_strategy:
             case BuildStrategy.ALL:
-                successful_images = [image for image in self.group_images if image not in failed_images]
+                successful_images = [
+                    image
+                    for image in self.group_images
+                    if image not in failed_set and image not in skipped_set
+                ]
             case BuildStrategy.EXCEPT:
                 successful_images = [
                     image
                     for image in self.group_images
-                    if image not in self.build_plan.images_excluded and image not in failed_images
+                    if image not in self.build_plan.images_excluded
+                    and image not in failed_set
+                    and image not in skipped_set
                 ]
             case BuildStrategy.ONLY:
-                successful_images = [image for image in self.image_list if image not in failed_images]
+                successful_images = [
+                    image
+                    for image in self.image_list
+                    if image not in failed_set and image not in skipped_set
+                ]
             case _:
                 raise ValueError(
                     f"Unknown build strategy: {self.build_plan.image_build_strategy}. Valid strategies: {[s.value for s in BuildStrategy]}"
@@ -192,7 +216,7 @@ class KonfluxOcpPipeline:
             *[reset_rebase_fail_counter(image, self.version, 'konflux') for image in successful_images]
         )
 
-        # Increment fail counters for failing images
+        # Increment fail counters only for images that failed rebase directly
         job_url = os.getenv('BUILD_URL')
         await asyncio.gather(
             *[increment_rebase_fail_counter(image, self.version, 'konflux', job_url=job_url) for image in failed_images]
@@ -271,7 +295,7 @@ class KonfluxOcpPipeline:
                     'Following images were skipped because a parent failed to rebase and won\'t be built: %s',
                     ','.join(skipped_due_to_parent),
                 )
-            await self.update_rebase_fail_counters(failed_images)
+            await self.update_rebase_fail_counters(failed_images, skipped_due_to_parent)
 
             # Exclude images that failed or were skipped due to parent from the build step
             if self.build_plan.image_build_strategy == BuildStrategy.ALL:

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -134,6 +134,7 @@ class KonfluxOcpPipeline:
 
         self.group_images = []
         self.rebase_failures = []
+        self.rebase_skipped_due_to_parent = []
 
         self.slack_client = runtime.new_slack_client()
 
@@ -254,30 +255,43 @@ class KonfluxOcpPipeline:
         except ChildProcessError:
             with open(f'{self.runtime.doozer_working}/state.yaml') as state_yaml:
                 state = yaml.safe_load(state_yaml)
-            failed_images = state.get('images:konflux:rebase', {}).get('failed-images', [])
-            if not failed_images:
+            konflux_rebase = state.get('images:konflux:rebase', {})
+            failed_images = konflux_rebase.get('failed-images', [])
+            skipped_due_to_parent = konflux_rebase.get('skipped-due-to-parent-rebase-failure', [])
+            excluded_from_build = list(dict.fromkeys(failed_images + skipped_due_to_parent))
+            if not excluded_from_build:
                 raise  # Something else went wrong
 
-            # Some images failed to rebase: log them, and track them in Redis
-            LOGGER.warning(f'Following images failed to rebase and won\'t be built: {",".join(failed_images)}')
+            # Some images failed to rebase: log them, and track direct failures in Redis (not dependents skipped
+            # because a parent failed — those are listed separately).
+            if failed_images:
+                LOGGER.warning(f'Following images failed to rebase and won\'t be built: {",".join(failed_images)}')
+            if skipped_due_to_parent:
+                LOGGER.warning(
+                    'Following images were skipped because a parent failed to rebase and won\'t be built: %s',
+                    ','.join(skipped_due_to_parent),
+                )
             await self.update_rebase_fail_counters(failed_images)
 
-            # Exclude images that failed to rebase from the build step
+            # Exclude images that failed or were skipped due to parent from the build step
             if self.build_plan.image_build_strategy == BuildStrategy.ALL:
                 # Move from building all to excluding failed images
                 self.build_plan.image_build_strategy = BuildStrategy.EXCEPT
-                self.build_plan.images_excluded = failed_images
+                self.build_plan.images_excluded = excluded_from_build
 
             elif self.build_plan.image_build_strategy == BuildStrategy.ONLY:
                 # Remove failed images from included ones
-                self.build_plan.images_included = [i for i in self.build_plan.images_included if i not in failed_images]
+                self.build_plan.images_included = [
+                    i for i in self.build_plan.images_included if i not in excluded_from_build
+                ]
 
             else:  # strategy = EXCLUDE
                 # Append failed images to excluded ones
-                self.build_plan.images_excluded.extend(failed_images)
+                self.build_plan.images_excluded.extend(excluded_from_build)
 
-            # Track rebase failures for later steps
+            # Track rebase issues for later steps (direct failures match Redis counters)
             self.rebase_failures = failed_images
+            self.rebase_skipped_due_to_parent = skipped_due_to_parent
 
     async def build_images(self):
         if not self.building_images():
@@ -621,9 +635,14 @@ class KonfluxOcpPipeline:
             ]
         )
 
-        # If any image failed to rebase, raise an exception to make the pipeline unstable
-        if self.rebase_failures:
-            raise RuntimeError(f'Following images failed to rebase: {",".join(self.rebase_failures)}')
+        # If any image failed to rebase or was skipped due to a parent failure, raise to make the pipeline unstable
+        if self.rebase_failures or self.rebase_skipped_due_to_parent:
+            parts = []
+            if self.rebase_failures:
+                parts.append(f'failed to rebase: {",".join(self.rebase_failures)}')
+            if self.rebase_skipped_due_to_parent:
+                parts.append(f'skipped (parent rebase failed): {",".join(self.rebase_skipped_due_to_parent)}')
+            raise RuntimeError('Following images ' + '; '.join(parts))
 
     def trigger_bundle_build(self):
         if self.skip_bundle_build:

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -190,9 +190,7 @@ class KonfluxOcpPipeline:
         match self.build_plan.image_build_strategy:
             case BuildStrategy.ALL:
                 successful_images = [
-                    image
-                    for image in self.group_images
-                    if image not in failed_set and image not in skipped_set
+                    image for image in self.group_images if image not in failed_set and image not in skipped_set
                 ]
             case BuildStrategy.EXCEPT:
                 successful_images = [
@@ -204,9 +202,7 @@ class KonfluxOcpPipeline:
                 ]
             case BuildStrategy.ONLY:
                 successful_images = [
-                    image
-                    for image in self.image_list
-                    if image not in failed_set and image not in skipped_set
+                    image for image in self.image_list if image not in failed_set and image not in skipped_set
                 ]
             case _:
                 raise ValueError(

--- a/pyartcd/tests/pipelines/test_build_layered_products.py
+++ b/pyartcd/tests/pipelines/test_build_layered_products.py
@@ -87,6 +87,27 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
 
         self.assertEqual(result, 'oadp-velero-restic-restore-helper')
 
+    async def test_rebase_failure_excludes_skipped_due_to_parent_images(self):
+        """Images listed only as skipped due to parent rebase failure are excluded from the build list."""
+        state = {
+            'images:konflux:rebase': {
+                'failed-images': ['parent-image'],
+                'skipped-due-to-parent-rebase-failure': ['child-image'],
+            }
+        }
+        state_path = Path(self.runtime.doozer_working, 'state.yaml')
+        with state_path.open('w') as f:
+            yaml.safe_dump(state, f)
+
+        with patch(
+            'pyartcd.pipelines.build_layered_products.exectools.cmd_assert_async',
+            new_callable=AsyncMock,
+            side_effect=ChildProcessError('exit code 1'),
+        ):
+            result = await self.pipeline._rebase('parent-image,child-image,other-image')
+
+        self.assertEqual(result, 'other-image')
+
     async def test_rebase_failure_all_images_failed(self):
         """When all requested images fail rebase, an empty string is returned."""
         state = {'images:konflux:rebase': {'failed-images': ['img-a', 'img-b']}}

--- a/pyartcd/tests/pipelines/test_ocp.py
+++ b/pyartcd/tests/pipelines/test_ocp.py
@@ -1,7 +1,10 @@
 import os
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import yaml
 from pyartcd.jenkins import Jobs
 from pyartcd.pipelines import ocp
 
@@ -881,3 +884,105 @@ class TestKonfluxOcpPipeline(unittest.IsolatedAsyncioTestCase):
         self.assertIn('open', rebase_call)
         self.assertIn('--network-mode', build_call)
         self.assertIn('open', build_call)
+
+
+class TestKonfluxOcpPipelineRebaseFailures(unittest.IsolatedAsyncioTestCase):
+    """Konflux rebase state: direct failures vs skipped children, and build image selection."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.runtime = MagicMock()
+        self.runtime.dry_run = False
+        self.runtime.doozer_working = str(Path(self.tmpdir) / 'doozer_working')
+        Path(self.runtime.doozer_working).mkdir(parents=True)
+
+    def _make_pipeline(self, **kwargs):
+        from pyartcd.pipelines.ocp4_konflux import KonfluxOcpPipeline
+
+        defaults = {
+            'runtime': self.runtime,
+            'assembly': 'stream',
+            'version': '4.14',
+            'data_path': 'test-path',
+            'image_build_strategy': 'all',
+            'image_list': '',
+            'rpm_build_strategy': 'none',
+            'rpm_list': '',
+            'data_gitref': '',
+            'kubeconfig': None,
+            'skip_rebase': False,
+            'skip_bundle_build': False,
+            'arches': (),
+            'plr_template': '',
+            'lock_identifier': 'test',
+            'skip_plashets': False,
+            'build_priority': 'auto',
+            'use_mass_rebuild_locks': False,
+            'network_mode': None,
+        }
+        defaults.update(kwargs)
+        return KonfluxOcpPipeline(**defaults)
+
+    def _write_rebase_state(self, failed, skipped):
+        state = {
+            'images:konflux:rebase': {
+                'failed-images': failed,
+                'skipped-due-to-parent-rebase-failure': skipped,
+            }
+        }
+        state_path = Path(self.runtime.doozer_working) / 'state.yaml'
+        with state_path.open('w') as f:
+            yaml.safe_dump(state, f)
+
+    @patch('pyartcd.pipelines.ocp4_konflux.exectools.cmd_assert_async')
+    async def test_rebase_failure_increments_counters_only_for_direct_failures(self, mock_cmd):
+        """Redis rebase-fail counters only receive failed-images, not skipped-due-to-parent entries."""
+        self._write_rebase_state(['parent-img'], ['child-a', 'child-b'])
+        mock_cmd.side_effect = ChildProcessError('rebase failed')
+
+        pipeline = self._make_pipeline()
+        with patch.object(pipeline, 'update_rebase_fail_counters', new_callable=AsyncMock) as mock_counters:
+            await pipeline.rebase_images('4.14.0', '1')
+
+        mock_counters.assert_called_once_with(['parent-img'])
+
+    @patch('pyartcd.pipelines.ocp4_konflux.exectools.cmd_assert_async')
+    async def test_build_after_rebase_uses_exclude_for_failed_and_skipped(self, mock_cmd):
+        """Build phase runs beta:images:konflux:build with --exclude covering every unrebased image."""
+        from pyartcd.pipelines.ocp4_konflux import BuildStrategy
+
+        self._write_rebase_state(['parent-img'], ['child-a', 'child-b'])
+        mock_cmd.side_effect = [ChildProcessError('rebase failed'), None]
+
+        pipeline = self._make_pipeline()
+        with patch.object(pipeline, 'update_rebase_fail_counters', new_callable=AsyncMock):
+            await pipeline.rebase_images('4.14.0', '1')
+        await pipeline.build_images()
+
+        self.assertEqual(mock_cmd.call_count, 2)
+        build_cmd = mock_cmd.call_args_list[1][0][0]
+        exclude_args = [arg for arg in build_cmd if arg.startswith('--exclude=')]
+        self.assertEqual(len(exclude_args), 1)
+        excluded = set(exclude_args[0].split('=', 1)[1].split(','))
+        self.assertEqual(excluded, {'parent-img', 'child-a', 'child-b'})
+        self.assertEqual(pipeline.build_plan.image_build_strategy, BuildStrategy.EXCEPT)
+
+    @patch('pyartcd.pipelines.ocp4_konflux.exectools.cmd_assert_async')
+    async def test_build_after_rebase_only_strategy_keeps_surviving_images(self, mock_cmd):
+        """ONLY strategy: build runs --images= for images that neither failed nor were skipped due to parent."""
+        from pyartcd.pipelines.ocp4_konflux import BuildStrategy
+
+        self._write_rebase_state(['parent-img'], ['child-a'])
+        mock_cmd.side_effect = [ChildProcessError('rebase failed'), None]
+
+        pipeline = self._make_pipeline(image_build_strategy='only', image_list='parent-img,child-a,survivor')
+        pipeline.build_plan.image_build_strategy = BuildStrategy.ONLY
+        pipeline.build_plan.images_included = ['parent-img', 'child-a', 'survivor']
+
+        with patch.object(pipeline, 'update_rebase_fail_counters', new_callable=AsyncMock):
+            await pipeline.rebase_images('4.14.0', '1')
+        await pipeline.build_images()
+
+        build_cmd = mock_cmd.call_args_list[1][0][0]
+        self.assertIn('--images=survivor', build_cmd)
+        self.assertEqual(pipeline.build_plan.images_included, ['survivor'])

--- a/pyartcd/tests/pipelines/test_ocp.py
+++ b/pyartcd/tests/pipelines/test_ocp.py
@@ -936,7 +936,7 @@ class TestKonfluxOcpPipelineRebaseFailures(unittest.IsolatedAsyncioTestCase):
 
     @patch('pyartcd.pipelines.ocp4_konflux.exectools.cmd_assert_async')
     async def test_rebase_failure_increments_counters_only_for_direct_failures(self, mock_cmd):
-        """Redis rebase-fail counters only receive failed-images, not skipped-due-to-parent entries."""
+        """rebase_images passes direct failures and skipped children so counters can treat skips as no-ops."""
         self._write_rebase_state(['parent-img'], ['child-a', 'child-b'])
         mock_cmd.side_effect = ChildProcessError('rebase failed')
 
@@ -944,7 +944,26 @@ class TestKonfluxOcpPipelineRebaseFailures(unittest.IsolatedAsyncioTestCase):
         with patch.object(pipeline, 'update_rebase_fail_counters', new_callable=AsyncMock) as mock_counters:
             await pipeline.rebase_images('4.14.0', '1')
 
-        mock_counters.assert_called_once_with(['parent-img'])
+        mock_counters.assert_called_once_with(['parent-img'], ['child-a', 'child-b'])
+
+    @patch('pyartcd.pipelines.ocp4_konflux.increment_rebase_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.reset_rebase_fail_counter', new_callable=AsyncMock)
+    async def test_update_rebase_fail_counters_skipped_children_unchanged_in_redis(self, mock_reset, mock_incr):
+        """Children skipped because a parent failed are not reset nor incremented (no-op)."""
+        from pyartcd.pipelines.ocp4_konflux import BuildStrategy
+
+        pipeline = self._make_pipeline()
+        pipeline.group_images = ['parent-img', 'child-a', 'healthy']
+        pipeline.build_plan.image_build_strategy = BuildStrategy.ALL
+
+        await pipeline.update_rebase_fail_counters(['parent-img'], ['child-a'])
+
+        reset_names = {c.args[0] for c in mock_reset.call_args_list}
+        incr_names = {c.args[0] for c in mock_incr.call_args_list}
+        self.assertEqual(reset_names, {'healthy'})
+        self.assertEqual(incr_names, {'parent-img'})
+        self.assertNotIn('child-a', reset_names)
+        self.assertNotIn('child-a', incr_names)
 
     @patch('pyartcd.pipelines.ocp4_konflux.exectools.cmd_assert_async')
     async def test_build_after_rebase_uses_exclude_for_failed_and_skipped(self, mock_cmd):


### PR DESCRIPTION
## Summary

When a parent image fails to rebase, dependent images raise a dedicated `ParentRebaseFailedError`. Previously those children were listed in `failed-images` and incremented Redis rebase-fail counters like direct failures.

## Changes

- Introduce `ParentRebaseFailedError` and record dependents under `skipped-due-to-parent-rebase-failure` in Doozer state.
- `failed-images` lists only direct rebase failures; pyartcd only increments Redis counters for that list.
- Build exclusion still applies to both failed and skipped dependents (`ocp4_konflux`, layered products).
- `clean_up` reports both direct failures and skipped dependents.

## Tests

- Doozer: `KonfluxRebaseCli` state split.
- pyartcd: counter args, `--exclude` / `--images` on build after rebase.