### PR TITLE
fix(doozer): honor Jenkins result for base image release wait

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -1251,12 +1251,13 @@ class KonfluxImageBuilder:
                 dry_run=self._config.dry_run,
                 block_until_complete=True,
             )
-            if result is not None:
+            # start_build(..., block_until_complete=True) returns Jenkins result strings (SUCCESS, FAILURE, …), not None.
+            success = result == "SUCCESS"
+            if success:
                 logger.info(f"Successfully completed base image release for {nvr}")
                 return True
-            else:
-                logger.error(f"Base image release job failed for {nvr}")
-                return False
+            logger.error("Base image release job failed for %s with Jenkins result=%r", nvr, result)
+            return False
 
         except Exception as e:
             logger.error(f"Failed to trigger base image release for {nvr}: {e}")

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -623,13 +623,25 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         metadata = self._metadata()
         metadata.is_snapshot_release_enabled.return_value = True
 
-        with patch.object(jenkins, 'start_base_image_release', return_value="job-result") as mock_jenkins:
+        with patch.object(jenkins, 'start_base_image_release', return_value="SUCCESS") as mock_jenkins:
             result = await self.builder._trigger_base_image_release(metadata, "test-nvr")
 
         self.assertTrue(result)
         mock_jenkins.assert_called_once()
         call_kwargs = mock_jenkins.call_args[1]
         self.assertTrue(call_kwargs.get('block_until_complete', False))
+
+    async def test_trigger_base_image_release_jenkins_failure_string_returns_false(self):
+        """start_build returns Jenkins result strings; FAILURE must not be treated as success."""
+        from pyartcd import jenkins
+
+        metadata = self._metadata()
+        metadata.is_snapshot_release_enabled.return_value = True
+
+        with patch.object(jenkins, 'start_base_image_release', return_value='FAILURE'):
+            result = await self.builder._trigger_base_image_release(metadata, "test-nvr")
+
+        self.assertFalse(result)
 
     async def test_trigger_base_image_release_respects_snapshot_release_disabled(self):
         """Test that snapshot_release disabled skips base image release."""


### PR DESCRIPTION
## Summary

`pyartcd.jenkins.start_build(..., block_until_complete=True)` returns the Jenkins **result string** (`SUCCESS`, `FAILURE`, …). `_trigger_base_image_release` treated **any non-`None`** return as success, so a failed **base-image-release** child job was still logged as completed successfully and the Konflux run continued.

## Problem

**Before:** After `Build completed with result: FAILURE`, doozer logged `Successfully completed base image release` and proceeded with SUCCESS-style DB updates.

**After:** Only `result == "SUCCESS"` is treated as success; other results log the actual Jenkins result and return `False` so callers can mark FAILURE and stop propagating bad state.

## Implementation

- `KonfluxImageBuilder._trigger_base_image_release`: compare to `"SUCCESS"` instead of `is not None`; improved error log with result repr.
- Tests: regression when mock returns `'FAILURE'`; `block_until_complete` test mocks `'SUCCESS'` to match real API.

_Add an **ART-** ticket to the title when you have one._

## Validation

`uv run pytest doozer/tests/backend/test_konflux_image_builder.py -q` (27 passed).