### PR TITLE
Warn when GitLab silently drops users from MR approval rules

### DIFF
--- a/artcommon/artcommonlib/gitlab.py
+++ b/artcommon/artcommonlib/gitlab.py
@@ -161,14 +161,28 @@ class GitLabClient:
             if not user_ids:
                 logger.warning(f"No valid user IDs resolved for approval rule '{name}', skipping")
                 continue
-            mr.approval_rules.create(
+            rule = mr.approval_rules.create(
                 {
                     "name": name,
                     "approvals_required": 1,
                     "user_ids": user_ids,
                 }
             )
-            logger.info(f"Created approval rule '{name}' with users: {usernames} (ids: {user_ids})")
+            actual_ids = [u["id"] for u in rule.users]
+            dropped = set(user_ids) - set(actual_ids)
+            if dropped:
+                dropped_names = [u for u, uid in zip(usernames, user_ids) if uid in dropped]
+                logger.warning(
+                    "Approval rule '%s': GitLab dropped users %s (ids: %s) "
+                    "— these users must be members of the ocp-shipment-data project "
+                    "(or a group shared with it, e.g. team-ert or layered-products) to be eligible as approvers",
+                    name,
+                    dropped_names,
+                    sorted(dropped),
+                )
+            logger.info(
+                f"Created approval rule '{name}' with users: {usernames} (ids: {user_ids}, actual: {actual_ids})"
+            )
 
     async def trigger_ci_pipeline(self, mr) -> str | None:
         """


### PR DESCRIPTION
## Summary
- GitLab accepts `user_ids` when creating MR-level approval rules but **silently discards** any user who is not a member of the target project (or a group shared with it)
- This caused `mr_approvers` from `group.yml` to appear configured in Jenkins logs while the actual approval rules on ocp-shipment-data MRs had **empty user lists**
- After creating a rule, we now compare the returned `rule.users` against the requested `user_ids` and log a `WARNING` with actionable guidance when users are dropped

## Root cause
The approver users (QE/DOCS contacts for layered products) were not members of the `ocp-shipment-data` project or any group shared with it. The `layered-products` group has now been shared with the project and missing users have been added.

## Test plan
- [x] `ruff check` and `ruff format` pass
- [ ] Verify with a test `release-from-fbc` Jenkins build that approval rules now have users attached
- [ ] Confirm WARNING appears in logs when a non-member user is specified