### PR TITLE
ART-18733: feat(images): gate base image snapshot-to-release on snapshot_release

### DIFF
--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -102,11 +102,10 @@ class BaseImageHandler:
                     continue
 
                 if not metadata.should_trigger_base_image_release():
-                    self.logger.warning(f"Image {nvr} does not qualify for base image release workflow, skipping")
-                    continue
-
-                if not metadata.is_snapshot_release_enabled():
-                    self.logger.warning(f"Image {nvr} has snapshot release disabled, skipping")
+                    self.logger.warning(
+                        f"Image {nvr} does not qualify for base image release workflow "
+                        "(base/golang, OCP, base_image_release.enabled), skipping"
+                    )
                     continue
 
                 if not build_record.image_pullspec:

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -1234,10 +1234,6 @@ class KonfluxImageBuilder:
         """
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
 
-        if not metadata.is_snapshot_release_enabled():
-            logger.info(f"Skipping base image release for {nvr}: snapshot_release disabled")
-            return True
-
         logger.info(f"Triggering base image release for {nvr}")
 
         try:

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -547,12 +547,17 @@ class KonfluxRebaser:
                     rh_pullspec = util.rh_art_images_base_pullspec(build.nvr)
                     if await self._registry_pullspec_exists(rh_pullspec):
                         return rh_pullspec, build.embargoed
-                    self._logger.info(
-                        "art-images-base %s not reachable; using Konflux image_pullspec for late-resolved parent %s",
-                        rh_pullspec,
-                        member,
+                    if parent_metadata.is_base_image_release_quay_fallback_enabled():
+                        self._logger.info(
+                            "art-images-base %s not reachable; using Konflux image_pullspec for late-resolved parent %s",
+                            rh_pullspec,
+                            member,
+                        )
+                        return build.image_pullspec, build.embargoed
+                    raise IOError(
+                        f"art-images-base pullspec not reachable for late-resolved parent {member} ({rh_pullspec!r}); "
+                        "base_image_release.quay_fallback is false"
                     )
-                    return build.image_pullspec, build.embargoed
                 return build.image_pullspec, build.embargoed
 
             return original_parent, False

--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -1472,7 +1472,9 @@ def release_to_base_repo(runtime, nvrs):
     4. Waits for release completion
     
     This is intended to be called as a separate job after base image builds complete.
-    Only processes base images (base_only: true) and golang builders with snapshot_release: true.
+    Only processes images for which the base-image release workflow applies (see
+    ``should_trigger_base_image_release``): base_only or golang builder, OCP variant,
+    ``base_image_release.enabled`` not disabled at image or group level.
     
     Examples:
     

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1396,7 +1396,7 @@ class ImageMetadata(Metadata):
         Returns:
             bool: True if this is a base image (base_only: true), False otherwise
         """
-        base_only_config = getattr(self.config, 'base_only', Missing)
+        base_only_config = self.config.base_only
         if base_only_config not in [Missing, None]:
             return bool(base_only_config)
         return False
@@ -1418,32 +1418,60 @@ class ImageMetadata(Metadata):
         """
         Determines whether this image should trigger the base image release workflow.
 
-        OKD builds never trigger the OCP registry.redhat.io base-image release path.
-        The test assembly does not use this path (Konflux UNRELEASED, Jenkins snapshot-to-release,
-        registry.redhat.io parent pullspecs, lockfile seeding with unreleased builds).
+        The method checks preconditions in the following order:
+        1. Variant must be OCP (not OKD)
+        2. Assembly must not be ``test``
+        3. Image must be ``base_only`` or a golang builder
+        4. Base image release enabled override:
+           - Image metadata configuration (``self.config.base_image_release.enabled``)
+           - Group configuration (``self.runtime.group_config.base_image_release.enabled``)
+        If no override is set for step 4, the enabled flag defaults to True.
 
         Returns:
-            bool: True if base image release workflow should be triggered, False otherwise
+            bool: True if base image release workflow should be triggered, False otherwise.
         """
         if self.runtime.variant is BuildVariant.OKD:
             return False
+
         if self.runtime.assembly == "test":
             return False
-        return self.is_base_image() or self.is_golang_builder()
 
-    def is_snapshot_release_enabled(self) -> bool:
+        if not (self.is_base_image() or self.is_golang_builder()):
+            return False
+
+        source = None
+        base_image_release_enabled = True
+        base_image_release_config_override = self.config.base_image_release.enabled
+
+        if base_image_release_config_override not in [Missing, None]:
+            base_image_release_enabled = bool(base_image_release_config_override)
+            source = "metadata config"
+        else:
+            base_image_release_group_override = self.runtime.group_config.base_image_release.enabled
+            if base_image_release_group_override not in [Missing, None]:
+                base_image_release_enabled = bool(base_image_release_group_override)
+                source = "group config"
+
+        self.logger.info(f"Base image release enabled set from {source} {base_image_release_enabled}")
+        return base_image_release_enabled
+
+    def is_base_image_release_quay_fallback_enabled(self) -> bool:
         """
-        Determines whether snapshot-to-release workflow is enabled for this image.
+        When False and ``should_trigger_base_image_release()`` applies, late parent resolve
+        must not fall back to Konflux ``image_pullspec`` if ``registry.redhat.io`` art-images-base
+        is unreachable (rebase fails instead).
 
-        The snapshot_release flag controls whether base images should trigger
-        the snapshot-to-release workflow when builds complete.
-
-        Returns:
-            bool: True if snapshot_release: true is configured, True by default if not specified
+        Image ``base_image_release.quay_fallback`` overrides group; default True
+        (same pattern as ``konflux.cachi2.lockfile.enabled``).
         """
-        snapshot_release_config = getattr(self.config, 'snapshot_release', Missing)
-        if snapshot_release_config not in [Missing, None]:
-            return bool(snapshot_release_config)
+        base_image_release_quay_fallback_config_override = self.config.base_image_release.quay_fallback
+        if base_image_release_quay_fallback_config_override not in [Missing, None]:
+            return bool(base_image_release_quay_fallback_config_override)
+        else:
+            base_image_release_quay_fallback_group_override = self.runtime.group_config.base_image_release.quay_fallback
+            if base_image_release_quay_fallback_group_override not in [Missing, None]:
+                return bool(base_image_release_quay_fallback_group_override)
+
         return True
 
     def get_required_artifacts(self) -> list:

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -18,7 +18,7 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
             {
                 "name": "test-base",
                 "base_only": True,
-                "snapshot_release": True,
+                "base_image_release": {"enabled": True},
                 "distgit": {"component": "ose-test-base-container"},
             }
         )
@@ -229,7 +229,7 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         golang_builder_model = Model(
             {
                 "name": GOLANG_BUILDER_IMAGE_NAME,
-                "snapshot_release": True,
+                "base_image_release": {"enabled": True},
                 "distgit": {"component": "ose-golang-builder-container"},
             }
         )

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -428,7 +428,6 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         """SUCCESS after base snapshot release refreshes Konflux DB without swapping image_pullspec to RH."""
         metadata = self._metadata()
         metadata.should_trigger_base_image_release.return_value = True
-        metadata.is_snapshot_release_enabled.return_value = True
         dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
         dest_dir.mkdir(parents=True)
 
@@ -493,7 +492,6 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         """Test base image release failure handling with FAILURE outcome update."""
         metadata = self._metadata()
         metadata.should_trigger_base_image_release.return_value = True
-        metadata.is_snapshot_release_enabled.return_value = True
         dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
         dest_dir.mkdir(parents=True)
 
@@ -621,7 +619,6 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         from pyartcd import jenkins
 
         metadata = self._metadata()
-        metadata.is_snapshot_release_enabled.return_value = True
 
         with patch.object(jenkins, 'start_base_image_release', return_value="SUCCESS") as mock_jenkins:
             result = await self.builder._trigger_base_image_release(metadata, "test-nvr")
