### PR TITLE
HYPBLD-844: Add MCE product mapping for Konflux kubeconfig and CPE labels

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -71,6 +71,7 @@ GOLANG_RPM_PACKAGE_NAME = 'golang'
 # Product-based mappings for Konflux tenant namespaces and kubeconfigs
 PRODUCT_NAMESPACE_MAP = {
     "acm": "art-acm-tenant",
+    "mce": "art-acm-tenant",
     "cert-manager": "art-oap-tenant",
     "external-secrets": "art-oap-tenant",
     "installer-ove-ui": "art-installer-agent-tenant",
@@ -86,6 +87,7 @@ PRODUCT_NAMESPACE_MAP = {
 
 PRODUCT_KUBECONFIG_MAP = {
     "acm": "ACM_KONFLUX_SA_KUBECONFIG",
+    "mce": "ACM_KONFLUX_SA_KUBECONFIG",
     "cert-manager": "OAP_KONFLUX_SA_KUBECONFIG",
     "external-secrets": "OAP_KONFLUX_SA_KUBECONFIG",
     "installer-ove-ui": "ASSISTED_INSTALLER_SA_KUBECONFIG",

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -41,6 +41,7 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 # Product name mapping for CPE labels
 CPE_PRODUCT_NAME_MAPPING = {
     'acm': 'advanced_cluster_management',
+    'mce': 'multicluster_engine',
     'rhmtc': 'rhmt',
     'oadp': 'openshift_api_data_protection',
     'mta': 'migration_toolkit_applications',


### PR DESCRIPTION
## Summary

Adds `mce` product mappings for MCE 2.11 ART onboarding ([HYPBLD-844](https://redhat.atlassian.net/browse/HYPBLD-844)), following the ACM changes in:

- [art-tools #2923](https://github.com/openshift-eng/art-tools/pull/2923) — `PRODUCT_KUBECONFIG_MAP` / `PRODUCT_NAMESPACE_MAP` for `acm`
- [art-tools #2910](https://github.com/openshift-eng/art-tools/pull/2910) — `CPE_PRODUCT_NAME_MAPPING` for `acm`

### `artcommon/artcommonlib/constants.py`

| Map | Entry |
|-----|-------|
| `PRODUCT_NAMESPACE_MAP` | `"mce": "art-acm-tenant"` |
| `PRODUCT_KUBECONFIG_MAP` | `"mce": "ACM_KONFLUX_SA_KUBECONFIG"` |

MCE 2.11 Konflux builds run in `crt-redhat-acm-tenant` (same workspace/credential as ACM).

### `doozer/doozerlib/backend/rebaser.py`

| Map | Entry |
|-----|-------|
| `CPE_PRODUCT_NAME_MAPPING` | `'mce': 'multicluster_engine'` |

Matches CPE labels used on MCE container images (e.g. `cpe:/a:redhat:multicluster_engine:...`).

Companion: [ocp-build-data #10730](https://github.com/openshift-eng/ocp-build-data/pull/10730) (`product: mce` on `mce-2.11`).

## Test plan

- [ ] `build-layered-products` for `mce-2.11` no longer raises `ValueError: Kubeconfig required for Konflux builds`
- [ ] Konflux builds use `art-acm-tenant` namespace for product `mce`
- [ ] Rebaser CPE labels on MCE images use `multicluster_engine`


Made with [Cursor](https://cursor.com)