### PR TITLE
Skip EC verification for seed-lockfile open builds

### DIFF
--- a/pyartcd/pyartcd/pipelines/seed_lockfile.py
+++ b/pyartcd/pyartcd/pipelines/seed_lockfile.py
@@ -155,6 +155,7 @@ class SeedLockfilePipeline:
                 '--konflux-namespace=ocp-art-tenant',
                 '--network-mode',
                 'open',
+                '--skip-ec-verify',
             ]
         )
         if self.kubeconfig:


### PR DESCRIPTION
## Summary
- Skip EC verification for the phase 1 (open network) build in seed-lockfile pipeline
- Open builds will fail EC verification because in pre-signing releases, the hermetic exception has expired
- The phase 2 hermetic build still runs EC verification as before

## Test plan
- [ ] Run seed-lockfile pipeline and verify phase 1 open build no longer fails on EC verification
- [ ] Verify phase 2 hermetic build still runs EC verification

[Test build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fseed-lockfile/353/)