### PR TITLE
ART-16004: feat(images): use art-images-base registry tags in update-golang streams

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -326,7 +326,7 @@ class UpdateGolangPipeline:
         if konflux_nvrs:
             for el_v, nvr in konflux_nvrs.items():
                 parsed_nvr = parse_nvr(nvr)
-                pullspec = self._get_builder_pullspec(parsed_nvr, 'konflux')
+                pullspec = self._streams_image_pullspec(parsed_nvr)
                 all_builder_messages.append(f"RHEL {el_v}: {nvr} -> {pullspec} (konflux)")
 
         builder_message = "New golang builders available:\n" + "\n".join([f"  - {msg}" for msg in all_builder_messages])
@@ -487,13 +487,37 @@ class UpdateGolangPipeline:
                 builder_nvrs[el_v] = build_record.nvr
         return builder_nvrs
 
+    @staticmethod
+    def _konflux_registry_streams_pullspec(parsed_nvr: dict) -> str:
+        """Released golang-builder image on registry.redhat.io (tag = full image NVR: name-version-release)."""
+        name = parsed_nvr.get('name')
+        version = parsed_nvr.get('version')
+        release = parsed_nvr.get('release')
+        if not name or not version or not release:
+            raise ValueError(
+                'Konflux golang-builder streams pullspec requires image NVR name, version, and release; '
+                f'got keys {list(parsed_nvr.keys())}'
+            )
+        tag = f'{name}-{version}-{release}'
+        return f'registry.redhat.io/openshift/art-images-base:{tag}'
+
+    @staticmethod
+    def _konflux_quay_golang_builder_pullspec(parsed_nvr: dict) -> str:
+        """Pullspec on the default Konflux quay repo (pre-art-images-base release); same layout as image push."""
+        return f'{KONFLUX_DEFAULT_IMAGE_REPO}:golang-builder-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
+
+    def _streams_image_pullspec(self, parsed_nvr: dict) -> str:
+        """Image value written to streams.yml: Brew short name, or Konflux registry URL for art-images-base."""
+        if self.build_system == 'brew':
+            return self._get_builder_pullspec(parsed_nvr, 'brew')
+        return self._konflux_registry_streams_pullspec(parsed_nvr)
+
     def _get_builder_pullspec(self, parsed_nvr, build_system: str):
         """Generate the complete pullspec based on build system"""
         if build_system == 'brew':
             return f'openshift/golang-builder:{parsed_nvr["version"]}-{parsed_nvr["release"]}'
         else:  # konflux or both (both uses konflux pullspec)
