### PR TITLE
pyartcd: scope update-golang image operations to builder

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -677,6 +677,8 @@ class UpdateGolangPipeline:
             [
                 "--group",
                 branch,
+                "-i",
+                GOLANG_BUILDER_IMAGE_NAME,
                 "images:rebase",
                 "--version",
                 version,
@@ -706,6 +708,8 @@ class UpdateGolangPipeline:
             [
                 "--group",
                 branch,
+                "-i",
+                GOLANG_BUILDER_IMAGE_NAME,
                 "images:build",
                 "--repo-type",
                 "unsigned",
@@ -741,6 +745,8 @@ class UpdateGolangPipeline:
             [
                 "--group",
                 branch,
+                "-i",
+                GOLANG_BUILDER_IMAGE_NAME,
                 "beta:images:konflux:rebase",
                 "--version",
                 version,
@@ -774,6 +780,8 @@ class UpdateGolangPipeline:
             [
                 "--group",
                 branch,
+                "-i",
+                GOLANG_BUILDER_IMAGE_NAME,
                 "beta:images:konflux:build",
                 f"--konflux-namespace={konflux_namespace}",
                 "--skip-ec-verify",


### PR DESCRIPTION
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgolang-builder/423/console

## Summary
- scope `update_golang` rebase commands to `openshift-golang-builder` with `-i`
- scope `update_golang` build commands to `openshift-golang-builder` for both Brew and Konflux
- avoid touching unrelated images when the pipeline rebuilds golang builder artifacts

## Test plan
- [x] Run `python3 -m py_compile pyartcd/pyartcd/pipelines/update_golang.py`
- [ ] Exercise `update-golang` against a real environment if needed

Made with [Cursor](https://cursor.com)