### PR TITLE
Improve _fix_failed_imagestream_imports

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1992,8 +1992,8 @@ class PromotePipeline:
                 await asyncio.gather(*import_tasks, return_exceptions=True)
                 self._logger.info("Waiting 60 seconds for imports to complete...")
                 await asyncio.sleep(60)
-        self._logger.warning(
-            f"Some imports in image stream {namespace}/{image_stream_name} may still be failing after {max_attempts} attempts."
+        raise RuntimeError(
+            f"Image stream {namespace}/{image_stream_name} still has failed imports after {max_attempts} attempts. "
         )
 
     async def get_image_info(self, pullspec: str, raise_if_not_found: bool = False):

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1966,9 +1966,10 @@ class PromotePipeline:
 
     async def _fix_failed_imagestream_imports(self, namespace: str, image_stream_name: str, max_attempts: int = 3):
         """Find tags with failed ImportSuccess conditions and trigger re-imports, retrying up to max_attempts times."""
-        for attempt in range(max_attempts):
+
+        async def get_failed_tags() -> List[str]:
             imagestream = await self.get_image_stream(namespace, image_stream_name)
-            failed_tags = [
+            return [
                 tag_status["tag"]
                 for tag_status in imagestream.get("status", {}).get("tags", [])
                 if any(
@@ -1976,6 +1977,9 @@ class PromotePipeline:
                     for cond in tag_status.get("conditions", [])
                 )
             ]
+
+        for attempt in range(max_attempts):
+            failed_tags = await get_failed_tags()
             if not failed_tags:
                 if attempt > 0:
                     self._logger.info(f"All imports in image stream {namespace}/{image_stream_name} succeeded.")
@@ -1985,16 +1989,20 @@ class PromotePipeline:
                 f"{', '.join(failed_tags)}. Triggering re-import (attempt {attempt + 1}/{max_attempts})..."
             )
             if not self.runtime.dry_run:
-                import_tasks = [
-                    exectools.cmd_gather_async(["oc", "-n", namespace, "import-image", f"is/{image_stream_name}:{tag}"])
-                    for tag in failed_tags
-                ]
-                await asyncio.gather(*import_tasks, return_exceptions=True)
+                for tag in failed_tags:
+                    await exectools.cmd_gather_async(
+                        ["oc", "-n", namespace, "import-image", f"is/{image_stream_name}:{tag}"],
+                        check=False,
+                    )
                 self._logger.info("Waiting 60 seconds for imports to complete...")
                 await asyncio.sleep(60)
-        raise RuntimeError(
-            f"Image stream {namespace}/{image_stream_name} still has failed imports after {max_attempts} attempts. "
-        )
+        still_failed = await get_failed_tags()
+        if still_failed:
+            raise RuntimeError(
+                f"Image stream {namespace}/{image_stream_name} still has {len(still_failed)} tag(s) with failed imports "
+                f"after {max_attempts} attempts: {', '.join(still_failed)}"
+            )
+        self._logger.info(f"All imports in image stream {namespace}/{image_stream_name} succeeded.")
 
     async def get_image_info(self, pullspec: str, raise_if_not_found: bool = False):
         try:

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1597,6 +1597,7 @@ class PromotePipeline:
             imagestream = await self.get_image_stream(f"ocp{go_arch_suffix}", is_name)
             if not imagestream:
                 raise ValueError(f"Image stream {is_name} is not found. Did you run build-sync?")
+            await self._fix_failed_imagestream_imports(f"ocp{go_arch_suffix}", is_name)
             self._logger.info(
                 "Building arch-specific release image %s for %s (%s)...", release_name, arch, dest_image_pullspec
             )
@@ -1962,6 +1963,48 @@ class PromotePipeline:
         if not stdout:  # Not found
             return None
         return json.loads(stdout)
+
+    async def _fix_failed_imagestream_imports(self, namespace: str, image_stream_name: str, max_attempts: int = 3):
+        """Find tags with failed ImportSuccess conditions and trigger re-imports, retrying up to max_attempts times."""
+        for attempt in range(max_attempts):
+            imagestream = await self.get_image_stream(namespace, image_stream_name)
+            if not imagestream:
+                return
+            failed_tags = [
+                tag_status["tag"]
+                for tag_status in imagestream.get("status", {}).get("tags", [])
+                if any(
+                    cond.get("type") == "ImportSuccess" and cond.get("status") == "False"
+                    for cond in tag_status.get("conditions", [])
+                )
+            ]
+            if not failed_tags:
+                if attempt > 0:
+                    self._logger.info("All imports in image stream %s/%s succeeded.", namespace, image_stream_name)
+                return
+            self._logger.warning(
+                "Image stream %s/%s has %d tag(s) with failed imports: %s. Triggering re-import (attempt %d/%d)...",
+                namespace,
+                image_stream_name,
+                len(failed_tags),
+                ", ".join(failed_tags),
+                attempt + 1,
+                max_attempts,
+            )
+            if not self.runtime.dry_run:
+                import_tasks = [
+                    exectools.cmd_gather_async(["oc", "-n", namespace, "import-image", f"is/{image_stream_name}:{tag}"])
+                    for tag in failed_tags
+                ]
+                await asyncio.gather(*import_tasks, return_exceptions=True)
+            self._logger.info("Waiting 60 seconds for imports to complete...")
+            await asyncio.sleep(60)
+        self._logger.warning(
+            "Some imports in image stream %s/%s may still be failing after %d attempts.",
+            namespace,
+            image_stream_name,
+            max_attempts,
+        )
 
     async def get_image_info(self, pullspec: str, raise_if_not_found: bool = False):
         try:

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1997,8 +1997,8 @@ class PromotePipeline:
                     for tag in failed_tags
                 ]
                 await asyncio.gather(*import_tasks, return_exceptions=True)
