### PR TITLE
WIP: Add network-mode and suppress-external-effects to build-microshift-bootc

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -77,6 +77,8 @@ class BuildMicroShiftBootcPipeline:
         data_path: str,
         slack_client,
         data_gitref: str | None = None,
+        network_mode: Optional[str] = None,
+        suppress_external_effects: bool = False,
         logger: Optional[logging.Logger] = None,
     ):
         self.runtime = runtime
@@ -88,6 +90,8 @@ class BuildMicroShiftBootcPipeline:
         self.force_plashet_sync = force_plashet_sync
         self.prepare_shipment = prepare_shipment
         self.slack_client = slack_client
+        self.network_mode = network_mode
+        self.suppress_external_effects = suppress_external_effects
         self._logger = logger or runtime.logger
 
         self._working_dir = self.runtime.working_dir.absolute()
@@ -187,6 +191,14 @@ class BuildMicroShiftBootcPipeline:
             await self._run_pipeline()
 
     async def _run_pipeline(self):
+        if self.network_mode == 'open' and not self.suppress_external_effects:
+            raise ValueError(
+                "Open builds require --suppress-external-effects to prevent "
+                "publishing non-hermetic builds to production."
+            )
+        if self.suppress_external_effects and self.prepare_shipment:
+            raise ValueError("--prepare-shipment and --suppress-external-effects are mutually exclusive.")
+
         data_path = self._doozer_env_vars["DOOZER_DATA_PATH"]
         self.releases_config = await load_releases_config(group=self.doozer_group, data_path=data_path)
         self.assembly_type = get_assembly_type(self.releases_config, self.assembly)
@@ -219,7 +231,7 @@ class BuildMicroShiftBootcPipeline:
         digest_by_arch = {m["platform"]["architecture"]: m["digest"] for m in manifest_list["manifests"]}
         self._logger.info("Bootc image digests by arch: %s", json.dumps(digest_by_arch, indent=4))
 
-        if not self.runtime.dry_run:
+        if not self.runtime.dry_run and not self.suppress_external_effects:
             major, _ = self._ocp_version
             if bootc_build.embargoed:
                 art_repo = get_art_prod_image_repo_for_version(major, "dev-priv")
@@ -239,10 +251,11 @@ class BuildMicroShiftBootcPipeline:
         else:
             major, _ = self._ocp_version
             art_repo = get_art_prod_image_repo_for_version(major, "dev")
-            self._logger.warning(f"Skipping sync to {art_repo} since in dry-run mode")
+            reason = 'suppress-external-effects' if self.suppress_external_effects else 'dry-run'
+            self._logger.warning(f"Skipping sync to {art_repo} ({reason})")
 
         # Pin the image to the assembly if not STREAM
-        if self.assembly_type != AssemblyTypes.STREAM:
+        if self.assembly_type != AssemblyTypes.STREAM and not self.suppress_external_effects:
             # Check if we need to create a PR to pin the build
             pinned_nvr = get_image_if_pinned_directly(self.releases_config, self.assembly, 'microshift-bootc')
             if bootc_build.nvr != pinned_nvr:
@@ -489,7 +502,8 @@ class BuildMicroShiftBootcPipeline:
             if pinned_nvr:
                 message = f"For assembly {self.assembly} microshift-bootc image is already pinned: {pinned_nvr}. Use FORCE to rebuild."
                 self._logger.info(message)
-                await self.slack_client.say_in_thread(message)
+                if not self.suppress_external_effects:
+                    await self.slack_client.say_in_thread(message)
 
                 # Fetch the actual build record from Konflux DB using the pinned NVR
                 if not self.konflux_db:
@@ -559,6 +573,8 @@ class BuildMicroShiftBootcPipeline:
         ]
         if assembly_label_value:
             rebase_cmd += ["--extra-label", f"assembly={assembly_label_value}"]
+        if self.network_mode:
+            rebase_cmd += ["--network-mode", self.network_mode]
         rebase_cmd += [
             "--message",
             f"Updating Dockerfile version and release {version}-{release}",
@@ -596,6 +612,8 @@ class BuildMicroShiftBootcPipeline:
                 "ocp-art-tenant",
             ]
         )
+        if self.network_mode:
+            build_cmd.extend(["--network-mode", self.network_mode])
         if self.runtime.dry_run:
             build_cmd.append("--dry-run")
         await exectools.cmd_assert_async(build_cmd, env=self._doozer_env_vars)
@@ -1214,6 +1232,17 @@ class BuildMicroShiftBootcPipeline:
     default="",
     help="Doozer data path git [branch / tag / sha] to use",
 )
