### PR TITLE
doozer: refresh reposync metadata after syncing

### DIFF
--- a/doozer/doozerlib/cli/__main__.py
+++ b/doozer/doozerlib/cli/__main__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import shlex
 import shutil
 import sys
 import tempfile
@@ -305,7 +306,22 @@ def beta_reposync(runtime, output, cachedir, arch, repo_type, names, dry_run):
         if cfg.is_reposync_enabled():
             enabled_repos.append(name)
 
-    yum_conf = """
+    optional_fails = []
+
+    if not os.path.isdir(output):
+        yellow_print('Creating outputdir: {}'.format(output))
+        exectools.cmd_assert('mkdir -p {}'.format(shlex.quote(output)))
+
+    if not os.path.isdir(cachedir):
+        yellow_print('Creating cachedir: {}'.format(cachedir))
+        exectools.cmd_assert('mkdir -p {}'.format(shlex.quote(cachedir)))
+
+    metadata_dir = None
+    yc_file = None
+    try:
+        # Use an isolated dnf cache so stale repodata from previous runs can't bleed into this sync.
+        metadata_dir = tempfile.mkdtemp(prefix='reposync-cache.', dir=cachedir)
+        yum_conf = """
 [main]
 cachedir={}/$basearch/$releasever
 keepcache=0
@@ -315,36 +331,20 @@ obsoletes=1
 gpgcheck=1
 plugins=1
 installonly_limit=3
-""".format(cachedir, runtime.working_dir)
+metadata_expire=0
+""".format(metadata_dir, runtime.working_dir)
+        repos_content = repos.repo_file(repo_type, enabled_repos=enabled_repos, arch=arch)
+        content = "{}\n\n{}".format(yum_conf, repos_content)
 
-    optional_fails = []
+        print("repo config:\n", content)
 
-    repos_content = repos.repo_file(repo_type, enabled_repos=enabled_repos, arch=arch)
-    content = "{}\n\n{}".format(yum_conf, repos_content)
-
-    print("repo config:\n", content)
-
-    if not os.path.isdir(output):
-        yellow_print('Creating outputdir: {}'.format(output))
-        exectools.cmd_assert('mkdir -p {}'.format(output))
-
-    if not os.path.isdir(cachedir):
-        yellow_print('Creating cachedir: {}'.format(cachedir))
-        exectools.cmd_assert('mkdir -p {}'.format(cachedir))
-
-    metadata_dir = None
-    yc_file = None
-    try:
-        # If corrupted, reposync metadata can interfere with subsequent runs.
-        # Ensure we have a clean space for each invocation.
-        metadata_dir = tempfile.mkdtemp(prefix='reposync-metadata.', dir=cachedir)
         yc_file = tempfile.NamedTemporaryFile()
         yc_file.write(content.encode('utf-8'))
 
         # must flush so it can be read
         yc_file.flush()
 
-        exectools.cmd_assert('yum clean all')  # clean the cache first to avoid outdated repomd.xml files
+        exectools.cmd_assert(f'dnf --config {shlex.quote(yc_file.name)} clean all')
 
         for repo in repos.values():
             # If specific names were specified, only synchronize them.
@@ -355,34 +355,48 @@ installonly_limit=3
                 runtime.logger.info('Skipping repo {} because reposync is disabled in group.yml'.format(repo.name))
                 continue
 
-            color_print('Syncing repo {}'.format(repo.name), 'blue')
-            cmd = (
-                'dnf '
-                f'--config {yc_file.name} '
-                f'--repoid {repo.name} '
-                'reposync '
-                f'--arch {arch} '
-                '--arch noarch '
-                '--delete '
-                '--download-metadata '
-                f'--download-path {output} '
-            )
-            if repo.is_reposync_latest_only():
-                cmd += '--newest-only '
+            try:
+                color_print('Syncing repo {}'.format(repo.name), 'blue')
+                cmd = (
+                    'dnf '
+                    f'--config {shlex.quote(yc_file.name)} '
+                    '--refresh '
+                    f'--repoid {shlex.quote(repo.name)} '
+                    'reposync '
+                    f'--arch {arch} '
+                    '--arch noarch '
+                    '--delete '
+                    '--download-metadata '
+                    f'--download-path {shlex.quote(output)} '
+                )
+                if repo.is_reposync_latest_only():
+                    cmd += '--newest-only '
 
-            if dry_run:
-                cmd += '--urls '
+                if dry_run:
+                    cmd += '--urls '
 
