### PR TITLE
ART-18934: refactor(images): isolate BaseImageSnapshotInput snapshot-release path

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -23,7 +23,6 @@ class KonfluxBuildOutcome(KonfluxEnum):
     FAILURE = 'failure'
     SUCCESS = 'success'
     PENDING = 'pending'
-    UNRELEASED = 'unreleased'
     TIMEOUT = 'timeout'
     CANCELLED = 'cancelled'
 

--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -1,17 +1,15 @@
 """
-Base Image Handler - Orchestrates snapshot-to-release workflow for golang base images.
+Konflux snapshot → release orchestration for OCP base / golang-builder images.
 
-This module handles the workflow for converting golang base image builds
-from Konflux snapshots to releases. Currently creates snapshots and releases,
-with URL extraction and streams.yml updates to be implemented later.
+:class:`BaseImageHandler` accepts exactly one :class:`BaseImageSnapshotInput` per run. Hydration from Konflux DB for the
+CLI lives in ``doozerlib.cli.images`` (see ``images:release-to-base-repo``).
 """
 
 import asyncio
-from typing import Dict, List, Optional, Tuple
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
 
 from artcommonlib import logutil
-from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildOutcome, KonfluxBuildRecord
-from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.util import (
     get_utc_now_formatted_str,
     normalize_group_name_for_k8s,
@@ -19,48 +17,35 @@ from artcommonlib.util import (
     resolve_konflux_namespace_by_product,
 )
 from doozerlib.backend.konflux_client import API_VERSION, KIND_RELEASE, KIND_RELEASE_PLAN, KIND_SNAPSHOT, KonfluxClient
-from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
 from doozerlib.constants import ART_IMAGES_BASE_APPLICATION
 from kubernetes.dynamic import exceptions
-
-from pyartcd import jenkins
 
 LOGGER = logutil.get_logger(__name__)
 ART_IMAGES_BASE_RELEASE_PLAN = "ocp-art-images-base-silent"
 
 
+@dataclass(frozen=True)
+class BaseImageSnapshotInput:
+    """One base-image snapshot component (container + optional source git for the Konflux Snapshot CR)."""
+
+    nvr: str
+    distgit_key: str
+    container_image: str
+    rebase_repo_url: str = ''
+    rebase_commitish: str = ''
+    is_golang_builder: bool = False
+
+
 class BaseImageHandler:
     """
-    Handles the snapshot-to-release workflow for golang base images.
-
-    This class orchestrates the process:
-    1. Create snapshot from NVR
-    2. Create release from snapshot using appropriate release plan
-    3. Wait for release completion
-
-    Future enhancements:
-    - Extract URLs from release artifacts
-    - Create PR to update streams.yml with new URLs
+    Create a Konflux Snapshot for ``art-images-base`` with **one** component, then a Release using
+    ``ocp-art-images-base-silent``, and wait until the Release reports success.
     """
 
-    def __init__(self, runtime, nvr_list: List[str], konflux_db: Optional[KonfluxDb] = None, dry_run: bool = False):
-        """
-        Initialize handler for batch processing (single image = batch of 1).
-
-        Args:
-            runtime: Runtime instance
-            nvr_list: List of NVRs to process
-            konflux_db: Optional KonfluxDb instance for source information lookup
-            dry_run: Whether to perform dry run
-        """
+    def __init__(self, runtime, dry_run: bool = False):
         self.runtime = runtime
-        self.nvr_list = nvr_list
         self.dry_run = dry_run
         self.logger = LOGGER
-
-        self.konflux_db = konflux_db
-        if not self.konflux_db and runtime.konflux_db:
-            self.konflux_db = runtime.konflux_db
 
         self.namespace = resolve_konflux_namespace_by_product(self.runtime.product, None)
         kubeconfig = resolve_konflux_kubeconfig_by_product(self.runtime.product, None)
@@ -72,181 +57,103 @@ class BaseImageHandler:
             dry_run=dry_run,
         )
 
-    async def process_base_image_completion(self) -> Optional[Tuple[str, str]]:
+    async def snapshot_release(self, snapshot_input: BaseImageSnapshotInput) -> Optional[Tuple[str, str]]:
         """
-        Process base image build completion through snapshot-to-release workflow.
+        Run snapshot→release for exactly one base-image component.
 
         Returns:
-            Tuple[str, str]: (release_name, snapshot_name) if successful, None if failed
+            ``(release_name, snapshot_name)`` on success, else ``None``.
         """
-        try:
-            self.logger.info(f"Starting base image snapshot-release workflow for {len(self.nvr_list)} NVRs")
+        inp = snapshot_input
 
-            build_records = await self._fetch_build_records(self.nvr_list)
-            valid_records = {}
-            critical_errors = []
-
-            for nvr in self.nvr_list:
-                build_record = build_records.get(nvr, None)
-                if build_record is None:
-                    self.logger.warning(f"No build record found for {nvr}, skipping")
-                    continue
-
-                if not build_record.name:
-                    critical_errors.append(f"No component name found for build record {nvr}")
-                    continue
-
-                metadata = self.runtime.image_map.get(build_record.name)
-                if not metadata:
-                    critical_errors.append(f"Could not resolve metadata for component {build_record.name} from {nvr}")
-                    continue
-
-                if not metadata.should_trigger_base_image_release():
-                    self.logger.warning(
-                        f"Image {nvr} does not qualify for base image release workflow "
-                        "(base/golang, OCP, base_image_release.enabled), skipping"
-                    )
-                    continue
-
-                if not build_record.image_pullspec:
-                    critical_errors.append(f"No image pullspec found for {nvr}")
-                    continue
-
-                valid_records[nvr] = build_record
-
-            if not valid_records:
-                self.logger.error("No valid base image components found after resolution and filtering")
-                return None
-
-            self.logger.info(f"Processing {len(valid_records)} valid base images")
-
-            # Update Jenkins job title and description with component information
-            component_names = [build_record.name for build_record in valid_records.values()]
-            group_name = self.runtime.group
-
-            if len(component_names) == 1:
-                title_suffix = f"{group_name}: {component_names[0]}"
-            else:
-                title_suffix = f"{group_name}: {len(component_names)} components"
-
-            description_content = f"Components: {', '.join(sorted(component_names))}"
-
-            try:
-                jenkins.init_jenkins()
-                jenkins.update_title(title_suffix, append=False)
-                jenkins.update_description(description_content)
-                self.logger.info("Updated Jenkins job title and description with component info")
-            except Exception as e:
-                self.logger.warning(f"Failed to update Jenkins job title/description: {e}")
-
-            snapshot_name = await self._create_snapshot(valid_records)
-            if not snapshot_name:
-                self.logger.error("Failed to create snapshot, aborting workflow")
-                return None
-
-            released_nvrs = ",".join(sorted(valid_records))
-            release_name = await self._create_release_from_snapshot(snapshot_name, released_nvrs)
-            if not release_name:
-                self.logger.error("Failed to create release, aborting workflow")
-                return None
-
-            completed_successfully = await self._wait_for_release_completion(release_name)
-            if not completed_successfully:
-                self.logger.error("Release did not complete successfully, aborting workflow")
-                return None
-
-            self.logger.info("✓ Base image workflow completed successfully")
-            self.logger.info(f"  Snapshot: {snapshot_name}")
-            self.logger.info(f"  Release: {release_name}")
-            self.logger.info(f"  Release plan: {ART_IMAGES_BASE_RELEASE_PLAN}")
-
-            if critical_errors:
-                error_summary = (
-                    f"Snapshot/Release completed successfully but {len(critical_errors)} critical validation failures occurred:\n"
-                    + "\n".join(critical_errors)
-                )
-                raise RuntimeError(error_summary)
-
-            return release_name, snapshot_name
-
-        except RuntimeError:
-            raise
-        except Exception as e:
-            self.logger.error(f"Base image workflow failed: {e}")
+        if not inp.container_image:
+            self.logger.error("No container image pullspec on snapshot input for NVR %s", inp.nvr)
             return None
 
-    async def _fetch_build_records(self, nvrs: List[str]) -> Dict[str, KonfluxBuildRecord]:
-        """
-        Fetch build records from Konflux database to get source information.
+        metadata = self.runtime.image_map.get(inp.distgit_key)
+        if metadata is None:
+            self.logger.error("Could not resolve metadata for distgit %s (%s)", inp.distgit_key, inp.nvr)
+            return None
 
-        Args:
-            nvrs: List of NVRs to fetch records for
-
-        Returns:
-            Dict mapping NVR to KonfluxBuildRecord
-        """
-        if not self.konflux_db:
-            self.logger.warning("No Konflux database available for source information lookup")
-            return {}
-
-        try:
-            where = {"group": self.runtime.group, "engine": Engine.KONFLUX.value}
-            records = await self.konflux_db.get_build_records_by_nvrs(
-                nvrs, outcome=KonfluxBuildOutcome.UNRELEASED, where=where, strict=False, exclude_large_columns=True
+        if not metadata.should_trigger_base_image_release():
+            self.logger.warning(
+                "Image %s does not qualify for base image release workflow (NVR %s)",
+                inp.distgit_key,
+                inp.nvr,
             )
-            return {record.nvr: record for record in records if record is not None}
-        except Exception as e:
-            self.logger.warning(f"Failed to fetch build records from database: {e}")
-            return {}
+            return None
 
-    async def _create_snapshot(self, valid_records: Dict[str, KonfluxBuildRecord]) -> Optional[str]:
-        """
-        Create snapshot from valid build records (always batch)
+        if inp.rebase_repo_url and inp.rebase_commitish:
+            self.logger.debug("Snapshot input %s includes source git revision", inp.nvr)
+        else:
+            self.logger.warning("No source git URL/revision on snapshot input for %s", inp.nvr)
 
-        Args:
-            valid_records: Dict mapping NVR to KonfluxBuildRecord for valid base images
+        self.logger.info("Starting base image snapshot-release for NVR %s", inp.nvr)
 
-        Returns:
-            str: Snapshot name if successful, None if failed
-        """
+        component = self._build_component_from_snapshot_input(inp)
+        snapshot_name = await self._snapshot_from_components([component])
+        if not snapshot_name:
+            self.logger.error("Failed to create snapshot, aborting workflow")
+            return None
+
+        release_name = await self._create_release_from_snapshot(snapshot_name, inp.nvr)
+        if not release_name:
+            self.logger.error("Failed to create release, aborting workflow")
+            return None
+
+        if not await self._wait_for_release_completion(release_name):
+            self.logger.error("Release did not complete successfully, aborting workflow")
+            return None
+
+        self.logger.info("✓ Base image workflow completed successfully")
+        self.logger.info("  Snapshot: %s", snapshot_name)
+        self.logger.info("  Release: %s", release_name)
+        self.logger.info("  Release plan: %s", ART_IMAGES_BASE_RELEASE_PLAN)
+
+        return release_name, snapshot_name
+
+    def _build_component_from_snapshot_input(self, snapshot_input: BaseImageSnapshotInput) -> dict:
+        """One Konflux snapshot component dict from :class:`BaseImageSnapshotInput`."""
+        from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
+
+        app_name = KonfluxImageBuilder.get_application_name(self.runtime.group_config.name)
+        nvr = snapshot_input.nvr
+
+        if snapshot_input.is_golang_builder:
+            comp_name = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
+        else:
+            comp_name = KonfluxImageBuilder.get_component_name(app_name, snapshot_input.distgit_key)
+
+        component = {
+            "name": comp_name,
+            "containerImage": snapshot_input.container_image,
+        }
+
+        if snapshot_input.rebase_repo_url and snapshot_input.rebase_commitish:
+            component["source"] = {
+                "git": {
+                    "url": snapshot_input.rebase_repo_url,
+                    "revision": snapshot_input.rebase_commitish,
+                }
+            }
+            self.logger.debug("Added source information for %s from snapshot input", nvr)
+
+        return component
+
+    async def _snapshot_from_components(self, components: List[dict]) -> Optional[str]:
+        """Build Snapshot CR from component list and create it in Konflux."""
         try:
             group_safe = normalize_group_name_for_k8s(self.runtime.group)
-            app_name = KonfluxImageBuilder.get_application_name(self.runtime.group_config.name)
 
             if not group_safe:
                 raise ValueError(f"Group name '{self.runtime.group}' produces invalid normalized name for Kubernetes")
 
             timestamp = get_utc_now_formatted_str()
-            snapshot_name = f"{group_safe}-batch-base-images-{timestamp}"
+            snapshot_name = f"{group_safe}-base-image-{timestamp}"
 
             if self.dry_run:
-                self.logger.info(f"[DRY-RUN] Would create snapshot: {snapshot_name}")
+                self.logger.info("[DRY-RUN] Would create snapshot: %s", snapshot_name)
                 return snapshot_name
-
-            components = []
-            for nvr, build_record in valid_records.items():
-                if build_record.name == "openshift-golang-builder":
-                    comp_name = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
-                else:
-                    comp_name = KonfluxImageBuilder.get_component_name(app_name, build_record.name)
-
-                component = {
-                    "name": comp_name,
-                    "containerImage": build_record.image_pullspec,
-                }
-
-                if build_record.rebase_repo_url and build_record.rebase_commitish:
-                    component["source"] = {
-                        "git": {
-                            "url": build_record.rebase_repo_url,
-                            "revision": build_record.rebase_commitish,
-                        }
-                    }
-                    self.logger.debug(f"Added source information for {nvr} from database")
-                else:
-                    self.logger.warning(f"No source information found for {nvr} in database")
-
-                components.append(component)
 
             snapshot_obj = {
                 "apiVersion": API_VERSION,
@@ -268,44 +175,37 @@ class BaseImageHandler:
             return await self._create_snapshot_object(snapshot_obj)
 
         except Exception as e:
-            self.logger.error(f"Failed to create snapshot: {e}")
-            self.logger.error(f"Exception type: {type(e).__name__}")
-            self.logger.error(f"Exception details: {str(e)}")
+            self.logger.error("Failed to create snapshot: %s", e)
+            self.logger.error("Exception type: %s", type(e).__name__)
+            self.logger.error("Exception details: %s", str(e))
             return None
 
     async def _create_snapshot_object(self, snapshot_obj) -> Optional[str]:
-        """Create snapshot resource with unique timestamped name"""
+        """Create snapshot resource with unique timestamped name."""
         try:
             result_snapshot = await self.konflux_client._create(snapshot_obj)
             snapshot_url = self.konflux_client.resource_url(result_snapshot)
-            self.logger.info(f"✓ Created base-image snapshot: {snapshot_url}")
+            self.logger.info("✓ Created base-image snapshot: %s", snapshot_url)
             return result_snapshot.metadata.name
         except Exception as e:
-            self.logger.error(f"Failed to create snapshot: {e}")
+            self.logger.error("Failed to create snapshot: %s", e)
             return None
 
     async def _create_release_from_snapshot(self, snapshot_name: str, released_nvrs: str) -> Optional[str]:
         """
-        Create Konflux release using the same pattern as CreateReleaseCli.new_release().
-
-        Args:
-            snapshot_name: Name of the snapshot to create release from
-            released_nvrs: Comma-separated NVRs validated for release
-
-        Returns:
-            str: Release name if successful, None if failed
+        Create Konflux Release from snapshot using the ocp-art-images-base-silent ReleasePlan.
         """
         try:
             if not self.dry_run:
-                self.logger.info(f"Verifying release plan {ART_IMAGES_BASE_RELEASE_PLAN} exists...")
+                self.logger.info("Verifying release plan %s exists...", ART_IMAGES_BASE_RELEASE_PLAN)
                 try:
                     await self.konflux_client._get(API_VERSION, KIND_RELEASE_PLAN, ART_IMAGES_BASE_RELEASE_PLAN)
                 except exceptions.NotFoundError:
                     raise RuntimeError(
                         f"Release plan {ART_IMAGES_BASE_RELEASE_PLAN} not found in namespace {self.namespace}"
-                    )
+                    ) from None
 
-                self.logger.info(f"Waiting for snapshot {snapshot_name} to become available...")
+                self.logger.info("Waiting for snapshot %s to become available...", snapshot_name)
                 snapshot_available = await self._wait_for_snapshot_availability(snapshot_name)
                 if not snapshot_available:
                     raise RuntimeError(f"Snapshot {snapshot_name} did not become available in time")
@@ -319,7 +219,7 @@ class BaseImageHandler:
                 "annotations": {
                     "art.redhat.com/kind": "image",
                     "art.redhat.com/group": self.runtime.group_config.name,
-                    "art.redhat.com/assembly": getattr(self.runtime, 'assembly', 'stream'),
+                    "art.redhat.com/assembly": getattr(self.runtime, "assembly", "stream"),
                     "art.redhat.com/env": "base-image-workflow",
                     "art.redhat.com/nvrs": released_nvrs,
                 },
@@ -336,34 +236,25 @@ class BaseImageHandler:
             }
 
             if self.dry_run:
-                self.logger.info(f"[DRY-RUN] Would create release with plan: {ART_IMAGES_BASE_RELEASE_PLAN}")
-                self.logger.info(f"[DRY-RUN] Release object: {release_obj}")
+                self.logger.info("[DRY-RUN] Would create release with plan: %s", ART_IMAGES_BASE_RELEASE_PLAN)
+                self.logger.info("[DRY-RUN] Release object: %s", release_obj)
                 return f"dry-run-release-{snapshot_name}"
 
             created_release = await self.konflux_client._create(release_obj)
             release_name = created_release.metadata.name
             release_url = self.konflux_client.resource_url(created_release)
 
-            self.logger.info(f"✓ Created base-image release: {release_url}")
+            self.logger.info("✓ Created base-image release: %s", release_url)
             return release_name
 
         except Exception as e:
-            self.logger.error(f"Failed to create release from snapshot {snapshot_name}: {e}")
-            self.logger.error(f"Exception type: {type(e).__name__}")
-            self.logger.error(f"Exception details: {str(e)}")
+            self.logger.error("Failed to create release from snapshot %s: %s", snapshot_name, e)
+            self.logger.error("Exception type: %s", type(e).__name__)
+            self.logger.error("Exception details: %s", str(e))
             return None
 
     async def _wait_for_release_completion(self, release_name: str, timeout_minutes: int = 30) -> bool:
-        """
-        Wait for Konflux release to complete successfully.
-
-        Args:
-            release_name: Name of the release to monitor
-            timeout_minutes: Maximum time to wait
-
-        Returns:
-            bool: True if release completed successfully, False otherwise
-        """
+        """Wait for Konflux release ``Released/Succeeded`` condition."""
         try:
             if self.dry_run:
                 return True
@@ -375,58 +266,51 @@ class BaseImageHandler:
             while elapsed < timeout_seconds:
                 try:
                     release_obj = await self.konflux_client._get(API_VERSION, KIND_RELEASE, release_name)
-                    status = release_obj.get('status', {})
-                    conditions = status.get('conditions', [])
+                    release_status = release_obj.get("status", {})
+                    conditions = release_status.get("conditions", [])
 
                     for condition in conditions:
-                        if condition.get('type') == 'Released':
-                            status = condition.get('status')
-                            reason = condition.get('reason', '')
+                        if condition.get("type") == "Released":
+                            cond_status = condition.get("status")
+                            reason = condition.get("reason", "")
 
-                            if status == 'True' and reason == 'Succeeded':
-                                self.logger.info(f"✓ Release {release_name} completed successfully")
+                            if cond_status == "True" and reason == "Succeeded":
+                                self.logger.info("✓ Release %s completed successfully", release_name)
                                 return True
-                            elif status == 'False' and reason == 'Failed':
-                                message = condition.get('message', 'No details')
-                                self.logger.error(f"Release {release_name} failed: {message}")
+                            elif cond_status == "False" and reason == "Failed":
+                                message = condition.get("message", "No details")
+                                self.logger.error("Release %s failed: %s", release_name, message)
                                 for cond in conditions:
-                                    if cond.get('type') == 'ManagedPipelineProcessed' and cond.get('status') == 'False':
-                                        pipeline_msg = cond.get('message', '')
+                                    if cond.get("type") == "ManagedPipelineProcessed" and cond.get("status") == "False":
+                                        pipeline_msg = cond.get("message", "")
                                         if pipeline_msg:
-                                            self.logger.error(f"Pipeline failure details: {pipeline_msg}")
+                                            self.logger.error("Pipeline failure details: %s", pipeline_msg)
                                 return False
-                            elif status == 'False' and reason == 'Progressing':
+                            elif cond_status == "False" and reason == "Progressing":
                                 if elapsed % 60 == 0:
                                     self.logger.info(
-                                        f"Release {release_name} is progressing... ({elapsed // 60} minutes elapsed)"
+                                        "Release %s is progressing... (%s minutes elapsed)",
+                                        release_name,
+                                        elapsed // 60,
                                     )
                                 break
 
                 except exceptions.NotFoundError:
-                    self.logger.error(f"Release {release_name} not found")
+                    self.logger.error("Release %s not found", release_name)
                     return False
 
                 await asyncio.sleep(poll_interval)
                 elapsed += poll_interval
 
-            self.logger.error(f"Release {release_name} timed out after {timeout_minutes} minutes")
+            self.logger.error("Release %s timed out after %s minutes", release_name, timeout_minutes)
             return False
 
         except Exception as e:
-            self.logger.error(f"Failed to monitor release {release_name}: {e}")
+            self.logger.error("Failed to monitor release %s: %s", release_name, e)
             return False
 
     async def _wait_for_snapshot_availability(self, snapshot_name: str, timeout_minutes: int = 1) -> bool:
-        """
-        Wait for Konflux snapshot to become available after creation.
-
-        Args:
-            snapshot_name: Name of the snapshot to wait for
-            timeout_minutes: Maximum time to wait
-
-        Returns:
-            bool: True if snapshot becomes available, False otherwise
-        """
+        """Wait until Snapshot object is readable after create."""
         try:
             if self.dry_run:
                 return True
@@ -438,16 +322,16 @@ class BaseImageHandler:
             while elapsed < timeout_seconds:
                 try:
                     await self.konflux_client._get(API_VERSION, KIND_SNAPSHOT, snapshot_name)
-                    self.logger.info(f"✓ Snapshot {snapshot_name} is available")
+                    self.logger.info("✓ Snapshot %s is available", snapshot_name)
                     return True
                 except exceptions.NotFoundError:
-                    self.logger.info(f"Waiting for snapshot {snapshot_name}... ({elapsed}s elapsed)")
+                    self.logger.info("Waiting for snapshot %s... (%ss elapsed)", snapshot_name, elapsed)
                     await asyncio.sleep(poll_interval)
                     elapsed += poll_interval
 
-            self.logger.error(f"Snapshot {snapshot_name} not available after {timeout_minutes} minutes")
+            self.logger.error("Snapshot %s not available after %s minutes", snapshot_name, timeout_minutes)
             return False
 
         except Exception as e:
-            self.logger.error(f"Failed to wait for snapshot {snapshot_name}: {e}")
+            self.logger.error("Failed to wait for snapshot %s: %s", snapshot_name, e)
             return False

--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -16,6 +16,7 @@ from artcommonlib.util import (
     resolve_konflux_kubeconfig_by_product,
     resolve_konflux_namespace_by_product,
 )
+from doozerlib import util as doozer_util
 from doozerlib.backend.konflux_client import API_VERSION, KIND_RELEASE, KIND_RELEASE_PLAN, KIND_SNAPSHOT, KonfluxClient
 from doozerlib.constants import ART_IMAGES_BASE_APPLICATION
 from kubernetes.dynamic import exceptions
@@ -115,15 +116,13 @@ class BaseImageHandler:
 
     def _build_component_from_snapshot_input(self, snapshot_input: BaseImageSnapshotInput) -> dict:
         """One Konflux snapshot component dict from :class:`BaseImageSnapshotInput`."""
-        from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
-
-        app_name = KonfluxImageBuilder.get_application_name(self.runtime.group_config.name)
+        app_name = doozer_util.konflux_application_name(self.runtime.group_config.name)
         nvr = snapshot_input.nvr
 
         if snapshot_input.is_golang_builder:
-            comp_name = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
+            comp_name = doozer_util.konflux_golang_builder_component_name(nvr)
         else:
-            comp_name = KonfluxImageBuilder.get_component_name(app_name, snapshot_input.distgit_key)
+            comp_name = doozer_util.konflux_image_component_name(app_name, snapshot_input.distgit_key)
 
         component = {
             "name": comp_name,

--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -7,7 +7,7 @@ CLI lives in ``doozerlib.cli.images`` (see ``images:release-to-base-repo``).
 
 import asyncio
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 from artcommonlib import logutil
 from artcommonlib.util import (
@@ -64,39 +64,41 @@ class BaseImageHandler:
         Returns:
             ``(release_name, snapshot_name)`` on success, else ``None``.
         """
-        inp = snapshot_input
-
-        if not inp.container_image:
-            self.logger.error("No container image pullspec on snapshot input for NVR %s", inp.nvr)
+        if not snapshot_input.container_image:
+            self.logger.error("No container image pullspec on snapshot input for NVR %s", snapshot_input.nvr)
             return None
 
-        metadata = self.runtime.image_map.get(inp.distgit_key)
+        metadata = self.runtime.image_map.get(snapshot_input.distgit_key)
         if metadata is None:
-            self.logger.error("Could not resolve metadata for distgit %s (%s)", inp.distgit_key, inp.nvr)
+            self.logger.error(
+                "Could not resolve metadata for distgit %s (%s)",
+                snapshot_input.distgit_key,
+                snapshot_input.nvr,
+            )
             return None
 
         if not metadata.should_trigger_base_image_release():
             self.logger.warning(
                 "Image %s does not qualify for base image release workflow (NVR %s)",
-                inp.distgit_key,
-                inp.nvr,
+                snapshot_input.distgit_key,
+                snapshot_input.nvr,
             )
             return None
 
-        if inp.rebase_repo_url and inp.rebase_commitish:
-            self.logger.debug("Snapshot input %s includes source git revision", inp.nvr)
+        if snapshot_input.rebase_repo_url and snapshot_input.rebase_commitish:
+            self.logger.debug("Snapshot input %s includes source git revision", snapshot_input.nvr)
         else:
-            self.logger.warning("No source git URL/revision on snapshot input for %s", inp.nvr)
+            self.logger.warning("No source git URL/revision on snapshot input for %s", snapshot_input.nvr)
 
-        self.logger.info("Starting base image snapshot-release for NVR %s", inp.nvr)
+        self.logger.info("Starting base image snapshot-release for NVR %s", snapshot_input.nvr)
 
-        component = self._build_component_from_snapshot_input(inp)
-        snapshot_name = await self._snapshot_from_components([component])
+        component = self._build_component_from_snapshot_input(snapshot_input)
+        snapshot_name = await self._snapshot_from_component(component)
         if not snapshot_name:
             self.logger.error("Failed to create snapshot, aborting workflow")
             return None
 
-        release_name = await self._create_release_from_snapshot(snapshot_name, inp.nvr)
+        release_name = await self._create_release_from_snapshot(snapshot_name, snapshot_input.nvr)
         if not release_name:
             self.logger.error("Failed to create release, aborting workflow")
             return None
@@ -140,8 +142,8 @@ class BaseImageHandler:
 
         return component
 
-    async def _snapshot_from_components(self, components: List[dict]) -> Optional[str]:
-        """Build Snapshot CR from component list and create it in Konflux."""
+    async def _snapshot_from_component(self, component: dict) -> Optional[str]:
+        """Build Snapshot CR with one component and create it in Konflux."""
         try:
             group_safe = normalize_group_name_for_k8s(self.runtime.group)
 
@@ -168,7 +170,7 @@ class BaseImageHandler:
                 },
                 "spec": {
                     "application": ART_IMAGES_BASE_APPLICATION,
-                    "components": components,
+                    "components": [component],
                 },
             }
 
@@ -191,9 +193,13 @@ class BaseImageHandler:
             self.logger.error("Failed to create snapshot: %s", e)
             return None
 
-    async def _create_release_from_snapshot(self, snapshot_name: str, released_nvrs: str) -> Optional[str]:
+    async def _create_release_from_snapshot(self, snapshot_name: str, released_nvr: str) -> Optional[str]:
         """
         Create Konflux Release from snapshot using the ocp-art-images-base-silent ReleasePlan.
+
+        Args:
+            snapshot_name: Snapshot resource name.
+            released_nvr: Single image NVR (stored on annotation ``art.redhat.com/nvrs`` for compatibility).
         """
         try:
             if not self.dry_run:
@@ -221,7 +227,7 @@ class BaseImageHandler:
                     "art.redhat.com/group": self.runtime.group_config.name,
                     "art.redhat.com/assembly": getattr(self.runtime, "assembly", "stream"),
                     "art.redhat.com/env": "base-image-workflow",
-                    "art.redhat.com/nvrs": released_nvrs,
+                    "art.redhat.com/nvrs": released_nvr,
                 },
             }
 

--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -107,7 +107,9 @@ class BaseImageHandler:
             self.logger.error(f"Release did not complete successfully (release={release_name})")
             return None
 
-        self.logger.info(f"Snapshot-release completed (nvr={snapshot_input.nvr}, snapshot={snapshot_name}, release={release_name})")
+        self.logger.info(
+            f"Snapshot-release completed (nvr={snapshot_input.nvr}, snapshot={snapshot_name}, release={release_name})"
+        )
 
         return release_name, snapshot_name
 
@@ -249,15 +251,11 @@ class BaseImageHandler:
             release_name = created_release.metadata.name
             release_url = self.konflux_client.resource_url(created_release)
 
-            self.logger.info(
-                f"Created release {release_name} for snapshot {snapshot_name} ({release_url})"
-            )
+            self.logger.info(f"Created release {release_name} for snapshot {snapshot_name} ({release_url})")
             return release_name
 
         except Exception as e:
-            self.logger.error(
-                f"Failed to create release from snapshot {snapshot_name} ({type(e).__name__}: {e})"
-            )
+            self.logger.error(f"Failed to create release from snapshot {snapshot_name} ({type(e).__name__}: {e})")
             return None
 
     async def _wait_for_release_completion(self, release_name: str, timeout_minutes: int = 30) -> bool:

--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -20,7 +20,6 @@ from doozerlib.backend.konflux_client import API_VERSION, KIND_RELEASE, KIND_REL
 from doozerlib.constants import ART_IMAGES_BASE_APPLICATION
 from kubernetes.dynamic import exceptions
 
-LOGGER = logutil.get_logger(__name__)
 ART_IMAGES_BASE_RELEASE_PLAN = "ocp-art-images-base-silent"
 
 
@@ -45,7 +44,8 @@ class BaseImageHandler:
     def __init__(self, runtime, dry_run: bool = False):
         self.runtime = runtime
         self.dry_run = dry_run
-        self.logger = LOGGER
+        # Prefix until snapshot_release scopes `[entity]` to the image (same pattern as ImageMetadata).
+        self.logger = logutil.EntityLoggingAdapter(self.runtime.logger, extra={'entity': 'base-image'})
 
         self.namespace = resolve_konflux_namespace_by_product(self.runtime.product, None)
         kubeconfig = resolve_konflux_kubeconfig_by_product(self.runtime.product, None)
@@ -57,6 +57,9 @@ class BaseImageHandler:
             dry_run=dry_run,
         )
 
+    def _scoped_logger(self, entity: str):
+        return logutil.EntityLoggingAdapter(self.runtime.logger, extra={'entity': entity})
+
     async def snapshot_release(self, snapshot_input: BaseImageSnapshotInput) -> Optional[Tuple[str, str]]:
         """
         Run snapshot→release for exactly one base-image component.
@@ -64,53 +67,47 @@ class BaseImageHandler:
         Returns:
             ``(release_name, snapshot_name)`` on success, else ``None``.
         """
+        # Provisional entity (matches qualified_key for typical OCP images) until image_map lookup succeeds.
+        self.logger = self._scoped_logger(f"containers/{snapshot_input.distgit_key}")
+
         if not snapshot_input.container_image:
-            self.logger.error("No container image pullspec on snapshot input for NVR %s", snapshot_input.nvr)
+            self.logger.error(f"No container image pullspec (nvr={snapshot_input.nvr})")
             return None
 
         metadata = self.runtime.image_map.get(snapshot_input.distgit_key)
         if metadata is None:
-            self.logger.error(
-                "Could not resolve metadata for distgit %s (%s)",
-                snapshot_input.distgit_key,
-                snapshot_input.nvr,
-            )
+            self.logger.error("Image metadata not found in runtime.image_map")
             return None
 
+        self.logger = self._scoped_logger(metadata.qualified_key)
+
         if not metadata.should_trigger_base_image_release():
-            self.logger.warning(
-                "Image %s does not qualify for base image release workflow (NVR %s)",
-                snapshot_input.distgit_key,
-                snapshot_input.nvr,
-            )
+            self.logger.warning("Does not qualify for base image release workflow")
             return None
 
         if snapshot_input.rebase_repo_url and snapshot_input.rebase_commitish:
-            self.logger.debug("Snapshot input %s includes source git revision", snapshot_input.nvr)
+            self.logger.debug("Snapshot input includes source git revision")
         else:
-            self.logger.warning("No source git URL/revision on snapshot input for %s", snapshot_input.nvr)
-
-        self.logger.info("Starting base image snapshot-release for NVR %s", snapshot_input.nvr)
+            self.logger.warning("No source git URL/revision on snapshot input")
 
         component = self._build_component_from_snapshot_input(snapshot_input)
+        self.logger.info(f"Starting snapshot-release (nvr={snapshot_input.nvr}, component={component['name']})")
+
         snapshot_name = await self._snapshot_from_component(component)
         if not snapshot_name:
-            self.logger.error("Failed to create snapshot, aborting workflow")
+            self.logger.error("Failed to create snapshot")
             return None
 
         release_name = await self._create_release_from_snapshot(snapshot_name, snapshot_input.nvr)
         if not release_name:
-            self.logger.error("Failed to create release, aborting workflow")
+            self.logger.error(f"Failed to create release (snapshot={snapshot_name})")
             return None
 
         if not await self._wait_for_release_completion(release_name):
-            self.logger.error("Release did not complete successfully, aborting workflow")
+            self.logger.error(f"Release did not complete successfully (release={release_name})")
             return None
 
-        self.logger.info("✓ Base image workflow completed successfully")
-        self.logger.info("  Snapshot: %s", snapshot_name)
-        self.logger.info("  Release: %s", release_name)
-        self.logger.info("  Release plan: %s", ART_IMAGES_BASE_RELEASE_PLAN)
+        self.logger.info(f"Snapshot-release completed (nvr={snapshot_input.nvr}, snapshot={snapshot_name}, release={release_name})")
 
         return release_name, snapshot_name
 
@@ -138,7 +135,7 @@ class BaseImageHandler:
                     "revision": snapshot_input.rebase_commitish,
                 }
             }
-            self.logger.debug("Added source information for %s from snapshot input", nvr)
+            self.logger.debug("Added source git from snapshot input")
 
         return component
 
@@ -154,7 +151,7 @@ class BaseImageHandler:
             snapshot_name = f"{group_safe}-base-image-{timestamp}"
 
             if self.dry_run:
-                self.logger.info("[DRY-RUN] Would create snapshot: %s", snapshot_name)
+                self.logger.info(f"[DRY-RUN] Would create snapshot {snapshot_name}")
                 return snapshot_name
 
             snapshot_obj = {
@@ -177,9 +174,7 @@ class BaseImageHandler:
             return await self._create_snapshot_object(snapshot_obj)
 
         except Exception as e:
-            self.logger.error("Failed to create snapshot: %s", e)
-            self.logger.error("Exception type: %s", type(e).__name__)
-            self.logger.error("Exception details: %s", str(e))
+            self.logger.error(f"Failed to create snapshot ({type(e).__name__}: {e})")
             return None
 
     async def _create_snapshot_object(self, snapshot_obj) -> Optional[str]:
@@ -187,10 +182,12 @@ class BaseImageHandler:
         try:
             result_snapshot = await self.konflux_client._create(snapshot_obj)
             snapshot_url = self.konflux_client.resource_url(result_snapshot)
-            self.logger.info("✓ Created base-image snapshot: %s", snapshot_url)
-            return result_snapshot.metadata.name
+            name = result_snapshot.metadata.name
+            self.logger.info(f"Created snapshot {name} ({snapshot_url})")
+            return name
         except Exception as e:
-            self.logger.error("Failed to create snapshot: %s", e)
+            meta_name = snapshot_obj.get("metadata", {}).get("name", "")
+            self.logger.error(f"Failed to create snapshot object (name={meta_name}): {type(e).__name__}: {e}")
             return None
 
     async def _create_release_from_snapshot(self, snapshot_name: str, released_nvr: str) -> Optional[str]:
@@ -203,7 +200,7 @@ class BaseImageHandler:
         """
         try:
             if not self.dry_run:
-                self.logger.info("Verifying release plan %s exists...", ART_IMAGES_BASE_RELEASE_PLAN)
+                self.logger.info(f"Verifying release plan {ART_IMAGES_BASE_RELEASE_PLAN} exists")
                 try:
                     await self.konflux_client._get(API_VERSION, KIND_RELEASE_PLAN, ART_IMAGES_BASE_RELEASE_PLAN)
                 except exceptions.NotFoundError:
@@ -211,12 +208,12 @@ class BaseImageHandler:
                         f"Release plan {ART_IMAGES_BASE_RELEASE_PLAN} not found in namespace {self.namespace}"
                     ) from None
 
-                self.logger.info("Waiting for snapshot %s to become available...", snapshot_name)
+                self.logger.info(f"Waiting for snapshot {snapshot_name} to become available")
                 snapshot_available = await self._wait_for_snapshot_availability(snapshot_name)
                 if not snapshot_available:
                     raise RuntimeError(f"Snapshot {snapshot_name} did not become available in time")
 
-            metadata = {
+            release_metadata = {
                 "generateName": "ocp-base-image-release-",
                 "namespace": self.namespace,
                 "labels": {
@@ -234,7 +231,7 @@ class BaseImageHandler:
             release_obj = {
                 "apiVersion": API_VERSION,
                 "kind": KIND_RELEASE,
-                "metadata": metadata,
+                "metadata": release_metadata,
                 "spec": {
                     "releasePlan": ART_IMAGES_BASE_RELEASE_PLAN,
                     "snapshot": snapshot_name,
@@ -242,21 +239,25 @@ class BaseImageHandler:
             }
 
             if self.dry_run:
-                self.logger.info("[DRY-RUN] Would create release with plan: %s", ART_IMAGES_BASE_RELEASE_PLAN)
-                self.logger.info("[DRY-RUN] Release object: %s", release_obj)
+                self.logger.info(
+                    f"[DRY-RUN] Would create release for snapshot={snapshot_name} plan={ART_IMAGES_BASE_RELEASE_PLAN}"
+                )
+                self.logger.debug(f"[DRY-RUN] Release object: {release_obj}")
                 return f"dry-run-release-{snapshot_name}"
 
             created_release = await self.konflux_client._create(release_obj)
             release_name = created_release.metadata.name
             release_url = self.konflux_client.resource_url(created_release)
 
-            self.logger.info("✓ Created base-image release: %s", release_url)
+            self.logger.info(
+                f"Created release {release_name} for snapshot {snapshot_name} ({release_url})"
+            )
             return release_name
 
         except Exception as e:
-            self.logger.error("Failed to create release from snapshot %s: %s", snapshot_name, e)
-            self.logger.error("Exception type: %s", type(e).__name__)
-            self.logger.error("Exception details: %s", str(e))
+            self.logger.error(
+                f"Failed to create release from snapshot {snapshot_name} ({type(e).__name__}: {e})"
+            )
             return None
 
     async def _wait_for_release_completion(self, release_name: str, timeout_minutes: int = 30) -> bool:
@@ -281,38 +282,36 @@ class BaseImageHandler:
                             reason = condition.get("reason", "")
 
                             if cond_status == "True" and reason == "Succeeded":
-                                self.logger.info("✓ Release %s completed successfully", release_name)
+                                self.logger.info(f"Release {release_name} completed successfully")
                                 return True
                             elif cond_status == "False" and reason == "Failed":
                                 message = condition.get("message", "No details")
-                                self.logger.error("Release %s failed: %s", release_name, message)
+                                self.logger.error(f"Release {release_name} failed: {message}")
                                 for cond in conditions:
                                     if cond.get("type") == "ManagedPipelineProcessed" and cond.get("status") == "False":
                                         pipeline_msg = cond.get("message", "")
                                         if pipeline_msg:
-                                            self.logger.error("Pipeline failure details: %s", pipeline_msg)
+                                            self.logger.error(f"Pipeline failure: {pipeline_msg}")
                                 return False
                             elif cond_status == "False" and reason == "Progressing":
                                 if elapsed % 60 == 0:
                                     self.logger.info(
-                                        "Release %s is progressing... (%s minutes elapsed)",
-                                        release_name,
-                                        elapsed // 60,
+                                        f"Release {release_name} still progressing ({elapsed // 60} min elapsed)"
                                     )
                                 break
 
                 except exceptions.NotFoundError:
-                    self.logger.error("Release %s not found", release_name)
+                    self.logger.error(f"Release {release_name} not found")
                     return False
 
                 await asyncio.sleep(poll_interval)
                 elapsed += poll_interval
 
-            self.logger.error("Release %s timed out after %s minutes", release_name, timeout_minutes)
+            self.logger.error(f"Release {release_name} timed out after {timeout_minutes} minutes")
             return False
 
         except Exception as e:
-            self.logger.error("Failed to monitor release %s: %s", release_name, e)
+            self.logger.error(f"Failed to monitor release {release_name}: {type(e).__name__}: {e}")
             return False
 
     async def _wait_for_snapshot_availability(self, snapshot_name: str, timeout_minutes: int = 1) -> bool:
@@ -328,16 +327,16 @@ class BaseImageHandler:
             while elapsed < timeout_seconds:
                 try:
                     await self.konflux_client._get(API_VERSION, KIND_SNAPSHOT, snapshot_name)
-                    self.logger.info("✓ Snapshot %s is available", snapshot_name)
+                    self.logger.info(f"Snapshot {snapshot_name} is available")
                     return True
                 except exceptions.NotFoundError:
-                    self.logger.info("Waiting for snapshot %s... (%ss elapsed)", snapshot_name, elapsed)
+                    self.logger.info(f"Waiting for snapshot {snapshot_name} ({elapsed}s elapsed)")
                     await asyncio.sleep(poll_interval)
                     elapsed += poll_interval
 
-            self.logger.error("Snapshot %s not available after %s minutes", snapshot_name, timeout_minutes)
+            self.logger.error(f"Snapshot {snapshot_name} not available after {timeout_minutes} minutes")
             return False
 
         except Exception as e:
-            self.logger.error("Failed to wait for snapshot %s: %s", snapshot_name, e)
+            self.logger.error(f"Failed waiting for snapshot {snapshot_name}: {type(e).__name__}: {e}")
             return False

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -963,23 +963,23 @@ class KonfluxImageBuilder:
             'ec_pipeline_url': ec_pipeline_url,
         }
 
-        # SUCCESS: completed image in pipelinerun results. FAILURE may still have IMAGE_URL/DIGEST when the pipeline
-        # produced an image but we mark FAILURE (e.g. base-image release failed after EC pass).
-        results = pipelinerun_dict.get('status', {}).get('results', [])
-        image_pullspec = next((r['value'] for r in results if r['name'] == 'IMAGE_URL'), None)
-        image_digest = next((r['value'] for r in results if r['name'] == 'IMAGE_DIGEST'), None)
-
-        enrich_image = False
         if outcome is KonfluxBuildOutcome.SUCCESS:
-            enrich_image = True
+            # results:
+            # - name: IMAGE_URL
+            #   value: quay.io/openshift-release-dev/ocp-v4.0-art-dev-test:ose-network-metrics-daemon-rhel9-v4.18.0-20241001.151532
+            # - name: IMAGE_DIGEST
+            #   value: sha256:49d65afba393950a93517f09385e1b441d1735e0071678edf6fc0fc1fe501807
+
+            results = pipelinerun_dict.get('status', {}).get('results', [])
+            image_pullspec = next((r['value'] for r in results if r['name'] == 'IMAGE_URL'), None)
+            image_digest = next((r['value'] for r in results if r['name'] == 'IMAGE_DIGEST'), None)
+
             if not (image_pullspec and image_digest):
                 raise ValueError(
-                    f"[{metadata.distgit_key}] Could not find expected results in konflux pipelinerun {pipelinerun_name}"
+                    f"[{metadata.distgit_key}] Could not find expected results in konflux "
+                    f"pipelinerun {pipelinerun_name}"
                 )
-        elif outcome is KonfluxBuildOutcome.FAILURE and image_pullspec and image_digest:
-            enrich_image = True
 
-        if enrich_image:
             definitive_image_pullspec = f"{image_pullspec.split(':')[0]}@{image_digest}"
 
             # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -358,7 +358,7 @@ class KonfluxImageBuilder:
                     logger.info("Dry run: Would have inserted build record in Konflux DB")
 
                 else:
-                    # One completion record per attempt. Base images run snapshot→release inline (digest pullspec)
+                    # One completion record per attempt. Base images trigger snapshot→release (digest pullspec)
                     # before persisting SUCCESS or FAILURE so Jenkins/batch workflows can query SUCCESS rows.
                     if outcome is KonfluxBuildOutcome.SUCCESS and metadata.should_trigger_base_image_release():
                         base_image_release_success = await self._trigger_base_image_release(
@@ -1228,7 +1228,7 @@ class KonfluxImageBuilder:
         """
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
 
-        logger.info(f"Running inline base image snapshot-release for {nvr}")
+        logger.info(f"Triggering base image snapshot-release for {nvr}")
 
         try:
             snapshot_input = BaseImageSnapshotInput(
@@ -1246,11 +1246,11 @@ class KonfluxImageBuilder:
             result = await handler.snapshot_release(snapshot_input)
             success = result is not None
             if success:
-                logger.info(f"Successfully completed inline base image release for {nvr}")
+                logger.info(f"Successfully triggered base image snapshot-release for {nvr}")
                 return True
-            logger.error("Inline base image release did not complete successfully for %s", nvr)
+            logger.error("Base image snapshot-release did not complete successfully for %s", nvr)
             return False
 
         except Exception as e:
-            logger.error(f"Failed inline base image release for {nvr}: {e}")
+            logger.error(f"Failed base image snapshot-release for {nvr}: {e}")
             return False

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -16,7 +16,6 @@ from artcommonlib import constants as artlib_constants
 from artcommonlib import util as artlib_util
 from artcommonlib.arch_util import go_arch_for_brew_arch
 from artcommonlib.build_visibility import is_release_embargoed
-from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
 from artcommonlib.konflux.konflux_build_record import (
     ArtifactType,
     Engine,
@@ -1238,7 +1237,7 @@ class KonfluxImageBuilder:
                 container_image=container_image,
                 rebase_repo_url=build_repo.https_url,
                 rebase_commitish=build_repo.commit_hash,
-                is_golang_builder=(metadata.config.name == GOLANG_BUILDER_IMAGE_NAME),
+                is_golang_builder=metadata.is_golang_builder(),
             )
             handler = BaseImageHandler(
                 metadata.runtime,

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -16,6 +16,7 @@ from artcommonlib import constants as artlib_constants
 from artcommonlib import util as artlib_util
 from artcommonlib.arch_util import go_arch_for_brew_arch
 from artcommonlib.build_visibility import is_release_embargoed
+from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
 from artcommonlib.konflux.konflux_build_record import (
     ArtifactType,
     Engine,
@@ -30,6 +31,7 @@ from artcommonlib.rpm_utils import compare_nvr, parse_nvr
 from artcommonlib.util import fetch_slsa_attestation, get_konflux_data
 from dockerfile_parse import DockerfileParser
 from doozerlib import constants, util
+from doozerlib.backend.base_image_handler import BaseImageHandler, BaseImageSnapshotInput
 from doozerlib.backend.build_repo import BuildRepo
 from doozerlib.backend.konflux_client import KonfluxClient
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
@@ -40,8 +42,6 @@ from doozerlib.record_logger import RecordLogger
 from doozerlib.source_resolver import SourceResolution
 from packageurl import PackageURL
 from tenacity import retry, stop_after_attempt, wait_fixed
-
-from pyartcd import jenkins
 
 LOGGER = logging.getLogger(__name__)
 
@@ -359,11 +359,20 @@ class KonfluxImageBuilder:
                     logger.info("Dry run: Would have inserted build record in Konflux DB")
 
                 else:
-                    # Create a build record after every attempt (both success and failure)
-                    # Base images need a synchronous release to registry.redhat.io before dependents can use RH
-                    # pullspecs. Mark SUCCESS as UNRELEASED in the DB until that release completes; see below.
+                    # One completion record per attempt. Base images run snapshot→release inline (digest pullspec)
+                    # before persisting SUCCESS or FAILURE so Jenkins/batch workflows can query SUCCESS rows.
                     if outcome is KonfluxBuildOutcome.SUCCESS and metadata.should_trigger_base_image_release():
-                        outcome = KonfluxBuildOutcome.UNRELEASED
+                        base_image_release_success = await self._trigger_base_image_release(
+                            metadata, nvr, definitive_image_pullspec, build_repo
+                        )
+                        if base_image_release_success:
+                            logger.info("Base image release succeeded for %s, persisting build record", nvr)
+                        else:
+                            logger.error("Base image release failed for %s, persisting build record as FAILURE", nvr)
+                        released_outcome = (
+                            KonfluxBuildOutcome.SUCCESS if base_image_release_success else KonfluxBuildOutcome.FAILURE
+                        )
+                        outcome = released_outcome
 
                     build_record = await self.update_konflux_db(
                         metadata,
@@ -377,27 +386,6 @@ class KonfluxImageBuilder:
                     )
                     if build_record:
                         record["record_id"] = build_record.record_id
-
-                    # Check base image release AFTER saving to database
-                    if outcome is KonfluxBuildOutcome.UNRELEASED and metadata.should_trigger_base_image_release():
-                        base_image_release_success = await self._trigger_base_image_release(metadata, nvr)
-                        if base_image_release_success:
-                            logger.info(f"Base image release succeeded for {nvr}, updating build record")
-                        else:
-                            logger.error(f"Base image release failed for {nvr}, updating build record to FAILURE")
-                        outcome = (
-                            KonfluxBuildOutcome.SUCCESS if base_image_release_success else KonfluxBuildOutcome.FAILURE
-                        )
-                        await self.update_konflux_db(
-                            metadata,
-                            build_repo,
-                            pipelinerun_info,
-                            outcome,
-                            building_arches,
-                            build_priority,
-                            ec_status=ec_status,
-                            ec_pipeline_url=ec_pipeline_url,
-                        )
 
                 if outcome is not KonfluxBuildOutcome.SUCCESS:
                     error = KonfluxImageBuildError(
@@ -976,25 +964,23 @@ class KonfluxImageBuilder:
             'ec_pipeline_url': ec_pipeline_url,
         }
 
-        # SUCCESS: normal completed build. UNRELEASED: build succeeded and is waiting for
-        # snapshot→release before final SUCCESS + registry.redhat.io pullspec — same pipelinerun IMAGE_URL/results.
-        if outcome in (KonfluxBuildOutcome.SUCCESS, KonfluxBuildOutcome.UNRELEASED):
-            # results:
-            # - name: IMAGE_URL
-            #   value: quay.io/openshift-release-dev/ocp-v4.0-art-dev-test:ose-network-metrics-daemon-rhel9-v4.18.0-20241001.151532
-            # - name: IMAGE_DIGEST
-            #   value: sha256:49d65afba393950a93517f09385e1b441d1735e0071678edf6fc0fc1fe501807
+        # SUCCESS: completed image in pipelinerun results. FAILURE may still have IMAGE_URL/DIGEST when the pipeline
+        # produced an image but we mark FAILURE (e.g. base-image release failed after EC pass).
+        results = pipelinerun_dict.get('status', {}).get('results', [])
+        image_pullspec = next((r['value'] for r in results if r['name'] == 'IMAGE_URL'), None)
+        image_digest = next((r['value'] for r in results if r['name'] == 'IMAGE_DIGEST'), None)
 
-            results = pipelinerun_dict.get('status', {}).get('results', [])
-            image_pullspec = next((r['value'] for r in results if r['name'] == 'IMAGE_URL'), None)
-            image_digest = next((r['value'] for r in results if r['name'] == 'IMAGE_DIGEST'), None)
-
+        enrich_image = False
+        if outcome is KonfluxBuildOutcome.SUCCESS:
+            enrich_image = True
             if not (image_pullspec and image_digest):
                 raise ValueError(
-                    f"[{metadata.distgit_key}] Could not find expected results in konflux "
-                    f"pipelinerun {pipelinerun_name}"
+                    f"[{metadata.distgit_key}] Could not find expected results in konflux pipelinerun {pipelinerun_name}"
                 )
+        elif outcome is KonfluxBuildOutcome.FAILURE and image_pullspec and image_digest:
+            enrich_image = True
 
+        if enrich_image:
             definitive_image_pullspec = f"{image_pullspec.split(':')[0]}@{image_digest}"
 
             # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
@@ -1223,39 +1209,49 @@ class KonfluxImageBuilder:
 
         return parent_image_nvrs
 
-    async def _trigger_base_image_release(self, metadata: ImageMetadata, nvr: str) -> bool:
-        """Trigger base image release for a single successful base image build.
+    async def _trigger_base_image_release(
+        self,
+        metadata: ImageMetadata,
+        nvr: str,
+        container_image: str,
+        build_repo: BuildRepo,
+    ) -> bool:
+        """Run snapshot→release for one base image via :class:`BaseImageHandler` (no Jenkins job).
 
-        Expects group_name format 'openshift-X.Y' (e.g., 'openshift-4.22') for
-        version extraction. Falls back to full group_name if format doesn't match.
+        Args:
+            metadata: Image metadata for the built image
+            nvr: Image NVR string
+            container_image: Definitive digest pullspec (``repo@sha256:…``)
+            build_repo: Build repo (rebase git URL and commit for snapshot source)
 
         Returns:
-            bool: True if base image release was triggered successfully, False otherwise
+            bool: True if base image release completed successfully
         """
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
 
-        logger.info(f"Triggering base image release for {nvr}")
+        logger.info(f"Running inline base image snapshot-release for {nvr}")
 
         try:
-            build_version = self._config.group_name
-
-            result = jenkins.start_base_image_release(
-                build_version=build_version,
-                assembly=metadata.runtime.assembly,
-                base_image_nvrs=[nvr],
-                doozer_data_path=getattr(metadata.runtime, 'data_path', ''),
-                doozer_data_gitref=getattr(metadata.runtime, 'data_gitref', ''),
-                dry_run=self._config.dry_run,
-                block_until_complete=True,
+            snapshot_input = BaseImageSnapshotInput(
+                nvr=nvr,
+                distgit_key=metadata.distgit_key,
+                container_image=container_image,
+                rebase_repo_url=build_repo.https_url,
+                rebase_commitish=build_repo.commit_hash,
+                is_golang_builder=(metadata.config.name == GOLANG_BUILDER_IMAGE_NAME),
             )
-            # start_build(..., block_until_complete=True) returns Jenkins result strings (SUCCESS, FAILURE, …), not None.
-            success = result == "SUCCESS"
+            handler = BaseImageHandler(
+                metadata.runtime,
+                dry_run=self._config.dry_run,
+            )
+            result = await handler.snapshot_release(snapshot_input)
+            success = result is not None
             if success:
-                logger.info(f"Successfully completed base image release for {nvr}")
+                logger.info(f"Successfully completed inline base image release for {nvr}")
                 return True
-            logger.error("Base image release job failed for %s with Jenkins result=%r", nvr, result)
+            logger.error("Inline base image release did not complete successfully for %s", nvr)
             return False
 
         except Exception as e:
-            logger.error(f"Failed to trigger base image release for {nvr}: {e}")
+            logger.error(f"Failed inline base image release for {nvr}: {e}")
             return False

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -303,7 +303,7 @@ class KonfluxImageBuilder:
                     and metadata.for_release
                 )
                 if should_run_ec:
-                    app_name = self.get_application_name(self._config.group_name)
+                    app_name = util.konflux_application_name(self._config.group_name)
 
                     # Select EC policy based on software lifecycle phase:
                     # - pre-release phase uses a more permissive policy that allows unsigned RPMs
@@ -319,7 +319,7 @@ class KonfluxImageBuilder:
 
                     image_with_digest = f"{image_pullspec.split(':')[0]}@{image_digest}"
                     source_url = artlib_util.convert_remote_git_to_https(build_repo.url)
-                    konflux_component_name = self.get_component_name(app_name, metadata.distgit_key)
+                    konflux_component_name = util.konflux_image_component_name(app_name, metadata.distgit_key)
 
                     ec_result = await self._konflux_client.verify_enterprise_contract(
                         namespace=self._config.namespace,
@@ -504,55 +504,6 @@ class KonfluxImageBuilder:
         return parent_members
 
     @staticmethod
-    def get_application_name(group_name: str):
-        # "openshift-4-18" -> "openshift-4-18"
-        return group_name.replace(".", "-")
-
-    @staticmethod
-    def get_component_name(application_name: str, image_name: str):
-        # Openshift doesn't allow dots or underscores in any of its fields, so we replace them with dashes
-        name = f"{application_name}-{image_name}".replace(".", "-").replace("_", "-")
-        # 'openshift-4-18-ose-installer-terraform' -> 'ose-4-18-ose-installer-terraform'
-        # A component resource name must start with a lower case letter and must be no more than 63 characters long.
-        name = f"ose-{name[10:]}" if name.startswith("openshift-") else name
-        return name
-
-    @staticmethod
-    def get_golang_builder_component_name(nvr: str) -> str:
-        """
-        Generate golang builder specific component name from NVR.
-
-        Args:
-            nvr: Build NVR (e.g., "openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.el8")
-
-        Returns:
-            Component name (e.g., "golang-builder-v1.25-rhel8")
-        """
-        nvr_parsed = parse_nvr(nvr)
-        version = nvr_parsed["version"]
-        release = nvr_parsed["release"]
-
-        # Extract major.minor from semantic version (e.g., "v1.25.8" -> "v1.25")
-        if version.startswith("v"):
-            version_parts = version[1:].split(".")  # Remove 'v' prefix and split
-        else:
-            version_parts = version.split(".")
-
-        if len(version_parts) >= 2:
-            major_minor = f"v{version_parts[0]}.{version_parts[1]}"
-        else:
-            # Fallback to original version if parsing fails
-            major_minor = version
-
-        # Determine RHEL version from release field
-        # Assumes exactly one .elX pattern per release (validated by production data)
-        el_suffix = "rhel9"  # Default to latest RHEL version
-        if ".el8" in release:
-            el_suffix = "rhel8"
-
-        return f"golang-builder-{major_minor}-{el_suffix}"
-
-    @staticmethod
     def _repo_gets_hermetic_module_hotfixes(repo_name: str, group: str, golang_pattern: re.Pattern) -> bool:
         """
         art-unsigned.repo sets module_hotfixes=1 on OSE (plashet) repos so non-modular RPMs there can win over
@@ -720,12 +671,12 @@ class KonfluxImageBuilder:
         git_commit = build_repo.commit_hash
 
         # Ensure the Application resource exists
-        app_name = self.get_application_name(self._config.group_name)
+        app_name = util.konflux_application_name(self._config.group_name)
         logger.info(f"Using application: {app_name}")
         await self._konflux_client.ensure_application(name=app_name, display_name=app_name)
 
         # Ensure the component resource exists
-        component_name = self.get_component_name(app_name, metadata.distgit_key)
+        component_name = util.konflux_image_component_name(app_name, metadata.distgit_key)
         default_revision = f"art-{self._config.group_name}-assembly-test-dgk-{metadata.distgit_key}"
         logger.info(f"Using component: {component_name}")
         await self._konflux_client.ensure_component(

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -778,9 +778,9 @@ class KonfluxOlmBundleBuilder:
                     # Run EC verification after a successful bundle build
                     is_ocp_group = self.group.startswith("openshift-")
                     if outcome is KonfluxBuildOutcome.SUCCESS and is_ocp_group and not self.skip_ec_verify:
-                        app_name = self.get_application_name(metadata.runtime.group)
+                        app_name = util.konflux_application_name(metadata.runtime.group)
                         bundle_name = metadata.get_olm_bundle_short_name()
-                        component_name = self.get_component_name(app_name, bundle_name)
+                        component_name = util.konflux_image_component_name(app_name, bundle_name)
                         image_with_digest = f"{image_pullspec.split(':')[0]}@{image_digest}"
                         source_url = artlib_util.convert_remote_git_to_https(bundle_build_repo.url)
 
@@ -852,22 +852,6 @@ class KonfluxOlmBundleBuilder:
         return pipelinerun_name, pipelinerun_dict
 
     @staticmethod
-    def get_application_name(group_name: str):
-        # Openshift doesn't allow dots or underscores in any of its fields, so we replace them with dashes
-        # "openshift-4.18" -> "openshift-4-18"
-        return group_name.replace(".", "-")
-
-    @staticmethod
-    def get_component_name(application_name: str, bundle_name: str):
-        # Openshift doesn't allow dots or underscores in any of its fields, so we replace them with dashes
-        name = f"{application_name}-{bundle_name}".replace(".", "-").replace("_", "-")
-        # Remove the 'openshift-' prefix and replace it with 'ose-'
-        # 'openshift-4-18-ose-installer-terraform' -> 'ose-4-18-ose-installer-terraform'
-        # A component resource name must start with a lower case letter and must be no more than 63 characters long.
-        name = f"ose-{name[10:]}" if name.startswith("openshift-") else name
-        return name
-
-    @staticmethod
     def get_old_component_name(application_name: str, bundle_name: str):
         # TODO: (2025-Jul-09) remove this once we have new builds using the new component name
         return f"{application_name}-{bundle_name}".replace(".", "-").replace("_", "-")
@@ -891,13 +875,13 @@ class KonfluxOlmBundleBuilder:
         target_branch = bundle_build_repo.branch or bundle_build_repo.commit_hash
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
         # Ensure the Application resource exists
-        app_name = self.get_application_name(metadata.runtime.group)
+        app_name = util.konflux_application_name(metadata.runtime.group)
         logger.info(f"Using Konflux application: {app_name}")
         await konflux_client.ensure_application(name=app_name, display_name=app_name)
         logger.info(f"Konflux application {app_name} created")
         # Ensure the Component resource exists
         bundle_name = metadata.get_olm_bundle_short_name()
-        component_name = self.get_component_name(app_name, bundle_name)
+        component_name = util.konflux_image_component_name(app_name, bundle_name)
         logger.info(f"Creating Konflux component: {component_name}")
         dest_image_repo = output_image.split(":")[0]
         await konflux_client.ensure_component(

--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -10,25 +10,99 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from numbers import Number
-from typing import Optional, cast
+from typing import List, Optional, cast
 
 import click
 import koji
 import yaml
 from artcommonlib import exectools, logutil
+from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
 from artcommonlib.format_util import color_print, green_print, yellow_print
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord
+from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.model import Missing, Model
 from artcommonlib.pushd import Dir
 from dockerfile_parse import DockerfileParser
 
 from doozerlib import Runtime, coverity, state
-from doozerlib.backend.base_image_handler import BaseImageHandler
+from doozerlib.backend.base_image_handler import BaseImageHandler, BaseImageSnapshotInput
 from doozerlib.brew import get_watch_task_info_copy
 from doozerlib.cli import cli, option_commit_message, option_push, pass_runtime, validate_semver_major_minor_patch
 from doozerlib.distgit import ImageDistGitRepo
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.source_resolver import SourceResolver
+
+LOGGER = logutil.get_logger(__name__)
+
+
+async def _snapshot_inputs_from_konflux_success_builds(runtime, nvrs: List[str]) -> List[BaseImageSnapshotInput]:
+    """
+    Map NVRs to :class:`BaseImageSnapshotInput` using latest matching **SUCCESS** Konflux image rows for ``runtime.group``.
+
+    Skips NVRs with no row, missing pullspec, unknown image metadata, or images that do not participate in the
+    base-image workflow. Callers should treat an empty list as failure to prepare any releasable snapshot.
+    """
+    if not nvrs:
+        return []
+
+    konflux_db = getattr(runtime, "konflux_db", None)
+    if not konflux_db:
+        LOGGER.warning("No Konflux database configured; cannot resolve NVRs to snapshot inputs")
+        return []
+
+    where = {"group": runtime.group, "engine": Engine.KONFLUX.value}
+    records = await konflux_db.get_build_records_by_nvrs(
+        nvrs, outcome=KonfluxBuildOutcome.SUCCESS, where=where, strict=False, exclude_large_columns=True
+    )
+
+    by_nvr = {r.nvr: r for r in records if r is not None}
+    inputs: List[BaseImageSnapshotInput] = []
+
+    for nvr in nvrs:
+        rec = by_nvr.get(nvr)
+        if not rec:
+            LOGGER.warning(
+                "No SUCCESS Konflux image build record for NVR %s in group %s",
+                nvr,
+                runtime.group,
+            )
+            continue
+        if not rec.name:
+            LOGGER.warning("Konflux record for NVR %s has no component name", nvr)
+            continue
+
+        md = runtime.image_map.get(rec.name)
+        if not md:
+            LOGGER.warning(
+                "No loaded image metadata for Konflux component %s (NVR %s); check --group and image list",
+                rec.name,
+                nvr,
+            )
+            continue
+
+        if not md.should_trigger_base_image_release():
+            LOGGER.warning(
+                "Image %s does not qualify for base image release workflow (NVR %s), skipping",
+                rec.name,
+                nvr,
+            )
+            continue
+
+        if not rec.image_pullspec:
+            LOGGER.warning("Konflux record for NVR %s has no image_pullspec", nvr)
+            continue
+
+        inputs.append(
+            BaseImageSnapshotInput(
+                nvr=nvr,
+                distgit_key=rec.name,
+                container_image=rec.image_pullspec,
+                rebase_repo_url=rec.rebase_repo_url or "",
+                rebase_commitish=rec.rebase_commitish or "",
+                is_golang_builder=(md.config.name == GOLANG_BUILDER_IMAGE_NAME),
+            )
+        )
+
+    return inputs
 
 
 @cli.command("images:clone", help="Clone a group's image distgit repos locally.")
@@ -1453,38 +1527,28 @@ def query_rpm_version(runtime, repo_type):
     click.echo("version: {}".format(version))
 
 
-@cli.command("images:release-to-base-repo", short_help="Process base images through snapshot-to-release workflow")
+@cli.command("images:release-to-base-repo", short_help="Snapshot→release one base image build (Konflux SUCCESS row)")
 @click.option(
-    '--nvrs',
-    metavar='NVRS',
+    '--nvr',
+    metavar='NVR',
     required=True,
-    help='Comma-separated list of build NVRs to process',
+    help='Exactly one Konflux image build NVR (must have a SUCCESS row for this group)',
 )
 @pass_runtime
-def release_to_base_repo(runtime, nvrs):
+def release_to_base_repo(runtime, nvr):
     """
-    Process completed base image builds through the snapshot-to-release workflow.
-    
-    This command handles the batch base image workflow that:
-    1. Resolves NVRs to image metadata using Konflux infrastructure
-    2. Creates a unified Konflux snapshot from all base image builds
-    3. Creates a release from the snapshot using the appropriate release plan
-    4. Waits for release completion
-    
-    This is intended to be called as a separate job after base image builds complete.
-    Only processes images for which the base-image release workflow applies (see
-    ``should_trigger_base_image_release``): base_only or golang builder, OCP variant,
-    ``base_image_release.enabled`` not disabled at image or group level.
-    
-    Examples:
-    
-    Process single base image workflow:
-    doozer --group openshift-4.22 images:release-to-base-repo \\
-        --nvrs openshift-enterprise-base-rhel9-container-v4.22.0-202602202227.p2.gcf42b3d.assembly.stream.el9
-    
-    Process multiple base images workflow:
-    doozer --group openshift-4.22 images:release-to-base-repo \\
-        --nvrs "nvr1,nvr2,nvr3"
+    Process one completed base image build through the snapshot-to-release workflow.
+
+    Resolves the NVR to a SUCCESS Konflux image record and loaded image metadata, builds one Snapshot component,
+    creates the Release for ``ocp-art-images-base-silent``, and waits for completion.
+
+    Intended as a separate job after that base image Konflux build completes. Only applies when
+    ``should_trigger_base_image_release`` is true for the image.
+
+    Example::
+
+        doozer --group openshift-4.22 images:release-to-base-repo \\
+            --nvr openshift-enterprise-base-rhel9-container-v4.22.0-202602202227.p2.gcf42b3d.assembly.stream.el9
     """
 
     async def run_workflow():
@@ -1495,15 +1559,24 @@ def release_to_base_repo(runtime, nvrs):
 
             runtime.konflux_db.bind(KonfluxBuildRecord)
 
-            nvr_list = [nvr.strip() for nvr in nvrs.split(',')]
+            one_nvr = nvr.strip()
+            if not one_nvr:
+                logger.error("--nvr must be non-empty")
+                return False
+            if "," in one_nvr:
+                logger.error("Only one NVR is supported; do not pass comma-separated values (use one --nvr)")
+                return False
 
-            logger.info(f"Processing {len(nvr_list)} NVRs through base image snapshot-to-release workflow")
-            logger.info(f"Group: {runtime.group}")
-            for nvr in nvr_list:
-                logger.info(f"NVR: {nvr}")
+            logger.info("Processing NVR %s through base image snapshot-to-release workflow", one_nvr)
+            logger.info("Group: %s", runtime.group)
 
-            handler = BaseImageHandler(runtime, nvr_list, dry_run=False)
-            result = await handler.process_base_image_completion()
+            snapshot_inputs = await _snapshot_inputs_from_konflux_success_builds(runtime, [one_nvr])
+            if len(snapshot_inputs) != 1:
+                logger.error("Could not derive exactly one snapshot input from Konflux SUCCESS row for %s", one_nvr)
+                return False
+
+            handler = BaseImageHandler(runtime, dry_run=False)
+            result = await handler.snapshot_release(snapshot_inputs[0])
 
             if result:
                 release_name, snapshot_name = result

--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -10,7 +10,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from numbers import Number
-from typing import List, Optional, cast
+from typing import Optional, cast
 
 import click
 import koji
@@ -34,75 +34,42 @@ from doozerlib.source_resolver import SourceResolver
 LOGGER = logutil.get_logger(__name__)
 
 
-async def _snapshot_inputs_from_konflux_success_builds(runtime, nvrs: List[str]) -> List[BaseImageSnapshotInput]:
-    """
-    Map NVRs to :class:`BaseImageSnapshotInput` using latest matching **SUCCESS** Konflux image rows for ``runtime.group``.
+async def _snapshot_input_from_konflux_success_build(runtime, nvr: str) -> Optional[BaseImageSnapshotInput]:
+    """Map a Konflux **SUCCESS** image row to :class:`BaseImageSnapshotInput`, or ``None`` if missing or unusable."""
+    nvr = (nvr or "").strip()
+    if not nvr:
+        return None
 
-    Skips NVRs with no row, missing pullspec, unknown image metadata, or images that do not participate in the
-    base-image workflow. Callers should treat an empty list as failure to prepare any releasable snapshot.
-    """
-    if not nvrs:
-        return []
+    db = getattr(runtime, "konflux_db", None)
+    if not db:
+        return None
 
-    konflux_db = getattr(runtime, "konflux_db", None)
-    if not konflux_db:
-        LOGGER.warning("No Konflux database configured; cannot resolve NVRs to snapshot inputs")
-        return []
-
-    where = {"group": runtime.group, "engine": Engine.KONFLUX.value}
-    records = await konflux_db.get_build_records_by_nvrs(
-        nvrs, outcome=KonfluxBuildOutcome.SUCCESS, where=where, strict=False, exclude_large_columns=True
+    rec = await db.get_latest_build(
+        nvr=nvr,
+        group=runtime.group,
+        engine=Engine.KONFLUX,
+        outcome=KonfluxBuildOutcome.SUCCESS,
+        strict=False,
+        exclude_large_columns=True,
     )
+    if not rec or not rec.name or not rec.image_pullspec:
+        return None
 
-    by_nvr = {r.nvr: r for r in records if r is not None}
-    inputs: List[BaseImageSnapshotInput] = []
+    md = (getattr(runtime, "image_map", None) or {}).get(rec.name)
+    if md is not None:
+        is_golang_builder = md.is_golang_builder()
+    else:
+        # NVR uses distgit-style openshift-golang-builder; keep substring check for older rows / missing image_map
+        is_golang_builder = GOLANG_BUILDER_IMAGE_NAME in nvr
 
-    for nvr in nvrs:
-        rec = by_nvr.get(nvr)
-        if not rec:
-            LOGGER.warning(
-                "No SUCCESS Konflux image build record for NVR %s in group %s",
-                nvr,
-                runtime.group,
-            )
-            continue
-        if not rec.name:
-            LOGGER.warning("Konflux record for NVR %s has no component name", nvr)
-            continue
-
-        md = runtime.image_map.get(rec.name)
-        if not md:
-            LOGGER.warning(
-                "No loaded image metadata for Konflux component %s (NVR %s); check --group and image list",
-                rec.name,
-                nvr,
-            )
-            continue
-
-        if not md.should_trigger_base_image_release():
-            LOGGER.warning(
-                "Image %s does not qualify for base image release workflow (NVR %s), skipping",
-                rec.name,
-                nvr,
-            )
-            continue
-
-        if not rec.image_pullspec:
-            LOGGER.warning("Konflux record for NVR %s has no image_pullspec", nvr)
-            continue
-
-        inputs.append(
-            BaseImageSnapshotInput(
-                nvr=nvr,
-                distgit_key=rec.name,
-                container_image=rec.image_pullspec,
-                rebase_repo_url=rec.rebase_repo_url or "",
-                rebase_commitish=rec.rebase_commitish or "",
-                is_golang_builder=(md.config.name == GOLANG_BUILDER_IMAGE_NAME),
-            )
-        )
-
-    return inputs
+    return BaseImageSnapshotInput(
+        nvr=nvr,
+        distgit_key=rec.name,
+        container_image=rec.image_pullspec,
+        rebase_repo_url=rec.rebase_repo_url or "",
+        rebase_commitish=rec.rebase_commitish or "",
+        is_golang_builder=is_golang_builder,
+    )
 
 
 @cli.command("images:clone", help="Clone a group's image distgit repos locally.")
@@ -1527,29 +1494,16 @@ def query_rpm_version(runtime, repo_type):
     click.echo("version: {}".format(version))
 
 
-@cli.command("images:release-to-base-repo", short_help="Snapshot→release one base image build (Konflux SUCCESS row)")
+@cli.command("images:release-to-base-repo", short_help="Snapshot→release one base image (SUCCESS Konflux row)")
 @click.option(
     '--nvr',
     metavar='NVR',
     required=True,
-    help='Exactly one Konflux image build NVR (must have a SUCCESS row for this group)',
+    help='Image build NVR',
 )
 @pass_runtime
 def release_to_base_repo(runtime, nvr):
-    """
-    Process one completed base image build through the snapshot-to-release workflow.
-
-    Resolves the NVR to a SUCCESS Konflux image record and loaded image metadata, builds one Snapshot component,
-    creates the Release for ``ocp-art-images-base-silent``, and waits for completion.
-
-    Intended as a separate job after that base image Konflux build completes. Only applies when
-    ``should_trigger_base_image_release`` is true for the image.
-
-    Example::
-
-        doozer --group openshift-4.22 images:release-to-base-repo \\
-            --nvr openshift-enterprise-base-rhel9-container-v4.22.0-202602202227.p2.gcf42b3d.assembly.stream.el9
-    """
+    """Run Konflux snapshot→release for one NVR (row must exist and be SUCCESS for this group)."""
 
     async def run_workflow():
         logger = logutil.get_logger(__name__)
@@ -1559,38 +1513,29 @@ def release_to_base_repo(runtime, nvr):
 
             runtime.konflux_db.bind(KonfluxBuildRecord)
 
-            one_nvr = nvr.strip()
-            if not one_nvr:
-                logger.error("--nvr must be non-empty")
-                return False
-            if "," in one_nvr:
-                logger.error("Only one NVR is supported; do not pass comma-separated values (use one --nvr)")
+            image_nvr = (nvr or "").strip()
+            if not image_nvr:
+                logger.error("NVR is empty")
                 return False
 
-            logger.info("Processing NVR %s through base image snapshot-to-release workflow", one_nvr)
-            logger.info("Group: %s", runtime.group)
-
-            snapshot_inputs = await _snapshot_inputs_from_konflux_success_builds(runtime, [one_nvr])
-            if len(snapshot_inputs) != 1:
-                logger.error("Could not derive exactly one snapshot input from Konflux SUCCESS row for %s", one_nvr)
+            snapshot_input = await _snapshot_input_from_konflux_success_build(runtime, image_nvr)
+            if snapshot_input is None:
+                logger.error("No SUCCESS Konflux image row for %s", image_nvr)
                 return False
 
             handler = BaseImageHandler(runtime, dry_run=False)
-            result = await handler.snapshot_release(snapshot_inputs[0])
+            result = await handler.snapshot_release(snapshot_input)
 
             if result:
                 release_name, snapshot_name = result
-                logger.info("Base image workflow completed successfully")
-                logger.info(f"Release: {release_name}")
-                logger.info(f"Snapshot: {snapshot_name}")
+                logger.info("Done: release=%s snapshot=%s", release_name, snapshot_name)
                 return True
-            else:
-                logger.error("Base image workflow failed")
-                return False
+            logger.error("snapshot_release returned no result")
+            return False
 
         except Exception as e:
-            logger.error(f"Base image workflow failed: {e}")
-            logger.debug(f"Base image workflow traceback: {traceback.format_exc()}")
+            logger.error("Base image workflow failed: %s", e)
+            logger.debug(traceback.format_exc())
             return False
 
     success = asyncio.run(run_workflow())

--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -1,4 +1,3 @@
-import asyncio
 import io
 import json
 import pathlib
@@ -26,7 +25,14 @@ from dockerfile_parse import DockerfileParser
 from doozerlib import Runtime, coverity, state
 from doozerlib.backend.base_image_handler import BaseImageHandler, BaseImageSnapshotInput
 from doozerlib.brew import get_watch_task_info_copy
-from doozerlib.cli import cli, option_commit_message, option_push, pass_runtime, validate_semver_major_minor_patch
+from doozerlib.cli import (
+    cli,
+    click_coroutine,
+    option_commit_message,
+    option_push,
+    pass_runtime,
+    validate_semver_major_minor_patch,
+)
 from doozerlib.distgit import ImageDistGitRepo
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.source_resolver import SourceResolver
@@ -1501,44 +1507,30 @@ def query_rpm_version(runtime, repo_type):
     required=True,
     help='Image build NVR',
 )
+@click_coroutine
 @pass_runtime
-def release_to_base_repo(runtime, nvr):
+async def release_to_base_repo(runtime, nvr):
     """Run Konflux snapshot→release for one NVR (row must exist and be SUCCESS for this group)."""
+    logger = logutil.get_logger(__name__)
 
-    async def run_workflow():
-        logger = logutil.get_logger(__name__)
+    runtime.initialize(mode='images', build_system='konflux', clone_distgits=False, prevent_cloning=True)
 
-        try:
-            runtime.initialize(mode='images', build_system='konflux', clone_distgits=False, prevent_cloning=True)
+    runtime.konflux_db.bind(KonfluxBuildRecord)
 
-            runtime.konflux_db.bind(KonfluxBuildRecord)
+    image_nvr = (nvr or "").strip()
+    if not image_nvr:
+        raise DoozerFatalError("NVR is empty")
 
-            image_nvr = (nvr or "").strip()
-            if not image_nvr:
-                logger.error("NVR is empty")
-                return False
+    snapshot_input = await _snapshot_input_from_konflux_success_build(runtime, image_nvr)
+    if snapshot_input is None:
+        raise DoozerFatalError(f"No SUCCESS Konflux image row for {image_nvr}")
 
-            snapshot_input = await _snapshot_input_from_konflux_success_build(runtime, image_nvr)
-            if snapshot_input is None:
-                logger.error("No SUCCESS Konflux image row for %s", image_nvr)
-                return False
+    handler = BaseImageHandler(runtime, dry_run=False)
+    result = await handler.snapshot_release(snapshot_input)
 
-            handler = BaseImageHandler(runtime, dry_run=False)
-            result = await handler.snapshot_release(snapshot_input)
+    if result:
+        release_name, snapshot_name = result
+        logger.info("Done: release=%s snapshot=%s", release_name, snapshot_name)
+        return
 
-            if result:
-                release_name, snapshot_name = result
-                logger.info("Done: release=%s snapshot=%s", release_name, snapshot_name)
-                return True
-            logger.error("snapshot_release returned no result")
-            return False
-
-        except Exception as e:
-            logger.error("Base image workflow failed: %s", e)
-            logger.debug(traceback.format_exc())
-            return False
-
-    success = asyncio.run(run_workflow())
-
-    if not success:
-        sys.exit(1)
+    raise DoozerFatalError("snapshot_release returned no result")

--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -17,7 +17,7 @@ import yaml
 from artcommonlib import exectools, logutil
 from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
 from artcommonlib.format_util import color_print, green_print, yellow_print
-from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildOutcome, KonfluxBuildRecord
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.model import Missing, Model
 from artcommonlib.pushd import Dir
 from dockerfile_parse import DockerfileParser
@@ -50,10 +50,8 @@ async def _snapshot_input_from_konflux_success_build(runtime, nvr: str) -> Optio
     if not db:
         return None
 
-    rec = await db.get_latest_build(
+    rec = await db.get_build_record_by_nvr(
         nvr=nvr,
-        group=runtime.group,
-        engine=Engine.KONFLUX,
         outcome=KonfluxBuildOutcome.SUCCESS,
         strict=False,
         exclude_large_columns=True,
@@ -61,9 +59,9 @@ async def _snapshot_input_from_konflux_success_build(runtime, nvr: str) -> Optio
     if not rec or not rec.name or not rec.image_pullspec:
         return None
 
-    md = (getattr(runtime, "image_map", None) or {}).get(rec.name)
-    if md is not None:
-        is_golang_builder = md.is_golang_builder()
+    image_metadata = runtime.image_map.get(rec.name)
+    if image_metadata is not None:
+        is_golang_builder = image_metadata.is_golang_builder()
     else:
         # NVR uses distgit-style openshift-golang-builder; keep substring check for older rows / missing image_map
         is_golang_builder = GOLANG_BUILDER_IMAGE_NAME in nvr

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -5,7 +5,6 @@ import pathlib
 import re
 from collections import OrderedDict
 from copy import copy
-from datetime import datetime, timezone
 from functools import lru_cache
 from multiprocessing import Event
 from typing import Any, Dict, List, Optional, Set, Tuple, cast
@@ -27,44 +26,6 @@ from doozerlib.build_info import BrewBuildRecordInspector
 from doozerlib.distgit import pull_image
 from doozerlib.metadata import Metadata, RebuildHint, RebuildHintCode
 from doozerlib.source_resolver import SourceResolver
-
-
-def _lockfile_seed_build_completion_ts(record: KonfluxBuildRecord) -> datetime:
-    """Best-effort completion timestamp for comparing Konflux builds (end_time, else start_time)."""
-    t = record.end_time or record.start_time
-    if t is None:
-        return datetime.min.replace(tzinfo=timezone.utc)
-    if t.tzinfo is None:
-        t = t.replace(tzinfo=timezone.utc)
-    return t.astimezone(timezone.utc)
-
-
-def _pick_lockfile_seed_build(
-    success_build: Optional[KonfluxBuildRecord],
-    unreleased_build: Optional[KonfluxBuildRecord],
-) -> Optional[KonfluxBuildRecord]:
-    """
-    Choose which Konflux DB row should seed lockfile installed_rpms: the latest of SUCCESS and UNRELEASED
-    by completion time. If the time-newest row has no installed_rpms, prefer the other when it does.
-    """
-    if success_build is None and unreleased_build is None:
-        return None
-    if success_build is None:
-        chosen = unreleased_build
-    elif unreleased_build is None:
-        chosen = success_build
-    else:
-        success_ts = _lockfile_seed_build_completion_ts(success_build)
-        unreleased_ts = _lockfile_seed_build_completion_ts(unreleased_build)
-        # Prefer UNRELEASED on equal completion time (same tie-break as index-based max before).
-        chosen = unreleased_build if unreleased_ts >= success_ts else success_build
-
-    if chosen.installed_rpms:
-        return chosen
-    for candidate in (success_build, unreleased_build):
-        if candidate is not None and candidate is not chosen and candidate.installed_rpms:
-            return candidate
-    return chosen
 
 
 @lru_cache(maxsize=256)
@@ -1194,10 +1155,8 @@ class ImageMetadata(Metadata):
         Returns either the full image RPM set or difference from parent packages,
         based on the inspect_parent configuration. Caches result in installed_rpms attribute.
 
-        When resolving the latest build (no matching lockfile_seed_nvrs): for images that participate
-        in the base-image release workflow (same predicate as Konflux: ``should_trigger_base_image_release()``),
-        uses the newer of the latest **success** and **unreleased** Konflux outcomes by completion time so
-        that builds waiting on release still contribute fresh SBOM RPMs. Other images query **success** only.
+        When resolving the latest build (no matching lockfile_seed_nvrs), uses the latest successful
+        Konflux build (outcome SUCCESS), including base/golang images after inline snapshot→release.
 
         Args:
             lockfile_seed_nvrs: NVRs of builds whose installed RPMs should seed lockfile
@@ -1229,16 +1188,9 @@ class ImageMetadata(Metadata):
                     'name': self.distgit_key,
                     'assembly': self.runtime.assembly,
                 }
-                build_success = await self.runtime.konflux_db.get_latest_build(
+                build = await self.runtime.konflux_db.get_latest_build(
                     **base_search_params, outcome=KonfluxBuildOutcome.SUCCESS
                 )
-                if self.should_trigger_base_image_release():
-                    build_unreleased = await self.runtime.konflux_db.get_latest_build(
-                        **base_search_params, outcome=KonfluxBuildOutcome.UNRELEASED
-                    )
-                    build = _pick_lockfile_seed_build(build_success, build_unreleased)
-                else:
-                    build = build_success
                 if build:
                     self.logger.info(
                         'Lockfile seed for %s: nvr=%s outcome=%s end_time=%s',

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1391,9 +1391,8 @@ class ImageMetadata(Metadata):
         if self.runtime.variant is BuildVariant.OKD:
             return False
 
-        # TODO: Revert — needed for local/base-image testing; restore before merge.
-        # if self.runtime.assembly == "test":
-        #     return False
+        if self.runtime.assembly == "test":
+            return False
 
         if not (self.is_base_image() or self.is_golang_builder()):
             return False

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1391,8 +1391,9 @@ class ImageMetadata(Metadata):
         if self.runtime.variant is BuildVariant.OKD:
             return False
 
-        if self.runtime.assembly == "test":
-            return False
+        # TODO: Revert — needed for local/base-image testing; restore before merge.
+        # if self.runtime.assembly == "test":
+        #     return False
 
         if not (self.is_base_image() or self.is_golang_builder()):
             return False

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -22,6 +22,7 @@ from artcommonlib.arch_util import GO_ARCHES, brew_arch_for_go_arch, go_arch_for
 from artcommonlib.assembly import AssemblyTypes
 from artcommonlib.format_util import red_print
 from artcommonlib.model import Missing, Model
+from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import (
     isolate_major_minor_in_group,
     oc_image_info,  # noqa: F401 - re-exported for backward compatibility
@@ -532,6 +533,58 @@ def get_konflux_build_priority(metadata, group):
 
     # Default
     return higher_by(0)
+
+
+def konflux_application_name(group_name: str) -> str:
+    """
+    Konflux Application slug for standard OCP image builds (not FBC ``fbc-*``).
+
+    Converts group dots to dashes so values match Konflux/Application Studio constraints.
+    """
+    # "openshift-4.18" -> "openshift-4-18"
+    return group_name.replace(".", "-")
+
+
+def konflux_image_component_name(application_name: str, image_name: str) -> str:
+    """
+    Konflux Component name for a container image (distgit member), given the Application slug.
+
+    OpenShift forbids dots/underscores; component names must be RFC1123-ish (lowercase, length limits).
+    """
+    name = f"{application_name}-{image_name}".replace(".", "-").replace("_", "-")
+    # 'openshift-4-18-ose-installer-terraform' -> 'ose-4-18-ose-installer-terraform'
+    name = f"ose-{name[10:]}" if name.startswith("openshift-") else name
+    return name
+
+
+def konflux_golang_builder_component_name(nvr: str) -> str:
+    """
+    Konflux Component name for a golang-builder image derived from build NVR.
+
+    Example NVR::
+        openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.el8
+    yields something like::
+        golang-builder-v1.25-rhel8
+    """
+    nvr_parsed = parse_nvr(nvr)
+    version = nvr_parsed["version"]
+    release = nvr_parsed["release"]
+
+    if version.startswith("v"):
+        version_parts = version[1:].split(".")
+    else:
+        version_parts = version.split(".")
+
+    if len(version_parts) >= 2:
+        major_minor = f"v{version_parts[0]}.{version_parts[1]}"
+    else:
+        major_minor = version
+
+    el_suffix = "rhel9"
+    if ".el8" in release:
+        el_suffix = "rhel8"
+
+    return f"golang-builder-{major_minor}-{el_suffix}"
 
 
 def rc_api_url(tag: str, arch: str, private_nightly: bool) -> str:

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -51,7 +51,7 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         handler = BaseImageHandler(self.runtime, dry_run=True)
         self.runtime.image_map = {"test-base": self.metadata}
 
-        with patch.object(handler, "_snapshot_from_components", new=AsyncMock(return_value="test-snapshot")):
+        with patch.object(handler, "_snapshot_from_component", new=AsyncMock(return_value="test-snapshot")):
             with patch.object(handler, "_create_release_from_snapshot", new=AsyncMock(return_value="test-release")):
                 with patch.object(handler, "_wait_for_release_completion", return_value=True):
                     result = await handler.snapshot_release(self.default_input)
@@ -72,15 +72,14 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         handler = BaseImageHandler(self.runtime, dry_run=True)
         self.runtime.image_map = {"test-base": self.metadata}
 
-        with patch.object(handler, "_snapshot_from_components", new=AsyncMock(return_value="snap")) as mock_snap:
+        with patch.object(handler, "_snapshot_from_component", new=AsyncMock(return_value="snap")) as mock_snap:
             with patch.object(handler, "_create_release_from_snapshot", new=AsyncMock(return_value="rel")):
                 with patch.object(handler, "_wait_for_release_completion", return_value=True):
                     await handler.snapshot_release(self.default_input)
 
         mock_snap.assert_awaited_once()
-        comps = mock_snap.await_args.args[0]
-        self.assertEqual(len(comps), 1)
-        self.assertEqual(comps[0]["containerImage"], self.image_pullspec)
+        comp = mock_snap.await_args.args[0]
+        self.assertEqual(comp["containerImage"], self.image_pullspec)
 
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
@@ -156,7 +155,7 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         handler = BaseImageHandler(self.runtime, dry_run=True)
         self.runtime.image_map = {"golang-builder": golang_metadata}
 
-        with patch.object(handler, "_snapshot_from_components", new=AsyncMock(return_value="golang-snapshot")):
+        with patch.object(handler, "_snapshot_from_component", new=AsyncMock(return_value="golang-snapshot")):
             with patch.object(handler, "_create_release_from_snapshot", new=AsyncMock(return_value="golang-release")):
                 with patch.object(handler, "_wait_for_release_completion", return_value=True):
                     result = await handler.snapshot_release(inp)

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -2,7 +2,8 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from artcommonlib.model import Model
-from doozerlib.backend.base_image_handler import BaseImageHandler
+from artcommonlib.variants import BuildVariant
+from doozerlib.backend.base_image_handler import BaseImageHandler, BaseImageSnapshotInput
 from doozerlib.image import ImageMetadata
 
 
@@ -13,6 +14,7 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         self.runtime.group_config.name = "openshift-4.22"
         self.runtime.assembly = "stream"
         self.runtime.product = "ocp"
+        self.runtime.variant = BuildVariant.OCP
 
         image_model = Model(
             {
@@ -29,36 +31,30 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         self.nvr = "test-base-container-v1.0.0-1.el9"
         self.image_pullspec = "quay.io/test/test-base:latest"
 
-        self.nvr_list = [self.nvr]
+        self.default_input = BaseImageSnapshotInput(
+            nvr=self.nvr,
+            distgit_key="test-base",
+            container_image=self.image_pullspec,
+            rebase_repo_url="https://example.com/repo.git",
+            rebase_commitish="abc123",
+            is_golang_builder=False,
+        )
 
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
-    async def test_process_base_image_completion_success(
-        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
-    ):
+    async def test_snapshot_release_success(self, mock_kubeconfig, mock_namespace, mock_konflux_client_init):
         mock_namespace.return_value = "ocp-art-tenant"
         mock_kubeconfig.return_value = "/path/to/kubeconfig"
+        mock_konflux_client_init.return_value = AsyncMock()
 
-        konflux_client = AsyncMock()
-        mock_konflux_client_init.return_value = konflux_client
+        handler = BaseImageHandler(self.runtime, dry_run=True)
+        self.runtime.image_map = {"test-base": self.metadata}
 
-        handler = BaseImageHandler(self.runtime, self.nvr_list, dry_run=True)
-
-        # Mock the component_map and build records
-        mock_build_record = MagicMock()
-        mock_build_record.name = "test-base"
-        mock_build_record.image_pullspec = self.image_pullspec
-        mock_build_record.rebase_repo_url = "https://example.com/repo.git"
-        mock_build_record.rebase_commitish = "abc123"
-
-        self.runtime.component_map = {"test-base-container": self.metadata}
-
-        with patch.object(handler, "_fetch_build_records", return_value={self.nvr: mock_build_record}):
-            with patch.object(handler, "_create_snapshot", return_value="test-snapshot"):
-                with patch.object(handler, "_create_release_from_snapshot", return_value="test-release"):
-                    with patch.object(handler, "_wait_for_release_completion", return_value=True):
-                        result = await handler.process_base_image_completion()
+        with patch.object(handler, "_snapshot_from_components", new=AsyncMock(return_value="test-snapshot")):
+            with patch.object(handler, "_create_release_from_snapshot", new=AsyncMock(return_value="test-release")):
+                with patch.object(handler, "_wait_for_release_completion", return_value=True):
+                    result = await handler.snapshot_release(self.default_input)
 
         self.assertIsNotNone(result)
         self.assertEqual(result, ("test-release", "test-snapshot"))
@@ -66,166 +62,76 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
-    async def test_process_base_image_completion_failure(
+    async def test_snapshot_release_builds_one_component(
         self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
     ):
         mock_namespace.return_value = "ocp-art-tenant"
         mock_kubeconfig.return_value = "/path/to/kubeconfig"
+        mock_konflux_client_init.return_value = AsyncMock()
 
-        konflux_client = AsyncMock()
-        mock_konflux_client_init.return_value = konflux_client
+        handler = BaseImageHandler(self.runtime, dry_run=True)
+        self.runtime.image_map = {"test-base": self.metadata}
 
-        handler = BaseImageHandler(self.runtime, self.nvr_list, dry_run=False)
+        with patch.object(handler, "_snapshot_from_components", new=AsyncMock(return_value="snap")) as mock_snap:
+            with patch.object(handler, "_create_release_from_snapshot", new=AsyncMock(return_value="rel")):
+                with patch.object(handler, "_wait_for_release_completion", return_value=True):
+                    await handler.snapshot_release(self.default_input)
 
-        # Mock empty image_map to cause failure
+        mock_snap.assert_awaited_once()
+        comps = mock_snap.await_args.args[0]
+        self.assertEqual(len(comps), 1)
+        self.assertEqual(comps[0]["containerImage"], self.image_pullspec)
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_snapshot_release_unknown_metadata_returns_none(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+        mock_konflux_client_init.return_value = AsyncMock()
+
+        handler = BaseImageHandler(self.runtime, dry_run=False)
         self.runtime.image_map = {}
 
-        with patch.object(handler, "_fetch_build_records", return_value={}):
-            result = await handler.process_base_image_completion()
+        result = await handler.snapshot_release(self.default_input)
 
         self.assertIsNone(result)
 
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
-    async def test_process_base_image_completion_critical_errors_with_success(
+    async def test_snapshot_release_empty_pullspec_returns_none(
         self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
     ):
         mock_namespace.return_value = "ocp-art-tenant"
         mock_kubeconfig.return_value = "/path/to/kubeconfig"
+        mock_konflux_client_init.return_value = AsyncMock()
 
-        konflux_client = AsyncMock()
-        mock_konflux_client_init.return_value = konflux_client
+        bad = BaseImageSnapshotInput(
+            nvr="x-container-v1-1.el9",
+            distgit_key="test-base",
+            container_image="",
+        )
+        handler = BaseImageHandler(self.runtime, dry_run=True)
+        self.runtime.image_map = {"test-base": self.metadata}
 
-        valid_nvr = "valid-base-container-v1.0.0-1.el9"
-        invalid_nvr = "invalid-base-container-v1.0.0-1.el9"
-
-        handler = BaseImageHandler(self.runtime, [valid_nvr, invalid_nvr], dry_run=True)
-
-        valid_build_record = MagicMock()
-        valid_build_record.name = "valid-base"
-        valid_build_record.image_pullspec = "quay.io/test/valid-base:latest"
-
-        invalid_build_record = MagicMock()
-        invalid_build_record.name = "invalid-base"
-        invalid_build_record.image_pullspec = None
-
-        self.runtime.image_map = {"valid-base": self.metadata}
-
-        build_records = {valid_nvr: valid_build_record, invalid_nvr: invalid_build_record}
-
-        with patch.object(handler, "_fetch_build_records", return_value=build_records):
-            with patch.object(handler, "_create_snapshot", return_value="test-snapshot"):
-                with patch.object(
-                    handler, "_create_release_from_snapshot", return_value="test-release"
-                ) as mock_release:
-                    with patch.object(handler, "_wait_for_release_completion", return_value=True):
-                        with self.assertRaises(RuntimeError) as context:
-                            await handler.process_base_image_completion()
-
-        error_message = str(context.exception)
-        mock_release.assert_awaited_once_with("test-snapshot", valid_nvr)
-        self.assertIn("Snapshot/Release completed successfully", error_message)
-        self.assertIn("1 critical validation failures", error_message)
-        self.assertIn("Could not resolve metadata", error_message)
-        self.assertIn("invalid-base", error_message)
+        result = await handler.snapshot_release(bad)
+        self.assertIsNone(result)
 
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
-    async def test_process_base_image_completion_metadata_missing_error(
+    async def test_snapshot_release_golang_builder_success(
         self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
     ):
-        mock_namespace.return_value = "ocp-art-tenant"
-        mock_kubeconfig.return_value = "/path/to/kubeconfig"
-
-        konflux_client = AsyncMock()
-        mock_konflux_client_init.return_value = konflux_client
-
-        valid_nvr = "valid-base-container-v1.0.0-1.el9"
-        missing_metadata_nvr = "missing-metadata-container-v1.0.0-1.el9"
-
-        handler = BaseImageHandler(self.runtime, [valid_nvr, missing_metadata_nvr], dry_run=True)
-
-        valid_build_record = MagicMock()
-        valid_build_record.name = "valid-base"
-        valid_build_record.image_pullspec = "quay.io/test/valid-base:latest"
-
-        missing_metadata_record = MagicMock()
-        missing_metadata_record.name = "missing-metadata"
-        missing_metadata_record.image_pullspec = "quay.io/test/missing:latest"
-
-        self.runtime.image_map = {"valid-base": self.metadata}
-
-        build_records = {valid_nvr: valid_build_record, missing_metadata_nvr: missing_metadata_record}
-
-        with patch.object(handler, "_fetch_build_records", return_value=build_records):
-            with patch.object(handler, "_create_snapshot", return_value="test-snapshot"):
-                with patch.object(handler, "_create_release_from_snapshot", return_value="test-release"):
-                    with patch.object(handler, "_wait_for_release_completion", return_value=True):
-                        with self.assertRaises(RuntimeError) as context:
-                            await handler.process_base_image_completion()
-
-        error_message = str(context.exception)
-        self.assertIn("Could not resolve metadata", error_message)
-        self.assertIn("missing-metadata", error_message)
-
-    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
-    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
-    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
-    async def test_process_base_image_completion_missing_component_name_error(
-        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
-    ):
-        mock_namespace.return_value = "ocp-art-tenant"
-        mock_kubeconfig.return_value = "/path/to/kubeconfig"
-
-        konflux_client = AsyncMock()
-        mock_konflux_client_init.return_value = konflux_client
-
-        valid_nvr = "valid-base-container-v1.0.0-1.el9"
-        missing_name_nvr = "missing-name-container-v1.0.0-1.el9"
-
-        handler = BaseImageHandler(self.runtime, [valid_nvr, missing_name_nvr], dry_run=True)
-
-        valid_build_record = MagicMock()
-        valid_build_record.name = "valid-base"
-        valid_build_record.image_pullspec = "quay.io/test/valid-base:latest"
-
-        missing_name_record = MagicMock()
-        missing_name_record.name = None
-        missing_name_record.image_pullspec = "quay.io/test/missing-name:latest"
-
-        self.runtime.image_map = {"valid-base": self.metadata}
-
-        build_records = {valid_nvr: valid_build_record, missing_name_nvr: missing_name_record}
-
-        with patch.object(handler, "_fetch_build_records", return_value=build_records):
-            with patch.object(handler, "_create_snapshot", return_value="test-snapshot"):
-                with patch.object(handler, "_create_release_from_snapshot", return_value="test-release"):
-                    with patch.object(handler, "_wait_for_release_completion", return_value=True):
-                        with self.assertRaises(RuntimeError) as context:
-                            await handler.process_base_image_completion()
-
-        error_message = str(context.exception)
-        self.assertIn("No component name found", error_message)
-        self.assertIn(missing_name_nvr, error_message)
-
-    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
-    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
-    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
-    async def test_process_base_image_completion_golang_builder_success(
-        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
-    ):
-        """Test that golang builders can successfully go through base image workflow."""
         from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
 
         mock_namespace.return_value = "ocp-art-tenant"
         mock_kubeconfig.return_value = "/path/to/kubeconfig"
+        mock_konflux_client_init.return_value = AsyncMock()
 
-        konflux_client = AsyncMock()
-        mock_konflux_client_init.return_value = konflux_client
-
-        # Create golang builder metadata
         golang_builder_model = Model(
             {
                 "name": GOLANG_BUILDER_IMAGE_NAME,
@@ -238,31 +144,30 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         golang_metadata.distgit_key = "golang-builder"
 
         golang_nvr = "golang-builder-container-v1.0.0-1.el9"
-        handler = BaseImageHandler(self.runtime, [golang_nvr], dry_run=True)
+        inp = BaseImageSnapshotInput(
+            nvr=golang_nvr,
+            distgit_key="golang-builder",
+            container_image="quay.io/test/golang-builder:latest",
+            rebase_repo_url="https://example.com/golang-builder.git",
+            rebase_commitish="def456",
+            is_golang_builder=True,
+        )
 
-        # Mock the build record for golang builder
-        golang_build_record = MagicMock()
-        golang_build_record.name = "golang-builder"
-        golang_build_record.image_pullspec = "quay.io/test/golang-builder:latest"
-        golang_build_record.rebase_repo_url = "https://example.com/golang-builder.git"
-        golang_build_record.rebase_commitish = "def456"
-
+        handler = BaseImageHandler(self.runtime, dry_run=True)
         self.runtime.image_map = {"golang-builder": golang_metadata}
 
-        with patch.object(handler, "_fetch_build_records", return_value={golang_nvr: golang_build_record}):
-            with patch.object(handler, "_create_snapshot", return_value="golang-snapshot"):
-                with patch.object(handler, "_create_release_from_snapshot", return_value="golang-release"):
-                    with patch.object(handler, "_wait_for_release_completion", return_value=True):
-                        result = await handler.process_base_image_completion()
+        with patch.object(handler, "_snapshot_from_components", new=AsyncMock(return_value="golang-snapshot")):
+            with patch.object(handler, "_create_release_from_snapshot", new=AsyncMock(return_value="golang-release")):
+                with patch.object(handler, "_wait_for_release_completion", return_value=True):
+                    result = await handler.snapshot_release(inp)
 
-        # Golang builder should successfully complete the workflow
         self.assertIsNotNone(result)
         self.assertEqual(result, ("golang-release", "golang-snapshot"))
 
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
-    async def test_create_release_from_snapshot_adds_nvr_annotation(
+    async def test_create_release_from_snapshot_sets_nvr_annotation(
         self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
     ):
         mock_namespace.return_value = "ocp-art-tenant"
@@ -275,22 +180,12 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         konflux_client.resource_url = MagicMock(return_value="https://konflux.example/releases/test-release")
         mock_konflux_client_init.return_value = konflux_client
 
-        handler = BaseImageHandler(
-            self.runtime,
-            [self.nvr, "another-base-container-v1.0.0-1.el8"],
-            dry_run=False,
-        )
+        handler = BaseImageHandler(self.runtime, dry_run=False)
 
         with patch.object(handler, "_wait_for_snapshot_availability", new=AsyncMock(return_value=True)):
-            await handler._create_release_from_snapshot(
-                "test-snapshot",
-                "another-base-container-v1.0.0-1.el8,test-base-container-v1.0.0-1.el9",
-            )
+            await handler._create_release_from_snapshot("test-snapshot", self.nvr)
 
         konflux_client._get.assert_awaited_once()
         konflux_client._create.assert_awaited_once()
         release_obj = konflux_client._create.await_args.args[0]
-        self.assertEqual(
-            release_obj["metadata"]["annotations"]["art.redhat.com/nvrs"],
-            "another-base-container-v1.0.0-1.el8,test-base-container-v1.0.0-1.el9",
-        )
+        self.assertEqual(release_obj["metadata"]["annotations"]["art.redhat.com/nvrs"], self.nvr)

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -363,67 +363,6 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         persisted = mock_add_build.call_args[0][0]
         self.assertEqual(persisted.image_pullspec, expected_pullspec)
 
-    async def test_update_konflux_db_unreleased_sets_quay_pullspec_like_success(self):
-        """UNRELEASED (base image build ok, awaiting release) must populate image_pullspec for snapshot workflow."""
-        metadata = self._metadata()
-        build_repo = MagicMock()
-        build_repo.https_url = "https://example.com/repo.git"
-        build_repo.commit_hash = "test-commit-hash"
-        build_repo.local_dir = Path(self.temp_dir.name)
-
-        pipelinerun = PipelineRunInfo(
-            {
-                "metadata": {
-                    "name": "test-pipelinerun",
-                    "uid": "test-uid",
-                    "labels": {"appstudio.openshift.io/component": "test-component"},
-                },
-                "status": {
-                    "results": [
-                        {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
-                        {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
-                    ],
-                    "startTime": "2023-10-01T12:00:00Z",
-                    "completionTime": "2023-10-01T12:30:00Z",
-                },
-            },
-            {},
-        )
-
-        with (
-            patch("doozerlib.backend.konflux_image_builder.DockerfileParser") as mock_dockerfile_parser,
-            patch.object(self.builder, "extract_parent_image_nvrs", new=AsyncMock(return_value=[])),
-            patch.object(
-                self.builder,
-                "get_installed_packages",
-                new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
-            ) as mock_get_installed_packages,
-            patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
-        ):
-            mock_dockerfile = MagicMock()
-            mock_dockerfile.labels = {
-                "io.openshift.build.source-location": "https://example.com/source-repo.git",
-                "io.openshift.build.commit.id": "source-commit-id",
-                "com.redhat.component": "test-component",
-                "version": "1.0",
-                "release": "1.el9",
-            }
-            mock_dockerfile.parent_images = []
-            mock_dockerfile_parser.return_value = mock_dockerfile
-            mock_bigquery_client.return_value.client.insert_rows_json.return_value = None
-
-            await self.builder.update_konflux_db(
-                metadata,
-                build_repo,
-                pipelinerun,
-                KonfluxBuildOutcome.UNRELEASED,
-                ["x86_64"],
-                "5",
-            )
-
-        expected_pullspec = "quay.io/test/image@sha256:testdigest"
-        mock_get_installed_packages.assert_awaited_once_with(expected_pullspec, ["x86_64"], None)
-
     async def test_trigger_base_image_release_success_flow(self):
         """SUCCESS after base snapshot release refreshes Konflux DB without swapping image_pullspec to RH."""
         metadata = self._metadata()
@@ -483,9 +422,9 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
 
         mock_trigger_release.assert_awaited_once()
 
-        # PENDING write + UNRELEASED write + SUCCESS after release
-        self.assertEqual(mock_update_db.await_count, 3)
-        success_call_args = mock_update_db.await_args_list[2][0]
+        # PENDING write + single completion write (SUCCESS after inline base release)
+        self.assertEqual(mock_update_db.await_count, 2)
+        success_call_args = mock_update_db.await_args_list[1][0]
         self.assertEqual(success_call_args[3], KonfluxBuildOutcome.SUCCESS)
 
     async def test_trigger_base_image_release_failure_flow(self):
@@ -547,10 +486,10 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 await self.builder.build(metadata)
 
         mock_trigger_release.assert_awaited_once()
-        self.assertEqual(mock_update_db.await_count, 3)
+        self.assertEqual(mock_update_db.await_count, 2)
 
         # Final update records FAILURE outcome
-        failure_call_args = mock_update_db.await_args_list[2][0]
+        failure_call_args = mock_update_db.await_args_list[1][0]
         self.assertEqual(failure_call_args[3], KonfluxBuildOutcome.FAILURE)
 
     async def test_non_base_image_skips_release_trigger(self):
@@ -614,30 +553,50 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         # Only 2 database updates: PENDING + final SUCCESS (no registry update)
         self.assertEqual(mock_update_db.await_count, 2)
 
-    async def test_trigger_base_image_release_calls_jenkins_with_block_until_complete(self):
-        """Test that base image release uses block_until_complete=True for synchronous execution."""
-        from pyartcd import jenkins
+    async def test_trigger_base_image_release_uses_base_image_handler(self):
+        """Per-build release uses BaseImageHandler with snapshot_input; no Jenkins."""
+        from doozerlib.backend import base_image_handler
 
         metadata = self._metadata()
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "abc123"
+        pullspec = "quay.io/test/img@sha256:deadbeef"
 
-        with patch.object(jenkins, 'start_base_image_release', return_value="SUCCESS") as mock_jenkins:
-            result = await self.builder._trigger_base_image_release(metadata, "test-nvr")
+        with patch.object(
+            base_image_handler.BaseImageHandler,
+            "snapshot_release",
+            new=AsyncMock(return_value=("test-release", "test-snapshot")),
+        ) as mock_snap:
+            result = await self.builder._trigger_base_image_release(metadata, "test-nvr", pullspec, build_repo)
 
         self.assertTrue(result)
-        mock_jenkins.assert_called_once()
-        call_kwargs = mock_jenkins.call_args[1]
-        self.assertTrue(call_kwargs.get('block_until_complete', False))
+        mock_snap.assert_awaited_once()
+        inp = mock_snap.await_args[0][0]
+        self.assertEqual(inp.nvr, "test-nvr")
+        self.assertEqual(inp.distgit_key, metadata.distgit_key)
+        self.assertEqual(inp.container_image, pullspec)
 
-    async def test_trigger_base_image_release_jenkins_failure_string_returns_false(self):
-        """start_build returns Jenkins result strings; FAILURE must not be treated as success."""
-        from pyartcd import jenkins
+    async def test_trigger_base_image_release_inline_failure_returns_false(self):
+        """When handler returns None, _trigger_base_image_release is False."""
+        from doozerlib.backend import base_image_handler
 
         metadata = self._metadata()
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "abc123"
 
-        with patch.object(jenkins, 'start_base_image_release', return_value='FAILURE'):
-            result = await self.builder._trigger_base_image_release(metadata, "test-nvr")
+        with patch.object(
+            base_image_handler.BaseImageHandler,
+            "snapshot_release",
+            new=AsyncMock(return_value=None),
+        ) as mock_snap:
+            result = await self.builder._trigger_base_image_release(
+                metadata, "test-nvr", "quay.io/x@sha256:y", build_repo
+            )
 
         self.assertFalse(result)
+        mock_snap.assert_awaited_once()
 
 
 class TestNormalizeVersion(unittest.TestCase):

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -423,7 +423,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
 
         mock_trigger_release.assert_awaited_once()
 
-        # PENDING write + single completion write (SUCCESS after inline base release)
+        # PENDING write + single completion write (SUCCESS after base image snapshot-release)
         self.assertEqual(mock_update_db.await_count, 2)
         success_call_args = mock_update_db.await_args_list[1][0]
         self.assertEqual(success_call_args[3], KonfluxBuildOutcome.SUCCESS)
@@ -602,7 +602,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         inp = mock_snap.await_args[0][0]
         self.assertTrue(inp.is_golang_builder)
 
-    async def test_trigger_base_image_release_inline_failure_returns_false(self):
+    async def test_trigger_base_image_release_returns_false_when_handler_returns_none(self):
         """When handler returns None, _trigger_base_image_release is False."""
         from doozerlib.backend import base_image_handler
 

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -11,6 +11,7 @@ from doozerlib.backend.konflux_image_builder import (
     _normalize_version,
 )
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
+from doozerlib.util import konflux_golang_builder_component_name
 
 
 class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
@@ -673,14 +674,14 @@ class TestKonfluxImageBuilderGolangComponent(unittest.TestCase):
         """Test basic golang builder component name generation."""
         nvr = "openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.el8"
         expected = "golang-builder-v1.25-rhel8"
-        result = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
+        result = konflux_golang_builder_component_name(nvr)
         self.assertEqual(result, expected)
 
     def test_get_golang_builder_component_name_el9(self):
         """Test golang builder component name with el9."""
         nvr = "openshift-golang-builder-container-v1.24.13-202603271102.p2.ge8e5642.el9"
         expected = "golang-builder-v1.24-rhel9"
-        result = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
+        result = konflux_golang_builder_component_name(nvr)
         self.assertEqual(result, expected)
 
     def test_get_golang_builder_component_name_various_versions(self):
@@ -697,7 +698,7 @@ class TestKonfluxImageBuilderGolangComponent(unittest.TestCase):
 
         for nvr, expected in test_cases:
             with self.subTest(nvr=nvr):
-                result = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
+                result = konflux_golang_builder_component_name(nvr)
                 self.assertEqual(result, expected)
 
     def test_get_golang_builder_component_name_comprehensive_dataset(self):
@@ -721,28 +722,28 @@ class TestKonfluxImageBuilderGolangComponent(unittest.TestCase):
 
         for nvr, expected in test_nvrs:
             with self.subTest(nvr=nvr):
-                result = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
+                result = konflux_golang_builder_component_name(nvr)
                 self.assertEqual(result, expected, f"Failed for NVR: {nvr}")
 
     def test_get_golang_builder_component_name_no_el_version_defaults_to_rhel9(self):
         """Test that missing RHEL version defaults to rhel9."""
         nvr = "openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.unknown"
         expected = "golang-builder-v1.25-rhel9"
-        result = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
+        result = konflux_golang_builder_component_name(nvr)
         self.assertEqual(result, expected)
 
     def test_get_golang_builder_component_name_version_without_v_prefix(self):
         """Test version without 'v' prefix."""
         nvr = "openshift-golang-builder-container-1.25.8-202604081607.p0.g2aa6a05.el8"
         expected = "golang-builder-v1.25-rhel8"
-        result = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
+        result = konflux_golang_builder_component_name(nvr)
         self.assertEqual(result, expected)
 
     def test_get_golang_builder_component_name_single_version_part(self):
         """Test with single version part (fallback behavior)."""
         nvr = "openshift-golang-builder-container-v1-202604081607.p0.g2aa6a05.el9"
         expected = "golang-builder-v1-rhel9"  # Should fallback to original version
-        result = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
+        result = konflux_golang_builder_component_name(nvr)
         self.assertEqual(result, expected)
 
     def test_get_golang_builder_component_name_edge_cases(self):
@@ -758,7 +759,7 @@ class TestKonfluxImageBuilderGolangComponent(unittest.TestCase):
 
         for nvr, expected in test_cases:
             with self.subTest(nvr=nvr):
-                result = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
+                result = konflux_golang_builder_component_name(nvr)
                 self.assertEqual(result, expected)
 
     def test_get_golang_builder_component_name_multiple_el_patterns(self):
@@ -766,5 +767,5 @@ class TestKonfluxImageBuilderGolangComponent(unittest.TestCase):
         # This documents the expected behavior: .el8 override wins due to simplified logic
         nvr = "openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.el8.dependency.el9"
         expected = "golang-builder-v1.25-rhel8"  # .el8 override takes precedence
-        result = KonfluxImageBuilder.get_golang_builder_component_name(nvr)
+        result = konflux_golang_builder_component_name(nvr)
         self.assertEqual(result, expected)

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -55,6 +55,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         metadata.get_konflux_network_mode.return_value = "open"
         metadata.is_base_image.return_value = False
         metadata.should_trigger_base_image_release.return_value = False
+        metadata.is_golang_builder = MagicMock(return_value=False)
         return metadata
 
     async def test_build_uses_definitive_pullspec_for_attestation_validation(self):
@@ -576,6 +577,30 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(inp.nvr, "test-nvr")
         self.assertEqual(inp.distgit_key, metadata.distgit_key)
         self.assertEqual(inp.container_image, pullspec)
+        self.assertFalse(inp.is_golang_builder)
+
+    async def test_trigger_base_image_release_golang_calls_is_golang_builder(self):
+        """Inline release passes through metadata.is_golang_builder() (openshift/golang-builder vs hyphen)."""
+        from doozerlib.backend import base_image_handler
+
+        metadata = self._metadata()
+        metadata.is_golang_builder = MagicMock(return_value=True)
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "abc123"
+        pullspec = "quay.io/test/img@sha256:deadbeef"
+
+        with patch.object(
+            base_image_handler.BaseImageHandler,
+            "snapshot_release",
+            new=AsyncMock(return_value=("test-release", "test-snapshot")),
+        ) as mock_snap:
+            result = await self.builder._trigger_base_image_release(metadata, "test-nvr", pullspec, build_repo)
+
+        self.assertTrue(result)
+        metadata.is_golang_builder.assert_called_once()
+        inp = mock_snap.await_args[0][0]
+        self.assertTrue(inp.is_golang_builder)
 
     async def test_trigger_base_image_release_inline_failure_returns_false(self):
         """When handler returns None, _trigger_base_image_release is False."""

--- a/doozer/tests/cli/test_images.py
+++ b/doozer/tests/cli/test_images.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
 from artcommonlib.gitdata import DataObj
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
 from artcommonlib.model import Model
 from artcommonlib.variants import BuildVariant
 from click.testing import CliRunner
@@ -141,11 +142,17 @@ class TestSnapshotInputFromKonfluxSuccessBuild(IsolatedAsyncioTestCase):
         record.rebase_commitish = "deadbeef"
 
         runtime.konflux_db = MagicMock()
-        runtime.konflux_db.get_latest_build = AsyncMock(return_value=record)
+        runtime.konflux_db.get_build_record_by_nvr = AsyncMock(return_value=record)
         runtime.image_map = {record.name: md}
 
         inp = await images_cli._snapshot_input_from_konflux_success_build(runtime, record.nvr)
 
+        runtime.konflux_db.get_build_record_by_nvr.assert_awaited_once_with(
+            nvr=record.nvr,
+            outcome=KonfluxBuildOutcome.SUCCESS,
+            strict=False,
+            exclude_large_columns=True,
+        )
         self.assertIsNotNone(inp)
         assert inp is not None
         self.assertEqual(inp.nvr, record.nvr)
@@ -158,7 +165,7 @@ class TestSnapshotInputFromKonfluxSuccessBuild(IsolatedAsyncioTestCase):
         runtime, _ = self._base_runtime_and_md()
 
         runtime.konflux_db = MagicMock()
-        runtime.konflux_db.get_latest_build = AsyncMock(return_value=None)
+        runtime.konflux_db.get_build_record_by_nvr = AsyncMock(return_value=None)
 
         inp = await images_cli._snapshot_input_from_konflux_success_build(runtime, "nosuch-container-v1-1.el9")
         self.assertIsNone(inp)
@@ -189,7 +196,7 @@ class TestSnapshotInputFromKonfluxSuccessBuild(IsolatedAsyncioTestCase):
         record.rebase_commitish = ""
 
         runtime.konflux_db = MagicMock()
-        runtime.konflux_db.get_latest_build = AsyncMock(return_value=record)
+        runtime.konflux_db.get_build_record_by_nvr = AsyncMock(return_value=record)
         runtime.image_map = {record.name: md}
 
         inp = await images_cli._snapshot_input_from_konflux_success_build(runtime, record.nvr)
@@ -224,7 +231,7 @@ class TestSnapshotInputFromKonfluxSuccessBuild(IsolatedAsyncioTestCase):
         record.rebase_commitish = ""
 
         runtime.konflux_db = MagicMock()
-        runtime.konflux_db.get_latest_build = AsyncMock(return_value=record)
+        runtime.konflux_db.get_build_record_by_nvr = AsyncMock(return_value=record)
         runtime.image_map = {record.name: md}
 
         inp = await images_cli._snapshot_input_from_konflux_success_build(runtime, record.nvr)

--- a/doozer/tests/cli/test_images.py
+++ b/doozer/tests/cli/test_images.py
@@ -1,10 +1,14 @@
 import unittest
-from unittest.mock import MagicMock, Mock, patch
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
+from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
 from artcommonlib.gitdata import DataObj
+from artcommonlib.model import Model
 from artcommonlib.variants import BuildVariant
 from click.testing import CliRunner
 from doozerlib import Runtime
+from doozerlib.cli import images as images_cli
 from doozerlib.cli.images import images_show_ancestors
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.image import ImageMetadata
@@ -104,6 +108,93 @@ class TestImagesCli(unittest.TestCase):
         result = self.runner.invoke(images_show_ancestors, ['--image-names', 'non-existent'], obj=runtime)
         self.assertIsInstance(result.exception, DoozerFatalError)
         self.assertIn("Image 'non-existent' not found in group.", str(result.exception))
+
+
+class TestSnapshotInputsFromKonfluxSuccessBuilds(IsolatedAsyncioTestCase):
+    def _base_runtime_and_md(self):
+        runtime = MagicMock()
+        runtime.group = "openshift-4.22"
+        runtime.product = "ocp"
+        runtime.variant = BuildVariant.OCP
+        runtime.assembly = "stream"
+        image_model = Model(
+            {
+                "name": "ose-base",
+                "base_only": True,
+                "base_image_release": {"enabled": True},
+                "distgit": {"component": "ose-base-container"},
+            }
+        )
+        data = Model({"key": "openshift-enterprise-base-rhel9", "data": image_model, "filename": "base.yaml"})
+        md = ImageMetadata(runtime, data)
+        md.distgit_key = "openshift-enterprise-base-rhel9"
+        return runtime, md
+
+    async def test_builds_inputs_from_success_rows(self):
+        runtime, md = self._base_runtime_and_md()
+
+        record = MagicMock()
+        record.nvr = "ose-base-container-v4.22-1.el9"
+        record.name = "openshift-enterprise-base-rhel9"
+        record.image_pullspec = "quay.io/x@sha256:abc"
+        record.rebase_repo_url = "https://git.example/r.git"
+        record.rebase_commitish = "deadbeef"
+
+        runtime.konflux_db = MagicMock()
+        runtime.konflux_db.get_build_records_by_nvrs = AsyncMock(return_value=[record])
+        runtime.image_map = {record.name: md}
+
+        inputs = await images_cli._snapshot_inputs_from_konflux_success_builds(runtime, [record.nvr])
+
+        self.assertEqual(len(inputs), 1)
+        self.assertEqual(inputs[0].nvr, record.nvr)
+        self.assertEqual(inputs[0].distgit_key, record.name)
+        self.assertEqual(inputs[0].container_image, record.image_pullspec)
+        self.assertEqual(inputs[0].rebase_repo_url, record.rebase_repo_url)
+        self.assertFalse(inputs[0].is_golang_builder)
+
+    async def test_skips_unknown_nvr(self):
+        runtime, md = self._base_runtime_and_md()
+
+        runtime.konflux_db = MagicMock()
+        runtime.konflux_db.get_build_records_by_nvrs = AsyncMock(return_value=[])
+        runtime.image_map = {md.distgit_key: md}
+
+        inputs = await images_cli._snapshot_inputs_from_konflux_success_builds(runtime, ["nosuch-container-v1-1.el9"])
+        self.assertEqual(inputs, [])
+
+    async def test_golang_builder_flag_from_metadata(self):
+        runtime = MagicMock()
+        runtime.group = "openshift-4.22"
+        runtime.product = "ocp"
+        runtime.variant = BuildVariant.OCP
+        runtime.assembly = "stream"
+
+        image_model = Model(
+            {
+                "name": GOLANG_BUILDER_IMAGE_NAME,
+                "base_image_release": {"enabled": True},
+                "distgit": {"component": "ose-golang-builder-container"},
+            }
+        )
+        data = Model({"key": "openshift-golang-builder", "data": image_model, "filename": "golang.yaml"})
+        md = ImageMetadata(runtime, data)
+        md.distgit_key = "openshift-golang-builder"
+
+        record = MagicMock()
+        record.nvr = "openshift-golang-builder-container-v1-1.el9"
+        record.name = "openshift-golang-builder"
+        record.image_pullspec = "quay.io/golang@sha256:x"
+        record.rebase_repo_url = ""
+        record.rebase_commitish = ""
+
+        runtime.konflux_db = MagicMock()
+        runtime.konflux_db.get_build_records_by_nvrs = AsyncMock(return_value=[record])
+        runtime.image_map = {record.name: md}
+
+        inputs = await images_cli._snapshot_inputs_from_konflux_success_builds(runtime, [record.nvr])
+        self.assertEqual(len(inputs), 1)
+        self.assertTrue(inputs[0].is_golang_builder)
 
 
 if __name__ == '__main__':

--- a/doozer/tests/cli/test_images.py
+++ b/doozer/tests/cli/test_images.py
@@ -110,7 +110,7 @@ class TestImagesCli(unittest.TestCase):
         self.assertIn("Image 'non-existent' not found in group.", str(result.exception))
 
 
-class TestSnapshotInputsFromKonfluxSuccessBuilds(IsolatedAsyncioTestCase):
+class TestSnapshotInputFromKonfluxSuccessBuild(IsolatedAsyncioTestCase):
     def _base_runtime_and_md(self):
         runtime = MagicMock()
         runtime.group = "openshift-4.22"
@@ -141,27 +141,27 @@ class TestSnapshotInputsFromKonfluxSuccessBuilds(IsolatedAsyncioTestCase):
         record.rebase_commitish = "deadbeef"
 
         runtime.konflux_db = MagicMock()
-        runtime.konflux_db.get_build_records_by_nvrs = AsyncMock(return_value=[record])
+        runtime.konflux_db.get_latest_build = AsyncMock(return_value=record)
         runtime.image_map = {record.name: md}
 
-        inputs = await images_cli._snapshot_inputs_from_konflux_success_builds(runtime, [record.nvr])
+        inp = await images_cli._snapshot_input_from_konflux_success_build(runtime, record.nvr)
 
-        self.assertEqual(len(inputs), 1)
-        self.assertEqual(inputs[0].nvr, record.nvr)
-        self.assertEqual(inputs[0].distgit_key, record.name)
-        self.assertEqual(inputs[0].container_image, record.image_pullspec)
-        self.assertEqual(inputs[0].rebase_repo_url, record.rebase_repo_url)
-        self.assertFalse(inputs[0].is_golang_builder)
+        self.assertIsNotNone(inp)
+        assert inp is not None
+        self.assertEqual(inp.nvr, record.nvr)
+        self.assertEqual(inp.distgit_key, record.name)
+        self.assertEqual(inp.container_image, record.image_pullspec)
+        self.assertEqual(inp.rebase_repo_url, record.rebase_repo_url)
+        self.assertFalse(inp.is_golang_builder)
 
     async def test_skips_unknown_nvr(self):
-        runtime, md = self._base_runtime_and_md()
+        runtime, _ = self._base_runtime_and_md()
 
         runtime.konflux_db = MagicMock()
-        runtime.konflux_db.get_build_records_by_nvrs = AsyncMock(return_value=[])
-        runtime.image_map = {md.distgit_key: md}
+        runtime.konflux_db.get_latest_build = AsyncMock(return_value=None)
 
-        inputs = await images_cli._snapshot_inputs_from_konflux_success_builds(runtime, ["nosuch-container-v1-1.el9"])
-        self.assertEqual(inputs, [])
+        inp = await images_cli._snapshot_input_from_konflux_success_build(runtime, "nosuch-container-v1-1.el9")
+        self.assertIsNone(inp)
 
     async def test_golang_builder_flag_from_metadata(self):
         runtime = MagicMock()
@@ -189,12 +189,48 @@ class TestSnapshotInputsFromKonfluxSuccessBuilds(IsolatedAsyncioTestCase):
         record.rebase_commitish = ""
 
         runtime.konflux_db = MagicMock()
-        runtime.konflux_db.get_build_records_by_nvrs = AsyncMock(return_value=[record])
+        runtime.konflux_db.get_latest_build = AsyncMock(return_value=record)
         runtime.image_map = {record.name: md}
 
-        inputs = await images_cli._snapshot_inputs_from_konflux_success_builds(runtime, [record.nvr])
-        self.assertEqual(len(inputs), 1)
-        self.assertTrue(inputs[0].is_golang_builder)
+        inp = await images_cli._snapshot_input_from_konflux_success_build(runtime, record.nvr)
+        self.assertIsNotNone(inp)
+        assert inp is not None
+        self.assertTrue(inp.is_golang_builder)
+
+    async def test_golang_builder_flag_slash_name_in_metadata(self):
+        """config.name openshift/golang-builder must match ImageMetadata.is_golang_builder (ART-18934)."""
+        runtime = MagicMock()
+        runtime.group = "rhel-9-golang-1.23"
+        runtime.product = "ocp"
+        runtime.variant = BuildVariant.OCP
+        runtime.assembly = "stream"
+
+        image_model = Model(
+            {
+                "name": "openshift/golang-builder",
+                "base_image_release": {"enabled": True},
+                "distgit": {"component": "openshift-golang-builder-container"},
+            }
+        )
+        data = Model({"key": "openshift-golang-builder", "data": image_model, "filename": "golang.yaml"})
+        md = ImageMetadata(runtime, data)
+        md.distgit_key = "openshift-golang-builder"
+
+        record = MagicMock()
+        record.nvr = "openshift-golang-builder-container-v1.23.10-1.el9"
+        record.name = "openshift-golang-builder"
+        record.image_pullspec = "quay.io/golang@sha256:x"
+        record.rebase_repo_url = ""
+        record.rebase_commitish = ""
+
+        runtime.konflux_db = MagicMock()
+        runtime.konflux_db.get_latest_build = AsyncMock(return_value=record)
+        runtime.image_map = {record.name: md}
+
+        inp = await images_cli._snapshot_input_from_konflux_success_build(runtime, record.nvr)
+        self.assertIsNotNone(inp)
+        assert inp is not None
+        self.assertTrue(inp.is_golang_builder)
 
 
 if __name__ == '__main__':

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import tempfile
 import unittest
-from datetime import datetime, timezone
 from unittest import IsolatedAsyncioTestCase, mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1425,7 +1424,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 1)
 
     async def test_fetch_rpms_from_build_regular_queries_success_only(self):
-        """Non base-image/golang images issue a single SUCCESS get_latest_build (no UNRELEASED query)."""
+        """Non-base images query the latest SUCCESS Konflux build once."""
         metadata = self._create_image_metadata('openshift/test-regular-lookup')
         mock_build = MagicMock()
         mock_build.installed_rpms = ['pkg-a']
@@ -1437,74 +1436,20 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         called = metadata.runtime.konflux_db.get_latest_build.await_args.kwargs
         self.assertEqual(called['outcome'], KonfluxBuildOutcome.SUCCESS)
 
-    async def test_fetch_rpms_from_build_prefers_newer_unreleased(self):
-        """Latest unreleased build wins over older success when seeding lockfile RPMs."""
+    async def test_fetch_rpms_from_build_golang_queries_success_only(self):
+        """Golang/base images use the same single SUCCESS latest-build lookup as other images."""
         metadata = self._create_image_metadata(GOLANG_BUILDER_IMAGE_NAME, distgit_key='openshift-golang-builder')
 
-        older = MagicMock()
-        older.installed_rpms = ['golang-1.22.12-11.el9']
-        older.nvr = 'openshift-golang-builder-container-v1-old'
-        older.outcome = KonfluxBuildOutcome.SUCCESS
-        older.end_time = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
-
-        newer = MagicMock()
-        newer.installed_rpms = ['golang-1.22.12-12.el9']
-        newer.nvr = 'openshift-golang-builder-container-v1-new'
-        newer.outcome = KonfluxBuildOutcome.UNRELEASED
-        newer.end_time = datetime(2026, 5, 7, 12, 0, 0, tzinfo=timezone.utc)
-
-        metadata.runtime.konflux_db.get_latest_build = AsyncMock(side_effect=[older, newer])
+        mock_build = MagicMock()
+        mock_build.installed_rpms = ['golang-pkg-1']
+        metadata.runtime.konflux_db.get_latest_build = AsyncMock(return_value=mock_build)
 
         result = await metadata.fetch_rpms_from_build()
 
-        self.assertEqual(result, {'golang-1.22.12-12.el9'})
-        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
-
-    async def test_fetch_rpms_from_build_prefers_newer_success(self):
-        """Latest success build wins over older unreleased when seeding lockfile RPMs."""
-        metadata = self._create_image_metadata(GOLANG_BUILDER_IMAGE_NAME, distgit_key='openshift-golang-builder')
-
-        older = MagicMock()
-        older.installed_rpms = ['pkg-old']
-        older.nvr = 'img-old'
-        older.outcome = KonfluxBuildOutcome.UNRELEASED
-        older.end_time = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
-
-        newer = MagicMock()
-        newer.installed_rpms = ['pkg-new']
-        newer.nvr = 'img-new'
-        newer.outcome = KonfluxBuildOutcome.SUCCESS
-        newer.end_time = datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc)
-
-        metadata.runtime.konflux_db.get_latest_build = AsyncMock(side_effect=[newer, older])
-
-        result = await metadata.fetch_rpms_from_build()
-
-        self.assertEqual(result, {'pkg-new'})
-        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
-
-    async def test_fetch_rpms_from_build_uses_other_when_newer_has_no_installed_rpms(self):
-        """If the time-newest row has no installed_rpms, use the other candidate when it does."""
-        metadata = self._create_image_metadata(GOLANG_BUILDER_IMAGE_NAME, distgit_key='openshift-golang-builder')
-
-        newer_empty = MagicMock()
-        newer_empty.installed_rpms = []
-        newer_empty.nvr = 'img-newer-empty'
-        newer_empty.outcome = KonfluxBuildOutcome.UNRELEASED
-        newer_empty.end_time = datetime(2026, 5, 10, 12, 0, 0, tzinfo=timezone.utc)
-
-        older_filled = MagicMock()
-        older_filled.installed_rpms = ['golang-1.22.12-12.el9']
-        older_filled.nvr = 'img-older'
-        older_filled.outcome = KonfluxBuildOutcome.SUCCESS
-        older_filled.end_time = datetime(2026, 5, 5, 12, 0, 0, tzinfo=timezone.utc)
-
-        metadata.runtime.konflux_db.get_latest_build = AsyncMock(side_effect=[older_filled, newer_empty])
-
-        result = await metadata.fetch_rpms_from_build()
-
-        self.assertEqual(result, {'golang-1.22.12-12.el9'})
-        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 2)
+        self.assertEqual(result, {'golang-pkg-1'})
+        self.assertEqual(metadata.runtime.konflux_db.get_latest_build.await_count, 1)
+        called = metadata.runtime.konflux_db.get_latest_build.await_args.kwargs
+        self.assertEqual(called['outcome'], KonfluxBuildOutcome.SUCCESS)
 
     def _setup_mock_config(self, metadata, lockfile_rpms=None):
         """Helper to setup mock config with lockfile RPMs."""

--- a/doozer/tests/test_util.py
+++ b/doozer/tests/test_util.py
@@ -286,6 +286,11 @@ class TestGetEffectivePackage(unittest.TestCase):
 class TestFindGoMainPackages(unittest.TestCase):
     """Tests for ``find_go_main_packages``."""
 
+    @staticmethod
+    def _root(td: str) -> pathlib.Path:
+        """Match find_go_main_packages(), which resolves *root_path* (needed on macOS /private/var)."""
+        return pathlib.Path(td).resolve()
+
     def _write(self, dir_path: pathlib.Path, name: str, content: str) -> pathlib.Path:
         dir_path.mkdir(parents=True, exist_ok=True)
         p = dir_path / name
@@ -294,7 +299,7 @@ class TestFindGoMainPackages(unittest.TestCase):
 
     def test_finds_simple_main_package(self):
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = self._root(td)
             cmd_dir = root / 'cmd' / 'myapp'
             self._write(cmd_dir, 'main.go', 'package main\n\nfunc main() {}\n')
             result = util.find_go_main_packages(root)
@@ -302,14 +307,14 @@ class TestFindGoMainPackages(unittest.TestCase):
 
     def test_skips_vendor_dirs(self):
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = self._root(td)
             self._write(root / 'vendor' / 'pkg', 'main.go', 'package main\n')
             result = util.find_go_main_packages(root)
             self.assertEqual(result, [])
 
     def test_skips_test_files(self):
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = self._root(td)
             # Directory with only a test file declaring package main
             self._write(root / 'pkg', 'main_test.go', 'package main\n')
             result = util.find_go_main_packages(root)
@@ -318,7 +323,7 @@ class TestFindGoMainPackages(unittest.TestCase):
     def test_skips_build_ignored_main(self):
         """A directory with only ``//go:build ignore`` main files should be skipped."""
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = self._root(td)
             plugins_dir = root / 'plugins'
             self._write(plugins_dir, 'example.go', '//go:build ignore\n\npackage main\n\nfunc main() {}\n')
             self._write(plugins_dir, 'minimum.go', 'package plugins\n')
@@ -331,7 +336,7 @@ class TestFindGoMainPackages(unittest.TestCase):
         check) should be skipped.
         """
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = self._root(td)
             mixed_dir = root / 'mixed'
             self._write(mixed_dir, 'main.go', 'package main\n\nfunc main() {}\n')
             self._write(mixed_dir, 'lib.go', 'package mixed\n')
@@ -344,7 +349,7 @@ class TestFindGoMainPackages(unittest.TestCase):
         ``//go:build ignore`` file with ``package main``.
         """
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = self._root(td)
             plugins_dir = root / 'plugins'
             self._write(plugins_dir, 'minimum.go', 'package plugins\n\nvar _ = 1\n')
             self._write(
@@ -367,7 +372,7 @@ class TestFindGoMainPackages(unittest.TestCase):
 
     def test_multiple_main_packages(self):
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = self._root(td)
             cmd1 = root / 'cmd' / 'app1'
             cmd2 = root / 'cmd' / 'app2'
             self._write(cmd1, 'main.go', 'package main\n\nfunc main() {}\n')
@@ -381,7 +386,7 @@ class TestFindGoMainPackages(unittest.TestCase):
         that ``go mod vendor`` does not copy injected files into vendor/.
         """
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = self._root(td)
             # Root module
             self._write(root, 'go.mod', 'module example.com/myproject\n')
             root_cmd = root / 'cmd' / 'myapp'
@@ -403,7 +408,7 @@ class TestFindGoMainPackages(unittest.TestCase):
         vendor/.
         """
         with tempfile.TemporaryDirectory() as td:
-            root = pathlib.Path(td)
+            root = self._root(td)
             self._write(root, 'go.mod', 'module example.com/olm\n')
             # Root cmd directories
             cmd_a = root / 'cmd' / 'collect-profiles'

--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -11,7 +11,7 @@ from artcommonlib.assembly import assembly_config_struct
 from artcommonlib.gitdata import SafeFormatter
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import is_ocp_delivery_repo, new_roundtrip_yaml_handler
-from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
+from doozerlib.util import konflux_application_name, konflux_image_component_name
 from errata_tool import Erratum
 
 from elliottlib import constants
@@ -45,8 +45,8 @@ def get_konflux_component_by_component(runtime: Runtime, component_name: str) ->
     if not image_meta:
         return None
 
-    application = KonfluxImageBuilder.get_application_name(runtime.group)
-    return KonfluxImageBuilder.get_component_name(application, image_meta.distgit_key)
+    application = konflux_application_name(runtime.group)
+    return konflux_image_component_name(application, image_meta.distgit_key)
 
 
 def _get_components_using_builder(runtime: Runtime, attached_components: Set[str], logger) -> Set[str]:
@@ -79,8 +79,8 @@ def _get_components_using_builder(runtime: Runtime, attached_components: Set[str
         # Check if this image uses the golang builder in its configuration
         if _image_uses_builder(image_meta, logger):
             # Get the Konflux component name for this image
-            application = KonfluxImageBuilder.get_application_name(runtime.group)
-            konflux_component_name = KonfluxImageBuilder.get_component_name(application, image_meta.distgit_key)
+            application = konflux_application_name(runtime.group)
+            konflux_component_name = konflux_image_component_name(application, image_meta.distgit_key)
 
             components_using_builder.append(f"{image_name} -> {konflux_component_name}")
 

--- a/elliott/elliottlib/cli/shipment_cli.py
+++ b/elliott/elliottlib/cli/shipment_cli.py
@@ -4,7 +4,7 @@ import click
 from artcommonlib import logutil
 from artcommonlib.gitdata import SafeFormatter
 from doozerlib.backend.konflux_fbc import KonfluxFbcBuilder
-from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
+from doozerlib.util import konflux_application_name
 from ruamel.yaml import YAML
 
 from elliottlib.cli.common import cli, click_coroutine
@@ -48,7 +48,7 @@ class InitShipmentCli:
         if self.kind == "fbc":
             application = KonfluxFbcBuilder.get_application_name(self.runtime.group)
         else:
-            application = KonfluxImageBuilder.get_application_name(self.runtime.group)
+            application = konflux_application_name(self.runtime.group)
 
         # load stage/prod rpa from shipment repo config
         # where defaults are set per application

--- a/elliott/elliottlib/cli/snapshot_cli.py
+++ b/elliott/elliottlib/cli/snapshot_cli.py
@@ -24,9 +24,8 @@ from artcommonlib.util import (
     resolve_konflux_namespace_by_product,
 )
 from doozerlib.backend.konflux_client import API_VERSION, KIND_SNAPSHOT, KonfluxClient
-from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder
 from doozerlib.backend.konflux_olm_bundler import KonfluxOlmBundleBuilder
-from doozerlib.util import oc_image_info_for_arch_async
+from doozerlib.util import konflux_image_component_name, oc_image_info_for_arch_async
 from kubernetes.dynamic import exceptions
 from kubernetes.dynamic.resource import ResourceInstance
 
@@ -225,10 +224,10 @@ class CreateSnapshotCli:
                     await self.konflux_client.get_component__caching(comp_name, strict=True)
                 except exceptions.NotFoundError:
                     if isinstance(record, KonfluxBuildRecord):
-                        comp_name = KonfluxImageBuilder.get_component_name(app_name, record.name)
+                        comp_name = konflux_image_component_name(app_name, record.name)
                         await self.konflux_client.get_component__caching(comp_name, strict=True)
                     elif isinstance(record, KonfluxBundleBuildRecord):
-                        comp_name = KonfluxOlmBundleBuilder.get_component_name(app_name, record.name)
+                        comp_name = konflux_image_component_name(app_name, record.name)
                         try:
                             await self.konflux_client.get_component__caching(comp_name, strict=True)
                         except exceptions.NotFoundError:


### PR DESCRIPTION
## Summary
- **`BaseImageHandler`** now only accepts sequences of **`BaseImageSnapshotInput`** via **`snapshot_release()`** (Konflux Snapshot → Release + wait). No Jenkins hooks and no Konflux DB reads inside the handler.
- **`snapshot_inputs_from_konflux_success_builds`** hydrates inputs from SUCCESS Konflux rows for **`images:release-to-base-repo`**.
- **`KonfluxImageBuilder`** writes one completion row after optional inline **`snapshot_release`**; **`KonfluxBuildOutcome.UNRELEASED`** removed.
- Lockfile RPM seed uses SUCCESS-only **`get_latest_build`** for all images.

## Problem
**Before:** One handler mixed Konflux orchestration with Jenkins metadata and DB-backed NVR hydration.

**After:** Clear boundary—explicit snapshot inputs for Konflux workflow; callers own persistence and CI UX.

## Test plan
- [x] `make lint` / targeted `ruff check` on touched paths (pre-commit ran clean on commit)
- [x] `uv run pytest doozer/tests/backend/test_base_image_handler.py doozer/tests/backend/test_base_image_snapshot_inputs.py doozer/tests/backend/test_konflux_image_builder.py doozer/tests/test_image.py::TestImageMetadataAsyncMethods`