### PR TITLE
ART-18938: Add Redis fail counters for EC and base image release errors

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -131,6 +131,9 @@ class KonfluxImageBuilder:
             "task_url": "n/a",
             "status": -1,  # Status defaults to failure until explicitly set by success. This handles raised exceptions.
             "has_olm_bundle": 1 if metadata.is_olm_operator else 0,
+            "ec_failed": "false",
+            "ec_pipeline_url": "",
+            "base_image_release_failed": "false",
         }
         try:
             if dest_dir.exists():
@@ -336,6 +339,8 @@ class KonfluxImageBuilder:
                     ec_failed = ec_result.ec_failed
                     if ec_failed:
                         outcome = KonfluxBuildOutcome.FAILURE
+                        record["ec_failed"] = "true"
+                        record["ec_pipeline_url"] = ec_pipeline_url
 
                 elif outcome is KonfluxBuildOutcome.SUCCESS:
                     if self._config.skip_ec_verify:
@@ -368,6 +373,7 @@ class KonfluxImageBuilder:
                             logger.info("Base image release succeeded for %s, persisting build record", nvr)
                         else:
                             logger.error("Base image release failed for %s, persisting build record as FAILURE", nvr)
+                            record["base_image_release_failed"] = "true"
                         released_outcome = (
                             KonfluxBuildOutcome.SUCCESS if base_image_release_success else KonfluxBuildOutcome.FAILURE
                         )

--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -83,7 +83,7 @@ class ImagesHealthPipeline:
         self.scanned_versions.append(version)
 
         group = f'openshift-{version}'
-        failures = await util.get_build_failures(group=group, logger=self.runtime.logger)
+        failures = await util.get_counter_failures('build-failure', group=group, logger=self.runtime.logger)
 
         # Use Redis failures to scope the image list for the BigQuery query.
         # If an explicit image_list was provided, intersect it with failing images.

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -235,10 +235,14 @@ class KonfluxOcpPipeline:
 
     async def update_build_fail_counters(self, built_images, failed_images, record_log):
         """
-        Update Redis build-failure counters after Konflux build run.
+        Update Redis failure counters after Konflux build run.
 
-        - Successfully built images: reset counter
-        - Failed builds: increment counter and store metadata
+        Categorizes failures into three types with separate Redis key patterns:
+        - Build failures:              count:build-failure:konflux:{group}:{image}
+        - EC (ITS) failures:           count:ec-failure:konflux:{group}:{image}
+        - Base image release failures: count:release-failure:konflux:{group}:{image}
+
+        Successfully built images reset all three counter types.
         """
         if self.assembly != 'stream':
             return
@@ -246,14 +250,35 @@ class KonfluxOcpPipeline:
         group = f'openshift-{self.version}'
         job_url = os.getenv('BUILD_URL')
 
-        # Build a lookup of failed entries for NVR metadata
+        # Build a lookup of failed entries for metadata
         failed_entries = {
             entry['name']: entry for entry in record_log.get('image_build_konflux', []) if int(entry['status'])
         }
 
+        # Categorize failures by type
+        ec_failed_images = []
+        release_failed_images = []
+        build_failed_images = []
+        for image in failed_images:
+            entry = failed_entries.get(image, {})
+            if entry.get('ec_failed') == 'true':
+                ec_failed_images.append(image)
+            elif entry.get('base_image_release_failed') == 'true':
+                release_failed_images.append(image)
+            else:
+                build_failed_images.append(image)
+
+        # Reset all counter types for successful builds
+        counter_types = ['build-failure', 'ec-failure', 'release-failure']
         await asyncio.gather(
-            *[reset_fail_counter(f'count:build-failure:konflux:{group}:{image}') for image in built_images]
+            *[
+                reset_fail_counter(f'count:{counter_type}:konflux:{group}:{image}')
+                for image in built_images
+                for counter_type in counter_types
+            ]
         )
+
+        # Increment counters for each failure type
         await asyncio.gather(
             *[
                 increment_fail_counter(
@@ -261,8 +286,25 @@ class KonfluxOcpPipeline:
                     jenkins_url=job_url,
                     nvr=failed_entries.get(image, {}).get('nvrs'),
                 )
-                for image in failed_images
-            ]
+                for image in build_failed_images
+            ],
+            *[
+                increment_fail_counter(
+                    f'count:ec-failure:konflux:{group}:{image}',
+                    jenkins_url=job_url,
+                    nvr=failed_entries.get(image, {}).get('nvrs'),
+                    ec_pipeline_url=failed_entries.get(image, {}).get('ec_pipeline_url'),
+                )
+                for image in ec_failed_images
+            ],
+            *[
+                increment_fail_counter(
+                    f'count:release-failure:konflux:{group}:{image}',
+                    jenkins_url=job_url,
+                    nvr=failed_entries.get(image, {}).get('nvrs'),
+                )
+                for image in release_failed_images
+            ],
         )
 
     def building_images(self):

--- a/pyartcd/pyartcd/pipelines/okd_images_health.py
+++ b/pyartcd/pyartcd/pipelines/okd_images_health.py
@@ -58,7 +58,7 @@ class ImagesHealthPipeline:
 
     async def get_report(self, version: str) -> Optional[list]:
         group = OKD_GROUP_TEMPLATE.format(version)
-        failures = await util.get_build_failures(group=group, logger=self.runtime.logger)
+        failures = await util.get_counter_failures('build-failure', group=group, logger=self.runtime.logger)
 
         failing_images = set(failures.keys())
         if self.image_list:

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -1023,9 +1023,7 @@ async def increment_fail_counter(branch: str, **kwargs):
         await increment_fail_counter('count:build:4.17:ironic', url='http://...', nvr='ironic-1.0')
     """
     failure_key = f'{branch}:failure'
-    fail_count = await redis.get_value(failure_key)
-    fail_count = int(fail_count) if fail_count else 0
-    await redis.set_value(key=failure_key, value=fail_count + 1)
+    await redis.call('incr', failure_key)
 
     for key, value in kwargs.items():
         if value is not None:
@@ -1171,16 +1169,22 @@ async def get_rebase_failures(version: str, branches: list[str], build_systems: 
     return all_failures
 
 
-async def get_build_failures(group: str, build_system: str = 'konflux', logger=None):
+async def get_counter_failures(
+    counter_type: str,
+    group: str,
+    build_system: str = 'konflux',
+    logger=None,
+):
     """
-    Fetch build failure data from Redis for a specific group.
+    Fetch failure data from Redis for a specific counter type and group.
 
     Arg(s):
+        counter_type (str): Counter type key segment (e.g., 'build-failure', 'ec-failure', 'release-failure')
         group (str): Group name (e.g., 'openshift-4.18', 'okd-4.21')
         build_system (str): Build system (default: 'konflux')
         logger (Logger): Optional logger for debugging
     Return Value(s):
         dict: {image_name: {failure_count, <all_metadata>}}
     """
-    pattern = f'count:build-failure:{build_system}:{group}:*:failure'
+    pattern = f'count:{counter_type}:{build_system}:{group}:*:failure'
     return await get_failures(pattern, entity_index=-2, logger=logger)

--- a/pyartcd/tests/pipelines/test_images_health.py
+++ b/pyartcd/tests/pipelines/test_images_health.py
@@ -198,7 +198,7 @@ class TestGetReport(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.images_health.util.is_build_permitted", new_callable=AsyncMock, return_value=True)
-    @patch("pyartcd.pipelines.images_health.util.get_build_failures", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.images_health.util.get_counter_failures", new_callable=AsyncMock)
     async def test_redis_pre_filters_doozer_call(self, mock_get_failures, _mock_permitted, mock_cmd):
         """Redis failures scope the --images flag on the doozer subprocess."""
         mock_get_failures.return_value = {
@@ -219,7 +219,9 @@ class TestGetReport(IsolatedAsyncioTestCase):
 
         await pipeline.get_report('4.18')
 
-        mock_get_failures.assert_called_once_with(group='openshift-4.18', logger=pipeline.runtime.logger)
+        mock_get_failures.assert_called_once_with(
+            'build-failure', group='openshift-4.18', logger=pipeline.runtime.logger
+        )
         mock_cmd.assert_called_once()
         cmd = mock_cmd.call_args[0][0]
         images_arg = next(a for a in cmd if a.startswith('--images='))
@@ -229,7 +231,7 @@ class TestGetReport(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.images_health.util.is_build_permitted", new_callable=AsyncMock, return_value=True)
-    @patch("pyartcd.pipelines.images_health.util.get_build_failures", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.images_health.util.get_counter_failures", new_callable=AsyncMock)
     async def test_image_list_intersects_with_redis(self, mock_get_failures, _mock_permitted, mock_cmd):
         """When --image-list is provided, only images in BOTH lists are queried."""
         mock_get_failures.return_value = {
@@ -262,7 +264,7 @@ class TestGetReport(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.images_health.util.is_build_permitted", new_callable=AsyncMock, return_value=True)
-    @patch("pyartcd.pipelines.images_health.util.get_build_failures", new_callable=AsyncMock, return_value={})
+    @patch("pyartcd.pipelines.images_health.util.get_counter_failures", new_callable=AsyncMock, return_value={})
     async def test_skips_bigquery_when_no_redis_failures(self, _mock_get_failures, _mock_permitted, mock_cmd):
         """When Redis reports no failures, doozer images:health is not called at all."""
         pipeline = self._make_pipeline()

--- a/pyartcd/tests/pipelines/test_ocp.py
+++ b/pyartcd/tests/pipelines/test_ocp.py
@@ -1006,3 +1006,202 @@ class TestKonfluxOcpPipelineRebaseFailures(unittest.IsolatedAsyncioTestCase):
         build_cmd = mock_cmd.call_args_list[1][0][0]
         self.assertIn('--images=survivor', build_cmd)
         self.assertEqual(pipeline.build_plan.images_included, ['survivor'])
+
+
+class TestKonfluxOcpPipelineBuildFailCounters(unittest.IsolatedAsyncioTestCase):
+    """Tests for update_build_fail_counters categorizing failures by type."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.runtime = MagicMock()
+        self.runtime.dry_run = False
+        self.runtime.doozer_working = str(Path(self.tmpdir) / 'doozer_working')
+        Path(self.runtime.doozer_working).mkdir(parents=True)
+
+    def _make_pipeline(self, assembly='stream', **kwargs):
+        from pyartcd.pipelines.ocp4_konflux import KonfluxOcpPipeline
+
+        defaults = {
+            'runtime': self.runtime,
+            'assembly': assembly,
+            'version': '4.18',
+            'data_path': 'test-path',
+            'image_build_strategy': 'all',
+            'image_list': '',
+            'rpm_build_strategy': 'none',
+            'rpm_list': '',
+            'data_gitref': '',
+            'kubeconfig': None,
+            'skip_rebase': False,
+            'skip_bundle_build': False,
+            'arches': (),
+            'plr_template': '',
+            'lock_identifier': 'test',
+            'skip_plashets': False,
+            'build_priority': 'auto',
+            'use_mass_rebuild_locks': False,
+            'network_mode': None,
+        }
+        defaults.update(kwargs)
+        return KonfluxOcpPipeline(**defaults)
+
+    @patch('pyartcd.pipelines.ocp4_konflux.increment_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.reset_fail_counter', new_callable=AsyncMock)
+    async def test_build_fail_counters_categorize_ec_failures(self, mock_reset, mock_incr):
+        """EC failures use count:ec-failure key pattern."""
+        pipeline = self._make_pipeline()
+        record_log = {
+            'image_build_konflux': [
+                {
+                    'name': 'ironic',
+                    'status': '-1',
+                    'nvrs': 'ironic-1.0-1',
+                    'ec_failed': 'true',
+                    'ec_pipeline_url': 'http://its/plr/1',
+                    'base_image_release_failed': 'false',
+                },
+            ]
+        }
+        await pipeline.update_build_fail_counters([], ['ironic'], record_log)
+
+        incr_branches = [c.args[0] for c in mock_incr.call_args_list]
+        self.assertEqual(len(incr_branches), 1)
+        self.assertIn('count:ec-failure:konflux:openshift-4.18:ironic', incr_branches[0])
+
+        # Verify ec_pipeline_url is passed as metadata
+        incr_kwargs = mock_incr.call_args_list[0].kwargs
+        self.assertEqual(incr_kwargs['ec_pipeline_url'], 'http://its/plr/1')
+
+    @patch('pyartcd.pipelines.ocp4_konflux.increment_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.reset_fail_counter', new_callable=AsyncMock)
+    async def test_build_fail_counters_categorize_release_failures(self, mock_reset, mock_incr):
+        """Base image release failures use count:release-failure key pattern."""
+        pipeline = self._make_pipeline()
+        record_log = {
+            'image_build_konflux': [
+                {
+                    'name': 'ose-base',
+                    'status': '-1',
+                    'nvrs': 'ose-base-1.0-1',
+                    'ec_failed': 'false',
+                    'ec_pipeline_url': '',
+                    'base_image_release_failed': 'true',
+                },
+            ]
+        }
+        await pipeline.update_build_fail_counters([], ['ose-base'], record_log)
+
+        incr_branches = [c.args[0] for c in mock_incr.call_args_list]
+        self.assertEqual(len(incr_branches), 1)
+        self.assertIn('count:release-failure:konflux:openshift-4.18:ose-base', incr_branches[0])
+
+    @patch('pyartcd.pipelines.ocp4_konflux.increment_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.reset_fail_counter', new_callable=AsyncMock)
+    async def test_build_fail_counters_regular_build_failure(self, mock_reset, mock_incr):
+        """Regular build failures still use count:build-failure key pattern."""
+        pipeline = self._make_pipeline()
+        record_log = {
+            'image_build_konflux': [
+                {
+                    'name': 'cluster-etcd-operator',
+                    'status': '-1',
+                    'nvrs': 'ceo-1.0-1',
+                    'ec_failed': 'false',
+                    'ec_pipeline_url': '',
+                    'base_image_release_failed': 'false',
+                },
+            ]
+        }
+        await pipeline.update_build_fail_counters([], ['cluster-etcd-operator'], record_log)
+
+        incr_branches = [c.args[0] for c in mock_incr.call_args_list]
+        self.assertEqual(len(incr_branches), 1)
+        self.assertIn('count:build-failure:konflux:openshift-4.18:cluster-etcd-operator', incr_branches[0])
+
+    @patch('pyartcd.pipelines.ocp4_konflux.increment_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.reset_fail_counter', new_callable=AsyncMock)
+    async def test_build_fail_counters_mixed_failures(self, mock_reset, mock_incr):
+        """Mixed failure types: each uses its own counter pattern."""
+        pipeline = self._make_pipeline()
+        record_log = {
+            'image_build_konflux': [
+                {
+                    'name': 'ironic',
+                    'status': '-1',
+                    'nvrs': 'ironic-1.0-1',
+                    'ec_failed': 'true',
+                    'ec_pipeline_url': 'http://its/1',
+                    'base_image_release_failed': 'false',
+                },
+                {
+                    'name': 'ose-base',
+                    'status': '-1',
+                    'nvrs': 'ose-base-1.0-1',
+                    'ec_failed': 'false',
+                    'ec_pipeline_url': '',
+                    'base_image_release_failed': 'true',
+                },
+                {
+                    'name': 'ceo',
+                    'status': '-1',
+                    'nvrs': 'ceo-1.0-1',
+                    'ec_failed': 'false',
+                    'ec_pipeline_url': '',
+                    'base_image_release_failed': 'false',
+                },
+            ]
+        }
+        await pipeline.update_build_fail_counters([], ['ironic', 'ose-base', 'ceo'], record_log)
+
+        incr_branches = {c.args[0] for c in mock_incr.call_args_list}
+        self.assertEqual(len(incr_branches), 3)
+        self.assertIn('count:ec-failure:konflux:openshift-4.18:ironic', incr_branches)
+        self.assertIn('count:release-failure:konflux:openshift-4.18:ose-base', incr_branches)
+        self.assertIn('count:build-failure:konflux:openshift-4.18:ceo', incr_branches)
+
+    @patch('pyartcd.pipelines.ocp4_konflux.increment_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.reset_fail_counter', new_callable=AsyncMock)
+    async def test_build_fail_counters_success_resets_all_types(self, mock_reset, mock_incr):
+        """Successfully built images reset all three counter types."""
+        pipeline = self._make_pipeline()
+        record_log = {
+            'image_build_konflux': [
+                {
+                    'name': 'ironic',
+                    'status': '0',
+                    'nvrs': 'ironic-1.0-1',
+                    'ec_failed': 'false',
+                    'ec_pipeline_url': '',
+                    'base_image_release_failed': 'false',
+                },
+            ]
+        }
+        await pipeline.update_build_fail_counters(['ironic'], [], record_log)
+
+        reset_branches = {c.args[0] for c in mock_reset.call_args_list}
+        self.assertEqual(len(reset_branches), 3)
+        self.assertIn('count:build-failure:konflux:openshift-4.18:ironic', reset_branches)
+        self.assertIn('count:ec-failure:konflux:openshift-4.18:ironic', reset_branches)
+        self.assertIn('count:release-failure:konflux:openshift-4.18:ironic', reset_branches)
+        mock_incr.assert_not_called()
+
+    @patch('pyartcd.pipelines.ocp4_konflux.increment_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.reset_fail_counter', new_callable=AsyncMock)
+    async def test_build_fail_counters_non_stream_skipped(self, mock_reset, mock_incr):
+        """Non-stream assemblies skip counter updates entirely."""
+        pipeline = self._make_pipeline(assembly='4.18.1')
+        record_log = {
+            'image_build_konflux': [
+                {
+                    'name': 'ironic',
+                    'status': '-1',
+                    'nvrs': 'ironic-1.0-1',
+                    'ec_failed': 'true',
+                    'ec_pipeline_url': 'http://its/1',
+                    'base_image_release_failed': 'false',
+                },
+            ]
+        }
+        await pipeline.update_build_fail_counters([], ['ironic'], record_log)
+        mock_reset.assert_not_called()
+        mock_incr.assert_not_called()

--- a/pyartcd/tests/pipelines/test_okd_images_health.py
+++ b/pyartcd/tests/pipelines/test_okd_images_health.py
@@ -39,7 +39,7 @@ class TestGetReport(IsolatedAsyncioTestCase):
         )
 
     @patch("pyartcd.pipelines.okd_images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
-    @patch("pyartcd.pipelines.okd_images_health.util.get_build_failures", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.okd_images_health.util.get_counter_failures", new_callable=AsyncMock)
     async def test_redis_pre_filters_doozer_call(self, mock_get_failures, mock_cmd):
         """Redis failures scope the --images flag on the doozer subprocess."""
         mock_get_failures.return_value = {
@@ -58,7 +58,7 @@ class TestGetReport(IsolatedAsyncioTestCase):
 
         await pipeline.get_report('4.21')
 
-        mock_get_failures.assert_called_once_with(group='okd-4.21', logger=pipeline.runtime.logger)
+        mock_get_failures.assert_called_once_with('build-failure', group='okd-4.21', logger=pipeline.runtime.logger)
         mock_cmd.assert_called_once()
         cmd = mock_cmd.call_args[0][0]
         images_arg = next(a for a in cmd if a.startswith('--images='))
@@ -67,7 +67,7 @@ class TestGetReport(IsolatedAsyncioTestCase):
         self.assertEqual(len(pipeline.report), 2)
 
     @patch("pyartcd.pipelines.okd_images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
-    @patch("pyartcd.pipelines.okd_images_health.util.get_build_failures", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.okd_images_health.util.get_counter_failures", new_callable=AsyncMock)
     async def test_image_list_intersects_with_redis(self, mock_get_failures, mock_cmd):
         """When --image-list is provided, only images in BOTH lists are queried."""
         mock_get_failures.return_value = {
@@ -90,7 +90,7 @@ class TestGetReport(IsolatedAsyncioTestCase):
         self.assertEqual(images_arg, '--images=ironic')
 
     @patch("pyartcd.pipelines.okd_images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
-    @patch("pyartcd.pipelines.okd_images_health.util.get_build_failures", new_callable=AsyncMock, return_value={})
+    @patch("pyartcd.pipelines.okd_images_health.util.get_counter_failures", new_callable=AsyncMock, return_value={})
     async def test_skips_bigquery_when_no_redis_failures(self, _mock_get_failures, mock_cmd):
         """When Redis reports no failures, doozer images:health is not called at all."""
         pipeline = self._make_pipeline()

--- a/pyartcd/tests/test_util.py
+++ b/pyartcd/tests/test_util.py
@@ -225,20 +225,19 @@ class TestUtil(IsolatedAsyncioTestCase):
         self.assertEqual(util.get_rpm_if_pinned_directly(releases_config, '4.11.0', 'bar'), dict())
 
     @patch("artcommonlib.redis.set_value", new_callable=AsyncMock)
-    @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
-    async def test_increment_fail_counter_new(self, mock_get, mock_set):
-        mock_get.return_value = None
+    @patch("artcommonlib.redis.call", new_callable=AsyncMock)
+    async def test_increment_fail_counter_new(self, mock_call, mock_set):
+        mock_call.return_value = 1
         await util.increment_fail_counter('count:test:branch', url='http://j/1', nvr='test-1.0-1')
-        mock_set.assert_any_call(key='count:test:branch:failure', value=1)
+        mock_call.assert_called_once_with('incr', 'count:test:branch:failure')
         mock_set.assert_any_call(key='count:test:branch:url', value='http://j/1')
         mock_set.assert_any_call(key='count:test:branch:nvr', value='test-1.0-1')
 
-    @patch("artcommonlib.redis.set_value", new_callable=AsyncMock)
-    @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
-    async def test_increment_fail_counter_existing(self, mock_get, mock_set):
-        mock_get.return_value = '5'
+    @patch("artcommonlib.redis.call", new_callable=AsyncMock)
+    async def test_increment_fail_counter_existing(self, mock_call):
+        mock_call.return_value = 6
         await util.increment_fail_counter('count:test:branch')
-        mock_set.assert_any_call(key='count:test:branch:failure', value=6)
+        mock_call.assert_called_once_with('incr', 'count:test:branch:failure')
 
     @patch("artcommonlib.redis.delete_keys_by_pattern", new_callable=AsyncMock)
     async def test_reset_fail_counter(self, mock_delete):
@@ -247,7 +246,7 @@ class TestUtil(IsolatedAsyncioTestCase):
 
     @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
     @patch("artcommonlib.redis.get_keys", new_callable=AsyncMock)
-    async def test_get_build_failures(self, mock_get_keys, mock_get_value):
+    async def test_get_counter_failures_build(self, mock_get_keys, mock_get_value):
         # Mock get_keys to handle both the initial failure key search and metadata discovery
         def mock_get_keys_side_effect(pattern):
             if pattern.endswith(':*:failure'):
@@ -281,20 +280,76 @@ class TestUtil(IsolatedAsyncioTestCase):
             'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:jenkins_url': '',
             'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:nvr': None,
         }.get(key)
-        result = await util.get_build_failures('openshift-4.21')
+        result = await util.get_counter_failures('build-failure', 'openshift-4.21')
         self.assertEqual(result['ironic']['failure_count'], 5)
         self.assertEqual(result['ironic']['jenkins_url'], 'http://j/1')
         self.assertEqual(result['ironic']['nvr'], 'ironic-1.0-1')
         self.assertEqual(result['ovn-kubernetes']['failure_count'], 2)
 
     @patch("artcommonlib.redis.get_keys", new_callable=AsyncMock)
-    async def test_get_build_failures_empty(self, mock_get_keys):
+    async def test_get_counter_failures_empty(self, mock_get_keys):
         mock_get_keys.return_value = []
-        result = await util.get_build_failures('openshift-4.21')
+        result = await util.get_counter_failures('build-failure', 'openshift-4.21')
         self.assertEqual(result, {})
 
     @patch("artcommonlib.redis.get_keys", new_callable=AsyncMock)
-    async def test_get_build_failures_redis_error(self, mock_get_keys):
+    async def test_get_counter_failures_redis_error(self, mock_get_keys):
         mock_get_keys.side_effect = Exception("Redis connection refused")
-        result = await util.get_build_failures('openshift-4.21', logger=MagicMock())
+        result = await util.get_counter_failures('build-failure', 'openshift-4.21', logger=MagicMock())
+        self.assertEqual(result, {})
+
+    @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
+    @patch("artcommonlib.redis.get_keys", new_callable=AsyncMock)
+    async def test_get_counter_failures_ec(self, mock_get_keys, mock_get_value):
+        def mock_get_keys_side_effect(pattern):
+            if pattern.endswith(':*:failure'):
+                return ['count:ec-failure:konflux:openshift-4.21:ironic:failure']
+            elif 'ironic' in pattern:
+                return [
+                    'count:ec-failure:konflux:openshift-4.21:ironic:failure',
+                    'count:ec-failure:konflux:openshift-4.21:ironic:jenkins_url',
+                    'count:ec-failure:konflux:openshift-4.21:ironic:ec_pipeline_url',
+                ]
+            return []
+
+        mock_get_keys.side_effect = mock_get_keys_side_effect
+        mock_get_value.side_effect = lambda key: {
+            'count:ec-failure:konflux:openshift-4.21:ironic:failure': '3',
+            'count:ec-failure:konflux:openshift-4.21:ironic:jenkins_url': 'http://j/1',
+            'count:ec-failure:konflux:openshift-4.21:ironic:ec_pipeline_url': 'http://its/plr/1',
+        }.get(key)
+        result = await util.get_counter_failures('ec-failure', 'openshift-4.21')
+        self.assertEqual(result['ironic']['failure_count'], 3)
+        self.assertEqual(result['ironic']['jenkins_url'], 'http://j/1')
+        self.assertEqual(result['ironic']['ec_pipeline_url'], 'http://its/plr/1')
+
+    @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
+    @patch("artcommonlib.redis.get_keys", new_callable=AsyncMock)
+    async def test_get_counter_failures_release(self, mock_get_keys, mock_get_value):
+        def mock_get_keys_side_effect(pattern):
+            if pattern.endswith(':*:failure'):
+                return ['count:release-failure:konflux:openshift-4.21:ose-base:failure']
+            elif 'ose-base' in pattern:
+                return [
+                    'count:release-failure:konflux:openshift-4.21:ose-base:failure',
+                    'count:release-failure:konflux:openshift-4.21:ose-base:jenkins_url',
+                    'count:release-failure:konflux:openshift-4.21:ose-base:nvr',
+                ]
+            return []
+
+        mock_get_keys.side_effect = mock_get_keys_side_effect
+        mock_get_value.side_effect = lambda key: {
+            'count:release-failure:konflux:openshift-4.21:ose-base:failure': '2',
+            'count:release-failure:konflux:openshift-4.21:ose-base:jenkins_url': 'http://j/2',
+            'count:release-failure:konflux:openshift-4.21:ose-base:nvr': 'ose-base-1.0-1',
+        }.get(key)
+        result = await util.get_counter_failures('release-failure', 'openshift-4.21')
+        self.assertEqual(result['ose-base']['failure_count'], 2)
+        self.assertEqual(result['ose-base']['jenkins_url'], 'http://j/2')
+        self.assertEqual(result['ose-base']['nvr'], 'ose-base-1.0-1')
+
+    @patch("artcommonlib.redis.get_keys", new_callable=AsyncMock)
+    async def test_get_counter_failures_ec_empty(self, mock_get_keys):
+        mock_get_keys.return_value = []
+        result = await util.get_counter_failures('ec-failure', 'openshift-4.21')
         self.assertEqual(result, {})


### PR DESCRIPTION
## Summary
- Add Redis failure counters for EC (Enterprise Contract / ITS) verification failures and base image release pipeline failures
- Failures are now categorized into three types with separate Redis key patterns:
  - `count:build-failure:konflux:{group}:{image}` — regular build failures (existing)
  - `count:ec-failure:konflux:{group}:{image}` — EC/ITS verification failures (new)
  - `count:release-failure:konflux:{group}:{image}` — base image release failures (new)
- Successfully built images reset all three counter types

## Changes

### doozer/doozerlib/backend/konflux_image_builder.py
- Add `ec_failed`, `ec_pipeline_url`, and `base_image_release_failed` fields to build record so they appear in `record_log`
- Set `ec_failed=true` and populate `ec_pipeline_url` when EC verification fails
- Set `base_image_release_failed=true` when base image snapshot-release fails

### pyartcd/pyartcd/pipelines/ocp4_konflux.py
- Update `update_build_fail_counters()` to categorize failures by type (build vs EC vs release)
- Each type uses its own Redis key pattern and stores relevant metadata
- Successful builds reset all three counter types

### pyartcd/pyartcd/util.py
- Add `get_ec_failures()` to query EC failure counters from Redis
- Add `get_release_failures()` to query release failure counters from Redis

## Testing
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/35686/

<img width="380" height="187" alt="image" src="https://github.com/user-attachments/assets/8a586c1e-7501-44e7-9b09-451b6cee1062" />
