### PR TITLE
Add verify-payload check to promote pipeline

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1506,7 +1506,9 @@ class PromotePipeline:
                 self._logger.info("[DRY-RUN] Would have run command: %s", ' '.join(cmd))
                 return
             async with self._elliott_lock:
-                _, stdout, _ = await exectools.cmd_gather_async(cmd, env=self._elliott_env_vars, stderr=None)
+                _, stdout, _ = await exectools.cmd_gather_async(
+                    cmd, env=self._elliott_env_vars, stderr=None, check=True
+                )
             results = json.loads(stdout)
             self._logger.info("Verify payload results for %s:\n%s", imagestream, json.dumps(results, indent=4))
             if results.get("missing_in_advisory") or results.get("payload_advisory_mismatch"):

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1487,7 +1487,7 @@ class PromotePipeline:
         version = f"{major}.{minor}"
 
         assembly_is_base_name = assembly_imagestream_base_name_generic(
-            version, self.assembly, assembly_type, build_system='brew'
+            version, self.assembly, assembly_type, build_system='konflux'
         )
 
         @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(10))
@@ -1497,6 +1497,7 @@ class PromotePipeline:
                 "elliott",
                 f"--group={self.group}",
                 f"--assembly={self.assembly}",
+                "--build-system=konflux",
             ]
             if self._registry_config:
                 cmd.append(f"--registry-config={self._registry_config}")
@@ -1651,7 +1652,7 @@ class PromotePipeline:
             is_namespace, is_name = payload_imagestream_namespace_and_name(
                 default_imagestream_namespace_base_name(),
                 assembly_imagestream_base_name_generic(
-                    f"{major}.{minor}", self.assembly, assembly_type, build_system='brew'
+                    f"{major}.{minor}", self.assembly, assembly_type, build_system='konflux'
                 ),
                 arch,
                 private=False,

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1495,9 +1495,10 @@ class PromotePipeline:
                 f"--group={self.group}",
                 f"--assembly={self.assembly}",
                 "--build-system=konflux",
-                "verify-payload",
-                imagestream,
             ]
+            if self._registry_config:
+                cmd.append(f"--registry-config={self._registry_config}")
+            cmd += ["verify-payload", imagestream]
             if self.runtime.dry_run:
                 self._logger.info("[DRY-RUN] Would have run command: %s", ' '.join(cmd))
                 return

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -36,6 +36,11 @@ from artcommonlib.oc_image_info import oc_image_info__cached_async
 from artcommonlib.registry_config import RegistryConfig
 from artcommonlib.rhcos import get_primary_container_name
 from artcommonlib.util import isolate_major_minor_in_group
+from doozerlib.cli.release_gen_payload import (
+    assembly_imagestream_base_name_generic,
+    default_imagestream_namespace_base_name,
+    payload_imagestream_namespace_and_name,
+)
 from elliottlib.errata import get_errata_live_id
 from elliottlib.shipment_model import ShipmentConfig
 from elliottlib.shipment_utils import (
@@ -416,6 +421,14 @@ class PromotePipeline:
                     else:
                         justification = self._reraise_if_not_permitted(err, "ATTACHED_BUGS", permits)
                         justifications.append(justification)
+
+            # Verify payload imagestreams match advisory builds before promoting
+            logger.info("Verifying payload imagestreams match advisory builds...")
+            try:
+                await self.verify_payload(assembly_type, arches)
+            except VerificationError as err:
+                justification = self._reraise_if_not_permitted(err, "PAYLOAD_MISMATCH", permits)
+                justifications.append(justification)
 
             # Promote release images
             metadata = {}
@@ -1469,6 +1482,51 @@ class PromotePipeline:
         async with self._elliott_lock:
             await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars, stdout=sys.stderr)
 
