### PR TITLE
build-sync, gen-payload, gen-assembly: use RegistryConfig for explicit registry auth

### DIFF
--- a/doozer/doozerlib/cli/release_gen_assembly.py
+++ b/doozer/doozerlib/cli/release_gen_assembly.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import re
 import sys
 from datetime import datetime
@@ -168,7 +167,6 @@ async def gen_assembly_from_releases(
         suggestions_url=suggestions_url,
         gen_microshift=gen_microshift,
         release_date=date,
-        registry_config=os.getenv("QUAY_AUTH_FILE"),
     ).run()
 
     # ruamel.yaml configuration
@@ -207,10 +205,8 @@ class GenAssemblyCli:
         suggestions_url: Optional[str] = None,
         gen_microshift: bool = False,
         release_date: Optional[str] = None,
-        registry_config: str = None,
     ):
         self.runtime = runtime
-        self.registry_config = registry_config
         # The name of the assembly we are going to output
         self.gen_assembly_name = gen_assembly_name
         self.nightlies = nightlies
@@ -362,7 +358,7 @@ class GenAssemblyCli:
             image_info = await util.oc_image_info_for_arch_async(
                 payload_tag_pullspec,
                 go_arch_for_brew_arch(brew_cpu_arch),
-                registry_config=self.registry_config,
+                registry_config=self.runtime.registry_config,
             )
             if payload_tag_name in rhcos_tag_names:
                 self.runtime.logger.info(f'Record rhcos tag name {payload_tag_name}')
@@ -377,7 +373,7 @@ class GenAssemblyCli:
 
             # Use shared utility to extract NVR and get build inspector
             name, version, release_ver = await release_inspector.extract_nvr_from_pullspec(
-                payload_tag_pullspec, registry_config=self.registry_config
+                payload_tag_pullspec, registry_config=self.runtime.registry_config
             )
             package_name = name
             build_nvr = f"{name}-{version}-{release_ver}"
@@ -616,7 +612,7 @@ class GenAssemblyCli:
                         amd64_rhcos_info = util.oc_image_info_for_arch(
                             self.rhcos_by_tag[tag.name]["x86_64"],
                             "amd64",
-                            registry_config=self.registry_config,
+                            registry_config=self.runtime.registry_config,
                         )
                         # NOTE: RHCOS images are currently always in ocp-v4.0-art-dev, even for OCP 5.x.
                         # When RHCOS 5.x images exist in their own repository, this should be updated to
@@ -625,7 +621,7 @@ class GenAssemblyCli:
                         rhcos_info = util.oc_image_info_for_arch(
                             f"{art_repo}:{amd64_rhcos_info['config']['config']['Labels']['coreos.build.manifest-list-tag']}",
                             go_arch_for_brew_arch(arch),
-                            registry_config=self.registry_config,
+                            registry_config=self.runtime.registry_config,
                         )
                         self.rhcos_by_tag[tag.name][arch] = f"{art_repo}@{rhcos_info['digest']}"
                         self.logger.info(f'Find RHCOS image {tag.name} for {arch}: {self.rhcos_by_tag[tag.name][arch]}')

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -1435,8 +1435,9 @@ class GenPayloadCli:
                 'login',
                 '--registry',
                 'quay.io/redhat-user-workloads',
-                f'--registry-config={self.runtime.registry_config}',
             ]
+            if self.runtime.registry_config:
+                cmd.append(f'--registry-config={self.runtime.registry_config}')
             await exectools.cmd_assert_async(cmd)
 
         for payload_entry in payload_entries.values():
@@ -1477,7 +1478,7 @@ class GenPayloadCli:
                     '--continue-on-error',
                     f'--filename={str(src_dest_path)}',
                 ]
-                if self.runtime.build_system == 'konflux':
+                if self.runtime.build_system == 'konflux' and self.runtime.registry_config:
                     cmd.append(f'--registry-config={self.runtime.registry_config}')
                 await asyncio.wait_for(exectools.cmd_assert_async(cmd), timeout=7200)
 

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -628,7 +628,6 @@ class GenPayloadCli:
             suggestions_url=None,
             gen_microshift=False,
             release_date=dummy_release_date,  # Prevent release schedule lookup
-            registry_config=os.getenv("QUAY_AUTH_FILE"),
         )
 
         # Run gen-assembly logic to create the assembly definition
