### PR TITLE
Annotate base image releases with NVRs

### DIFF
--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -145,7 +145,8 @@ class BaseImageHandler:
                 self.logger.error("Failed to create snapshot, aborting workflow")
                 return None
 
-            release_name = await self._create_release_from_snapshot(snapshot_name)
+            released_nvrs = ",".join(sorted(valid_records))
+            release_name = await self._create_release_from_snapshot(snapshot_name, released_nvrs)
             if not release_name:
                 self.logger.error("Failed to create release, aborting workflow")
                 return None
@@ -284,12 +285,13 @@ class BaseImageHandler:
             self.logger.error(f"Failed to create snapshot: {e}")
             return None
 
-    async def _create_release_from_snapshot(self, snapshot_name: str) -> Optional[str]:
+    async def _create_release_from_snapshot(self, snapshot_name: str, released_nvrs: str) -> Optional[str]:
         """
         Create Konflux release using the same pattern as CreateReleaseCli.new_release().
 
         Args:
             snapshot_name: Name of the snapshot to create release from
+            released_nvrs: Comma-separated NVRs validated for release
 
         Returns:
             str: Release name if successful, None if failed
@@ -308,8 +310,6 @@ class BaseImageHandler:
                 snapshot_available = await self._wait_for_snapshot_availability(snapshot_name)
                 if not snapshot_available:
                     raise RuntimeError(f"Snapshot {snapshot_name} did not become available in time")
-
-            released_nvrs = ",".join(sorted(self.nvr_list))
 
             metadata = {
                 "generateName": "ocp-base-image-release-",

--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -309,6 +309,8 @@ class BaseImageHandler:
                 if not snapshot_available:
                     raise RuntimeError(f"Snapshot {snapshot_name} did not become available in time")
 
+            released_nvrs = ",".join(sorted(self.nvr_list))
+
             metadata = {
                 "generateName": "ocp-base-image-release-",
                 "namespace": self.namespace,
@@ -320,6 +322,7 @@ class BaseImageHandler:
                     "art.redhat.com/group": self.runtime.group_config.name,
                     "art.redhat.com/assembly": getattr(self.runtime, 'assembly', 'stream'),
                     "art.redhat.com/env": "base-image-workflow",
+                    "art.redhat.com/nvrs": released_nvrs,
                 },
             }
 

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -255,3 +255,36 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         # Golang builder should successfully complete the workflow
         self.assertIsNotNone(result)
         self.assertEqual(result, ("golang-release", "golang-snapshot"))
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_create_release_from_snapshot_adds_nvr_annotation(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+
+        konflux_client = AsyncMock()
+        created_release = MagicMock()
+        created_release.metadata.name = "test-release"
+        konflux_client._create.return_value = created_release
+        konflux_client.resource_url = MagicMock(return_value="https://konflux.example/releases/test-release")
+        mock_konflux_client_init.return_value = konflux_client
+
+        handler = BaseImageHandler(
+            self.runtime,
+            [self.nvr, "another-base-container-v1.0.0-1.el8"],
+            dry_run=False,
+        )
+
+        with patch.object(handler, "_wait_for_snapshot_availability", new=AsyncMock(return_value=True)):
+            await handler._create_release_from_snapshot("test-snapshot")
+
+        konflux_client._get.assert_awaited_once()
+        konflux_client._create.assert_awaited_once()
+        release_obj = konflux_client._create.await_args.args[0]
+        self.assertEqual(
+            release_obj["metadata"]["annotations"]["art.redhat.com/nvrs"],
+            "another-base-container-v1.0.0-1.el8,test-base-container-v1.0.0-1.el9",
+        )

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -116,7 +116,9 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
 
         with patch.object(handler, "_fetch_build_records", return_value=build_records):
             with patch.object(handler, "_create_snapshot", return_value="test-snapshot"):
-                with patch.object(handler, "_create_release_from_snapshot", return_value="test-release") as mock_release:
+                with patch.object(
+                    handler, "_create_release_from_snapshot", return_value="test-release"
+                ) as mock_release:
                     with patch.object(handler, "_wait_for_release_completion", return_value=True):
                         with self.assertRaises(RuntimeError) as context:
                             await handler.process_base_image_completion()

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -116,12 +116,13 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
 
         with patch.object(handler, "_fetch_build_records", return_value=build_records):
             with patch.object(handler, "_create_snapshot", return_value="test-snapshot"):
-                with patch.object(handler, "_create_release_from_snapshot", return_value="test-release"):
+                with patch.object(handler, "_create_release_from_snapshot", return_value="test-release") as mock_release:
                     with patch.object(handler, "_wait_for_release_completion", return_value=True):
                         with self.assertRaises(RuntimeError) as context:
                             await handler.process_base_image_completion()
 
         error_message = str(context.exception)
+        mock_release.assert_awaited_once_with("test-snapshot", valid_nvr)
         self.assertIn("Snapshot/Release completed successfully", error_message)
         self.assertIn("1 critical validation failures", error_message)
         self.assertIn("Could not resolve metadata", error_message)
@@ -279,7 +280,10 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         )
 
         with patch.object(handler, "_wait_for_snapshot_availability", new=AsyncMock(return_value=True)):
-            await handler._create_release_from_snapshot("test-snapshot")
+            await handler._create_release_from_snapshot(
+                "test-snapshot",
+                "another-base-container-v1.0.0-1.el8,test-base-container-v1.0.0-1.el9",
+            )
 
         konflux_client._get.assert_awaited_once()
         konflux_client._create.assert_awaited_once()


### PR DESCRIPTION
## Summary
- add an `art.redhat.com/nvrs` annotation to Konflux base image Release objects
- keep the annotation value deterministic by sorting and joining the released NVRs
- cover the new release metadata with a focused base image handler test

## Test plan
- [x] `uv run pytest --verbose --color=yes doozer/tests/backend/test_base_image_handler.py`

Made with [Cursor](https://cursor.com)