### PR TITLE
Add --major-bump flag to update-golang command

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -206,6 +206,7 @@ class UpdateGolangPipeline:
         skip_pr: bool = False,
         external_golang_rpms: bool = False,
         network_mode: str | None = None,
+        major_bump: bool = False,
     ):
         self.runtime = runtime
         self.dry_run = runtime.dry_run
@@ -224,6 +225,7 @@ class UpdateGolangPipeline:
         self.skip_pr = skip_pr
         self.external_golang_rpms = external_golang_rpms
         self.network_mode = network_mode
+        self.major_bump = major_bump
         self._slack_client = self.runtime.new_slack_client()
         self._doozer_working_dir = self.runtime.working_dir / "doozer-working"
         self._doozer_env_vars = os.environ.copy()
@@ -285,22 +287,39 @@ class UpdateGolangPipeline:
         branch, allowed_major_minors = self._get_allowed_go_major_minors()
         build_major_minor = extract_major_minor(go_version, "golang build version")
         if build_major_minor not in allowed_major_minors.values():
-            allowed_versions = ", ".join(
-                f"{var_name} ({major_minor})" for var_name, major_minor in allowed_major_minors.items()
-            )
-            raise ValueError(
-                f"The provided golang build major.minor ({build_major_minor}) must match "
-                f"one of {branch} group.yml vars: {allowed_versions}."
-            )
+            if self.major_bump:
+                _LOGGER.info(
+                    "--major-bump is set: permitting golang build major.minor (%s) that does not match "
+                    "any of %s group.yml vars",
+                    build_major_minor,
+                    branch,
+                )
+            else:
+                allowed_versions = ", ".join(
+                    f"{var_name} ({major_minor})" for var_name, major_minor in allowed_major_minors.items()
+                )
+                raise ValueError(
+                    f"The provided golang build major.minor ({build_major_minor}) must match "
+                    f"one of {branch} group.yml vars: {allowed_versions}."
+                )
         return branch, allowed_major_minors, build_major_minor
 
     def validate_tag_builds_go_latest(self, branch: str, allowed_major_minors: dict[str, str], build_major_minor: str):
         latest_major_minor = allowed_major_minors["GO_LATEST"]
         if build_major_minor != latest_major_minor:
-            raise ValueError(
-                f"When --tag-builds is set, the provided golang build major.minor ({build_major_minor}) must match "
-                f"{branch} group.yml GO_LATEST major.minor ({latest_major_minor})."
-            )
+            if self.major_bump:
+                _LOGGER.info(
+                    "--major-bump is set: permitting --tag-builds with golang build major.minor (%s) "
+                    "that does not match %s group.yml GO_LATEST (%s)",
+                    build_major_minor,
+                    branch,
+                    latest_major_minor,
+                )
+            else:
+                raise ValueError(
+                    f"When --tag-builds is set, the provided golang build major.minor ({build_major_minor}) must match "
+                    f"{branch} group.yml GO_LATEST major.minor ({latest_major_minor})."
+                )
 
     async def run(self):
         try:
@@ -1010,6 +1029,13 @@ class UpdateGolangPipeline:
     default=None,
     help='Override network mode for Konflux builds. Takes precedence over image and group config settings.',
 )