+    async def verify_payload(self, assembly_type: AssemblyTypes, arches: List[str]):
+        """Verify that the imagestream contents match the advisory builds before promoting."""
+        major, minor = isolate_major_minor_in_group(self.group)
+        version = f"{major}.{minor}"
+
+        assembly_is_base_name = assembly_imagestream_base_name_generic(
+            version, self.assembly, assembly_type, build_system='konflux'
+        )
+
+        @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(10))
+        async def _verify(imagestream):
+            self._logger.info("Verifying payload against imagestream %s", imagestream)
+            cmd = [
+                "elliott",
+                f"--group={self.group}",
+                f"--assembly={self.assembly}",
+                "--build-system=konflux",
+                "verify-payload",
+                imagestream,
+            ]
+            if self.runtime.dry_run:
+                self._logger.info("[DRY-RUN] Would have run command: %s", ' '.join(cmd))
+                return
+            async with self._elliott_lock:
+                _, stdout, _ = await exectools.cmd_gather_async(cmd, env=self._elliott_env_vars, stderr=None)
+            results = json.loads(stdout)
+            self._logger.info("Verify payload results for %s:\n%s", imagestream, json.dumps(results, indent=4))
+            if results.get("missing_in_advisory") or results.get("payload_advisory_mismatch"):
+                raise VerificationError(
+                    f"Payload verification failed for imagestream {imagestream}. "
+                    "The imagestream contents do not match the advisory builds. "
+                    "Ensure gen-payload/build-sync has been run for the current assembly spec."
+                )
+            self._logger.info("Payload verification succeeded for imagestream %s", imagestream)
+
+        imagestreams = [
+            "{}/{}".format(
+                *payload_imagestream_namespace_and_name(
+                    default_imagestream_namespace_base_name(), assembly_is_base_name, arch, private=False
+                )
+            )
+            for arch in arches
+        ]
+        await asyncio.gather(*[_verify(is_ref) for is_ref in imagestreams])
+
     async def promote(
         self,
         assembly_type: AssemblyTypes,
@@ -1585,7 +1643,6 @@ class PromotePipeline:
             self._logger.warning(
                 "Release image %s for %s (%s) already exists", release_name, arch, dest_image_info["image"]
             )
-            # TODO: Check if the existing release image matches the assembly definition.
 
         if not dest_image_info or self.permit_overwrite:
             if dest_image_info:

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -424,11 +424,7 @@ class PromotePipeline:
 
             # Verify payload imagestreams match advisory builds before promoting
             logger.info("Verifying payload imagestreams match advisory builds...")
-            try:
-                await self.verify_payload(assembly_type, arches)
-            except VerificationError as err:
-                justification = self._reraise_if_not_permitted(err, "PAYLOAD_MISMATCH", permits)
-                justifications.append(justification)
+            await self.verify_payload(assembly_type, arches)
 
             # Promote release images
             metadata = {}

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -423,8 +423,11 @@ class PromotePipeline:
                         justifications.append(justification)
 
             # Verify payload imagestreams match advisory builds before promoting
-            logger.info("Verifying payload imagestreams match advisory builds...")
-            await self.verify_payload(assembly_type, arches)
+            if image_advisory > 0 or shipment_config:
+                logger.info("Verifying payload imagestreams match advisory builds...")
+                await self.verify_payload(assembly_type, arches)
+            else:
+                logger.info("Skipping payload verification: no image advisory or shipment config defined")
 
             # Promote release images
             metadata = {}
@@ -1646,8 +1649,15 @@ class PromotePipeline:
                 self._logger.warning("The existing release image %s will be overwritten!", dest_image_pullspec)
             major, minor = isolate_major_minor_in_group(self.group)
             # Ensure build-sync has been run for this assembly
-            is_name = f"{major}.{minor}-art-assembly-{self.assembly}{go_arch_suffix}"
-            imagestream = await self.get_image_stream(f"ocp{go_arch_suffix}", is_name)
+            is_namespace, is_name = payload_imagestream_namespace_and_name(
+                default_imagestream_namespace_base_name(),
+                assembly_imagestream_base_name_generic(
+                    f"{major}.{minor}", self.assembly, assembly_type, build_system='konflux'
+                ),
+                arch,
+                private=False,
+            )
+            imagestream = await self.get_image_stream(is_namespace, is_name)
             if not imagestream:
                 raise ValueError(f"Image stream {is_name} is not found. Did you run build-sync?")
             self._logger.info(

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1487,7 +1487,7 @@ class PromotePipeline:
         version = f"{major}.{minor}"
 
         assembly_is_base_name = assembly_imagestream_base_name_generic(
-            version, self.assembly, assembly_type, build_system='konflux'
+            version, self.assembly, assembly_type, build_system='brew'
         )
 
         @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(10))
@@ -1497,7 +1497,6 @@ class PromotePipeline:
                 "elliott",
                 f"--group={self.group}",
                 f"--assembly={self.assembly}",
-                "--build-system=konflux",
             ]
             if self._registry_config:
                 cmd.append(f"--registry-config={self._registry_config}")
