### PR TITLE
Skip non-OLM name_in_bundle registration

### DIFF
--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -250,6 +250,45 @@ class Runtime(GroupRuntime):
     def group_config(self, config: Model):
         self._group_config = config
 
+    @staticmethod
+    def _should_register_name_in_bundle(image_data: Model) -> bool:
+        name_in_bundle = image_data.get('name_in_bundle')
+        if name_in_bundle not in (None, Missing):
+            return True
+
+        update_csv = image_data.get('update-csv')
+        if update_csv not in (None, Missing):
+            return True
+
+        dependents = image_data.get('dependents', [])
+        return dependents not in (None, Missing, [])
+
+    def _populate_image_name_maps(self, image_name_data):
+        def _register_name_in_bundle(name_in_bundle: str, distgit_key: str):
+            if name_in_bundle in self.name_in_bundle_map:
+                raise ValueError(
+                    f"Image {distgit_key} has name_in_bundle={name_in_bundle}, which is already taken by image {self.name_in_bundle_map[name_in_bundle]}"
+                )
+            self.name_in_bundle_map[name_in_bundle] = distgit_key
+
+        for img in image_name_data.values():
+            name = img.data.get('name')
+            short_name = name.split('/')[1]
+            self.image_name_map[name] = img.key
+            self.image_name_map[short_name] = img.key
+
+            if not self._should_register_name_in_bundle(img.data):
+                continue
+
+            name_in_bundle = img.data.get('name_in_bundle')
+            if name_in_bundle:
+                _register_name_in_bundle(name_in_bundle, img.key)
+            else:
+                short_name_without_ose = short_name[4:] if short_name.startswith("ose-") else short_name
+                _register_name_in_bundle(short_name_without_ose, img.key)
+                short_name_with_ose = "ose-" + short_name_without_ose
+                _register_name_in_bundle(short_name_with_ose, img.key)
+
     @functools.lru_cache(maxsize=1)
     def get_group_config(self) -> Model:
         """
@@ -714,26 +753,7 @@ class Runtime(GroupRuntime):
             # name or distgit. For now this is used elsewhere
             image_name_data = self.gitdata.load_data(path='images')
 
-            def _register_name_in_bundle(name_in_bundle: str, distgit_key: str):
-                if name_in_bundle in self.name_in_bundle_map:
-                    raise ValueError(
-                        f"Image {distgit_key} has name_in_bundle={name_in_bundle}, which is already taken by image {self.name_in_bundle_map[name_in_bundle]}"
-                    )
-                self.name_in_bundle_map[name_in_bundle] = img.key
-
-            for img in image_name_data.values():
-                name = img.data.get('name')
-                short_name = name.split('/')[1]
-                self.image_name_map[name] = img.key
-                self.image_name_map[short_name] = img.key
-                name_in_bundle = img.data.get('name_in_bundle')
-                if name_in_bundle:
-                    _register_name_in_bundle(name_in_bundle, img.key)
-                else:
-                    short_name_without_ose = short_name[4:] if short_name.startswith("ose-") else short_name
-                    _register_name_in_bundle(short_name_without_ose, img.key)
-                    short_name_with_ose = "ose-" + short_name_without_ose
-                    _register_name_in_bundle(short_name_with_ose, img.key)
+            self._populate_image_name_maps(image_name_data)
 
             image_data = self.gitdata.load_data(
                 path='images',

--- a/doozer/tests/test_runtime.py
+++ b/doozer/tests/test_runtime.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import logging
 import unittest
+from types import SimpleNamespace
 
 from artcommonlib.model import Model
 from doozerlib import runtime
@@ -16,6 +17,74 @@ def stub_runtime():
     rt._logger = logging.getLogger(__name__)
     rt.group_config = Model()
     return rt
+
+
+class TestRuntime(unittest.TestCase):
+    @staticmethod
+    def _entry(key, data):
+        return SimpleNamespace(key=key, data=Model(dict_to_model=data))
+
+    def test_populate_image_name_maps_skips_non_olm_duplicates(self):
+        rt = stub_runtime()
+
+        rt._populate_image_name_maps(
+            {
+                "openshift-golang-builder": self._entry(
+                    "openshift-golang-builder",
+                    {"name": "openshift/golang-builder"},
+                ),
+                "openshift-golang-builder-94": self._entry(
+                    "openshift-golang-builder-94",
+                    {"name": "openshift/golang-builder"},
+                ),
+            }
+        )
+
+        self.assertEqual({}, rt.name_in_bundle_map)
+
+    def test_populate_image_name_maps_registers_olm_related_images(self):
+        rt = stub_runtime()
+
+        rt._populate_image_name_maps(
+            {
+                "my-operator": self._entry(
+                    "my-operator",
+                    {
+                        "name": "openshift/ose-my-operator",
+                        "update-csv": {"manifests-dir": "manifests"},
+                    },
+                ),
+                "my-operand": self._entry(
+                    "my-operand",
+                    {
+                        "name": "openshift/ose-my-operand",
+                        "dependents": ["my-operator"],
+                    },
+                ),
+            }
+        )
+
+        self.assertEqual("my-operator", rt.name_in_bundle_map["my-operator"])
+        self.assertEqual("my-operator", rt.name_in_bundle_map["ose-my-operator"])
+        self.assertEqual("my-operand", rt.name_in_bundle_map["my-operand"])
+        self.assertEqual("my-operand", rt.name_in_bundle_map["ose-my-operand"])
+
+    def test_populate_image_name_maps_keeps_explicit_name_in_bundle(self):
+        rt = stub_runtime()
+
+        rt._populate_image_name_maps(
+            {
+                "custom-image": self._entry(
+                    "custom-image",
+                    {
+                        "name": "openshift/custom-image",
+                        "name_in_bundle": "explicit-bundle-name",
+                    },
+                ),
+            }
+        )
+
+        self.assertEqual("custom-image", rt.name_in_bundle_map["explicit-bundle-name"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Error seen at https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgolang-builder/421/console

https://redhat-internal.slack.com/archives/GDBRP5YJH/p1777291714375859?thread_ts=1777048881.085539&cid=GDBRP5YJH

## Summary
- avoid registering inferred bundle names for images that are not part of OLM bundle rewriting
- keep explicit `name_in_bundle` entries and OLM operator or operand registration unchanged
- add runtime tests covering non-OLM duplicate names and OLM-related registration

## Test plan
- [x] `uv run pytest --verbose --color=yes doozer/tests/test_runtime.py`
