### PR TITLE
microshift-bootc: hermetic build improvements

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -515,6 +515,9 @@ class BuildMicroShiftBootcPipeline:
             "--latest-parent-version",
             "-i",
             self.BOOTC_IMAGE_NAME,
+            # Lock to the same commit as the microshift RPM to ensure consistency
+            # between RPM and bootc artifacts. Without this, doozer would try to
+            # use brew to find the commit which fails for Konflux-built images.
             "--lock-upstream",
             self.BOOTC_IMAGE_NAME,
             upstream_commit,
@@ -554,6 +557,7 @@ class BuildMicroShiftBootcPipeline:
             [
                 "-i",
                 self.BOOTC_IMAGE_NAME,
+                # Lock to the same commit as the microshift RPM to ensure consistency
                 "--lock-upstream",
                 self.BOOTC_IMAGE_NAME,
                 upstream_commit,

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -66,6 +66,8 @@ yaml = new_roundtrip_yaml_handler()
 class BuildMicroShiftBootcPipeline:
     """Rebase and build MicroShift for an assembly"""
 
+    BOOTC_IMAGE_NAME = "microshift-bootc"
+
     def __init__(
         self,
         runtime: Runtime,
@@ -77,6 +79,7 @@ class BuildMicroShiftBootcPipeline:
         data_path: str,
         slack_client,
         data_gitref: str | None = None,
+        trigger_open_build_first: bool = False,
         logger: Optional[logging.Logger] = None,
     ):
         self.runtime = runtime
@@ -88,6 +91,7 @@ class BuildMicroShiftBootcPipeline:
         self.force_plashet_sync = force_plashet_sync
         self.prepare_shipment = prepare_shipment
         self.slack_client = slack_client
+        self.trigger_open_build_first = trigger_open_build_first
         self._logger = logger or runtime.logger
 
         self._working_dir = self.runtime.working_dir.absolute()
@@ -313,15 +317,13 @@ class BuildMicroShiftBootcPipeline:
             await _run_for(local_dir, latest_path)
 
     async def get_latest_bootc_build(self):
-        bootc_image_name = "microshift-bootc"
-
         if not self.konflux_db:
             self.konflux_db = KonfluxDb()
             self.konflux_db.bind(KonfluxBuildRecord)
             self._logger.info('Konflux DB initialized')
 
         build = await self.konflux_db.get_latest_build(
-            name=bootc_image_name,
+            name=self.BOOTC_IMAGE_NAME,
             group=self.group,
             assembly=self.assembly,
             outcome=KonfluxBuildOutcome.SUCCESS,
@@ -493,8 +495,86 @@ class BuildMicroShiftBootcPipeline:
             )
         raise ValueError(f"Assembly type {self.assembly_type} is not supported for microshift-bootc builds")
 
+    async def _do_rebase_and_build(
+        self,
+        network_mode: str,
+        upstream_commit: str,
+        assembly_label_value: Optional[str],
+        seed_nvr: Optional[str] = None,
+    ):
+        """Run a single rebase+build cycle with the given network mode."""
+        major, minor = self._ocp_version
+        version = f"v{major}.{minor}"
+        release = default_release_suffix()
+        rebase_cmd = [
+            "doozer",
+            "--group",
+            self.doozer_group,
+            "--assembly",
+            self.assembly,
+            "--latest-parent-version",
+            "-i",
+            self.BOOTC_IMAGE_NAME,
+            "--lock-upstream",
+            self.BOOTC_IMAGE_NAME,
+            upstream_commit,
+            "--build-system",
+            "konflux",
+            "beta:images:konflux:rebase",
+            "--version",
+            version,
+            "--release",
+            release,
+        ]
+        if seed_nvr:
+            rebase_cmd += ["--lockfile-seed-nvrs", seed_nvr]
+        if assembly_label_value:
+            rebase_cmd += ["--extra-label", f"assembly={assembly_label_value}"]
+        rebase_cmd += ["--network-mode", network_mode]
+        rebase_cmd += [
+            "--message",
+            f"Updating Dockerfile version and release {version}-{release}",
+        ]
+        if not self.runtime.dry_run:
+            rebase_cmd.append("--push")
+        await exectools.cmd_assert_async(rebase_cmd, env=self._doozer_env_vars)
+
+        kubeconfig = os.environ['KONFLUX_SA_KUBECONFIG']
+        build_cmd = [
+            "doozer",
+            "--group",
+            self.doozer_group,
+            "--assembly",
+            self.assembly,
+            "--latest-parent-version",
+        ]
+        if self._registry_config:
+            build_cmd.append(f"--registry-config={self._registry_config}")
+        build_cmd.extend(
+            [
+                "-i",
+                self.BOOTC_IMAGE_NAME,
+                "--lock-upstream",
+                self.BOOTC_IMAGE_NAME,
+                upstream_commit,
+                "--build-system",
+                "konflux",
+                "beta:images:konflux:build",
+                "--image-repo",
+                KONFLUX_DEFAULT_IMAGE_REPO,
+                "--konflux-kubeconfig",
+                kubeconfig,
+                "--konflux-namespace",
+                "ocp-art-tenant",
+                "--network-mode",
+                network_mode,
+            ]
+        )
+        if self.runtime.dry_run:
+            build_cmd.append("--dry-run")
+        await exectools.cmd_assert_async(build_cmd, env=self._doozer_env_vars)
+
     async def _rebase_and_build_bootc(self):
-        bootc_image_name = "microshift-bootc"
         major, minor = self._ocp_version
         # do not run for version < 4.18
         if (major, minor) < (4, 18):
@@ -503,7 +583,7 @@ class BuildMicroShiftBootcPipeline:
 
         # Check if an image is already pinned and don't rebuild unless forced
         if not self.force and self.assembly_type != AssemblyTypes.STREAM:
-            pinned_nvr = get_image_if_pinned_directly(self.releases_config, self.assembly, bootc_image_name)
+            pinned_nvr = get_image_if_pinned_directly(self.releases_config, self.assembly, self.BOOTC_IMAGE_NAME)
             if pinned_nvr:
                 message = f"For assembly {self.assembly} microshift-bootc image is already pinned: {pinned_nvr}. Use FORCE to rebuild."
                 self._logger.info(message)
@@ -535,10 +615,9 @@ class BuildMicroShiftBootcPipeline:
         else:
             self._logger.info("Force flag is set. Forcing bootc image build")
 
-        kubeconfig = os.environ.get('KONFLUX_SA_KUBECONFIG')
-        if not kubeconfig:
+        if not os.environ.get('KONFLUX_SA_KUBECONFIG'):
             raise ValueError(
-                f"KONFLUX_SA_KUBECONFIG environment variable is required to build {bootc_image_name} image"
+                f"KONFLUX_SA_KUBECONFIG environment variable is required to build {self.BOOTC_IMAGE_NAME} image"
             )
 
         await self._build_plashet_for_bootc()
@@ -549,84 +628,28 @@ class BuildMicroShiftBootcPipeline:
         # Determine the assembly label value based on assembly type
         assembly_label_value = self._get_assembly_label_value()
 
-        # Find the most recent prior bootc build (any assembly) to seed the RPM lockfile.
-        # This is a no-op when the image is not configured as hermetic in ocp-build-data.
-        seed_build = await self.get_bootc_build_for_seeding()
-        if seed_build:
-            self._logger.info("Found bootc build for lockfile seeding: %s", seed_build.nvr)
+        if self.trigger_open_build_first:
+            # Phase 1: open build — populates the installed_rpms DB field that doozer uses for lockfile generation
+            self._logger.info("Running open build phase (needed for hermetic lockfile generation)...")
+            await self.slack_client.say_in_thread(
+                "Running open build phase (needed for hermetic lockfile generation)..."
+            )
+            await self._do_rebase_and_build("open", upstream_commit, assembly_label_value)
+            # Wait for the open build record to propagate in BigQuery before the hermetic build queries it
+            await asyncio.sleep(10)
+            await self._do_rebase_and_build("hermetic", upstream_commit, assembly_label_value)
         else:
-            self._logger.info("No prior bootc build found for lockfile seeding")
-
-        # Rebase and build bootc image
-        version = f"v{major}.{minor}"
-        release = default_release_suffix()
-        rebase_cmd = [
-            "doozer",
-            "--group",
-            self.doozer_group,
-            "--assembly",
-            self.assembly,
-            "--latest-parent-version",
-            "-i",
-            bootc_image_name,
-            # Lock to the same commit as the microshift RPM to ensure consistency
-            # between RPM and bootc artifacts. Without this, doozer would try to
-            # use brew to find the commit which fails for Konflux-built images.
-            "--lock-upstream",
-            bootc_image_name,
-            upstream_commit,
-            "--build-system",
-            "konflux",
-            "beta:images:konflux:rebase",
-            "--version",
-            version,
-            "--release",
-            release,
-        ]
-        if seed_build:
-            rebase_cmd += ["--lockfile-seed-nvrs", seed_build.nvr]
-        if assembly_label_value:
-            rebase_cmd += ["--extra-label", f"assembly={assembly_label_value}"]
-        rebase_cmd += [
-            "--message",
-            f"Updating Dockerfile version and release {version}-{release}",
-        ]
-        if not self.runtime.dry_run:
-            rebase_cmd.append("--push")
-        await exectools.cmd_assert_async(rebase_cmd, env=self._doozer_env_vars)
-
-        build_cmd = [
-            "doozer",
-            "--group",
-            self.doozer_group,
-            "--assembly",
-            self.assembly,
-            "--latest-parent-version",
-        ]
-        if self._registry_config:
-            build_cmd.append(f"--registry-config={self._registry_config}")
-        build_cmd.extend(
-            [
-                "-i",
-                bootc_image_name,
-                # Lock to the same commit as the microshift RPM to ensure consistency
-                "--lock-upstream",
-                bootc_image_name,
-                upstream_commit,
-                "--build-system",
-                "konflux",
-                "beta:images:konflux:build",
-                "--image-repo",
-                KONFLUX_DEFAULT_IMAGE_REPO,
-                "--konflux-kubeconfig",
-                kubeconfig,
-                "--konflux-namespace",
-                "ocp-art-tenant",
-            ]
-        )
-        if self.runtime.dry_run:
-            build_cmd.append("--dry-run")
-        await exectools.cmd_assert_async(build_cmd, env=self._doozer_env_vars)
+            # Find the most recent prior bootc build (any assembly) to seed the RPM lockfile.
+            # This is a no-op when the image is not configured as hermetic in ocp-build-data.
+            seed_build = await self.get_bootc_build_for_seeding()
+            if seed_build:
+                self._logger.info("Found bootc build for lockfile seeding: %s", seed_build.nvr)
+            else:
+                self._logger.info("No prior bootc build found for lockfile seeding")
+            await self._do_rebase_and_build(
+                "hermetic", upstream_commit, assembly_label_value,
+                seed_nvr=seed_build.nvr if seed_build else None,
+            )
 
         # sleep a little bit to account for time drift between systems
         await asyncio.sleep(10)
@@ -1241,6 +1264,12 @@ class BuildMicroShiftBootcPipeline:
     default="",
     help="Doozer data path git [branch / tag / sha] to use",
 )
