### PR TITLE
fix(doozer): Konflux digest in DB; art-images-base FROM handling in rebaser

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -381,7 +381,7 @@ class KonfluxImageBuilder:
                     if outcome is KonfluxBuildOutcome.UNRELEASED and metadata.should_trigger_base_image_release():
                         base_image_release_success = await self._trigger_base_image_release(metadata, nvr)
                         if base_image_release_success:
-                            logger.info(f"Base image release succeeded for {nvr}, updating with registry pullspec")
+                            logger.info(f"Base image release succeeded for {nvr}, updating build record")
                         else:
                             logger.error(f"Base image release failed for {nvr}, updating build record to FAILURE")
                         outcome = (
@@ -396,7 +396,6 @@ class KonfluxImageBuilder:
                             build_priority,
                             ec_status=ec_status,
                             ec_pipeline_url=ec_pipeline_url,
-                            released=base_image_release_success,
                         )
 
                 if outcome is not KonfluxBuildOutcome.SUCCESS:
@@ -908,7 +907,6 @@ class KonfluxImageBuilder:
         build_priority,
         ec_status=KonfluxECStatus.NOT_APPLICABLE,
         ec_pipeline_url='',
-        released=False,
     ) -> Optional[KonfluxBuildRecord]:
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
         if not metadata.runtime.konflux_db:
@@ -996,10 +994,7 @@ class KonfluxImageBuilder:
                     f"pipelinerun {pipelinerun_name}"
                 )
 
-            if released:
-                definitive_image_pullspec = util.rh_art_images_base_pullspec(nvr)
-            else:
-                definitive_image_pullspec = f"{image_pullspec.split(':')[0]}@{image_digest}"
+            definitive_image_pullspec = f"{image_pullspec.split(':')[0]}@{image_digest}"
 
             # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
             package_nvrs, source_rpms = await self.get_installed_packages(

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -22,7 +22,7 @@ from artcommonlib.build_visibility import BuildVisibility, get_visibility_suffix
 from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildRecord
 from artcommonlib.model import ListModel, Missing, Model
 from artcommonlib.telemetry import start_as_current_span_async
-from artcommonlib.util import deep_merge, detect_package_managers, is_cachito_enabled
+from artcommonlib.util import deep_merge, detect_package_managers, is_cachito_enabled, oc_image_info_for_arch_async
 from artcommonlib.variants import BuildVariant
 from dockerfile_parse import DockerfileParser
 from doozerlib import constants, util
@@ -503,6 +503,16 @@ class KonfluxRebaser:
         private_fix = any(private_fix for _, private_fix in mapped_images)
         return downstream_parents, private_fix
 
+    async def _registry_pullspec_exists(self, pullspec: str) -> bool:
+        """Return True if the registry reports the image readable (manifest present). Used for lazy DB lookups."""
+        registry_config = getattr(self._runtime, "registry_config", None)
+        try:
+            await oc_image_info_for_arch_async(pullspec, registry_config=registry_config)
+            return True
+        except Exception as exc:
+            self._logger.debug("Could not read pullspec %s: %s", pullspec, exc)
+            return False
+
     @start_as_current_span_async(TRACER, "rebase.resolve_member_parent")
     async def _resolve_member_parent(self, member: str, original_parent: str):
         """Resolve the parent image for the given image metadata."""
@@ -539,6 +549,16 @@ class KonfluxRebaser:
 
                 if not build:
                     raise IOError(f"A build of parent image {member} is not found.")
+                if parent_metadata.should_trigger_base_image_release():
+                    rh_pullspec = util.rh_art_images_base_pullspec(build.nvr)
+                    if await self._registry_pullspec_exists(rh_pullspec):
+                        return rh_pullspec, build.embargoed
+                    self._logger.info(
+                        "art-images-base %s not reachable; using Konflux image_pullspec for late-resolved parent %s",
+                        rh_pullspec,
+                        member,
+                    )
+                    return build.image_pullspec, build.embargoed
                 return build.image_pullspec, build.embargoed
 
             return original_parent, False

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -297,8 +297,8 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         call_kwargs = mock_verify_ec.await_args[1]
         self.assertEqual(call_kwargs['ec_policy'], constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION)
 
-    async def test_update_konflux_db_with_released_true_sets_registry_pullspec(self):
-        """Test that released=True sets registry.redhat.io pullspec for base images."""
+    async def test_update_konflux_db_success_keeps_konflux_digest_after_base_release_completion(self):
+        """Final SUCCESS after base-image release keeps Konflux digest in DB for SBOM (not RH tag)."""
         metadata = self._metadata()
         metadata.should_trigger_base_image_release.return_value = True
         build_repo = MagicMock()
@@ -354,69 +354,6 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 KonfluxBuildOutcome.SUCCESS,
                 ["x86_64"],
                 "5",
-                released=True,
-            )
-
-        expected_pullspec = "registry.redhat.io/openshift/art-images-base:test-component-1.0-1.el9"
-        mock_get_installed_packages.assert_awaited_once_with(expected_pullspec, ["x86_64"], None)
-
-    async def test_update_konflux_db_with_released_false_uses_quay_pullspec(self):
-        """Test that released=False uses standard quay.io pullspec."""
-        metadata = self._metadata()
-        build_repo = MagicMock()
-        build_repo.https_url = "https://example.com/repo.git"
-        build_repo.commit_hash = "test-commit-hash"
-        build_repo.local_dir = Path(self.temp_dir.name)
-
-        pipelinerun = PipelineRunInfo(
-            {
-                "metadata": {
-                    "name": "test-pipelinerun",
-                    "uid": "test-uid",
-                    "labels": {"appstudio.openshift.io/component": "test-component"},
-                },
-                "status": {
-                    "results": [
-                        {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
-                        {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
-                    ],
-                    "startTime": "2023-10-01T12:00:00Z",
-                    "completionTime": "2023-10-01T12:30:00Z",
-                },
-            },
-            {},
-        )
-
-        with (
-            patch("doozerlib.backend.konflux_image_builder.DockerfileParser") as mock_dockerfile_parser,
-            patch.object(self.builder, "extract_parent_image_nvrs", new=AsyncMock(return_value=[])),
-            patch.object(
-                self.builder,
-                "get_installed_packages",
-                new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
-            ) as mock_get_installed_packages,
-            patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
-        ):
-            mock_dockerfile = MagicMock()
-            mock_dockerfile.labels = {
-                "io.openshift.build.source-location": "https://example.com/source-repo.git",
-                "io.openshift.build.commit.id": "source-commit-id",
-                "com.redhat.component": "test-component",
-                "version": "1.0",
-                "release": "1.el9",
-            }
-            mock_dockerfile.parent_images = []
-            mock_dockerfile_parser.return_value = mock_dockerfile
-            mock_bigquery_client.return_value.client.insert_rows_json.return_value = None
-
-            await self.builder.update_konflux_db(
-                metadata,
-                build_repo,
-                pipelinerun,
-                KonfluxBuildOutcome.SUCCESS,
-                ["x86_64"],
-                "5",
-                released=False,
             )
 
         expected_pullspec = "quay.io/test/image@sha256:testdigest"
@@ -478,14 +415,13 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 KonfluxBuildOutcome.UNRELEASED,
                 ["x86_64"],
                 "5",
-                released=False,
             )
 
         expected_pullspec = "quay.io/test/image@sha256:testdigest"
         mock_get_installed_packages.assert_awaited_once_with(expected_pullspec, ["x86_64"], None)
 
     async def test_trigger_base_image_release_success_flow(self):
-        """Test successful base image release triggering with registry pullspec update."""
+        """SUCCESS after base snapshot release refreshes Konflux DB without swapping image_pullspec to RH."""
         metadata = self._metadata()
         metadata.should_trigger_base_image_release.return_value = True
         metadata.is_snapshot_release_enabled.return_value = True
@@ -544,12 +480,10 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
 
         mock_trigger_release.assert_awaited_once()
 
-        # Verify database was updated twice: initial PENDING + final SUCCESS with released=True
+        # PENDING write + UNRELEASED write + SUCCESS after release
         self.assertEqual(mock_update_db.await_count, 3)
-
-        # Check that the final call had released=True
-        final_call_kwargs = mock_update_db.await_args_list[2][1]
-        self.assertTrue(final_call_kwargs.get('released', False))
+        success_call_args = mock_update_db.await_args_list[2][0]
+        self.assertEqual(success_call_args[3], KonfluxBuildOutcome.SUCCESS)
 
     async def test_trigger_base_image_release_failure_flow(self):
         """Test base image release failure handling with FAILURE outcome update."""
@@ -613,11 +547,9 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         mock_trigger_release.assert_awaited_once()
         self.assertEqual(mock_update_db.await_count, 3)
 
-        # Check that the failure update call had outcome=FAILURE and no released=True
+        # Final update records FAILURE outcome
         failure_call_args = mock_update_db.await_args_list[2][0]
-        failure_call_kwargs = mock_update_db.await_args_list[2][1]
         self.assertEqual(failure_call_args[3], KonfluxBuildOutcome.FAILURE)
-        self.assertFalse(failure_call_kwargs.get('released', False))
 
     async def test_non_base_image_skips_release_trigger(self):
         """Test that non-base images skip the release trigger logic entirely."""

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -358,6 +358,10 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
 
         expected_pullspec = "quay.io/test/image@sha256:testdigest"
         mock_get_installed_packages.assert_awaited_once_with(expected_pullspec, ["x86_64"], None)
+        mock_add_build = metadata.runtime.konflux_db.add_build
+        mock_add_build.assert_called_once()
+        persisted = mock_add_build.call_args[0][0]
+        self.assertEqual(persisted.image_pullspec, expected_pullspec)
 
     async def test_update_konflux_db_unreleased_sets_quay_pullspec_like_success(self):
         """UNRELEASED (base image build ok, awaiting release) must populate image_pullspec for snapshot workflow."""

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -1357,6 +1357,68 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
             "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.21-1.el9",
         )
 
+    async def test_resolve_member_parent_late_resolve_uses_rh_art_base_tag(self):
+        """Late-resolve (DB) base/golang: RH art-images-base if tag is reachable, else Konflux digest from DB."""
+        parent = MagicMock()
+        parent.distgit_key = "golang-builder"
+        parent.should_trigger_base_image_release.return_value = True
+        parent.branch_el_target.return_value = 9
+        kb = MagicMock()
+        kb.nvr = "openshift-golang-builder-container-v1.21-1.el9"
+        kb.image_pullspec = "quay.io/k@sha256:abc"
+        kb.embargoed = False
+        parent.get_latest_build = AsyncMock(return_value=kb)
+
+        runtime = MagicMock()
+        runtime.resolve_image.return_value = None
+        runtime.ignore_missing_base = True
+        runtime.latest_parent_version = True
+        runtime.late_resolve_image = MagicMock(return_value=parent)
+        runtime.group_config = Model({"konflux": Model({})})
+
+        rebaser = KonfluxRebaser(runtime, self.base_dir, MagicMock(), "unsigned")
+        rebaser.variant = BuildVariant.OCP
+        rebaser.image_repo = "quay.io/fake"
+        rebaser.uuid_tag = "v4.18-tag"
+        rebaser.group = "openshift-4.18"
+        rebaser._registry_pullspec_exists = AsyncMock(return_value=True)
+
+        resolved, emb = await rebaser._resolve_member_parent("golang-builder", "orig")
+        self.assertEqual(
+            resolved, "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.21-1.el9"
+        )
+        self.assertFalse(emb)
+
+    async def test_resolve_member_parent_late_resolve_falls_back_to_db_pullspec_when_art_base_missing(self):
+        """Late-resolved golang parent: use RH only if tag exists; otherwise Konflux digest from DB."""
+        parent = MagicMock()
+        parent.distgit_key = "golang-builder"
+        parent.should_trigger_base_image_release.return_value = True
+        parent.branch_el_target.return_value = 9
+        kb = MagicMock()
+        kb.nvr = "openshift-golang-builder-container-v1.21-1.el9"
+        kb.image_pullspec = "quay.io/k@sha256:beef"
+        kb.embargoed = False
+        parent.get_latest_build = AsyncMock(return_value=kb)
+
+        runtime = MagicMock()
+        runtime.resolve_image.return_value = None
+        runtime.ignore_missing_base = True
+        runtime.latest_parent_version = True
+        runtime.late_resolve_image = MagicMock(return_value=parent)
+        runtime.group_config = Model({"konflux": Model({})})
+
+        rebaser = KonfluxRebaser(runtime, self.base_dir, MagicMock(), "unsigned")
+        rebaser.variant = BuildVariant.OCP
+        rebaser.image_repo = "quay.io/fake"
+        rebaser.uuid_tag = "v4.18-tag"
+        rebaser.group = "openshift-4.18"
+        rebaser._registry_pullspec_exists = AsyncMock(return_value=False)
+
+        resolved, emb = await rebaser._resolve_member_parent("golang-builder", "orig")
+        self.assertEqual(resolved, "quay.io/k@sha256:beef")
+        self.assertFalse(emb)
+
     async def test_resolve_member_parent_keeps_quay_for_regular_member(self):
         parent = MagicMock()
         parent.distgit_key = "ose-cli"


### PR DESCRIPTION
## Summary

Base and golang builder images get a Konflux build on quay with SBOMs attached there. The earlier base-image release work started storing **registry.redhat.io** on the Konflux DB row after release so dependents could point their Dockerfiles at Red Hat. That helped **FROM** lines, but anything that still uses **image_pullspec** to pull metadata or SBOMs was suddenly asking **cosign** (and the registry) for the wrong place—the SBOM never moved to that RH tag the same way. So we were trading one fix for a quiet break.

This change keeps the **digest-pinned Konflux pullspec** on the build record (what the pipeline actually produced), and moves the “use Red Hat for **FROM**” decision into the **rebaser** where it belongs.

## Problem

**Before:** After a successful base-image release, `update_konflux_db` could replace `image_pullspec` with `registry.redhat.io/.../art-images-base:<nvr>`. Downstream tooling that still reads `image_pullspec` for SBOM or registry access was no longer hitting the image the pipeline published.

**After:** Success records keep the Konflux digest pullspec. Coordinated rebases (parent in the same run) still set **FROM** to the **prospective** art-images-base tag from `_rebased_member_image_nvr`—we assume the base will build and publish; no registry probe there. If the parent is only **late-resolved from the DB**, we try the RH tag for that build’s NVR and **only if** `oc image info` says it exists; otherwise we fall back to the stored Konflux digest so the rebase doesn’t assume a tag that was never published.

## Implementation

- `konflux_image_builder.update_konflux_db`: always persist pipeline `repo@digest` for SUCCESS/UNRELEASED; remove `released` parameter and second-call kwarg.
- `KonfluxRebaser._resolve_member_parent`: restore unconditional RH for in-group base/golang; add `_registry_pullspec_exists` + RH-then-fallback only on the **late-resolve** + `get_latest_build` path.
- Tests updated for builder and rebaser.

_Add an **ART-** ticket to the title when you have one._