### PR TITLE
Add retry to git ls-remote

### DIFF
--- a/artcommon/artcommonlib/exectools.py
+++ b/artcommon/artcommonlib/exectools.py
@@ -455,7 +455,7 @@ def cmd_gather(
                         error = os.read(proc.stderr.fileno(), 4096)
                         if error:
                             yellow_print(error.rstrip())
-                            out += error
+                            err += error
                         else:
                             stderr_complete = True
                     except OSError as ose:

--- a/artcommon/artcommonlib/exectools.py
+++ b/artcommon/artcommonlib/exectools.py
@@ -348,6 +348,8 @@ def cmd_gather(
     log_stderr=True,
     timeout: Optional[int] = None,
     cwd: Optional[str] = None,
+    retries: int = 1,
+    pollrate: int = 60,
 ) -> Tuple[int, str, str]:
     """
     Runs a command and returns rc,stdout,stderr as a tuple.
@@ -364,6 +366,8 @@ def cmd_gather(
     :param log_stderr: Whether stderr should be logged into the DEBUG log
     :param timeout: Kill the process if it does not terminate after timeout seconds.
     :param cwd: Set current working directory
+    :param retries: The number of times to try before giving up
+    :param pollrate: Seconds to sleep between retries
     :return: (rc,stdout,stderr)
     """
 
@@ -392,94 +396,104 @@ def cmd_gather(
     # Make sure output of launched commands is utf-8
     env['LC_ALL'] = 'en_US.UTF-8'
 
-    with timer(logger.debug, f'{cmd_info}: Executed:cmd_gather'):
-        logger.info(f'{cmd_info}: Executing:cmd_gather: {" ".join(cmd_list)}')
-        try:
-            proc = subprocess.Popen(
-                cmd_list, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.DEVNULL
-            )
-        except OSError as exc:
-            description = "{}: Errored:\nException:\n{}\nIs {} installed?".format(cmd_info, exc, cmd_list[0])
-            logger.error(description)
-            return exc.errno, "", description
+    rc, out, err = -1, '', ''
 
-        if not realtime:
+    for try_num in range(retries):
+        if try_num > 0:
+            logger.debug("cmd_gather: Failed {} times. Retrying in {} seconds: {}".format(try_num, pollrate, cmd))
+            time.sleep(pollrate)
+
+        with timer(logger.debug, f'{cmd_info}: Executed:cmd_gather'):
+            logger.info(f'{cmd_info}: Executing:cmd_gather: {" ".join(cmd_list)}')
             try:
-                out, err = proc.communicate(timeout=timeout)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                out, err = proc.communicate()
-            rc = proc.returncode
-        else:
-            out = b''
-            err = b''
-
-            # Many thanks to http://eyalarubas.com/python-subproc-nonblock.html
-            # setup non-blocking read
-            # set the O_NONBLOCK flag of proc.stdout file descriptor:
-            flags = fcntl(proc.stdout, F_GETFL)  # get current proc.stdout flags
-            fcntl(proc.stdout, F_SETFL, flags | os.O_NONBLOCK)
-            # set the O_NONBLOCK flag of proc.stderr file descriptor:
-            flags = fcntl(proc.stderr, F_GETFL)  # get current proc.stderr flags
-            fcntl(proc.stderr, F_SETFL, flags | os.O_NONBLOCK)
-
-            rc = None
-            stdout_complete = False
-            stderr_complete = False
-            while not stdout_complete or not stderr_complete or rc is None:
-                try:
-                    output = os.read(proc.stdout.fileno(), 4096)
-                    if output:
-                        green_print(output.rstrip())
-                        out += output
-                    else:
-                        stdout_complete = True
-                except OSError as ose:
-                    if ose.errno == errno.EAGAIN or ose.errno == errno.EWOULDBLOCK:
-                        pass  # It is supposed to raise one of these exceptions
-                    else:
-                        raise
-
-                try:
-                    error = os.read(proc.stderr.fileno(), 4096)
-                    if error:
-                        yellow_print(error.rstrip())
-                        out += error
-                    else:
-                        stderr_complete = True
-                except OSError as ose:
-                    if ose.errno == errno.EAGAIN or ose.errno == errno.EWOULDBLOCK:
-                        pass  # It is supposed to raise one of these exceptions
-                    else:
-                        raise
-
-                if rc is None:
-                    rc = proc.poll()
-                    time.sleep(0.5)  # reduce busy-wait
-
-        # We read in bytes representing utf-8 output; decode so that python recognizes them as unicode strings
-        out = out.decode('utf-8')
-        err = err.decode('utf-8')
-
-        log_output_stdout = out
-        log_output_stderr = err
-        if not log_stdout and len(out) > 200:
-            log_output_stdout = f'{out[:200]}\n..truncated..'
-        if not log_stderr and len(err) > 200:
-            log_output_stderr = f'{err[:200]}\n..truncated..'
-
-        if rc:
-            logger.debug(
-                "{}: Exited with error: {}\nstdout>>{}<<\nstderr>>{}<<\n".format(
-                    cmd_info, rc, log_output_stdout, log_output_stderr
+                proc = subprocess.Popen(
+                    cmd_list, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.DEVNULL
                 )
-            )
-        else:
-            logger.debug(
-                "{}: Exited with: {}\nstdout>>{}<<\nstderr>>{}<<\n".format(
-                    cmd_info, rc, log_output_stdout, log_output_stderr
+            except OSError as exc:
+                description = "{}: Errored:\nException:\n{}\nIs {} installed?".format(cmd_info, exc, cmd_list[0])
+                logger.error(description)
+                return exc.errno, "", description
+
+            if not realtime:
+                try:
+                    out, err = proc.communicate(timeout=timeout)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    out, err = proc.communicate()
+                rc = proc.returncode
+            else:
+                out = b''
+                err = b''
+
+                # Many thanks to http://eyalarubas.com/python-subproc-nonblock.html
+                # setup non-blocking read
+                # set the O_NONBLOCK flag of proc.stdout file descriptor:
+                flags = fcntl(proc.stdout, F_GETFL)  # get current proc.stdout flags
+                fcntl(proc.stdout, F_SETFL, flags | os.O_NONBLOCK)
+                # set the O_NONBLOCK flag of proc.stderr file descriptor:
+                flags = fcntl(proc.stderr, F_GETFL)  # get current proc.stderr flags
+                fcntl(proc.stderr, F_SETFL, flags | os.O_NONBLOCK)
+
+                rc = None
+                stdout_complete = False
+                stderr_complete = False
+                while not stdout_complete or not stderr_complete or rc is None:
+                    try:
+                        output = os.read(proc.stdout.fileno(), 4096)
+                        if output:
+                            green_print(output.rstrip())
+                            out += output
+                        else:
+                            stdout_complete = True
+                    except OSError as ose:
+                        if ose.errno == errno.EAGAIN or ose.errno == errno.EWOULDBLOCK:
+                            pass  # It is supposed to raise one of these exceptions
+                        else:
+                            raise
+
+                    try:
+                        error = os.read(proc.stderr.fileno(), 4096)
+                        if error:
+                            yellow_print(error.rstrip())
+                            out += error
+                        else:
+                            stderr_complete = True
+                    except OSError as ose:
+                        if ose.errno == errno.EAGAIN or ose.errno == errno.EWOULDBLOCK:
+                            pass  # It is supposed to raise one of these exceptions
+                        else:
+                            raise
+
+                    if rc is None:
+                        rc = proc.poll()
+                        time.sleep(0.5)  # reduce busy-wait
+
+            # We read in bytes representing utf-8 output; decode so that python recognizes them as unicode strings
+            out = out.decode('utf-8')
+            err = err.decode('utf-8')
+
+            log_output_stdout = out
+            log_output_stderr = err
+            if not log_stdout and len(out) > 200:
+                log_output_stdout = f'{out[:200]}\n..truncated..'
+            if not log_stderr and len(err) > 200:
+                log_output_stderr = f'{err[:200]}\n..truncated..'
+
+            if rc:
+                logger.debug(
+                    "{}: Exited with error: {}\nstdout>>{}<<\nstderr>>{}<<\n".format(
+                        cmd_info, rc, log_output_stdout, log_output_stderr
+                    )
                 )
-            )
+            else:
+                logger.debug(
+                    "{}: Exited with: {}\nstdout>>{}<<\nstderr>>{}<<\n".format(
+                        cmd_info, rc, log_output_stdout, log_output_stderr
+                    )
+                )
+
+        if rc == SUCCESS:
+            break
 
     if strip:
         out = out.strip()

--- a/artcommon/artcommonlib/gitdata.py
+++ b/artcommon/artcommonlib/gitdata.py
@@ -1,5 +1,4 @@
 import io
-import logging
 import os
 import shutil
 import string
@@ -7,7 +6,6 @@ import urllib.parse
 
 import ruamel.yaml
 import ruamel.yaml.util
-import tenacity
 import yaml
 from artcommonlib import exectools
 from artcommonlib.constants import GIT_NO_PROMPTS
@@ -171,18 +169,14 @@ class GitData(object):
                             raise GitDataBranchException(msg)
                     else:
                         # Check if local is synced with remote
-                        for attempt in tenacity.Retrying(
-                            stop=tenacity.stop_after_attempt(3),
-                            wait=tenacity.wait_fixed(5),
-                            before_sleep=tenacity.before_sleep_log(self.logger, logging.WARNING),
-                            reraise=True,
-                        ):
-                            with attempt:
-                                rc, out, err = exectools.cmd_gather(
-                                    ["git", "ls-remote", self.data_path, self.branch], set_env=git_env
-                                )
-                                if rc:
-                                    raise GitDataException('Unable to check remote sha: {}'.format(err))
+                        rc, out, err = exectools.cmd_gather(
+                            ["git", "ls-remote", self.data_path, self.branch],
+                            set_env=git_env,
+                            retries=3,
+                            pollrate=5,
+                        )
+                        if rc:
+                            raise GitDataException('Unable to check remote sha: {}'.format(err))
                         remote = out.strip().split('\t')[0]
                         try:
                             exectools.cmd_assert('git branch --contains {}'.format(remote))
@@ -203,7 +197,7 @@ class GitData(object):
                 self.logger.info('Cloning config data from {}'.format(self.data_path))
                 if not os.path.isdir(data_destination):
                     cmd = "git clone --no-single-branch {} {}".format(self.data_path, data_destination)
-                    exectools.cmd_assert(cmd, set_env=git_env)
+                    exectools.cmd_assert(cmd, set_env=git_env, retries=3)
                     exectools.cmd_assert(f'git -C {data_destination} checkout {self.branch}', set_env=git_env)
 
             self.remote_path = self.data_path
@@ -334,4 +328,4 @@ class GitData(object):
         """
         self.logger.info('Pushing config...')
         with Dir(self.data_path):
-            exectools.cmd_assert('git push')
+            exectools.cmd_assert('git push', retries=3)

--- a/artcommon/artcommonlib/gitdata.py
+++ b/artcommon/artcommonlib/gitdata.py
@@ -1,4 +1,5 @@
 import io
+import logging
 import os
 import shutil
 import string
@@ -6,6 +7,7 @@ import urllib.parse
 
 import ruamel.yaml
 import ruamel.yaml.util
+import tenacity
 import yaml
 from artcommonlib import exectools
 from artcommonlib.constants import GIT_NO_PROMPTS
@@ -169,11 +171,18 @@ class GitData(object):
                             raise GitDataBranchException(msg)
                     else:
                         # Check if local is synced with remote
-                        rc, out, err = exectools.cmd_gather(
-                            ["git", "ls-remote", self.data_path, self.branch], set_env=git_env
-                        )
-                        if rc:
-                            raise GitDataException('Unable to check remote sha: {}'.format(err))
+                        for attempt in tenacity.Retrying(
+                            stop=tenacity.stop_after_attempt(3),
+                            wait=tenacity.wait_fixed(5),
+                            before_sleep=tenacity.before_sleep_log(self.logger, logging.WARNING),
+                            reraise=True,
+                        ):
+                            with attempt:
+                                rc, out, err = exectools.cmd_gather(
+                                    ["git", "ls-remote", self.data_path, self.branch], set_env=git_env
+                                )
+                                if rc:
+                                    raise GitDataException('Unable to check remote sha: {}'.format(err))
                         remote = out.strip().split('\t')[0]
                         try:
                             exectools.cmd_assert('git branch --contains {}'.format(remote))


### PR DESCRIPTION
Guard against transient github errors

seen at https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/45808/console

```
File "/mnt/jenkins-workspace/d-builds_build_ocp4-scan-konflux/art-tools/artcommon/artcommonlib/gitdata.py", line 176, in clone_data
12:22:27      raise GitDataException('Unable to check remote sha: {}'.format(err))
12:22:27  artcommonlib.gitdata.GitDataException: Unable to check remote sha: error: RPC failed; HTTP 500 curl 22 The requested URL returned error: 500
12:22:27  fatal: expected flush after ref listing
```

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED