### PR TITLE
ART-18307: build-microshift-bootc: two-phase build (open then hermetic)

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -66,6 +66,8 @@ yaml = new_roundtrip_yaml_handler()
 class BuildMicroShiftBootcPipeline:
     """Rebase and build MicroShift for an assembly"""
 
+    BOOTC_IMAGE_NAME = "microshift-bootc"
+
     def __init__(
         self,
         runtime: Runtime,
@@ -77,6 +79,7 @@ class BuildMicroShiftBootcPipeline:
         data_path: str,
         slack_client,
         data_gitref: str | None = None,
+        force_open_build: bool = False,
         logger: Optional[logging.Logger] = None,
     ):
         self.runtime = runtime
@@ -88,6 +91,7 @@ class BuildMicroShiftBootcPipeline:
         self.force_plashet_sync = force_plashet_sync
         self.prepare_shipment = prepare_shipment
         self.slack_client = slack_client
+        self.force_open_build = force_open_build
         self._logger = logger or runtime.logger
 
         self._working_dir = self.runtime.working_dir.absolute()
@@ -312,16 +316,14 @@ class BuildMicroShiftBootcPipeline:
             await _run_for(local_dir, release_path)
             await _run_for(local_dir, latest_path)
 
-    async def get_latest_bootc_build(self):
-        bootc_image_name = "microshift-bootc"
-
+    async def get_latest_bootc_build(self, hermetic: Optional[bool] = None):
         if not self.konflux_db:
             self.konflux_db = KonfluxDb()
             self.konflux_db.bind(KonfluxBuildRecord)
             self._logger.info('Konflux DB initialized')
 
