### PR TITLE
Pin builds for layered RHCOS

### DIFF
--- a/doozer/doozerlib/rhcos.py
+++ b/doozer/doozerlib/rhcos.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 from typing import Dict, List, Optional, Tuple
 from urllib import request
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 
 import koji
 from artcommonlib import exectools, logutil, rhcos
@@ -201,8 +201,11 @@ class RHCOSBuildFinder:
         if not arch:
             arch = self.brew_arch
         url = f"{self.rhcos_release_url()}/{build_id}/{arch}/{meta_type}.json"
-        with request.urlopen(url, timeout=60) as req:
-            return json.loads(req.read().decode())
+        try:
+            with request.urlopen(url, timeout=60) as req:
+                return json.loads(req.read().decode())
+        except HTTPError as e:
+            raise HTTPError(e.url or url, e.code, f"{e.reason} ({url})", e.headers, e.fp) from e
 
     @retry(reraise=True, stop=stop_after_attempt(10), wait=wait_fixed(3))
     def rhel_build_meta_layered(self, pullspec: str):

--- a/elliott/elliottlib/cli/pin_builds_cli.py
+++ b/elliott/elliottlib/cli/pin_builds_cli.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 import click
 import yaml
 from artcommonlib import logutil
-from artcommonlib.arch_util import brew_arch_for_go_arch, go_arch_for_brew_arch
+from artcommonlib.arch_util import go_arch_for_brew_arch
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.model import ListModel, Model
@@ -309,9 +309,8 @@ class AssemblyPinBuildsCli:
                         timestamp,
                     )
                 else:
-                    brew_arch = brew_arch_for_go_arch(arch)
                     version = f"{major}.{minor}"
-                    finder = RHCOSBuildFinder(self.runtime, version, brew_arch, False)
+                    finder = RHCOSBuildFinder(self.runtime, version, arch, False)
                     build_meta = finder.rhcos_build_meta(build_id)
                     pullspec = get_container_pullspec(
                         build_meta,
@@ -320,10 +319,14 @@ class AssemblyPinBuildsCli:
 
                 rhcos_info[container_conf.name]["images"][arch] = pullspec
 
+        if not rhcos_info:
+            raise ValueError(f"No container configs matched RHCOS NVR {rhcos_nvr}")
+
         self.assembly_config.setdefault("rhcos", Model({}))
         current_rhcos = self.assembly_config["rhcos"].primitive()
-        if current_rhcos != rhcos_info:
-            self.assembly_config["rhcos"] = Model(rhcos_info)
+        merged_rhcos = {**current_rhcos, **rhcos_info}
+        if current_rhcos != merged_rhcos:
+            self.assembly_config["rhcos"] = Model(merged_rhcos)
             changed = True
 
         return changed

--- a/elliott/elliottlib/cli/pin_builds_cli.py
+++ b/elliott/elliottlib/cli/pin_builds_cli.py
@@ -294,11 +294,10 @@ class AssemblyPinBuildsCli:
 
         for container_conf in container_configs:
             if layered:
-                # Only process tags matching the RHEL version from the input
-                tag_part = str(container_conf.rhcos_index_tag).split(":")[-1]
-                tag_rhel_version = tag_part.split("-")[1]
-                if tag_rhel_version != rhel_version:
-                    LOGGER.info(f"Skipping {container_conf.name}: RHEL version {tag_rhel_version} != {rhel_version}")
+                if str(container_conf.rhel_version) != rhel_version:
+                    LOGGER.info(
+                        f"Skipping {container_conf.name}: RHEL version {container_conf.rhel_version} != {rhel_version}"
+                    )
                     continue
             rhcos_info[container_conf.name] = {"images": {}}
 

--- a/elliott/elliottlib/cli/pin_builds_cli.py
+++ b/elliott/elliottlib/cli/pin_builds_cli.py
@@ -3,13 +3,14 @@ from typing import List, Optional
 import click
 import yaml
 from artcommonlib import logutil
-from artcommonlib.arch_util import brew_arch_for_go_arch
+from artcommonlib.arch_util import brew_arch_for_go_arch, go_arch_for_brew_arch
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.model import ListModel, Model
 from artcommonlib.release_util import isolate_el_version_in_release
 from artcommonlib.rhcos import get_container_configs, get_container_pullspec
 from artcommonlib.rpm_utils import parse_nvr
+from artcommonlib.util import get_art_prod_image_repo_for_version, oc_image_info_for_arch
 from doozerlib.brew import get_build_objects
 from doozerlib.rhcos import RHCOSBuildFinder
 from github import Github
@@ -56,8 +57,8 @@ class AssemblyPinBuildsCli:
                 if f"{major}.{minor}" not in parsed['version']:
                     raise ValueError(f"Does nvr belong to the current group? {nvr}")
                 images.append(nvr)
-            elif parsed['name'].startswith("rhcos"):
-                if f"{major}{minor}" not in parsed['version']:
+            elif nvr.startswith("rhcos"):
+                if f"{major}{minor}" not in nvr and f"{major}.{minor}" not in nvr:
                     raise ValueError(f"Does rhcos nvr belong to the current group: {nvr}")
                 rhcos.append(nvr)
             elif parsed['name'] in art_rpms_by_comp:
@@ -264,29 +265,60 @@ class AssemblyPinBuildsCli:
     def pin_rhcos(self, rhcos_nvr):
         """
         Pin RHCOS build to the assembly's group.rhcos section.
-        The RHCOS build is identified by its build ID, which is extracted from the NVR.
-        For each architecture in the group, we generate the appropriate container pullspecs.
+
+        Accepts two formats:
+        - Non-layered NVR: rhcos-418.92.202309222337-0
+        - Layered build ID: rhcos-4.21-9.6-202605121024
+
+        For layered RHCOS (4.19+), each payload_tag config has an rhcos_index_tag pointing to
+        a manifest-list in art-prod (e.g. "art-dev:4.21-9.6-node-image"). We construct the
+        build-specific tag by inserting the timestamp, then query per-arch digests via oc image info.
         """
-        parsed = parse_nvr(rhcos_nvr)
-        build_id = f"{parsed['version']}-{parsed['release']}"
-        LOGGER.info(f"Pinning RHCOS build: {build_id}")
+        layered = self.runtime.group_config.rhcos.get("layered_rhcos", False)
+        major, minor = self.runtime.get_major_minor()
+
+        if not layered:
+            parsed = parse_nvr(rhcos_nvr)
+            build_id = f"{parsed['version']}-{parsed['release']}"
+        else:
+            # Format: rhcos-{major}.{minor}-{rhel_major}.{rhel_minor}-{timestamp}
+            parts = rhcos_nvr.removeprefix("rhcos-").split("-")
+            rhel_version = parts[1]  # e.g. "9.6"
+            timestamp = parts[-1]
+
+        LOGGER.info(f"Pinning RHCOS build from NVR: {rhcos_nvr}")
 
         rhcos_info = {}
         changed = False
+        container_configs = get_container_configs(self.runtime)
 
-        for arch in self.runtime.group_config.arches:
-            brew_arch = brew_arch_for_go_arch(arch)
-            LOGGER.info(f"Getting RHCOS pullspecs for build {build_id}-{brew_arch}...")
-            for container_conf in get_container_configs(self.runtime):
-                major, minor = self.runtime.get_major_minor()
-                version = f"{major}.{minor}"
-                finder = RHCOSBuildFinder(self.runtime, version, brew_arch, False)
-                if container_conf.name not in rhcos_info:
-                    rhcos_info[container_conf.name] = {"images": {}}
-                pullspec = get_container_pullspec(
-                    finder.rhcos_build_meta(build_id),
-                    container_conf or finder.get_primary_container_conf(),
-                )
+        for container_conf in container_configs:
+            if layered:
+                # Only process tags matching the RHEL version from the input
+                tag_part = str(container_conf.rhcos_index_tag).split(":")[-1]
+                tag_rhel_version = tag_part.split("-")[1]
+                if tag_rhel_version != rhel_version:
+                    LOGGER.info(f"Skipping {container_conf.name}: RHEL version {tag_rhel_version} != {rhel_version}")
+                    continue
+            rhcos_info[container_conf.name] = {"images": {}}
+
+            for arch in self.runtime.group_config.arches:
+                if layered:
+                    pullspec = self._get_layered_rhcos_pullspec(
+                        container_conf,
+                        arch,
+                        timestamp,
+                    )
+                else:
+                    brew_arch = brew_arch_for_go_arch(arch)
+                    version = f"{major}.{minor}"
+                    finder = RHCOSBuildFinder(self.runtime, version, brew_arch, False)
+                    build_meta = finder.rhcos_build_meta(build_id)
+                    pullspec = get_container_pullspec(
+                        build_meta,
+                        container_conf or finder.get_primary_container_conf(),
+                    )
+
                 rhcos_info[container_conf.name]["images"][arch] = pullspec
 
         self.assembly_config.setdefault("rhcos", Model({}))
@@ -296,6 +328,38 @@ class AssemblyPinBuildsCli:
             changed = True
 
         return changed
+
+    def _get_layered_rhcos_pullspec(self, container_conf, arch, timestamp):
+        """
+        Get the pullspec for a layered RHCOS container at a specific build timestamp.
+
+        Constructs the build-specific manifest-list tag from the container_conf's rhcos_index_tag
+        by inserting the timestamp, then queries oc image info for the per-arch digest.
+
+        rhcos_index_tag (latest):   "quay.io/.../art-dev:4.21-9.6-node-image"
+        Build-specific tag:         "4.21-9.6-202605121024-node-image"
+
+        The tag has the form {ocp_version}-{rhel_version}-{suffix}. We find the suffix
+        (everything after the second hyphen-separated version segment) and insert the timestamp.
+        """
+        index_tag = str(container_conf.rhcos_index_tag)
+        tag_part = index_tag.split(":")[-1]
+        # Split: ["4.21", "9.6", "node", "image"] or ["4.21", "10.2", "node", "image", "extensions"]
+        parts = tag_part.split("-")
+        # First two segments are version numbers (ocp, rhel); the rest is the suffix
+        version_prefix = f"{parts[0]}-{parts[1]}-"
+        suffix = "-".join(parts[2:])
+        build_tag = f"{version_prefix}{timestamp}-{suffix}"
+
+        art_repo = get_art_prod_image_repo_for_version(major=4, repo_type="dev")
+        go_arch = go_arch_for_brew_arch(arch)
+        LOGGER.info(f"Fetching layered RHCOS pullspec: {art_repo}:{build_tag} for {go_arch}")
+        image_info = oc_image_info_for_arch(
+            f"{art_repo}:{build_tag}",
+            go_arch,
+            registry_config=self.runtime.registry_config,
+        )
+        return f"{art_repo}@{image_info['digest']}"
 
 
 @cli.command("pin-builds", short_help="Pin given builds to assembly")

--- a/elliott/tests/test_pin_builds_cli.py
+++ b/elliott/tests/test_pin_builds_cli.py
@@ -214,6 +214,7 @@ class TestAssemblyPinBuildsCli(IsolatedAsyncioTestCase):
     ):
         self.runtime.group_config = MagicMock()
         self.runtime.group_config.arches = ["x86_64", "aarch64"]
+        self.runtime.group_config.rhcos.get.return_value = False
         mock_brew_arch_for_go_arch.side_effect = lambda arch: arch  # Return the input arch
 
         # Setup container configs
@@ -264,6 +265,94 @@ class TestAssemblyPinBuildsCli(IsolatedAsyncioTestCase):
                     "images": {
                         "x86_64": "registry.example.com/rhel-coreos/machine-os-content@sha256:abc123",
                         "aarch64": "registry.example.com/rhel-coreos/machine-os-content@sha256:abc123",
+                    },
+                },
+            },
+        }
+        self.assertEqual(changed, True)
+        self.assertEqual(out["releases"][self.runtime.assembly]["assembly"], expected_assembly_config)
+
+    @patch("elliottlib.cli.pin_builds_cli.get_container_configs")
+    @patch("elliottlib.cli.pin_builds_cli.oc_image_info_for_arch")
+    @patch("elliottlib.cli.pin_builds_cli.get_art_prod_image_repo_for_version")
+    @patch("elliottlib.cli.pin_builds_cli.go_arch_for_brew_arch")
+    async def test_run_with_layered_rhcos_nvr(
+        self,
+        mock_go_arch_for_brew_arch,
+        mock_get_art_repo,
+        mock_oc_image_info,
+        mock_get_container_configs,
+    ):
+        self.runtime.get_major_minor.return_value = (4, 21)
+        self.runtime.group_config = MagicMock()
+        self.runtime.group_config.arches = ["x86_64", "aarch64"]
+        self.runtime.group_config.rhcos.get.return_value = True
+        self.runtime.group_config.vars.RHCOS_EL_MAJOR = 9
+        self.runtime.group_config.vars.RHCOS_EL_MINOR = 6
+
+        mock_go_arch_for_brew_arch.side_effect = lambda a: {"x86_64": "amd64", "aarch64": "arm64"}[a]
+        art_repo = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+        mock_get_art_repo.return_value = art_repo
+
+        # Layered container configs have rhcos_index_tag instead of build_metadata_key
+        primary_conf = MagicMock()
+        primary_conf.name = "rhel-coreos"
+        primary_conf.rhcos_index_tag = f"{art_repo}:4.21-9.6-node-image"
+
+        ext_conf = MagicMock()
+        ext_conf.name = "rhel-coreos-extensions"
+        ext_conf.rhcos_index_tag = f"{art_repo}:4.21-9.6-node-image-extensions"
+
+        mock_get_container_configs.return_value = [primary_conf, ext_conf]
+
+        # Return different digests per tag+arch to verify correct routing
+        def fake_oc_image_info(pullspec, go_arch, registry_config=None):
+            if "node-image-extensions" in pullspec:
+                return {"digest": f"sha256:ext-{go_arch}"}
+            return {"digest": f"sha256:primary-{go_arch}"}
+
+        mock_oc_image_info.side_effect = fake_oc_image_info
+
+        layered_rhcos_build = "rhcos-4.21-9.6-202605121024"
+        cli = AssemblyPinBuildsCli(
+            runtime=self.runtime,
+            nvrs=[layered_rhcos_build],
+            pr=None,
+            why=self.why,
+            github_client=self.github_client,
+        )
+        out, changed = await cli.run()
+
+        # Verify build-specific tags were constructed correctly
+        mock_oc_image_info.assert_any_call(
+            f"{art_repo}:4.21-9.6-202605121024-node-image",
+            "amd64",
+            registry_config=self.runtime.registry_config,
+        )
+        mock_oc_image_info.assert_any_call(
+            f"{art_repo}:4.21-9.6-202605121024-node-image-extensions",
+            "arm64",
+            registry_config=self.runtime.registry_config,
+        )
+        self.assertEqual(mock_oc_image_info.call_count, 4)  # 2 containers x 2 arches
+
+        expected_assembly_config = {
+            "members": {
+                "images": [],
+                "rpms": [],
+            },
+            "group": {},
+            "rhcos": {
+                "rhel-coreos": {
+                    "images": {
+                        "x86_64": f"{art_repo}@sha256:primary-amd64",
+                        "aarch64": f"{art_repo}@sha256:primary-arm64",
+                    },
+                },
+                "rhel-coreos-extensions": {
+                    "images": {
+                        "x86_64": f"{art_repo}@sha256:ext-amd64",
+                        "aarch64": f"{art_repo}@sha256:ext-arm64",
                     },
                 },
             },

--- a/elliott/tests/test_pin_builds_cli.py
+++ b/elliott/tests/test_pin_builds_cli.py
@@ -202,20 +202,17 @@ class TestAssemblyPinBuildsCli(IsolatedAsyncioTestCase):
         self.assertEqual(out["releases"][self.runtime.assembly]["assembly"], expected_assembly_config)
 
     @patch("elliottlib.cli.pin_builds_cli.get_container_configs")
-    @patch("elliottlib.cli.pin_builds_cli.brew_arch_for_go_arch")
     @patch("elliottlib.cli.pin_builds_cli.get_container_pullspec")
     @patch("elliottlib.cli.pin_builds_cli.RHCOSBuildFinder")
     async def test_run_with_rhcos_nvr(
         self,
         mock_rhcos_build_finder,
         mock_get_container_pullspec,
-        mock_brew_arch_for_go_arch,
         mock_get_container_configs,
     ):
         self.runtime.group_config = MagicMock()
         self.runtime.group_config.arches = ["x86_64", "aarch64"]
         self.runtime.group_config.rhcos.get.return_value = False
-        mock_brew_arch_for_go_arch.side_effect = lambda arch: arch  # Return the input arch
 
         # Setup container configs
         mock_container_conf = MagicMock()

--- a/elliott/tests/test_pin_builds_cli.py
+++ b/elliott/tests/test_pin_builds_cli.py
@@ -298,10 +298,12 @@ class TestAssemblyPinBuildsCli(IsolatedAsyncioTestCase):
         primary_conf = MagicMock()
         primary_conf.name = "rhel-coreos"
         primary_conf.rhcos_index_tag = f"{art_repo}:4.21-9.6-node-image"
+        primary_conf.rhel_version = "9.6"
 
         ext_conf = MagicMock()
         ext_conf.name = "rhel-coreos-extensions"
         ext_conf.rhcos_index_tag = f"{art_repo}:4.21-9.6-node-image-extensions"
+        ext_conf.rhel_version = "9.6"
 
         mock_get_container_configs.return_value = [primary_conf, ext_conf]
 


### PR DESCRIPTION
## Summary
- Add support for pinning layered RHCOS builds in `elliott pin-builds`
- Layered RHCOS builds use a different NVR format (`rhcos-4.21-9.6-202605121024`) and resolve pullspecs via `oc image info` against art-prod manifest-list tags instead of querying RHCOS build metadata
- Improve error messages for `HTTPError` in `RHCOSBuildFinder.rhcos_build_meta` by including the URL in the error

## Test

```
# non-layered
$ uv run elliott -g openshift-4.18 --assembly 4.18.40 pin-builds rhcos-418.94.202605101521-0 --why "cve"
...
      rhcos:
        rhel-coreos:
          images:
            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c85eb306b9ba2087b577dcb600598096f9914bd5180a17ce5b7c3bde500b2dd8
            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:af6f8afc1fabe5117aa40d7b786c87d759e438fb09f33c6f163804ae6084b326
            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5e32e301c5fec8bcd5eae90477c7f045fc3b8d6643ed7a364ae8098164feabab
            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4e1a87314fdd56fffcc5812be57d861c7e164239ef26dbd4fd292e1b6fde683f
        rhel-coreos-extensions:
          images:
            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5bfb238eb7ed063ab0ebac0f2cf3ca12639900aa688a8a8497fc15bd69275501
            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1dfd195c38e044d08559b2fb8bb57b65f130d6cfda72b86a53991296dde7d44e
            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2bb8435ab17a3b200dadfbebd9800c1ad73217a06be36ba1a9e1b0fd21f2cbd4
            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7933b68dce9d40247e8853a4a55e8d626a3583b39dc9cbcc3d888244b727b3e6

$ uv run elliott -g openshift-4.18 --assembly 4.18.41 pin-builds rhcos-418.94.202605101521-0 --why "cve"
2026-05-12 11:32:13,066 art_tools.elliottlib.cli.pin_builds_cli INFO No change in assembly config. Pins already exist.

# layered
$ uv run elliott -g openshift-4.19 --assembly 4.19.30 pin-builds rhcos-4.19-9.6-202605110225 --why "cve"
...
      rhcos:
        rhel-coreos:
          images:
            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7e4ec322dc2c1f2310f096aa3b5a8d3049e6409d8c5e894e779801e0b490d03e
            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ea7b9240f7a25a845d0b118cfff6391db19bb972c346126855f0c7b5fa1754f5
            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e1bc2e4024b6493bfde344fc5dd25f81d958acb66d757b5846cc438cc1fd81dd
            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fd89043c1128c2d729bae0c15038893bbbf88b98a36f74007e72e27c886068ab
        rhel-coreos-extensions:
          images:
            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3eee528c163e25f4e9eaf83929231af0400e391a960e1bd31930bb611efb1c3c
            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:af5271eaa8853c4e2c78e288a95ff2d49d4024c80aa74f8b2fa3e60e3e225a17
            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e3fe70bc7856517f9ea077e3c38790382d7574b44297f35204d46a449b114ce5
            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:74d6c81a4435478b0820bbec84fd04d21f16d8c46249c06b6fbe83b7c646ccd8

$ uv run elliott -g openshift-4.19 --assembly 4.19.31 pin-builds rhcos-4.19-9.6-202605110225 --why "cve"
2026-05-12 11:35:59,387 art_tools.elliottlib.cli.pin_builds_cli INFO No change in assembly config. Pins already exist.

# layered multi-rhel
$ uv run elliott -g openshift-4.21 --assembly 4.21.14 pin-builds rhcos-4.21-9.6-202605110143 --why "cve"
...
      rhcos:
        rhel-coreos:
          images:
            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:672c881a93cc18c90a2a6e31464f08126c1cedc8db35beaa44cd75217a52142c
            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8fa225e1ccdc3069286903fcd6be09130b59158a0a6757b9d97083fc2c6cab45
            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e0a44947598b2cf8e64500e8f14daec4070577b2be97458f6795e1ef976adf7d
            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0ec6a32535eeed2d3bc3947c652d5c6705f3385e968b59bcf6c778cfe5a4e62e
        rhel-coreos-extensions:
          images:
            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:bfcc28957aed0b21bc116cd8a0d04adac7a85a8a567c970f02683f62bafa5911
            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0c47f58c78ed921a840150e6ee2a123ce87c2302b4f9d919855ea4e0b277ced5
            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d72d80472e5543cfe09cbe011d844e935daadfb4bbbb9e9b1c2843c5f2b1d279
            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ff920fae8f5efa60b096bc070f7832b93ba3d5c410dd574301bf182f41a072fd

$ uv run elliott -g openshift-4.21 --assembly 4.21.15 pin-builds rhcos-4.21-9.6-202605110143 --why "cve"
2026-05-12 11:38:26,156 art_tools.elliottlib.cli.pin_builds_cli INFO No change in assembly config. Pins already exist.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)