### PR TITLE
rayfordj: Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -17,6 +17,7 @@ approvers:
 - thegreyd
 - locriandev
 - ashwindasr
+- rayfordj
 emeritus_approvers:
 - sosiouxme
 - thiagoalessio


### PR DESCRIPTION
Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED