### PR TITLE
ART-18058: Restrict /approve in OWNERS to senior team members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,8 @@
 reviewers:
-- sosiouxme
 - jupierce
-- thiagoalessio
 - joepvd
 - thegreyd
-- vfreex
 - locriandev
-- Ximinhan
 - ashwindasr
 - mbiarnes
 - lgarciaaco
@@ -16,21 +12,15 @@ reviewers:
 - pruan-rht
 - fgallott
 approvers:
-- sosiouxme
 - jupierce
-- thiagoalessio
 - joepvd
 - thegreyd
-- vfreex
 - locriandev
-- Ximinhan
 - ashwindasr
-- mbiarnes
-- lgarciaaco
-- rayfordj
-- fbladilo
-- adobes1
-- pruan-rht
-- fgallott
+emeritus_approvers:
+- sosiouxme
+- thiagoalessio
+- vfreex
+- Ximinhan
 # this is to keep automation from complaining about ownership of base image builds
 component: Release


### PR DESCRIPTION
## Summary

- Restrict the `approvers` list in OWNERS to 5 senior team members (jupierce, joepvd, thegreyd, locriandev, ashwindasr) to prevent premature approvals that bypass proper gating
- Keep all active team members as `reviewers` so anyone can still review code

Jira: https://redhat.atlassian.net/browse/ART-18058

Made with [Cursor](https://cursor.com)