-            rc, out, err = exectools.cmd_gather(cmd, realtime=True)
-            if rc != 0:
+                rc, out, err = exectools.cmd_gather(cmd, realtime=True)
+                if rc != 0:
+                    raise DoozerFatalError(err or out or f'Failed to sync repo {repo.name}')
+
+                if dry_run:
+                    continue
+
+                local_repo_dir = os.path.join(output, repo.name)
+                if not os.path.isdir(local_repo_dir):
+                    raise DoozerFatalError(f'Expected mirrored repo directory was not created: {local_repo_dir}')
+
+                exectools.cmd_assert(f'createrepo_c --update --keep-all-metadata {shlex.quote(local_repo_dir)}')
+            except Exception as ex:
                 if not repo.cs_optional:
-                    raise DoozerFatalError(err)
-                else:
-                    runtime.logger.warning('Failed to sync repo {} but marked as optional: {}'.format(repo.name, err))
-                    optional_fails.append(repo.name)
+                    raise
+                runtime.logger.warning('Failed to sync repo %s but marked as optional: %s', repo.name, ex)
+                optional_fails.append(repo.name)
     finally:
-        yc_file.close()
-        shutil.rmtree(metadata_dir, ignore_errors=True)
+        if yc_file:
+            yc_file.close()
+        if metadata_dir:
+            shutil.rmtree(metadata_dir, ignore_errors=True)
 
     if optional_fails:
         yellow_print(

--- a/doozer/doozerlib/repodata.py
+++ b/doozer/doozerlib/repodata.py
@@ -380,6 +380,55 @@ class Repodata:
 
 class RepodataLoader:
     @staticmethod
+    def _extract_metadata_refs(repomd_xml: xml.etree.ElementTree.Element):
+        primary_data_element = repomd_xml.find('repo:data[@type="primary"]', NAMESPACES)
+        if primary_data_element is None:
+            raise ValueError("Couldn't find primary data in repodata")
+        primary_location = primary_data_element.find('repo:location', NAMESPACES)
+        if primary_location is None:
+            raise ValueError("Couldn't find primary location in repodata")
+        primary_ref = primary_location.attrib['href']
+
+        modules_ref = None
+        modules_checksum = None
+        modules_size = None
+        modules_data_element = repomd_xml.find('repo:data[@type="modules"]', NAMESPACES)
+        if modules_data_element is not None:
+            modules_location = modules_data_element.find('repo:location', NAMESPACES)
+            if modules_location is None:
+                raise ValueError("Couldn't find modules location in repodata")
+            modules_ref = modules_location.attrib['href']
+
+            modules_checksum_element = modules_data_element.find('repo:checksum', NAMESPACES)
+            if modules_checksum_element is not None:
+                modules_checksum = f"{modules_checksum_element.attrib['type']}:{modules_checksum_element.text}"
+
+            modules_size_element = modules_data_element.find('repo:size', NAMESPACES)
+            if modules_size_element is not None:
+                modules_size = int(modules_size_element.text)
+
+        return primary_ref, modules_ref, modules_checksum, modules_size
+
+    @staticmethod
+    def _build_repodata(
+        repo_name: str,
+        primary_bytes: bytes,
+        modules_bytes: bytes,
+        modules_checksum: Optional[str] = None,
+        modules_size: Optional[int] = None,
+        modules_url: Optional[str] = None,
+    ):
+        yaml = YAML(typ='safe')
+        return Repodata.from_metadatas(
+            repo_name,
+            ET.fromstring(primary_bytes),
+            list(yaml.load_all(modules_bytes) if modules_bytes else []),
+            modules_checksum=modules_checksum,
+            modules_size=modules_size,
+            modules_url=modules_url,
+        )
+
+    @staticmethod
     async def _fetch_remote_compressed(session: aiohttp.ClientSession, url: Optional[str]):
         if not url:
             return b''
@@ -418,32 +467,9 @@ class RepodataLoader:
                 _, _, err = await cmd_gather_async(curl_cmd)
                 LOGGER.info('curl command stderr: %s', err)
                 raise
-
-            primary_data_element = repomd_xml.find('repo:data[@type="primary"]', NAMESPACES)
-            if primary_data_element is None:
-                raise ValueError("Couldn't find primary data in repodata")
-            primary_location = primary_data_element.find('repo:location', NAMESPACES)
-            if primary_location is None:
-                raise ValueError("Couldn't find primary location in repodata")
-            primary_url = parse.urljoin(repo_url, primary_location.attrib['href'])
-
-            modules_url = None
-            modules_checksum = None
-            modules_size = None
-            modules_data_element = repomd_xml.find('repo:data[@type="modules"]', NAMESPACES)
-            if modules_data_element is not None:
-                modules_location = modules_data_element.find('repo:location', NAMESPACES)
-                if modules_location is None:
-                    raise ValueError("Couldn't find modules location in repodata")
-                modules_url = parse.urljoin(repo_url, modules_location.attrib['href'])
-
-                modules_checksum_element = modules_data_element.find('repo:checksum', NAMESPACES)
-                if modules_checksum_element is not None:
-                    modules_checksum = f"{modules_checksum_element.attrib['type']}:{modules_checksum_element.text}"
-
-                modules_size_element = modules_data_element.find('repo:size', NAMESPACES)
-                if modules_size_element is not None:
-                    modules_size = int(modules_size_element.text)
+            primary_ref, modules_ref, modules_checksum, modules_size = self._extract_metadata_refs(repomd_xml)
+            primary_url = parse.urljoin(repo_url, primary_ref)
+            modules_url = parse.urljoin(repo_url, modules_ref) if modules_ref else None
 
             @retry(
                 reraise=True,
@@ -468,17 +494,14 @@ class RepodataLoader:
                 fetch_remote_compressed(primary_url),
                 fetch_remote_compressed(modules_url),
             )
-
-        yaml = YAML(typ='safe')
-        repodata = Repodata.from_metadatas(
+        return self._build_repodata(
             repo_name,
-            ET.fromstring(primary_bytes),
-            list(yaml.load_all(modules_bytes) if modules_bytes else []),
+            primary_bytes,
+            modules_bytes,
             modules_checksum=modules_checksum,
             modules_size=modules_size,
             modules_url=modules_url,
         )
-        return repodata
 
 
 class OutdatedRPMFinder:

--- a/doozer/tests/cli/test_beta_reposync.py
+++ b/doozer/tests/cli/test_beta_reposync.py
@@ -1,0 +1,60 @@
+import shlex
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+from doozerlib import Runtime
+from doozerlib.cli.__main__ import beta_reposync
+
+
+class TestBetaRepoSyncCli(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_rebuilds_local_metadata_after_sync(self):
+        runtime = Runtime()
+        runtime.initialize = MagicMock(return_value=None)
+        runtime.working_dir = "workdir"
+        runtime._logger = MagicMock()
+
+        repo = MagicMock()
+        repo.name = "rhel-9-baseos-rpms"
+        repo.cs_optional = False
+        repo.is_reposync_enabled.return_value = True
+        repo.is_reposync_latest_only.return_value = True
+
+        repos = MagicMock()
+        repos.items.return_value = [(repo.name, repo)]
+        repos.values.return_value = [repo]
+        repos.repo_file.return_value = "[rhel-9-baseos-rpms]\nbaseurl = https://example.com/\n"
+        runtime.repos = repos
+
+        def fake_cmd_assert(cmd):
+            parts = shlex.split(cmd)
+            if parts[:2] == ["mkdir", "-p"]:
+                Path(parts[2]).mkdir(parents=True, exist_ok=True)
+
+        def fake_cmd_gather(cmd, realtime=True):
+            Path("out").joinpath(repo.name).mkdir(parents=True, exist_ok=True)
+            return 0, "", ""
+
+        with self.runner.isolated_filesystem():
+            with patch("doozerlib.cli.__main__.exectools.cmd_assert", side_effect=fake_cmd_assert) as cmd_assert:
+                with patch("doozerlib.cli.__main__.exectools.cmd_gather", side_effect=fake_cmd_gather) as cmd_gather:
+                    result = self.runner.invoke(
+                        beta_reposync,
+                        [
+                            "-o",
+                            "out",
+                            "-c",
+                            "cache",
+                        ],
+                        obj=runtime,
+                    )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        synced_command = cmd_gather.call_args.args[0]
+        self.assertIn("--refresh", synced_command)
+        self.assertIn("--newest-only", synced_command)
+        cmd_assert.assert_any_call("createrepo_c --update --keep-all-metadata out/rhel-9-baseos-rpms")


### PR DESCRIPTION
## Summary
- use an isolated dnf cache for `beta:reposync` so stale cached repodata does not leak across runs
- force metadata refresh during sync and rebuild local repodata with `createrepo_c --update --keep-all-metadata`
- add focused coverage for the reposync CLI flow and repodata loader refactor

## Test plan
- [x] `uv run pytest --verbose --color=yes doozer/tests/test_repodata.py doozer/tests/cli/test_beta_reposync.py`
- [x] `uv run ruff check doozer/doozerlib/cli/__main__.py doozer/doozerlib/repodata.py doozer/tests/test_repodata.py doozer/tests/cli/test_beta_reposync.py`
- [x] `uv run ruff format --check doozer/doozerlib/cli/__main__.py doozer/doozerlib/repodata.py doozer/tests/test_repodata.py doozer/tests/cli/test_beta_reposync.py`

Made with [Cursor](https://cursor.com)

Test dry-run: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fsync-for-ci/298470/console