### PR TITLE
ART-14708: Auto-sync golang builders to layered operator branches

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -16,7 +16,6 @@ from artcommonlib.constants import (
     PRODUCT_NAMESPACE_MAP,
 )
 from artcommonlib.github_auth import get_github_client_for_org
-from github import GithubException
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.release_util import split_el_suffix_in_release
@@ -24,6 +23,7 @@ from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import new_roundtrip_yaml_handler
 from elliottlib import util as elliottutil
 from elliottlib.constants import GOLANG_BUILDER_CVE_COMPONENT
+from github import GithubException
 
 from pyartcd import constants, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -16,6 +16,7 @@ from artcommonlib.constants import (
     PRODUCT_NAMESPACE_MAP,
 )
 from artcommonlib.github_auth import get_github_client_for_org
+from github import GithubException
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.release_util import split_el_suffix_in_release
@@ -342,7 +343,8 @@ class UpdateGolangPipeline:
         else:  # konflux
             builder_nvrs = konflux_nvrs
 
-        await self.update_golang_streams(go_version, builder_nvrs)
+        replacements = await self.update_golang_streams(go_version, builder_nvrs)
+        await self.update_layered_branches(go_version, replacements)
 
         await move_golang_bugs(
             ocp_version=self.ocp_version,
@@ -495,13 +497,15 @@ class UpdateGolangPipeline:
             # TODO: This is temporary. In the future we need a location to share with multiple teams.
             return f'{KONFLUX_DEFAULT_IMAGE_REPO}:golang-builder-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
 
-    async def update_golang_streams(self, go_version, builder_nvrs):
+    async def update_golang_streams(self, go_version, builder_nvrs) -> dict[str, str]:
         """
         Update golang builders for current release in ocp-build-data
         1. First check go verion from group.yml var to decide if it's a major version bump or minor version bump
         2. Get the golang image value, find and replace for each item in streams.yml
         3. If it'a major version bump, also need to update key in streams.yml and vars in group.yml
         4. Create pr to update changes
+
+        Returns a dict mapping old pullspecs to new pullspecs for all replacements made.
         """
         branch = f"openshift-{self.ocp_version}"
         upstream_repo = get_github_client_for_org("openshift-eng").get_repo("openshift-eng/ocp-build-data")
@@ -529,6 +533,7 @@ class UpdateGolangPipeline:
             return f'rhel-{el_v}-golang-{go_previous_var_template}'
 
         update_streams = update_group = False
+        replacements: dict[str, str] = {}
 
         # register aliases
         stream_alias_map = {}
@@ -557,6 +562,7 @@ class UpdateGolangPipeline:
                 latest_go = get_stream(latest_go_stream_name(el_v))['image']
 
                 new_latest_go = self._get_builder_pullspec(parsed_nvr, self.build_system)
+                replacements[latest_go] = new_latest_go
                 for _, info in streams_content.items():
                     if info['image'] == latest_go:
                         info['image'] = new_latest_go
@@ -570,6 +576,7 @@ class UpdateGolangPipeline:
                 previous_go = get_stream(previous_go_stream_name(el_v))['image']
 
                 new_previous_go = self._get_builder_pullspec(parsed_nvr, self.build_system)
+                replacements[previous_go] = new_previous_go
                 for _, info in streams_content.items():
                     if info['image'] == previous_go:
                         info['image'] = new_previous_go
@@ -586,10 +593,13 @@ class UpdateGolangPipeline:
                 previous_go = get_stream(previous_go_stream_name(el_v))['image'] if go_previous else None
 
                 new_latest_go = self._get_builder_pullspec(parsed_nvr, self.build_system)
+                replacements[latest_go] = new_latest_go
+                if previous_go:
+                    replacements[previous_go] = latest_go
                 for _, info in streams_content.items():
                     if info['image'] == latest_go:
                         info['image'] = new_latest_go
-                    if info['image'] == previous_go:
+                    if previous_go and info['image'] == previous_go:
                         info['image'] = latest_go
                 group_content['vars'][go_latest_var] = go_version
                 group_content['vars']['GO_EXTRA'] = go_version
@@ -600,7 +610,7 @@ class UpdateGolangPipeline:
         if update_streams:
             if self.dry_run:
                 _LOGGER.info(f"[DRY RUN] Would have created PR to update {go_version} golang builders")
-                return
+                return replacements
             if self.skip_pr:
                 # Log NVRs and pullspecs for golang builder images
                 builder_info = []
@@ -618,7 +628,7 @@ class UpdateGolangPipeline:
                     f"Skipping PR creation (--skip-pr flag set) for {go_version} golang builders update.\n"
                     f"Golang builder images:\n{builder_details}"
                 )
