### PR TITLE
ART-18747: Fix OutdatedRPMFinder perma-rebuild loops for dependency conflicts

### DIFF
--- a/doozer/doozerlib/repodata.py
+++ b/doozer/doozerlib/repodata.py
@@ -37,6 +37,7 @@ class Rpm:
     sourcerpm: str
     release: str
     arch: str
+    requires: List[str] = field(default_factory=list)
 
     @property
     def nevra(self):
@@ -89,6 +90,7 @@ class Rpm:
             size=0,
             location="",
             sourcerpm="",
+            requires=[],
         )
 
     @staticmethod
@@ -114,10 +116,19 @@ class Rpm:
 
         format_elem = metadata.find("common:format", NAMESPACES)
         sourcerpm = ''
+        requires = []
         if format_elem is not None:
             sourcerpm_elem = format_elem.find("rpm:sourcerpm", NAMESPACES)
             if sourcerpm_elem is not None and sourcerpm_elem.text:
                 sourcerpm = sourcerpm_elem.text
+
+            # Parse package requirements
+            requires_elem = format_elem.find("rpm:requires", NAMESPACES)
+            if requires_elem is not None:
+                for entry in requires_elem.findall("rpm:entry", NAMESPACES):
+                    pkg_name = entry.attrib.get("name")
+                    if pkg_name:
+                        requires.append(pkg_name)
 
         return Rpm(
             name=name.text,
@@ -129,6 +140,7 @@ class Rpm:
             sourcerpm=sourcerpm,
             release=version.attrib["rel"],
             arch=arch.text,
+            requires=requires,
         )
 
 
@@ -496,6 +508,78 @@ class RepodataLoader:
 
 class OutdatedRPMFinder:
     @staticmethod
+    def _has_incompatible_dependencies(candidate_rpm: Rpm, installed_rpms: Dict[str, Dict]) -> bool:
+        """
+        Check if a candidate RPM has dependencies that conflict with currently installed packages.
+
+        This detects cases where upgrading would require replacing installed packages with
+        incompatible alternatives. For example:
+        - Installed: bind9.18
+        - Candidate requires: bind (which conflicts with bind9.18)
+
+        Args:
+            candidate_rpm: The newer RPM being considered
+            installed_rpms: Dict of currently installed RPMs (name => rpm_dict)
+
+        Returns:
+            True if the candidate has incompatible dependencies, False otherwise
+        """
+        if not candidate_rpm.requires:
+            return False
+
+        # Extract base package names from candidate requirements
+        # Filter out non-package requirements (capabilities, files, etc.)
+        candidate_pkg_requires = set()
+        for req in candidate_rpm.requires:
+            # Skip requirements that are:
+            # - file paths (start with /)
+            # - capabilities/provides (contain parentheses or special chars)
+            # - rpmlib dependencies
+            if req.startswith('/') or '(' in req or req.startswith('rpmlib'):
+                continue
+            candidate_pkg_requires.add(req)
+
+        # Check if any required package conflicts with installed packages
+        for required_pkg in candidate_pkg_requires:
+            # First check if the requirement is exactly satisfied
+            if required_pkg in installed_rpms:
+                continue  # Requirement satisfied, no conflict
+
+            # Check for versioned package conflicts (e.g., bind vs bind9.18)
+            # Pattern: required package is base name, but we have a versioned variant installed
+            for installed_name in installed_rpms.keys():
+                # Skip exact matches (already handled above)
+                if installed_name == required_pkg:
+                    continue
+
+                # Check if installed package is a versioned variant of the required package
+                # E.g., required="bind", installed="bind9.18"
+                if installed_name.startswith(required_pkg) and len(installed_name) > len(required_pkg):
+                    # Check if what follows is a version number
+                    suffix = installed_name[len(required_pkg) :]
+                    # Versioned package patterns: bind9.18, python3.11, etc.
+                    # The suffix should start with a digit (with or without separator)
+                    if suffix[0].isdigit() or (
+                        suffix[0] in ['-', '.', '_'] and len(suffix) > 1 and suffix[1].isdigit()
+                    ):
+                        # We have a versioned variant installed (e.g., bind9.18)
+                        # but candidate requires the base package (e.g., bind)
+                        # These are typically mutually exclusive
+                        return True
+
+                # Also check the reverse: required package is versioned, but base is installed
+                # E.g., required="bind9.18", installed="bind"
+                if required_pkg.startswith(installed_name) and len(required_pkg) > len(installed_name):
+                    suffix = required_pkg[len(installed_name) :]
+                    if suffix[0].isdigit() or (
+                        suffix[0] in ['-', '.', '_'] and len(suffix) > 1 and suffix[1].isdigit()
+                    ):
+                        # Candidate requires versioned package but base is installed
+                        return True
+
+        return False
+
+    @staticmethod
     def _find_candidate_modular_rpms(all_modules, enabled_streams):
         """Finds all candidate modular rpms in enabled module streams"""
         # Find the latest module versions for each enabled streams
