### PR TITLE
ART-16004: pyartcd use published Konflux golang pullspecs in streams

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -568,7 +568,7 @@ class UpdateGolangPipeline:
 
     async def _ensure_builder_pullspec_available(self, pullspec: str):
         """Verify the published golang builder pullspec is available before updating streams.yml."""
-        registry_config = os.getenv("REGISTRY_AUTH_FILE")
+        registry_config = os.getenv("QUAY_AUTH_FILE")
         try:
             await get_image_info(pullspec, raise_if_not_found=True, registry_config=registry_config)
         except Exception as e:

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -12,8 +12,8 @@ from artcommonlib.brew import BuildStates
 from artcommonlib.constants import (
     BREW_HUB,
     GOLANG_BUILDER_IMAGE_NAME,
-    KONFLUX_DEFAULT_IMAGE_REPO,
     PRODUCT_NAMESPACE_MAP,
+    REGISTRY_REDHAT_IO,
 )
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
@@ -21,16 +21,19 @@ from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.release_util import split_el_suffix_in_release
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import new_roundtrip_yaml_handler
+from doozerlib.backend.base_image_handler import ART_IMAGES_BASE_APPLICATION
 from elliottlib import util as elliottutil
 from elliottlib.constants import GOLANG_BUILDER_CVE_COMPONENT
 
 from pyartcd import constants, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.oc import get_image_info
 from pyartcd.runtime import Runtime
 from pyartcd.util import default_release_suffix
 
 _LOGGER = logging.getLogger(__name__)
 yaml = new_roundtrip_yaml_handler()
+PUBLISHED_GOLANG_BUILDER_REPO = f"{REGISTRY_REDHAT_IO}/openshift/{ART_IMAGES_BASE_APPLICATION}"
 
 
 def is_latest_build(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool:
@@ -391,34 +394,23 @@ class UpdateGolangPipeline:
                     )
                 raise ValueError(error_msg)
 
-        _LOGGER.info("Updating streams.yml with found builder images")
-        # Prepare message with all newly built builders
-        all_builder_messages = []
-        if brew_nvrs:
-            for el_v, nvr in brew_nvrs.items():
-                parsed_nvr = parse_nvr(nvr)
-                pullspec = self._get_builder_pullspec(parsed_nvr, 'brew')
-                all_builder_messages.append(f"RHEL {el_v}: {nvr} -> {pullspec} (brew)")
-        if konflux_nvrs:
-            for el_v, nvr in konflux_nvrs.items():
-                parsed_nvr = parse_nvr(nvr)
-                pullspec = self._get_builder_pullspec(parsed_nvr, 'konflux')
-                all_builder_messages.append(f"RHEL {el_v}: {nvr} -> {pullspec} (konflux)")
+        # streams.yml should only reference the published pullspecs for Konflux-built builders.
+        builder_nvrs = konflux_nvrs
+        builder_pullspecs = {el_v: self._get_builder_pullspec(nvr) for el_v, nvr in builder_nvrs.items()}
+        if builder_pullspecs:
+            await asyncio.gather(
+                *[self._ensure_builder_pullspec_available(pullspec) for pullspec in builder_pullspecs.values()]
+            )
+            builder_details = "\n".join(
+                [f"  - RHEL {el_v}: {nvr} -> {builder_pullspecs[el_v]}" for el_v, nvr in builder_nvrs.items()]
+            )
+            builder_message = "Konflux golang builders available for streams.yml:\n" + builder_details
+            _LOGGER.info(builder_message)
+            await self._slack_client.say_in_thread(builder_message)
+        else:
+            _LOGGER.info("No Konflux golang builder images found; streams.yml will not be updated.")
 
-        builder_message = "New golang builders available:\n" + "\n".join([f"  - {msg}" for msg in all_builder_messages])
-        _LOGGER.info(builder_message)
-        await self._slack_client.say_in_thread(builder_message)
-
-        # For 'both' mode, only update streams.yml with konflux builds
-        # For 'brew' mode, use brew_nvrs; for 'konflux' mode, use konflux_nvrs
-        if self.build_system == 'both':
-            builder_nvrs = konflux_nvrs
-        elif self.build_system == 'brew':
-            builder_nvrs = brew_nvrs
-        else:  # konflux
-            builder_nvrs = konflux_nvrs
-
-        await self.update_golang_streams(go_version, builder_nvrs)
+        await self.update_golang_streams(go_version, builder_pullspecs)
 
         await move_golang_bugs(
             ocp_version=self.ocp_version,
@@ -563,15 +555,27 @@ class UpdateGolangPipeline:
                 builder_nvrs[el_v] = build_record.nvr
         return builder_nvrs
 
-    def _get_builder_pullspec(self, parsed_nvr, build_system: str):
-        """Generate the complete pullspec based on build system"""
-        if build_system == 'brew':
-            return f'openshift/golang-builder:{parsed_nvr["version"]}-{parsed_nvr["release"]}'
-        else:  # konflux or both (both uses konflux pullspec)
-            # TODO: This is temporary. In the future we need a location to share with multiple teams.
-            return f'{KONFLUX_DEFAULT_IMAGE_REPO}:golang-builder-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
+    def _get_builder_pullspec(self, builder_nvr: str):
+        """Generate the published pullspec used in streams.yml for Konflux-built builders."""
+        parsed_nvr = parse_nvr(builder_nvr)
+        component_name = parsed_nvr["name"]
+        if component_name == GOLANG_BUILDER_IMAGE_NAME:
+            component_name = GOLANG_BUILDER_CVE_COMPONENT
+        elif component_name != GOLANG_BUILDER_CVE_COMPONENT:
+            raise ValueError(f"Expected a golang builder image NVR, got: {builder_nvr}")
+        published_nvr = f'{component_name}-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
+        return f'{PUBLISHED_GOLANG_BUILDER_REPO}:{published_nvr}'
 
-    async def update_golang_streams(self, go_version, builder_nvrs):
+    async def _ensure_builder_pullspec_available(self, pullspec: str, retries: int = 3):
+        """Verify the published golang builder pullspec is available before updating streams.yml."""
+        if retries != 3:
+            _LOGGER.warning("Ignoring custom retry count %s; pyartcd.oc.get_image_info retries 3 times", retries)
+        try:
+            await get_image_info(pullspec, raise_if_not_found=True)
+        except Exception as e:
+            raise RuntimeError(f"Published golang builder pullspec is not available: {pullspec}: {e}") from e
+
+    async def update_golang_streams(self, go_version, builder_pullspecs):
         """
         Update golang builders for current release in ocp-build-data
         1. First check go verion from group.yml var to decide if it's a major version bump or minor version bump
@@ -632,45 +636,36 @@ class UpdateGolangPipeline:
 
         # This is to bump minor golang for GO_LATEST
         if build_major_minor == latest_major_minor:
-            for el_v, builder_nvr in builder_nvrs.items():
-                parsed_nvr = parse_nvr(builder_nvr)
-
+            for el_v, pullspec in builder_pullspecs.items():
                 _LOGGER.info("Looking for golang stream %s in streams.yml", latest_go_stream_name(el_v))
                 latest_go = get_stream(latest_go_stream_name(el_v))['image']
 
-                new_latest_go = self._get_builder_pullspec(parsed_nvr, self.build_system)
                 for _, info in streams_content.items():
                     if info['image'] == latest_go:
-                        info['image'] = new_latest_go
+                        info['image'] = pullspec
                         update_streams = True
         # This is to bump minor golang for GO_PREVIOUS
         elif previous_major_minor and build_major_minor == previous_major_minor:
-            for el_v, builder_nvr in builder_nvrs.items():
-                parsed_nvr = parse_nvr(builder_nvr)
-
+            for el_v, pullspec in builder_pullspecs.items():
                 _LOGGER.info("Looking for golang stream %s in streams.yml", previous_go_stream_name(el_v))
                 previous_go = get_stream(previous_go_stream_name(el_v))['image']
 
-                new_previous_go = self._get_builder_pullspec(parsed_nvr, self.build_system)
                 for _, info in streams_content.items():
                     if info['image'] == previous_go:
-                        info['image'] = new_previous_go
+                        info['image'] = pullspec
                         update_streams = True
         # This is to bump major golang for GO_LATEST and update GO_PREVIOUS to current GO_LATEST
         elif build_major_minor_tuple > latest_major_minor_tuple:
-            for el_v, builder_nvr in builder_nvrs.items():
-                parsed_nvr = parse_nvr(builder_nvr)
-
+            for el_v, pullspec in builder_pullspecs.items():
                 _LOGGER.info("Looking for golang stream %s in streams.yml", latest_go_stream_name(el_v))
                 latest_go = get_stream(latest_go_stream_name(el_v))['image']
 
                 _LOGGER.info("Looking for golang stream %s in streams.yml", previous_go_stream_name(el_v))
                 previous_go = get_stream(previous_go_stream_name(el_v))['image'] if go_previous else None
 
-                new_latest_go = self._get_builder_pullspec(parsed_nvr, self.build_system)
                 for _, info in streams_content.items():
                     if info['image'] == latest_go:
-                        info['image'] = new_latest_go
+                        info['image'] = pullspec
                     if info['image'] == previous_go:
                         info['image'] = latest_go
                 group_content['vars'][go_latest_var] = go_version
@@ -686,10 +681,8 @@ class UpdateGolangPipeline:
             if self.skip_pr:
                 # Log NVRs and pullspecs for golang builder images
                 builder_info = []
-                for el_v, nvr in builder_nvrs.items():
-                    parsed_nvr = parse_nvr(nvr)
-                    pullspec = self._get_builder_pullspec(parsed_nvr, self.build_system)
-                    builder_info.append(f"  - RHEL {el_v}: {nvr} -> {pullspec}")
+                for el_v, pullspec in builder_pullspecs.items():
+                    builder_info.append(f"  - RHEL {el_v}: {pullspec}")
                 builder_details = "\n".join(builder_info)
 
                 _LOGGER.info(

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -395,22 +395,29 @@ class UpdateGolangPipeline:
                 raise ValueError(error_msg)
 
         # streams.yml should only reference the published pullspecs for Konflux-built builders.
-        builder_nvrs = konflux_nvrs
-        builder_pullspecs = {el_v: self._get_builder_pullspec(nvr) for el_v, nvr in builder_nvrs.items()}
-        if builder_pullspecs:
-            await asyncio.gather(
-                *[self._ensure_builder_pullspec_available(pullspec) for pullspec in builder_pullspecs.values()]
+        if self.build_system == "brew":
+            skip_message = (
+                "Skipping streams.yml update for brew-only run; "
+                "streams.yml only references Konflux-built golang builder pullspecs."
             )
-            builder_details = "\n".join(
-                [f"  - RHEL {el_v}: {nvr} -> {builder_pullspecs[el_v]}" for el_v, nvr in builder_nvrs.items()]
-            )
-            builder_message = "Konflux golang builders available for streams.yml:\n" + builder_details
-            _LOGGER.info(builder_message)
-            await self._slack_client.say_in_thread(builder_message)
+            _LOGGER.info(skip_message)
+            await self._slack_client.say_in_thread(skip_message)
         else:
-            _LOGGER.info("No Konflux golang builder images found; streams.yml will not be updated.")
-
-        await self.update_golang_streams(go_version, builder_pullspecs)
+            builder_nvrs = konflux_nvrs
+            builder_pullspecs = {el_v: self._get_builder_pullspec(nvr) for el_v, nvr in builder_nvrs.items()}
+            if builder_pullspecs:
+                await asyncio.gather(
+                    *[self._ensure_builder_pullspec_available(pullspec) for pullspec in builder_pullspecs.values()]
+                )
+                builder_details = "\n".join(
+                    [f"  - RHEL {el_v}: {nvr} -> {builder_pullspecs[el_v]}" for el_v, nvr in builder_nvrs.items()]
+                )
+                builder_message = "Konflux golang builders available for streams.yml:\n" + builder_details
+                _LOGGER.info(builder_message)
+                await self._slack_client.say_in_thread(builder_message)
+                await self.update_golang_streams(go_version, builder_pullspecs)
+            else:
+                _LOGGER.info("No Konflux golang builder images found; streams.yml will not be updated.")
 
         await move_golang_bugs(
             ocp_version=self.ocp_version,

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -568,8 +568,9 @@ class UpdateGolangPipeline:
 
     async def _ensure_builder_pullspec_available(self, pullspec: str):
         """Verify the published golang builder pullspec is available before updating streams.yml."""
+        registry_config = os.getenv("REGISTRY_AUTH_FILE")
         try:
-            await get_image_info(pullspec, raise_if_not_found=True)
+            await get_image_info(pullspec, raise_if_not_found=True, registry_config=registry_config)
         except Exception as e:
             raise RuntimeError(f"Published golang builder pullspec is not available: {pullspec}: {e}") from e
 

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -566,10 +566,8 @@ class UpdateGolangPipeline:
         published_nvr = f'{component_name}-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
         return f'{PUBLISHED_GOLANG_BUILDER_REPO}:{published_nvr}'
 
-    async def _ensure_builder_pullspec_available(self, pullspec: str, retries: int = 3):
+    async def _ensure_builder_pullspec_available(self, pullspec: str):
         """Verify the published golang builder pullspec is available before updating streams.yml."""
-        if retries != 3:
-            _LOGGER.warning("Ignoring custom retry count %s; pyartcd.oc.get_image_info retries 3 times", retries)
         try:
             await get_image_info(pullspec, raise_if_not_found=True)
         except Exception as e:

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -774,6 +774,10 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
     async def test_run_brew_only_skips_updating_streams(self, mock_konflux_db, move_golang_bugs):
         """Test brew-only runs skip streams.yml updates because streams use Konflux pullspecs"""
         pipeline = self._make_pipeline(build_system="brew")
+        pipeline.validate_go_version_matches_group_vars = Mock(
+            return_value=("openshift-4.16", {"GO_LATEST": "1.25"}, "1.25")
+        )
+        pipeline.validate_tag_builds_go_latest = Mock()
         pipeline.process_build = AsyncMock(return_value=True)
         pipeline.get_existing_builders = Mock(
             return_value={9: "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9"}

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -674,6 +674,143 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         self.assertEqual(url, "/brewroot/repos/rhaos-4.16-rhel-8-build/latest")
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_get_builder_pullspec(self, mock_konflux_db):
+        """Test stream-update pullspec uses the published registry.redhat.io form"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.8-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="brew",
+        )
+
+        builder_nvr = "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9"
+        pullspec = pipeline._get_builder_pullspec(builder_nvr)
+
+        self.assertEqual(
+            pullspec,
+            "registry.redhat.io/openshift/art-images-base:"
+            "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9",
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_get_builder_pullspec_normalizes_konflux_nvr_name(self, mock_konflux_db):
+        """Test stream-update pullspec normalizes Konflux NVRs to the published container name"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.8-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="konflux",
+        )
+
+        builder_nvr = "openshift-golang-builder-v1.25.8-202604150744.p2.gf28329a.el9"
+        pullspec = pipeline._get_builder_pullspec(builder_nvr)
+
+        self.assertEqual(
+            pullspec,
+            "registry.redhat.io/openshift/art-images-base:"
+            "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9",
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_get_builder_pullspec_rejects_non_golang_nvr(self, mock_konflux_db):
+        """Test stream-update pullspec helper rejects non-golang image NVRs"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.8-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="konflux",
+        )
+
+        with self.assertRaisesRegex(ValueError, "Expected a golang builder image NVR"):
+            pipeline._get_builder_pullspec("ose-cli-v4.16.0-202604150744.p2.gdeadbee.el9")
+
+    @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_ensure_builder_pullspec_available_reuses_oc_helper(self, mock_konflux_db, get_image_info):
+        """Test published pullspec availability check reuses pyartcd.oc.get_image_info"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.8-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="konflux",
+        )
+
+        pullspec = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-test"
+
+        await pipeline._ensure_builder_pullspec_available(pullspec)
+
+        get_image_info.assert_awaited_once_with(pullspec, raise_if_not_found=True)
+
+    @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_ensure_builder_pullspec_available_errors_when_oc_helper_fails(
+        self, mock_konflux_db, get_image_info
+    ):
+        """Test published pullspec availability check raises when pyartcd.oc.get_image_info fails"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.8-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="konflux",
+        )
+
+        pullspec = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-test"
+        get_image_info.side_effect = ValueError("Image pullspec is not found.")
+
+        with self.assertRaisesRegex(RuntimeError, "Published golang builder pullspec is not available"):
+            await pipeline._ensure_builder_pullspec_available(pullspec)
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_module_tag(self, mock_konflux_db):
         """Test get_module_tag method"""
         mock_runtime = Mock(

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -735,9 +735,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_ensure_builder_pullspec_available_reuses_oc_helper(
-        self, mock_konflux_db, get_image_info
-    ):
+    async def test_ensure_builder_pullspec_available_reuses_oc_helper(self, mock_konflux_db, get_image_info):
         """Test published pullspec availability check reuses pyartcd.oc.get_image_info with quay auth"""
         pipeline = self._make_pipeline(build_system="konflux")
 
@@ -751,15 +749,11 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         ):
             await pipeline._ensure_builder_pullspec_available(pullspec)
 
-        get_image_info.assert_awaited_once_with(
-            pullspec, raise_if_not_found=True, registry_config=quay_auth_file
-        )
+        get_image_info.assert_awaited_once_with(pullspec, raise_if_not_found=True, registry_config=quay_auth_file)
 
     @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_ensure_builder_pullspec_available_errors_when_oc_helper_fails(
-        self, mock_konflux_db, get_image_info
-    ):
+    async def test_ensure_builder_pullspec_available_errors_when_oc_helper_fails(self, mock_konflux_db, get_image_info):
         """Test published pullspec availability check raises when pyartcd.oc.get_image_info fails"""
         pipeline = self._make_pipeline(build_system="konflux")
 

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -756,8 +756,10 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_ensure_builder_pullspec_available_reuses_oc_helper(self, mock_konflux_db, get_image_info):
-        """Test published pullspec availability check reuses pyartcd.oc.get_image_info"""
+    async def test_ensure_builder_pullspec_available_reuses_oc_helper(
+        self, mock_konflux_db, get_image_info
+    ):
+        """Test published pullspec availability check reuses pyartcd.oc.get_image_info with env auth"""
         mock_runtime = Mock(
             dry_run=False,
             working_dir=Path("/tmp/working"),
@@ -777,9 +779,16 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         pullspec = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-test"
 
-        await pipeline._ensure_builder_pullspec_available(pullspec)
+        with patch.dict(
+            "os.environ",
+            {"REGISTRY_AUTH_FILE": "/tmp/registry-auth.json"},
+            clear=False,
+        ):
+            await pipeline._ensure_builder_pullspec_available(pullspec)
 
-        get_image_info.assert_awaited_once_with(pullspec, raise_if_not_found=True)
+        get_image_info.assert_awaited_once_with(
+            pullspec, raise_if_not_found=True, registry_config="/tmp/registry-auth.json"
+        )
 
     @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -807,8 +816,13 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         pullspec = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-test"
         get_image_info.side_effect = ValueError("Image pullspec is not found.")
 
-        with self.assertRaisesRegex(RuntimeError, "Published golang builder pullspec is not available"):
-            await pipeline._ensure_builder_pullspec_available(pullspec)
+        with patch.dict(
+            "os.environ",
+            {"REGISTRY_AUTH_FILE": "/tmp/registry-auth.json"},
+            clear=False,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Published golang builder pullspec is not available"):
+                await pipeline._ensure_builder_pullspec_available(pullspec)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_module_tag(self, mock_konflux_db):

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -759,7 +759,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
     async def test_ensure_builder_pullspec_available_reuses_oc_helper(
         self, mock_konflux_db, get_image_info
     ):
-        """Test published pullspec availability check reuses pyartcd.oc.get_image_info with env auth"""
+        """Test published pullspec availability check reuses pyartcd.oc.get_image_info with quay auth"""
         mock_runtime = Mock(
             dry_run=False,
             working_dir=Path("/tmp/working"),
@@ -781,13 +781,13 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         with patch.dict(
             "os.environ",
-            {"REGISTRY_AUTH_FILE": "/tmp/registry-auth.json"},
+            {"QUAY_AUTH_FILE": "/tmp/quay-auth.json"},
             clear=False,
         ):
             await pipeline._ensure_builder_pullspec_available(pullspec)
 
         get_image_info.assert_awaited_once_with(
-            pullspec, raise_if_not_found=True, registry_config="/tmp/registry-auth.json"
+            pullspec, raise_if_not_found=True, registry_config="/tmp/quay-auth.json"
         )
 
     @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
@@ -818,7 +818,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         with patch.dict(
             "os.environ",
-            {"REGISTRY_AUTH_FILE": "/tmp/registry-auth.json"},
+            {"QUAY_AUTH_FILE": "/tmp/quay-auth.json"},
             clear=False,
         ):
             with self.assertRaisesRegex(RuntimeError, "Published golang builder pullspec is not available"):

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import IsolatedAsyncioTestCase
@@ -266,6 +267,29 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
                 "GITHUB_TOKEN": "fake-github-token",
                 "KONFLUX_SA_KUBECONFIG": "/path/to/kubeconfig",
             }
+        )
+
+    def _make_test_runtime(self, working_dir: Path | None = None):
+        if working_dir is None:
+            temp_dir = Path(self.enterContext(tempfile.TemporaryDirectory()))
+            working_dir = temp_dir / "working"
+            working_dir.mkdir()
+        mock_runtime = Mock(dry_run=False, working_dir=working_dir)
+        mock_runtime.new_slack_client.return_value = Mock(bind_channel=Mock(), say_in_thread=AsyncMock())
+        return mock_runtime
+
+    def _make_pipeline(self, build_system="konflux", go_nvrs=None):
+        if go_nvrs is None:
+            go_nvrs = ["golang-1.25.8-1.el9"]
+        return UpdateGolangPipeline(
+            runtime=self._make_test_runtime(),
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=go_nvrs,
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system=build_system,
         )
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -676,22 +700,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_builder_pullspec(self, mock_konflux_db):
         """Test stream-update pullspec uses the published registry.redhat.io form"""
-        mock_runtime = Mock(
-            dry_run=False,
-            working_dir=Path("/tmp/working"),
-        )
-        mock_runtime.new_slack_client.return_value = Mock()
-
-        pipeline = UpdateGolangPipeline(
-            runtime=mock_runtime,
-            ocp_version="4.16",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.25.8-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-            build_system="brew",
-        )
+        pipeline = self._make_pipeline(build_system="brew")
 
         builder_nvr = "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9"
         pullspec = pipeline._get_builder_pullspec(builder_nvr)
@@ -705,22 +714,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_builder_pullspec_normalizes_konflux_nvr_name(self, mock_konflux_db):
         """Test stream-update pullspec normalizes Konflux NVRs to the published container name"""
-        mock_runtime = Mock(
-            dry_run=False,
-            working_dir=Path("/tmp/working"),
-        )
-        mock_runtime.new_slack_client.return_value = Mock()
-
-        pipeline = UpdateGolangPipeline(
-            runtime=mock_runtime,
-            ocp_version="4.16",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.25.8-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-            build_system="konflux",
-        )
+        pipeline = self._make_pipeline(build_system="konflux")
 
         builder_nvr = "openshift-golang-builder-v1.25.8-202604150744.p2.gf28329a.el9"
         pullspec = pipeline._get_builder_pullspec(builder_nvr)
@@ -734,22 +728,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_builder_pullspec_rejects_non_golang_nvr(self, mock_konflux_db):
         """Test stream-update pullspec helper rejects non-golang image NVRs"""
-        mock_runtime = Mock(
-            dry_run=False,
-            working_dir=Path("/tmp/working"),
-        )
-        mock_runtime.new_slack_client.return_value = Mock()
-
-        pipeline = UpdateGolangPipeline(
-            runtime=mock_runtime,
-            ocp_version="4.16",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.25.8-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-            build_system="konflux",
-        )
+        pipeline = self._make_pipeline(build_system="konflux")
 
         with self.assertRaisesRegex(ValueError, "Expected a golang builder image NVR"):
             pipeline._get_builder_pullspec("ose-cli-v4.16.0-202604150744.p2.gdeadbee.el9")
@@ -760,34 +739,20 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         self, mock_konflux_db, get_image_info
     ):
         """Test published pullspec availability check reuses pyartcd.oc.get_image_info with quay auth"""
