### PR TITLE
ART-18048: feat(images): implement synchronous base image registry coordination

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -23,6 +23,7 @@ class KonfluxBuildOutcome(KonfluxEnum):
     FAILURE = 'failure'
     SUCCESS = 'success'
     PENDING = 'pending'
+    UNRELEASED = 'unreleased'
     TIMEOUT = 'timeout'
     CANCELLED = 'cancelled'
 

--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -10,7 +10,7 @@ import asyncio
 from typing import Dict, List, Optional, Tuple
 
 from artcommonlib import logutil
-from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildRecord
+from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.util import (
     get_utc_now_formatted_str,
@@ -20,13 +20,13 @@ from artcommonlib.util import (
 )
 from doozerlib.backend.konflux_client import API_VERSION, KIND_RELEASE, KIND_RELEASE_PLAN, KIND_SNAPSHOT, KonfluxClient
 from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
+from doozerlib.constants import ART_IMAGES_BASE_APPLICATION
 from kubernetes.dynamic import exceptions
 
 from pyartcd import jenkins
 
 LOGGER = logutil.get_logger(__name__)
 ART_IMAGES_BASE_RELEASE_PLAN = "ocp-art-images-base-silent"
-ART_IMAGES_BASE_APPLICATION = "art-images-base"
 
 
 class BaseImageHandler:
@@ -193,7 +193,7 @@ class BaseImageHandler:
         try:
             where = {"group": self.runtime.group, "engine": Engine.KONFLUX.value}
             records = await self.konflux_db.get_build_records_by_nvrs(
-                nvrs, where=where, strict=False, exclude_large_columns=True
+                nvrs, outcome=KonfluxBuildOutcome.UNRELEASED, where=where, strict=False, exclude_large_columns=True
             )
             return {record.nvr: record for record in records}
         except Exception as e:

--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -195,7 +195,7 @@ class BaseImageHandler:
             records = await self.konflux_db.get_build_records_by_nvrs(
                 nvrs, outcome=KonfluxBuildOutcome.UNRELEASED, where=where, strict=False, exclude_large_columns=True
             )
-            return {record.nvr: record for record in records}
+            return {record.nvr: record for record in records if record is not None}
         except Exception as e:
             self.logger.warning(f"Failed to fetch build records from database: {e}")
             return {}

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -359,6 +359,9 @@ class KonfluxImageBuilder:
 
                 else:
                     # Create a build record after every attempt (both success and failure)
+                    if outcome is KonfluxBuildOutcome.SUCCESS and metadata.should_trigger_base_image_release():
+                        outcome = KonfluxBuildOutcome.UNRELEASED
+
                     build_record = await self.update_konflux_db(
                         metadata,
                         build_repo,
@@ -373,13 +376,26 @@ class KonfluxImageBuilder:
                         record["record_id"] = build_record.record_id
 
                     # Check base image release AFTER saving to database
-                    if outcome is KonfluxBuildOutcome.SUCCESS and metadata.should_trigger_base_image_release():
+                    if outcome is KonfluxBuildOutcome.UNRELEASED and metadata.should_trigger_base_image_release():
                         base_image_release_success = await self._trigger_base_image_release(metadata, nvr)
-                        if not base_image_release_success:
-                            logger.error(
-                                f"Base image release failed for {metadata.distgit_key}, but build already stored in database"
-                            )
-                            # outcome = KonfluxBuildOutcome.FAILURE
+                        if base_image_release_success:
+                            logger.info(f"Base image release succeeded for {nvr}, updating with registry pullspec")
+                        else:
+                            logger.error(f"Base image release failed for {nvr}, updating build record to FAILURE")
+                        outcome = (
+                            KonfluxBuildOutcome.SUCCESS if base_image_release_success else KonfluxBuildOutcome.FAILURE
+                        )
+                        await self.update_konflux_db(
+                            metadata,
+                            build_repo,
+                            pipelinerun_info,
+                            outcome,
+                            building_arches,
+                            build_priority,
+                            ec_status=ec_status,
+                            ec_pipeline_url=ec_pipeline_url,
+                            released=base_image_release_success,
+                        )
 
                 if outcome is not KonfluxBuildOutcome.SUCCESS:
                     error = KonfluxImageBuildError(
@@ -890,6 +906,7 @@ class KonfluxImageBuilder:
         build_priority,
         ec_status=KonfluxECStatus.NOT_APPLICABLE,
         ec_pipeline_url='',
+        released=False,
     ) -> Optional[KonfluxBuildRecord]:
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
         if not metadata.runtime.konflux_db:
@@ -958,7 +975,9 @@ class KonfluxImageBuilder:
             'ec_pipeline_url': ec_pipeline_url,
         }
 
-        if outcome == KonfluxBuildOutcome.SUCCESS:
+        # SUCCESS: normal completed build. UNRELEASED: build succeeded and is waiting for
+        # snapshot→release before final SUCCESS + registry.redhat.io pullspec — same pipelinerun IMAGE_URL/results.
+        if outcome in (KonfluxBuildOutcome.SUCCESS, KonfluxBuildOutcome.UNRELEASED):
             # results:
             # - name: IMAGE_URL
             #   value: quay.io/openshift-release-dev/ocp-v4.0-art-dev-test:ose-network-metrics-daemon-rhel9-v4.18.0-20241001.151532
@@ -975,7 +994,10 @@ class KonfluxImageBuilder:
                     f"pipelinerun {pipelinerun_name}"
                 )
 
-            definitive_image_pullspec = f"{image_pullspec.split(':')[0]}@{image_digest}"
+            if released:
+                definitive_image_pullspec = util.rh_art_images_base_pullspec(nvr)
+            else:
+                definitive_image_pullspec = f"{image_pullspec.split(':')[0]}@{image_digest}"
 
             # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
             package_nvrs, source_rpms = await self.get_installed_packages(
@@ -1223,16 +1245,21 @@ class KonfluxImageBuilder:
         try:
             build_version = self._config.group_name
 
-            jenkins.start_base_image_release(
+            result = jenkins.start_base_image_release(
                 build_version=build_version,
                 assembly=metadata.runtime.assembly,
                 base_image_nvrs=[nvr],
                 doozer_data_path=getattr(metadata.runtime, 'data_path', ''),
                 doozer_data_gitref=getattr(metadata.runtime, 'data_gitref', ''),
                 dry_run=self._config.dry_run,
+                block_until_complete=True,
             )
-            logger.info(f"Successfully triggered base image release for {nvr}")
-            return True
+            if result is not None:
+                logger.info(f"Successfully completed base image release for {nvr}")
+                return True
+            else:
+                logger.error(f"Base image release job failed for {nvr}")
+                return False
 
         except Exception as e:
             logger.error(f"Failed to trigger base image release for {nvr}: {e}")

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -359,6 +359,8 @@ class KonfluxImageBuilder:
 
                 else:
                     # Create a build record after every attempt (both success and failure)
+                    # Base images need a synchronous release to registry.redhat.io before dependents can use RH
+                    # pullspecs. Mark SUCCESS as UNRELEASED in the DB until that release completes; see below.
                     if outcome is KonfluxBuildOutcome.SUCCESS and metadata.should_trigger_base_image_release():
                         outcome = KonfluxBuildOutcome.UNRELEASED
 

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -225,6 +225,8 @@ class KonfluxRebaser:
                 force = (self._runtime.assembly != "stream") or (build_repo.url != build_repo.pull_url)
                 await build_repo.push(force=force)
 
+            metadata.rebased_image_version = actual_version
+            metadata.rebased_image_release = actual_release
             metadata.rebase_status = True
         finally:
             # notify child images
@@ -388,6 +390,17 @@ class KonfluxRebaser:
                 await file.write("\n!/.oit/**\n")
                 await file.write("\n!labels.json\n")
 
+    def _rebased_member_image_nvr(self, parent_metadata: ImageMetadata) -> str:
+        """NVR from parent's rebase (same as Dockerfile labels / Konflux DB): component-version-release."""
+        version = parent_metadata.rebased_image_version
+        release = parent_metadata.rebased_image_release
+        if not version or not release:
+            raise IOError(
+                f"Parent image {parent_metadata.distgit_key} has no rebased_image_version/rebased_image_release; "
+                f"expected KonfluxRebaser to set them after a successful rebase."
+            )
+        return f"{parent_metadata.get_component_name()}-{version}-{release}"
+
     @staticmethod
     def _identify_stage_references(dfp: DockerfileParser) -> List[bool]:
         """
@@ -539,6 +552,9 @@ class KonfluxRebaser:
                     "This indicates a bug in Doozer. Please report this issue.",
                 )
             private_fix = parent_metadata.private_fix
+            if self.variant is not BuildVariant.OKD and parent_metadata.should_trigger_base_image_release():
+                parent_nvr = self._rebased_member_image_nvr(parent_metadata)
+                return util.rh_art_images_base_pullspec(parent_nvr), private_fix
             return f"{self.image_repo}:{parent_metadata.image_name_short}-{self.uuid_tag}", private_fix
 
     @start_as_current_span_async(TRACER, "rebase.resolve_stream_parent")

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -552,7 +552,7 @@ class KonfluxRebaser:
                     "This indicates a bug in Doozer. Please report this issue.",
                 )
             private_fix = parent_metadata.private_fix
-            if self.variant is not BuildVariant.OKD and parent_metadata.should_trigger_base_image_release():
+            if parent_metadata.should_trigger_base_image_release():
                 parent_nvr = self._rebased_member_image_nvr(parent_metadata)
                 return util.rh_art_images_base_pullspec(parent_nvr), private_fix
             return f"{self.image_repo}:{parent_metadata.image_name_short}-{self.uuid_tag}", private_fix

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -92,6 +92,7 @@ class KonfluxRebaser:
         self.uuid_tag = ''
         self.variant = variant
         self.extra_labels = extra_labels or {}
+        self._rebased_nvr_info: Dict[str, Tuple[str, str]] = {}
 
         self.konflux_db = self._runtime.konflux_db
         if self.konflux_db:
@@ -225,8 +226,7 @@ class KonfluxRebaser:
                 force = (self._runtime.assembly != "stream") or (build_repo.url != build_repo.pull_url)
                 await build_repo.push(force=force)
 
-            metadata.rebased_image_version = actual_version
-            metadata.rebased_image_release = actual_release
+            self._rebased_nvr_info[metadata.distgit_key] = (actual_version, actual_release)
             metadata.rebase_status = True
         finally:
             # notify child images
@@ -392,13 +392,13 @@ class KonfluxRebaser:
 
     def _rebased_member_image_nvr(self, parent_metadata: ImageMetadata) -> str:
         """NVR from parent's rebase (same as Dockerfile labels / Konflux DB): component-version-release."""
-        version = parent_metadata.rebased_image_version
-        release = parent_metadata.rebased_image_release
-        if not version or not release:
+        nvr_info = self._rebased_nvr_info.get(parent_metadata.distgit_key)
+        if not nvr_info:
             raise IOError(
-                f"Parent image {parent_metadata.distgit_key} has no rebased_image_version/rebased_image_release; "
-                f"expected KonfluxRebaser to set them after a successful rebase."
+                f"Parent image {parent_metadata.distgit_key} has no rebased NVR in this KonfluxRebaser session; "
+                f"expected a successful rebase_to for that image first."
             )
+        version, release = nvr_info
         return f"{parent_metadata.get_component_name()}-{version}-{release}"
 
     @staticmethod

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -76,3 +76,5 @@ KONFLUX_PREGA_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-ec
 # Base image EC policy (base_only images use a dedicated prod policy for all assembly types)
 # https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/kflux-ocp-p01.7ayg.p1/product/EnterpriseContractPolicy/registry-ocp-art-base-prod.yaml
 KONFLUX_BASE_IMAGE_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-base-prod"
+
+ART_IMAGES_BASE_APPLICATION = "art-images-base"

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1339,7 +1339,7 @@ class ImageMetadata(Metadata):
         Returns:
             bool: True if base image release workflow should be triggered, False otherwise
         """
-        if getattr(self.runtime, 'variant', None) is BuildVariant.OKD:
+        if self.runtime.variant is BuildVariant.OKD:
             return False
         return self.is_base_image() or self.is_golang_builder()
 

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -121,6 +121,9 @@ class ImageMetadata(Metadata):
         """ Event that is set when this image is being rebased. """
         self.rebase_status = False
         """ True if this image has been successfully rebased. """
+        # KonfluxRebaser.rebase_to sets these after _rebase_dir succeeds (same inputs as Dockerfile labels).
+        self.rebased_image_version: Optional[str] = None
+        self.rebased_image_release: Optional[str] = None
         self.build_event = Event()
         """ Event that is set when this image is being built. """
         self.build_status = False

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -122,9 +122,6 @@ class ImageMetadata(Metadata):
         """ Event that is set when this image is being rebased. """
         self.rebase_status = False
         """ True if this image has been successfully rebased. """
-        # KonfluxRebaser.rebase_to sets these after _rebase_dir succeeds (same inputs as Dockerfile labels).
-        self.rebased_image_version: Optional[str] = None
-        self.rebased_image_release: Optional[str] = None
         self.build_event = Event()
         """ Event that is set when this image is being built. """
         self.build_status = False

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -17,6 +17,7 @@ from artcommonlib.pushd import Dir
 from artcommonlib.release_util import isolate_el_version_in_release
 from artcommonlib.rpm_utils import parse_nvr, to_nevra
 from artcommonlib.util import deep_merge
+from artcommonlib.variants import BuildVariant
 from dockerfile_parse import DockerfileParser
 
 import doozerlib
@@ -895,8 +896,6 @@ class ImageMetadata(Metadata):
         if not matched:
             # For OKD variant, RHEL version mismatches are expected (e.g., OKD 5.0 uses el10 while upstream uses el9)
             # Log a warning instead of raising an error to allow canonical builders to work
-            from artcommonlib.variants import BuildVariant
-
             if self.runtime.variant == BuildVariant.OKD:
                 self.logger.warning(
                     '[%s] OKD variant: Upstream uses el%s but ART uses el%s. '
@@ -1338,9 +1337,13 @@ class ImageMetadata(Metadata):
         """
         Determines whether this image should trigger the base image release workflow.
 
+        OKD builds never trigger the OCP registry.redhat.io base-image release path.
+
         Returns:
             bool: True if base image release workflow should be triggered, False otherwise
         """
+        if getattr(self.runtime, 'variant', None) is BuildVariant.OKD:
+            return False
         return self.is_base_image() or self.is_golang_builder()
 
     def is_snapshot_release_enabled(self) -> bool:

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -33,6 +33,8 @@ from artcommonlib.util import (
     uses_konflux_imagestream_override,
 )
 
+from doozerlib import constants as doozer_constants
+
 try:
     from reprlib import repr
 except ImportError:
@@ -41,6 +43,11 @@ except ImportError:
 
 DICT_EMPTY = object()
 logger = logging.getLogger(__name__)
+
+
+def rh_art_images_base_pullspec(nvr: str) -> str:
+    """Pullspec for golang/base images after art-images-base release (NVR = component-version-release)."""
+    return f"{doozer_constants.DELIVERY_IMAGE_REGISTRY}/openshift/{doozer_constants.ART_IMAGES_BASE_APPLICATION}:{nvr}"
 
 
 def dict_get(dct, path, default=DICT_EMPTY):

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -7,6 +7,7 @@ from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
 from doozerlib.backend.konflux_image_builder import (
     KonfluxImageBuilder,
     KonfluxImageBuilderConfig,
+    KonfluxImageBuildError,
     _normalize_version,
 )
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
@@ -53,6 +54,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         metadata.get_arches.return_value = ["x86_64"]
         metadata.get_konflux_network_mode.return_value = "open"
         metadata.is_base_image.return_value = False
+        metadata.should_trigger_base_image_release.return_value = False
         return metadata
 
     async def test_build_uses_definitive_pullspec_for_attestation_validation(self):
@@ -294,6 +296,413 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         mock_verify_ec.assert_awaited_once()
         call_kwargs = mock_verify_ec.await_args[1]
         self.assertEqual(call_kwargs['ec_policy'], constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION)
+
+    async def test_update_konflux_db_with_released_true_sets_registry_pullspec(self):
+        """Test that released=True sets registry.redhat.io pullspec for base images."""
+        metadata = self._metadata()
+        metadata.should_trigger_base_image_release.return_value = True
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "test-commit-hash"
+        build_repo.local_dir = Path(self.temp_dir.name)
+
+        pipelinerun = PipelineRunInfo(
+            {
+                "metadata": {
+                    "name": "test-pipelinerun",
+                    "uid": "test-uid",
+                    "labels": {"appstudio.openshift.io/component": "test-component"},
+                },
+                "status": {
+                    "results": [
+                        {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                        {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                    ],
+                    "startTime": "2023-10-01T12:00:00Z",
+                    "completionTime": "2023-10-01T12:30:00Z",
+                },
+            },
+            {},
+        )
+
+        with (
+            patch("doozerlib.backend.konflux_image_builder.DockerfileParser") as mock_dockerfile_parser,
+            patch.object(self.builder, "extract_parent_image_nvrs", new=AsyncMock(return_value=[])),
+            patch.object(
+                self.builder,
+                "get_installed_packages",
+                new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
+            ) as mock_get_installed_packages,
+            patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
+        ):
+            mock_dockerfile = MagicMock()
+            mock_dockerfile.labels = {
+                "io.openshift.build.source-location": "https://example.com/source-repo.git",
+                "io.openshift.build.commit.id": "source-commit-id",
+                "com.redhat.component": "test-component",
+                "version": "1.0",
+                "release": "1.el9",
+            }
+            mock_dockerfile.parent_images = []
+            mock_dockerfile_parser.return_value = mock_dockerfile
+            mock_bigquery_client.return_value.client.insert_rows_json.return_value = None
+
+            await self.builder.update_konflux_db(
+                metadata,
+                build_repo,
+                pipelinerun,
+                KonfluxBuildOutcome.SUCCESS,
+                ["x86_64"],
+                "5",
+                released=True,
+            )
+
+        expected_pullspec = "registry.redhat.io/openshift/art-images-base:test-component-1.0-1.el9"
+        mock_get_installed_packages.assert_awaited_once_with(expected_pullspec, ["x86_64"], None)
+
+    async def test_update_konflux_db_with_released_false_uses_quay_pullspec(self):
+        """Test that released=False uses standard quay.io pullspec."""
+        metadata = self._metadata()
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "test-commit-hash"
+        build_repo.local_dir = Path(self.temp_dir.name)
+
+        pipelinerun = PipelineRunInfo(
+            {
+                "metadata": {
+                    "name": "test-pipelinerun",
+                    "uid": "test-uid",
+                    "labels": {"appstudio.openshift.io/component": "test-component"},
+                },
+                "status": {
+                    "results": [
+                        {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                        {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                    ],
+                    "startTime": "2023-10-01T12:00:00Z",
+                    "completionTime": "2023-10-01T12:30:00Z",
+                },
+            },
+            {},
+        )
+
+        with (
+            patch("doozerlib.backend.konflux_image_builder.DockerfileParser") as mock_dockerfile_parser,
+            patch.object(self.builder, "extract_parent_image_nvrs", new=AsyncMock(return_value=[])),
+            patch.object(
+                self.builder,
+                "get_installed_packages",
+                new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
+            ) as mock_get_installed_packages,
+            patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
+        ):
+            mock_dockerfile = MagicMock()
+            mock_dockerfile.labels = {
+                "io.openshift.build.source-location": "https://example.com/source-repo.git",
+                "io.openshift.build.commit.id": "source-commit-id",
+                "com.redhat.component": "test-component",
+                "version": "1.0",
+                "release": "1.el9",
+            }
+            mock_dockerfile.parent_images = []
+            mock_dockerfile_parser.return_value = mock_dockerfile
+            mock_bigquery_client.return_value.client.insert_rows_json.return_value = None
+
+            await self.builder.update_konflux_db(
+                metadata,
+                build_repo,
+                pipelinerun,
+                KonfluxBuildOutcome.SUCCESS,
+                ["x86_64"],
+                "5",
+                released=False,
+            )
+
+        expected_pullspec = "quay.io/test/image@sha256:testdigest"
+        mock_get_installed_packages.assert_awaited_once_with(expected_pullspec, ["x86_64"], None)
+
+    async def test_update_konflux_db_unreleased_sets_quay_pullspec_like_success(self):
+        """UNRELEASED (base image build ok, awaiting release) must populate image_pullspec for snapshot workflow."""
+        metadata = self._metadata()
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "test-commit-hash"
+        build_repo.local_dir = Path(self.temp_dir.name)
+
+        pipelinerun = PipelineRunInfo(
+            {
+                "metadata": {
+                    "name": "test-pipelinerun",
+                    "uid": "test-uid",
+                    "labels": {"appstudio.openshift.io/component": "test-component"},
+                },
+                "status": {
+                    "results": [
+                        {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                        {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                    ],
+                    "startTime": "2023-10-01T12:00:00Z",
+                    "completionTime": "2023-10-01T12:30:00Z",
+                },
+            },
+            {},
+        )
+
+        with (
+            patch("doozerlib.backend.konflux_image_builder.DockerfileParser") as mock_dockerfile_parser,
+            patch.object(self.builder, "extract_parent_image_nvrs", new=AsyncMock(return_value=[])),
+            patch.object(
+                self.builder,
+                "get_installed_packages",
+                new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
+            ) as mock_get_installed_packages,
+            patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
+        ):
+            mock_dockerfile = MagicMock()
+            mock_dockerfile.labels = {
+                "io.openshift.build.source-location": "https://example.com/source-repo.git",
+                "io.openshift.build.commit.id": "source-commit-id",
+                "com.redhat.component": "test-component",
+                "version": "1.0",
+                "release": "1.el9",
+            }
+            mock_dockerfile.parent_images = []
+            mock_dockerfile_parser.return_value = mock_dockerfile
+            mock_bigquery_client.return_value.client.insert_rows_json.return_value = None
+
+            await self.builder.update_konflux_db(
+                metadata,
+                build_repo,
+                pipelinerun,
+                KonfluxBuildOutcome.UNRELEASED,
+                ["x86_64"],
+                "5",
+                released=False,
+            )
+
+        expected_pullspec = "quay.io/test/image@sha256:testdigest"
+        mock_get_installed_packages.assert_awaited_once_with(expected_pullspec, ["x86_64"], None)
+
+    async def test_trigger_base_image_release_success_flow(self):
+        """Test successful base image release triggering with registry pullspec update."""
+        metadata = self._metadata()
+        metadata.should_trigger_base_image_release.return_value = True
+        metadata.is_snapshot_release_enabled.return_value = True
+        dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        build_repo = MagicMock()
+        build_repo.local_dir = dest_dir
+        build_repo.url = "https://github.com/test/repo.git"
+        build_repo.commit_hash = "test-commit"
+
+        initial_pipelinerun = MagicMock()
+        initial_pipelinerun.name = "test-pipelinerun"
+        initial_pipelinerun.to_dict.return_value = {"metadata": {"name": "test-pipelinerun"}}
+
+        completed_pipelinerun = MagicMock()
+        completed_pipelinerun.name = "test-pipelinerun"
+        completed_pipelinerun.find_condition.return_value = {"status": "True"}
+        completed_pipelinerun.to_dict.return_value = {
+            "metadata": {"name": "test-pipelinerun"},
+            "status": {
+                "results": [
+                    {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                    {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                ]
+            },
+        }
+        self.mock_konflux_client.wait_for_pipelinerun = AsyncMock(return_value=completed_pipelinerun)
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=build_repo),
+            ),
+            patch.object(self.builder, "_parse_dockerfile", return_value=("test-uuid", "test-component", "1.0", "1")),
+            patch.object(self.builder, "_wait_for_parent_members", new=AsyncMock(return_value=[])),
+            patch.object(self.builder, "_start_build", new=AsyncMock(return_value=initial_pipelinerun)),
+            patch.object(
+                self.builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))
+            ) as mock_update_db,
+            patch.object(
+                self.builder, "_trigger_base_image_release", new=AsyncMock(return_value=True)
+            ) as mock_trigger_release,
+            patch.object(self.builder, "_validate_build_attestation_and_signature", new=AsyncMock()),
+            patch.object(
+                self.builder._konflux_client,
+                "verify_enterprise_contract",
+                new=AsyncMock(return_value=MagicMock(ec_status="PASSED", ec_pipeline_url="", ec_failed=False)),
+            ),
+            patch(
+                "doozerlib.backend.konflux_image_builder.KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition",
+                return_value=KonfluxBuildOutcome.SUCCESS,
+            ),
+        ):
+            await self.builder.build(metadata)
+
+        mock_trigger_release.assert_awaited_once()
+
+        # Verify database was updated twice: initial PENDING + final SUCCESS with released=True
+        self.assertEqual(mock_update_db.await_count, 3)
+
+        # Check that the final call had released=True
+        final_call_kwargs = mock_update_db.await_args_list[2][1]
+        self.assertTrue(final_call_kwargs.get('released', False))
+
+    async def test_trigger_base_image_release_failure_flow(self):
+        """Test base image release failure handling with FAILURE outcome update."""
+        metadata = self._metadata()
+        metadata.should_trigger_base_image_release.return_value = True
+        metadata.is_snapshot_release_enabled.return_value = True
+        dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        build_repo = MagicMock()
+        build_repo.local_dir = dest_dir
+        build_repo.url = "https://github.com/test/repo.git"
+        build_repo.commit_hash = "test-commit"
+
+        initial_pipelinerun = MagicMock()
+        initial_pipelinerun.name = "test-pipelinerun"
+        initial_pipelinerun.to_dict.return_value = {"metadata": {"name": "test-pipelinerun"}}
+
+        completed_pipelinerun = MagicMock()
+        completed_pipelinerun.name = "test-pipelinerun"
+        completed_pipelinerun.find_condition.return_value = {"status": "True"}
+        completed_pipelinerun.to_dict.return_value = {
+            "metadata": {"name": "test-pipelinerun"},
+            "status": {
+                "results": [
+                    {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                    {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                ]
+            },
+        }
+        self.mock_konflux_client.wait_for_pipelinerun = AsyncMock(return_value=completed_pipelinerun)
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=build_repo),
+            ),
+            patch.object(self.builder, "_parse_dockerfile", return_value=("test-uuid", "test-component", "1.0", "1")),
+            patch.object(self.builder, "_wait_for_parent_members", new=AsyncMock(return_value=[])),
+            patch.object(self.builder, "_start_build", new=AsyncMock(return_value=initial_pipelinerun)),
+            patch.object(
+                self.builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))
+            ) as mock_update_db,
+            patch.object(
+                self.builder, "_trigger_base_image_release", new=AsyncMock(return_value=False)
+            ) as mock_trigger_release,
+            patch.object(self.builder, "_validate_build_attestation_and_signature", new=AsyncMock()),
+            patch.object(
+                self.builder._konflux_client,
+                "verify_enterprise_contract",
+                new=AsyncMock(return_value=MagicMock(ec_status="PASSED", ec_pipeline_url="", ec_failed=False)),
+            ),
+            patch(
+                "doozerlib.backend.konflux_image_builder.KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition",
+                return_value=KonfluxBuildOutcome.SUCCESS,
+            ),
+        ):
+            with self.assertRaises(KonfluxImageBuildError):
+                await self.builder.build(metadata)
+
+        mock_trigger_release.assert_awaited_once()
+        self.assertEqual(mock_update_db.await_count, 3)
+
+        # Check that the failure update call had outcome=FAILURE and no released=True
+        failure_call_args = mock_update_db.await_args_list[2][0]
+        failure_call_kwargs = mock_update_db.await_args_list[2][1]
+        self.assertEqual(failure_call_args[3], KonfluxBuildOutcome.FAILURE)
+        self.assertFalse(failure_call_kwargs.get('released', False))
+
+    async def test_non_base_image_skips_release_trigger(self):
+        """Test that non-base images skip the release trigger logic entirely."""
+        metadata = self._metadata()
+        metadata.should_trigger_base_image_release.return_value = False
+        dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        build_repo = MagicMock()
+        build_repo.local_dir = dest_dir
+        build_repo.url = "https://github.com/test/repo.git"
+        build_repo.commit_hash = "test-commit"
+
+        initial_pipelinerun = MagicMock()
+        initial_pipelinerun.name = "test-pipelinerun"
+        initial_pipelinerun.to_dict.return_value = {"metadata": {"name": "test-pipelinerun"}}
+
+        completed_pipelinerun = MagicMock()
+        completed_pipelinerun.name = "test-pipelinerun"
+        completed_pipelinerun.find_condition.return_value = {"status": "True"}
+        completed_pipelinerun.to_dict.return_value = {
+            "metadata": {"name": "test-pipelinerun"},
+            "status": {
+                "results": [
+                    {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                    {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                ]
+            },
+        }
+        self.mock_konflux_client.wait_for_pipelinerun = AsyncMock(return_value=completed_pipelinerun)
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=build_repo),
+            ),
+            patch.object(self.builder, "_parse_dockerfile", return_value=("test-uuid", "test-component", "1.0", "1")),
+            patch.object(self.builder, "_wait_for_parent_members", new=AsyncMock(return_value=[])),
+            patch.object(self.builder, "_start_build", new=AsyncMock(return_value=initial_pipelinerun)),
+            patch.object(
+                self.builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))
+            ) as mock_update_db,
+            patch.object(self.builder, "_trigger_base_image_release", new=AsyncMock()) as mock_trigger_release,
+            patch.object(self.builder, "_validate_build_attestation_and_signature", new=AsyncMock()),
+            patch.object(
+                self.builder._konflux_client,
+                "verify_enterprise_contract",
+                new=AsyncMock(return_value=MagicMock(ec_status="PASSED", ec_pipeline_url="", ec_failed=False)),
+            ),
+            patch(
+                "doozerlib.backend.konflux_image_builder.KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition",
+                return_value=KonfluxBuildOutcome.SUCCESS,
+            ),
+        ):
+            await self.builder.build(metadata)
+
+        # Base image release should not be triggered for non-base images
+        mock_trigger_release.assert_not_awaited()
+
+        # Only 2 database updates: PENDING + final SUCCESS (no registry update)
+        self.assertEqual(mock_update_db.await_count, 2)
+
+    async def test_trigger_base_image_release_calls_jenkins_with_block_until_complete(self):
+        """Test that base image release uses block_until_complete=True for synchronous execution."""
+        from pyartcd import jenkins
+
+        metadata = self._metadata()
+        metadata.is_snapshot_release_enabled.return_value = True
+
+        with patch.object(jenkins, 'start_base_image_release', return_value="job-result") as mock_jenkins:
+            result = await self.builder._trigger_base_image_release(metadata, "test-nvr")
+
+        self.assertTrue(result)
+        mock_jenkins.assert_called_once()
+        call_kwargs = mock_jenkins.call_args[1]
+        self.assertTrue(call_kwargs.get('block_until_complete', False))
+
+    async def test_trigger_base_image_release_respects_snapshot_release_disabled(self):
+        """Test that snapshot_release disabled skips base image release."""
+        metadata = self._metadata()
+        metadata.is_snapshot_release_enabled.return_value = False
+
+        result = await self.builder._trigger_base_image_release(metadata, "test-nvr")
+
+        self.assertTrue(result)  # Should return True (no-op success) when disabled
 
 
 class TestNormalizeVersion(unittest.TestCase):

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -3,11 +3,12 @@ import re
 import stat
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest import TestCase
+from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, MagicMock
 
 import semver
 from artcommonlib.model import Missing, Model
+from artcommonlib.variants import BuildVariant
 from dockerfile_parse import DockerfileParser
 from doozerlib.backend.rebaser import KonfluxRebaser
 
@@ -1309,3 +1310,71 @@ class TestCpeVersionExtraction(TestCase):
 
     def test_single_segment(self):
         self.assertEqual(self._extract_cpe_version("v4"), "4")
+
+
+class TestRhArtImagesBasePullspec(TestCase):
+    def test_rh_art_images_base_pullspec_matches_db_convention(self):
+        from doozerlib.util import rh_art_images_base_pullspec
+
+        nvr = "openshift-golang-builder-container-v1.21-1.el9"
+        self.assertEqual(
+            rh_art_images_base_pullspec(nvr),
+            f"registry.redhat.io/openshift/art-images-base:{nvr}",
+        )
+
+
+class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
+    """Member parent resolution uses registry.redhat.io for art-managed base images."""
+
+    def setUp(self):
+        self.directory = TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.base_dir = Path(self.directory.name)
+
+    async def test_resolve_member_parent_uses_rh_when_art_base_and_labels_present(self):
+        parent = MagicMock()
+        parent.distgit_key = "golang-builder"
+        parent.qualified_key = "openshift/golang-builder"
+        parent.private_fix = False
+        parent.image_name_short = "golang-builder"
+        parent.rebased_image_version = "v1.21"
+        parent.rebased_image_release = "1.el9"
+        parent.get_component_name.return_value = "openshift-golang-builder-container"
+        parent.should_trigger_base_image_release.return_value = True
+
+        runtime = MagicMock()
+        runtime.resolve_image.return_value = parent
+        runtime.group_config = Model({"konflux": Model({})})
+
+        rebaser = KonfluxRebaser(runtime, self.base_dir, MagicMock(), "unsigned")
+        rebaser.variant = BuildVariant.OCP
+        rebaser.image_repo = "quay.io/fake"
+        rebaser.uuid_tag = "v4.18-abc"
+        rebaser.group = "openshift-4.18"
+
+        resolved, _embargo = await rebaser._resolve_member_parent("golang-builder", "ignored")
+        self.assertEqual(
+            resolved,
+            "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.21-1.el9",
+        )
+
+    async def test_resolve_member_parent_keeps_quay_for_regular_member(self):
+        parent = MagicMock()
+        parent.distgit_key = "ose-cli"
+        parent.qualified_key = "openshift/ose-cli"
+        parent.private_fix = False
+        parent.image_name_short = "ose-cli"
+        parent.should_trigger_base_image_release.return_value = False
+
+        runtime = MagicMock()
+        runtime.resolve_image.return_value = parent
+        runtime.group_config = Model({"konflux": Model({})})
+
+        rebaser = KonfluxRebaser(runtime, self.base_dir, MagicMock(), "unsigned")
+        rebaser.variant = BuildVariant.OCP
+        rebaser.image_repo = "quay.io/fake"
+        rebaser.uuid_tag = "v4.18-uuid"
+        rebaser.group = "openshift-4.18"
+
+        resolved, _ = await rebaser._resolve_member_parent("ose-cli", "ignored")
+        self.assertEqual(resolved, "quay.io/fake:ose-cli-v4.18-uuid")

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -1337,8 +1337,6 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         parent.qualified_key = "openshift/golang-builder"
         parent.private_fix = False
         parent.image_name_short = "golang-builder"
-        parent.rebased_image_version = "v1.21"
-        parent.rebased_image_release = "1.el9"
         parent.get_component_name.return_value = "openshift-golang-builder-container"
         parent.should_trigger_base_image_release.return_value = True
 
@@ -1351,6 +1349,7 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         rebaser.image_repo = "quay.io/fake"
         rebaser.uuid_tag = "v4.18-abc"
         rebaser.group = "openshift-4.18"
+        rebaser._rebased_nvr_info["golang-builder"] = ("v1.21", "1.el9")
 
         resolved, _embargo = await rebaser._resolve_member_parent("golang-builder", "ignored")
         self.assertEqual(

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1650,6 +1650,16 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         regular_metadata = ImageMetadata(runtime, regular_data)
         self.assertFalse(regular_metadata.should_trigger_base_image_release())
 
+        # OKD: base image would trigger on OCP but never on OKD (no RH registry release)
+        okd_runtime = MagicMock()
+        okd_runtime.logger = logging.getLogger('test_runtime')
+        okd_runtime.variant = BuildVariant.OKD
+        okd_base_metadata = ImageMetadata(okd_runtime, base_data)
+        self.assertFalse(okd_base_metadata.should_trigger_base_image_release())
+
+        okd_golang_metadata = ImageMetadata(okd_runtime, golang_data)
+        self.assertFalse(okd_golang_metadata.should_trigger_base_image_release())
+
     def test_is_snapshot_release_enabled(self):
         from artcommonlib.model import Model
 


### PR DESCRIPTION
## Summary
Fixes coordination gap where 235+ dependent images continued using stale quay.io references after base images were released to registry.redhat.io. Implements synchronous base image release handling with proper failure management and database updates using correct registry.redhat.io pullspecs.

## Problem
**Before:** Base images release to registry.redhat.io but 235+ dependent images continue using stale quay.io references in their FROM statements because Konflux database pullspecs are not updated after registry releases.

**After:** Dependent images automatically resolve to use the released registry.redhat.io pullspec in their FROM statements after base image releases complete successfully.

## Implementation Details
Adds synchronous base image release coordination through:

### Key Changes
- Add `released` parameter to `update_konflux_db` for registry pullspec coordination
- Implement synchronous base image release with `block_until_complete=True`  
- Add comprehensive test coverage for success/failure scenarios (7 new test cases)
- Ensure proper failure handling with FAILURE outcome updates when registry release fails

The solution eliminates the database coordination gap by making base image release synchronous and updating database records with correct registry.redhat.io pullspecs upon successful release, while marking builds as FAILURE when release fails.