### PR TITLE
fix: remove special-casing of assembly-included tracker bugs

### DIFF
--- a/elliott/elliottlib/cli/find_bugs_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_cli.py
@@ -11,7 +11,6 @@ from elliottlib.cli.common import click_coroutine
 from elliottlib.cli.find_bugs_sweep_cli import (
     FindBugsSweep,
     categorize_bugs_by_type,
-    get_assembly_bug_ids,
     get_bugs_sweep,
     get_builds_by_advisory_kind,
 )
@@ -131,7 +130,6 @@ class FindBugsCli:
         LOGGER.info(f"Searching {self.bug_tracker.type} for bugs with status {statuses} and target releases: {tr}\n")
 
         bugs = await get_bugs_sweep(self.runtime, find_bugs_obj, self.bug_tracker)
-        included_bug_ids, _ = get_assembly_bug_ids(self.runtime, bug_tracker_type=self.bug_tracker.type)
         major_version, minor_version = self.runtime.get_major_minor()
 
         builds_by_advisory_kind = get_builds_by_advisory_kind(self.runtime)
@@ -139,7 +137,6 @@ class FindBugsCli:
             runtime=self.runtime,
             bugs=bugs,
             builds_by_advisory_kind=builds_by_advisory_kind,
-            permitted_bug_ids=included_bug_ids,
             major_version=major_version,
             minor_version=minor_version,
             operator_bundle_advisory="metadata",

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -330,7 +330,6 @@ async def find_and_attach_bugs(
         return []
 
     advisory_ids = runtime.get_default_advisories()
-    included_bug_ids, _ = get_assembly_bug_ids(runtime, bug_tracker_type=bug_tracker.type)
     major_version, minor_version = runtime.get_major_minor()
 
     builds_by_advisory_kind = get_builds_by_advisory_kind(runtime)
@@ -339,7 +338,6 @@ async def find_and_attach_bugs(
         runtime=runtime,
         bugs=bugs,
         builds_by_advisory_kind=builds_by_advisory_kind,
-        permitted_bug_ids=included_bug_ids,
         major_version=major_version,
         minor_version=minor_version,
         operator_bundle_advisory=operator_bundle_advisory,
@@ -436,7 +434,6 @@ def categorize_bugs_by_type(
     builds_by_advisory_kind: Dict[str, List[str]],
     major_version: int,
     minor_version: int,
-    permitted_bug_ids: Optional[set] = None,
     operator_bundle_advisory: Optional[str] = "metadata",
     permissive: bool = False,
     exclude_trackers: bool = False,
@@ -446,7 +443,6 @@ def categorize_bugs_by_type(
     :param builds_by_advisory_kind: Dict of {advisory_kind: [builds]} where builds are the NVRs attached to advisories
     :param major_version: Major version of the release
     :param minor_version: Minor version of the release
-    :param permitted_bug_ids: Set of bug IDs that are explicitly permitted for inclusion
     :param operator_bundle_advisory: Type of advisory for operator bundles, defaults to "metadata"
     :param permissive: If True, ignore invalid bugs instead of raising an error
     :param exclude_trackers: If True, exclude tracker bugs from the categorization
@@ -598,26 +594,16 @@ def categorize_bugs_by_type(
 
     not_found = set(tracker_bugs) - found
     if not_found:
-        still_not_found = not_found
-        if permitted_bug_ids:
-            logger.info(
-                'The following tracker bugs will be included in image advisory because they are '
-                f'explicitly included in the assembly config: {permitted_bug_ids}'
-            )
-            bugs_by_type["image"] = {b for b in not_found if b.id in permitted_bug_ids}
-            still_not_found = {b for b in not_found if b.id not in permitted_bug_ids}
-
-        if still_not_found:
-            bug_data = [(b.id, b.whiteboard_component) for b in still_not_found]
-            message = (
-                f'No attached builds found in advisories for tracker bugs (bug, package): '
-                f'{bug_data}. Either attach builds or explicitly include/exclude the bug ids in the assembly definition'
-            )
-            if permissive:
-                logger.warning(f"{message} Ignoring them because --permissive.")
-                issues.append(message)
-            else:
-                raise ValueError(message)
+        bug_data = [(b.id, b.whiteboard_component) for b in not_found]
+        message = (
+            f'No attached builds found in advisories for tracker bugs (bug, package): '
+            f'{bug_data}. Either exclude the bugs or include the builds in the assembly definition'
+        )
+        if permissive:
+            logger.warning(f"{message} Ignoring them because --permissive.")
+            issues.append(message)
+        else:
+            raise ValueError(message)
 
     return bugs_by_type, issues
 

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -597,7 +597,7 @@ def categorize_bugs_by_type(
         bug_data = [(b.id, b.whiteboard_component) for b in not_found]
         message = (
             f'No attached builds found in advisories for tracker bugs (bug, package): '
-            f'{bug_data}. Either exclude the bugs or include the builds in the assembly definition'
+            f'{bug_data}. Either exclude the bugs or ensure the corresponding builds are attached to the relevant advisory or otherwise included for this assembly'
         )
         if permissive:
             logger.warning(f"{message} Ignoring them because --permissive.")

--- a/elliott/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_bugs_cli.py
@@ -5,7 +5,6 @@ import re
 from typing import Any, Dict, Iterable, List, Set, Tuple
 
 import click
-from artcommonlib.assembly import assembly_issues_config
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import is_release_next_week
 from errata_tool import ErrataException
@@ -135,13 +134,7 @@ async def verify_attached_bugs(
         # skip advisory type check if advisories are
         # manually passed in, and we don't know their type
         if '?' not in advisory_id_map.keys():
-            included_bug_ids = set()
-            if runtime.assembly:
-                issues_config = assembly_issues_config(runtime.get_releases_config(), runtime.assembly)
-                included_bug_ids = {issue["id"] for issue in issues_config.include}
-            validator.verify_bugs_advisory_type(
-                runtime, non_flaw_bugs, advisory_id_map, advisory_bug_map, included_bug_ids
-            )
+            validator.verify_bugs_advisory_type(runtime, non_flaw_bugs, advisory_id_map, advisory_bug_map)
 
         if not skip_multiple_advisories_check:
             await validator.verify_bugs_multiple_advisories(non_flaw_bugs)
@@ -283,7 +276,7 @@ class BugValidator:
             blocking_bugs_for = self._get_blocking_bugs_for(non_flaw_bugs)
             self._verify_blocking_bugs(blocking_bugs_for, is_attached=is_attached)
 
-    def verify_bugs_advisory_type(self, runtime, non_flaw_bugs, advisory_id_map, advisory_bug_map, permitted_bug_ids):
+    def verify_bugs_advisory_type(self, runtime, non_flaw_bugs, advisory_id_map, advisory_bug_map):
         advance_release = False
         if "advance" in advisory_id_map and is_advisory_editable(advisory_id_map["advance"]):
             advance_release = True
@@ -294,7 +287,6 @@ class BugValidator:
             runtime,
             non_flaw_bugs,
             builds_by_advisory_kind,
-            permitted_bug_ids=permitted_bug_ids,
             permissive=True,
             operator_bundle_advisory=operator_bundle_advisory,
             major_version=major_version,

--- a/elliott/tests/test_verify_attached_bugs_cli.py
+++ b/elliott/tests/test_verify_attached_bugs_cli.py
@@ -214,7 +214,6 @@ class VerifyAttachedBugs(IsolatedAsyncioTestCase):
             result.output,
         )
 
-    @patch('elliottlib.cli.verify_attached_bugs_cli.assembly_issues_config')
     @patch('elliottlib.cli.verify_attached_bugs_cli.BugValidator.verify_bugs_multiple_advisories')
     @patch('elliottlib.errata_async.AsyncErrataAPI._generate_auth_header')
     def test_verify_attached_bugs_cli_fail_on_type(self, *_):


### PR DESCRIPTION
This special case of including traacker bugs leads us to errors down the line
- attach-cve-flaws errors
- konflux cve association errors

## Summary
- Assembly-included tracker bugs no longer bypass build validation — they go through the same flow as all other tracker bugs
- When builds are not found for included tracker bugs, the error message now says to exclude the bugs or include the builds
- Removed the `permitted_bug_ids` parameter from `categorize_bugs_by_type()` and related call sites

## Test plan
- [x] Unit tests pass (`elliott/tests/test_find_bugs_sweep_cli.py`, `elliott/tests/test_verify_attached_bugs_cli.py`)
- [ ] Verify that explicitly included tracker bugs without matching builds now raise an error (or warn under `--permissive`)
- [ ] Verify that explicitly included tracker bugs with matching builds are correctly categorized by advisory type

🤖 Generated with [Claude Code](https://claude.com/claude-code)