### PR TITLE
Add timestamps to MicroShift bootc shipment branch names

### DIFF
--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -192,6 +192,22 @@
       "$ref": "#/properties/shipment"
     },
     "shipment-": {},
+    "microshift_bootc_shipment": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "microshift_bootc_shipment!": {
+      "$ref": "#/properties/microshift_bootc_shipment"
+    },
+    "microshift_bootc_shipment?": {
+      "$ref": "#/properties/microshift_bootc_shipment"
+    },
+    "microshift_bootc_shipment-": {},
     "upgrades!": {
       "$ref": "#/properties/upgrades"
     },

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -1,6 +1,5 @@
 import asyncio
 import copy
-import glob
 import io
 import json
 import logging
@@ -20,7 +19,7 @@ import click
 import requests
 from artcommonlib import exectools
 from artcommonlib.arch_util import brew_arch_for_go_arch
-from artcommonlib.assembly import AssemblyTypes
+from artcommonlib.assembly import AssemblyTypes, assembly_config_struct
 from artcommonlib.config.repo import RepoList
 from artcommonlib.constants import SHIPMENT_DATA_URL_TEMPLATE
 from artcommonlib.github_auth import get_github_client_for_org
@@ -35,7 +34,6 @@ from artcommonlib.util import (
     sync_to_quay,
 )
 from doozerlib.backend.konflux_client import API_VERSION, KIND_SNAPSHOT
-from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
 from doozerlib.constants import KONFLUX_DEFAULT_IMAGE_REPO
 from doozerlib.util import isolate_git_commit_in_release
 from elliottlib.shipment_model import ShipmentConfig, Snapshot, SnapshotSpec
@@ -86,9 +84,6 @@ class BuildMicroShiftBootcPipeline:
         self.prepare_shipment = prepare_shipment
         self.slack_client = slack_client
         self._logger = logger or runtime.logger
-
-        # Track existing shipment timestamp to avoid creating new files on MR updates
-        self.existing_shipment_timestamp = None
 
         self._working_dir = self.runtime.working_dir.absolute()
         self.releases_config = None
@@ -141,6 +136,11 @@ class BuildMicroShiftBootcPipeline:
             f'--working-dir={self._working_dir / "elliott-working"}',
             f'--data-path={data_path or constants.OCP_BUILD_DATA_URL}',
         ]
+
+    @property
+    def assembly_group_config(self) -> Model:
+        """Get the assembly-specific group configuration"""
+        return assembly_config_struct(Model(self.releases_config), self.assembly, "group", {})
 
     async def run(self):
         # Make sure our api.ci token is fresh
@@ -734,8 +734,7 @@ class BuildMicroShiftBootcPipeline:
         await self._setup_shipment_data_repo()
 
         # Step 3: Check for existing shipment branch and try to load existing config
-        source_branch = f"prepare-microshift-bootc-shipment-{self.assembly}"
-        shipment_config = await self._load_or_init_shipment_config(source_branch)
+        shipment_config = await self._load_or_init_shipment_config()
 
         # Step 4: Use the provided bootc build
         self._logger.info("Using bootc build: %s", bootc_build.nvr)
@@ -787,71 +786,38 @@ class BuildMicroShiftBootcPipeline:
 
         self._logger.info("Shipment environment setup completed")
 
-    async def _load_or_init_shipment_config(self, source_branch: str) -> ShipmentConfig:
-        """Load existing shipment config from branch or initialize new one"""
-        # Check if branch already exists upstream
-        branch_exists = await self.shipment_data_repo.does_branch_exist_on_remote(source_branch, remote="origin")
+    async def _load_or_init_shipment_config(self) -> ShipmentConfig:
+        """Load existing shipment config from branch or initialize new one
 
-        if branch_exists:
-            self._logger.info('Branch %s exists, checking for existing shipment config...', source_branch)
+        If a shipment MR already exists (URL in config), reuse the existing branch.
+        Otherwise, create a new branch with timestamp.
+        """
+        # Check if shipment already exists in assembly config
+        assembly_shipment_config = self.assembly_group_config.get("shipment", {})
+        existing_mr_url = assembly_shipment_config.get("url")
+
+        if existing_mr_url:
+            # Extract branch name from existing MR
+            # The MR URL contains the branch name in the source_branch field
+            # We need to fetch the MR details to get the branch name
+            parsed_url = urlparse(existing_mr_url)
+            mr_id = parsed_url.path.split('/')[-1]
+            project_path = parsed_url.path.strip('/').split('/-/merge_requests')[0]
+
+            # Use the cached GitLab client
+            project = self._gitlab.get_project(project_path)
+            mr = project.mergerequests.get(mr_id)
+            source_branch = mr.source_branch
+
+            self._logger.info('Found existing shipment MR, using branch: %s', source_branch)
             await self.shipment_data_repo.fetch_switch_branch(source_branch, remote="origin")
 
-            # Try to find existing shipment YAML file
-            shipment_config = await self._load_existing_shipment_config()
-            if shipment_config:
-                self._logger.info("Found existing shipment configuration, reusing it")
-                return shipment_config
-            else:
-                self._logger.info("No existing shipment configuration found in branch, will initialize new one")
+            # Initialize new config - we'll load the snapshot from existing files later if needed
+            return await self._init_shipment_config()
         else:
-            self._logger.info('Branch %s does not exist, will create new branch and shipment config', source_branch)
-
-        # Initialize new shipment configuration if not found
-        return await self._init_shipment_config()
-
-    async def _load_existing_shipment_config(self) -> Optional[ShipmentConfig]:
-        """Try to load existing shipment config from current branch"""
-        try:
-            # Look for shipment files in the expected directory structure
-            # Pattern: shipment/{product}/{group}/{application}/prod/{assembly}.microshift-bootc.*.yaml
-            application = KonfluxImageBuilder.get_application_name(self.group)
-            env = 'prod'
-
-            shipment_dir = (
-                self.shipment_data_repo._directory / "shipment" / self.product / self.group / application / env
-            )
-
-            if not shipment_dir.exists():
-                self._logger.info("Shipment directory does not exist: %s", shipment_dir)
-                return None
-
-            # Look for files matching the pattern: {assembly}.microshift-bootc.*.yaml
-            pattern = f"{self.assembly}.microshift-bootc.*.yaml"
-            matching_files = glob.glob(str(shipment_dir / pattern))
-
-            if not matching_files:
-                self._logger.info("No existing shipment files found matching pattern: %s", pattern)
-                return None
-
-            # Use the most recent file (by filename, which includes timestamp)
-            latest_file = max(matching_files)
-            self._logger.info("Loading existing shipment config from: %s", latest_file)
-
-            # Extract timestamp from filename: {assembly}.microshift-bootc.{timestamp}.yaml
-            filename = Path(latest_file).name
-            timestamp_part = filename.replace(f"{self.assembly}.microshift-bootc.", "").replace(".yaml", "")
-            self.existing_shipment_timestamp = timestamp_part
-
-            with open(latest_file, 'r') as f:
-                shipment_data = yaml.load(f.read())
-
-            # Convert to ShipmentConfig object
-            shipment_config = ShipmentConfig(**shipment_data)
-            return shipment_config
-
-        except Exception as e:
-            self._logger.warning("Failed to load existing shipment config: %s", e)
-            return None
+            # No existing MR - this is the first run, initialize new config
+            self._logger.info('No existing shipment MR found, will initialize new shipment config')
+            return await self._init_shipment_config()
 
     async def _init_shipment_config(self) -> ShipmentConfig:
         """Initialize shipment configuration using elliott shipment init"""
