### PR TITLE
ART-18732: feat(konflux): persist authz fields for base-image release workflow

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -34,8 +34,8 @@ ACTIVE_OCP_VERSIONS = [
 ]
 
 # Konflux DB related vars
-GOOGLE_CLOUD_PROJECT = 'openshift-art'
-DATASET_ID = 'events'
+GOOGLE_CLOUD_PROJECT = 'openshift-gce-devel'
+DATASET_ID = 'art_test'
 BUILDS_TABLE_ID = 'builds'
 BUNDLES_TABLE_ID = 'bundles'
 FBCS_TABLE_ID = 'fbcs'

--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -51,6 +51,28 @@ class KonfluxECStatus(KonfluxEnum):
     NOT_APPLICABLE = 'n/a'
 
 
+class KonfluxAuthzOutcome(KonfluxEnum):
+    """Outcome of the Jenkins base-image-release (authz) pipeline for a build record.
+
+    PENDING is set by writers when the image build exists but release has not finished.
+    Terminal Jenkins results after block_until_complete map via from_jenkins_result: only
+    SUCCESS stays SUCCESS; FAILURE and every other value (UNSTABLE, ABORTED, NOT_BUILT,
+    empty, None) map to FAILURE.
+    """
+
+    NOT_APPLICABLE = 'n/a'
+    PENDING = 'pending'
+    SUCCESS = 'success'
+    FAILURE = 'failure'
+
+    @classmethod
+    def from_jenkins_result(cls, result: Optional[str]) -> "KonfluxAuthzOutcome":
+        """Map jenkinsapi poll()['result'] (or equivalent) to a storage enum."""
+        if result and str(result).strip().upper() == "SUCCESS":
+            return cls.SUCCESS
+        return cls.FAILURE
+
+
 class ArtifactType(KonfluxEnum):
     RPM = 'rpm'
     IMAGE = 'image'
@@ -69,6 +91,9 @@ class KonfluxRecord:
         'nvr',
         'ec_status',
         'ec_pipeline_url',
+        'authz_pullspec',
+        'authz_pipeline_url',
+        'authz_outcome',
     ]
 
     TABLE_ID = None
@@ -293,6 +318,9 @@ class KonfluxBuildRecord(KonfluxRecord):
         build_priority: int = constants.KONFLUX_DEFAULT_BUILD_PRIORITY,
         ec_status: KonfluxECStatus = KonfluxECStatus.NOT_APPLICABLE,
         ec_pipeline_url: str = '',
+        authz_pullspec: str = '',
+        authz_pipeline_url: str = '',
+        authz_outcome: KonfluxAuthzOutcome = KonfluxAuthzOutcome.NOT_APPLICABLE,
     ):
         super().__init__(
             name,
@@ -333,6 +361,13 @@ class KonfluxBuildRecord(KonfluxRecord):
             else KonfluxECStatus(ec_status or KonfluxECStatus.NOT_APPLICABLE.value)
         )
         self.ec_pipeline_url = ec_pipeline_url
+        self.authz_pullspec = authz_pullspec or ''
+        self.authz_pipeline_url = authz_pipeline_url or ''
+        self.authz_outcome = (
+            authz_outcome
+            if isinstance(authz_outcome, KonfluxAuthzOutcome)
+            else KonfluxAuthzOutcome(authz_outcome or KonfluxAuthzOutcome.NOT_APPLICABLE.value)
+        )
         self.init_uuids(record_id, build_id, nvr)
 
 

--- a/artcommon/tests/test_konflux_build_record.py
+++ b/artcommon/tests/test_konflux_build_record.py
@@ -2,6 +2,7 @@ import json
 from unittest import TestCase
 
 from artcommonlib.konflux.konflux_build_record import (
+    KonfluxAuthzOutcome,
     KonfluxBuildRecord,
     KonfluxBundleBuildRecord,
     KonfluxECStatus,
@@ -102,6 +103,46 @@ class TestKonfluxBuild(TestCase):
 
         build = KonfluxBuildRecord(ec_status='n/a')
         self.assertEqual(build.ec_status, KonfluxECStatus.NOT_APPLICABLE)
+
+    def test_authz_outcome_default(self):
+        build = KonfluxBuildRecord()
+        self.assertEqual(build.authz_outcome, KonfluxAuthzOutcome.NOT_APPLICABLE)
+        self.assertEqual(build.authz_pullspec, '')
+        self.assertEqual(build.authz_pipeline_url, '')
+
+    def test_authz_fields_serialization(self):
+        build = KonfluxBuildRecord(
+            authz_pullspec='registry.redhat.io/openshift/art-images-base:foo-1-1',
+            authz_pipeline_url='https://jenkins.example/job/1',
+            authz_outcome=KonfluxAuthzOutcome.SUCCESS,
+        )
+        d = build.to_dict()
+        self.assertEqual(d['authz_pullspec'], 'registry.redhat.io/openshift/art-images-base:foo-1-1')
+        self.assertEqual(d['authz_pipeline_url'], 'https://jenkins.example/job/1')
+        self.assertEqual(d['authz_outcome'], 'success')
+
+    def test_authz_outcome_excluded_from_build_id(self):
+        build_1 = KonfluxBuildRecord(authz_outcome=KonfluxAuthzOutcome.NOT_APPLICABLE)
+        build_2 = KonfluxBuildRecord(
+            authz_outcome=KonfluxAuthzOutcome.SUCCESS,
+            authz_pullspec='registry.redhat.io/openshift/art-images-base:x',
+            authz_pipeline_url='https://j/1',
+        )
+        self.assertEqual(build_1.build_id, build_2.build_id)
+
+    def test_authz_outcome_pending_and_failure_serialization(self):
+        for outcome in (KonfluxAuthzOutcome.PENDING, KonfluxAuthzOutcome.FAILURE):
+            with self.subTest(outcome=outcome):
+                build = KonfluxBuildRecord(authz_outcome=outcome)
+                d = build.to_dict()
+                self.assertEqual(d['authz_outcome'], outcome.value)
+
+    def test_authz_outcome_from_jenkins_result(self):
+        self.assertEqual(KonfluxAuthzOutcome.from_jenkins_result('SUCCESS'), KonfluxAuthzOutcome.SUCCESS)
+        self.assertEqual(KonfluxAuthzOutcome.from_jenkins_result('success'), KonfluxAuthzOutcome.SUCCESS)
+        self.assertEqual(KonfluxAuthzOutcome.from_jenkins_result('FAILURE'), KonfluxAuthzOutcome.FAILURE)
+        self.assertEqual(KonfluxAuthzOutcome.from_jenkins_result('UNSTABLE'), KonfluxAuthzOutcome.FAILURE)
+        self.assertEqual(KonfluxAuthzOutcome.from_jenkins_result(None), KonfluxAuthzOutcome.FAILURE)
 
 
 class TestKonfluxBundleBuildRecordEC(TestCase):

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -660,8 +660,10 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             SchemaField('build_priority', 'INTEGER', 'REQUIRED'),
             SchemaField('ec_status', 'STRING', 'REQUIRED'),
             SchemaField('ec_pipeline_url', 'STRING', 'REQUIRED'),
+            SchemaField('authz_pullspec', 'STRING', 'REQUIRED'),
+            SchemaField('authz_pipeline_url', 'STRING', 'REQUIRED'),
+            SchemaField('authz_outcome', 'STRING', 'REQUIRED'),
         ]
-        self.db.bind(KonfluxBuildRecord)
         self.assertEqual(self.db.generate_build_schema(), expected_fields)
 
     def test_generate_bundle_builds_schema(self):

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -9,7 +9,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple, cast
+from typing import Dict, List, NamedTuple, Optional, Set, Tuple, cast
 
 from artcommonlib import bigquery, exectools
 from artcommonlib import constants as artlib_constants
@@ -19,6 +19,7 @@ from artcommonlib.build_visibility import is_release_embargoed
 from artcommonlib.konflux.konflux_build_record import (
     ArtifactType,
     Engine,
+    KonfluxAuthzOutcome,
     KonfluxBuildOutcome,
     KonfluxBuildRecord,
     KonfluxECStatus,
@@ -44,6 +45,14 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 from pyartcd import jenkins
 
 LOGGER = logging.getLogger(__name__)
+
+
+class _BaseImageReleaseResult(NamedTuple):
+    """Result of synchronous base-image-release Jenkins run (or no-op when snapshot release disabled)."""
+
+    ok: bool
+    jenkins_build_url: str
+    authz_outcome: KonfluxAuthzOutcome
 
 
 def _normalize_version(version: str) -> str:
@@ -364,6 +373,14 @@ class KonfluxImageBuilder:
                     if outcome is KonfluxBuildOutcome.SUCCESS and metadata.should_trigger_base_image_release():
                         outcome = KonfluxBuildOutcome.UNRELEASED
 
+                    authz_extras = {}
+                    if outcome is KonfluxBuildOutcome.UNRELEASED:
+                        authz_extras = {
+                            'authz_outcome': KonfluxAuthzOutcome.PENDING,
+                            'authz_pullspec': '',
+                            'authz_pipeline_url': '',
+                        }
+
                     build_record = await self.update_konflux_db(
                         metadata,
                         build_repo,
@@ -373,19 +390,23 @@ class KonfluxImageBuilder:
                         build_priority,
                         ec_status=ec_status,
                         ec_pipeline_url=ec_pipeline_url,
+                        **authz_extras,
                     )
                     if build_record:
                         record["record_id"] = build_record.record_id
 
                     # Check base image release AFTER saving to database
                     if outcome is KonfluxBuildOutcome.UNRELEASED and metadata.should_trigger_base_image_release():
-                        base_image_release_success = await self._trigger_base_image_release(metadata, nvr)
-                        if base_image_release_success:
+                        release_result = await self._trigger_base_image_release(metadata, nvr)
+                        if release_result.ok:
                             logger.info(f"Base image release succeeded for {nvr}, updating build record")
                         else:
                             logger.error(f"Base image release failed for {nvr}, updating build record to FAILURE")
-                        outcome = (
-                            KonfluxBuildOutcome.SUCCESS if base_image_release_success else KonfluxBuildOutcome.FAILURE
+                        outcome = KonfluxBuildOutcome.SUCCESS if release_result.ok else KonfluxBuildOutcome.FAILURE
+                        authz_pullspec = (
+                            util.rh_art_images_base_pullspec(nvr)
+                            if release_result.ok and release_result.authz_outcome is KonfluxAuthzOutcome.SUCCESS
+                            else ''
                         )
                         await self.update_konflux_db(
                             metadata,
@@ -396,6 +417,9 @@ class KonfluxImageBuilder:
                             build_priority,
                             ec_status=ec_status,
                             ec_pipeline_url=ec_pipeline_url,
+                            authz_pullspec=authz_pullspec,
+                            authz_pipeline_url=release_result.jenkins_build_url,
+                            authz_outcome=release_result.authz_outcome,
                         )
 
                 if outcome is not KonfluxBuildOutcome.SUCCESS:
@@ -907,6 +931,9 @@ class KonfluxImageBuilder:
         build_priority,
         ec_status=KonfluxECStatus.NOT_APPLICABLE,
         ec_pipeline_url='',
+        authz_pullspec: str = '',
+        authz_pipeline_url: str = '',
+        authz_outcome: KonfluxAuthzOutcome = KonfluxAuthzOutcome.NOT_APPLICABLE,
     ) -> Optional[KonfluxBuildRecord]:
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
         if not metadata.runtime.konflux_db:
@@ -973,6 +1000,9 @@ class KonfluxImageBuilder:
             'build_priority': int(build_priority),
             'ec_status': ec_status,
             'ec_pipeline_url': ec_pipeline_url,
+            'authz_pullspec': authz_pullspec or '',
+            'authz_pipeline_url': authz_pipeline_url or '',
+            'authz_outcome': authz_outcome,
         }
 
         # SUCCESS: normal completed build. UNRELEASED: build succeeded and is waiting for
@@ -1222,27 +1252,27 @@ class KonfluxImageBuilder:
 
         return parent_image_nvrs
 
-    async def _trigger_base_image_release(self, metadata: ImageMetadata, nvr: str) -> bool:
+    async def _trigger_base_image_release(self, metadata: ImageMetadata, nvr: str) -> _BaseImageReleaseResult:
         """Trigger base image release for a single successful base image build.
 
         Expects group_name format 'openshift-X.Y' (e.g., 'openshift-4.22') for
         version extraction. Falls back to full group_name if format doesn't match.
 
         Returns:
-            bool: True if base image release was triggered successfully, False otherwise
+            _BaseImageReleaseResult: ok, Jenkins build URL (if run), and authz outcome for Konflux DB.
         """
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
 
         if not metadata.is_snapshot_release_enabled():
             logger.info(f"Skipping base image release for {nvr}: snapshot_release disabled")
-            return True
+            return _BaseImageReleaseResult(True, '', KonfluxAuthzOutcome.NOT_APPLICABLE)
 
         logger.info(f"Triggering base image release for {nvr}")
 
         try:
             build_version = self._config.group_name
 
-            result = jenkins.start_base_image_release(
+            blocking = jenkins.start_base_image_release(
                 build_version=build_version,
                 assembly=metadata.runtime.assembly,
                 base_image_nvrs=[nvr],
@@ -1250,15 +1280,26 @@ class KonfluxImageBuilder:
                 doozer_data_gitref=getattr(metadata.runtime, 'data_gitref', ''),
                 dry_run=self._config.dry_run,
                 block_until_complete=True,
+                return_build_url=True,
             )
-            # start_build(..., block_until_complete=True) returns Jenkins result strings (SUCCESS, FAILURE, …), not None.
-            success = result == "SUCCESS"
-            if success:
+            if blocking is None:
+                logger.error("Base image release returned no Jenkins result for %s", nvr)
+                return _BaseImageReleaseResult(False, '', KonfluxAuthzOutcome.FAILURE)
+
+            authz_outcome = KonfluxAuthzOutcome.from_jenkins_result(blocking.result)
+            ok = blocking.result == "SUCCESS"
+            if ok:
                 logger.info(f"Successfully completed base image release for {nvr}")
-                return True
-            logger.error("Base image release job failed for %s with Jenkins result=%r", nvr, result)
-            return False
+                return _BaseImageReleaseResult(True, blocking.build_url, authz_outcome)
+
+            logger.error(
+                "Base image release job failed for %s with Jenkins result=%r url=%s",
+                nvr,
+                blocking.result,
+                blocking.build_url,
+            )
+            return _BaseImageReleaseResult(False, blocking.build_url, authz_outcome)
 
         except Exception as e:
             logger.error(f"Failed to trigger base image release for {nvr}: {e}")
-            return False
+            return _BaseImageReleaseResult(False, '', KonfluxAuthzOutcome.FAILURE)

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -22,7 +22,7 @@ from artcommonlib.build_visibility import BuildVisibility, get_visibility_suffix
 from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildRecord
 from artcommonlib.model import ListModel, Missing, Model
 from artcommonlib.telemetry import start_as_current_span_async
-from artcommonlib.util import deep_merge, detect_package_managers, is_cachito_enabled, oc_image_info_for_arch_async
+from artcommonlib.util import deep_merge, detect_package_managers, is_cachito_enabled
 from artcommonlib.variants import BuildVariant
 from dockerfile_parse import DockerfileParser
 from doozerlib import constants, util
@@ -503,16 +503,6 @@ class KonfluxRebaser:
         private_fix = any(private_fix for _, private_fix in mapped_images)
         return downstream_parents, private_fix
 
-    async def _registry_pullspec_exists(self, pullspec: str) -> bool:
-        """Return True if the registry reports the image readable (manifest present). Used for lazy DB lookups."""
-        registry_config = getattr(self._runtime, "registry_config", None)
-        try:
-            await oc_image_info_for_arch_async(pullspec, registry_config=registry_config)
-            return True
-        except Exception as exc:
-            self._logger.debug("Could not read pullspec %s: %s", pullspec, exc)
-            return False
-
     @start_as_current_span_async(TRACER, "rebase.resolve_member_parent")
     async def _resolve_member_parent(self, member: str, original_parent: str):
         """Resolve the parent image for the given image metadata."""
@@ -550,13 +540,16 @@ class KonfluxRebaser:
                 if not build:
                     raise IOError(f"A build of parent image {member} is not found.")
                 if parent_metadata.should_trigger_base_image_release():
-                    rh_pullspec = util.rh_art_images_base_pullspec(build.nvr)
-                    if await self._registry_pullspec_exists(rh_pullspec):
-                        return rh_pullspec, build.embargoed
-                    self._logger.info(
-                        "art-images-base %s not reachable; using Konflux image_pullspec for late-resolved parent %s",
-                        rh_pullspec,
+                    authz = build.authz_pullspec.strip()
+                    if authz:
+                        return authz, build.embargoed
+                    # TODO: Reinstate strict authz_pullspec (or fail/retry) once DB backfill and release workflow are reliably populated for all base images.
+                    self._logger.error(
+                        "Parent image %s (nvr=%r) has no authz_pullspec in Konflux DB (outcome=%s); "
+                        "using Konflux image_pullspec until base-image release populates authz.",
                         member,
+                        build.nvr,
+                        build.outcome,
                     )
                     return build.image_pullspec, build.embargoed
                 return build.image_pullspec, build.embargoed
@@ -574,6 +567,7 @@ class KonfluxRebaser:
             private_fix = parent_metadata.private_fix
             if parent_metadata.should_trigger_base_image_release():
                 parent_nvr = self._rebased_member_image_nvr(parent_metadata)
+                # Session NVR exists before a Konflux row (with authz_pullspec) is written; use canonical tag.
                 return util.rh_art_images_base_pullspec(parent_nvr), private_fix
             return f"{self.image_repo}:{parent_metadata.image_name_short}-{self.uuid_tag}", private_fix
 

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -3,11 +3,12 @@ import unittest
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
+from artcommonlib.konflux.konflux_build_record import KonfluxAuthzOutcome, KonfluxBuildOutcome
 from doozerlib.backend.konflux_image_builder import (
     KonfluxImageBuilder,
     KonfluxImageBuilderConfig,
     KonfluxImageBuildError,
+    _BaseImageReleaseResult,
     _normalize_version,
 )
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
@@ -467,7 +468,11 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 self.builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))
             ) as mock_update_db,
             patch.object(
-                self.builder, "_trigger_base_image_release", new=AsyncMock(return_value=True)
+                self.builder,
+                "_trigger_base_image_release",
+                new=AsyncMock(
+                    return_value=_BaseImageReleaseResult(True, 'https://jenkins/release/1', KonfluxAuthzOutcome.SUCCESS)
+                ),
             ) as mock_trigger_release,
             patch.object(self.builder, "_validate_build_attestation_and_signature", new=AsyncMock()),
             patch.object(
@@ -488,6 +493,9 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(mock_update_db.await_count, 3)
         success_call_args = mock_update_db.await_args_list[2][0]
         self.assertEqual(success_call_args[3], KonfluxBuildOutcome.SUCCESS)
+        success_call_kwargs = mock_update_db.await_args_list[2][1]
+        self.assertEqual(success_call_kwargs.get('authz_outcome'), KonfluxAuthzOutcome.SUCCESS)
+        self.assertEqual(success_call_kwargs.get('authz_pipeline_url'), 'https://jenkins/release/1')
 
     async def test_trigger_base_image_release_failure_flow(self):
         """Test base image release failure handling with FAILURE outcome update."""
@@ -532,7 +540,13 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 self.builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))
             ) as mock_update_db,
             patch.object(
-                self.builder, "_trigger_base_image_release", new=AsyncMock(return_value=False)
+                self.builder,
+                "_trigger_base_image_release",
+                new=AsyncMock(
+                    return_value=_BaseImageReleaseResult(
+                        False, 'https://jenkins/release/2', KonfluxAuthzOutcome.FAILURE
+                    )
+                ),
             ) as mock_trigger_release,
             patch.object(self.builder, "_validate_build_attestation_and_signature", new=AsyncMock()),
             patch.object(
@@ -554,6 +568,9 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         # Final update records FAILURE outcome
         failure_call_args = mock_update_db.await_args_list[2][0]
         self.assertEqual(failure_call_args[3], KonfluxBuildOutcome.FAILURE)
+        failure_call_kwargs = mock_update_db.await_args_list[2][1]
+        self.assertEqual(failure_call_kwargs.get('authz_outcome'), KonfluxAuthzOutcome.FAILURE)
+        self.assertEqual(failure_call_kwargs.get('authz_pipeline_url'), 'https://jenkins/release/2')
 
     async def test_non_base_image_skips_release_trigger(self):
         """Test that non-base images skip the release trigger logic entirely."""
@@ -617,31 +634,42 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(mock_update_db.await_count, 2)
 
     async def test_trigger_base_image_release_calls_jenkins_with_block_until_complete(self):
-        """Test that base image release uses block_until_complete=True for synchronous execution."""
+        """Test that base image release uses block_with_complete and return_build_url for DB correlation."""
+        from pyartcd.jenkins import JenkinsBlockingBuildResult
+
         from pyartcd import jenkins
 
         metadata = self._metadata()
         metadata.is_snapshot_release_enabled.return_value = True
 
-        with patch.object(jenkins, 'start_base_image_release', return_value="SUCCESS") as mock_jenkins:
+        blocking = JenkinsBlockingBuildResult('SUCCESS', 'https://jenkins.example/job/1')
+        with patch.object(jenkins, 'start_base_image_release', return_value=blocking) as mock_jenkins:
             result = await self.builder._trigger_base_image_release(metadata, "test-nvr")
 
-        self.assertTrue(result)
+        self.assertTrue(result.ok)
+        self.assertEqual(result.jenkins_build_url, 'https://jenkins.example/job/1')
+        self.assertEqual(result.authz_outcome, KonfluxAuthzOutcome.SUCCESS)
         mock_jenkins.assert_called_once()
         call_kwargs = mock_jenkins.call_args[1]
         self.assertTrue(call_kwargs.get('block_until_complete', False))
+        self.assertTrue(call_kwargs.get('return_build_url', False))
 
     async def test_trigger_base_image_release_jenkins_failure_string_returns_false(self):
         """start_build returns Jenkins result strings; FAILURE must not be treated as success."""
+        from pyartcd.jenkins import JenkinsBlockingBuildResult
+
         from pyartcd import jenkins
 
         metadata = self._metadata()
         metadata.is_snapshot_release_enabled.return_value = True
 
-        with patch.object(jenkins, 'start_base_image_release', return_value='FAILURE'):
+        blocking = JenkinsBlockingBuildResult('FAILURE', 'https://jenkins.example/job/2')
+        with patch.object(jenkins, 'start_base_image_release', return_value=blocking):
             result = await self.builder._trigger_base_image_release(metadata, "test-nvr")
 
-        self.assertFalse(result)
+        self.assertFalse(result.ok)
+        self.assertEqual(result.authz_outcome, KonfluxAuthzOutcome.FAILURE)
+        self.assertEqual(result.jenkins_build_url, 'https://jenkins.example/job/2')
 
     async def test_trigger_base_image_release_respects_snapshot_release_disabled(self):
         """Test that snapshot_release disabled skips base image release."""
@@ -650,7 +678,9 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
 
         result = await self.builder._trigger_base_image_release(metadata, "test-nvr")
 
-        self.assertTrue(result)  # Should return True (no-op success) when disabled
+        self.assertTrue(result.ok)
+        self.assertEqual(result.jenkins_build_url, '')
+        self.assertEqual(result.authz_outcome, KonfluxAuthzOutcome.NOT_APPLICABLE)
 
 
 class TestNormalizeVersion(unittest.TestCase):

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -7,6 +7,7 @@ from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, MagicMock
 
 import semver
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
 from artcommonlib.model import Missing, Model
 from artcommonlib.variants import BuildVariant
 from dockerfile_parse import DockerfileParser
@@ -1324,7 +1325,8 @@ class TestRhArtImagesBasePullspec(TestCase):
 
 
 class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
-    """Member parent resolution uses registry.redhat.io for art-managed base images."""
+    """RH base/golang parents: loaded member uses rh_art_images_base tag from session NVR;
+    late-resolve prefers authz_pullspec when set, otherwise logs and uses Konflux image_pullspec."""
 
     def setUp(self):
         self.directory = TemporaryDirectory()
@@ -1332,6 +1334,7 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         self.base_dir = Path(self.directory.name)
 
     async def test_resolve_member_parent_uses_rh_when_art_base_and_labels_present(self):
+        """Parent in this session may not have a Konflux DB row yet; FROM line uses tag convention."""
         parent = MagicMock()
         parent.distgit_key = "golang-builder"
         parent.qualified_key = "openshift/golang-builder"
@@ -1357,16 +1360,19 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
             "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.21-1.el9",
         )
 
-    async def test_resolve_member_parent_late_resolve_uses_rh_art_base_tag(self):
-        """Late-resolve (DB) base/golang: RH art-images-base if tag is reachable, else Konflux digest from DB."""
+    async def test_resolve_member_parent_late_resolve_uses_authz_pullspec_from_db(self):
+        """Late-resolved base parent: use authz_pullspec from the Konflux row when present."""
         parent = MagicMock()
         parent.distgit_key = "golang-builder"
         parent.should_trigger_base_image_release.return_value = True
         parent.branch_el_target.return_value = 9
+        expected_authz = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.21-1.el9"
         kb = MagicMock()
         kb.nvr = "openshift-golang-builder-container-v1.21-1.el9"
         kb.image_pullspec = "quay.io/k@sha256:abc"
         kb.embargoed = False
+        kb.authz_pullspec = expected_authz
+        kb.outcome = KonfluxBuildOutcome.SUCCESS
         parent.get_latest_build = AsyncMock(return_value=kb)
 
         runtime = MagicMock()
@@ -1375,22 +1381,20 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         runtime.latest_parent_version = True
         runtime.late_resolve_image = MagicMock(return_value=parent)
         runtime.group_config = Model({"konflux": Model({})})
+        runtime.assembly = "stream"
 
         rebaser = KonfluxRebaser(runtime, self.base_dir, MagicMock(), "unsigned")
         rebaser.variant = BuildVariant.OCP
         rebaser.image_repo = "quay.io/fake"
         rebaser.uuid_tag = "v4.18-tag"
         rebaser.group = "openshift-4.18"
-        rebaser._registry_pullspec_exists = AsyncMock(return_value=True)
 
         resolved, emb = await rebaser._resolve_member_parent("golang-builder", "orig")
-        self.assertEqual(
-            resolved, "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.21-1.el9"
-        )
+        self.assertEqual(resolved, expected_authz)
         self.assertFalse(emb)
 
-    async def test_resolve_member_parent_late_resolve_falls_back_to_db_pullspec_when_art_base_missing(self):
-        """Late-resolved golang parent: use RH only if tag exists; otherwise Konflux digest from DB."""
+    async def test_resolve_member_parent_late_resolve_falls_back_when_authz_pullspec_missing(self):
+        """Late-resolved art-managed base: empty authz_pullspec logs ERROR and uses Konflux digest."""
         parent = MagicMock()
         parent.distgit_key = "golang-builder"
         parent.should_trigger_base_image_release.return_value = True
@@ -1399,6 +1403,8 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         kb.nvr = "openshift-golang-builder-container-v1.21-1.el9"
         kb.image_pullspec = "quay.io/k@sha256:beef"
         kb.embargoed = False
+        kb.authz_pullspec = ""
+        kb.outcome = KonfluxBuildOutcome.UNRELEASED
         parent.get_latest_build = AsyncMock(return_value=kb)
 
         runtime = MagicMock()
