### PR TITLE
fix _get_rpm_advisory_id failing when releases.yml uses advisories! key

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -2599,34 +2599,21 @@ class PromotePipeline:
             raise
 
     async def _get_rpm_advisory_id(self) -> Optional[str]:
-        """Get RPM advisory ID from releases.yml and query errata endpoint for advisory type.
+        """
+        Get RPM advisory ID from the assembly group config and query errata endpoint for advisory type.
 
-        :return: Formatted RPM advisory string like "RHBA-2025:12345" or None if not found
+        Uses group_runtime.group_config which properly resolves assembly inheritance
+        and handles special key suffixes (e.g. 'advisories!' for full replacement).
+
+        Return Value(s):
+            Formatted RPM advisory string like "RHBA-2025:12345" or None if not found.
         """
         try:
-            # Load releases.yml config to get RPM advisory ID
-            releases_config = await util.load_releases_config(
-                group=self.group,
-                data_path=self._doozer_env_vars.get("DOOZER_DATA_PATH", None) or constants.OCP_BUILD_DATA_URL,
-            )
+            group_config = self.group_runtime.group_config
+            advisories = group_config.get("advisories", {})
+            rpm_advisory_id = advisories.get("rpm")
 
-            # Debug: Show available releases in the config
-            available_releases = list(releases_config.get("releases", {}).keys())
-            self._logger.info("Available releases in releases.yml: %s", available_releases)
-
-            # Get the assembly config from releases.yml
-            assembly_config = releases_config.get("releases", {}).get(self.assembly)
-            if not assembly_config:
-                self._logger.warning("Assembly %s not found in releases.yml", self.assembly)
-                return None
-
-            self._logger.info("Assembly config keys for %s: %s", self.assembly, list(assembly_config.keys()))
-
-            # Get RPM advisory ID from assembly.group.advisories path
-            assembly_group_advisories = assembly_config.get("assembly", {}).get("group", {}).get("advisories", {})
-            rpm_advisory_id = assembly_group_advisories.get("rpm")
-
-            self._logger.info("Assembly group advisories for %s: %s", self.assembly, assembly_group_advisories)
+            self._logger.info("Assembly group advisories for %s: %s", self.assembly, advisories)
 
             if not rpm_advisory_id:
                 self._logger.info("No RPM advisory ID found for assembly %s", self.assembly)

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
-from artcommonlib.assembly import AssemblyTypes
+from artcommonlib.assembly import AssemblyTypes, assembly_field
 from artcommonlib.exceptions import VerificationError
 from artcommonlib.jira_config import JIRA_SERVER_URL
 from artcommonlib.model import Model
@@ -2116,6 +2116,158 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
                 }
             },
         )
+
+    @patch("pyartcd.pipelines.promote.get_errata_live_id", return_value="RHBA-2026:166757")
+    @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
+    @patch("pyartcd.pipelines.promote.util.load_releases_config", return_value={})
+    @patch(
+        "pyartcd.pipelines.promote.util.load_group_config",
+        return_value=Model(
+            {
+                "arches": ["x86_64", "s390x"],
+                "advisories": {"rpm": 166757, "rhcos": 166758},
+            }
+        ),
+    )
+    async def test_get_rpm_advisory_id_from_group_config(
+        self, load_group_config: AsyncMock, load_releases_config: AsyncMock, _, get_errata_live_id: Mock
+    ):
+        """
+        Simulate the 4.21.14 scenario where releases.yml uses 'advisories!' (with '!' suffix)
+        to override inherited advisories. The raw YAML key 'advisories!' would not match a
+        plain .get("advisories") lookup, but group_runtime.group_config (which goes through
+        assembly_field merging) strips the '!' and returns the clean key.
+        This test verifies that _get_rpm_advisory_id correctly reads the RPM advisory ID
+        from the merged group config.
+        """
+        runtime = MagicMock(
+            config={
+                "build_config": {
+                    "ocp_build_data_url": "https://example.com/ocp-build-data.git",
+                },
+                "jira": {
+                    "url": JIRA_SERVER_URL,
+                },
+            },
+            working_dir=Path("/path/to/working"),
+            dry_run=False,
+        )
+        pipeline = await PromotePipeline.create(
+            runtime, group="openshift-4.21", assembly="4.21.14", signing_env="prod", skip_sigstore=True
+        )
+
+        result = await pipeline._get_rpm_advisory_id()
+
+        self.assertEqual(result, "RHBA-2026:166757")
+        get_errata_live_id.assert_called_once_with(166757)
+
+    @patch("pyartcd.pipelines.promote.get_errata_live_id", return_value="RHBA-2026:166757")
+    @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
+    @patch("pyartcd.pipelines.promote.util.load_releases_config", return_value={})
+    async def test_get_rpm_advisory_id_with_advisories_bang_suffix(
+        self, load_releases_config: AsyncMock, _, get_errata_live_id: Mock
+    ):
+        """
+        Reproduce the exact 4.21.14 scenario: releases.yml uses 'advisories!' (with '!')
+        to prevent inheriting parent assembly's advisories. Run the raw releases config
+        through assembly_field (the real merge function) to produce the group config,
+        proving that the '!' suffix is correctly stripped and the RPM advisory is found.
+        """
+        # Raw releases.yml structure mirroring the 4.21.14 PR (ocp-build-data#10405)
+        releases_config = {
+            "releases": {
+                "4.21.13": {
+                    "assembly": {
+                        "group": {
+                            "advisories": {"rpm": 99999, "rhcos": 99998},
+                        },
+                    },
+                },
+                "4.21.14": {
+                    "assembly": {
+                        "basis": {
+                            "assembly": "4.21.13",
+                        },
+                        "group": {
+                            # The '!' suffix means: do NOT inherit advisories from 4.21.13
+                            "advisories!": {"rpm": 166757, "rhcos": 166758},
+                        },
+                    },
+                },
+            },
+        }
+
+        # Run through the real assembly merge — this is what doozer config:read-group does
+        merged_group = assembly_field(releases_config, "4.21.14", "group", {})
+
+        # Verify the merge stripped the '!' and did NOT inherit parent's advisories
+        self.assertEqual(merged_group["advisories"]["rpm"], 166757)
+        self.assertNotEqual(merged_group["advisories"]["rpm"], 99999)
+
+        # Now use this merged config as load_group_config return value
+        with patch(
+            "pyartcd.pipelines.promote.util.load_group_config",
+            return_value=Model({**merged_group, "arches": ["x86_64", "s390x"]}),
+        ):
+            runtime = MagicMock(
+                config={
+                    "build_config": {
+                        "ocp_build_data_url": "https://example.com/ocp-build-data.git",
+                    },
+                    "jira": {
+                        "url": JIRA_SERVER_URL,
+                    },
+                },
+                working_dir=Path("/path/to/working"),
+                dry_run=False,
+            )
+            pipeline = await PromotePipeline.create(
+                runtime, group="openshift-4.21", assembly="4.21.14", signing_env="prod", skip_sigstore=True
+            )
+
+            result = await pipeline._get_rpm_advisory_id()
+
+            self.assertEqual(result, "RHBA-2026:166757")
+            get_errata_live_id.assert_called_once_with(166757)
+
+    @patch("pyartcd.pipelines.promote.get_errata_live_id")
+    @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
+    @patch("pyartcd.pipelines.promote.util.load_releases_config", return_value={})
+    @patch(
+        "pyartcd.pipelines.promote.util.load_group_config",
+        return_value=Model(
+            {
+                "arches": ["x86_64", "s390x"],
+            }
+        ),
+    )
+    async def test_get_rpm_advisory_id_returns_none_when_no_advisories(
+        self, load_group_config: AsyncMock, load_releases_config: AsyncMock, _, get_errata_live_id: Mock
+    ):
+        """
+        Verify that _get_rpm_advisory_id returns None when no advisories are defined
+        in the group config (e.g. stream assembly or assembly without RPM advisory).
+        """
+        runtime = MagicMock(
+            config={
+                "build_config": {
+                    "ocp_build_data_url": "https://example.com/ocp-build-data.git",
+                },
+                "jira": {
+                    "url": JIRA_SERVER_URL,
+                },
+            },
+            working_dir=Path("/path/to/working"),
+            dry_run=False,
+        )
+        pipeline = await PromotePipeline.create(
+            runtime, group="openshift-4.21", assembly="4.21.14", signing_env="prod", skip_sigstore=True
+        )
+
+        result = await pipeline._get_rpm_advisory_id()
+
+        self.assertIsNone(result)
+        get_errata_live_id.assert_not_called()
 
     @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
     @patch("pyartcd.pipelines.promote.exectools.cmd_assert_async")


### PR DESCRIPTION
The method was reading raw releases.yml and doing .get("advisories"), which missed the "advisories!" key (used to prevent inheriting parent assembly's advisories). Use group_runtime.group_config instead, which goes through assembly_field merging and strips the "!" suffix.

Triggered by [ocp-build-data#10405](https://github.com/openshift-eng/ocp-build-data/pull/10405) adding advisories! for 4.21.14.
