### PR TITLE
ART-14447: add direct signing transport

### DIFF
--- a/brainstorming/2026-04-22-signing-umb-to-kafka-design.md
+++ b/brainstorming/2026-04-22-signing-umb-to-kafka-design.md
@@ -1,0 +1,275 @@
+# ART-14447: Sign Without UMB — Migrate Signing Transport from UMB to Kafka
+
+## Summary
+
+UMB is being decommissioned in Q3 2026 (code-complete deadline: end of Q2 2026). The only ART
+interaction with UMB is in the signing flow during release promotion. This design replaces the
+STOMP-based UMB transport with Kafka, using IT Platform's Messaging Bridge to maintain
+compatibility with RADAS (which still consumes from UMB).
+
+## Context
+
+### Current Flow
+
+`AsyncSignatory` in `pyartcd/pyartcd/signatory.py` signs OCP artifacts by:
+
+1. Connecting to UMB via STOMP (`AsyncUMBClient` in `pyartcd/pyartcd/umb_client.py`)
+2. Sending a signing request (base64-encoded artifact + metadata) to
+   `/topic/VirtualTopic.eng.art.artifact.sign`
+3. Subscribing to a consumer queue
+   `/queue/Consumer.{sa}.{sub}.VirtualTopic.eng.robosignatory.art.sign`
+4. Waiting for RADAS to return the signed artifact on that queue
+5. Decoding the base64 response and writing the signature file
+
+This is called from `pyartcd/pyartcd/pipelines/promote.py` to sign JSON digest claims
+(container image signatures) and message digests (sha256sum.txt.gpg).
+
+### Why Messaging Bridge (Not Direct Signing Server or Waiting for RADAS on Kafka)
+
+- **RADAS's migration to Kafka is TBD** — the RADAS team hasn't decided their path yet
+  (see CLOUDWF-11222). Waiting on them risks missing the Q2 deadline.
+- **Direct signing server API** (bypassing RADAS) is unexplored and would require
+  reimplementing RADAS business logic — too much risk under deadline pressure.
+- **Messaging Bridge** is already in production, recommended by IT Platform for exactly this
+  use case, and forwards messages bidirectionally between UMB topics and Kafka topics. The
+  message format stays identical.
+
+## Design
+
+### Transport Abstraction
+
+Introduce a `SigningTransport` protocol that `AsyncSignatory` delegates to, keeping all signing
+logic in one place:
+
+```python
+class SigningTransport(Protocol):
+    async def connect(self) -> None: ...
+    async def close(self) -> None: ...
+    async def send(self, destination: str, body: str) -> None: ...
+    async def subscribe(self, queue: str, subscription_id: str) -> AsyncIterator: ...
+    async def ack(self, message_id: str, subscription_id: str) -> None: ...
+```
+
+Two implementations:
+
+- **`UMBTransport`** — wraps the existing `AsyncUMBClient` (extracts what `AsyncSignatory`
+  already does today)
+- **`KafkaTransport`** — wraps `Retriable-Kafka-Client`, mapping `send()` to the Kafka
+  producer and `subscribe()` to the Kafka consumer on the response topic
+
+`AsyncSignatory.__init__` accepts a `transport: SigningTransport` instead of URI/cert/key
+directly. The factory logic in `promote.py` decides which transport to create based on
+`--signing-transport`.
+
+Benefits:
+- `AsyncSignatory` signing logic doesn't change — zero risk
+- Each transport is independently testable
+- When UMB is decommissioned, delete `UMBTransport` and `umb_client.py`
+- No `if/else kafka/umb` scattered through signing code
+
+### Async Bridging for KafkaTransport
+
+`Retriable-Kafka-Client` uses synchronous `confluent_kafka` with a thread-based executor pool
+model. Our signing flow is async (asyncio). `KafkaTransport` bridges this by running the Kafka
+consumer poll loop in a thread and feeding messages into an `asyncio.Queue` — the same pattern
+`AsyncUMBClient` already uses to bridge `stomp.py`'s threading model into asyncio.
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `pyartcd/pyartcd/signing_transport.py` (new) | `SigningTransport` protocol, `UMBTransport`, `KafkaTransport` |
+| `pyartcd/pyartcd/kafka_client.py` (new) | Async Kafka client wrapping `Retriable-Kafka-Client` |
+| `pyartcd/pyartcd/signatory.py` | Refactor `AsyncSignatory` to accept `SigningTransport` instead of UMB-specific params |
+| `pyartcd/pyartcd/constants.py` | Add `KAFKA_BROKERS` dict (per environment) and Kafka topic names |
+| `pyartcd/pyartcd/pipelines/promote.py` | `sign_artifacts()` reads `--signing-transport` flag, creates appropriate transport |
+| CLI wiring (promote pipeline argparse/click) | Add `--signing-transport` option (choices: `umb`, `kafka`, default: `umb`) |
+
+### Kafka Authentication & Configuration
+
+Kafka uses SASL username/password auth (unlike UMB's certificate-based auth):
+
+- **Broker URLs** — `KAFKA_BROKERS` in `constants.py`, keyed by environment (prod/stage/qa/dev)
+- **Credentials** — environment variables `KAFKA_USERNAME` and `KAFKA_PASSWORD`, following the
+  same pattern as `SIGNING_CERT`/`SIGNING_KEY` for UMB
+- **Consumer group ID** — `artcd-signing-{uuid}` per instance, ensuring no two promote runs
+  steal each other's responses. Ephemeral groups are cleaned up by Kafka automatically.
+- **Topics** — Kafka topic names set up during Messaging Bridge onboarding, stored in
+  `constants.py`
+
+Topic mapping (exact names TBD during onboarding):
+
+| UMB | Kafka |
+|---|---|
+| `/topic/VirtualTopic.eng.art.artifact.sign` (send) | TBD during bridge setup |
+| `/queue/Consumer.{sa}.{sub}.VirtualTopic.eng.robosignatory.art.sign` (receive) | TBD during bridge setup |
+
+Request/response correlation: the existing `request_id` field in the message body is used to
+match responses. On Kafka, the consumer receives all messages on the response topic and filters
+by `request_id`, discarding unrelated messages — same as the current UMB flow.
+
+### Toggle Mechanism
+
+New CLI flag `--signing-transport` on the promote pipeline:
+
+- Choices: `umb`, `kafka`
+- Default: `umb` (safe rollout)
+- Mirrors the existing `--signing-env` pattern (prod/stage/qa/dev)
+- Set in Jenkins/Tekton pipeline configuration
+- Removed after UMB decommissioning (along with UMB code)
+
+### Error Handling & Resilience
+
+| Failure Mode | Behavior |
+|---|---|
+| **Connection failure** | `KafkaTransport` lets the error bubble up and fail the pipeline, same as `UMBTransport` |
+| **Stale messages** | Same 1-hour staleness check on message timestamp — transport-independent |
+| **Signing failure** | RADAS returning `signing_status != "success"` raises `SignatoryServerError` — unchanged |
+| **Response timeout** | NEW: configurable timeout (default 10 minutes) on both transports. Raises `TimeoutError` instead of hanging indefinitely. This fixes a pre-existing issue in the UMB path too. |
+| **Consumer group conflicts** | Unique group ID per instance (`artcd-signing-{uuid}`) prevents response stealing |
+
+### Testing Strategy
+
+**Unit tests:**
+
+- `KafkaTransport` — mock `Retriable-Kafka-Client` producer/consumer, verify send/subscribe/ack
+- `UMBTransport` — refactor existing `test_signatory.py` tests to use the wrapper
+- `AsyncSignatory` with transport injection — signing logic works identically with either transport
+- Timeout — both transports raise clear error when no response arrives
+- Stale message filtering — existing coverage adapted for both transports
+
+**Integration/manual testing:**
+
+1. Stage: set up Kafka + Bridge on stage, run `--signing-transport kafka --signing-env stage`
+2. Verify end-to-end: request → Kafka → Bridge → UMB → RADAS → UMB → Bridge → Kafka → response
+3. Prod: flip to `--signing-transport kafka --signing-env prod`
+
+## Alternative Considered: Move Signing to a Konflux Task
+
+Instead of migrating the transport layer inside pyartcd, an alternative approach is to move
+the signing step itself into a Konflux Tekton Task. The promote pipeline (Jenkins) would
+trigger a Konflux TaskRun, passing signing parameters, and wait for the signed artifacts to
+come back.
+
+### How It Would Work
+
+1. A **Tekton Task** is deployed in the ART Konflux tenant that handles signing requests
+   (initially via RADAS/UMB or Kafka, eventually via the direct signing server API)
+2. `promote.py` uses the existing `KonfluxClient` (from `artcommon/artcommonlib/konflux/`)
+   to create a TaskRun with parameters: pullspecs, digests, version, sig_keyname
+3. The TaskRun produces signature files (either as OCI artifacts or pushes directly to S3)
+4. `promote.py` waits for the TaskRun to complete, then continues with publishing
+
+This pattern already exists in ART: `ocp4_konflux.py` shells out to doozer, which uses
+`KonfluxImageBuilder` and `KonfluxClient` to create PipelineRuns via the Kubernetes API and
+watch them to completion. The machinery for Konflux orchestration is proven.
+
+### Where Signing Happens Today
+
+Signing via RADAS/UMB (`AsyncSignatory`) is used in two pipelines:
+
+| Pipeline | What It Signs |
+|---|---|
+| `promote.py` | JSON digest claims (container image signatures) and message digests (sha256sum.txt.gpg) |
+| `sync_rhcos.py` | RHCOS message digests |
+
+Both would need to be migrated if this approach is taken. Sigstore/cosign signing
+(`SigstoreSignatory`) is unrelated — it doesn't use UMB and is unaffected.
+
+### Comparison
+
+| | Approach A: Kafka Transport Swap | Approach B: Move Signing to Konflux |
+|---|---|---|
+| **Scope** | Replace transport layer in existing pyartcd code | Build new Tekton Task + pyartcd→Konflux orchestration |
+| **Effort** | ~1-2 weeks | Significantly more — Tekton Task definition, cross-system orchestration for a non-build use case, S3 publishing from Konflux or artifact handoff |
+| **UMB dependency** | ART owns the Kafka migration | Konflux Task owns the RADAS interaction |
+| **Future benefit** | Will need another migration when direct signing lands | Automatically gets direct signing when [KONFLUX-11077](https://redhat.atlassian.net/browse/KONFLUX-11077) delivers — the Tekton Task switches internally, promote doesn't change |
+| **Complexity** | Low — well-understood transport swap | Medium — new cross-system orchestration pattern, Konflux Task needs RADAS access/credentials, distributed lock coordination across Jenkins and Konflux |
+| **Q2 2026 deadline** | Comfortable margin | Tight — depends on Tekton Task development + integration testing |
+| **Signing credentials** | Stay in Jenkins/pipeline secrets | Move to Konflux (cleaner long-term) |
+| **Debugging** | Signing failures visible in promote job logs | Signing failures require checking Konflux TaskRun logs |
+| **sync_rhcos.py** | Also migrated with the same transport abstraction | Also needs migration — or becomes a second signing path |
+
+### Recommendation
+
+**Approach A (Kafka transport swap) is recommended for the Q2 deadline.** It's lower risk,
+lower effort, and gets ART off UMB on time. Approach B is the better long-term architecture —
+when KONFLUX-11077 delivers direct signing, moving signing into a Konflux Task becomes the
+natural evolution. At that point, the Tekton Task uses the direct signing server API (no
+message bus at all), and promote simply triggers and waits.
+
+A possible phased path:
+1. **Now (Q2 2026):** Kafka transport swap (this spec) — meets the UMB deadline
+2. **When KONFLUX-11077 is proven (Q3-Q4 2026):** Move signing into a Konflux Task using the
+   direct signing API — eliminates Kafka, RADAS, and the Messaging Bridge from ART's stack
+
+## Rollout Plan
+
+### Phase 1 — Code (this PR)
+
+- Add `SigningTransport` protocol, `UMBTransport`, `KafkaTransport`
+- Add `kafka_client.py` wrapping `Retriable-Kafka-Client`
+- Refactor `AsyncSignatory` to accept transport injection
+- Add `--signing-transport` flag (default: `umb`)
+- Add response timeout to both transports
+- Unit tests
+
+### Phase 2 — Infrastructure Onboarding (non-code)
+
+- Request Kafka access from IT Platform (IT Managed Kafka User Guide)
+- Create Kafka topics for signing request/response
+- Request Messaging Bridge sync for RADAS VirtualTopics
+- Obtain Kafka credentials, store in pipeline secrets
+
+### Phase 3 — Validate on Stage
+
+- Run promote on stage with `--signing-transport kafka`
+- Verify full round-trip through the bridge
+
+### Phase 4 — Prod Cutover
+
+- Flip Jenkins/Tekton configs to `--signing-transport kafka`
+- Keep `umb` available as fallback
+- Monitor several successful releases
+
+### Phase 5 — Cleanup (after UMB decommissioned)
+
+- Remove `--signing-transport` flag, `UMBTransport`, `umb_client.py`
+- Remove `stomp.py` dependency
+- Remove `UMB_BROKERS` from constants
+- Notify IT Platform to remove Messaging Bridge sync
+- Optionally inline `KafkaTransport` if abstraction no longer adds value
+
+### Future: Direct Signing Server (Phase 6)
+
+The Konflux team is actively developing direct access to the signing server, bypassing both
+RADAS and UMB/Kafka entirely ([KONFLUX-11077](https://redhat.atlassian.net/browse/KONFLUX-11077),
+[KONFLUX-8400](https://redhat.atlassian.net/browse/KONFLUX-8400)). As of April 2026, the PoC
+is nearly complete, with the RADAS team (Martin Sikora, Wai Cheang) working on the API. Once
+this is proven in Konflux, ART could adopt the same direct signing API — replacing
+`KafkaTransport`, the Messaging Bridge dependency, and RADAS from the flow entirely.
+
+This is not in scope for ART-14447 because:
+- The direct API is not yet available outside of Konflux pipelines
+- ART's promote pipeline runs in Jenkins/Tekton, not as a Konflux pipeline
+- The Q2 2026 deadline doesn't allow time to wait for or integrate an unfinished API
+- Rate-limiting concerns (RADAS currently throttles requests) have not been resolved yet
+
+When the direct signing API stabilizes, a follow-up ticket should evaluate migrating ART to it.
+This would be the cleanest long-term solution — no message bus dependency at all.
+
+### Timeline
+
+Phase 1 is ~1-2 weeks of development. Phases 2-3 can overlap. Q2 deadline (end of June)
+provides comfortable margin.
+
+## References
+
+- Jira: [ART-14447](https://redhat.atlassian.net/browse/ART-14447)
+- UMB Decommissioning plan: [Google Doc](https://docs.google.com/document/d/1k0ch92nck9vFotretm3O2mPVhPIEmzyvidRsEvBXcQ0)
+- RADAS to Kafka: [Google Doc](https://docs.google.com/document/d/1j0L-C9KCQQqXtMc0tgSs8DgetZRXkW40FqZr1zm3B_s)
+- Retriable Kafka Client: [GitHub](https://github.com/release-engineering/Retriable-Kafka-Client)
+- RADAS Kafka decision: CLOUDWF-11222
+- UMB decommission epic: ITESPLAT-4153
+- Konflux direct signing (containers): [KONFLUX-11077](https://redhat.atlassian.net/browse/KONFLUX-11077)
+- Konflux direct signing (RPMs): [KONFLUX-8400](https://redhat.atlassian.net/browse/KONFLUX-8400)

--- a/brainstorming/2026-04-22-signing-umb-to-kafka-design.md
+++ b/brainstorming/2026-04-22-signing-umb-to-kafka-design.md
@@ -1,11 +1,19 @@
-# ART-14447: Sign Without UMB — Migrate Signing Transport from UMB to Kafka
+# ART-14447: Sign Without UMB — Migrate Off RADAS/UMB for Release Signing
 
 ## Summary
 
-UMB is being decommissioned in Q3 2026 (code-complete deadline: end of Q2 2026). The only ART
-interaction with UMB is in the signing flow during release promotion. This design replaces the
-STOMP-based UMB transport with Kafka, using IT Platform's Messaging Bridge to maintain
-compatibility with RADAS (which still consumes from UMB).
+UMB is being decommissioned in Q3 2026. The only ART interaction with UMB is in the signing
+flow during release promotion, where `AsyncSignatory` sends requests to RADAS over
+STOMP/UMB and waits for signed artifacts.
+
+Based on feedback from the RADAS team: RADAS has received an extension to stay on UMB with
+reduced support until Q1 2027, and the plan is to sunset RADAS entirely rather than migrate
+it to Kafka. The RADAS team recommends exploring direct signing server access, which is
+reportedly simpler than a Kafka migration and is already being adopted by Konflux
+([KONFLUX-11077](https://redhat.atlassian.net/browse/KONFLUX-11077)).
+
+**Updated recommendation:** Explore direct signing server access as the primary approach.
+The Kafka transport swap remains a viable fallback if direct signing doesn't pan out in time.
 
 ## Context
 
@@ -22,24 +30,118 @@ compatibility with RADAS (which still consumes from UMB).
 5. Decoding the base64 response and writing the signature file
 
 This is called from `pyartcd/pyartcd/pipelines/promote.py` to sign JSON digest claims
-(container image signatures) and message digests (sha256sum.txt.gpg).
+(container image signatures) and message digests (sha256sum.txt.gpg). It is also used in
+`pyartcd/pyartcd/pipelines/sync_rhcos.py` for RHCOS message digest signing.
 
-### Why Messaging Bridge (Not Direct Signing Server or Waiting for RADAS on Kafka)
+Sigstore/cosign signing (`SigstoreSignatory`) is a separate mechanism that does not use UMB
+and is unaffected by this work.
 
-- **RADAS's migration to Kafka is TBD** — the RADAS team hasn't decided their path yet
-  (see CLOUDWF-11222). Waiting on them risks missing the Q2 deadline.
-- **Direct signing server API** (bypassing RADAS) is unexplored and would require
-  reimplementing RADAS business logic — too much risk under deadline pressure.
-- **Messaging Bridge** is already in production, recommended by IT Platform for exactly this
-  use case, and forwards messages bidirectionally between UMB topics and Kafka topics. The
-  message format stays identical.
+### Timeline Constraints
 
-## Design
+- **UMB decommissioned:** Q3 2026 (general), but RADAS has an extension until Q1 2027
+- **UMB code-complete deadline:** Originally end of Q2 2026, but with the RADAS extension
+  there is more flexibility
+- **Konflux direct signing PoC:** Nearly complete as of April 2026
+  ([KONFLUX-11077](https://redhat.atlassian.net/browse/KONFLUX-11077))
+- **RADAS sunset:** Planned for 2027 — the RADAS team prefers to sunset rather than migrate
+  to Kafka
 
-### Transport Abstraction
+## Recommended Approach: Direct Signing Server Access
 
-Introduce a `SigningTransport` protocol that `AsyncSignatory` delegates to, keeping all signing
-logic in one place:
+### Rationale
+
+Feedback from the RADAS team indicates that calling the signing server directly (bypassing
+RADAS and UMB entirely) is straightforward and likely simpler than migrating to Kafka. The
+main complexity is working with ProdSec to get approval and access. Konflux is already in
+the process of switching to direct signing
+([KONFLUX-11077](https://redhat.atlassian.net/browse/KONFLUX-11077),
+[KONFLUX-8400](https://redhat.atlassian.net/browse/KONFLUX-8400)).
+
+This approach is the cleanest long-term solution:
+- No message bus dependency at all (no UMB, no Kafka, no Messaging Bridge)
+- No RADAS dependency (which is being sunset anyway)
+- Aligns with the direction Konflux is already taking
+- Fewer moving parts and infrastructure to maintain
+
+### What Needs to Be Explored
+
+Before committing to this approach, the following must be clarified:
+
+1. **Signing server API:** What is the interface? REST, gRPC, or something else? What
+   authentication is required?
+2. **ProdSec approval:** What is the process and timeline for getting ART approved for
+   direct access?
+3. **ART's signing use cases:** Can all of ART's signing operations (JSON digest claims,
+   message digests) be handled by direct signing, or are some RADAS-specific?
+4. **Rate limiting:** RADAS currently acts as a throttling layer. Does the signing server
+   have its own rate limits, and does ART's volume require any throttling on our side?
+5. **Environments:** Does the signing server have stage/prod environments matching ART's
+   needs?
+6. **Credentials and access:** What credentials are needed, and how are they provisioned?
+
+### High-Level Design (Pending Exploration)
+
+If direct signing is viable, the implementation would:
+
+- Replace `AsyncSignatory` (which wraps RADAS/UMB request/response) with a new
+  `DirectSignatory` that calls the signing server API directly
+- Keep the same public interface (`sign_json_digest`, `sign_message_digest`) so callers
+  in `promote.py` and `sync_rhcos.py` don't change
+- Use `--signing-transport` CLI flag (choices: `umb`, `direct`, default: `umb`) to allow
+  incremental rollout, same toggle pattern as the Kafka approach
+- Add a configurable response timeout (default 10 minutes) — fixes a pre-existing issue
+  in the UMB path where there is no timeout
+- Include solid unit tests and docstrings per the acceptance criteria
+
+### Rollout Plan (Direct Signing)
+
+#### Phase 1 — Exploration and ProdSec Approval
+
+- Investigate signing server API (interface, auth, environments)
+- Coordinate with ProdSec for approval and access
+- Validate that ART's signing use cases are supported
+- Assess rate-limiting requirements
+
+#### Phase 2 — Implementation
+
+- Implement `DirectSignatory` (or refactor `AsyncSignatory`) with the signing server API
+- Add `--signing-transport` flag (choices: `umb`, `direct`, default: `umb`) to both
+  `promote.py` and `sync_rhcos.py`
+- Add response timeout to both paths
+- Unit tests
+
+#### Phase 3 — Validate on Stage
+
+- Run promote on stage with `--signing-transport direct`
+- Run `sync_rhcos` signing on stage with `--signing-transport direct`
+- Verify end-to-end signing and signature publishing
+
+#### Phase 4 — Prod Cutover
+
+- Flip Jenkins/Tekton configs to `--signing-transport direct`
+- Keep `umb` available as fallback
+- Monitor several successful releases
+
+#### Phase 5 — Cleanup
+
+- Remove `--signing-transport` flag, `AsyncSignatory`, `AsyncUMBClient`, `umb_client.py`
+- Remove `stomp.py` dependency
+- Remove `UMB_BROKERS` from constants
+
+## Fallback: Kafka Transport Swap via Messaging Bridge
+
+If direct signing doesn't pan out (ProdSec approval delays, API not ready, etc.), the Kafka
+transport swap remains a viable fallback that can be implemented within the timeline.
+
+### How It Works
+
+IT Platform's Messaging Bridge (already in production) bidirectionally syncs UMB topics to
+Kafka topics. ART migrates from STOMP to Kafka; the bridge forwards messages to/from RADAS
+on UMB. The message format stays identical — only the transport changes.
+
+### Design
+
+Introduce a `SigningTransport` protocol that `AsyncSignatory` delegates to:
 
 ```python
 class SigningTransport(Protocol):
@@ -61,24 +163,12 @@ Two implementations:
   responses are tolerated via existing `request_id` correlation (duplicates are discarded
   since the corresponding `Future` has already been resolved).
 
-`AsyncSignatory.__init__` accepts a `transport: SigningTransport` instead of URI/cert/key
-directly. The factory logic in `promote.py` decides which transport to create based on
-`--signing-transport`.
+`Retriable-Kafka-Client` uses synchronous `confluent_kafka` with a thread-based executor
+pool model. `KafkaTransport` bridges this into asyncio by running the Kafka consumer poll
+loop in a thread and feeding messages into an `asyncio.Queue` — the same pattern
+`AsyncUMBClient` already uses to bridge `stomp.py`'s threading model.
 
-Benefits:
-- `AsyncSignatory` signing logic doesn't change — zero risk
-- Each transport is independently testable
-- When UMB is decommissioned, delete `UMBTransport` and `umb_client.py`
-- No `if/else kafka/umb` scattered through signing code
-
-### Async Bridging for KafkaTransport
-
-`Retriable-Kafka-Client` uses synchronous `confluent_kafka` with a thread-based executor pool
-model. Our signing flow is async (asyncio). `KafkaTransport` bridges this by running the Kafka
-consumer poll loop in a thread and feeding messages into an `asyncio.Queue` — the same pattern
-`AsyncUMBClient` already uses to bridge `stomp.py`'s threading model into asyncio.
-
-### Files Changed
+### Files Changed (Kafka Approach)
 
 | File | Change |
 |---|---|
@@ -113,17 +203,7 @@ Request/response correlation: the existing `request_id` field in the message bod
 match responses. On Kafka, the consumer receives all messages on the response topic and filters
 by `request_id`, discarding unrelated messages — same as the current UMB flow.
 
-### Toggle Mechanism
-
-New CLI flag `--signing-transport` on the promote pipeline:
-
-- Choices: `umb`, `kafka`
-- Default: `umb` (safe rollout)
-- Mirrors the existing `--signing-env` pattern (prod/stage/qa/dev)
-- Set in Jenkins/Tekton pipeline configuration
-- Removed after UMB decommissioning (along with UMB code)
-
-### Error Handling & Resilience
+### Error Handling & Resilience (Kafka Approach)
 
 | Failure Mode | Behavior |
 |---|---|
@@ -134,21 +214,13 @@ New CLI flag `--signing-transport` on the promote pipeline:
 | **Consumer group conflicts** | Unique group ID per instance (`artcd-signing-{uuid}`) prevents response stealing |
 | **Kafka offset-commit semantics** | `KafkaTransport` commits offsets only after a response with matching `request_id` is successfully validated and processed. Unmatched or stale messages are not committed until a valid response is found. This provides at-least-once delivery; duplicates are tolerated via `request_id` correlation. |
 
-### Testing Strategy
+### Kafka Rollout Plan
 
-**Unit tests:**
-
-- `KafkaTransport` — mock `Retriable-Kafka-Client` producer/consumer, verify send/subscribe/ack
-- `UMBTransport` — refactor existing `test_signatory.py` tests to use the wrapper
-- `AsyncSignatory` with transport injection — signing logic works identically with either transport
-- Timeout — both transports raise clear error when no response arrives
-- Stale message filtering — existing coverage adapted for both transports
-
-**Integration/manual testing:**
-
-1. Stage: set up Kafka + Bridge on stage, run `--signing-transport kafka --signing-env stage`
-2. Verify end-to-end: request → Kafka → Bridge → UMB → RADAS → UMB → Bridge → Kafka → response
-3. Prod: flip to `--signing-transport kafka --signing-env prod`
+1. **Infrastructure onboarding** — Kafka access, topics, Messaging Bridge sync
+2. **Code** — transport abstraction, `--signing-transport` flag, timeout, unit tests
+3. **Validate on stage** — both `promote.py` and `sync_rhcos.py`
+4. **Prod cutover** — flip to `--signing-transport kafka`, monitor
+5. **Cleanup** — remove UMB code after decommissioning
 
 ## Alternative Considered: Move Signing to a Konflux Task
 
@@ -170,105 +242,43 @@ This pattern already exists in ART: `ocp4_konflux.py` shells out to doozer, whic
 `KonfluxImageBuilder` and `KonfluxClient` to create PipelineRuns via the Kubernetes API and
 watch them to completion. The machinery for Konflux orchestration is proven.
 
-### Where Signing Happens Today
+### Comparison of All Three Approaches
 
-Signing via RADAS/UMB (`AsyncSignatory`) is used in two pipelines:
+| | Direct Signing Server | Kafka Transport Swap | Move to Konflux Task |
+|---|---|---|---|
+| **Scope** | Replace RADAS with direct API calls | Replace STOMP with Kafka transport | Build Tekton Task + cross-system orchestration |
+| **Effort** | TBD (depends on API complexity) | ~1-2 weeks | Significantly more |
+| **Message bus dependency** | None | Kafka + Messaging Bridge | Depends on what the Task uses internally |
+| **RADAS dependency** | None | Still depends on RADAS (via bridge) | Depends on implementation |
+| **Future-proof** | Yes — this is the target architecture | Temporary — needs another migration later | Yes — if built on direct signing |
+| **ProdSec approval** | Required | Not required | Required (for direct signing) |
+| **Q2 2026 deadline** | Depends on ProdSec timeline | Comfortable margin | Tight |
+| **Signing credentials** | New signing server credentials | Kafka username/password | In Konflux |
+| **sync_rhcos.py** | Same approach applies | Same transport abstraction | Needs separate migration |
 
-| Pipeline | What It Signs |
-|---|---|
-| `promote.py` | JSON digest claims (container image signatures) and message digests (sha256sum.txt.gpg) |
-| `sync_rhcos.py` | RHCOS message digests |
+## Decision
 
-Both would need to be migrated if this approach is taken. Sigstore/cosign signing
-(`SigstoreSignatory`) is unrelated — it doesn't use UMB and is unaffected.
+**Explore direct signing server access first.** This is the cleanest solution and aligns
+with the direction Konflux is already taking. The RADAS UMB extension to Q1 2027 removes
+the immediate urgency, giving time to work through ProdSec approval and integration.
 
-### Comparison
+If direct signing is blocked or delayed beyond the timeline, fall back to the Kafka
+transport swap, which can be implemented quickly.
 
-| | Approach A: Kafka Transport Swap | Approach B: Move Signing to Konflux |
-|---|---|---|
-| **Scope** | Replace transport layer in existing pyartcd code | Build new Tekton Task + pyartcd→Konflux orchestration |
-| **Effort** | ~1-2 weeks | Significantly more — Tekton Task definition, cross-system orchestration for a non-build use case, S3 publishing from Konflux or artifact handoff |
-| **UMB dependency** | ART owns the Kafka migration | Konflux Task owns the RADAS interaction |
-| **Future benefit** | Will need another migration when direct signing lands | Automatically gets direct signing when [KONFLUX-11077](https://redhat.atlassian.net/browse/KONFLUX-11077) delivers — the Tekton Task switches internally, promote doesn't change |
-| **Complexity** | Low — well-understood transport swap | Medium — new cross-system orchestration pattern, Konflux Task needs RADAS access/credentials, distributed lock coordination across Jenkins and Konflux |
-| **Q2 2026 deadline** | Comfortable margin | Tight — depends on Tekton Task development + integration testing |
-| **Signing credentials** | Stay in Jenkins/pipeline secrets | Move to Konflux (cleaner long-term) |
-| **Debugging** | Signing failures visible in promote job logs | Signing failures require checking Konflux TaskRun logs |
-| **sync_rhcos.py** | Also migrated with the same transport abstraction | Also needs migration — or becomes a second signing path |
+## Testing Strategy (Applies to Both Approaches)
 
-### Recommendation
+**Unit tests:**
 
-**Approach A (Kafka transport swap) is recommended for the Q2 deadline.** It's lower risk,
-lower effort, and gets ART off UMB on time. Approach B is the better long-term architecture —
-when KONFLUX-11077 delivers direct signing, moving signing into a Konflux Task becomes the
-natural evolution. At that point, the Tekton Task uses the direct signing server API (no
-message bus at all), and promote simply triggers and waits.
+- Mock the signing server (or Kafka client) and verify signing logic
+- Test timeout behavior — both transports raise clear error when no response arrives
+- Test stale message filtering
+- Existing `test_signatory.py` tests adapted for the new transport
 
-A possible phased path:
-1. **Now (Q2 2026):** Kafka transport swap (this spec) — meets the UMB deadline
-2. **When KONFLUX-11077 is proven (Q3-Q4 2026):** Move signing into a Konflux Task using the
-   direct signing API — eliminates Kafka, RADAS, and the Messaging Bridge from ART's stack
+**Integration/manual testing:**
 
-## Rollout Plan
-
-### Phase 1 — Code (this PR)
-
-- Add `SigningTransport` protocol, `UMBTransport`, `KafkaTransport`
-- Add `kafka_client.py` wrapping `Retriable-Kafka-Client`
-- Refactor `AsyncSignatory` to accept transport injection
-- Add `--signing-transport` flag (default: `umb`) to both `promote.py` and `sync_rhcos.py`
-- Add response timeout to both transports
-- Unit tests
-
-### Phase 2 — Infrastructure Onboarding (non-code)
-
-- Request Kafka access from IT Platform (IT Managed Kafka User Guide)
-- Create Kafka topics for signing request/response
-- Request Messaging Bridge sync for RADAS VirtualTopics
-- Obtain Kafka credentials, store in pipeline secrets
-
-### Phase 3 — Validate on Stage
-
-- Run promote on stage with `--signing-transport kafka`
-- Run `sync_rhcos` signing on stage with `--signing-transport kafka`
-- Verify full round-trip through the bridge for both pipelines
-
-### Phase 4 — Prod Cutover
-
-- Flip Jenkins/Tekton configs to `--signing-transport kafka`
-- Keep `umb` available as fallback
-- Monitor several successful releases
-
-### Phase 5 — Cleanup (after UMB decommissioned)
-
-- Remove `--signing-transport` flag, `UMBTransport`, `umb_client.py`
-- Remove `stomp.py` dependency
-- Remove `UMB_BROKERS` from constants
-- Notify IT Platform to remove Messaging Bridge sync
-- Optionally inline `KafkaTransport` if abstraction no longer adds value
-
-### Future: Direct Signing Server (Phase 6)
-
-The Konflux team is actively developing direct access to the signing server, bypassing both
-RADAS and UMB/Kafka entirely ([KONFLUX-11077](https://redhat.atlassian.net/browse/KONFLUX-11077),
-[KONFLUX-8400](https://redhat.atlassian.net/browse/KONFLUX-8400)). As of April 2026, the PoC
-is nearly complete, with the RADAS team (Martin Sikora, Wai Cheang) working on the API. Once
-this is proven in Konflux, ART could adopt the same direct signing API — replacing
-`KafkaTransport`, the Messaging Bridge dependency, and RADAS from the flow entirely.
-
-This is not in scope for ART-14447 because:
-- The direct API is not yet available outside of Konflux pipelines
-- ART's promote pipeline runs in Jenkins/Tekton, not as a Konflux pipeline
-- The Q2 2026 deadline doesn't allow time to wait for or integrate an unfinished API
-- Rate-limiting concerns (RADAS currently throttles requests) have not been resolved yet
-
-When the direct signing API stabilizes, a follow-up ticket should evaluate migrating ART to it.
-This would be the cleanest long-term solution — no message bus dependency at all.
-
-### Timeline
-
-Phase 1 is ~1-2 weeks of development. Phases 2-3 can overlap. Q2 deadline (end of June)
-provides comfortable margin.
+1. Stage environment first with the new transport
+2. Verify both `promote.py` and `sync_rhcos.py` signing paths
+3. Prod cutover after successful stage validation
 
 ## References
 
@@ -280,3 +290,5 @@ provides comfortable margin.
 - UMB decommission epic: ITESPLAT-4153
 - Konflux direct signing (containers): [KONFLUX-11077](https://redhat.atlassian.net/browse/KONFLUX-11077)
 - Konflux direct signing (RPMs): [KONFLUX-8400](https://redhat.atlassian.net/browse/KONFLUX-8400)
+- Signing Server Operations Guide: [Confluence](https://redhat.atlassian.net/wiki/spaces/PRODSEC/pages/289239814/Signing+Server+Operations+Guide)
+- ProdSec overview of Konflux direct signing: [Google Doc](https://docs.google.com/document/d/1TqRfCKI_XdHG4npLSdEEw-2Tj21nKF3ANgvf70DMKHc)

--- a/brainstorming/2026-04-22-signing-umb-to-kafka-design.md
+++ b/brainstorming/2026-04-22-signing-umb-to-kafka-design.md
@@ -53,9 +53,13 @@ class SigningTransport(Protocol):
 Two implementations:
 
 - **`UMBTransport`** — wraps the existing `AsyncUMBClient` (extracts what `AsyncSignatory`
-  already does today)
+  already does today). `ack()` maps directly to STOMP's per-message acknowledgement.
 - **`KafkaTransport`** — wraps `Retriable-Kafka-Client`, mapping `send()` to the Kafka
-  producer and `subscribe()` to the Kafka consumer on the response topic
+  producer and `subscribe()` to the Kafka consumer on the response topic. `ack()` commits
+  the Kafka offset. Offsets are committed only after a response with matching `request_id`
+  is successfully validated and processed. This provides at-least-once delivery; duplicate
+  responses are tolerated via existing `request_id` correlation (duplicates are discarded
+  since the corresponding `Future` has already been resolved).
 
 `AsyncSignatory.__init__` accepts a `transport: SigningTransport` instead of URI/cert/key
 directly. The factory logic in `promote.py` decides which transport to create based on
@@ -83,7 +87,8 @@ consumer poll loop in a thread and feeding messages into an `asyncio.Queue` — 
 | `pyartcd/pyartcd/signatory.py` | Refactor `AsyncSignatory` to accept `SigningTransport` instead of UMB-specific params |
 | `pyartcd/pyartcd/constants.py` | Add `KAFKA_BROKERS` dict (per environment) and Kafka topic names |
 | `pyartcd/pyartcd/pipelines/promote.py` | `sign_artifacts()` reads `--signing-transport` flag, creates appropriate transport |
-| CLI wiring (promote pipeline argparse/click) | Add `--signing-transport` option (choices: `umb`, `kafka`, default: `umb`) |
+| `pyartcd/pyartcd/pipelines/sync_rhcos.py` | Same transport selection for RHCOS message digest signing |
+| CLI wiring (promote and sync_rhcos pipelines) | Add `--signing-transport` option (choices: `umb`, `kafka`, default: `umb`) |
 
 ### Kafka Authentication & Configuration
 
@@ -127,6 +132,7 @@ New CLI flag `--signing-transport` on the promote pipeline:
 | **Signing failure** | RADAS returning `signing_status != "success"` raises `SignatoryServerError` — unchanged |
 | **Response timeout** | NEW: configurable timeout (default 10 minutes) on both transports. Raises `TimeoutError` instead of hanging indefinitely. This fixes a pre-existing issue in the UMB path too. |
 | **Consumer group conflicts** | Unique group ID per instance (`artcd-signing-{uuid}`) prevents response stealing |
+| **Kafka offset-commit semantics** | `KafkaTransport` commits offsets only after a response with matching `request_id` is successfully validated and processed. Unmatched or stale messages are not committed until a valid response is found. This provides at-least-once delivery; duplicates are tolerated via `request_id` correlation. |
 
 ### Testing Strategy
 
@@ -210,7 +216,7 @@ A possible phased path:
 - Add `SigningTransport` protocol, `UMBTransport`, `KafkaTransport`
 - Add `kafka_client.py` wrapping `Retriable-Kafka-Client`
 - Refactor `AsyncSignatory` to accept transport injection
-- Add `--signing-transport` flag (default: `umb`)
+- Add `--signing-transport` flag (default: `umb`) to both `promote.py` and `sync_rhcos.py`
 - Add response timeout to both transports
 - Unit tests
 
@@ -224,7 +230,8 @@ A possible phased path:
 ### Phase 3 — Validate on Stage
 
 - Run promote on stage with `--signing-transport kafka`
-- Verify full round-trip through the bridge
+- Run `sync_rhcos` signing on stage with `--signing-transport kafka`
+- Verify full round-trip through the bridge for both pipelines
 
 ### Phase 4 — Prod Cutover
 

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -82,7 +82,12 @@ from pyartcd.oc import (
 )
 from pyartcd.pipelines.advisory_drop import drop_advisory
 from pyartcd.runtime import GroupRuntime, Runtime
-from pyartcd.signatory import AsyncSignatory, SigstoreSignatory
+from pyartcd.signatory import (
+    Signatory,
+    SigstoreSignatory,
+    create_signatory,
+    get_direct_signing_credential_env_names,
+)
 
 yaml = YAML(typ="safe")
 yaml.default_flow_style = False
@@ -131,6 +136,7 @@ class PromotePipeline:
         skip_mirror_binaries: bool = False,
         use_multi_hack: bool = False,
         signing_env: Optional[str] = None,
+        signing_transport: str = "umb",
     ) -> None:
         self.runtime = runtime
         self.group = group
@@ -152,6 +158,9 @@ class PromotePipeline:
         self.multi_only = multi_only
         self.use_multi_hack = use_multi_hack
         self._multi_enabled = False
+        if signing_transport not in ("umb", "direct"):
+            raise ValueError("signing_transport must be either 'umb' or 'direct'")
+        self.signing_transport = signing_transport
         if not self.skip_signing and not signing_env:
             raise ValueError("--signing-env is required unless --skip-signing is set")
         if not self.skip_sigstore and not signing_env:
@@ -189,7 +198,11 @@ class PromotePipeline:
         if not self.skip_mirror_binaries and not self.skip_signing:
             required_vars += ["AWS_SHARED_CREDENTIALS_FILE", "CLOUDFLARE_ENDPOINT"]
         if not self.skip_signing:
-            required_vars += ["SIGNING_CERT", "SIGNING_KEY", "REDIS_SERVER_PASSWORD"]
+            required_vars += ["REDIS_SERVER_PASSWORD"]
+            if self.signing_transport == "umb":
+                required_vars += ["SIGNING_CERT", "SIGNING_KEY"]
+            else:
+                required_vars += list(get_direct_signing_credential_env_names(self.signing_env))
         if not self.skip_sigstore:
             required_vars += ["KMS_CRED_FILE", "KMS_KEY_ID"]
         if not self.skip_build_microshift:
@@ -815,16 +828,21 @@ class PromotePipeline:
         """Signs artifacts and publishes signature files to mirror"""
         if not self.signing_env:
             raise ValueError("--signing-env is missing")
-        cert_file = os.environ["SIGNING_CERT"]
-        key_file = os.environ["SIGNING_KEY"]
-        uri = constants.UMB_BROKERS[self.signing_env]
+        cert_file = os.environ.get("SIGNING_CERT")
+        key_file = os.environ.get("SIGNING_KEY")
         sig_keyname = "redhatrelease2" if client_type == 'ocp' else "beta2"
         self._logger.info("About to sign artifacts with key %s", sig_keyname)
         json_digest_sig_dir = self._working_dir / "json_digests"
         message_digest_sig_dir = self._working_dir / "message_digests"
         base_to_mirror_dir = self._working_dir / "to_mirror/openshift-v4"
 
-        async with AsyncSignatory(uri, cert_file, key_file, sig_keyname=sig_keyname) as signatory:
+        async with create_signatory(
+            self.signing_transport,
+            signing_env=self.signing_env,
+            sig_keyname=sig_keyname,
+            cert_file=cert_file,
+            key_file=key_file,
+        ) as signatory:
             tasks = []
             json_digests = []
             for release_info in release_infos.values():
@@ -867,7 +885,7 @@ class PromotePipeline:
             self._logger.warning("[DRY RUN] Would have published signatures.")
 
     async def _sign_json_digest(
-        self, signatory: AsyncSignatory, release_name: str, pullspec: str, digest: str, sig_path: Path
+        self, signatory: Signatory, release_name: str, pullspec: str, digest: str, sig_path: Path
     ):
         """Sign a JSON digest claim
         :param signatory: Signatory
@@ -882,7 +900,7 @@ class PromotePipeline:
                 product="openshift", release_name=release_name, pullspec=pullspec, digest=digest, sig_file=sig_file
             )
 
-    async def _sign_message_digest(self, signatory: AsyncSignatory, release_name, input_path: Path, sig_path: Path):
+    async def _sign_message_digest(self, signatory: Signatory, release_name, input_path: Path, sig_path: Path):
         """Sign a message digest
         :param signatory: Signatory
         :param input_path: Path to the message digest file
@@ -3062,6 +3080,13 @@ class PromotePipeline:
     "--use-multi-hack", is_flag=True, help="Add '-multi' to heterogeneous payload name to workaround a Cincinnati issue"
 )
 @click.option("--signing-env", type=click.Choice(("prod", "stage")), help="Signing server environment: prod or stage")
+@click.option(
+    "--signing-transport",
+    type=click.Choice(("umb", "direct")),
+    default="umb",
+    show_default=True,
+    help="Signing transport to use for artifact signing",
+)
 @pass_runtime
 @click_coroutine
 async def promote(
@@ -3082,6 +3107,7 @@ async def promote(
     skip_mirror_binaries: bool,
     use_multi_hack: bool,
     signing_env: Optional[str],
+    signing_transport: str,
 ):
     pipeline = await PromotePipeline.create(
         runtime,
@@ -3101,5 +3127,6 @@ async def promote(
         skip_mirror_binaries,
         use_multi_hack,
         signing_env,
+        signing_transport,
     )
     await pipeline.run()

--- a/pyartcd/pyartcd/pipelines/sync_rhcos.py
+++ b/pyartcd/pyartcd/pipelines/sync_rhcos.py
@@ -8,7 +8,7 @@ This pipeline:
 2. Renames them with release version, creates unversioned symlinks
 3. Creates legacy rhcos-installer-* symlinks from rhcos-live-* files
 4. Generates sha256sum.txt and rhcos-id.txt
-5. GPG-signs sha256sum.txt via RADAS/UMB
+5. Signs sha256sum.txt via the configured signing transport
 6. Syncs everything (including sha256sum.txt.gpg) to S3 and Cloudflare
 7. Updates latest directories as appropriate
 """
@@ -24,10 +24,10 @@ import aiohttp
 import click
 from artcommonlib.exectools import limit_concurrency
 
-from pyartcd import constants, util
+from pyartcd import util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.runtime import Runtime
-from pyartcd.signatory import AsyncSignatory
+from pyartcd.signatory import create_signatory
 
 S3_BUCKET = "s3://art-srv-enterprise"
 
@@ -46,6 +46,7 @@ class SyncRhcosPipeline:
         synclist: str,
         no_latest: bool = False,
         signing_env: Optional[str] = None,
+        signing_transport: str = "umb",
     ):
         self.runtime = runtime
         self.arch = arch
@@ -56,6 +57,11 @@ class SyncRhcosPipeline:
         self.synclist = synclist
         self.no_latest = no_latest
         self.signing_env = signing_env
+        if signing_transport not in ("umb", "direct"):
+            raise ValueError("signing_transport must be either 'umb' or 'direct'")
+        if signing_transport == "direct" and not signing_env:
+            raise ValueError("--signing-env is required for direct signing")
+        self.signing_transport = signing_transport
         self.logger = runtime.logger
 
         self.staging_dir = Path(runtime.working_dir) / f"staging-{version}"
@@ -219,21 +225,31 @@ class SyncRhcosPipeline:
         return h.hexdigest()
 
     async def _sign_sha256sum(self):
-        """GPG-sign sha256sum.txt via RADAS/UMB and write sha256sum.txt.gpg."""
+        """Sign sha256sum.txt via the configured transport and write sha256sum.txt.gpg."""
         cert_file = os.environ.get("SIGNING_CERT")
         key_file = os.environ.get("SIGNING_KEY")
-        if not cert_file or not key_file:
+        if self.signing_transport == "umb" and (not cert_file or not key_file):
             self.logger.warning("SIGNING_CERT/SIGNING_KEY not set; skipping sha256sum.txt signing")
             return
 
-        uri = constants.UMB_BROKERS[self.signing_env]
         sig_keyname = "redhatrelease2" if self.signing_env == "prod" else "beta2"
         sha256sum_path = self.staging_dir / "sha256sum.txt"
         gpg_path = self.staging_dir / "sha256sum.txt.gpg"
 
-        self.logger.info("Signing sha256sum.txt with key %s via %s", sig_keyname, self.signing_env)
+        self.logger.info(
+            "Signing sha256sum.txt with key %s via %s/%s",
+            sig_keyname,
+            self.signing_env,
+            self.signing_transport,
+        )
 
-        async with AsyncSignatory(uri, cert_file, key_file, sig_keyname=sig_keyname) as signatory:
+        async with create_signatory(
+            self.signing_transport,
+            signing_env=self.signing_env,
+            sig_keyname=sig_keyname,
+            cert_file=cert_file,
+            key_file=key_file,
+        ) as signatory:
             with open(sha256sum_path, "rb") as in_file, open(gpg_path, "wb") as sig_file:
                 await signatory.sign_message_digest(
                     product="openshift",
@@ -328,6 +344,13 @@ class SyncRhcosPipeline:
     default=None,
     help="Signing environment for GPG-signing sha256sum.txt (omit to skip signing)",
 )
+@click.option(
+    "--signing-transport",
+    type=click.Choice(["umb", "direct"]),
+    default="umb",
+    show_default=True,
+    help="Signing transport to use for sha256sum.txt",
+)
 @pass_runtime
 @click_coroutine
 async def sync_rhcos(
@@ -340,6 +363,7 @@ async def sync_rhcos(
     synclist: str,
     no_latest: bool,
     signing_env: Optional[str],
+    signing_transport: str,
 ):
     pipeline = SyncRhcosPipeline(
         runtime=runtime,
@@ -351,5 +375,6 @@ async def sync_rhcos(
         synclist=synclist,
         no_latest=no_latest,
         signing_env=signing_env,
+        signing_transport=signing_transport,
     )
     await pipeline.run()

--- a/pyartcd/pyartcd/signatory.py
+++ b/pyartcd/pyartcd/signatory.py
@@ -5,13 +5,14 @@ import itertools
 import json
 import logging
 import os
+import shlex
 import shutil
 import tempfile
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from random import uniform
-from typing import BinaryIO, Dict, Iterable, List, Optional, Set, Tuple, cast
+from typing import Awaitable, BinaryIO, Callable, Dict, Iterable, List, Optional, Protocol, Sequence, Set, Tuple, cast
 
 import aiofiles
 import aiohttp
@@ -220,6 +221,320 @@ class AsyncSignatory:
             sig_file=sig_file,
         )
         return signature_meta
+
+
+CommandRunner = Callable[..., Awaitable[Tuple[Optional[int], str, str]]]
+
+
+class Signatory(Protocol):
+    """Common interface implemented by UMB and direct signing transports."""
+
+    async def sign_json_digest(
+        self, product: str, release_name: str, pullspec: str, digest: str, sig_file: BinaryIO
+    ) -> dict[str, str]: ...
+
+    async def sign_message_digest(
+        self, product: str, release_name: str, artifact: BinaryIO, sig_file: BinaryIO
+    ) -> dict[str, str]: ...
+
+
+def get_direct_signing_credential_env_names(signing_env: str) -> tuple[str, str]:
+    """
+    Returns the keytab and principal environment variables for a signing environment.
+
+    Args:
+        signing_env: Signing environment. Supported values are ``stage`` and ``prod``.
+    Return Value(s):
+        A tuple containing the keytab variable name and principal variable name.
+    """
+    normalized_env = signing_env.lower()
+    if normalized_env not in ("stage", "prod"):
+        raise ValueError(f"Unsupported direct signing environment: {signing_env}")
+
+    prefix = f"DIRECT_SIGNING_{normalized_env.upper()}"
+    return f"{prefix}_KEYTAB", f"{prefix}_PRINCIPAL"
+
+
+class DirectSignatory:
+    """
+    DirectSignatory signs artifacts by invoking the signing team's direct client.
+
+    The client receives a temporary input artifact and output signature path. The
+    command construction is kept in this class so the signing client interface can
+    change without changing the promote and RHCOS sync pipelines.
+    """
+
+    DEFAULT_CLIENT_COMMAND = ("rh-signing-client",)
+    DEFAULT_TIMEOUT = 10 * 60
+
+    def __init__(
+        self,
+        client_command: Sequence[str],
+        sig_keyname: str = "test",
+        requestor: str = "timer",
+        signing_env: str | None = None,
+        keytab_file: str | None = None,
+        principal: str | None = None,
+        ccache_path: str | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+        command_runner: CommandRunner = exectools.cmd_gather_async,
+    ) -> None:
+        """
+        Initializes a direct signing client.
+
+        Args:
+            client_command: Executable and fixed arguments for the direct signing client.
+            sig_keyname: Signing key name passed to the direct client.
+            requestor: Requester recorded by the signing server as ``--onbehalfof``.
+            signing_env: Signing environment, such as ``stage`` or ``prod``.
+            keytab_file: Keytab used to initialize the isolated signing credential cache.
+            principal: Kerberos principal used with ``keytab_file``.
+            ccache_path: Optional credential-cache path. A temporary path is created when omitted.
+            timeout: Maximum duration in seconds for each subprocess invocation.
+            command_runner: Async subprocess runner, injectable for unit tests.
+        """
+        if not client_command:
+            raise ValueError("The direct signing client command cannot be empty")
+        if timeout <= 0:
+            raise ValueError("The direct signing timeout must be positive")
+
+        self.client_command = tuple(client_command)
+        self.sig_keyname = sig_keyname
+        self.requestor = requestor
+        self.signing_env = signing_env
+        self.keytab_file = keytab_file
+        self.principal = principal
+        self.ccache_path = ccache_path
+        self.timeout = timeout
+        self._command_runner = command_runner
+        self._environment = os.environ.copy()
+        self._ccache_name: str | None = None
+        self._owns_ccache = ccache_path is None
+
+    @classmethod
+    def from_environment(cls, signing_env: str, sig_keyname: str) -> "DirectSignatory":
+        """
+        Creates a direct signatory from Jenkins-provided environment variables.
+
+        The direct signing credentials are deliberately separate from the UMB
+        ``SIGNING_CERT`` and ``SIGNING_KEY`` variables. The signing server team can
+        confirm the final client command and credential names without changing the
+        pipeline call sites. The keytab is managed by Jenkins and is not removed by
+        this signatory.
+        """
+        keytab_env_name, principal_env_name = get_direct_signing_credential_env_names(signing_env)
+        keytab_file = os.environ.get(keytab_env_name)
+        principal = os.environ.get(principal_env_name)
+        missing = [
+            name for name, value in ((keytab_env_name, keytab_file), (principal_env_name, principal)) if not value
+        ]
+        if missing:
+            raise ValueError(f"Direct signing requires: {', '.join(missing)}")
+
+        command = os.environ.get("DIRECT_SIGNING_CLIENT_COMMAND")
+        client_command = shlex.split(command) if command else list(cls.DEFAULT_CLIENT_COMMAND)
+        requestor = os.environ.get("DIRECT_SIGNING_REQUESTOR", "timer")
+        timeout = int(os.environ.get("DIRECT_SIGNING_TIMEOUT", str(cls.DEFAULT_TIMEOUT)))
+        return cls(
+            client_command=client_command,
+            sig_keyname=sig_keyname,
+            requestor=requestor,
+            signing_env=signing_env,
+            keytab_file=keytab_file,
+            principal=principal,
+            timeout=timeout,
+        )
+
+    async def __aenter__(self) -> "DirectSignatory":
+        """
+        Starts the isolated direct-signing session.
+        """
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        """
+        Closes the isolated direct-signing session.
+        """
+        await self.close()
+
+    async def start(self) -> None:
+        """
+        Initializes a dedicated Kerberos credential cache when credentials are configured.
+        """
+        if bool(self.keytab_file) != bool(self.principal):
+            raise ValueError("Direct signing keytab and principal must be provided together")
+        if not self.keytab_file:
+            return
+
+        if self.ccache_path is None:
+            self.ccache_path = self._new_ccache_path()
+        self._ccache_name = f"FILE:{self.ccache_path}"
+        self._environment["KRB5CCNAME"] = self._ccache_name
+        command = [
+            "kinit",
+            "-k",
+            "-t",
+            self.keytab_file,
+            "-c",
+            self._ccache_name,
+            self.principal,
+        ]
+        rc, _, stderr = await self._command_runner(
+            command,
+            check=False,
+            env=self._environment,
+            timeout=self.timeout,
+        )
+        if rc != 0:
+            await self.close()
+            raise SignatoryServerError(f"Direct signing Kerberos initialization failed: {stderr.strip()}")
+
+    async def close(self) -> None:
+        """
+        Destroys the dedicated Kerberos cache and removes owned temporary files.
+        """
+        if not self._ccache_name:
+            return
+
+        try:
+            rc, _, stderr = await self._command_runner(
+                ["kdestroy", "-c", self._ccache_name],
+                check=False,
+                env=self._environment,
+                timeout=self.timeout,
+            )
+            if rc != 0:
+                _LOGGER.warning("Direct signing Kerberos cleanup failed: %s", stderr.strip())
+        finally:
+            if self._owns_ccache and self.ccache_path:
+                try:
+                    os.unlink(self.ccache_path)
+                except FileNotFoundError:
+                    pass
+            self._ccache_name = None
+
+    async def sign_json_digest(
+        self, product: str, release_name: str, pullspec: str, digest: str, sig_file: BinaryIO
+    ) -> dict[str, str]:
+        """
+        Signs a JSON digest claim with the direct signing client.
+        """
+        json_claim = {
+            "critical": {
+                "image": {"docker-manifest-digest": digest},
+                "type": "atomic container signature",
+                "identity": {"docker-reference": pullspec},
+            },
+            "optional": {"creator": "Red Hat OpenShift Signing Authority 0.0.1"},
+        }
+        artifact = io.BytesIO(json.dumps(json_claim).encode())
+        return await self._sign_artifact(
+            typ="json-digest",
+            product=product,
+            release_name=release_name,
+            name=digest.replace(":", "="),
+            artifact=artifact,
+            sig_file=sig_file,
+        )
+
+    async def sign_message_digest(
+        self, product: str, release_name: str, artifact: BinaryIO, sig_file: BinaryIO
+    ) -> dict[str, str]:
+        """
+        Signs a message digest with the direct signing client.
+        """
+        return await self._sign_artifact(
+            typ="message-digest",
+            product=product,
+            release_name=release_name,
+            name="sha256sum.txt.gpg",
+            artifact=artifact,
+            sig_file=sig_file,
+        )
+
+    async def _sign_artifact(
+        self,
+        typ: str,
+        product: str,
+        release_name: str,
+        name: str,
+        artifact: BinaryIO,
+        sig_file: BinaryIO,
+    ) -> dict[str, str]:
+        """
+        Writes an artifact to a temporary directory and invokes the direct signing client.
+        """
+        with tempfile.TemporaryDirectory(prefix="art-direct-signing-") as directory:
+            input_path = os.path.join(directory, "artifact")
+            output_path = os.path.join(directory, "signature")
+            with open(input_path, "wb") as input_file:
+                shutil.copyfileobj(artifact, input_file)
+
+            command = [
+                *self.client_command,
+                "--key",
+                self.sig_keyname,
+                input_path,
+                "--gpgsign",
+                "--output",
+                output_path,
+                "--onbehalfof",
+                self.requestor,
+            ]
+
+            rc, _, stderr = await self._command_runner(
+                command,
+                check=False,
+                env=self._environment,
+                timeout=self.timeout,
+            )
+            if rc != 0:
+                raise SignatoryServerError(f"Direct signing failed: {stderr.strip()}")
+            if not os.path.isfile(output_path):
+                raise SignatoryServerError("Direct signing did not produce a signature file")
+
+            with open(output_path, "rb") as generated_signature:
+                signature = generated_signature.read()
+            if not signature:
+                raise SignatoryServerError("Direct signing produced an empty signature file")
+            sig_file.write(signature)
+
+        return {
+            "name": name,
+            "product": product,
+            "release_name": release_name,
+            "type": typ,
+        }
+
+    @staticmethod
+    def _new_ccache_path() -> str:
+        """
+        Returns a unique temporary path for an isolated Kerberos credential cache.
+        """
+        return os.path.join(tempfile.gettempdir(), f"krb5cc-art-signing-{uuid.uuid4()}")
+
+
+def create_signatory(
+    transport: str,
+    *,
+    signing_env: str,
+    sig_keyname: str,
+    cert_file: str | None = None,
+    key_file: str | None = None,
+) -> Signatory:
+    """
+    Creates the configured UMB or direct signatory for a pipeline signing session.
+    """
+    if transport == "direct":
+        return DirectSignatory.from_environment(signing_env=signing_env, sig_keyname=sig_keyname)
+    if transport == "umb":
+        if not cert_file or not key_file:
+            raise ValueError("UMB signing requires SIGNING_CERT and SIGNING_KEY")
+        from pyartcd import constants
+
+        return AsyncSignatory(constants.UMB_BROKERS[signing_env], cert_file, key_file, sig_keyname=sig_keyname)
+    raise ValueError(f"Unsupported signing transport: {transport}")
 
 
 @dataclass

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -2336,6 +2336,74 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             self.assertNotIn("--exclude-bugs", call_args)
 
 
+class TestPromoteSigningTransport(IsolatedAsyncioTestCase):
+    def _make_pipeline(self, signing_transport="umb", **kwargs):
+        runtime = MagicMock(
+            config={
+                "build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"},
+                "jira": {"url": JIRA_SERVER_URL},
+            },
+            dry_run=False,
+            logger=MagicMock(),
+            new_slack_client=MagicMock(return_value=AsyncMock()),
+            new_mail_client=MagicMock(return_value=AsyncMock()),
+            working_dir=Path(tempfile.mkdtemp()),
+        )
+        return PromotePipeline(
+            runtime,
+            group="openshift-4.10",
+            assembly="4.10.99",
+            signing_env="prod",
+            signing_transport=signing_transport,
+            **kwargs,
+        )
+
+    @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
+    def test_direct_transport_is_stored(self, _):
+        pipeline = self._make_pipeline(signing_transport="direct")
+
+        self.assertEqual(pipeline.signing_transport, "direct")
+
+    @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
+    def test_direct_transport_requires_direct_credentials_not_umb_credentials(self, _):
+        pipeline = self._make_pipeline(
+            signing_transport="direct",
+            skip_sigstore=True,
+            skip_build_microshift=True,
+            skip_mirror_binaries=True,
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "JIRA_TOKEN": "jira-token",
+                "QUAY_PASSWORD": "quay-password",
+                "REDIS_SERVER_PASSWORD": "redis-password",
+                "DIRECT_SIGNING_PROD_KEYTAB": "/path/to/prod-keytab",
+                "DIRECT_SIGNING_PROD_PRINCIPAL": "art-signing-prod@IPA.REDHAT.COM",
+            },
+            clear=True,
+        ):
+            pipeline.check_environment_variables()
+
+    @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
+    @patch("pyartcd.pipelines.promote.create_signatory")
+    async def test_sign_artifacts_uses_direct_transport(self, create_signatory, _):
+        pipeline = self._make_pipeline(signing_transport="direct")
+        signatory = AsyncMock()
+        create_signatory.return_value = signatory
+
+        await pipeline.sign_artifacts("4.10.99", "ocp", {}, [])
+
+        create_signatory.assert_called_once_with(
+            "direct",
+            signing_env="prod",
+            sig_keyname="redhatrelease2",
+            cert_file=None,
+            key_file=None,
+        )
+
+
 class TestDropAdvisory(IsolatedAsyncioTestCase):
     """Tests for the reusable drop_advisory function."""
 

--- a/pyartcd/tests/pipelines/test_sync_rhcos.py
+++ b/pyartcd/tests/pipelines/test_sync_rhcos.py
@@ -9,6 +9,10 @@ from pyartcd.pipelines.sync_rhcos import SyncRhcosPipeline
 
 
 class TestSyncRhcosPipeline(IsolatedAsyncioTestCase):
+    def test_direct_signing_requires_signing_environment(self):
+        with self.assertRaisesRegex(ValueError, "--signing-env is required for direct signing"):
+            self._make_pipeline(signing_transport="direct")
+
     def _make_pipeline(self, **overrides):
         runtime = MagicMock()
         runtime.dry_run = False
@@ -25,6 +29,7 @@ class TestSyncRhcosPipeline(IsolatedAsyncioTestCase):
             synclist=str(Path(self.tmpdir) / "synclist.txt"),
             no_latest=False,
             signing_env=None,
+            signing_transport="umb",
         )
         defaults.update(overrides)
         return SyncRhcosPipeline(**defaults)
@@ -221,46 +226,81 @@ class TestSyncRhcosPipeline(IsolatedAsyncioTestCase):
             delete=True,
         )
 
-    @patch("pyartcd.pipelines.sync_rhcos.AsyncSignatory")
-    async def test_sign_sha256sum(self, mock_signatory_cls):
+    @patch("pyartcd.pipelines.sync_rhcos.create_signatory")
+    async def test_sign_sha256sum(self, mock_create_signatory):
         pipeline = self._make_pipeline(signing_env="prod")
         pipeline.staging_dir.mkdir(parents=True, exist_ok=True)
         sha256_file = pipeline.staging_dir / "sha256sum.txt"
         sha256_file.write_text("abc123  file.bin\n")
 
         mock_signatory = AsyncMock()
-        mock_signatory_cls.return_value = mock_signatory
+        mock_create_signatory.return_value = mock_signatory
         mock_signatory.__aenter__ = AsyncMock(return_value=mock_signatory)
         mock_signatory.__aexit__ = AsyncMock(return_value=False)
 
         with patch.dict(os.environ, {"SIGNING_CERT": "/fake/cert", "SIGNING_KEY": "/fake/key"}):
             await pipeline._sign_sha256sum()
 
-        mock_signatory_cls.assert_called_once()
-        _, kwargs = mock_signatory_cls.call_args
-        self.assertEqual(kwargs["sig_keyname"], "redhatrelease2")
+        mock_create_signatory.assert_called_once_with(
+            "umb",
+            signing_env="prod",
+            sig_keyname="redhatrelease2",
+            cert_file="/fake/cert",
+            key_file="/fake/key",
+        )
 
         mock_signatory.sign_message_digest.assert_awaited_once()
         call_kwargs = mock_signatory.sign_message_digest.call_args[1]
         self.assertEqual(call_kwargs["product"], "openshift")
         self.assertEqual(call_kwargs["release_name"], "4.19.0-ec.0")
 
-    @patch("pyartcd.pipelines.sync_rhcos.AsyncSignatory")
-    async def test_sign_sha256sum_stage(self, mock_signatory_cls):
+    @patch("pyartcd.pipelines.sync_rhcos.create_signatory")
+    async def test_sign_sha256sum_stage(self, mock_create_signatory):
         pipeline = self._make_pipeline(signing_env="stage")
         pipeline.staging_dir.mkdir(parents=True, exist_ok=True)
         (pipeline.staging_dir / "sha256sum.txt").write_text("abc123  file.bin\n")
 
         mock_signatory = AsyncMock()
-        mock_signatory_cls.return_value = mock_signatory
+        mock_create_signatory.return_value = mock_signatory
         mock_signatory.__aenter__ = AsyncMock(return_value=mock_signatory)
         mock_signatory.__aexit__ = AsyncMock(return_value=False)
 
         with patch.dict(os.environ, {"SIGNING_CERT": "/fake/cert", "SIGNING_KEY": "/fake/key"}):
             await pipeline._sign_sha256sum()
 
-        _, kwargs = mock_signatory_cls.call_args
-        self.assertEqual(kwargs["sig_keyname"], "beta2")
+        mock_create_signatory.assert_called_once_with(
+            "umb",
+            signing_env="stage",
+            sig_keyname="beta2",
+            cert_file="/fake/cert",
+            key_file="/fake/key",
+        )
+
+    @patch("pyartcd.pipelines.sync_rhcos.create_signatory")
+    async def test_sign_sha256sum_direct_transport(self, mock_create_signatory):
+        pipeline = self._make_pipeline(signing_env="prod", signing_transport="direct")
+        pipeline.staging_dir.mkdir(parents=True, exist_ok=True)
+        (pipeline.staging_dir / "sha256sum.txt").write_text("abc123  file.bin\n")
+
+        mock_signatory = AsyncMock()
+        mock_create_signatory.return_value = mock_signatory
+
+        with patch.dict(
+            os.environ,
+            {
+                "DIRECT_SIGNING_PROD_KEYTAB": "/fake/prod-keytab",
+                "DIRECT_SIGNING_PROD_PRINCIPAL": "art-signing-prod@IPA.REDHAT.COM",
+            },
+        ):
+            await pipeline._sign_sha256sum()
+
+        mock_create_signatory.assert_called_once_with(
+            "direct",
+            signing_env="prod",
+            sig_keyname="redhatrelease2",
+            cert_file=None,
+            key_file=None,
+        )
 
     async def test_sign_sha256sum_skips_without_creds(self):
         pipeline = self._make_pipeline(signing_env="prod")

--- a/pyartcd/tests/test_signatory.py
+++ b/pyartcd/tests/test_signatory.py
@@ -1,8 +1,11 @@
 import asyncio
 import base64
 import json
+import os
+import tempfile
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
+from pathlib import Path
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
@@ -11,7 +14,8 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.x509.oid import NameOID
-from pyartcd.signatory import AsyncSignatory, SigstoreSignatory
+from pyartcd.exceptions import SignatoryServerError
+from pyartcd.signatory import AsyncSignatory, DirectSignatory, SigstoreSignatory, create_signatory
 
 
 class TestAsyncSignatory(IsolatedAsyncioTestCase):
@@ -287,6 +291,157 @@ class TestAsyncSignatory(IsolatedAsyncioTestCase):
             sig_file=sig_file,
         )
         self.assertEqual(sig_file.getvalue(), b'fake-signature')
+
+
+class TestDirectSignatory(IsolatedAsyncioTestCase):
+    async def test_sign_message_digest_writes_signature_from_client_output(self):
+        command_runner = AsyncMock(return_value=(0, "", ""))
+
+        async def write_signature(command, **kwargs):
+            output_path = Path(command[command.index("--output") + 1])
+            output_path.write_bytes(b"fake-direct-signature")
+            return 0, "", ""
+
+        command_runner.side_effect = write_signature
+        signatory = DirectSignatory(
+            client_command=("rh-signing-client",),
+            sig_keyname="redhatrelease2",
+            command_runner=command_runner,
+        )
+        sig_file = BytesIO()
+
+        await signatory.sign_message_digest("openshift", "4.19.0", BytesIO(b"sha256 data"), sig_file)
+
+        self.assertEqual(sig_file.getvalue(), b"fake-direct-signature")
+        command = command_runner.await_args.args[0]
+        self.assertEqual(command[:3], ["rh-signing-client", "--key", "redhatrelease2"])
+        self.assertEqual(command[4], "--gpgsign")
+        self.assertEqual(command[5], "--output")
+        self.assertEqual(command[7:], ["--onbehalfof", "timer"])
+
+    async def test_sign_json_digest_writes_signature_from_client_output(self):
+        command_runner = AsyncMock()
+
+        async def write_signature(command, **kwargs):
+            input_path = Path(command[3])
+            output_path = Path(command[command.index("--output") + 1])
+            claim = json.loads(input_path.read_text())
+            self.assertEqual(claim["critical"]["image"]["docker-manifest-digest"], "sha256:dead-beef")
+            output_path.write_bytes(b"fake-json-signature")
+            return 0, "", ""
+
+        command_runner.side_effect = write_signature
+        signatory = DirectSignatory(
+            client_command=("rh-signing-client",),
+            sig_keyname="redhatrelease2",
+            command_runner=command_runner,
+        )
+        sig_file = BytesIO()
+
+        await signatory.sign_json_digest(
+            "openshift", "4.19.0", "quay.io/example/release:4.19.0", "sha256:dead-beef", sig_file
+        )
+
+        self.assertEqual(sig_file.getvalue(), b"fake-json-signature")
+
+    async def test_context_manager_uses_isolated_kerberos_cache_and_leaves_keytab_untouched(self):
+        command_runner = AsyncMock(return_value=(0, "", ""))
+        with tempfile.TemporaryDirectory() as temp_dir:
+            keytab = Path(temp_dir) / "signing.keytab"
+            ccache = Path(temp_dir) / "krb5cc"
+            keytab.write_bytes(b"temporary-keytab")
+            signatory = DirectSignatory(
+                client_command=("rh-signing-client",),
+                sig_keyname="redhatrelease2",
+                keytab_file=str(keytab),
+                principal="art-signing@IPA.REDHAT.COM",
+                ccache_path=str(ccache),
+                command_runner=command_runner,
+            )
+
+            async with signatory:
+                pass
+            self.assertTrue(keytab.exists())
+
+        kinit_command = command_runner.await_args_list[0].args[0]
+        kdestroy_command = command_runner.await_args_list[1].args[0]
+        self.assertEqual(kinit_command[:2], ["kinit", "-k"])
+        self.assertIn(f"FILE:{ccache}", kinit_command)
+        self.assertEqual(kdestroy_command, ["kdestroy", "-c", f"FILE:{ccache}"])
+        self.assertEqual(command_runner.await_args_list[0].kwargs["env"]["KRB5CCNAME"], f"FILE:{ccache}")
+
+    async def test_sign_artifact_raises_when_client_fails(self):
+        command_runner = AsyncMock(return_value=(1, "", "signing server rejected request"))
+        signatory = DirectSignatory(client_command=("rh-signing-client",), command_runner=command_runner)
+
+        with self.assertRaisesRegex(SignatoryServerError, "signing server rejected request"):
+            await signatory.sign_message_digest("openshift", "4.19.0", BytesIO(b"sha256 data"), BytesIO())
+
+    async def test_sign_artifact_raises_when_client_does_not_write_signature(self):
+        command_runner = AsyncMock(return_value=(0, "", ""))
+        signatory = DirectSignatory(client_command=("rh-signing-client",), command_runner=command_runner)
+
+        with self.assertRaisesRegex(SignatoryServerError, "did not produce a signature"):
+            await signatory.sign_message_digest("openshift", "4.19.0", BytesIO(b"sha256 data"), BytesIO())
+
+    async def test_from_environment_requires_direct_signing_credentials(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(ValueError, "DIRECT_SIGNING_PROD_KEYTAB"):
+                DirectSignatory.from_environment("prod", "redhatrelease2")
+
+    async def test_from_environment_does_not_use_credentials_from_another_environment(self):
+        with patch.dict(
+            os.environ,
+            {
+                "DIRECT_SIGNING_STAGE_KEYTAB": "/path/to/stage-keytab",
+                "DIRECT_SIGNING_STAGE_PRINCIPAL": "art-signing-stage@IPA.REDHAT.COM",
+            },
+            clear=True,
+        ):
+            with self.assertRaisesRegex(ValueError, "DIRECT_SIGNING_PROD_KEYTAB"):
+                DirectSignatory.from_environment("prod", "redhatrelease2")
+
+    async def test_from_environment_reads_direct_signing_configuration(self):
+        with patch.dict(
+            os.environ,
+            {
+                "DIRECT_SIGNING_STAGE_KEYTAB": "/path/to/stage-keytab",
+                "DIRECT_SIGNING_STAGE_PRINCIPAL": "art-signing-stage@IPA.REDHAT.COM",
+                "DIRECT_SIGNING_CLIENT_COMMAND": "rh-signing-client --config /path/to/config",
+                "DIRECT_SIGNING_REQUESTOR": "fabio.gallotti",
+                "DIRECT_SIGNING_TIMEOUT": "42",
+            },
+            clear=True,
+        ):
+            signatory = DirectSignatory.from_environment("stage", "beta2")
+
+        self.assertEqual(signatory.client_command, ("rh-signing-client", "--config", "/path/to/config"))
+        self.assertEqual(signatory.keytab_file, "/path/to/stage-keytab")
+        self.assertEqual(signatory.principal, "art-signing-stage@IPA.REDHAT.COM")
+        self.assertEqual(signatory.signing_env, "stage")
+        self.assertEqual(signatory.sig_keyname, "beta2")
+        self.assertEqual(signatory.requestor, "fabio.gallotti")
+        self.assertEqual(signatory.timeout, 42)
+
+
+class TestCreateSignatory(IsolatedAsyncioTestCase):
+    @patch("pyartcd.signatory.AsyncSignatory")
+    async def test_create_signatory_uses_umb_transport(self, async_signatory):
+        create_signatory(
+            "umb",
+            signing_env="prod",
+            sig_keyname="redhatrelease2",
+            cert_file="/path/cert",
+            key_file="/path/key",
+        )
+
+        async_signatory.assert_called_once()
+
+    @patch("pyartcd.signatory.DirectSignatory.from_environment")
+    async def test_create_signatory_uses_direct_transport(self, direct_signatory):
+        create_signatory("direct", signing_env="prod", sig_keyname="redhatrelease2")
+
+        direct_signatory.assert_called_once_with(signing_env="prod", sig_keyname="redhatrelease2")
 
 
 class TestSigstoreSignatory(IsolatedAsyncioTestCase):


### PR DESCRIPTION
  ## What does this PR do?

  Adds direct signing support to `pyartcd` so ART can migrate away from the UMB/RADAS signing transport.

  UMB remains the default transport until signing permissions and Jenkins rollout are complete.

  ## Changes

  - Add asynchronous `DirectSignatory` support using `rh-signing-client`.
  - Preserve `--onbehalfof` attribution through `DIRECT_SIGNING_REQUESTOR`.
  - Support direct signing in:
    - `promote`
    - `sync-rhcos`
  - Add `--signing-transport {umb,direct}` CLI options.
  - Enforce separate stage/prod Kerberos credentials:
    - `DIRECT_SIGNING_STAGE_KEYTAB`
    - `DIRECT_SIGNING_STAGE_PRINCIPAL`
    - `DIRECT_SIGNING_PROD_KEYTAB`
    - `DIRECT_SIGNING_PROD_PRINCIPAL`
  - Authenticate using an isolated Kerberos credential cache.
  - Destroy the temporary ccache with `kdestroy`.
  - Leave Jenkins-managed keytabs under Jenkins lifecycle management.
  - Add tests for command construction, credential validation, Kerberos lifecycle, transport selection, and pipeline integration.

  ## Jenkins integration

  The corresponding `aos-cd-jobs` changes are committed separately: https://github.com/openshift-eng/aos-cd-jobs/pull/4815

  Those changes keep the existing UMB credentials and add the direct stage/prod keytab and principal bindings. The Jenkins jobs do not yet enable direct signing.

  ## Rollout prerequisites

  - Obtain signing ACL approval through SIGNSERVER-2597.
  - Ensure rh-signing-client, kinit, and kdestroy are available on the Jenkins agent.
  - Enable --signing-transport direct in aos-cd-jobs after permissions are available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a design document describing release-signing workflow options and integration models.
  * Documented approval, authentication, credential, timeout, error-handling, testing, rollout, and production cutover requirements.
  * Described Jenkins lifecycle considerations, stable signatory boundaries, staged rollback procedures, and contingency use of Kafka through Messaging Bridge.
  * Included implementation alternatives, operational safeguards, and cleanup activities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->