### PR TITLE
elliott find-bugs:qe: Close reconciliation bugs in any status

### DIFF
--- a/elliott/elliottlib/cli/find_bugs_qe_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_qe_cli.py
@@ -32,7 +32,7 @@ def find_bugs_qe_cli(runtime: Runtime, noop, art_managed_trackers_only):
     """Find MODIFIED bugs for the target-releases, and set them to ON_QA.
         with a release comment on each bug.
 
-        Also finds and closes VERIFIED bugs with art:reconciliation label.
+        Also finds and closes bugs with art:reconciliation label.
 
     \b
         $ elliott -g openshift-4.6 find-bugs:qe
@@ -51,7 +51,7 @@ def find_bugs_qe_cli(runtime: Runtime, noop, art_managed_trackers_only):
         LOGGER.error(f'exception with JIRA bug tracker (find_bugs_qe): {e}')
         exit_code = 1
 
-    # Second, close VERIFIED bugs with art:reconciliation label
+    # Second, close reconciliation bugs with art:reconciliation label
     try:
         close_reconciliation_bugs(runtime, noop, bug_tracker)
     except Exception as e:
@@ -62,43 +62,41 @@ def find_bugs_qe_cli(runtime: Runtime, noop, art_managed_trackers_only):
     sys.exit(exit_code)
 
 
-def close_reconciliation_bugs(runtime, noop, bug_tracker):
-    """Find and close VERIFIED bugs with art:reconciliation label.
+def close_reconciliation_bugs(runtime, noop: bool, bug_tracker):
+    """Find and close bugs with art:reconciliation label.
 
-    These bugs have no customer value and will be closed without shipping.
+    These bugs track PRs for upstream/downstream reconciliation. They are closed
+    when the discrepancy is resolved (e.g. after a golang builder update).
     """
-    major_version, minor_version = runtime.get_major_minor()
+    statuses = ['MODIFIED', 'ON_QA', 'Verified']
     tr = bug_tracker.target_release()
     LOGGER.info(
-        f"Searching {bug_tracker.type} for VERIFIED bugs with art:reconciliation label and target releases: {tr}"
+        f"Searching {bug_tracker.type} for bugs with art:reconciliation label "
+        f"in statuses {statuses} and target releases: {tr}"
     )
 
-    # Query for VERIFIED bugs with art:reconciliation label
     query = bug_tracker._query(
-        status=['Verified'],
+        status=statuses,
         include_labels=['art:reconciliation'],
     )
     bugs = bug_tracker._search(query, verbose=runtime.debug)
     LOGGER.info(f"Found {len(bugs)} bugs to close: {', '.join(sorted(str(b.id) for b in bugs))}")
 
     close_comment = (
-        "This bug has been identified as having no customer value and will be closed without shipping. "
-        "It was part of an ART reconciliation process and does not require further action."
+        "Base image updates are what production build config expects. "
+        "Closing this issue as Done, no need to inform customers about this change."
     )
 
     for bug in bugs:
-        LOGGER.info(f"Closing bug {bug.id} with resolution Done")
+        LOGGER.info(f"Closing bug {bug.id} (status: {bug.status}) with resolution Done")
         if noop:
             LOGGER.info(f"Would have closed {bug.id} from {bug.status} to Closed with resolution Done")
             LOGGER.info(f"Would have added comment to {bug.id}: {close_comment}")
         else:
             try:
-                # Transition to Closed with resolution Done
-                # JIRA requires both transition and resolution to be set
                 bug_tracker._client.transition_issue(bug.id, 'Closed', fields={'resolution': {'name': 'Done'}})
                 LOGGER.info(f"Closed {bug.id} with resolution Done")
 
-                # Add comment explaining the closure
                 bug_tracker.add_comment(bug.id, close_comment, private=False, noop=False)
                 LOGGER.info(f"Added closure comment to {bug.id}")
             except Exception as e:

--- a/elliott/tests/test_find_bugs_qe_cli.py
+++ b/elliott/tests/test_find_bugs_qe_cli.py
@@ -5,15 +5,22 @@ import elliottlib.cli.find_bugs_qe_cli as qe_cli
 from click.testing import CliRunner
 from elliottlib.bzutil import JIRABugTracker
 from elliottlib.cli.common import Runtime, cli
-from elliottlib.cli.find_bugs_qe_cli import FindBugsQE, close_reconciliation_bugs, find_bugs_qe
+from elliottlib.cli.find_bugs_qe_cli import (
+    FindBugsQE,
+    close_reconciliation_bugs,
+    find_bugs_qe,
+)
 from flexmock import flexmock
+
+# Statuses used by close_reconciliation_bugs
+RECONCILIATION_STATUSES = ['MODIFIED', 'ON_QA', 'Verified']
 
 
 class FindBugsQETestCase(unittest.TestCase):
     def test_find_bugs_qe(self):
         runner = CliRunner()
         jira_bug = flexmock(id='OCPBUGS-123', status="MODIFIED", is_tracker_bug=lambda: False, security_level=None)
