### PR TITLE
Reset rebase-fail counter when seed-lockfile fixes a rebase error

### DIFF
--- a/pyartcd/pyartcd/pipelines/seed_lockfile.py
+++ b/pyartcd/pyartcd/pipelines/seed_lockfile.py
@@ -1,3 +1,4 @@
+import asyncio
 import html as html_mod
 import logging
 import os
@@ -14,7 +15,7 @@ from pyartcd import constants, jenkins
 from pyartcd import record as record_util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.runtime import Runtime
-from pyartcd.util import build_history_link_url, default_release_suffix
+from pyartcd.util import build_history_link_url, default_release_suffix, reset_rebase_fail_counter
 
 LOGGER = logging.getLogger(__name__)
 
@@ -124,7 +125,9 @@ class SeedLockfilePipeline:
         LOGGER.info('Generating lockfiles in %s assembly with seed map: %s', self.assembly, self.seed_map)
         await self._rebase_and_build_with_seed_map()
 
-        await self._post_report()
+        test_failed, solved, stream_failed = self._categorize_results()
+        await self._reset_rebase_counters_for_solved(solved)
+        await self._post_report(test_failed, solved, stream_failed)
 
     async def _build_in_test_assembly(self):
         """Phase 1: Build components in the test assembly with network_mode=open."""
@@ -214,6 +217,23 @@ class SeedLockfilePipeline:
             name = entry['name']
             # Overwrite -- the last entry per name is the stream build
             self.stream_results[name] = entry
+
+    async def _reset_rebase_counters_for_solved(self, solved: list[str]):
+        """Reset Redis rebase-fail counters for images that built successfully in the stream assembly."""
+        if self.assembly != 'stream' or self.runtime.dry_run:
+            return
+
+        if not solved:
+            return
+
+        LOGGER.info('Resetting rebase-fail counters for solved images: %s', ', '.join(solved))
+        results = await asyncio.gather(
+            *[reset_rebase_fail_counter(image, self.version, 'konflux') for image in solved],
+            return_exceptions=True,
+        )
+        for image, result in zip(solved, results):
+            if isinstance(result, Exception):
+                LOGGER.warning('Failed to reset rebase-fail counter for %s: %s', image, result)
 
     async def _rebase_and_build_with_seed_map(self):
         """Phase 2: Rebase and build in the target assembly with --lockfile-seed-nvrs for lockfile generation."""
@@ -426,9 +446,7 @@ class SeedLockfilePipeline:
 
         return '\n'.join(lines)
 
-    async def _post_report(self):
-        test_failed, solved, stream_failed = self._categorize_results()
-
+    async def _post_report(self, test_failed: list[str], solved: list[str], stream_failed: list[str]):
         slack_report = self._build_slack_report(test_failed, solved, stream_failed)
         LOGGER.info('Report:\n%s', slack_report)
         await self.slack_client.say(slack_report)

--- a/pyartcd/tests/pipelines/test_seed_lockfile.py
+++ b/pyartcd/tests/pipelines/test_seed_lockfile.py
@@ -375,7 +375,7 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
         pipeline.stream_results = {'ironic': {'name': 'ironic', 'status': '0'}}
         pipeline.slack_client.say = AsyncMock()
 
-        await pipeline._post_report()
+        await pipeline._post_report(*pipeline._categorize_results())
 
         pipeline.slack_client.say.assert_awaited_once()
         mock_title.assert_called_once()
@@ -390,7 +390,7 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
         pipeline.stream_results = {'ironic': {'name': 'ironic', 'status': '0'}}
         pipeline.slack_client.say = AsyncMock()
 
-        await pipeline._post_report()
+        await pipeline._post_report(*pipeline._categorize_results())
 
         mock_title.assert_called_once()
         title_arg = mock_title.call_args[0][0]
@@ -405,7 +405,7 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
         pipeline.stream_results = {'ironic': {'name': 'ironic', 'status': '0'}}
         pipeline.slack_client.say = AsyncMock()
 
-        await pipeline._post_report()
+        await pipeline._post_report(*pipeline._categorize_results())
 
         mock_title.assert_called_once()
         title_arg = mock_title.call_args[0][0]
@@ -421,9 +421,113 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
         pipeline.test_results = {'ironic': {'name': 'ironic', 'status': '0'}}
         pipeline.slack_client.say = AsyncMock()
 
-        await pipeline._post_report()
+        await pipeline._post_report(*pipeline._categorize_results())
 
         mock_title.assert_not_called()
