### PR TITLE
Fix build-sync-multi: use RegistryConfig for CI registry auth

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_sync_multi.py
+++ b/pyartcd/pyartcd/pipelines/build_sync_multi.py
@@ -4,8 +4,14 @@ import re
 import click
 import yaml
 from artcommonlib import exectools, redis
+from artcommonlib.constants import (
+    KONFLUX_DEFAULT_IMAGE_REPO,
+    REGISTRY_CI_OPENSHIFT,
+    REGISTRY_QUAY_OCP_RELEASE_DEV,
+)
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.redis import RedisError
+from artcommonlib.registry_config import RegistryConfig
 from artcommonlib.release_util import SoftwareLifecyclePhase
 from artcommonlib.telemetry import start_as_current_span_async
 from artcommonlib.util import split_git_url
@@ -14,7 +20,6 @@ from opentelemetry import trace
 from pyartcd import constants, jenkins, locks
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.jenkins import get_build_url
-from pyartcd.oc import registry_login
 from pyartcd.runtime import GroupRuntime, Runtime
 from pyartcd.util import branch_arches
 
@@ -147,12 +152,31 @@ class BuildSyncMultiPipeline:
             text_body = f"Multi-model build sync job [run]({self.job_run}) has been triggered"
             await self.comment_on_assembly_pr(text_body)
 
-        # Make sure we're logged into the OC registry
-        await registry_login()
+        quay_auth_file = os.getenv('QUAY_AUTH_FILE')
+        if not quay_auth_file:
+            raise ValueError(
+                "QUAY_AUTH_FILE environment variable is required but not set. "
+                "Ensure Jenkins credentials are properly bound."
+            )
 
-        # Generate multi-model nightly imagestream
-        self.logger.info('Generate multi-model nightly imagestream...')
-        await self._generate_multi_model_imagestream()
+        with RegistryConfig(
+            kubeconfig=os.environ.get('KUBECONFIG'),
+            source_files=[quay_auth_file],
+            registries=[
+                REGISTRY_QUAY_OCP_RELEASE_DEV,
+                KONFLUX_DEFAULT_IMAGE_REPO,
+                REGISTRY_CI_OPENSHIFT,
+            ],
+        ) as global_auth_file:
+            self._registry_config = global_auth_file
+            self.logger.info(
+                'Set registry auth file=%s for pipeline operations',
+                global_auth_file,
+            )
+
+            # Generate multi-model nightly imagestream
+            self.logger.info('Generate multi-model nightly imagestream...')
+            await self._generate_multi_model_imagestream()
 
     @start_as_current_span_async(TRACER, "build-sync-multi.handle-success")
     async def handle_success(self):
@@ -203,6 +227,8 @@ class BuildSyncMultiPipeline:
         if self.doozer_data_gitref:
             group_param += f'@{self.doozer_data_gitref}'
         cmd.append(group_param)
+        if self._registry_config:
+            cmd.append(f'--registry-config={self._registry_config}')
         cmd.extend(
             [
                 'release:gen-payload',


### PR DESCRIPTION
## Summary
- **Root cause**: `build-sync-multi` called bare `registry_login()` which writes CI registry creds to `~/.docker/config.json`. However, doozer's runtime falls back to `QUAY_AUTH_FILE` env var as `--registry-config`, which overrides default docker config. CI registry creds (`registry.ci.openshift.org`) never reached `oc adm release info`, causing persistent `unauthorized` failures.
- **Fix**: Use the same `RegistryConfig` pattern as `build_sync.py` to merge CI registry credentials (via `oc registry login` + kubeconfig) with Quay credentials from `QUAY_AUTH_FILE` into a single temp auth file, then pass it via `--registry-config` to doozer.
- **Impact**: Multi-model nightly generation for 4.22 has been failing 69+ consecutive times due to this auth issue.

## Test plan
- [ ] Verify `build-sync-multi` Jenkins job for 4.22 succeeds after merge
- [ ] Confirm `oc adm release info` can access `registry.ci.openshift.org` nightlies with merged auth file
- [ ] Verify no regression in regular `build-sync` pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)