### PR TITLE
fix(doozer): seed lockfile RPMs from latest success or unreleased build

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -47,27 +47,17 @@ def _pick_lockfile_seed_build(
     Choose which Konflux DB row should seed lockfile installed_rpms: the latest of SUCCESS and UNRELEASED
     by completion time. If the time-newest row has no installed_rpms, prefer the other when it does.
     """
-    raw = [b for b in (success_build, unreleased_build) if b is not None]
-    candidates = []
-    seen_ids: set[int] = set()
-    for b in raw:
-        bid = id(b)
-        if bid not in seen_ids:
-            seen_ids.add(bid)
-            candidates.append(b)
+    candidates = [b for b in (success_build, unreleased_build) if b is not None]
     if not candidates:
         return None
-    if len(candidates) == 1:
-        chosen = candidates[0]
-    else:
-        a, b = candidates[0], candidates[1]
-        chosen = a if _lockfile_seed_build_completion_ts(a) > _lockfile_seed_build_completion_ts(b) else b
-
-    if not (chosen.installed_rpms or []):
-        for other in candidates:
-            if other is not chosen and (other.installed_rpms or []):
-                return other
-    return chosen
+    # Newer completion time wins; on equal timestamps prefer the latter (UNRELEASED) like strict `>` ordering.
+    chosen = max(
+        enumerate(candidates),
+        key=lambda ib: (_lockfile_seed_build_completion_ts(ib[1]), ib[0]),
+    )[1]
+    if chosen.installed_rpms:
+        return chosen
+    return next((c for c in candidates if c is not chosen and c.installed_rpms), chosen)
 
 
 @lru_cache(maxsize=256)
@@ -1173,9 +1163,10 @@ class ImageMetadata(Metadata):
         Returns either the full image RPM set or difference from parent packages,
         based on the inspect_parent configuration. Caches result in installed_rpms attribute.
 
-        When resolving the latest build (no matching lockfile_seed_nvrs), uses the newer of the
-        latest **success** and **unreleased** Konflux outcomes by build completion time so that
-        images waiting on release still contribute fresh SBOM RPMs to lockfile generation.
+        When resolving the latest build (no matching lockfile_seed_nvrs): for images that participate
+        in the base-image release workflow (same predicate as Konflux: ``should_trigger_base_image_release()``),
+        uses the newer of the latest **success** and **unreleased** Konflux outcomes by completion time so
+        that builds waiting on release still contribute fresh SBOM RPMs. Other images query **success** only.
 
         Args:
             lockfile_seed_nvrs: NVRs of builds whose installed RPMs should seed lockfile
@@ -1210,10 +1201,13 @@ class ImageMetadata(Metadata):
                 build_success = await self.runtime.konflux_db.get_latest_build(
                     **base_search_params, outcome=KonfluxBuildOutcome.SUCCESS
                 )
-                build_unreleased = await self.runtime.konflux_db.get_latest_build(
-                    **base_search_params, outcome=KonfluxBuildOutcome.UNRELEASED
-                )
-                build = _pick_lockfile_seed_build(build_success, build_unreleased)
+                if self.should_trigger_base_image_release():
+                    build_unreleased = await self.runtime.konflux_db.get_latest_build(
+                        **base_search_params, outcome=KonfluxBuildOutcome.UNRELEASED
+                    )
+                    build = _pick_lockfile_seed_build(build_success, build_unreleased)
+                else:
+                    build = build_success
                 if build:
                     self.logger.info(
                         'Lockfile seed for %s: nvr=%s outcome=%s end_time=%s',

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -47,17 +47,24 @@ def _pick_lockfile_seed_build(
     Choose which Konflux DB row should seed lockfile installed_rpms: the latest of SUCCESS and UNRELEASED
     by completion time. If the time-newest row has no installed_rpms, prefer the other when it does.
     """
-    candidates = [b for b in (success_build, unreleased_build) if b is not None]
-    if not candidates:
+    if success_build is None and unreleased_build is None:
         return None
-    # Newer completion time wins; on equal timestamps prefer the latter (UNRELEASED) like strict `>` ordering.
-    chosen = max(
-        enumerate(candidates),
-        key=lambda ib: (_lockfile_seed_build_completion_ts(ib[1]), ib[0]),
-    )[1]
+    if success_build is None:
+        chosen = unreleased_build
+    elif unreleased_build is None:
+        chosen = success_build
+    else:
+        success_ts = _lockfile_seed_build_completion_ts(success_build)
+        unreleased_ts = _lockfile_seed_build_completion_ts(unreleased_build)
+        # Prefer UNRELEASED on equal completion time (same tie-break as index-based max before).
+        chosen = unreleased_build if unreleased_ts >= success_ts else success_build
+
     if chosen.installed_rpms:
         return chosen
-    return next((c for c in candidates if c is not chosen and c.installed_rpms), chosen)
+    for candidate in (success_build, unreleased_build):
+        if candidate is not None and candidate is not chosen and candidate.installed_rpms:
+            return candidate
+    return chosen
 
 
 @lru_cache(maxsize=256)

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -5,6 +5,7 @@ import pathlib
 import re
 from collections import OrderedDict
 from copy import copy
+from datetime import datetime, timezone
 from functools import lru_cache
 from multiprocessing import Event
 from typing import Any, Dict, List, Optional, Set, Tuple, cast
@@ -26,6 +27,47 @@ from doozerlib.build_info import BrewBuildRecordInspector
 from doozerlib.distgit import pull_image
 from doozerlib.metadata import Metadata, RebuildHint, RebuildHintCode
 from doozerlib.source_resolver import SourceResolver
+
+
+def _lockfile_seed_build_completion_ts(record: KonfluxBuildRecord) -> datetime:
+    """Best-effort completion timestamp for comparing Konflux builds (end_time, else start_time)."""
+    t = record.end_time or record.start_time
+    if t is None:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if t.tzinfo is None:
+        t = t.replace(tzinfo=timezone.utc)
+    return t.astimezone(timezone.utc)
+
+
+def _pick_lockfile_seed_build(
+    success_build: Optional[KonfluxBuildRecord],
+    unreleased_build: Optional[KonfluxBuildRecord],
+) -> Optional[KonfluxBuildRecord]:
+    """
+    Choose which Konflux DB row should seed lockfile installed_rpms: the latest of SUCCESS and UNRELEASED
+    by completion time. If the time-newest row has no installed_rpms, prefer the other when it does.
+    """
+    raw = [b for b in (success_build, unreleased_build) if b is not None]
+    candidates = []
+    seen_ids: set[int] = set()
+    for b in raw:
+        bid = id(b)
+        if bid not in seen_ids:
+            seen_ids.add(bid)
+            candidates.append(b)
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        chosen = candidates[0]
+    else:
+        a, b = candidates[0], candidates[1]
+        chosen = a if _lockfile_seed_build_completion_ts(a) > _lockfile_seed_build_completion_ts(b) else b
+
+    if not (chosen.installed_rpms or []):
+        for other in candidates:
+            if other is not chosen and (other.installed_rpms or []):
+                return other
+    return chosen
 
 
 @lru_cache(maxsize=256)
@@ -1131,6 +1173,10 @@ class ImageMetadata(Metadata):
         Returns either the full image RPM set or difference from parent packages,
         based on the inspect_parent configuration. Caches result in installed_rpms attribute.
 
+        When resolving the latest build (no matching lockfile_seed_nvrs), uses the newer of the
+        latest **success** and **unreleased** Konflux outcomes by build completion time so that
+        images waiting on release still contribute fresh SBOM RPMs to lockfile generation.
+
         Args:
             lockfile_seed_nvrs: NVRs of builds whose installed RPMs should seed lockfile
                 generation. When provided, the method checks these NVRs first and uses the
@@ -1157,12 +1203,25 @@ class ImageMetadata(Metadata):
             if build is None:
                 base_search_params = {
                     'group': self.runtime.group,
-                    'outcome': "success",
                     'engine': self.runtime.build_system,
                     'name': self.distgit_key,
                     'assembly': self.runtime.assembly,
                 }
-                build = await self.runtime.konflux_db.get_latest_build(**base_search_params)
+                build_success = await self.runtime.konflux_db.get_latest_build(
+                    **base_search_params, outcome=KonfluxBuildOutcome.SUCCESS
+                )
+                build_unreleased = await self.runtime.konflux_db.get_latest_build(
+                    **base_search_params, outcome=KonfluxBuildOutcome.UNRELEASED
+                )
+                build = _pick_lockfile_seed_build(build_success, build_unreleased)
+                if build:
+                    self.logger.info(
+                        'Lockfile seed for %s: nvr=%s outcome=%s end_time=%s',
+                        self.distgit_key,
+                        getattr(build, 'nvr', None),
+                        build.outcome,
+                        build.end_time,
+                    )
 
             if not build:
                 self.logger.debug(f"No build record found for {self.distgit_key}/{self.runtime.group}")

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -3,10 +3,12 @@ import os
 import shutil
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from unittest import IsolatedAsyncioTestCase, mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from artcommonlib import exectools
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
 from artcommonlib.model import Missing, Model
 from artcommonlib.variants import BuildVariant
 from doozerlib import build_info, image
@@ -1230,6 +1232,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
 
         self.assertEqual(result, set())
         self.assertEqual(metadata.installed_rpms, [])
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
         self.logger.error.assert_not_called()
 
     async def test_fetch_rpms_from_build_build_no_packages(self):
@@ -1245,6 +1248,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
 
         self.assertEqual(result, set())
         self.assertEqual(metadata.installed_rpms, [])
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
         self.logger.error.assert_not_called()
 
     async def test_fetch_rpms_from_build_no_parent_full_package_set(self):
@@ -1265,6 +1269,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
 
         self.assertEqual(result, {'pkg1', 'pkg2', 'pkg3'})
         self.assertEqual(set(metadata.installed_rpms), {'pkg1', 'pkg2', 'pkg3'})
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
 
     async def test_fetch_rpms_from_build_exception_handling(self):
         """Test fetch_rpms_from_build handles exceptions gracefully"""
@@ -1311,7 +1316,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         result = await metadata.fetch_rpms_from_build(lockfile_seed_nvrs=['other-container-v4.22.0-assembly.test'])
 
         self.assertEqual(result, {'latest-pkg1'})
-        metadata.runtime.konflux_db.get_latest_build.assert_awaited_once()
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
 
     async def test_fetch_rpms_from_build_seed_nvr_not_in_db(self):
         """Test fetch_rpms_from_build falls back when seed NVR not found in DB"""
@@ -1326,7 +1331,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         result = await metadata.fetch_rpms_from_build(lockfile_seed_nvrs=['nonexistent-v4.22.0-assembly.test'])
 
         self.assertEqual(result, {'pkg1'})
-        metadata.runtime.konflux_db.get_latest_build.assert_awaited_once()
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
 
     async def test_fetch_rpms_from_build_no_seed_nvrs(self):
         """Test fetch_rpms_from_build works when no lockfile_seed_nvrs are provided"""
@@ -1339,7 +1344,76 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         result = await metadata.fetch_rpms_from_build()
 
         self.assertEqual(result, {'pkg1'})
-        metadata.runtime.konflux_db.get_latest_build.assert_awaited_once()
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
+
+    async def test_fetch_rpms_from_build_prefers_newer_unreleased(self):
+        """Latest unreleased build wins over older success when seeding lockfile RPMs."""
+        metadata = self._create_image_metadata('openshift/test-newer-unreleased')
+
+        older = MagicMock()
+        older.installed_rpms = ['golang-1.22.12-11.el9']
+        older.nvr = 'openshift-golang-builder-container-v1-old'
+        older.outcome = KonfluxBuildOutcome.SUCCESS
+        older.end_time = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        newer = MagicMock()
+        newer.installed_rpms = ['golang-1.22.12-12.el9']
+        newer.nvr = 'openshift-golang-builder-container-v1-new'
+        newer.outcome = KonfluxBuildOutcome.UNRELEASED
+        newer.end_time = datetime(2026, 5, 7, 12, 0, 0, tzinfo=timezone.utc)
+
+        metadata.runtime.konflux_db.get_latest_build = AsyncMock(side_effect=[older, newer])
+
+        result = await metadata.fetch_rpms_from_build()
+
+        self.assertEqual(result, {'golang-1.22.12-12.el9'})
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
+
+    async def test_fetch_rpms_from_build_prefers_newer_success(self):
+        """Latest success build wins over older unreleased when seeding lockfile RPMs."""
+        metadata = self._create_image_metadata('openshift/test-newer-success')
+
+        older = MagicMock()
+        older.installed_rpms = ['pkg-old']
+        older.nvr = 'img-old'
+        older.outcome = KonfluxBuildOutcome.UNRELEASED
+        older.end_time = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        newer = MagicMock()
+        newer.installed_rpms = ['pkg-new']
+        newer.nvr = 'img-new'
+        newer.outcome = KonfluxBuildOutcome.SUCCESS
+        newer.end_time = datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc)
+
+        metadata.runtime.konflux_db.get_latest_build = AsyncMock(side_effect=[newer, older])
+
+        result = await metadata.fetch_rpms_from_build()
+
+        self.assertEqual(result, {'pkg-new'})
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
+
+    async def test_fetch_rpms_from_build_uses_other_when_newer_has_no_installed_rpms(self):
+        """If the time-newest row has no installed_rpms, use the other candidate when it does."""
+        metadata = self._create_image_metadata('openshift/test-empty-newer')
+
+        newer_empty = MagicMock()
+        newer_empty.installed_rpms = []
+        newer_empty.nvr = 'img-newer-empty'
+        newer_empty.outcome = KonfluxBuildOutcome.UNRELEASED
+        newer_empty.end_time = datetime(2026, 5, 10, 12, 0, 0, tzinfo=timezone.utc)
+
+        older_filled = MagicMock()
+        older_filled.installed_rpms = ['golang-1.22.12-12.el9']
+        older_filled.nvr = 'img-older'
+        older_filled.outcome = KonfluxBuildOutcome.SUCCESS
+        older_filled.end_time = datetime(2026, 5, 5, 12, 0, 0, tzinfo=timezone.utc)
+
+        metadata.runtime.konflux_db.get_latest_build = AsyncMock(side_effect=[older_filled, newer_empty])
+
+        result = await metadata.fetch_rpms_from_build()
+
+        self.assertEqual(result, {'golang-1.22.12-12.el9'})
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
 
     def _setup_mock_config(self, metadata, lockfile_rpms=None):
         """Helper to setup mock config with lockfile RPMs."""

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -8,6 +8,7 @@ from unittest import IsolatedAsyncioTestCase, mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from artcommonlib import exectools
+from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
 from artcommonlib.model import Missing, Model
 from artcommonlib.variants import BuildVariant