@@ -1101,7 +1100,7 @@ class GenPayloadCli:
 
         public_entries_for_arch: Dict[str, Dict[str, PayloadEntry]] = dict()  # arch => img tag => PayloadEntry
         private_entries_for_arch: Dict[str, Dict[str, PayloadEntry]] = dict()  # arch => img tag => PayloadEntry
-        registry_config = os.getenv("QUAY_AUTH_FILE")
+        registry_config = self.runtime.registry_config
 
         arches = (
             self.runtime.group_config.konflux.arches if self.runtime.build_system == 'konflux' else self.runtime.arches
@@ -1436,7 +1435,7 @@ class GenPayloadCli:
                 'login',
                 '--registry',
                 'quay.io/redhat-user-workloads',
-                f'--registry-config={os.getenv("QUAY_AUTH_FILE")}',
+                f'--registry-config={self.runtime.registry_config}',
             ]
             await exectools.cmd_assert_async(cmd)
 
@@ -1479,7 +1478,7 @@ class GenPayloadCli:
                     f'--filename={str(src_dest_path)}',
                 ]
                 if self.runtime.build_system == 'konflux':
-                    cmd.append(f'--registry-config={os.getenv("QUAY_AUTH_FILE")}')
+                    cmd.append(f'--registry-config={self.runtime.registry_config}')
                 await asyncio.wait_for(exectools.cmd_assert_async(cmd), timeout=7200)
 
         # Mirror the images in chunks to avoid erroring out due to possible registry issues
@@ -1960,10 +1959,10 @@ class GenPayloadCli:
         # write the manifest list to a file and push it to the registry.
         async with aiofiles.open(component_manifest_path, mode="w+") as ml:
             await ml.write(yaml.safe_dump(dict(image=output_pullspec, manifests=manifests), default_flow_style=False))
-        await manifest_tool(f'push from-spec {str(component_manifest_path)}', auth_file=os.getenv("QUAY_AUTH_FILE"))
+        await manifest_tool(f'push from-spec {str(component_manifest_path)}', auth_file=self.runtime.registry_config)
 
         # we are pushing a new manifest list, so return its sha256 based pullspec
-        sha = await find_manifest_list_sha(output_pullspec, registry_config=os.getenv("QUAY_AUTH_FILE"))
+        sha = await find_manifest_list_sha(output_pullspec, registry_config=self.runtime.registry_config)
         return exchange_pullspec_tag_for_shasum(output_pullspec, sha)
 
     async def create_multi_release_image(
@@ -2004,9 +2003,8 @@ class GenPayloadCli:
                 "--metadata",
                 json.dumps({"release.openshift.io/architecture": "multi"}),
             ]
-            registry_config = os.getenv("QUAY_AUTH_FILE")
-            if registry_config:
-                cmd.append(f"--registry-config={registry_config}")
+            if self.runtime.registry_config:
+                cmd.append(f"--registry-config={self.runtime.registry_config}")
             return await exectools.cmd_assert_async(cmd)
 
         # This will map arch names to a release payload pullspec we create for that arch
@@ -2059,10 +2057,10 @@ class GenPayloadCli:
         async with aiofiles.open(release_payload_ml_path, mode="w+") as ml:
             await ml.write(yaml.safe_dump(ml_dict, default_flow_style=False))
 
-        await manifest_tool(f'push from-spec {str(release_payload_ml_path)}', auth_file=os.getenv("QUAY_AUTH_FILE"))
+        await manifest_tool(f'push from-spec {str(release_payload_ml_path)}', auth_file=self.runtime.registry_config)
 
         # if we are actually pushing a manifest list, then we should derive a sha256 based pullspec
-        sha = await find_manifest_list_sha(multi_release_dest, registry_config=os.getenv("QUAY_AUTH_FILE"))
+        sha = await find_manifest_list_sha(multi_release_dest, registry_config=self.runtime.registry_config)
         return exchange_pullspec_tag_for_shasum(multi_release_dest, sha)
 
     async def apply_multi_imagestream_update(
@@ -2844,7 +2842,7 @@ class PayloadGenerator:
 
         payload_entries: Dict[str, PayloadEntry]
         issues: List[AssemblyIssue]
-        registry_config = os.getenv("QUAY_AUTH_FILE")
+        registry_config = self.runtime.registry_config
         payload_entries, issues = self.find_payload_entries(
             assembly_inspector, arch, "", registry_config=registry_config
         )

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -867,8 +867,8 @@ spec:
     @patch("artcommonlib.exectools.cmd_assert_async")
     @patch("aiofiles.open")
     async def test_create_multi_manifest_list(self, open_mock, exec_mock, fmlsha_mock):
-        with patch.dict(os.environ, {"QUAY_AUTH_FILE": "/tmp/quay-auth.json"}, clear=True):
-            runtime = MagicMock(uuid="uuid")
+        with patch.dict(os.environ, {}, clear=True):
+            runtime = MagicMock(uuid="uuid", registry_config="/tmp/quay-auth.json")
             gpcli = rgp_cli.GenPayloadCli(runtime, output_dir="/tmp", organization="org", repository="repo")
 
             buffer = io.StringIO()
@@ -907,7 +907,8 @@ spec:
     @patch("artcommonlib.exectools.cmd_assert_async")
     @patch("pathlib.Path.open")
     async def test_create_multi_release_images(self, open_mock, exec_mock):
-        gpcli = flexmock(rgp_cli.GenPayloadCli(output_dir="/tmp"))
+        runtime = MagicMock(registry_config="/tmp/quay-auth.json")
+        gpcli = flexmock(rgp_cli.GenPayloadCli(runtime, output_dir="/tmp"))
 
         exec_mock.return_value = None  # do not actually execute command
         cmgr = MagicMock(__enter__=lambda _: io.StringIO())  # mock Path.open()
@@ -937,8 +938,9 @@ spec:
     async def test_create_multi_release_manifest_list(
         self, open_mock, exec_mock, mirror_payload_content_mock, fmlsha_mock
     ):
-        with patch.dict(os.environ, {"QUAY_AUTH_FILE": "/tmp/quay-auth.json"}, clear=True):
-            gpcli = rgp_cli.GenPayloadCli(output_dir="/tmp")
+        with patch.dict(os.environ, {}, clear=True):
+            runtime = MagicMock(registry_config="/tmp/quay-auth.json")
+            gpcli = rgp_cli.GenPayloadCli(runtime, output_dir="/tmp")
 
             exec_mock.return_value = None  # do not actually execute command
             buffer = io.StringIO()

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -8,7 +8,11 @@ import click
 import yaml
 from artcommonlib import exectools, redis, rhcos
 from artcommonlib.arch_util import go_arch_for_brew_arch, go_suffix_for_arch
-from artcommonlib.constants import REGISTRY_CI_OPENSHIFT, REGISTRY_QUAY_OCP_RELEASE_DEV
+from artcommonlib.constants import (
+    KONFLUX_DEFAULT_IMAGE_REPO,
+    REGISTRY_CI_OPENSHIFT,
+    REGISTRY_QUAY_OCP_RELEASE_DEV,
+)
 from artcommonlib.exectools import limit_concurrency
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.redis import RedisError
@@ -164,6 +168,7 @@ class BuildSyncPipeline:
             source_files=source_files,
             registries=[
                 REGISTRY_QUAY_OCP_RELEASE_DEV,
+                KONFLUX_DEFAULT_IMAGE_REPO,
                 REGISTRY_CI_OPENSHIFT,
             ],
         ) as global_auth_file:

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -8,9 +8,11 @@ import click
 import yaml
 from artcommonlib import exectools, redis, rhcos
 from artcommonlib.arch_util import go_arch_for_brew_arch, go_suffix_for_arch
+from artcommonlib.constants import REGISTRY_CI_OPENSHIFT, REGISTRY_QUAY_OCP_RELEASE_DEV
 from artcommonlib.exectools import limit_concurrency
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.redis import RedisError
+from artcommonlib.registry_config import RegistryConfig
 from artcommonlib.release_util import SoftwareLifecyclePhase
 from artcommonlib.telemetry import start_as_current_span_async
 from artcommonlib.util import split_git_url, uses_konflux_imagestream_override
@@ -80,6 +82,8 @@ class BuildSyncPipeline:
         self.slack_client = self.runtime.new_slack_client()
         self.slack_client.bind_channel(f'openshift-{self.version}')
 