-            # TODO: This is temporary. In the future we need a location to share with multiple teams.
-            return f'{KONFLUX_DEFAULT_IMAGE_REPO}:golang-builder-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
+            return self._konflux_registry_streams_pullspec(parsed_nvr)
 
     async def update_golang_streams(self, go_version, builder_nvrs):
         """
@@ -556,7 +580,7 @@ class UpdateGolangPipeline:
                 _LOGGER.info("Looking for golang stream %s in streams.yml", latest_go_stream_name(el_v))
                 latest_go = get_stream(latest_go_stream_name(el_v))['image']
 
-                new_latest_go = self._get_builder_pullspec(parsed_nvr, self.build_system)
+                new_latest_go = self._streams_image_pullspec(parsed_nvr)
                 for _, info in streams_content.items():
                     if info['image'] == latest_go:
                         info['image'] = new_latest_go
@@ -569,7 +593,7 @@ class UpdateGolangPipeline:
                 _LOGGER.info("Looking for golang stream %s in streams.yml", previous_go_stream_name(el_v))
                 previous_go = get_stream(previous_go_stream_name(el_v))['image']
 
-                new_previous_go = self._get_builder_pullspec(parsed_nvr, self.build_system)
+                new_previous_go = self._streams_image_pullspec(parsed_nvr)
                 for _, info in streams_content.items():
                     if info['image'] == previous_go:
                         info['image'] = new_previous_go
@@ -585,7 +609,7 @@ class UpdateGolangPipeline:
                 _LOGGER.info("Looking for golang stream %s in streams.yml", previous_go_stream_name(el_v))
                 previous_go = get_stream(previous_go_stream_name(el_v))['image'] if go_previous else None
 
-                new_latest_go = self._get_builder_pullspec(parsed_nvr, self.build_system)
+                new_latest_go = self._streams_image_pullspec(parsed_nvr)
                 for _, info in streams_content.items():
                     if info['image'] == latest_go:
                         info['image'] = new_latest_go
@@ -606,7 +630,7 @@ class UpdateGolangPipeline:
                 builder_info = []
                 for el_v, nvr in builder_nvrs.items():
                     parsed_nvr = parse_nvr(nvr)
-                    pullspec = self._get_builder_pullspec(parsed_nvr, self.build_system)
+                    pullspec = self._streams_image_pullspec(parsed_nvr)
                     builder_info.append(f"  - RHEL {el_v}: {nvr} -> {pullspec}")
                 builder_details = "\n".join(builder_info)
 

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -6,7 +6,9 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import click
 import koji
+from artcommonlib.constants import KONFLUX_DEFAULT_IMAGE_REPO
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord
+from artcommonlib.rpm_utils import parse_nvr
 from pyartcd.pipelines.update_golang import (
     UpdateGolangPipeline,
     extract_and_validate_golang_nvrs,
@@ -377,6 +379,116 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         branch = UpdateGolangPipeline.get_golang_branch(9, "1.21.5")
         self.assertEqual(branch, "rhel-9-golang-1.21")
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_konflux_streams_pullspec_art_images_base_registry(self, mock_konflux_db):
+        """Konflux streams.yml image uses registry.redhat.io/openshift/art-images-base with NVR tag."""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.8-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="konflux",
+        )
+        parsed = {
+            "name": "openshift-golang-builder-container",
+            "version": "v1.25.8",
+            "release": "202604150744.p2.gf28329a.el9",
+        }
+        self.assertEqual(
+            pipeline._streams_image_pullspec(parsed),
+            "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9",
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_konflux_quay_golang_builder_pullspec_uses_konflux_default_repo(self, mock_konflux_db):
+        """Pre-release builder location uses KONFLUX_DEFAULT_IMAGE_REPO (for fallback / coordination)."""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.8-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="konflux",
+        )
+        parsed = {
+            "name": "openshift-golang-builder-container",
+            "version": "v1.25.8",
+            "release": "202604150744.p2.gf28329a.el9",
+        }
+        self.assertEqual(
+            pipeline._konflux_quay_golang_builder_pullspec(parsed),
+            f'{KONFLUX_DEFAULT_IMAGE_REPO}:golang-builder-v1.25.8-202604150744.p2.gf28329a.el9',
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_brew_streams_image_pullspec_brew_short_name(self, mock_konflux_db):
+        """Brew streams.yml image uses openshift/golang-builder with version-release (not registry.redhat.io)."""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.20.12-2.el8"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="brew",
+        )
+        parsed = {
+            "name": "openshift-golang-builder-container",
+            "version": "v1.20.12",
+            "release": "202403212137.el8.g144a3f8",
+        }
+        self.assertEqual(
+            pipeline._streams_image_pullspec(parsed),
+            "openshift/golang-builder:v1.20.12-202403212137.el8.g144a3f8",
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_brew_streams_image_pullspec_default_build_system_matches_get_builder(self, mock_konflux_db):
+        """Default build_system is brew; _streams_image_pullspec matches _get_builder_pullspec(..., brew)."""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.21.0-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+        )
+        parsed = parse_nvr("openshift-golang-builder-container-v1.21.0-202501011200.el9.gabcdef1.el9")
+        expected = pipeline._get_builder_pullspec(parsed, "brew")
+        self.assertEqual(pipeline._streams_image_pullspec(parsed), expected)
+        self.assertEqual(expected, "openshift/golang-builder:v1.21.0-202501011200.el9.gabcdef1.el9")
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_brew_login_when_logged_out(self, mock_konflux_db):


### PR DESCRIPTION
## Summary

update-golang now writes Konflux golang-builder stream entries as `registry.redhat.io/openshift/art-images-base:` plus the full image NVR tag (`name-version-release`), matching released images. Brew continues to use the short `openshift/golang-builder:` pullspec. Tests cover Konflux and Brew.

## Problem
**Before:** Streams PRs used quay.io pullspecs for Konflux-built golang builders, not the registry.redhat.io tags used after release ([ART-16004](https://issues.redhat.com/browse/ART-16004)).

**After:** `streams.yml` updates use the same tag form as `art-images-base` (e.g. `openshift-golang-builder-container-v1.25.8-...`) so downstream matches released content.

## Implementation Details
- `_konflux_registry_streams_pullspec` / `_streams_image_pullspec` in `pyartcd/pyartcd/pipelines/update_golang.py`
- Unit tests in `pyartcd/tests/pipelines/test_update_golang.py` for Konflux registry URL and Brew short name
