### PR TITLE
Add assembly_resolved() and fix inheritance in config:read-assembly and promote

### DIFF
--- a/artcommon/artcommonlib/assembly.py
+++ b/artcommon/artcommonlib/assembly.py
@@ -158,6 +158,13 @@ def _check_recursion(releases_config: dict, assembly: str):
             raise ValueError(f'Infinite recursion in {assembly} detected; {next_assembly} detected twice in chain')
         found.add(next_assembly)
         target_assembly = releases.get(next_assembly, {}).get("assembly")
+        for k in target_assembly:
+            if k != 'basis' and isinstance(k, str) and k[-1:] in ('!', '?', '-'):
+                raise ValueError(
+                    f'Assembly {next_assembly} has top-level key "{k}" with merge operator suffix; '
+                    f'merge operators (!/?/-) are only supported on keys nested inside assembly values, '
+                    f'not on top-level assembly keys like "group", "members", "rhcos", etc.'
+                )
         next_assembly = target_assembly.get("basis", {}).get("assembly")
 
 

--- a/artcommon/artcommonlib/assembly.py
+++ b/artcommon/artcommonlib/assembly.py
@@ -430,13 +430,22 @@ def assembly_metadata_config(
     return Model(dict_to_model=config_dict)
 
 
-def _collect_assembly_keys(releases_config: dict, assembly: str) -> set[str]:
-    """Collect all top-level keys from an assembly and its ancestors in the basis chain."""
-    keys: set[str] = set()
+def _collect_assembly_keys(releases_config: dict, assembly: str) -> list[str]:
+    """Collect all top-level keys from an assembly and its ancestors in the basis chain.
+    Keys are returned in original YAML order: ancestor keys first, then any new
+    keys introduced by child assemblies.
+    """
     target = releases_config.get('releases', {}).get(assembly, {}).get('assembly', {})
-    keys.update(target.keys())
-    if basis_assembly := target.get('basis', {}).get('assembly'):
-        keys.update(_collect_assembly_keys(releases_config, basis_assembly))
+    basis_assembly = target.get('basis', {}).get('assembly')
+    if basis_assembly:
+        keys = _collect_assembly_keys(releases_config, basis_assembly)
+    else:
+        keys = []
+    seen = set(keys)
+    for k in target.keys():
+        if k not in seen:
+            keys.append(k)
+            seen.add(k)
     return keys
 
 
@@ -445,7 +454,7 @@ def assembly_resolved(releases_config: Model, assembly: typing.Optional[str]) ->
     Resolves the entire assembly definition after applying inheritance through
     the basis chain. Returns a Model with all keys fully merged.
     The 'basis' key is excluded from the result since it is the inheritance
-    mechanism itself.
+    mechanism itself. Key ordering from the original YAML is preserved.
     :param releases_config: The content of releases.yml in Model form.
     :param assembly: The name of the assembly to resolve
     :return: A Model containing the fully resolved assembly definition.
@@ -457,10 +466,11 @@ def assembly_resolved(releases_config: Model, assembly: typing.Optional[str]) ->
     _check_recursion(raw_config, assembly)
 
     all_keys = _collect_assembly_keys(raw_config, assembly)
-    all_keys.discard('basis')
 
     result = {}
-    for key in sorted(all_keys):
+    for key in all_keys:
+        if key == 'basis':
+            continue
         result[key] = assembly_field(raw_config, assembly, key, {})
 
     return Model(dict_to_model=result)

--- a/artcommon/artcommonlib/assembly.py
+++ b/artcommon/artcommonlib/assembly.py
@@ -430,6 +430,42 @@ def assembly_metadata_config(
     return Model(dict_to_model=config_dict)
 
 
+def _collect_assembly_keys(releases_config: dict, assembly: str) -> set[str]:
+    """Collect all top-level keys from an assembly and its ancestors in the basis chain."""
+    keys: set[str] = set()
+    target = releases_config.get('releases', {}).get(assembly, {}).get('assembly', {})
+    keys.update(target.keys())
+    if basis_assembly := target.get('basis', {}).get('assembly'):
+        keys.update(_collect_assembly_keys(releases_config, basis_assembly))
+    return keys
+
+
+def assembly_resolved(releases_config: Model, assembly: typing.Optional[str]) -> Model:
+    """
+    Resolves the entire assembly definition after applying inheritance through
+    the basis chain. Returns a Model with all keys fully merged.
+    The 'basis' key is excluded from the result since it is the inheritance
+    mechanism itself.
+    :param releases_config: The content of releases.yml in Model form.
+    :param assembly: The name of the assembly to resolve
+    :return: A Model containing the fully resolved assembly definition.
+    """
+    if not assembly or not isinstance(releases_config, Model):
+        return Model(dict_to_model={})
+
+    raw_config = releases_config.primitive()
+    _check_recursion(raw_config, assembly)
+
+    all_keys = _collect_assembly_keys(raw_config, assembly)
+    all_keys.discard('basis')
+
+    result = {}
+    for key in sorted(all_keys):
+        result[key] = assembly_field(raw_config, assembly, key, {})
+
+    return Model(dict_to_model=result)
+
+
 def assembly_excluded_components(releases_config: Model, assembly: typing.Optional[str], meta_type: str) -> set[str]:
     """
     Returns a set of distgit_keys that have `exclude: true` in the assembly's members section.

--- a/artcommon/tests/test_assembly.py
+++ b/artcommon/tests/test_assembly.py
@@ -684,6 +684,20 @@ releases:
         with self.assertRaises(ValueError):
             assembly_resolved(self.releases_config, 'ART_INFINITE')
 
+    def test_top_level_merge_operator_rejected(self):
+        for suffix in ('!', '?', '-'):
+            releases_yml = f"""
+releases:
+  bad_assembly:
+    assembly:
+      group{suffix}:
+        advisories:
+          image: 1
+"""
+            releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+            with self.assertRaises(ValueError, msg=f'suffix "{suffix}" should be rejected'):
+                assembly_resolved(releases_config, 'bad_assembly')
+
     def test_merger(self):
         # First value dominates on primitive
         self.assertEqual(_merger(4, 5), 4)

--- a/artcommon/tests/test_assembly.py
+++ b/artcommon/tests/test_assembly.py
@@ -9,6 +9,7 @@ from artcommonlib.assembly import (
     assembly_excluded_components,
     assembly_group_config,
     assembly_metadata_config,
+    assembly_resolved,
     assembly_rhcos_config,
 )
 from artcommonlib.model import Missing, Model
@@ -643,6 +644,45 @@ releases:
     def test_assembly_excluded_components_infinite_recursion(self):
         with self.assertRaises(ValueError):
             assembly_excluded_components(self.releases_config, 'ART_INFINITE', 'rpm')
+
+    def test_assembly_resolved_empty(self):
+        self.assertEqual(assembly_resolved(self.releases_config, None).primitive(), {})
+        self.assertEqual(assembly_resolved(self.releases_config, '').primitive(), {})
+        self.assertEqual(assembly_resolved(None, 'ART_1').primitive(), {})
+
+    def test_assembly_resolved_no_inheritance(self):
+        resolved = assembly_resolved(self.releases_config, 'ART_1')
+        self.assertEqual(resolved.group.advisories.image, 11)
+        self.assertEqual(resolved.group.advisories.extras, 12)
+        self.assertEqual(len(resolved.group.arches), 3)
+        self.assertIsNotNone(resolved.members)
+
+    def test_assembly_resolved_with_inheritance(self):
+        # ART_3 inherits from ART_2
+        resolved = assembly_resolved(self.releases_config, 'ART_3')
+        self.assertEqual(resolved.group.advisories.image, 31)
+        # members inherited from ART_2
+        self.assertIsNotNone(resolved.members)
+
+    def test_assembly_resolved_bang_override(self):
+        # ART_5 uses ! to completely replace arches and advisories
+        resolved = assembly_resolved(self.releases_config, 'ART_5')
+        self.assertEqual(len(resolved.group.arches), 1)
+        self.assertEqual(resolved.group.arches[0], 's390x')
+        self.assertEqual(resolved.group.advisories.image, 51)
+        self.assertEqual(resolved.group.advisories.extras, Missing)
+
+    def test_assembly_resolved_excludes_basis(self):
+        resolved = assembly_resolved(self.releases_config, 'ART_3')
+        self.assertEqual(resolved.basis, Missing)
+
+    def test_assembly_resolved_includes_rhcos(self):
+        resolved = assembly_resolved(self.releases_config, 'ART_8')
+        self.assertEqual(len(resolved.rhcos.dependencies.rpms), 3)
+
+    def test_assembly_resolved_infinite_recursion(self):
+        with self.assertRaises(ValueError):
+            assembly_resolved(self.releases_config, 'ART_INFINITE')
 
     def test_merger(self):
         # First value dominates on primitive

--- a/doozer/doozerlib/cli/config.py
+++ b/doozer/doozerlib/cli/config.py
@@ -7,9 +7,11 @@ from typing import Dict, List
 import click
 import yaml
 from artcommonlib import gitdata
+from artcommonlib.assembly import assembly_resolved
 from artcommonlib.format_util import color_print, green_print, red_print, yellow_print
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.metadata import CONFIG_MODES
+from artcommonlib.model import Model
 
 from doozerlib import Runtime
 from doozerlib.cli import cli, click_coroutine, pass_runtime
@@ -236,9 +238,9 @@ def config_read_releases(runtime, as_len, as_yaml, out_file):
 @pass_runtime
 def config_read_assemblies(runtime, default, as_len, as_yaml, out_file, key):
     """
-    Read data from releases.yaml for given group, assembly and key.
-    An assembly must be specified. To get a global representation of release.yaml,
-    use doozer config:read-releases instead
+    Read the fully resolved assembly definition from releases.yaml for a given
+    group and assembly. Inheritance through the basis chain is applied so the
+    output includes values from ancestor assemblies.
 
     Usage:
 
@@ -257,11 +259,14 @@ def config_read_assemblies(runtime, default, as_len, as_yaml, out_file, key):
 
     CONFIG_RUNTIME_OPTS['group_only'] = True
     runtime.initialize(**CONFIG_RUNTIME_OPTS)
-    releases = get_releases(runtime)['releases']
-    try:
-        assembly_data = releases[runtime.assembly]
-    except KeyError:
+    releases = get_releases(runtime)
+    releases_config = Model(dict_to_model=releases)
+
+    if runtime.assembly not in releases.get('releases', {}):
         raise DoozerFatalError(f'No assembly data found for assembly "{runtime.assembly}" in group {runtime.group}')
+
+    resolved = assembly_resolved(releases_config, runtime.assembly).primitive()
+    assembly_data = {'assembly': resolved}
 
     if key is not None:
         assembly_data = dict_get(assembly_data, key, None)

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -25,13 +25,14 @@ from artcommonlib.arch_util import (
     go_arch_for_brew_arch,
     go_suffix_for_arch,
 )
-from artcommonlib.assembly import AssemblyTypes
+from artcommonlib.assembly import AssemblyTypes, assembly_config_struct
 from artcommonlib.constants import REGISTRY_CI_OPENSHIFT, REGISTRY_QUAY_OCP_RELEASE_DEV
 from artcommonlib.exceptions import VerificationError
 from artcommonlib.exectools import manifest_tool, manifest_tool_auth_file, to_thread
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.gitlab import GitLabClient
 from artcommonlib.jira_config import JIRA_EMAIL, JIRA_SERVER_URL
+from artcommonlib.model import Model
 from artcommonlib.oc_image_info import oc_image_info__cached_async
 from artcommonlib.registry_config import RegistryConfig
 from artcommonlib.rhcos import get_primary_container_name
@@ -2610,20 +2611,14 @@ class PromotePipeline:
                 data_path=self._doozer_env_vars.get("DOOZER_DATA_PATH", None) or constants.OCP_BUILD_DATA_URL,
             )
 
-            # Debug: Show available releases in the config
-            available_releases = list(releases_config.get("releases", {}).keys())
-            self._logger.info("Available releases in releases.yml: %s", available_releases)
-
-            # Get the assembly config from releases.yml
-            assembly_config = releases_config.get("releases", {}).get(self.assembly)
-            if not assembly_config:
+            if releases_config.get("releases", {}).get(self.assembly) is None:
                 self._logger.warning("Assembly %s not found in releases.yml", self.assembly)
                 return None
 
-            self._logger.info("Assembly config keys for %s: %s", self.assembly, list(assembly_config.keys()))
-
-            # Get RPM advisory ID from assembly.group.advisories path
-            assembly_group_advisories = assembly_config.get("assembly", {}).get("group", {}).get("advisories", {})
+            group_config = assembly_config_struct(Model(releases_config), self.assembly, "group", {})
+            assembly_group_advisories = group_config.get("advisories", {})
+            if isinstance(assembly_group_advisories, Model):
+                assembly_group_advisories = assembly_group_advisories.primitive()
             rpm_advisory_id = assembly_group_advisories.get("rpm")
 
             self._logger.info("Assembly group advisories for %s: %s", self.assembly, assembly_group_advisories)


### PR DESCRIPTION
## Summary
- Add `assembly_resolved()` to `artcommonlib/assembly.py` that resolves an entire assembly definition after applying inheritance through the basis chain, returning a fully merged Model with all ancestor keys included
- Update `config:read-assembly` to use `assembly_resolved()` so output reflects inherited values from ancestor assemblies instead of returning raw YAML
- Fix `promote` pipeline's `_get_rpm_advisory_id()` which bypassed inheritance by reading raw dict access — if the RPM advisory was defined in a parent assembly, it would return `None`
- Preserve original YAML key ordering in resolved output (ancestor keys first, then child-specific keys)
- Reject merge operator suffixes (`!`, `?`, `-`) on top-level assembly keys with a clear error

### Why reject top-level merge operators?

`assembly_field()` resolves keys by exact name (`if key in target_assembly`). If someone writes `group!:` in their assembly YAML, the actual dict key is the string `"group!"` — but `assembly_field` searches for `"group"`, so the override is silently ignored and the parent's value is returned instead. The `!/?/-` suffixes are only processed inside `_merger()`, which handles them when iterating over dict *values* during a recursive merge. They were never designed to work at the top level of the assembly definition. The guard turns a silent misconfiguration into an immediate, clear error.

This extends the work in [#1940](https://github.com/openshift-eng/art-tools/pull/1940) ([ART-12601](https://issues.redhat.com/browse/ART-12601)), which added a schema-level validation in `ocp-build-data-validator` to reject `group!` specifically. Our guard is the runtime equivalent and is broader — it catches all three suffixes (`!`, `?`, `-`) on all top-level assembly keys (not just `group!`), and it fires during assembly resolution rather than only at schema validation time.

## Test plan
- [x] Unit tests for `assembly_resolved()`: empty/None inputs, no-inheritance, basis chain inheritance, bang (`!`) overrides, basis exclusion, rhcos inclusion, infinite recursion detection
- [x] Unit test for top-level merge operator rejection (all three suffixes)
- [x] `make test` passes (2144 tests across all packages)
- [x] `make lint` and `make format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)