### PR TITLE
ART-18057: make LP shipment MRs ready and trigger stage pipeline

### DIFF
--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -639,6 +639,26 @@ class ReleaseFromFbcPipeline:
         self.shipment_mr_url = mr_url
         return mr_url
 
+    async def set_shipment_mr_ready(self):
+        """
+        Mark the shipment MR as ready by removing the Draft prefix from the title.
+        This should be called at the end of the pipeline when all work is complete.
+        """
+        mr = await self._gitlab.set_mr_ready(self.shipment_mr_url)
+
+        if mr and not self.dry_run:
+            self.logger.info("Waiting for 30 seconds to ensure MR is updated...")
+            await asyncio.sleep(30)
+
+            try:
+                pipeline_url = await self._gitlab.trigger_ci_pipeline(mr)
+                if pipeline_url:
+                    self.logger.info(f"CI pipeline triggered: {pipeline_url}")
+                else:
+                    self.logger.warning(f"Failed to trigger CI pipeline for MR branch {mr.source_branch}")
+            except Exception as e:
+                self.logger.warning(f"Failed to trigger CI MR pipeline for branch {mr.source_branch}: {e}")
+
     async def update_shipment_data(
         self, shipments_by_kind: Dict[str, ShipmentConfig], env: str, commit_message: str, branch: str
     ) -> bool:
@@ -922,6 +942,7 @@ class ReleaseFromFbcPipeline:
                 mr_url = await self.create_shipment_mr(shipments_by_kind, env="prod")
                 if mr_url:
                     self.logger.info(f"Created shipment MR: {mr_url}")
+                    await self.set_shipment_mr_ready()
             except Exception as e:
                 self.logger.exception(f"Failed to create MR: {e}")
                 if not self.dry_run:

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -586,6 +586,96 @@ class TestExtraImageNvrsValidation(unittest.TestCase):
             self.assertNotIn("FBC builds", str(e))
 
 