@@ -533,8 +617,7 @@ class OutdatedRPMFinder:
         the non-modular rpm will be exempt.
         """
         candidate_non_modular_rpms: Dict[str, Tuple[str, Rpm]] = {}  # package_name => (repo_name, rpm)
-        for nevra, repo in all_non_modular_rpms.items():
-            rpm = Rpm.from_nevra(nevra)
+        for nevra, (repo, rpm) in all_non_modular_rpms.items():
             _, candidate = candidate_non_modular_rpms.get(rpm.name, (None, None))
             if not candidate or rpm.compare(candidate) > 0:
                 candidate_non_modular_rpms[rpm.name] = (repo, rpm)
@@ -597,20 +680,20 @@ class OutdatedRPMFinder:
             candidate_modular_rpms = self._find_candidate_modular_rpms(all_modules, enabled_streams)
 
         # Populate a dict to hold all non-modular rpms
-        all_non_modular_rpms: Dict[str, str] = {}  # rpm_nvera => repo_name
+        all_non_modular_rpms: Dict[str, Tuple[str, Rpm]] = {}  # rpm_nvera => (repo_name, rpm_object)
         for repodata in repodatas:
             for rpm in repodata.primary_rpms:
                 if rpm.nevra in all_modular_rpms:
                     continue  # It is a modular rpm
-                all_non_modular_rpms[rpm.nevra] = repodata.name
+                all_non_modular_rpms[rpm.nevra] = (repodata.name, rpm)
 
         # fetch all visible non-modular rpms that are latest among all configured repos
         candidate_non_modular_rpms = self._find_candidate_non_modular_rpms(all_non_modular_rpms)
 
         # Compare archive rpms to all candidate rpms
         results: List[Tuple[str, str, str]] = []
-        for name, archive_rpm in archive_rpms.items():
-            archive_rpm = Rpm.from_dict(archive_rpm)
+        for name, archive_rpm_dict in archive_rpms.items():
+            archive_rpm = Rpm.from_dict(archive_rpm_dict)
             repo, candidate_rpm = None, None
             if archive_rpm.nevra in all_modular_rpms:  # Archive rpm is a modular rpm
                 repo, candidate_rpm = candidate_modular_rpms.get(name, (None, None))
@@ -619,5 +702,13 @@ class OutdatedRPMFinder:
             if not repo or not candidate_rpm:
                 continue  # Archive rpm is not available in any configured repos
             if archive_rpm.compare(candidate_rpm) < 0:  # Archive rpm is older than candidate rpm
+                # Check if the newer version has incompatible dependencies
+                if self._has_incompatible_dependencies(candidate_rpm, archive_rpms):
+                    logger.info(
+                        "Skipping outdated RPM %s -> %s: newer version has incompatible dependencies",
+                        archive_rpm.nevra,
+                        candidate_rpm.nevra,
+                    )
+                    continue
                 results.append((archive_rpm.nevra, candidate_rpm.nevra, repo))
         return results

--- a/doozer/tests/test_repodata.py
+++ b/doozer/tests/test_repodata.py
@@ -1165,3 +1165,148 @@ class TestOutdatedRPMFinder(IsolatedAsyncioTestCase):
             ('f-0:1.0.0-el8.x86_64', 'f-0:999.0.0-el8.x86_64', 'bravo-x86_64'),
         ]
         self.assertEqual(actual, expected)
+
+    async def test_find_non_latest_rpms_with_dependency_conflicts(self):
+        """
+        Test that newer RPMs with incompatible dependencies are not flagged as outdated.
+
+        Scenario: bind-dyndb-ldap has newer version available, but:
+        - Installed: bind-dyndb-ldap-11.11-2 (requires bind9.18)
+        - Available: bind-dyndb-ldap-11.11-3 (requires bind)
+        - System has: bind9.18 installed
+        - bind and bind9.18 are mutually exclusive
+
+        Expected: bind-dyndb-ldap-11.11-2 should NOT be flagged as outdated
+        """
+        # Installed RPMs include bind9.18 and bind-dyndb-ldap-11.11-2
+        installed_rpms = [
+            "bind9.18-32:9.18.29-14.el9_8.1.x86_64",
+            "bind-dyndb-ldap-0:11.11-2.el9.x86_64",
+        ]
+
+        # Create the older version with requires for bind9.18
+        old_bind_dyndb_ldap = Rpm(
+            name="bind-dyndb-ldap",
+            epoch=0,
+            version="11.11",
+            release="2.el9",
+            arch="x86_64",
+            checksum="sha256:old",
+            size=100,
+            location="bind-dyndb-ldap-11.11-2.el9.x86_64.rpm",
+            sourcerpm="bind-dyndb-ldap-11.11-2.el9.src.rpm",
+            requires=["bind9.18"],  # Requires bind9.18
+        )
+
+        # Create the newer version with requires for bind (incompatible)
+        new_bind_dyndb_ldap = Rpm(
+            name="bind-dyndb-ldap",
+            epoch=0,
+            version="11.11",
+            release="3.el9_6",
+            arch="x86_64",
+            checksum="sha256:new",
+            size=100,
+            location="bind-dyndb-ldap-11.11-3.el9_6.x86_64.rpm",
+            sourcerpm="bind-dyndb-ldap-11.11-3.el9_6.src.rpm",
+            requires=["bind"],  # Requires bind (conflicts with bind9.18)
+        )
+
+        finder = OutdatedRPMFinder()
+        repodatas = [
+            Repodata(
+                name="rhel-9-appstream-e4s",
+                primary_rpms=[
+                    Rpm.from_nevra("bind9.18-32:9.18.29-14.el9_8.1.x86_64"),
+                    old_bind_dyndb_ldap,
+                    new_bind_dyndb_ldap,
+                ],
+                modules=[],
+            ),
+        ]
+
+        logger = MagicMock()
+        actual = finder.find_non_latest_rpms(
+            [Rpm.from_nevra(nevra).to_dict() for nevra in installed_rpms],
+            repodatas,
+            logger,
+        )
+
+        # Expected: bind-dyndb-ldap should NOT be flagged as outdated
+        # because the newer version has incompatible dependencies
+        expected = []
+        self.assertEqual(actual, expected)
+
+        # Verify that the logger was called to indicate skipping
+        logger.info.assert_called()
+        log_calls = [str(call) for call in logger.info.call_args_list]
+        self.assertTrue(
+            any("incompatible dependencies" in call for call in log_calls),
+            f"Expected incompatible dependencies log message, got: {log_calls}",
+        )
+
+    async def test_find_non_latest_rpms_no_conflict_when_exact_match_installed(self):
+        """
+        Test that exact package matches don't trigger false conflicts.
+
+        Scenario: Both bind and bind9.18 are installed, newer package requires bind.
+        Expected: No conflict (bind requirement is satisfied by exact match)
+        """
+        installed_rpms = [
+            "bind-32:9.16.23-40.el9_8.1.x86_64",
+            "bind9.18-32:9.18.29-14.el9_8.1.x86_64",
+            "test-pkg-0:1.0.0-1.el9.x86_64",
+        ]
+
+        # Older version requires bind (which is installed)
+        old_test_pkg = Rpm(
+            name="test-pkg",
+            epoch=0,
+            version="1.0.0",
+            release="1.el9",
+            arch="x86_64",
+            checksum="sha256:old",
+            size=100,
+            location="test-pkg-1.0.0-1.el9.x86_64.rpm",
+            sourcerpm="test-pkg-1.0.0-1.el9.src.rpm",
+            requires=["bind"],
+        )
+
+        # Newer version also requires bind (which is installed)
+        new_test_pkg = Rpm(
+            name="test-pkg",
+            epoch=0,
+            version="2.0.0",
+            release="1.el9",
+            arch="x86_64",
+            checksum="sha256:new",
+            size=100,
+            location="test-pkg-2.0.0-1.el9.x86_64.rpm",
+            sourcerpm="test-pkg-2.0.0-1.el9.src.rpm",
+            requires=["bind"],  # bind is installed, so no conflict
+        )
+
+        finder = OutdatedRPMFinder()
+        repodatas = [
+            Repodata(
+                name="rhel-9-appstream",
+                primary_rpms=[
+                    Rpm.from_nevra("bind-32:9.16.23-40.el9_8.1.x86_64"),
+                    Rpm.from_nevra("bind9.18-32:9.18.29-14.el9_8.1.x86_64"),
+                    old_test_pkg,
+                    new_test_pkg,
+                ],
+                modules=[],
+            ),
+        ]
+
+        logger = MagicMock()
+        actual = finder.find_non_latest_rpms(
+            [Rpm.from_nevra(nevra).to_dict() for nevra in installed_rpms],
+            repodatas,
+            logger,
+        )
+
+        # Expected: test-pkg SHOULD be flagged as outdated because bind requirement is satisfied
+        expected = [('test-pkg-0:1.0.0-1.el9.x86_64', 'test-pkg-0:2.0.0-1.el9.x86_64', 'rhel-9-appstream')]
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
## Problem

The OutdatedRPMFinder was causing **perma-rebuild loops** for images where newer RPM versions have incompatible dependencies. This resulted in continuous rebuilds that could never resolve the "outdated" condition.

### Example: ironic Container

The `ironic` container was stuck in a rebuild loop:

- **Installed**: `bind-dyndb-ldap-11.11-2` (requires `bind9.18`)
- **Available in repo**: `bind-dyndb-ldap-11.11-3` (requires `bind`)
- **System has**: `bind9.18` installed
- **Problem**: `bind` and `bind9.18` are mutually exclusive packages

**Build history showing continuous rebuilds:**
https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=ironic&group=openshift-4.22&assembly=stream&outcome=success&engine=konflux&dateRange=2026-05-11+to+2026-05-13

**The Loop:**
```
1. Scan detects: bind-dyndb-ldap-11.11-2 < 11.11-3 (available) → Flag as outdated
2. Trigger rebuild
3. Build installs bind-dyndb-ldap-11.11-2 (11.11-3 requires incompatible 'bind' package)
4. Next scan detects: Still have 11.11-2 < 11.11-3 → Flag as outdated
5. ♻️ LOOP forever
```

### Root Cause

OutdatedRPMFinder compared versions without checking if the newer version could actually be installed given current dependencies. It flagged RPMs as outdated even when upgrading would require breaking dependency changes.

## Solution

Added **dependency-aware detection** to OutdatedRPMFinder:

### Changes Made

1. **Extended Rpm class** to parse and store package requirements from repodata XML
2. **Added conflict detection** (`_has_incompatible_dependencies()`) to detect versioned package conflicts
3. **Updated scan logic** to skip flagging when newer version has incompatible dependencies
4. **Preserved Rpm objects** through candidate selection to maintain dependency information

### How It Works

```python
# Before scanning, check if newer RPM is actually installable
if newer_version_has_incompatible_deps(candidate_rpm, installed_rpms):
    logger.info("Skipping outdated RPM: newer version has incompatible dependencies")
    continue  # Don't flag as outdated
```

**Conflict detection:**
- Detects versioned package conflicts (e.g., `bind` vs `bind9.18`, `python3` vs `python3.11`)
- Checks if candidate requires base package when versioned variant is installed
- Checks if candidate requires versioned package when base is installed

## Testing
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/47721/ shows:
```
images:
-   changed: true
    code: TASK_BUNDLE_OUTDATED
    name: ironic
    reason: Task bundle task-clair-scan is 20586 days old (>=10 days) and newer version
        is available (staggered rebuild)
```
instead of the outdated RPM issue.
On the other hand, findings about RHCOS status are exactly the same.