### PR TITLE
Add --registry-config option to doozer for explicit registry auth

### DIFF
--- a/doozer/doozerlib/cli/__init__.py
+++ b/doozer/doozerlib/cli/__init__.py
@@ -220,6 +220,13 @@ def print_version(ctx, param, value):
     envvar='BUILD_SYSTEM',
     help="Which build system (Brew/Konflux) to consider when searching for builds.",
 )
+@click.option(
+    "--registry-config",
+    "registry_config",
+    metavar='PATH',
+    default=None,
+    help="Path to a Docker config.json for registry auth (passed to oc/cosign commands).",
+)
 @click.pass_context
 def cli(ctx, **kwargs):
     global CTX_GLOBAL

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import logging
-import os
 import sys
 import traceback
 from pathlib import Path
@@ -424,7 +423,7 @@ async def images_konflux_build(
         konflux_context=konflux_context,
         konflux_namespace=konflux_namespace,
         image_repo=image_repo,
-        registry_auth_file=os.getenv("QUAY_AUTH_FILE"),
+        registry_auth_file=runtime.registry_config,
         skip_checks=skip_checks,
         dry_run=dry_run,
         plr_template=plr_template,

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -104,7 +104,6 @@ class ConfigScanSources:
         self.image_tree = {}
         self.changing_rpm_names = set()
         self.rhcos_status = []
-        self.registry_auth_file = os.getenv("QUAY_AUTH_FILE")
         self.current_task_bundles: Dict[str, str] = {}
 
     def _is_okd_enabled(self, image_meta: ImageMetadata) -> bool:
@@ -691,7 +690,7 @@ class ConfigScanSources:
 
         # Fetch the SLSA attestation for the latest build
         attestation = await fetch_slsa_attestation(
-            build_record.image_pullspec, build_record.name, self.registry_auth_file
+            build_record.image_pullspec, build_record.name, self.runtime.registry_config
         )
         if not attestation:
             self.logger.warning('Skipping network mode check for %s', image_meta.distgit_key)
@@ -955,9 +954,9 @@ class ConfigScanSources:
         # Use KONFLUX_OPERATOR_INDEX_AUTH_FILE for non-openshift groups (like OADP), otherwise use default
         # Since OADP et. al. uses other streams like https://github.com/openshift-eng/ocp-build-data/blob/oadp-1.5/streams.yml#L13
         builder_auth_file = (
-            (os.getenv("KONFLUX_OPERATOR_INDEX_AUTH_FILE") or self.registry_auth_file)
+            (os.getenv("KONFLUX_OPERATOR_INDEX_AUTH_FILE") or self.runtime.registry_config)
             if not self.runtime.group.startswith("openshift-")
-            else self.registry_auth_file
+            else self.runtime.registry_config
         )
         latest_builder_image_info = Model(
             await oc_image_info_for_arch_async(builder_image_url, registry_config=builder_auth_file)
@@ -1210,7 +1209,7 @@ class ConfigScanSources:
 
         # Fetch SLSA attestation
         attestation = await fetch_slsa_attestation(
-            build_record.image_pullspec, build_record.name, self.registry_auth_file
+            build_record.image_pullspec, build_record.name, self.runtime.registry_config
         )
         if not attestation:
             self.logger.warning('Skipping task bundle check for %s', image_meta.distgit_key)
@@ -1383,7 +1382,7 @@ class ConfigScanSources:
         pullspec = f"quay.io/konflux-ci/tekton-catalog/{task_name}@sha256:{sha}"
         self.logger.info(f'Getting age for task bundle {task_name} using pullspec {pullspec}')
         try:
-            out = await oc_image_info__cached_async(pullspec, registry_config=self.registry_auth_file)
+            out = await oc_image_info__cached_async(pullspec, registry_config=self.runtime.registry_config)
             image_info = json.loads(out)
             created_str = image_info.get('config', {}).get('created', '')
             if not created_str:
@@ -1636,7 +1635,7 @@ class ConfigScanSources:
                 for container_conf in self.runtime.group_config.rhcos.payload_tags:
                     if self.runtime.group_config.rhcos.get("layered_rhcos", False):
                         build_id, pullspec = get_latest_layered_rhcos_build(
-                            container_conf, brew_arch, registry_config=self.registry_auth_file
+                            container_conf, brew_arch, registry_config=self.runtime.registry_config
                         )
                     else:
                         build_id, pullspec = rhcos.RHCOSBuildFinder(
@@ -1648,7 +1647,7 @@ class ConfigScanSources:
                     pullspec_for_tag,
                     brew_arch,
                     build_id,
-                    registry_config=self.registry_auth_file,
+                    registry_config=self.runtime.registry_config,
                 ).find_non_latest_rpms(exclude_rhel=True)
                 if non_latest_rpms:
                     status['outdated'] = True
@@ -1689,7 +1688,7 @@ class ConfigScanSources:
         rhcos_index = next(
             (tag.rhcos_index_tag for tag in self.runtime.group_config.rhcos.payload_tags if tag.primary), ""
         )
-        rhcos_info = util.oc_image_info_for_arch(rhcos_index, go_arch, registry_config=self.registry_auth_file)
+        rhcos_info = util.oc_image_info_for_arch(rhcos_index, go_arch, registry_config=self.runtime.registry_config)
         return rhcos_info['digest']
 
     def tagged_rhcos_id(self, container_name, version, arch, private) -> Optional[str]:

--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -100,6 +100,7 @@ class Runtime(GroupRuntime):
         self.db = None
         self.session_pool = {}
         self.session_pool_available = {}
+        self.registry_config: Optional[str] = None
         self.brew_event = None
         self.assembly_basis_event = None
         self.assembly_type = None
@@ -150,6 +151,9 @@ class Runtime(GroupRuntime):
 
         for key, val in kwargs.items():
             self.__dict__[key] = val
+
+        if not self.registry_config:
+            self.registry_config = os.getenv("QUAY_AUTH_FILE")
 
         # Convert variant string to BuildVariant enum if it's a string
         if isinstance(self.variant, str):

--- a/doozer/tests/cli/test_scan_sources_konflux.py
+++ b/doozer/tests/cli/test_scan_sources_konflux.py
@@ -21,6 +21,7 @@ class TestScanSourcesKonflux(IsolatedAsyncioTestCase):
         self.runtime.konflux_db = MagicMock()
         self.runtime.group = 'openshift-4.20'  # Default to OCP group for tests
         self.runtime.load_disabled = False
+        self.runtime.registry_config = None
         self.runtime.image_metas.return_value = []
         self.runtime.rpm_metas.return_value = []
         self.runtime.image_map = {}
@@ -319,7 +320,7 @@ class TestScanTaskBundleChanges(TestScanSourcesKonflux):
 
         # Should call fetch_slsa_attestation when for_release is None (not skipped)
         mock_get_attestation.assert_called_once_with(
-            self.build_record.image_pullspec, self.build_record.name, self.scanner.registry_auth_file
+            self.build_record.image_pullspec, self.build_record.name, self.scanner.runtime.registry_config
         )
 
     @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
@@ -336,7 +337,7 @@ class TestScanTaskBundleChanges(TestScanSourcesKonflux):
 
         # Should call fetch_slsa_attestation when for_release is Missing (not skipped)
         mock_get_attestation.assert_called_once_with(
-            self.build_record.image_pullspec, self.build_record.name, self.scanner.registry_auth_file
+            self.build_record.image_pullspec, self.build_record.name, self.scanner.runtime.registry_config
         )
 
     @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
@@ -353,7 +354,7 @@ class TestScanTaskBundleChanges(TestScanSourcesKonflux):
 
         # Should call fetch_slsa_attestation when for_release is True (not skipped)
         mock_get_attestation.assert_called_once_with(
-            self.build_record.image_pullspec, self.build_record.name, self.scanner.registry_auth_file
+            self.build_record.image_pullspec, self.build_record.name, self.scanner.runtime.registry_config
         )
 
     @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
@@ -662,7 +663,7 @@ class TestTaskBundleIntegration(TestScanSourcesKonflux):
 
         # Verify all methods were called in correct order
         mock_get_attestation.assert_called_once_with(
-            self.build_record.image_pullspec, self.build_record.name, self.scanner.registry_auth_file
+            self.build_record.image_pullspec, self.build_record.name, self.scanner.runtime.registry_config
         )
         mock_get_age.assert_called_once_with("git-clone", "old123")
 

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -837,6 +837,7 @@ class KonfluxOcpPipeline:
             credentials=credentials,
         ) as global_auth_file:
             self._registry_auth_file = global_auth_file
+            self._doozer_base_command.append(f'--registry-config={global_auth_file}')
 
             # cosign requires DOCKER_CONFIG pointing to a dir containing config.json
             docker_config_dir = tempfile.mkdtemp(prefix='docker_config_')


### PR DESCRIPTION
Doozer's cosign and oc commands were reading QUAY_AUTH_FILE directly, which points to the original Jenkins file rather than the merged auth file crafted by RegistryConfig. Add --registry-config as a global CLI option that defaults to QUAY_AUTH_FILE when not specified. The ocp4_konflux pipeline now passes the merged auth file to doozer via this option, ensuring cosign download attestation has the right credentials.