### PR TITLE
ART-18904: Remove ineffective task bundle age checking logic

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import logging
 import os
-import random
 import re
 import tempfile
 from datetime import datetime, timedelta, timezone
@@ -22,7 +21,6 @@ from artcommonlib.github_auth import get_github_client_for_org, get_github_git_a
 from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.konflux.package_rpm_finder import PackageRpmFinder
 from artcommonlib.model import Missing, Model
-from artcommonlib.oc_image_info import oc_image_info__cached_async
 from artcommonlib.pushd import Dir
 from artcommonlib.release_util import isolate_timestamp_in_release
 from artcommonlib.rhcos import get_latest_layered_rhcos_build, get_primary_container_name
@@ -46,7 +44,6 @@ from doozerlib.source_resolver import SourceResolver
 from doozerlib.util import oc_image_info_for_arch_async
 
 DEFAULT_THRESHOLD_HOURS = 6
-TASK_BUNDLE_AGE_THRESHOLD_DAYS = 10
 
 
 class ConfigScanSources:
@@ -1176,32 +1173,11 @@ class ConfigScanSources:
 
         return task_bundles
 
-    async def check_task_bundle_age(self, task_name: str, used_sha: str, current_sha: str):
-        """
-        Check if a single task bundle is old enough to warrant a rebuild.
-        Returns a tuple with task info and age if old enough, None otherwise.
-        """
-        self.logger.info(
-            f'Task bundle {task_name} version differs: used={used_sha[:12]}... vs current={current_sha[:12]}...'
-        )
-
-        task_age_days = await self.get_task_bundle_age_days(task_name, used_sha)
-        if not task_age_days:
-            return None
-
-        if task_age_days >= TASK_BUNDLE_AGE_THRESHOLD_DAYS:
-            return task_name, used_sha, current_sha, task_age_days
-        else:
-            self.logger.info(
-                f'Task bundle {task_name} is only {task_age_days} days old (< {TASK_BUNDLE_AGE_THRESHOLD_DAYS} days), skipping rebuild'
-            )
-            return None
-
     @skip_check_if_changing
     async def scan_task_bundle_changes(self, image_meta: ImageMetadata):
         """
-        Check if task bundles used in the build are outdated compared to current versions
-        and if old task bundles are more than {TASK_BUNDLE_AGE_THRESHOLD_DAYS} days old, trigger a rebuild.
+        Check if task bundles used in the build are outdated compared to current versions.
+        If any task bundle SHA doesn't match, trigger a rebuild.
         """
         # Skip if image is not being released
         for_release = image_meta.config.for_release
@@ -1239,7 +1215,7 @@ class ConfigScanSources:
         # Check each task bundle for outdated versions
         self.logger.info(f'Comparing task bundle versions for {image_meta.distgit_key}')
 
-        # Filter out task bundles that are up-to-date or not found in current template
+        # Find task bundles with SHA mismatches
         outdated_task_bundles = []
         for task_name, used_sha in task_bundles.items():
             current_sha = current_task_bundles.get(task_name)
@@ -1251,69 +1227,24 @@ class ConfigScanSources:
                 self.logger.info(f'Task bundle {task_name} is up to date (SHA: {used_sha[:12]}...)')
                 continue
 
+            self.logger.info(
+                f'Task bundle {task_name} version differs: used={used_sha[:12]}... vs current={current_sha[:12]}...'
+            )
             outdated_task_bundles.append((task_name, used_sha, current_sha))
 
         if not outdated_task_bundles:
             return
 
-        # Check if any outdated task bundles are old enough and apply staggered rebuild logic once
-        # Execute all age checks in parallel
-        age_check_results = await asyncio.gather(
-            *[
-                self.check_task_bundle_age(task_name, used_sha, current_sha)
-                for task_name, used_sha, current_sha in outdated_task_bundles
-            ]
-        )
-
-        # Filter out None results to get only old enough task bundles
-        old_outdated_tasks = [result for result in age_check_results if result is not None]
-
-        if not old_outdated_tasks:
-            return
-
-        # Apply staggered rebuild logic once for all old outdated tasks
-        # Use the oldest task for probability calculation
-        oldest_task = max(old_outdated_tasks, key=lambda x: x[3])
-        task_name, used_sha, current_sha, task_age_days = oldest_task
+        # Trigger rebuild for any SHA mismatch
+        task_name, used_sha, current_sha = outdated_task_bundles[0]
+        task_list = ', '.join([name for name, _, _ in outdated_task_bundles])
 
         self.logger.info(
-            f'Found {len(old_outdated_tasks)} outdated task bundles >= {TASK_BUNDLE_AGE_THRESHOLD_DAYS} days old, '
-            f'applying staggered rebuild logic based on oldest task {task_name} ({task_age_days} days old)'
-        )
-
-        # Staggered rebuild logic: probability increases as age increases
-        #   - At 10 days: 1 in 21 chance (~5%)
-        #   - At 15 days: 1 in 16 chance (~6%)
-        #   - At 20 days: 1 in 11 chance (~9%)
-        #   - At 25 days: 1 in 6 chance (~17%)
-        #   - At 29 days: 1 in 2 chance (50%)
-        #   - At 30+ days: Always rebuild (100%)
-        rebuild_probability_denominator = max(30 - task_age_days, 1)
-        probability_percentage = (1.0 / rebuild_probability_denominator) * 100
-        random_number = random.randint(1, rebuild_probability_denominator)
-        should_rebuild = random_number == 1
-
-        self.logger.info(
-            f'Staggered rebuild probability: {probability_percentage:.1f}% (1/{rebuild_probability_denominator}), '
-            f'generated random number: {random_number}, rebuild decision: {should_rebuild}'
-        )
-
-        if not should_rebuild:
-            self.logger.info(
-                f'Staggered rebuild logic decided not to rebuild despite {len(old_outdated_tasks)} outdated task bundles '
-                f'(probability was {probability_percentage:.1f}% based on oldest task {task_name})'
-            )
-            return
-
-        # Trigger rebuild using the oldest task as the reason
-        self.logger.info(
-            f'Triggering rebuild for {image_meta.distgit_key} due to outdated task bundles '
-            f'(oldest: {task_name}, {task_age_days} days old)'
+            f'Triggering rebuild for {image_meta.distgit_key} due to {len(outdated_task_bundles)} outdated task bundle(s): {task_list}'
         )
         rebuild_hint = RebuildHint(
             RebuildHintCode.TASK_BUNDLE_OUTDATED,
-            f'Task bundle {task_name} is {task_age_days} days old (>={TASK_BUNDLE_AGE_THRESHOLD_DAYS} days) '
-            f'and newer version is available (staggered rebuild)',
+            f'Task bundle(s) outdated: {task_list}',
         )
         self.add_image_meta_change(image_meta, rebuild_hint)
 
@@ -1379,33 +1310,6 @@ class ConfigScanSources:
         elif isinstance(obj, list):
             for item in obj:
                 self._extract_task_refs(item, task_bundles)
-
-    async def get_task_bundle_age_days(self, task_name: str, sha: str) -> Optional[int]:
-        """
-        Get the age of a task bundle in days using oc image info
-        """
-        pullspec = f"quay.io/konflux-ci/tekton-catalog/{task_name}@sha256:{sha}"
-        self.logger.info(f'Getting age for task bundle {task_name} using pullspec {pullspec}')
-        try:
-            out = await oc_image_info__cached_async(pullspec, registry_config=self.runtime.registry_config)
-            image_info = json.loads(out)
-            created_str = image_info.get('config', {}).get('created', '')
-            if not created_str:
-                return None
-
-            # Parse creation time and calculate age
-            created_time = datetime.fromisoformat(created_str.rstrip('Z')).replace(tzinfo=timezone.utc)
-            now = datetime.now(timezone.utc)
-            age_days = (now - created_time).days
-
-            self.logger.info(
-                f'Task bundle {task_name} was created on {created_time.strftime("%Y-%m-%d")}, age: {age_days} days'
-            )
-            return age_days
-
-        except Exception as e:
-            self.logger.warning(f'Failed to get age for task bundle {task_name}@{sha}: {e}')
-            return None
 
     async def check_changing_rpms(self):
         """

--- a/doozer/tests/cli/test_scan_sources_konflux.py
+++ b/doozer/tests/cli/test_scan_sources_konflux.py
@@ -1,6 +1,5 @@
 import base64
 import json
-from datetime import datetime, timezone
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -226,36 +225,15 @@ class TestScanTaskBundleChanges(TestScanSourcesKonflux):
         self.assertEqual(len(self.scanner.changing_image_names), 0)
 
     @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
-    @patch.object(ConfigScanSources, 'get_current_task_bundle_shas')
-    @patch.object(ConfigScanSources, 'get_task_bundle_age_days')
-    async def test_scan_task_bundle_changes_not_old_enough(self, mock_get_age, mock_get_current, mock_get_attestation):
-        """Test that task bundles less than 10 days old don't trigger rebuilds."""
-        mock_get_attestation.return_value = self.sample_attestation
-        mock_get_current.return_value = self.current_task_bundles
-        mock_get_age.return_value = 5  # Less than 10 days
-
-        await self.scanner.scan_task_bundle_changes(self.image_meta)
-
-        # Should not add any changes when task bundle is not old enough
-        self.assertEqual(len(self.scanner.changing_image_names), 0)
-
-    @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
-    @patch.object(ConfigScanSources, 'get_task_bundle_age_days')
     @patch.object(ConfigScanSources, 'add_image_meta_change')
-    @patch('random.randint')
-    async def test_scan_task_bundle_changes_staggered_rebuild_triggers(
-        self, mock_randint, mock_add_change, mock_get_age, mock_get_attestation
-    ):
-        """Test that staggered rebuild logic triggers rebuild when random condition is met."""
+    async def test_scan_task_bundle_changes_sha_mismatch_triggers_rebuild(self, mock_add_change, mock_get_attestation):
+        """Test that task bundles with SHA mismatch trigger rebuilds."""
         mock_get_attestation.return_value = self.sample_attestation
-        mock_get_age.return_value = 35  # 35 days old
-        mock_randint.return_value = 1  # This should trigger rebuild
-
         self.scanner.current_task_bundles = self.current_task_bundles
 
         await self.scanner.scan_task_bundle_changes(self.image_meta)
 
-        # Should add change when staggered rebuild condition is met
+        # Should add change when SHA doesn't match
         mock_add_change.assert_called_once()
 
         # Verify the rebuild hint
@@ -263,33 +241,9 @@ class TestScanTaskBundleChanges(TestScanSourcesKonflux):
         rebuild_hint = call_args[1]
         self.assertEqual(rebuild_hint.code, RebuildHintCode.TASK_BUNDLE_OUTDATED)
         self.assertIn("task-git-clone", rebuild_hint.reason)
-        self.assertIn("35 days old", rebuild_hint.reason)
 
     @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
-    @patch.object(ConfigScanSources, 'get_current_task_bundle_shas')
-    @patch.object(ConfigScanSources, 'get_task_bundle_age_days')
-    @patch.object(ConfigScanSources, 'add_image_meta_change')
-    @patch('random.randint')
-    async def test_scan_task_bundle_changes_staggered_rebuild_skips(
-        self, mock_randint, mock_add_change, mock_get_age, mock_get_current, mock_get_attestation
-    ):
-        """Test that staggered rebuild logic skips rebuild when random condition is not met."""
-        mock_get_attestation.return_value = self.sample_attestation
-        mock_get_current.return_value = self.current_task_bundles
-        mock_get_age.return_value = 15  # 15 days old
-        mock_randint.return_value = 2  # With denominator of 15 (max(30-15, 1)), this should not trigger rebuild
-
-        await self.scanner.scan_task_bundle_changes(self.image_meta)
-
-        # Should not add change when staggered rebuild condition is not met
-        mock_add_change.assert_not_called()
-
-    @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
-    @patch.object(ConfigScanSources, 'get_current_task_bundle_shas')
-    @patch.object(ConfigScanSources, 'get_task_bundle_age_days')
-    async def test_scan_task_bundle_changes_same_sha_no_rebuild(
-        self, mock_get_age, mock_get_current, mock_get_attestation
-    ):
+    async def test_scan_task_bundle_changes_same_sha_no_rebuild(self, mock_get_attestation):
         """Test that task bundles with same SHA don't trigger rebuilds."""
         # Modify current bundles to have same SHA as used SHA
         current_bundles_same = {
@@ -298,12 +252,11 @@ class TestScanTaskBundleChanges(TestScanSourcesKonflux):
         }
 
         mock_get_attestation.return_value = self.sample_attestation