+class TestSetShipmentMrReady(unittest.TestCase):
+    """Tests for ReleaseFromFbcPipeline.set_shipment_mr_ready()."""
+
+    def _make_pipeline(self, dry_run=False):
+        runtime = MagicMock()
+        runtime.dry_run = dry_run
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        runtime.config = {}
+
+        pipeline = ReleaseFromFbcPipeline(
+            runtime=runtime,
+            group="oadp-1.4",
+            assembly="1.4.5",
+            fbc_pullspecs=["quay.io/test/fbc:latest"],
+            create_mr=True,
+        )
+        pipeline.product = "oadp"
+        pipeline.shipment_mr_url = "https://gitlab.cee.redhat.com/test/repo/-/merge_requests/42"
+        return pipeline
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    def test_set_shipment_mr_ready_happy_path(self, mock_sleep):
+        """MR is marked ready, 30s sleep, pipeline triggered. Assert all three calls."""
+        pipeline = self._make_pipeline(dry_run=False)
+
+        mock_mr = MagicMock()
+        mock_gitlab = MagicMock()
+        mock_gitlab.set_mr_ready = AsyncMock(return_value=mock_mr)
+        mock_gitlab.trigger_ci_pipeline = AsyncMock(return_value="https://gitlab.cee.redhat.com/pipeline/123")
+        pipeline.__dict__["_gitlab"] = mock_gitlab
+
+        asyncio.run(pipeline.set_shipment_mr_ready())
+
+        mock_gitlab.set_mr_ready.assert_awaited_once_with(pipeline.shipment_mr_url)
+        mock_sleep.assert_awaited_once_with(30)
+        mock_gitlab.trigger_ci_pipeline.assert_awaited_once_with(mock_mr)
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    def test_set_shipment_mr_ready_dry_run(self, mock_sleep):
+        """dry_run=True. set_mr_ready is called but sleep and trigger_ci_pipeline are NOT called."""
+        pipeline = self._make_pipeline(dry_run=True)
+
+        mock_mr = MagicMock()
+        mock_gitlab = MagicMock()
+        mock_gitlab.set_mr_ready = AsyncMock(return_value=mock_mr)
+        mock_gitlab.trigger_ci_pipeline = AsyncMock()
+        pipeline.__dict__["_gitlab"] = mock_gitlab
+
+        asyncio.run(pipeline.set_shipment_mr_ready())
+
+        mock_gitlab.set_mr_ready.assert_awaited_once_with(pipeline.shipment_mr_url)
+        mock_sleep.assert_not_awaited()
+        mock_gitlab.trigger_ci_pipeline.assert_not_awaited()
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    def test_set_shipment_mr_ready_pipeline_trigger_fails(self, mock_sleep):
+        """trigger_ci_pipeline raises Exception. Assert it doesn't propagate (method catches it)."""
+        pipeline = self._make_pipeline(dry_run=False)
+
+        mock_mr = MagicMock()
+        mock_gitlab = MagicMock()
+        mock_gitlab.set_mr_ready = AsyncMock(return_value=mock_mr)
+        mock_gitlab.trigger_ci_pipeline = AsyncMock(side_effect=Exception("GitLab API error"))
+        pipeline.__dict__["_gitlab"] = mock_gitlab
+
+        # Should not raise
+        asyncio.run(pipeline.set_shipment_mr_ready())
+
+        mock_gitlab.set_mr_ready.assert_awaited_once_with(pipeline.shipment_mr_url)
+        mock_sleep.assert_awaited_once_with(30)
+        mock_gitlab.trigger_ci_pipeline.assert_awaited_once_with(mock_mr)
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    def test_set_shipment_mr_ready_mr_is_none(self, mock_sleep):
+        """set_mr_ready returns None. Assert sleep and trigger_ci_pipeline are NOT called."""
+        pipeline = self._make_pipeline(dry_run=False)
+
+        mock_gitlab = MagicMock()
+        mock_gitlab.set_mr_ready = AsyncMock(return_value=None)
+        mock_gitlab.trigger_ci_pipeline = AsyncMock()
+        pipeline.__dict__["_gitlab"] = mock_gitlab
+
+        asyncio.run(pipeline.set_shipment_mr_ready())
+
+        mock_gitlab.set_mr_ready.assert_awaited_once_with(pipeline.shipment_mr_url)
+        mock_sleep.assert_not_awaited()
+        mock_gitlab.trigger_ci_pipeline.assert_not_awaited()
+
+
 class TestCliValidation(unittest.TestCase):
     """Test CLI argument validation via CliRunner against the real Click command."""
 


### PR DESCRIPTION
  ## Summary                                         
  - Layered Product shipment MRs (created by `release-from-fbc`) now automatically transition from draft to ready and trigger the stage pipeline, matching the existing OCP (`prepare-release-konflux`) and microshift-bootc behavior.                                                                                                                                                                                        
  - Previously, LP shipment MRs stayed in draft state, requiring manual intervention to mark ready and trigger the pipeline.
                                                                                                                                                                                                                    
  ## Changes                                         
  - Added `set_shipment_mr_ready()` method to `ReleaseFromFbcPipeline` that removes the "Draft:" prefix, waits 30s for GitLab to update, then triggers the CI stage pipeline                                        
  - Called from `run()` after `create_shipment_mr()` succeeds, inside the existing try/except block so failures don't crash the pipeline                                                                            
  - Uses `self.logger` for output (no Slack client in this pipeline)                                                                                                                                                
                                                                                                                                                                                                                    
  ## Test plan                                                                                                                                                                                                      
  - [x] 4 new unit tests: happy path, dry run, pipeline trigger failure, set_mr_ready returns None                                                                                                                  
  - [x] All 48 tests pass                                                                                                                                                                                           
  - [x] Linting clean                                
                                                                                                                                                                                                                    
  Resolves: [ART-18057](https://redhat.atlassian.net/browse/ART-18057)