### PR TITLE
ART-14734 Late resolve canonical builders

### DIFF
--- a/doozer/doozerlib/cli/scan_sources.py
+++ b/doozer/doozerlib/cli/scan_sources.py
@@ -83,7 +83,7 @@ class ConfigScanSources:
         await self.generate_report()
 
     def _is_meta_enabled(self, meta: Metadata) -> bool:
-        return meta.enabled or meta.mode == "disabled" and self.runtime.load_disabled
+        return meta.enabled or (meta.mode == "disabled" and self.runtime.load_disabled)
 
     def _skip_image(self, image_meta: ImageMetadata, issue: str) -> None:
         if image_meta.distgit_key in self.skipped_image_dgks:

--- a/doozer/doozerlib/cli/scan_sources.py
+++ b/doozer/doozerlib/cli/scan_sources.py
@@ -89,6 +89,11 @@ class ConfigScanSources:
         if image_meta.distgit_key in self.skipped_image_dgks:
             return
         self.skipped_image_dgks.add(image_meta.distgit_key)
+        self.changing_image_metas = {
+            meta for meta in self.changing_image_metas if meta.distgit_key != image_meta.distgit_key
+        }
+        qualified_key = getattr(image_meta, "qualified_key", image_meta.distgit_key)
+        self.assessment_reason.pop(f'{qualified_key}+True', None)
         self.runtime.logger.warning("[%s] %s", image_meta.distgit_key, issue)
         self.issues.append({"name": image_meta.distgit_key, "issue": issue})
 
@@ -590,9 +595,13 @@ class ConfigScanSources:
             self.assessment_reason[key] = rebuild_hint.reason
 
     def add_image_meta_change(self, meta: ImageMetadata, rebuild_hint: RebuildHint):
+        if meta.distgit_key in self.skipped_image_dgks:
+            return
         self.changing_image_metas.add(meta)
         self.add_assessment_reason(meta, rebuild_hint)
         for descendant_meta in meta.get_descendants():
