### PR TITLE
promote: remove XDG_RUNTIME_DIR from env var dicts

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -194,6 +194,8 @@ class PromotePipeline:
         if 'XDG_RUNTIME_DIR' in os.environ:
             logger.info('Unsetting XDG_RUNTIME_DIR to prevent use of default registry auth')
             del os.environ['XDG_RUNTIME_DIR']
+        self._doozer_env_vars.pop('XDG_RUNTIME_DIR', None)
+        self._elliott_env_vars.pop('XDG_RUNTIME_DIR', None)
 
         quay_auth_file = os.getenv('QUAY_AUTH_FILE')
         if not quay_auth_file:


### PR DESCRIPTION
When `XDG_RUNTIME_DIR` is deleted from os.environ in run(), it must also be removed from the  `_doozer_env_vars` and `_elliott_env_vars` dictionaries that were copied from os.environ in __init__().

Otherwise, doozer and elliott commands will still inherit the XDG_RUNTIME_DIR value and potentially use unintended registry auth.

This follows the same pattern already applied in gen_assembly.py via PR #2828.