@@ -929,23 +895,36 @@ class BuildMicroShiftBootcPipeline:
         """Create or update shipment MR with the given shipment config. Returns None if no changes."""
         self._logger.info("Creating or updating shipment MR...")
 
-        # Branch handling is now done in _load_or_init_shipment_config
-        source_branch = f"prepare-microshift-bootc-shipment-{self.assembly}"
-        target_branch = "main"
-        # Use existing timestamp if available (updating existing MR), otherwise create new one
-        timestamp = self.existing_shipment_timestamp or datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
+        # Check if shipment already exists in assembly config
+        assembly_shipment_config = self.assembly_group_config.get("shipment", {})
+        existing_mr_url = assembly_shipment_config.get("url")
 
-        # Check if branch exists and switch to it, or create it
-        branch_exists = await self.shipment_data_repo.does_branch_exist_on_remote(source_branch, remote="origin")
-        if branch_exists:
+        target_branch = "main"
+
+        if existing_mr_url:
+            # Extract branch name from existing MR (already done in _load_or_init_shipment_config)
+            parsed_url = urlparse(existing_mr_url)
+            mr_id = parsed_url.path.split('/')[-1]
+            project_path = parsed_url.path.strip('/').split('/-/merge_requests')[0]
+
+            # Use the cached GitLab client
+            project = self._gitlab.get_project(project_path)
+            mr = project.mergerequests.get(mr_id)
+            source_branch = mr.source_branch
+
+            self._logger.info('Reusing existing shipment branch: %s', source_branch)
             await self.shipment_data_repo.fetch_switch_branch(source_branch, remote="origin")
         else:
+            # Create new branch with timestamp
+            timestamp = datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
+            source_branch = f"prepare-microshift-bootc-shipment-{self.assembly}-{timestamp}"
+            self._logger.info('Creating new shipment branch: %s', source_branch)
             await self.shipment_data_repo.create_branch(source_branch)
 
         # Update shipment data repo with shipment config
         release_name = get_release_name_for_assembly(self.group, self.releases_config, self.assembly)
         commit_message = f"Add microshift-bootc shipment configuration for {release_name}"
-        updated = await self._update_shipment_data(shipment_config, timestamp, commit_message, source_branch)
+        updated = await self._update_shipment_data(shipment_config, commit_message, source_branch)
         if not updated:
             self._logger.info("No changes in shipment data. MR will not be created or updated.")
             return None
@@ -963,7 +942,7 @@ class BuildMicroShiftBootcPipeline:
         mr_description = f"Created by job: {job_url}\n\n{commit_message}"
 
         if self.runtime.dry_run:
-            action = "updated" if branch_exists else "created"
+            action = "updated" if existing_mr_url else "created"
             self._logger.info("[DRY-RUN] Would have %s MR with title: %s", action, mr_title)
             mr_url = f"{self.gitlab_url}/placeholder/placeholder/-/merge_requests/placeholder"
         else:
@@ -996,10 +975,11 @@ class BuildMicroShiftBootcPipeline:
 
         return mr_url
 
-    async def _update_shipment_data(
-        self, shipment_config: ShipmentConfig, timestamp: str, commit_message: str, branch: str
-    ) -> bool:
+    async def _update_shipment_data(self, shipment_config: ShipmentConfig, commit_message: str, branch: str) -> bool:
         """Update shipment data repo with the given shipment config file"""
+        # Extract timestamp from branch name (last segment after splitting by "-")
+        # Branch format: prepare-microshift-bootc-shipment-{assembly}-{timestamp}
+        timestamp = branch.split("-")[-1]
         filename = f"{self.assembly}.microshift-bootc.{timestamp}.yaml"
         product = shipment_config.shipment.metadata.product
         group = shipment_config.shipment.metadata.group

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -736,6 +736,10 @@ class BuildMicroShiftBootcPipeline:
         # Step 3: Check for existing shipment branch and try to load existing config
         shipment_config = await self._load_or_init_shipment_config()
 
+        # Check if there was an existing microshift_bootc_shipment URL
+        assembly_shipment_config = self.assembly_group_config.get("microshift_bootc_shipment", {})
+        had_existing_url = bool(assembly_shipment_config.get("url"))
+
         # Step 4: Use the provided bootc build
         self._logger.info("Using bootc build: %s", bootc_build.nvr)
 
@@ -748,6 +752,11 @@ class BuildMicroShiftBootcPipeline:
 
         if self.shipment_mr_url:
             await self.slack_client.say_in_thread(f"Shipment MR created: {self.shipment_mr_url}")
+
+            # Step 7: If this is the first run (no existing URL), write the URL back to releases.yml
+            if not had_existing_url:
+                self._logger.info("First shipment run for this assembly - writing URL to releases.yml")
+                await self._create_or_update_build_data_pr()
         else:
             await self.slack_client.say_in_thread("No changes in shipment data. MR was not created or updated.")
 
@@ -786,6 +795,138 @@ class BuildMicroShiftBootcPipeline:
 
         self._logger.info("Shipment environment setup completed")
 
+    def _validate_shipment_mr(self, shipment_url: str):
+        """Validate the shipment MR state
+        :param shipment_url: The URL of the existing shipment MR to validate
+        :raises ValueError: If the MR is not in opened state
+        """
+        # Parse the shipment URL to extract project and MR details
+        parsed_url = urlparse(shipment_url)
+        project_path = parsed_url.path.strip('/').split('/-/merge_requests')[0]
+        mr_id = parsed_url.path.split('/')[-1]
+
+        # Load the existing MR
+        project = self._gitlab.get_project(project_path)
+        mr = project.mergerequests.get(mr_id)
+
+        # Make sure MR is in opened state
+        if mr.state != "opened":
+            raise ValueError(f"MR state {mr.state} is not opened. This is not supported.")
+
+    async def _update_build_data(self, branch: str) -> bool:
+        """Update releases.yml in build data repo with microshift_bootc_shipment URL.
+        Commits the changes and pushes to the remote repo.
+        :param branch: The branch to update in the build data repo
+        :return: True if the changes were committed and pushed successfully, False otherwise.
+        """
+        data_path = self._doozer_env_vars["DOOZER_DATA_PATH"]
+        build_data_repo_dir = self._working_dir / "build-data-push"
+
+        # Clean up existing directory if it exists
+        if build_data_repo_dir.exists():
+            shutil.rmtree(build_data_repo_dir, ignore_errors=True)
+
+        # Initialize GitRepository for build data
+        build_data_repo = GitRepository(build_data_repo_dir, self.runtime.dry_run)
+
+        # Setup build-data repo
+        # For pushing, we need GitHub token auth
+        github_token = os.getenv("GITHUB_TOKEN")
+        if not github_token and not self.runtime.dry_run:
+            raise ValueError("GITHUB_TOKEN environment variable is required to update build data")
+
+        user, repo = self.extract_git_repo(data_path)
+        push_url = f"https://oauth2:{github_token}@github.com/{user}/{repo}.git" if github_token else data_path
+
+        await build_data_repo.setup(
+            remote_url=push_url,
+            upstream_remote_url=data_path,
+        )
+
+        # Check if branch exists on remote, if so fetch and switch to it
+        if await build_data_repo.does_branch_exist_on_remote(branch, remote="origin"):
+            self._logger.info('Fetching and switching to existing branch %s', branch)
+            await build_data_repo.fetch_switch_branch(branch, remote="origin")
+        else:
+            # Fetch and switch to group branch first
+            await build_data_repo.fetch_switch_branch(self.group, remote="upstream")
+            self._logger.info('Creating new branch %s', branch)
+            await build_data_repo.create_branch(branch)
+
+        # Load current releases.yml
+        releases_yml_path = "releases.yml"
+        new_releases_config = copy.deepcopy(self.releases_config)
+
+        # Update the microshift_bootc_shipment section
+        microshift_bootc_shipment_config = {"url": self.shipment_mr_url}
+
+        # Get the assembly definition to check if it has a parent
+        assembly_def = new_releases_config["releases"][self.assembly]["assembly"]
+        has_parent = bool(assembly_def.get("basis", {}).get("assembly"))
+
+        # If this assembly has a basis assembly, use the override marker (!)
+        # to prevent inheritance from causing the URL to be lost on subsequent runs
+        if has_parent:
+            key_name = "microshift_bootc_shipment!"
+        else:
+            key_name = "microshift_bootc_shipment"
+
+        # Set the microshift_bootc_shipment config
+        new_releases_config["releases"][self.assembly]["assembly"]["group"][key_name] = microshift_bootc_shipment_config
+
+        # Write updated releases.yml
+        out = StringIO()
+        yaml.dump(new_releases_config, out)
+        await build_data_repo.write_file(releases_yml_path, out.getvalue())
+        await build_data_repo.add_all()
+        await build_data_repo.log_diff()
+
+        commit_message = f"Update microshift-bootc shipment URL for assembly {self.assembly}"
+        return await build_data_repo.commit_push(commit_message, safe=True)
+
+    async def _create_or_update_build_data_pr(self) -> bool:
+        """Create or update a pull request in the build data repo with the microshift_bootc_shipment URL.
+        :return: True if the PR was created or updated successfully, False otherwise.
+        """
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+        branch = f"update-microshift-bootc-shipment-{self.assembly}-{timestamp}"
+        updated = await self._update_build_data(branch)
+        if not updated:
+            self._logger.info("No changes in microshift_bootc_shipment config. PR will not be created.")
+            return False
+
+        data_path = self._doozer_env_vars["DOOZER_DATA_PATH"]
+        user, repo = self.extract_git_repo(data_path)
+
+        head = f"{user}:{branch}"
+        base = self.group
+        gh_repo = get_github_client_for_org(user).get_repo(f"{user}/{repo}")
+        existing_prs = list(gh_repo.get_pulls(state="open", head=head, base=base))
+
+        if not existing_prs:
+            pr_title = f"Update microshift-bootc shipment URL for assembly {self.assembly}"
+            pr_body = f"This PR updates microshift_bootc_shipment URL for {self.assembly} assembly."
+            job_url = jenkins.get_build_url()
+            if job_url:
+                pr_body += f"\n\nCreated by job: {job_url}"
+
+            if self.runtime.dry_run:
+                self._logger.info("[DRY-RUN] Would have created a new PR with title '%s'", pr_title)
+                return True
+
+            pr = gh_repo.create_pull(title=pr_title, body=pr_body, base=base, head=branch)
+            self._logger.info("Created PR to update microshift-bootc shipment URL: %s", pr.html_url)
+            await self.slack_client.say_in_thread(f"PR created to update microshift-bootc shipment URL: {pr.html_url}")
+
+            # Wait for CI tests to pass, then merge
+            await self._wait_for_pr_merge(pr)
+        else:
+            # PR already exists, update it
+            pr = existing_prs[0]
+            self._logger.info("PR already exists: %s", pr.html_url)
+
+        return True
+
     async def _load_or_init_shipment_config(self) -> ShipmentConfig:
         """Load existing shipment config from branch or initialize new one
 
@@ -793,10 +934,13 @@ class BuildMicroShiftBootcPipeline:
         Otherwise, create a new branch with timestamp.
         """
         # Check if shipment already exists in assembly config
-        assembly_shipment_config = self.assembly_group_config.get("shipment", {})
+        assembly_shipment_config = self.assembly_group_config.get("microshift_bootc_shipment", {})
         existing_mr_url = assembly_shipment_config.get("url")
 
         if existing_mr_url:
+            # Validate MR state before using it
+            self._validate_shipment_mr(existing_mr_url)
+
             # Extract branch name from existing MR
             # The MR URL contains the branch name in the source_branch field
             # We need to fetch the MR details to get the branch name
@@ -896,12 +1040,15 @@ class BuildMicroShiftBootcPipeline:
         self._logger.info("Creating or updating shipment MR...")
 
         # Check if shipment already exists in assembly config
-        assembly_shipment_config = self.assembly_group_config.get("shipment", {})
+        assembly_shipment_config = self.assembly_group_config.get("microshift_bootc_shipment", {})
         existing_mr_url = assembly_shipment_config.get("url")
 
         target_branch = "main"
 
         if existing_mr_url:
+            # Validate MR state before using it
+            self._validate_shipment_mr(existing_mr_url)
+
             # Extract branch name from existing MR (already done in _load_or_init_shipment_config)
             parsed_url = urlparse(existing_mr_url)
             mr_id = parsed_url.path.split('/')[-1]

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -813,49 +813,22 @@ class BuildMicroShiftBootcPipeline:
         if mr.state != "opened":
             raise ValueError(f"MR state {mr.state} is not opened. This is not supported.")
 
