### PR TITLE
ART-18048: feat(base-image): add database coordination after registry release

### DIFF
--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -10,6 +10,7 @@ import asyncio
 from typing import Dict, List, Optional, Tuple
 
 from artcommonlib import logutil
+from artcommonlib.constants import REGISTRY_REDHAT_IO
 from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildRecord
 from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.util import (
@@ -154,6 +155,8 @@ class BaseImageHandler:
             if not completed_successfully:
                 self.logger.error("Release did not complete successfully, aborting workflow")
                 return None
+
+            await self._update_database_pullspecs(valid_records)
 
             self.logger.info("✓ Base image workflow completed successfully")
             self.logger.info(f"  Snapshot: {snapshot_name}")
@@ -413,6 +416,40 @@ class BaseImageHandler:
         except Exception as e:
             self.logger.error(f"Failed to monitor release {release_name}: {e}")
             return False
+
+    async def _update_database_pullspecs(self, valid_records: Dict[str, KonfluxBuildRecord]) -> None:
+        if not self.konflux_db:
+            return
+
+        try:
+            # Filter out test assemblies
+            non_test_records = {nvr: record for nvr, record in valid_records.items() if record.assembly != 'test'}
+
+            if not non_test_records:
+                self.logger.info("No non-test assembly records to update")
+                return
+
+            self.logger.info(
+                f"Updating {len(non_test_records)} non-test assembly records "
+                f"(skipped {len(valid_records) - len(non_test_records)} test assembly records)"
+            )
+
+            updated_records = []
+            for nvr, build_record in non_test_records.items():
+                registry_pullspec = f"{REGISTRY_REDHAT_IO}/openshift/{ART_IMAGES_BASE_APPLICATION}:{nvr}"
+
+                # Copy existing record and update only the changed fields
+                updated_record = KonfluxBuildRecord(**vars(build_record))
+                updated_record.image_pullspec = registry_pullspec
+                updated_record.ingestion_time = get_utc_now_formatted_str()
+                updated_records.append(updated_record)
+
+            if updated_records and not self.dry_run:
+                await self.konflux_db.insert_build_records(updated_records)
+                self.logger.info(f"✓ Updated {len(updated_records)} database records with registry.redhat.io pullspecs")
+
+        except Exception as e:
+            self.logger.error(f"Failed to update database pullspecs: {e}")
 
     async def _wait_for_snapshot_availability(self, snapshot_name: str, timeout_minutes: int = 1) -> bool:
         """

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1333,16 +1333,34 @@ class ImageMetadata(Metadata):
         """
         Determines whether snapshot-to-release workflow is enabled for this image.
 
-        The snapshot_release flag controls whether base images should trigger
-        the snapshot-to-release workflow when builds complete.
+        Checks configuration in the following order:
+        1. Image metadata configuration (snapshot_release)
+        2. Group configuration (snapshot_release)
+        3. Default value (True)
 
         Returns:
-            bool: True if snapshot_release: true is configured, True by default if not specified
+            bool: True if snapshot_release is enabled, False otherwise
         """
-        snapshot_release_config = getattr(self.config, 'snapshot_release', Missing)
-        if snapshot_release_config not in [Missing, None]:
-            return bool(snapshot_release_config)
-        return True
+        snapshot_release_config_override = getattr(self.config, 'snapshot_release', Missing)
+        snapshot_release_group_override = getattr(self.runtime.group_config, 'snapshot_release', Missing)
+
+        if snapshot_release_config_override not in [Missing, None]:
+            # If snapshot_release override is defined in image metadata
+            snapshot_release_enabled = bool(snapshot_release_config_override)
+            source = "metadata config"
+
+        elif snapshot_release_group_override not in [Missing, None]:
+            # If snapshot_release override is defined in group metadata
+            snapshot_release_enabled = bool(snapshot_release_group_override)
+            source = "group config"
+
+        else:
+            # Default to enabled
+            snapshot_release_enabled = True
+            source = "default"
+
+        self.logger.info("snapshot_release %s from %s", "enabled" if snapshot_release_enabled else "disabled", source)
+        return snapshot_release_enabled
 
     def get_required_artifacts(self) -> list:
         """

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -326,7 +326,7 @@ class UpdateGolangPipeline:
         if konflux_nvrs:
             for el_v, nvr in konflux_nvrs.items():
                 parsed_nvr = parse_nvr(nvr)
-                pullspec = self._get_builder_pullspec(parsed_nvr, 'konflux')
+                pullspec = self._streams_image_pullspec(parsed_nvr)
                 all_builder_messages.append(f"RHEL {el_v}: {nvr} -> {pullspec} (konflux)")
 
         builder_message = "New golang builders available:\n" + "\n".join([f"  - {msg}" for msg in all_builder_messages])
@@ -487,13 +487,37 @@ class UpdateGolangPipeline:
                 builder_nvrs[el_v] = build_record.nvr
         return builder_nvrs
 
+    @staticmethod
+    def _konflux_registry_streams_pullspec(parsed_nvr: dict) -> str:
+        """Released golang-builder image on registry.redhat.io (tag = full image NVR: name-version-release)."""
+        name = parsed_nvr.get('name')
+        version = parsed_nvr.get('version')
+        release = parsed_nvr.get('release')
+        if not name or not version or not release:
+            raise ValueError(
+                'Konflux golang-builder streams pullspec requires image NVR name, version, and release; '
+                f'got keys {list(parsed_nvr.keys())}'
+            )
+        tag = f'{name}-{version}-{release}'
+        return f'registry.redhat.io/openshift/art-images-base:{tag}'
+
+    @staticmethod
+    def _konflux_quay_golang_builder_pullspec(parsed_nvr: dict) -> str:
+        """Pullspec on the default Konflux quay repo (pre-art-images-base release); same layout as image push."""
+        return f'{KONFLUX_DEFAULT_IMAGE_REPO}:golang-builder-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
+
+    def _streams_image_pullspec(self, parsed_nvr: dict) -> str:
+        """Image value written to streams.yml: Brew short name, or Konflux registry URL for art-images-base."""
+        if self.build_system == 'brew':
+            return self._get_builder_pullspec(parsed_nvr, 'brew')
+        return self._konflux_registry_streams_pullspec(parsed_nvr)
+
     def _get_builder_pullspec(self, parsed_nvr, build_system: str):
         """Generate the complete pullspec based on build system"""
         if build_system == 'brew':
             return f'openshift/golang-builder:{parsed_nvr["version"]}-{parsed_nvr["release"]}'
         else:  # konflux or both (both uses konflux pullspec)
-            # TODO: This is temporary. In the future we need a location to share with multiple teams.
-            return f'{KONFLUX_DEFAULT_IMAGE_REPO}:golang-builder-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
+            return self._konflux_registry_streams_pullspec(parsed_nvr)
 
     async def update_golang_streams(self, go_version, builder_nvrs):
         """
@@ -556,7 +580,7 @@ class UpdateGolangPipeline:
                 _LOGGER.info("Looking for golang stream %s in streams.yml", latest_go_stream_name(el_v))
                 latest_go = get_stream(latest_go_stream_name(el_v))['image']
 
-                new_latest_go = self._get_builder_pullspec(parsed_nvr, self.build_system)
+                new_latest_go = self._streams_image_pullspec(parsed_nvr)
                 for _, info in streams_content.items():
                     if info['image'] == latest_go:
                         info['image'] = new_latest_go
@@ -569,7 +593,7 @@ class UpdateGolangPipeline:
                 _LOGGER.info("Looking for golang stream %s in streams.yml", previous_go_stream_name(el_v))
                 previous_go = get_stream(previous_go_stream_name(el_v))['image']
 
-                new_previous_go = self._get_builder_pullspec(parsed_nvr, self.build_system)
+                new_previous_go = self._streams_image_pullspec(parsed_nvr)
                 for _, info in streams_content.items():
                     if info['image'] == previous_go:
                         info['image'] = new_previous_go
@@ -585,7 +609,7 @@ class UpdateGolangPipeline:
                 _LOGGER.info("Looking for golang stream %s in streams.yml", previous_go_stream_name(el_v))
                 previous_go = get_stream(previous_go_stream_name(el_v))['image'] if go_previous else None
 
-                new_latest_go = self._get_builder_pullspec(parsed_nvr, self.build_system)
+                new_latest_go = self._streams_image_pullspec(parsed_nvr)
                 for _, info in streams_content.items():
                     if info['image'] == latest_go:
                         info['image'] = new_latest_go
@@ -606,7 +630,7 @@ class UpdateGolangPipeline:
                 builder_info = []
                 for el_v, nvr in builder_nvrs.items():
                     parsed_nvr = parse_nvr(nvr)
-                    pullspec = self._get_builder_pullspec(parsed_nvr, self.build_system)
+                    pullspec = self._streams_image_pullspec(parsed_nvr)
                     builder_info.append(f"  - RHEL {el_v}: {nvr} -> {pullspec}")
                 builder_details = "\n".join(builder_info)
 

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -6,7 +6,9 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import click
 import koji
+from artcommonlib.constants import KONFLUX_DEFAULT_IMAGE_REPO
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord
+from artcommonlib.rpm_utils import parse_nvr
 from pyartcd.pipelines.update_golang import (
     UpdateGolangPipeline,
     extract_and_validate_golang_nvrs,
@@ -377,6 +379,116 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         branch = UpdateGolangPipeline.get_golang_branch(9, "1.21.5")
         self.assertEqual(branch, "rhel-9-golang-1.21")
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_konflux_streams_pullspec_art_images_base_registry(self, mock_konflux_db):
+        """Konflux streams.yml image uses registry.redhat.io/openshift/art-images-base with NVR tag."""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.8-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="konflux",
+        )
+        parsed = {
+            "name": "openshift-golang-builder-container",
+            "version": "v1.25.8",
+            "release": "202604150744.p2.gf28329a.el9",
+        }
+        self.assertEqual(
+            pipeline._streams_image_pullspec(parsed),
+            "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9",
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_konflux_quay_golang_builder_pullspec_uses_konflux_default_repo(self, mock_konflux_db):
+        """Pre-release builder location uses KONFLUX_DEFAULT_IMAGE_REPO (for fallback / coordination)."""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.8-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="konflux",
+        )
+        parsed = {
+            "name": "openshift-golang-builder-container",
+            "version": "v1.25.8",
+            "release": "202604150744.p2.gf28329a.el9",
+        }
+        self.assertEqual(
+            pipeline._konflux_quay_golang_builder_pullspec(parsed),
+            f'{KONFLUX_DEFAULT_IMAGE_REPO}:golang-builder-v1.25.8-202604150744.p2.gf28329a.el9',
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_brew_streams_image_pullspec_brew_short_name(self, mock_konflux_db):
+        """Brew streams.yml image uses openshift/golang-builder with version-release (not registry.redhat.io)."""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.20.12-2.el8"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="brew",
+        )
+        parsed = {
+            "name": "openshift-golang-builder-container",
+            "version": "v1.20.12",
+            "release": "202403212137.el8.g144a3f8",
+        }
+        self.assertEqual(
+            pipeline._streams_image_pullspec(parsed),
+            "openshift/golang-builder:v1.20.12-202403212137.el8.g144a3f8",
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_brew_streams_image_pullspec_default_build_system_matches_get_builder(self, mock_konflux_db):
+        """Default build_system is brew; _streams_image_pullspec matches _get_builder_pullspec(..., brew)."""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.21.0-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+        )
+        parsed = parse_nvr("openshift-golang-builder-container-v1.21.0-202501011200.el9.gabcdef1.el9")
+        expected = pipeline._get_builder_pullspec(parsed, "brew")
+        self.assertEqual(pipeline._streams_image_pullspec(parsed), expected)
+        self.assertEqual(expected, "openshift/golang-builder:v1.21.0-202501011200.el9.gabcdef1.el9")
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_brew_login_when_logged_out(self, mock_konflux_db):


### PR DESCRIPTION
## Summary
Add database coordination mechanism to sync base image releases with dependent image FROM statements. When base images complete registry.redhat.io release, update Konflux database records with released pullspecs enabling automatic coordination for 235+ dependent images.

## Problem
**Before:** Base images release to registry.redhat.io but 235+ dependent images continue using stale quay.io references in FROM statements because Konflux database pullspecs are not updated after registry releases.

**After:** Dependent images automatically resolve to use the released registry.redhat.io pullspec in their FROM statements when rebasing after base image registry releases.

## Implementation Details
This leverages the existing FROM resolution mechanism: when dependent images rebase and call `_resolve_member_parent()` → `get_latest_build()`, they automatically receive the updated registry.redhat.io pullspec and their FROM statements get rewritten correctly.

### Key Changes
- Add `_update_database_pullspecs()` method to BaseImageHandler for database coordination
- Filter non-test assemblies for production coordination only
- Rework `is_snapshot_release_enabled()` for global toggle control with hierarchical config (image > group > default)
- Enable pattern consistency following established toggle patterns

Fixes coordination gap where dependent images using `from.member: openshift-enterprise-base-rhel9` continued using stale quay.io references after base image registry.redhat.io releases.

Resolves: [ART-18048](https://redhat.atlassian.net/browse/ART-18048)