### PR TITLE
fix(doozer): fetch SBOM from quay pullspec, not registry.redhat.io

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -996,14 +996,16 @@ class KonfluxImageBuilder:
                     f"pipelinerun {pipelinerun_name}"
                 )
 
+            quay_image_pullspec = f"{image_pullspec.split(':')[0]}@{image_digest}"
             if released:
                 definitive_image_pullspec = util.rh_art_images_base_pullspec(nvr)
             else:
-                definitive_image_pullspec = f"{image_pullspec.split(':')[0]}@{image_digest}"
+                definitive_image_pullspec = quay_image_pullspec
 
-            # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
+            # Always fetch SBOM from quay — it is attached to the Konflux-built
+            # image, not mirrored to registry.redhat.io by the release pipeline.
             package_nvrs, source_rpms = await self.get_installed_packages(
-                definitive_image_pullspec, building_arches, self._config.registry_auth_file
+                quay_image_pullspec, building_arches, self._config.registry_auth_file
             )
 
             build_record_params.update(

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -298,7 +298,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(call_kwargs['ec_policy'], constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION)
 
     async def test_update_konflux_db_with_released_true_sets_registry_pullspec(self):
-        """Test that released=True sets registry.redhat.io pullspec for base images."""
+        """Test that released=True stores registry.redhat.io pullspec in DB but fetches SBOM from quay."""
         metadata = self._metadata()
         metadata.should_trigger_base_image_release.return_value = True
         build_repo = MagicMock()
@@ -347,7 +347,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
             mock_dockerfile_parser.return_value = mock_dockerfile
             mock_bigquery_client.return_value.client.insert_rows_json.return_value = None
 
-            await self.builder.update_konflux_db(
+            record = await self.builder.update_konflux_db(
                 metadata,
                 build_repo,
                 pipelinerun,
@@ -357,8 +357,13 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 released=True,
             )
 
-        expected_pullspec = "registry.redhat.io/openshift/art-images-base:test-component-1.0-1.el9"
-        mock_get_installed_packages.assert_awaited_once_with(expected_pullspec, ["x86_64"], None)
+        # SBOM must be fetched from quay (where Konflux attaches it), not registry.redhat.io
+        quay_pullspec = "quay.io/test/image@sha256:testdigest"
+        mock_get_installed_packages.assert_awaited_once_with(quay_pullspec, ["x86_64"], None)
+
+        # DB record should store the registry.redhat.io pullspec for downstream consumers
+        expected_registry_pullspec = "registry.redhat.io/openshift/art-images-base:test-component-1.0-1.el9"
+        self.assertEqual(record.image_pullspec, expected_registry_pullspec)
 
     async def test_update_konflux_db_with_released_false_uses_quay_pullspec(self):
         """Test that released=False uses standard quay.io pullspec."""


### PR DESCRIPTION
PR #2851 introduced a regression where update_konflux_db() uses a registry.redhat.io tag-based pullspec for cosign download sbom when released=True. The SBOM is only attached to the Konflux-built image on quay.io, not mirrored to registry.redhat.io by the release pipeline, causing MANIFEST_UNKNOWN errors for all base_only images.

Always use the quay.io digest-based pullspec for SBOM download while still storing the registry.redhat.io pullspec in the DB record for downstream consumers.

[test build with this PR](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/fgallott/job/ocp4-konflux/774/console)

[failing build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/fgallott/job/ocp4-konflux/771/console)