-    async def _update_build_data(self, branch: str) -> bool:
+    def _update_build_data(self, branch: str, upstream_repo) -> tuple[bool, dict]:
         """Update releases.yml in build data repo with microshift_bootc_shipment URL.
-        Commits the changes and pushes to the remote repo.
         :param branch: The branch to update in the build data repo
-        :return: True if the changes were committed and pushed successfully, False otherwise.
+        :param upstream_repo: GitHub repository object
+        :return: Tuple of (changed: bool, new_releases_config: dict)
         """
-        data_path = self._doozer_env_vars["DOOZER_DATA_PATH"]
-        build_data_repo_dir = self._working_dir / "build-data-push"
+        # Load current releases.yml from the branch (or group branch if branch doesn't exist yet)
+        try:
+            # Try to get releases.yml from the target branch first
+            release_file_content = yaml.load(upstream_repo.get_contents("releases.yml", ref=branch).decoded_content)
+        except Exception:
+            # Branch doesn't exist yet, get from group branch
+            release_file_content = yaml.load(upstream_repo.get_contents("releases.yml", ref=self.group).decoded_content)
 
-        # Clean up existing directory if it exists
-        if build_data_repo_dir.exists():
-            shutil.rmtree(build_data_repo_dir, ignore_errors=True)
-
-        # Initialize GitRepository for build data
-        build_data_repo = GitRepository(build_data_repo_dir, self.runtime.dry_run)
-
-        # Setup build-data repo
-        # For pushing, we need GitHub token auth
-        github_token = os.getenv("GITHUB_TOKEN")
-        if not github_token and not self.runtime.dry_run:
-            raise ValueError("GITHUB_TOKEN environment variable is required to update build data")
-
-        user, repo = self.extract_git_repo(data_path)
-        push_url = f"https://oauth2:{github_token}@github.com/{user}/{repo}.git" if github_token else data_path
-
-        await build_data_repo.setup(
-            remote_url=push_url,
-            upstream_remote_url=data_path,
-        )
-
-        # Check if branch exists on remote, if so fetch and switch to it
-        if await build_data_repo.does_branch_exist_on_remote(branch, remote="origin"):
-            self._logger.info('Fetching and switching to existing branch %s', branch)
-            await build_data_repo.fetch_switch_branch(branch, remote="origin")
-        else:
-            # Fetch and switch to group branch first
-            await build_data_repo.fetch_switch_branch(self.group, remote="upstream")
-            self._logger.info('Creating new branch %s', branch)
-            await build_data_repo.create_branch(branch)
-
-        # Load current releases.yml
-        releases_yml_path = "releases.yml"
-        new_releases_config = copy.deepcopy(self.releases_config)
+        source_file_content = copy.deepcopy(release_file_content)
+        new_releases_config = copy.deepcopy(release_file_content)
 
         # Update the microshift_bootc_shipment section
         microshift_bootc_shipment_config = {"url": self.shipment_mr_url}
@@ -874,57 +847,65 @@ class BuildMicroShiftBootcPipeline:
         # Set the microshift_bootc_shipment config
         new_releases_config["releases"][self.assembly]["assembly"]["group"][key_name] = microshift_bootc_shipment_config
 
-        # Write updated releases.yml
-        out = StringIO()
-        yaml.dump(new_releases_config, out)
-        await build_data_repo.write_file(releases_yml_path, out.getvalue())
-        await build_data_repo.add_all()
-        await build_data_repo.log_diff()
+        # Check if anything changed
+        if source_file_content == new_releases_config:
+            return False, new_releases_config
 
-        commit_message = f"Update microshift-bootc shipment URL for assembly {self.assembly}"
-        return await build_data_repo.commit_push(commit_message, safe=True)
+        return True, new_releases_config
 
     async def _create_or_update_build_data_pr(self) -> bool:
         """Create or update a pull request in the build data repo with the microshift_bootc_shipment URL.
         :return: True if the PR was created or updated successfully, False otherwise.
         """
-        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-        branch = f"update-microshift-bootc-shipment-{self.assembly}-{timestamp}"
-        updated = await self._update_build_data(branch)
-        if not updated:
-            self._logger.info("No changes in microshift_bootc_shipment config. PR will not be created.")
-            return False
+        branch = f"update-microshift-bootc-shipment-{self.assembly}"
+        pr_title = f"Update microshift-bootc shipment URL for assembly {self.assembly}"
+        pr_body = f"This PR updates microshift_bootc_shipment URL for {self.assembly} assembly."
+        job_url = jenkins.get_build_url()
+        if job_url:
+            pr_body += f"\n\nCreated by job: {job_url}"
+
+        if self.runtime.dry_run:
+            self._logger.info(
+                "[DRY-RUN] Would have created pull-request with head '%s', title '%s', body '%s'",
+                branch,
+                pr_title,
+                pr_body,
+            )
+            return True
 
         data_path = self._doozer_env_vars["DOOZER_DATA_PATH"]
         user, repo = self.extract_git_repo(data_path)
+        github_client = get_github_client_for_org(user)
+        upstream_repo = github_client.get_repo(f"{user}/{repo}")
 
-        head = f"{user}:{branch}"
-        base = self.group
-        gh_repo = get_github_client_for_org(user).get_repo(f"{user}/{repo}")
-        existing_prs = list(gh_repo.get_pulls(state="open", head=head, base=base))
+        # Check if anything needs to be updated
+        changed, new_releases_config = self._update_build_data(branch, upstream_repo)
+        if not changed:
+            self._logger.info("No changes in microshift_bootc_shipment config. PR will not be created.")
+            return False
 
-        if not existing_prs:
-            pr_title = f"Update microshift-bootc shipment URL for assembly {self.assembly}"
-            pr_body = f"This PR updates microshift_bootc_shipment URL for {self.assembly} assembly."
-            job_url = jenkins.get_build_url()
-            if job_url:
-                pr_body += f"\n\nCreated by job: {job_url}"
+        # Delete existing branch if it exists
+        for b in upstream_repo.get_branches():
+            if b.name == branch:
+                upstream_repo.get_git_ref(f"heads/{branch}").delete()
 
-            if self.runtime.dry_run:
-                self._logger.info("[DRY-RUN] Would have created a new PR with title '%s'", pr_title)
-                return True
+        # Create new branch
+        upstream_repo.create_git_ref(f"refs/heads/{branch}", upstream_repo.get_branch(self.group).commit.sha)
 
-            pr = gh_repo.create_pull(title=pr_title, body=pr_body, base=base, head=branch)
-            self._logger.info("Created PR to update microshift-bootc shipment URL: %s", pr.html_url)
-            await self.slack_client.say_in_thread(f"PR created to update microshift-bootc shipment URL: {pr.html_url}")
+        # Update releases.yml
+        output = io.BytesIO()
+        yaml.dump(new_releases_config, output)
+        output.seek(0)
+        fork_file = upstream_repo.get_contents("releases.yml", ref=branch)
+        upstream_repo.update_file("releases.yml", pr_body, output.read(), fork_file.sha, branch=branch)
 
-            # Wait for CI tests to pass, then merge
-            await self._wait_for_pr_merge(pr)
-        else:
-            # PR already exists, update it
-            pr = existing_prs[0]
-            self._logger.info("PR already exists: %s", pr.html_url)
+        # Create PR
+        pr = upstream_repo.create_pull(title=pr_title, body=pr_body, base=self.group, head=branch)
+        self._logger.info("Created PR to update microshift-bootc shipment URL: %s", pr.html_url)
+        await self.slack_client.say_in_thread(f"PR created to update microshift-bootc shipment URL: {pr.html_url}")
 
+        # Wait for CI tests to pass, then merge
+        await self._wait_for_pr_merge(pr)
         return True
 
     async def _load_or_init_shipment_config(self) -> ShipmentConfig:

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -795,21 +795,30 @@ class BuildMicroShiftBootcPipeline:
 
         self._logger.info("Shipment environment setup completed")
 
+    def _get_shipment_mr_branch(self, shipment_url: str) -> str:
+        """Get the source branch from a shipment MR URL.
+        :param shipment_url: The URL of the shipment MR
+        :returns: The source branch name of the MR
+        :raises ValueError: If the MR is not in opened state
+        """
+        mr = self._gitlab.get_mr_from_url(shipment_url)
+        if not mr:
+            raise ValueError(f"Could not find MR at URL: {shipment_url}")
+
+        if mr.state != "opened":
+            raise ValueError(f"MR state {mr.state} is not opened. This is not supported.")
+
+        return mr.source_branch
+
     def _validate_shipment_mr(self, shipment_url: str):
         """Validate the shipment MR state
         :param shipment_url: The URL of the existing shipment MR to validate
         :raises ValueError: If the MR is not in opened state
         """
-        # Parse the shipment URL to extract project and MR details
-        parsed_url = urlparse(shipment_url)
-        project_path = parsed_url.path.strip('/').split('/-/merge_requests')[0]
-        mr_id = parsed_url.path.split('/')[-1]
+        mr = self._gitlab.get_mr_from_url(shipment_url)
+        if not mr:
+            raise ValueError(f"Could not find MR at URL: {shipment_url}")
 
-        # Load the existing MR
-        project = self._gitlab.get_project(project_path)
-        mr = project.mergerequests.get(mr_id)
-
-        # Make sure MR is in opened state
         if mr.state != "opened":
             raise ValueError(f"MR state {mr.state} is not opened. This is not supported.")
 
@@ -844,8 +853,9 @@ class BuildMicroShiftBootcPipeline:
         else:
             key_name = "microshift_bootc_shipment"
 
-        # Set the microshift_bootc_shipment config
-        new_releases_config["releases"][self.assembly]["assembly"]["group"][key_name] = microshift_bootc_shipment_config
+        # Set the microshift_bootc_shipment config (ensure group dict exists first)
+        group_config = new_releases_config["releases"][self.assembly]["assembly"].setdefault("group", {})
+        group_config[key_name] = microshift_bootc_shipment_config
 
         # Check if anything changed
         if source_file_content == new_releases_config:
@@ -913,35 +923,26 @@ class BuildMicroShiftBootcPipeline:
 
         If a shipment MR already exists (URL in config), reuse the existing branch.
         Otherwise, create a new branch with timestamp.
