### PR TITLE
Add ACM to CPE_PRODUCT_NAME_MAPPING

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -40,6 +40,7 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 
 # Product name mapping for CPE labels
 CPE_PRODUCT_NAME_MAPPING = {
+    'acm': 'advanced_cluster_management',
     'rhmtc': 'rhmt',
     'oadp': 'openshift_api_data_protection',
     'mta': 'migration_toolkit_applications',


### PR DESCRIPTION
[HYPBLD-847](https://redhat.atlassian.net/browse/HYPBLD-847): Map 'acm' product to 'advanced_cluster_management' for CPE label generation in Dockerfile rebasing.

Signed-off-by: Brian Smith <briansmi@redhat.com>