### PR TITLE
NO-ISSUE: doozer/doozerlib/cli/images_streams: Explain how sync-ci-images OCPBUGS are closed

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -973,6 +973,12 @@ in #forum-ocp-art to discuss the discrepancy.
 
 Closing this issue without addressing the difference will cause the issue to
 be reopened automatically.
+
+Once the differences have been resolved (either by merging this pull or updating the
+downstream production build configuration), ART will automatically move this issue
+from ON_QA to Closed (at some point during the release's Release Candidate phase).
+There is no need for QE verification beyond the existing CI signal this change helps
+improve.
 '''
         if potential_project != project or potential_component != component:
             description += f'''


### PR DESCRIPTION
ART wants to create these OCPBUGS to get engineer attention about preserving CI fidelity (we want CI builds to be similar to the shipped ART builds).  These bugs are not linked from errata since 01692b6598 ( #508).  And there's no expectation for QE load either, because the running CI signal that the image-sync improves is already covering the CI images being updated (or we wouldn't care about aligning the CI and ART images).  This commit updates the message to explain that no QE time is needed, and that ART will run a bulk close, and that that bulk close is expected during the RC phase.  Hopefully that keeps component teams from wasting post-merge time on these tickets.