### PR TITLE
prepare-release-konflux: pass --registry-config to elliott/doozer

### DIFF
--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -21,13 +21,17 @@ import click
 import semver
 from artcommonlib import exectools
 from artcommonlib.assembly import AssemblyTypes, assembly_config_struct, assembly_group_config
-from artcommonlib.constants import SHIPMENT_DATA_URL_TEMPLATE
+from artcommonlib.constants import (
+    REGISTRY_QUAY_OCP_RELEASE_DEV,
+    SHIPMENT_DATA_URL_TEMPLATE,
+)
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.gitlab import GitLabClient
 from artcommonlib.jira_config import JIRA_EMAIL
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBundleBuildRecord
 from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.model import Model
+from artcommonlib.registry_config import RegistryConfig
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import convert_remote_git_to_ssh, new_roundtrip_yaml_handler
 from doozerlib.backend.konflux_client import API_VERSION, KIND_SNAPSHOT
@@ -216,6 +220,36 @@ class PrepareReleaseKonfluxPipeline:
     async def run(self):
         await self.initialize()
 
+        quay_auth_file = os.getenv('QUAY_AUTH_FILE')
+        if not quay_auth_file:
+            raise ValueError(
+                "QUAY_AUTH_FILE environment variable is required but not set. "
+                "Ensure Jenkins credentials are properly bound."
+            )
+
+        source_files = [quay_auth_file]
+        redhat_registry_auth_file = os.getenv('KONFLUX_OPERATOR_INDEX_AUTH_FILE')
+        if redhat_registry_auth_file:
+            source_files.append(redhat_registry_auth_file)
+
+        with RegistryConfig(
+            kubeconfig=os.environ.get('KUBECONFIG'),
+            source_files=source_files,
+            registries=[
+                REGISTRY_QUAY_OCP_RELEASE_DEV,
+            ],
+        ) as global_auth_file:
+            self._elliott_base_command.append(f'--registry-config={global_auth_file}')
+            self._doozer_base_command.append(f'--registry-config={global_auth_file}')
+
+            self.logger.info(
+                f'Set registry auth file={global_auth_file} for pipeline operations '
+                f'(cherry-picked from {len(source_files)} source file(s))'
+            )
+
+            await self._run_pipeline()
+
+    async def _run_pipeline(self):
         # Check advisory stage policy early for fail-fast behavior
         await self.check_advisory_stage_policy(self.assembly_type)
 

--- a/pyartcd/tests/pipelines/test_prepare_release_konflux.py
+++ b/pyartcd/tests/pipelines/test_prepare_release_konflux.py
@@ -919,8 +919,10 @@ class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
     @patch.object(PrepareReleaseKonfluxPipeline, 'check_blockers', new_callable=AsyncMock)
     @patch.object(PrepareReleaseKonfluxPipeline, 'check_advisory_stage_policy', new_callable=AsyncMock)
     @patch.object(PrepareReleaseKonfluxPipeline, 'initialize', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.prepare_release_konflux.RegistryConfig')
     async def test_run_exits_unstable_when_deferred_build_failures_exist(
         self,
+        mock_registry_config,
         mock_initialize,
         mock_check_advisory_stage_policy,
         mock_check_blockers,
@@ -932,6 +934,9 @@ class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
         mock_verify_payload,
         mock_report_deferred_build_failures,
     ):
+        mock_registry_config.return_value.__enter__ = Mock(return_value='/tmp/fake-auth.json')
+        mock_registry_config.return_value.__exit__ = Mock(return_value=False)
+
         pipeline = PrepareReleaseKonfluxPipeline(
             slack_client=self.mock_slack_client,
             runtime=self.runtime,
@@ -941,8 +946,9 @@ class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
         pipeline.assembly_type = AssemblyTypes.STANDARD
         pipeline.bundle_build_errors = ["bundle build failed for operator=test-operator: boom"]
 
-        with self.assertRaises(SystemExit) as cm:
-            await pipeline.run()
+        with patch.dict('os.environ', {'QUAY_AUTH_FILE': '/tmp/fake-quay-auth.json'}):
+            with self.assertRaises(SystemExit) as cm:
+                await pipeline.run()
         self.assertEqual(cm.exception.code, 2)
 
         mock_initialize.assert_awaited_once()


### PR DESCRIPTION
The pipeline's oc image info calls fail with "unauthorized" on quay.io/openshift-release-dev because QUAY_AUTH_FILE credentials aren't at any default auth path oc checks. Use RegistryConfig to create a merged auth file and pass it via --registry-config, matching the fix already applied to ocp4-konflux.