+            if descendant_meta.distgit_key in self.skipped_image_dgks:
+                continue
             self.changing_image_metas.add(descendant_meta)
             self.add_assessment_reason(
                 descendant_meta,
@@ -601,9 +610,13 @@ class ConfigScanSources:
 
     async def generate_report(self):
         image_results = []
-        changing_image_dgks = [meta.distgit_key for meta in self.changing_image_metas]
+        changing_image_dgks = {
+            meta.distgit_key for meta in self.changing_image_metas if meta.distgit_key not in self.skipped_image_dgks
+        }
         for image_meta in self.all_image_metas:
             dgk = image_meta.distgit_key
+            if dgk in self.skipped_image_dgks:
+                continue
             is_changing = dgk in changing_image_dgks
             if is_changing:
                 image_results.append(

--- a/doozer/doozerlib/cli/scan_sources.py
+++ b/doozer/doozerlib/cli/scan_sources.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from datetime import datetime, timezone
-from typing import List, Optional, Tuple
+from typing import Optional, Set
 
 import artcommonlib.util
 import click
@@ -37,6 +37,7 @@ class ConfigScanSources:
         self.changing_rpm_packages = set()
         self.assessment_reason = dict()  # maps metadata qualified_key => message describing change
         self.issues = list()  # tracks issues that arose during the scan, which did not interrupt the job
+        self.skipped_image_dgks: Set[str] = set()
 
         self.all_rpm_metas = set(runtime.rpm_metas())
         self.all_image_metas = set(runtime.image_metas())
@@ -80,6 +81,40 @@ class ConfigScanSources:
 
         # We have our information. Now build and print the output report
         await self.generate_report()
+
+    def _is_meta_enabled(self, meta: Metadata) -> bool:
+        return meta.enabled or meta.mode == "disabled" and self.runtime.load_disabled
+
+    def _skip_image(self, image_meta: ImageMetadata, issue: str) -> None:
+        if image_meta.distgit_key in self.skipped_image_dgks:
+            return
+        self.skipped_image_dgks.add(image_meta.distgit_key)
+        self.runtime.logger.warning("[%s] %s", image_meta.distgit_key, issue)
+        self.issues.append({"name": image_meta.distgit_key, "issue": issue})
+
+    def _prepare_image_for_scan(self, image_meta: ImageMetadata, phase: str) -> bool:
+        if image_meta.distgit_key in self.skipped_image_dgks:
+            return False
+        if not self._is_meta_enabled(image_meta):
+            return False
+        try:
+            image_meta.ensure_canonical_builders_resolved()
+        except Exception as err:
+            self._skip_image(image_meta, f"Failed resolving canonical builders before {phase}: {err}")
+            return False
+        return True
+
+    def _handle_image_scan_exception(self, image_meta: ImageMetadata, phase: str, err: Exception) -> None:
+        issue = f"Failed scanning image during {phase}: {err}"
+        self._skip_image(image_meta, issue)
+
+    def _scan_meta_for_upstream_changes(self, meta: Metadata):
+        if meta.meta_type == "image" and not self._prepare_image_for_scan(meta, "upstream commit checks"):
+            return meta, None, None
+        try:
+            return meta, meta.needs_rebuild(), None
+        except Exception as err:
+            return meta, None, err
 
     def _try_reconciliation(self, metadata: Metadata, repo_name: str, pub_branch_name: str, priv_branch_name: str):
         reconciled = False
@@ -290,15 +325,22 @@ class ConfigScanSources:
         # Determine if the current upstream source commit hash has a downstream build associated with it.
         # Result is a list of tuples, where each tuple contains an rpm or image metadata
         # and a change tuple (changed: bool, message: str).
-        upstream_changes: List[Tuple[Metadata, RebuildHint]] = exectools.parallel_exec(
-            lambda image_meta, _: (image_meta, image_meta.needs_rebuild()),
+        upstream_changes = exectools.parallel_exec(
+            lambda meta, _: self._scan_meta_for_upstream_changes(meta),
             self.all_metas,
             n_threads=20,
         ).get()
 
-        for meta, rebuild_hint in upstream_changes:
+        for meta, rebuild_hint, err in upstream_changes:
+            if err:
+                if meta.meta_type == 'image':
+                    self._handle_image_scan_exception(meta, 'upstream commit checks', err)
+                    continue
+                raise err
+            if rebuild_hint is None:
+                continue
             dgk = meta.distgit_key
-            if not (meta.enabled or meta.mode == "disabled" and self.runtime.load_disabled):
+            if not self._is_meta_enabled(meta):
                 # An enabled image's dependents are always loaded.
                 # Ignore disabled configs unless explicitly indicated
                 continue
@@ -352,27 +394,33 @@ class ConfigScanSources:
 
     async def check_for_image_changes(self, koji_api):
         async def _inner(image_meta):
+            if not self._prepare_image_for_scan(image_meta, "image change checks"):
+                return
+
             # If a rebuild is already requested, skip following checks
             if image_meta in self.changing_image_metas:
                 return
 
-            build_info = await image_meta.get_latest_build(default=None, exclude_large_columns=True)
+            try:
+                build_info = await image_meta.get_latest_build(default=None, exclude_large_columns=True)
 
-            if build_info is None:
-                return
+                if build_info is None:
+                    return
 
-            # To limit the size of the queries we are going to make, find the oldest and newest image
-            self.find_oldest_newest(koji_api, build_info)
+                # To limit the size of the queries we are going to make, find the oldest and newest image
+                self.find_oldest_newest(koji_api, build_info)
 
-            # Request a rebuild if A is a dependent (operator or child image) of B
-            # but the latest build of A is older than B.
-            self.check_dependents(image_meta, build_info)
+                # Request a rebuild if A is a dependent (operator or child image) of B
+                # but the latest build of A is older than B.
+                self.check_dependents(image_meta, build_info)
 
-            # If no upstream change has been detected, check configurations
-            # like image meta, repos, and streams to see if they have changed
-            # We detect config changes by comparing their digest changes.
-            # The config digest of the previous build is stored at .oit/config_digest on distgit repo.
-            self.check_config_changes(image_meta, build_info)
+                # If no upstream change has been detected, check configurations
+                # like image meta, repos, and streams to see if they have changed
+                # We detect config changes by comparing their digest changes.
+                # The config digest of the previous build is stored at .oit/config_digest on distgit repo.
+                self.check_config_changes(image_meta, build_info)
+            except Exception as err:
+                self._handle_image_scan_exception(image_meta, 'image change checks', err)
 
         await asyncio.gather(*[_inner(image_meta) for image_meta in self.runtime.image_metas()])
 
@@ -413,19 +461,25 @@ class ConfigScanSources:
                 )
                 return
 
-            dep_info = dep.get_latest_brew_build(default=None)
-            if not dep_info:
+            if not self._prepare_image_for_scan(dep, "dependency checks"):
                 return
 
-            dep_rebase_time = release_util.isolate_timestamp_in_release(dep_info["release"])
-            if not dep_rebase_time:  # no timestamp string in NVR?
-                return
+            try:
+                dep_info = dep.get_latest_brew_build(default=None)
+                if not dep_info:
+                    return
 
-            dep_rebase_time = datetime.strptime(dep_rebase_time, "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
-            if dep_rebase_time > rebase_time:
-                self.add_image_meta_change(
-                    image_meta, RebuildHint(RebuildHintCode.DEPENDENCY_NEWER, 'Dependency has a newer build')
-                )
+                dep_rebase_time = release_util.isolate_timestamp_in_release(dep_info["release"])
+                if not dep_rebase_time:  # no timestamp string in NVR?
+                    return
+
+                dep_rebase_time = datetime.strptime(dep_rebase_time, "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
+                if dep_rebase_time > rebase_time:
+                    self.add_image_meta_change(
+                        image_meta, RebuildHint(RebuildHintCode.DEPENDENCY_NEWER, 'Dependency has a newer build')
+                    )
+            except Exception as err:
+                self._handle_image_scan_exception(dep, 'dependency checks', err)
 
         exectools.parallel_exec(
             f=lambda dep, _: _check_dep(dep),
@@ -477,12 +531,18 @@ class ConfigScanSources:
         # because we are about to rebuild it.
 
         async def _thread_does_image_need_change(image_meta):
-            return await image_meta.does_image_need_change(
-                changing_rpm_packages=self.changing_rpm_packages,
-                buildroot_tag=image_meta.build_root_tag(),
-                newest_image_event_ts=self.newest_image_event_ts,
-                oldest_image_event_ts=self.oldest_image_event_ts,
-            )
+            if not self._prepare_image_for_scan(image_meta, "RPM impact checks"):
+                return None
+            try:
+                return await image_meta.does_image_need_change(
+                    changing_rpm_packages=self.changing_rpm_packages,
+                    buildroot_tag=image_meta.build_root_tag(),
+                    newest_image_event_ts=self.newest_image_event_ts,
+                    oldest_image_event_ts=self.oldest_image_event_ts,
+                )
+            except Exception as err:
+                self._handle_image_scan_exception(image_meta, 'RPM impact checks', err)
+                return None
 
         change_results = await asyncio.gather(
             *[_thread_does_image_need_change(image_meta) for image_meta in self.runtime.image_metas()],
@@ -501,6 +561,8 @@ class ConfigScanSources:
         while True:
             changing_image_dgks = [meta.distgit_key for meta in self.changing_image_metas]
             for image_meta in self.all_image_metas:
+                if not self._prepare_image_for_scan(image_meta, "builder change checks"):
+                    continue
                 dgk = image_meta.distgit_key
                 if dgk in changing_image_dgks:  # Already in? Don't look any further
                     continue
@@ -777,10 +839,7 @@ async def config_scan_source_changes(runtime: Runtime, ci_kubeconfig, as_yaml, r
     # Initialize group config: we need this to determine the canonical builders behavior
     runtime.initialize(config_only=True)
 
-    if runtime.group_config.canonical_builders_from_upstream and runtime.build_system == 'brew':
-        runtime.initialize(mode="both", clone_distgits=True)
-    else:
-        runtime.initialize(mode='both', clone_distgits=False)
+    runtime.initialize(mode='both', clone_distgits=False)
 
     await ConfigScanSources(runtime, ci_kubeconfig, as_yaml, rebase_priv, dry_run).run()
 

--- a/doozer/doozerlib/cli/scan_sources.py
+++ b/doozer/doozerlib/cli/scan_sources.py
@@ -836,9 +836,6 @@ async def config_scan_source_changes(runtime: Runtime, ci_kubeconfig, as_yaml, r
     It will report RHCOS updates available per imagestream.
     """
 
-    # Initialize group config: we need this to determine the canonical builders behavior
-    runtime.initialize(config_only=True)
-
     runtime.initialize(mode='both', clone_distgits=False)
 
     await ConfigScanSources(runtime, ci_kubeconfig, as_yaml, rebase_priv, dry_run).run()

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -111,6 +111,10 @@ class ConfigScanSources:
         if image_meta.distgit_key in self.skipped_image_names:
             return
         self.skipped_image_names.add(image_meta.distgit_key)
+        self.changing_image_names.discard(image_meta.distgit_key)
+        qualified_key = getattr(image_meta, "qualified_key", image_meta.distgit_key)
+        self.assessment_reason.pop(f'{qualified_key}+True', None)
+        self.assessment_code.pop(f'{qualified_key}+True', None)
         self.logger.warning("[%s] %s", image_meta.distgit_key, issue)
         self.issues.append({'name': image_meta.distgit_key, 'issue': issue})
 
@@ -1582,6 +1586,8 @@ class ConfigScanSources:
             self.assessment_code[key] = rebuild_hint.code
 
     def add_image_meta_change(self, meta: ImageMetadata, rebuild_hint: RebuildHint):
+        if meta.distgit_key in self.skipped_image_names:
+            return
         # If the rebuild hint does not require a rebuild, do nothing
         if not rebuild_hint.rebuild:
             return
@@ -1591,6 +1597,8 @@ class ConfigScanSources:
 
         # Mark all descendants for rebuild, so to prevent redundant scans
         for descendant_meta in meta.get_descendants():
+            if descendant_meta.distgit_key in self.skipped_image_names:
+                continue
             self.changing_image_names.add(descendant_meta.distgit_key)
             self.add_assessment_reason(
                 descendant_meta,
@@ -1785,7 +1793,10 @@ class ConfigScanSources:
 
         # Filter out images that are disabled or wip at the konflux level
         changing_image_names = list(
-            filter(lambda image_name: self.is_image_enabled(image_name), self.changing_image_names)
+            filter(
+                lambda image_name: image_name not in self.skipped_image_names and self.is_image_enabled(image_name),
+                self.changing_image_names,
+            )
         )
 
         # For non-openshift groups (layered products like oadp-1.4), find images
@@ -1798,6 +1809,8 @@ class ConfigScanSources:
 
         for image_meta in self.all_image_metas:
             dgk = image_meta.distgit_key
+            if dgk in self.skipped_image_names:
+                continue
             is_changing = dgk in changing_image_names
             if is_changing:
                 key = f'{image_meta.qualified_key}+{is_changing}'

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -97,6 +97,7 @@ class ConfigScanSources:
         self.assessment_reason = dict()  # maps metadata qualified_key => message describing change
         self.assessment_code = dict()  # maps metadata qualified_key => RebuildHintCode
         self.issues = list()  # tracks issues that arose during the scan, which did not interrupt the job
+        self.skipped_image_names: Set[str] = set()
 
         self.package_rpm_finder = PackageRpmFinder(runtime)
         self.latest_image_build_records_map: Dict[str, KonfluxBuildRecord] = {}
@@ -105,6 +106,23 @@ class ConfigScanSources:
         self.changing_rpm_names = set()
         self.rhcos_status = []
         self.current_task_bundles: Dict[str, str] = {}
+
+    def _skip_image(self, image_meta: ImageMetadata, issue: str) -> None:
+        if image_meta.distgit_key in self.skipped_image_names:
+            return
+        self.skipped_image_names.add(image_meta.distgit_key)
+        self.logger.warning("[%s] %s", image_meta.distgit_key, issue)
+        self.issues.append({'name': image_meta.distgit_key, 'issue': issue})
+
+    def _prepare_image_for_scan(self, image_meta: ImageMetadata, phase: str) -> bool:
+        if image_meta.distgit_key in self.skipped_image_names:
+            return False
+        try:
+            image_meta.ensure_canonical_builders_resolved()
+        except Exception as err:
+            self._skip_image(image_meta, f'Failed resolving canonical builders before {phase}: {err}')
+            return False
+        return True
 
     def _is_okd_enabled(self, image_meta: ImageMetadata) -> bool:
         """
@@ -533,7 +551,7 @@ class ConfigScanSources:
             tasks.extend([_find_target_build(rpm, f'el{target}') for target in rpm.determine_rhel_targets()])
         await asyncio.gather(*tasks)
 
-    async def find_latest_image_builds(self, image_names: List[str]):
+    async def find_latest_image_builds(self, image_names: List[str]) -> List[str]:
         self.logger.info('Gathering latest image build records information...')
         # For OCP, need installed_packages column for RPM analysis in scan_rpm_changes
         # For OKD, exclude large columns to reduce BigQuery cost (OKD doesn't check RPM changes)
@@ -543,31 +561,57 @@ class ConfigScanSources:
         # This is critical for OKD where images may have different el_targets (e.g., el9 vs el10)
         # than their upstream sources, preventing false change detection
         tasks = []
-        for name in image_names:
-            image_meta = self.runtime.image_map[name]
-            el_target = self._get_image_el_target(image_meta)
-            tasks.append(
-                image_meta.get_latest_build(
+        prepared_names = []
+
+        async def _find_latest_build(image_meta: ImageMetadata):
+            if not self._prepare_image_for_scan(image_meta, 'latest build lookup'):
+                return image_meta.distgit_key, None, None
+            try:
+                el_target = self._get_image_el_target(image_meta)
+                build_record = await image_meta.get_latest_build(
                     engine=Engine.KONFLUX.value,
                     exclude_large_columns=exclude_large_columns,
                     el_target=el_target,
                 )
-            )
+                return image_meta.distgit_key, build_record, None
+            except Exception as err:
+                return image_meta.distgit_key, None, err
+
+        for name in image_names:
+            image_meta = self.runtime.image_map[name]
+            tasks.append(_find_latest_build(image_meta))
 
         latest_image_builds = await asyncio.gather(*tasks)
-        self.latest_image_build_records_map.update((zip(image_names, latest_image_builds)))
+        for name, build_record, err in latest_image_builds:
+            if name in self.skipped_image_names:
+                continue
+            if err:
+                self._skip_image(
+                    self.runtime.image_map[name], f'Failed finding latest build during latest build lookup: {err}'
+                )
+                continue
+            self.latest_image_build_records_map[name] = build_record
+            prepared_names.append(name)
+
+        return prepared_names
 
     async def scan_images(self, image_names: List[str]):
         # Filter to only enabled images (variant-aware filtering is handled by _is_image_enabled)
         image_names = filter(lambda name: self._is_image_enabled(self.runtime.image_map[name]), image_names)
 
         # Do not scan images that have already been requested for rebuild
-        image_names = list(filter(lambda name: name not in self.changing_image_names, image_names))
+        image_names = list(
+            filter(
+                lambda name: name not in self.changing_image_names and name not in self.skipped_image_names, image_names
+            )
+        )
         if not image_names:
             return
 
         # Store latest build records in a map, to reduce DB queries and execution time
-        await self.find_latest_image_builds(image_names)
+        image_names = await self.find_latest_image_builds(image_names)
+        if not image_names:
+            return
 
         # Scan images for changes
         scanning_image_metas = [self.runtime.image_map[image_name] for image_name in image_names]
@@ -590,8 +634,10 @@ class ConfigScanSources:
 
     @skip_check_if_changing
     async def scan_image(self, image_meta: ImageMetadata):
-        stage = 'initialization'
+        stage = 'canonical builder resolution'
         try:
+            if not self._prepare_image_for_scan(image_meta, stage):
+                return
             self.logger.info(f'Scanning {image_meta.distgit_key} for changes')
             if image_meta.config.konflux is not Missing:
                 image_meta.config = Model(
@@ -646,7 +692,7 @@ class ConfigScanSources:
 
         except Exception as e:
             self.logger.exception('Failed scanning image %s during %s', image_meta.distgit_key, stage)
-            self.issues.append({'name': image_meta.distgit_key, 'issue': f'Failed scanning image during {stage}: {e}'})
+            self._skip_image(image_meta, f'Failed scanning image during {stage}: {e}')
 
     def find_upstream_commit_hash(self, meta: Metadata):
         """

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -494,6 +494,7 @@ class ImageDistGitRepo(DistGitRepo):
             # 1. we failed to determine upstream rhel version
             # 2. upstream and ART rhel versions match: in this case, alternative_upstream is ignored
             self._update_image_config()
+            self.metadata._mark_canonical_builders_resolved()
 
         # Initialize our distgit directory, if necessary
         if autoclone:
@@ -1921,6 +1922,7 @@ class ImageDistGitRepo(DistGitRepo):
             self.branch = self.config.distgit.branch
             # Also update metadata config
             self.metadata.config = self.config
+            self.metadata._mark_canonical_builders_resolved()
             self.metadata.targets = self.metadata.determine_targets()
 
     def rebase_from_directives(self, dfp):

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -44,6 +44,7 @@ from artcommonlib.util import (
     isolate_el_version_in_brew_tag,
     isolate_rhel_major_from_distgit_branch,
 )
+from artcommonlib.variants import BuildVariant
 from dockerfile_parse import DockerfileParser
 from tenacity import before_sleep_log, retry, retry_if_not_result, stop_after_attempt, wait_fixed
 
@@ -484,8 +485,10 @@ class ImageDistGitRepo(DistGitRepo):
         # (e.g., for commands like images:list that don't need this information)
         # This avoids expensive oc image info operations
         if self.metadata.canonical_builders_enabled and autoclone:
+            attempted_resolution = False
             # If the image is distgit-only, this logic does not apply
             if self.has_source():
+                attempted_resolution = True
                 source_path = self.runtime.source_resolver.resolve_source(self.metadata).source_path
                 self.art_intended_el_version = self._determine_art_rhel_version()
                 self.upstream_intended_el_version = self._determine_upstream_rhel_version(source_path)
@@ -493,8 +496,17 @@ class ImageDistGitRepo(DistGitRepo):
             # and find a related alternative_upstream config stanza. This won't happen if:
             # 1. we failed to determine upstream rhel version
             # 2. upstream and ART rhel versions match: in this case, alternative_upstream is ignored
-            self._update_image_config()
-            self.metadata._mark_canonical_builders_resolved()
+            metadata_resolved = self._update_image_config()
+            if (
+                attempted_resolution
+                and not metadata_resolved
+                and (
+                    self.upstream_intended_el_version is None
+                    or self.upstream_intended_el_version == self.art_intended_el_version
+                    or self.runtime.variant == BuildVariant.OKD
+                )
+            ):
+                self.metadata._mark_canonical_builders_resolved()
 
         # Initialize our distgit directory, if necessary
         if autoclone:
@@ -1876,7 +1888,7 @@ class ImageDistGitRepo(DistGitRepo):
 
         return version
 
-    def _update_image_config(self):
+    def _update_image_config(self) -> bool:
         """
         If we're trying to match upstream, check if there's a 'when' clause in image alternative_config field
         that matches upstream RHEL version. If so, merge the 'when' clause content with the main image config
@@ -1886,13 +1898,13 @@ class ImageDistGitRepo(DistGitRepo):
             # Could not determine upstream rhel version: do not match upstream builders
             self.logger.warning('Unknown upstream rhel version: will not merge configs')
             self.should_match_upstream = False
-            return
+            return False
 
         elif self.upstream_intended_el_version == self.art_intended_el_version:
             # ART/upstream el versions match: do not merge configs, but match upstream builders
             self.logger.warning('ART and upstream intended rhel version match: will not merge configs')
             self.should_match_upstream = True
-            return
+            return False
 
         # Check if there is an alternative configuration matching upstream RHEL version
         alt_configs = self.config.alternative_upstream
@@ -1914,16 +1926,17 @@ class ImageDistGitRepo(DistGitRepo):
                 self.upstream_intended_el_version,
             )
             self.should_match_upstream = False
+            return False
 
-        else:
-            # We found an alternative_upstream config stanza. We can match upstream
-            self.should_match_upstream = True
-            # Distgit branch must be changed to track the alternative one
-            self.branch = self.config.distgit.branch
-            # Also update metadata config
-            self.metadata.config = self.config
-            self.metadata._mark_canonical_builders_resolved()
-            self.metadata.targets = self.metadata.determine_targets()
+        # We found an alternative_upstream config stanza. We can match upstream
+        self.should_match_upstream = True
+        # Distgit branch must be changed to track the alternative one
+        self.branch = self.config.distgit.branch
+        # Also update metadata config
+        self.metadata.config = self.config
+        self.metadata.targets = self.metadata.determine_targets()
+        self.metadata._mark_canonical_builders_resolved()
+        return True
 
     def rebase_from_directives(self, dfp):
         image_from = Model(self.config.get('from', None))

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -489,7 +489,13 @@ class ImageDistGitRepo(DistGitRepo):
             # If the image is distgit-only, this logic does not apply
             if self.has_source():
                 attempted_resolution = True
-                source_path = self.runtime.source_resolver.resolve_source(self.metadata).source_path
+                source_resolution = self.runtime.source_resolver.resolve_source(self.metadata)
+                source_path = getattr(source_resolution, "source_path", None) if source_resolution else None
+                if not source_path:
+                    raise IOError(
+                        f'[{self.metadata.distgit_key}] canonical_builders_from_upstream is enabled but '
+                        'source could not be resolved. Cannot determine upstream RHEL version.'
+                    )
                 self.art_intended_el_version = self._determine_art_rhel_version()
                 self.upstream_intended_el_version = self._determine_upstream_rhel_version(source_path)
             # To match upstream, we need to be able to infer upstream intended RHEL version
@@ -1846,14 +1852,16 @@ class ImageDistGitRepo(DistGitRepo):
 
     def _determine_upstream_rhel_version(self, source_path) -> Optional[int]:
         """
-        The upstream indended RHEL version is obtained from the last build layer as defined in the Dockerfile.
+        Determine the upstream intended RHEL version from upstream Dockerfile parents.
 
-        Given a pullspec such as registry.ci.openshift.org/ocp/4.15:base-rhel9, use "oc image info" and Brew API
-        to determine the RHEL version. Use an in-memory caching mechanism to store the pullspec/rhel version pair
-        within the same Doozer execution.
+        Uses the same parent-selection rule as ImageMetadata canonical-builder
+        resolution so scan-time config resolution and the distgit path derive
+        the same upstream RHEL version for multi-stage Dockerfiles.
 
         Return either an integer representing the RHEL major version, or None if something went wrong.
         """
+        from doozerlib.image import determine_builder_info_from_parent_images
+
         df_name = self.config.content.source.dockerfile
         if not df_name:
             df_name = 'Dockerfile'
@@ -1868,15 +1876,7 @@ class ImageDistGitRepo(DistGitRepo):
                 dfp = DockerfileParser(fileobj=f)
                 parent_images = dfp.parent_images
 
-            # We will infer the rhel version from the last build layer in the upstream Dockerfile
-            last_layer_pullspec = parent_images[-1]
-            image_labels = util.oc_image_info_for_arch(last_layer_pullspec)['config']['config']['Labels']
-            if 'version' not in image_labels or 'release' not in image_labels:
-                # This does not appear to be a brew image. We can't determine RHEL.
-                return None
-
-            bbii = BrewBuildRecordInspector(self.runtime, last_layer_pullspec)
-            version = bbii.get_rhel_base_version()
+            version, _ = determine_builder_info_from_parent_images(parent_images)
 
         except Exception as e:
             # Swallow exception as this is not fatal. We just can't determine the

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -4,7 +4,9 @@ import json
 import pathlib
 import re
 from collections import OrderedDict
+from contextlib import contextmanager
 from copy import copy
+from enum import Enum
 from functools import lru_cache
 from multiprocessing import Event
 from typing import Any, Dict, List, Optional, Set, Tuple, cast
@@ -89,6 +91,23 @@ def extract_builder_info_from_pullspec(pullspec: str) -> tuple[int | None, tuple
     return rhel_version, golang_version
 
 
+class CanonicalBuildersResolutionError(RuntimeError):
+    """Raised when canonical builders resolution fails."""
+
+
+class UnresolvedCanonicalBuildersError(CanonicalBuildersResolutionError):
+    """Raised when canonical-sensitive values are accessed before canonical builders are resolved."""
+
+
+class CanonicalBuildersPreparationState(Enum):
+    INITIALIZING = "initializing"
+    UNRESOLVED = "unresolved"
+    PREPARING = "preparing"
+    RESOLVED = "resolved"
+    FAILED = "failed"
+    NOT_APPLICABLE = "not-applicable"
+
+
 class ImageMetadata(Metadata):
     def __init__(
         self,
@@ -99,6 +118,9 @@ class ImageMetadata(Metadata):
         prevent_cloning: Optional[bool] = False,
         process_dependents: Optional[bool] = True,
     ):
+        self._canonical_builders_preparation_state = CanonicalBuildersPreparationState.INITIALIZING
+        self._canonical_builders_preparation_exception: Optional[Exception] = None
+        self._canonical_builders_guard_depth = 0
         super(ImageMetadata, self).__init__('image', runtime, data_obj, commitish, prevent_cloning=prevent_cloning)
         self.required = self.config.get('required', False)
         self.parent = None
@@ -126,31 +148,119 @@ class ImageMetadata(Metadata):
         self.build_status = False
         """ True if this image has been successfully built. """
 
-        # Apply alternative upstream config if canonical builders is enabled
-        # This must happen early so config is correct for all subsequent operations
-        if self.canonical_builders_enabled:
-            if prevent_cloning:
-                self.logger.warning(
-                    '[%s] canonical_builders_from_upstream is enabled but prevent_cloning=True. '
-                    'Skipping upstream RHEL version detection; alternative_upstream config will not be applied.',
-                    self.distgit_key,
-                )
-            else:
-                if not clone_source:
-                    self.logger.warning(
-                        '[%s] canonical_builders_from_upstream is enabled but clone_source=False. '
-                        'Source will be cloned anyway to determine upstream RHEL version.',
-                        self.distgit_key,
-                    )
-                # When canonical_builders_from_upstream is enabled, we need to determine
-                # the upstream RHEL version and merge alternative_upstream config if needed.
-                # This will clone source as part of the process.
-                self._apply_alternative_upstream_config()
-        elif clone_source:
-            # Normal case: clone source if requested (and canonical builders not enabled)
+        if clone_source:
+            # Preserve explicit clone_source behavior, but defer canonical builder config changes
+            # until a caller explicitly resolves canonical-sensitive config for this image.
             runtime.source_resolver.resolve_source(self)
 
+        if self.canonical_builders_enabled:
+            self._canonical_builders_preparation_state = CanonicalBuildersPreparationState.UNRESOLVED
+        else:
+            self._canonical_builders_preparation_state = CanonicalBuildersPreparationState.NOT_APPLICABLE
+
         self.installed_rpms = None
+
+    @property
+    def canonical_builders_preparation_state(self) -> CanonicalBuildersPreparationState:
+        return self._canonical_builders_preparation_state
+
+    @contextmanager
+    def _suspend_canonical_builders_guard(self):
+        self._canonical_builders_guard_depth += 1
+        try:
+            yield
+        finally:
+            self._canonical_builders_guard_depth -= 1
+
+    def _mark_canonical_builders_resolved(self):
+        if self.canonical_builders_enabled:
+            self._canonical_builders_preparation_state = CanonicalBuildersPreparationState.RESOLVED
+        else:
+            self._canonical_builders_preparation_state = CanonicalBuildersPreparationState.NOT_APPLICABLE
+        self._canonical_builders_preparation_exception = None
+
+    def _assert_canonical_builders_resolved(self, operation: str) -> None:
+        if not self.canonical_builders_enabled:
+            return
+        if self._canonical_builders_guard_depth > 0:
+            return
+
+        state = self._canonical_builders_preparation_state
+        if state in (
+            CanonicalBuildersPreparationState.INITIALIZING,
+            CanonicalBuildersPreparationState.PREPARING,
+            CanonicalBuildersPreparationState.RESOLVED,
+            CanonicalBuildersPreparationState.NOT_APPLICABLE,
+        ):
+            return
+
+        if getattr(self.runtime, "initialized", None) is False:
+            return
+
+        if state is CanonicalBuildersPreparationState.FAILED:
+            previous = self._canonical_builders_preparation_exception
+            raise UnresolvedCanonicalBuildersError(
+                f'[{self.distgit_key}] Cannot {operation} because canonical builders resolution previously failed: '
+                f'{previous}. Call ensure_canonical_builders_resolved() first.'
+            ) from previous
+
+        raise UnresolvedCanonicalBuildersError(
+            f'[{self.distgit_key}] Cannot {operation} before canonical builders are resolved. '
+            'canonical_builders_from_upstream may change branch, targets, or other image config. '
+            'Call ensure_canonical_builders_resolved() first.'
+        )
+
+    def ensure_canonical_builders_resolved(self) -> None:
+        state = self._canonical_builders_preparation_state
+        if state in (
+            CanonicalBuildersPreparationState.RESOLVED,
+            CanonicalBuildersPreparationState.NOT_APPLICABLE,
+            CanonicalBuildersPreparationState.INITIALIZING,
+        ):
+            return
+
+        if state is CanonicalBuildersPreparationState.FAILED:
+            previous = self._canonical_builders_preparation_exception
+            raise CanonicalBuildersResolutionError(
+                f'[{self.distgit_key}] Canonical builders resolution previously failed: {previous}'
+            ) from previous
+
+        if state is CanonicalBuildersPreparationState.PREPARING:
+            return
+
+        self._canonical_builders_preparation_state = CanonicalBuildersPreparationState.PREPARING
+        self._canonical_builders_preparation_exception = None
+        try:
+            with self._suspend_canonical_builders_guard():
+                self._apply_alternative_upstream_config()
+        except Exception as err:
+            self._canonical_builders_preparation_state = CanonicalBuildersPreparationState.FAILED
+            self._canonical_builders_preparation_exception = err
+            raise CanonicalBuildersResolutionError(
+                f'[{self.distgit_key}] Failed resolving canonical builders: {err}'
+            ) from err
+
+        self._mark_canonical_builders_resolved()
+
+    def branch(self):
+        self._assert_canonical_builders_resolved("read image branch")
+        return super().branch()
+
+    def determine_targets(self) -> list[str]:
+        self._assert_canonical_builders_resolved("determine image targets")
+        return super().determine_targets()
+
+    def branch_el_target(self) -> int:
+        self._assert_canonical_builders_resolved("determine branch EL target")
+        return super().branch_el_target()
+
+    def determine_rhel_targets(self) -> list[int]:
+        self._assert_canonical_builders_resolved("determine RHEL targets")
+        return super().determine_rhel_targets()
+
+    def needs_rebuild(self):
+        self._assert_canonical_builders_resolved("check whether the image needs rebuild")
+        return super().needs_rebuild()
 
     @property
     def image_name(self):
@@ -711,6 +821,7 @@ class ImageMetadata(Metadata):
                 return False
 
     def calculate_config_digest(self, group_config, streams):
+        self._assert_canonical_builders_resolved("calculate config digest")
         ignore_keys = [
             "owners",
             "okd",
@@ -819,7 +930,7 @@ class ImageMetadata(Metadata):
     def _apply_alternative_upstream_config(self) -> None:
         """
         When canonical_builders_enabled, merge alternative_upstream config based on upstream RHEL version.
-        This must happen early in initialization so config is correct for all subsequent operations.
+        This is invoked explicitly by callers that need canonical-sensitive image config to be resolved.
 
         This method determines both ART and upstream intended RHEL versions, then merges the appropriate
         alternative_upstream config stanza if the versions differ. If versions match, no merge is needed.

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -91,6 +91,26 @@ def extract_builder_info_from_pullspec(pullspec: str) -> tuple[int | None, tuple
     return rhel_version, golang_version
 
 
+def determine_builder_info_from_parent_images(parent_images: list[str]) -> tuple[int | None, tuple[int, int] | None]:
+    """
+    Determine canonical builder info from upstream Dockerfile parents.
+
+    Walk parent images in Dockerfile order and stop at the first parent that
+    exposes a RHEL version. This keeps scan-time canonical resolution and the
+    distgit path aligned for multi-stage Dockerfiles that include compatibility
+    builders later in the file.
+    """
+    rhel_version = None
+    golang_version = None
+
+    for pullspec in parent_images:
+        rhel_version, golang_version = extract_builder_info_from_pullspec(pullspec)
+        if rhel_version:
+            break
+
+    return rhel_version, golang_version
+
+
 class CanonicalBuildersResolutionError(RuntimeError):
     """Raised when canonical builders resolution fails."""
 
@@ -1028,9 +1048,11 @@ class ImageMetadata(Metadata):
         self, source_dir: pathlib.Path
     ) -> Tuple[Optional[int], Optional[Tuple[int, int]]]:
         """
-        Determine the upstream intended RHEL version and golang version from the last build layer in the upstream Dockerfile.
+        Determine the upstream intended RHEL version and golang version from upstream Dockerfile parents.
 
-        Delegates to extract_builder_info_from_pullspec() for the actual extraction logic.
+        Delegates to determine_builder_info_from_parent_images() for the shared
+        parent-selection rule used by both scan-time canonical resolution and
+        the distgit path.
 
         Args:
             source_dir: Path to the upstream source directory (already includes content.source.path if applicable)
@@ -1053,17 +1075,7 @@ class ImageMetadata(Metadata):
                 dfp = DockerfileParser(fileobj=f)
                 parent_images = dfp.parent_images
 
-            # Iterate forward: the first FROM in a multi-stage Dockerfile is the primary builder,
-            # which reliably encodes the target RHEL version. Reverse iteration would incorrectly
-            # pick up compatibility builders (e.g. rhel-8-golang used only for upgrade shim binaries
-            # in ovn-kubernetes) before the primary rhel-9 builder.
-            # Also, some images (e.g. deployer) use image stream tags like :cli or :base that don't encode RHEL version. In these cases, we want to iterate through all parent images in case any of them encode RHEL version info in the tag.
-            # NOTE: the rhel version should be determined by the final layer. This is a hotfix and is probably wrong,
-            # but is needed to unblock canonical builders for now.
-            for pullspec in parent_images:
-                rhel_version, golang_version = extract_builder_info_from_pullspec(pullspec)
-                if rhel_version:
-                    break
+            rhel_version, golang_version = determine_builder_info_from_parent_images(parent_images)
 
         except Exception as e:
             self.logger.warning('[%s] Failed determining upstream builder info: %s', self.distgit_key, e)

--- a/doozer/tests/cli/test_scan_sources.py
+++ b/doozer/tests/cli/test_scan_sources.py
@@ -110,3 +110,28 @@ class TestScanSourcesCli(IsolatedAsyncioTestCase):
         broken_image.does_image_need_change.assert_not_called()
         good_image.ensure_canonical_builders_resolved.assert_called()
         good_image.does_image_need_change.assert_awaited_once()
+
+    def test_skip_image_removes_broken_image_from_change_tracking(self):
+        broken_image = MagicMock()
+        broken_image.distgit_key = "broken-image"
+        broken_image.qualified_key = "images:broken-image"
+        broken_image.get_descendants.return_value = set()
+
+        good_image = MagicMock()
+        good_image.distgit_key = "good-image"
+        good_image.qualified_key = "images:good-image"
+        good_image.get_descendants.return_value = {broken_image}
+
+        runtime = MagicMock()
+        runtime.rpm_metas.return_value = []
+        runtime.image_metas.return_value = [broken_image, good_image]
+
+        scanner = ConfigScanSources(runtime, "dummy", False)
+        scanner.add_image_meta_change(broken_image, RebuildHint(RebuildHintCode.CONFIG_CHANGE, "broken"))
+
+        self.assertEqual({meta.distgit_key for meta in scanner.changing_image_metas}, {"broken-image"})
+
+        scanner._skip_image(broken_image, "broken")
+        scanner.add_image_meta_change(good_image, RebuildHint(RebuildHintCode.ANCESTOR_CHANGING, "good"))
+
+        self.assertEqual({meta.distgit_key for meta in scanner.changing_image_metas}, {"good-image"})

--- a/doozer/tests/cli/test_scan_sources.py
+++ b/doozer/tests/cli/test_scan_sources.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from artcommonlib.model import Model
 from doozerlib import rhcos
 from doozerlib.cli.scan_sources import ConfigScanSources
+from doozerlib.metadata import RebuildHint, RebuildHintCode
 
 
 class TestScanSourcesCli(IsolatedAsyncioTestCase):
@@ -56,3 +57,56 @@ class TestScanSourcesCli(IsolatedAsyncioTestCase):
 
         mock_get_build.side_effect = rhcos.RHCOSNotFound("test")
         cli._latest_rhcos_build_id("4.9", "aarch64", False)
+
+    @patch("doozerlib.cli.scan_sources.exectools.parallel_exec")
+    async def test_scan_sources_skips_broken_canonical_image_and_continues(self, mock_parallel_exec):
+        broken_image = MagicMock()
+        broken_image.meta_type = "image"
+        broken_image.enabled = True
+        broken_image.mode = "enabled"
+        broken_image.distgit_key = "broken-image"
+        broken_image.ensure_canonical_builders_resolved.side_effect = Exception("bad canonical")
+        broken_image.does_image_need_change = AsyncMock()
+
+        good_image = MagicMock()
+        good_image.meta_type = "image"
+        good_image.enabled = True
+        good_image.mode = "enabled"
+        good_image.distgit_key = "good-image"
+        good_image.ensure_canonical_builders_resolved.return_value = None
+        good_image.needs_rebuild.return_value = RebuildHint(RebuildHintCode.BUILD_IS_UP_TO_DATE, "no change")
+        good_image.build_root_tag.return_value = "good-buildroot"
+        good_image.does_image_need_change = AsyncMock(return_value=None)
+
+        runtime = MagicMock()
+        runtime.rpm_metas.return_value = []
+        runtime.image_metas.return_value = [broken_image, good_image]
+        runtime.load_disabled = False
+
+        def fake_parallel_exec(f, args, n_threads):
+            return MagicMock(get=MagicMock(return_value=[f(arg, None) for arg in args]))
+
+        mock_parallel_exec.side_effect = fake_parallel_exec
+
+        scanner = ConfigScanSources(runtime, "dummy", False)
+        scanner.scan_for_upstream_changes(MagicMock())
+
+        self.assertEqual(
+            scanner.issues,
+            [
+                {
+                    "name": "broken-image",
+                    "issue": "Failed resolving canonical builders before upstream commit checks: bad canonical",
+                }
+            ],
+        )
+        self.assertIn("broken-image", scanner.skipped_image_dgks)
+        broken_image.needs_rebuild.assert_not_called()
+        good_image.needs_rebuild.assert_called_once()
+
+        await scanner.check_changing_rpms()
+
+        broken_image.ensure_canonical_builders_resolved.assert_called_once()
+        broken_image.does_image_need_change.assert_not_called()
+        good_image.ensure_canonical_builders_resolved.assert_called()
+        good_image.does_image_need_change.assert_awaited_once()

--- a/doozer/tests/cli/test_scan_sources_konflux.py
+++ b/doozer/tests/cli/test_scan_sources_konflux.py
@@ -10,7 +10,7 @@ from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord
 from artcommonlib.model import Missing
 from doozerlib.cli.scan_sources_konflux import ConfigScanSources
 from doozerlib.image import ImageMetadata
-from doozerlib.metadata import RebuildHintCode
+from doozerlib.metadata import RebuildHint, RebuildHintCode
 from doozerlib.runtime import Runtime
 
 
@@ -123,6 +123,29 @@ class TestMinimalCrashIsolation(TestScanSourcesKonflux):
             self.scanner.issues,
             [{'name': 'test-image', 'issue': 'Failed scanning image during upstream commit checks: boom'}],
         )
+
+    def test_skip_image_removes_broken_image_from_change_tracking(self):
+        broken_image = MagicMock(spec=ImageMetadata)
+        broken_image.distgit_key = "broken-image"
+        broken_image.qualified_key = "images:broken-image"
+        broken_image.get_descendants.return_value = set()
+
+        good_image = MagicMock(spec=ImageMetadata)
+        good_image.distgit_key = "good-image"
+        good_image.qualified_key = "images:good-image"
+        good_image.get_descendants.return_value = [broken_image]
+
+        broken_key = f"{broken_image.qualified_key}+True"
+        self.scanner.changing_image_names.add("broken-image")
+        self.scanner.assessment_reason[broken_key] = "broken"
+        self.scanner.assessment_code[broken_key] = RebuildHintCode.CONFIG_CHANGE
+
+        self.scanner._skip_image(broken_image, "broken")
+        self.scanner.add_image_meta_change(good_image, RebuildHint(RebuildHintCode.ANCESTOR_CHANGING, "good"))
+
+        self.assertEqual(self.scanner.changing_image_names, {"good-image"})
+        self.assertNotIn(broken_key, self.scanner.assessment_reason)
+        self.assertNotIn(broken_key, self.scanner.assessment_code)
 
     @patch('doozerlib.cli.scan_sources_konflux.Dir')
     @patch('doozerlib.cli.scan_sources_konflux.exectools.parallel_exec')

--- a/doozer/tests/cli/test_scan_sources_konflux.py
+++ b/doozer/tests/cli/test_scan_sources_konflux.py
@@ -67,6 +67,42 @@ class TestScanSourcesKonflux(IsolatedAsyncioTestCase):
 
 
 class TestMinimalCrashIsolation(TestScanSourcesKonflux):
+    async def test_scan_images_skips_broken_canonical_image_and_continues(self):
+        broken_image = MagicMock(spec=ImageMetadata)
+        broken_image.distgit_key = "broken-image"
+        broken_image.enabled = True
+        broken_image.ensure_canonical_builders_resolved.side_effect = RuntimeError("bad canonical")
+        broken_image.get_latest_build = AsyncMock()
+
+        good_image = MagicMock(spec=ImageMetadata)
+        good_image.distgit_key = "good-image"
+        good_image.enabled = True
+        good_image.ensure_canonical_builders_resolved.return_value = None
+        good_image.get_latest_build = AsyncMock(return_value=self.build_record)
+
+        self.runtime.image_map = {
+            "broken-image": broken_image,
+            "good-image": good_image,
+        }
+        self.scanner.latest_image_build_records_map = {}
+
+        with patch.object(self.scanner, 'scan_image', AsyncMock()) as mock_scan_image:
+            await self.scanner.scan_images(["broken-image", "good-image"])
+
+        self.assertEqual(
+            self.scanner.issues,
+            [
+                {
+                    'name': 'broken-image',
+                    'issue': 'Failed resolving canonical builders before latest build lookup: bad canonical',
+                }
+            ],
+        )
+        self.assertIn('broken-image', self.scanner.skipped_image_names)
+        broken_image.get_latest_build.assert_not_called()
+        self.assertEqual(self.scanner.latest_image_build_records_map, {"good-image": self.build_record})
+        mock_scan_image.assert_awaited_once_with(good_image)
+
     async def test_scan_image_records_issue_instead_of_raising(self):
         self.image_meta.config.konflux = Missing
 

--- a/doozer/tests/test_distgit/test_image_distgit/test_image_distgit.py
+++ b/doozer/tests/test_distgit/test_image_distgit/test_image_distgit.py
@@ -685,6 +685,46 @@ COPY --from=builder /some/path/a /some/path/b
         self.assertFalse(self.img_dg.should_match_upstream)
         self.assertEqual(self.img_dg.config['distgit']['branch'], 'rhaos-4.16-rhel-9')
 
+    @patch('builtins.open', create=True)
+    def test_determine_upstream_rhel_version_prefers_first_rhel_parent(self, mock_open):
+        self.img_dg.config = Model(
+            {
+                'distgit': {'branch': 'rhaos-4.16-rhel-9'},
+                'content': {'source': {'path': '.', 'dockerfile': 'Dockerfile'}},
+            }
+        )
+        mock_open.return_value.__enter__.return_value = io.StringIO("")
+
+        with patch('doozerlib.distgit.DockerfileParser') as mock_dfp:
+            mock_dfp_instance = MagicMock()
+            mock_dfp_instance.parent_images = [
+                'registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22',
+                'registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.22',
+            ]
+            mock_dfp.return_value = mock_dfp_instance
+
+            self.assertEqual(9, self.img_dg._determine_upstream_rhel_version('/tmp/source'))
+
+    def test_init_raises_ioerror_when_source_resolution_has_no_path(self):
+        runtime = self.mock_runtime(
+            distgits_dir="/tmp/distgits",
+            source_resolver=flexmock(resolve_source=lambda *_: None),
+        )
+        metadata = flexmock(
+            runtime=runtime,
+            config=flexmock(distgit=flexmock(branch="rhaos-4.16-rhel-9")),
+            name="test-image",
+            distgit_key="test-image",
+            canonical_builders_enabled=True,
+            has_source=lambda: True,
+            logger=flexmock(info=lambda *_: None, warning=lambda *_: None),
+        )
+
+        with self.assertRaises(IOError) as ctx:
+            distgit.ImageDistGitRepo(metadata, autoclone=True)
+
+        self.assertIn("source could not be resolved", str(ctx.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -10,7 +10,13 @@ from artcommonlib import exectools
 from artcommonlib.model import Missing, Model
 from artcommonlib.variants import BuildVariant
 from doozerlib import build_info, image
-from doozerlib.image import ImageMetadata, extract_builder_info_from_pullspec
+from doozerlib.image import (
+    CanonicalBuildersPreparationState,
+    CanonicalBuildersResolutionError,
+    ImageMetadata,
+    UnresolvedCanonicalBuildersError,
+    extract_builder_info_from_pullspec,
+)
 from doozerlib.repodata import Repodata, Rpm
 from doozerlib.repos import Repos
 from flexmock import flexmock
@@ -183,6 +189,74 @@ class TestImageMetadata(unittest.TestCase):
         rt = MagicMock()
         rt.logger = logging.getLogger('test_runtime')  # Use real logger
         return image.ImageMetadata(rt, data_obj)
+
+    def _create_canonical_image_metadata(self, name='openshift/test_canonical'):
+        image_model = Model(
+            {
+                'name': name,
+                'canonical_builders_from_upstream': True,
+                'distgit': {'branch': 'rhaos-4.16-rhel-9'},
+                'content': {'source': {'git': {'url': 'https://github.com/test/repo.git'}}},
+            }
+        )
+        data_obj = Model(
+            {
+                'key': 'my-distgit',
+                'data': image_model,
+                'filename': 'my-distgit.yaml',
+            }
+        )
+        rt = MagicMock()
+        rt.logger = logging.getLogger('test_runtime')
+        rt.initialized = True
+        return image.ImageMetadata(rt, data_obj)
+
+    @patch.object(ImageMetadata, '_apply_alternative_upstream_config')
+    def test_init_defers_canonical_resolution(self, apply_alternative_upstream_config):
+        metadata = self._create_canonical_image_metadata()
+
+        apply_alternative_upstream_config.assert_not_called()
+        self.assertEqual(metadata.canonical_builders_preparation_state, CanonicalBuildersPreparationState.UNRESOLVED)
+
+    def test_branch_requires_canonical_resolution(self):
+        metadata = self._create_canonical_image_metadata()
+
+        with self.assertRaises(UnresolvedCanonicalBuildersError) as ctx:
+            metadata.branch()
+
+        self.assertIn('ensure_canonical_builders_resolved', str(ctx.exception))
+
+    def test_calculate_config_digest_requires_canonical_resolution(self):
+        metadata = self._create_canonical_image_metadata()
+
+        with self.assertRaises(UnresolvedCanonicalBuildersError):
+            metadata.calculate_config_digest(Model({}), Model({}))
+
+    @patch.object(ImageMetadata, '_apply_alternative_upstream_config')
+    def test_ensure_canonical_builders_resolved_is_idempotent(self, apply_alternative_upstream_config):
+        metadata = self._create_canonical_image_metadata()
+
+        metadata.ensure_canonical_builders_resolved()
+        metadata.ensure_canonical_builders_resolved()
+
+        apply_alternative_upstream_config.assert_called_once()
+        self.assertEqual(metadata.canonical_builders_preparation_state, CanonicalBuildersPreparationState.RESOLVED)
+
+    @patch.object(ImageMetadata, '_apply_alternative_upstream_config', side_effect=IOError('boom'))
+    def test_ensure_canonical_builders_resolved_caches_failures(self, apply_alternative_upstream_config):
+        metadata = self._create_canonical_image_metadata()
+
+        with self.assertRaises(CanonicalBuildersResolutionError) as ctx:
+            metadata.ensure_canonical_builders_resolved()
+
+        self.assertIn('Failed resolving canonical builders', str(ctx.exception))
+        self.assertEqual(metadata.canonical_builders_preparation_state, CanonicalBuildersPreparationState.FAILED)
+
+        with self.assertRaises(CanonicalBuildersResolutionError) as second_ctx:
+            metadata.ensure_canonical_builders_resolved()
+
+        self.assertIn('previously failed', str(second_ctx.exception))
+        apply_alternative_upstream_config.assert_called_once()
 
     def test_cachi2_enabled_1(self):
         metadata = self._create_image_metadata('openshift/test_0')


### PR DESCRIPTION
- Part of the effort to make scan-sources individual image fail resistent. 
- https://redhat.atlassian.net/browse/ART-14734
- Previous change: https://github.com/openshift-eng/art-tools/pull/2705

## Summary
- Defer canonical builder `alternative_upstream` resolution out of `ImageMetadata` initialization so image loading does not fail up front during `config:scan-sources`.
- Track canonical-builder resolution state explicitly and raise a targeted error when canonical-sensitive values are accessed before resolution.
- Update `config:scan-sources` to resolve canonical builders per image, record issues for broken images, and continue scanning the rest; add regression coverage for the new flow.

## Test plan
- `uv run pytest --verbose --color=yes doozer/tests/test_image.py doozer/tests/cli/test_scan_sources.py`
- `uv run pytest --verbose --color=yes doozer/tests/test_distgit/test_image_distgit/test_image_distgit.py`
- ocp4-scan job: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/45815/console

```
issues:
14:24:06  -   issue: 'Failed resolving canonical builders before latest build lookup: [ose-operator-framework-tools]
14:24:06          Failed resolving canonical builders: [ose-operator-framework-tools] Upstream
14:24:06          uses el8 but ART uses el9, and no matching alternative_upstream config was
14:24:06          found. Please add an alternative_upstream config with "when: el8".'
14:24:06      name: ose-operator-framework-tools
14:24:06  -   issue: 'Failed resolving canonical builders before latest build lookup: [ib-sriov-cni]
14:24:06          Failed resolving canonical builders: [ib-sriov-cni] Upstream uses el8 but
14:24:06          ART uses el9, and no matching alternative_upstream config was found. Please
14:24:06          add an alternative_upstream config with "when: el8".'
14:24:06      name: ib-sriov-cni
14:24:06  -   issue: 'Failed resolving canonical builders before latest build lookup: [oc-mirror-plugin]
14:24:06          Failed resolving canonical builders: [oc-mirror-plugin] Upstream uses el8
14:24:06          but ART uses el9, and no matching alternative_upstream config was found. Please
14:24:06          add an alternative_upstream config with "when: el8".'
14:24:06      name: oc-mirror-plugin
14:24:06  -   issue: 'Failed resolving canonical builders before latest build lookup: [ose-sriov-rdma-cni]
14:24:06          Failed resolving canonical builders: [ose-sriov-rdma-cni] Upstream uses el8
14:24:06          but ART uses el9, and no matching alternative_upstream config was found. Please
14:24:06          add an alternative_upstream config with "when: el8".'
14:24:06      name: ose-sriov-rdma-cni
14:24:06  -   issue: 'Failed resolving canonical builders before latest build lookup: [sriov-cni]
14:24:06          Failed resolving canonical builders: [sriov-cni] Upstream uses el8 but ART
14:24:06          uses el9, and no matching alternative_upstream config was found. Please add
14:24:06          an alternative_upstream config with "when: el8".'
14:24:06      name: sriov-cni
```

Assisted-by: GPT-5.4 (Cursor)