### PR TITLE
ART-18150 add release notes text support for layered operators

### DIFF
--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -76,6 +76,10 @@ class ReleaseFromFbcPipeline:
         jira_bugs: Optional[List[str]] = None,
         target_release_date: Optional[str] = None,
         extra_image_nvrs: Optional[List[str]] = None,
+        release_notes_synopsis: Optional[str] = None,
+        release_notes_topic: Optional[str] = None,
+        release_notes_description: Optional[str] = None,
+        release_notes_solution: Optional[str] = None,
     ) -> None:
         self.logger = logging.getLogger(__name__)
         self.runtime = runtime
@@ -115,6 +119,10 @@ class ReleaseFromFbcPipeline:
 
         self.jira_bugs = jira_bugs
         self.target_release_date = target_release_date
+        self.release_notes_synopsis = release_notes_synopsis
+        self.release_notes_topic = release_notes_topic
+        self.release_notes_description = release_notes_description
+        self.release_notes_solution = release_notes_solution
 
         # Base elliott command template
         self._elliott_base_command = [
@@ -502,6 +510,36 @@ class ReleaseFromFbcPipeline:
             len(release_notes.issues.fixed) if release_notes.issues and release_notes.issues.fixed else 0,
             len(release_notes.cves) if release_notes.cves else 0,
         )
+        return release_notes
+
+    def _apply_release_notes_text(self, release_notes: Optional[ReleaseNotes]) -> Optional[ReleaseNotes]:
+        """
+        Merge user-provided release notes text fields into a ReleaseNotes object.
+
+        Arg(s):
+            release_notes (ReleaseNotes | None): Existing ReleaseNotes from JIRA bug processing, or None.
+        Return Value(s):
+            ReleaseNotes | None: The merged ReleaseNotes, a new one, or None if nothing to apply.
+        """
+        text_fields = {
+            "synopsis": self.release_notes_synopsis,
+            "topic": self.release_notes_topic,
+            "description": self.release_notes_description,
+            "solution": self.release_notes_solution,
+        }
+        provided = {k: v for k, v in text_fields.items() if v is not None and v.strip()}
+
+        if not provided:
+            return release_notes
+
+        if release_notes is None:
+            self.logger.info("No JIRA bugs provided; creating RHBA release notes from text fields")
+            release_notes = ReleaseNotes(type="RHBA")
+
+        for field, value in provided.items():
+            self.logger.info("Setting release notes %s from CLI parameter", field)
+            setattr(release_notes, field, value)
+
         return release_notes
 
     def create_shipment_config(
@@ -913,6 +951,9 @@ class ReleaseFromFbcPipeline:
         if self.jira_bugs:
             release_notes = self.generate_release_notes()
 
+        # Overlay user-provided release notes text fields
+        release_notes = self._apply_release_notes_text(release_notes)
+
         # Create shipment configurations
         timestamp = datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
         shipments_by_kind = {}
@@ -1009,6 +1050,26 @@ class ReleaseFromFbcPipeline:
     help='Target ship date for the release (e.g., 2026-Mar-31 or 2026-03-31). '
     'When provided, the date is included in the shipment MR title.',
 )
+@click.option(
+    '--release-notes-synopsis',
+    default=None,
+    help='Optional synopsis text for release notes (short advisory summary).',
+)
+@click.option(
+    '--release-notes-topic',
+    default=None,
+    help='Optional topic text for release notes (expanded description).',
+)
+@click.option(
+    '--release-notes-description',
+    default=None,
+    help='Optional description text for release notes (full detailed description).',
+)
+@click.option(
+    '--release-notes-solution',
+    default=None,
+    help='Optional solution text for release notes (how to apply the fix/update).',
+)
 @pass_runtime
 @click_coroutine
 async def release_from_fbc(
@@ -1022,6 +1083,10 @@ async def release_from_fbc(
     shipment_path: Optional[str],
     jira_bugs: Optional[str],
     target_release_date: Optional[str],
+    release_notes_synopsis: Optional[str],
+    release_notes_topic: Optional[str],
+    release_notes_description: Optional[str],
+    release_notes_solution: Optional[str],
 ):
     """
     Create shipment files from an FBC image for non-OpenShift products.
@@ -1094,6 +1159,10 @@ async def release_from_fbc(
         jira_bugs=jira_bugs_list,
         target_release_date=normalized_date,
         extra_image_nvrs=extra_image_nvrs_list,
+        release_notes_synopsis=release_notes_synopsis,
+        release_notes_topic=release_notes_topic,
+        release_notes_description=release_notes_description,
+        release_notes_solution=release_notes_solution,
     )
 
     await pipeline.run()

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -716,6 +716,170 @@ class TestCliValidation(unittest.TestCase):
         result = self._invoke(["--extra-image-nvrs", "foo-container-1.0-1.el9"])
         self.assertNotIsInstance(result.exception, click.ClickException)
 
+    @patch("pyartcd.pipelines.release_from_fbc.ReleaseFromFbcPipeline")
+    def test_release_notes_options_passed_to_pipeline(self, mock_pipeline_cls):
+        """Release notes CLI options should be passed through to the pipeline."""
+        mock_pipeline_cls.return_value.run = AsyncMock()
+        result = self._invoke(
+            [
+                "--fbc-pullspecs",
+                "quay.io/example/fbc:v1",
+                "--release-notes-synopsis",
+                "Bug fix update",
+                "--release-notes-topic",
+                "An update is available",
+                "--release-notes-description",
+                "Fixes several bugs",
+                "--release-notes-solution",
+                "Apply the update",
+            ]
+        )
+        self.assertIsNone(result.exception)
+
+        call_kwargs = mock_pipeline_cls.call_args[1]
+        self.assertEqual(call_kwargs["release_notes_synopsis"], "Bug fix update")
+        self.assertEqual(call_kwargs["release_notes_topic"], "An update is available")
+        self.assertEqual(call_kwargs["release_notes_description"], "Fixes several bugs")
+        self.assertEqual(call_kwargs["release_notes_solution"], "Apply the update")
+
+    @patch("pyartcd.pipelines.release_from_fbc.ReleaseFromFbcPipeline")
+    def test_release_notes_options_default_none(self, mock_pipeline_cls):
+        """Release notes CLI options should default to None when not provided."""
+        mock_pipeline_cls.return_value.run = AsyncMock()
+        result = self._invoke(["--fbc-pullspecs", "quay.io/example/fbc:v1"])
+        self.assertIsNone(result.exception)
+
+        call_kwargs = mock_pipeline_cls.call_args[1]
+        self.assertIsNone(call_kwargs["release_notes_synopsis"])
+        self.assertIsNone(call_kwargs["release_notes_topic"])
+        self.assertIsNone(call_kwargs["release_notes_description"])
+        self.assertIsNone(call_kwargs["release_notes_solution"])
+
+
+class TestApplyReleaseNotesText(unittest.TestCase):
+    """Tests for _apply_release_notes_text merge logic."""
+
+    def _make_pipeline(self, synopsis=None, topic=None, description=None, solution=None):
+        runtime = MagicMock()
+        runtime.dry_run = False
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        runtime.config = {}
+
+        pipeline = ReleaseFromFbcPipeline(
+            runtime=runtime,
+            group="logging-6.5",
+            assembly="6.5.0",
+            fbc_pullspecs=["quay.io/test/fbc:latest"],
+            release_notes_synopsis=synopsis,
+            release_notes_topic=topic,
+            release_notes_description=description,
+            release_notes_solution=solution,
+        )
+        pipeline.product = "logging"
+        return pipeline
+
+    def test_overlay_on_existing_release_notes(self):
+        """User-provided text fields are overlaid onto ReleaseNotes from bug processing."""
+        pipeline = self._make_pipeline(
+            synopsis="Logging 6.5.0 bug fix update",
+            topic="An update is available for Logging 6.5.",
+        )
+        existing_rn = ReleaseNotes(type="RHSA")
+
+        result = pipeline._apply_release_notes_text(existing_rn)
+
+        self.assertIs(result, existing_rn)
+        self.assertEqual(result.type, "RHSA")
+        self.assertEqual(result.synopsis, "Logging 6.5.0 bug fix update")
+        self.assertEqual(result.topic, "An update is available for Logging 6.5.")
+        self.assertIsNone(result.description)
+        self.assertIsNone(result.solution)
+
+    def test_text_only_creates_rhba(self):
+        """When no existing ReleaseNotes, a new RHBA is created with text fields."""
+        pipeline = self._make_pipeline(
+            synopsis="Logging 6.5.0 bug fix update",
+            description="This update fixes several bugs.",
+            solution="Apply the update using the operator.",
+        )
+
+        result = pipeline._apply_release_notes_text(None)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.type, "RHBA")
+        self.assertEqual(result.synopsis, "Logging 6.5.0 bug fix update")
+        self.assertIsNone(result.topic)
+        self.assertEqual(result.description, "This update fixes several bugs.")
+        self.assertEqual(result.solution, "Apply the update using the operator.")
+
+    def test_neither_bugs_nor_text_returns_none(self):
+        """When no text fields and no existing ReleaseNotes, returns None."""
+        pipeline = self._make_pipeline()
+
+        result = pipeline._apply_release_notes_text(None)
+
+        self.assertIsNone(result)
+
+    def test_partial_text_only_sets_provided_fields(self):
+        """Only provided text fields are set; others remain None."""
+        pipeline = self._make_pipeline(solution="Apply the update.")
+        existing_rn = ReleaseNotes(type="RHBA")
+
+        result = pipeline._apply_release_notes_text(existing_rn)
+
+        self.assertIsNone(result.synopsis)
+        self.assertIsNone(result.topic)
+        self.assertIsNone(result.description)
+        self.assertEqual(result.solution, "Apply the update.")
+
+    def test_all_four_fields(self):
+        """All four text fields are set when all are provided."""
+        pipeline = self._make_pipeline(
+            synopsis="Synopsis text",
+            topic="Topic text",
+            description="Description text",
+            solution="Solution text",
+        )
+
+        result = pipeline._apply_release_notes_text(None)
+
+        self.assertEqual(result.type, "RHBA")
+        self.assertEqual(result.synopsis, "Synopsis text")
+        self.assertEqual(result.topic, "Topic text")
+        self.assertEqual(result.description, "Description text")
+        self.assertEqual(result.solution, "Solution text")
+
+    def test_no_text_with_existing_rn_returns_unchanged(self):
+        """When no text fields are provided but ReleaseNotes exists, it passes through unchanged."""
+        pipeline = self._make_pipeline()
+        existing_rn = ReleaseNotes(type="RHSA")
+
+        result = pipeline._apply_release_notes_text(existing_rn)
+
+        self.assertIs(result, existing_rn)
+        self.assertIsNone(result.synopsis)
+
+    def test_empty_and_whitespace_strings_ignored(self):
+        """Empty and whitespace-only strings are treated as not provided."""
+        pipeline = self._make_pipeline(synopsis="", topic="   ", description=None, solution="Real value")
+        existing_rn = ReleaseNotes(type="RHBA")
+
+        result = pipeline._apply_release_notes_text(existing_rn)
+
+        self.assertIsNone(result.synopsis)
+        self.assertIsNone(result.topic)
+        self.assertIsNone(result.description)
+        self.assertEqual(result.solution, "Real value")
+
+    def test_all_empty_strings_returns_unchanged(self):
+        """When all text fields are empty strings, release_notes passes through unchanged."""
+        pipeline = self._make_pipeline(synopsis="", topic="", description="", solution="")
+
+        result = pipeline._apply_release_notes_text(None)
+
+        self.assertIsNone(result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
  ## Summary                                            
                                          
  - Adds 4 optional CLI options (`--release-notes-synopsis`, `--release-notes-topic`, `--release-notes-description`, `--release-notes-solution`) to `artcd release-from-fbc`             
  - New `_apply_release_notes_text()` method merges user-provided text into `ReleaseNotes` from JIRA bug processing, or creates a new `RHBA` when no `--jira-bugs` are provided
  - 8 new unit tests covering overlay, text-only, partial, and default scenarios                                                                                                         

  ## Follow-up work (separate repos)                                                                                                                                                     

  - **aos-cd-jobs**: Add matching Jenkins job parameters -> https://github.com/openshift-eng/aos-cd-jobs/pull/4671                                                                                                                         
  - **art-ai-helpers**: Update AI skill to parse release notes from JIRA tickets -> https://gitlab.cee.redhat.com/hybrid-platforms/art/art-ai-helpers/-/merge_requests/29               
