### PR TITLE
feat(elliott): rewrite rhcos command to output manifest list tags

### DIFF
--- a/elliott/elliottlib/cli/rhcos_cli.py
+++ b/elliott/elliottlib/cli/rhcos_cli.py
@@ -8,7 +8,7 @@ from artcommonlib.arch_util import brew_arch_for_go_arch
 from artcommonlib.constants import RHCOS_RELEASES_STREAM_URL
 from artcommonlib.format_util import green_print
 from artcommonlib.rhcos import get_container_configs
-from artcommonlib.util import get_art_prod_image_repo_for_version, oc_image_info
+from artcommonlib.util import get_art_prod_image_repo_for_version, oc_image_info, oc_image_info_show_multiarch
 from doozerlib.util import get_nightly_pullspec
 
 from elliottlib.cli.common import cli
@@ -87,7 +87,7 @@ def _get_rhcos_pullspec_from_payload(payload_pullspec, tag_name):
 
 
 def _verify_tag(tag_pullspec):
-    result = oc_image_info(tag_pullspec, strict=False)
+    result = oc_image_info_show_multiarch(tag_pullspec, strict=False)
     if result is None:
         raise click.ClickException(f"Tag is not live in registry: {tag_pullspec}")
 

--- a/elliott/elliottlib/cli/rhcos_cli.py
+++ b/elliott/elliottlib/cli/rhcos_cli.py
@@ -1,155 +1,160 @@
+import json
 import logging
+from urllib import request
 
 import click
-from artcommonlib.arch_util import BREW_ARCHES, GO_ARCHES, brew_arch_for_go_arch
+from artcommonlib import exectools
+from artcommonlib.arch_util import brew_arch_for_go_arch
+from artcommonlib.constants import RHCOS_RELEASES_STREAM_URL
 from artcommonlib.format_util import green_print
-from artcommonlib.rhcos import get_build_id_from_rhcos_pullspec, get_primary_container_name
+from artcommonlib.rhcos import get_container_configs
+from artcommonlib.util import get_art_prod_image_repo_for_version, oc_image_info
 from doozerlib.util import get_nightly_pullspec
 
-from elliottlib import rhcos, util
 from elliottlib.cli.common import cli
 from elliottlib.runtime import Runtime
 
 LOGGER = logging.getLogger(__name__)
 
 
-@cli.command("rhcos", short_help="Show details of packages contained in OCP RHCOS builds")
+@cli.command("rhcos", short_help="Get RHCOS manifest list tags from an OCP release payload")
 @click.option(
     '--release',
     '-r',
     'release',
-    help='Show details for this OCP release. Can be a full pullspec or a named release ex: 4.8.4',
+    help='OCP release: nightly name, named release (e.g. 4.16.5), or full pullspec',
 )
-@click.option(
-    '--arch',
-    'arch',
-    default='x86_64',
-    type=click.Choice(BREW_ARCHES + ['all']),
-    help='Specify architecture. Default is x86_64. "all" to get all arches. aarch64 only works for 4.8+',
-)
-@click.option('--packages', '-p', 'packages', help='Show details for only these package names (comma-separated)')
-@click.option('--go', '-g', 'go', is_flag=True, help='Show go version for packages that are go binaries')
 @click.pass_obj
-def rhcos_cli(runtime: Runtime, release, packages, arch, go):
+def rhcos_cli(runtime: Runtime, release):
     """
-        Show packages in an RHCOS build in a payload image.
-        There are several ways to specify the location of the RHCOS build.
+        Extract RHCOS manifest list tags from an OCP release payload.
+
+        Inspects the RHCOS images in a release payload and outputs their
+        manifest list tags (e.g. quay.io/openshift-release-dev/ocp-v4.0-art-dev:418.94.202605101521-0-coreos).
+
+        For layered RHCOS (4.19+), reads the coreos.build.manifest-list-tag label
+        from each RHCOS image in the payload.
+
+        For non-layered RHCOS, fetches RHCOS build metadata (meta.json) and
+        extracts the build-specific tags from each container entry.
+
+        Each tag is verified to be live in the registry before being returned.
 
         Usage:
 
     \b Nightly
-        $ elliott -g openshift-4.8 rhcos -r 4.8.0-0.nightly-s390x-2021-07-31-070046
+        $ elliott -g openshift-4.19 rhcos -r 4.19.0-0.nightly-2025-05-01-010101
 
     \b Named Release
-        $ elliott -g openshift-4.6 rhcos -r 4.6.31
+        $ elliott -g openshift-4.16 rhcos -r 4.16.5
 
     \b Any Pullspec
         $ elliott -g openshift-4.X rhcos -r <pullspec>
 
-    \b Assembly Definition
-        $ elliott --group openshift-4.8 --assembly 4.8.21 rhcos
-
-    \b Only lookup specified package(s)
-        $ elliott -g openshift-4.6 rhcos -r 4.6.31 -p "openshift,runc,cri-o,selinux-policy"
-
-    \b Also lookup go build version (if available)
-        $ elliott -g openshift-4.6 rhcos -r 4.6.31 -p openshift --go
-
-    \b Specify arch (default being x64)
-        $ elliott -g openshift-4.6 rhcos -r 4.6.31 --arch s390x -p openshift
-
-    \b Get all arches (supported only for named release and assembly)
-        $ elliott -g openshift-4.6 rhcos -r 4.6.31 --arch all -p openshift
+    \b Assembly
+        $ elliott -g openshift-4.19 --assembly 4.19.3 rhcos
     """
     named_assembly = runtime.assembly not in ['stream', 'test']
-    count_options = sum(map(bool, [named_assembly, release]))
-    if count_options != 1:
-        raise click.BadParameter("Use one of --assembly or --release")
-
-    nightly = release and 'nightly' in release
-    pullspec = release and '/' in release
-    named_release = not (nightly or pullspec or named_assembly)
-    if arch == "all" and (pullspec or nightly):
-        raise click.BadParameter("--arch=all cannot be used with --release <pullspec> or <*nightly*>")
+    if not release and not named_assembly:
+        raise click.BadParameter("Use one of --release or --assembly")
+    if release and named_assembly:
+        raise click.BadParameter("Use only one of --release or --assembly")
 
     runtime.initialize()
-    major, minor = runtime.get_major_minor()
+
+    if named_assembly:
+        release = runtime.assembly
+        LOGGER.info("Using assembly name as release: %s", release)
+
+    nightly = 'nightly' in release
+    pullspec = '/' in release
+
     if nightly:
-        for a in GO_ARCHES:
-            if a in release:
-                arch = a
-                break
-
-    version = f'{major}.{minor}'
-
-    if arch == 'all':
-        target_arches = BREW_ARCHES
-        if (major, minor) < (4, 9):
-            target_arches.remove("aarch64")
+        payload_pullspec = get_nightly_pullspec(release, runtime.build_system)
+    elif pullspec:
+        payload_pullspec = release
     else:
-        target_arches = [arch]
+        payload_pullspec = f'quay.io/openshift-release-dev/ocp-release:{release}-x86_64'
 
-    payload_pullspecs = []
-    if release:
-        if pullspec:
-            payload_pullspecs.append(release)
-        elif nightly:
-            payload_pullspecs.append(get_nightly_pullspec(release, runtime.build_system))
-        elif named_release:
-            for local_arch in target_arches:
-                p = get_pullspec(release, local_arch)
-                payload_pullspecs.append(p)
-        build_ids = [get_build_id_from_image_pullspec(runtime, p) for p in payload_pullspecs]
-    elif named_assembly:
-        rhcos_pullspecs = get_rhcos_pullspecs_from_assembly(runtime)
-        build_ids = [
-            (get_build_id_from_rhcos_pullspec(p), arch) for arch, p in rhcos_pullspecs.items() if arch in target_arches
-        ]
-
-    for build, local_arch in build_ids:
-        _via_build_id(runtime, build, local_arch, version, packages, go)
+    tags = get_rhcos_tags(runtime, payload_pullspec)
+    for tag_name, full_tag in tags.items():
+        green_print(f"{tag_name}: {full_tag}")
 
 
-def get_pullspec(release, arch):
-    return f'quay.io/openshift-release-dev/ocp-release:{release}-{arch}'
+def _get_rhcos_pullspec_from_payload(payload_pullspec, tag_name):
+    out, _ = exectools.cmd_assert(["oc", "adm", "release", "info", "--image-for", tag_name, "--", payload_pullspec])
+    return out.strip()
 
 
-def get_rhcos_pullspecs_from_assembly(runtime):
-    rhcos_def = runtime.releases_config.releases[runtime.assembly].assembly.rhcos
-    if not rhcos_def:
-        raise click.BadParameter(
-            "only named assemblies with valid rhcos values are supported. If an assembly is "
-            "based on another, try using the original assembly"
-        )
-
-    images = rhcos_def[get_primary_container_name(runtime)]['images']
-    return images
+def _verify_tag(tag_pullspec):
+    result = oc_image_info(tag_pullspec, strict=False)
+    if result is None:
+        raise click.ClickException(f"Tag is not live in registry: {tag_pullspec}")
 
 
-def get_build_id_from_image_pullspec(runtime, pullspec):
-    green_print(f"Image pullspec: {pullspec}")
-    build_id, arch = rhcos.get_build_from_payload(runtime, pullspec)
-    return build_id, arch
+def get_rhcos_tags(runtime, payload_pullspec):
+    art_repo = get_art_prod_image_repo_for_version(4, "dev")
+    container_configs = get_container_configs(runtime)
+    primary_conf = next(c for c in container_configs if c.primary)
+
+    primary_rhcos_pullspec = _get_rhcos_pullspec_from_payload(payload_pullspec, primary_conf.name)
+    image_info = oc_image_info(primary_rhcos_pullspec)
+    labels = image_info["config"]["config"]["Labels"]
+    arch = brew_arch_for_go_arch(image_info["config"]["architecture"])
+
+    manifest_list_tag = labels.get("coreos.build.manifest-list-tag")
+    if manifest_list_tag:
+        return _get_layered_tags(runtime, payload_pullspec, container_configs, art_repo)
+    else:
+        build_id = labels.get("org.opencontainers.image.version") or labels.get("version")
+        if not build_id:
+            raise click.ClickException(f"Cannot determine RHCOS build ID from {primary_rhcos_pullspec}")
+        return _get_non_layered_tags(runtime, build_id, arch, container_configs, art_repo)
 
 
-def _via_build_id(runtime, build_id, arch, version, packages, go):
-    if not build_id:
-        Exception('Cannot find build_id')
+def _get_layered_tags(runtime, payload_pullspec, container_configs, art_repo):
+    tags = {}
+    for container_conf in container_configs:
+        tag_name = container_conf.name
+        rhcos_pullspec = _get_rhcos_pullspec_from_payload(payload_pullspec, tag_name)
+        image_info = oc_image_info(rhcos_pullspec)
+        mlt = image_info["config"]["config"]["Labels"].get("coreos.build.manifest-list-tag")
+        if not mlt:
+            raise click.ClickException(f"No coreos.build.manifest-list-tag label found for {tag_name}")
+        tag_pullspec = f"{art_repo}:{mlt}"
+        _verify_tag(tag_pullspec)
+        tags[tag_name] = tag_pullspec
+    return tags
 
-    arch = brew_arch_for_go_arch(arch)
-    green_print(f'Build: {build_id} Arch: {arch}')
-    nvrs = rhcos.get_rpm_nvrs(runtime, build_id, version, arch)
-    if not nvrs:
-        return
-    if packages:
-        packages = [p.strip() for p in packages.split(',')]
-        if 'openshift' in packages:
-            packages.remove('openshift')
-            packages.append('openshift-hyperkube')
-        nvrs = [p for p in nvrs if p[0] in packages]
-    if go:
-        go_rpm_nvrs = util.get_golang_rpm_nvrs(nvrs)
-        util.pretty_print_nvrs_go(go_rpm_nvrs, ignore_na=True)
-        return
-    for nvr in sorted(nvrs):
-        print('-'.join(nvr))
+
+def _get_non_layered_tags(runtime, build_id, arch, container_configs, art_repo):
+    major, minor = runtime.get_major_minor()
+    major_minor = f"{major}.{minor}"
+    rhcos_el_major = runtime.group_config.vars.RHCOS_EL_MAJOR
+    rhcos_el_minor = runtime.group_config.vars.RHCOS_EL_MINOR
+    url_key = f"{major_minor}-{rhcos_el_major}.{rhcos_el_minor}" if rhcos_el_major > 8 else major_minor
+    meta_url = f"{RHCOS_RELEASES_STREAM_URL}/{url_key}/builds/{build_id}/{arch}/meta.json"
+
+    LOGGER.info("Fetching RHCOS metadata: %s", meta_url)
+    with request.urlopen(meta_url) as resp:
+        meta = json.loads(resp.read().decode())
+
+    tags = {}
+    for container_conf in container_configs:
+        key = container_conf.build_metadata_key
+        if key not in meta:
+            raise click.ClickException(
+                f"Key '{key}' not found in RHCOS metadata for {container_conf.name}. URL: {meta_url}"
+            )
+        container = meta[key]
+        image = container["image"]
+        container_tags = container.get("tags", [])
+        build_tag = next((t for t in container_tags if build_id in t), None)
+        if not build_tag:
+            raise click.ClickException(
+                f"No build-specific tag (containing {build_id}) found for {container_conf.name} in RHCOS metadata"
+            )
+        tag_pullspec = f"{image}:{build_tag}"
+        _verify_tag(tag_pullspec)
+        tags[container_conf.name] = tag_pullspec
+    return tags

