### PR TITLE
Refactor fail counter system

### DIFF
--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -397,13 +397,13 @@ class ImagesHealthPipeline:
             report += '*Rebase Failures:*\n'
             for image_name, failure_info in sorted(rebase_failures.items()):
                 failure_count = failure_info.get('failure_count', 0)
-                job_url = failure_info.get('url', '')
+                jenkins_url = failure_info.get('jenkins_url', '')
                 build_system = failure_info.get('build_system', 'unknown')
                 report += (
                     f'- `{image_name}` ({build_system}): Failed {failure_count} time{"s" if failure_count != 1 else ""}'
                 )
-                if job_url:
-                    report += f' ({self.url_text(job_url, "Last failure job")})'
+                if jenkins_url:
+                    report += f' ({self.url_text(jenkins_url, "Last failure job")})'
                 report += '\n'
 
         await self.slack_client.say(report, thread_ts=response['ts'], unfurl_links=False, unfurl_media=False)
@@ -433,7 +433,7 @@ class ImagesHealthPipeline:
                     {
                         'version': version,
                         'failure_count': failure_info.get('failure_count', 0),
-                        'url': failure_info.get('url', ''),
+                        'jenkins_url': failure_info.get('jenkins_url', ''),
                         'build_system': failure_info.get('build_system', 'unknown'),
                     }
                 )
@@ -474,14 +474,14 @@ class ImagesHealthPipeline:
             for failure in failures:
                 version = failure['version']
                 failure_count = failure['failure_count']
-                job_url = failure['url']
+                jenkins_url = failure['jenkins_url']
                 build_system = failure['build_system']
                 image_message += (
                     f'\n• openshift-{version} ({build_system}): '
                     f'Failed {failure_count} time{"s" if failure_count != 1 else ""}'
                 )
-                if job_url:
-                    image_message += f' ({self.url_text(job_url, "Last failure job")})'
+                if jenkins_url:
+                    image_message += f' ({self.url_text(jenkins_url, "Last failure job")})'
             await self.slack_client.say(
                 image_message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False, unfurl_media=False
             )

--- a/pyartcd/pyartcd/pipelines/ocp.py
+++ b/pyartcd/pyartcd/pipelines/ocp.py
@@ -14,7 +14,7 @@ from pyartcd import record as record_util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.locks import Lock
 from pyartcd.runtime import Runtime
-from pyartcd.util import get_group_images, increment_rebase_fail_counter, mass_rebuild_score, reset_rebase_fail_counter
+from pyartcd.util import get_group_images, increment_fail_counter, mass_rebuild_score, reset_fail_counter
 
 
 class BuildPlan:
@@ -495,10 +495,14 @@ class OcpPipeline:
             ]
         elif self.build_images.lower() == 'only':
             successful_images = [image for image in self.build_plan.images_included if image not in failed_images]
-        await asyncio.gather(*[reset_rebase_fail_counter(image, self.version, 'brew') for image in successful_images])
+        await asyncio.gather(
+            *[reset_fail_counter(f'count:rebase-failure:brew:{self.version}:{image}') for image in successful_images]
+        )
 
         # Increment fail counters for failing images.
