### PR TITLE
ART-18733: fix(doozer): gate base image release on stream assembly

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1395,11 +1395,15 @@ class ImageMetadata(Metadata):
         Determines whether this image should trigger the base image release workflow.
 
         OKD builds never trigger the OCP registry.redhat.io base-image release path.
+        Only the stream assembly uses this path (Konflux UNRELEASED, Jenkins snapshot-to-release,
+        registry.redhat.io parent pullspecs, lockfile seeding with unreleased builds).
 
         Returns:
             bool: True if base image release workflow should be triggered, False otherwise
         """
         if self.runtime.variant is BuildVariant.OKD:
+            return False
+        if self.runtime.assembly != "stream":
             return False
         return self.is_base_image() or self.is_golang_builder()
 

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1191,6 +1191,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         rt.group = 'test-group'
         rt.build_system = 'konflux'
         rt.konflux_db = MagicMock()
+        rt.assembly = 'stream'
 
         metadata = image.ImageMetadata(rt, data_obj)
         metadata.logger = self.logger
@@ -1719,6 +1720,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         runtime = MagicMock()
         runtime.logger = logging.getLogger('test_runtime')
         runtime.variant = BuildVariant.OCP
+        runtime.assembly = 'stream'
 
         # Test base image - should trigger workflow
         base_image = Model({'name': 'test-base', 'base_only': True})
@@ -1732,6 +1734,14 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         golang_metadata = ImageMetadata(runtime, golang_data)
         self.assertTrue(golang_metadata.should_trigger_base_image_release())
 
+        # Non-stream assembly: base/golang do not use the base-image release path
+        test_assembly_runtime = MagicMock()
+        test_assembly_runtime.logger = logging.getLogger('test_runtime')
+        test_assembly_runtime.variant = BuildVariant.OCP
+        test_assembly_runtime.assembly = 'test'
+        self.assertFalse(ImageMetadata(test_assembly_runtime, base_data).should_trigger_base_image_release())
+        self.assertFalse(ImageMetadata(test_assembly_runtime, golang_data).should_trigger_base_image_release())
+
         # Test regular image - should NOT trigger workflow
         regular_image = Model({'name': 'test-regular'})
         regular_data = Model({'key': 'test-regular', 'data': regular_image, 'filename': 'test-regular.yaml'})
@@ -1742,6 +1752,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         okd_runtime = MagicMock()
         okd_runtime.logger = logging.getLogger('test_runtime')
         okd_runtime.variant = BuildVariant.OKD
+        okd_runtime.assembly = 'stream'
         okd_base_metadata = ImageMetadata(okd_runtime, base_data)
         self.assertFalse(okd_base_metadata.should_trigger_base_image_release())
 


### PR DESCRIPTION
## Summary

`ImageMetadata.should_trigger_base_image_release()` now returns false unless `runtime.assembly == "stream"` (after the existing OKD guard). This aligns with how rebaser and Konflux code treat stream-only behavior.

## Problem

**Before:** Base and golang-builder images used the base-image release path (UNRELEASED outcome, Jenkins snapshot-to-release, registry.redhat.io parent resolution, lockfile seeding with unreleased builds) for every assembly.

**After:** That path runs only for the **stream** assembly. Non-stream assemblies behave like ordinary images for those mechanisms.

## Implementation

- Added `self.runtime.assembly != "stream"` early return in `should_trigger_base_image_release()` (`doozer/doozerlib/image.py`).
- Tests: OCP cases set `assembly='stream'`; added coverage for `assembly='test'`; `_create_image_metadata` sets `assembly='stream'` so existing golang lockfile tests still exercise the UNRELEASED merge.

https://redhat.atlassian.net/browse/ART-18048