-            self._logger.info("Waiting 60 seconds for imports to complete...")
-            await asyncio.sleep(60)
+                self._logger.info("Waiting 60 seconds for imports to complete...")
+                await asyncio.sleep(60)
         self._logger.warning(
             "Some imports in image stream %s/%s may still be failing after %d attempts.",
             namespace,

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1968,8 +1968,6 @@ class PromotePipeline:
         """Find tags with failed ImportSuccess conditions and trigger re-imports, retrying up to max_attempts times."""
         for attempt in range(max_attempts):
             imagestream = await self.get_image_stream(namespace, image_stream_name)
-            if not imagestream:
-                return
             failed_tags = [
                 tag_status["tag"]
                 for tag_status in imagestream.get("status", {}).get("tags", [])
@@ -1980,16 +1978,11 @@ class PromotePipeline:
             ]
             if not failed_tags:
                 if attempt > 0:
-                    self._logger.info("All imports in image stream %s/%s succeeded.", namespace, image_stream_name)
+                    self._logger.info(f"All imports in image stream {namespace}/{image_stream_name} succeeded.")
                 return
             self._logger.warning(
-                "Image stream %s/%s has %d tag(s) with failed imports: %s. Triggering re-import (attempt %d/%d)...",
-                namespace,
-                image_stream_name,
-                len(failed_tags),
-                ", ".join(failed_tags),
-                attempt + 1,
-                max_attempts,
+                f"Image stream {namespace}/{image_stream_name} has {len(failed_tags)} tag(s) with failed imports: "
+                f"{', '.join(failed_tags)}. Triggering re-import (attempt {attempt + 1}/{max_attempts})..."
             )
             if not self.runtime.dry_run:
                 import_tasks = [
@@ -2000,10 +1993,7 @@ class PromotePipeline:
                 self._logger.info("Waiting 60 seconds for imports to complete...")
                 await asyncio.sleep(60)
         self._logger.warning(
-            "Some imports in image stream %s/%s may still be failing after %d attempts.",
-            namespace,
-            image_stream_name,
-            max_attempts,
+            f"Some imports in image stream {namespace}/{image_stream_name} may still be failing after {max_attempts} attempts."
         )
 
     async def get_image_info(self, pullspec: str, raise_if_not_found: bool = False):

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -307,6 +307,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             signing_env="prod",
             skip_sigstore=True,
         )
+        get_image_stream.return_value = {"status": {"tags": []}}
 
         await pipeline.run()
         load_group_config.assert_awaited_once()
@@ -642,6 +643,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         pipeline.send_image_list_email = AsyncMock()
         pipeline.is_accepted = AsyncMock(return_value=False)
         pipeline.ocp_doomsday_backup = AsyncMock(return_value=None)
+        get_image_stream.return_value = {"status": {"tags": []}}
         await pipeline.run()
         load_group_config.assert_awaited_once()
         load_releases_config.assert_awaited_once_with(
@@ -778,6 +780,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             dry_run=False,
         )
         pipeline = PromotePipeline(runtime, group="openshift-4.10", assembly="4.10.99", signing_env="prod")
+        get_image_stream.return_value = {"status": {"tags": []}}
         previous_list = ["4.10.98", "4.10.97", "4.9.99"]
         metadata = {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}
 


### PR DESCRIPTION
Follow-up to #2913.

## Summary
- Add inner async `get_failed_tags()` helper to encapsulate imagestream fetch and tag filtering
- Add a final recheck after all retry attempts, raising with the count and names of still-failing tags instead of a generic error
- Run `oc import-image` sequentially instead of concurrently to avoid overwhelming the registry with parallel requests
- Skip the 60s sleep during dry-run
- Remove redundant imagestream existence check (caller already validates this)

## Test plan
- [ ] Unit tests passing (`uv run pytest pyartcd/tests/pipelines/test_promote.py`)