### PR TITLE
ART-14804: Add ACM product mapping for Konflux kubeconfig and namespace

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -61,6 +61,7 @@ GOLANG_RPM_PACKAGE_NAME = 'golang'
 
 # Product-based mappings for Konflux tenant namespaces and kubeconfigs
 PRODUCT_NAMESPACE_MAP = {
+    "acm": "art-acm-tenant",
     "cert-manager": "art-oap-tenant",
     "external-secrets": "art-oap-tenant",
     "logging": "art-logging-tenant",
@@ -74,6 +75,7 @@ PRODUCT_NAMESPACE_MAP = {
 }
 
 PRODUCT_KUBECONFIG_MAP = {
+    "acm": "ACM_KONFLUX_SA_KUBECONFIG",
     "cert-manager": "OAP_KONFLUX_SA_KUBECONFIG",
     "external-secrets": "OAP_KONFLUX_SA_KUBECONFIG",
     "logging": "LOGGING_KONFLUX_SA_KUBECONFIG",


### PR DESCRIPTION
## Summary
- Adds `"acm"` to `PRODUCT_KUBECONFIG_MAP` mapping to `ACM_KONFLUX_SA_KUBECONFIG`
- Adds `"acm"` to `PRODUCT_NAMESPACE_MAP` mapping to `art-acm-tenant`

Without this, `build-layered-products` raises `ValueError: Kubeconfig required for Konflux builds` when run for the ACM product, even though the Jenkins job injects `ACM_KONFLUX_SA_KUBECONFIG` via the `openshift-bot-acm-konflux-service-account` credential.

## Test plan
- [ ] Verify the Jenkins `cd-builds_build_layered-products` job for ACM no longer raises the `ValueError`
- [ ] Confirm `art-acm-tenant` is the correct Konflux namespace for ACM builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)