@@ -1175,9 +1176,9 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
     def setUp(self):
         self.logger = MagicMock()
 
-    def _create_image_metadata(self, name, distgit_key=None):
-        """Helper to create ImageMetadata with mock runtime"""
-        image_model = Model({'name': name})
+    def _create_image_metadata(self, name, distgit_key=None, **extra_image_fields):
+        """Helper to create ImageMetadata with mock runtime (e.g. base_only=True or golang-builder name)."""
+        image_model = Model({'name': name, **extra_image_fields})
         data_obj = Model(
             {
                 'key': distgit_key or 'test-image',
@@ -1232,7 +1233,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
 
         self.assertEqual(result, set())
         self.assertEqual(metadata.installed_rpms, [])
-        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 1)
         self.logger.error.assert_not_called()
 
     async def test_fetch_rpms_from_build_build_no_packages(self):
@@ -1248,7 +1249,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
 
         self.assertEqual(result, set())
         self.assertEqual(metadata.installed_rpms, [])
-        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 1)
         self.logger.error.assert_not_called()
 
     async def test_fetch_rpms_from_build_no_parent_full_package_set(self):
@@ -1269,7 +1270,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
 
         self.assertEqual(result, {'pkg1', 'pkg2', 'pkg3'})
         self.assertEqual(set(metadata.installed_rpms), {'pkg1', 'pkg2', 'pkg3'})
-        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 1)
 
     async def test_fetch_rpms_from_build_exception_handling(self):
         """Test fetch_rpms_from_build handles exceptions gracefully"""
@@ -1316,7 +1317,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         result = await metadata.fetch_rpms_from_build(lockfile_seed_nvrs=['other-container-v4.22.0-assembly.test'])
 
         self.assertEqual(result, {'latest-pkg1'})
-        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 1)
 
     async def test_fetch_rpms_from_build_seed_nvr_not_in_db(self):
         """Test fetch_rpms_from_build falls back when seed NVR not found in DB"""
@@ -1331,7 +1332,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         result = await metadata.fetch_rpms_from_build(lockfile_seed_nvrs=['nonexistent-v4.22.0-assembly.test'])
 
         self.assertEqual(result, {'pkg1'})
-        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 1)
 
     async def test_fetch_rpms_from_build_no_seed_nvrs(self):
         """Test fetch_rpms_from_build works when no lockfile_seed_nvrs are provided"""
@@ -1344,11 +1345,24 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         result = await metadata.fetch_rpms_from_build()
 
         self.assertEqual(result, {'pkg1'})
-        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 1)
+
+    async def test_fetch_rpms_from_build_regular_queries_success_only(self):
+        """Non base-image/golang images issue a single SUCCESS get_latest_build (no UNRELEASED query)."""
+        metadata = self._create_image_metadata('openshift/test-regular-lookup')
+        mock_build = MagicMock()
+        mock_build.installed_rpms = ['pkg-a']
+        metadata.runtime.konflux_db.get_latest_build = AsyncMock(return_value=mock_build)
+
+        await metadata.fetch_rpms_from_build()
+
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 1)
+        called = metadata.runtime.konflux_db.get_latest_build.await_args.kwargs
+        self.assertEqual(called['outcome'], KonfluxBuildOutcome.SUCCESS)
 
     async def test_fetch_rpms_from_build_prefers_newer_unreleased(self):
         """Latest unreleased build wins over older success when seeding lockfile RPMs."""