-        build = await self.konflux_db.get_latest_build(
-            name=bootc_image_name,
+        kwargs: dict = dict(
+            name=self.BOOTC_IMAGE_NAME,
             group=self.group,
             assembly=self.assembly,
             outcome=KonfluxBuildOutcome.SUCCESS,
@@ -330,6 +332,10 @@ class BuildMicroShiftBootcPipeline:
             el_target='el9',
             exclude_large_columns=True,
         )
+        if hermetic is not None:
+            kwargs['extra_patterns'] = {'hermetic': hermetic}
+
+        build = await self.konflux_db.get_latest_build(**kwargs)
         return cast(Optional[KonfluxBuildRecord], build)
 
     async def _build_plashet_for_bootc(self):
@@ -476,7 +482,6 @@ class BuildMicroShiftBootcPipeline:
         raise ValueError(f"Assembly type {self.assembly_type} is not supported for microshift-bootc builds")
 
     async def _rebase_and_build_bootc(self):
-        bootc_image_name = "microshift-bootc"
         major, minor = self._ocp_version
         # do not run for version < 4.18
         if (major, minor) < (4, 18):
@@ -485,7 +490,7 @@ class BuildMicroShiftBootcPipeline:
 
         # Check if an image is already pinned and don't rebuild unless forced
         if not self.force and self.assembly_type != AssemblyTypes.STREAM:
-            pinned_nvr = get_image_if_pinned_directly(self.releases_config, self.assembly, bootc_image_name)
+            pinned_nvr = get_image_if_pinned_directly(self.releases_config, self.assembly, self.BOOTC_IMAGE_NAME)
             if pinned_nvr:
                 message = f"For assembly {self.assembly} microshift-bootc image is already pinned: {pinned_nvr}. Use FORCE to rebuild."
                 self._logger.info(message)
@@ -503,24 +508,24 @@ class BuildMicroShiftBootcPipeline:
                 self._logger.info("Found existing build record for pinned NVR: %s", pinned_nvr)
                 return build
 
-        # check if an image build already exists in Konflux DB
+        # Check for existing hermetic build
         if not self.force:
-            build = await self.get_latest_bootc_build()
+            build = await self.get_latest_bootc_build(hermetic=True)
             if build:
                 self._logger.info(
-                    "Bootc image build exists for assembly: %s. Will use that. To force a rebuild use --force",
+                    "Hermetic bootc build exists for assembly: %s. Will use that. To force a rebuild use --force",
                     build.nvr,
                 )
                 return build
             else:
-                self._logger.info("Bootc image build does not exist for assembly. Will proceed to build")
+                self._logger.info("No hermetic bootc build exists for assembly. Will proceed to build")
         else:
             self._logger.info("Force flag is set. Forcing bootc image build")
 
         kubeconfig = os.environ.get('KONFLUX_SA_KUBECONFIG')
         if not kubeconfig:
             raise ValueError(
-                f"KONFLUX_SA_KUBECONFIG environment variable is required to build {bootc_image_name} image"
+                f"KONFLUX_SA_KUBECONFIG environment variable is required to build {self.BOOTC_IMAGE_NAME} image"
             )
 
         await self._build_plashet_for_bootc()
@@ -531,9 +536,39 @@ class BuildMicroShiftBootcPipeline:
         # Determine the assembly label value based on assembly type
         assembly_label_value = self._get_assembly_label_value()
 
-        # Rebase and build bootc image
+        # Phase 1: Open build to produce a successful build record whose installed_rpms
+        # can be used by Phase 2's lockfile generator
+        open_build = await self.get_latest_bootc_build(hermetic=False)
+        if open_build and not self.force_open_build:
+            self._logger.info("Open build already exists for assembly (%s). Skipping open build phase.", open_build.nvr)
+        else:
+            if self.force_open_build:
+                self._logger.info("Forcing open build phase (--force-open-build)")
+            else:
+                self._logger.info(
+                    "No open build found. Running open build to produce build record for lockfile generation."
+                )
+            await self.slack_client.say_in_thread(
+                "Running open build phase (needed for hermetic lockfile generation)..."
+            )
+            await self._do_rebase_and_build("open", upstream_commit, assembly_label_value)
+            # Wait for the build record to propagate in BigQuery before Phase 2 queries it for lockfile generation
+            await asyncio.sleep(10)
+
+        # Phase 2: Hermetic build using lockfile seeded from Phase 1
+        self._logger.info("Running hermetic build phase...")
+        await self.slack_client.say_in_thread("Running hermetic build phase...")
+        await self._do_rebase_and_build("hermetic", upstream_commit, assembly_label_value)
+        await asyncio.sleep(10)
+
+        return await self.get_latest_bootc_build(hermetic=True)
+
+    async def _do_rebase_and_build(self, network_mode: str, upstream_commit: str, assembly_label_value: Optional[str]):
+        """Run a single rebase+build cycle with the specified network mode."""
+        major, minor = self._ocp_version
         version = f"v{major}.{minor}"
         release = default_release_suffix()
+
         rebase_cmd = [
             "doozer",
             "--group",
@@ -542,12 +577,12 @@ class BuildMicroShiftBootcPipeline:
             self.assembly,
             "--latest-parent-version",
             "-i",
-            bootc_image_name,
+            self.BOOTC_IMAGE_NAME,
             # Lock to the same commit as the microshift RPM to ensure consistency
             # between RPM and bootc artifacts. Without this, doozer would try to
             # use brew to find the commit which fails for Konflux-built images.
             "--lock-upstream",
-            bootc_image_name,
+            self.BOOTC_IMAGE_NAME,
             upstream_commit,
             "--build-system",
             "konflux",
@@ -559,6 +594,7 @@ class BuildMicroShiftBootcPipeline:
         ]
         if assembly_label_value:
             rebase_cmd += ["--extra-label", f"assembly={assembly_label_value}"]
+        rebase_cmd += ["--network-mode", network_mode]
         rebase_cmd += [
             "--message",
             f"Updating Dockerfile version and release {version}-{release}",
@@ -567,6 +603,7 @@ class BuildMicroShiftBootcPipeline:
             rebase_cmd.append("--push")
         await exectools.cmd_assert_async(rebase_cmd, env=self._doozer_env_vars)
 
+        kubeconfig = os.environ['KONFLUX_SA_KUBECONFIG']
         build_cmd = [
             "doozer",
             "--group",
@@ -580,10 +617,10 @@ class BuildMicroShiftBootcPipeline:
         build_cmd.extend(
             [
                 "-i",
-                bootc_image_name,
+                self.BOOTC_IMAGE_NAME,
                 # Lock to the same commit as the microshift RPM to ensure consistency
                 "--lock-upstream",
-                bootc_image_name,
+                self.BOOTC_IMAGE_NAME,
                 upstream_commit,
                 "--build-system",
                 "konflux",
@@ -594,17 +631,13 @@ class BuildMicroShiftBootcPipeline:
                 kubeconfig,
                 "--konflux-namespace",
                 "ocp-art-tenant",
+                "--network-mode",
+                network_mode,
             ]
         )
         if self.runtime.dry_run:
             build_cmd.append("--dry-run")
         await exectools.cmd_assert_async(build_cmd, env=self._doozer_env_vars)
-
-        # sleep a little bit to account for time drift between systems
-        await asyncio.sleep(10)
-
-        # now that build is complete, fetch it
-        return await self.get_latest_bootc_build()
 
     def extract_git_repo(self, data_path: str):
         """
@@ -1214,6 +1247,11 @@ class BuildMicroShiftBootcPipeline:
     default="",
     help="Doozer data path git [branch / tag / sha] to use",
 )
+@click.option(
+    "--force-open-build",
+    is_flag=True,
+    help="Force open build phase even if one already exists for the assembly.",
+)
 @pass_runtime
 @click_coroutine
 async def build_microshift_bootc(
@@ -1225,6 +1263,7 @@ async def build_microshift_bootc(
     force_plashet_sync: bool,
     prepare_shipment: bool,
     data_gitref: str | None = None,
+    force_open_build: bool = False,
 ):
     # slack client is dry-run aware and will not send messages if dry-run is enabled
     slack_client = runtime.new_slack_client()
@@ -1240,6 +1279,7 @@ async def build_microshift_bootc(
             data_path=data_path,
             slack_client=slack_client,
             data_gitref=data_gitref,
+            force_open_build=force_open_build,
         )
         await pipeline.run()
     except Exception as err:

--- a/pyartcd/tests/pipelines/test_build_microshift_bootc.py
+++ b/pyartcd/tests/pipelines/test_build_microshift_bootc.py
@@ -325,7 +325,7 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
             await pipeline._get_microshift_rpm_commit()
         self.assertIn("commit", str(ctx.exception).lower())
 
-    def _make_pipeline(self, group="openshift-4.21", assembly="4.21.0"):
+    def _make_pipeline(self, group="openshift-4.21", assembly="4.21.0", force_open_build=False):
         """Helper to create a pipeline instance with the given group and assembly."""
         return BuildMicroShiftBootcPipeline(
             runtime=self.runtime,
@@ -336,6 +336,7 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
             prepare_shipment=False,
             data_path="https://github.com/openshift-eng/ocp-build-data",
             slack_client=self.mock_slack_client,
+            force_open_build=force_open_build,
         )
 
     def test_get_assembly_label_value_standard(self):
@@ -375,6 +376,18 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
         pipeline.assembly_type = AssemblyTypes.STREAM
         self.assertIsNone(pipeline._get_assembly_label_value())
 
+    def _mock_get_latest_bootc_build(self, open_build=None, hermetic_build=None):
+        """Create a side_effect for get_latest_bootc_build that returns different builds by hermetic filter."""
+
+        async def _side_effect(hermetic=None):
+            if hermetic is True:
+                return hermetic_build
+            if hermetic is False:
+                return open_build
+            return hermetic_build or open_build
+
+        return _side_effect
+
     @patch("pyartcd.pipelines.build_microshift_bootc.exectools.cmd_assert_async", new_callable=AsyncMock)
     @patch.object(BuildMicroShiftBootcPipeline, "get_latest_bootc_build", new_callable=AsyncMock)
     @patch.object(BuildMicroShiftBootcPipeline, "_get_microshift_rpm_commit", new_callable=AsyncMock)
@@ -386,7 +399,8 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
         (OCPBUGS-78040).
         """
         mock_get_commit.return_value = "abc1234"
-        mock_get_build.return_value = Mock(nvr="microshift-bootc-4.21.0-1.el9")
+        hermetic_build = Mock(nvr="microshift-bootc-4.21.7-1.el9")
+        mock_get_build.side_effect = self._mock_get_latest_bootc_build(hermetic_build=hermetic_build)
         pipeline = self._make_pipeline(group="openshift-4.21", assembly="4.21.7")
         pipeline.assembly_type = AssemblyTypes.STANDARD
         pipeline.force = True
@@ -422,7 +436,8 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
         """
         # given
         mock_get_commit.return_value = "0d0943b"
-        mock_get_build.return_value = Mock(nvr="microshift-bootc-4.21.0-1.el9")
+        hermetic_build = Mock(nvr="microshift-bootc-4.21.0-1.el9")
+        mock_get_build.side_effect = self._mock_get_latest_bootc_build(hermetic_build=hermetic_build)
         pipeline = BuildMicroShiftBootcPipeline(
             runtime=self.runtime,
             group=self.group,
@@ -456,6 +471,97 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
             lock_idx = build_cmd.index("--lock-upstream")
             self.assertEqual(build_cmd[lock_idx + 1], "microshift-bootc")
             self.assertEqual(build_cmd[lock_idx + 2], "0d0943b")
+        finally:
+            os.environ.pop("KONFLUX_SA_KUBECONFIG", None)
+
+    @patch("pyartcd.pipelines.build_microshift_bootc.exectools.cmd_assert_async", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "get_latest_bootc_build", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "_get_microshift_rpm_commit", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "_build_plashet_for_bootc", new_callable=AsyncMock)
+    async def test_two_phase_build_passes_network_mode(self, mock_plashet, mock_get_commit, mock_get_build, mock_cmd):
+        """Phase 1 passes --network-mode open, Phase 2 passes --network-mode hermetic."""
+        mock_get_commit.return_value = "abc1234"
+        hermetic_build = Mock(nvr="microshift-bootc-4.21.0-1.el9")
+        mock_get_build.side_effect = self._mock_get_latest_bootc_build(hermetic_build=hermetic_build)
+        pipeline = self._make_pipeline()
+        pipeline.assembly_type = AssemblyTypes.STANDARD
+        pipeline.force = True
+        os.environ["KONFLUX_SA_KUBECONFIG"] = "/fake/kubeconfig"
+
+        try:
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                await pipeline._rebase_and_build_bootc()
+
+            # 4 cmd_assert_async calls: open rebase, open build, hermetic rebase, hermetic build
+            self.assertEqual(len(mock_cmd.call_args_list), 4)
+
+            # Phase 1: open
+            open_rebase = mock_cmd.call_args_list[0][0][0]
+            self.assertEqual(open_rebase[open_rebase.index("--network-mode") + 1], "open")
+            open_build = mock_cmd.call_args_list[1][0][0]
+            self.assertEqual(open_build[open_build.index("--network-mode") + 1], "open")
+
+            # Phase 2: hermetic
+            hermetic_rebase = mock_cmd.call_args_list[2][0][0]
+            self.assertEqual(hermetic_rebase[hermetic_rebase.index("--network-mode") + 1], "hermetic")
+            hermetic_build_cmd = mock_cmd.call_args_list[3][0][0]
+            self.assertEqual(hermetic_build_cmd[hermetic_build_cmd.index("--network-mode") + 1], "hermetic")
+        finally:
+            os.environ.pop("KONFLUX_SA_KUBECONFIG", None)
+
+    @patch("pyartcd.pipelines.build_microshift_bootc.exectools.cmd_assert_async", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "get_latest_bootc_build", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "_get_microshift_rpm_commit", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "_build_plashet_for_bootc", new_callable=AsyncMock)
+    async def test_phase1_skipped_when_open_build_exists(self, mock_plashet, mock_get_commit, mock_get_build, mock_cmd):
+        """Phase 1 is skipped when an open build already exists in BigQuery."""
+        mock_get_commit.return_value = "abc1234"
+        open_build = Mock(nvr="microshift-bootc-4.21.0-open.el9")
+        hermetic_build = Mock(nvr="microshift-bootc-4.21.0-hermetic.el9")
+        mock_get_build.side_effect = self._mock_get_latest_bootc_build(
+            open_build=open_build, hermetic_build=hermetic_build
+        )
+        pipeline = self._make_pipeline()
+        pipeline.assembly_type = AssemblyTypes.STANDARD
+        pipeline.force = True
+        os.environ["KONFLUX_SA_KUBECONFIG"] = "/fake/kubeconfig"
+
+        try:
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                await pipeline._rebase_and_build_bootc()
+
+            # Only 2 calls: hermetic rebase + hermetic build (open phase skipped)
+            self.assertEqual(len(mock_cmd.call_args_list), 2)
+            rebase_cmd = mock_cmd.call_args_list[0][0][0]
+            self.assertEqual(rebase_cmd[rebase_cmd.index("--network-mode") + 1], "hermetic")
+        finally:
+            os.environ.pop("KONFLUX_SA_KUBECONFIG", None)
+
+    @patch("pyartcd.pipelines.build_microshift_bootc.exectools.cmd_assert_async", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "get_latest_bootc_build", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "_get_microshift_rpm_commit", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "_build_plashet_for_bootc", new_callable=AsyncMock)
+    async def test_force_open_build_reruns_phase1(self, mock_plashet, mock_get_commit, mock_get_build, mock_cmd):
+        """--force-open-build forces Phase 1 even when an open build already exists."""
+        mock_get_commit.return_value = "abc1234"
+        open_build = Mock(nvr="microshift-bootc-4.21.0-open.el9")
+        hermetic_build = Mock(nvr="microshift-bootc-4.21.0-hermetic.el9")
+        mock_get_build.side_effect = self._mock_get_latest_bootc_build(
+            open_build=open_build, hermetic_build=hermetic_build
+        )
+        pipeline = self._make_pipeline(force_open_build=True)
+        pipeline.assembly_type = AssemblyTypes.STANDARD
+        pipeline.force = True
+        os.environ["KONFLUX_SA_KUBECONFIG"] = "/fake/kubeconfig"
+
+        try:
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                await pipeline._rebase_and_build_bootc()
+
+            # 4 calls: both phases run despite existing open build
+            self.assertEqual(len(mock_cmd.call_args_list), 4)
+            open_rebase = mock_cmd.call_args_list[0][0][0]
+            self.assertEqual(open_rebase[open_rebase.index("--network-mode") + 1], "open")
         finally:
             os.environ.pop("KONFLUX_SA_KUBECONFIG", None)
 


### PR DESCRIPTION
## Summary
- Hermetic Konflux builds require RPM lockfiles, which are populated in part from a prior successful build's `installed_rpms` in BigQuery. Since microshift-bootc is typically built once per assembly, there is no prior build to draw from.
- The pipeline now automatically runs an open build first (Phase 1) to produce a successful build record, then a hermetic build (Phase 2) whose lockfile generator uses that record's `installed_rpms`.
- Phase 1 is auto-skipped on retries if an open build already exists for the assembly. A `--force-open-build` flag allows forcing a redo when the open build is stale.

## Test plan
- [x] Unit tests pass (`pytest pyartcd/tests/pipelines/test_build_microshift_bootc.py`)
- [ ] Test with a dry-run build on a test assembly
- [ ] Verify Phase 1 skip works on retry (open build already exists)
- [ ] Verify `--force-open-build` forces Phase 1 redo

Companion aos-cd-jobs PR to follow (adds `FORCE_OPEN_BUILD` Jenkins parameter). The art-tools change works standalone — the new flag just defaults to False.