### PR TITLE
ART-18911: filter bugs already attached to open shipment MRs

### DIFF
--- a/artcommon/artcommonlib/gitlab.py
+++ b/artcommon/artcommonlib/gitlab.py
@@ -2,6 +2,7 @@
 GitLab client for ART tools.
 """
 
+import os
 from logging import getLogger
 from urllib.parse import urlparse
 
@@ -43,6 +44,24 @@ class GitLabClient:
         except Exception as e:
             logger.error(f"Failed to connect to GitLab at {gitlab_url}: {e}")
             raise
+
+    @classmethod
+    def from_url(cls, url: str, gitlab_token: str | None = None, dry_run: bool = False) -> "GitLabClient":
+        """
+        Create a GitLabClient from a full GitLab URL, extracting the server base URL automatically.
+
+        Arg(s):
+            url (str): Any GitLab URL (project, MR, etc.)
+            gitlab_token (str | None): GitLab token. If None, reads from GITLAB_TOKEN env var.
+            dry_run (bool): If True, operations will be logged but not executed
+        Return Value(s):
+            GitLabClient: Authenticated client instance
+        """
+        parsed = urlparse(url)
+        gitlab_url = f"{parsed.scheme}://{parsed.netloc}"
+        if gitlab_token is None:
+            gitlab_token = os.getenv("GITLAB_TOKEN", "")
+        return cls(gitlab_url, gitlab_token, dry_run=dry_run)
 
     def get_project(self, project_path: str):
         """
@@ -204,3 +223,17 @@ class GitLabClient:
         pipeline_url = pipeline.web_url
         logger.info(f"CI MR pipeline triggered successfully: {pipeline_url}")
         return pipeline_url
+
+    def list_merge_requests(self, project_path: str, state: str = "opened", **kwargs):
+        """
+        List merge requests for a project, filtered by state and optional criteria.
+
+        Arg(s):
+            project_path (str): Project path (e.g., "hybrid-platforms/art/ocp-shipment-data")
+            state (str): MR state filter ("opened", "closed", "merged", "all")
+            **kwargs: Additional filters passed to python-gitlab (source_branch, target_branch, etc.)
+        Return Value(s):
+            list: List of merge request objects
+        """
+        project = self.get_project(project_path)
+        return project.mergerequests.list(state=state, get_all=True, **kwargs)

--- a/artcommon/tests/test_gitlab_client.py
+++ b/artcommon/tests/test_gitlab_client.py
@@ -1,0 +1,79 @@
+"""
+Unit tests for GitLabClient.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class TestGitLabClient(unittest.TestCase):
+    @patch("artcommonlib.gitlab.gitlab.Gitlab")
+    def test_list_merge_requests_delegates_to_python_gitlab(self, mock_gitlab_class):
+        """
+        list_merge_requests should call project.mergerequests.list
+        with the given state and extra kwargs.
+        """
+        from artcommonlib.gitlab import GitLabClient
+
+        mock_gl = mock_gitlab_class.return_value
+        mock_project = MagicMock()
+        mock_gl.projects.get.return_value = mock_project
+        mock_mr1 = MagicMock()
+        mock_mr2 = MagicMock()
+        mock_project.mergerequests.list.return_value = [mock_mr1, mock_mr2]
+
+        client = GitLabClient("https://gitlab.example.com", "fake-token")
+        result = client.list_merge_requests("group/project", state="opened", target_branch="main")
+
+        mock_gl.projects.get.assert_called_with("group/project")
+        mock_project.mergerequests.list.assert_called_once_with(state="opened", get_all=True, target_branch="main")
+        self.assertEqual(result, [mock_mr1, mock_mr2])
+
+    @patch("artcommonlib.gitlab.gitlab.Gitlab")
+    def test_list_merge_requests_defaults_to_opened(self, mock_gitlab_class):
+        """
+        list_merge_requests should default state to 'opened'.
+        """
+        from artcommonlib.gitlab import GitLabClient
+
+        mock_gl = mock_gitlab_class.return_value
+        mock_project = MagicMock()
+        mock_gl.projects.get.return_value = mock_project
+        mock_project.mergerequests.list.return_value = []
+
+        client = GitLabClient("https://gitlab.example.com", "fake-token")
+        client.list_merge_requests("group/project")
+
+        mock_project.mergerequests.list.assert_called_once_with(state="opened", get_all=True)
+
+    @patch("artcommonlib.gitlab.gitlab.Gitlab")
+    def test_from_url_extracts_server_and_reads_token_from_env(self, mock_gitlab_class):
+        """
+        from_url should extract the server base URL and read GITLAB_TOKEN from env.
+        """
+        import os
+        from unittest.mock import patch as mock_patch
+
+        from artcommonlib.gitlab import GitLabClient
+
+        with mock_patch.dict(os.environ, {"GITLAB_TOKEN": "env-token"}):
+            client = GitLabClient.from_url("https://gitlab.cee.redhat.com/group/project/-/merge_requests/1")
+
+        mock_gitlab_class.assert_called_once_with("https://gitlab.cee.redhat.com", private_token="env-token")
+        self.assertIsInstance(client, GitLabClient)
+
+    @patch("artcommonlib.gitlab.gitlab.Gitlab")
+    def test_from_url_uses_explicit_token_over_env(self, mock_gitlab_class):
+        """
+        from_url should prefer an explicit token over the env var.
+        """
+        from artcommonlib.gitlab import GitLabClient
+
+        client = GitLabClient.from_url("https://gitlab.example.com/project", gitlab_token="explicit-token")
+
+        mock_gitlab_class.assert_called_once_with("https://gitlab.example.com", private_token="explicit-token")
+        self.assertIsInstance(client, GitLabClient)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/elliott/elliottlib/cli/find_bugs_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_cli.py
@@ -45,6 +45,11 @@ type_bug_set = Set[Bug]
     default=True,
     help="Filter image component CVE trackers to ART-managed images only",
 )
+@click.option(
+    "--filter-attached-bugs/--no-filter-attached-bugs",
+    default=True,
+    help="Filter out bugs already attached to errata advisories or open shipment MRs",
+)
 @click.pass_obj
 @click_coroutine
 async def find_bugs_cli(
@@ -54,6 +59,7 @@ async def find_bugs_cli(
     output,
     cve_only,
     art_managed_trackers_only,
+    filter_attached_bugs,
 ):
     """Find OCP bugs for the given group and assembly, eligible for release.
 
@@ -84,6 +90,7 @@ async def find_bugs_cli(
         cve_only=cve_only,
         exclude_trackers=exclude_trackers,
         art_managed_trackers_only=art_managed_trackers_only,
+        filter_attached_bugs=filter_attached_bugs,
     )
     await cli.run()
 
@@ -97,6 +104,7 @@ class FindBugsCli:
         cve_only: bool,
         exclude_trackers: bool,
         art_managed_trackers_only: bool,
+        filter_attached_bugs: bool = True,
     ):
         self.runtime = runtime
         self.permissive = permissive
@@ -104,6 +112,7 @@ class FindBugsCli:
         self.cve_only = cve_only
         self.exclude_trackers = exclude_trackers
         self.art_managed_trackers_only = art_managed_trackers_only
+        self.filter_attached_bugs = filter_attached_bugs
         self.bug_tracker = None
 
     async def run(self):
@@ -129,7 +138,9 @@ class FindBugsCli:
         tr = self.bug_tracker.target_release()
         LOGGER.info(f"Searching {self.bug_tracker.type} for bugs with status {statuses} and target releases: {tr}\n")
 
-        bugs = await get_bugs_sweep(self.runtime, find_bugs_obj, self.bug_tracker)
+        bugs = await get_bugs_sweep(
+            self.runtime, find_bugs_obj, self.bug_tracker, filter_attached_bugs=self.filter_attached_bugs
+        )
         major_version, minor_version = self.runtime.get_major_minor()
 
         builds_by_advisory_kind = get_builds_by_advisory_kind(self.runtime)

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -20,7 +20,7 @@ from elliottlib.bzutil import Bug, BugTracker, JIRABug
 from elliottlib.cli import common
 from elliottlib.cli.common import click_coroutine
 from elliottlib.exceptions import ElliottFatalError
-from elliottlib.shipment_utils import get_builds_from_mr
+from elliottlib.shipment_utils import get_bug_ids_from_open_shipment_mrs, get_builds_from_mr
 from elliottlib.util import chunk, normalize_component_by_ocp_delivery_repo
 
 logger = logutil.get_logger(__name__)
@@ -246,7 +246,7 @@ async def find_bugs_sweep_cli(
     sys.exit(0)
 
 
-async def get_bugs_sweep(runtime: Runtime, find_bugs_obj, bug_tracker):
+async def get_bugs_sweep(runtime: Runtime, find_bugs_obj, bug_tracker, filter_attached_bugs: bool = True):
     releases_config = runtime.get_releases_config()
     is_targeted = assembly_targeted_fixes_only(releases_config, runtime.assembly)
     if is_targeted:
@@ -290,14 +290,31 @@ async def get_bugs_sweep(runtime: Runtime, find_bugs_obj, bug_tracker):
             logger.info(f"{len(qualified_bugs)} of {len(bugs)} bugs are qualified for the cutoff time {utc_ts}")
             bugs = qualified_bugs
 
-        # filter bugs that have been swept into other advisories
-        logger.info("Filtering bugs that haven't been attached to any advisories...")
-        attached_bugs = await bug_tracker.filter_attached_bugs(bugs)
-        if attached_bugs:
-            attached_bug_ids = {b.id for b in attached_bugs}
-            logger.debug(f"Bugs attached to other advisories: {sorted(attached_bug_ids)}")
-            bugs = [b for b in bugs if b.id not in attached_bug_ids]
-            logger.info(f"Filtered {len(attached_bugs)} bugs since they are attached to other advisories")
+        if filter_attached_bugs:
+            # filter bugs that have been swept into other advisories
+            logger.info("Filtering bugs that haven't been attached to any advisories...")
+            attached_bugs = await bug_tracker.filter_attached_bugs(bugs)
+            if attached_bugs:
+                attached_bug_ids = {b.id for b in attached_bugs}
+                logger.debug(f"Bugs attached to other advisories: {sorted(attached_bug_ids)}")
+                bugs = [b for b in bugs if b.id not in attached_bug_ids]
+                logger.info(f"Filtered {len(attached_bugs)} bugs since they are attached to other advisories")
+
+            # filter bugs that are attached to open shipment MRs
+            shipment_data_url = runtime.shipment_path
+            shipment_bug_ids = set()
+            if shipment_data_url:
+                shipment_bug_ids = get_bug_ids_from_open_shipment_mrs(
+                    shipment_data_url=shipment_data_url,
+                    group=runtime.group,
+                    exclude_assembly=runtime.assembly,
+                )
+            if shipment_bug_ids:
+                before_count = len(bugs)
+                bugs = [b for b in bugs if b.id not in shipment_bug_ids]
+                filtered_count = before_count - len(bugs)
+                if filtered_count:
+                    logger.info(f"Filtered {filtered_count} bugs already attached to open shipment MRs")
 
         if find_bugs_obj.art_managed_trackers_only:
             bugs = filter_art_managed_jira_trackers(runtime, bugs, bug_tracker_type=bug_tracker.type)

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -307,7 +307,8 @@ async def get_bugs_sweep(runtime: Runtime, find_bugs_obj, bug_tracker, filter_at
                 shipment_bug_ids = get_bug_ids_from_open_shipment_mrs(
                     shipment_data_url=shipment_data_url,
                     group=runtime.group,
-                    exclude_assembly=runtime.assembly,
+                    releases_config=releases_config,
+                    current_assembly=runtime.assembly,
                 )
             if shipment_bug_ids:
                 before_count = len(bugs)

--- a/elliott/elliottlib/shipment_utils.py
+++ b/elliott/elliottlib/shipment_utils.py
@@ -2,6 +2,7 @@ import logging
 from typing import Dict, Iterable, List, Tuple
 from urllib.parse import urlparse
 
+from artcommonlib.assembly import assembly_config_struct
 from artcommonlib.gitlab import GitLabClient
 from artcommonlib.jira_config import JIRA_DOMAIN_NAME
 from artcommonlib.model import Model
@@ -109,16 +110,22 @@ def set_jira_bug_ids(release_notes: ReleaseNotes, bug_ids: Iterable[str]):
 def get_bug_ids_from_open_shipment_mrs(
     shipment_data_url: str,
     group: str,
-    exclude_assembly: str | None = None,
+    releases_config: Model,
+    current_assembly: str,
 ) -> set[str]:
     """
     Collect bug IDs from all open shipment MRs in ocp-shipment-data that match
     the given group, excluding the current assembly's own MR.
 
+    Only considers MRs whose assembly is defined in releases_config and whose
+    MR URL matches the shipment URL configured for that assembly. This filters
+    out test/incomplete MRs.
+
     Arg(s):
         shipment_data_url (str): GitLab URL for ocp-shipment-data repo
         group (str): OCP group to match (e.g., 'openshift-4.18')
-        exclude_assembly (str | None): Assembly name to skip (current assembly)
+        releases_config (Model): Parsed releases.yml config for assembly validation
+        current_assembly (str): Assembly being prepared (its own MR is excluded)
     Return Value(s):
         set[str]: Set of bug IDs already attached to open shipment MRs
     """
@@ -136,11 +143,13 @@ def get_bug_ids_from_open_shipment_mrs(
             logger.warning("Failed to parse shipment configs from MR %s, skipping", mr.web_url, exc_info=True)
             continue
 
-        for kind, config in shipment_configs.items():
+        for config in shipment_configs.values():
             metadata = config.shipment.metadata
             if metadata.group != group:
                 continue
-            if exclude_assembly and metadata.assembly == exclude_assembly:
+            if metadata.assembly == current_assembly:
+                continue
+            if not _is_assembly_shipment_valid(releases_config, metadata.assembly, mr.web_url):
                 continue
             if metadata.fbc:
                 continue
@@ -156,3 +165,38 @@ def get_bug_ids_from_open_shipment_mrs(
         logger.info("Found %d bugs attached to open shipment MRs: %s", len(bug_ids), sorted(bug_ids))
 
     return bug_ids
+
+
+def _is_assembly_shipment_valid(releases_config: Model, assembly: str, mr_url: str) -> bool:
+    """
+    Check that an assembly exists in releases_config and that its configured
+    shipment URL matches the given MR URL.
+
+    Arg(s):
+        releases_config (Model): Parsed releases.yml
+        assembly (str): Assembly name from shipment metadata
+        mr_url (str): MR web URL to validate against
+    Return Value(s):
+        bool: True if assembly is defined and its shipment URL matches mr_url
+    """
+    if not releases_config.releases[assembly]:
+        logger.debug("Assembly %s not found in releases_config, skipping MR %s", assembly, mr_url)
+        return False
+
+    assembly_group_config = assembly_config_struct(releases_config, assembly, "group", {})
+    shipment = assembly_group_config.get("shipment") or {}
+    configured_url = shipment.get("url") if isinstance(shipment, dict) else getattr(shipment, "url", None)
+    if not configured_url:
+        logger.debug("No shipment URL configured for assembly %s, skipping MR %s", assembly, mr_url)
+        return False
+
+    if configured_url != mr_url:
+        logger.debug(
+            "MR URL %s does not match configured shipment URL %s for assembly %s, skipping",
+            mr_url,
+            configured_url,
+            assembly,
+        )
+        return False
+
+    return True

--- a/elliott/elliottlib/shipment_utils.py
+++ b/elliott/elliottlib/shipment_utils.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from typing import Dict, Iterable, List, Tuple
 from urllib.parse import urlparse
 
@@ -26,14 +25,7 @@ def get_shipment_configs_from_mr(
 
     shipment_configs: Dict[str, ShipmentConfig] = {}
 
-    gitlab_token = os.getenv("GITLAB_TOKEN")
-    if not gitlab_token:
-        raise ValueError("GITLAB_TOKEN environment variable is required for Konflux operations")
-
-    parsed_url = urlparse(mr_url)
-    gitlab_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
-
-    gl = GitLabClient(gitlab_url, gitlab_token)
+    gl = GitLabClient.from_url(mr_url)
 
     mr = gl.get_mr_from_url(mr_url)
     source_project = gl.get_project(mr.source_project_id)
@@ -112,3 +104,55 @@ def set_jira_bug_ids(release_notes: ReleaseNotes, bug_ids: Iterable[str]):
         release_notes.issues = None
     else:
         release_notes.issues = Issues(fixed=fixed)
+
+
+def get_bug_ids_from_open_shipment_mrs(
+    shipment_data_url: str,
+    group: str,
+    exclude_assembly: str | None = None,
+) -> set[str]:
+    """
+    Collect bug IDs from all open shipment MRs in ocp-shipment-data that match
+    the given group, excluding the current assembly's own MR.
+
+    Arg(s):
+        shipment_data_url (str): GitLab URL for ocp-shipment-data repo
+        group (str): OCP group to match (e.g., 'openshift-4.18')
+        exclude_assembly (str | None): Assembly name to skip (current assembly)
+    Return Value(s):
+        set[str]: Set of bug IDs already attached to open shipment MRs
+    """
+    parsed_url = urlparse(shipment_data_url)
+    project_path = parsed_url.path.strip("/")
+
+    gl = GitLabClient.from_url(shipment_data_url)
+    open_mrs = gl.list_merge_requests(project_path, state="opened")
+
+    bug_ids: set[str] = set()
+    for mr in open_mrs:
+        try:
+            shipment_configs = get_shipment_configs_from_mr(mr.web_url)
+        except (ValueError, TypeError, KeyError):
+            logger.warning("Failed to parse shipment configs from MR %s, skipping", mr.web_url, exc_info=True)
+            continue
+
+        for kind, config in shipment_configs.items():
+            metadata = config.shipment.metadata
+            if metadata.group != group:
+                continue
+            if exclude_assembly and metadata.assembly == exclude_assembly:
+                continue
+            if metadata.fbc:
+                continue
+            if not config.shipment.data or not config.shipment.data.releaseNotes:
+                continue
+            issues = config.shipment.data.releaseNotes.issues
+            if not issues or not issues.fixed:
+                continue
+            for issue in issues.fixed:
+                bug_ids.add(issue.id)
+
+    if bug_ids:
+        logger.info("Found %d bugs attached to open shipment MRs: %s", len(bug_ids), sorted(bug_ids))
+
+    return bug_ids

--- a/elliott/tests/test_find_bugs_sweep_cli.py
+++ b/elliott/tests/test_find_bugs_sweep_cli.py
@@ -179,6 +179,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError, msg="targeted_fixes_only=true but issues.exclude is non-empty"):
             await sweep_cli.get_bugs_sweep(runtime, find_bugs_obj, bug_tracker)
 
+    @patch("elliottlib.cli.find_bugs_sweep_cli.get_bug_ids_from_open_shipment_mrs", return_value=set())
     @patch("elliottlib.cli.find_bugs_sweep_cli.get_assembly_bug_ids", return_value=(set(), set()))
     @patch("elliottlib.cli.find_bugs_sweep_cli.get_sweep_cutoff_timestamp", new_callable=AsyncMock, return_value=0)
     async def test_get_bugs_sweep_opt_out_skips_art_managed_filter(self, *_):
@@ -194,6 +195,54 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(actual, [bug])
         filter_mock.assert_not_called()
+
+    @patch("elliottlib.cli.find_bugs_sweep_cli.get_bug_ids_from_open_shipment_mrs")
+    @patch("elliottlib.cli.find_bugs_sweep_cli.get_assembly_bug_ids", return_value=(set(), set()))
+    @patch("elliottlib.cli.find_bugs_sweep_cli.get_sweep_cutoff_timestamp", new_callable=AsyncMock, return_value=0)
+    async def test_get_bugs_sweep_filters_shipment_bugs(self, mock_cutoff, mock_bug_ids, mock_shipment_bugs):
+        """When filter_attached_bugs=True, bugs in open shipment MRs should be filtered out."""
+        runtime = MagicMock(debug=False, group="openshift-4.18", assembly="4.18.40")
+        runtime.shipment_path = "https://gitlab.example.com/project"
+
+        bug_keep = flexmock(id="OCPBUGS-1")
+        bug_filter = flexmock(id="OCPBUGS-2")
+
+        find_bugs_obj = sweep_cli.FindBugsSweep(art_managed_trackers_only=False)
+        find_bugs_obj.search = Mock(return_value=[bug_keep, bug_filter])
+
+        bug_tracker = MagicMock(type="jira")
+        bug_tracker.filter_attached_bugs = AsyncMock(return_value=[])
+
+        mock_shipment_bugs.return_value = {"OCPBUGS-2"}
+
+        actual = await sweep_cli.get_bugs_sweep(runtime, find_bugs_obj, bug_tracker, filter_attached_bugs=True)
+
+        self.assertEqual([b.id for b in actual], ["OCPBUGS-1"])
+        mock_shipment_bugs.assert_called_once_with(
+            shipment_data_url="https://gitlab.example.com/project",
+            group="openshift-4.18",
+            exclude_assembly="4.18.40",
+        )
+
+    @patch("elliottlib.cli.find_bugs_sweep_cli.get_bug_ids_from_open_shipment_mrs")
+    @patch("elliottlib.cli.find_bugs_sweep_cli.get_assembly_bug_ids", return_value=(set(), set()))
+    @patch("elliottlib.cli.find_bugs_sweep_cli.get_sweep_cutoff_timestamp", new_callable=AsyncMock, return_value=0)
+    async def test_get_bugs_sweep_no_filter_skips_both(self, mock_cutoff, mock_bug_ids, mock_shipment_bugs):
+        """When filter_attached_bugs=False, skip both errata and shipment filtering."""
+        runtime = MagicMock(debug=False)
+        bug = flexmock(id="OCPBUGS-1")
+
+        find_bugs_obj = sweep_cli.FindBugsSweep(art_managed_trackers_only=False)
+        find_bugs_obj.search = Mock(return_value=[bug])
+
+        bug_tracker = MagicMock(type="jira")
+        bug_tracker.filter_attached_bugs = AsyncMock(return_value=[])
+
+        actual = await sweep_cli.get_bugs_sweep(runtime, find_bugs_obj, bug_tracker, filter_attached_bugs=False)
+
+        self.assertEqual([b.id for b in actual], ["OCPBUGS-1"])
+        bug_tracker.filter_attached_bugs.assert_not_called()
+        mock_shipment_bugs.assert_not_called()
 
     @patch('elliottlib.bzutil.JIRABugTracker.filter_attached_bugs')
     @patch('elliottlib.cli.find_bugs_sweep_cli.FindBugsSweep.search')
@@ -214,6 +263,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
         flexmock(Runtime).should_receive("get_releases_config").and_return(MagicMock())
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
+        flexmock(sweep_cli).should_receive("get_bug_ids_from_open_shipment_mrs").and_return(set())
         flexmock(Runtime).should_receive("get_default_advisories").and_return({})
         flexmock(sweep_cli).should_receive("get_builds_by_advisory_kind")
         flexmock(sweep_cli).should_receive("categorize_bugs_by_type").and_return({"image": {jira_bug}}, [])
@@ -253,6 +303,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
 
         # common mocks
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
+        flexmock(sweep_cli).should_receive("get_bug_ids_from_open_shipment_mrs").and_return(set())
         flexmock(Runtime).should_receive("get_default_advisories").and_return({})
 
         result = runner.invoke(
@@ -283,6 +334,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
         flexmock(Runtime).should_receive("get_releases_config").and_return(MagicMock())
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
+        flexmock(sweep_cli).should_receive("get_bug_ids_from_open_shipment_mrs").and_return(set())
         flexmock(Runtime).should_receive("get_default_advisories").and_return({})
         flexmock(sweep_cli).should_receive("get_builds_by_advisory_kind").and_return({})
 
@@ -316,6 +368,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
         flexmock(Runtime).should_receive("get_releases_config").and_return(MagicMock())
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
+        flexmock(sweep_cli).should_receive("get_bug_ids_from_open_shipment_mrs").and_return(set())
         flexmock(Runtime).should_receive("get_default_advisories").and_return({'image': 123})
         flexmock(sweep_cli).should_receive("get_builds_by_advisory_kind")
         flexmock(sweep_cli).should_receive("categorize_bugs_by_type").and_return({"image": set(bugs)}, [])
@@ -360,6 +413,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
         flexmock(Runtime).should_receive("get_releases_config").and_return(MagicMock())
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
+        flexmock(sweep_cli).should_receive("get_bug_ids_from_open_shipment_mrs").and_return(set())
         flexmock(sweep_cli).should_receive("get_builds_by_advisory_kind")
         flexmock(sweep_cli).should_receive("categorize_bugs_by_type").and_return(
             {

--- a/elliott/tests/test_find_bugs_sweep_cli.py
+++ b/elliott/tests/test_find_bugs_sweep_cli.py
@@ -221,7 +221,8 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         mock_shipment_bugs.assert_called_once_with(
             shipment_data_url="https://gitlab.example.com/project",
             group="openshift-4.18",
-            exclude_assembly="4.18.40",
+            releases_config=runtime.get_releases_config(),
+            current_assembly="4.18.40",
         )
 
     @patch("elliottlib.cli.find_bugs_sweep_cli.get_bug_ids_from_open_shipment_mrs")

--- a/elliott/tests/test_shipment_utils.py
+++ b/elliott/tests/test_shipment_utils.py
@@ -294,5 +294,197 @@ shipment:
         self.assertEqual(set(result.keys()), expected_kinds)
 
 
+@patch.dict(os.environ, {"GITLAB_TOKEN": "fake-token"})
+class TestGetBugIdsFromOpenShipmentMrs(unittest.TestCase):
+    """Test cases for get_bug_ids_from_open_shipment_mrs"""
+
+    @patch("elliottlib.shipment_utils.get_shipment_configs_from_mr")
+    @patch("elliottlib.shipment_utils.GitLabClient")
+    def test_filters_bugs_from_matching_group(self, mock_gitlab_cls, mock_get_configs):
+        """Bugs from open MRs matching the group should be returned."""
+        mock_client = Mock()
+        mock_gitlab_cls.from_url.return_value = mock_client
+
+        mock_mr = Mock()
+        mock_mr.web_url = "https://gitlab.example.com/project/-/merge_requests/1"
+        mock_client.list_merge_requests.return_value = [mock_mr]
+
+        mock_shipment = Mock()
+        mock_shipment.shipment.metadata.group = "openshift-4.18"
+        mock_shipment.shipment.metadata.assembly = "4.18.39"
+        mock_shipment.shipment.metadata.fbc = False
+        mock_shipment.shipment.data.releaseNotes.issues.fixed = [
+            Mock(id="OCPBUGS-100", source="issues.redhat.com"),
+            Mock(id="OCPBUGS-200", source="issues.redhat.com"),
+        ]
+        mock_get_configs.return_value = {"image": mock_shipment}
+
+        result = shipment_utils.get_bug_ids_from_open_shipment_mrs(
+            shipment_data_url="https://gitlab.example.com/project",
+            group="openshift-4.18",
+        )
+
+        self.assertEqual(result, {"OCPBUGS-100", "OCPBUGS-200"})
+
+    @patch("elliottlib.shipment_utils.get_shipment_configs_from_mr")
+    @patch("elliottlib.shipment_utils.GitLabClient")
+    def test_excludes_current_assembly(self, mock_gitlab_cls, mock_get_configs):
+        """Bugs from the current assembly's MR should be excluded."""
+        mock_client = Mock()
+        mock_gitlab_cls.from_url.return_value = mock_client
+
+        mock_mr = Mock()
+        mock_mr.web_url = "https://gitlab.example.com/project/-/merge_requests/1"
+        mock_client.list_merge_requests.return_value = [mock_mr]
+
+        mock_shipment = Mock()
+        mock_shipment.shipment.metadata.group = "openshift-4.18"
+        mock_shipment.shipment.metadata.assembly = "4.18.40"
+        mock_shipment.shipment.metadata.fbc = False
+        mock_shipment.shipment.data.releaseNotes.issues.fixed = [
+            Mock(id="OCPBUGS-300", source="issues.redhat.com"),
+        ]
+        mock_get_configs.return_value = {"image": mock_shipment}
+
+        result = shipment_utils.get_bug_ids_from_open_shipment_mrs(
+            shipment_data_url="https://gitlab.example.com/project",
+            group="openshift-4.18",
+            exclude_assembly="4.18.40",
+        )
+
+        self.assertEqual(result, set())
+
+    @patch("elliottlib.shipment_utils.get_shipment_configs_from_mr")
+    @patch("elliottlib.shipment_utils.GitLabClient")
+    def test_skips_different_group(self, mock_gitlab_cls, mock_get_configs):
+        """Bugs from MRs for a different OCP group should not be returned."""
+        mock_client = Mock()
+        mock_gitlab_cls.from_url.return_value = mock_client
+
+        mock_mr = Mock()
+        mock_mr.web_url = "https://gitlab.example.com/project/-/merge_requests/1"
+        mock_client.list_merge_requests.return_value = [mock_mr]
+
+        mock_shipment = Mock()
+        mock_shipment.shipment.metadata.group = "openshift-4.17"
+        mock_shipment.shipment.metadata.assembly = "4.17.10"
+        mock_shipment.shipment.metadata.fbc = False
+        mock_shipment.shipment.data.releaseNotes.issues.fixed = [
+            Mock(id="OCPBUGS-999", source="issues.redhat.com"),
+        ]
+        mock_get_configs.return_value = {"image": mock_shipment}
+
+        result = shipment_utils.get_bug_ids_from_open_shipment_mrs(
+            shipment_data_url="https://gitlab.example.com/project",
+            group="openshift-4.18",
+        )
+
+        self.assertEqual(result, set())
+
+    @patch.dict(os.environ, {"GITLAB_TOKEN": ""})
+    def test_raises_when_no_gitlab_token(self):
+        """When GITLAB_TOKEN env var is empty, GitLabClient raises ValueError."""
+        with self.assertRaises(ValueError):
+            shipment_utils.get_bug_ids_from_open_shipment_mrs(
+                shipment_data_url="https://gitlab.example.com/project",
+                group="openshift-4.18",
+            )
+
+    @patch("elliottlib.shipment_utils.get_shipment_configs_from_mr")
+    @patch("elliottlib.shipment_utils.GitLabClient")
+    def test_skips_fbc_shipments(self, mock_gitlab_cls, mock_get_configs):
+        """FBC shipments (no releaseNotes) should be skipped without error."""
+        mock_client = Mock()
+        mock_gitlab_cls.from_url.return_value = mock_client
+
+        mock_mr = Mock()
+        mock_mr.web_url = "https://gitlab.example.com/project/-/merge_requests/1"
+        mock_client.list_merge_requests.return_value = [mock_mr]
+
+        mock_fbc_shipment = Mock()
+        mock_fbc_shipment.shipment.metadata.group = "openshift-4.18"
+        mock_fbc_shipment.shipment.metadata.assembly = "4.18.39"
+        mock_fbc_shipment.shipment.metadata.fbc = True
+        mock_fbc_shipment.shipment.data = None
+
+        mock_image_shipment = Mock()
+        mock_image_shipment.shipment.metadata.group = "openshift-4.18"
+        mock_image_shipment.shipment.metadata.assembly = "4.18.39"
+        mock_image_shipment.shipment.metadata.fbc = False
+        mock_image_shipment.shipment.data.releaseNotes.issues.fixed = [
+            Mock(id="OCPBUGS-500", source="issues.redhat.com"),
+        ]
+
+        mock_get_configs.return_value = {
+            "fbc": mock_fbc_shipment,
+            "image": mock_image_shipment,
+        }
+
+        result = shipment_utils.get_bug_ids_from_open_shipment_mrs(
+            shipment_data_url="https://gitlab.example.com/project",
+            group="openshift-4.18",
+        )
+
+        self.assertEqual(result, {"OCPBUGS-500"})
+
+    @patch("elliottlib.shipment_utils.get_shipment_configs_from_mr")
+    @patch("elliottlib.shipment_utils.GitLabClient")
+    def test_handles_mr_parse_error_gracefully(self, mock_gitlab_cls, mock_get_configs):
+        """If parsing an MR fails, skip it and continue with others."""
+        mock_client = Mock()
+        mock_gitlab_cls.from_url.return_value = mock_client
+
+        mock_mr_bad = Mock()
+        mock_mr_bad.web_url = "https://gitlab.example.com/project/-/merge_requests/1"
+        mock_mr_good = Mock()
+        mock_mr_good.web_url = "https://gitlab.example.com/project/-/merge_requests/2"
+        mock_client.list_merge_requests.return_value = [mock_mr_bad, mock_mr_good]
+
+        mock_shipment = Mock()
+        mock_shipment.shipment.metadata.group = "openshift-4.18"
+        mock_shipment.shipment.metadata.assembly = "4.18.39"
+        mock_shipment.shipment.metadata.fbc = False
+        mock_shipment.shipment.data.releaseNotes.issues.fixed = [
+            Mock(id="OCPBUGS-700", source="issues.redhat.com"),
+        ]
+
+        mock_get_configs.side_effect = [
+            ValueError("YAML parse error"),
+            {"image": mock_shipment},
+        ]
+
+        result = shipment_utils.get_bug_ids_from_open_shipment_mrs(
+            shipment_data_url="https://gitlab.example.com/project",
+            group="openshift-4.18",
+        )
+
+        self.assertEqual(result, {"OCPBUGS-700"})
+
+    @patch("elliottlib.shipment_utils.get_shipment_configs_from_mr")
+    @patch("elliottlib.shipment_utils.GitLabClient")
+    def test_shipment_with_no_issues_fixed(self, mock_gitlab_cls, mock_get_configs):
+        """Shipments with no issues.fixed should be handled gracefully."""
+        mock_client = Mock()
+        mock_gitlab_cls.from_url.return_value = mock_client
+
+        mock_mr = Mock()
+        mock_mr.web_url = "https://gitlab.example.com/project/-/merge_requests/1"
+        mock_client.list_merge_requests.return_value = [mock_mr]
+
+        mock_shipment = Mock()
+        mock_shipment.shipment.metadata.group = "openshift-4.18"
+        mock_shipment.shipment.metadata.assembly = "4.18.39"
+        mock_shipment.shipment.metadata.fbc = False
+        mock_shipment.shipment.data.releaseNotes.issues = None
+        mock_get_configs.return_value = {"image": mock_shipment}
+
+        result = shipment_utils.get_bug_ids_from_open_shipment_mrs(
+            shipment_data_url="https://gitlab.example.com/project",
+            group="openshift-4.18",
+        )
+
+        self.assertEqual(result, set())
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/elliott/tests/test_shipment_utils.py
+++ b/elliott/tests/test_shipment_utils.py
@@ -2,6 +2,7 @@ import os
 import unittest
 from unittest.mock import Mock, patch
 
+from artcommonlib.model import Model
 from elliottlib import shipment_utils
 
 
@@ -298,6 +299,24 @@ shipment:
 class TestGetBugIdsFromOpenShipmentMrs(unittest.TestCase):
     """Test cases for get_bug_ids_from_open_shipment_mrs"""
 
+    SHIPMENT_URL = "https://gitlab.example.com/project"
+
+    @staticmethod
+    def _make_releases_config(assembly: str, mr_url: str) -> Model:
+        """
+        Build a minimal releases_config Model with a single assembly
+        whose shipment URL matches the given MR URL.
+        """
+        return Model(dict_to_model={"releases": {assembly: {"assembly": {"group": {"shipment": {"url": mr_url}}}}}})
+
+    def _call(self, releases_config=None, current_assembly="4.18.40", group="openshift-4.18"):
+        return shipment_utils.get_bug_ids_from_open_shipment_mrs(
+            shipment_data_url=self.SHIPMENT_URL,
+            group=group,
+            releases_config=releases_config or Model(dict_to_model={"releases": {}}),
+            current_assembly=current_assembly,
+        )
+
     @patch("elliottlib.shipment_utils.get_shipment_configs_from_mr")
     @patch("elliottlib.shipment_utils.GitLabClient")
     def test_filters_bugs_from_matching_group(self, mock_gitlab_cls, mock_get_configs):
@@ -305,8 +324,9 @@ class TestGetBugIdsFromOpenShipmentMrs(unittest.TestCase):
         mock_client = Mock()
         mock_gitlab_cls.from_url.return_value = mock_client
 
+        mr_url = "https://gitlab.example.com/project/-/merge_requests/1"
         mock_mr = Mock()
-        mock_mr.web_url = "https://gitlab.example.com/project/-/merge_requests/1"
+        mock_mr.web_url = mr_url
         mock_client.list_merge_requests.return_value = [mock_mr]
 
         mock_shipment = Mock()
@@ -319,11 +339,7 @@ class TestGetBugIdsFromOpenShipmentMrs(unittest.TestCase):
         ]
         mock_get_configs.return_value = {"image": mock_shipment}
 
-        result = shipment_utils.get_bug_ids_from_open_shipment_mrs(
-            shipment_data_url="https://gitlab.example.com/project",
-            group="openshift-4.18",
-        )
-
+        result = self._call(releases_config=self._make_releases_config("4.18.39", mr_url))
         self.assertEqual(result, {"OCPBUGS-100", "OCPBUGS-200"})
 
     @patch("elliottlib.shipment_utils.get_shipment_configs_from_mr")
@@ -333,8 +349,9 @@ class TestGetBugIdsFromOpenShipmentMrs(unittest.TestCase):
         mock_client = Mock()
         mock_gitlab_cls.from_url.return_value = mock_client
 
+        mr_url = "https://gitlab.example.com/project/-/merge_requests/1"
         mock_mr = Mock()
-        mock_mr.web_url = "https://gitlab.example.com/project/-/merge_requests/1"
+        mock_mr.web_url = mr_url
         mock_client.list_merge_requests.return_value = [mock_mr]
 
         mock_shipment = Mock()
@@ -346,12 +363,10 @@ class TestGetBugIdsFromOpenShipmentMrs(unittest.TestCase):
         ]
         mock_get_configs.return_value = {"image": mock_shipment}
 
-        result = shipment_utils.get_bug_ids_from_open_shipment_mrs(
-            shipment_data_url="https://gitlab.example.com/project",
-            group="openshift-4.18",
-            exclude_assembly="4.18.40",
+        result = self._call(
+            releases_config=self._make_releases_config("4.18.40", mr_url),
+            current_assembly="4.18.40",
         )
-
         self.assertEqual(result, set())
 
     @patch("elliottlib.shipment_utils.get_shipment_configs_from_mr")
@@ -374,21 +389,14 @@ class TestGetBugIdsFromOpenShipmentMrs(unittest.TestCase):
         ]
         mock_get_configs.return_value = {"image": mock_shipment}
 
-        result = shipment_utils.get_bug_ids_from_open_shipment_mrs(
-            shipment_data_url="https://gitlab.example.com/project",
-            group="openshift-4.18",
-        )
-
+        result = self._call()
         self.assertEqual(result, set())
 
     @patch.dict(os.environ, {"GITLAB_TOKEN": ""})
     def test_raises_when_no_gitlab_token(self):
         """When GITLAB_TOKEN env var is empty, GitLabClient raises ValueError."""
         with self.assertRaises(ValueError):
-            shipment_utils.get_bug_ids_from_open_shipment_mrs(
-                shipment_data_url="https://gitlab.example.com/project",
-                group="openshift-4.18",
-            )
+            self._call()
 
     @patch("elliottlib.shipment_utils.get_shipment_configs_from_mr")
     @patch("elliottlib.shipment_utils.GitLabClient")
@@ -397,8 +405,9 @@ class TestGetBugIdsFromOpenShipmentMrs(unittest.TestCase):
         mock_client = Mock()
         mock_gitlab_cls.from_url.return_value = mock_client
 
+        mr_url = "https://gitlab.example.com/project/-/merge_requests/1"
         mock_mr = Mock()
-        mock_mr.web_url = "https://gitlab.example.com/project/-/merge_requests/1"
+        mock_mr.web_url = mr_url
         mock_client.list_merge_requests.return_value = [mock_mr]
 
         mock_fbc_shipment = Mock()
@@ -420,11 +429,7 @@ class TestGetBugIdsFromOpenShipmentMrs(unittest.TestCase):
             "image": mock_image_shipment,
         }
 
-        result = shipment_utils.get_bug_ids_from_open_shipment_mrs(
-            shipment_data_url="https://gitlab.example.com/project",
-            group="openshift-4.18",
-        )
-
+        result = self._call(releases_config=self._make_releases_config("4.18.39", mr_url))
         self.assertEqual(result, {"OCPBUGS-500"})
 
     @patch("elliottlib.shipment_utils.get_shipment_configs_from_mr")
@@ -436,8 +441,9 @@ class TestGetBugIdsFromOpenShipmentMrs(unittest.TestCase):
 
         mock_mr_bad = Mock()
         mock_mr_bad.web_url = "https://gitlab.example.com/project/-/merge_requests/1"
+        mr_good_url = "https://gitlab.example.com/project/-/merge_requests/2"
         mock_mr_good = Mock()
-        mock_mr_good.web_url = "https://gitlab.example.com/project/-/merge_requests/2"
+        mock_mr_good.web_url = mr_good_url
         mock_client.list_merge_requests.return_value = [mock_mr_bad, mock_mr_good]
 
         mock_shipment = Mock()
@@ -453,11 +459,7 @@ class TestGetBugIdsFromOpenShipmentMrs(unittest.TestCase):
             {"image": mock_shipment},
         ]
 
-        result = shipment_utils.get_bug_ids_from_open_shipment_mrs(
-            shipment_data_url="https://gitlab.example.com/project",
-            group="openshift-4.18",
-        )
-
+        result = self._call(releases_config=self._make_releases_config("4.18.39", mr_good_url))
         self.assertEqual(result, {"OCPBUGS-700"})
 
     @patch("elliottlib.shipment_utils.get_shipment_configs_from_mr")
@@ -467,8 +469,9 @@ class TestGetBugIdsFromOpenShipmentMrs(unittest.TestCase):
         mock_client = Mock()
         mock_gitlab_cls.from_url.return_value = mock_client
 
+        mr_url = "https://gitlab.example.com/project/-/merge_requests/1"
         mock_mr = Mock()
-        mock_mr.web_url = "https://gitlab.example.com/project/-/merge_requests/1"
+        mock_mr.web_url = mr_url
         mock_client.list_merge_requests.return_value = [mock_mr]
 
         mock_shipment = Mock()
@@ -478,12 +481,90 @@ class TestGetBugIdsFromOpenShipmentMrs(unittest.TestCase):
         mock_shipment.shipment.data.releaseNotes.issues = None
         mock_get_configs.return_value = {"image": mock_shipment}
 
-        result = shipment_utils.get_bug_ids_from_open_shipment_mrs(
-            shipment_data_url="https://gitlab.example.com/project",
-            group="openshift-4.18",
+        result = self._call(releases_config=self._make_releases_config("4.18.39", mr_url))
+        self.assertEqual(result, set())
+
+    @patch("elliottlib.shipment_utils.get_shipment_configs_from_mr")
+    @patch("elliottlib.shipment_utils.GitLabClient")
+    def test_skips_assembly_not_in_releases_config(self, mock_gitlab_cls, mock_get_configs):
+        """MRs whose assembly is not defined in releases_config should be skipped."""
+        mock_client = Mock()
+        mock_gitlab_cls.from_url.return_value = mock_client
+
+        mock_mr = Mock()
+        mock_mr.web_url = "https://gitlab.example.com/project/-/merge_requests/1"
+        mock_client.list_merge_requests.return_value = [mock_mr]
+
+        mock_shipment = Mock()
+        mock_shipment.shipment.metadata.group = "openshift-4.18"
+        mock_shipment.shipment.metadata.assembly = "4.18.99"
+        mock_shipment.shipment.metadata.fbc = False
+        mock_shipment.shipment.data.releaseNotes.issues.fixed = [
+            Mock(id="OCPBUGS-800", source="issues.redhat.com"),
+        ]
+        mock_get_configs.return_value = {"image": mock_shipment}
+
+        result = self._call()
+        self.assertEqual(result, set())
+
+    @patch("elliottlib.shipment_utils.get_shipment_configs_from_mr")
+    @patch("elliottlib.shipment_utils.GitLabClient")
+    def test_skips_mr_url_mismatch(self, mock_gitlab_cls, mock_get_configs):
+        """MRs whose URL doesn't match the configured shipment URL for the assembly should be skipped."""
+        mock_client = Mock()
+        mock_gitlab_cls.from_url.return_value = mock_client
+
+        mock_mr = Mock()
+        mock_mr.web_url = "https://gitlab.example.com/project/-/merge_requests/999"
+        mock_client.list_merge_requests.return_value = [mock_mr]
+
+        mock_shipment = Mock()
+        mock_shipment.shipment.metadata.group = "openshift-4.18"
+        mock_shipment.shipment.metadata.assembly = "4.18.39"
+        mock_shipment.shipment.metadata.fbc = False
+        mock_shipment.shipment.data.releaseNotes.issues.fixed = [
+            Mock(id="OCPBUGS-900", source="issues.redhat.com"),
+        ]
+        mock_get_configs.return_value = {"image": mock_shipment}
+
+        releases_config = Model(
+            dict_to_model={
+                "releases": {
+                    "4.18.39": {
+                        "assembly": {
+                            "group": {"shipment": {"url": "https://gitlab.example.com/project/-/merge_requests/42"}}
+                        }
+                    }
+                }
+            }
         )
 
+        result = self._call(releases_config=releases_config)
         self.assertEqual(result, set())
+
+    @patch("elliottlib.shipment_utils.get_shipment_configs_from_mr")
+    @patch("elliottlib.shipment_utils.GitLabClient")
+    def test_includes_bugs_when_releases_config_matches(self, mock_gitlab_cls, mock_get_configs):
+        """Bugs should be included when assembly exists in releases_config and shipment URL matches."""
+        mock_client = Mock()
+        mock_gitlab_cls.from_url.return_value = mock_client
+
+        mr_url = "https://gitlab.example.com/project/-/merge_requests/42"
+        mock_mr = Mock()
+        mock_mr.web_url = mr_url
+        mock_client.list_merge_requests.return_value = [mock_mr]
+
+        mock_shipment = Mock()
+        mock_shipment.shipment.metadata.group = "openshift-4.18"
+        mock_shipment.shipment.metadata.assembly = "4.18.39"
+        mock_shipment.shipment.metadata.fbc = False
+        mock_shipment.shipment.data.releaseNotes.issues.fixed = [
+            Mock(id="OCPBUGS-1000", source="issues.redhat.com"),
+        ]
+        mock_get_configs.return_value = {"image": mock_shipment}
+
+        result = self._call(releases_config=self._make_releases_config("4.18.39", mr_url))
+        self.assertEqual(result, {"OCPBUGS-1000"})
 
 
 if __name__ == '__main__':

--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -470,7 +470,7 @@ class PrepareReleaseKonfluxPipeline:
         bug categorization sees builds from both brew and konflux sources.
         """
         self.logger.info("Finding bugs for all advisories and shipments...")
-        bugs_by_kind = await self.find_bugs()
+        bugs_by_kind = await self.find_bugs(filter_attached_bugs=True)
 
         # Attach bugs to ET advisories
         # Process bugs
@@ -1106,12 +1106,14 @@ class PrepareReleaseKonfluxPipeline:
         build_system='konflux',
         permissive: bool | None = None,
         exclude_trackers: bool | None = None,
+        filter_attached_bugs: bool = True,
     ) -> Dict[str, List[str]]:
         """Find bugs for the current assembly.
 
         :param build_system: The build system to use (default: 'konflux').
         :param permissive: Whether to use permissive mode. None means use default behavior.
         :param exclude_trackers: Whether to exclude tracker bugs. None means use default behavior.
+        :param filter_attached_bugs: Whether to filter bugs already attached to advisories/shipments.
         :return: A dictionary mapping advisory kinds to lists of bug IDs
         """
         match build_system:
@@ -1133,6 +1135,10 @@ class PrepareReleaseKonfluxPipeline:
             find_bugs_cmd.append("--exclude-trackers")
         if permissive:
             find_bugs_cmd.append("--permissive")
+        if filter_attached_bugs:
+            find_bugs_cmd.append("--filter-attached-bugs")
+        else:
+            find_bugs_cmd.append("--no-filter-attached-bugs")
         stdout = await self.execute_command_with_logging(find_bugs_cmd)
         return json.loads(stdout)
 

--- a/pyartcd/tests/pipelines/test_prepare_release_konflux.py
+++ b/pyartcd/tests/pipelines/test_prepare_release_konflux.py
@@ -831,8 +831,7 @@ class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
         mock_errata_api_instance.close.assert_called_once()
 
         # assert bug finding was done and MR updated with the right shipment configs
-        mock_find_bugs.assert_any_call()
-        self.assertEqual(mock_find_bugs.call_count, 1)
+        mock_find_bugs.assert_awaited_once_with(filter_attached_bugs=True)
 
         # update_shipment_mr is called 3 times: builds, bugs (via sweep_bugs), CVE flaws (via finalize_shipment)
         self.assertEqual(mock_update_shipment_mr.call_count, 3)


### PR DESCRIPTION
  ## Summary

  When preparing consecutive OCP releases via Konflux (e.g., 4.18.40 before 4.18.39 ships), `elliott find-bugs` can sweep bugs already attached to a previous in-flight shipment MR in ocp-shipment-data. 
  The existing errata-based filtering (`filter_attached_bugs()` in `bzutil.py`) only checks the Errata Tool API — Konflux shipments store bugs in YAML files inside GitLab MRs that Errata knows nothing about until the shipment actually ships.

  This PR adds shipment-aware bug filtering to `elliott find-bugs`, controlled by a single `--filter-attached-bugs/--no-filter-attached-bugs` CLI flag that gates both errata and shipment filtering.

  ## Changes

  - **`artcommon/artcommonlib/gitlab.py`** — Add `list_merge_requests()` method to `GitLabClient` (with `get_all=True` for full pagination)
  - **`elliott/elliottlib/shipment_utils.py`** — Add `get_bug_ids_from_open_shipment_mrs()` that scans all open MRs, parses shipment YAMLs, filters by group, excludes current assembly's own MR, skips FBC shipments, and returns the union of all bug IDs
  - **`elliott/elliottlib/cli/find_bugs_cli.py`** — Add `--filter-attached-bugs/--no-filter-attached-bugs` flag (default: `True`), pass through `FindBugsCli` to `get_bugs_sweep()`
  - **`elliott/elliottlib/cli/find_bugs_sweep_cli.py`** — Gate both errata and shipment filtering behind `filter_attached_bugs` param; guard against `None` shipment path
  - **`pyartcd/pyartcd/pipelines/prepare_release_konflux.py`** — Add `filter_attached_bugs` param to `find_bugs()`, pass explicitly from `sweep_bugs()`

  ## How it works

  1. `get_bug_ids_from_open_shipment_mrs()` lists all **open** MRs in ocp-shipment-data via GitLab API
  2. For each MR, parses shipment YAML configs using existing `get_shipment_configs_from_mr()`
  3. Skips MRs for different OCP groups, the current assembly's own MR, and FBC shipments
  4. Extracts bug IDs from `shipment.data.releaseNotes.issues.fixed[]`
  5. Filters those bugs from the sweep results

  Only open MRs need checking — merged MRs = shipped releases where bugs have moved to CLOSED and won't appear in sweep results (which searches MODIFIED, ON_QA, VERIFIED).

  ## Error handling

  | Scenario | Behavior |
  |----------|----------|
  | No `GITLAB_TOKEN` | `GitLabClient` raises `ValueError` — token is required for Konflux operations |
  | No `shipment_path` on runtime | Skip shipment filtering silently |
  | No open MRs | Return empty set — normal for first release of a version |
  | MR YAML parsing fails | Log warning, skip that MR, continue with others |
  | FBC shipment (no releaseNotes) | Skip — consistent with existing pipeline behavior |