@@ -1407,17 +1413,19 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         runtime.latest_parent_version = True
         runtime.late_resolve_image = MagicMock(return_value=parent)
         runtime.group_config = Model({"konflux": Model({})})
+        runtime.assembly = "stream"
 
         rebaser = KonfluxRebaser(runtime, self.base_dir, MagicMock(), "unsigned")
         rebaser.variant = BuildVariant.OCP
         rebaser.image_repo = "quay.io/fake"
         rebaser.uuid_tag = "v4.18-tag"
         rebaser.group = "openshift-4.18"
-        rebaser._registry_pullspec_exists = AsyncMock(return_value=False)
 
-        resolved, emb = await rebaser._resolve_member_parent("golang-builder", "orig")
+        with self.assertLogs('doozerlib.backend.rebaser', level='ERROR') as log_cm:
+            resolved, emb = await rebaser._resolve_member_parent("golang-builder", "orig")
         self.assertEqual(resolved, "quay.io/k@sha256:beef")
         self.assertFalse(emb)
+        self.assertTrue(any('authz_pullspec' in r.getMessage() for r in log_cm.records))
 
     async def test_resolve_member_parent_keeps_quay_for_regular_member(self):
         parent = MagicMock()

--- a/doozer/tests/test_util.py
+++ b/doozer/tests/test_util.py
@@ -294,7 +294,7 @@ class TestFindGoMainPackages(unittest.TestCase):
 
     def test_finds_simple_main_package(self):
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             cmd_dir = root / 'cmd' / 'myapp'
             self._write(cmd_dir, 'main.go', 'package main\n\nfunc main() {}\n')
             result = util.find_go_main_packages(root)
@@ -302,14 +302,14 @@ class TestFindGoMainPackages(unittest.TestCase):
 
     def test_skips_vendor_dirs(self):
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             self._write(root / 'vendor' / 'pkg', 'main.go', 'package main\n')
             result = util.find_go_main_packages(root)
             self.assertEqual(result, [])
 
     def test_skips_test_files(self):
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             # Directory with only a test file declaring package main
             self._write(root / 'pkg', 'main_test.go', 'package main\n')
             result = util.find_go_main_packages(root)
@@ -318,7 +318,7 @@ class TestFindGoMainPackages(unittest.TestCase):
     def test_skips_build_ignored_main(self):
         """A directory with only ``//go:build ignore`` main files should be skipped."""
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             plugins_dir = root / 'plugins'
             self._write(plugins_dir, 'example.go', '//go:build ignore\n\npackage main\n\nfunc main() {}\n')
             self._write(plugins_dir, 'minimum.go', 'package plugins\n')