@@ -636,21 +633,11 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         from pyartcd import jenkins
 
         metadata = self._metadata()
-        metadata.is_snapshot_release_enabled.return_value = True
 
         with patch.object(jenkins, 'start_base_image_release', return_value='FAILURE'):
             result = await self.builder._trigger_base_image_release(metadata, "test-nvr")
 
         self.assertFalse(result)
-
-    async def test_trigger_base_image_release_respects_snapshot_release_disabled(self):
-        """Test that snapshot_release disabled skips base image release."""
-        metadata = self._metadata()
-        metadata.is_snapshot_release_enabled.return_value = False
-
-        result = await self.builder._trigger_base_image_release(metadata, "test-nvr")
-
-        self.assertTrue(result)  # Should return True (no-op success) when disabled
 
 
 class TestNormalizeVersion(unittest.TestCase):

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -1339,6 +1339,7 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         parent.image_name_short = "golang-builder"
         parent.get_component_name.return_value = "openshift-golang-builder-container"
         parent.should_trigger_base_image_release.return_value = True
+        parent.is_base_image_release_quay_fallback_enabled.return_value = True
 
         runtime = MagicMock()
         runtime.resolve_image.return_value = parent
@@ -1362,6 +1363,7 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         parent = MagicMock()
         parent.distgit_key = "golang-builder"
         parent.should_trigger_base_image_release.return_value = True
+        parent.is_base_image_release_quay_fallback_enabled.return_value = True
         parent.branch_el_target.return_value = 9
         kb = MagicMock()
         kb.nvr = "openshift-golang-builder-container-v1.21-1.el9"
@@ -1394,6 +1396,7 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         parent = MagicMock()
         parent.distgit_key = "golang-builder"
         parent.should_trigger_base_image_release.return_value = True
+        parent.is_base_image_release_quay_fallback_enabled.return_value = True
         parent.branch_el_target.return_value = 9
         kb = MagicMock()
         kb.nvr = "openshift-golang-builder-container-v1.21-1.el9"
@@ -1418,6 +1421,37 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         resolved, emb = await rebaser._resolve_member_parent("golang-builder", "orig")
         self.assertEqual(resolved, "quay.io/k@sha256:beef")
         self.assertFalse(emb)
+
+    async def test_resolve_member_parent_late_resolve_fails_when_art_base_missing_and_quay_fallback_disabled(self):
+        """Late-resolve: no Konflux fallback when base_image_release.quay_fallback is false."""
+        parent = MagicMock()
+        parent.distgit_key = "golang-builder"
+        parent.should_trigger_base_image_release.return_value = True
+        parent.is_base_image_release_quay_fallback_enabled.return_value = False
+        parent.branch_el_target.return_value = 9
+        kb = MagicMock()
+        kb.nvr = "openshift-golang-builder-container-v1.21-1.el9"
+        kb.image_pullspec = "quay.io/k@sha256:beef"
+        kb.embargoed = False
+        parent.get_latest_build = AsyncMock(return_value=kb)
+
+        runtime = MagicMock()
+        runtime.resolve_image.return_value = None
+        runtime.ignore_missing_base = True
+        runtime.latest_parent_version = True
+        runtime.late_resolve_image = MagicMock(return_value=parent)
+        runtime.group_config = Model({"konflux": Model({})})
+
+        rebaser = KonfluxRebaser(runtime, self.base_dir, MagicMock(), "unsigned")
+        rebaser.variant = BuildVariant.OCP
+        rebaser.image_repo = "quay.io/fake"
+        rebaser.uuid_tag = "v4.18-tag"
+        rebaser.group = "openshift-4.18"
+        rebaser._registry_pullspec_exists = AsyncMock(return_value=False)
+
+        with self.assertRaises(IOError) as ctx:
+            await rebaser._resolve_member_parent("golang-builder", "orig")
+        self.assertIn("quay_fallback is false", str(ctx.exception))
 
     async def test_resolve_member_parent_keeps_quay_for_regular_member(self):
         parent = MagicMock()

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1796,6 +1796,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         runtime.logger = logging.getLogger('test_runtime')
         runtime.variant = BuildVariant.OCP
         runtime.assembly = 'stream'
