### PR TITLE
ART-18909: Add generic fail counter functions and build failure tracking

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -39,8 +39,10 @@ from pyartcd.util import (
     build_history_link_url,
     get_group_images,
     get_group_rpms,
+    increment_build_fail_counter,
     increment_rebase_fail_counter,
     mass_rebuild_score,
+    reset_build_fail_counter,
     reset_rebase_fail_counter,
 )
 
@@ -230,6 +232,37 @@ class KonfluxOcpPipeline:
             *[increment_rebase_fail_counter(image, self.version, 'konflux', job_url=job_url) for image in failed_images]
         )
 
+    async def update_build_fail_counters(self, built_images, failed_images, record_log):
+        """
+        Update Redis build-failure counters after Konflux build run.
+
+        - Successfully built images: reset counter
+        - Failed builds: increment counter and store metadata
+        """
+        if self.assembly != 'stream':
+            return
+
+        group = f'openshift-{self.version}'
+        job_url = os.getenv('BUILD_URL')
+
+        # Build a lookup of failed entries for NVR metadata
+        failed_entries = {
+            entry['name']: entry for entry in record_log.get('image_build_konflux', []) if int(entry['status'])
+        }
+
+        await asyncio.gather(*[reset_build_fail_counter(image, group) for image in built_images])
+        await asyncio.gather(
+            *[
+                increment_build_fail_counter(
+                    image,
+                    group,
+                    url=job_url,
+                    nvr=failed_entries.get(image, {}).get('nvrs'),
+                )
+                for image in failed_images
+            ]
+        )
+
     def building_images(self):
         """
         Returns True if images are being built, False otherwise.
@@ -397,6 +430,8 @@ class KonfluxOcpPipeline:
             jenkins.update_description(f'Failed images: {", ".join(failed_images)}<br/>')
         elif len(failed_images) > 10:
             jenkins.update_description(f'{len(failed_images)} images failed. Check record.log for details<br/>')
+
+        await self.update_build_fail_counters(built_images, failed_images, record_log)
 
         if not built_images:
             # Nothing to do, skipping build-sync

--- a/pyartcd/pyartcd/pipelines/okd.py
+++ b/pyartcd/pyartcd/pipelines/okd.py
@@ -24,7 +24,9 @@ from pyartcd.util import (
     build_history_link_url,
     default_release_suffix,
     get_group_images,
+    increment_build_fail_counter,
     increment_rebase_fail_counter,
+    reset_build_fail_counter,
     reset_rebase_fail_counter,
 )
 
@@ -396,9 +398,9 @@ class KonfluxOkdPipeline:
             pass
 
         finally:
-            self.handle_built_images()
+            await self.handle_built_images()
 
-    def handle_built_images(self):
+    async def handle_built_images(self):
         record_log = self.parse_record_log()
         if not record_log:
             self.logger.error('record.log not found!')
@@ -429,6 +431,42 @@ class KonfluxOkdPipeline:
                 jenkins.update_description(f'Build failures: {", ".join(failed_images)}<br>')
             else:
                 jenkins.update_description(f'Build failures: {len(failed_images)} images<br>')
+
+        await self.update_build_fail_counters(
+            [img['name'] for img in self.built_images],
+            failed_images,
+            record_log,
+        )
+
+    async def update_build_fail_counters(self, built_images, failed_images, record_log):
+        """
+        Update Redis build-failure counters after OKD build run.
+
+        - Successfully built images: reset counter
+        - Failed builds: increment counter and store metadata
+        """
+        if self.assembly != 'stream':
+            return
+
+        group = f'okd-{self.version}'
+        job_url = os.getenv('BUILD_URL')
+
+        failed_entries = {
+            entry['name']: entry for entry in record_log.get('image_build_okd', []) if int(entry['status'])
+        }
+
+        await asyncio.gather(*[reset_build_fail_counter(image, group) for image in built_images])
+        await asyncio.gather(
+            *[
+                increment_build_fail_counter(
+                    image,
+                    group,
+                    url=job_url,
+                    nvr=failed_entries.get(image, {}).get('nvrs'),
+                )
+                for image in failed_images
+            ]
+        )
 
     async def detect_embargoed_builds(self):
         """

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -1008,45 +1008,72 @@ async def get_group_rpms(
     return out.splitlines()
 
 
+async def increment_fail_counter(branch: str, **kwargs):
+    """
+    Generic Redis failure counter increment with optional metadata fields.
+
+    Always increments a 'failure' field at {branch}:failure.
+    Additional kwargs are stored as {branch}:{key} if value is not None.
+
+    Arg(s):
+        branch (str): Full Redis key prefix (e.g., 'count:build-failure:konflux:openshift-4.17:ironic')
+        **kwargs: Optional metadata fields (url, nvr, etc.)
+
+    Example:
+        await increment_fail_counter('count:build:4.17:ironic', url='http://...', nvr='ironic-1.0')
+    """
+    failure_key = f'{branch}:failure'
+    fail_count = await redis.get_value(failure_key)
+    fail_count = int(fail_count) if fail_count else 0
+    await redis.set_value(key=failure_key, value=fail_count + 1)
+
+    for key, value in kwargs.items():
+        if value is not None:
+            await redis.set_value(key=f'{branch}:{key}', value=value)
+
+
+@limit_concurrency(50)
+async def reset_fail_counter(branch: str):
+    """
+    Remove all keys under a Redis branch pattern.
+    Limit concurrency as we might reset many counters in parallel.
+
+    Arg(s):
+        branch (str): Full Redis key prefix
+    """
+    await redis.delete_keys_by_pattern(f'{branch}:*')
+
+
 async def increment_rebase_fail_counter(image, version, build_system, branch='rebase-failure', job_url=None):
     """
-    Increment the fail counter for a given image in Redis.
+    Increment the rebase fail counter for a given image in Redis.
     Optionally store the job URL where the failure occurred.
 
     Arg(s):
         image (str): Image name
         version (str): OCP version (e.g., '4.17')
         build_system (str): Build system ('brew', 'konflux')
-        branch (str): Branch identifier for the counter (default: 'rebase-failure')
+        branch (str): Branch identifier (default: 'rebase-failure')
         job_url (str): Optional job URL where the failure occurred
     """
-
     redis_branch = f'count:{branch}:{build_system}:{version}:{image}'
-    failure_key = f'{redis_branch}:failure'
-    fail_count = await redis.get_value(failure_key)
-    fail_count = int(fail_count) if fail_count else 0
-    await redis.set_value(key=failure_key, value=fail_count + 1)
-
-    # Store the job URL if provided
-    if job_url:
-        await redis.set_value(key=f'{redis_branch}:url', value=job_url)
+    await increment_fail_counter(redis_branch, url=job_url)
 
 
 @limit_concurrency(50)
 async def reset_rebase_fail_counter(image, version, build_system, branch='rebase-failure'):
     """
-    Reset the fail counter for a given image in Redis.
+    Reset the rebase fail counter for a given image in Redis.
     Limit concurrency as we might have a lot of images to reset.
 
     Arg(s):
         image (str): Image name
         version (str): OCP version (e.g., '4.17')
         build_system (str): Build system ('brew', 'konflux')
-        branch (str): Branch identifier for the counter (default: 'rebase-failure')
+        branch (str): Branch identifier (default: 'rebase-failure')
     """
-
-    redis_branch = f'count:{branch}:{build_system}:{version}:{image}:*'
-    await redis.delete_keys_by_pattern(redis_branch)
+    redis_branch = f'count:{branch}:{build_system}:{version}:{image}'
+    await reset_fail_counter(redis_branch)
 
 
 async def get_rebase_failures(version: str, branches: list[str], build_systems: list[str], logger=None):
@@ -1123,5 +1150,92 @@ async def get_rebase_failures(version: str, branches: list[str], build_systems: 
     except Exception as e:
         if logger:
             logger.warning('Failed to fetch rebase failures from Redis for version %s: %s', version, e)
+
+    return failures
+
+
+async def increment_build_fail_counter(image, group, build_system='konflux', **kwargs):
+    """
+    Increment the build fail counter for a given image in Redis.
+    Optionally store metadata like job URL and NVR of the failed build.
+
+    Key format: count:build-failure:{build_system}:{group}:{image}:{field}
+    Consistent with the rebase failure key pattern.
+
+    Arg(s):
+        image (str): Image name (distgit key)
+        group (str): Group name (e.g., 'openshift-4.17', 'okd-4.21')
+        build_system (str): Build system (default: 'konflux')
+        **kwargs: Optional metadata (url, nvr, etc.)
+    """
+    redis_branch = f'count:build-failure:{build_system}:{group}:{image}'
+    await increment_fail_counter(redis_branch, **kwargs)
+
+
+@limit_concurrency(50)
+async def reset_build_fail_counter(image, group, build_system='konflux'):
+    """
+    Reset the build fail counter for a given image in Redis.
+    Limit concurrency as we might have a lot of images to reset.
+
+    Arg(s):
+        image (str): Image name (distgit key)
+        group (str): Group name (e.g., 'openshift-4.17', 'okd-4.21')
+        build_system (str): Build system (default: 'konflux')
+    """
+    redis_branch = f'count:build-failure:{build_system}:{group}:{image}'
+    await reset_fail_counter(redis_branch)
+
+
+async def get_build_failures(group: str, build_system: str = 'konflux', logger=None):
+    """
+    Fetch build failure data from Redis for a specific group.
+
+    Arg(s):
+        group (str): Group name (e.g., 'openshift-4.18', 'okd-4.21')
+        build_system (str): Build system (default: 'konflux')
+        logger (Logger): Optional logger for debugging
+    Return Value(s):
+        dict: {image_name: {failure_count, url, nvr}}
+    """
+    failures = {}
+
+    try:
+        pattern = f'count:build-failure:{build_system}:{group}:*:failure'
+        failure_keys = await redis.get_keys(pattern)
+
+        if not failure_keys:
+            if logger:
+                logger.info('No %s build failures found for group %s', build_system, group)
+            return failures
+
+        if logger:
+            logger.info('Found %d %s build failure keys for group %s', len(failure_keys), build_system, group)
+
+        # Key format: count:build-failure:{build_system}:{group}:{image}:failure
+        for failure_key in failure_keys:
+            parts = failure_key.split(':')
+            if len(parts) >= 6:
+                image_name = parts[4]
+                base_key = f'count:build-failure:{build_system}:{group}:{image_name}'
+
+                failure_count = await redis.get_value(failure_key)
+                job_url = await redis.get_value(f'{base_key}:url')
+                nvr = await redis.get_value(f'{base_key}:nvr')
+
+                failures[image_name] = {
+                    'failure_count': int(failure_count) if failure_count else 0,
+                    'url': job_url or '',
+                    'nvr': nvr or '',
+                }
+
+        if logger and failures:
+            import json
+
+            logger.info('Build failures for group %s: %s', group, json.dumps(failures, indent=2))
+
+    except Exception as e:
+        if logger:
+            logger.warning('Failed to fetch build failures from Redis for group %s: %s', group, e)
 
     return failures

--- a/pyartcd/tests/test_util.py
+++ b/pyartcd/tests/test_util.py
@@ -1,5 +1,5 @@
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from pyartcd import util
 
@@ -223,3 +223,78 @@ class TestUtil(IsolatedAsyncioTestCase):
         self.assertEqual(util.get_rpm_if_pinned_directly(releases_config, '4.11.0', 'foo'), rpms)
         self.assertEqual(util.get_rpm_if_pinned_directly(releases_config, '4.11.1', 'foo'), dict())
         self.assertEqual(util.get_rpm_if_pinned_directly(releases_config, '4.11.0', 'bar'), dict())
+
+    @patch("artcommonlib.redis.set_value", new_callable=AsyncMock)
+    @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
+    async def test_increment_fail_counter_new(self, mock_get, mock_set):
+        mock_get.return_value = None
+        await util.increment_fail_counter('count:test:branch', url='http://j/1', nvr='test-1.0-1')
+        mock_set.assert_any_call(key='count:test:branch:failure', value=1)
+        mock_set.assert_any_call(key='count:test:branch:url', value='http://j/1')
+        mock_set.assert_any_call(key='count:test:branch:nvr', value='test-1.0-1')
+
+    @patch("artcommonlib.redis.set_value", new_callable=AsyncMock)
+    @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
+    async def test_increment_fail_counter_existing(self, mock_get, mock_set):
+        mock_get.return_value = '5'
+        await util.increment_fail_counter('count:test:branch')
+        mock_set.assert_any_call(key='count:test:branch:failure', value=6)
+
+    @patch("artcommonlib.redis.delete_keys_by_pattern", new_callable=AsyncMock)
+    async def test_reset_fail_counter(self, mock_delete):
+        await util.reset_fail_counter('count:test:branch')
+        mock_delete.assert_called_once_with('count:test:branch:*')
+
+    @patch("artcommonlib.redis.set_value", new_callable=AsyncMock)
+    @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
+    async def test_increment_build_fail_counter_new(self, mock_get, mock_set):
+        mock_get.return_value = None
+        await util.increment_build_fail_counter('ironic', 'openshift-4.21', url='http://j/1', nvr='ironic-1.0-1')
+        mock_set.assert_any_call(key='count:build-failure:konflux:openshift-4.21:ironic:failure', value=1)
+        mock_set.assert_any_call(key='count:build-failure:konflux:openshift-4.21:ironic:url', value='http://j/1')
+        mock_set.assert_any_call(key='count:build-failure:konflux:openshift-4.21:ironic:nvr', value='ironic-1.0-1')
+
+    @patch("artcommonlib.redis.set_value", new_callable=AsyncMock)
+    @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
+    async def test_increment_build_fail_counter_existing(self, mock_get, mock_set):
+        mock_get.return_value = '3'
+        await util.increment_build_fail_counter('ironic', 'openshift-4.21')
+        mock_set.assert_any_call(key='count:build-failure:konflux:openshift-4.21:ironic:failure', value=4)
+
+    @patch("artcommonlib.redis.delete_keys_by_pattern", new_callable=AsyncMock)
+    async def test_reset_build_fail_counter(self, mock_delete):
+        await util.reset_build_fail_counter('ironic', 'openshift-4.21')
+        mock_delete.assert_called_once_with('count:build-failure:konflux:openshift-4.21:ironic:*')
+
+    @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
+    @patch("artcommonlib.redis.get_keys", new_callable=AsyncMock)
+    async def test_get_build_failures(self, mock_get_keys, mock_get_value):
+        mock_get_keys.return_value = [
+            'count:build-failure:konflux:openshift-4.21:ironic:failure',
+            'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:failure',
+        ]
+        mock_get_value.side_effect = lambda key: {
+            'count:build-failure:konflux:openshift-4.21:ironic:failure': '5',
+            'count:build-failure:konflux:openshift-4.21:ironic:url': 'http://j/1',
+            'count:build-failure:konflux:openshift-4.21:ironic:nvr': 'ironic-1.0-1',
+            'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:failure': '2',
+            'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:url': '',
+            'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:nvr': None,
+        }.get(key)
+        result = await util.get_build_failures('openshift-4.21')
+        self.assertEqual(result['ironic']['failure_count'], 5)
+        self.assertEqual(result['ironic']['url'], 'http://j/1')
+        self.assertEqual(result['ironic']['nvr'], 'ironic-1.0-1')
+        self.assertEqual(result['ovn-kubernetes']['failure_count'], 2)
+
+    @patch("artcommonlib.redis.get_keys", new_callable=AsyncMock)
+    async def test_get_build_failures_empty(self, mock_get_keys):
+        mock_get_keys.return_value = []
+        result = await util.get_build_failures('openshift-4.21')
+        self.assertEqual(result, {})
+
+    @patch("artcommonlib.redis.get_keys", new_callable=AsyncMock)
+    async def test_get_build_failures_redis_error(self, mock_get_keys):
+        mock_get_keys.side_effect = Exception("Redis connection refused")
+        result = await util.get_build_failures('openshift-4.21', logger=MagicMock())
+        self.assertEqual(result, {})


### PR DESCRIPTION
## Summary
This PR implements generic Redis counter functions to eliminate code duplication and adds build failure tracking to Konflux pipelines. This supersedes/complements PR #2782 by providing a cleaner, more reusable implementation.

## Changes

### Generic Counter Functions (`pyartcd/util.py`)
- **`increment_fail_counter(branch, **kwargs)`**: Generic function to increment a failure counter and store optional metadata
- **`reset_fail_counter(branch)`**: Generic function to reset all keys under a branch

### Refactored Existing Code
- Updated `increment_rebase_fail_counter()` to use `increment_fail_counter()`
- Updated `reset_rebase_fail_counter()` to use `reset_fail_counter()`
- No behavior changes for existing rebase failure tracking

### Build Failure Tracking (from PR #2782)
- **`increment_build_fail_counter(image, group, **kwargs)`**: Track build failures per image/group
- **`reset_build_fail_counter(image, group)`**: Reset build failure counters
- **`get_build_failures(group)`**: Retrieve build failures from Redis

### Pipeline Integration
- **OCP4 Konflux** (`ocp4_konflux.py`): Added `update_build_fail_counters()` method, called from `sync_images()`
- **OKD** (`okd.py`): Added `update_build_fail_counters()` method, called from `handle_built_images()`

### Tests
- Comprehensive unit tests for generic counter functions
- Tests for build failure tracking functions
- All 2195 existing tests still pass

## Key Design Decisions

**Why keep `:failure` instead of `:count`?**
- Maintains backwards compatibility with existing rebase failure data in Redis
- Avoids migration complexity
- Consistent field naming across all failure types

**Why generic functions?**
- Eliminates code duplication between rebase and build failures
- Makes it easy to add new counter types in the future (e.g., build-sync, build-sync-multi)
- Cleaner API with **kwargs for metadata

## Test Plan
- [x] All existing tests pass (2195 tests)
- [x] New unit tests for generic functions
- [x] New unit tests for build failure functions
- [x] Linting and formatting pass
- [ ] Deploy to test environment and verify Redis counters work correctly

## Related
- Addresses feedback from https://github.com/openshift-eng/art-tools/pull/2782
- Implements the generic counter pattern suggested in code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)