@@ -331,7 +331,7 @@ class TestFindGoMainPackages(unittest.TestCase):
         check) should be skipped.
         """
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             mixed_dir = root / 'mixed'
             self._write(mixed_dir, 'main.go', 'package main\n\nfunc main() {}\n')
             self._write(mixed_dir, 'lib.go', 'package mixed\n')
@@ -344,7 +344,7 @@ class TestFindGoMainPackages(unittest.TestCase):
         ``//go:build ignore`` file with ``package main``.
         """
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             plugins_dir = root / 'plugins'
             self._write(plugins_dir, 'minimum.go', 'package plugins\n\nvar _ = 1\n')
             self._write(
@@ -367,7 +367,7 @@ class TestFindGoMainPackages(unittest.TestCase):
 
     def test_multiple_main_packages(self):
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             cmd1 = root / 'cmd' / 'app1'
             cmd2 = root / 'cmd' / 'app2'
             self._write(cmd1, 'main.go', 'package main\n\nfunc main() {}\n')
@@ -381,7 +381,7 @@ class TestFindGoMainPackages(unittest.TestCase):
         that ``go mod vendor`` does not copy injected files into vendor/.
         """
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             # Root module
             self._write(root, 'go.mod', 'module example.com/myproject\n')
             root_cmd = root / 'cmd' / 'myapp'
@@ -403,7 +403,7 @@ class TestFindGoMainPackages(unittest.TestCase):
         vendor/.
         """
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             self._write(root, 'go.mod', 'module example.com/olm\n')
             # Root cmd directories
             cmd_a = root / 'cmd' / 'collect-profiles'
@@ -431,7 +431,7 @@ class TestInjectCoverageServer(unittest.TestCase):
 
     def test_injects_into_main_packages(self):
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             cmd_dir = root / 'cmd' / 'myapp'
             self._write(cmd_dir, 'main.go', 'package main\n\nfunc main() {}\n')
 
@@ -445,7 +445,7 @@ class TestInjectCoverageServer(unittest.TestCase):
         have conflicting package names (the prometheus/plugins scenario).
         """
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             plugins_dir = root / 'plugins'
             self._write(plugins_dir, 'minimum.go', 'package plugins\n')
             self._write(plugins_dir, 'example.go', '//go:build ignore\n\npackage main\n\nfunc main() {}\n')
@@ -470,7 +470,7 @@ class TestInjectCoverageProducer(unittest.TestCase):
         is a package main directory.
         """
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             kubelet_dir = root / 'cmd' / 'kubelet'
             self._write(kubelet_dir, 'kubelet.go', 'package main\n\nfunc main() {}\n')
 
@@ -482,7 +482,7 @@ class TestInjectCoverageProducer(unittest.TestCase):
     def test_does_not_inject_without_cmd_kubelet(self):
         """Producer should NOT be injected when there is no cmd/kubelet/ dir."""
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             other_dir = root / 'cmd' / 'kube-apiserver'
             self._write(other_dir, 'main.go', 'package main\n\nfunc main() {}\n')
 
@@ -494,7 +494,7 @@ class TestInjectCoverageProducer(unittest.TestCase):
     def test_does_not_inject_if_kubelet_not_package_main(self):
         """If cmd/kubelet/ exists but is not package main, skip injection."""
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             kubelet_dir = root / 'cmd' / 'kubelet'
             self._write(kubelet_dir, 'lib.go', 'package kubelet\n')
 
@@ -506,7 +506,7 @@ class TestInjectCoverageProducer(unittest.TestCase):
     def test_injects_alongside_coverage_server(self):
         """Both server and producer should coexist in cmd/kubelet/."""
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = pathlib.Path(td).resolve()
             kubelet_dir = root / 'cmd' / 'kubelet'
             self._write(kubelet_dir, 'kubelet.go', 'package main\n\nfunc main() {}\n')
             # Also create another cmd to verify server is injected everywhere

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -4,7 +4,7 @@ import os
 import time
 import uuid
 from enum import Enum
-from typing import Optional
+from typing import NamedTuple, Optional, Union
 from urllib.parse import unquote, urlparse
 
 import requests
@@ -19,6 +19,14 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 from pyartcd import constants
 
 logger = logging.getLogger(__name__)
+
+
+class JenkinsBlockingBuildResult(NamedTuple):
+    """Jenkins build result when ``block_until_complete`` and ``return_build_url`` are True."""
+
+    result: Optional[str]
+    build_url: str
+
 
 current_build_url: Optional[str] = None
 current_job_name: Optional[str] = None
@@ -336,7 +344,8 @@ def start_build(
     block_until_building: bool = True,
     block_until_complete: bool = False,
     watch_building_delay: int = 5,
-) -> Optional[str]:
+    return_build_url: bool = False,
+) -> Union[str, JenkinsBlockingBuildResult, None]:
     """
     Starts a new Jenkins build
 
@@ -346,6 +355,8 @@ def start_build(
         triggered jobs are properly backlinked to parent jobs.
     :param block_until_complete: False by default. Will block until the new build completes
     :param watch_building_delay: Poll rate for building state
+    :param return_build_url: If True with block_until_complete, return JenkinsBlockingBuildResult
+        with (result string, absolute/build URL); otherwise return only the result string.
 
     Returns the build result if block_until_complete is True, None otherwise
     """
