### PR TITLE
Add generic skip_tasks mechanism for Konflux builds

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -1179,6 +1179,7 @@ class KonfluxClient:
         additional_tags: Optional[Sequence[str]] = None,
         skip_checks: bool = False,
         skip_fips_check: bool = False,
+        skip_tasks: Sequence[str] = (),
         build_priority: str = None,
         hermetic: Optional[bool] = None,
         sast: Optional[bool] = None,
@@ -1311,27 +1312,23 @@ class KonfluxClient:
             raise IOError(
                 "SAST task is enabled, but the template does not contain it. Please ensure the template is up-to-date."
             )
-        if sast is False and has_sast_task:  # if SAST is explicitly disabled, remove SAST tasks
-            tasks = []
-            has_sast_task = False
-            for task in obj["spec"]["pipelineSpec"]["tasks"]:
-                task_name = task.get("name")
-                if task_name in ("sast-unicode-check", "sast-shell-check"):
-                    self._logger.info(f"Removing {task_name} tasks since SAST is disabled")
-                    continue
-                tasks.append(task)
 
-            obj["spec"]["pipelineSpec"]["tasks"] = tasks
-
+        # Build the effective skip set from explicit skip_tasks + legacy flags
+        effective_skip: set[str] = set(skip_tasks)
+        if sast is False and has_sast_task:
+            effective_skip |= {"sast-unicode-check", "sast-shell-check"}
         if skip_fips_check:
-            tasks = []
+            effective_skip.add("fbc-fips-check-oci-ta")
+
+        if effective_skip:
+            kept = []
             for task in obj["spec"]["pipelineSpec"]["tasks"]:
                 task_name = task.get("name")
-                if task_name == "fbc-fips-check-oci-ta":
-                    self._logger.info("Removing fbc-fips-check-oci-ta task since skip_fips_check is enabled")
+                if task_name in effective_skip:
+                    self._logger.info("Removing task %s from PipelineRun (skip_tasks)", task_name)
                     continue
-                tasks.append(task)
-            obj["spec"]["pipelineSpec"]["tasks"] = tasks
+                kept.append(task)
+            obj["spec"]["pipelineSpec"]["tasks"] = kept
 
         # https://konflux.pages.redhat.com/docs/users/how-tos/configuring/overriding-compute-resources.html
         # ose-installer-artifacts fails with OOM with default values, hence bumping memory limit
@@ -1405,6 +1402,7 @@ class KonfluxClient:
         additional_tags: Sequence[str] = [],
         skip_checks: bool = False,
         skip_fips_check: bool = False,
+        skip_tasks: Sequence[str] = (),
         build_priority: str = None,
         hermetic: Optional[bool] = None,
         dockerfile: Optional[str] = None,
@@ -1433,6 +1431,7 @@ class KonfluxClient:
         :param additional_tags: Additional tags to apply to the image.
         :param skip_checks: Whether to skip checks.
         :param skip_fips_check: Whether to skip the FIPS compliance check.
+        :param skip_tasks: List of Tekton task names to remove from the PipelineRun.
         :param hermetic: Whether to build the image in a hermetic environment. If None, the default value is used.
         :param dockerfile: Optional Dockerfile name
         :param pipelinerun_template_url: The URL to the PipelineRun template.
@@ -1467,6 +1466,7 @@ class KonfluxClient:
             git_auth_secret=git_auth_secret,
             skip_checks=skip_checks,
             skip_fips_check=skip_fips_check,
+            skip_tasks=skip_tasks,
             hermetic=hermetic,
             additional_tags=additional_tags,
             dockerfile=dockerfile,

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -366,6 +366,7 @@ class KonfluxFbcFragmentMerger:
         registry_auth: Optional[str] = None,
         skip_checks: bool = False,
         skip_fips_check: bool = False,
+        skip_tasks: Sequence[str] = (),
         plr_template: Optional[str] = None,
         major_minor_override: Optional[Tuple[int, int]] = None,
         logger: logging.Logger | None = None,
@@ -391,6 +392,7 @@ class KonfluxFbcFragmentMerger:
         self.registry_auth = registry_auth
         self.skip_checks = skip_checks
         self.skip_fips_check = skip_fips_check
+        self.skip_tasks = tuple(skip_tasks)
         self.plr_template = plr_template or constants.KONFLUX_DEFAULT_FBC_BUILD_PLR_TEMPLATE_URL
         self.major_minor_override = major_minor_override
         self._logger = logger or LOGGER.getChild(self.__class__.__name__)
@@ -648,6 +650,7 @@ class KonfluxFbcFragmentMerger:
             dockerfile="catalog.Dockerfile",
             skip_checks=self.skip_checks,
             skip_fips_check=self.skip_fips_check,
+            skip_tasks=self.skip_tasks,
             pipelinerun_template_url=self.plr_template,
             build_priority=FBC_BUILD_PRIORITY,
         )
@@ -1592,6 +1595,7 @@ class KonfluxFbcBuilder:
         konflux_context: Optional[str] = None,
         image_repo: str = constants.KONFLUX_DEFAULT_IMAGE_REPO,
         skip_checks: bool = False,
+        skip_tasks: Sequence[str] = (),
         pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_FBC_BUILD_PLR_TEMPLATE_URL,
         dry_run: bool = False,
         major_minor_override: Optional[Tuple[int, int]] = None,
@@ -1609,6 +1613,7 @@ class KonfluxFbcBuilder:
         self.konflux_context = konflux_context
         self.image_repo = image_repo
         self.skip_checks = skip_checks
+        self.skip_tasks = tuple(skip_tasks)
         self.pipelinerun_template_url = pipelinerun_template_url
         self.dry_run = dry_run
         self.major_minor_override = major_minor_override
@@ -2005,6 +2010,7 @@ class KonfluxFbcBuilder:
             building_arches=arches,
             additional_tags=list(additional_tags),
             skip_checks=self.skip_checks,
+            skip_tasks=self.skip_tasks,
             hermetic=True,
             dockerfile="catalog.Dockerfile",
             pipelinerun_template_url=self.pipelinerun_template_url,

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -85,6 +85,7 @@ class KonfluxImageBuilderConfig:
     image_repo: str = constants.KONFLUX_DEFAULT_IMAGE_REPO
     registry_auth_file: Optional[str] = None
     skip_checks: bool = False
+    skip_tasks: tuple[str, ...] = ()
     dry_run: bool = False
     build_priority: Optional[str] = None
     ec_policy_configuration: str = constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION
@@ -744,6 +745,11 @@ class KonfluxImageBuilder:
         image_config_sast_task = metadata.config.get("konflux", {}).get("sast", {}).get("enabled", Missing)
         sast = image_config_sast_task if image_config_sast_task is not Missing else group_config_sast_task
 
