### PR TITLE
Add --registry-config option to elliott for explicit registry auth

### DIFF
--- a/elliott/elliottlib/cli/common.py
+++ b/elliott/elliottlib/cli/common.py
@@ -96,6 +96,13 @@ context_settings = dict(help_option_names=['-h', '--help'])
     envvar='BUILD_SYSTEM',
     help="Which build system (Brew/Konflux) to consider when searching for builds.",
 )
+@click.option(
+    "--registry-config",
+    "registry_config",
+    metavar='PATH',
+    default=None,
+    help="Path to a Docker config.json for registry auth (passed to oc --registry-config).",
+)
 @click.pass_context
 def cli(ctx, **kwargs):
     cfg = dotconfig.Config(

--- a/elliott/elliottlib/cli/conforma_cli.py
+++ b/elliott/elliottlib/cli/conforma_cli.py
@@ -200,7 +200,9 @@ class ConformaVerifyCli:
 
         if self.pullspec:
             rhcos_images = {c['name'] for c in get_container_configs(self.runtime)}
-            nvr_map = await get_nvrs_from_release(self.pullspec, rhcos_images, LOGGER)
+            nvr_map = await get_nvrs_from_release(
+                self.pullspec, rhcos_images, LOGGER, registry_config=self.runtime.registry_config
+            )
             self.nvrs = []
             for component, (v, r) in nvr_map.items():
                 self.nvrs.append(f"{component}-{v}-{r}")

--- a/elliott/elliottlib/cli/find_bugs_golang_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_golang_cli.py
@@ -335,7 +335,9 @@ class FindBugsGolangCli:
             self._logger.info(f"Fetching go build nvrs for {self.pullspec}...")
             rhcos_images = {c['name'] for c in get_container_configs(self._runtime)}
             try:
-                nvr_map = await get_nvrs_from_release(self.pullspec, rhcos_images)
+                nvr_map = await get_nvrs_from_release(
+                    self.pullspec, rhcos_images, registry_config=self._runtime.registry_config
+                )
             except Exception as e:
                 self._logger.error(
                     "Does pullspec exist? To override use --pullspec. "

--- a/elliott/elliottlib/cli/get_golang_versions_cli.py
+++ b/elliott/elliottlib/cli/get_golang_versions_cli.py
@@ -74,7 +74,7 @@ async def get_golang_versions_cli(
             raise click.BadParameter('components for payload should end with -container')
 
     if release:
-        return await print_release_golang(release, rhcos_images, components, output, report)
+        return await print_release_golang(release, rhcos_images, components, output, report, runtime.registry_config)
     elif advisory_id:
         return print_advisory_golang(advisory_id, components, output, report)
     elif nvrs:
@@ -134,8 +134,8 @@ def print_advisory_golang(advisory_id, components, output, report):
         util.pretty_print_nvrs_go(go_nvr_map, report)
 
 
-async def print_release_golang(pullspec, rhcos_images, components, output, report):
-    nvr_map = await util.get_nvrs_from_release(pullspec, rhcos_images, _LOGGER)
+async def print_release_golang(pullspec, rhcos_images, components, output, report, registry_config=None):
+    nvr_map = await util.get_nvrs_from_release(pullspec, rhcos_images, _LOGGER, registry_config=registry_config)
     nvrs = [(n, vr_tuple[0], vr_tuple[1]) for n, vr_tuple in nvr_map.items()]
     _LOGGER.debug(f'{len(nvrs)} builds found in {pullspec}')
     if not nvrs:

--- a/elliott/elliottlib/cli/verify_payload.py
+++ b/elliott/elliottlib/cli/verify_payload.py
@@ -34,7 +34,9 @@ class VerifyPayloadPipeline:
         rhcos_images = {c['name'] for c in rhcos.get_container_configs(self.runtime)}
 
         # Get the payload or imagestream NVRs
-        self.all_payload_nvrs = await get_nvrs_from_release(self.payload_or_imagestream, rhcos_images, self.logger)
+        self.all_payload_nvrs = await get_nvrs_from_release(
+            self.payload_or_imagestream, rhcos_images, self.logger, registry_config=self.runtime.registry_config
+        )
 
         # Check if the payload or imagestream is a Konflux assembly or a Brew assembly
         assembly_basis = assembly_config_struct(releases_config, self.runtime.assembly, "basis", {})

--- a/elliott/elliottlib/runtime.py
+++ b/elliott/elliottlib/runtime.py
@@ -68,6 +68,7 @@ class Runtime(GroupRuntime):
             self.use_jira = False
         self._bug_trackers = {}
         self.brew_event: Optional[int] = None
+        self.registry_config: Optional[str] = None
         self.assembly: Optional[str] = 'stream'
         self.assembly_basis_event: Optional[int] = None
         self.releases_config: Optional[Model] = None

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -682,9 +682,15 @@ def all_same(items: Iterable[Any]):
     return all(x == first for x in it)
 
 
-async def get_nvrs_from_release(pullspec_or_imagestream, rhcos_images, logger=None):
+async def get_nvrs_from_release(pullspec_or_imagestream, rhcos_images, logger=None, registry_config=None):
     """
     Get all payload NVRs from a release pullspec or imagestream.
+
+    Arg(s):
+        pullspec_or_imagestream: A release pullspec or imagestream name.
+        rhcos_images: Set of RHCOS image names to skip.
+        logger: Optional logger for progress messages.
+        registry_config (str): Optional path to a Docker config.json for registry auth.
     """
 
     def log(msg):
@@ -701,8 +707,9 @@ async def get_nvrs_from_release(pullspec_or_imagestream, rhcos_images, logger=No
     all_payload_nvrs = {}
     log("Fetching release info...")
     if is_pullspec:
+        registry_config_arg = f'--registry-config={registry_config}' if registry_config else ''
         rc, stdout, stderr = await exectools.cmd_gather_async(
-            f'oc adm release info -o json -n ocp {pullspec_or_imagestream}'
+            f'oc adm release info {registry_config_arg} -o json -n ocp {pullspec_or_imagestream}'
         )
         tags = json.loads(stdout)['references']['spec']['tags']
     else:  # it is an imagestream
@@ -721,7 +728,6 @@ async def get_nvrs_from_release(pullspec_or_imagestream, rhcos_images, logger=No
     async def _get_image_info(tag):
         pullspec = tag['from']['name']
         try:
-            registry_config = os.getenv("QUAY_AUTH_FILE")
             return await oc_image_info__cached_async(pullspec, registry_config=registry_config)
         except ChildProcessError as e:
             raise RuntimeError(f"Unable to run oc image info for {pullspec}: {e}") from e

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -488,6 +488,7 @@ class KonfluxOcpPipeline:
             '--assembly',
             'stream',
             f'--group=openshift-{self.version}',
+            f'--registry-config={self._registry_auth_file}',
             "find-bugs:golang",
             "--analyze",
             "--update-tracker",


### PR DESCRIPTION
The ocp4-konflux pipeline's RegistryConfig sets DOCKER_CONFIG but not REGISTRY_AUTH_FILE, causing oc to fall back to an inaccessible system path. Instead of relying on environment variables, elliott now accepts an explicit --registry-config CLI option that is threaded through Runtime into get_nvrs_from_release() and all its callers. The ocp4_konflux pipeline passes its merged auth file via this option when invoking elliott's find-bugs:golang command.
