### PR TITLE
golang pipelines - Stream command outputs to log

### DIFF
--- a/artcommon/artcommonlib/exectools.py
+++ b/artcommon/artcommonlib/exectools.py
@@ -718,10 +718,13 @@ async def manifest_tool(options, dry_run=False, auth_file: Optional[str] = None)
 
 
 @start_as_current_span_async(TRACER, "cmd_gather_async")
-async def cmd_gather_async(cmd: Union[List[str], str], check: bool = True, **kwargs) -> Tuple[Optional[int], str, str]:
+async def cmd_gather_async(
+    cmd: Union[List[str], str], check: bool = True, log_stdout: bool = False, **kwargs
+) -> Tuple[Optional[int], str, str]:
     """Runs a command asynchronously and returns rc,stdout,stderr as a tuple
     :param cmd <string|list>: A shell command
     :param check: If check is True and the exit code was non-zero, it raises a ChildProcessError
+    :param log_stdout: If True, stream stdout lines to the logger in real time
     :param kwargs: Other arguments passing to asyncio.subprocess.create_subprocess_exec
     :return: rc, stdout, stderr
     """
@@ -757,7 +760,7 @@ async def cmd_gather_async(cmd: Union[List[str], str], check: bool = True, **kwa
     if "traceparent" in carrier:
         env = kwargs.get("env")
         if env is None:
-            # Per Popen doc, a None env means "inheriting the current process’ environment".
+            # Per Popen doc, a None env means "inheriting the current process' environment".
             # To inject the trace context, we need to copy the current environment.
             env = kwargs["env"] = os.environ.copy()
         env["TRACEPARENT"] = carrier["traceparent"]
@@ -768,11 +771,21 @@ async def cmd_gather_async(cmd: Union[List[str], str], check: bool = True, **kwa
     proc = await asyncio.subprocess.create_subprocess_exec(cmd_list[0], *cmd_list[1:], **kwargs)
     span.set_attribute("process.pid", proc.pid)
 
-    stdout, stderr = await proc.communicate()
+    if log_stdout and kwargs.get("stdout") == asyncio.subprocess.PIPE:
+        stdout_lines: list[str] = []
+        async for raw_line in proc.stdout:
+            line = raw_line.decode("utf-8", errors="replace").rstrip()
+            logger.info(line)
+            stdout_lines.append(line)
+        stderr_raw = await proc.stderr.read() if proc.stderr else b""
+        await proc.wait()
+        stdout = "\n".join(stdout_lines)
+        stderr = stderr_raw.decode("utf-8", errors="replace") if stderr_raw else ""
+    else:
+        stdout_raw, stderr_raw = await proc.communicate()
+        stdout = stdout_raw.decode() if stdout_raw else ""
+        stderr = stderr_raw.decode() if stderr_raw else ""
     duration_seconds = time.time() - start_time
-
-    stdout = stdout.decode() if stdout else ""
-    stderr = stderr.decode() if stderr else ""
 
     span.set_attribute("result.exit_code", str(proc.returncode))
     span.set_attribute("execution.duration_seconds", duration_seconds)
@@ -834,12 +847,13 @@ def _get_meaningful_span_name(cmd: Union[List[str], str]) -> str:
 
 @start_as_current_span_async(TRACER, "cmd_assert_async")
 async def cmd_assert_async(
-    cmd: Union[List[str], str], check: bool = True, suppress_output: bool = False, **kwargs
+    cmd: Union[List[str], str], check: bool = True, suppress_output: bool = False, log_stdout: bool = False, **kwargs
 ) -> int:
     """Runs a command and optionally raises an exception if the return code of the command indicates failure.
     :param cmd <string|list>: A shell command
     :param check: If check is True and the exit code was non-zero, it raises a ChildProcessError
     :param suppress_output: If True, stdout and stderr are discarded (/dev/null).
+    :param log_stdout: If True, pipe and stream stdout lines to the logger in real time.
     :param kwargs: Other arguments passing to asyncio.subprocess.create_subprocess_exec
     :return: return code of the command
     """
@@ -866,13 +880,17 @@ async def cmd_assert_async(
         kwargs.setdefault("stdout", asyncio.subprocess.DEVNULL)
         kwargs.setdefault("stderr", asyncio.subprocess.DEVNULL)
 
+    if log_stdout and not suppress_output:
+        kwargs.setdefault("stdout", asyncio.subprocess.PIPE)
+        kwargs.setdefault("stderr", asyncio.subprocess.STDOUT)
+
     # Propagate trace context to subprocess
     carrier = {}
     TraceContextTextMapPropagator().inject(carrier)
     if "traceparent" in carrier:
         env = kwargs.get("env")
         if env is None:
-            # Per Popen doc, a None env means "inheriting the current process’ environment".
+            # Per Popen doc, a None env means "inheriting the current process' environment".
             # To inject the trace context, we need to copy the current environment.
             env = kwargs["env"] = os.environ.copy()
         env["TRACEPARENT"] = carrier["traceparent"]
@@ -882,6 +900,10 @@ async def cmd_assert_async(
     start_time = time.time()
     proc = await asyncio.subprocess.create_subprocess_exec(cmd_list[0], *cmd_list[1:], **kwargs)
     span.set_attribute("process.pid", proc.pid)
+
+    if log_stdout and proc.stdout:
+        async for raw_line in proc.stdout:
+            logger.info(raw_line.decode("utf-8", errors="replace").rstrip())
 
     returncode = await proc.wait()
     duration_seconds = time.time() - start_time

--- a/artcommon/artcommonlib/exectools.py
+++ b/artcommon/artcommonlib/exectools.py
@@ -724,7 +724,8 @@ async def cmd_gather_async(
     """Runs a command asynchronously and returns rc,stdout,stderr as a tuple
     :param cmd <string|list>: A shell command
     :param check: If check is True and the exit code was non-zero, it raises a ChildProcessError
-    :param log_stdout: If True, stream stdout lines to the logger in real time
+    :param log_stdout: If True, stream stdout lines to the logger in real time. Stderr is merged
+        into stdout to avoid pipe deadlocks, so the returned stderr will be empty.
     :param kwargs: Other arguments passing to asyncio.subprocess.create_subprocess_exec
     :return: rc, stdout, stderr
     """
@@ -751,7 +752,9 @@ async def cmd_gather_async(
     # capture stdout and stderr if they are not set in kwargs
     if "stdout" not in kwargs:
         kwargs["stdout"] = asyncio.subprocess.PIPE
-    if "stderr" not in kwargs:
+    if log_stdout:
+        kwargs["stderr"] = asyncio.subprocess.STDOUT
+    elif "stderr" not in kwargs:
         kwargs["stderr"] = asyncio.subprocess.PIPE
 
     # Propagate trace context to subprocess
@@ -777,10 +780,9 @@ async def cmd_gather_async(
             line = raw_line.decode("utf-8", errors="replace").rstrip()
             logger.info(line)
             stdout_lines.append(line)
-        stderr_raw = await proc.stderr.read() if proc.stderr else b""
         await proc.wait()
         stdout = "\n".join(stdout_lines)
-        stderr = stderr_raw.decode("utf-8", errors="replace") if stderr_raw else ""
+        stderr = ""
     else:
         stdout_raw, stderr_raw = await proc.communicate()
         stdout = stdout_raw.decode() if stdout_raw else ""

--- a/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py
+++ b/pyartcd/pyartcd/pipelines/rebuild_golang_rpms.py
@@ -259,7 +259,7 @@ class RebuildGolangRPMsPipeline:
     @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(10))
     async def rhpkg_clone(branch, rpm, dg_dir):
         cmd = f'rhpkg clone --branch {branch} rpms/{rpm} {dg_dir}'
-        await exectools.cmd_assert_async(cmd)
+        await exectools.cmd_assert_async(cmd, log_stdout=True)
 
     async def bump_and_rebuild_rpm(self, rpm, el_v, author, email) -> bool:
         """
@@ -322,7 +322,7 @@ class RebuildGolangRPMsPipeline:
             _LOGGER.info(f'{dg_dir}/{branch} - Dry run, would have triggered build')
         else:
             cmd = 'rhpkg build'
-            await exectools.cmd_assert_async(cmd, cwd=dg_dir)
+            await exectools.cmd_assert_async(cmd, cwd=dg_dir, log_stdout=True)
 
         _LOGGER.info(f'{dg_dir}/{branch} - Successfully built rpm {rpm}')
         return True

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -160,7 +160,7 @@ async def move_golang_bugs(
         cmd.append('--rpms-only')
     if dry_run:
         cmd.append('--dry-run')
-    await exectools.cmd_assert_async(cmd)
+    await exectools.cmd_assert_async(cmd, log_stdout=True)
 
 
 class UpdateGolangPipeline:
@@ -812,7 +812,7 @@ class UpdateGolangPipeline:
         )
         if not self.dry_run:
             cmd.append("--push")
-        await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars)
+        await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars, log_stdout=True)
 
     async def _build_brew(self, el_v, go_version):
         _LOGGER.info("Building on Brew...")
@@ -842,7 +842,7 @@ class UpdateGolangPipeline:
             cmd.append("--dry-run")
         if self.scratch:
             cmd.append("--scratch")
-        await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars)
+        await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars, log_stdout=True)
 
     async def _rebase_and_build_brew(self, el_v, go_version):
         await self._rebase_brew(el_v, go_version)
@@ -915,7 +915,7 @@ class UpdateGolangPipeline:
             cmd.extend(["--network-mode", self.network_mode])
         if self.dry_run:
             cmd.append("--dry-run")
-        await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars)
+        await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars, log_stdout=True)
 
     async def _rebase_and_build_konflux(self, el_v, go_version):
         """Rebase and build golang-builder image on Konflux"""

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -64,26 +64,8 @@ async def is_latest_and_available(ocp_version: str, el_v: int, nvr: str, koji_se
     # sadly --timeout cannot be less than 1 minute, so we wait for 1 minute
     build_tag = f'rhaos-{ocp_version}-rhel-{el_v}-build'
     cmd = f'brew wait-repo {build_tag} --build {nvr} --timeout=1 --verbose'
-    rc, out, err = await exectools.cmd_gather_async(cmd, check=False)
+    rc = await exectools.cmd_assert_async(cmd, check=False, log_stdout=True)
     if rc != 0:
-        output = "\n".join(stream.strip() for stream in (err, out) if stream and stream.strip())
-        if output:
-            _LOGGER.warning(
-                "`%s` failed while checking whether %s is available in %s (exit code %s):\n%s",
-                cmd,
-                nvr,
-                build_tag,
-                rc,
-                output,
-            )
-        else:
-            _LOGGER.warning(
-                "`%s` failed while checking whether %s is available in %s (exit code %s) and produced no output.",
-                cmd,
-                nvr,
-                build_tag,
-                rc,
-            )
         _LOGGER.info(f'Build {nvr} could not be confirmed available in {build_tag}.')
         return False
     _LOGGER.info(f'{nvr} is available in {build_tag}')
@@ -496,7 +478,7 @@ class UpdateGolangPipeline:
 
         regen_cmd = f'brew regen-repo {build_tag}'
         _LOGGER.info("Requesting repo regen: %s", regen_cmd)
-        await exectools.cmd_assert_async(regen_cmd)
+        await exectools.cmd_assert_async(regen_cmd, log_stdout=True)
 
         # Wait for repo to be available (5 hours max)
         for _ in range(30):

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -228,7 +228,7 @@ class TestMoveGolangBugs(IsolatedAsyncioTestCase):
             "--component",
             "openshift-golang-builder-container",
         ]
-        mock_cmd_assert.assert_called_once_with(expected_cmd)
+        mock_cmd_assert.assert_called_once_with(expected_cmd, log_stdout=True)
 
     @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_move_golang_bugs_with_force_update(self, mock_cmd_assert):

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -158,18 +158,17 @@ class TestIsLatestAndAvailable(IsolatedAsyncioTestCase):
     """Test the is_latest_and_available async function"""
 
     @patch("pyartcd.pipelines.update_golang.is_latest_build")
-    @patch("artcommonlib.exectools.cmd_gather_async")
-    async def test_build_is_latest_and_available(self, mock_cmd_gather, mock_is_latest):
+    @patch("artcommonlib.exectools.cmd_assert_async", return_value=0)
+    async def test_build_is_latest_and_available(self, mock_cmd_assert, mock_is_latest):
         """Test when build is latest and available"""
         mock_is_latest.return_value = True
-        mock_cmd_gather.return_value = (0, "", "")
         mock_koji_session = Mock()
 
         result = await is_latest_and_available("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session)
 
         self.assertTrue(result)
         mock_is_latest.assert_called_once_with("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session)
-        mock_cmd_gather.assert_called_once()
+        mock_cmd_assert.assert_called_once()
 
     @patch("pyartcd.pipelines.update_golang.is_latest_build")
     async def test_build_is_not_latest(self, mock_is_latest):
@@ -182,25 +181,18 @@ class TestIsLatestAndAvailable(IsolatedAsyncioTestCase):
         self.assertFalse(result)
 
     @patch("pyartcd.pipelines.update_golang.is_latest_build")
-    @patch("artcommonlib.exectools.cmd_gather_async")
-    async def test_build_is_latest_but_not_available(self, mock_cmd_gather, mock_is_latest):
+    @patch("artcommonlib.exectools.cmd_assert_async", return_value=1)
+    async def test_build_is_latest_but_not_available(self, mock_cmd_assert, mock_is_latest):
         """Test when build is latest but not available in repo"""
         mock_is_latest.return_value = True
-        mock_cmd_gather.return_value = (1, "", "timeout")
         mock_koji_session = Mock()
 
         with self.assertLogs("pyartcd.pipelines.update_golang", level="INFO") as cm:
             result = await is_latest_and_available("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session)
 
         self.assertFalse(result)
-        self.assertEqual(len(cm.output), 2)
-        self.assertIn(
-            "brew wait-repo rhaos-4.16-rhel-8-build --build golang-1.20.12-2.el8 --timeout=1 --verbose",
-            cm.output[0],
-        )
-        self.assertIn("exit code 1", cm.output[0])
-        self.assertIn("timeout", cm.output[0])
-        self.assertIn("could not be confirmed available", cm.output[1])
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn("could not be confirmed available", cm.output[0])
 
 
 class TestMoveGolangBugs(IsolatedAsyncioTestCase):


### PR DESCRIPTION
The issue is golang builder job has a 1 hour timeout if there is no log activity.
This means that the job gets aborted even if there is a command that's running silently.
So start streaming command logs.

## Summary

Adds a `log_stdout` parameter to `cmd_gather_async` and `cmd_assert_async` in exectools that streams stdout lines to the logger in real time, instead of buffering until command completion. When enabled, stderr is merged into stdout (via `STDOUT`) to avoid pipe deadlocks from sequentially draining two pipes.

Applied `log_stdout=True` to long-running commands in the golang pipelines:

**update_golang.py**
- `brew regen-repo` and `brew wait-repo` (already in initial commits)
- `doozer images:rebase` and `doozer images:build` (Brew)
- `doozer beta:images:konflux:rebase` and `doozer beta:images:konflux:build` (Konflux)
- `elliott find-bugs:golang --analyze --update-tracker`

**rebuild_golang_rpms.py**
- `rhpkg clone`
- `rhpkg build`

## Test plan
- [x] `make lint` passes
- [x] `artcommon/tests/test_exectools.py` tests pass
- [x] `pyartcd/tests/pipelines/test_update_golang.py` tests pass (69 tests)
- [x] `pyartcd/tests/test_rebuild_golang_rpms.py` tests pass
- [ ] Trigger an update-golang pipeline run and confirm command output appears in logs in real time

🤖 Generated with [Claude Code](https://claude.com/claude-code)