+        # Merge skip_tasks: CLI list + group config + image config
+        group_skip_tasks = metadata.runtime.group_config.get("konflux", {}).get("skip_tasks", [])
+        image_skip_tasks = metadata.config.get("konflux", {}).get("skip_tasks", [])
+        merged_skip_tasks = list(set(self._config.skip_tasks) | set(group_skip_tasks) | set(image_skip_tasks))
+
         # Prepare annotations
         annotations = {
             "art-network-mode": metadata.get_konflux_network_mode(),
@@ -768,6 +774,7 @@ class KonfluxImageBuilder:
             building_arches=building_arches,
             additional_tags=additional_tags,
             skip_checks=self._config.skip_checks,
+            skip_tasks=merged_skip_tasks,
             hermetic=hermetic,
             vm_override=metadata.config.get("konflux", {}).get("vm_override"),
             pipelinerun_template_url=self._config.plr_template,

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -607,6 +607,7 @@ class KonfluxOlmBundleBuilder:
         konflux_context: Optional[str] = None,
         image_repo: str = constants.KONFLUX_DEFAULT_IMAGE_REPO,
         skip_checks: bool = False,
+        skip_tasks: Sequence[str] = (),
         pipelinerun_template_url: str = constants.KONFLUX_DEFAULT_BUNDLE_BUILD_PLR_TEMPLATE_URL,
         dry_run: bool = False,
         skip_ec_verify: bool = False,
@@ -624,6 +625,7 @@ class KonfluxOlmBundleBuilder:
         self.konflux_context = konflux_context
         self.image_repo = image_repo
         self.skip_checks = skip_checks
+        self.skip_tasks = tuple(skip_tasks)
         self.pipelinerun_template_url = pipelinerun_template_url
         self.dry_run = dry_run
         self.skip_ec_verify = skip_ec_verify
@@ -726,6 +728,7 @@ class KonfluxOlmBundleBuilder:
                     output_image,
                     self.konflux_namespace,
                     self.skip_checks,
+                    skip_tasks=self.skip_tasks,
                     git_auth_secret=git_auth_secret,
                 )
                 pipelinerun_name = pipelinerun_info.name
@@ -879,6 +882,7 @@ class KonfluxOlmBundleBuilder:
         output_image: str,
         namespace: str,
         skip_checks: bool = False,
+        skip_tasks: Sequence[str] = (),
         additional_tags: Optional[Sequence[str]] = None,
         git_auth_secret: Optional[str] = None,
     ) -> Tuple[PipelineRunInfo, str]:
@@ -923,6 +927,7 @@ class KonfluxOlmBundleBuilder:
             building_arches=["x86_64"],
             additional_tags=list(additional_tags),
             skip_checks=skip_checks,
+            skip_tasks=skip_tasks,
             hermetic=True,
             pipelinerun_template_url=self.pipelinerun_template_url,
             artifact_type="operatorbundle",

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -208,9 +208,10 @@ class FbcMergeCli:
         message: Optional[str],
         skip_checks: bool,
         skip_fips_check: bool,