+        runtime.group_config = Model({})
 
         # Test base image - should trigger workflow
         base_image = Model({'name': 'test-base', 'base_only': True})
@@ -1814,6 +1815,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         test_assembly_runtime.logger = logging.getLogger('test_runtime')
         test_assembly_runtime.variant = BuildVariant.OCP
         test_assembly_runtime.assembly = 'test'
+        test_assembly_runtime.group_config = Model({})
         self.assertFalse(ImageMetadata(test_assembly_runtime, base_data).should_trigger_base_image_release())
         self.assertFalse(ImageMetadata(test_assembly_runtime, golang_data).should_trigger_base_image_release())
 
@@ -1822,6 +1824,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         named_runtime.logger = logging.getLogger('test_runtime')
         named_runtime.variant = BuildVariant.OCP
         named_runtime.assembly = '4.17.1'
+        named_runtime.group_config = Model({})
         self.assertTrue(ImageMetadata(named_runtime, base_data).should_trigger_base_image_release())
         self.assertTrue(ImageMetadata(named_runtime, golang_data).should_trigger_base_image_release())
 
@@ -1831,38 +1834,83 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         regular_metadata = ImageMetadata(runtime, regular_data)
         self.assertFalse(regular_metadata.should_trigger_base_image_release())
 
+        # Regular image with base_image_release.enabled: true does not qualify (not base/golang)
+        snap_regular = Model({'name': 'test-regular', 'base_image_release': Model({'enabled': True})})
+        snap_regular_data = Model({'key': 'test-snap', 'data': snap_regular, 'filename': 'test-snap.yaml'})
+        snap_regular_metadata = ImageMetadata(runtime, snap_regular_data)
+        self.assertFalse(snap_regular_metadata.should_trigger_base_image_release())
+
+        # Base image with base_image_release.enabled: false
+        base_snap_off = Model({'name': 'test-base', 'base_only': True, 'base_image_release': Model({'enabled': False})})
+        base_snap_off_data = Model({'key': 'base-off', 'data': base_snap_off, 'filename': 'base-off.yaml'})
+        base_snap_off_metadata = ImageMetadata(runtime, base_snap_off_data)
+        self.assertFalse(base_snap_off_metadata.should_trigger_base_image_release())
+
+        # Golang builder with base_image_release.enabled: false
+        golang_snap_off = Model({'name': GOLANG_BUILDER_IMAGE_NAME, 'base_image_release': Model({'enabled': False})})
+        golang_snap_off_data = Model({'key': 'go-off', 'data': golang_snap_off, 'filename': 'go-off.yaml'})
+        golang_snap_off_metadata = ImageMetadata(runtime, golang_snap_off_data)
+        self.assertFalse(golang_snap_off_metadata.should_trigger_base_image_release())
+
+        # Group base_image_release.enabled: false, image omits field (inherits group -> off)
+        runtime_group_off = MagicMock()
+        runtime_group_off.logger = logging.getLogger('test_runtime')
+        runtime_group_off.variant = BuildVariant.OCP
+        runtime_group_off.assembly = 'stream'
+        runtime_group_off.group_config = Model({'base_image_release': Model({'enabled': False})})
+        group_off_base = Model({'name': 'g-off-base', 'base_only': True})
+        group_off_data = Model({'key': 'g-off-base', 'data': group_off_base, 'filename': 'g-off-base.yaml'})
+        group_off_metadata = ImageMetadata(runtime_group_off, group_off_data)
+        self.assertFalse(group_off_metadata.should_trigger_base_image_release())
+
+        # Group off, image base_image_release.enabled: true (image overrides)
+        runtime_both = MagicMock()
+        runtime_both.logger = logging.getLogger('test_runtime')
+        runtime_both.variant = BuildVariant.OCP
+        runtime_both.assembly = 'stream'
+        runtime_both.group_config = Model({'base_image_release': Model({'enabled': False})})
+        base_override = Model(
+            {
+                'name': 'override-base',
+                'base_only': True,
+                'base_image_release': Model({'enabled': True}),
+            }
+        )
+        both_data = Model({'key': 'override-base', 'data': base_override, 'filename': 'override-base.yaml'})
+        both_metadata = ImageMetadata(runtime_both, both_data)
+        self.assertTrue(both_metadata.should_trigger_base_image_release())
+
         # OKD: base image would trigger on OCP but never on OKD (no RH registry release)
         okd_runtime = MagicMock()
         okd_runtime.logger = logging.getLogger('test_runtime')
         okd_runtime.variant = BuildVariant.OKD
         okd_runtime.assembly = 'stream'
