### PR TITLE
pyartcd: validate update-golang against group go vars

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -119,7 +119,10 @@ def extract_and_validate_golang_nvrs(ocp_version: str, go_nvrs: List[str]):
 
 
 def extract_major_minor(version: str, label: str = "version") -> str:
-    version = str(version)
+    if not isinstance(version, str):
+        output = io.StringIO()
+        yaml.dump({"value": version}, output)
+        version = output.getvalue().split(":", 1)[1].strip()
     match = re.fullmatch(r"(\d+)\.(\d+)(?:\.\d+)?", version)
     if not match:
         raise ValueError(f"Invalid {label}: {version}")
@@ -257,8 +260,7 @@ class UpdateGolangPipeline:
             )
         return branch, allowed_major_minors, build_major_minor
 
-    def validate_tag_builds_go_latest(self, go_version: str):
-        branch, allowed_major_minors, build_major_minor = self.validate_go_version_matches_group_vars(go_version)
+    def validate_tag_builds_go_latest(self, branch: str, allowed_major_minors: dict[str, str], build_major_minor: str):
         latest_major_minor = allowed_major_minors["GO_LATEST"]
         if build_major_minor != latest_major_minor:
             raise ValueError(
@@ -270,9 +272,9 @@ class UpdateGolangPipeline:
         go_version, el_nvr_map = extract_and_validate_golang_nvrs(self.ocp_version, self.go_nvrs)
         _LOGGER.info(f'Golang version detected: {go_version}')
         _LOGGER.info(f'NVRs by rhel version: {el_nvr_map}')
-        self.validate_go_version_matches_group_vars(go_version)
+        branch, allowed_major_minors, build_major_minor = self.validate_go_version_matches_group_vars(go_version)
         if self.tag_builds:
-            self.validate_tag_builds_go_latest(go_version)
+            self.validate_tag_builds_go_latest(branch, allowed_major_minors, build_major_minor)
 
         # el10 is only supported for build roots (RPM tagging), not for golang-builder images yet
         el_nvr_map_for_images = {el_v: nvr for el_v, nvr in el_nvr_map.items() if el_v != 10}
@@ -576,6 +578,11 @@ class UpdateGolangPipeline:
                 f"{go_latest_var} variable not found in group.yml, please make sure it is defined before running the pipeline"
             )
         go_previous = group_content['vars'].get(go_previous_var)
+        build_major_minor = extract_major_minor(go_version, "golang build version")
+        latest_major_minor = extract_major_minor(go_latest, f"group.yml {go_latest_var}")
+        previous_major_minor = extract_major_minor(go_previous, f"group.yml {go_previous_var}") if go_previous else None
+        build_major_minor_tuple = tuple(map(int, build_major_minor.split(".")))
+        latest_major_minor_tuple = tuple(map(int, latest_major_minor.split(".")))
 
         # these group var templates are used in streams.yml
         # but we do not need to replace/update them
@@ -610,7 +617,7 @@ class UpdateGolangPipeline:
             return streams_content.get(stream_key, None)
 
         # This is to bump minor golang for GO_LATEST
-        if go_latest in go_version:
+        if build_major_minor == latest_major_minor:
             for el_v, builder_nvr in builder_nvrs.items():
                 parsed_nvr = parse_nvr(builder_nvr)
 
@@ -623,7 +630,7 @@ class UpdateGolangPipeline:
                         info['image'] = new_latest_go
                         update_streams = True
         # This is to bump minor golang for GO_PREVIOUS
-        elif go_previous and go_previous in go_version:
+        elif previous_major_minor and build_major_minor == previous_major_minor:
             for el_v, builder_nvr in builder_nvrs.items():
                 parsed_nvr = parse_nvr(builder_nvr)
 
@@ -636,7 +643,7 @@ class UpdateGolangPipeline:
                         info['image'] = new_previous_go
                         update_streams = True
         # This is to bump major golang for GO_LATEST and update GO_PREVIOUS to current GO_LATEST