@@ -371,6 +382,9 @@ def start_build(
     triggered_build.block_until_complete()
     result = triggered_build.poll()['result']
     logger.info('Build completed with result: %s', result)
+    if return_build_url:
+        url = getattr(triggered_build, 'baseurl', None) or ''
+        return JenkinsBlockingBuildResult(result, str(url).rstrip('/'))
     return result
 
 
@@ -687,8 +701,9 @@ def start_base_image_release(
     doozer_data_path: str = constants.OCP_BUILD_DATA_URL,
     doozer_data_gitref: str = '',
     dry_run: bool = False,
+    return_build_url: bool = False,
     **kwargs,
-) -> Optional[str]:
+) -> Union[str, JenkinsBlockingBuildResult, None]:
     if not base_image_nvrs:
         logger.warning('Empty base image NVR list: skipping base image release')
         return
@@ -706,6 +721,7 @@ def start_base_image_release(
     return start_build(
         job=Jobs.BASE_IMAGE_RELEASE,
         params=params,
+        return_build_url=return_build_url,
         **kwargs,
     )
 

--- a/pyartcd/tests/test_jenkins.py
+++ b/pyartcd/tests/test_jenkins.py
@@ -72,6 +72,41 @@ class TestJenkinsStartBuild(unittest.TestCase):
         mock_queue_item.poll.assert_called_once()
         mock_build.assert_called_once_with(url=triggered_url, buildno=1, job=mock_job)
 
+    @mock.patch("pyartcd.jenkins.Build")
+    @mock.patch("pyartcd.jenkins.init_jenkins")
+    @mock.patch("pyartcd.jenkins.jenkins_client")
+    def test_start_build_block_until_complete_with_return_build_url(self, mock_client, mock_init_jenkins, mock_build):
+        job = Jobs.OCP4
+        params = {"param1": "value1", "param2": "value2"}
+        delay = 10
+        mock_client.get_job.return_value = mock_job = mock.MagicMock()
+        mock_job.invoke.return_value = mock_queue_item = mock.MagicMock()
+        mock_queue_item.poll.return_value = {'executable': {'number': 1}, 'task': {'url': 'folder/foo/'}}
+        triggered_url = 'folder/foo/1'
+        os.environ['BUILD_URL'] = 'folder/bar/1'
+        os.environ['JOB_NAME'] = 'bar'
+        os.environ['JENKINS_URL'] = 'buildvm.com'
+        mock_build.return_value.poll.return_value = {'result': 'SUCCESS'}
+        mock_build.return_value.baseurl = 'https://jenkins.example/job/1/'
+
+        result = jenkins.start_build(
+            job,
+            params,
+            block_until_building=True,
+            block_until_complete=True,
+            watch_building_delay=delay,
+            return_build_url=True,
+        )
+        self.assertIsInstance(result, jenkins.JenkinsBlockingBuildResult)
+        self.assertEqual(result.result, 'SUCCESS')
+        self.assertEqual(result.build_url, 'https://jenkins.example/job/1')
+
+        mock_init_jenkins.assert_called_once()
+        mock_client.get_job.assert_called_once_with(job.value)
+        mock_job.invoke.assert_called_once_with(build_params=params)
+        mock_queue_item.poll.assert_called_once()
+        mock_build.assert_called_once_with(url=triggered_url, buildno=1, job=mock_job)
+
     def test_get_build_url_and_path(self):
         # No BUILD_URL env var defined
         if os.environ.get('BUILD_URL'):


### PR DESCRIPTION
## Summary

Extend Konflux build records with authorization/release metadata: `authz_pullspec`, `authz_pipeline_url`, and `authz_outcome` (plus trimmed `KonfluxAuthzOutcome` enum and `from_jenkins_result`). Doozer writes these around the snapshot-to-release Jenkins run; pyartcd can return a blocking result with the child job URL via `return_build_url`. Rebaser uses DB `authz_pullspec` when late-resolving a parent that already has a row, but logs and falls back to the Konflux digest when authz is not populated yet. Also fixes Go main-package tests on macOS path canonicalization.

## Problem

**Before:** Konflux DB rows did not record post-release consumer pullspec, release pipeline URL, or release outcome; correlating base-image release with Konflux builds was awkward. Late-resolve had no structured authz signal.

**After:** Build records carry authz fields; `image_pullspec` remains the Konflux digest. First-run / pre-backfill behavior logs and falls back instead of hard-failing rebases.

## Implementation

- **artcommon:** New fields on `KonfluxBuildRecord`, excluded from `build_id`; tests + schema list updates.
- **pyartcd:** `JenkinsBlockingBuildResult`, `start_build(..., return_build_url=True)`, forwarded from `start_base_image_release`; unit test.
- **doozer:** `KonfluxImageBuilder` UNRELEASED + final `update_konflux_db` paths; `_trigger_base_image_release` uses blocking Jenkins result.
- **doozer rebaser:** Prefer `authz_pullspec` when present; else ERROR log + `image_pullspec`; loaded parents keep `rh_art_images_base_pullspec` from session NVR; `# TODO` for stricter policy after backfill.
- **doozer tests:** `Path(td).resolve()` in `find_go_main_packages` / coverage inject tests.

Refs: [ART-18732](https://redhat.atlassian.net/browse/ART-18732) ([ART-14300](https://redhat.atlassian.net/browse/ART-14300) sub-task).