+
+        Sets self._shipment_source_branch to the resolved branch name for reuse in _create_shipment_mr.
         """
         # Check if shipment already exists in assembly config
         assembly_shipment_config = self.assembly_group_config.get("microshift_bootc_shipment", {})
         existing_mr_url = assembly_shipment_config.get("url")
 
         if existing_mr_url:
-            # Validate MR state before using it
-            self._validate_shipment_mr(existing_mr_url)
+            # Get the branch name from the existing MR (validates MR state)
+            self._shipment_source_branch = self._get_shipment_mr_branch(existing_mr_url)
 
-            # Extract branch name from existing MR
-            # The MR URL contains the branch name in the source_branch field
-            # We need to fetch the MR details to get the branch name
-            parsed_url = urlparse(existing_mr_url)
-            mr_id = parsed_url.path.split('/')[-1]
-            project_path = parsed_url.path.strip('/').split('/-/merge_requests')[0]
-
-            # Use the cached GitLab client
-            project = self._gitlab.get_project(project_path)
-            mr = project.mergerequests.get(mr_id)
-            source_branch = mr.source_branch
-
-            self._logger.info('Found existing shipment MR, using branch: %s', source_branch)
-            await self.shipment_data_repo.fetch_switch_branch(source_branch, remote="origin")
+            self._logger.info('Found existing shipment MR, using branch: %s', self._shipment_source_branch)
+            await self.shipment_data_repo.fetch_switch_branch(self._shipment_source_branch, remote="origin")
 
             # Initialize new config - we'll load the snapshot from existing files later if needed
             return await self._init_shipment_config()
         else:
             # No existing MR - this is the first run, initialize new config
             self._logger.info('No existing shipment MR found, will initialize new shipment config')
+            self._shipment_source_branch = None
             return await self._init_shipment_config()
 
     async def _init_shipment_config(self) -> ShipmentConfig:
@@ -1020,28 +1021,14 @@ class BuildMicroShiftBootcPipeline:
         """Create or update shipment MR with the given shipment config. Returns None if no changes."""
         self._logger.info("Creating or updating shipment MR...")
 
-        # Check if shipment already exists in assembly config
-        assembly_shipment_config = self.assembly_group_config.get("microshift_bootc_shipment", {})
-        existing_mr_url = assembly_shipment_config.get("url")
-
         target_branch = "main"
 
-        if existing_mr_url:
-            # Validate MR state before using it
-            self._validate_shipment_mr(existing_mr_url)
-
-            # Extract branch name from existing MR (already done in _load_or_init_shipment_config)
-            parsed_url = urlparse(existing_mr_url)
-            mr_id = parsed_url.path.split('/')[-1]
-            project_path = parsed_url.path.strip('/').split('/-/merge_requests')[0]
-
-            # Use the cached GitLab client
-            project = self._gitlab.get_project(project_path)
-            mr = project.mergerequests.get(mr_id)
-            source_branch = mr.source_branch
-
+        # Use the cached branch name from _load_or_init_shipment_config (if available)
+        cached_branch = getattr(self, '_shipment_source_branch', None)
+        if cached_branch:
+            # Reusing existing MR branch (already switched in _load_or_init_shipment_config)
+            source_branch = cached_branch
             self._logger.info('Reusing existing shipment branch: %s', source_branch)
-            await self.shipment_data_repo.fetch_switch_branch(source_branch, remote="origin")
         else:
             # Create new branch with timestamp
             timestamp = datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
@@ -1070,7 +1057,7 @@ class BuildMicroShiftBootcPipeline:
         mr_description = f"Created by job: {job_url}\n\n{commit_message}"
 
         if self.runtime.dry_run:
-            action = "updated" if existing_mr_url else "created"
+            action = "updated" if cached_branch else "created"
             self._logger.info("[DRY-RUN] Would have %s MR with title: %s", action, mr_title)
             mr_url = f"{self.gitlab_url}/placeholder/placeholder/-/merge_requests/placeholder"
         else:

--- a/pyartcd/tests/pipelines/test_build_microshift_bootc.py
+++ b/pyartcd/tests/pipelines/test_build_microshift_bootc.py
@@ -147,6 +147,7 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
 
         mock_gitlab_instance = Mock()
         mock_gitlab_instance.get_project.return_value = mock_project
+        mock_gitlab_instance.get_mr_from_url.return_value = mock_mr
         mock_gitlab_class.return_value = mock_gitlab_instance
 
         mock_shipment_config = Mock()
@@ -156,6 +157,8 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
         mock_shipment_config.model_dump = Mock(return_value={"shipment": {}})
 
         pipeline._gitlab = mock_gitlab_instance
+        # Simulate _load_or_init_shipment_config having cached the branch
+        pipeline._shipment_source_branch = existing_branch
 
         # when
         with patch('pyartcd.pipelines.build_microshift_bootc.get_release_name_for_assembly', return_value="4.21.0"):
@@ -478,11 +481,8 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
         mock_mr = Mock()
         mock_mr.state = "closed"
 
-        mock_project = Mock()
-        mock_project.mergerequests.get.return_value = mock_mr
-
         mock_gitlab_instance = Mock()
-        mock_gitlab_instance.get_project.return_value = mock_project
+        mock_gitlab_instance.get_mr_from_url.return_value = mock_mr
         pipeline._gitlab = mock_gitlab_instance
 
         shipment_url = "https://gitlab.example.com/shipment-data/-/merge_requests/123"

--- a/pyartcd/tests/pipelines/test_build_microshift_bootc.py
+++ b/pyartcd/tests/pipelines/test_build_microshift_bootc.py
@@ -132,10 +132,12 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
         mock_mr = Mock()
         mock_mr.source_branch = existing_branch
         mock_mr.web_url = existing_mr_url
+        mock_mr.description = "Original description"
 
         mock_project = Mock()
         mock_project.mergerequests.get.return_value = mock_mr
-        mock_project.mergerequests.list.return_value = []  # No existing MRs for this branch (will create new one)
+        # Return existing MR to exercise the update path (not create new)
+        mock_project.mergerequests.list.return_value = [mock_mr]
         mock_project.mergerequests.create.return_value = mock_mr
 
         mock_gitlab_instance = Mock()
@@ -159,6 +161,10 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
         written_filepath = pipeline.shipment_data_repo.write_file.call_args[0][0]
         expected_filename = f"{self.assembly}.microshift-bootc.{existing_timestamp}.yaml"
         self.assertTrue(str(written_filepath).endswith(expected_filename))
+
+        # Verify the update path was exercised (not create)
+        mock_project.mergerequests.create.assert_not_called()
+        mock_mr.save.assert_called_once()
 
     @patch('pyartcd.pipelines.build_microshift_bootc.get_github_client_for_org')
     async def test_create_shipment_mr_generates_new_timestamp_for_new_shipment(self, mock_get_client):

--- a/pyartcd/tests/pipelines/test_build_microshift_bootc.py
+++ b/pyartcd/tests/pipelines/test_build_microshift_bootc.py
@@ -125,7 +125,11 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
 
         # Mock releases config with existing shipment URL - use Model wrapper like in test_prepare_release_konflux
         pipeline.releases_config = Model(
-            {"releases": {self.assembly: {"assembly": {"group": {"shipment": {"url": existing_mr_url}}}}}}
+            {
+                "releases": {
+                    self.assembly: {"assembly": {"group": {"microshift_bootc_shipment": {"url": existing_mr_url}}}}
+                }
+            }
         )
 
         # Mock GitLab MR to return existing branch
@@ -133,6 +137,7 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
         mock_mr.source_branch = existing_branch
         mock_mr.web_url = existing_mr_url
         mock_mr.description = "Original description"
+        mock_mr.state = "opened"
 
         mock_project = Mock()
         mock_project.mergerequests.get.return_value = mock_mr
@@ -450,3 +455,40 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
             self.assertEqual(build_cmd[lock_idx + 2], "0d0943b")
         finally:
             os.environ.pop("KONFLUX_SA_KUBECONFIG", None)
+
+    def test_validate_shipment_mr_raises_on_closed_mr(self):
+        """
+        Test that _validate_shipment_mr raises ValueError when MR is not in opened state
+        """
+        # given
+        pipeline = BuildMicroShiftBootcPipeline(
+            runtime=self.runtime,
+            group=self.group,
+            assembly=self.assembly,
+            force=False,
+            force_plashet_sync=False,
+            prepare_shipment=True,
+            data_path="https://github.com/openshift-eng/ocp-build-data",
+            slack_client=self.mock_slack_client,
+        )
+
+        pipeline.gitlab_token = "fake-gitlab-token"
+
+        # Mock GitLab MR in closed state
+        mock_mr = Mock()
+        mock_mr.state = "closed"
+
+        mock_project = Mock()
+        mock_project.mergerequests.get.return_value = mock_mr
+
+        mock_gitlab_instance = Mock()
+        mock_gitlab_instance.get_project.return_value = mock_project
+        pipeline._gitlab = mock_gitlab_instance
+
+        shipment_url = "https://gitlab.example.com/shipment-data/-/merge_requests/123"
+
+        # when / then
+        with self.assertRaises(ValueError) as ctx:
+            pipeline._validate_shipment_mr(shipment_url)
+        self.assertIn("closed", str(ctx.exception))
+        self.assertIn("not opened", str(ctx.exception))

--- a/pyartcd/tests/pipelines/test_build_microshift_bootc.py
+++ b/pyartcd/tests/pipelines/test_build_microshift_bootc.py
@@ -9,6 +9,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, Mock, patch
 
 from artcommonlib.assembly import AssemblyTypes
+from artcommonlib.model import Model
 from pyartcd.pipelines.build_microshift_bootc import BuildMicroShiftBootcPipeline
 from pyartcd.runtime import Runtime
 from pyartcd.slack import SlackClient
@@ -47,72 +48,10 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
         os.environ.pop("GITHUB_TOKEN", None)
         os.environ.pop("GITLAB_TOKEN", None)
 
-    @patch('pyartcd.pipelines.build_microshift_bootc.ShipmentConfig')
-    @patch('pyartcd.pipelines.build_microshift_bootc.KonfluxImageBuilder.get_application_name')
     @patch('pyartcd.pipelines.build_microshift_bootc.get_github_client_for_org')
-    async def test_load_existing_shipment_config_extracts_timestamp(
-        self, mock_get_client, mock_get_app_name, mock_shipment_config_class
-    ):
+    async def test_update_shipment_data_extracts_timestamp_from_branch(self, mock_get_client):
         """