@@ -1652,7 +1651,7 @@ class PromotePipeline:
             is_namespace, is_name = payload_imagestream_namespace_and_name(
                 default_imagestream_namespace_base_name(),
                 assembly_imagestream_base_name_generic(
-                    f"{major}.{minor}", self.assembly, assembly_type, build_system='konflux'
+                    f"{major}.{minor}", self.assembly, assembly_type, build_system='brew'
                 ),
                 arch,
                 private=False,

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1495,7 +1495,7 @@ class PromotePipeline:
         version = f"{major}.{minor}"
 
         assembly_is_base_name = assembly_imagestream_base_name_generic(
-            version, self.assembly, assembly_type, build_system='brew'
+            version, self.assembly, assembly_type, build_system='konflux'
         )
 
         @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(10))
@@ -1505,6 +1505,7 @@ class PromotePipeline:
                 "elliott",
                 f"--group={self.group}",
                 f"--assembly={self.assembly}",
+                "--build-system=konflux",
             ]
             if self._registry_config:
                 cmd.append(f"--registry-config={self._registry_config}")
@@ -1659,7 +1660,7 @@ class PromotePipeline:
             is_namespace, is_name = payload_imagestream_namespace_and_name(
                 default_imagestream_namespace_base_name(),
                 assembly_imagestream_base_name_generic(
-                    f"{major}.{minor}", self.assembly, assembly_type, build_system='brew'
+                    f"{major}.{minor}", self.assembly, assembly_type, build_system='konflux'
                 ),
                 arch,
                 private=False,

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -37,6 +37,11 @@ from artcommonlib.oc_image_info import oc_image_info__cached_async
 from artcommonlib.registry_config import RegistryConfig
 from artcommonlib.rhcos import get_primary_container_name
 from artcommonlib.util import isolate_major_minor_in_group
+from doozerlib.cli.release_gen_payload import (
+    assembly_imagestream_base_name_generic,
+    default_imagestream_namespace_base_name,
+    payload_imagestream_namespace_and_name,
+)
 from elliottlib.errata import get_errata_live_id
 from elliottlib.shipment_model import ShipmentConfig
 from elliottlib.shipment_utils import (
@@ -424,6 +429,14 @@ class PromotePipeline:
                     else:
                         justification = self._reraise_if_not_permitted(err, "ATTACHED_BUGS", permits)
                         justifications.append(justification)
+
+            # Verify payload imagestreams match advisory builds before promoting
+            logger.info("Verifying payload imagestreams match advisory builds...")
+            try:
+                await self.verify_payload(assembly_type, arches)
+            except VerificationError as err:
+                justification = self._reraise_if_not_permitted(err, "PAYLOAD_MISMATCH", permits)
+                justifications.append(justification)
 
             # Promote release images
             metadata = {}
@@ -1477,6 +1490,51 @@ class PromotePipeline:
         async with self._elliott_lock:
             await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars, stdout=sys.stderr)
 
+    async def verify_payload(self, assembly_type: AssemblyTypes, arches: List[str]):
+        """Verify that the imagestream contents match the advisory builds before promoting."""
+        major, minor = isolate_major_minor_in_group(self.group)
+        version = f"{major}.{minor}"
+
+        assembly_is_base_name = assembly_imagestream_base_name_generic(
+            version, self.assembly, assembly_type, build_system='konflux'
+        )
+
+        @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(10))
+        async def _verify(imagestream):
+            self._logger.info("Verifying payload against imagestream %s", imagestream)
+            cmd = [
+                "elliott",
+                f"--group={self.group}",
+                f"--assembly={self.assembly}",
+                "--build-system=konflux",
+                "verify-payload",
+                imagestream,
+            ]
+            if self.runtime.dry_run:
+                self._logger.info("[DRY-RUN] Would have run command: %s", ' '.join(cmd))
+                return
+            async with self._elliott_lock:
+                _, stdout, _ = await exectools.cmd_gather_async(cmd, env=self._elliott_env_vars, stderr=None)
+            results = json.loads(stdout)
+            self._logger.info("Verify payload results for %s:\n%s", imagestream, json.dumps(results, indent=4))
+            if results.get("missing_in_advisory") or results.get("payload_advisory_mismatch"):
+                raise VerificationError(
+                    f"Payload verification failed for imagestream {imagestream}. "
+                    "The imagestream contents do not match the advisory builds. "
+                    "Ensure gen-payload/build-sync has been run for the current assembly spec."
+                )
+            self._logger.info("Payload verification succeeded for imagestream %s", imagestream)
+
+        imagestreams = [
+            "{}/{}".format(
+                *payload_imagestream_namespace_and_name(
+                    default_imagestream_namespace_base_name(), assembly_is_base_name, arch, private=False
+                )
+            )
+            for arch in arches
+        ]
+        await asyncio.gather(*[_verify(is_ref) for is_ref in imagestreams])
+
     async def promote(
         self,
         assembly_type: AssemblyTypes,
@@ -1593,7 +1651,6 @@ class PromotePipeline:
             self._logger.warning(
                 "Release image %s for %s (%s) already exists", release_name, arch, dest_image_info["image"]
             )
-            # TODO: Check if the existing release image matches the assembly definition.
 
         if not dest_image_info or self.permit_overwrite:
             if dest_image_info:

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -432,11 +432,7 @@ class PromotePipeline:
 
             # Verify payload imagestreams match advisory builds before promoting
             logger.info("Verifying payload imagestreams match advisory builds...")
-            try:
-                await self.verify_payload(assembly_type, arches)
-            except VerificationError as err:
-                justification = self._reraise_if_not_permitted(err, "PAYLOAD_MISMATCH", permits)
-                justifications.append(justification)
+            await self.verify_payload(assembly_type, arches)
 
             # Promote release images
             metadata = {}

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1503,9 +1503,10 @@ class PromotePipeline:
                 f"--group={self.group}",
                 f"--assembly={self.assembly}",
                 "--build-system=konflux",
-                "verify-payload",
-                imagestream,
             ]
+            if self._registry_config:
+                cmd.append(f"--registry-config={self._registry_config}")
+            cmd += ["verify-payload", imagestream]
             if self.runtime.dry_run:
                 self._logger.info("[DRY-RUN] Would have run command: %s", ' '.join(cmd))
                 return

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1495,7 +1495,7 @@ class PromotePipeline:
         version = f"{major}.{minor}"
 
         assembly_is_base_name = assembly_imagestream_base_name_generic(
-            version, self.assembly, assembly_type, build_system='konflux'
+            version, self.assembly, assembly_type, build_system='brew'
         )
 
         @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(10))
@@ -1505,7 +1505,6 @@ class PromotePipeline:
                 "elliott",
                 f"--group={self.group}",
                 f"--assembly={self.assembly}",
-                "--build-system=konflux",
             ]
             if self._registry_config:
                 cmd.append(f"--registry-config={self._registry_config}")
@@ -1660,7 +1659,7 @@ class PromotePipeline:
             is_namespace, is_name = payload_imagestream_namespace_and_name(
                 default_imagestream_namespace_base_name(),
                 assembly_imagestream_base_name_generic(
-                    f"{major}.{minor}", self.assembly, assembly_type, build_system='konflux'
+                    f"{major}.{minor}", self.assembly, assembly_type, build_system='brew'
                 ),
                 arch,
                 private=False,

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1510,9 +1510,6 @@ class PromotePipeline:
             if self._registry_config:
                 cmd.append(f"--registry-config={self._registry_config}")
             cmd += ["verify-payload", imagestream]
-            if self.runtime.dry_run:
-                self._logger.info("[DRY-RUN] Would have run command: %s", ' '.join(cmd))
-                return
             async with self._elliott_lock:
                 _, stdout, _ = await exectools.cmd_gather_async(
                     cmd, env=self._elliott_env_vars, stderr=None, check=True
@@ -1520,11 +1517,15 @@ class PromotePipeline:
             results = json.loads(stdout)
             self._logger.info("Verify payload results for %s:\n%s", imagestream, json.dumps(results, indent=4))
             if results.get("missing_in_advisory") or results.get("payload_advisory_mismatch"):
-                raise VerificationError(
+                msg = (
                     f"Payload verification failed for imagestream {imagestream}. "
                     "The imagestream contents do not match the advisory builds. "
                     "Ensure gen-payload/build-sync has been run for the current assembly spec."
                 )
+                if self.runtime.dry_run:
+                    self._logger.warning("[DRY-RUN] %s", msg)
+                    return
+                raise VerificationError(msg)
             self._logger.info("Payload verification succeeded for imagestream %s", imagestream)
 
         imagestreams = [

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1514,7 +1514,9 @@ class PromotePipeline:
                 self._logger.info("[DRY-RUN] Would have run command: %s", ' '.join(cmd))
                 return
             async with self._elliott_lock:
-                _, stdout, _ = await exectools.cmd_gather_async(cmd, env=self._elliott_env_vars, stderr=None)
+                _, stdout, _ = await exectools.cmd_gather_async(
+                    cmd, env=self._elliott_env_vars, stderr=None, check=True
+                )
             results = json.loads(stdout)
             self._logger.info("Verify payload results for %s:\n%s", imagestream, json.dumps(results, indent=4))
             if results.get("missing_in_advisory") or results.get("payload_advisory_mismatch"):

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -431,8 +431,11 @@ class PromotePipeline:
                         justifications.append(justification)
 
             # Verify payload imagestreams match advisory builds before promoting
-            logger.info("Verifying payload imagestreams match advisory builds...")
-            await self.verify_payload(assembly_type, arches)
+            if image_advisory > 0 or shipment_config:
+                logger.info("Verifying payload imagestreams match advisory builds...")
+                await self.verify_payload(assembly_type, arches)
+            else:
+                logger.info("Skipping payload verification: no image advisory or shipment config defined")
 
             # Promote release images
             metadata = {}
@@ -1654,8 +1657,15 @@ class PromotePipeline:
                 self._logger.warning("The existing release image %s will be overwritten!", dest_image_pullspec)
             major, minor = isolate_major_minor_in_group(self.group)
             # Ensure build-sync has been run for this assembly
-            is_name = f"{major}.{minor}-art-assembly-{self.assembly}{go_arch_suffix}"
-            imagestream = await self.get_image_stream(f"ocp{go_arch_suffix}", is_name)
+            is_namespace, is_name = payload_imagestream_namespace_and_name(
+                default_imagestream_namespace_base_name(),
+                assembly_imagestream_base_name_generic(
+                    f"{major}.{minor}", self.assembly, assembly_type, build_system='konflux'
+                ),
+                arch,
+                private=False,
+            )
+            imagestream = await self.get_image_stream(is_namespace, is_name)
             if not imagestream:
                 raise ValueError(f"Image stream {is_name} is not found. Did you run build-sync?")
             await self._fix_failed_imagestream_imports(f"ocp{go_arch_suffix}", is_name)

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -331,7 +331,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             {},
             "quay.io/openshift-release-dev/ocp-release:4.10.99-assembly.art0001-x86_64",
             None,
-            '4.10-art-assembly-art0001',
+            '4.10-konflux-art-assembly-art0001',
             keep_manifest_list=False,
         )
         build_release_image.assert_any_await(
@@ -342,7 +342,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             {},
             "quay.io/openshift-release-dev/ocp-release:4.10.99-assembly.art0001-s390x",
             None,
-            '4.10-art-assembly-art0001-s390x',
+            '4.10-konflux-art-assembly-art0001-s390x',
             keep_manifest_list=False,
         )
         pipeline._slack_client.bind_channel.assert_called_once_with("4.10.99-assembly.art0001")
@@ -580,8 +580,10 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
     @patch("pyartcd.pipelines.promote.PromotePipeline.get_image_stream")
     @patch("pyartcd.pipelines.promote.PromotePipeline.send_promote_complete_email")
     @patch("pyartcd.pipelines.promote.PromotePipeline.create_cincinnati_prs")
+    @patch("pyartcd.pipelines.promote.PromotePipeline.verify_payload")
     async def test_run_with_standard_assembly(
         self,
+        verify_payload: AsyncMock,
         create_cincinnati_prs: AsyncMock,
         send_promote_complete_email: Mock,
         get_image_stream: AsyncMock,
@@ -672,7 +674,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"},
             "quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64",
             None,
-            "4.10-art-assembly-4.10.99",
+            "4.10-konflux-art-assembly-4.10.99",
             keep_manifest_list=False,
         )
         build_release_image.assert_any_await(
@@ -683,7 +685,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"},
             "quay.io/openshift-release-dev/ocp-release:4.10.99-s390x",
             None,
-            "4.10-art-assembly-4.10.99-s390x",
+            "4.10-konflux-art-assembly-4.10.99-s390x",
             keep_manifest_list=False,
         )
         build_release_image.assert_any_await(
@@ -694,7 +696,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"},
             "quay.io/openshift-release-dev/ocp-release:4.10.99-ppc64le",
             None,
-            "4.10-art-assembly-4.10.99-ppc64le",
+            "4.10-konflux-art-assembly-4.10.99-ppc64le",
             keep_manifest_list=False,
         )
         build_release_image.assert_any_await(
@@ -705,7 +707,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"},
             "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64",
             None,
-            "4.10-art-assembly-4.10.99-arm64",
+            "4.10-konflux-art-assembly-4.10.99-arm64",
             keep_manifest_list=False,
         )
         pipeline._slack_client.bind_channel.assert_called_once_with("4.10.99")
@@ -803,7 +805,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             metadata,
             "quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64",
             None,
-            '4.10-art-assembly-4.10.99',
+            '4.10-konflux-art-assembly-4.10.99',
             keep_manifest_list=False,
         )
         get_image_stream_tag.assert_awaited_once_with("ocp", "release:4.10.99")
@@ -838,7 +840,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             metadata,
             "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64",
             None,
-            '4.10-art-assembly-4.10.99-arm64',
+            '4.10-konflux-art-assembly-4.10.99-arm64',
             keep_manifest_list=False,
         )
         get_image_stream_tag.assert_awaited_once_with("ocp-arm64", "release-arm64:4.10.99")
@@ -879,7 +881,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             metadata,
             "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64",
             None,
-            '4.10-art-assembly-4.10.99-arm64',
+            '4.10-konflux-art-assembly-4.10.99-arm64',
             keep_manifest_list=False,
         )
         get_image_stream_tag.assert_awaited_once_with("ocp-arm64", "release-arm64:4.10.99")
