### PR TITLE
ART-18508: prevent inherited assembly bugs from sneaking into child advisories

### DIFF
--- a/artcommon/artcommonlib/assembly.py
+++ b/artcommon/artcommonlib/assembly.py
@@ -386,6 +386,42 @@ def assembly_issues_config(releases_config: Model, assembly: str) -> Model:
     return assembly_config_struct(releases_config, assembly, 'issues', {})
 
 
+def assembly_targeted_fixes_only(releases_config: Model, assembly: typing.Optional[str]) -> bool:
+    """
+    Returns True if the assembly's own issues config has targeted_fixes_only: true, without
+    traversing the inheritance chain. Use to detect targeted/emergency releases that should
+    skip automated bug sweeps, inheritance of parent issues, and blocker checks.
+
+    Arg(s):
+        releases_config (Model): The content of releases.yml in Model form.
+        assembly (str | None): The name of the assembly to assess.
+    Return Value(s):
+        bool: True if issues.targeted_fixes_only is set on the assembly's own node, False otherwise.
+    """
+    return bool(assembly_own_issues_config(releases_config, assembly).targeted_fixes_only)
+
+
+def assembly_own_issues_config(releases_config: Model, assembly: typing.Optional[str]) -> Model:
+    """
+    Returns the issues config defined ONLY in the given assembly's own node,
+    without traversing the inheritance chain. Use instead of assembly_issues_config()
+    to prevent parent assembly bugs from bleeding into child assembly advisories.
+
+    Arg(s):
+        releases_config (Model): The content of releases.yml in Model form.
+        assembly (str | None): The name of the assembly to assess.
+    Return Value(s):
+        Model: The issues config for the assembly's own node, or an empty Model if
+               not defined or inputs are invalid.
+    """
+    if not assembly or not isinstance(releases_config, Model):
+        return Model(dict_to_model={})
+    own_issues = releases_config.releases[assembly].assembly.issues
+    if own_issues is Missing:
+        return Model(dict_to_model={})
+    return own_issues
+
+
 def assembly_streams_config(releases_config: Model, assembly: typing.Optional[str], streams_config: Model) -> Model:
     """
     Returns a streams config based on the assembly information

--- a/artcommon/tests/test_assembly.py
+++ b/artcommon/tests/test_assembly.py
@@ -9,8 +9,10 @@ from artcommonlib.assembly import (
     assembly_excluded_components,
     assembly_group_config,
     assembly_metadata_config,
+    assembly_own_issues_config,
     assembly_resolved,
     assembly_rhcos_config,
+    assembly_targeted_fixes_only,
 )
 from artcommonlib.model import Missing, Model
 
@@ -757,3 +759,97 @@ releases:
             _merger({'r-': [1, 2]}, {'r': [3, 4]}),
             {},
         )
+
+
+class TestAssemblyOwnIssuesConfig(TestCase):
+    def setUp(self):
+        releases_yml = """
+releases:
+  parent_assembly:
+    assembly:
+      basis:
+        time: "2026-01-01T00:00:00+00:00"
+      issues:
+        include:
+          - id: OCPBUGS-100
+        exclude:
+          - id: OCPBUGS-200
+  child_assembly:
+    assembly:
+      basis:
+        assembly: parent_assembly
+      issues:
+        include:
+          - id: OCPBUGS-300
+        exclude:
+          - id: OCPBUGS-400
+  no_issues_assembly:
+    assembly:
+      basis:
+        time: "2026-01-01T00:00:00+00:00"
+"""
+        self.releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+
+    def test_own_issues_not_inherited(self):
+        """Child assembly must NOT inherit parent's issues.include or issues.exclude."""
+        config = assembly_own_issues_config(self.releases_config, "child_assembly")
+        include_ids = [i["id"] for i in config.include]
+        exclude_ids = [i["id"] for i in config.exclude]
+        self.assertIn("OCPBUGS-300", include_ids)
+        self.assertNotIn("OCPBUGS-100", include_ids)
+        self.assertIn("OCPBUGS-400", exclude_ids)
+        self.assertNotIn("OCPBUGS-200", exclude_ids)
+
+    def test_no_issues_key_returns_empty(self):
+        """Assembly with no issues key returns a Model with empty include/exclude."""
+        config = assembly_own_issues_config(self.releases_config, "no_issues_assembly")
+        self.assertEqual(list(config.include), [])
+        self.assertEqual(list(config.exclude), [])
+
+    def test_none_assembly_returns_empty(self):
+        config = assembly_own_issues_config(self.releases_config, None)
+        self.assertEqual(config.primitive(), {})
+
+    def test_none_releases_config_returns_empty(self):
+        config = assembly_own_issues_config(None, "child_assembly")
+        self.assertEqual(config.primitive(), {})
+
+
+class TestAssemblyTargetedFixesOnly(TestCase):
+    def setUp(self):
+        releases_yml = """
+releases:
+  targeted_assembly:
+    assembly:
+      basis:
+        time: "2026-01-01T00:00:00+00:00"
+      issues:
+        targeted_fixes_only: true
+        include:
+          - id: OCPBUGS-1
+  normal_assembly:
+    assembly:
+      basis:
+        time: "2026-01-01T00:00:00+00:00"
+  child_assembly:
+    assembly:
+      basis:
+        assembly: targeted_assembly
+"""
+        self.releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+
+    def test_targeted_assembly_returns_true(self):
+        self.assertTrue(assembly_targeted_fixes_only(self.releases_config, "targeted_assembly"))
+
+    def test_normal_assembly_returns_false(self):
+        self.assertFalse(assembly_targeted_fixes_only(self.releases_config, "normal_assembly"))
+
+    def test_not_inherited_from_parent(self):
+        # child_assembly inherits from targeted_assembly but does NOT have its own targeted_fixes_only flag
+        self.assertFalse(assembly_targeted_fixes_only(self.releases_config, "child_assembly"))
+
+    def test_none_assembly_returns_false(self):
+        self.assertFalse(assembly_targeted_fixes_only(self.releases_config, None))
+
+    def test_none_releases_config_returns_false(self):
+        self.assertFalse(assembly_targeted_fixes_only(None, "targeted_assembly"))

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -5,7 +5,12 @@ from typing import Dict, List, Optional, Set
 
 import click
 from artcommonlib import arch_util, logutil
-from artcommonlib.assembly import assembly_config_struct, assembly_issues_config
+from artcommonlib.assembly import (
+    assembly_config_struct,
+    assembly_issues_config,
+    assembly_own_issues_config,
+    assembly_targeted_fixes_only,
+)
 from artcommonlib.format_util import green_print
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import is_ocp_delivery_repo, new_roundtrip_yaml_handler
@@ -242,7 +247,22 @@ async def find_bugs_sweep_cli(
 
 
 async def get_bugs_sweep(runtime: Runtime, find_bugs_obj, bug_tracker):
-    bugs = find_bugs_obj.search(bug_tracker_obj=bug_tracker, verbose=runtime.debug)
+    releases_config = runtime.get_releases_config()
+    is_targeted = assembly_targeted_fixes_only(releases_config, runtime.assembly)
+    if is_targeted:
+        own_issues = assembly_own_issues_config(releases_config, runtime.assembly)
+        if not list(own_issues.include):
+            raise ValueError(
+                f"Assembly {runtime.assembly} has targeted_fixes_only=true but issues.include is empty. "
+                "A targeted release must explicitly list the bugs it ships."
+            )
+        logger.info(
+            "Skipping Jira sweep: assembly %s has targeted_fixes_only=true. Only explicitly included bugs will be attached.",
+            runtime.assembly,
+        )
+        bugs = []
+    else:
+        bugs = find_bugs_obj.search(bug_tracker_obj=bug_tracker, verbose=runtime.debug)
     if bugs:
         sweep_cutoff_timestamp = await get_sweep_cutoff_timestamp(runtime)
         if sweep_cutoff_timestamp:
@@ -277,7 +297,9 @@ async def get_bugs_sweep(runtime: Runtime, find_bugs_obj, bug_tracker):
         if find_bugs_obj.art_managed_trackers_only:
             bugs = filter_art_managed_jira_trackers(runtime, bugs, bug_tracker_type=bug_tracker.type)
 
-    included_bug_ids, excluded_bug_ids = get_assembly_bug_ids(runtime, bug_tracker_type=bug_tracker.type)
+    included_bug_ids, excluded_bug_ids = get_assembly_bug_ids(
+        runtime, bug_tracker_type=bug_tracker.type, use_own_only=is_targeted
+    )
     if included_bug_ids & excluded_bug_ids:
         raise ValueError(
             f"The following {bug_tracker.type} bugs are defined in both 'include' and 'exclude': "
@@ -413,9 +435,13 @@ def get_builds_by_advisory_kind(runtime: Runtime) -> Dict[str, List[str]]:
     return builds_by_kind
 
 
-def get_assembly_bug_ids(runtime, bug_tracker_type) -> tuple[Set[str], Set[str]]:
-    # Loads included/excluded bugs from assembly config
-    issues_config = assembly_issues_config(runtime.get_releases_config(), runtime.assembly)
+def get_assembly_bug_ids(runtime, bug_tracker_type, use_own_only: bool = False) -> tuple[Set[str], Set[str]]:
+    # For hotfix releases, use only the assembly's own issues (no inheritance).
+    # Otherwise use the merged inheritance chain so explicit includes/excludes work across releases.
+    if use_own_only:
+        issues_config = assembly_own_issues_config(runtime.get_releases_config(), runtime.assembly)
+    else:
+        issues_config = assembly_issues_config(runtime.get_releases_config(), runtime.assembly)
     included_bug_ids = {i["id"] for i in issues_config.include}
     excluded_bug_ids = {i["id"] for i in issues_config.exclude}
 

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -256,6 +256,11 @@ async def get_bugs_sweep(runtime: Runtime, find_bugs_obj, bug_tracker):
                 f"Assembly {runtime.assembly} has targeted_fixes_only=true but issues.include is empty. "
                 "A targeted release must explicitly list the bugs it ships."
             )
+        if list(own_issues.exclude):
+            raise ValueError(
+                f"Assembly {runtime.assembly} has targeted_fixes_only=true but issues.exclude is non-empty. "
+                "A targeted release must not use exclude; only include the bugs it ships."
+            )
         logger.info(
             "Skipping Jira sweep: assembly %s has targeted_fixes_only=true. Only explicitly included bugs will be attached.",
             runtime.assembly,
@@ -436,7 +441,7 @@ def get_builds_by_advisory_kind(runtime: Runtime) -> Dict[str, List[str]]:
 
 
 def get_assembly_bug_ids(runtime, bug_tracker_type, use_own_only: bool = False) -> tuple[Set[str], Set[str]]:
-    # For hotfix releases, use only the assembly's own issues (no inheritance).
+    # For targeted fix releases, use only the assembly's own issues (no inheritance).
     # Otherwise use the merged inheritance chain so explicit includes/excludes work across releases.
     if use_own_only:
         issues_config = assembly_own_issues_config(runtime.get_releases_config(), runtime.assembly)

--- a/elliott/tests/test_find_bugs_sweep_cli.py
+++ b/elliott/tests/test_find_bugs_sweep_cli.py
@@ -125,6 +125,43 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(actual, [])
 
+    @patch("elliottlib.cli.find_bugs_sweep_cli.assembly_own_issues_config")
+    @patch("elliottlib.cli.find_bugs_sweep_cli.assembly_targeted_fixes_only", return_value=True)
+    @patch("elliottlib.cli.find_bugs_sweep_cli.get_assembly_bug_ids")
+    async def test_get_bugs_sweep_targeted_fixes_only_skips_jira_search(
+        self, mock_get_bug_ids, mock_targeted_fixes_only, mock_own_issues
+    ):
+        """When targeted_fixes_only=true, Jira search must not run; only explicit includes are returned."""
+        included_bug = flexmock(id="OCPBUGS-84781")
+        mock_own_issues.return_value = flexmock(include=[{"id": "OCPBUGS-84781"}])
+        mock_get_bug_ids.return_value = ({"OCPBUGS-84781"}, set())
+
+        find_bugs_obj = sweep_cli.FindBugsSweep()
+        find_bugs_obj.search = Mock(return_value=[])
+        bug_tracker = MagicMock(type="jira")
+        bug_tracker.get_bugs = Mock(return_value=[included_bug])
+        runtime = MagicMock(debug=False)
+
+        actual = await sweep_cli.get_bugs_sweep(runtime, find_bugs_obj, bug_tracker)
+
+        find_bugs_obj.search.assert_not_called()
+        self.assertEqual([b.id for b in actual], ["OCPBUGS-84781"])
+
+    @patch("elliottlib.cli.find_bugs_sweep_cli.assembly_own_issues_config")
+    @patch("elliottlib.cli.find_bugs_sweep_cli.assembly_targeted_fixes_only", return_value=True)
+    @patch("elliottlib.cli.find_bugs_sweep_cli.get_assembly_bug_ids")
+    async def test_get_bugs_sweep_targeted_fixes_only_fails_without_include(
+        self, mock_get_bug_ids, mock_targeted_fixes_only, mock_own_issues
+    ):
+        """When targeted_fixes_only=true but issues.include is empty, raise ValueError."""
+        mock_own_issues.return_value = flexmock(include=[])
+        find_bugs_obj = sweep_cli.FindBugsSweep()
+        bug_tracker = MagicMock(type="jira")
+        runtime = MagicMock(debug=False)
+
+        with self.assertRaises(ValueError, msg="targeted_fixes_only=true but issues.include is empty"):
+            await sweep_cli.get_bugs_sweep(runtime, find_bugs_obj, bug_tracker)
+
     @patch("elliottlib.cli.find_bugs_sweep_cli.get_assembly_bug_ids", return_value=(set(), set()))
     @patch("elliottlib.cli.find_bugs_sweep_cli.get_sweep_cutoff_timestamp", new_callable=AsyncMock, return_value=0)
     async def test_get_bugs_sweep_opt_out_skips_art_managed_filter(self, *_):
@@ -158,6 +195,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         # common mocks
         flexmock(Runtime).should_receive("initialize").and_return(None)
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
+        flexmock(Runtime).should_receive("get_releases_config").and_return(MagicMock())
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
         flexmock(Runtime).should_receive("get_default_advisories").and_return({})
         flexmock(sweep_cli).should_receive("get_builds_by_advisory_kind")
@@ -186,6 +224,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         bugs = [flexmock(id='BZ1', status='ON_QA')]
         flexmock(Runtime).should_receive("initialize").and_return(None)
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
+        flexmock(Runtime).should_receive("get_releases_config").and_return(MagicMock())
 
         # jira mocks
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
@@ -225,6 +264,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         # common mocks
         flexmock(Runtime).should_receive("initialize")
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
+        flexmock(Runtime).should_receive("get_releases_config").and_return(MagicMock())
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
         flexmock(Runtime).should_receive("get_default_advisories").and_return({})
         flexmock(sweep_cli).should_receive("get_builds_by_advisory_kind").and_return({})
@@ -257,6 +297,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         # common mocks
         flexmock(Runtime).should_receive("initialize")
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
+        flexmock(Runtime).should_receive("get_releases_config").and_return(MagicMock())
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
         flexmock(Runtime).should_receive("get_default_advisories").and_return({'image': 123})
         flexmock(sweep_cli).should_receive("get_builds_by_advisory_kind")
@@ -300,6 +341,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         # common mocks
         flexmock(Runtime).should_receive("initialize").and_return(None)
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
+        flexmock(Runtime).should_receive("get_releases_config").and_return(MagicMock())
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
         flexmock(sweep_cli).should_receive("get_builds_by_advisory_kind")
         flexmock(sweep_cli).should_receive("categorize_bugs_by_type").and_return(
@@ -663,22 +705,32 @@ class TestGenAssemblyBugIDs(unittest.TestCase):
     @patch("elliottlib.cli.find_bugs_sweep_cli.assembly_issues_config")
     def test_gen_assembly_bug_ids_jira(self, assembly_issues_config: Mock):
         assembly_issues_config.return_value = flexmock(
-            include=[{"id": 1}, {"id": 'OCPBUGS-2'}], exclude=[{"id": "2"}, {"id": 'OCPBUGS-3'}]
+            include=[{"id": 1}, {"id": "OCPBUGS-2"}], exclude=[{"id": "2"}, {"id": "OCPBUGS-3"}]
         )
-        runtime = flexmock(get_releases_config=lambda: None, assembly='foo')
+        runtime = flexmock(get_releases_config=lambda: None, assembly="foo")
         expected = ({"OCPBUGS-2"}, {"OCPBUGS-3"})
-        actual = get_assembly_bug_ids(runtime, 'jira')
+        actual = get_assembly_bug_ids(runtime, "jira")
         self.assertEqual(actual, expected)
 
     @patch("elliottlib.cli.find_bugs_sweep_cli.assembly_issues_config")
     def test_gen_assembly_bug_ids_bz(self, assembly_issues_config: Mock):
         assembly_issues_config.return_value = flexmock(
-            include=[{"id": 1}, {"id": 'OCPBUGS-2'}], exclude=[{"id": "2"}, {"id": 'OCPBUGS-3'}]
+            include=[{"id": 1}, {"id": "OCPBUGS-2"}], exclude=[{"id": "2"}, {"id": "OCPBUGS-3"}]
         )
-        runtime = flexmock(get_releases_config=lambda: None, assembly='foo')
+        runtime = flexmock(get_releases_config=lambda: None, assembly="foo")
         expected = ({1}, {"2"})
-        actual = get_assembly_bug_ids(runtime, 'bugzilla')
+        actual = get_assembly_bug_ids(runtime, "bugzilla")
         self.assertEqual(actual, expected)
+
+    @patch("elliottlib.cli.find_bugs_sweep_cli.assembly_own_issues_config")
+    def test_gen_assembly_bug_ids_use_own_only(self, assembly_own_issues_config: Mock):
+        """When use_own_only=True, get_assembly_bug_ids uses assembly_own_issues_config (no inheritance)."""
+        assembly_own_issues_config.return_value = flexmock(include=[{"id": "OCPBUGS-99999"}], exclude=[])
+        runtime = flexmock(get_releases_config=lambda: None, assembly="child_assembly")
+        included, excluded = get_assembly_bug_ids(runtime, "jira", use_own_only=True)
+        self.assertEqual(included, {"OCPBUGS-99999"})
+        self.assertEqual(excluded, set())
+        assembly_own_issues_config.assert_called_once()
 
 
 class TestExtrasBugs(unittest.TestCase):

--- a/elliott/tests/test_find_bugs_sweep_cli.py
+++ b/elliott/tests/test_find_bugs_sweep_cli.py
@@ -133,7 +133,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
     ):
         """When targeted_fixes_only=true, Jira search must not run; only explicit includes are returned."""
         included_bug = flexmock(id="OCPBUGS-84781")
-        mock_own_issues.return_value = flexmock(include=[{"id": "OCPBUGS-84781"}])
+        mock_own_issues.return_value = flexmock(include=[{"id": "OCPBUGS-84781"}], exclude=[])
         mock_get_bug_ids.return_value = ({"OCPBUGS-84781"}, set())
 
         find_bugs_obj = sweep_cli.FindBugsSweep()
@@ -145,6 +145,8 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         actual = await sweep_cli.get_bugs_sweep(runtime, find_bugs_obj, bug_tracker)
 
         find_bugs_obj.search.assert_not_called()
+        mock_own_issues.assert_called_once_with(runtime.get_releases_config(), runtime.assembly)
+        mock_get_bug_ids.assert_called_once_with(runtime, bug_tracker_type="jira", use_own_only=True)
         self.assertEqual([b.id for b in actual], ["OCPBUGS-84781"])
 
     @patch("elliottlib.cli.find_bugs_sweep_cli.assembly_own_issues_config")
@@ -154,12 +156,27 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         self, mock_get_bug_ids, mock_targeted_fixes_only, mock_own_issues
     ):
         """When targeted_fixes_only=true but issues.include is empty, raise ValueError."""
-        mock_own_issues.return_value = flexmock(include=[])
+        mock_own_issues.return_value = flexmock(include=[], exclude=[])
         find_bugs_obj = sweep_cli.FindBugsSweep()
         bug_tracker = MagicMock(type="jira")
         runtime = MagicMock(debug=False)
 
         with self.assertRaises(ValueError, msg="targeted_fixes_only=true but issues.include is empty"):
+            await sweep_cli.get_bugs_sweep(runtime, find_bugs_obj, bug_tracker)
+
+    @patch("elliottlib.cli.find_bugs_sweep_cli.assembly_own_issues_config")
+    @patch("elliottlib.cli.find_bugs_sweep_cli.assembly_targeted_fixes_only", return_value=True)
+    @patch("elliottlib.cli.find_bugs_sweep_cli.get_assembly_bug_ids")
+    async def test_get_bugs_sweep_targeted_fixes_only_fails_with_exclude(
+        self, mock_get_bug_ids, mock_targeted_fixes_only, mock_own_issues
+    ):
+        """When targeted_fixes_only=true but issues.exclude is non-empty, raise ValueError."""
+        mock_own_issues.return_value = flexmock(include=[{"id": "OCPBUGS-1"}], exclude=[{"id": "OCPBUGS-2"}])
+        find_bugs_obj = sweep_cli.FindBugsSweep()
+        bug_tracker = MagicMock(type="jira")
+        runtime = MagicMock(debug=False)
+
+        with self.assertRaises(ValueError, msg="targeted_fixes_only=true but issues.exclude is non-empty"):
             await sweep_cli.get_bugs_sweep(runtime, find_bugs_obj, bug_tracker)
 
     @patch("elliottlib.cli.find_bugs_sweep_cli.get_assembly_bug_ids", return_value=(set(), set()))

--- a/ocp-build-data-validator/validator/json_schemas/assembly_issues.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_issues.schema.json
@@ -52,14 +52,26 @@
       "description": "When true, skips the Jira bug sweep, uses only own issues.include/exclude without inheritance, and skips the blocker bug check. Use for targeted/emergency releases. Requires issues.include to be non-empty.",
       "type": "boolean"
     },
