### PR TITLE
ART-18909: Fix JIRA link unfurling by adding unfurl_media parameter

### DIFF
--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -308,7 +308,7 @@ class ImagesHealthPipeline:
                     report += f' ({self.url_text(job_url, "Last failure job")})'
                 report += '\n'
 
-        await self.slack_client.say(report, thread_ts=response['ts'], unfurl_links=False)
+        await self.slack_client.say(report, thread_ts=response['ts'], unfurl_links=False, unfurl_media=False)
 
     async def notify_forum_ocp_art(self):
         self.slack_client.bind_channel('#forum-ocp-art')
@@ -367,7 +367,7 @@ class ImagesHealthPipeline:
             for concern in concerns:
                 image_message += f'\n• {self.get_message_for_forum(concern)}'
             await self.slack_client.say(
-                image_message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False
+                image_message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False, unfurl_media=False
             )
 
         # Rebase failures
@@ -385,7 +385,7 @@ class ImagesHealthPipeline:
                 if job_url:
                     image_message += f' ({self.url_text(job_url, "Last failure job")})'
             await self.slack_client.say(
-                image_message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False
+                image_message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False, unfurl_media=False
             )
 
     def get_message_for_release(self, concern: dict):

--- a/pyartcd/pyartcd/slack.py
+++ b/pyartcd/pyartcd/slack.py
@@ -66,6 +66,7 @@ class SlackClient:
         broadcast: bool = False,
         link_build_url: bool = True,
         unfurl_links: bool = True,
+        unfurl_media: bool = True,
     ):
         attachments = []
         if self.build_url and link_build_url:
@@ -88,6 +89,7 @@ class SlackClient:
             icon_emoji=self.icon_emoji,
             reply_broadcast=broadcast,
             unfurl_links=unfurl_links,
+            unfurl_media=unfurl_media,
         )
         # https://api.slack.com/methods/reactions.add
         if reaction:


### PR DESCRIPTION
PR #2912 only set unfurl_links=False, but the Slack API requires both unfurl_links and unfurl_media to be set to False to prevent all types of link unfurling.

According to Slack API documentation:
"To prevent links from unfurling, set both unfurl_links and unfurl_media to false when posting messages to stop Slack from crawling a link and attempting to display an unfurl."

Changes:
- Added unfurl_media parameter to SlackClient.say() method
- Set unfurl_media=False for all images-health Slack messages that already had unfurl_links=False
- This should prevent JIRA ticket previews from appearing in health reports

## Test
https://redhat-internal.slack.com/archives/C04L1FPFHNH/p1779109969257409