### PR TITLE
ART-18048: fix(doozer): skip base image release path for test assembly

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1395,7 +1395,7 @@ class ImageMetadata(Metadata):
         Determines whether this image should trigger the base image release workflow.
 
         OKD builds never trigger the OCP registry.redhat.io base-image release path.
-        Only the stream assembly uses this path (Konflux UNRELEASED, Jenkins snapshot-to-release,
+        The test assembly does not use this path (Konflux UNRELEASED, Jenkins snapshot-to-release,
         registry.redhat.io parent pullspecs, lockfile seeding with unreleased builds).
 
         Returns:
@@ -1403,7 +1403,7 @@ class ImageMetadata(Metadata):
         """
         if self.runtime.variant is BuildVariant.OKD:
             return False
-        if self.runtime.assembly != "stream":
+        if self.runtime.assembly == "test":
             return False
         return self.is_base_image() or self.is_golang_builder()
 

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1734,13 +1734,21 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         golang_metadata = ImageMetadata(runtime, golang_data)
         self.assertTrue(golang_metadata.should_trigger_base_image_release())
 
-        # Non-stream assembly: base/golang do not use the base-image release path
+        # Test assembly: base/golang do not use the base-image release path
         test_assembly_runtime = MagicMock()
         test_assembly_runtime.logger = logging.getLogger('test_runtime')
         test_assembly_runtime.variant = BuildVariant.OCP
         test_assembly_runtime.assembly = 'test'
         self.assertFalse(ImageMetadata(test_assembly_runtime, base_data).should_trigger_base_image_release())
         self.assertFalse(ImageMetadata(test_assembly_runtime, golang_data).should_trigger_base_image_release())
+
+        # Named (non-test) assembly still uses the base-image release path
+        named_runtime = MagicMock()
+        named_runtime.logger = logging.getLogger('test_runtime')
+        named_runtime.variant = BuildVariant.OCP
+        named_runtime.assembly = '4.17.1'
+        self.assertTrue(ImageMetadata(named_runtime, base_data).should_trigger_base_image_release())
+        self.assertTrue(ImageMetadata(named_runtime, golang_data).should_trigger_base_image_release())
 
         # Test regular image - should NOT trigger workflow
         regular_image = Model({'name': 'test-regular'})


### PR DESCRIPTION
## Summary

`should_trigger_base_image_release()` now returns false only when `runtime.assembly == "test"` (after the OKD guard). Stream and named assemblies keep the Konflux UNRELEASED / Jenkins snapshot-to-release / RH parent pullspec / lockfile UNRELEASED behavior for base and golang-builder images.

## Problem

**Before:** Only `assembly == stream` used that path (PR #2888).

**After:** Every assembly **except** `test` uses the path, so product assemblies (e.g. `4.17.1`) behave like stream for this mechanism while `test` stays excluded.

## Implementation

- `doozer/doozerlib/image.py`: `assembly == "test"` early return; docstring updated.
- Tests: `test` still negative; added `4.17.1` positive cases; `_create_image_metadata` still sets a non-test assembly for lockfile tests.

https://redhat.atlassian.net/browse/ART-18048