### PR TITLE
prepare-release-konflux: unset XDG_RUNTIME_DIR for registry auth

### DIFF
--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -220,6 +220,10 @@ class PrepareReleaseKonfluxPipeline:
     async def run(self):
         await self.initialize()
 
+        if 'XDG_RUNTIME_DIR' in os.environ:
+            self.logger.info('Unsetting XDG_RUNTIME_DIR to prevent use of default registry auth')
+            del os.environ['XDG_RUNTIME_DIR']
+
         quay_auth_file = os.getenv('QUAY_AUTH_FILE')
         if not quay_auth_file:
             raise ValueError(


### PR DESCRIPTION
## Summary
- Unset `XDG_RUNTIME_DIR` before setting up `RegistryConfig` in prepare-release-konflux, matching the pattern used in ocp4-konflux
- Prevents `oc` from picking up stale/incorrect credentials from the default `$XDG_RUNTIME_DIR/containers/auth.json` path

## Test plan
- [ ] Run prepare-release-konflux pipeline and verify no registry auth errors
- [ ] Confirm verify-payload completes successfully against quay.io/openshift-release-dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)