-        Test that when loading an existing shipment config, the timestamp is correctly extracted
-        from the filename and stored in existing_shipment_timestamp
-        """
-        # given
-        mock_get_app_name.return_value = "openshift-4-21"
-        mock_shipment_instance = Mock()
-        mock_shipment_config_class.return_value = mock_shipment_instance
-
-        pipeline = BuildMicroShiftBootcPipeline(
-            runtime=self.runtime,
-            group=self.group,
-            assembly=self.assembly,
-            force=False,
-            force_plashet_sync=False,
-            prepare_shipment=True,
-            data_path="https://github.com/openshift-eng/ocp-build-data",
-            slack_client=self.mock_slack_client,
-        )
-        pipeline.shipment_data_repo = Mock()
-        pipeline.shipment_data_repo._directory = self.runtime.working_dir
-
-        application = "openshift-4-21"
-        env = "prod"
-        shipment_dir = self.runtime.working_dir / "shipment" / "ocp" / self.group / application / env
-        shipment_dir.mkdir(parents=True, exist_ok=True)
-
-        existing_timestamp = "20260129004538"
-        existing_filename = f"{self.assembly}.microshift-bootc.{existing_timestamp}.yaml"
-        existing_file = shipment_dir / existing_filename
-
-        shipment_yaml_content = """
-shipment:
-  metadata:
-    product: ocp
-    application: openshift-4-21
-    group: openshift-4.21
-    assembly: 4.21.0
-    fbc: false
-  snapshot:
-    spec:
-      application: openshift-4-21
-      components:
-        - name: ose-4-21-microshift-bootc
-    nvrs:
-      - microshift-bootc-container-v4.21.0-202601290005.p2.g509fdb7.assembly.4.21.0.el9
-"""
-        existing_file.write_text(shipment_yaml_content)
-
-        # when
-        shipment_config = await pipeline._load_existing_shipment_config()
-        # then
-        self.assertIsNotNone(shipment_config)
-        self.assertEqual(pipeline.existing_shipment_timestamp, existing_timestamp)
-
-    @patch('pyartcd.pipelines.build_microshift_bootc.get_github_client_for_org')
-    async def test_create_shipment_mr_reuses_existing_timestamp(self, mock_get_client):
-        """
-        Test that when updating an existing MR, the existing timestamp is reused
-        instead of generating a new one
+        Test that timestamp is correctly extracted from branch name for filename generation
         """
         # given
         pipeline = BuildMicroShiftBootcPipeline(
@@ -126,35 +65,90 @@ shipment:
             slack_client=self.mock_slack_client,
         )
 
-        existing_timestamp = "20260129004538"
-        pipeline.existing_shipment_timestamp = existing_timestamp
-
         pipeline.shipment_data_repo = Mock()
         pipeline.shipment_data_repo._directory = self.runtime.working_dir
-        pipeline.shipment_data_repo.does_branch_exist_on_remote = AsyncMock(return_value=True)
-        pipeline.shipment_data_repo.fetch_switch_branch = AsyncMock()
-        pipeline.shipment_data_repo.create_branch = AsyncMock()
         pipeline.shipment_data_repo.write_file = AsyncMock()
         pipeline.shipment_data_repo.add_all = AsyncMock()
         pipeline.shipment_data_repo.log_diff = AsyncMock()
         pipeline.shipment_data_repo.commit_push = AsyncMock(return_value=True)
 
-        pipeline.releases_config = {"releases": {self.assembly: {}}}
-
-        mock_gitlab_client = Mock()
         mock_shipment_config = Mock()
         mock_shipment_config.shipment.metadata.product = "ocp"
         mock_shipment_config.shipment.metadata.group = self.group
         mock_shipment_config.shipment.metadata.application = "ocp-art-tenant"
         mock_shipment_config.model_dump = Mock(return_value={"shipment": {}})
 
-        mock_project = Mock()
-        mock_project.mergerequests.list.return_value = []
+        existing_timestamp = "20260129004538"
+        source_branch = f"prepare-microshift-bootc-shipment-{self.assembly}-{existing_timestamp}"
+
+        # when
+        await pipeline._update_shipment_data(mock_shipment_config, "Test commit", source_branch)
+
+        # then
+        pipeline.shipment_data_repo.write_file.assert_called_once()
+        written_filepath = pipeline.shipment_data_repo.write_file.call_args[0][0]
+        expected_filename = f"{self.assembly}.microshift-bootc.{existing_timestamp}.yaml"
+        self.assertTrue(str(written_filepath).endswith(expected_filename))
+
+    @patch('pyartcd.pipelines.build_microshift_bootc.GitLabClient')
+    @patch('pyartcd.pipelines.build_microshift_bootc.get_github_client_for_org')
+    async def test_create_shipment_mr_reuses_existing_timestamp(self, mock_get_client, mock_gitlab_class):
+        """
+        Test that when updating an existing MR, the timestamp from the existing branch is reused
+        """
+        # given
+        existing_timestamp = "20260129004538"
+        existing_branch = f"prepare-microshift-bootc-shipment-{self.assembly}-{existing_timestamp}"
+        existing_mr_url = "https://gitlab.example.com/shipment-data/-/merge_requests/123"
+
+        pipeline = BuildMicroShiftBootcPipeline(
+            runtime=self.runtime,
+            group=self.group,
+            assembly=self.assembly,
+            force=False,
+            force_plashet_sync=False,
+            prepare_shipment=True,
+            data_path="https://github.com/openshift-eng/ocp-build-data",
+            slack_client=self.mock_slack_client,
+        )
+
+        # Set gitlab_token like in test_prepare_release_konflux
+        pipeline.gitlab_token = "fake-gitlab-token"
+
+        pipeline.shipment_data_repo = Mock()
+        pipeline.shipment_data_repo._directory = self.runtime.working_dir
+        pipeline.shipment_data_repo.fetch_switch_branch = AsyncMock()
+        pipeline.shipment_data_repo.write_file = AsyncMock()
+        pipeline.shipment_data_repo.add_all = AsyncMock()
+        pipeline.shipment_data_repo.log_diff = AsyncMock()
+        pipeline.shipment_data_repo.commit_push = AsyncMock(return_value=True)
+
+        # Mock releases config with existing shipment URL - use Model wrapper like in test_prepare_release_konflux
+        pipeline.releases_config = Model(
+            {"releases": {self.assembly: {"assembly": {"group": {"shipment": {"url": existing_mr_url}}}}}}
+        )
+
+        # Mock GitLab MR to return existing branch
         mock_mr = Mock()
-        mock_mr.web_url = "https://gitlab.example.com/shipment-data/-/merge_requests/123"
+        mock_mr.source_branch = existing_branch
+        mock_mr.web_url = existing_mr_url
+
+        mock_project = Mock()
+        mock_project.mergerequests.get.return_value = mock_mr
+        mock_project.mergerequests.list.return_value = []  # No existing MRs for this branch (will create new one)
         mock_project.mergerequests.create.return_value = mock_mr
-        mock_gitlab_client.get_project.return_value = mock_project
-        pipeline._gitlab = mock_gitlab_client
+
+        mock_gitlab_instance = Mock()
+        mock_gitlab_instance.get_project.return_value = mock_project
+        mock_gitlab_class.return_value = mock_gitlab_instance
+
+        mock_shipment_config = Mock()
+        mock_shipment_config.shipment.metadata.product = "ocp"
+        mock_shipment_config.shipment.metadata.group = self.group
+        mock_shipment_config.shipment.metadata.application = "ocp-art-tenant"
+        mock_shipment_config.model_dump = Mock(return_value={"shipment": {}})
+
+        pipeline._gitlab = mock_gitlab_instance
 
         # when
         with patch('pyartcd.pipelines.build_microshift_bootc.get_release_name_for_assembly', return_value="4.21.0"):
@@ -164,13 +158,12 @@ shipment:
         pipeline.shipment_data_repo.write_file.assert_called_once()
         written_filepath = pipeline.shipment_data_repo.write_file.call_args[0][0]
         expected_filename = f"{self.assembly}.microshift-bootc.{existing_timestamp}.yaml"
-
         self.assertTrue(str(written_filepath).endswith(expected_filename))
 
     @patch('pyartcd.pipelines.build_microshift_bootc.get_github_client_for_org')
     async def test_create_shipment_mr_generates_new_timestamp_for_new_shipment(self, mock_get_client):
         """
