### PR TITLE
ART-14302: Define derived_group in KonfluxRebaser to clarify OKD group handling

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -99,9 +99,9 @@ class KonfluxRebaser:
             self.konflux_db.bind(KonfluxBuildRecord)
         if self.variant is BuildVariant.OKD:
             major, minor = runtime.get_major_minor_fields()
-            self.group = f'okd-{major}.{minor}'
+            self.derived_group = f'okd-{major}.{minor}'
         else:
-            self.group = runtime.group
+            self.derived_group = runtime.group
 
     @staticmethod
     def construct_dest_branch(group: str, assembly_name: Optional[str], distgit_key: str) -> str:
@@ -165,14 +165,8 @@ class KonfluxRebaser:
                     f"Image {metadata.qualified_key} doesn't have upstream source. This is no longer supported."
                 )
 
-            if self.variant is BuildVariant.OKD:
-                major, minor = self._runtime.get_major_minor_fields()
-                group = f'okd-{major}.{minor}'
-            else:
-                group = self._runtime.group
-
             dest_branch = self.construct_dest_branch(
-                group=group,
+                group=self.derived_group,
                 assembly_name=self._runtime.assembly,
                 distgit_key=metadata.distgit_key,
             )
@@ -543,7 +537,7 @@ class KonfluxRebaser:
                 build = await parent_metadata.get_latest_build(
                     el_target=self._get_el_target_string(parent_metadata.branch_el_target()),
                     engine=Engine.KONFLUX,
-                    group=self.group,
+                    group=self.derived_group,
                     exclude_large_columns=True,
                 )
 

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -1348,7 +1348,7 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         rebaser.variant = BuildVariant.OCP
         rebaser.image_repo = "quay.io/fake"
         rebaser.uuid_tag = "v4.18-abc"
-        rebaser.group = "openshift-4.18"
+        rebaser.derived_group = "openshift-4.18"
         rebaser._rebased_nvr_info["golang-builder"] = ("v1.21", "1.el9")
 
         resolved, _embargo = await rebaser._resolve_member_parent("golang-builder", "ignored")
@@ -1380,7 +1380,7 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         rebaser.variant = BuildVariant.OCP
         rebaser.image_repo = "quay.io/fake"
         rebaser.uuid_tag = "v4.18-tag"
-        rebaser.group = "openshift-4.18"
+        rebaser.derived_group = "openshift-4.18"
         rebaser._registry_pullspec_exists = AsyncMock(return_value=True)
 
         resolved, emb = await rebaser._resolve_member_parent("golang-builder", "orig")
@@ -1412,7 +1412,7 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         rebaser.variant = BuildVariant.OCP
         rebaser.image_repo = "quay.io/fake"
         rebaser.uuid_tag = "v4.18-tag"
-        rebaser.group = "openshift-4.18"
+        rebaser.derived_group = "openshift-4.18"
         rebaser._registry_pullspec_exists = AsyncMock(return_value=False)
 
         resolved, emb = await rebaser._resolve_member_parent("golang-builder", "orig")
@@ -1436,7 +1436,7 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         rebaser.variant = BuildVariant.OCP
         rebaser.image_repo = "quay.io/fake"
         rebaser.uuid_tag = "v4.18-uuid"
-        rebaser.group = "openshift-4.18"
+        rebaser.derived_group = "openshift-4.18"
 
         resolved, _ = await rebaser._resolve_member_parent("ose-cli", "ignored")
         self.assertEqual(resolved, "quay.io/fake:ose-cli-v4.18-uuid")


### PR DESCRIPTION
Renamed self.group to self.derived_group in KonfluxRebaser to make it explicit that for OKD builds, this is a derived value (okd-{major}.{minor}) rather than the runtime's actual group name.

Test: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/47722/