### PR TITLE
Fix RHEL version detection picking up compat builders

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -942,10 +942,14 @@ class ImageMetadata(Metadata):
                 dfp = DockerfileParser(fileobj=f)
                 parent_images = dfp.parent_images
 
-            # Try the last build layer first (the runtime base), then fall back to earlier layers (builders).
-            # Some base images (e.g. aws-efs-utils-base) don't encode RHEL version in their tag and may
-            # not be inspectable, but builder images (e.g. rhel-9-golang-1.25) almost always do.
-            for pullspec in reversed(parent_images):
+            # Iterate forward: the first FROM in a multi-stage Dockerfile is the primary builder,
+            # which reliably encodes the target RHEL version. Reverse iteration would incorrectly
+            # pick up compatibility builders (e.g. rhel-8-golang used only for upgrade shim binaries
+            # in ovn-kubernetes) before the primary rhel-9 builder.
+            # Also, some images (e.g. deployer) use image stream tags like :cli or :base that don't encode RHEL version. In these cases, we want to iterate through all parent images in case any of them encode RHEL version info in the tag.
+            # NOTE: the rhel version should be determined by the final layer. This is a hotfix and is probably wrong,
+            # but is needed to unblock canonical builders for now.
+            for pullspec in parent_images:
                 rhel_version, golang_version = extract_builder_info_from_pullspec(pullspec)
                 if rhel_version:
                     break

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -918,6 +918,51 @@ RUN echo "test"
     @patch('doozerlib.image.SourceResolver')
     @patch('builtins.open', create=True)
     @patch('pathlib.Path.joinpath')
+    @patch('doozerlib.image.util.oc_image_info_for_arch', return_value={'config': {'config': {'Labels': {}}}})
+    def test_determine_upstream_rhel_version_skips_compat_builder(
+        self, mock_oc_image_info, mock_joinpath, mock_open, mock_source_resolver
+    ):
+        """Test that primary rhel-9 builder is detected over a rhel-8 compatibility builder"""
+        extract_builder_info_from_pullspec.cache_clear()
+        metadata = self._create_image_metadata('openshift/ose-ovn-kubernetes-rhel9')
+
+        metadata.config = Model(
+            {
+                'name': 'openshift/ose-ovn-kubernetes-rhel9',
+                'distgit': {'branch': 'rhaos-5.0-rhel-9'},
+                'content': {'source': {'git': {'url': 'https://github.com/test/repo.git'}}},
+            }
+        )
+        metadata.branch_el_target = MagicMock(return_value=9)
+
+        mock_source_resolution = MagicMock()
+        metadata.runtime.source_resolver.resolve_source = MagicMock(return_value=mock_source_resolution)
+
+        mock_source_dir = MagicMock()
+        mock_source_resolver.get_source_dir = MagicMock(return_value=mock_source_dir)
+
+        mock_df_path = MagicMock()
+        mock_joinpath.return_value = mock_df_path
+
+        mock_open.return_value.__enter__.return_value = mock.mock_open(read_data="").return_value
+
+        with patch('doozerlib.image.DockerfileParser') as mock_dfp:
+            mock_dfp_instance = MagicMock()
+            # ovn-kubernetes pattern: primary rhel-9 builder, rhel-8 compat builder, base with no RHEL tag
+            mock_dfp_instance.parent_images = [
+                'registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22',
+                'registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.22',
+                'registry.ci.openshift.org/ocp/4.22:ovn-kubernetes-base',
+            ]
+            mock_dfp.return_value = mock_dfp_instance
+            metadata.determine_targets = MagicMock(return_value=['target-1'])
+
+            # Should detect el9 from the primary builder, not el8 from the compat builder
+            metadata._apply_alternative_upstream_config()
+
+    @patch('doozerlib.image.SourceResolver')
+    @patch('builtins.open', create=True)
+    @patch('pathlib.Path.joinpath')
     @patch('doozerlib.image.util.oc_image_info_for_arch', side_effect=Exception('image not accessible'))
     def test_apply_alternative_upstream_config_undetermined_rhel_version(
         self, mock_oc_image_info, mock_joinpath, mock_open, mock_source_resolver


### PR DESCRIPTION
## Summary
- Changes `_determine_upstream_builder_info()` to iterate **forward** through parent images instead of reverse
- Fixes ovn-kubernetes incorrectly detecting el8 from its rhel-8 compatibility builder (used only for upgrade shim binaries), when the primary builder is rhel-9
- Adds test for the ovn-kubernetes multi-builder pattern

## Context
Build 32185 of ocp4-konflux failed with:
```
OSError: [ose-ovn-kubernetes] Upstream uses el8 but ART uses el9, and no matching alternative_upstream config was found.
```

The ovn-kubernetes Dockerfile has three FROM stages:
1. `rhel-9-golang-1.25` (primary builder)
2. `rhel-8-golang-1.25` (compatibility shim for upgrades from OCP 4.12)
3. `ovn-kubernetes-base` (runtime base, no RHEL tag)

Reverse iteration tried `ovn-kubernetes-base` (no match), then `rhel-8-golang` (matched el8 — wrong). Forward iteration correctly finds `rhel-9-golang` first.

## Test plan
- [x] Existing `test_determine_upstream_rhel_version_fallback_to_builder` still passes (aws-efs-utils pattern)
- [x] New `test_determine_upstream_rhel_version_skips_compat_builder` covers ovn-kubernetes pattern
- [x] `test_apply_alternative_upstream_config_undetermined_rhel_version` covers deployer pattern
- [ ] Trigger ocp4-konflux build with `ART_TOOLS_COMMIT=locriandev@fix-ovn-rhel-detection` to verify no OSError for ose-ovn-kubernetes

🤖 Generated with [Claude Code](https://claude.com/claude-code)