--- a/elliott/tests/test_rhcos_cli.py
+++ b/elliott/tests/test_rhcos_cli.py
@@ -1,0 +1,324 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from click import ClickException
+from elliottlib.cli.rhcos_cli import (
+    _get_layered_tags,
+    _get_non_layered_tags,
+    _get_rhcos_pullspec_from_payload,
+    _verify_tag,
+    get_rhcos_tags,
+)
+
+
+class TestGetRhcosPullspecFromPayload(unittest.TestCase):
+    @patch("elliottlib.cli.rhcos_cli.exectools.cmd_assert")
+    def test_extracts_pullspec(self, mock_cmd):
+        mock_cmd.return_value = ("quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123\n", "")
+        result = _get_rhcos_pullspec_from_payload("payload:latest", "rhel-coreos")
+        mock_cmd.assert_called_once_with(
+            ["oc", "adm", "release", "info", "--image-for", "rhel-coreos", "--", "payload:latest"]
+        )
+        self.assertEqual(result, "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123")
+
+
+class TestVerifyTag(unittest.TestCase):
+    @patch("elliottlib.cli.rhcos_cli.oc_image_info")
+    def test_passes_when_live(self, mock_info):
+        mock_info.return_value = {"some": "info"}
+        _verify_tag("quay.io/repo:tag")
+        mock_info.assert_called_once_with("quay.io/repo:tag", strict=False)
+
+    @patch("elliottlib.cli.rhcos_cli.oc_image_info")
+    def test_raises_when_not_live(self, mock_info):
+        mock_info.return_value = None
+        with self.assertRaises(ClickException) as ctx:
+            _verify_tag("quay.io/repo:tag")
+        self.assertIn("not live", str(ctx.exception))
+
+
+class TestGetRhcosTags(unittest.TestCase):
+    @patch("elliottlib.cli.rhcos_cli._get_layered_tags")
+    @patch("elliottlib.cli.rhcos_cli.oc_image_info")
+    @patch("elliottlib.cli.rhcos_cli._get_rhcos_pullspec_from_payload")
+    @patch("elliottlib.cli.rhcos_cli.get_container_configs")
+    @patch("elliottlib.cli.rhcos_cli.get_art_prod_image_repo_for_version")
+    def test_dispatches_layered(self, mock_art_repo, mock_configs, mock_get_pullspec, mock_info, mock_layered):
+        mock_art_repo.return_value = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+        primary = MagicMock()
+        primary.primary = True
+        primary.name = "rhel-coreos"
+        mock_configs.return_value = [primary]
+        mock_get_pullspec.return_value = "quay.io/art-dev@sha256:abc"
+        mock_info.return_value = {
+            "config": {
+                "architecture": "amd64",
+                "config": {"Labels": {"coreos.build.manifest-list-tag": "4.19-9.6-202505-node-image"}},
+            }
+        }
+        mock_layered.return_value = {"rhel-coreos": "quay.io/art-dev:4.19-9.6-202505-node-image"}
+
+        runtime = MagicMock()
+        result = get_rhcos_tags(runtime, "payload:latest")
+
+        mock_layered.assert_called_once()
+        self.assertEqual(result, {"rhel-coreos": "quay.io/art-dev:4.19-9.6-202505-node-image"})
+
+    @patch("elliottlib.cli.rhcos_cli._get_non_layered_tags")
+    @patch("elliottlib.cli.rhcos_cli.oc_image_info")
+    @patch("elliottlib.cli.rhcos_cli._get_rhcos_pullspec_from_payload")
+    @patch("elliottlib.cli.rhcos_cli.get_container_configs")
+    @patch("elliottlib.cli.rhcos_cli.get_art_prod_image_repo_for_version")
+    def test_dispatches_non_layered(self, mock_art_repo, mock_configs, mock_get_pullspec, mock_info, mock_non_layered):
+        mock_art_repo.return_value = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+        primary = MagicMock()
+        primary.primary = True
+        primary.name = "machine-os-content"
+        mock_configs.return_value = [primary]
+        mock_get_pullspec.return_value = "quay.io/art-dev@sha256:abc"
+        mock_info.return_value = {
+            "config": {
+                "architecture": "amd64",
+                "config": {"Labels": {"org.opencontainers.image.version": "418.94.202605101521-0"}},
+            }
+        }
+        mock_non_layered.return_value = {"machine-os-content": "quay.io/art-dev:418.94.202605101521-0-coreos"}
+
+        runtime = MagicMock()
+        result = get_rhcos_tags(runtime, "payload:latest")
+
+        mock_non_layered.assert_called_once()
+        self.assertEqual(result, {"machine-os-content": "quay.io/art-dev:418.94.202605101521-0-coreos"})
+
+    @patch("elliottlib.cli.rhcos_cli.oc_image_info")
+    @patch("elliottlib.cli.rhcos_cli._get_rhcos_pullspec_from_payload")
+    @patch("elliottlib.cli.rhcos_cli.get_container_configs")
+    @patch("elliottlib.cli.rhcos_cli.get_art_prod_image_repo_for_version")
+    def test_raises_when_no_build_id(self, mock_art_repo, mock_configs, mock_get_pullspec, mock_info):
+        mock_art_repo.return_value = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+        primary = MagicMock()
+        primary.primary = True
+        primary.name = "machine-os-content"
+        mock_configs.return_value = [primary]
+        mock_get_pullspec.return_value = "quay.io/art-dev@sha256:abc"
+        mock_info.return_value = {
+            "config": {
+                "architecture": "amd64",
+                "config": {"Labels": {}},
+            }
+        }
+
+        runtime = MagicMock()
+        with self.assertRaises(ClickException) as ctx:
+            get_rhcos_tags(runtime, "payload:latest")
+        self.assertIn("Cannot determine RHCOS build ID", str(ctx.exception))
+
+
+class TestGetLayeredTags(unittest.TestCase):
+    @patch("elliottlib.cli.rhcos_cli._verify_tag")
+    @patch("elliottlib.cli.rhcos_cli.oc_image_info")
+    @patch("elliottlib.cli.rhcos_cli._get_rhcos_pullspec_from_payload")
+    def test_constructs_tags(self, mock_get_pullspec, mock_info, mock_verify):
+        art_repo = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+        conf1 = MagicMock()
+        conf1.name = "rhel-coreos"
+        conf2 = MagicMock()
+        conf2.name = "rhel-coreos-extensions"
+
+        mock_get_pullspec.side_effect = ["quay.io/art-dev@sha256:aaa", "quay.io/art-dev@sha256:bbb"]
+        mock_info.side_effect = [
+            {"config": {"config": {"Labels": {"coreos.build.manifest-list-tag": "4.19-9.6-202505-node-image"}}}},
+            {
+                "config": {
+                    "config": {"Labels": {"coreos.build.manifest-list-tag": "4.19-9.6-202505-node-image-extensions"}}
+                }
+            },
+        ]
+
+        runtime = MagicMock()
+        result = _get_layered_tags(runtime, "payload:latest", [conf1, conf2], art_repo)
+
+        self.assertEqual(result["rhel-coreos"], f"{art_repo}:4.19-9.6-202505-node-image")
+        self.assertEqual(result["rhel-coreos-extensions"], f"{art_repo}:4.19-9.6-202505-node-image-extensions")
+        self.assertEqual(mock_verify.call_count, 2)
+
+    @patch("elliottlib.cli.rhcos_cli.oc_image_info")
+    @patch("elliottlib.cli.rhcos_cli._get_rhcos_pullspec_from_payload")
+    def test_raises_when_no_label(self, mock_get_pullspec, mock_info):
+        conf = MagicMock()
+        conf.name = "rhel-coreos"
+        mock_get_pullspec.return_value = "quay.io/art-dev@sha256:aaa"
+        mock_info.return_value = {"config": {"config": {"Labels": {}}}}
+
+        runtime = MagicMock()
+        with self.assertRaises(ClickException) as ctx:
+            _get_layered_tags(runtime, "payload:latest", [conf], "art-repo")
+        self.assertIn("No coreos.build.manifest-list-tag", str(ctx.exception))
+
+
+class TestGetNonLayeredTags(unittest.TestCase):
+    @patch("elliottlib.cli.rhcos_cli._verify_tag")
+    @patch("elliottlib.cli.rhcos_cli.request.urlopen")
+    def test_constructs_tags_from_meta(self, mock_urlopen, mock_verify):
+        build_id = "418.94.202605101521-0"
+        meta = {
+            "base-oscontainer": {
+                "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+                "digest": "sha256:aaa",
+                "tags": ["4.18-9.4-coreos", f"{build_id}-coreos"],
+            },
+            "extensions-container": {
+                "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+                "digest": "sha256:bbb",
+                "tags": ["4.18-9.4-coreos-extensions", f"{build_id}-coreos-extensions"],
+            },
+        }
+        import io
+        import json
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(meta).encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        conf1 = MagicMock()
+        conf1.name = "rhel-coreos"
+        conf1.build_metadata_key = "base-oscontainer"
+        conf2 = MagicMock()
+        conf2.name = "rhel-coreos-extensions"
+        conf2.build_metadata_key = "extensions-container"
+
+        runtime = MagicMock()
+        runtime.get_major_minor.return_value = (4, 18)
+        runtime.group_config.vars.RHCOS_EL_MAJOR = 9
+        runtime.group_config.vars.RHCOS_EL_MINOR = 4
+
+        art_repo = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+        result = _get_non_layered_tags(runtime, build_id, "x86_64", [conf1, conf2], art_repo)
+
+        self.assertEqual(result["rhel-coreos"], f"{art_repo}:{build_id}-coreos")
+        self.assertEqual(result["rhel-coreos-extensions"], f"{art_repo}:{build_id}-coreos-extensions")
+        self.assertEqual(mock_verify.call_count, 2)
+
+    @patch("elliottlib.cli.rhcos_cli.request.urlopen")
+    def test_raises_when_key_missing(self, mock_urlopen):
+        import io
+        import json
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({}).encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        conf = MagicMock()
+        conf.name = "rhel-coreos"
+        conf.build_metadata_key = "base-oscontainer"
+
+        runtime = MagicMock()
+        runtime.get_major_minor.return_value = (4, 18)
+        runtime.group_config.vars.RHCOS_EL_MAJOR = 9
+        runtime.group_config.vars.RHCOS_EL_MINOR = 4
+
+        with self.assertRaises(ClickException) as ctx:
+            _get_non_layered_tags(runtime, "418.94.202605101521-0", "x86_64", [conf], "art-repo")
+        self.assertIn("not found in RHCOS metadata", str(ctx.exception))
+
+    @patch("elliottlib.cli.rhcos_cli.request.urlopen")
+    def test_raises_when_no_build_tag(self, mock_urlopen):
+        import io
+        import json
+
+        meta = {
+            "base-oscontainer": {
+                "image": "quay.io/art-dev",
+                "digest": "sha256:aaa",
+                "tags": ["4.18-9.4-coreos"],
+            },
+        }
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(meta).encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        conf = MagicMock()
+        conf.name = "rhel-coreos"
+        conf.build_metadata_key = "base-oscontainer"
+
+        runtime = MagicMock()
+        runtime.get_major_minor.return_value = (4, 18)
+        runtime.group_config.vars.RHCOS_EL_MAJOR = 9
+        runtime.group_config.vars.RHCOS_EL_MINOR = 4
+
+        with self.assertRaises(ClickException) as ctx:
+            _get_non_layered_tags(runtime, "418.94.202605101521-0", "x86_64", [conf], "art-repo")
+        self.assertIn("No build-specific tag", str(ctx.exception))
+
+    @patch("elliottlib.cli.rhcos_cli.request.urlopen")
+    def test_url_uses_el_version_when_gt_8(self, mock_urlopen):
+        import json
+
+        build_id = "418.94.202605101521-0"
+        meta = {
+            "oscontainer": {
+                "image": "quay.io/art-dev",
+                "digest": "sha256:aaa",
+                "tags": [f"{build_id}-coreos"],
+            },
+        }
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(meta).encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        conf = MagicMock()
+        conf.name = "machine-os-content"
+        conf.build_metadata_key = "oscontainer"
+
+        runtime = MagicMock()
+        runtime.get_major_minor.return_value = (4, 18)
+        runtime.group_config.vars.RHCOS_EL_MAJOR = 9
+        runtime.group_config.vars.RHCOS_EL_MINOR = 4
+
+        with patch("elliottlib.cli.rhcos_cli._verify_tag"):
+            _get_non_layered_tags(runtime, build_id, "x86_64", [conf], "art-repo")
+
+        url_arg = mock_urlopen.call_args[0][0]
+        self.assertIn("/4.18-9.4/", url_arg)
+
+    @patch("elliottlib.cli.rhcos_cli.request.urlopen")
+    def test_url_uses_major_minor_when_el8(self, mock_urlopen):
+        import json
+
+        build_id = "415.92.202301010101-0"
+        meta = {
+            "oscontainer": {
+                "image": "quay.io/art-dev",
+                "digest": "sha256:aaa",
+                "tags": [f"{build_id}-coreos"],
+            },
+        }
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(meta).encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        conf = MagicMock()
+        conf.name = "machine-os-content"
+        conf.build_metadata_key = "oscontainer"
+
+        runtime = MagicMock()
+        runtime.get_major_minor.return_value = (4, 15)
+        runtime.group_config.vars.RHCOS_EL_MAJOR = 8
+        runtime.group_config.vars.RHCOS_EL_MINOR = 8
+
+        with patch("elliottlib.cli.rhcos_cli._verify_tag"):
+            _get_non_layered_tags(runtime, build_id, "x86_64", [conf], "art-repo")
+
+        url_arg = mock_urlopen.call_args[0][0]
+        self.assertIn("/4.15/", url_arg)
+        self.assertNotIn("-8.", url_arg)

--- a/elliott/tests/test_rhcos_cli.py
+++ b/elliott/tests/test_rhcos_cli.py
@@ -23,13 +23,13 @@ class TestGetRhcosPullspecFromPayload(unittest.TestCase):
 
 
 class TestVerifyTag(unittest.TestCase):
-    @patch("elliottlib.cli.rhcos_cli.oc_image_info")
+    @patch("elliottlib.cli.rhcos_cli.oc_image_info_show_multiarch")
     def test_passes_when_live(self, mock_info):
         mock_info.return_value = {"some": "info"}
         _verify_tag("quay.io/repo:tag")
         mock_info.assert_called_once_with("quay.io/repo:tag", strict=False)
 
-    @patch("elliottlib.cli.rhcos_cli.oc_image_info")
+    @patch("elliottlib.cli.rhcos_cli.oc_image_info_show_multiarch")
     def test_raises_when_not_live(self, mock_info):
         mock_info.return_value = None
         with self.assertRaises(ClickException) as ctx:


### PR DESCRIPTION
## Summary
- Rewrites the `elliott rhcos` command to extract and output RHCOS manifest list tags from release payloads
- For layered RHCOS (4.19+), reads `coreos.build.manifest-list-tag` labels from each RHCOS image
- For non-layered RHCOS, fetches `meta.json` from the RHCOS releases stream and extracts build-specific tags (e.g. `418.94.202605101521-0-coreos`)
- Removes the old RPM package lookup (`--packages`, `--go`, `--arch` options)
- Supports nightlies, named releases, raw pullspecs, and named assemblies
- All output tags are verified live in the registry before being returned

## Test

```
# non-layered
$ uv run elliott -g openshift-4.18 --assembly 4.18.41 rhcos
rhel-coreos: quay.io/openshift-release-dev/ocp-v4.0-art-dev:418.94.202605101521-0-coreos
rhel-coreos-extensions: quay.io/openshift-release-dev/ocp-v4.0-art-dev:418.94.202605101521-0-coreos-extensions

# layered
$ uv run elliott -g openshift-4.19 --assembly 4.19.31 rhcos
rhel-coreos: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.19-9.6-202605110225-node-image
rhel-coreos-extensions: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.19-9.6-202605110225-node-image-extensions

# layered multi-rhel
$ uv run elliott -g openshift-4.21 --assembly 4.21.15 rhcos
rhel-coreos: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-9.6-202605110143-node-image
rhel-coreos-extensions: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-9.6-202605110143-node-image-extensions
rhel-coreos-10: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-10.2-202604300152-node-image
rhel-coreos-10-extensions: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-10.2-202604300152-node-image-extensions
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)