### PR TITLE
fix: resolve pylint E0401/E0015 errors

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -104,10 +104,6 @@ recursive=yes
 # source root.
 source-roots=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no

--- a/doozer/rundoozer/setup.py
+++ b/doozer/rundoozer/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup
+from setuptools import setup  # pylint: disable=import-error
 
 
 def _get_version():

--- a/pyartcd/pyartcd/pipelines/build_rhcos.py
+++ b/pyartcd/pyartcd/pipelines/build_rhcos.py
@@ -9,7 +9,7 @@ import click
 import openshift_client as oc
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 
 from pyartcd.cli import cli, pass_runtime
 from pyartcd.runtime import Runtime


### PR DESCRIPTION
## Summary
- Remove deprecated `suggestion-mode` option from `.pylintrc` (E0015)
- Suppress `import-error` for `setuptools` in legacy `doozer/rundoozer/setup.py` (E0401)
- Import `Retry` directly from `urllib3` instead of `requests.packages` shim in `build_rhcos.py` (E0401)

## Test plan
- [x] `uv run pylint --disable=all --enable=E0401,E0611 --score=no artcommon/ doozer/ elliott/ pyartcd/ ocp-build-data-validator/` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)