-        plr_template: Optional[str],
-        target_index: Optional[str],
-        major_minor: Optional[str],
+        skip_tasks: tuple[str, ...] = (),
+        plr_template: Optional[str] = None,
+        target_index: Optional[str] = None,
+        major_minor: Optional[str] = None,
     ):
         """
         Initialize the FBCFragmentMergerCli.
@@ -228,6 +229,7 @@ class FbcMergeCli:
         self.message = message
         self.skip_checks = skip_checks
         self.skip_fips_check = skip_fips_check
+        self.skip_tasks = skip_tasks
         self.plr_template = plr_template
         self.target_index = target_index
         self.major_minor = major_minor
@@ -326,6 +328,7 @@ class FbcMergeCli:
             konflux_namespace=self.konflux_namespace,
             skip_checks=self.skip_checks,
             skip_fips_check=self.skip_fips_check,
+            skip_tasks=self.skip_tasks,
             plr_template=self.plr_template,
             major_minor_override=(major, minor) if self.major_minor else None,
         )
@@ -398,6 +401,10 @@ class FbcMergeCli:
 @click.option('--skip-checks', is_flag=True, default=False, help='Skip all post build checks')
 @click.option('--skip-fips-check', is_flag=True, default=False, help='Skip the FIPS compliance check task')
 @click.option(
+    '--skip-task', 'skip_tasks', multiple=True,
+    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan).',
+)
+@click.option(
     '--target-index',
     metavar='TARGET_INDEX',
     default=None,
@@ -424,6 +431,7 @@ async def fbc_merge(
     registry_auth: Optional[str],
     skip_checks: bool,
     skip_fips_check: bool,
+    skip_tasks: tuple,
     plr_template: Optional[str],
     target_index: Optional[str],
     major_minor: Optional[str],
@@ -454,6 +462,7 @@ async def fbc_merge(
         konflux_namespace=resolved_namespace,
         skip_checks=skip_checks,
         skip_fips_check=skip_fips_check,
+        skip_tasks=skip_tasks,
         plr_template=plr_template,
         target_index=target_index,
         major_minor=major_minor,
@@ -483,6 +492,7 @@ class FbcRebaseAndBuildCli:
         prod_registry_auth: Optional[str] = None,
         major_minor: Optional[str] = None,
         insert_missing_entry: bool = False,
+        skip_tasks: tuple[str, ...] = (),
     ):
         self.runtime = runtime
         self.version = version
@@ -495,6 +505,7 @@ class FbcRebaseAndBuildCli:
         self.konflux_namespace = konflux_namespace
         self.image_repo = image_repo
         self.skip_checks = skip_checks
+        self.skip_tasks = skip_tasks
         self.plr_template = plr_template
         self.dry_run = dry_run
         self.force = force
@@ -745,6 +756,7 @@ class FbcRebaseAndBuildCli:
             konflux_namespace=self.konflux_namespace,
             image_repo=self.image_repo,
             skip_checks=self.skip_checks,
+            skip_tasks=self.skip_tasks,
             pipelinerun_template_url=self.plr_template,
             dry_run=self.dry_run,
             major_minor_override=ocp_version if self.major_minor else None,
@@ -853,6 +865,10 @@ class FbcRebaseAndBuildCli:
 )
 @click.option('--image-repo', default=constants.KONFLUX_DEFAULT_FBC_REPO, help='Push images to the specified repo.')
 @click.option('--skip-checks', default=False, is_flag=True, help='Skip all post build checks')
+@click.option(
+    '--skip-task', 'skip_tasks', multiple=True,
+    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan).',
+)
 @click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
 @click.option(
     '--force',
@@ -911,6 +927,7 @@ async def fbc_rebase_and_build(
     konflux_namespace: str,
     image_repo: str,
     skip_checks: bool,
+    skip_tasks: tuple,
     dry_run: bool,
     force: bool,
     plr_template: str,
@@ -951,6 +968,7 @@ async def fbc_rebase_and_build(
         konflux_namespace=konflux_namespace,
         image_repo=image_repo,
         skip_checks=skip_checks,
+        skip_tasks=skip_tasks,
         plr_template=plr_template,
         dry_run=dry_run,
         force=force,

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -263,6 +263,7 @@ class KonfluxBuildCli:
         plr_template: str,
         build_priority: Optional[str],
         skip_ec_verify: bool = False,
+        skip_tasks: tuple[str, ...] = (),
     ):
         self.runtime = runtime
         self.konflux_kubeconfig = konflux_kubeconfig
@@ -271,6 +272,7 @@ class KonfluxBuildCli:
         self.image_repo = image_repo
         self.registry_auth_file = registry_auth_file
         self.skip_checks = skip_checks
+        self.skip_tasks = skip_tasks
         self.dry_run = dry_run
         self.plr_template = plr_template
         self.build_priority = build_priority
@@ -309,6 +311,7 @@ class KonfluxBuildCli:
             image_repo=self.image_repo,
             registry_auth_file=self.registry_auth_file,
             skip_checks=self.skip_checks,
+            skip_tasks=self.skip_tasks,
             dry_run=self.dry_run,
             plr_template=self.plr_template,
             build_priority=self.build_priority,
@@ -373,6 +376,10 @@ class KonfluxBuildCli:
 )
 @click.option('--image-repo', default=constants.KONFLUX_DEFAULT_IMAGE_REPO, help='Push images to the specified repo.')
 @click.option('--skip-checks', default=False, is_flag=True, help='Skip all post build checks')
+@click.option(
+    '--skip-task', 'skip_tasks', multiple=True,
+    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan --skip-task sast-snyk-check).',
+)
 @click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
 @click.option(
     '--plr-template',
@@ -408,6 +415,7 @@ async def images_konflux_build(
     konflux_namespace: str,
     image_repo: str,
     skip_checks: bool,
+    skip_tasks: tuple,
     dry_run: bool,
     plr_template: str,
     build_priority: Optional[str],
@@ -425,6 +433,7 @@ async def images_konflux_build(
         image_repo=image_repo,
         registry_auth_file=runtime.registry_config,
         skip_checks=skip_checks,
+        skip_tasks=skip_tasks,
         dry_run=dry_run,
         plr_template=plr_template,
         build_priority=build_priority,
@@ -448,6 +457,7 @@ class KonfluxBundleCli:
         release: Optional[str],
         plr_template: str,
         output: str,
+        skip_tasks: tuple[str, ...] = (),
     ):
         self.runtime = runtime
         self.operator_nvrs = list(operator_nvrs)
@@ -458,6 +468,7 @@ class KonfluxBundleCli:
         self.konflux_namespace = konflux_namespace
         self.image_repo = image_repo
         self.skip_checks = skip_checks
+        self.skip_tasks = skip_tasks
         self.release = release
         self.output = output
         self.plr_template = plr_template
@@ -607,6 +618,7 @@ class KonfluxBundleCli:
             konflux_context=self.konflux_context,
             image_repo=self.image_repo,
             skip_checks=self.skip_checks,
+            skip_tasks=self.skip_tasks,
             pipelinerun_template_url=self.plr_template,
             dry_run=self.dry_run,
             assembly_type=runtime.assembly_type,
@@ -712,6 +724,10 @@ class KonfluxBundleCli:
 )
 @click.option('--image-repo', default=constants.KONFLUX_DEFAULT_IMAGE_REPO, help='Push images to the specified repo.')
 @click.option('--skip-checks', default=False, is_flag=True, help='Skip all post build checks')
+@click.option(
+    '--skip-task', 'skip_tasks', multiple=True,
+    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan --skip-task sast-snyk-check).',
+)
 @click.option("--release", metavar='RELEASE', help="Release string to populate in bundle's Dockerfiles.")
 @click.option(
     '--plr-template',
@@ -738,6 +754,7 @@ async def images_konflux_bundle(
     konflux_namespace: str,
     image_repo: str,
     skip_checks: bool,
+    skip_tasks: tuple,
     release: Optional[str],
     plr_template: str,
     output: str,
@@ -752,6 +769,7 @@ async def images_konflux_bundle(
         konflux_namespace=konflux_namespace,
         image_repo=image_repo,
         skip_checks=skip_checks,
+        skip_tasks=skip_tasks,
         release=release,
         plr_template=plr_template,
         output=output,

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -3,6 +3,7 @@ import logging
 from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import jinja2
 from artcommonlib.konflux.konflux_build_record import KonfluxECStatus
 from doozerlib.backend.konflux_client import (
     API_VERSION,
@@ -533,3 +534,109 @@ class TestVerifyEnterpriseContract(IsolatedAsyncioTestCase):
             application_name="openshift-4-21",
             policy_configuration="rhtap-releng-tenant/registry-ocp-art-base-prod",
         )
+
+
+class TestSkipTasks(IsolatedAsyncioTestCase):
+    """Tests for the generic skip_tasks mechanism in _new_pipelinerun_for_image_build."""
+
+    MINIMAL_TEMPLATE = jinja2.Template(json.dumps({
+        "metadata": {
+            "name": "test-plr",
+            "namespace": "test-ns",
+            "annotations": {
+                "pipelinesascode.tekton.dev/on-cel-expression": "dummy",
+                "build.appstudio.openshift.io/repo": "",
+            },
+            "labels": {
+                "appstudio.openshift.io/application": "test-app",
+                "appstudio.openshift.io/component": "test-comp",
+            },
+        },
+        "spec": {
+            "params": [],
+            "timeouts": {},
+            "taskRunTemplate": {"serviceAccountName": "default"},
+            "pipelineSpec": {
+                "tasks": [
+                    {"name": "clone-repository", "params": [{"name": "refspec", "value": ""}]},
+                    {"name": "build-images", "params": [{"name": "SBOM_TYPE", "value": ""}]},
+                    {"name": "clair-scan", "params": []},
+                    {"name": "sast-snyk-check", "params": []},
+                    {"name": "sast-unicode-check", "params": []},
+                    {"name": "sast-shell-check", "params": []},
+                    {"name": "apply-tags", "params": [{"name": "ADDITIONAL_TAGS", "value": []}]},
+                    {"name": "fbc-fips-check-oci-ta", "params": []},
+                ],
+            },
+        },
+    }))
+
+    def _make_client(self):
+        client = MagicMock(spec=KonfluxClient)
+        client._logger = logging.getLogger("test")
+        client.dry_run = False
+
+        async def fake_get_template(url):
+            return self.MINIMAL_TEMPLATE
+
+        client._get_pipelinerun_template = fake_get_template
+        return client
+
+    async def _build_plr(self, **kwargs):
+        """Helper to call _new_pipelinerun_for_image_build with minimal defaults."""
+        defaults = dict(
+            generate_name="test-",
+            namespace="ns",
+            application_name="app",
+            component_name="comp",
+            git_url="https://github.com/org/repo",
+            commit_sha="abc123",
+            target_branch="main",
+            output_image="quay.io/test:latest",
+            build_platforms=["linux/x86_64"],
+        )
+        defaults.update(kwargs)
+        client = self._make_client()
+        return await KonfluxClient._new_pipelinerun_for_image_build(client, **defaults)
+
+    async def test_skip_tasks_removes_named_tasks(self):
+        result = await self._build_plr(skip_tasks=["clair-scan"])
+        task_names = [t["name"] for t in result["spec"]["pipelineSpec"]["tasks"]]
+        self.assertNotIn("clair-scan", task_names)
+        self.assertIn("build-images", task_names)
+        self.assertIn("sast-snyk-check", task_names)
+
+    async def test_skip_tasks_multiple(self):
+        result = await self._build_plr(skip_tasks=["clair-scan", "sast-snyk-check"])
+        task_names = [t["name"] for t in result["spec"]["pipelineSpec"]["tasks"]]
+        self.assertNotIn("clair-scan", task_names)
+        self.assertNotIn("sast-snyk-check", task_names)
+        self.assertIn("build-images", task_names)
+
+    async def test_legacy_sast_false_still_removes_tasks(self):
+        result = await self._build_plr(sast=False)
+        task_names = [t["name"] for t in result["spec"]["pipelineSpec"]["tasks"]]
+        self.assertNotIn("sast-unicode-check", task_names)
+        self.assertNotIn("sast-shell-check", task_names)
+        self.assertIn("clair-scan", task_names)
+
+    async def test_legacy_skip_fips_check_still_removes_task(self):
+        result = await self._build_plr(skip_fips_check=True)
+        task_names = [t["name"] for t in result["spec"]["pipelineSpec"]["tasks"]]
+        self.assertNotIn("fbc-fips-check-oci-ta", task_names)
+        self.assertIn("clair-scan", task_names)
+
+    async def test_skip_tasks_combined_with_legacy_flags(self):
+        result = await self._build_plr(skip_tasks=["clair-scan"], sast=False, skip_fips_check=True)
+        task_names = [t["name"] for t in result["spec"]["pipelineSpec"]["tasks"]]
+        self.assertNotIn("clair-scan", task_names)
+        self.assertNotIn("sast-unicode-check", task_names)
+        self.assertNotIn("sast-shell-check", task_names)
+        self.assertNotIn("fbc-fips-check-oci-ta", task_names)
+        self.assertIn("build-images", task_names)
+        self.assertIn("clone-repository", task_names)
+
+    async def test_skip_tasks_unknown_name_is_silently_ignored(self):
+        result = await self._build_plr(skip_tasks=["nonexistent-task"])
+        task_names = [t["name"] for t in result["spec"]["pipelineSpec"]["tasks"]]
+        self.assertEqual(len(task_names), 8)

--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -440,6 +440,18 @@
           "$ref": "#/properties/konflux/properties/sast"
         },
         "sast-": {},
+        "skip_tasks": {
+          "description": "List of Tekton task names to remove from PipelineRuns",
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "skip_tasks!": {
+          "$ref": "#/properties/konflux/properties/skip_tasks"
+        },
+        "skip_tasks?": {
+          "$ref": "#/properties/konflux/properties/skip_tasks"
+        },
+        "skip_tasks-": {},
         "network_mode": {
           "type": "string"
         },

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -1402,6 +1402,18 @@
           "$ref": "#/properties/konflux/properties/build_attempts"
         },
         "build_attempts-": {},
+        "skip_tasks": {
+          "description": "List of Tekton task names to remove from PipelineRuns for this image",
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "skip_tasks!": {
+          "$ref": "#/properties/konflux/properties/skip_tasks"
+        },
+        "skip_tasks?": {
+          "$ref": "#/properties/konflux/properties/skip_tasks"
+        },
+        "skip_tasks-": {},
         "content": {
           "$ref": "image_content.base.schema.json"
         }

--- a/pyartcd/pyartcd/pipelines/build_fbc.py
+++ b/pyartcd/pyartcd/pipelines/build_fbc.py
@@ -59,13 +59,14 @@ class BuildFbcPipeline:
         kubeconfig: str,
         plr_template: str,
         skip_checks: bool,
-        reset_to_prod: bool,
-        prod_registry_auth: Optional[str],
-        force: bool,
-        group: str,
-        major_minor: Optional[str],
-        ignore_locks: bool,
-        insert_missing_entry: bool,
+        skip_tasks: tuple[str, ...] = (),
+        reset_to_prod: bool = True,
+        prod_registry_auth: Optional[str] = None,
+        force: bool = False,
+        group: str = '',
+        major_minor: Optional[str] = None,
+        ignore_locks: bool = False,
+        insert_missing_entry: bool = False,
     ):
         self.runtime = runtime
         self.version = version
@@ -80,6 +81,7 @@ class BuildFbcPipeline:
         self.kubeconfig = kubeconfig
         self.plr_template = plr_template
         self.skip_checks = skip_checks
+        self.skip_tasks = skip_tasks
         self.reset_to_prod = reset_to_prod
         self.prod_registry_auth = prod_registry_auth
         self.force = force
@@ -216,6 +218,8 @@ class BuildFbcPipeline:
             doozer_opts.extend(['--plr-template', plr_template_url])
         if self.skip_checks:
             doozer_opts.append('--skip-checks')
+        for task_name in self.skip_tasks:
+            doozer_opts.extend(['--skip-task', task_name])
         if self.reset_to_prod:
             doozer_opts.append('--reset-to-prod')
         else:
@@ -314,6 +318,10 @@ class BuildFbcPipeline:
 )
 @click.option("--skip-checks", is_flag=True, help="Skip all post build checks in the FBC build pipeline")
 @click.option(
+    '--skip-task', 'skip_tasks', multiple=True,
+    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan).',
+)
+@click.option(
     "--reset-to-prod/--no-reset-to-prod", is_flag=True, help="Reset FBC builds to the latest production version"
 )
 @click.option(
@@ -354,6 +362,7 @@ async def build_fbc(
     kubeconfig: str,
     plr_template: str,
     skip_checks: bool,
+    skip_tasks: tuple,
     reset_to_prod: bool,
     prod_registry_auth: Optional[str],
     force: bool,
@@ -379,6 +388,7 @@ async def build_fbc(
         kubeconfig=kubeconfig,
         plr_template=plr_template,
         skip_checks=skip_checks,
+        skip_tasks=skip_tasks,
         reset_to_prod=reset_to_prod,
         prod_registry_auth=prod_registry_auth,
         force=force,

--- a/pyartcd/pyartcd/pipelines/build_merged_fbc.py
+++ b/pyartcd/pyartcd/pipelines/build_merged_fbc.py
@@ -25,6 +25,7 @@ class BuildMergedFbcPipeline:
         kubeconfig: str,
         plr_template: str,
         skip_checks: bool,
+        skip_tasks: tuple[str, ...] = (),
     ):
         self.runtime = runtime
         self.version = version
@@ -36,6 +37,7 @@ class BuildMergedFbcPipeline:
         self.kubeconfig = kubeconfig
         self.plr_template = plr_template
         self.skip_checks = skip_checks
+        self.skip_tasks = skip_tasks
 
         self._logger = logging.getLogger(__name__)
         self._slack_client = runtime.new_slack_client()
@@ -101,6 +103,8 @@ class BuildMergedFbcPipeline:
             doozer_opts.extend(['--plr-template', plr_template_url])
         if self.skip_checks:
             doozer_opts.append('--skip-checks')
+        for task_name in self.skip_tasks:
+            doozer_opts.extend(['--skip-task', task_name])
         doozer_opts.append('--')
         stage_index_repo = "quay.io/openshift-art/stage-fbc-fragments"
         for dgk in operator_dgks:
@@ -154,6 +158,10 @@ class BuildMergedFbcPipeline:
     help='Override the Pipeline Run template commit from openshift-priv/art-konflux-template; format: <owner>@<branch>',
 )
 @click.option("--skip-checks", is_flag=True, help="Skip all post build checks in the FBC build pipeline")
+@click.option(
+    '--skip-task', 'skip_tasks', multiple=True,
+    help='Remove a named Tekton task from the PipelineRun. Repeatable (e.g. --skip-task clair-scan).',
+)
 @pass_runtime
 @click_coroutine
 async def build_merged_fbc(
@@ -167,6 +175,7 @@ async def build_merged_fbc(
     kubeconfig: str,
     plr_template: str,
     skip_checks: bool,
+    skip_tasks: tuple,
 ):
     pipeline = BuildMergedFbcPipeline(
         runtime=runtime,
@@ -179,5 +188,6 @@ async def build_merged_fbc(
         kubeconfig=kubeconfig,
         plr_template=plr_template,
         skip_checks=skip_checks,
+        skip_tasks=skip_tasks,
     )
     await pipeline.run()


### PR DESCRIPTION
## Summary

- Introduces a generic `skip_tasks` mechanism that replaces accumulating one-off boolean flags (`sast`, `skip_fips_check`) with a single list of Tekton task names to remove from PipelineRun specs
- Adds `--skip-task` (repeatable) CLI option to doozer image/FBC build commands and pyartcd pipelines
- Adds `konflux.skip_tasks` field to both group and image JSON schemas in ocp-build-data, allowing persistent config alongside CLI usage

This lets us skip `clair-scan` (or any future task) without code changes. Fully backward-compatible with existing `--skip-checks`, `sast=False`, and `--skip-fips-check` flags.

## Test plan

- [x] 6 new unit tests covering: generic removal, multiple tasks, legacy sast/fips compat, combined usage, unknown task names silently ignored
- [x] All 28 existing `test_konflux_client.py` tests pass
- [x] All 47 tests in `test_konflux_client.py` + `test_konflux_image_builder.py` pass
- [x] `ruff check` passes on all modified files
- [ ] Manual test: `doozer ... beta:images:konflux:build --skip-task clair-scan` skips the clair-scan task
- [ ] Manual test: `konflux.skip_tasks: [clair-scan]` in group.yml removes the task


Made with [Cursor](https://cursor.com)