### PR TITLE
ART-18150: load release notes from ocp-build-data templates

### DIFF
--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -16,6 +16,8 @@ import click
 import yaml as stdlib_yaml
 from artcommonlib import exectools
 from artcommonlib.constants import SHIPMENT_DATA_URL_TEMPLATE
+from artcommonlib.gitdata import SafeFormatter
+from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.gitlab import GitLabClient
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import new_roundtrip_yaml_handler
@@ -30,9 +32,11 @@ from elliottlib.shipment_model import (
     Snapshot,
     SnapshotSpec,
 )
-from elliottlib.util import extract_nvrs_from_fbc
+from elliottlib.util import extract_nvrs_from_fbc, get_advisory_boilerplate
+from github import GithubException
 from tenacity import retry, stop_after_attempt
 
+from pyartcd import constants
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.git import GitRepository
 from pyartcd.runtime import Runtime
@@ -76,10 +80,6 @@ class ReleaseFromFbcPipeline:
         jira_bugs: Optional[List[str]] = None,
         target_release_date: Optional[str] = None,
         extra_image_nvrs: Optional[List[str]] = None,
-        release_notes_synopsis: Optional[str] = None,
-        release_notes_topic: Optional[str] = None,
-        release_notes_description: Optional[str] = None,
-        release_notes_solution: Optional[str] = None,
     ) -> None:
         self.logger = logging.getLogger(__name__)
         self.runtime = runtime
@@ -119,10 +119,6 @@ class ReleaseFromFbcPipeline:
 
         self.jira_bugs = jira_bugs
         self.target_release_date = target_release_date
-        self.release_notes_synopsis = release_notes_synopsis
-        self.release_notes_topic = release_notes_topic
-        self.release_notes_description = release_notes_description
-        self.release_notes_solution = release_notes_solution
 
         # Base elliott command template
         self._elliott_base_command = [
@@ -148,6 +144,86 @@ class ReleaseFromFbcPipeline:
             or SHIPMENT_DATA_URL_TEMPLATE
         )
         return shipment_data_repo_pull_url, shipment_data_repo_push_url
+
+    def get_file_from_branch(self, branch: str, filename: str, data_path: str | None = None) -> bytes:
+        """
+        Fetch a file from ocp-build-data using PyGithub.
+        Matches the interface expected by get_advisory_boilerplate().
+        """
+        if data_path is None:
+            data_path = constants.OCP_BUILD_DATA_URL
+        try:
+            data_path = data_path.rstrip(".git")
+            parts = data_path.rstrip("/").split("/")
+            if len(parts) < 2:
+                raise ValueError(f"Invalid git repo URL: {data_path}")
+            user, repo_name = parts[-2], parts[-1]
+            github_client = get_github_client_for_org(user)
+            repo = github_client.get_repo(f"{user}/{repo_name}")
+            file_content = repo.get_contents(filename, ref=branch)
+            return file_content.decoded_content
+        except GithubException as e:
+            raise ValueError(f"Failed to fetch {filename} from {data_path} branch {branch}: {e}")
+
+    def _load_release_notes_template(self) -> dict | None:
+        """
+        Load and populate release notes template from ocp-build-data using get_advisory_boilerplate(),
+        matching the pattern used by get_advisory_boilerplate().
+
+        Return Value(s):
+            dict | None: Template dict with synopsis, topic, description, solution, or None if not found.
+        """
+        try:
+            boilerplate = get_advisory_boilerplate(
+                runtime=self,
+                et_data={},
+                art_advisory_key=self.product,
+                errata_type="RHBA",
+            )
+        except (ValueError, KeyError):
+            self.logger.debug("No release notes template found for product '%s'", self.product)
+            return None
+        except Exception as e:
+            self.logger.warning("Failed to load release notes template: %s", e)
+            return None
+
+        try:
+            group_content = self.get_file_from_branch(self.group, "group.yml")
+            group_config = stdlib_yaml.safe_load(group_content)
+
+            ocp_version = str(group_config.get("OCP_RELEASE_NOTES_VERSION", ""))
+            if not ocp_version:
+                self.logger.warning("OCP_RELEASE_NOTES_VERSION not found in group.yml for group '%s'", self.group)
+                return None
+
+            ocp_version_dashed = ocp_version.replace(".", "-")
+
+            assembly_parts = self.assembly.split(".")
+            replace_vars = {
+                "OCP_RELEASE_NOTES_VERSION": ocp_version,
+                "OCP_RELEASE_NOTES_VERSION_DASHED": ocp_version_dashed,
+                "PRODUCT_MAJOR": assembly_parts[0] if len(assembly_parts) > 0 else "",
+                "PRODUCT_MINOR": assembly_parts[1] if len(assembly_parts) > 1 else "",
+                "PRODUCT_PATCH": assembly_parts[2] if len(assembly_parts) > 2 else "",
+            }
+
+            formatter = SafeFormatter()
+            result = {}
+            for field in ("synopsis", "topic", "description", "solution"):
+                value = boilerplate.get(field, "")
+                result[field] = formatter.format(value, **replace_vars)
+
+            self.logger.info(
+                "Loaded release notes template for '%s' (OCP_RELEASE_NOTES_VERSION=%s, assembly=%s)",
+                self.product,
+                ocp_version,
+                self.assembly,
+            )
+            return result
+
+        except Exception as e:
+            self.logger.warning("Failed to process release notes template: %s", e)
+            return None
 
     @staticmethod
     def basic_auth_url(url: str, token: str) -> str:
@@ -510,36 +586,6 @@ class ReleaseFromFbcPipeline:
             len(release_notes.issues.fixed) if release_notes.issues and release_notes.issues.fixed else 0,
             len(release_notes.cves) if release_notes.cves else 0,
         )
-        return release_notes
-
-    def _apply_release_notes_text(self, release_notes: Optional[ReleaseNotes]) -> Optional[ReleaseNotes]:
-        """
-        Merge user-provided release notes text fields into a ReleaseNotes object.
-
-        Arg(s):
-            release_notes (ReleaseNotes | None): Existing ReleaseNotes from JIRA bug processing, or None.
-        Return Value(s):
-            ReleaseNotes | None: The merged ReleaseNotes, a new one, or None if nothing to apply.
-        """
-        text_fields = {
-            "synopsis": self.release_notes_synopsis,
-            "topic": self.release_notes_topic,
-            "description": self.release_notes_description,
-            "solution": self.release_notes_solution,
-        }
-        provided = {k: v for k, v in text_fields.items() if v is not None and v.strip()}
-
-        if not provided:
-            return release_notes
-
-        if release_notes is None:
-            self.logger.info("No JIRA bugs provided; creating RHBA release notes from text fields")
-            release_notes = ReleaseNotes(type="RHBA")
-
-        for field, value in provided.items():
-            self.logger.info("Setting release notes %s from CLI parameter", field)
-            setattr(release_notes, field, value)
-
         return release_notes
 
     def create_shipment_config(
@@ -951,8 +997,15 @@ class ReleaseFromFbcPipeline:
         if self.jira_bugs:
             release_notes = self.generate_release_notes()
 
-        # Overlay user-provided release notes text fields
-        release_notes = self._apply_release_notes_text(release_notes)
+        # Load release notes template from ocp-build-data
+        template = self._load_release_notes_template()
+        if template:
+            if release_notes is None:
+                release_notes = ReleaseNotes(type="RHBA")
+            release_notes.synopsis = template["synopsis"]
+            release_notes.topic = template["topic"]
+            release_notes.description = template["description"]
+            release_notes.solution = template["solution"]
 
         # Create shipment configurations
         timestamp = datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
@@ -1050,26 +1103,6 @@ class ReleaseFromFbcPipeline:
     help='Target ship date for the release (e.g., 2026-Mar-31 or 2026-03-31). '
     'When provided, the date is included in the shipment MR title.',
 )