+@click.option(
+    "--network-mode",
+    type=click.Choice(['hermetic', 'open']),
+    default=None,
+    help="Override network mode for Konflux builds.",
+)
+@click.option(
+    "--suppress-external-effects",
+    is_flag=True,
+    help="Skip Quay sync, mirror sync, PR creation, shipment MR, and Slack notifications.",
+)
 @pass_runtime
 @click_coroutine
 async def build_microshift_bootc(
@@ -1225,6 +1254,8 @@ async def build_microshift_bootc(
     force_plashet_sync: bool,
     prepare_shipment: bool,
     data_gitref: str | None = None,
+    network_mode: str | None = None,
+    suppress_external_effects: bool = False,
 ):
     # slack client is dry-run aware and will not send messages if dry-run is enabled
     slack_client = runtime.new_slack_client()
@@ -1240,11 +1271,14 @@ async def build_microshift_bootc(
             data_path=data_path,
             slack_client=slack_client,
             data_gitref=data_gitref,
+            network_mode=network_mode,
+            suppress_external_effects=suppress_external_effects,
         )
         await pipeline.run()
     except Exception as err:
         slack_message = f"build-microshift-bootc pipeline encountered error: {err}"
         error_message = slack_message + f"\n {traceback.format_exc()}"
         runtime.logger.error(error_message)
-        await slack_client.say_in_thread(slack_message)
+        if not suppress_external_effects:
+            await slack_client.say_in_thread(slack_message)
         raise

--- a/pyartcd/tests/pipelines/test_build_microshift_bootc.py
+++ b/pyartcd/tests/pipelines/test_build_microshift_bootc.py
@@ -325,7 +325,14 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
             await pipeline._get_microshift_rpm_commit()
         self.assertIn("commit", str(ctx.exception).lower())
 
-    def _make_pipeline(self, group="openshift-4.21", assembly="4.21.0"):
+    def _make_pipeline(
+        self,
+        group="openshift-4.21",
+        assembly="4.21.0",
+        network_mode=None,
+        suppress_external_effects=False,
+        prepare_shipment=False,
+    ):
         """Helper to create a pipeline instance with the given group and assembly."""
         return BuildMicroShiftBootcPipeline(
             runtime=self.runtime,
@@ -333,9 +340,11 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
             assembly=assembly,
             force=False,
             force_plashet_sync=False,
-            prepare_shipment=False,
+            prepare_shipment=prepare_shipment,
             data_path="https://github.com/openshift-eng/ocp-build-data",
             slack_client=self.mock_slack_client,
+            network_mode=network_mode,
+            suppress_external_effects=suppress_external_effects,
         )
 
     def test_get_assembly_label_value_standard(self):
@@ -458,6 +467,158 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
             self.assertEqual(build_cmd[lock_idx + 2], "0d0943b")
         finally:
             os.environ.pop("KONFLUX_SA_KUBECONFIG", None)
+
+    async def test_open_network_mode_without_suppress_raises(self):
+        """Open builds must use --suppress-external-effects."""
+        pipeline = self._make_pipeline(network_mode="open", suppress_external_effects=False)
+        with self.assertRaises(ValueError) as ctx:
+            await pipeline._run_pipeline()
+        self.assertIn("suppress-external-effects", str(ctx.exception))
+
+    async def test_suppress_with_prepare_shipment_raises(self):
+        """--prepare-shipment and --suppress-external-effects are mutually exclusive."""
+        pipeline = self._make_pipeline(prepare_shipment=True, suppress_external_effects=True)
+        with self.assertRaises(ValueError) as ctx:
+            await pipeline._run_pipeline()
+        self.assertIn("mutually exclusive", str(ctx.exception))
+
+    @patch("pyartcd.pipelines.build_microshift_bootc.exectools.cmd_assert_async", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "get_latest_bootc_build", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "_get_microshift_rpm_commit", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "_build_plashet_for_bootc", new_callable=AsyncMock)
+    async def test_network_mode_passed_to_rebase_and_build(
+        self, mock_plashet, mock_get_commit, mock_get_build, mock_cmd
+    ):
+        """--network-mode should appear in both rebase and build doozer commands."""
+        mock_get_commit.return_value = "abc1234"
+        mock_get_build.return_value = Mock(nvr="microshift-bootc-4.21.0-1.el9")
+        pipeline = self._make_pipeline(network_mode="open", suppress_external_effects=True)
+        pipeline.assembly_type = AssemblyTypes.STANDARD
+        pipeline.force = True
+        os.environ["KONFLUX_SA_KUBECONFIG"] = "/fake/kubeconfig"
+
+        try:
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                await pipeline._rebase_and_build_bootc()
+
+            rebase_cmd = mock_cmd.call_args_list[0][0][0]
+            self.assertIn("--network-mode", rebase_cmd)
+            self.assertEqual(rebase_cmd[rebase_cmd.index("--network-mode") + 1], "open")
+
+            build_cmd = mock_cmd.call_args_list[1][0][0]
+            self.assertIn("--network-mode", build_cmd)
+            self.assertEqual(build_cmd[build_cmd.index("--network-mode") + 1], "open")
+        finally:
+            os.environ.pop("KONFLUX_SA_KUBECONFIG", None)
+
+    @patch("pyartcd.pipelines.build_microshift_bootc.exectools.cmd_assert_async", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "get_latest_bootc_build", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "_get_microshift_rpm_commit", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "_build_plashet_for_bootc", new_callable=AsyncMock)
+    async def test_network_mode_omitted_when_not_set(self, mock_plashet, mock_get_commit, mock_get_build, mock_cmd):
+        """--network-mode should NOT appear in commands when not set."""
+        mock_get_commit.return_value = "abc1234"
+        mock_get_build.return_value = Mock(nvr="microshift-bootc-4.21.0-1.el9")
+        pipeline = self._make_pipeline()
+        pipeline.assembly_type = AssemblyTypes.STANDARD
+        pipeline.force = True
+        os.environ["KONFLUX_SA_KUBECONFIG"] = "/fake/kubeconfig"
+
+        try:
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                await pipeline._rebase_and_build_bootc()
+
+            rebase_cmd = mock_cmd.call_args_list[0][0][0]
+            self.assertNotIn("--network-mode", rebase_cmd)
+
+            build_cmd = mock_cmd.call_args_list[1][0][0]
+            self.assertNotIn("--network-mode", build_cmd)
+        finally:
+            os.environ.pop("KONFLUX_SA_KUBECONFIG", None)
+
+    @patch("pyartcd.pipelines.build_microshift_bootc.sync_to_quay", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "_create_or_update_pull_request_for_image", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "sync_to_mirror", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.build_microshift_bootc.exectools.cmd_gather_async", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "_rebase_and_build_bootc", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.build_microshift_bootc.load_releases_config", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.build_microshift_bootc.load_group_config", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.build_microshift_bootc.get_assembly_type")
+    async def test_suppress_skips_quay_sync_and_pr(
+        self,
+        mock_get_type,
+        mock_load_group,
+        mock_load_releases,
+        mock_rebase,
+        mock_gather,
+        mock_mirror,
+        mock_pr,
+        mock_quay_sync,
+    ):
+        """With suppress_external_effects, quay sync, mirror sync, PR creation, and slack should be skipped."""
+        mock_load_releases.return_value = {"releases": {"4.21.0": {"assembly": {"group": {}}}}}
+        mock_load_group.return_value = {}
+        mock_get_type.return_value = AssemblyTypes.STANDARD
+
+        mock_build = Mock(
+            nvr="microshift-bootc-4.21.0-1.el9",
+            image_pullspec="quay.io/test/microshift-bootc@sha256:abc",
+            embargoed=False,
+            el_target="el9",
+        )
+        mock_rebase.return_value = mock_build
+        mock_gather.return_value = (
+            0,
+            '{"manifests":[{"platform":{"architecture":"amd64"},"digest":"sha256:abc"}]}',
+            "",
+        )
+
+        pipeline = self._make_pipeline(suppress_external_effects=True)
+        await pipeline._run_pipeline()
+
+        mock_quay_sync.assert_not_called()
+        mock_mirror.assert_not_called()
+        mock_pr.assert_not_called()
+        self.mock_slack_client.say_in_thread.assert_not_called()
+
+    @patch("pyartcd.pipelines.build_microshift_bootc.exectools.cmd_assert_async", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "get_latest_bootc_build", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "_get_microshift_rpm_commit", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "_build_plashet_for_bootc", new_callable=AsyncMock)
+    async def test_suppress_skips_slack_for_pinned_build(self, mock_plashet, mock_get_commit, mock_get_build, mock_cmd):
+        """With suppress_external_effects, the 'already pinned' Slack message should be skipped."""
+        pipeline = self._make_pipeline(suppress_external_effects=True)
+        pipeline.assembly_type = AssemblyTypes.STANDARD
+        pipeline.force = False
+        pipeline.releases_config = {
+            "releases": {
+                "4.21.0": {
+                    "assembly": {
+                        "members": {
+                            "images": [
+                                {
+                                    "distgit_key": "microshift-bootc",
+                                    "metadata": {"is": {"nvr": "microshift-bootc-4.21.0-1.el9"}},
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+
+        mock_build = Mock(nvr="microshift-bootc-4.21.0-1.el9")
+        pipeline.konflux_db = Mock()
+        pipeline.konflux_db.get_build_record_by_nvr = AsyncMock(return_value=mock_build)
+
+        with patch(
+            "pyartcd.pipelines.build_microshift_bootc.get_image_if_pinned_directly",
+            return_value="microshift-bootc-4.21.0-1.el9",
+        ):
+            result = await pipeline._rebase_and_build_bootc()
+
+        self.assertEqual(result, mock_build)
+        self.mock_slack_client.say_in_thread.assert_not_called()
 
     def test_validate_shipment_mr_raises_on_closed_mr(self):
         """


### PR DESCRIPTION
## Summary
- Add `--network-mode` param to override Konflux build network mode (hermetic/open)
- Add `--suppress-external-effects` flag to skip Quay sync, mirror sync, PR creation, shipment MR, and Slack notifications
- Safety guard: open builds fail without `--suppress-external-effects` to prevent publishing non-hermetic builds to production

These params enable running open builds to seed lockfiles without any production side effects.

## Test plan
- [ ] Verify CLI flags appear in `artcd build-microshift-bootc --help`
- [ ] Test with `--network-mode=open --suppress-external-effects` on a test assembly
- [ ] Verify safety guard rejects `--network-mode=open` without `--suppress-external-effects`
- [ ] Verify normal builds (without new flags) are unaffected

Corresponding Jenkinsfile changes: https://github.com/openshift-eng/aos-cd-jobs/pull/4680