### PR TITLE
fix(assembly): strip special suffixes from nested keys in dominant values

### DIFF
--- a/artcommon/artcommonlib/assembly.py
+++ b/artcommon/artcommonlib/assembly.py
@@ -161,6 +161,27 @@ def _check_recursion(releases_config: dict, assembly: str):
         next_assembly = target_assembly.get("basis", {}).get("assembly")
 
 
+def _strip_special_suffixes(obj):
+    """
+    Recursively strip special suffixes (!, ?, -) from all keys in a nested structure.
+    This is needed when a value is set with a dominant key (!) since the value itself
+    may contain keys with special suffixes that need to be normalized.
+    """
+    if isinstance(obj, dict):
+        result = {}
+        for k, v in obj.items():
+            # Strip special suffix from key
+            if k.endswith(('!', '?', '-')):
+                k = k[:-1]
+            # Recursively process value
+            result[k] = _strip_special_suffixes(v)
+        return result
+    elif isinstance(obj, list):
+        return [_strip_special_suffixes(item) for item in obj]
+    else:
+        return obj
+
+
 def _merger(a, b):
     """
     Merges two, potentially deep, objects into a new one and returns the result.
@@ -200,11 +221,13 @@ def _merger(a, b):
         for k, v in a.items():
             if k.endswith('!'):  # full dominant key
                 k = k[:-1]
-                c[k] = v
+                # Strip special suffixes from nested keys since value is set exactly
+                c[k] = _strip_special_suffixes(v)
             elif k.endswith('?'):  # default value key
                 k = k[:-1]
                 if k not in c:
-                    c[k] = v
+                    # Strip special suffixes from nested keys
+                    c[k] = _strip_special_suffixes(v)
             elif k.endswith('-'):  # remove key entirely
                 k = k[:-1]
                 c.pop(k, None)

--- a/artcommon/tests/test_assembly.py
+++ b/artcommon/tests/test_assembly.py
@@ -703,3 +703,21 @@ releases:
             _merger({'r-': [1, 2]}, {'r': [3, 4]}),
             {},
         )
+
+        # ! key with nested ! keys - nested special suffixes should be stripped
+        self.assertEqual(
+            _merger({'shipment!': {'advisories!': [{'kind': 'image'}], 'url!': ''}}, {'shipment': {'advisories': [{'kind': 'extras'}], 'url': 'http://example.com'}}),
+            {'shipment': {'advisories': [{'kind': 'image'}], 'url': ''}},
+        )
+
+        # ? key with nested special suffixes should also be stripped
+        self.assertEqual(
+            _merger({'shipment?': {'advisories!': [{'kind': 'image'}]}}, {}),
+            {'shipment': {'advisories': [{'kind': 'image'}]}},
+        )
+
+        # Deeply nested special suffixes should be stripped
+        self.assertEqual(
+            _merger({'a!': {'b!': {'c!': 'value'}}}, {'a': {'x': 1}}),
+            {'a': {'b': {'c': 'value'}}},
+        )


### PR DESCRIPTION
## Summary

When using dominant key override syntax like `shipment!: {advisories!: [...]}` in `releases.yml`,
the `_merger` function was correctly stripping the `!` from `shipment!` but leaving nested
`!` suffixes intact. This caused `shipment_config.get("advisories")` to return `None` because
the actual key was `"advisories!"`.

This broke `prepare-release-konflux` with:
```
ValueError: Shipment config should specify which advisories to create and prepare
```

## Fix

Added `_strip_special_suffixes()` helper that recursively strips `!`, `?`, `-` suffixes from
all keys when setting values with dominant (`!`) or default (`?`) markers.

## Test plan

- [x] All existing assembly tests pass (21 tests)
- [x] Added new tests for nested special suffix stripping
- [x] Verified with simulated 4.19.30 config that `shipment.advisories` is now accessible