### PR TITLE
Skip package name comparison for test assembly builds

### DIFF
--- a/artcommon/artcommonlib/rpm_utils.py
+++ b/artcommon/artcommonlib/rpm_utils.py
@@ -96,7 +96,9 @@ def compare_nvr(nvr_dict1: NVR, nvr_dict2: NVR, ignore_epoch: bool = False, igno
     @type ignore_epoch: bool
     @param ignore_name: skip package name comparison check
     @type ignore_name: bool
-    @return: nvr1 newer than nvr2: 1, same nvrs: 0, nvr1 older: -1, different names: ValueError
+    @return: nvr1 newer than nvr2: 1, same nvrs: 0, nvr1 older: -1.
+             When ignore_name=False (default), raises ValueError if package names differ.
+             When ignore_name=True, name differences are ignored and comparison proceeds.
     @rtype: int
     """
 

--- a/artcommon/artcommonlib/rpm_utils.py
+++ b/artcommon/artcommonlib/rpm_utils.py
@@ -83,7 +83,7 @@ def to_nevra(d: Dict):
     return to_nevr(d) + f".{arch}"
 
 
-def compare_nvr(nvr_dict1: NVR, nvr_dict2: NVR, ignore_epoch: bool = False):
+def compare_nvr(nvr_dict1: NVR, nvr_dict2: NVR, ignore_epoch: bool = False, ignore_name: bool = False):
     """Compare two N-V-R dictionaries.
 
     This function is backported from `kobo.rpmlib.compare_nvr`.
@@ -94,6 +94,8 @@ def compare_nvr(nvr_dict1: NVR, nvr_dict2: NVR, ignore_epoch: bool = False):
     @type nvr_dict2: dict
     @param ignore_epoch: ignore epoch during the comparison
     @type ignore_epoch: bool
+    @param ignore_name: skip package name comparison check
+    @type ignore_name: bool
     @return: nvr1 newer than nvr2: 1, same nvrs: 0, nvr1 older: -1, different names: ValueError
     @rtype: int
     """
@@ -104,7 +106,7 @@ def compare_nvr(nvr_dict1: NVR, nvr_dict2: NVR, ignore_epoch: bool = False):
     nvr1["epoch"] = nvr1.get("epoch", None)
     nvr2["epoch"] = nvr2.get("epoch", None)
 
-    if nvr1["name"] != nvr2["name"]:
+    if not ignore_name and nvr1["name"] != nvr2["name"]:
         raise ValueError("Package names doesn't match: %s, %s" % (nvr1["name"], nvr2["name"]))
 
     if ignore_epoch:

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -179,8 +179,10 @@ class KonfluxImageBuilder:
                 target_nvr_dict["version"] = _normalize_version(target_nvr_dict["version"])
                 latest_nvr_dict["version"] = _normalize_version(latest_nvr_dict["version"])
 
+                # Skip package name comparison for test assemblies
                 # compare_nvr returns: 1 if target > latest, 0 if equal, -1 if target < latest
-                if compare_nvr(target_nvr_dict, latest_nvr_dict) <= 0:
+                ignore_name = metadata.runtime.assembly == "test"
+                if compare_nvr(target_nvr_dict, latest_nvr_dict, ignore_name=ignore_name) <= 0:
                     raise ValueError(
                         f"Target NVR {nvr} is not greater than the latest successful build {latest_build.nvr}. "
                         f"Latest build pullspec: {latest_build.image_pullspec}. "


### PR DESCRIPTION
Add an optional `ignore_name` parameter to `compare_nvr()` to skip package name comparison during NVR checks.

This change is needed to avoid issues with test assembly containing NVRs without `-container` suffix (remnant of Konflux test builds which did not add `-container` to the NVR).

[Test build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/32507/)