### PR TITLE
fix(doozer): fetch base image Konflux records with SUCCESS as fallback

### DIFF
--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -192,10 +192,33 @@ class BaseImageHandler:
 
         try:
             where = {"group": self.runtime.group, "engine": Engine.KONFLUX.value}
-            records = await self.konflux_db.get_build_records_by_nvrs(
-                nvrs, outcome=KonfluxBuildOutcome.UNRELEASED, where=where, strict=False, exclude_large_columns=True
+            unreleased_records = await self.konflux_db.get_build_records_by_nvrs(
+                nvrs,
+                outcome=KonfluxBuildOutcome.UNRELEASED,
+                where=where,
+                strict=False,
+                exclude_large_columns=True,
             )
-            return {record.nvr: record for record in records if record is not None}
+            merged: Dict[str, KonfluxBuildRecord] = {}
+            missing_nvrs: List[str] = []
+            for nvr, record in zip(nvrs, unreleased_records, strict=True):
+                if record is not None:
+                    merged[nvr] = record
+                else:
+                    missing_nvrs.append(nvr)
+
+            if missing_nvrs:
+                success_records = await self.konflux_db.get_build_records_by_nvrs(
+                    missing_nvrs,
+                    outcome=KonfluxBuildOutcome.SUCCESS,
+                    where=where,
+                    strict=False,
+                    exclude_large_columns=True,
+                )
+                for nvr, record in zip(missing_nvrs, success_records, strict=True):
+                    if record is not None:
+                        merged[nvr] = record
+            return merged
         except Exception as e:
             self.logger.warning(f"Failed to fetch build records from database: {e}")
             return {}

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -1,6 +1,7 @@
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
 from artcommonlib.model import Model
 from doozerlib.backend.base_image_handler import BaseImageHandler
 from doozerlib.image import ImageMetadata
@@ -30,6 +31,110 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         self.image_pullspec = "quay.io/test/test-base:latest"
 
         self.nvr_list = [self.nvr]
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_fetch_build_records_success_fallback_after_unreleased_miss(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+        mock_konflux_client_init.return_value = AsyncMock()
+
+        konflux_db = AsyncMock()
+        success_only = MagicMock()
+        success_only.nvr = self.nvr
+
+        async def get_by_nvrs(nvrs_arg, outcome=None, **_kwargs):
+            if outcome == KonfluxBuildOutcome.UNRELEASED:
+                self.assertEqual(list(nvrs_arg), self.nvr_list)
+                return [None]
+            if outcome == KonfluxBuildOutcome.SUCCESS:
+                self.assertEqual(list(nvrs_arg), self.nvr_list)
+                return [success_only]
+            raise AssertionError(f"unexpected outcome {outcome}")
+
+        konflux_db.get_build_records_by_nvrs = get_by_nvrs
+
+        handler = BaseImageHandler(self.runtime, self.nvr_list, konflux_db=konflux_db, dry_run=True)
+        result = await handler._fetch_build_records(self.nvr_list)
+
+        self.assertEqual(result, {self.nvr: success_only})
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_fetch_build_records_skips_success_when_unreleased_hits(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+        mock_konflux_client_init.return_value = AsyncMock()
+
+        unreleased_rec = MagicMock()
+        unreleased_rec.nvr = self.nvr
+
+        calls = []
+
+        async def get_by_nvrs(nvrs_arg, outcome=None, **_kwargs):
+            calls.append((outcome, list(nvrs_arg)))
+            if outcome == KonfluxBuildOutcome.UNRELEASED:
+                return [unreleased_rec]
+            raise AssertionError(f"unexpected outcome {outcome}")
+
+        konflux_db = AsyncMock()
+        konflux_db.get_build_records_by_nvrs = get_by_nvrs
+
+        handler = BaseImageHandler(self.runtime, self.nvr_list, konflux_db=konflux_db, dry_run=True)
+        result = await handler._fetch_build_records(self.nvr_list)
+
+        self.assertEqual(result, {self.nvr: unreleased_rec})
+        self.assertEqual(calls, [(KonfluxBuildOutcome.UNRELEASED, self.nvr_list)])
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_fetch_build_records_success_only_for_missing_nvrs_in_batch(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+        mock_konflux_client_init.return_value = AsyncMock()
+
+        nvr_kept = "kept-base-container-v1.0.0-1.el9"
+        nvr_fallback = "fallback-base-container-v1.0.0-1.el9"
+        nvr_list = [nvr_kept, nvr_fallback]
+
+        unreleased_kept = MagicMock()
+        unreleased_kept.nvr = nvr_kept
+        success_fallback = MagicMock()
+        success_fallback.nvr = nvr_fallback
+
+        calls = []
+
+        async def get_by_nvrs(nvrs_arg, outcome=None, **_kwargs):
+            calls.append((outcome, list(nvrs_arg)))
+            if outcome == KonfluxBuildOutcome.UNRELEASED:
+                return [unreleased_kept, None]
+            if outcome == KonfluxBuildOutcome.SUCCESS:
+                return [success_fallback]
+            raise AssertionError(f"unexpected outcome {outcome}")
+
+        konflux_db = AsyncMock()
+        konflux_db.get_build_records_by_nvrs = get_by_nvrs
+
+        handler = BaseImageHandler(self.runtime, nvr_list, konflux_db=konflux_db, dry_run=True)
+        result = await handler._fetch_build_records(nvr_list)
+
+        self.assertEqual(
+            calls,
+            [
+                (KonfluxBuildOutcome.UNRELEASED, nvr_list),
+                (KonfluxBuildOutcome.SUCCESS, [nvr_fallback]),
+            ],
+        )
+        self.assertEqual(result, {nvr_kept: unreleased_kept, nvr_fallback: success_fallback})
 
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")


### PR DESCRIPTION
## Summary
`BaseImageHandler._fetch_build_records` now resolves Konflux DB rows by querying `UNRELEASED` for all NVRs first, then querying `SUCCESS` only for NVRs that had no unreleased record. This matches the usual case (unreleased) and avoids a second batch lookup when every NVR already matches.

## Problem
**Before:** Builds stored only as `SUCCESS` were missed when the query filtered on `UNRELEASED` alone. A parallel UNRELEASED+SUCCESS approach also always incurred two full batch lookups.

**After:** One UNreleased pass covers the common path; `SUCCESS` is a targeted fallback for gaps only, so unreleased rows stay authoritative and the happy path does a single `get_build_records_by_nvrs` call.

## Implementation Details
- `doozer/doozerlib/backend/base_image_handler.py`: collect `missing_nvrs` after the unreleased lookup; call `get_build_records_by_nvrs` with `KonfluxBuildOutcome.SUCCESS` only for that list.
- `doozer/tests/backend/test_base_image_handler.py`: tests for SUCCESS fallback, skipping SUCCESS when unreleased succeeds, and partial batch behavior.

---

_Add an `ART-_____` prefix to the PR title if your team requires a JIRA key._