-        await asyncio.gather(*[increment_rebase_fail_counter(image, self.version, 'brew') for image in failed_images])
+        await asyncio.gather(
+            *[increment_fail_counter(f'count:rebase-failure:brew:{self.version}:{image}') for image in failed_images]
+        )
 
     def _handle_image_build_failures(self):
         with open(f'{self.runtime.doozer_working}/record.log', 'r') as file:

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -39,11 +39,9 @@ from pyartcd.util import (
     build_history_link_url,
     get_group_images,
     get_group_rpms,
-    increment_build_fail_counter,
-    increment_rebase_fail_counter,
+    increment_fail_counter,
     mass_rebuild_score,
-    reset_build_fail_counter,
-    reset_rebase_fail_counter,
+    reset_fail_counter,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -223,13 +221,16 @@ class KonfluxOcpPipeline:
                     f"Unknown build strategy: {self.build_plan.image_build_strategy}. Valid strategies: {[s.value for s in BuildStrategy]}"
                 )
         await asyncio.gather(
-            *[reset_rebase_fail_counter(image, self.version, 'konflux') for image in successful_images]
+            *[reset_fail_counter(f'count:rebase-failure:konflux:{self.version}:{image}') for image in successful_images]
         )
 
         # Increment fail counters only for images that failed rebase directly
         job_url = os.getenv('BUILD_URL')
         await asyncio.gather(
-            *[increment_rebase_fail_counter(image, self.version, 'konflux', job_url=job_url) for image in failed_images]
+            *[
+                increment_fail_counter(f'count:rebase-failure:konflux:{self.version}:{image}', jenkins_url=job_url)
+                for image in failed_images
+            ]
         )
 
     async def update_build_fail_counters(self, built_images, failed_images, record_log):
@@ -250,13 +251,14 @@ class KonfluxOcpPipeline:
             entry['name']: entry for entry in record_log.get('image_build_konflux', []) if int(entry['status'])
         }
 
