### PR TITLE
pyartcd: tighten update-golang builder updates

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -490,10 +490,8 @@ class UpdateGolangPipeline:
         published_nvr = f'{component_name}-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
         return f'{PUBLISHED_GOLANG_BUILDER_REPO}:{published_nvr}'
 
-    async def _ensure_builder_pullspec_available(self, pullspec: str, retries: int = 3):
+    async def _ensure_builder_pullspec_available(self, pullspec: str):
         """Verify the published golang builder pullspec is available before updating streams.yml."""
-        if retries != 3:
-            _LOGGER.warning("Ignoring custom retry count %s; pyartcd.oc.get_image_info retries 3 times", retries)
         try:
             await get_image_info(pullspec, raise_if_not_found=True)
         except Exception as e:

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -121,6 +121,13 @@ def extract_and_validate_golang_nvrs(ocp_version: str, go_nvrs: List[str]):
     return go_version, el_nvr_map
 
 
+def extract_major_minor(version: str, label: str = "version") -> str:
+    match = re.fullmatch(r"(\d+)\.(\d+)(?:\.\d+)?", version)
+    if not match:
+        raise ValueError(f"Invalid {label}: {version}")
+    return f"{match[1]}.{match[2]}"
+
+
 async def move_golang_bugs(
     ocp_version: str,
     cves: list[str] | None = None,
@@ -211,10 +218,39 @@ class UpdateGolangPipeline:
             self.konflux_db = KonfluxDb()
             self.konflux_db.bind(KonfluxBuildRecord)
 
+    @staticmethod
+    def _load_yaml_from_repo(repo, path: str, ref: str):
+        return yaml.load(repo.get_contents(path, ref=ref).decoded_content)
+
+    def _get_upstream_ocp_build_data_repo(self):
+        return get_github_client_for_org("openshift-eng").get_repo("openshift-eng/ocp-build-data")
+
+    def validate_tag_builds_go_latest(self, go_version: str):
+        branch = f"openshift-{self.ocp_version}"
+        upstream_repo = self._get_upstream_ocp_build_data_repo()
+        group_content = self._load_yaml_from_repo(upstream_repo, "group.yml", branch)
+
+        go_latest_var = "GO_LATEST"
+        go_latest = group_content.get("vars", {}).get(go_latest_var)
+        if not go_latest:
+            raise ValueError(
+                f"{go_latest_var} variable not found in group.yml, please make sure it is defined before running the pipeline"
+            )
+
+        build_major_minor = extract_major_minor(go_version, "golang build version")
+        latest_major_minor = extract_major_minor(go_latest, f"group.yml {go_latest_var}")
+        if build_major_minor != latest_major_minor:
+            raise ValueError(
+                f"When --tag-builds is set, the provided golang build major.minor ({build_major_minor}) must match "
+                f"{branch} group.yml {go_latest_var} major.minor ({latest_major_minor})."
+            )
+
     async def run(self):
         go_version, el_nvr_map = extract_and_validate_golang_nvrs(self.ocp_version, self.go_nvrs)
         _LOGGER.info(f'Golang version detected: {go_version}')
         _LOGGER.info(f'NVRs by rhel version: {el_nvr_map}')
+        if self.tag_builds:
+            self.validate_tag_builds_go_latest(go_version)
 
         # el10 is only supported for build roots (RPM tagging), not for golang-builder images yet
         el_nvr_map_for_images = {el_v: nvr for el_v, nvr in el_nvr_map.items() if el_v != 10}
@@ -507,9 +543,9 @@ class UpdateGolangPipeline:
         4. Create pr to update changes
         """
         branch = f"openshift-{self.ocp_version}"
-        upstream_repo = get_github_client_for_org("openshift-eng").get_repo("openshift-eng/ocp-build-data")
-        streams_content = yaml.load(upstream_repo.get_contents("streams.yml", ref=branch).decoded_content)
-        group_content = yaml.load(upstream_repo.get_contents("group.yml", ref=branch).decoded_content)
+        upstream_repo = self._get_upstream_ocp_build_data_repo()
+        streams_content = self._load_yaml_from_repo(upstream_repo, "streams.yml", branch)
+        group_content = self._load_yaml_from_repo(upstream_repo, "group.yml", branch)
 
         go_latest_var, go_previous_var = "GO_LATEST", "GO_PREVIOUS"
         go_latest = group_content['vars'].get(go_latest_var)

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -492,7 +492,7 @@ class UpdateGolangPipeline:
 
     async def _ensure_builder_pullspec_available(self, pullspec: str):
         """Verify the published golang builder pullspec is available before updating streams.yml."""
-        registry_config = os.getenv("REGISTRY_AUTH_FILE")
+        registry_config = os.getenv("QUAY_AUTH_FILE")
         try:
             await get_image_info(pullspec, raise_if_not_found=True, registry_config=registry_config)
         except Exception as e:

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -12,8 +12,8 @@ from artcommonlib.brew import BuildStates
 from artcommonlib.constants import (
     BREW_HUB,
     GOLANG_BUILDER_IMAGE_NAME,
-    KONFLUX_DEFAULT_IMAGE_REPO,
     PRODUCT_NAMESPACE_MAP,
+    REGISTRY_REDHAT_IO,
 )
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
@@ -21,16 +21,19 @@ from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.release_util import split_el_suffix_in_release
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import new_roundtrip_yaml_handler
+from doozerlib.backend.base_image_handler import ART_IMAGES_BASE_APPLICATION
 from elliottlib import util as elliottutil
 from elliottlib.constants import GOLANG_BUILDER_CVE_COMPONENT
 
 from pyartcd import constants, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.oc import get_image_info
 from pyartcd.runtime import Runtime
 from pyartcd.util import default_release_suffix
 
 _LOGGER = logging.getLogger(__name__)
 yaml = new_roundtrip_yaml_handler()
+PUBLISHED_GOLANG_BUILDER_REPO = f"{REGISTRY_REDHAT_IO}/openshift/{ART_IMAGES_BASE_APPLICATION}"
 
 
 def is_latest_build(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool:
@@ -315,34 +318,23 @@ class UpdateGolangPipeline:
                     )
                 raise ValueError(error_msg)
 
-        _LOGGER.info("Updating streams.yml with found builder images")
-        # Prepare message with all newly built builders
-        all_builder_messages = []
-        if brew_nvrs:
-            for el_v, nvr in brew_nvrs.items():
-                parsed_nvr = parse_nvr(nvr)
-                pullspec = self._get_builder_pullspec(parsed_nvr, 'brew')
-                all_builder_messages.append(f"RHEL {el_v}: {nvr} -> {pullspec} (brew)")
-        if konflux_nvrs:
-            for el_v, nvr in konflux_nvrs.items():
-                parsed_nvr = parse_nvr(nvr)
-                pullspec = self._get_builder_pullspec(parsed_nvr, 'konflux')
-                all_builder_messages.append(f"RHEL {el_v}: {nvr} -> {pullspec} (konflux)")
+        # streams.yml should only reference the published pullspecs for Konflux-built builders.
+        builder_nvrs = konflux_nvrs
+        builder_pullspecs = {el_v: self._get_builder_pullspec(nvr) for el_v, nvr in builder_nvrs.items()}
+        if builder_pullspecs:
+            await asyncio.gather(
+                *[self._ensure_builder_pullspec_available(pullspec) for pullspec in builder_pullspecs.values()]
+            )
+            builder_details = "\n".join(
+                [f"  - RHEL {el_v}: {nvr} -> {builder_pullspecs[el_v]}" for el_v, nvr in builder_nvrs.items()]
+            )
+            builder_message = "Konflux golang builders available for streams.yml:\n" + builder_details
+            _LOGGER.info(builder_message)
+            await self._slack_client.say_in_thread(builder_message)
+        else:
+            _LOGGER.info("No Konflux golang builder images found; streams.yml will not be updated.")
 
-        builder_message = "New golang builders available:\n" + "\n".join([f"  - {msg}" for msg in all_builder_messages])
-        _LOGGER.info(builder_message)
-        await self._slack_client.say_in_thread(builder_message)
-
-        # For 'both' mode, only update streams.yml with konflux builds
-        # For 'brew' mode, use brew_nvrs; for 'konflux' mode, use konflux_nvrs
-        if self.build_system == 'both':
-            builder_nvrs = konflux_nvrs
-        elif self.build_system == 'brew':
-            builder_nvrs = brew_nvrs
-        else:  # konflux
-            builder_nvrs = konflux_nvrs
-
-        await self.update_golang_streams(go_version, builder_nvrs)
+        await self.update_golang_streams(go_version, builder_pullspecs)
 
         await move_golang_bugs(
             ocp_version=self.ocp_version,
@@ -487,15 +479,27 @@ class UpdateGolangPipeline:
                 builder_nvrs[el_v] = build_record.nvr
         return builder_nvrs
 
-    def _get_builder_pullspec(self, parsed_nvr, build_system: str):
-        """Generate the complete pullspec based on build system"""
-        if build_system == 'brew':
-            return f'openshift/golang-builder:{parsed_nvr["version"]}-{parsed_nvr["release"]}'
-        else:  # konflux or both (both uses konflux pullspec)
-            # TODO: This is temporary. In the future we need a location to share with multiple teams.
-            return f'{KONFLUX_DEFAULT_IMAGE_REPO}:golang-builder-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
+    def _get_builder_pullspec(self, builder_nvr: str):
+        """Generate the published pullspec used in streams.yml for Konflux-built builders."""
+        parsed_nvr = parse_nvr(builder_nvr)
+        component_name = parsed_nvr["name"]
+        if component_name == GOLANG_BUILDER_IMAGE_NAME:
+            component_name = GOLANG_BUILDER_CVE_COMPONENT
+        elif component_name != GOLANG_BUILDER_CVE_COMPONENT:
+            raise ValueError(f"Expected a golang builder image NVR, got: {builder_nvr}")
+        published_nvr = f'{component_name}-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
+        return f'{PUBLISHED_GOLANG_BUILDER_REPO}:{published_nvr}'
 
-    async def update_golang_streams(self, go_version, builder_nvrs):
+    async def _ensure_builder_pullspec_available(self, pullspec: str, retries: int = 3):
+        """Verify the published golang builder pullspec is available before updating streams.yml."""
+        if retries != 3:
+            _LOGGER.warning("Ignoring custom retry count %s; pyartcd.oc.get_image_info retries 3 times", retries)
+        try:
+            await get_image_info(pullspec, raise_if_not_found=True)
+        except Exception as e:
+            raise RuntimeError(f"Published golang builder pullspec is not available: {pullspec}: {e}") from e
+
+    async def update_golang_streams(self, go_version, builder_pullspecs):
         """
         Update golang builders for current release in ocp-build-data
         1. First check go verion from group.yml var to decide if it's a major version bump or minor version bump
@@ -550,45 +554,36 @@ class UpdateGolangPipeline:
 
         # This is to bump minor golang for GO_LATEST
         if go_latest in go_version:
-            for el_v, builder_nvr in builder_nvrs.items():
-                parsed_nvr = parse_nvr(builder_nvr)
-
+            for el_v, pullspec in builder_pullspecs.items():
                 _LOGGER.info("Looking for golang stream %s in streams.yml", latest_go_stream_name(el_v))
                 latest_go = get_stream(latest_go_stream_name(el_v))['image']
 
-                new_latest_go = self._get_builder_pullspec(parsed_nvr, self.build_system)
                 for _, info in streams_content.items():
                     if info['image'] == latest_go:
-                        info['image'] = new_latest_go
+                        info['image'] = pullspec
                         update_streams = True
         # This is to bump minor golang for GO_PREVIOUS
         elif go_previous and go_previous in go_version:
-            for el_v, builder_nvr in builder_nvrs.items():
-                parsed_nvr = parse_nvr(builder_nvr)
-
+            for el_v, pullspec in builder_pullspecs.items():
                 _LOGGER.info("Looking for golang stream %s in streams.yml", previous_go_stream_name(el_v))
                 previous_go = get_stream(previous_go_stream_name(el_v))['image']
 
-                new_previous_go = self._get_builder_pullspec(parsed_nvr, self.build_system)
                 for _, info in streams_content.items():
                     if info['image'] == previous_go:
-                        info['image'] = new_previous_go
+                        info['image'] = pullspec
                         update_streams = True
         # This is to bump major golang for GO_LATEST and update GO_PREVIOUS to current GO_LATEST
         elif go_version.split('.')[0] >= go_latest.split('.')[0] and go_version.split('.')[1] > go_latest.split('.')[1]:
-            for el_v, builder_nvr in builder_nvrs.items():
-                parsed_nvr = parse_nvr(builder_nvr)
-
+            for el_v, pullspec in builder_pullspecs.items():
                 _LOGGER.info("Looking for golang stream %s in streams.yml", latest_go_stream_name(el_v))
                 latest_go = get_stream(latest_go_stream_name(el_v))['image']
 
                 _LOGGER.info("Looking for golang stream %s in streams.yml", previous_go_stream_name(el_v))
                 previous_go = get_stream(previous_go_stream_name(el_v))['image'] if go_previous else None
 
-                new_latest_go = self._get_builder_pullspec(parsed_nvr, self.build_system)
                 for _, info in streams_content.items():
                     if info['image'] == latest_go:
-                        info['image'] = new_latest_go
+                        info['image'] = pullspec
                     if info['image'] == previous_go:
                         info['image'] = latest_go
                 group_content['vars'][go_latest_var] = go_version
@@ -604,10 +599,8 @@ class UpdateGolangPipeline:
             if self.skip_pr:
                 # Log NVRs and pullspecs for golang builder images
                 builder_info = []
-                for el_v, nvr in builder_nvrs.items():
-                    parsed_nvr = parse_nvr(nvr)
-                    pullspec = self._get_builder_pullspec(parsed_nvr, self.build_system)
-                    builder_info.append(f"  - RHEL {el_v}: {nvr} -> {pullspec}")
+                for el_v, pullspec in builder_pullspecs.items():
+                    builder_info.append(f"  - RHEL {el_v}: {pullspec}")
                 builder_details = "\n".join(builder_info)
 
                 _LOGGER.info(

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -492,8 +492,9 @@ class UpdateGolangPipeline:
 
     async def _ensure_builder_pullspec_available(self, pullspec: str):
         """Verify the published golang builder pullspec is available before updating streams.yml."""
+        registry_config = os.getenv("REGISTRY_AUTH_FILE")
         try:
-            await get_image_info(pullspec, raise_if_not_found=True)
+            await get_image_info(pullspec, raise_if_not_found=True, registry_config=registry_config)
         except Exception as e:
             raise RuntimeError(f"Published golang builder pullspec is not available: {pullspec}: {e}") from e
 

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -535,8 +535,10 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_ensure_builder_pullspec_available_reuses_oc_helper(self, mock_konflux_db, get_image_info):
-        """Test published pullspec availability check reuses pyartcd.oc.get_image_info"""
+    async def test_ensure_builder_pullspec_available_reuses_oc_helper(
+        self, mock_konflux_db, get_image_info
+    ):
+        """Test published pullspec availability check reuses pyartcd.oc.get_image_info with env auth"""
         mock_runtime = Mock(
             dry_run=False,
             working_dir=Path("/tmp/working"),
@@ -556,9 +558,16 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         pullspec = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-test"
 
-        await pipeline._ensure_builder_pullspec_available(pullspec)
+        with patch.dict(
+            "os.environ",
+            {"REGISTRY_AUTH_FILE": "/tmp/registry-auth.json"},
+            clear=False,
+        ):
+            await pipeline._ensure_builder_pullspec_available(pullspec)
 
-        get_image_info.assert_awaited_once_with(pullspec, raise_if_not_found=True)
+        get_image_info.assert_awaited_once_with(
+            pullspec, raise_if_not_found=True, registry_config="/tmp/registry-auth.json"
+        )
 
     @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -586,8 +595,13 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         pullspec = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-test"
         get_image_info.side_effect = ValueError("Image pullspec is not found.")
 
-        with self.assertRaisesRegex(RuntimeError, "Published golang builder pullspec is not available"):
-            await pipeline._ensure_builder_pullspec_available(pullspec)
+        with patch.dict(
+            "os.environ",
+            {"REGISTRY_AUTH_FILE": "/tmp/registry-auth.json"},
+            clear=False,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Published golang builder pullspec is not available"):
+                await pipeline._ensure_builder_pullspec_available(pullspec)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_module_tag(self, mock_konflux_db):

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -378,6 +378,63 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         branch = UpdateGolangPipeline.get_golang_branch(9, "1.21.5")
         self.assertEqual(branch, "rhel-9-golang-1.21")
 
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_validate_tag_builds_go_latest_accepts_matching_major_minor(self, mock_konflux_db, mock_get_github_client):
+        """Test tag-build validation accepts a build version matching group.yml GO_LATEST major.minor"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        upstream_repo = Mock()
+        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22.7\n")
+        mock_get_github_client.return_value.get_repo.return_value = upstream_repo
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=True,
+        )
+
+        pipeline.validate_tag_builds_go_latest("1.22.9")
+
+        upstream_repo.get_contents.assert_called_once_with("group.yml", ref="openshift-4.16")
+
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_validate_tag_builds_go_latest_rejects_mismatched_major_minor(
+        self, mock_konflux_db, mock_get_github_client
+    ):
+        """Test tag-build validation rejects build versions that do not match group.yml GO_LATEST major.minor"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        upstream_repo = Mock()
+        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22.7\n")
+        mock_get_github_client.return_value.get_repo.return_value = upstream_repo
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.21.13-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=True,
+        )
+
+        with self.assertRaisesRegex(ValueError, r"--tag-builds.*\(1\.21\).*\(1\.22\)"):
+            pipeline.validate_tag_builds_go_latest("1.21.13")
+
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_brew_login_when_logged_out(self, mock_konflux_db):
         """Test brew_login when session is logged out"""
@@ -535,9 +592,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_ensure_builder_pullspec_available_reuses_oc_helper(
-        self, mock_konflux_db, get_image_info
-    ):
+    async def test_ensure_builder_pullspec_available_reuses_oc_helper(self, mock_konflux_db, get_image_info):
         """Test published pullspec availability check reuses pyartcd.oc.get_image_info with quay auth"""
         mock_runtime = Mock(
             dry_run=False,
@@ -571,9 +626,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_ensure_builder_pullspec_available_errors_when_oc_helper_fails(
-        self, mock_konflux_db, get_image_info
-    ):
+    async def test_ensure_builder_pullspec_available_errors_when_oc_helper_fails(self, mock_konflux_db, get_image_info):
         """Test published pullspec availability check raises when pyartcd.oc.get_image_info fails"""
         mock_runtime = Mock(
             dry_run=False,

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -453,6 +453,143 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         self.assertEqual(url, "/brewroot/repos/rhaos-4.16-rhel-8-build/latest")
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_get_builder_pullspec(self, mock_konflux_db):
+        """Test stream-update pullspec uses the published registry.redhat.io form"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.8-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="brew",
+        )
+
+        builder_nvr = "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9"
+        pullspec = pipeline._get_builder_pullspec(builder_nvr)
+
+        self.assertEqual(
+            pullspec,
+            "registry.redhat.io/openshift/art-images-base:"
+            "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9",
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_get_builder_pullspec_normalizes_konflux_nvr_name(self, mock_konflux_db):
+        """Test stream-update pullspec normalizes Konflux NVRs to the published container name"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.8-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="konflux",
+        )
+
+        builder_nvr = "openshift-golang-builder-v1.25.8-202604150744.p2.gf28329a.el9"
+        pullspec = pipeline._get_builder_pullspec(builder_nvr)
+
+        self.assertEqual(
+            pullspec,
+            "registry.redhat.io/openshift/art-images-base:"
+            "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9",
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_get_builder_pullspec_rejects_non_golang_nvr(self, mock_konflux_db):
+        """Test stream-update pullspec helper rejects non-golang image NVRs"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.8-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="konflux",
+        )
+
+        with self.assertRaisesRegex(ValueError, "Expected a golang builder image NVR"):
+            pipeline._get_builder_pullspec("ose-cli-v4.16.0-202604150744.p2.gdeadbee.el9")
+
+    @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_ensure_builder_pullspec_available_reuses_oc_helper(self, mock_konflux_db, get_image_info):
+        """Test published pullspec availability check reuses pyartcd.oc.get_image_info"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.8-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="konflux",
+        )
+
+        pullspec = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-test"
+
+        await pipeline._ensure_builder_pullspec_available(pullspec)
+
+        get_image_info.assert_awaited_once_with(pullspec, raise_if_not_found=True)
+
+    @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_ensure_builder_pullspec_available_errors_when_oc_helper_fails(
+        self, mock_konflux_db, get_image_info
+    ):
+        """Test published pullspec availability check raises when pyartcd.oc.get_image_info fails"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.8-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="konflux",
+        )
+
+        pullspec = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-test"
+        get_image_info.side_effect = ValueError("Image pullspec is not found.")
+
+        with self.assertRaisesRegex(RuntimeError, "Published golang builder pullspec is not available"):
+            await pipeline._ensure_builder_pullspec_available(pullspec)
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_module_tag(self, mock_konflux_db):
         """Test get_module_tag method"""
         mock_runtime = Mock(

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -538,7 +538,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
     async def test_ensure_builder_pullspec_available_reuses_oc_helper(
         self, mock_konflux_db, get_image_info
     ):
-        """Test published pullspec availability check reuses pyartcd.oc.get_image_info with env auth"""
+        """Test published pullspec availability check reuses pyartcd.oc.get_image_info with quay auth"""
         mock_runtime = Mock(
             dry_run=False,
             working_dir=Path("/tmp/working"),
@@ -560,13 +560,13 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         with patch.dict(
             "os.environ",
-            {"REGISTRY_AUTH_FILE": "/tmp/registry-auth.json"},
+            {"QUAY_AUTH_FILE": "/tmp/quay-auth.json"},
             clear=False,
         ):
             await pipeline._ensure_builder_pullspec_available(pullspec)
 
         get_image_info.assert_awaited_once_with(
-            pullspec, raise_if_not_found=True, registry_config="/tmp/registry-auth.json"
+            pullspec, raise_if_not_found=True, registry_config="/tmp/quay-auth.json"
         )
 
     @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
@@ -597,7 +597,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         with patch.dict(
             "os.environ",
-            {"REGISTRY_AUTH_FILE": "/tmp/registry-auth.json"},
+            {"QUAY_AUTH_FILE": "/tmp/quay-auth.json"},
             clear=False,
         ):
             with self.assertRaisesRegex(RuntimeError, "Published golang builder pullspec is not available"):


### PR DESCRIPTION
## Summary
- use published golang builder pullspecs and dedicated auth handling when updating `update-golang` streams
- simplify the related pullspec availability path and tests around the builder update flow
- prevent `--tag-builds` from tagging golang builds whose major.minor does not match the target group's `GO_LATEST`

## Test plan
- [x] `uv run --python 3.11 pytest --verbose --color=yes pyartcd/tests/pipelines/test_update_golang.py`

Made with [Cursor](https://cursor.com)