+@click.option(
+    "--trigger-open-build-first",
+    is_flag=True,
+    default=False,
+    help="Run an open (non-hermetic) build before the hermetic build to produce an installed-RPMs record for lockfile generation.",
+)
 @pass_runtime
 @click_coroutine
 async def build_microshift_bootc(
@@ -1252,6 +1281,7 @@ async def build_microshift_bootc(
     force_plashet_sync: bool,
     prepare_shipment: bool,
     data_gitref: str | None = None,
+    trigger_open_build_first: bool = False,
 ):
     # slack client is dry-run aware and will not send messages if dry-run is enabled
     slack_client = runtime.new_slack_client()
@@ -1267,6 +1297,7 @@ async def build_microshift_bootc(
             data_path=data_path,
             slack_client=slack_client,
             data_gitref=data_gitref,
+            trigger_open_build_first=trigger_open_build_first,
         )
         await pipeline.run()
     except Exception as err:

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -188,7 +188,7 @@ class BuildMicroShiftBootcPipeline:
 
     async def _run_pipeline(self):
         data_path = self._doozer_env_vars["DOOZER_DATA_PATH"]
-        self.releases_config = await load_releases_config(group=self.doozer_group, data_path=data_path)
+        self.releases_config = await load_releases_config(group=self.group, data_path=constants.OCP_BUILD_DATA_URL)
         self.assembly_type = get_assembly_type(self.releases_config, self.assembly)
         # Load group config
         self.group_config = await load_group_config(
@@ -697,7 +697,7 @@ class BuildMicroShiftBootcPipeline:
             )
             return "https://github.example.com/foo/bar/pull/1234"
 
-        user, repo = self.extract_git_repo(self._doozer_env_vars["DOOZER_DATA_PATH"])
+        user, repo = self.extract_git_repo(constants.OCP_BUILD_DATA_URL)
         github_client = get_github_client_for_org(user)
         upstream_repo = github_client.get_repo(f"{user}/{repo}")
         release_file_content = yaml.load(upstream_repo.get_contents("releases.yml", ref=self.group).decoded_content)
@@ -749,7 +749,7 @@ class BuildMicroShiftBootcPipeline:
                 raise TimeoutError(error_msg)
 
             # Refresh PR to get latest status
-            user, repo = self.extract_git_repo(self._doozer_env_vars['DOOZER_DATA_PATH'])
+            user, repo = self.extract_git_repo(constants.OCP_BUILD_DATA_URL)
             pr = get_github_client_for_org(user).get_repo(f"{user}/{repo}").get_pull(pr.number)
 
             # Check if PR was closed/merged by someone else
@@ -945,8 +945,7 @@ class BuildMicroShiftBootcPipeline:
             )
             return True
 
