### PR TITLE
resolve vendor/ symlinks during Konflux rebase for hermetic builds

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import re
 import shutil
+import stat
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple, cast
 
@@ -594,6 +595,61 @@ class KonfluxRebaser:
         cmd = 'rsync -av {} {}/ {}/'.format(exclude, src, dest)
         await exectools.cmd_assert_async(cmd, suppress_output=True)
 
+    async def _resolve_vendor_symlinks(self, dest_dir: Path):
+        """
+        Replace symlinks in vendor/ with copies of their target directories.
+
+        Some repos (e.g. openshift/kubernetes <= 4.16) have symlinks in vendor/
+        pointing to staging/ directories. Konflux hermetic builds reject these
+        because cachi2's gomod-vendor-check expects real files, not symlinks.
+
+        After copying, executable permissions are stripped from all files because
+        `go mod vendor` writes files as 0644 — leaving exec bits causes the
+        vendor consistency check to report diffs.
+        """
+        vendor_dir = dest_dir / "vendor"
+        if not vendor_dir.is_dir():
+            return
+
+        symlinks = [entry for entry in vendor_dir.rglob("*") if entry.is_symlink()]
+        if not symlinks:
+            return
+
+        self._logger.info("Resolving %d symlink(s) in vendor/ directory", len(symlinks))
+        for link in symlinks:
+            target = link.resolve()
+            if not target.exists():
+                self._logger.warning("Vendor symlink %s points to non-existent target %s, skipping", link, target)
+                continue
+
+            link.unlink()
+            if target.is_dir():
+                await exectools.to_thread(shutil.copytree, str(target), str(link))
+            else:
+                await exectools.to_thread(shutil.copy2, str(target), str(link))
+
+            self._strip_exec_permissions(link)
+
+        self._logger.info("Resolved vendor/ symlinks successfully")
+
+    @staticmethod
+    def _strip_exec_permissions(path: Path):
+        """
+        Remove executable bits from all files under path (or from path itself
+        if it is a file), matching the 0644 permissions that `go mod vendor` uses.
+        """
+        exec_bits = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        if path.is_file():
+            mode = path.stat().st_mode
+            if mode & exec_bits:
+                path.chmod(mode & ~exec_bits)
+        elif path.is_dir():
+            for f in path.rglob("*"):
+                if f.is_file():
+                    mode = f.stat().st_mode
+                    if mode & exec_bits:
+                        f.chmod(mode & ~exec_bits)
+
     @start_as_current_span_async(TRACER, "rebase.merge_source")
     async def _merge_source(self, metadata: ImageMetadata, source: SourceResolution, source_dir: Path, dest_dir: Path):
         """
@@ -632,6 +688,11 @@ class KonfluxRebaser:
 
         # Copy all files and overwrite where necessary
         await self._recursive_overwrite(source_dir, dest_dir)
+
+        # Resolve symlinks in vendor/ so that Konflux hermetic builds pass gomod-vendor-check.
+        # Some repos (e.g. openshift/kubernetes <= 4.16) use symlinks in vendor/ pointing to
+        # staging/ directories — cachi2 rejects these because they don't match `go mod vendor` output.
+        await self._resolve_vendor_symlinks(dest_dir)
 
         df_path = dest_dir.joinpath('Dockerfile')
 

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+import stat
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
@@ -1151,6 +1152,132 @@ USER 3000
         # Note: COPY --from=metadata is not a FROM directive, so not counted
         self.assertEqual(result, [False, True, True])
         self.assertEqual(len(result), 3)
+
+
+class TestResolveVendorSymlinks(TestCase):
+    def setUp(self):
+        self.directory = TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.dest_dir = Path(self.directory.name)
+
+        self.rebaser = KonfluxRebaser.__new__(KonfluxRebaser)
+        self.rebaser._logger = MagicMock()
+
+    def test_no_vendor_dir(self):
+        asyncio.run(self.rebaser._resolve_vendor_symlinks(self.dest_dir))
+        self.rebaser._logger.info.assert_not_called()
+
+    def test_vendor_dir_no_symlinks(self):
+        vendor = self.dest_dir / "vendor" / "example.com" / "pkg"
+        vendor.mkdir(parents=True)
+        (vendor / "main.go").write_text("package pkg")
+
+        asyncio.run(self.rebaser._resolve_vendor_symlinks(self.dest_dir))
+        self.rebaser._logger.info.assert_not_called()
+
+    def test_resolves_directory_symlinks(self):
+        staging = self.dest_dir / "staging" / "src" / "k8s.io" / "api"
+        staging.mkdir(parents=True)
+        (staging / "types.go").write_text("package api")
+        (staging / "doc.go").write_text("package api // doc")
+
+        vendor = self.dest_dir / "vendor" / "k8s.io"
+        vendor.mkdir(parents=True)
+        (vendor / "api").symlink_to(staging)
+
+        asyncio.run(self.rebaser._resolve_vendor_symlinks(self.dest_dir))
+
+        resolved = vendor / "api"
+        self.assertTrue(resolved.is_dir())
+        self.assertFalse(resolved.is_symlink())
+        self.assertEqual((resolved / "types.go").read_text(), "package api")
+        self.assertEqual((resolved / "doc.go").read_text(), "package api // doc")
+
+    def test_resolves_file_symlinks(self):
+        real_file = self.dest_dir / "real_module.go"
+        real_file.write_text("package real")
+
+        vendor = self.dest_dir / "vendor" / "example.com"
+        vendor.mkdir(parents=True)
+        (vendor / "module.go").symlink_to(real_file)
+
+        asyncio.run(self.rebaser._resolve_vendor_symlinks(self.dest_dir))
+
+        resolved = vendor / "module.go"
+        self.assertTrue(resolved.is_file())
+        self.assertFalse(resolved.is_symlink())
+        self.assertEqual(resolved.read_text(), "package real")
+
+    def test_skips_broken_symlinks(self):
+        vendor = self.dest_dir / "vendor" / "k8s.io"
+        vendor.mkdir(parents=True)
+        (vendor / "missing").symlink_to("/nonexistent/path")
+
+        asyncio.run(self.rebaser._resolve_vendor_symlinks(self.dest_dir))
+
+        self.assertTrue((vendor / "missing").is_symlink())
+        self.rebaser._logger.warning.assert_called_once()
+
+    def test_resolves_multiple_symlinks(self):
+        staging_base = self.dest_dir / "staging" / "src" / "k8s.io"
+
+        for name in ["api", "client-go", "apimachinery"]:
+            pkg = staging_base / name
+            pkg.mkdir(parents=True)
+            (pkg / "main.go").write_text(f"package {name}")
+
+        vendor = self.dest_dir / "vendor" / "k8s.io"
+        vendor.mkdir(parents=True)
+        for name in ["api", "client-go", "apimachinery"]:
+            (vendor / name).symlink_to(staging_base / name)
+
+        asyncio.run(self.rebaser._resolve_vendor_symlinks(self.dest_dir))
+
+        for name in ["api", "client-go", "apimachinery"]:
+            resolved = vendor / name
+            self.assertTrue(resolved.is_dir())
+            self.assertFalse(resolved.is_symlink())
+            self.assertEqual((resolved / "main.go").read_text(), f"package {name}")
+
+    def test_strips_executable_permissions_from_resolved_dir(self):
+        staging = self.dest_dir / "staging" / "src" / "k8s.io" / "apiserver"
+        webhook_dir = staging / "pkg" / "util" / "webhook"
+        webhook_dir.mkdir(parents=True)
+        gencerts = webhook_dir / "gencerts.sh"
+        gencerts.write_text("#!/bin/bash\necho hello")
+        gencerts.chmod(0o755)
+        (webhook_dir / "webhook.go").write_text("package webhook")
+
+        vendor = self.dest_dir / "vendor" / "k8s.io"
+        vendor.mkdir(parents=True)
+        (vendor / "apiserver").symlink_to(staging)
+
+        asyncio.run(self.rebaser._resolve_vendor_symlinks(self.dest_dir))
+
+        resolved_sh = vendor / "apiserver" / "pkg" / "util" / "webhook" / "gencerts.sh"
+        self.assertTrue(resolved_sh.is_file())
+        self.assertFalse(resolved_sh.is_symlink())
+        self.assertEqual(resolved_sh.read_text(), "#!/bin/bash\necho hello")
+        mode = resolved_sh.stat().st_mode
+        exec_bits = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        self.assertEqual(mode & exec_bits, 0, "Executable bits should be stripped")
+
+    def test_strips_executable_permissions_from_resolved_file(self):
+        real_file = self.dest_dir / "staging" / "run.sh"
+        real_file.parent.mkdir(parents=True)
+        real_file.write_text("#!/bin/bash")
+        real_file.chmod(0o755)
+
+        vendor = self.dest_dir / "vendor" / "example.com"
+        vendor.mkdir(parents=True)
+        (vendor / "run.sh").symlink_to(real_file)
+
+        asyncio.run(self.rebaser._resolve_vendor_symlinks(self.dest_dir))
+
+        resolved = vendor / "run.sh"
+        mode = resolved.stat().st_mode
+        exec_bits = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        self.assertEqual(mode & exec_bits, 0, "Executable bits should be stripped")
 
 
 class TestCpeVersionExtraction(TestCase):


### PR DESCRIPTION
## Summary                             
  - Adds `_resolve_vendor_symlinks()` to `KonfluxRebaser` that replaces symlinks in `vendor/` with copies of their targets after source merge
  - Strips executable permissions from resolved files to match `go mod vendor`'s 0644 output — prevents hermeto from flagging `.sh` files like `gencerts.sh` as modified
  - Fixes hermetic builds for openshift/kubernetes 4.12–4.16, which use 30 symlinks in `vendor/k8s.io/` → `staging/src/k8s.io/`
  - No-op for repos without vendor symlinks (4.17+ and all non-kubernetes images)
  
## Test plan                                                                                                                                                                           
  - [x] 8 unit tests covering: no vendor dir, no symlinks, directory symlinks, file symlinks, broken symlinks, multiple symlinks, exec permission stripping (dir and file)
  - [x] All 49 rebaser tests pass
  - [x] Ruff lint passes 
  - [test build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/fgallott/job/ocp4-konflux/657/console) 
  - [konflux build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-openshift-enterprise-hyperkube-6plfk)