-        Test that when creating a new MR (no existing shipment), a new timestamp is generated
+        Test that when creating a new MR (no existing shipment), a new branch with timestamp is created
         """
         # given
         pipeline = BuildMicroShiftBootcPipeline(
@@ -184,19 +177,21 @@ shipment:
             slack_client=self.mock_slack_client,
         )
 
-        self.assertIsNone(pipeline.existing_shipment_timestamp)
+        # Set gitlab_token like in test_prepare_release_konflux
+        pipeline.gitlab_token = "fake-gitlab-token"
 
         pipeline.shipment_data_repo = Mock()
         pipeline.shipment_data_repo._directory = self.runtime.working_dir
-        pipeline.shipment_data_repo.does_branch_exist_on_remote = AsyncMock(return_value=False)
-        pipeline.shipment_data_repo.fetch_switch_branch = AsyncMock()
         pipeline.shipment_data_repo.create_branch = AsyncMock()
         pipeline.shipment_data_repo.write_file = AsyncMock()
         pipeline.shipment_data_repo.add_all = AsyncMock()
         pipeline.shipment_data_repo.log_diff = AsyncMock()
         pipeline.shipment_data_repo.commit_push = AsyncMock(return_value=True)
 
-        pipeline.releases_config = {"releases": {self.assembly: {}}}
+        # No existing shipment URL in releases config - use Model wrapper with proper structure
+        pipeline.releases_config = Model(
+            {"releases": {self.assembly: {"assembly": {"group": {}}}}}  # No shipment URL here
+        )
 
         mock_gitlab_client = Mock()
         mock_shipment_config = Mock()
@@ -218,6 +213,12 @@ shipment:
             _ = await pipeline._create_shipment_mr(mock_shipment_config)
 
         # then
+        # Verify a new branch with timestamp was created
+        pipeline.shipment_data_repo.create_branch.assert_called_once()
+        created_branch = pipeline.shipment_data_repo.create_branch.call_args[0][0]
+        self.assertTrue(created_branch.startswith(f"prepare-microshift-bootc-shipment-{self.assembly}-"))
+
+        # Verify the filename uses the timestamp from the branch
         pipeline.shipment_data_repo.write_file.assert_called_once()
         written_filepath = pipeline.shipment_data_repo.write_file.call_args[0][0]
         filename = str(written_filepath.name)
@@ -225,7 +226,10 @@ shipment:
         self.assertTrue(filename.startswith(f"{self.assembly}.microshift-bootc."))
         self.assertTrue(filename.endswith(".yaml"))
 
+        # Extract timestamp from branch and verify it matches the filename
+        timestamp_from_branch = created_branch.split("-")[-1]
         timestamp_part = filename.replace(f"{self.assembly}.microshift-bootc.", "").replace(".yaml", "")
+        self.assertEqual(timestamp_from_branch, timestamp_part)
         self.assertEqual(len(timestamp_part), 14)
         self.assertTrue(timestamp_part.isdigit())
 


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

MicroShift bootc shipment branches are currently named without timestamps:                                                                                                                                        
- prepare-microshift-bootc-shipment-rc.0
                                                                                                                                                                                                                    
This causes multiple assemblies with the same name (e.g., 4.21.0-rc.0 and 4.22.0-rc.0) to push to the same branch, resulting in merge requests that incorrectly include commits from multiple releases.
                                                                                                                                                                                                                    
Example: [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/473) commits from both 4.21.0-rc.0 and 4.22.0-rc.0 because they share the branch name.                        
                                                                                                                                                                                                                    Solution:                                                                                                                                                                                                      Align MicroShift bootc shipment branch naming with the OCP shipment pattern used in prepare_release_konflux.py:                                                                                                   
   
Before: prepare-microshift-bootc-shipment-rc.0                                                                                                                                                                    
After: prepare-microshift-bootc-shipment-rc.0-20260420084437
                                                                                                                                                                                                                    
Each pipeline run now creates a unique timestamped branch, ensuring each assembly gets its own branch and MR.