-        data_path = self._doozer_env_vars["DOOZER_DATA_PATH"]
-        user, repo = self.extract_git_repo(data_path)
+        user, repo = self.extract_git_repo(constants.OCP_BUILD_DATA_URL)
         github_client = get_github_client_for_org(user)
         upstream_repo = github_client.get_repo(f"{user}/{repo}")
 

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -647,7 +647,9 @@ class BuildMicroShiftBootcPipeline:
             else:
                 self._logger.info("No prior bootc build found for lockfile seeding")
             await self._do_rebase_and_build(
-                "hermetic", upstream_commit, assembly_label_value,
+                "hermetic",
+                upstream_commit,
+                assembly_label_value,
                 seed_nvr=seed_build.nvr if seed_build else None,
             )
 

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -316,13 +316,13 @@ class BuildMicroShiftBootcPipeline:
             await _run_for(local_dir, release_path)
             await _run_for(local_dir, latest_path)
 
-    async def get_latest_bootc_build(self):
+    async def get_latest_bootc_build(self, hermetic: Optional[bool] = None):
         if not self.konflux_db:
             self.konflux_db = KonfluxDb()
             self.konflux_db.bind(KonfluxBuildRecord)
             self._logger.info('Konflux DB initialized')
 
-        build = await self.konflux_db.get_latest_build(
+        kwargs: dict = dict(
             name=self.BOOTC_IMAGE_NAME,
             group=self.group,
             assembly=self.assembly,
@@ -332,6 +332,10 @@ class BuildMicroShiftBootcPipeline:
             el_target='el9',
             exclude_large_columns=True,
         )
+        if hermetic is not None:
+            kwargs['extra_patterns'] = {'hermetic': hermetic}
+
+        build = await self.konflux_db.get_latest_build(**kwargs)
         return cast(Optional[KonfluxBuildRecord], build)
 
     async def get_bootc_build_for_seeding(self) -> Optional[KonfluxBuildRecord]:
@@ -342,7 +346,7 @@ class BuildMicroShiftBootcPipeline:
             self._logger.info('Konflux DB initialized')
 
         build = await self.konflux_db.get_latest_build(
-            name="microshift-bootc",
+            name=self.BOOTC_IMAGE_NAME,
             group=self.group,
             outcome=KonfluxBuildOutcome.SUCCESS,
             engine=Engine.KONFLUX,
@@ -542,7 +546,11 @@ class BuildMicroShiftBootcPipeline:
             rebase_cmd.append("--push")
         await exectools.cmd_assert_async(rebase_cmd, env=self._doozer_env_vars)
 
-        kubeconfig = os.environ['KONFLUX_SA_KUBECONFIG']
+        kubeconfig = os.environ.get('KONFLUX_SA_KUBECONFIG')
+        if not kubeconfig:
+            raise ValueError(
+                f"KONFLUX_SA_KUBECONFIG environment variable is required to build {self.BOOTC_IMAGE_NAME} image"
+            )
         build_cmd = [
             "doozer",
             "--group",
@@ -619,11 +627,6 @@ class BuildMicroShiftBootcPipeline:
         else:
             self._logger.info("Force flag is set. Forcing bootc image build")
 
-        if not os.environ.get('KONFLUX_SA_KUBECONFIG'):
-            raise ValueError(
-                f"KONFLUX_SA_KUBECONFIG environment variable is required to build {self.BOOTC_IMAGE_NAME} image"
-            )
-
         await self._build_plashet_for_bootc()
 
         # Extract the commit from the microshift RPM to ensure bootc is built from the same source
@@ -660,8 +663,8 @@ class BuildMicroShiftBootcPipeline:
         # sleep a little bit to account for time drift between systems
         await asyncio.sleep(10)
 
-        # now that build is complete, fetch it
-        return await self.get_latest_bootc_build()
+        # now that build is complete, fetch the hermetic build
+        return await self.get_latest_bootc_build(hermetic=True)
 
     def extract_git_repo(self, data_path: str):
         """
@@ -1274,7 +1277,7 @@ class BuildMicroShiftBootcPipeline:
     "--trigger-open-build-first",
     is_flag=True,
     default=False,
-    help="Run an open (non-hermetic) build before the hermetic build to produce an installed-RPMs record for lockfile generation.",
+    help="Run an open (non-hermetic) build before the hermetic build to populate the installed_rpms DB field used for lockfile generation.",
 )
 @pass_runtime
 @click_coroutine

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -332,6 +332,24 @@ class BuildMicroShiftBootcPipeline:
         )
         return cast(Optional[KonfluxBuildRecord], build)
 
+    async def get_bootc_build_for_seeding(self) -> Optional[KonfluxBuildRecord]:
+        """Find the most recent successful bootc build across any assembly to use as a lockfile seed."""
+        if not self.konflux_db:
+            self.konflux_db = KonfluxDb()
+            self.konflux_db.bind(KonfluxBuildRecord)
+            self._logger.info('Konflux DB initialized')
+
+        build = await self.konflux_db.get_latest_build(
+            name="microshift-bootc",
+            group=self.group,
+            outcome=KonfluxBuildOutcome.SUCCESS,
+            engine=Engine.KONFLUX,
+            artifact_type=ArtifactType.IMAGE,
+            el_target='el9',
+            exclude_large_columns=True,
+        )
+        return cast(Optional[KonfluxBuildRecord], build)
+
     async def _build_plashet_for_bootc(self):
         microshift_plashet_name = "rhel-9-server-microshift-rpms"
         major, minor = self._ocp_version
@@ -531,6 +549,14 @@ class BuildMicroShiftBootcPipeline:
         # Determine the assembly label value based on assembly type
         assembly_label_value = self._get_assembly_label_value()
 
+        # Find the most recent prior bootc build (any assembly) to seed the RPM lockfile.
+        # This is a no-op when the image is not configured as hermetic in ocp-build-data.
+        seed_build = await self.get_bootc_build_for_seeding()
+        if seed_build:
+            self._logger.info("Found bootc build for lockfile seeding: %s", seed_build.nvr)
+        else:
+            self._logger.info("No prior bootc build found for lockfile seeding")
+
         # Rebase and build bootc image
         version = f"v{major}.{minor}"
         release = default_release_suffix()
@@ -557,6 +583,8 @@ class BuildMicroShiftBootcPipeline:
             "--release",
             release,
         ]
+        if seed_build:
+            rebase_cmd += ["--lockfile-seed-nvrs", seed_build.nvr]
         if assembly_label_value:
             rebase_cmd += ["--extra-label", f"assembly={assembly_label_value}"]
         rebase_cmd += [

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -642,9 +642,21 @@ class BuildMicroShiftBootcPipeline:
                 "Running open build phase (needed for hermetic lockfile generation)..."
             )
             await self._do_rebase_and_build("open", upstream_commit, assembly_label_value)
-            # Wait for the open build record to propagate in BigQuery before the hermetic build queries it
-            await asyncio.sleep(10)
-            await self._do_rebase_and_build("hermetic", upstream_commit, assembly_label_value)
+
+            # Fetch the open build record and verify it belongs to this job run before using it as seed
+            open_build = await self.get_latest_bootc_build(hermetic=False)
+            if not open_build:
+                raise IOError("Open build phase completed but no build record found in Konflux DB")
+            build_url = os.environ.get('BUILD_URL')
+            if build_url and open_build.art_job_url != build_url:
+                raise IOError(
+                    f"Open build record art_job_url ({open_build.art_job_url}) does not match "
+                    f"current BUILD_URL ({build_url}). Refusing to proceed with hermetic build."
+                )
+            self._logger.info("Open build record verified: %s", open_build.nvr)
+
+            # Phase 2: hermetic build — pass the verified open build NVR so doozer uses its installed_rpms for lockfile generation
+            await self._do_rebase_and_build("hermetic", upstream_commit, assembly_label_value, seed_nvr=open_build.nvr)
         else:
             # Find the most recent prior bootc build (any assembly) to seed the RPM lockfile.
             # This is a no-op when the image is not configured as hermetic in ocp-build-data.

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -91,7 +91,7 @@ class BuildMicroShiftBootcPipeline:
         self.force_plashet_sync = force_plashet_sync
         self.prepare_shipment = prepare_shipment
         self.slack_client = slack_client
-        self.trigger_open_build_first = True  # TEST MODE: always run open build first
+        self.trigger_open_build_first = trigger_open_build_first
         self._logger = logger or runtime.logger
 
         self._working_dir = self.runtime.working_dir.absolute()

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -91,7 +91,7 @@ class BuildMicroShiftBootcPipeline:
         self.force_plashet_sync = force_plashet_sync
         self.prepare_shipment = prepare_shipment
         self.slack_client = slack_client
-        self.trigger_open_build_first = trigger_open_build_first
+        self.trigger_open_build_first = True  # TEST MODE: always run open build first
         self._logger = logger or runtime.logger
 
         self._working_dir = self.runtime.working_dir.absolute()

--- a/pyartcd/tests/pipelines/test_build_microshift_bootc.py
+++ b/pyartcd/tests/pipelines/test_build_microshift_bootc.py
@@ -376,10 +376,13 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
         self.assertIsNone(pipeline._get_assembly_label_value())
 
     @patch("pyartcd.pipelines.build_microshift_bootc.exectools.cmd_assert_async", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "get_bootc_build_for_seeding", new_callable=AsyncMock)
     @patch.object(BuildMicroShiftBootcPipeline, "get_latest_bootc_build", new_callable=AsyncMock)
     @patch.object(BuildMicroShiftBootcPipeline, "_get_microshift_rpm_commit", new_callable=AsyncMock)
     @patch.object(BuildMicroShiftBootcPipeline, "_build_plashet_for_bootc", new_callable=AsyncMock)
-    async def test_rebase_uses_two_segment_version(self, mock_plashet, mock_get_commit, mock_get_build, mock_cmd):
+    async def test_rebase_uses_two_segment_version(
+        self, mock_plashet, mock_get_commit, mock_get_build, mock_get_seed, mock_cmd
+    ):
         """
         Test that _rebase_and_build_bootc passes --version v4.21 (2 segments)
         instead of v4.21.0 to avoid confusing tags on the container catalog
@@ -410,11 +413,12 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
             os.environ.pop("KONFLUX_SA_KUBECONFIG", None)
 
     @patch("pyartcd.pipelines.build_microshift_bootc.exectools.cmd_assert_async", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "get_bootc_build_for_seeding", new_callable=AsyncMock)
     @patch.object(BuildMicroShiftBootcPipeline, "get_latest_bootc_build", new_callable=AsyncMock)
     @patch.object(BuildMicroShiftBootcPipeline, "_get_microshift_rpm_commit", new_callable=AsyncMock)
     @patch.object(BuildMicroShiftBootcPipeline, "_build_plashet_for_bootc", new_callable=AsyncMock)
     async def test_rebase_and_build_bootc_uses_rpm_commit(
-        self, mock_plashet, mock_get_commit, mock_get_build, mock_cmd
+        self, mock_plashet, mock_get_commit, mock_get_build, mock_get_seed, mock_cmd
     ):
         """
         Test that _rebase_and_build_bootc passes the RPM commit to --lock-upstream


### PR DESCRIPTION
## Summary

- **Seed lockfile from prior bootc build**: when no open build is triggered first, seeds the hermetic RPM lockfile from the most recent successful bootc build across any assembly
- **Always target upstream ocp-build-data for releases.yml operations**: decouples `DOOZER_DATA_PATH` (used for image configs) from the repo used to read/write `releases.yml`, pin PRs, and shipment MR URLs — these always target `openshift-eng/ocp-build-data` regardless of fork overrides
- **Add `--trigger-open-build-first` / `TRIGGER_OPEN_BUILD_FIRST`**: runs an open (non-hermetic) build before the hermetic build, populating the `installed_rpms` DB field that doozer uses for lockfile generation; useful for the first hermetic build in a new group (e.g. openshift-4.21) where no prior build exists

Companion Jenkins job change: https://github.com/openshift-eng/aos-cd-jobs/pull/4699