-        mock_get_current.return_value = current_bundles_same
+        self.scanner.current_task_bundles = current_bundles_same
 
         await self.scanner.scan_task_bundle_changes(self.image_meta)
 
-        # Should not call get_age when SHAs match
-        mock_get_age.assert_not_called()
+        # Should not add any changes when SHAs match
         self.assertEqual(len(self.scanner.changing_image_names), 0)
 
     @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
@@ -550,95 +503,12 @@ class TestGetCurrentTaskBundleShas(TestScanSourcesKonflux):
         self.assertEqual(result, expected)
 
 
-class TestGetTaskBundleAgeDays(TestScanSourcesKonflux):
-    """Test the get_task_bundle_age_days method."""
-
-    @patch('doozerlib.cli.scan_sources_konflux.oc_image_info__cached_async')
-    async def test_get_task_bundle_age_days_success(self, mock_oc_image_info):
-        """Test successful calculation of task bundle age."""
-        # Mock oc image info output
-        created_time = "2024-01-01T10:00:00Z"
-        mock_image_info = {"config": {"created": created_time}}
-
-        mock_oc_image_info.return_value = json.dumps(mock_image_info)
-
-        # Mock current time to be 35 days after creation
-        with patch('doozerlib.cli.scan_sources_konflux.datetime') as mock_datetime:
-            mock_now = datetime(2024, 2, 5, 10, 0, 0, tzinfo=timezone.utc)
-            mock_datetime.now.return_value = mock_now
-            mock_datetime.fromisoformat = datetime.fromisoformat
-
-            result = await self.scanner.get_task_bundle_age_days("test-task", "abc123")
-
-        self.assertEqual(result, 35)
-
-        # Verify correct pullspec was queried with registry_config
-        expected_pullspec = "quay.io/konflux-ci/tekton-catalog/test-task@sha256:abc123"
-        mock_oc_image_info.assert_called_once_with(expected_pullspec, registry_config=None)
-
-    @patch('doozerlib.cli.scan_sources_konflux.oc_image_info__cached_async')
-    async def test_get_task_bundle_age_days_missing_created_field(self, mock_oc_image_info):
-        """Test handling when created field is missing from image info."""
-        mock_image_info = {"config": {}}  # Missing 'created' field
-
-        mock_oc_image_info.return_value = json.dumps(mock_image_info)
-
-        result = await self.scanner.get_task_bundle_age_days("test-task", "abc123")
-
-        self.assertIsNone(result)
-
-    @patch('doozerlib.cli.scan_sources_konflux.oc_image_info__cached_async')
-    async def test_get_task_bundle_age_days_command_failure(self, mock_oc_image_info):
-        """Test handling when oc image info command fails."""
-        mock_oc_image_info.side_effect = Exception("Command failed")
-
-        result = await self.scanner.get_task_bundle_age_days("test-task", "abc123")
-
-        self.assertIsNone(result)
-
-    @patch('doozerlib.cli.scan_sources_konflux.oc_image_info__cached_async')
-    async def test_get_task_bundle_age_days_invalid_json(self, mock_oc_image_info):
-        """Test handling when oc command returns invalid JSON."""
-        mock_oc_image_info.return_value = "invalid json"
-
-        result = await self.scanner.get_task_bundle_age_days("test-task", "abc123")
-
-        self.assertIsNone(result)
-
-    @patch('doozerlib.cli.scan_sources_konflux.oc_image_info__cached_async')
-    async def test_get_task_bundle_age_days_timezone_handling(self, mock_oc_image_info):
-        """Test proper timezone handling in age calculation."""
-        # Test with different timezone formats
-        test_cases = [
-            "2024-01-01T10:00:00Z",  # UTC with Z
-            "2024-01-01T10:00:00+00:00",  # UTC with offset
-        ]
-
-        for created_time in test_cases:
-            with self.subTest(created_time=created_time):
-                mock_image_info = {"config": {"created": created_time}}
-                mock_oc_image_info.return_value = json.dumps(mock_image_info)
-
-                with patch('doozerlib.cli.scan_sources_konflux.datetime') as mock_datetime:
-                    mock_now = datetime(2024, 1, 11, 10, 0, 0, tzinfo=timezone.utc)
-                    mock_datetime.now.return_value = mock_now
-                    mock_datetime.fromisoformat = datetime.fromisoformat
-
-                    result = await self.scanner.get_task_bundle_age_days("test-task", "abc123")
-
-                self.assertEqual(result, 10)
-
-
 class TestTaskBundleIntegration(TestScanSourcesKonflux):
     """Integration tests for the complete task bundle scanning workflow."""
 
     @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