+        okd_runtime.group_config = Model({})
         okd_base_metadata = ImageMetadata(okd_runtime, base_data)
         self.assertFalse(okd_base_metadata.should_trigger_base_image_release())
 
         okd_golang_metadata = ImageMetadata(okd_runtime, golang_data)
         self.assertFalse(okd_golang_metadata.should_trigger_base_image_release())
 
-    def test_is_snapshot_release_enabled(self):
+    def test_base_image_release_quay_fallback_image_overrides_group(self):
         from artcommonlib.model import Model
 
         runtime = MagicMock()
         runtime.logger = logging.getLogger('test_runtime')
-        runtime.variant = BuildVariant.OCP
+        runtime.group_config = Model({'base_image_release': Model({'quay_fallback': False})})
+        img_on = Model({'name': 't', 'base_image_release': Model({'quay_fallback': True})})
+        meta_on = ImageMetadata(runtime, Model({'key': 't', 'data': img_on, 'filename': 't.yaml'}))
+        self.assertTrue(meta_on.is_base_image_release_quay_fallback_enabled())
 
-        enabled_image = Model({'name': 'test-snapshot', 'snapshot_release': True})
-        enabled_data = Model({'key': 'test-snapshot', 'data': enabled_image, 'filename': 'test-snapshot.yaml'})
-        enabled_metadata = ImageMetadata(runtime, enabled_data)
-        self.assertTrue(enabled_metadata.is_snapshot_release_enabled())
+        img_inherit = Model({'name': 't2'})
+        meta_inherit = ImageMetadata(runtime, Model({'key': 't2', 'data': img_inherit, 'filename': 't2.yaml'}))
+        self.assertFalse(meta_inherit.is_base_image_release_quay_fallback_enabled())
 
-        disabled_image = Model({'name': 'test-regular', 'snapshot_release': False})
-        disabled_data = Model({'key': 'test-regular', 'data': disabled_image, 'filename': 'test-regular.yaml'})
-        disabled_metadata = ImageMetadata(runtime, disabled_data)
-        self.assertFalse(disabled_metadata.is_snapshot_release_enabled())
-
-        default_image = Model({'name': 'test-default'})
-        default_data = Model({'key': 'test-default', 'data': default_image, 'filename': 'test-default.yaml'})
-        default_metadata = ImageMetadata(runtime, default_data)
-        self.assertTrue(default_metadata.is_snapshot_release_enabled())
+        runtime_default = MagicMock()
+        runtime_default.logger = logging.getLogger('test_runtime')
+        runtime_default.group_config = Model({})
+        meta_default = ImageMetadata(runtime_default, Model({'key': 't2', 'data': img_inherit, 'filename': 't2.yaml'}))
+        self.assertTrue(meta_default.is_base_image_release_quay_fallback_enabled())
 
 
 class TestExtractBuilderInfoFromPullspec(unittest.TestCase):

--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -344,6 +344,42 @@
       "$ref": "#/properties/canonical_builders_from_upstream"
     },
     "canonical_builders_from_upstream-": {},
+    "base_image_release": {
+      "description": "Default base-image release behavior for the group. Per-image base_image_release overrides.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "If false, disables snapshot-to-release for qualifying base images unless overridden per image. Omitted defaults to true.",
+          "type": "boolean"
+        },
+        "enabled!": {
+          "$ref": "#/properties/base_image_release/properties/enabled"
+        },
+        "enabled?": {
+          "$ref": "#/properties/base_image_release/properties/enabled"
+        },
+        "enabled-": {},
+        "quay_fallback": {
+          "description": "When false, late parent resolve fails if art-images-base is unreachable instead of Konflux fallback. Default true.",
+          "type": "boolean"
+        },
+        "quay_fallback!": {
+          "$ref": "#/properties/base_image_release/properties/quay_fallback"
+        },
+        "quay_fallback?": {
+          "$ref": "#/properties/base_image_release/properties/quay_fallback"
+        },
+        "quay_fallback-": {}
+      },
+      "additionalProperties": false
+    },
+    "base_image_release!": {
+      "$ref": "#/properties/base_image_release"
+    },
+    "base_image_release?": {
+      "$ref": "#/properties/base_image_release"
+    },
+    "base_image_release-": {},
     "konflux": {
       "description": "Konflux configuration",
       "type": "object",

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -173,17 +173,42 @@
       "$ref": "#/properties/base_only"
     },
     "base_only-": {},
-    "snapshot_release": {
-      "description": "If true, enables snapshot-to-release workflow for base images. Only applies to base_only images",
-      "type": "boolean"
+    "base_image_release": {
+      "description": "Controls Konflux base-image snapshot-to-release and rebaser RH art-images-base behavior for qualifying images. Per-image overrides group.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "If false, disables snapshot-to-release for this image when it qualifies as a base-image workflow target. Omitted: inherit group or default true.",
+          "type": "boolean"
+        },
+        "enabled!": {
+          "$ref": "#/properties/base_image_release/properties/enabled"
+        },
+        "enabled?": {
+          "$ref": "#/properties/base_image_release/properties/enabled"
+        },
+        "enabled-": {},
+        "quay_fallback": {
+          "description": "When false, late parent resolve fails if registry.redhat.io art-images-base is unreachable instead of falling back to Konflux image_pullspec. Default true. Image overrides group.",
+          "type": "boolean"
+        },
+        "quay_fallback!": {
+          "$ref": "#/properties/base_image_release/properties/quay_fallback"
+        },
+        "quay_fallback?": {
+          "$ref": "#/properties/base_image_release/properties/quay_fallback"
+        },
+        "quay_fallback-": {}
+      },
+      "additionalProperties": false
     },
-    "snapshot_release!": {
-      "$ref": "#/properties/snapshot_release"
+    "base_image_release!": {
+      "$ref": "#/properties/base_image_release"
     },
-    "snapshot_release?": {
-      "$ref": "#/properties/snapshot_release"
+    "base_image_release?": {
+      "$ref": "#/properties/base_image_release"
     },
-    "snapshot_release-": {},
+    "base_image_release-": {},
     "cachito": {
       "description": "Cachito integration configuration",
       "$ref": "cachito.schema.json"


### PR DESCRIPTION
## Summary

Adds optional `snapshot_release` at group and image level (image overrides group; default **true**, same precedence style as lockfile flags) and folds that gate into `ImageMetadata.should_trigger_base_image_release()` together with existing OKD and `test`-assembly exclusions and base/golang qualification.

## Problem

**Before:** Snapshot-to-release could be toggled via `is_snapshot_release_enabled()` while `should_trigger_base_image_release()` only reflected image kind and assembly, so callers duplicated checks.

**After:** One predicate (`should_trigger_base_image_release`) decides whether the Konflux base-image / snapshot-to-release path applies. `_is_snapshot_release_enabled()` is only used from there. JSON schemas document `snapshot_release` on group and image config.

## Implementation details

- `should_trigger_base_image_release`: OCP, assembly not `test`, `(base_only | golang builder) and _is_snapshot_release_enabled()`.
- Removed redundant snapshot checks from `konflux_image_builder._trigger_base_image_release` and `base_image_handler`.
- Validator: `assembly_group_config` + `image_config.base` schema updates for `snapshot_release`.