-    "targeted_fixes_only!": {
-      "$ref": "#/properties/targeted_fixes_only"
-    },
-    "targeted_fixes_only?": {
-      "$ref": "#/properties/targeted_fixes_only"
-    },
-    "targeted_fixes_only-": {},
     "additionalProperties": false
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "targeted_fixes_only": {"const": true}
+        },
+        "required": ["targeted_fixes_only"]
+      },
+      "then": {
+        "required": ["include"],
+        "properties": {
+          "include": {
+            "type": "array",
+            "minItems": 1
+          }
+        }
+      }
+    }
+  ],
   "additionalProperties": false
 }

--- a/ocp-build-data-validator/validator/json_schemas/assembly_issues.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_issues.schema.json
@@ -48,6 +48,17 @@
       "$ref": "#/properties/exclude"
     },
     "exclude-": {},
+    "targeted_fixes_only": {
+      "description": "When true, skips the Jira bug sweep, uses only own issues.include/exclude without inheritance, and skips the blocker bug check. Use for targeted/emergency releases. Requires issues.include to be non-empty.",
+      "type": "boolean"
+    },
+    "targeted_fixes_only!": {
+      "$ref": "#/properties/targeted_fixes_only"
+    },
+    "targeted_fixes_only?": {
+      "$ref": "#/properties/targeted_fixes_only"
+    },
+    "targeted_fixes_only-": {},
     "additionalProperties": false
   },
   "additionalProperties": false


### PR DESCRIPTION
## Summary

- Add `assembly_own_issues_config()` to `artcommonlib/assembly.py` — reads only the assembly's own `issues` node without inheritance traversal.
- Add `assembly_targeted_fixes_only()` to `artcommonlib/assembly.py` — reads `issues.targeted_fixes_only` from the assembly's own issues node (no inheritance).
- Add `issues.targeted_fixes_only: true` field (under the `issues` block). When set:
  - Skips the Jira bug sweep entirely
  - Uses only own `issues.include`/`issues.exclude` without inheritance
  - Skips the blocker bug check (handled in [ART-18509](https://redhat.atlassian.net/browse/ART-18509) / #2918)
  - Fails with an error if `issues.include` is empty
- Add `targeted_fixes_only` to `assembly_issues.schema.json` in `ocp-build-data-validator`.

Assemblies without `targeted_fixes_only` retain existing merged-inheritance behavior for `issues.include`/`issues.exclude`.

## Root Cause

Two sources of "extra bugs" in inherited emergency assemblies:

1. **Inherited includes**: `assembly_issues_config()` merges the full basis-chain, so bugs explicitly listed in a parent's `issues.include` (e.g. 4.18.40) bled into child assembly advisories (e.g. 4.18.41).
2. **Jira sweep**: `find-bugs` searches all VERIFIED bugs. For a targeted assembly sharing the same basis event as its parent, unrelated verified bugs (e.g. microshift bugs) were swept in alongside the intended CVE fix.

## Usage

For targeted/emergency releases that should ship only specific bugs:

```yaml
4.18.41:
  assembly:
    basis:
      assembly: 4.18.40
    issues:
      targeted_fixes_only: true
      include:
        - id: OCPBUGS-85292
```

## Test Plan

- [ ] `uv run pytest artcommon/tests/test_assembly.py::TestAssemblyTargetedFixesOnly -v` — 5 tests for new helper
- [ ] `uv run pytest artcommon/tests/test_assembly.py::TestAssemblyOwnIssuesConfig -v` — 4 tests for own issues
- [ ] `uv run pytest elliott/tests/test_find_bugs_sweep_cli.py -v` — includes targeted sweep + empty-include error tests
- [ ] `uv run pytest artcommon/tests/ elliott/tests/ ocp-build-data-validator/tests/ -q` — all passing

Jira: https://issues.redhat.com/browse/ART-18508