-        mock_runtime = Mock(
-            dry_run=False,
-            working_dir=Path("/tmp/working"),
-        )
-        mock_runtime.new_slack_client.return_value = Mock()
-
-        pipeline = UpdateGolangPipeline(
-            runtime=mock_runtime,
-            ocp_version="4.16",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.25.8-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-            build_system="konflux",
-        )
+        pipeline = self._make_pipeline(build_system="konflux")
 
         pullspec = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-test"
+        quay_auth_file = str(Path(self.enterContext(tempfile.TemporaryDirectory())) / "quay-auth.json")
 
         with patch.dict(
             "os.environ",
-            {"QUAY_AUTH_FILE": "/tmp/quay-auth.json"},
+            {"QUAY_AUTH_FILE": quay_auth_file},
             clear=False,
         ):
             await pipeline._ensure_builder_pullspec_available(pullspec)
 
         get_image_info.assert_awaited_once_with(
-            pullspec, raise_if_not_found=True, registry_config="/tmp/quay-auth.json"
+            pullspec, raise_if_not_found=True, registry_config=quay_auth_file
         )
 
     @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
@@ -796,33 +761,40 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         self, mock_konflux_db, get_image_info
     ):
         """Test published pullspec availability check raises when pyartcd.oc.get_image_info fails"""
-        mock_runtime = Mock(
-            dry_run=False,
-            working_dir=Path("/tmp/working"),
-        )
-        mock_runtime.new_slack_client.return_value = Mock()
-
-        pipeline = UpdateGolangPipeline(
-            runtime=mock_runtime,
-            ocp_version="4.16",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.25.8-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-            build_system="konflux",
-        )
+        pipeline = self._make_pipeline(build_system="konflux")
 
         pullspec = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-test"
         get_image_info.side_effect = ValueError("Image pullspec is not found.")
+        quay_auth_file = str(Path(self.enterContext(tempfile.TemporaryDirectory())) / "quay-auth.json")
 
         with patch.dict(
             "os.environ",
-            {"QUAY_AUTH_FILE": "/tmp/quay-auth.json"},
+            {"QUAY_AUTH_FILE": quay_auth_file},
             clear=False,
         ):
             with self.assertRaisesRegex(RuntimeError, "Published golang builder pullspec is not available"):
                 await pipeline._ensure_builder_pullspec_available(pullspec)
+
+    @patch("pyartcd.pipelines.update_golang.move_golang_bugs", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_run_brew_only_skips_updating_streams(self, mock_konflux_db, move_golang_bugs):
+        """Test brew-only runs skip streams.yml updates because streams use Konflux pullspecs"""
+        pipeline = self._make_pipeline(build_system="brew")
+        pipeline.process_build = AsyncMock(return_value=True)
+        pipeline.get_existing_builders = Mock(
+            return_value={9: "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9"}
+        )
+        pipeline.update_golang_streams = AsyncMock()
+
+        await pipeline.run()
+
+        pipeline.update_golang_streams.assert_not_awaited()
+        move_golang_bugs.assert_awaited_once()
+        slack_messages = [call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list]
+        self.assertTrue(
+            any("Skipping streams.yml update for brew-only run" in message for message in slack_messages),
+            slack_messages,
+        )
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_module_tag(self, mock_konflux_db):


### PR DESCRIPTION
## Summary
- update `update_golang` to write `streams.yml` only from published Konflux golang builder pullspecs in `registry.redhat.io/openshift/art-images-base`
- normalize Konflux builder NVRs to the published golang builder container naming and reject non-golang NVRs when constructing stream pullspecs
- verify each constructed pullspec is available before updating `streams.yml` by reusing `pyartcd.oc.get_image_info`

## Test plan
- [x] `uv run pytest --verbose --color=yes pyartcd/tests/pipelines/test_update_golang.py`
- [X] https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgolang-builder/434/console

Made with [Cursor](https://cursor.com)