### PR TITLE
ART-18909: Disable JIRA link unfurling in images-health Slack reports

### DIFF
--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -308,7 +308,7 @@ class ImagesHealthPipeline:
                     report += f' ({self.url_text(job_url, "Last failure job")})'
                 report += '\n'
 
-        await self.slack_client.say(report, thread_ts=response['ts'])
+        await self.slack_client.say(report, thread_ts=response['ts'], unfurl_links=False)
 
     async def notify_forum_ocp_art(self):
         self.slack_client.bind_channel('#forum-ocp-art')
@@ -366,7 +366,9 @@ class ImagesHealthPipeline:
             image_message = f'`{image_name}` (build issues):'
             for concern in concerns:
                 image_message += f'\n• {self.get_message_for_forum(concern)}'
-            await self.slack_client.say(image_message, thread_ts=response['ts'], link_build_url=False)
+            await self.slack_client.say(
+                image_message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False
+            )
 
         # Rebase failures
         for image_name, failures in sorted(image_rebase_failures.items()):
@@ -382,7 +384,9 @@ class ImagesHealthPipeline:
                 )
                 if job_url:
                     image_message += f' ({self.url_text(job_url, "Last failure job")})'
-            await self.slack_client.say(image_message, thread_ts=response['ts'], link_build_url=False)
+            await self.slack_client.say(
+                image_message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False
+            )
 
     def get_message_for_release(self, concern: dict):
         """

--- a/pyartcd/pyartcd/slack.py
+++ b/pyartcd/pyartcd/slack.py
@@ -65,6 +65,7 @@ class SlackClient:
         reaction: Optional[str] = None,
         broadcast: bool = False,
         link_build_url: bool = True,
+        unfurl_links: bool = True,
     ):
         attachments = []
         if self.build_url and link_build_url:
@@ -86,6 +87,7 @@ class SlackClient:
             attachments=attachments,
             icon_emoji=self.icon_emoji,
             reply_broadcast=broadcast,
+            unfurl_links=unfurl_links,
         )
         # https://api.slack.com/methods/reactions.add
         if reaction:


### PR DESCRIPTION
## Summary
The images-health reports in Slack were becoming difficult to read because JIRA ticket links were being expanded with full preview cards. This change disables unfurling for those links while keeping them clickable.

## Changes
- Added `unfurl_links` parameter to `SlackClient.say()` method (defaults to `True` for backward compatibility)
- Set `unfurl_links=False` for threaded messages in `notify_release_channel()`
- Set `unfurl_links=False` for build concern and rebase failure messages in `notify_forum_ocp_art()`

## Test Plan
- [x] All existing tests pass
- [x] Linting passes
- [ ] Deploy to test environment and verify Slack messages are more readable

## Example
Before: JIRA links expanded with full ticket preview cards, making reports very long
After: JIRA links remain clickable but no longer expand, keeping reports compact

🤖 Generated with [Claude Code](https://claude.com/claude-code)