### PR TITLE
ART-18958: fix get_inflight() selecting future Y-1

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -334,11 +334,18 @@ def is_release_next_week(group):
 
 def get_inflight(assembly, group, date=None):
     """
-    Get inflight release name from current assembly release
+    Get inflight release name from current assembly release.
+
+    Searches the previous minor's release schedule for a Y-1 z-stream release
+    whose date_start falls within 7 days before (or on the same day as) the
+    assembly release date. When multiple releases qualify, the latest is chosen.
+    A same-day release is included because it is expected to ship by the time
+    the assembly reaches customers.
 
     :param assembly: Assembly name
     :param group: Group name
     :param date: Optional explicitly provided date in format YYYY-MMM-DD (e.g., 2026-Mar-31)
+    :return: Version string (e.g., '4.21.16') of the in-flight release, or None
     """
     inflight_release = None
     assembly_release_date = get_assembly_release_date(assembly, group, date)
@@ -357,22 +364,26 @@ def get_inflight(assembly, group, date=None):
         response.raise_for_status()
         try:
             data = response.json()
+            assembly_date = datetime.strptime(assembly_release_date, "%Y-%b-%d")
+            best_candidate = None
+            best_date = None
+
             for release in data['all_ga_tasks']:
-                is_future = is_future_release_date(release['date_start'])
-                if is_future:
-                    days_diff = abs(
-                        (
-                            datetime.strptime(assembly_release_date, "%Y-%b-%d")
-                            - datetime.strptime(release['date_start'], "%Y-%m-%d")
-                        ).days
-                    )
-                    if days_diff <= 5:  # if next Y-1 release and assembly release in the same week
-                        match = re.search(r'\d+\.\d+\.\d+', release['name'])
-                        if match:
-                            inflight_release = match.group()
-                            break
-                        else:
-                            raise ValueError(f"Didn't find in_inflight release in {release['name']}")
+                release_date = datetime.strptime(release['date_start'], "%Y-%m-%d")
+                if release_date > assembly_date:
+                    continue
+                days_diff = (assembly_date - release_date).days
+                if days_diff <= 7:  # if next Y-1 release and assembly release in the same week
+                    match = re.search(r'\d+\.\d+\.\d+', release['name'])
+                    if match:
+                        if best_date is None or release_date > best_date:
+                            best_candidate = match.group()
+                            best_date = release_date
+                    else:
+                        LOGGER.warning(f"Release '{release['name']}' qualified but has no X.Y.Z version in its name")
+
+            if best_candidate:
+                inflight_release = best_candidate
         except json.JSONDecodeError as e:
             raise ValueError(f'Failed to parse JSON for {prev_group}: {e}')
         except ValueError as e:

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -337,14 +337,16 @@ def get_inflight(assembly, group, date=None):
     Get inflight release name from current assembly release.
 
     Searches the previous minor's release schedule for a Y-1 z-stream release
-    whose date_start falls within 7 days before (or on the same day as) the
-    assembly release date. When multiple releases qualify, the latest is chosen.
+    whose date_start (the scheduled GA/errata date from Product Pages) falls
+    within 7 days before (or on the same day as) the assembly release date.
+    When multiple releases qualify, the latest is chosen.
     A same-day release is included because it is expected to ship by the time
     the assembly reaches customers.
 
     :param assembly: Assembly name
     :param group: Group name
