### PR TITLE
feat(konflux): include patch in golang-builder Konflux component names

### DIFF
--- a/artcommon/artcommonlib/rpm_utils.py
+++ b/artcommon/artcommonlib/rpm_utils.py
@@ -68,6 +68,34 @@ def parse_nvr(nvre: str):
     return result
 
 
+def rpm_version_to_golang_v_semver(version: str) -> str:
+    """
+    Normalize an RPM NVR *version* field to ``v`` + exactly three dot-separated segments (Go-style semver core).
+
+    Used for golang-builder labels (Konflux component names, etc.). First three segments of the version are kept;
+    shorter versions are zero-padded (``1.24`` -> ``v1.24.0``); four or more segments truncate (``1.24.0.1`` ->
+    ``v1.24.0``). Optional leading ``v`` / ``V`` is stripped before parsing.
+
+    :param version: The ``version`` value from :func:`parse_nvr`
+    :return: String like ``v1.25.8``
+    :raises ValueError: if *version* is empty/whitespace or has an empty segment among the first three parts
+    """
+    if not isinstance(version, str) or not version.strip():
+        raise ValueError("RPM version must be a non-empty string")
+    v = version.strip()
+    if v[:1].lower() == "v":
+        v = v[1:]
+    parts = v.split(".")
+    if not parts:
+        raise ValueError(f"Invalid RPM version: {version!r}")
+    head = parts[:3]
+    if any(not seg for seg in head):
+        raise ValueError(f"Invalid RPM version (empty segment): {version!r}")
+    while len(head) < 3:
+        head.append("0")
+    return f"v{head[0]}.{head[1]}.{head[2]}"
+
+
 def to_nevr(d: Dict):
     """Converts an NEVR dict to N-E:V-R string"""
     n = d["name"]

--- a/artcommon/tests/test_rpm_utils.py
+++ b/artcommon/tests/test_rpm_utils.py
@@ -1,0 +1,45 @@
+import unittest
+
+from artcommonlib.rpm_utils import parse_nvr, rpm_version_to_golang_v_semver
+
+
+class TestRpmVersionToGolangVSemver(unittest.TestCase):
+    def test_three_segments_unchanged(self):
+        self.assertEqual(rpm_version_to_golang_v_semver("v1.25.8"), "v1.25.8")
+        self.assertEqual(rpm_version_to_golang_v_semver("1.25.8"), "v1.25.8")
+
+    def test_two_segments_padded(self):
+        self.assertEqual(rpm_version_to_golang_v_semver("v1.24"), "v1.24.0")
+        self.assertEqual(rpm_version_to_golang_v_semver("1.24"), "v1.24.0")
+
+    def test_one_segment_padded(self):
+        self.assertEqual(rpm_version_to_golang_v_semver("v1"), "v1.0.0")
+        self.assertEqual(rpm_version_to_golang_v_semver("1"), "v1.0.0")
+
+    def test_four_plus_truncates_to_three(self):
+        self.assertEqual(rpm_version_to_golang_v_semver("v1.24.0.1"), "v1.24.0")
+
+    def test_whitespace_stripped(self):
+        self.assertEqual(rpm_version_to_golang_v_semver("  v1.22.12 \t"), "v1.22.12")
+
+    def test_uppercase_v_prefix(self):
+        self.assertEqual(rpm_version_to_golang_v_semver("V1.20.12"), "v1.20.12")
+
+    def test_empty_raises(self):
+        with self.assertRaises(ValueError):
+            rpm_version_to_golang_v_semver("")
+        with self.assertRaises(ValueError):
+            rpm_version_to_golang_v_semver("   ")
+
+    def test_empty_segment_raises(self):
+        with self.assertRaises(ValueError):
+            rpm_version_to_golang_v_semver("1..3")
+
+    def test_via_parse_nvr_golang_builder(self):
+        nvr = "openshift-golang-builder-container-v1.22.12-202603171846.p2.g3a22db8.el8"
+        v = parse_nvr(nvr)["version"]
+        self.assertEqual(rpm_version_to_golang_v_semver(v), "v1.22.12")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -26,7 +26,7 @@ from artcommonlib.konflux.konflux_build_record import (
 from artcommonlib.model import Missing
 from artcommonlib.oc_image_info import oc_image_info__cached_async
 from artcommonlib.release_util import SoftwareLifecyclePhase, isolate_el_version_in_release, split_el_suffix_in_release
-from artcommonlib.rpm_utils import compare_nvr, parse_nvr
+from artcommonlib.rpm_utils import compare_nvr, parse_nvr, rpm_version_to_golang_v_semver
 from artcommonlib.util import fetch_slsa_attestation, get_konflux_data
 from dockerfile_parse import DockerfileParser
 from doozerlib import constants, util
@@ -539,23 +539,11 @@ class KonfluxImageBuilder:
             nvr: Build NVR (e.g., "openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.el8")
 
         Returns:
-            Component name (e.g., "golang-builder-v1.25-rhel8")
+            Component name (e.g., "golang-builder-v1.25.8-rhel8")
         """
         nvr_parsed = parse_nvr(nvr)
-        version = nvr_parsed["version"]
+        v_semver = rpm_version_to_golang_v_semver(nvr_parsed["version"])
         release = nvr_parsed["release"]
-
-        # Extract major.minor from semantic version (e.g., "v1.25.8" -> "v1.25")
-        if version.startswith("v"):
-            version_parts = version[1:].split(".")  # Remove 'v' prefix and split
-        else:
-            version_parts = version.split(".")
-
-        if len(version_parts) >= 2:
-            major_minor = f"v{version_parts[0]}.{version_parts[1]}"
-        else:
-            # Fallback to original version if parsing fails
-            major_minor = version
 
         # Determine RHEL version from release field
         # Assumes exactly one .elX pattern per release (validated by production data)
@@ -563,7 +551,7 @@ class KonfluxImageBuilder:
         if ".el8" in release:
             el_suffix = "rhel8"
 
-        return f"golang-builder-{major_minor}-{el_suffix}"
+        return f"golang-builder-{v_semver}-{el_suffix}"
 
     @staticmethod
     def _repo_gets_hermetic_module_hotfixes(repo_name: str, group: str, golang_pattern: re.Pattern) -> bool:

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -753,27 +753,27 @@ class TestKonfluxImageBuilderGolangComponent(unittest.TestCase):
     def test_get_golang_builder_component_name_basic(self):
         """Test basic golang builder component name generation."""
         nvr = "openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.el8"
-        expected = "golang-builder-v1.25-rhel8"
+        expected = "golang-builder-v1.25.8-rhel8"
         result = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
         self.assertEqual(result, expected)
 
     def test_get_golang_builder_component_name_el9(self):
         """Test golang builder component name with el9."""
         nvr = "openshift-golang-builder-container-v1.24.13-202603271102.p2.ge8e5642.el9"
-        expected = "golang-builder-v1.24-rhel9"
+        expected = "golang-builder-v1.24.13-rhel9"
         result = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
         self.assertEqual(result, expected)
 
     def test_get_golang_builder_component_name_various_versions(self):
-        """Test various golang versions extract major.minor correctly."""
+        """Test various golang versions normalize to vMAJ.MIN.PAT."""
         test_cases = [
-            ("openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.el8", "golang-builder-v1.25-rhel8"),
-            ("openshift-golang-builder-container-v1.24.13-202603271102.p2.ge8e5642.el9", "golang-builder-v1.24-rhel9"),
-            ("openshift-golang-builder-container-v1.19.13-202604151155.p2.g47c3be5.el9", "golang-builder-v1.19-rhel9"),
-            ("openshift-golang-builder-container-v1.23.10-202604151125.p2.gd0321dd.el9", "golang-builder-v1.23-rhel9"),
-            ("openshift-golang-builder-container-v1.21.13-202603251649.p0.g670cbfa.el9", "golang-builder-v1.21-rhel9"),
-            ("openshift-golang-builder-container-v1.22.12-202603171846.p2.g3a22db8.el8", "golang-builder-v1.22-rhel8"),
-            ("openshift-golang-builder-container-v1.20.12-202604101100.p0.g6e050e4.el8", "golang-builder-v1.20-rhel8"),
+            ("openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.el8", "golang-builder-v1.25.8-rhel8"),
+            ("openshift-golang-builder-container-v1.24.13-202603271102.p2.ge8e5642.el9", "golang-builder-v1.24.13-rhel9"),
+            ("openshift-golang-builder-container-v1.19.13-202604151155.p2.g47c3be5.el9", "golang-builder-v1.19.13-rhel9"),
+            ("openshift-golang-builder-container-v1.23.10-202604151125.p2.gd0321dd.el9", "golang-builder-v1.23.10-rhel9"),
+            ("openshift-golang-builder-container-v1.21.13-202603251649.p0.g670cbfa.el9", "golang-builder-v1.21.13-rhel9"),
+            ("openshift-golang-builder-container-v1.22.12-202603171846.p2.g3a22db8.el8", "golang-builder-v1.22.12-rhel8"),
+            ("openshift-golang-builder-container-v1.20.12-202604101100.p0.g6e050e4.el8", "golang-builder-v1.20.12-rhel8"),
         ]
 
         for nvr, expected in test_cases:
@@ -784,20 +784,20 @@ class TestKonfluxImageBuilderGolangComponent(unittest.TestCase):
     def test_get_golang_builder_component_name_comprehensive_dataset(self):
         """Test with comprehensive dataset of real NVRs."""
         test_nvrs = [
-            ("openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.el8", "golang-builder-v1.25-rhel8"),
-            ("openshift-golang-builder-container-v1.25.8-202604081723.p0.gf28329a.el9", "golang-builder-v1.25-rhel9"),
-            ("openshift-golang-builder-container-v1.25.8-202604081550.p2.gf28329a.el9", "golang-builder-v1.25-rhel9"),
-            ("openshift-golang-builder-container-v1.25.8-202604150842.p2.g2aa6a05.el8", "golang-builder-v1.25-rhel8"),
-            ("openshift-golang-builder-container-v1.19.13-202604151155.p2.g47c3be5.el9", "golang-builder-v1.19-rhel9"),
-            ("openshift-golang-builder-container-v1.23.10-202604151125.p2.gd0321dd.el9", "golang-builder-v1.23-rhel9"),
-            ("openshift-golang-builder-container-v1.24.13-202604151125.p2.g04d2cd5.el9", "golang-builder-v1.24-rhel9"),
-            ("openshift-golang-builder-container-v1.21.13-202603251649.p0.g670cbfa.el9", "golang-builder-v1.21-rhel9"),
-            ("openshift-golang-builder-container-v1.25.7-202604020943.p2.g5015a16.el9", "golang-builder-v1.25-rhel9"),
-            ("openshift-golang-builder-container-v1.25.7-202604021351.p2.g5015a16.el9", "golang-builder-v1.25-rhel9"),
-            ("openshift-golang-builder-container-v1.22.12-202603171846.p2.g3a22db8.el8", "golang-builder-v1.22-rhel8"),
-            ("openshift-golang-builder-container-v1.24.13-202603270926.p2.g1f0d617.el8", "golang-builder-v1.24-rhel8"),
-            ("openshift-golang-builder-container-v1.24.13-202603271102.p2.ge8e5642.el9", "golang-builder-v1.24-rhel9"),
-            ("openshift-golang-builder-container-v1.20.12-202604101100.p0.g6e050e4.el8", "golang-builder-v1.20-rhel8"),
+            ("openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.el8", "golang-builder-v1.25.8-rhel8"),
+            ("openshift-golang-builder-container-v1.25.8-202604081723.p0.gf28329a.el9", "golang-builder-v1.25.8-rhel9"),
+            ("openshift-golang-builder-container-v1.25.8-202604081550.p2.gf28329a.el9", "golang-builder-v1.25.8-rhel9"),
+            ("openshift-golang-builder-container-v1.25.8-202604150842.p2.g2aa6a05.el8", "golang-builder-v1.25.8-rhel8"),
+            ("openshift-golang-builder-container-v1.19.13-202604151155.p2.g47c3be5.el9", "golang-builder-v1.19.13-rhel9"),
+            ("openshift-golang-builder-container-v1.23.10-202604151125.p2.gd0321dd.el9", "golang-builder-v1.23.10-rhel9"),
+            ("openshift-golang-builder-container-v1.24.13-202604151125.p2.g04d2cd5.el9", "golang-builder-v1.24.13-rhel9"),
+            ("openshift-golang-builder-container-v1.21.13-202603251649.p0.g670cbfa.el9", "golang-builder-v1.21.13-rhel9"),
+            ("openshift-golang-builder-container-v1.25.7-202604020943.p2.g5015a16.el9", "golang-builder-v1.25.7-rhel9"),
+            ("openshift-golang-builder-container-v1.25.7-202604021351.p2.g5015a16.el9", "golang-builder-v1.25.7-rhel9"),
+            ("openshift-golang-builder-container-v1.22.12-202603171846.p2.g3a22db8.el8", "golang-builder-v1.22.12-rhel8"),
+            ("openshift-golang-builder-container-v1.24.13-202603270926.p2.g1f0d617.el8", "golang-builder-v1.24.13-rhel8"),
+            ("openshift-golang-builder-container-v1.24.13-202603271102.p2.ge8e5642.el9", "golang-builder-v1.24.13-rhel9"),
+            ("openshift-golang-builder-container-v1.20.12-202604101100.p0.g6e050e4.el8", "golang-builder-v1.20.12-rhel8"),
         ]
 
         for nvr, expected in test_nvrs:
@@ -808,33 +808,33 @@ class TestKonfluxImageBuilderGolangComponent(unittest.TestCase):
     def test_get_golang_builder_component_name_no_el_version_defaults_to_rhel9(self):
         """Test that missing RHEL version defaults to rhel9."""
         nvr = "openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.unknown"
-        expected = "golang-builder-v1.25-rhel9"
+        expected = "golang-builder-v1.25.8-rhel9"
         result = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
         self.assertEqual(result, expected)
 
     def test_get_golang_builder_component_name_version_without_v_prefix(self):
         """Test version without 'v' prefix."""
         nvr = "openshift-golang-builder-container-1.25.8-202604081607.p0.g2aa6a05.el8"
-        expected = "golang-builder-v1.25-rhel8"
+        expected = "golang-builder-v1.25.8-rhel8"
         result = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
         self.assertEqual(result, expected)
 
     def test_get_golang_builder_component_name_single_version_part(self):
-        """Test with single version part (fallback behavior)."""
+        """Single-segment RPM version is zero-padded to vX.0.0."""
         nvr = "openshift-golang-builder-container-v1-202604081607.p0.g2aa6a05.el9"
-        expected = "golang-builder-v1-rhel9"  # Should fallback to original version
+        expected = "golang-builder-v1.0.0-rhel9"
         result = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
         self.assertEqual(result, expected)
 
     def test_get_golang_builder_component_name_edge_cases(self):
         """Test edge cases and boundary conditions."""
         test_cases = [
-            # Two-part version (standard case)
-            ("openshift-golang-builder-container-v1.24-202604081607.p0.g2aa6a05.el9", "golang-builder-v1.24-rhel9"),
+            # Two-part version -> patch .0
+            ("openshift-golang-builder-container-v1.24-202604081607.p0.g2aa6a05.el9", "golang-builder-v1.24.0-rhel9"),
             # Three-part version
-            ("openshift-golang-builder-container-v1.24.0-202604081607.p0.g2aa6a05.el8", "golang-builder-v1.24-rhel8"),
-            # Four-part version
-            ("openshift-golang-builder-container-v1.24.0.1-202604081607.p0.g2aa6a05.el9", "golang-builder-v1.24-rhel9"),
+            ("openshift-golang-builder-container-v1.24.0-202604081607.p0.g2aa6a05.el8", "golang-builder-v1.24.0-rhel8"),
+            # Four-part version -> first three only
+            ("openshift-golang-builder-container-v1.24.0.1-202604081607.p0.g2aa6a05.el9", "golang-builder-v1.24.0-rhel9"),
         ]
 
         for nvr, expected in test_cases:
@@ -846,6 +846,6 @@ class TestKonfluxImageBuilderGolangComponent(unittest.TestCase):
         """Test theoretical edge case where both .el8 and .el9 appear in release."""
         # This documents the expected behavior: .el8 override wins due to simplified logic
         nvr = "openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.el8.dependency.el9"
-        expected = "golang-builder-v1.25-rhel8"  # .el8 override takes precedence
+        expected = "golang-builder-v1.25.8-rhel8"  # .el8 override takes precedence
         result = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
         self.assertEqual(result, expected)

--- a/elliott/elliottlib/cli/get_golang_report_cli.py
+++ b/elliott/elliottlib/cli/get_golang_report_cli.py
@@ -1,11 +1,10 @@
 import json
-import re
 
 import click
 from artcommonlib import logutil
 from artcommonlib.format_util import green_print
 from artcommonlib.release_util import split_el_suffix_in_release
-from artcommonlib.rpm_utils import parse_nvr
+from artcommonlib.rpm_utils import parse_nvr, rpm_version_to_golang_v_semver
 
 from elliottlib.cli.common import cli
 from elliottlib.runtime import Runtime
@@ -175,9 +174,8 @@ def golang_report_for_version(runtime, ocp_version: str, ignore_rhel: bool = Fal
 
 def go_version_from_nvr_string(nvr_string: str, ignore_rhel: bool) -> str:
     nvr = parse_nvr(nvr_string)
-    match = re.search(r'(\d+\.\d+\.\d+)', nvr['version'])
-    version = match.group(1)
-    _, el_version = split_el_suffix_in_release(nvr['release'])
+    version = rpm_version_to_golang_v_semver(nvr["version"])[1:]
+    _, el_version = split_el_suffix_in_release(nvr["release"])
     if not ignore_rhel:
         version = f"{version}.{el_version}"
     return version


### PR DESCRIPTION
## Summary

Konflux base-image release snapshots now name golang-builder components with the full Go patch level (for example `golang-builder-v1.22.12-rhel8` instead of `golang-builder-v1.22-rhel8`).

## Problem

**Before:** `get_golang_builder_component_name` only used major.minor from the NVR version field.

**After:** Component names always use `vMAJOR.MINOR.PATCH`, using a single normalization helper shared with `go:report` version extraction.

## Implementation

- Added `rpm_version_to_golang_v_semver` in `artcommonlib.rpm_utils` (first three dot-separated segments, zero-pad to three, optional leading `v` stripped for parsing).
- `KonfluxImageBuilder.get_golang_builder_component_name` uses that helper after `parse_nvr`.
- `elliott go:report` (`go_version_from_nvr_string`) uses the same helper for the semantic triple (still appends `.el*` when `--ignore-rhel` is not set).
- Tests in `artcommon/tests/test_rpm_utils.py` and updated expectations in `TestKonfluxImageBuilderGolangComponent`.