-@click.option(
-    '--release-notes-synopsis',
-    default=None,
-    help='Optional synopsis text for release notes (short advisory summary).',
-)
-@click.option(
-    '--release-notes-topic',
-    default=None,
-    help='Optional topic text for release notes (expanded description).',
-)
-@click.option(
-    '--release-notes-description',
-    default=None,
-    help='Optional description text for release notes (full detailed description).',
-)
-@click.option(
-    '--release-notes-solution',
-    default=None,
-    help='Optional solution text for release notes (how to apply the fix/update).',
-)
 @pass_runtime
 @click_coroutine
 async def release_from_fbc(
@@ -1083,10 +1116,6 @@ async def release_from_fbc(
     shipment_path: Optional[str],
     jira_bugs: Optional[str],
     target_release_date: Optional[str],
-    release_notes_synopsis: Optional[str],
-    release_notes_topic: Optional[str],
-    release_notes_description: Optional[str],
-    release_notes_solution: Optional[str],
 ):
     """
     Create shipment files from an FBC image for non-OpenShift products.
@@ -1159,10 +1188,6 @@ async def release_from_fbc(
         jira_bugs=jira_bugs_list,
         target_release_date=normalized_date,
         extra_image_nvrs=extra_image_nvrs_list,
-        release_notes_synopsis=release_notes_synopsis,
-        release_notes_topic=release_notes_topic,
-        release_notes_description=release_notes_description,
-        release_notes_solution=release_notes_solution,
     )
 
     await pipeline.run()

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -6,6 +6,8 @@ import click
 from elliottlib.shipment_model import (
     ComponentSource,
     GitSource,
+    Issue,
+    Issues,
     ReleaseNotes,
     Snapshot,
     SnapshotComponent,
@@ -716,50 +718,11 @@ class TestCliValidation(unittest.TestCase):
         result = self._invoke(["--extra-image-nvrs", "foo-container-1.0-1.el9"])
         self.assertNotIsInstance(result.exception, click.ClickException)
 
-    @patch("pyartcd.pipelines.release_from_fbc.ReleaseFromFbcPipeline")
-    def test_release_notes_options_passed_to_pipeline(self, mock_pipeline_cls):
-        """Release notes CLI options should be passed through to the pipeline."""
-        mock_pipeline_cls.return_value.run = AsyncMock()
-        result = self._invoke(
-            [
-                "--fbc-pullspecs",
-                "quay.io/example/fbc:v1",
-                "--release-notes-synopsis",
-                "Bug fix update",
-                "--release-notes-topic",
-                "An update is available",
-                "--release-notes-description",
-                "Fixes several bugs",
-                "--release-notes-solution",
-                "Apply the update",
-            ]
-        )
-        self.assertIsNone(result.exception)
 
-        call_kwargs = mock_pipeline_cls.call_args[1]
-        self.assertEqual(call_kwargs["release_notes_synopsis"], "Bug fix update")
-        self.assertEqual(call_kwargs["release_notes_topic"], "An update is available")
-        self.assertEqual(call_kwargs["release_notes_description"], "Fixes several bugs")
-        self.assertEqual(call_kwargs["release_notes_solution"], "Apply the update")
+class TestGetFileFromBranch(unittest.TestCase):
+    """Tests for get_file_from_branch helper method."""
 
-    @patch("pyartcd.pipelines.release_from_fbc.ReleaseFromFbcPipeline")
-    def test_release_notes_options_default_none(self, mock_pipeline_cls):
-        """Release notes CLI options should default to None when not provided."""
-        mock_pipeline_cls.return_value.run = AsyncMock()
-        result = self._invoke(["--fbc-pullspecs", "quay.io/example/fbc:v1"])
-        self.assertIsNone(result.exception)
-
-        call_kwargs = mock_pipeline_cls.call_args[1]
-        self.assertIsNone(call_kwargs["release_notes_synopsis"])
-        self.assertIsNone(call_kwargs["release_notes_topic"])
-        self.assertIsNone(call_kwargs["release_notes_description"])
-        self.assertIsNone(call_kwargs["release_notes_solution"])
-
-
-class TestApplyReleaseNotesText(unittest.TestCase):
-    """Tests for _apply_release_notes_text merge logic."""
-
-    def _make_pipeline(self, synopsis=None, topic=None, description=None, solution=None):
+    def _make_pipeline(self):
         runtime = MagicMock()
         runtime.dry_run = False
         runtime.working_dir = MagicMock()
@@ -771,114 +734,246 @@ class TestApplyReleaseNotesText(unittest.TestCase):
             group="logging-6.5",
             assembly="6.5.0",
             fbc_pullspecs=["quay.io/test/fbc:latest"],
-            release_notes_synopsis=synopsis,
-            release_notes_topic=topic,
-            release_notes_description=description,
-            release_notes_solution=solution,
         )
         pipeline.product = "logging"
         return pipeline
 
-    def test_overlay_on_existing_release_notes(self):
-        """User-provided text fields are overlaid onto ReleaseNotes from bug processing."""
-        pipeline = self._make_pipeline(
-            synopsis="Logging 6.5.0 bug fix update",
-            topic="An update is available for Logging 6.5.",
+    @patch("pyartcd.pipelines.release_from_fbc.get_github_client_for_org")
+    def test_successful_fetch(self, mock_get_client):
+        """get_file_from_branch should fetch file content from GitHub."""
+        pipeline = self._make_pipeline()
+
+        mock_github = MagicMock()
+        mock_get_client.return_value = mock_github
+
+        mock_repo = MagicMock()
+        mock_github.get_repo.return_value = mock_repo
+
+        mock_file = MagicMock()
+        mock_file.decoded_content = b"file content here"
+        mock_repo.get_contents.return_value = mock_file
+
+        result = pipeline.get_file_from_branch("openshift-4.20", "releases.yml")
+
+        self.assertEqual(result, b"file content here")
+        mock_get_client.assert_called_once_with("openshift-eng")
+        mock_github.get_repo.assert_called_once_with("openshift-eng/ocp-build-data")
+        mock_repo.get_contents.assert_called_once_with("releases.yml", ref="openshift-4.20")
+
+    @patch("pyartcd.pipelines.release_from_fbc.get_github_client_for_org")
+    def test_github_exception_raises_value_error(self, mock_get_client):
+        """get_file_from_branch should raise ValueError on GithubException."""
+        from github import GithubException
+
+        pipeline = self._make_pipeline()
+
+        mock_github = MagicMock()
+        mock_get_client.return_value = mock_github
+
+        mock_repo = MagicMock()
+        mock_github.get_repo.return_value = mock_repo
+
+        mock_repo.get_contents.side_effect = GithubException(404, "Not Found", {})
+
+        with self.assertRaises(ValueError) as ctx:
+            pipeline.get_file_from_branch("openshift-4.20", "releases.yml")
+
+        self.assertIn("Failed to fetch", str(ctx.exception))
+        self.assertIn("releases.yml", str(ctx.exception))
+
+
+class TestLoadReleaseNotesTemplate(unittest.TestCase):
+    """Tests for _load_release_notes_template method."""
+
+    def _make_pipeline(self, group="logging-6.5", assembly="6.5.0"):
+        runtime = MagicMock()
+        runtime.dry_run = False
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        runtime.config = {}
+
+        pipeline = ReleaseFromFbcPipeline(
+            runtime=runtime,
+            group=group,
+            assembly=assembly,
+            fbc_pullspecs=["quay.io/test/fbc:latest"],
         )
-        existing_rn = ReleaseNotes(type="RHSA")
+        pipeline.product = "openshift-logging"
+        return pipeline
 
-        result = pipeline._apply_release_notes_text(existing_rn)
+    @patch("pyartcd.pipelines.release_from_fbc.get_advisory_boilerplate")
+    @patch.object(ReleaseFromFbcPipeline, "get_file_from_branch")
+    def test_template_found_with_placeholder_substitution(self, mock_get_file, mock_get_boilerplate):
+        """Template is found via get_advisory_boilerplate and all placeholders are substituted."""
+        mock_get_boilerplate.return_value = {
+            "synopsis": "Logging {PRODUCT_MAJOR}.{PRODUCT_MINOR}.{PRODUCT_PATCH}",
+            "topic": "Logging {PRODUCT_MAJOR}.{PRODUCT_MINOR}.{PRODUCT_PATCH}",
+            "description": "Logging {PRODUCT_MAJOR}.{PRODUCT_MINOR}.{PRODUCT_PATCH} update",
+            "solution": "For OCP {OCP_RELEASE_NOTES_VERSION} see ocp-{OCP_RELEASE_NOTES_VERSION_DASHED}-release-notes",
+        }
+        mock_get_file.return_value = b"""
+OCP_RELEASE_NOTES_VERSION: "4.21"
+"""
 
-        self.assertIs(result, existing_rn)
-        self.assertEqual(result.type, "RHSA")
-        self.assertEqual(result.synopsis, "Logging 6.5.0 bug fix update")
-        self.assertEqual(result.topic, "An update is available for Logging 6.5.")
-        self.assertIsNone(result.description)
-        self.assertIsNone(result.solution)
-
-    def test_text_only_creates_rhba(self):
-        """When no existing ReleaseNotes, a new RHBA is created with text fields."""
-        pipeline = self._make_pipeline(
-            synopsis="Logging 6.5.0 bug fix update",
-            description="This update fixes several bugs.",
-            solution="Apply the update using the operator.",
-        )
-
-        result = pipeline._apply_release_notes_text(None)
+        pipeline = self._make_pipeline()
+        result = pipeline._load_release_notes_template()
 
         self.assertIsNotNone(result)
-        self.assertEqual(result.type, "RHBA")
-        self.assertEqual(result.synopsis, "Logging 6.5.0 bug fix update")
-        self.assertIsNone(result.topic)
-        self.assertEqual(result.description, "This update fixes several bugs.")
-        self.assertEqual(result.solution, "Apply the update using the operator.")
+        self.assertEqual(result["synopsis"], "Logging 6.5.0")
+        self.assertEqual(result["topic"], "Logging 6.5.0")
+        self.assertEqual(result["description"], "Logging 6.5.0 update")
+        self.assertEqual(result["solution"], "For OCP 4.21 see ocp-4-21-release-notes")
 
-    def test_neither_bugs_nor_text_returns_none(self):
-        """When no text fields and no existing ReleaseNotes, returns None."""
+        mock_get_boilerplate.assert_called_once_with(
+            runtime=pipeline,
+            et_data={},
+            art_advisory_key="openshift-logging",
+            errata_type="RHBA",
+        )
+        mock_get_file.assert_called_once_with("logging-6.5", "group.yml")
+
+    @patch("pyartcd.pipelines.release_from_fbc.get_advisory_boilerplate")
+    def test_template_not_found_returns_none(self, mock_get_boilerplate):
+        """When get_advisory_boilerplate raises ValueError, return None."""
+        mock_get_boilerplate.side_effect = ValueError("Boilerplate mta not found")
+
         pipeline = self._make_pipeline()
-
-        result = pipeline._apply_release_notes_text(None)
+        pipeline.product = "mta"
+        result = pipeline._load_release_notes_template()
 
         self.assertIsNone(result)
 
-    def test_partial_text_only_sets_provided_fields(self):
-        """Only provided text fields are set; others remain None."""
-        pipeline = self._make_pipeline(solution="Apply the update.")
-        existing_rn = ReleaseNotes(type="RHBA")
+    @patch("pyartcd.pipelines.release_from_fbc.get_advisory_boilerplate")
+    def test_github_api_failure_returns_none(self, mock_get_boilerplate):
+        """When get_advisory_boilerplate raises an unexpected error, return None."""
+        mock_get_boilerplate.side_effect = Exception("GitHub API failure")
 
-        result = pipeline._apply_release_notes_text(existing_rn)
+        pipeline = self._make_pipeline()
+        result = pipeline._load_release_notes_template()
 
-        self.assertIsNone(result.synopsis)
-        self.assertIsNone(result.topic)
-        self.assertIsNone(result.description)
-        self.assertEqual(result.solution, "Apply the update.")
+        self.assertIsNone(result)
 
-    def test_all_four_fields(self):
-        """All four text fields are set when all are provided."""
-        pipeline = self._make_pipeline(
-            synopsis="Synopsis text",
-            topic="Topic text",
-            description="Description text",
-            solution="Solution text",
+    @patch("pyartcd.pipelines.release_from_fbc.get_advisory_boilerplate")
+    @patch.object(ReleaseFromFbcPipeline, "get_file_from_branch")
+    def test_missing_ocp_release_notes_version_returns_none(self, mock_get_file, mock_get_boilerplate):
+        """When group.yml has no OCP_RELEASE_NOTES_VERSION, return None."""
+        mock_get_boilerplate.return_value = {
+            "synopsis": "Synopsis",
+            "topic": "Topic",
+            "description": "Description",
+            "solution": "Solution",
+        }
+        mock_get_file.return_value = b"""
+product: logging
+"""
+
+        pipeline = self._make_pipeline()
+        result = pipeline._load_release_notes_template()
+
+        self.assertIsNone(result)
+
+    @patch("pyartcd.pipelines.release_from_fbc.get_advisory_boilerplate")
+    @patch.object(ReleaseFromFbcPipeline, "get_file_from_branch")
+    def test_assembly_version_parsing_two_components(self, mock_get_file, mock_get_boilerplate):
+        """Assembly with only major.minor (no PRODUCT_PATCH) uses empty string for PRODUCT_PATCH."""
+        mock_get_boilerplate.return_value = {
+            "synopsis": "Version {PRODUCT_MAJOR}.{PRODUCT_MINOR}.{PRODUCT_PATCH}",
+            "topic": "Topic",
+            "description": "Description",
+            "solution": "Solution",
+        }
+        mock_get_file.return_value = b"""
+OCP_RELEASE_NOTES_VERSION: "4.21"
+"""
+
+        pipeline = self._make_pipeline(assembly="6.5")
+        result = pipeline._load_release_notes_template()
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["synopsis"], "Version 6.5.")
+
+
+class TestRunWithTemplate(unittest.TestCase):
+    def _make_pipeline(self, group="logging-6.5", assembly="6.5.0", jira_bugs=None):
+        runtime = MagicMock()
+        runtime.dry_run = False
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        runtime.config = {}
+        pipeline = ReleaseFromFbcPipeline(
+            runtime=runtime,
+            group=group,
+            assembly=assembly,
+            fbc_pullspecs=["quay.io/test/fbc:latest"],
+            jira_bugs=jira_bugs,
+        )
+        pipeline.product = "openshift-logging"
+        return pipeline
+
+    @patch.object(ReleaseFromFbcPipeline, "_load_release_notes_template")
+    def test_template_applied_when_no_jira_bugs(self, mock_load_template):
+        pipeline = self._make_pipeline()
+        mock_load_template.return_value = {
+            "synopsis": "Logging 6.5.0",
+            "topic": "Logging 6.5.0 topic",
+            "description": "Logging 6.5.0 description",
+            "solution": "Logging 6.5.0 solution",
+        }
+
+        release_notes = None
+        template = pipeline._load_release_notes_template()
+        if template:
+            if release_notes is None:
+                release_notes = ReleaseNotes(type="RHBA")
+            release_notes.synopsis = template["synopsis"]
+            release_notes.topic = template["topic"]
+            release_notes.description = template["description"]
+            release_notes.solution = template["solution"]
+
+        self.assertIsNotNone(release_notes)
+        self.assertEqual(release_notes.type, "RHBA")
+        self.assertEqual(release_notes.synopsis, "Logging 6.5.0")
+        self.assertEqual(release_notes.topic, "Logging 6.5.0 topic")
+
+    @patch.object(ReleaseFromFbcPipeline, "_load_release_notes_template")
+    def test_template_preserves_jira_fields(self, mock_load_template):
+        pipeline = self._make_pipeline(jira_bugs=["LOG-1234"])
+        mock_load_template.return_value = {
+            "synopsis": "Logging 6.5.0",
+            "topic": "Logging 6.5.0 topic",
+            "description": "Logging 6.5.0 description",
+            "solution": "Logging 6.5.0 solution",
+        }
+
+        release_notes = ReleaseNotes(
+            type="RHSA",
+            issues=Issues(fixed=[Issue(id="LOG-1234", source="redhat.atlassian.net")]),
         )
 
-        result = pipeline._apply_release_notes_text(None)
+        template = pipeline._load_release_notes_template()
+        if template:
+            release_notes.synopsis = template["synopsis"]
+            release_notes.topic = template["topic"]
+            release_notes.description = template["description"]
+            release_notes.solution = template["solution"]
 
-        self.assertEqual(result.type, "RHBA")
-        self.assertEqual(result.synopsis, "Synopsis text")
-        self.assertEqual(result.topic, "Topic text")
-        self.assertEqual(result.description, "Description text")
-        self.assertEqual(result.solution, "Solution text")
+        self.assertEqual(release_notes.type, "RHSA")
+        self.assertEqual(release_notes.synopsis, "Logging 6.5.0")
+        self.assertEqual(len(release_notes.issues.fixed), 1)
+        self.assertEqual(release_notes.issues.fixed[0].id, "LOG-1234")
 
-    def test_no_text_with_existing_rn_returns_unchanged(self):
-        """When no text fields are provided but ReleaseNotes exists, it passes through unchanged."""
+    @patch.object(ReleaseFromFbcPipeline, "_load_release_notes_template")
+    def test_no_template_no_bugs_returns_none(self, mock_load_template):
         pipeline = self._make_pipeline()
-        existing_rn = ReleaseNotes(type="RHSA")
+        mock_load_template.return_value = None
 
-        result = pipeline._apply_release_notes_text(existing_rn)
+        release_notes = None
+        template = pipeline._load_release_notes_template()
+        if template:
+            if release_notes is None:
+                release_notes = ReleaseNotes(type="RHBA")
 
-        self.assertIs(result, existing_rn)
-        self.assertIsNone(result.synopsis)
-
-    def test_empty_and_whitespace_strings_ignored(self):
-        """Empty and whitespace-only strings are treated as not provided."""
-        pipeline = self._make_pipeline(synopsis="", topic="   ", description=None, solution="Real value")
-        existing_rn = ReleaseNotes(type="RHBA")
-
-        result = pipeline._apply_release_notes_text(existing_rn)
-
-        self.assertIsNone(result.synopsis)
-        self.assertIsNone(result.topic)
-        self.assertIsNone(result.description)
-        self.assertEqual(result.solution, "Real value")
-
-    def test_all_empty_strings_returns_unchanged(self):
-        """When all text fields are empty strings, release_notes passes through unchanged."""
-        pipeline = self._make_pipeline(synopsis="", topic="", description="", solution="")
-
-        result = pipeline._apply_release_notes_text(None)
-
-        self.assertIsNone(result)
+        self.assertIsNone(release_notes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary                                                                                                                                                                             
  - Replace the four CLI `--release-notes-*` options (added in #2832) with template loading from ocp-build-data's `advisory_templates.yml`
  - Use `get_advisory_boilerplate()` to look up product-keyed templates (e.g., `openshift-logging`), matching the existing pattern used by `build_microshift.py`
  - Substitute placeholders at runtime: `{PRODUCT_MAJOR}`, `{PRODUCT_MINOR}`, `{PRODUCT_PATCH}` from the assembly version, and `{OCP_RELEASE_NOTES_VERSION}`, `{OCP_RELEASE_NOTES_VERSION_DASHED}` from the group's `group.yml`                                                                                                                      
  - Products without a template (MTA, MTC, OADP) continue to work as before — no release notes text is generated
  - JIRA-derived fields (issues, cves, type) are preserved; the template only fills text fields (synopsis, topic, description, solution)

  ## Related PRs (in rollout order)
  1. **ocp-build-data** 
        - add `openshift-logging` boilerplate to `config/advisory_templates.yml` on main -> https://github.com/openshift-eng/ocp-build-data/pull/10310
        - add `OCP_RELEASE_NOTES_VERSION` to logging group.yml branches
           - https://github.com/openshift-eng/ocp-build-data/pull/10311
           - https://github.com/openshift-eng/ocp-build-data/pull/10312
           - https://github.com/openshift-eng/ocp-build-data/pull/10313
           - https://github.com/openshift-eng/ocp-build-data/pull/10314
           - https://github.com/openshift-eng/ocp-build-data/pull/10315
           - https://github.com/openshift-eng/ocp-build-data/pull/10316
  2. **art-tools** — This PR
  3. **aos-cd-jobs** — Remove the four release notes text Jenkins parameters -> https://github.com/openshift-eng/aos-cd-jobs/pull/4679
  4. **art-ai-helpers** — Simplify `art-release:layered-operators` skill -> https://gitlab.cee.redhat.com/hybrid-platforms/art/art-ai-helpers/-/merge_requests/30
  5. **[template] Operator release request** — Remove 'Release Notes' section from layered-product Jira template -> https://redhat.atlassian.net/browse/ART-14539
            
  Ref: [ART-18150](https://redhat.atlassian.net/browse/ART-18150)              