-        reconciliation_bug = flexmock(id='OCPBUGS-456', status="Verified", is_tracker_bug=lambda: False)
+        reconciliation_bug = flexmock(id='OCPBUGS-456', status="New", is_tracker_bug=lambda: False)
 
         flexmock(Runtime).should_receive("initialize").with_args(mode="images").and_return(None)
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
@@ -42,7 +49,7 @@ class FindBugsQETestCase(unittest.TestCase):
 
         # Mock for reconciliation bugs search
         flexmock(JIRABugTracker).should_receive("_query").with_args(
-            status=['Verified'],
+            status=RECONCILIATION_STATUSES,
             include_labels=['art:reconciliation'],
         ).and_return("mocked query").once()
 
@@ -75,36 +82,51 @@ class FindBugsQETestCase(unittest.TestCase):
 
         filter_mock.assert_not_called()
 
-    def test_close_reconciliation_bugs_unchanged(self):
-        runtime = flexmock(debug=False, get_major_minor=lambda: (4, 6))
-        bug1 = flexmock(id='OCPBUGS-456', status="Verified")
-        bug2 = flexmock(id='OCPBUGS-789', status="Verified")
+    def test_close_reconciliation_bugs(self):
+        """Test closing reconciliation bugs."""
+        runtime = flexmock(debug=False)
+        bug1 = flexmock(id='OCPBUGS-100', status="MODIFIED")
+        bug2 = flexmock(id='OCPBUGS-200', status="ON_QA")
+        bug3 = flexmock(id='OCPBUGS-300', status="Verified")
         client = flexmock()
         bug_tracker = flexmock(type='jira', _client=client)
-        flexmock(bug_tracker).should_receive("target_release").and_return(["4.6.z"])
+        flexmock(bug_tracker).should_receive("target_release").and_return(["4.22.z"])
         flexmock(bug_tracker).should_receive("_query").with_args(
-            status=['Verified'],
+            status=RECONCILIATION_STATUSES,
             include_labels=['art:reconciliation'],
         ).and_return("mocked query").once()
         flexmock(bug_tracker).should_receive("_search").with_args("mocked query", verbose=False).and_return(
-            [bug1, bug2]
+            [bug1, bug2, bug3]
         ).once()
-        for bug in [bug1, bug2]:
+
+        for bug in [bug1, bug2, bug3]:
             flexmock(client).should_receive("transition_issue").with_args(
                 bug.id, 'Closed', fields={'resolution': {'name': 'Done'}}
             ).once()
-            flexmock(bug_tracker).should_receive("add_comment").with_args(
-                bug.id,
-                "This bug has been identified as having no customer value and will be closed without shipping. "
-                "It was part of an ART reconciliation process and does not require further action.",
-                private=False,
-                noop=False,
-            ).once()
+        flexmock(bug_tracker).should_receive("add_comment").times(3)
 
-        with patch.object(qe_cli, "filter_art_managed_jira_trackers") as filter_mock:
-            close_reconciliation_bugs(runtime, False, bug_tracker)
+        close_reconciliation_bugs(runtime, False, bug_tracker)
 
-        filter_mock.assert_not_called()
+    def test_close_reconciliation_bugs_noop(self):
+        """Test that noop mode doesn't actually close bugs."""
+        runtime = flexmock(debug=False)
+        bug = flexmock(id='OCPBUGS-600', status="ON_QA")
+        client = flexmock()
+        bug_tracker = flexmock(type='jira', _client=client)
+        flexmock(bug_tracker).should_receive("target_release").and_return(["4.22.z"])
+        flexmock(bug_tracker).should_receive("_query").with_args(
+            status=RECONCILIATION_STATUSES,
+            include_labels=['art:reconciliation'],
+        ).and_return("mocked query").once()
+        flexmock(bug_tracker).should_receive("_search").with_args("mocked query", verbose=False).and_return(
+            [bug]
+        ).once()
+
+        # In noop mode, transition_issue and add_comment should NOT be called
+        flexmock(client).should_receive("transition_issue").never()
+        flexmock(bug_tracker).should_receive("add_comment").never()
+
+        close_reconciliation_bugs(runtime, True, bug_tracker)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- `find-bugs:qe` now closes `art:reconciliation` bugs in MODIFIED, ON_QA, or Verified status (previously only Verified)
- This allows bulk closing of reconciliation bugs when the underlying issue (e.g. golang builder update) has been resolved

Test run: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/jdelft/job/hack/3/console

(yes, i closed the three 4.22 reconciliation bugs)

## Test plan

- [x] Unit tests pass
- [x] Manual test with `--noop` flag