### PR TITLE
ART-18751: resolve Konflux base-image plan and app by product

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -85,6 +85,18 @@ PRODUCT_NAMESPACE_MAP = {
     "zero-trust": "art-oap-tenant",
 }
 
+# Konflux silent base-image workflow: ReleasePlan metadata.name and Application (Snapshot/Releases spec.application).
+# Must stay aligned with konflux-release-data ReleasePlan resources per product tenant.
+# Konflux Application: OCP uses art-images-base; layered products use <product>-images-base (no stream suffix).
+PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP = {
+    "ocp": ("ocp-art-images-base-silent", "art-images-base"),
+    "rhmtc": ("mtc-images-base-silent", "mtc-images-base"),
+    "mta": ("mta-images-base-silent", "mta-images-base"),
+    "oadp": ("oadp-images-base-silent", "oadp-images-base"),
+    "logging": ("logging-images-base-silent", "logging-images-base"),
+    "openshift-logging": ("logging-images-base-silent", "logging-images-base"),
+}
+
 PRODUCT_KUBECONFIG_MAP = {
     "acm": "ACM_KONFLUX_SA_KUBECONFIG",
     "mce": "ACM_KONFLUX_SA_KUBECONFIG",

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -20,6 +20,7 @@ from artcommonlib.constants import (
     GOLANG_BUILDER_IMAGE_NAME,
     KONFLUX_DEFAULT_IMAGE_REPO,
     KONFLUX_DEFAULT_NAMESPACE,
+    PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP,
     PRODUCT_KUBECONFIG_MAP,
     PRODUCT_NAMESPACE_MAP,
     RELEASE_SCHEDULES,
@@ -1194,6 +1195,39 @@ def resolve_konflux_namespace_by_product(product: str, provided_namespace: Optio
         f"No namespace mapping found for product '{product}'. Available products: {list(PRODUCT_NAMESPACE_MAP.keys())}. Using default: '{KONFLUX_DEFAULT_NAMESPACE}'"
     )
     return KONFLUX_DEFAULT_NAMESPACE
+
+
+def resolve_konflux_base_image_release_targets(product: str) -> Tuple[str, str]:
+    """
+    Resolve the Konflux ReleasePlan name and Application for the silent base-image workflow.
+
+    The ReleasePlan name is the resource metadata.name; the Application is Snapshot/Release
+    spec.application and matching labels. These must match konflux-release-data for the product's tenant.
+    Layered products use `<product>-images-base` (e.g. `mtc-images-base`). OCP keeps `art-images-base`.
+
+    Unknown products default to the OCP targets (same as resolve_konflux_namespace_by_product fallback).
+
+    Args:
+        product: Runtime product key (e.g. ocp, rhmtc, mta).
+
+    Returns:
+        (release_plan_name, application_name)
+    """
+    targets = PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP.get(product)
+    if targets:
+        plan, app = targets
+        KONFLUX_LOGGER.info(
+            f"Using base-image Konflux releasePlan '{plan}' and application '{app}' for product '{product}'"
+        )
+        return targets
+
+    default_plan, default_app = PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP["ocp"]
+    KONFLUX_LOGGER.warning(
+        f"No base-image Konflux mapping for product '{product}'. "
+        f"Known keys: {list(PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP.keys())}. "
+        f"Using OCP defaults: releasePlan={default_plan!r}, application={default_app!r}"
+    )
+    return default_plan, default_app
 
 
 async def run_safe(func: Callable[[], Any], failures_list: Optional[List[Tuple[str, Exception]]] = None) -> Any:

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -292,6 +292,38 @@ alternative_upstream:
         self.assertEqual(major, None)
         self.assertEqual(minor, None)
 
+    def test_resolve_konflux_base_image_release_targets_known_products(self):
+        self.assertEqual(
+            util.resolve_konflux_base_image_release_targets("ocp"),
+            ("ocp-art-images-base-silent", "art-images-base"),
+        )
+        self.assertEqual(
+            util.resolve_konflux_base_image_release_targets("rhmtc"),
+            ("mtc-images-base-silent", "mtc-images-base"),
+        )
+        self.assertEqual(
+            util.resolve_konflux_base_image_release_targets("mta"),
+            ("mta-images-base-silent", "mta-images-base"),
+        )
+        self.assertEqual(
+            util.resolve_konflux_base_image_release_targets("oadp"),
+            ("oadp-images-base-silent", "oadp-images-base"),
+        )
+        self.assertEqual(
+            util.resolve_konflux_base_image_release_targets("logging"),
+            ("logging-images-base-silent", "logging-images-base"),
+        )
+        self.assertEqual(
+            util.resolve_konflux_base_image_release_targets("openshift-logging"),
+            ("logging-images-base-silent", "logging-images-base"),
+        )
+
+    def test_resolve_konflux_base_image_release_targets_unknown_defaults_to_ocp(self):
+        self.assertEqual(
+            util.resolve_konflux_base_image_release_targets("unknown-product"),
+            ("ocp-art-images-base-silent", "art-images-base"),
+        )
+
 
 class TestSoftwareLifecyclePhase(unittest.TestCase):
     def test_from_name_valid(self):

--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -13,15 +13,13 @@ from artcommonlib import logutil
 from artcommonlib.util import (
     get_utc_now_formatted_str,
     normalize_group_name_for_k8s,
+    resolve_konflux_base_image_release_targets,
     resolve_konflux_kubeconfig_by_product,
     resolve_konflux_namespace_by_product,
 )
 from doozerlib import util as doozer_util
 from doozerlib.backend.konflux_client import API_VERSION, KIND_RELEASE, KIND_RELEASE_PLAN, KIND_SNAPSHOT, KonfluxClient
-from doozerlib.constants import ART_IMAGES_BASE_APPLICATION
 from kubernetes.dynamic import exceptions
-
-ART_IMAGES_BASE_RELEASE_PLAN = "ocp-art-images-base-silent"
 
 
 @dataclass(frozen=True)
@@ -38,8 +36,8 @@ class BaseImageSnapshotInput:
 
 class BaseImageHandler:
     """
-    Create a Konflux Snapshot for ``art-images-base`` with **one** component, then a Release using
-    ``ocp-art-images-base-silent``, and wait until the Release reports success.
+    Create a Konflux Snapshot for the product's base-image Application with **one** component, then a Release using
+    the product's silent base-image ReleasePlan, and wait until the Release reports success.
     """
 
     def __init__(self, runtime, dry_run: bool = False):
@@ -50,6 +48,14 @@ class BaseImageHandler:
 
         self.namespace = resolve_konflux_namespace_by_product(self.runtime.product, None)
         kubeconfig = resolve_konflux_kubeconfig_by_product(self.runtime.product, None)
+
+        resolved_plan, resolved_application = resolve_konflux_base_image_release_targets(self.runtime.product)
+        self.base_image_release_plan = resolved_plan
+        self.base_image_application = resolved_application
+        self.logger.info(
+            f"Base image Konflux targets: namespace={self.namespace} "
+            f"releasePlan={self.base_image_release_plan} application={self.base_image_application}"
+        )
 
         self.konflux_client = KonfluxClient.from_kubeconfig(
             default_namespace=self.namespace,
@@ -163,11 +169,11 @@ class BaseImageHandler:
                     "namespace": self.namespace,
                     "labels": {
                         "test.appstudio.openshift.io/type": "override",
-                        "appstudio.openshift.io/application": ART_IMAGES_BASE_APPLICATION,
+                        "appstudio.openshift.io/application": self.base_image_application,
                     },
                 },
                 "spec": {
-                    "application": ART_IMAGES_BASE_APPLICATION,
+                    "application": self.base_image_application,
                     "components": [component],
                 },
             }
@@ -193,7 +199,7 @@ class BaseImageHandler:
 
     async def _create_release_from_snapshot(self, snapshot_name: str, released_nvr: str) -> Optional[str]:
         """
-        Create Konflux Release from snapshot using the ocp-art-images-base-silent ReleasePlan.
+        Create Konflux Release from snapshot using the product's silent base-image ReleasePlan.
 
         Args:
             snapshot_name: Snapshot resource name.
@@ -201,12 +207,12 @@ class BaseImageHandler:
         """
         try:
             if not self.dry_run:
-                self.logger.info(f"Verifying release plan {ART_IMAGES_BASE_RELEASE_PLAN} exists")
+                self.logger.info(f"Verifying release plan {self.base_image_release_plan} exists")
                 try:
-                    await self.konflux_client._get(API_VERSION, KIND_RELEASE_PLAN, ART_IMAGES_BASE_RELEASE_PLAN)
+                    await self.konflux_client._get(API_VERSION, KIND_RELEASE_PLAN, self.base_image_release_plan)
                 except exceptions.NotFoundError:
                     raise RuntimeError(
-                        f"Release plan {ART_IMAGES_BASE_RELEASE_PLAN} not found in namespace {self.namespace}"
+                        f"Release plan {self.base_image_release_plan} not found in namespace {self.namespace}"
                     ) from None
 
                 self.logger.info(f"Waiting for snapshot {snapshot_name} to become available")
@@ -218,7 +224,7 @@ class BaseImageHandler:
                 "generateName": "ocp-base-image-release-",
                 "namespace": self.namespace,
                 "labels": {
-                    "appstudio.openshift.io/application": ART_IMAGES_BASE_APPLICATION,
+                    "appstudio.openshift.io/application": self.base_image_application,
                 },
                 "annotations": {
                     "art.redhat.com/kind": "image",
@@ -234,14 +240,14 @@ class BaseImageHandler:
                 "kind": KIND_RELEASE,
                 "metadata": release_metadata,
                 "spec": {
-                    "releasePlan": ART_IMAGES_BASE_RELEASE_PLAN,
+                    "releasePlan": self.base_image_release_plan,
                     "snapshot": snapshot_name,
                 },
             }
 
             if self.dry_run:
                 self.logger.info(
-                    f"[DRY-RUN] Would create release for snapshot={snapshot_name} plan={ART_IMAGES_BASE_RELEASE_PLAN}"
+                    f"[DRY-RUN] Would create release for snapshot={snapshot_name} plan={self.base_image_release_plan}"
                 )
                 self.logger.debug(f"[DRY-RUN] Release object: {release_obj}")
                 return f"dry-run-release-{snapshot_name}"

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1393,23 +1393,17 @@ class ImageMetadata(Metadata):
         Determines whether this image should trigger the base image release workflow.
 
         The method checks preconditions in the following order:
-        1. When ``runtime.product`` is set and not ``ocp``, skip (layered products). Unset or
-           falsy product continues to later checks.
-        2. Variant must be OCP (not OKD)
-        3. Assembly must not be ``test``
-        4. Image must be ``base_only`` or a golang builder
-        5. Base image release enabled override:
+        1. Variant must be OCP (not OKD)
+        2. Assembly must not be ``test``
+        3. Image must be ``base_only`` or a golang builder
+        4. Base image release enabled override:
            - Image metadata configuration (``self.config.base_image_release.enabled``)
            - Group configuration (``self.runtime.group_config.base_image_release.enabled``)
-           If no override is set for step 5, the enabled flag defaults to True.
+           If no override is set for step 4, the enabled flag defaults to True.
 
         Returns:
             bool: True if base image release workflow should be triggered, False otherwise.
         """
-        rp = self.runtime.product
-        if rp and rp != "ocp":
-            return False
-
         if self.runtime.variant is BuildVariant.OKD:
             return False
 

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1407,8 +1407,8 @@ class ImageMetadata(Metadata):
         if self.runtime.variant is BuildVariant.OKD:
             return False
 
-        if self.runtime.assembly == "test":
-            return False
+        # if self.runtime.assembly == "test":
+        #     return False
 
         if not (self.is_base_image() or self.is_golang_builder()):
             return False

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1407,8 +1407,8 @@ class ImageMetadata(Metadata):
         if self.runtime.variant is BuildVariant.OKD:
             return False
 
-        # if self.runtime.assembly == "test":
-        #     return False
+        if self.runtime.assembly == "test":
+            return False
 
         if not (self.is_base_image() or self.is_golang_builder()):
             return False

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -188,3 +188,37 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         konflux_client._create.assert_awaited_once()
         release_obj = konflux_client._create.await_args.args[0]
         self.assertEqual(release_obj["metadata"]["annotations"]["art.redhat.com/nvrs"], self.nvr)
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_create_release_from_snapshot_rhmtc_uses_product_plan_and_application(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        mock_namespace.return_value = "art-mtc-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+
+        konflux_client = AsyncMock()
+        created_release = MagicMock()
+        created_release.metadata.name = "test-release"
+        konflux_client._create.return_value = created_release
+        konflux_client.resource_url = MagicMock(return_value="https://konflux.example/releases/test-release")
+        mock_konflux_client_init.return_value = konflux_client
+
+        self.runtime.product = "rhmtc"
+
+        handler = BaseImageHandler(self.runtime, dry_run=False)
+
+        with patch.object(handler, "_wait_for_snapshot_availability", new=AsyncMock(return_value=True)):
+            await handler._create_release_from_snapshot("test-snapshot", self.nvr)
+
+        konflux_client._get.assert_awaited_once()
+        self.assertEqual(konflux_client._get.await_args.args[2], "mtc-images-base-silent")
+
+        konflux_client._create.assert_awaited_once()
+        release_obj = konflux_client._create.await_args.args[0]
+        self.assertEqual(release_obj["spec"]["releasePlan"], "mtc-images-base-silent")
+        self.assertEqual(
+            release_obj["metadata"]["labels"]["appstudio.openshift.io/application"],
+            "mtc-images-base",
+        )

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1831,15 +1831,15 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         both_metadata = ImageMetadata(runtime_both, both_data)
         self.assertTrue(both_metadata.should_trigger_base_image_release())
 
-        # Layered product: base-image registry workflow is OCP-only
+        # Layered product: same base/golang trigger rules as OCP when variant and assembly allow
         layered_runtime = MagicMock()
         layered_runtime.logger = logging.getLogger('test_runtime')
         layered_runtime.variant = BuildVariant.OCP
         layered_runtime.assembly = 'stream'
         layered_runtime.product = 'rhmtc'
         layered_runtime.group_config = Model({})
-        self.assertFalse(ImageMetadata(layered_runtime, base_data).should_trigger_base_image_release())
-        self.assertFalse(ImageMetadata(layered_runtime, golang_data).should_trigger_base_image_release())
+        self.assertTrue(ImageMetadata(layered_runtime, base_data).should_trigger_base_image_release())
+        self.assertTrue(ImageMetadata(layered_runtime, golang_data).should_trigger_base_image_release())
 
         # OKD: base image would trigger on OCP but never on OKD (no RH registry release)
         okd_runtime = MagicMock()

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -22,7 +22,7 @@ from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.release_util import split_el_suffix_in_release
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import new_roundtrip_yaml_handler
-from doozerlib.backend.base_image_handler import ART_IMAGES_BASE_APPLICATION
+from doozerlib.constants import ART_IMAGES_BASE_APPLICATION
 from elliottlib import util as elliottutil
 from elliottlib.constants import GOLANG_BUILDER_CVE_COMPONENT
 


### PR DESCRIPTION
## Summary

Complete [ART-18751](https://redhat.atlassian.net/browse/ART-18751): layered products can trigger the Konflux silent base-image workflow and use product-specific ReleasePlan/Application targets instead of hardcoded OCP values.

## Problem

**Before:** `resolve_konflux_namespace_by_product()` picked the correct tenant, but snapshots/releases still used `ocp-art-images-base-silent` / `art-images-base`. `should_trigger_base_image_release()` also returned `False` for non-OCP products (#2902).

**After:**
- `PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP` + `resolve_konflux_base_image_release_targets()` in artcommon
- `BaseImageHandler` (snapshot API from #2926) resolves plan + application per `runtime.product`
- Layered products (MTC, MTA, OADP, logging, etc.) can trigger the workflow when other gates pass

## Implementation

- `artcommon/artcommonlib/constants.py` — product → (ReleasePlan, Application) map
- `artcommon/artcommonlib/util.py` — resolver with OCP fallback for unknown products
- `doozer/doozerlib/backend/base_image_handler.py` — per-product snapshot/release targets
- `doozer/doozerlib/image.py` — remove OCP-only product gate (supersedes #2902 partial revert)
- Tests: `artcommon/tests/test_util.py`, `doozer/tests/backend/test_base_image_handler.py`, `doozer/tests/test_image.py`
- `pyartcd/pyartcd/pipelines/update_golang.py` — import `ART_IMAGES_BASE_APPLICATION` from `doozerlib.constants`

## Dependencies

Konflux `konflux-release-data` must define matching ReleasePlans and Application CRs per product tenant before this is live in cluster.

## Jira

- [ART-18751](https://redhat.atlassian.net/browse/ART-18751) (sub-task of [ART-14300](https://redhat.atlassian.net/browse/ART-14300))

Supersedes #2952.