+
+    @patch('pyartcd.pipelines.seed_lockfile.reset_rebase_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.init_jenkins')
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_title')
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_description')
+    @patch('pyartcd.pipelines.seed_lockfile.exectools.cmd_assert_async', new_callable=AsyncMock)
+    async def test_stream_build_resets_rebase_counter(self, mock_cmd, _desc, _title, _init, mock_reset):
+        """When stream build succeeds, rebase-fail counter is reset to 0."""
+        pipeline = self._create_pipeline(
+            seed_nvrs='ironic@ironic-container-v4.22.0-assembly.test',
+        )
+        pipeline.slack_client.say = AsyncMock()
+
+        def populate_stream_results():
+            pipeline.stream_results = {'ironic': {'name': 'ironic', 'status': '0', 'nvrs': 'ironic-nvr'}}
+
+        with patch.object(pipeline, '_extract_stream_results_from_record_log', side_effect=populate_stream_results):
+            await pipeline.run()
+
+        mock_reset.assert_awaited_once_with('ironic', '4.22', 'konflux')
+
+    @patch('pyartcd.pipelines.seed_lockfile.reset_rebase_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.init_jenkins')
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_title')
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_description')
+    @patch('pyartcd.pipelines.seed_lockfile.exectools.cmd_assert_async', new_callable=AsyncMock)
+    async def test_non_stream_assembly_does_not_reset_counter(self, mock_cmd, _desc, _title, _init, mock_reset):
+        """When assembly is not stream, rebase-fail counter is not reset."""
+        pipeline = self._create_pipeline(
+            assembly='test',
+            seed_nvrs='ironic@ironic-container-v4.22.0-assembly.test',
+        )
+        pipeline.slack_client.say = AsyncMock()
+
+        def populate_stream_results():
+            pipeline.stream_results = {'ironic': {'name': 'ironic', 'status': '0', 'nvrs': 'ironic-nvr'}}
+
+        with patch.object(pipeline, '_extract_stream_results_from_record_log', side_effect=populate_stream_results):
+            await pipeline.run()
+
+        mock_reset.assert_not_awaited()
+
+    @patch('pyartcd.pipelines.seed_lockfile.reset_rebase_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.init_jenkins')
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_title')
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_description')
+    @patch('pyartcd.pipelines.seed_lockfile.exectools.cmd_assert_async', new_callable=AsyncMock)
+    async def test_failed_stream_build_does_not_reset_counter(self, mock_cmd, _desc, _title, _init, mock_reset):
+        """When stream build fails, rebase-fail counter is not reset."""
+        pipeline = self._create_pipeline(
+            seed_nvrs='ironic@ironic-container-v4.22.0-assembly.test',
+        )
+        pipeline.slack_client.say = AsyncMock()
+
+        def populate_stream_results():
+            pipeline.stream_results = {'ironic': {'name': 'ironic', 'status': '-1', 'nvrs': 'n/a'}}
+
+        with patch.object(pipeline, '_extract_stream_results_from_record_log', side_effect=populate_stream_results):
+            await pipeline.run()
+
+        mock_reset.assert_not_awaited()
+
+    @patch('pyartcd.pipelines.seed_lockfile.reset_rebase_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.init_jenkins')
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_title')
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_description')
+    @patch('pyartcd.pipelines.seed_lockfile.exectools.cmd_assert_async', new_callable=AsyncMock)
+    async def test_dry_run_does_not_reset_counter(self, mock_cmd, _desc, _title, _init, mock_reset):
+        """In dry-run mode, rebase-fail counter is not reset."""
+        pipeline = self._create_pipeline(
+            runtime=MagicMock(dry_run=True, doozer_working='/tmp/doozer-working'),
+            seed_nvrs='ironic@ironic-container-v4.22.0-assembly.test',
+        )
+        pipeline.slack_client.say = AsyncMock()
+
+        def populate_stream_results():
+            pipeline.stream_results = {'ironic': {'name': 'ironic', 'status': '0', 'nvrs': 'ironic-nvr'}}
+
+        with patch.object(pipeline, '_extract_stream_results_from_record_log', side_effect=populate_stream_results):
+            await pipeline.run()
+
+        mock_reset.assert_not_awaited()
+
+    @patch('pyartcd.pipelines.seed_lockfile.reset_rebase_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.init_jenkins')
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_title')
+    @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_description')
+    @patch('pyartcd.pipelines.seed_lockfile.exectools.cmd_assert_async', new_callable=AsyncMock)
+    async def test_redis_error_does_not_fail_pipeline(self, mock_cmd, _desc, _title, _init, mock_reset):
+        """Redis errors during counter reset are logged but do not fail the pipeline."""
+        mock_reset.side_effect = ConnectionError('Redis unavailable')
+        pipeline = self._create_pipeline(
+            seed_nvrs='ironic@ironic-container-v4.22.0-assembly.test',
+        )
+        pipeline.slack_client.say = AsyncMock()
+
+        def populate_stream_results():
+            pipeline.stream_results = {'ironic': {'name': 'ironic', 'status': '0', 'nvrs': 'ironic-nvr'}}
+
+        with patch.object(pipeline, '_extract_stream_results_from_record_log', side_effect=populate_stream_results):
+            # Should not raise despite Redis error
+            await pipeline.run()
+
+        mock_reset.assert_awaited_once_with('ironic', '4.22', 'konflux')
 
     def test_init_stores_jira_key(self):
         pipeline = self._create_pipeline(jira_key='ART-12345')


### PR DESCRIPTION
## Summary
- When the seed-lockfile pipeline successfully builds an image in the stream assembly, reset its Redis rebase-fail counter to 0
- This matches the existing behavior in the ocp4_konflux pipeline, where successful rebases clear the counter
- Only applies to stream assembly builds; non-stream assemblies leave counters unchanged

## Test plan
- [x] Unit test: stream build success resets counter
- [x] Unit test: non-stream assembly does not reset counter
- [x] Unit test: failed stream build does not reset counter
- [x] All 39 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)