### PR TITLE
feat: add per-image konflux.image_repo override

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -190,7 +190,8 @@ class KonfluxImageBuilder:
                     )
 
             record["nvrs"] = nvr
-            output_image = f"{self._config.image_repo}:{uuid_tag}"
+            image_repo = metadata.get_konflux_image_repo(default=self._config.image_repo)
+            output_image = f"{image_repo}:{uuid_tag}"
             additional_tags = [f"{metadata.image_name_short}-{version}-{release}"]
 
             # Wait for parent members to be built

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -575,7 +575,8 @@ class KonfluxRebaser:
             if parent_metadata.should_trigger_base_image_release():
                 parent_nvr = self._rebased_member_image_nvr(parent_metadata)
                 return util.rh_art_images_base_pullspec(parent_nvr), private_fix
-            return f"{self.image_repo}:{parent_metadata.image_name_short}-{self.uuid_tag}", private_fix
+            parent_image_repo = parent_metadata.get_konflux_image_repo(default=self.image_repo)
+            return f"{parent_image_repo}:{parent_metadata.image_name_short}-{self.uuid_tag}", private_fix
 
     @start_as_current_span_async(TRACER, "rebase.resolve_stream_parent")
     async def _resolve_stream_parent(

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -856,6 +856,28 @@ class ImageMetadata(Metadata):
 
         return attempts
 
+    def get_konflux_image_repo(self, default: str) -> str:
+        """
+        Returns the Konflux image repository for this image's builds.
+
+        Checks configuration in the following order:
+        1. Image metadata configuration (konflux.image_repo)
+        2. Group configuration (konflux.image_repo)
+        3. Provided default value (typically the CLI --image-repo option)
+
+        Args:
+            default: Fallback image repo if no override is configured
+
+        Returns:
+            str: The Konflux image repository URL
+        """
+        if (override := self.config.konflux.image_repo) not in [Missing, None]:
+            self.logger.info("Using per-image Konflux image repo for %s: %s", self.distgit_key, override)
+            return str(override)
+        if (group_override := self.runtime.group_config.konflux.image_repo) not in [Missing, None]:
+            return str(group_override)
+        return default
+
     def _apply_alternative_upstream_config(self) -> None:
         """
         When canonical_builders_enabled, merge alternative_upstream config based on upstream RHEL version.

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -871,11 +871,11 @@ class ImageMetadata(Metadata):
         Returns:
             str: The Konflux image repository URL
         """
-        if (override := self.config.konflux.image_repo) not in [Missing, None]:
+        if (override := self.config.konflux.image_repo) not in [Missing, None] and str(override).strip():
             self.logger.info("Using per-image Konflux image repo for %s: %s", self.distgit_key, override)
-            return str(override)
-        if (group_override := self.runtime.group_config.konflux.image_repo) not in [Missing, None]:
-            return str(group_override)
+            return str(override).strip()
+        if (group_override := self.runtime.group_config.konflux.image_repo) not in [Missing, None] and str(group_override).strip():
+            return str(group_override).strip()
         return default
 
     def _apply_alternative_upstream_config(self) -> None:

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -874,7 +874,9 @@ class ImageMetadata(Metadata):
         if (override := self.config.konflux.image_repo) not in [Missing, None] and str(override).strip():
             self.logger.info("Using per-image Konflux image repo for %s: %s", self.distgit_key, override)
             return str(override).strip()
-        if (group_override := self.runtime.group_config.konflux.image_repo) not in [Missing, None] and str(group_override).strip():
+        if (group_override := self.runtime.group_config.konflux.image_repo) not in [Missing, None] and str(
+            group_override
+        ).strip():
             return str(group_override).strip()
         return default
 

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -1426,6 +1426,7 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         parent.private_fix = False
         parent.image_name_short = "ose-cli"
         parent.should_trigger_base_image_release.return_value = False
+        parent.get_konflux_image_repo.return_value = "quay.io/fake"
 
         runtime = MagicMock()
         runtime.resolve_image.return_value = parent

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -536,6 +536,48 @@ class TestImageMetadata(unittest.TestCase):
         attempts = metadata.get_konflux_build_attempts()
         self.assertEqual(attempts, 1)
 
+    def test_get_konflux_image_repo_default(self):
+        """
+        Test default image repo is returned when no override is configured
+        """
+        metadata = self._create_image_metadata('openshift/test')
+        mock_config = MagicMock()
+        mock_config.konflux.image_repo = Missing
+        metadata.config = mock_config
+        metadata.runtime.group_config.konflux.image_repo = Missing
+        metadata.logger = MagicMock()
+
+        repo = metadata.get_konflux_image_repo(default="quay.io/default/repo")
+        self.assertEqual(repo, "quay.io/default/repo")
+
+    def test_get_konflux_image_repo_metadata_override(self):
+        """
+        Test image-level override takes precedence over group and default
+        """
+        metadata = self._create_image_metadata('openshift/test')
+        mock_config = MagicMock()
+        mock_config.konflux.image_repo = "quay.io/custom/image-repo"
+        metadata.config = mock_config
+        metadata.runtime.group_config.konflux.image_repo = "quay.io/group/repo"
+        metadata.logger = MagicMock()
+
+        repo = metadata.get_konflux_image_repo(default="quay.io/default/repo")
+        self.assertEqual(repo, "quay.io/custom/image-repo")
+
+    def test_get_konflux_image_repo_group_override(self):
+        """
+        Test group-level override when image config is not set
+        """
+        metadata = self._create_image_metadata('openshift/test')
+        mock_config = MagicMock()
+        mock_config.konflux.image_repo = Missing
+        metadata.config = mock_config
+        metadata.runtime.group_config.konflux.image_repo = "quay.io/group/repo"
+        metadata.logger = MagicMock()
+
+        repo = metadata.get_konflux_image_repo(default="quay.io/default/repo")
+        self.assertEqual(repo, "quay.io/group/repo")
+
     def test_calculate_config_digest_old_style_repos(self):
         """
         Test calculate_config_digest with old-style repos (dict format).

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -578,6 +578,39 @@ class TestImageMetadata(unittest.TestCase):
         repo = metadata.get_konflux_image_repo(default="quay.io/default/repo")
         self.assertEqual(repo, "quay.io/group/repo")
 
+    def test_get_konflux_image_repo_empty_string_falls_through(self):
+        metadata = self._create_image_metadata('openshift/test')
+        mock_config = MagicMock()
+        mock_config.konflux.image_repo = ""
+        metadata.config = mock_config
+        metadata.runtime.group_config.konflux.image_repo = "quay.io/group/repo"
+        metadata.logger = MagicMock()
+
+        repo = metadata.get_konflux_image_repo(default="quay.io/default/repo")
+        self.assertEqual(repo, "quay.io/group/repo")
+
+    def test_get_konflux_image_repo_whitespace_falls_through(self):
+        metadata = self._create_image_metadata('openshift/test')
+        mock_config = MagicMock()
+        mock_config.konflux.image_repo = "   "
+        metadata.config = mock_config
+        metadata.runtime.group_config.konflux.image_repo = Missing
+        metadata.logger = MagicMock()
+
+        repo = metadata.get_konflux_image_repo(default="quay.io/default/repo")
+        self.assertEqual(repo, "quay.io/default/repo")
+
+    def test_get_konflux_image_repo_both_blank_falls_to_default(self):
+        metadata = self._create_image_metadata('openshift/test')
+        mock_config = MagicMock()
+        mock_config.konflux.image_repo = ""
+        metadata.config = mock_config
+        metadata.runtime.group_config.konflux.image_repo = "  "
+        metadata.logger = MagicMock()
+
+        repo = metadata.get_konflux_image_repo(default="quay.io/default/repo")
+        self.assertEqual(repo, "quay.io/default/repo")
+
     def test_calculate_config_digest_old_style_repos(self):
         """
         Test calculate_config_digest with old-style repos (dict format).

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -1402,6 +1402,17 @@
           "$ref": "#/properties/konflux/properties/build_attempts"
         },
         "build_attempts-": {},
+        "image_repo": {
+          "description": "Override the default Konflux image repository for this image's builds",
+          "type": "string"
+        },
+        "image_repo?": {
+          "$ref": "#/properties/konflux/properties/image_repo"
+        },
+        "image_repo!": {
+          "$ref": "#/properties/konflux/properties/image_repo"
+        },
+        "image_repo-": {},
         "content": {
           "$ref": "image_content.base.schema.json"
         }


### PR DESCRIPTION
## Summary

- Adds a new `konflux.image_repo` field to ocp-build-data image YAML schema, allowing individual images to override the default Konflux destination repository (`art-images`)
- Implements 3-tier precedence: image config > group config > CLI `--image-repo` default
- Updates `KonfluxImageBuilder` and `KonfluxRebaser` to use per-image overrides when constructing output image references and resolving parent images

## Motivation

Some images (e.g. `ose-4-21-block-copyfail`) need to push builds to a different Quay repository than the default `quay.io/redhat-user-workloads/ocp-art-tenant/art-images`. Currently `image_repo` is a global CLI option with no per-image override.

## Usage

In ocp-build-data image YAML:

```yaml
konflux:
  image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/ocp-block-copy-fail
```

## Test plan

- [x] Unit tests for `get_konflux_image_repo()` covering default, image-level, and group-level overrides
- [x] All existing tests pass (`doozer/tests/test_image.py` - 75 passed)
- [x] Ruff lint clean
- [ ] Functional test with a real image build using the override


Made with [Cursor](https://cursor.com)