-        elif go_version.split('.')[0] >= go_latest.split('.')[0] and go_version.split('.')[1] > go_latest.split('.')[1]:
+        elif build_major_minor_tuple > latest_major_minor_tuple:
             for el_v, builder_nvr in builder_nvrs.items():
                 parsed_nvr = parse_nvr(builder_nvr)
 

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -119,6 +119,7 @@ def extract_and_validate_golang_nvrs(ocp_version: str, go_nvrs: List[str]):
 
 
 def extract_major_minor(version: str, label: str = "version") -> str:
+    version = str(version)
     match = re.fullmatch(r"(\d+)\.(\d+)(?:\.\d+)?", version)
     if not match:
         raise ValueError(f"Invalid {label}: {version}")
@@ -215,30 +216,61 @@ class UpdateGolangPipeline:
             self.konflux_db = KonfluxDb()
             self.konflux_db.bind(KonfluxBuildRecord)
 
-    def validate_tag_builds_go_latest(self, go_version: str):
-        branch = f"openshift-{self.ocp_version}"
-        upstream_repo = get_github_client_for_org("openshift-eng").get_repo("openshift-eng/ocp-build-data")
-        group_content = yaml.load(upstream_repo.get_contents("group.yml", ref=branch).decoded_content)
+    @staticmethod
+    def _load_yaml_from_repo(repo, path: str, ref: str):
+        return yaml.load(repo.get_contents(path, ref=ref).decoded_content)
 
+    def _get_upstream_ocp_build_data_repo(self):
+        return get_github_client_for_org("openshift-eng").get_repo("openshift-eng/ocp-build-data")
+
+    def _get_allowed_go_major_minors(self) -> tuple[str, dict[str, str]]:
+        branch = f"openshift-{self.ocp_version}"
+        upstream_repo = self._get_upstream_ocp_build_data_repo()
+        group_content = self._load_yaml_from_repo(upstream_repo, "group.yml", branch)
+
+        vars_content = group_content.get("vars", {})
         go_latest_var = "GO_LATEST"
-        go_latest = group_content.get("vars", {}).get(go_latest_var)
+        go_latest = vars_content.get(go_latest_var)
         if not go_latest:
             raise ValueError(
                 f"{go_latest_var} variable not found in group.yml, please make sure it is defined before running the pipeline"
             )
 
+        allowed_major_minors = {
+            var_name: extract_major_minor(var_value, f"group.yml {var_name}")
+            for var_name in ("GO_LATEST", "GO_EXTRA", "GO_PREVIOUS")
+            for var_value in [vars_content.get(var_name)]
+            if var_value
+        }
+        return branch, allowed_major_minors
+
+    def validate_go_version_matches_group_vars(self, go_version: str):
+        branch, allowed_major_minors = self._get_allowed_go_major_minors()
         build_major_minor = extract_major_minor(go_version, "golang build version")
-        latest_major_minor = extract_major_minor(go_latest, f"group.yml {go_latest_var}")
+        if build_major_minor not in allowed_major_minors.values():
+            allowed_versions = ", ".join(
+                f"{var_name} ({major_minor})" for var_name, major_minor in allowed_major_minors.items()
+            )
+            raise ValueError(
+                f"The provided golang build major.minor ({build_major_minor}) must match "
+                f"one of {branch} group.yml vars: {allowed_versions}."
+            )
+        return branch, allowed_major_minors, build_major_minor
+
+    def validate_tag_builds_go_latest(self, go_version: str):
+        branch, allowed_major_minors, build_major_minor = self.validate_go_version_matches_group_vars(go_version)
+        latest_major_minor = allowed_major_minors["GO_LATEST"]
         if build_major_minor != latest_major_minor:
             raise ValueError(
                 f"When --tag-builds is set, the provided golang build major.minor ({build_major_minor}) must match "
-                f"{branch} group.yml {go_latest_var} major.minor ({latest_major_minor})."
+                f"{branch} group.yml GO_LATEST major.minor ({latest_major_minor})."
             )
 
     async def run(self):
         go_version, el_nvr_map = extract_and_validate_golang_nvrs(self.ocp_version, self.go_nvrs)
         _LOGGER.info(f'Golang version detected: {go_version}')
         _LOGGER.info(f'NVRs by rhel version: {el_nvr_map}')
+        self.validate_go_version_matches_group_vars(go_version)
         if self.tag_builds:
             self.validate_tag_builds_go_latest(go_version)
 
@@ -533,9 +565,9 @@ class UpdateGolangPipeline:
         4. Create pr to update changes
         """
         branch = f"openshift-{self.ocp_version}"
-        upstream_repo = get_github_client_for_org("openshift-eng").get_repo("openshift-eng/ocp-build-data")
-        streams_content = yaml.load(upstream_repo.get_contents("streams.yml", ref=branch).decoded_content)
-        group_content = yaml.load(upstream_repo.get_contents("group.yml", ref=branch).decoded_content)
+        upstream_repo = self._get_upstream_ocp_build_data_repo()
+        streams_content = self._load_yaml_from_repo(upstream_repo, "streams.yml", branch)
+        group_content = self._load_yaml_from_repo(upstream_repo, "group.yml", branch)
 
         go_latest_var, go_previous_var = "GO_LATEST", "GO_PREVIOUS"
         go_latest = group_content['vars'].get(go_latest_var)

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -206,6 +206,7 @@ class UpdateGolangPipeline:
         self._slack_client = self.runtime.new_slack_client()
         self._doozer_working_dir = self.runtime.working_dir / "doozer-working"
         self._doozer_env_vars = os.environ.copy()
+        self._group_content = None
 
         # Get kubeconfig from environment variable if not provided
         if not kubeconfig:
@@ -226,10 +227,16 @@ class UpdateGolangPipeline:
     def _get_upstream_ocp_build_data_repo(self):
         return get_github_client_for_org("openshift-eng").get_repo("openshift-eng/ocp-build-data")
 
+    def _get_group_content(self):
+        if self._group_content is None:
+            branch = f"openshift-{self.ocp_version}"
+            upstream_repo = self._get_upstream_ocp_build_data_repo()
+            self._group_content = self._load_yaml_from_repo(upstream_repo, "group.yml", branch)
+        return self._group_content
+
     def _get_allowed_go_major_minors(self) -> tuple[str, dict[str, str]]:
         branch = f"openshift-{self.ocp_version}"
-        upstream_repo = self._get_upstream_ocp_build_data_repo()
-        group_content = self._load_yaml_from_repo(upstream_repo, "group.yml", branch)
+        group_content = self._get_group_content()
 
         vars_content = group_content.get("vars", {})
         go_latest_var = "GO_LATEST"
@@ -569,7 +576,7 @@ class UpdateGolangPipeline:
         branch = f"openshift-{self.ocp_version}"
         upstream_repo = self._get_upstream_ocp_build_data_repo()
         streams_content = self._load_yaml_from_repo(upstream_repo, "streams.yml", branch)
-        group_content = self._load_yaml_from_repo(upstream_repo, "group.yml", branch)
+        group_content = self._get_group_content()
 
         go_latest_var, go_previous_var = "GO_LATEST", "GO_PREVIOUS"
         go_latest = group_content['vars'].get(go_latest_var)

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -206,7 +206,7 @@ class UpdateGolangPipeline:
         self._slack_client = self.runtime.new_slack_client()
         self._doozer_working_dir = self.runtime.working_dir / "doozer-working"
         self._doozer_env_vars = os.environ.copy()
-        self._group_content = None
+        self._branch_content = None
 
         # Get kubeconfig from environment variable if not provided
         if not kubeconfig:
@@ -227,16 +227,22 @@ class UpdateGolangPipeline:
     def _get_upstream_ocp_build_data_repo(self):
         return get_github_client_for_org("openshift-eng").get_repo("openshift-eng/ocp-build-data")
 
-    def _get_group_content(self):
-        if self._group_content is None:
+    def _get_branch_content(self):
+        if self._branch_content is None:
             branch = f"openshift-{self.ocp_version}"
             upstream_repo = self._get_upstream_ocp_build_data_repo()
-            self._group_content = self._load_yaml_from_repo(upstream_repo, "group.yml", branch)
-        return self._group_content
+            self._branch_content = {
+                "branch": branch,
+                "repo": upstream_repo,
+                "group": self._load_yaml_from_repo(upstream_repo, "group.yml", branch),
+                "streams": self._load_yaml_from_repo(upstream_repo, "streams.yml", branch),
+            }
+        return self._branch_content
 
     def _get_allowed_go_major_minors(self) -> tuple[str, dict[str, str]]:
-        branch = f"openshift-{self.ocp_version}"
-        group_content = self._get_group_content()
+        branch_content = self._get_branch_content()
+        branch = branch_content["branch"]
+        group_content = branch_content["group"]
 
         vars_content = group_content.get("vars", {})
         go_latest_var = "GO_LATEST"
@@ -573,10 +579,11 @@ class UpdateGolangPipeline:
         3. If it'a major version bump, also need to update key in streams.yml and vars in group.yml
         4. Create pr to update changes
         """
