### PR TITLE
fix(doozer): skip conflicted inherited dependency check for external RPMs

### DIFF
--- a/doozer/doozerlib/assembly_inspector.py
+++ b/doozer/doozerlib/assembly_inspector.py
@@ -202,12 +202,20 @@ class AssemblyInspector:
                 build_dict = external_rpms.get(entry["tag"], {}).get(package_name)
                 if not build_dict:
                     continue
+                installed_rpm = installed_packages.get(package_name)
+                if installed_rpm and installed_rpm["nvr"] != build_dict["nvr"]:
+                    if not self._is_installed_rpm_in_tag(installed_rpm, entry["tag"]):
+                        self.runtime.logger.info(
+                            "Installed rpm %s in RHCOS %s (%s) is not tagged in %s; skipping check_external_packages complaint",
+                            installed_rpm["nvr"],
+                            rhcos_build.build_id,
+                            rhcos_build.brew_arch,
+                            entry["tag"],
+                        )
+                        continue
                 if entry["condition"] == "match":
                     desired_packages[package_name] = build_dict["nvr"]
                 elif entry["condition"] == "greater_equal":
-                    # installed_rpm = installed_packages.get(package_name)
-                    # desired_packages[package_name] = build_dict["nvr"] if not installed_rpm or compare_nvr(build_dict, installed_rpm) > 0 else installed_rpm["nvr"]
-                    installed_rpm = installed_packages.get(package_name)
                     if not installed_rpm or compare_nvr(build_dict, installed_rpm) >= 0:
                         desired_packages[package_name] = build_dict["nvr"]
                     else:
@@ -422,10 +430,19 @@ class AssemblyInspector:
                 build_dict = external_rpms.get(entry["tag"], {}).get(package_name)
                 if not build_dict:
                     continue
+                installed_rpm = installed_packages.get(package_name)
+                if installed_rpm and installed_rpm["nvr"] != build_dict["nvr"]:
+                    if not self._is_installed_rpm_in_tag(installed_rpm, entry["tag"]):
+                        image_meta.logger.info(
+                            "Installed rpm %s in image %s is not tagged in %s; skipping check_external_packages complaint",
+                            installed_rpm["nvr"],
+                            dgk,
+                            entry["tag"],
+                        )
+                        continue
                 if entry["condition"] == "match":
                     desired_packages[package_name] = build_dict["nvr"]
                 elif entry["condition"] == "greater_equal":
-                    installed_rpm = installed_packages.get(package_name)
                     if not installed_rpm or compare_nvr(build_dict, installed_rpm) >= 0:
                         desired_packages[package_name] = build_dict["nvr"]
                     else:
@@ -568,6 +585,19 @@ class AssemblyInspector:
             self._rpm_build_cache[el_ver] = assembly_rpm_dicts
 
         return self._rpm_build_cache[el_ver]
+
+    def _is_installed_rpm_in_tag(self, installed_rpm: Optional[Dict], tag: str) -> bool:
+        """Check if an installed RPM build is tagged in the given Brew tag.
+        :param installed_rpm: installed package build dict (must have 'id' key), or None
+        :param tag: Brew tag name to check
+        :return: True if the installed RPM is tagged in the given tag
+        """
+        if not installed_rpm:
+            return False
+        tag_names = {
+            t["name"] for t in self.brew_session.listTags(brew.KojiWrapperOpts(caching=True), build=installed_rpm["id"])
+        }
+        return tag in tag_names
 
     def get_external_rpm_build_dicts(self):
         """Get external rpm build dicts from rhaos candidate Brew tags.

--- a/doozer/tests/test_assembly_inspector.py
+++ b/doozer/tests/test_assembly_inspector.py
@@ -79,4 +79,27 @@ class TestAssemblyInspector(IsolatedAsyncioTestCase):
         issues = ai.check_installed_rpms_in_image("foo", build_inspector, None)
         self.assertEqual(issues, [])
 
+    def test_is_installed_rpm_in_tag(self):
+        rt = MagicMock(mode="both", group_config=Model({}))
+        brew_session = MagicMock()
+        ai = AssemblyInspector(rt, brew_session)
+
+        # None installed_rpm returns False
+        self.assertFalse(ai._is_installed_rpm_in_tag(None, "my-candidate-tag"))
+
+        # Installed RPM is tagged in the candidate tag
+        brew_session.listTags.return_value = [
+            {"name": "my-candidate-tag"},
+            {"name": "other-tag"},
+        ]
+        installed_rpm = {"id": 100, "nvr": "cri-o-1.28.0-1.el9"}
+        self.assertTrue(ai._is_installed_rpm_in_tag(installed_rpm, "my-candidate-tag"))
+
+        # Installed RPM is NOT tagged in the candidate tag
+        brew_session.listTags.return_value = [
+            {"name": "rhel-9.2.0-z"},
+            {"name": "RHSA-2026:13971-released"},
+        ]
+        self.assertFalse(ai._is_installed_rpm_in_tag(installed_rpm, "my-candidate-tag"))
+
     pass


### PR DESCRIPTION
slack ref: https://redhat-internal.slack.com/archives/C07RAB68T5G/p1778603952146369?thread_ts=1778602266.618429&cid=C07RAB68T5G

## Summary

- Skip the `conflicted_inherited_dependency` check when the installed RPM is not tagged in given tag in group.yml `check_external_packages` config (ART's candidate Brew tag)
- Add `_is_installed_rpm_in_tag` helper that queries Brew to determine whether the installed RPM actually comes from defined repo
- Applies to both RHCOS and image inspection paths

## Rationale

The `conflicted_inherited_dependency` check was put in place so that if we have `rpm_old` and `rpm_new` tagged in our repo, RHCOS or an image should have `rpm_new` (https://redhat.atlassian.net/browse/ART-8416). This assumes the package is coming from the repo that is defined in the group config (our candidate tag). 

https://github.com/openshift-eng/ocp-build-data/blob/d7c0293dfde19e573e11bc876e590e713f1c03a9/group.yml#L128

But if it comes from another repo (like RHEL), this check becomes invalid — the installed RPM was never sourced from our candidate tag, so flagging a version mismatch against our tagged build is a false positive.

## Test plan

- [x] Unit test for `_is_installed_rpm_in_tag` (RPM tagged, RPM not tagged, None input)
- [ ] Verify with a real assembly inspection that previously noisy false positives are suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)