### PR TITLE
Use a fresh safe YAML instance for parsing yaml

### DIFF
--- a/artcommon/artcommonlib/config/__init__.py
+++ b/artcommon/artcommonlib/config/__init__.py
@@ -18,6 +18,14 @@ class _IncludeConstructor:
         self.base_dir = base_dir.resolve() if base_dir else None
         self.replace_vars = replace_vars
 
+    def _new_yaml(self) -> YAML:
+        """Create a fresh parser so nested !include loads are not re-entrant."""
+        nested_yaml = YAML(typ='safe')
+        nested_yaml.constructor.add_constructor(
+            '!include', _IncludeConstructor(base_dir=self.base_dir, replace_vars=self.replace_vars)
+        )
+        return nested_yaml
+
     def __call__(self, loader, node) -> Any:
         if node.id == "scalar":  # for `!include "file.yml"`
             patterns = (loader.construct_scalar(node),)
@@ -42,7 +50,7 @@ class _IncludeConstructor:
                     content = content.format(**self.replace_vars)
                 f = StringIO(content)
                 f.name = str(file)
-                doc = yaml.load(f)
+                doc = self._new_yaml().load(f)
                 if isinstance(merged_doc, dict):
                     merged_doc = {**merged_doc, **doc}
                 elif isinstance(merged_doc, list):

--- a/artcommon/tests/test_build_data_loader.py
+++ b/artcommon/tests/test_build_data_loader.py
@@ -1,0 +1,67 @@
+from io import StringIO
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+
+from artcommonlib.config import BuildDataLoader
+from ruamel.yaml import YAML
+
+
+class _StubGitData:
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = str(data_dir)
+
+    def load_data(self, key, replace_vars=None):
+        path = Path(self.data_dir) / f"{key}.yml"
+        content = path.read_text()
+        if replace_vars:
+            content = content.format(**replace_vars)
+        f = StringIO(content)
+        f.name = str(path)
+        return SimpleNamespace(data=YAML(typ='safe').load(f))
+
+
+class TestBuildDataLoader(TestCase):
+    def test_load_group_config_with_includes(self):
+        with self.subTest("group.ext !include uses a fresh parser"):
+            from tempfile import TemporaryDirectory
+
+            with TemporaryDirectory() as temp_dir:
+                data_dir = Path(temp_dir)
+                (data_dir / "group.yml").write_text(
+                    "\n".join(
+                        [
+                            "vars:",
+                            "  MAJOR: 4",
+                            "  MINOR: 21",
+                            "name: openshift-{MAJOR}.{MINOR}",
+                            "",
+                        ]
+                    )
+                )
+                (data_dir / "group.ext.yml").write_text("plashet: !include plashet.yml\n")
+                (data_dir / "plashet.yml").write_text(
+                    "\n".join(
+                        [
+                            'base_dir: "{MAJOR}.{MINOR}/$runtime_assembly/$slug"',
+                            'plashet_dir: "$yyyy-$MM/$revision"',
+                            "create_symlinks: true",
+                            "",
+                        ]
+                    )
+                )
+
+                loader = BuildDataLoader(
+                    data_path=str(data_dir),
+                    clone_dir=str(data_dir),
+                    commitish="openshift-4.21",
+                    build_system="brew",
+                    gitdata=_StubGitData(data_dir),
+                )
+
+                group_config = loader.load_group_config(assembly=None, releases_config=None)
+
+                self.assertEqual(group_config["name"], "openshift-4.21")
+                self.assertEqual(group_config["plashet"]["base_dir"], "4.21/$runtime_assembly/$slug")
+                self.assertEqual(group_config["plashet"]["plashet_dir"], "$yyyy-$MM/$revision")
+                self.assertTrue(group_config["plashet"]["create_symlinks"])


### PR DESCRIPTION
## Summary
- fix `BuildDataLoader` `!include` parsing to use a fresh `YAML(typ='safe')` instance for each included file instead of re-entering the active parser
- address the `ruamel.yaml` re-entrancy failure seen in `art-bot` while loading `openshift-4.21` `group.ext.yml -> plashet.yml`
- add a focused regression test covering `load_group_config()` with `group.ext.yml` includes and variable substitution

## Where This Failed
- observed in `art-bot` while running `elliott`, where loading build data for `openshift-4.21` crashed before command execution completed - https://redhat-internal.slack.com/archives/GTDLQU9LH/p1777300616700729

## Testing
- `uv run pytest --verbose --color=yes artcommon/tests/test_build_data_loader.py`