### PR TITLE
pyartcd: harden update-golang kerberos and wait-repo handling

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -29,7 +29,7 @@ from pyartcd import constants, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.oc import get_image_info
 from pyartcd.runtime import Runtime
-from pyartcd.util import default_release_suffix
+from pyartcd.util import default_release_suffix, kinit
 
 _LOGGER = logging.getLogger(__name__)
 yaml = new_roundtrip_yaml_handler()
@@ -303,6 +303,12 @@ class UpdateGolangPipeline:
             )
 
     async def run(self):
+        try:
+            await kinit()
+        except ChildProcessError as err:
+            _LOGGER.error("Failed initializing Kerberos credentials")
+            raise RuntimeError("Failed initializing Kerberos credentials") from err
+
         go_version, el_nvr_map = extract_and_validate_golang_nvrs(self.ocp_version, self.go_nvrs)
         _LOGGER.info(f'Golang version detected: {go_version}')
         _LOGGER.info(f'NVRs by rhel version: {el_nvr_map}')

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -67,11 +67,29 @@ async def is_latest_and_available(ocp_version: str, el_v: int, nvr: str, koji_se
     # sadly --timeout cannot be less than 1 minute, so we wait for 1 minute
     build_tag = f'rhaos-{ocp_version}-rhel-{el_v}-build'
     cmd = f'brew wait-repo {build_tag} --build {nvr} --request --timeout=1'
-    rc, _, _ = await exectools.cmd_gather_async(cmd, check=False)
+    rc, out, err = await exectools.cmd_gather_async(cmd, check=False)
     if rc != 0:
+        output = "\n".join(stream.strip() for stream in (err, out) if stream and stream.strip())
+        if output:
+            _LOGGER.warning(
+                "`%s` failed while checking whether %s is available in %s (exit code %s):\n%s",
+                cmd,
+                nvr,
+                build_tag,
+                rc,
+                output,
+            )
+        else:
+            _LOGGER.warning(
+                "`%s` failed while checking whether %s is available in %s (exit code %s) and produced no output.",
+                cmd,
+                nvr,
+                build_tag,
+                rc,
+            )
         _LOGGER.info(
-            f'Build {nvr} is tagged but not available in {build_tag}. Run `brew regen-repo {build_tag} to '
-            'make the build available.'
+            f'Build {nvr} could not be confirmed available in {build_tag}. If the build is already tagged, '
+            f'run `brew regen-repo {build_tag}` to make it available.'
         )
         return False
     _LOGGER.info(f'{nvr} is available in {build_tag}')

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -66,7 +66,7 @@ async def is_latest_and_available(ocp_version: str, el_v: int, nvr: str, koji_se
     # If regen repo has been run this would take a few seconds
     # sadly --timeout cannot be less than 1 minute, so we wait for 1 minute
     build_tag = f'rhaos-{ocp_version}-rhel-{el_v}-build'
-    cmd = f'brew wait-repo {build_tag} --build {nvr} --request --timeout=1'
+    cmd = f'brew wait-repo {build_tag} --build {nvr} --timeout=1 --verbose'
     rc, out, err = await exectools.cmd_gather_async(cmd, check=False)
     if rc != 0:
         output = "\n".join(stream.strip() for stream in (err, out) if stream and stream.strip())

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -195,7 +195,7 @@ class TestIsLatestAndAvailable(IsolatedAsyncioTestCase):
         self.assertFalse(result)
         self.assertEqual(len(cm.output), 2)
         self.assertIn(
-            "brew wait-repo rhaos-4.16-rhel-8-build --build golang-1.20.12-2.el8 --request --timeout=1",
+            "brew wait-repo rhaos-4.16-rhel-8-build --build golang-1.20.12-2.el8 --timeout=1 --verbose",
             cm.output[0],
         )
         self.assertIn("exit code 1", cm.output[0])

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -189,9 +189,18 @@ class TestIsLatestAndAvailable(IsolatedAsyncioTestCase):
         mock_cmd_gather.return_value = (1, "", "timeout")
         mock_koji_session = Mock()
 
-        result = await is_latest_and_available("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session)
+        with self.assertLogs("pyartcd.pipelines.update_golang", level="INFO") as cm:
+            result = await is_latest_and_available("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session)
 
         self.assertFalse(result)
+        self.assertEqual(len(cm.output), 2)
+        self.assertIn(
+            "brew wait-repo rhaos-4.16-rhel-8-build --build golang-1.20.12-2.el8 --request --timeout=1",
+            cm.output[0],
+        )
+        self.assertIn("exit code 1", cm.output[0])
+        self.assertIn("timeout", cm.output[0])
+        self.assertIn("could not be confirmed available", cm.output[1])
 
 
 class TestMoveGolangBugs(IsolatedAsyncioTestCase):

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -778,9 +778,10 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             with self.assertRaisesRegex(RuntimeError, "Published golang builder pullspec is not available"):
                 await pipeline._ensure_builder_pullspec_available(pullspec)
 
+    @patch("pyartcd.pipelines.update_golang.kinit", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.update_golang.move_golang_bugs", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_run_brew_only_skips_updating_streams(self, mock_konflux_db, move_golang_bugs):
+    async def test_run_brew_only_skips_updating_streams(self, mock_konflux_db, move_golang_bugs, mock_kinit):
         """Test brew-only runs skip streams.yml updates because streams use Konflux pullspecs"""
         pipeline = self._make_pipeline(build_system="brew")
         pipeline.validate_go_version_matches_group_vars = Mock(
@@ -795,6 +796,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         await pipeline.run()
 
+        mock_kinit.assert_awaited_once()
         pipeline.update_golang_streams.assert_not_awaited()
         move_golang_bugs.assert_awaited_once()
         slack_messages = [call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list]


### PR DESCRIPTION
## Summary
- initialize Kerberos at the start of `update-golang` so Brew-backed work fails early if credentials are unavailable
- switch `brew wait-repo` to the verbose invocation and log its stdout/stderr plus exit code when availability checks fail
- keep the existing retry flow intact while making the follow-up availability message clearer and extending unit coverage for the new behavior

## Test plan
- [x] `make format`
- [x] `make test`

https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgolang-builder/439/console