-    @patch.object(ConfigScanSources, 'get_task_bundle_age_days')
     @patch.object(ConfigScanSources, 'add_image_meta_change')
-    @patch('random.randint')
-    async def test_full_workflow_rebuild_triggered(
-        self, mock_randint, mock_add_change, mock_get_age, mock_get_attestation
-    ):
+    async def test_full_workflow_rebuild_triggered(self, mock_add_change, mock_get_attestation):
         """Test the complete workflow when a rebuild should be triggered."""
         # Setup test data
         attestation = {
@@ -655,8 +525,6 @@ class TestTaskBundleIntegration(TestScanSourcesKonflux):
         current_bundles = {"git-clone": "new456"}  # Different SHA
 
         mock_get_attestation.return_value = attestation
-        mock_get_age.return_value = 35  # Old enough to trigger rebuild
-        mock_randint.return_value = 1  # Will trigger rebuild
         self.scanner.current_task_bundles = current_bundles
 
         await self.scanner.scan_task_bundle_changes(self.image_meta)
@@ -665,10 +533,6 @@ class TestTaskBundleIntegration(TestScanSourcesKonflux):
         mock_get_attestation.assert_called_once_with(
             self.build_record.image_pullspec, self.build_record.name, self.scanner.runtime.registry_config
         )
-        mock_get_age.assert_called_once_with("git-clone", "old123")
-
-        # Verify staggered rebuild logic
-        mock_randint.assert_called_once_with(1, 1)  # max(30 - 35, 1) = 1
 
         # Verify rebuild hint was added
         mock_add_change.assert_called_once()
@@ -676,19 +540,29 @@ class TestTaskBundleIntegration(TestScanSourcesKonflux):
         self.assertEqual(rebuild_hint.code, RebuildHintCode.TASK_BUNDLE_OUTDATED)
 
     @patch('doozerlib.cli.scan_sources_konflux.fetch_slsa_attestation')
-    @patch.object(ConfigScanSources, 'get_task_bundle_age_days')
     @patch.object(ConfigScanSources, 'add_image_meta_change')
-    async def test_full_workflow_no_rebuild_needed(self, mock_add_change, mock_get_age, mock_get_attestation):
+    async def test_full_workflow_no_rebuild_needed(self, mock_add_change, mock_get_attestation):
         """Test the complete workflow when no rebuild is needed."""
         # Setup test data with matching SHAs
+        attestation = {
+            "predicate": {
+                "materials": [
+                    {
+                        "uri": "quay.io/konflux-ci/tekton-catalog/git-clone",
+                        "digest": {"sha256": "same123"},
+                    }
+                ]
+            }
+        }
+
         current_bundles = {"git-clone": "same123"}  # Same SHA
+        mock_get_attestation.return_value = attestation
         self.scanner.current_task_bundles = current_bundles
 
         await self.scanner.scan_task_bundle_changes(self.image_meta)
 
         # Verify early exit when SHAs match
         mock_get_attestation.assert_called_once()
-        mock_get_age.assert_not_called()  # Should not check age when SHAs match
         mock_add_change.assert_not_called()
 
     async def test_skip_check_if_changing_decorator(self):


### PR DESCRIPTION
## Problem

The task bundle age validation logic was ineffective because Konflux task bundle images have their `created` timestamp set to the Unix epoch (1970-01-01T00:00:00Z) instead of their actual creation time.

### Evidence

When checking task bundle metadata using `oc image info`:
```bash
$ oc image info quay.io/konflux-ci/tekton-catalog/task-clair-scan@sha256:8fad4c2e2f470f82ee43d6b2ac72327b4d9c6e9cb514a678911c1c9359c29894 -o json | jq .config.created
"1970-01-01T00:00:00Z"
```

### Impact

- The age check always evaluated as "older than 10 days"
- This triggered unnecessary rebuilds when they should be skipped based on age
- The staggered rebuild logic added complexity without providing the intended benefit
- Mass rebuilds occurred unnecessarily

## Solution

Removed the task age checking logic entirely and simplified to: **if task bundle SHAs don't match → rebuild**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)