@@ -1872,8 +1874,10 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             }
         ),
     )
+    @patch("pyartcd.pipelines.promote.PromotePipeline.verify_payload")
     async def test_run_with_shipment_config_valid(
         self,
+        verify_payload: AsyncMock,
         load_group_config: AsyncMock,
         load_releases_config: AsyncMock,
         datetime_mock: Mock,

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -332,7 +332,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             {},
             "quay.io/openshift-release-dev/ocp-release:4.10.99-assembly.art0001-x86_64",
             None,
-            '4.10-art-assembly-art0001',
+            '4.10-konflux-art-assembly-art0001',
             keep_manifest_list=False,
         )
         build_release_image.assert_any_await(
@@ -343,7 +343,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             {},
             "quay.io/openshift-release-dev/ocp-release:4.10.99-assembly.art0001-s390x",
             None,
-            '4.10-art-assembly-art0001-s390x',
+            '4.10-konflux-art-assembly-art0001-s390x',
             keep_manifest_list=False,
         )
         pipeline._slack_client.bind_channel.assert_called_once_with("4.10.99-assembly.art0001")
@@ -581,8 +581,10 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
     @patch("pyartcd.pipelines.promote.PromotePipeline.get_image_stream")
     @patch("pyartcd.pipelines.promote.PromotePipeline.send_promote_complete_email")
     @patch("pyartcd.pipelines.promote.PromotePipeline.create_cincinnati_prs")
+    @patch("pyartcd.pipelines.promote.PromotePipeline.verify_payload")
     async def test_run_with_standard_assembly(
         self,
+        verify_payload: AsyncMock,
         create_cincinnati_prs: AsyncMock,
         send_promote_complete_email: Mock,
         get_image_stream: AsyncMock,
@@ -674,7 +676,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"},
             "quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64",
             None,
-            "4.10-art-assembly-4.10.99",
+            "4.10-konflux-art-assembly-4.10.99",
             keep_manifest_list=False,
         )
         build_release_image.assert_any_await(
@@ -685,7 +687,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"},
             "quay.io/openshift-release-dev/ocp-release:4.10.99-s390x",
             None,
-            "4.10-art-assembly-4.10.99-s390x",
+            "4.10-konflux-art-assembly-4.10.99-s390x",
             keep_manifest_list=False,
         )
         build_release_image.assert_any_await(
@@ -696,7 +698,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"},
             "quay.io/openshift-release-dev/ocp-release:4.10.99-ppc64le",
             None,
-            "4.10-art-assembly-4.10.99-ppc64le",
+            "4.10-konflux-art-assembly-4.10.99-ppc64le",
             keep_manifest_list=False,
         )
         build_release_image.assert_any_await(
@@ -707,7 +709,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"},
             "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64",
             None,
-            "4.10-art-assembly-4.10.99-arm64",
+            "4.10-konflux-art-assembly-4.10.99-arm64",
             keep_manifest_list=False,
         )
         pipeline._slack_client.bind_channel.assert_called_once_with("4.10.99")
@@ -806,7 +808,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             metadata,
             "quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64",
             None,
-            '4.10-art-assembly-4.10.99',
+            '4.10-konflux-art-assembly-4.10.99',
             keep_manifest_list=False,
         )
         get_image_stream_tag.assert_awaited_once_with("ocp", "release:4.10.99")
@@ -841,7 +843,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             metadata,
             "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64",
             None,
-            '4.10-art-assembly-4.10.99-arm64',
+            '4.10-konflux-art-assembly-4.10.99-arm64',
             keep_manifest_list=False,
         )
         get_image_stream_tag.assert_awaited_once_with("ocp-arm64", "release-arm64:4.10.99")
@@ -882,7 +884,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             metadata,
             "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64",
             None,
-            '4.10-art-assembly-4.10.99-arm64',
+            '4.10-konflux-art-assembly-4.10.99-arm64',
             keep_manifest_list=False,
         )
         get_image_stream_tag.assert_awaited_once_with("ocp-arm64", "release-arm64:4.10.99")
@@ -1875,8 +1877,10 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             }
         ),
     )
+    @patch("pyartcd.pipelines.promote.PromotePipeline.verify_payload")
     async def test_run_with_shipment_config_valid(
         self,
+        verify_payload: AsyncMock,
         load_group_config: AsyncMock,
         load_releases_config: AsyncMock,
         datetime_mock: Mock,


### PR DESCRIPTION
## Summary
- Adds `verify_payload()` to the promote pipeline that runs `elliott verify-payload` against each arch-specific imagestream **before** promoting release images
- Fills the gap where the promote pipeline trusted imagestream contents without verifying they match the advisory builds (previously marked with a TODO)
- This is a hard failure — if the payload doesn't match, promotion stops. The correct fix is to re-run gen-payload/build-sync, not to bypass the check
- Removes the stale TODO comment in `_promote_arch`

## Test plan
- [x] Verify linting passes (`make lint`)
- [X] Verify dry-run promote pipeline logs the `[DRY-RUN] Would have run command` message for verify-payload
- [x] Test with a real assembly to confirm `elliott verify-payload` runs before promotion and catches mismatches

Test run: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fpromote-assembly/1169/consoleFull

🤖 Generated with [Claude Code](https://claude.com/claude-code)