+        self._registry_config: str | None = None
+
         # Imagestream name for Brew builds is 4.y-art-latest
         # For konflux, it is 4.y-konflux-art-latest
         self.is_base_name = (
@@ -143,6 +147,38 @@ class BuildSyncPipeline:
 
     @start_as_current_span_async(TRACER, "build-sync.run")
     async def run(self):
+        if 'XDG_RUNTIME_DIR' in os.environ:
+            self.logger.info('Unsetting XDG_RUNTIME_DIR to prevent use of default registry auth')
+            del os.environ['XDG_RUNTIME_DIR']
+
+        quay_auth_file = os.getenv('QUAY_AUTH_FILE')
+        if not quay_auth_file:
+            raise ValueError(
+                "QUAY_AUTH_FILE environment variable is required but not set. "
+                "Ensure Jenkins credentials are properly bound."
+            )
+
+        source_files = [quay_auth_file]
+
+        with RegistryConfig(
+            kubeconfig=os.environ.get('KUBECONFIG'),
+            source_files=source_files,
+            registries=[
+                REGISTRY_QUAY_OCP_RELEASE_DEV,
+                REGISTRY_CI_OPENSHIFT,
+            ],
+        ) as global_auth_file:
+            self._registry_config = global_auth_file
+
+            self.logger.info(
+                'Set registry auth file=%s for pipeline operations (cherry-picked from %d source file(s))',
+                global_auth_file,
+                len(source_files),
+            )
+
+            await self._run_pipeline()
+
+    async def _run_pipeline(self):
         current_span = trace.get_current_span()
         current_span.set_attribute("build-sync.version", self.version)
         current_span.set_attribute("build-sync.assembly", self.assembly)
@@ -162,23 +198,19 @@ class BuildSyncPipeline:
             jenkins.update_title(' [KONFLUX]')
 
         if self.assembly not in ('stream', 'test') and not self.runtime.dry_run:
-            # Comment on PR if triggered from gen assembly
             text_body = f"Build sync job [run]({self.job_run}) has been triggered"
             await self.comment_on_assembly_pr(text_body)
 
         # Make sure we're logged into the OC registry
         await registry_login()
 
-        # Should we retrigger current nightly?
         if self.retrigger_current_nightly:
             await self._retrigger_current_nightlies()
             return
 
-        # Backup imagestreams
         self.logger.info('Backup all imagestreams...')
         await self._backup_all_imagestreams()
 
-        # Update nightly imagestreams
         self.logger.info('Update nightly imagestreams...')
         await self._update_nightly_imagestreams()
 
@@ -433,6 +465,8 @@ class BuildSyncPipeline:
             group_param += f'@{self.doozer_data_gitref}'
         cmd.append(group_param)
         cmd.append(f'--build-system={self.build_system}')
+        if self._registry_config:
+            cmd.append(f'--registry-config={self._registry_config}')
         cmd.extend(
             [
                 'release:gen-payload',
@@ -485,6 +519,8 @@ class BuildSyncPipeline:
                 f'oc adm release new --to-image={image} --name {name} '
                 f'--reference-mode=source -n {namespace} --from-image-stream {meta["name"]}'
             )
+            if self._registry_config:
+                cmd += f' --registry-config={self._registry_config}'
 
             if self.runtime.dry_run:
                 self.logger.info('Would have created the release image as follows: %s', cmd)

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -21,7 +21,6 @@ from opentelemetry import trace
 from pyartcd import constants, jenkins, locks
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.jenkins import get_build_url
-from pyartcd.oc import registry_login
 from pyartcd.runtime import GroupRuntime, Runtime
 from pyartcd.util import branch_arches
 
@@ -200,9 +199,6 @@ class BuildSyncPipeline:
         if self.assembly not in ('stream', 'test') and not self.runtime.dry_run:
             text_body = f"Build sync job [run]({self.job_run}) has been triggered"
             await self.comment_on_assembly_pr(text_body)
-
-        # Make sure we're logged into the OC registry
-        await registry_login()
 
         if self.retrigger_current_nightly:
             await self._retrigger_current_nightlies()


### PR DESCRIPTION
Wrap build_sync.run() with RegistryConfig context manager to create a
temporary merged auth file with cherry-picked credentials, replacing
reliance on QUAY_AUTH_FILE env var. Pass --registry-config to doozer
and oc commands so the auth flows through the entire pipeline.

In doozer, replace all os.getenv("QUAY_AUTH_FILE") calls in
release_gen_payload.py (10 occurrences) and release_gen_assembly.py
(4 occurrences) with self.runtime.registry_config, which is set from
the --registry-config CLI flag with fallback to QUAY_AUTH_FILE.

Remove the registry_config parameter from GenAssemblyCli since it now
reads from runtime.registry_config directly.

Test builds:
- https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgen-assembly/1148/
- https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync-konflux/19209/