### PR TITLE
sync-for-ci-ironic: handle corrupted state.yaml files gracefully

### DIFF
--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -400,7 +400,18 @@ class Runtime(GroupRuntime):
         self.state = dict(state.TEMPLATE_BASE_STATE)
         if os.path.isfile(self.state_file):
             with io.open(self.state_file, 'r', encoding='utf-8') as f:
-                self.state = yaml.full_load(f)
+                loaded = yaml.full_load(f)
+                if loaded is not None:
+                    self.state = loaded
+                else:
+                    # Corrupted or empty state file detected (e.g., from disk full), delete and start fresh
+                    self._logger.warning(
+                        f'Corrupted state file detected: {self.state_file}, regenerating from template'
+                    )
+                    try:
+                        os.remove(self.state_file)
+                    except OSError as e:
+                        self._logger.warning(f'Failed to remove corrupted state file: {e}')
 
     def save_state(self):
         with io.open(self.state_file, 'w', encoding='utf-8') as f:

--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -398,6 +398,11 @@ class Runtime(GroupRuntime):
 
     def init_state(self):
         self.state = dict(state.TEMPLATE_BASE_STATE)
+
+        # Skip file I/O for read-only operations (config commands don't need persistent state)
+        if self.prevent_cloning:
+            return
+
         if os.path.isfile(self.state_file):
             with io.open(self.state_file, 'r', encoding='utf-8') as f:
                 try:
@@ -419,6 +424,10 @@ class Runtime(GroupRuntime):
                         self._logger.warning(f'Failed to remove corrupted state file: {e}')
 
     def save_state(self):
+        # Skip file I/O for read-only operations (config commands don't need persistent state)
+        if self.prevent_cloning:
+            return
+
         with io.open(self.state_file, 'w', encoding='utf-8') as f:
             yaml.safe_dump(self.state, f, default_flow_style=False)
 

--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -400,8 +400,13 @@ class Runtime(GroupRuntime):
         self.state = dict(state.TEMPLATE_BASE_STATE)
         if os.path.isfile(self.state_file):
             with io.open(self.state_file, 'r', encoding='utf-8') as f:
-                loaded = yaml.full_load(f)
-                if loaded is not None:
+                try:
+                    loaded = yaml.full_load(f)
+                except yaml.YAMLError as e:
+                    self._logger.warning(f'Failed to parse state file {self.state_file}: {e}')
+                    loaded = None
+
+                if isinstance(loaded, dict):
                     self.state = loaded
                 else:
                     # Corrupted or empty state file detected (e.g., from disk full), delete and start fresh


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

What the Fix Does:                                                                                                                                                                                        
                                                                                                                                                                                                                      The fix handles corrupted/empty state.yaml files gracefully:                                                                                                                                              
                                                                                                                                                                                                                      
  1. Detects corruption: Checks if yaml.full_load() returns None (happens with empty files)                                                                                                                           
  2. Logs warning: Alerts that corruption was detected with file path                                                                                                                                                 
  3. Auto-recovers: Deletes the corrupted file and uses fresh template state                                                                                                                                          
  4. Prevents crashes: Ensures self.state is always a valid dict, never None    