-        branch = f"openshift-{self.ocp_version}"
-        upstream_repo = self._get_upstream_ocp_build_data_repo()
-        streams_content = self._load_yaml_from_repo(upstream_repo, "streams.yml", branch)
-        group_content = self._get_group_content()
+        branch_content = self._get_branch_content()
+        branch = branch_content["branch"]
+        upstream_repo = branch_content["repo"]
+        streams_content = branch_content["streams"]
+        group_content = branch_content["group"]
 
         go_latest_var, go_previous_var = "GO_LATEST", "GO_PREVIOUS"
         go_latest = group_content['vars'].get(go_latest_var)

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -118,6 +118,13 @@ def extract_and_validate_golang_nvrs(ocp_version: str, go_nvrs: List[str]):
     return go_version, el_nvr_map
 
 
+def extract_major_minor(version: str, label: str = "version") -> str:
+    match = re.fullmatch(r"(\d+)\.(\d+)(?:\.\d+)?", version)
+    if not match:
+        raise ValueError(f"Invalid {label}: {version}")
+    return f"{match[1]}.{match[2]}"
+
+
 async def move_golang_bugs(
     ocp_version: str,
     cves: list[str] | None = None,
@@ -208,10 +215,32 @@ class UpdateGolangPipeline:
             self.konflux_db = KonfluxDb()
             self.konflux_db.bind(KonfluxBuildRecord)
 
+    def validate_tag_builds_go_latest(self, go_version: str):
+        branch = f"openshift-{self.ocp_version}"
+        upstream_repo = get_github_client_for_org("openshift-eng").get_repo("openshift-eng/ocp-build-data")
+        group_content = yaml.load(upstream_repo.get_contents("group.yml", ref=branch).decoded_content)
+
+        go_latest_var = "GO_LATEST"
+        go_latest = group_content.get("vars", {}).get(go_latest_var)
+        if not go_latest:
+            raise ValueError(
+                f"{go_latest_var} variable not found in group.yml, please make sure it is defined before running the pipeline"
+            )
+
+        build_major_minor = extract_major_minor(go_version, "golang build version")
+        latest_major_minor = extract_major_minor(go_latest, f"group.yml {go_latest_var}")
+        if build_major_minor != latest_major_minor:
+            raise ValueError(
+                f"When --tag-builds is set, the provided golang build major.minor ({build_major_minor}) must match "
+                f"{branch} group.yml {go_latest_var} major.minor ({latest_major_minor})."
+            )
+
     async def run(self):
         go_version, el_nvr_map = extract_and_validate_golang_nvrs(self.ocp_version, self.go_nvrs)
         _LOGGER.info(f'Golang version detected: {go_version}')
         _LOGGER.info(f'NVRs by rhel version: {el_nvr_map}')
+        if self.tag_builds:
+            self.validate_tag_builds_go_latest(go_version)
 
         # el10 is only supported for build roots (RPM tagging), not for golang-builder images yet
         el_nvr_map_for_images = {el_v: nvr for el_v, nvr in el_nvr_map.items() if el_v != 10}

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -429,7 +429,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             force_update_tracker=False,
             go_nvrs=["golang-1.23.9-1.el8"],
             art_jira="ART-1234",
-            tag_builds=True,
+            tag_builds=False,
         )
 
         pipeline.validate_go_version_matches_group_vars("1.23.9")
