### PR TITLE
fix(pyartcd): skip EC validation for test assembly in ocp4-konflux

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -362,6 +362,11 @@ class KonfluxOcpPipeline:
         LOGGER.info(f"Using build priority: {self.build_priority}")
         cmd.extend(['--build-priority', self.build_priority])
 
+        # Skip EC verification for test assembly
+        if self.assembly == 'test':
+            LOGGER.info('Skipping EC verification for test assembly')
+            cmd.append('--skip-ec-verify')
+
         await exectools.cmd_assert_async(cmd)
 
         LOGGER.info("All builds completed successfully")


### PR DESCRIPTION
## Summary
Skip Enterprise Contract (EC) verification when building images for test assembly in the ocp4-konflux pipeline.

## Changes
- Add check for `assembly == 'test'` in the `build_images()` method
- Pass `--skip-ec-verify` flag to doozer when building test assembly images
- Prevents EC validation pipeline from running and storing `ec_pipeline_url` in the database

## Motivation
EC validation for test assemblies can cause conformance issues to surface at prepare-release time, which is unnecessary for test builds. This change aligns with how other test assembly exceptions are handled in the pipeline (e.g., build-sync is also skipped for test assemblies).

## Testing
- [x] Syntax validation passed
- [x] No new linting errors introduced
- [x] Follows existing code patterns (matches build-sync skip pattern at line 404)

## Test
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/34289/