+@click.option(
+    '--major-bump',
+    is_flag=True,
+    default=False,
+    help='Indicates a major.minor golang version bump (e.g. 1.22 -> 1.23). '
+    'Permits validation of go_latest even when the new version does not match current group.yml vars.',
+)
 @pass_runtime
 @click_coroutine
 async def update_golang(
@@ -1030,6 +1056,7 @@ async def update_golang(
     skip_pr: bool,
     external_golang_rpms: bool,
     network_mode: str | None,
+    major_bump: bool,
 ):
     if not runtime.dry_run and not confirm:
         _LOGGER.info('--confirm is not set, running in dry-run mode')
@@ -1057,4 +1084,5 @@ async def update_golang(
         skip_pr,
         external_golang_rpms,
         network_mode,
+        major_bump,
     ).run()

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -60,15 +60,13 @@ def get_latest_nvr_in_tag(tag: str, package: str, koji_session) -> str:
     return latest_build[0]['nvr']
 
 
-async def is_latest_and_available(ocp_version: str, el_v: int, nvr: str, koji_session, request: bool = False) -> bool:
+async def is_latest_and_available(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool:
     if not is_latest_build(ocp_version, el_v, nvr, koji_session):
         return False
     # If regen repo has been run this would take a few seconds
     # sadly --timeout cannot be less than 1 minute, so we wait for 1 minute
     build_tag = f'rhaos-{ocp_version}-rhel-{el_v}-build'
     cmd = f'brew wait-repo {build_tag} --build {nvr} --timeout=1 --verbose'
-    if request:
-        cmd += ' --request'
     rc, out, err = await exectools.cmd_gather_async(cmd, check=False)
     if rc != 0:
         output = "\n".join(stream.strip() for stream in (err, out) if stream and stream.strip())
@@ -481,15 +479,22 @@ class UpdateGolangPipeline:
             return False
         # Tag builds into override tag
         await self.tag_build(el_v, nvr)
-        # Wait for repo to be available (5 hours max)
 
+        # Request a repo regen so the newly tagged build becomes available
+        build_tag = f'rhaos-{self.ocp_version}-rhel-{el_v}-build'
         if self.dry_run:
+            _LOGGER.info(f"[DRY RUN] Would have run `brew regen-repo {build_tag}`")
             _LOGGER.info(f"[DRY RUN] Would have waited for {nvr} to be available in build tags")
             return True
 
+        regen_cmd = f'brew regen-repo {build_tag}'
+        _LOGGER.info("Requesting repo regen: %s", regen_cmd)
+        await exectools.cmd_assert_async(regen_cmd)
+
+        # Wait for repo to be available (5 hours max)
         for _ in range(30):
             await asyncio.sleep(600)  # 10 minutes
-            if await is_latest_and_available(self.ocp_version, el_v, nvr, self.koji_session, request=True):
+            if await is_latest_and_available(self.ocp_version, el_v, nvr, self.koji_session):
                 return True
             _LOGGER.info("wait 10 mins...")
         _LOGGER.info("build not available after 5 hours")

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -60,13 +60,15 @@ def get_latest_nvr_in_tag(tag: str, package: str, koji_session) -> str:
     return latest_build[0]['nvr']
 
 
-async def is_latest_and_available(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool:
+async def is_latest_and_available(ocp_version: str, el_v: int, nvr: str, koji_session, request: bool = False) -> bool:
     if not is_latest_build(ocp_version, el_v, nvr, koji_session):
         return False
     # If regen repo has been run this would take a few seconds
     # sadly --timeout cannot be less than 1 minute, so we wait for 1 minute
     build_tag = f'rhaos-{ocp_version}-rhel-{el_v}-build'
     cmd = f'brew wait-repo {build_tag} --build {nvr} --timeout=1 --verbose'
+    if request:
+        cmd += ' --request'
     rc, out, err = await exectools.cmd_gather_async(cmd, check=False)
     if rc != 0:
         output = "\n".join(stream.strip() for stream in (err, out) if stream and stream.strip())
@@ -487,7 +489,7 @@ class UpdateGolangPipeline:
 
         for _ in range(30):
             await asyncio.sleep(600)  # 10 minutes
-            if await is_latest_and_available(self.ocp_version, el_v, nvr, self.koji_session):
+            if await is_latest_and_available(self.ocp_version, el_v, nvr, self.koji_session, request=True):
                 return True
             _LOGGER.info("wait 10 mins...")
         _LOGGER.info("build not available after 5 hours")

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -45,11 +45,7 @@ def is_latest_build(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool
     if nvr == latest_build[0]['nvr']:
         _LOGGER.info(f'{nvr} is the latest build in {build_tag}')
         return True
-    override_tag = f'rhaos-{ocp_version}-rhel-{el_v}-override'
-    _LOGGER.info(
-        f'{nvr} is not the latest build in {build_tag}. Run `brew tag {override_tag} {nvr}` to tag the '
-        f'build and then run `brew regen-repo {build_tag}` to make it available.'
-    )
+    _LOGGER.info(f'{nvr} is not the latest build in {build_tag}. Use --tag-builds to tag and regen-repo automatically.')
     return False
 
 
@@ -87,10 +83,7 @@ async def is_latest_and_available(ocp_version: str, el_v: int, nvr: str, koji_se
                 build_tag,
                 rc,
             )
-        _LOGGER.info(
-            f'Build {nvr} could not be confirmed available in {build_tag}. If the build is already tagged, '
-            f'run `brew regen-repo {build_tag}` to make it available.'
-        )
+        _LOGGER.info(f'Build {nvr} could not be confirmed available in {build_tag}.')
         return False
     _LOGGER.info(f'{nvr} is available in {build_tag}')
     return True

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -172,21 +172,6 @@ class TestIsLatestAndAvailable(IsolatedAsyncioTestCase):
         mock_cmd_gather.assert_called_once()
 
     @patch("pyartcd.pipelines.update_golang.is_latest_build")
-    @patch("artcommonlib.exectools.cmd_gather_async")
-    async def test_build_is_latest_and_available_with_request(self, mock_cmd_gather, mock_is_latest):
-        """Test when build is latest and available with request=True"""
-        mock_is_latest.return_value = True
-        mock_cmd_gather.return_value = (0, "", "")
-        mock_koji_session = Mock()
-
-        result = await is_latest_and_available("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session, request=True)
-
-        self.assertTrue(result)
-        mock_cmd_gather.assert_called_once()
-        cmd = mock_cmd_gather.call_args[0][0]
-        self.assertIn("--request", cmd)
-
-    @patch("pyartcd.pipelines.update_golang.is_latest_build")
     async def test_build_is_not_latest(self, mock_is_latest):
         """Test when build is not latest"""
         mock_is_latest.return_value = False

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -607,6 +607,68 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_validate_go_version_matches_group_vars_permits_mismatch_with_major_bump(
+        self, mock_konflux_db, mock_get_github_client
+    ):
+        """Test version validation permits mismatched major.minor when --major-bump is set"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        upstream_repo = Mock()
+        upstream_repo.get_contents.return_value = Mock(
+            decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_PREVIOUS: 1.21\n"
+        )
+        mock_get_github_client.return_value.get_repo.return_value = upstream_repo
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.23.1-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            major_bump=True,
+        )
+
+        branch, allowed_major_minors, build_major_minor = pipeline.validate_go_version_matches_group_vars("1.23.1")
+        self.assertEqual(build_major_minor, "1.23")
+        self.assertEqual(allowed_major_minors["GO_LATEST"], "1.22")
+
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_validate_tag_builds_go_latest_permits_mismatch_with_major_bump(
+        self, mock_konflux_db, mock_get_github_client
+    ):
+        """Test tag-build validation permits mismatched GO_LATEST when --major-bump is set"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        upstream_repo = Mock()
+        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22\n")
+        mock_get_github_client.return_value.get_repo.return_value = upstream_repo
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.23.9-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            major_bump=True,
+        )
+
+        pipeline.validate_tag_builds_go_latest("openshift-4.16", {"GO_LATEST": "1.22"}, "1.23")
+
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_validate_tag_builds_go_latest_rejects_go_extra_match(self, mock_konflux_db, mock_get_github_client):
         """Test tag-build validation still requires GO_LATEST even when GO_EXTRA matches"""
         mock_runtime = Mock(

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -172,6 +172,21 @@ class TestIsLatestAndAvailable(IsolatedAsyncioTestCase):
         mock_cmd_gather.assert_called_once()
 
     @patch("pyartcd.pipelines.update_golang.is_latest_build")
+    @patch("artcommonlib.exectools.cmd_gather_async")
+    async def test_build_is_latest_and_available_with_request(self, mock_cmd_gather, mock_is_latest):
+        """Test when build is latest and available with request=True"""
+        mock_is_latest.return_value = True
+        mock_cmd_gather.return_value = (0, "", "")
+        mock_koji_session = Mock()
+
+        result = await is_latest_and_available("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session, request=True)
+
+        self.assertTrue(result)
+        mock_cmd_gather.assert_called_once()
+        cmd = mock_cmd_gather.call_args[0][0]
+        self.assertIn("--request", cmd)
+
+    @patch("pyartcd.pipelines.update_golang.is_latest_build")
     async def test_build_is_not_latest(self, mock_is_latest):
         """Test when build is not latest"""
         mock_is_latest.return_value = False


### PR DESCRIPTION
## Summary
- Adds `--major-bump` flag to the `update-golang` CLI command. When set, permits `go_latest` validation to pass even when the new golang version doesn't match any of `GO_LATEST`/`GO_EXTRA`/`GO_PREVIOUS` in group.yml, and permits `--tag-builds` validation when the build version doesn't match current `GO_LATEST`
- Runs `brew regen-repo` once after tagging a new build, instead of passively waiting in the loop
- Cleans up log messages to stop suggesting manual `brew regen-repo` / `brew tag` commands since the pipeline now handles both automatically

## Test plan
- [x] `make lint` passes
- [x] `make unit` passes (all 2186 tests across all packages)
- [x] New tests verify `--major-bump` bypasses both `validate_go_version_matches_group_vars` and `validate_tag_builds_go_latest`
- [x] Existing rejection tests still pass (no regressions)

Companion PR: https://github.com/openshift-eng/aos-cd-jobs/pull/4689

🤖 Generated with [Claude Code](https://claude.com/claude-code)