### PR TITLE
ART-18751: OCP-only base image registry release trigger

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1419,17 +1419,23 @@ class ImageMetadata(Metadata):
         Determines whether this image should trigger the base image release workflow.
 
         The method checks preconditions in the following order:
-        1. Variant must be OCP (not OKD)
-        2. Assembly must not be ``test``
-        3. Image must be ``base_only`` or a golang builder
-        4. Base image release enabled override:
+        1. Runtime ``product`` must be OCP (when set to a string). Layered products skip the
+           ocp-art-images registry base-image release workflow.
+        2. Variant must be OCP (not OKD)
+        3. Assembly must not be ``test``
+        4. Image must be ``base_only`` or a golang builder
+        5. Base image release enabled override:
            - Image metadata configuration (``self.config.base_image_release.enabled``)
            - Group configuration (``self.runtime.group_config.base_image_release.enabled``)
-        If no override is set for step 4, the enabled flag defaults to True.
+           If no override is set for step 5, the enabled flag defaults to True.
 
         Returns:
             bool: True if base image release workflow should be triggered, False otherwise.
         """
+        rp = getattr(self.runtime, "product", None)
+        if isinstance(rp, str) and rp != "ocp":
+            return False
+
         if self.runtime.variant is BuildVariant.OKD:
             return False
 

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1419,8 +1419,8 @@ class ImageMetadata(Metadata):
         Determines whether this image should trigger the base image release workflow.
 
         The method checks preconditions in the following order:
-        1. Runtime ``product`` must be OCP (when set to a string). Layered products skip the
-           ocp-art-images registry base-image release workflow.
+        1. When ``runtime.product`` is set and not ``ocp``, skip (layered products). Unset or
+           falsy product continues to later checks.
         2. Variant must be OCP (not OKD)
         3. Assembly must not be ``test``
         4. Image must be ``base_only`` or a golang builder
@@ -1432,8 +1432,8 @@ class ImageMetadata(Metadata):
         Returns:
             bool: True if base image release workflow should be triggered, False otherwise.
         """
-        rp = getattr(self.runtime, "product", None)
-        if isinstance(rp, str) and rp != "ocp":
+        rp = self.runtime.product
+        if rp and rp != "ocp":
             return False
 
         if self.runtime.variant is BuildVariant.OKD:

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1796,6 +1796,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         runtime.logger = logging.getLogger('test_runtime')
         runtime.variant = BuildVariant.OCP
         runtime.assembly = 'stream'
+        runtime.product = 'ocp'
         runtime.group_config = Model({})
 
         # Test base image - should trigger workflow
@@ -1815,6 +1816,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         test_assembly_runtime.logger = logging.getLogger('test_runtime')
         test_assembly_runtime.variant = BuildVariant.OCP
         test_assembly_runtime.assembly = 'test'
+        test_assembly_runtime.product = 'ocp'
         test_assembly_runtime.group_config = Model({})
         self.assertFalse(ImageMetadata(test_assembly_runtime, base_data).should_trigger_base_image_release())
         self.assertFalse(ImageMetadata(test_assembly_runtime, golang_data).should_trigger_base_image_release())
@@ -1824,6 +1826,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         named_runtime.logger = logging.getLogger('test_runtime')
         named_runtime.variant = BuildVariant.OCP
         named_runtime.assembly = '4.17.1'
+        named_runtime.product = 'ocp'
         named_runtime.group_config = Model({})
         self.assertTrue(ImageMetadata(named_runtime, base_data).should_trigger_base_image_release())
         self.assertTrue(ImageMetadata(named_runtime, golang_data).should_trigger_base_image_release())
@@ -1857,6 +1860,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         runtime_group_off.logger = logging.getLogger('test_runtime')
         runtime_group_off.variant = BuildVariant.OCP
         runtime_group_off.assembly = 'stream'
+        runtime_group_off.product = 'ocp'
         runtime_group_off.group_config = Model({'base_image_release': Model({'enabled': False})})
         group_off_base = Model({'name': 'g-off-base', 'base_only': True})
         group_off_data = Model({'key': 'g-off-base', 'data': group_off_base, 'filename': 'g-off-base.yaml'})
@@ -1868,6 +1872,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         runtime_both.logger = logging.getLogger('test_runtime')
         runtime_both.variant = BuildVariant.OCP
         runtime_both.assembly = 'stream'
+        runtime_both.product = 'ocp'
         runtime_both.group_config = Model({'base_image_release': Model({'enabled': False})})
         base_override = Model(
             {
@@ -1895,6 +1900,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         okd_runtime.logger = logging.getLogger('test_runtime')
         okd_runtime.variant = BuildVariant.OKD
         okd_runtime.assembly = 'stream'
+        okd_runtime.product = 'ocp'
         okd_runtime.group_config = Model({})
         okd_base_metadata = ImageMetadata(okd_runtime, base_data)
         self.assertFalse(okd_base_metadata.should_trigger_base_image_release())

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1880,6 +1880,16 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         both_metadata = ImageMetadata(runtime_both, both_data)
         self.assertTrue(both_metadata.should_trigger_base_image_release())
 
+        # Layered product: base-image registry workflow is OCP-only
+        layered_runtime = MagicMock()
+        layered_runtime.logger = logging.getLogger('test_runtime')
+        layered_runtime.variant = BuildVariant.OCP
+        layered_runtime.assembly = 'stream'
+        layered_runtime.product = 'rhmtc'
+        layered_runtime.group_config = Model({})
+        self.assertFalse(ImageMetadata(layered_runtime, base_data).should_trigger_base_image_release())
+        self.assertFalse(ImageMetadata(layered_runtime, golang_data).should_trigger_base_image_release())
+
         # OKD: base image would trigger on OCP but never on OKD (no RH registry release)
         okd_runtime = MagicMock()
         okd_runtime.logger = logging.getLogger('test_runtime')

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1267,6 +1267,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         rt.build_system = 'konflux'
         rt.konflux_db = MagicMock()
         rt.assembly = 'stream'
+        rt.product = 'ocp'
 
         metadata = image.ImageMetadata(rt, data_obj)
         metadata.logger = self.logger


### PR DESCRIPTION
## Summary

Restrict `ImageMetadata.should_trigger_base_image_release()` so the ocp-art-images registry base-image workflow applies only when `runtime.product` is the string `ocp`. Layered products (e.g. `rhmtc`) return false early.

Uses `isinstance(product, str)` so unit tests that leave `runtime.product` as a `MagicMock` keep the previous behavior.

## Testing

`pytest doozer/tests/test_image.py`