-        metadata = self._create_image_metadata('openshift/test-newer-unreleased')
+        metadata = self._create_image_metadata(GOLANG_BUILDER_IMAGE_NAME, distgit_key='openshift-golang-builder')
 
         older = MagicMock()
         older.installed_rpms = ['golang-1.22.12-11.el9']
@@ -1371,7 +1385,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
 
     async def test_fetch_rpms_from_build_prefers_newer_success(self):
         """Latest success build wins over older unreleased when seeding lockfile RPMs."""
-        metadata = self._create_image_metadata('openshift/test-newer-success')
+        metadata = self._create_image_metadata(GOLANG_BUILDER_IMAGE_NAME, distgit_key='openshift-golang-builder')
 
         older = MagicMock()
         older.installed_rpms = ['pkg-old']
@@ -1394,7 +1408,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
 
     async def test_fetch_rpms_from_build_uses_other_when_newer_has_no_installed_rpms(self):
         """If the time-newest row has no installed_rpms, use the other candidate when it does."""
-        metadata = self._create_image_metadata('openshift/test-empty-newer')
+        metadata = self._create_image_metadata(GOLANG_BUILDER_IMAGE_NAME, distgit_key='openshift-golang-builder')
 
         newer_empty = MagicMock()
         newer_empty.installed_rpms = []


### PR DESCRIPTION
## Summary

Regression follow-up to https://github.com/openshift-eng/art-tools/pull/2851. That change introduced `KonfluxBuildOutcome.UNRELEASED` and persists many successful Konflux builds as `unreleased` (with SBOM-backed `installed_rpms`) before or instead of a `success` row. Lockfile generation still called `get_latest_build(outcome=success)` only, so the **newest** install set could live on `unreleased` while we seeded from an **older** `success` row—stale NVR pins and failing hermetic `dnf` (notably golang-builder).

## Problem

**Before:** `fetch_rpms_from_build` ignored newer `unreleased` DB rows when a `success` row existed with an earlier completion time.

**After:** We load the latest `success` and latest `unreleased`, take the newer by `end_time` (else `start_time`), dedupe identical objects from the two lookups, and if the time-winner has no `installed_rpms`, prefer the other candidate when it does. Unit tests cover ordering and fallback.

## Implementation

- `doozer/doozerlib/image.py`: `_lockfile_seed_build_completion_ts`, `_pick_lockfile_seed_build`, dual `get_latest_build` + info logging in `fetch_rpms_from_build`.
- `doozer/tests/test_image.py`: expect two DB calls where applicable; add tests for newer unreleased vs success and empty-rpms fallback.

No change to `pull_url()` / base-image coordination—this is scoped to lockfile RPM seeding only.

## Validation / test runs

Test Jenkins build (base-image-release): https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbase-image-release/5140/

Test Konflux PipelineRun (rhel-9-golang-1-22 / openshift-golang-builder): https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/rhel-9-golang-1-22/pipelineruns/rhel-9-golang-1-22-openshift-golang-builder-hprk5

The PLR **builds with hermetic** prefetch as expected; the overall run still **fails at release policy (Conforma / EC)**—that failure is separate from the image build+hermetic path exercised here.