-                return
+                return replacements
             fork_repo = get_github_client_for_org("openshift-bot").get_repo("openshift-bot/ocp-build-data")
             branch_name = f"update-golang-{self.ocp_version}-{go_version}"
             title = f"{self.art_jira} - Bump {self.ocp_version} golang builders to {go_version}"
@@ -658,6 +668,130 @@ class UpdateGolangPipeline:
                 )
             else:
                 _LOGGER.info(f"No update needed in {branch}")
+        return replacements
+
+    async def update_layered_branches(self, go_version: str, replacements: dict[str, str]):
+        """
+        For each layered operator branch listed in golang_sync_branches, update
+        streams.yml with the same builder pullspec replacements applied to the
+        main OCP branch.
+        """
+        branch = f"openshift-{self.ocp_version}"
+        upstream_repo = get_github_client_for_org("openshift-eng").get_repo("openshift-eng/ocp-build-data")
+        group_content = yaml.load(upstream_repo.get_contents("group.yml", ref=branch).decoded_content)
+        sync_branches = group_content.get('vars', {}).get('golang_sync_branches', [])
+
+        if not sync_branches:
+            _LOGGER.info("No golang_sync_branches configured for %s, skipping layered branch sync", branch)
+            return
+
+        if not replacements:
+            _LOGGER.info("No replacements to apply, skipping layered branch sync")
+            return
+
+        if self.dry_run:
+            _LOGGER.info(
+                "[DRY RUN] Would update layered branches %s with replacements: %s", sync_branches, replacements
+            )
+            return
+
+        if self.skip_pr:
+            _LOGGER.info("Skipping layered branch PRs (--skip-pr flag set) for branches: %s", sync_branches)
+            return
+
+        results = await asyncio.gather(
+            *[self._update_layered_branch(b, go_version, replacements) for b in sync_branches],
+            return_exceptions=True,
+        )
+
+        summary_lines = []
+        for branch_name, result in zip(sync_branches, results):
+            if isinstance(result, Exception):
+                summary_lines.append(f"  - {branch_name}: :x: error: {result}")
+                _LOGGER.error("Failed to update layered branch %s: %s", branch_name, result)
+            elif result is None:
+                summary_lines.append(f"  - {branch_name}: skipped (no matching builders)")
+            else:
+                summary_lines.append(f"  - {branch_name}: {result}")
+
+        summary = f"Layered branch PRs for golang {go_version}:\n" + "\n".join(summary_lines)
+        _LOGGER.info(summary)
+        await self._slack_client.say_in_thread(summary)
+
+    async def _update_layered_branch(
+        self, branch_name: str, go_version: str, replacements: dict[str, str]
+    ) -> str | None:
+        """
+        Apply pullspec replacements to streams.yml on a single layered branch.
+        Returns the PR URL if a PR was created, or None if no changes were needed.
+        """
+        upstream_repo = get_github_client_for_org("openshift-eng").get_repo("openshift-eng/ocp-build-data")
+        try:
+            upstream_repo.get_branch(branch_name)
+        except GithubException as e:
+            if e.status == 404:
+                raise ValueError(f"Branch '{branch_name}' does not exist in ocp-build-data")
+            raise
+        streams_raw = upstream_repo.get_contents("streams.yml", ref=branch_name)
+        streams_content = yaml.load(streams_raw.decoded_content)
+
+        changed = False
+        for stream_name, info in streams_content.items():
+            old_image = info.get('image', '')
+            if old_image in replacements:
+                _LOGGER.debug(
+                    "Replacing golang builder in %s: %s -> %s", branch_name, old_image, replacements[old_image]
+                )
+                info['image'] = replacements[old_image]
+                changed = True
+
+        if not changed:
+            _LOGGER.info("No matching builders in %s, skipping", branch_name)
+            return None
+
+        fork_repo = get_github_client_for_org("openshift-bot").get_repo("openshift-bot/ocp-build-data")
+        fork_branch_name = f"update-golang-{branch_name}-{go_version}"
+        try:
+            fork_repo.get_git_ref(f"heads/{fork_branch_name}").delete()
+        except GithubException as e:
+            if e.status != 404:
+                raise
+        fork_repo.create_git_ref(
+            f"refs/heads/{fork_branch_name}",
+            upstream_repo.get_branch(branch_name).commit.sha,
+        )
+
+        output = io.BytesIO()
+        yaml.dump(streams_content, output)
+        output.seek(0)
+        fork_file = fork_repo.get_contents("streams.yml", ref=fork_branch_name)
+        commit_msg = f"Bump {branch_name} golang builders to {go_version}"
+        fork_repo.update_file("streams.yml", commit_msg, output.read(), fork_file.sha, branch=fork_branch_name)
+
+        title = f"{self.art_jira} - Bump {branch_name} golang builders to {go_version}"
+        build_url = jenkins.get_build_url()
+
+        if not branch_name.startswith("openshift-"):
+            replacements_applied = []
+            for sname, sinfo in streams_content.items():
+                for old, new in replacements.items():
+                    if sinfo.get('image') == new:
+                        replacements_applied.append(f"- `{sname}`: {old.split(':')[-1]} \u2192 {new.split(':')[-1]}")
+                        break
+            body = (
+                f"Created by job run {build_url or 'manual trigger'}\n\n"
+                f"This PR was automatically generated to sync golang builder "
+                f"updates from openshift-{self.ocp_version}.\n\n"
+                f"**Golang builder replacements:**\n"
+                + ("\n".join(replacements_applied) if replacements_applied else "- (no streams updated)")
+            )
+        else:
+            body = f"Created by job run {build_url}" if build_url else ""
+        pr = upstream_repo.create_pull(
+            title=title, body=body, base=branch_name, head=f"openshift-bot:{fork_branch_name}"
+        )
+        _LOGGER.info("PR created %s for layered branch %s", pr.html_url, branch_name)
+        return pr.html_url
 
     async def _rebase_brew(self, el_v, go_version):
         _LOGGER.info("Rebasing for Brew...")

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1027,5 +1027,269 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         self.assertEqual(mock_cmd_assert.call_count, 2)
 
 
+class TestUpdateLayeredBranches(IsolatedAsyncioTestCase):
+    """Test the update_layered_branches / _update_layered_branch methods"""
+
+    def _make_pipeline(self, dry_run=False, skip_pr=False, build_system="konflux"):
+        mock_runtime = Mock(
+            dry_run=dry_run,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_slack = Mock()
+        mock_slack.say_in_thread = AsyncMock()
+        mock_runtime.new_slack_client.return_value = mock_slack
+        return UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.22",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.8-1.el9"],
+            art_jira="ART-14708",
+            tag_builds=False,
+            build_system=build_system,
+            skip_pr=skip_pr,
+        )
+
+    def _mock_github(self, group_vars, layered_streams=None):
+        """Return (mock_upstream_repo, mock_fork_repo) with canned GitHub responses."""
+        import io as _io
+        from artcommonlib.util import new_roundtrip_yaml_handler
+
+        _yaml = new_roundtrip_yaml_handler()
+
+        group_yml = {"vars": group_vars}
+        group_bytes = _io.BytesIO()
+        _yaml.dump(group_yml, group_bytes)
+        group_bytes.seek(0)
+        group_raw = group_bytes.read()
+
+        mock_upstream = Mock()
+        mock_fork = Mock()
+
+        def get_contents(path, ref=None):
+            content_mock = Mock()
+            if path == "group.yml":
+                content_mock.decoded_content = group_raw
+                return content_mock
+            if path == "streams.yml":
+                streams = layered_streams or {}
+                buf = _io.BytesIO()
+                _yaml.dump(streams, buf)
+                buf.seek(0)
+                content_mock.decoded_content = buf.read()
+                content_mock.sha = "fake-sha"
+                return content_mock
+            return content_mock
+
+        mock_upstream.get_contents = Mock(side_effect=get_contents)
+        mock_upstream.get_branch = Mock(return_value=Mock(commit=Mock(sha="abc123")))
+        mock_upstream.create_pull = Mock(
+            return_value=Mock(html_url="https://github.com/openshift-eng/ocp-build-data/pull/9999")
+        )
+
+        mock_fork.get_branches = Mock(return_value=[])
+        mock_fork.create_git_ref = Mock()
+        mock_fork.get_contents = Mock(return_value=Mock(sha="fork-sha"))
+        mock_fork.update_file = Mock()
+
+        return mock_upstream, mock_fork
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    async def test_no_sync_list(self, mock_gh_client, mock_konflux_db):
+        """golang_sync_branches absent in vars -- no streams.yml reads"""
+        pipeline = self._make_pipeline()
+        mock_upstream, _ = self._mock_github(group_vars={"GO_LATEST": "1.25"})
+        mock_gh_client.return_value.get_repo.return_value = mock_upstream
+
+        await pipeline.update_layered_branches("1.25.8", {"old": "new"})
+
+        mock_upstream.get_contents.assert_called_once_with("group.yml", ref="openshift-4.22")
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    async def test_empty_replacements(self, mock_gh_client, mock_konflux_db):
+        """Replacements map is empty -- immediate return after reading group.yml"""
+        pipeline = self._make_pipeline()
+        mock_upstream, _ = self._mock_github(
+            group_vars={"GO_LATEST": "1.25", "golang_sync_branches": ["logging-6.0"]},
+        )
+        mock_gh_client.return_value.get_repo.return_value = mock_upstream
+
+        await pipeline.update_layered_branches("1.25.8", {})
+
+        mock_upstream.get_contents.assert_called_once_with("group.yml", ref="openshift-4.22")
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("pyartcd.pipelines.update_golang.jenkins")
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    async def test_creates_pr(self, mock_gh_client, mock_jenkins, mock_konflux_db):
+        """Layered branch stream matches old pullspec -- PR created with correct params"""
+        mock_jenkins.get_build_url.return_value = "https://jenkins/job/123"
+        pipeline = self._make_pipeline()
+        old_pullspec = "quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.7-old.el9"
+        new_pullspec = "quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-new.el9"
+        replacements = {old_pullspec: new_pullspec}
+        layered_streams = {
+            "rhel-9-golang": {"image": old_pullspec, "aliases": []},
+        }
+        mock_upstream, mock_fork = self._mock_github(
+            group_vars={"GO_LATEST": "1.25", "golang_sync_branches": ["logging-6.0"]},
+            layered_streams=layered_streams,
+        )
+
+        def get_repo(name):
+            if "openshift-bot" in name:
+                return mock_fork
+            return mock_upstream
+
+        mock_gh_client.return_value.get_repo = Mock(side_effect=get_repo)
+
+        await pipeline.update_layered_branches("1.25.8", replacements)
+
+        mock_upstream.create_pull.assert_called_once()
+        call_kwargs = mock_upstream.create_pull.call_args
+        self.assertEqual(call_kwargs.kwargs["base"], "logging-6.0")
+        self.assertIn("logging-6.0", call_kwargs.kwargs["title"])
+        self.assertIn("1.25.8", call_kwargs.kwargs["title"])
+        self.assertIn("openshift-bot:", call_kwargs.kwargs["head"])
+        pipeline._slack_client.say_in_thread.assert_called()
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    async def test_no_match(self, mock_gh_client, mock_konflux_db):
+        """Layered branch uses a different builder -- no PR, skip reported"""
+        pipeline = self._make_pipeline()
+        replacements = {"old-pullspec-that-wont-match": "new-pullspec"}
+        layered_streams = {
+            "rhel-9-golang": {"image": "completely-different-pullspec", "aliases": []},
+        }
+        mock_upstream, mock_fork = self._mock_github(
+            group_vars={"GO_LATEST": "1.25", "golang_sync_branches": ["oadp-1.3"]},
+            layered_streams=layered_streams,
+        )
+
+        def get_repo(name):
+            if "openshift-bot" in name:
+                return mock_fork
+            return mock_upstream
+
+        mock_gh_client.return_value.get_repo = Mock(side_effect=get_repo)
+
+        await pipeline.update_layered_branches("1.25.8", replacements)
+
+        mock_upstream.create_pull.assert_not_called()
+        pipeline._slack_client.say_in_thread.assert_called()
+        summary = pipeline._slack_client.say_in_thread.call_args[0][0]
+        self.assertIn("skipped", summary)
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    async def test_dry_run(self, mock_gh_client, mock_konflux_db):
+        """Dry-run logs but does not create PR"""
+        pipeline = self._make_pipeline(dry_run=True)
+        mock_upstream, _ = self._mock_github(
+            group_vars={"GO_LATEST": "1.25", "golang_sync_branches": ["logging-6.0"]},
+        )
+        mock_gh_client.return_value.get_repo.return_value = mock_upstream
+
+        await pipeline.update_layered_branches("1.25.8", {"old": "new"})
+
+        mock_upstream.create_pull.assert_not_called()
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    async def test_skip_pr(self, mock_gh_client, mock_konflux_db):
+        """--skip-pr flag is respected"""
+        pipeline = self._make_pipeline(skip_pr=True)
+        mock_upstream, _ = self._mock_github(
+            group_vars={"GO_LATEST": "1.25", "golang_sync_branches": ["logging-6.0"]},
+        )
+        mock_gh_client.return_value.get_repo.return_value = mock_upstream
+
+        await pipeline.update_layered_branches("1.25.8", {"old": "new"})
+
+        mock_upstream.create_pull.assert_not_called()
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("pyartcd.pipelines.update_golang.jenkins")
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    async def test_partial_failure(self, mock_gh_client, mock_jenkins, mock_konflux_db):
+        """One branch PR fails, others succeed -- failures reported but pipeline continues"""
+        mock_jenkins.get_build_url.return_value = ""
+        pipeline = self._make_pipeline()
+        old_pullspec = "quay.io/ocp-art-tenant/art-images:golang-builder-v1.25.7-old.el9"
+        new_pullspec = "quay.io/ocp-art-tenant/art-images:golang-builder-v1.25.8-new.el9"
+        replacements = {old_pullspec: new_pullspec}
+
+        layered_streams = {
+            "rhel-9-golang": {"image": old_pullspec, "aliases": []},
+        }
+        mock_upstream, mock_fork = self._mock_github(
+            group_vars={
+                "GO_LATEST": "1.25",
+                "golang_sync_branches": ["logging-6.0", "logging-6.2"],
+            },
+            layered_streams=layered_streams,
+        )
+
+        call_count = 0
+
+        def create_pull_side_effect(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("GitHub API error")
+            return Mock(html_url="https://github.com/openshift-eng/ocp-build-data/pull/9999")
+
+        mock_upstream.create_pull = Mock(side_effect=create_pull_side_effect)
+
+        def get_repo(name):
+            if "openshift-bot" in name:
+                return mock_fork
+            return mock_upstream
+
+        mock_gh_client.return_value.get_repo = Mock(side_effect=get_repo)
+
+        await pipeline.update_layered_branches("1.25.8", replacements)
+
+        self.assertEqual(mock_upstream.create_pull.call_count, 2)
+        pipeline._slack_client.say_in_thread.assert_called()
+        summary = pipeline._slack_client.say_in_thread.call_args[0][0]
+        self.assertIn("error", summary)
+        self.assertIn("pull/9999", summary)
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    async def test_branch_not_found(self, mock_gh_client, mock_konflux_db):
+        """Branch in sync list doesn't exist -- error caught and reported"""
+        from github import GithubException
+
+        pipeline = self._make_pipeline()
+        mock_upstream, mock_fork = self._mock_github(
+            group_vars={"GO_LATEST": "1.25", "golang_sync_branches": ["nonexistent-branch"]},
+        )
+        mock_upstream.get_branch.side_effect = GithubException(
+            404,
+            {"message": "Branch not found"},
+            headers={},
+        )
+
+        def get_repo(name):
+            if "openshift-bot" in name:
+                return mock_fork
+            return mock_upstream
+
+        mock_gh_client.return_value.get_repo = Mock(side_effect=get_repo)
+
+        await pipeline.update_layered_branches("1.25.8", {"old": "new"})
+
+        mock_upstream.create_pull.assert_not_called()
+        pipeline._slack_client.say_in_thread.assert_called()
+        summary = pipeline._slack_client.say_in_thread.call_args[0][0]
+        self.assertIn("error", summary.lower())
+        self.assertIn("nonexistent-branch", summary)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1053,6 +1053,7 @@ class TestUpdateLayeredBranches(IsolatedAsyncioTestCase):
     def _mock_github(self, group_vars, layered_streams=None):
         """Return (mock_upstream_repo, mock_fork_repo) with canned GitHub responses."""
         import io as _io
+
         from artcommonlib.util import new_roundtrip_yaml_handler
 
         _yaml = new_roundtrip_yaml_handler()


### PR DESCRIPTION
Add golang_sync_branches support to the update-golang pipeline. When golang is bumped for an OCP version, PRs are automatically created for layered operator branches (logging, oadp, etc.) listed in group.yml vars.golang_sync_branches.

Made-with: Cursor

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED