### PR TITLE
ART-19029: feat(doozer): use openshift/golang-builder for released golang-builder pullspec

### DIFF
--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -92,3 +92,4 @@ KONFLUX_RELEASE_PREGA_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-oc
 KONFLUX_RELEASE_FBC_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/fbc-ocp-art-stage"
 
 ART_IMAGES_BASE_APPLICATION = "art-images-base"
+ART_IMAGES_GOLANG_BUILDER_APPLICATION = "golang-builder"

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1542,6 +1542,26 @@ class ImageMetadata(Metadata):
         self.logger.info(f"Golang builder shipment enabled set from {source} {enabled}")
         return enabled
 
+    def is_base_image_release_quay_fallback_enabled(self) -> bool:
+        """
+        When False and ``should_trigger_base_image_release()`` applies, late parent resolve
+        must not fall back to Konflux ``image_pullspec`` if the ``registry.redhat.io`` delivery mirror
+        (``openshift/golang-builder`` for golang builders, ``openshift/art-images-base`` for other base_only images)
+        is unreachable (rebase fails instead).
+
+        Image ``base_image_release.quay_fallback`` overrides group; default True
+        (same pattern as ``konflux.cachi2.lockfile.enabled``).
+        """
+        base_image_release_quay_fallback_config_override = self.config.base_image_release.quay_fallback
+        if base_image_release_quay_fallback_config_override not in [Missing, None]:
+            return bool(base_image_release_quay_fallback_config_override)
+        else:
+            base_image_release_quay_fallback_group_override = self.runtime.group_config.base_image_release.quay_fallback
+            if base_image_release_quay_fallback_group_override not in [Missing, None]:
+                return bool(base_image_release_quay_fallback_group_override)
+
+        return True
+
     def get_required_artifacts(self) -> list:
         """
         Get list of required artifacts from image config.

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1461,6 +1461,26 @@ class ImageMetadata(Metadata):
         self.logger.info(f"Base image release enabled set from {source} {base_image_release_enabled}")
         return base_image_release_enabled
 
+    def is_base_image_release_quay_fallback_enabled(self) -> bool:
+        """
+        When False and ``should_trigger_base_image_release()`` applies, late parent resolve
+        must not fall back to Konflux ``image_pullspec`` if the ``registry.redhat.io`` delivery mirror
+        (``openshift/golang-builder`` for golang builders, ``openshift/art-images-base`` for other base_only images)
+        is unreachable (rebase fails instead).
+
+        Image ``base_image_release.quay_fallback`` overrides group; default True
+        (same pattern as ``konflux.cachi2.lockfile.enabled``).
+        """
+        base_image_release_quay_fallback_config_override = self.config.base_image_release.quay_fallback
+        if base_image_release_quay_fallback_config_override not in [Missing, None]:
+            return bool(base_image_release_quay_fallback_config_override)
+        else:
+            base_image_release_quay_fallback_group_override = self.runtime.group_config.base_image_release.quay_fallback
+            if base_image_release_quay_fallback_group_override not in [Missing, None]:
+                return bool(base_image_release_quay_fallback_group_override)
+
+        return True
+
     def get_required_artifacts(self) -> list:
         """
         Get list of required artifacts from image config.

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -53,8 +53,17 @@ logger = logging.getLogger(__name__)
 
 
 def rh_art_images_base_pullspec(nvr: str) -> str:
-    """Pullspec for golang/base images after art-images-base release (NVR = component-version-release)."""
-    return f"{doozer_constants.DELIVERY_IMAGE_REGISTRY}/openshift/{doozer_constants.ART_IMAGES_BASE_APPLICATION}:{nvr}"
+    """registry.redhat.io pullspec after Konflux silent release (image tag = full publish NVR string).
+
+    openshift-golang-builder image NVRs publish under openshift/ ``ART_IMAGES_GOLANG_BUILDER_APPLICATION``.
+    Other silent-released base images publish under openshift/ ``ART_IMAGES_BASE_APPLICATION``.
+    """
+    repo_app = (
+        doozer_constants.ART_IMAGES_GOLANG_BUILDER_APPLICATION
+        if nvr.startswith("openshift-golang-builder")
+        else doozer_constants.ART_IMAGES_BASE_APPLICATION
+    )
+    return f"{doozer_constants.DELIVERY_IMAGE_REGISTRY}/openshift/{repo_app}:{nvr}"
 
 
 def dict_get(dct, path, default=DICT_EMPTY):

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -1504,10 +1504,19 @@ class TestCpeVersionExtraction(TestCase):
 
 
 class TestRhArtImagesBasePullspec(TestCase):
-    def test_rh_art_images_base_pullspec_matches_db_convention(self):
+    def test_golang_builder_uses_delivery_golang_repo(self):
         from doozerlib.util import rh_art_images_base_pullspec
 
         nvr = "openshift-golang-builder-container-v1.21-1.el9"
+        self.assertEqual(
+            rh_art_images_base_pullspec(nvr),
+            f"registry.redhat.io/openshift/golang-builder:{nvr}",
+        )
+
+    def test_non_golang_base_uses_art_images_base_repo(self):
+        from doozerlib.util import rh_art_images_base_pullspec
+
+        nvr = "ose-base-rhel9-container-v1.0.0-test"
         self.assertEqual(
             rh_art_images_base_pullspec(nvr),
             f"registry.redhat.io/openshift/art-images-base:{nvr}",
@@ -1545,11 +1554,11 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         resolved, _embargo = await rebaser._resolve_member_parent("golang-builder", "ignored")
         self.assertEqual(
             resolved,
-            "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.21-1.el9",
+            "registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.21-1.el9",
         )
 
-    async def test_resolve_member_parent_late_resolve_uses_rh_art_base_tag(self):
-        """Late-resolve (DB) base/golang: RH art-images-base when tag is reachable."""
+    async def test_resolve_member_parent_late_resolve_uses_rh_delivery_tag(self):
+        """Late-resolve (DB) golang-builder: openshift/golang-builder on RH if reachable, else Konflux digest."""
         parent = MagicMock()
         parent.distgit_key = "golang-builder"
         parent.should_trigger_base_image_release.return_value = True
@@ -1577,7 +1586,7 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
 
         resolved, emb = await rebaser._resolve_member_parent("golang-builder", "orig")
         self.assertEqual(
-            resolved, "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.21-1.el9"
+            resolved, "registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.21-1.el9"
         )
         self.assertFalse(emb)
 
@@ -1608,7 +1617,7 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         rebaser.derived_group = "openshift-4.18"
         rebaser._registry_pullspec_exists = AsyncMock(return_value=False)
 
-        rh_pullspec = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.21-1.el9"
+        rh_pullspec = "registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.21-1.el9"
         with self.assertRaises(IOError) as ctx:
             await rebaser._resolve_member_parent("golang-builder", "orig")
         self.assertIn("golang-builder", str(ctx.exception))

--- a/elliott/elliottlib/cli/get_golang_report_cli.py
+++ b/elliott/elliottlib/cli/get_golang_report_cli.py
@@ -83,7 +83,8 @@ def golang_report_for_version(runtime, ocp_version: str, ignore_rhel: bool = Fal
         else:
             tag = image_nvr_like.split(':')[-1]
             if tag.startswith('openshift-golang-builder-container-'):
-                # registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-...
+                # registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.8-...
+                # (formerly art-images-base before ART moved published golang builders)
                 # Tag is already in NVR name format
                 nvr = tag
             else:

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -16,7 +16,6 @@ from artcommonlib.constants import (
     GOLANG_NVR_LABEL,
     KONFLUX_DEFAULT_IMAGE_REPO,
     PRODUCT_NAMESPACE_MAP,
-    REGISTRY_REDHAT_IO,
 )
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
@@ -25,7 +24,7 @@ from artcommonlib.release_util import isolate_el_version_in_release
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import new_roundtrip_yaml_handler
 from doozerlib.cli.config_plashet import KNOWN_SIGNING_KEYS
-from doozerlib.constants import ART_IMAGES_BASE_APPLICATION
+from doozerlib.util import rh_art_images_base_pullspec
 from elliottlib import util as elliottutil
 from elliottlib.constants import GOLANG_BUILDER_CVE_COMPONENT
 from tenacity import before_sleep_log, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
@@ -38,7 +37,6 @@ from pyartcd.util import default_release_suffix, kinit
 
 _LOGGER = logging.getLogger(__name__)
 yaml = new_roundtrip_yaml_handler()
-PUBLISHED_GOLANG_BUILDER_REPO = f"{REGISTRY_REDHAT_IO}/openshift/{ART_IMAGES_BASE_APPLICATION}"
 
 
 def is_latest(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool:
@@ -781,7 +779,7 @@ class UpdateGolangPipeline:
         elif component_name != GOLANG_BUILDER_CVE_COMPONENT:
             raise ValueError(f"Expected a golang builder image NVR, got: {builder_nvr}")
         published_nvr = f'{component_name}-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
-        return f'{PUBLISHED_GOLANG_BUILDER_REPO}:{published_nvr}'
+        return rh_art_images_base_pullspec(published_nvr)
 
     @staticmethod
     def _get_konflux_builder_pullspec(builder_nvr: str):

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -16,7 +16,6 @@ from artcommonlib.constants import (
     GOLANG_NVR_LABEL,
     KONFLUX_DEFAULT_IMAGE_REPO,
     PRODUCT_NAMESPACE_MAP,
-    REGISTRY_REDHAT_IO,
 )
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
@@ -25,7 +24,7 @@ from artcommonlib.release_util import isolate_assembly_in_release, isolate_el_ve
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import new_roundtrip_yaml_handler
 from doozerlib.cli.config_plashet import KNOWN_SIGNING_KEYS
-from doozerlib.constants import ART_IMAGES_BASE_APPLICATION
+from doozerlib.util import rh_art_images_base_pullspec
 from elliottlib import util as elliottutil
 from elliottlib.constants import GOLANG_BUILDER_CVE_COMPONENT
 from tenacity import before_sleep_log, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
@@ -38,7 +37,6 @@ from pyartcd.util import default_release_suffix, kinit
 
 _LOGGER = logging.getLogger(__name__)
 yaml = new_roundtrip_yaml_handler()
-PUBLISHED_GOLANG_BUILDER_REPO = f"{REGISTRY_REDHAT_IO}/openshift/{ART_IMAGES_BASE_APPLICATION}"
 GOLANG_ASSEMBLIES = ("stream", "test")
 DEFAULT_GOLANG_ASSEMBLY = "stream"
 BREW_TEST_ASSEMBLY_UNSUPPORTED = (
@@ -820,7 +818,7 @@ class UpdateGolangPipeline:
         elif component_name != GOLANG_BUILDER_CVE_COMPONENT:
             raise ValueError(f"Expected a golang builder image NVR, got: {builder_nvr}")
         published_nvr = f'{component_name}-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
-        return f'{PUBLISHED_GOLANG_BUILDER_REPO}:{published_nvr}'
+        return rh_art_images_base_pullspec(published_nvr)
 
     @staticmethod
     def _get_konflux_builder_pullspec(builder_nvr: str):

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -835,7 +835,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         self.assertEqual(
             pullspec,
-            "registry.redhat.io/openshift/art-images-base:"
+            "registry.redhat.io/openshift/golang-builder:"
             "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9",
         )
 
@@ -849,7 +849,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         self.assertEqual(
             pullspec,
-            "registry.redhat.io/openshift/art-images-base:"
+            "registry.redhat.io/openshift/golang-builder:"
             "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9",
         )
 
@@ -867,7 +867,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         """Test published pullspec availability check reuses pyartcd.oc.get_image_info with quay auth"""
         pipeline = self._make_pipeline(build_system="konflux")
 
-        pullspec = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-test"
+        pullspec = "registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.8-test"
         quay_auth_file = str(Path(self.enterContext(tempfile.TemporaryDirectory())) / "quay-auth.json")
 
         with patch.dict(
@@ -885,7 +885,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         """Test published pullspec availability check raises when pyartcd.oc.get_image_info fails"""
         pipeline = self._make_pipeline(build_system="konflux")
 
-        pullspec = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-test"
+        pullspec = "registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.8-test"
         get_image_info.side_effect = ValueError("Image pullspec is not found.")
         quay_auth_file = str(Path(self.enterContext(tempfile.TemporaryDirectory())) / "quay-auth.json")
 

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1031,7 +1031,7 @@ repos:
 
         self.assertEqual(
             pullspec,
-            "registry.redhat.io/openshift/art-images-base:"
+            "registry.redhat.io/openshift/golang-builder:"
             "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9",
         )
 
@@ -1045,7 +1045,7 @@ repos:
 
         self.assertEqual(
             pullspec,
-            "registry.redhat.io/openshift/art-images-base:"
+            "registry.redhat.io/openshift/golang-builder:"
             "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9",
         )
 
@@ -1063,7 +1063,7 @@ repos:
         """Test published pullspec availability check reuses pyartcd.oc.get_image_info with quay auth"""
         pipeline = self._make_pipeline(build_system="konflux")
 
-        pullspec = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-test"
+        pullspec = "registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.8-test"
         quay_auth_file = str(Path(self.enterContext(tempfile.TemporaryDirectory())) / "quay-auth.json")
 
         with patch.dict(
@@ -1081,7 +1081,7 @@ repos:
         """Test published pullspec availability check raises when pyartcd.oc.get_image_info fails"""
         pipeline = self._make_pipeline(build_system="konflux")
 
-        pullspec = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-test"
+        pullspec = "registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.8-test"
         get_image_info.side_effect = ValueError("Image pullspec is not found.")
         quay_auth_file = str(Path(self.enterContext(tempfile.TemporaryDirectory())) / "quay-auth.json")
 


### PR DESCRIPTION
## Summary
- Centralize RHSI delivery URLs for released **openshift-golang-builder** images in `rh_art_images_base_pullspec` so they resolve to `registry.redhat.io/openshift/golang-builder` instead of `art-images-base`.
- Wire `update-golang` to build stream pullspecs via the same helper to avoid drift.

## Problem
**Before:** Doozer/pyartcd assumed published golang builders lived under `openshift/art-images-base`, which no longer matches Konflux silent-release delivery for golang builders.

**After:** `openshift-golang-builder*` NVR strings map to `openshift/golang-builder`; other silent-released bases stay on `openshift/art-images-base`. Rebase call sites unchanged.

## Links
- Konflux release data: https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/18169
- Tracking: [ART-19029](https://issues.redhat.com/browse/ART-19029) (sub-task of [ART-14300](https://issues.redhat.com/browse/ART-14300))

## Testing
- Lint: `make` / ruff as in `make test` front half (pass).
- Packages (from correct roots where required): `pytest doozer/tests/ -k 'not FindGoMainPackages'` (908 passed — excludes macOS `/private/var` temp-path flakes in `TestFindGoMainPackages`), `pytest pyartcd/tests` from `pyartcd/`, `pytest elliott/tests` from `elliott/`, `pytest artcommon/tests` + `ocp-build-data-validator/tests` (all pass).
- Repo `make test` currently fails on Darwin for unrelated `TestFindGoMainPackages` path canonicalization and parallel runner `grep -P` quirks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Golang builder images now use the dedicated `openshift/golang-builder` repository.
  * Image pullspecs include the complete build version as the image tag.
  * Base-image Quay fallback settings can be configured through image metadata or group settings, defaulting to enabled.
  * Golang updates now support `stream` and `test` assemblies, with assembly-specific build and publishing behavior.
  * Konflux component names can be customized and are validated for length.

* **Bug Fixes**
  * Non-Golang base images continue using the standard ART base-image repository.
  * Builder image publishing and availability checks now use the correct repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->