### PR TITLE
Fix upstream RHEL version detection 

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -936,14 +936,15 @@ class ImageMetadata(Metadata):
                 dfp = DockerfileParser(fileobj=f)
                 parent_images = dfp.parent_images
 
-            # We will infer the versions from the last build layer in the upstream Dockerfile
-            last_layer_pullspec = parent_images[-1]
-
-            # Use the cached function to extract builder info
-            rhel_version, golang_version = extract_builder_info_from_pullspec(last_layer_pullspec)
+            # Try the last build layer first (the runtime base), then fall back to earlier layers (builders).
+            # Some base images (e.g. aws-efs-utils-base) don't encode RHEL version in their tag and may
+            # not be inspectable, but builder images (e.g. rhel-9-golang-1.25) almost always do.
+            for pullspec in reversed(parent_images):
+                rhel_version, golang_version = extract_builder_info_from_pullspec(pullspec)
+                if rhel_version:
+                    break
 
         except Exception as e:
-            # Log the exception but don't raise - caller will decide how to handle None return
             self.logger.warning('[%s] Failed determining upstream builder info: %s', self.distgit_key, e)
 
         if not rhel_version:

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -872,6 +872,49 @@ RUN echo "test"
         # Verify config was merged (should detect el8 from ubi8 tag)
         self.assertEqual(metadata.config['distgit']['branch'], 'rhaos-4.16-rhel-8')
 
+    @patch('doozerlib.image.SourceResolver')
+    @patch('builtins.open', create=True)
+    @patch('pathlib.Path.joinpath')
+    @patch('doozerlib.image.util.oc_image_info_for_arch', return_value={'config': {'config': {'Labels': {}}}})
+    def test_determine_upstream_rhel_version_fallback_to_builder(
+        self, mock_oc_image_info, mock_joinpath, mock_open, mock_source_resolver
+    ):
+        """Test that RHEL version detection falls back to builder images when the base image tag is unhelpful"""
+        extract_builder_info_from_pullspec.cache_clear()
+        metadata = self._create_image_metadata('openshift/test_fallback')
+
+        metadata.config = Model(
+            {
+                'name': 'openshift/test_fallback',
+                'distgit': {'branch': 'rhaos-5.0-rhel-9'},
+                'content': {'source': {'git': {'url': 'https://github.com/test/repo.git'}}},
+            }
+        )
+        metadata.branch_el_target = MagicMock(return_value=9)
+
+        mock_source_resolution = MagicMock()
+        metadata.runtime.source_resolver.resolve_source = MagicMock(return_value=mock_source_resolution)
+
+        mock_source_dir = MagicMock()
+        mock_source_resolver.get_source_dir = MagicMock(return_value=mock_source_dir)
+
+        mock_df_path = MagicMock()
+        mock_joinpath.return_value = mock_df_path
+
+        mock_open.return_value.__enter__.return_value = mock.mock_open(read_data="").return_value
+
+        with patch('doozerlib.image.DockerfileParser') as mock_dfp:
+            mock_dfp_instance = MagicMock()
+            mock_dfp_instance.parent_images = [
+                'registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25',
+                'registry.ci.openshift.org/ocp/4.22:aws-efs-utils-base',
+            ]
+            mock_dfp.return_value = mock_dfp_instance
+            metadata.determine_targets = MagicMock(return_value=['target-1'])
+
+            # Should not raise - RHEL version 9 detected from the builder image fallback
+            metadata._apply_alternative_upstream_config()
+
     def test_get_olm_bundle_delivery_repo_name_override_single_entry(self):
         metadata = self._create_image_metadata('openshift/test')
         mock_config = MagicMock()


### PR DESCRIPTION
When canonical_builders_from_upstream is enabled, _determine_upstream_builder_info only checked the last FROM layer (the runtime base) for RHEL version info. Images like ose-aws-efs-csi-driver whose base image tag (aws-efs-utils-base) doesn't encode RHEL version caused the entire doozer rebase to crash with an IOError.

Now iterates all parent images in reverse order, falling back to builder images (e.g. rhel-9-golang-1.25) which reliably encode RHEL version in their tags.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED