### PR TITLE
ART-14960: Use Redis as pre-filter for images-health BigQuery queries

### DIFF
--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -103,7 +103,9 @@ class ImagesHealthPipeline:
         if skipped_images:
             self.runtime.logger.warning(
                 'Filtered out %d image(s) from Redis that do not exist in %s metadata: %s',
-                len(skipped_images), group, ', '.join(sorted(skipped_images))
+                len(skipped_images),
+                group,
+                ', '.join(sorted(skipped_images)),
             )
 
         if not filtered_failing_images:
@@ -113,7 +115,9 @@ class ImagesHealthPipeline:
             return
 
         self.runtime.logger.info(
-            'Redis reports %d failing image(s) for %s; querying BigQuery for details', len(filtered_failing_images), group
+            'Redis reports %d failing image(s) for %s; querying BigQuery for details',
+            len(filtered_failing_images),
+            group,
         )
 
         group_param = f'--group={group}'
@@ -171,7 +175,9 @@ class ImagesHealthPipeline:
         if skipped_images:
             self.runtime.logger.warning(
                 'Filtered out %d rebase failure(s) from Redis that do not exist in openshift-%s metadata: %s',
-                len(skipped_images), version, ', '.join(sorted(skipped_images))
+                len(skipped_images),
+                version,
+                ', '.join(sorted(skipped_images)),
             )
 
         self.rebase_failures[version] = filtered_failures
@@ -208,8 +214,7 @@ class ImagesHealthPipeline:
             return valid_images
         except Exception as e:
             self.runtime.logger.warning(
-                'Failed to fetch valid images for openshift-%s: %s. Proceeding without filtering.',
-                version, e
+                'Failed to fetch valid images for openshift-%s: %s. Proceeding without filtering.', version, e
             )
             # On failure, return empty set to fail safe (don't process any images from Redis)
             return set()

--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -71,7 +71,6 @@ class ImagesHealthPipeline:
 
     async def get_report(self, version: str) -> Optional[list]:
         doozer_working = f'{self.doozer_working}-{version}'
-        # Check if automation is frozen for current group
         if not await util.is_build_permitted(
             version,
             doozer_working=str(doozer_working),
@@ -83,8 +82,41 @@ class ImagesHealthPipeline:
 
         self.scanned_versions.append(version)
 
-        # Get doozer report for the given version
-        group_param = f'--group=openshift-{version}'
+        group = f'openshift-{version}'
+        failures = await util.get_build_failures(group=group, logger=self.runtime.logger)
+
+        # Use Redis failures to scope the image list for the BigQuery query.
+        # If an explicit image_list was provided, intersect it with failing images.
+        failing_images = set(failures.keys())
+        if self.image_list:
+            failing_images &= set(self.image_list)
+
+        if not failing_images:
+            self.runtime.logger.info('No build failures in Redis for %s; skipping BigQuery scan', group)
+            return
+
+        # Filter failing_images to only include images that exist in current ocp-build-data
+        valid_images = await self._get_valid_images(version, doozer_working)
+        filtered_failing_images = failing_images & valid_images
+        skipped_images = failing_images - valid_images
+
+        if skipped_images:
+            self.runtime.logger.warning(
+                'Filtered out %d image(s) from Redis that do not exist in %s metadata: %s',
+                len(skipped_images), group, ', '.join(sorted(skipped_images))
+            )
+
+        if not filtered_failing_images:
+            self.runtime.logger.info(
+                'No valid failing images remain for %s after filtering; skipping BigQuery scan', group
+            )
+            return
+
+        self.runtime.logger.info(
+            'Redis reports %d failing image(s) for %s; querying BigQuery for details', len(filtered_failing_images), group
+        )
+
+        group_param = f'--group={group}'
         if self.data_gitref:
             group_param += f'@{self.data_gitref}'
         cmd = [
@@ -92,34 +124,95 @@ class ImagesHealthPipeline:
             f'--working-dir={doozer_working}',
             f'--data-path={self.data_path}',
             group_param,
+            f'--images={",".join(sorted(filtered_failing_images))}',
+            'images:health',
         ]
-        if self.image_list:
-            cmd.append(f'--images={",".join(self.image_list)}')
-        cmd.append('images:health')
 
         if self.assembly:
             cmd.append(f'--assembly={self.assembly}')
 
         _, out, err = await exectools.cmd_gather_async(cmd, stderr=None)
         report = json.loads(out.strip())
-        self.runtime.logger.info('images:health output for openshift-%s:\n%s', version, out)
+        self.runtime.logger.info('images:health output for %s:\n%s', group, out)
         self.report.extend(report)
 
     async def get_rebase_failures(self, version: str):
         """
         Fetch OCP rebase failure data from Redis for a specific version.
         Checks both Brew and Konflux build systems.
+        Filters out images that don't exist in current ocp-build-data.
         Populates self.rebase_failures[version] with {image: {failure_count, url, build_system}}.
 
         Arg(s):
             version (str): OCP version (e.g., "4.18")
         """
-        self.rebase_failures[version] = await util.get_rebase_failures(
+        # Fetch all rebase failures from Redis
+        all_failures = await util.get_rebase_failures(
             version=version,
             branches=['rebase-failure'],
             build_systems=['brew', 'konflux'],
             logger=self.runtime.logger,
         )
+
+        # Get list of valid images for this version from metadata
+        doozer_working = f'{self.doozer_working}-{version}'
+        valid_images = await self._get_valid_images(version, doozer_working)
+
+        # Filter to only include images that exist in metadata
+        filtered_failures = {}
+        skipped_images = []
+
+        for image_name, failure_info in all_failures.items():
+            if image_name in valid_images:
+                filtered_failures[image_name] = failure_info
+            else:
+                skipped_images.append(image_name)
+
+        if skipped_images:
+            self.runtime.logger.warning(
+                'Filtered out %d rebase failure(s) from Redis that do not exist in openshift-%s metadata: %s',
+                len(skipped_images), version, ', '.join(sorted(skipped_images))
+            )
+
+        self.rebase_failures[version] = filtered_failures
+
+    async def _get_valid_images(self, version: str, doozer_working: str) -> set[str]:
+        """
+        Get the set of valid image names for a given version from ocp-build-data.
+
+        Arg(s):
+            version (str): OCP version (e.g., "4.18")
+            doozer_working (str): Doozer working directory path
+        Return Value(s):
+            set[str]: Set of valid image distgit keys
+        """
+        group_param = f'--group=openshift-{version}'
+        if self.data_gitref:
+            group_param += f'@{self.data_gitref}'
+
+        cmd = [
+            'doozer',
+            f'--working-dir={doozer_working}',
+            f'--data-path={self.data_path}',
+            group_param,
+            'images:print',
+            '--short',
+            '{name}',
+        ]
+
+        try:
+            _, out, _ = await exectools.cmd_gather_async(cmd, stderr=None)
+            # Parse the output - one image name per line
+            valid_images = {line.strip() for line in out.strip().split('\n') if line.strip()}
+            self.runtime.logger.info('Found %d valid images for openshift-%s', len(valid_images), version)
+            return valid_images
+        except Exception as e:
+            self.runtime.logger.warning(
+                'Failed to fetch valid images for openshift-%s: %s. Proceeding without filtering.',
+                version, e
+            )
+            # On failure, return empty set to fail safe (don't process any images from Redis)
+            return set()
 
     def sync_jira(self):
         jira_client = self.runtime.new_jira_client()

--- a/pyartcd/pyartcd/pipelines/okd_images_health.py
+++ b/pyartcd/pyartcd/pipelines/okd_images_health.py
@@ -78,7 +78,9 @@ class ImagesHealthPipeline:
         if skipped_images:
             self.runtime.logger.warning(
                 'Filtered out %d image(s) from Redis that do not exist in %s metadata: %s',
-                len(skipped_images), group, ', '.join(sorted(skipped_images))
+                len(skipped_images),
+                group,
+                ', '.join(sorted(skipped_images)),
             )
 
         if not filtered_failing_images:
@@ -89,7 +91,9 @@ class ImagesHealthPipeline:
             return
 
         self.runtime.logger.info(
-            'Redis reports %d failing image(s) for %s; querying BigQuery for details', len(filtered_failing_images), group
+            'Redis reports %d failing image(s) for %s; querying BigQuery for details',
+            len(filtered_failing_images),
+            group,
         )
 
         group_param = f'--group=openshift-{version}'
@@ -151,7 +155,9 @@ class ImagesHealthPipeline:
         if skipped_images:
             self.runtime.logger.warning(
                 'Filtered out %d rebase failure(s) from Redis that do not exist in okd-%s metadata: %s',
-                len(skipped_images), version, ', '.join(sorted(skipped_images))
+                len(skipped_images),
+                version,
+                ', '.join(sorted(skipped_images)),
             )
 
         self.rebase_failures[version] = filtered_failures
@@ -189,8 +195,7 @@ class ImagesHealthPipeline:
             return valid_images
         except Exception as e:
             self.runtime.logger.warning(
-                'Failed to fetch valid OKD images for openshift-%s: %s. Proceeding without filtering.',
-                version, e
+                'Failed to fetch valid OKD images for openshift-%s: %s. Proceeding without filtering.', version, e
             )
             # On failure, return empty set to fail safe (don't process any images from Redis)
             return set()

--- a/pyartcd/pyartcd/pipelines/okd_images_health.py
+++ b/pyartcd/pyartcd/pipelines/okd_images_health.py
@@ -57,8 +57,41 @@ class ImagesHealthPipeline:
             await self.notify_okd_channel()
 
     async def get_report(self, version: str) -> Optional[list]:
-        # Get doozer report for the given version
+        group = OKD_GROUP_TEMPLATE.format(version)
+        failures = await util.get_build_failures(group=group, logger=self.runtime.logger)
+
+        failing_images = set(failures.keys())
+        if self.image_list:
+            failing_images &= set(self.image_list)
+
+        if not failing_images:
+            self.runtime.logger.info('No build failures in Redis for %s; skipping BigQuery scan', group)
+            self.scanned_versions.append(version)
+            return
+
+        # Filter failing_images to only include images that exist in current ocp-build-data
         doozer_working = f'{self.doozer_working}-{version}'
+        valid_images = await self._get_valid_images(version, doozer_working)
+        filtered_failing_images = failing_images & valid_images
+        skipped_images = failing_images - valid_images
+
+        if skipped_images:
+            self.runtime.logger.warning(
+                'Filtered out %d image(s) from Redis that do not exist in %s metadata: %s',
+                len(skipped_images), group, ', '.join(sorted(skipped_images))
+            )
+
+        if not filtered_failing_images:
+            self.runtime.logger.info(
+                'No valid failing images remain for %s after filtering; skipping BigQuery scan', group
+            )
+            self.scanned_versions.append(version)
+            return
+
+        self.runtime.logger.info(
+            'Redis reports %d failing image(s) for %s; querying BigQuery for details', len(filtered_failing_images), group
+        )
+
         group_param = f'--group=openshift-{version}'
         if self.data_gitref:
             group_param += f'@{self.data_gitref}'
@@ -69,12 +102,10 @@ class ImagesHealthPipeline:
             f'--data-path={self.data_path}',
             '--variant=okd',
             group_param,
+            f'--images={",".join(sorted(filtered_failing_images))}',
+            'images:health',
+            f'--group={group}',
         ]
-
-        if self.image_list:
-            cmd.append(f'--images={",".join(self.image_list)}')
-
-        cmd.extend(['images:health', f'--group={OKD_GROUP_TEMPLATE.format(version)}'])
 
         if self.assembly:
             cmd.append(f'--assembly={self.assembly}')
@@ -82,24 +113,87 @@ class ImagesHealthPipeline:
         _, out, err = await exectools.cmd_gather_async(cmd, stderr=None)
         report = json.loads(out.strip())
 
-        self.runtime.logger.info('images:health output for openshift-%s:\n%s', version, out)
+        self.runtime.logger.info('images:health output for %s:\n%s', group, out)
         self.report.extend(report)
         self.scanned_versions.append(version)
 
     async def get_rebase_failures(self, version: str):
         """
         Fetch OKD rebase failure data from Redis for a specific version.
+        Filters out images that don't exist in current ocp-build-data.
         Populates self.rebase_failures[version] with {image: {failure_count, url}}.
 
         Arg(s):
             version (str): OKD version (e.g., "4.21")
         """
-        self.rebase_failures[version] = await util.get_rebase_failures(
+        # Fetch all rebase failures from Redis
+        all_failures = await util.get_rebase_failures(
             version=version,
             branches=['okd-rebase-failure'],
             build_systems=['konflux'],
             logger=self.runtime.logger,
         )
+
+        # Get list of valid images for this version from metadata
+        doozer_working = f'{self.doozer_working}-{version}'
+        valid_images = await self._get_valid_images(version, doozer_working)
+
+        # Filter to only include images that exist in metadata
+        filtered_failures = {}
+        skipped_images = []
+
+        for image_name, failure_info in all_failures.items():
+            if image_name in valid_images:
+                filtered_failures[image_name] = failure_info
+            else:
+                skipped_images.append(image_name)
+
+        if skipped_images:
+            self.runtime.logger.warning(
+                'Filtered out %d rebase failure(s) from Redis that do not exist in okd-%s metadata: %s',
+                len(skipped_images), version, ', '.join(sorted(skipped_images))
+            )
+
+        self.rebase_failures[version] = filtered_failures
+
+    async def _get_valid_images(self, version: str, doozer_working: str) -> set[str]:
+        """
+        Get the set of valid image names for a given OKD version from ocp-build-data.
+
+        Arg(s):
+            version (str): OKD version (e.g., "4.21")
+            doozer_working (str): Doozer working directory path
+        Return Value(s):
+            set[str]: Set of valid image distgit keys
+        """
+        group_param = f'--group=openshift-{version}'
+        if self.data_gitref:
+            group_param += f'@{self.data_gitref}'
+
+        cmd = [
+            'doozer',
+            f'--working-dir={doozer_working}',
+            f'--data-path={self.data_path}',
+            '--variant=okd',
+            group_param,
+            'images:print',
+            '--short',
+            '{name}',
+        ]
+
+        try:
+            _, out, _ = await exectools.cmd_gather_async(cmd, stderr=None)
+            # Parse the output - one image name per line
+            valid_images = {line.strip() for line in out.strip().split('\n') if line.strip()}
+            self.runtime.logger.info('Found %d valid OKD images for openshift-%s', len(valid_images), version)
+            return valid_images
+        except Exception as e:
+            self.runtime.logger.warning(
+                'Failed to fetch valid OKD images for openshift-%s: %s. Proceeding without filtering.',
+                version, e
+            )
+            # On failure, return empty set to fail safe (don't process any images from Redis)
+            return set()
 
     async def notify_release_channel(self, version):
         """

--- a/pyartcd/tests/pipelines/test_images_health.py
+++ b/pyartcd/tests/pipelines/test_images_health.py
@@ -1,3 +1,4 @@
+import json
 from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -176,6 +177,101 @@ class TestImagesHealthPipeline(IsolatedAsyncioTestCase):
         mock_slack_client.say.assert_called_once_with(
             ":white_check_mark: All images are healthy for all monitored releases"
         )
+
+
+class TestGetReport(IsolatedAsyncioTestCase):
+    def _make_pipeline(self, versions="4.18", image_list=""):
+        runtime = MagicMock()
+        runtime.working_dir = MagicMock()
+        runtime.logger = MagicMock()
+        runtime.new_slack_client.return_value = MagicMock()
+        return ImagesHealthPipeline(
+            runtime=runtime,
+            versions=versions,
+            send_to_release_channel=False,
+            send_to_forum_ocp_art=False,
+            data_path=DATA_PATH,
+            data_gitref="",
+            image_list=image_list,
+            assembly="stream",
+        )
+
+    @patch("pyartcd.pipelines.images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.images_health.util.is_build_permitted", new_callable=AsyncMock, return_value=True)
+    @patch("pyartcd.pipelines.images_health.util.get_build_failures", new_callable=AsyncMock)
+    async def test_redis_pre_filters_doozer_call(self, mock_get_failures, _mock_permitted, mock_cmd):
+        """Redis failures scope the --images flag on the doozer subprocess."""
+        mock_get_failures.return_value = {
+            'ironic': {'failure_count': 3, 'url': '', 'nvr': ''},
+            'hypershift': {'failure_count': 5, 'url': '', 'nvr': ''},
+        }
+        doozer_report = [
+            _make_concern("ironic", "openshift-4.18", ConcernCode.LATEST_ATTEMPT_FAILED.value, latest_success_idx=3),
+            _make_concern(
+                "hypershift", "openshift-4.18", ConcernCode.LATEST_ATTEMPT_FAILED.value, latest_success_idx=5
+            ),
+        ]
+        mock_cmd.return_value = (0, json.dumps(doozer_report), '')
+
+        pipeline = self._make_pipeline()
+        # Mock _get_valid_images to return all images as valid
+        pipeline._get_valid_images = AsyncMock(return_value={'ironic', 'hypershift'})
+
+        await pipeline.get_report('4.18')
+
+        mock_get_failures.assert_called_once_with(group='openshift-4.18', logger=pipeline.runtime.logger)
+        mock_cmd.assert_called_once()
+        cmd = mock_cmd.call_args[0][0]
+        images_arg = next(a for a in cmd if a.startswith('--images='))
+        self.assertIn('ironic', images_arg)
+        self.assertIn('hypershift', images_arg)
+        self.assertEqual(len(pipeline.report), 2)
+
+    @patch("pyartcd.pipelines.images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.images_health.util.is_build_permitted", new_callable=AsyncMock, return_value=True)
+    @patch("pyartcd.pipelines.images_health.util.get_build_failures", new_callable=AsyncMock)
+    async def test_image_list_intersects_with_redis(self, mock_get_failures, _mock_permitted, mock_cmd):
+        """When --image-list is provided, only images in BOTH lists are queried."""
+        mock_get_failures.return_value = {
+            'ironic': {'failure_count': 3, 'url': '', 'nvr': ''},
+            'hypershift': {'failure_count': 5, 'url': '', 'nvr': ''},
+        }
+        doozer_report = [
+            _make_concern("ironic", "openshift-4.18", ConcernCode.LATEST_ATTEMPT_FAILED.value, latest_success_idx=3),
+        ]
+        mock_cmd.return_value = (0, json.dumps(doozer_report), '')
+
+        pipeline = self._make_pipeline(image_list="ironic")
+        # Mock _get_valid_images to return ironic as valid
+        pipeline._get_valid_images = AsyncMock(return_value={'ironic', 'hypershift'})
+
+        await pipeline.get_report('4.18')
+
+        cmd = mock_cmd.call_args[0][0]
+        images_arg = next(a for a in cmd if a.startswith('--images='))
+        self.assertEqual(images_arg, '--images=ironic')
+
+    @patch("pyartcd.pipelines.images_health.util.is_build_permitted", new_callable=AsyncMock, return_value=False)
+    async def test_skips_frozen_group(self, _mock_permitted):
+        pipeline = self._make_pipeline()
+
+        await pipeline.get_report('4.18')
+
+        self.assertEqual(len(pipeline.report), 0)
+        self.assertNotIn('4.18', pipeline.scanned_versions)
+
+    @patch("pyartcd.pipelines.images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.images_health.util.is_build_permitted", new_callable=AsyncMock, return_value=True)
+    @patch("pyartcd.pipelines.images_health.util.get_build_failures", new_callable=AsyncMock, return_value={})
+    async def test_skips_bigquery_when_no_redis_failures(self, _mock_get_failures, _mock_permitted, mock_cmd):
+        """When Redis reports no failures, doozer images:health is not called at all."""
+        pipeline = self._make_pipeline()
+
+        await pipeline.get_report('4.18')
+
+        mock_cmd.assert_not_called()
+        self.assertEqual(len(pipeline.report), 0)
+        self.assertIn('4.18', pipeline.scanned_versions)
 
 
 class TestSyncJira(TestCase):

--- a/pyartcd/tests/pipelines/test_okd_images_health.py
+++ b/pyartcd/tests/pipelines/test_okd_images_health.py
@@ -1,0 +1,102 @@
+import json
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from doozerlib.cli.images_health import ConcernCode
+from pyartcd.pipelines.okd_images_health import ImagesHealthPipeline
+
+DATA_PATH = "https://github.com/openshift-eng/ocp-build-data"
+
+
+def _make_concern(image_name, group, code, **kwargs):
+    concern = {
+        "image_name": image_name,
+        "group": group,
+        "code": code,
+        "latest_failed_build_time": "2025-12-17T10:00:00+00:00",
+        "latest_failed_nvr": f"{image_name}-1.0-1",
+        "latest_failed_build_record_id": "12345",
+    }
+    concern.update(kwargs)
+    return concern
+
+
+class TestGetReport(IsolatedAsyncioTestCase):
+    def _make_pipeline(self, versions="4.21", image_list=""):
+        runtime = MagicMock()
+        runtime.working_dir = MagicMock()
+        runtime.logger = MagicMock()
+        runtime.new_slack_client.return_value = MagicMock()
+        return ImagesHealthPipeline(
+            runtime=runtime,
+            versions=versions,
+            send_to_release_channel=False,
+            send_to_okd_channel=False,
+            data_path=DATA_PATH,
+            data_gitref="",
+            image_list=image_list,
+            assembly="stream",
+        )
+
+    @patch("pyartcd.pipelines.okd_images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.okd_images_health.util.get_build_failures", new_callable=AsyncMock)
+    async def test_redis_pre_filters_doozer_call(self, mock_get_failures, mock_cmd):
+        """Redis failures scope the --images flag on the doozer subprocess."""
+        mock_get_failures.return_value = {
+            'ironic': {'failure_count': 3, 'url': '', 'nvr': ''},
+            'ovn-kubernetes': {'failure_count': 2, 'url': '', 'nvr': ''},
+        }
+        doozer_report = [
+            _make_concern("ironic", "okd-4.21", ConcernCode.LATEST_ATTEMPT_FAILED.value, latest_success_idx=3),
+            _make_concern("ovn-kubernetes", "okd-4.21", ConcernCode.LATEST_ATTEMPT_FAILED.value, latest_success_idx=2),
+        ]
+        mock_cmd.return_value = (0, json.dumps(doozer_report), '')
+
+        pipeline = self._make_pipeline()
+        # Mock _get_valid_images to return all images as valid
+        pipeline._get_valid_images = AsyncMock(return_value={'ironic', 'ovn-kubernetes'})
+
+        await pipeline.get_report('4.21')
+
+        mock_get_failures.assert_called_once_with(group='okd-4.21', logger=pipeline.runtime.logger)
+        mock_cmd.assert_called_once()
+        cmd = mock_cmd.call_args[0][0]
+        images_arg = next(a for a in cmd if a.startswith('--images='))
+        self.assertIn('ironic', images_arg)
+        self.assertIn('ovn-kubernetes', images_arg)
+        self.assertEqual(len(pipeline.report), 2)
+
+    @patch("pyartcd.pipelines.okd_images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.okd_images_health.util.get_build_failures", new_callable=AsyncMock)
+    async def test_image_list_intersects_with_redis(self, mock_get_failures, mock_cmd):
+        """When --image-list is provided, only images in BOTH lists are queried."""
+        mock_get_failures.return_value = {
+            'ironic': {'failure_count': 3, 'url': '', 'nvr': ''},
+            'ovn-kubernetes': {'failure_count': 2, 'url': '', 'nvr': ''},
+        }
+        doozer_report = [
+            _make_concern("ironic", "okd-4.21", ConcernCode.LATEST_ATTEMPT_FAILED.value, latest_success_idx=3),
+        ]
+        mock_cmd.return_value = (0, json.dumps(doozer_report), '')
+
+        pipeline = self._make_pipeline(image_list="ironic")
+        # Mock _get_valid_images to return ironic as valid
+        pipeline._get_valid_images = AsyncMock(return_value={'ironic', 'ovn-kubernetes'})
+
+        await pipeline.get_report('4.21')
+
+        cmd = mock_cmd.call_args[0][0]
+        images_arg = next(a for a in cmd if a.startswith('--images='))
+        self.assertEqual(images_arg, '--images=ironic')
+
+    @patch("pyartcd.pipelines.okd_images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.okd_images_health.util.get_build_failures", new_callable=AsyncMock, return_value={})
+    async def test_skips_bigquery_when_no_redis_failures(self, _mock_get_failures, mock_cmd):
+        """When Redis reports no failures, doozer images:health is not called at all."""
+        pipeline = self._make_pipeline()
+
+        await pipeline.get_report('4.21')
+
+        mock_cmd.assert_not_called()
+        self.assertEqual(len(pipeline.report), 0)
+        self.assertIn('4.21', pipeline.scanned_versions)


### PR DESCRIPTION
This change implements a two-phase optimization for images-health:

Phase 1 (already in main): Build pipelines write failure state to Redis
- On build success: delete failure counter
- On build failure: increment counter and store metadata (NVR, job URL)
- Key format: count:build-failure:{build_system}:{group}:{image}:{field}

Phase 2 (this commit): images-health reads from Redis first
- Query Redis for failing images before touching BigQuery
- Only query BigQuery for images that Redis reports as failing
- Skip BigQuery entirely if Redis reports no failures
- Apply same optimization to both OCP and OKD variants

Robustness improvements:
- Filter Redis failures against current ocp-build-data metadata
- Skip images that don't exist (e.g., test images, removed images)
- Add _get_valid_images() helper to validate image names
- Prevents "missing or filtered out" errors from doozer

Benefits:
- Drastically reduces BigQuery query volume (only failing images)
- Faster execution (skip BigQuery when all images healthy)
- More reliable (handles stale/test data in Redis gracefully)
- Full metadata preserved for failing images (logs, NVRs, etc.)

Resolves: [ART-14960](https://redhat.atlassian.net/browse/ART-14960)

## Testing
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/scanning/job/scanning%252Fimages-health/3921/console
https://redhat-internal.slack.com/archives/C0A9FSYAAA1/p1779204193021139