### PR TITLE
fix(elliott): fix broken error message in attach-cve-flaws shipment validation

### DIFF
--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -246,7 +246,7 @@ class AttachCveFlaws:
         kinds = [advisory.get("kind") for advisory in advisories]
         if self.default_advisory_type not in kinds:
             raise click.UsageError(
-                f"Default advisory type '{self.default_advisory_type}' not found in shipment advisories: {advisories.keys()}"
+                f"Default advisory type '{self.default_advisory_type}' not found in shipment advisories. Available kinds: {kinds}"
             )
 
         # Get the shipment configs from the merge request URL


### PR DESCRIPTION
## Summary
- `advisories` is a list (from `shipment.get("advisories", [])`), so calling `.keys()` on it raises `AttributeError` before the intended error message is ever shown
- Display the extracted `kinds` list instead, which is what the validation actually checks against

## Test plan
- [x] Existing unit tests pass (`elliott/tests/test_attach_cve_flaws_cli.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)