@@ -459,7 +459,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             force_update_tracker=False,
             go_nvrs=["golang-1.21.13-1.el8"],
             art_jira="ART-1234",
-            tag_builds=True,
+            tag_builds=False,
         )
 
         pipeline.validate_go_version_matches_group_vars("1.21.13")
@@ -469,7 +469,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
     def test_validate_go_version_matches_group_vars_rejects_mismatched_major_minor(
         self, mock_konflux_db, mock_get_github_client
     ):
-        """Test tag-build validation rejects build versions that match none of GO_LATEST/GO_EXTRA/GO_PREVIOUS"""
+        """Test version validation rejects build versions that match none of GO_LATEST/GO_EXTRA/GO_PREVIOUS"""
         mock_runtime = Mock(
             dry_run=False,
             working_dir=Path("/tmp/working"),
@@ -489,7 +489,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             force_update_tracker=False,
             go_nvrs=["golang-1.24.1-1.el8"],
             art_jira="ART-1234",
-            tag_builds=True,
+            tag_builds=False,
         )
 
         with self.assertRaisesRegex(

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -402,15 +402,14 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             tag_builds=True,
         )
 
-        pipeline.validate_tag_builds_go_latest("1.22.9")
+        branch, allowed_major_minors, build_major_minor = pipeline.validate_go_version_matches_group_vars("1.22.9")
+        pipeline.validate_tag_builds_go_latest(branch, allowed_major_minors, build_major_minor)
 
         upstream_repo.get_contents.assert_called_once_with("group.yml", ref="openshift-4.16")
 
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    def test_validate_go_version_matches_group_vars_accepts_matching_go_extra(
-        self, mock_konflux_db, mock_get_github_client
-    ):
+    def test_validate_go_version_matches_group_vars_accepts_matching_go_extra(self, mock_konflux_db, mock_get_github_client):
         """Test version validation accepts a build version matching group.yml GO_EXTRA major.minor"""
         mock_runtime = Mock(
             dry_run=False,
@@ -419,7 +418,9 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         mock_runtime.new_slack_client.return_value = Mock()
 
         upstream_repo = Mock()
-        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_EXTRA: 1.23\n")
+        upstream_repo.get_contents.return_value = Mock(
+            decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_EXTRA: 1.23\n"
+        )
         mock_get_github_client.return_value.get_repo.return_value = upstream_repo
 
         pipeline = UpdateGolangPipeline(
@@ -436,9 +437,37 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    def test_validate_go_version_matches_group_vars_accepts_matching_go_previous(
+    def test_validate_go_version_matches_group_vars_accepts_unquoted_trailing_zero(
         self, mock_konflux_db, mock_get_github_client
     ):
+        """Test version validation accepts unquoted trailing-zero YAML scalars like 1.20"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        upstream_repo = Mock()
+        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.20\n")
+        mock_get_github_client.return_value.get_repo.return_value = upstream_repo
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.20.12-2.el8"],
+            art_jira="ART-1234",
+            tag_builds=False,
+        )
+
+        pipeline.validate_go_version_matches_group_vars("1.20.12")
+
+        upstream_repo.get_contents.assert_called_once_with("group.yml", ref="openshift-4.16")
+
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_validate_go_version_matches_group_vars_accepts_matching_go_previous(self, mock_konflux_db, mock_get_github_client):
         """Test version validation accepts a build version matching group.yml GO_PREVIOUS major.minor"""
         mock_runtime = Mock(
             dry_run=False,
@@ -509,7 +538,9 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         mock_runtime.new_slack_client.return_value = Mock()
 
         upstream_repo = Mock()
-        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_EXTRA: 1.23\n")
+        upstream_repo.get_contents.return_value = Mock(
+            decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_EXTRA: 1.23\n"
+        )
         mock_get_github_client.return_value.get_repo.return_value = upstream_repo
 
         pipeline = UpdateGolangPipeline(
@@ -523,7 +554,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         )
 
         with self.assertRaisesRegex(ValueError, r"--tag-builds.*\(1\.23\).*\(1\.22\)"):
-            pipeline.validate_tag_builds_go_latest("1.23.9")
+            pipeline.validate_tag_builds_go_latest("openshift-4.16", {"GO_LATEST": "1.22", "GO_EXTRA": "1.23"}, "1.23")
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_brew_login_when_logged_out(self, mock_konflux_db):

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -378,6 +378,63 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         branch = UpdateGolangPipeline.get_golang_branch(9, "1.21.5")
         self.assertEqual(branch, "rhel-9-golang-1.21")
 
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_validate_tag_builds_go_latest_accepts_matching_major_minor(self, mock_konflux_db, mock_get_github_client):
+        """Test tag-build validation accepts a build version matching group.yml GO_LATEST major.minor"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        upstream_repo = Mock()
+        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22.7\n")
+        mock_get_github_client.return_value.get_repo.return_value = upstream_repo
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=True,
+        )
+
+        pipeline.validate_tag_builds_go_latest("1.22.9")
+
+        upstream_repo.get_contents.assert_called_once_with("group.yml", ref="openshift-4.16")
+
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_validate_tag_builds_go_latest_rejects_mismatched_major_minor(
+        self, mock_konflux_db, mock_get_github_client
+    ):
+        """Test tag-build validation rejects build versions that do not match group.yml GO_LATEST major.minor"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        upstream_repo = Mock()
+        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22.7\n")
+        mock_get_github_client.return_value.get_repo.return_value = upstream_repo
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.21.13-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=True,
+        )
+
+        with self.assertRaisesRegex(ValueError, r"--tag-builds.*\(1\.21\).*\(1\.22\)"):
+            pipeline.validate_tag_builds_go_latest("1.21.13")
+
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_brew_login_when_logged_out(self, mock_konflux_db):
         """Test brew_login when session is logged out"""

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -467,6 +467,46 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_update_golang_streams_reuses_cached_group_content(self, mock_konflux_db, mock_get_github_client):
+        """Test update_golang_streams reuses the same cached group.yml content loaded during validation"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_slack = Mock()
+        mock_slack.say_in_thread = AsyncMock()
+        mock_runtime.new_slack_client.return_value = mock_slack
+
+        upstream_repo = Mock()
+
+        def get_contents(path, ref):
+            if path == "group.yml":
+                return Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22\n")
+            if path == "streams.yml":
+                return Mock(decoded_content=b"{}\n")
+            raise AssertionError(f"Unexpected path requested: {path}")
+
+        upstream_repo.get_contents.side_effect = get_contents
+        mock_get_github_client.return_value.get_repo.return_value = upstream_repo
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=False,
+        )
+
+        pipeline.validate_go_version_matches_group_vars("1.22.9")
+        await pipeline.update_golang_streams("1.22.9", {})
+
+        group_calls = [call for call in upstream_repo.get_contents.call_args_list if call.args[0] == "group.yml"]
+        self.assertEqual(len(group_calls), 1)
+
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_validate_go_version_matches_group_vars_accepts_matching_go_previous(
         self, mock_konflux_db, mock_get_github_client
     ):

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -405,7 +405,8 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         branch, allowed_major_minors, build_major_minor = pipeline.validate_go_version_matches_group_vars("1.22.9")
         pipeline.validate_tag_builds_go_latest(branch, allowed_major_minors, build_major_minor)
 
-        upstream_repo.get_contents.assert_called_once_with("group.yml", ref="openshift-4.16")
+        requested_paths = [call.args[0] for call in upstream_repo.get_contents.call_args_list]
+        self.assertEqual(sorted(requested_paths), ["group.yml", "streams.yml"])
 
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -463,12 +464,13 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         pipeline.validate_go_version_matches_group_vars("1.20.12")
 
-        upstream_repo.get_contents.assert_called_once_with("group.yml", ref="openshift-4.16")
+        requested_paths = [call.args[0] for call in upstream_repo.get_contents.call_args_list]
+        self.assertEqual(sorted(requested_paths), ["group.yml", "streams.yml"])
 
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_update_golang_streams_reuses_cached_group_content(self, mock_konflux_db, mock_get_github_client):
-        """Test update_golang_streams reuses the same cached group.yml content loaded during validation"""
+    async def test_update_golang_streams_reuses_cached_branch_content(self, mock_konflux_db, mock_get_github_client):
+        """Test update_golang_streams reuses the same cached branch content loaded during validation"""
         mock_runtime = Mock(
             dry_run=False,
             working_dir=Path("/tmp/working"),
@@ -502,8 +504,9 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         pipeline.validate_go_version_matches_group_vars("1.22.9")
         await pipeline.update_golang_streams("1.22.9", {})
 
-        group_calls = [call for call in upstream_repo.get_contents.call_args_list if call.args[0] == "group.yml"]
-        self.assertEqual(len(group_calls), 1)
+        requested_paths = [call.args[0] for call in upstream_repo.get_contents.call_args_list]
+        self.assertEqual(requested_paths.count("group.yml"), 1)
+        self.assertEqual(requested_paths.count("streams.yml"), 1)
 
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -409,7 +409,9 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    def test_validate_go_version_matches_group_vars_accepts_matching_go_extra(self, mock_konflux_db, mock_get_github_client):
+    def test_validate_go_version_matches_group_vars_accepts_matching_go_extra(
+        self, mock_konflux_db, mock_get_github_client
+    ):
         """Test version validation accepts a build version matching group.yml GO_EXTRA major.minor"""
         mock_runtime = Mock(
             dry_run=False,
@@ -418,9 +420,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         mock_runtime.new_slack_client.return_value = Mock()
 
         upstream_repo = Mock()
-        upstream_repo.get_contents.return_value = Mock(
-            decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_EXTRA: 1.23\n"
-        )
+        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_EXTRA: 1.23\n")
         mock_get_github_client.return_value.get_repo.return_value = upstream_repo
 
         pipeline = UpdateGolangPipeline(
@@ -467,7 +467,9 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    def test_validate_go_version_matches_group_vars_accepts_matching_go_previous(self, mock_konflux_db, mock_get_github_client):
+    def test_validate_go_version_matches_group_vars_accepts_matching_go_previous(
+        self, mock_konflux_db, mock_get_github_client
+    ):
         """Test version validation accepts a build version matching group.yml GO_PREVIOUS major.minor"""
         mock_runtime = Mock(
             dry_run=False,
@@ -538,9 +540,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         mock_runtime.new_slack_client.return_value = Mock()
 
         upstream_repo = Mock()
-        upstream_repo.get_contents.return_value = Mock(
-            decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_EXTRA: 1.23\n"
-        )
+        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_EXTRA: 1.23\n")
         mock_get_github_client.return_value.get_repo.return_value = upstream_repo
 
         pipeline = UpdateGolangPipeline(

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -389,7 +389,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         mock_runtime.new_slack_client.return_value = Mock()
 
         upstream_repo = Mock()
-        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22.7\n")
+        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22\n")
         mock_get_github_client.return_value.get_repo.return_value = upstream_repo
 
         pipeline = UpdateGolangPipeline(
@@ -408,10 +408,10 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    def test_validate_tag_builds_go_latest_rejects_mismatched_major_minor(
+    def test_validate_go_version_matches_group_vars_accepts_matching_go_extra(
         self, mock_konflux_db, mock_get_github_client
     ):
-        """Test tag-build validation rejects build versions that do not match group.yml GO_LATEST major.minor"""
+        """Test version validation accepts a build version matching group.yml GO_EXTRA major.minor"""
         mock_runtime = Mock(
             dry_run=False,
             working_dir=Path("/tmp/working"),
@@ -419,7 +419,37 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         mock_runtime.new_slack_client.return_value = Mock()
 
         upstream_repo = Mock()
-        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22.7\n")
+        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_EXTRA: 1.23\n")
+        mock_get_github_client.return_value.get_repo.return_value = upstream_repo
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.23.9-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=True,
+        )
+
+        pipeline.validate_go_version_matches_group_vars("1.23.9")
+
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_validate_go_version_matches_group_vars_accepts_matching_go_previous(
+        self, mock_konflux_db, mock_get_github_client
+    ):
+        """Test version validation accepts a build version matching group.yml GO_PREVIOUS major.minor"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        upstream_repo = Mock()
+        upstream_repo.get_contents.return_value = Mock(
+            decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_PREVIOUS: 1.21\n"
+        )
         mock_get_github_client.return_value.get_repo.return_value = upstream_repo
 
         pipeline = UpdateGolangPipeline(
@@ -432,8 +462,68 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             tag_builds=True,
         )
 
-        with self.assertRaisesRegex(ValueError, r"--tag-builds.*\(1\.21\).*\(1\.22\)"):
-            pipeline.validate_tag_builds_go_latest("1.21.13")
+        pipeline.validate_go_version_matches_group_vars("1.21.13")
+
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_validate_go_version_matches_group_vars_rejects_mismatched_major_minor(
+        self, mock_konflux_db, mock_get_github_client
+    ):
+        """Test tag-build validation rejects build versions that match none of GO_LATEST/GO_EXTRA/GO_PREVIOUS"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        upstream_repo = Mock()
+        upstream_repo.get_contents.return_value = Mock(
+            decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_EXTRA: 1.23\n  GO_PREVIOUS: 1.21\n"
+        )
+        mock_get_github_client.return_value.get_repo.return_value = upstream_repo
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.24.1-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=True,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"must match one of .*GO_LATEST \(1\.22\).*GO_EXTRA \(1\.23\).*GO_PREVIOUS \(1\.21\)",
+        ):
+            pipeline.validate_go_version_matches_group_vars("1.24.1")
+
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_validate_tag_builds_go_latest_rejects_go_extra_match(self, mock_konflux_db, mock_get_github_client):
+        """Test tag-build validation still requires GO_LATEST even when GO_EXTRA matches"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        upstream_repo = Mock()
+        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_EXTRA: 1.23\n")
+        mock_get_github_client.return_value.get_repo.return_value = upstream_repo
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.23.9-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=True,
+        )
+
+        with self.assertRaisesRegex(ValueError, r"--tag-builds.*\(1\.23\).*\(1\.22\)"):
+            pipeline.validate_tag_builds_go_latest("1.23.9")
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_brew_login_when_logged_out(self, mock_konflux_db):


### PR DESCRIPTION
## Summary
- require `update-golang` builds to match at least one configured group `GO_*` major.minor (`GO_LATEST`, `GO_EXTRA`, or `GO_PREVIOUS`)
- keep `--tag-builds` stricter by requiring the build major.minor to match `GO_LATEST`
- normalize YAML scalar `GO_*` values and add focused tests for accepted and rejected combinations

## Test plan
- [x] `uv run --python 3.11 pytest --verbose --color=yes pyartcd/tests/pipelines/test_update_golang.py`