### PR TITLE
Reduce oc_image_info Redis cache TTL from 60 days to 14 days

### DIFF
--- a/artcommon/artcommonlib/oc_image_info.py
+++ b/artcommon/artcommonlib/oc_image_info.py
@@ -34,8 +34,8 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 
 logger = logging.getLogger(__name__)
 
-# Cached entries expire after 60 days (seconds).
-_CACHE_EXPIRY_SECONDS = 60 * 24 * 60 * 60
+# Cached entries expire after 14 days (seconds).
+_CACHE_EXPIRY_SECONDS = 14 * 24 * 60 * 60
 
 # Bump to invalidate every cached entry at once.
 _CACHE_KEY_VERSION = "v1"


### PR DESCRIPTION
## Summary
- Reduces Redis cache TTL for `oc_image_info` from 60 days to 14 days
- Helps manage cache size (currently 184,731 entries) while maintaining effective caching

## Context
The `oc_image_info` Redis cache had accumulated 184,731 entries with a 60-day TTL. While the long TTL makes sense for immutable sha256-pinned images, reducing it to 2 weeks will help control Redis storage usage without significantly impacting cache effectiveness.

## Changes
- Updated `_CACHE_EXPIRY_SECONDS` from `60 * 24 * 60 * 60` to `14 * 24 * 60 * 60` in `artcommon/artcommonlib/oc_image_info.py`

## Note
Existing entries in Redis will retain their original 60-day TTL and expire naturally. Only new entries will use the 14-day TTL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)