-        await asyncio.gather(*[reset_build_fail_counter(image, group) for image in built_images])
+        await asyncio.gather(
+            *[reset_fail_counter(f'count:build-failure:konflux:{group}:{image}') for image in built_images]
+        )
         await asyncio.gather(
             *[
-                increment_build_fail_counter(
-                    image,
-                    group,
-                    url=job_url,
+                increment_fail_counter(
+                    f'count:build-failure:konflux:{group}:{image}',
+                    jenkins_url=job_url,
                     nvr=failed_entries.get(image, {}).get('nvrs'),
                 )
                 for image in failed_images

--- a/pyartcd/pyartcd/pipelines/okd.py
+++ b/pyartcd/pyartcd/pipelines/okd.py
@@ -24,10 +24,8 @@ from pyartcd.util import (
     build_history_link_url,
     default_release_suffix,
     get_group_images,
-    increment_build_fail_counter,
-    increment_rebase_fail_counter,
-    reset_build_fail_counter,
-    reset_rebase_fail_counter,
+    increment_fail_counter,
+    reset_fail_counter,
 )
 
 OKD_ARCHES = ['x86_64']
@@ -313,7 +311,7 @@ class KonfluxOkdPipeline:
 
         await asyncio.gather(
             *[
-                reset_rebase_fail_counter(image, self.version, 'konflux', branch='okd-rebase-failure')
+                reset_fail_counter(f'count:okd-rebase-failure:konflux:{self.version}:{image}')
                 for image in successful_images
             ]
         )
@@ -322,9 +320,7 @@ class KonfluxOkdPipeline:
         job_url = os.getenv('BUILD_URL')
         await asyncio.gather(
             *[
-                increment_rebase_fail_counter(
-                    image, self.version, 'konflux', branch='okd-rebase-failure', job_url=job_url
-                )
+                increment_fail_counter(f'count:okd-rebase-failure:konflux:{self.version}:{image}', jenkins_url=job_url)
                 for image in failed_images
             ]
         )
@@ -455,13 +451,14 @@ class KonfluxOkdPipeline:
             entry['name']: entry for entry in record_log.get('image_build_okd', []) if int(entry['status'])
         }
 
-        await asyncio.gather(*[reset_build_fail_counter(image, group) for image in built_images])
+        await asyncio.gather(
+            *[reset_fail_counter(f'count:build-failure:konflux:{group}:{image}') for image in built_images]
+        )
         await asyncio.gather(
             *[
-                increment_build_fail_counter(
-                    image,
-                    group,
-                    url=job_url,
+                increment_fail_counter(
+                    f'count:build-failure:konflux:{group}:{image}',
+                    jenkins_url=job_url,
                     nvr=failed_entries.get(image, {}).get('nvrs'),
                 )
                 for image in failed_images

--- a/pyartcd/pyartcd/pipelines/okd_images_health.py
+++ b/pyartcd/pyartcd/pipelines/okd_images_health.py
@@ -264,10 +264,10 @@ class ImagesHealthPipeline:
             report += '*Rebase Failures:*\n'
             for image_name, failure_info in sorted(rebase_failures.items()):
                 failure_count = failure_info.get('failure_count', 0)
-                job_url = failure_info.get('url', '')
+                jenkins_url = failure_info.get('jenkins_url', '')
                 report += f'- `{image_name}`: Failed {failure_count} time{"s" if failure_count != 1 else ""}'
-                if job_url:
-                    report += f' ({self.url_text(job_url, "Last failure job")})'
+                if jenkins_url:
+                    report += f' ({self.url_text(jenkins_url, "Last failure job")})'
                 report += '\n'
 
         await self.slack_client.say(report, thread_ts=response['ts'])
@@ -302,7 +302,7 @@ class ImagesHealthPipeline:
                     {
                         'version': version,
                         'failure_count': failure_info.get('failure_count', 0),
-                        'url': failure_info.get('url', ''),
+                        'jenkins_url': failure_info.get('jenkins_url', ''),
                     }
                 )
 
@@ -340,10 +340,10 @@ class ImagesHealthPipeline:
             for failure in failures:
                 version = failure['version']
                 failure_count = failure['failure_count']
-                job_url = failure['url']
+                jenkins_url = failure['jenkins_url']
                 image_message += f'\n• okd-{version}: Failed {failure_count} time{"s" if failure_count != 1 else ""}'
-                if job_url:
-                    image_message += f' ({self.url_text(job_url, "Last failure job")})'
+                if jenkins_url:
+                    image_message += f' ({self.url_text(jenkins_url, "Last failure job")})'
             await self.slack_client.say(image_message, thread_ts=response['ts'], link_build_url=False)
 
     def get_message_for_release(self, concern: dict):

--- a/pyartcd/pyartcd/pipelines/seed_lockfile.py
+++ b/pyartcd/pyartcd/pipelines/seed_lockfile.py
@@ -15,7 +15,7 @@ from pyartcd import constants, jenkins
 from pyartcd import record as record_util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.runtime import Runtime
-from pyartcd.util import build_history_link_url, default_release_suffix, reset_rebase_fail_counter
+from pyartcd.util import build_history_link_url, default_release_suffix, reset_fail_counter
 
 LOGGER = logging.getLogger(__name__)
 
@@ -229,7 +229,7 @@ class SeedLockfilePipeline:
 
         LOGGER.info('Resetting rebase-fail counters for solved images: %s', ', '.join(solved))
         results = await asyncio.gather(
-            *[reset_rebase_fail_counter(image, self.version, 'konflux') for image in solved],
+            *[reset_fail_counter(f'count:rebase-failure:konflux:{self.version}:{image}') for image in solved],
             return_exceptions=True,
         )
         for image, result in zip(solved, results):

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -1044,36 +1044,98 @@ async def reset_fail_counter(branch: str):
     await redis.delete_keys_by_pattern(f'{branch}:*')
 
 
-async def increment_rebase_fail_counter(image, version, build_system, branch='rebase-failure', job_url=None):
+async def get_failures(pattern: str, entity_index: int = -2, logger=None, **context):
     """
-    Increment the rebase fail counter for a given image in Redis.
-    Optionally store the job URL where the failure occurred.
+    Generic function to fetch failure data from Redis.
+    Dynamically discovers all metadata fields stored with each failure.
 
     Arg(s):
-        image (str): Image name
-        version (str): OCP version (e.g., '4.17')
-        build_system (str): Build system ('brew', 'konflux')
-        branch (str): Branch identifier (default: 'rebase-failure')
-        job_url (str): Optional job URL where the failure occurred
-    """
-    redis_branch = f'count:{branch}:{build_system}:{version}:{image}'
-    await increment_fail_counter(redis_branch, url=job_url)
+        pattern (str): Redis key pattern to search for failure keys
+                      (e.g., 'count:build-failure:konflux:openshift-4.18:*:failure')
+        entity_index (int): Index in the split key where entity name is located (default: -2, second from end)
+        logger (Logger): Optional logger for debugging
+        **context: Additional context to include in each failure record (e.g., build_system='konflux')
 
+    Return Value(s):
+        dict: {entity_name: {failure_count, <all_stored_metadata_fields>, **context}}
 
-@limit_concurrency(50)
-async def reset_rebase_fail_counter(image, version, build_system, branch='rebase-failure'):
-    """
-    Reset the rebase fail counter for a given image in Redis.
-    Limit concurrency as we might have a lot of images to reset.
+    Example:
+        # Get build failures
+        await get_failures('count:build-failure:konflux:openshift-4.18:*:failure', build_system='konflux')
 
-    Arg(s):
-        image (str): Image name
-        version (str): OCP version (e.g., '4.17')
-        build_system (str): Build system ('brew', 'konflux')
-        branch (str): Branch identifier (default: 'rebase-failure')
+        # Get rebase failures for multiple patterns
+        for branch in ['rebase-failure', 'okd-rebase-failure']:
+            await get_failures(f'count:{branch}:konflux:4.18:*:failure', branch=branch, build_system='konflux')
     """
-    redis_branch = f'count:{branch}:{build_system}:{version}:{image}'
-    await reset_fail_counter(redis_branch)
+    failures = {}
+
+    try:
+        failure_keys = await redis.get_keys(pattern)
+
+        if not failure_keys:
+            if logger:
+                logger.info('No failures found for pattern %s', pattern)
+            return failures
+
+        if logger:
+            logger.info('Found %d failure keys for pattern %s', len(failure_keys), pattern)
+
+        for failure_key in failure_keys:
+            # Extract entity name from key using the specified index
+            # e.g., 'count:build-failure:konflux:openshift-4.18:ironic:failure' -> 'ironic' (at index -2)
+            parts = failure_key.split(':')
+            if len(parts) < abs(entity_index) + 1:
+                if logger:
+                    logger.warning('Skipping malformed key: %s', failure_key)
+                continue
+
+            entity_name = parts[entity_index]
+
+            # Reconstruct base key (without ':failure' suffix)
+            base_key = ':'.join(parts[:-1])
+
+            # Fetch the failure count
+            failure_count = await redis.get_value(failure_key)
+
+            # Discover all metadata fields by fetching all keys under this base
+            metadata_keys = await redis.get_keys(f'{base_key}:*')
+
+            # Build failure record with count and all discovered metadata
+            failure_data = {'failure_count': int(failure_count) if failure_count else 0}
+
+            # Fetch all metadata fields dynamically
+            for metadata_key in metadata_keys:
+                # Skip the failure key itself (already fetched)
+                if metadata_key == failure_key:
+                    continue
+
+                # Extract field name from key (last part after final ':')
+                field_name = metadata_key.split(':')[-1]
+                field_value = await redis.get_value(metadata_key)
+                failure_data[field_name] = field_value or ''
+
+            # Add any context passed in (e.g., build_system, branch)
+            failure_data.update(context)
+
+            # If entity already exists (from previous pattern match), keep the one with higher count
+            if entity_name in failures:
+                existing_count = failures[entity_name]['failure_count']
+                new_count = failure_data['failure_count']
+                if new_count > existing_count:
+                    failures[entity_name] = failure_data
+            else:
+                failures[entity_name] = failure_data
+
+        if logger and failures:
+            import json
+
+            logger.info('Failures for pattern %s: %s', pattern, json.dumps(failures, indent=2))
+
+    except Exception as e:
+        if logger:
+            logger.warning('Failed to fetch failures for pattern %s: %s', pattern, e)
+
+    return failures
 
 
 async def get_rebase_failures(version: str, branches: list[str], build_systems: list[str], logger=None):
@@ -1087,104 +1149,26 @@ async def get_rebase_failures(version: str, branches: list[str], build_systems: 
         build_systems (list[str]): Build systems to check (e.g., ['brew', 'konflux'])
         logger (Logger): Optional logger for debugging
     Return Value(s):
-        dict: {image_name: {failure_count, url, build_system, branch}}
+        dict: {image_name: {failure_count, <all_metadata>, build_system, branch}}
     """
-    failures = {}
+    all_failures = {}
 
-    try:
-        for branch in branches:
-            for build_system in build_systems:
-                pattern = f'count:{branch}:{build_system}:{version}:*:failure'
-                failure_keys = await redis.get_keys(pattern)
+    for branch in branches:
+        for build_system in build_systems:
+            pattern = f'count:{branch}:{build_system}:{version}:*:failure'
+            failures = await get_failures(
+                pattern, entity_index=-2, logger=logger, build_system=build_system, branch=branch
+            )
 
-                if not failure_keys:
-                    if logger:
-                        logger.info('No %s %s rebase failures found for version %s', branch, build_system, version)
-                    continue
+            # Merge results, keeping highest failure count for each image
+            for image_name, failure_data in failures.items():
+                if (
+                    image_name not in all_failures
+                    or failure_data['failure_count'] > all_failures[image_name]['failure_count']
+                ):
+                    all_failures[image_name] = failure_data
 
-                if logger:
-                    logger.info(
-                        'Found %d %s %s rebase failure keys for version %s',
-                        len(failure_keys),
-                        branch,
-                        build_system,
-                        version,
-                    )
-
-                # Parse failure keys to extract image names and fetch counts + URLs
-                for failure_key in failure_keys:
-                    # Extract image name from key: count:rebase-failure:konflux:4.18:ironic:failure
-                    parts = failure_key.split(':')
-                    if len(parts) >= 5:
-                        image_name = parts[4]
-                        url_key = f'count:{branch}:{build_system}:{version}:{image_name}:url'
-
-                        # Fetch failure count and URL
-                        failure_count = await redis.get_value(failure_key)
-                        job_url = await redis.get_value(url_key)
-
-                        # If image already exists (from another build system/branch), keep the one with higher count
-                        if image_name in failures:
-                            existing_count = failures[image_name]['failure_count']
-                            new_count = int(failure_count or 0)
-                            if new_count > existing_count:
-                                failures[image_name] = {
-                                    'failure_count': new_count,
-                                    'url': job_url or '',
-                                    'build_system': build_system,
-                                    'branch': branch,
-                                }
-                        else:
-                            failures[image_name] = {
-                                'failure_count': int(failure_count) if failure_count else 0,
-                                'url': job_url or '',
-                                'build_system': build_system,
-                                'branch': branch,
-                            }
-
-        if logger and failures:
-            import json
-
-            logger.info('Rebase failures for version %s: %s', version, json.dumps(failures, indent=2))
-
-    except Exception as e:
-        if logger:
-            logger.warning('Failed to fetch rebase failures from Redis for version %s: %s', version, e)
-
-    return failures
-
-
-async def increment_build_fail_counter(image, group, build_system='konflux', **kwargs):
-    """
-    Increment the build fail counter for a given image in Redis.
-    Optionally store metadata like job URL and NVR of the failed build.
-
-    Key format: count:build-failure:{build_system}:{group}:{image}:{field}
-    Consistent with the rebase failure key pattern.
-
-    Arg(s):
-        image (str): Image name (distgit key)
-        group (str): Group name (e.g., 'openshift-4.17', 'okd-4.21')
-        build_system (str): Build system (default: 'konflux')
-        **kwargs: Optional metadata (url, nvr, etc.)
-    """
-    redis_branch = f'count:build-failure:{build_system}:{group}:{image}'
-    await increment_fail_counter(redis_branch, **kwargs)
-
-
-@limit_concurrency(50)
-async def reset_build_fail_counter(image, group, build_system='konflux'):
-    """
-    Reset the build fail counter for a given image in Redis.
-    Limit concurrency as we might have a lot of images to reset.
-
-    Arg(s):
-        image (str): Image name (distgit key)
-        group (str): Group name (e.g., 'openshift-4.17', 'okd-4.21')
-        build_system (str): Build system (default: 'konflux')
-    """
-    redis_branch = f'count:build-failure:{build_system}:{group}:{image}'
-    await reset_fail_counter(redis_branch)
+    return all_failures
 
 
 async def get_build_failures(group: str, build_system: str = 'konflux', logger=None):
@@ -1196,46 +1180,7 @@ async def get_build_failures(group: str, build_system: str = 'konflux', logger=N
         build_system (str): Build system (default: 'konflux')
         logger (Logger): Optional logger for debugging
     Return Value(s):
-        dict: {image_name: {failure_count, url, nvr}}
+        dict: {image_name: {failure_count, <all_metadata>}}
     """
-    failures = {}
-
-    try:
-        pattern = f'count:build-failure:{build_system}:{group}:*:failure'
-        failure_keys = await redis.get_keys(pattern)
-
-        if not failure_keys:
-            if logger:
-                logger.info('No %s build failures found for group %s', build_system, group)
-            return failures
-
-        if logger:
-            logger.info('Found %d %s build failure keys for group %s', len(failure_keys), build_system, group)
-
-        # Key format: count:build-failure:{build_system}:{group}:{image}:failure
-        for failure_key in failure_keys:
-            parts = failure_key.split(':')
-            if len(parts) >= 6:
-                image_name = parts[4]
-                base_key = f'count:build-failure:{build_system}:{group}:{image_name}'
-
-                failure_count = await redis.get_value(failure_key)
-                job_url = await redis.get_value(f'{base_key}:url')
-                nvr = await redis.get_value(f'{base_key}:nvr')
-
-                failures[image_name] = {
-                    'failure_count': int(failure_count) if failure_count else 0,
-                    'url': job_url or '',
-                    'nvr': nvr or '',
-                }
-
-        if logger and failures:
-            import json
-
-            logger.info('Build failures for group %s: %s', group, json.dumps(failures, indent=2))
-
-    except Exception as e:
-        if logger:
-            logger.warning('Failed to fetch build failures from Redis for group %s: %s', group, e)
-
-    return failures
+    pattern = f'count:build-failure:{build_system}:{group}:*:failure'
+    return await get_failures(pattern, entity_index=-2, logger=logger)

--- a/pyartcd/tests/pipelines/test_ocp.py
+++ b/pyartcd/tests/pipelines/test_ocp.py
@@ -946,8 +946,8 @@ class TestKonfluxOcpPipelineRebaseFailures(unittest.IsolatedAsyncioTestCase):
 
         mock_counters.assert_called_once_with(['parent-img'], ['child-a', 'child-b'])
 
-    @patch('pyartcd.pipelines.ocp4_konflux.increment_rebase_fail_counter', new_callable=AsyncMock)
-    @patch('pyartcd.pipelines.ocp4_konflux.reset_rebase_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.increment_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.reset_fail_counter', new_callable=AsyncMock)
     async def test_update_rebase_fail_counters_skipped_children_unchanged_in_redis(self, mock_reset, mock_incr):
         """Children skipped because a parent failed are not reset nor incremented (no-op)."""
         from pyartcd.pipelines.ocp4_konflux import BuildStrategy
@@ -958,8 +958,9 @@ class TestKonfluxOcpPipelineRebaseFailures(unittest.IsolatedAsyncioTestCase):
 
         await pipeline.update_rebase_fail_counters(['parent-img'], ['child-a'])
 
-        reset_names = {c.args[0] for c in mock_reset.call_args_list}
-        incr_names = {c.args[0] for c in mock_incr.call_args_list}
+        # Extract image names from the redis branch strings
+        reset_names = {c.args[0].split(':')[-1] for c in mock_reset.call_args_list}
+        incr_names = {c.args[0].split(':')[-1] for c in mock_incr.call_args_list}
         self.assertEqual(reset_names, {'healthy'})
         self.assertEqual(incr_names, {'parent-img'})
         self.assertNotIn('child-a', reset_names)

--- a/pyartcd/tests/pipelines/test_seed_lockfile.py
+++ b/pyartcd/tests/pipelines/test_seed_lockfile.py
@@ -425,7 +425,7 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
 
         mock_title.assert_not_called()
 
-    @patch('pyartcd.pipelines.seed_lockfile.reset_rebase_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.seed_lockfile.reset_fail_counter', new_callable=AsyncMock)
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.init_jenkins')
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_title')
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_description')
@@ -443,9 +443,9 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
         with patch.object(pipeline, '_extract_stream_results_from_record_log', side_effect=populate_stream_results):
             await pipeline.run()
 
-        mock_reset.assert_awaited_once_with('ironic', '4.22', 'konflux')
+        mock_reset.assert_awaited_once_with('count:rebase-failure:konflux:4.22:ironic')
 
-    @patch('pyartcd.pipelines.seed_lockfile.reset_rebase_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.seed_lockfile.reset_fail_counter', new_callable=AsyncMock)
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.init_jenkins')
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_title')
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_description')
@@ -466,7 +466,7 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
 
         mock_reset.assert_not_awaited()
 
-    @patch('pyartcd.pipelines.seed_lockfile.reset_rebase_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.seed_lockfile.reset_fail_counter', new_callable=AsyncMock)
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.init_jenkins')
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_title')
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_description')
@@ -486,7 +486,7 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
 
         mock_reset.assert_not_awaited()
 
-    @patch('pyartcd.pipelines.seed_lockfile.reset_rebase_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.seed_lockfile.reset_fail_counter', new_callable=AsyncMock)
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.init_jenkins')
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_title')
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_description')
@@ -507,7 +507,7 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
 
         mock_reset.assert_not_awaited()
 
-    @patch('pyartcd.pipelines.seed_lockfile.reset_rebase_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.seed_lockfile.reset_fail_counter', new_callable=AsyncMock)
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.init_jenkins')
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_title')
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.update_description')
@@ -527,7 +527,7 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
             # Should not raise despite Redis error
             await pipeline.run()
 
-        mock_reset.assert_awaited_once_with('ironic', '4.22', 'konflux')
+        mock_reset.assert_awaited_once_with('count:rebase-failure:konflux:4.22:ironic')
 
     def test_init_stores_jira_key(self):
         pipeline = self._create_pipeline(jira_key='ART-12345')

--- a/pyartcd/tests/test_util.py
+++ b/pyartcd/tests/test_util.py
@@ -245,45 +245,45 @@ class TestUtil(IsolatedAsyncioTestCase):
         await util.reset_fail_counter('count:test:branch')
         mock_delete.assert_called_once_with('count:test:branch:*')
 
-    @patch("artcommonlib.redis.set_value", new_callable=AsyncMock)
-    @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
-    async def test_increment_build_fail_counter_new(self, mock_get, mock_set):
-        mock_get.return_value = None
-        await util.increment_build_fail_counter('ironic', 'openshift-4.21', url='http://j/1', nvr='ironic-1.0-1')
-        mock_set.assert_any_call(key='count:build-failure:konflux:openshift-4.21:ironic:failure', value=1)
-        mock_set.assert_any_call(key='count:build-failure:konflux:openshift-4.21:ironic:url', value='http://j/1')
-        mock_set.assert_any_call(key='count:build-failure:konflux:openshift-4.21:ironic:nvr', value='ironic-1.0-1')
-
-    @patch("artcommonlib.redis.set_value", new_callable=AsyncMock)
-    @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
-    async def test_increment_build_fail_counter_existing(self, mock_get, mock_set):
-        mock_get.return_value = '3'
-        await util.increment_build_fail_counter('ironic', 'openshift-4.21')
-        mock_set.assert_any_call(key='count:build-failure:konflux:openshift-4.21:ironic:failure', value=4)
-
-    @patch("artcommonlib.redis.delete_keys_by_pattern", new_callable=AsyncMock)
-    async def test_reset_build_fail_counter(self, mock_delete):
-        await util.reset_build_fail_counter('ironic', 'openshift-4.21')
-        mock_delete.assert_called_once_with('count:build-failure:konflux:openshift-4.21:ironic:*')
-
     @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
     @patch("artcommonlib.redis.get_keys", new_callable=AsyncMock)
     async def test_get_build_failures(self, mock_get_keys, mock_get_value):
-        mock_get_keys.return_value = [
-            'count:build-failure:konflux:openshift-4.21:ironic:failure',
-            'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:failure',
-        ]
+        # Mock get_keys to handle both the initial failure key search and metadata discovery
+        def mock_get_keys_side_effect(pattern):
+            if pattern.endswith(':*:failure'):
+                # Initial search for failure keys
+                return [
+                    'count:build-failure:konflux:openshift-4.21:ironic:failure',
+                    'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:failure',
+                ]
+            elif 'ironic' in pattern:
+                # Metadata discovery for ironic
+                return [
+                    'count:build-failure:konflux:openshift-4.21:ironic:failure',
+                    'count:build-failure:konflux:openshift-4.21:ironic:jenkins_url',
+                    'count:build-failure:konflux:openshift-4.21:ironic:nvr',
+                ]
+            elif 'ovn-kubernetes' in pattern:
+                # Metadata discovery for ovn-kubernetes
+                return [
+                    'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:failure',
+                    'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:jenkins_url',
+                    'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:nvr',
+                ]
+            return []
+
+        mock_get_keys.side_effect = mock_get_keys_side_effect
         mock_get_value.side_effect = lambda key: {
             'count:build-failure:konflux:openshift-4.21:ironic:failure': '5',
-            'count:build-failure:konflux:openshift-4.21:ironic:url': 'http://j/1',
+            'count:build-failure:konflux:openshift-4.21:ironic:jenkins_url': 'http://j/1',
             'count:build-failure:konflux:openshift-4.21:ironic:nvr': 'ironic-1.0-1',
             'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:failure': '2',
-            'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:url': '',
+            'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:jenkins_url': '',
             'count:build-failure:konflux:openshift-4.21:ovn-kubernetes:nvr': None,
         }.get(key)
         result = await util.get_build_failures('openshift-4.21')
         self.assertEqual(result['ironic']['failure_count'], 5)
-        self.assertEqual(result['ironic']['url'], 'http://j/1')
+        self.assertEqual(result['ironic']['jenkins_url'], 'http://j/1')
         self.assertEqual(result['ironic']['nvr'], 'ironic-1.0-1')
         self.assertEqual(result['ovn-kubernetes']['failure_count'], 2)
 


### PR DESCRIPTION
This commit makes the fail counter system more generic and maintainable:

1. Rename url field to jenkins_url throughout the codebase
   - Updated increment_fail_counter to use jenkins_url parameter
   - Updated images_health.py and okd_images_health.py to consume jenkins_url
   - Updated all test expectations

2. Consolidate specialized functions into generic ones
   - Removed increment_rebase_fail_counter, increment_build_fail_counter
   - Removed reset_rebase_fail_counter, reset_build_fail_counter
   - Callers now construct full Redis key pattern and call increment_fail_counter/reset_fail_counter directly
   - Uses **kwargs to accept any metadata fields, not just hardcoded ones

3. Consolidate get_*_failures functions into single generic get_failures
   - get_failures() now accepts a Redis pattern and entity_index parameter
   - Dynamically discovers ALL metadata fields stored in Redis (not just jenkins_url, nvr)
   - get_build_failures() and get_rebase_failures() now use get_failures() under the hood
   - Future-proof: works with any additional metadata added via **kwargs

## Test
- https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/35072/parameters/
- https://redhat-internal.slack.com/archives/C0A8KF38N9L/p1779287715169099?thread_ts=1779287714.980149&cid=C0A8KF38N9L