-    :param date: Optional explicitly provided date in format YYYY-MMM-DD (e.g., 2026-Mar-31)
+    :param date: Optional explicitly provided date. Accepts YYYY-MM-DD
+                 (e.g., 2026-03-31) or YYYY-MMM-DD (e.g., 2026-Mar-31)
     :return: Version string (e.g., '4.21.16') of the in-flight release, or None
     """
     inflight_release = None
@@ -373,7 +375,7 @@ def get_inflight(assembly, group, date=None):
                 if release_date > assembly_date:
                     continue
                 days_diff = (assembly_date - release_date).days
-                if days_diff <= 7:  # if next Y-1 release and assembly release in the same week
+                if days_diff <= 7:  # Y-1 release within 7-day lookback window
                     match = re.search(r'\d+\.\d+\.\d+', release['name'])
                     if match:
                         if best_date is None or release_date > best_date:

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -10,6 +10,7 @@ from artcommonlib.release_util import SoftwareLifecyclePhase
 from artcommonlib.util import (
     deep_merge,
     extract_related_images_from_fbc,
+    get_inflight,
     isolate_major_minor_in_group,
     normalize_group_name_for_k8s,
 )
@@ -1077,3 +1078,119 @@ class TestExtractRelatedImagesFromFBC(unittest.TestCase):
         self.assertEqual(len(result), 2)
         self.assertIn('sha256:444', str(result))
         self.assertIn('sha256:555', str(result))
+
+class TestGetInflight(unittest.TestCase):
+    """Tests for get_inflight() — ART-18958 fix."""
+
+    def _mock_pp_response(self, all_ga_tasks):
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {'all_ga_tasks': all_ga_tasks}
+        return mock_response
+
+    @patch('artcommonlib.util.get_assembly_release_date')
+    @patch('artcommonlib.util.requests_gssapi')
+    @patch('artcommonlib.util.requests.Session')
+    def test_selects_release_scheduled_before_assembly_date(self, mock_session_cls, mock_gssapi, mock_get_date):
+        """A Y-1 release with date_start 1 day before assembly date should be selected."""
+        mock_get_date.return_value = '2026-May-25'
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+        mock_session.get.return_value = self._mock_pp_response(
+            [
+                {'name': '4.21.15 in Fast Channel', 'date_start': '2026-05-12'},
+                {'name': '4.21.16 in Fast Channel', 'date_start': '2026-05-24'},
+            ]
+        )
+
+        result = get_inflight('rc.4', 'openshift-4.22', date='2026-05-25')
+
+        self.assertEqual(result, '4.21.16')
+
+    @patch('artcommonlib.util.get_assembly_release_date')
+    @patch('artcommonlib.util.requests_gssapi')
+    @patch('artcommonlib.util.requests.Session')
+    def test_does_not_select_release_after_assembly_date(self, mock_session_cls, mock_gssapi, mock_get_date):
+        """A Y-1 release with date_start after assembly date must NOT be selected (the ART-18958 bug)."""
+        mock_get_date.return_value = '2026-May-25'
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+        mock_session.get.return_value = self._mock_pp_response(
+            [
+                {'name': '4.21.16 in Fast Channel', 'date_start': '2026-05-19'},
+                {'name': '4.21.17 in Fast Channel', 'date_start': '2026-05-26'},
+            ]
+        )
+
+        result = get_inflight('rc.4', 'openshift-4.22', date='2026-05-25')
+
+        # 4.21.16 is 6 days before (outside 7-day window: 25-19=6, within 7)
+        # 4.21.17 is 1 day AFTER — must be excluded
+        self.assertEqual(result, '4.21.16')
+
+    @patch('artcommonlib.util.get_assembly_release_date')
+    @patch('artcommonlib.util.requests_gssapi')
+    @patch('artcommonlib.util.requests.Session')
+    def test_picks_latest_when_multiple_qualify(self, mock_session_cls, mock_gssapi, mock_get_date):
+        """When multiple Y-1 releases are within the window, the latest one wins."""
+        mock_get_date.return_value = '2026-May-25'
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+        mock_session.get.return_value = self._mock_pp_response(
+            [
+                {'name': '4.21.15 in Fast Channel', 'date_start': '2026-05-20'},
+                {'name': '4.21.16 in Fast Channel', 'date_start': '2026-05-23'},
+            ]
+        )
+
+        result = get_inflight('rc.4', 'openshift-4.22', date='2026-05-25')
+
+        self.assertEqual(result, '4.21.16')
+
+    @patch('artcommonlib.util.get_assembly_release_date')
+    @patch('artcommonlib.util.requests_gssapi')
+    @patch('artcommonlib.util.requests.Session')
+    def test_returns_none_when_no_release_in_window(self, mock_session_cls, mock_gssapi, mock_get_date):
+        """When no Y-1 releases are within the 7-day window, returns None."""
+        mock_get_date.return_value = '2026-May-25'
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+        mock_session.get.return_value = self._mock_pp_response(
+            [
+                {'name': '4.21.14 in Fast Channel', 'date_start': '2026-05-10'},
+                {'name': '4.21.15 in Fast Channel', 'date_start': '2026-05-17'},
+                {'name': '4.21.16 in Fast Channel', 'date_start': '2026-05-30'},
+            ]
+        )
+
+        result = get_inflight('rc.4', 'openshift-4.22', date='2026-05-25')
+
+        # 4.21.14: 15 days before (outside), 4.21.15: 8 days before (outside), 4.21.16: after
+        self.assertIsNone(result)
+
+    @patch('artcommonlib.util.get_assembly_release_date')
+    def test_returns_none_for_minor_zero(self, mock_get_date):
+        """When minor version is 0, there is no Y-1 group to query."""
+        mock_get_date.return_value = '2026-May-25'
+
+        result = get_inflight('rc.0', 'openshift-5.0', date='2026-05-25')
+
+        self.assertIsNone(result)
+
+    @patch('artcommonlib.util.get_assembly_release_date')
+    @patch('artcommonlib.util.requests_gssapi')
+    @patch('artcommonlib.util.requests.Session')
+    def test_exact_same_day_is_selected(self, mock_session_cls, mock_gssapi, mock_get_date):
+        """A Y-1 release on exactly the same day as assembly should be selected (days_diff=0)."""
+        mock_get_date.return_value = '2026-May-25'
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+        mock_session.get.return_value = self._mock_pp_response(
+            [
+                {'name': '4.21.16 in Fast Channel', 'date_start': '2026-05-25'},
+            ]
+        )
+
+        result = get_inflight('rc.4', 'openshift-4.22', date='2026-05-25')
+
+        self.assertEqual(result, '4.21.16')

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -1079,6 +1079,7 @@ class TestExtractRelatedImagesFromFBC(unittest.TestCase):
         self.assertIn('sha256:444', str(result))
         self.assertIn('sha256:555', str(result))
 
+
 class TestGetInflight(unittest.TestCase):
     """Tests for get_inflight() — ART-18958 fix."""
 


### PR DESCRIPTION
fix get_inflight() selecting future-dated Y-1 releases

get_inflight() used is_future_release_date() combined with abs(days_diff) <= 5, which could select a Y-1 release scheduled *after* the assembly date — injecting a non-existent release into upgrade edges.

Replace the algorithm to only consider Y-1 releases with date_start <= assembly_release_date, picking the latest one within a 7-day window. This ensures we never reference a release that doesn't yet exist while still capturing "in-flight" releases shipping in the same week.

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED