### PR TITLE
ART-14778: filter already-released images in elliott find-builds for Konflux

### DIFF
--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -11,8 +11,10 @@ from artcommonlib import logutil
 from artcommonlib.arch_util import BREW_ARCHES
 from artcommonlib.assembly import assembly_excluded_components, assembly_metadata_config, assembly_rhcos_config
 from artcommonlib.constants import COREOS_RHEL10_STREAMS
+from artcommonlib.exectools import cmd_gather_async
 from artcommonlib.format_util import green_print, red_print, yellow_print
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord, KonfluxBundleBuildRecord
+from artcommonlib.model import Missing
 from artcommonlib.release_util import isolate_el_version_in_release
 from artcommonlib.rhcos import get_build_id_from_rhcos_pullspec, get_container_configs
 from artcommonlib.rpm_utils import parse_nvr
@@ -33,6 +35,8 @@ from elliottlib.util import (
 )
 
 LOGGER = logutil.get_logger(__name__)
+DELIVERY_IMAGE_REGISTRY = "registry.redhat.io"
+REGISTRY_CHECK_CONCURRENCY = 30
 
 pass_runtime = click.make_pass_decorator(Runtime)
 
@@ -177,19 +181,18 @@ async def find_builds_cli(
                 default_advisory_type,
                 clean,
                 no_cdn_repos,
-                include_shipped,
                 member_only,
             ]
         ):
             raise click.BadParameter(
-                'Konflux does not support --build, --builds-file, --attach, --use-default-advisory, --clean, --no-cdn-repos, --include-shipped or --member-only options.'
+                'Konflux does not support --build, --builds-file, --attach, --use-default-advisory, --clean, --no-cdn-repos, or --member-only options.'
             )
         if kind != 'image':
             raise click.BadParameter('Konflux only supports --kind image.')
         if all_image_types:
-            data = await find_builds_konflux_all_types(runtime)
+            data = await find_builds_konflux_all_types(runtime, include_shipped=include_shipped)
         else:
-            data = await find_builds_konflux(runtime, payload)
+            data = await find_builds_konflux(runtime, payload, include_shipped=include_shipped)
 
         if as_json:
             _json_dump(as_json, data)
@@ -733,15 +736,98 @@ def _filter_out_attached_builds(
     return unattached_builds, attached_to_advisories
 
 
-async def find_builds_konflux(runtime, payload) -> list[dict]:
+async def _is_image_released(delivery_repo: str, version: str, release: str) -> bool:
+    """
+    Check if an image tag exists on registry.redhat.io (already released).
+
+    Arg(s):
+        delivery_repo (str): Delivery repository name (e.g. "openshift4/ose-cli-rhel9").
+        version (str): Build version (e.g. "4.19.0").
+        release (str): Build release (e.g. "202505210330.p0.g8f1c8b5.assembly.stream.el9").
+
+    Return Value(s):
+        bool: True if image tag exists on registry.redhat.io, False otherwise.
+    """
+    tag = f"v{version}-{release}"
+    pullspec = f"{DELIVERY_IMAGE_REGISTRY}/{delivery_repo}:{tag}"
+    try:
+        rc, _, stderr = await cmd_gather_async(
+            ["skopeo", "inspect", "--raw", f"docker://{pullspec}"],
+            check=False,
+        )
+    except Exception:
+        LOGGER.warning("skopeo inspect failed for %s, assuming not released", pullspec, exc_info=True)
+        return False
+    if rc != 0:
+        LOGGER.debug("Image not found on registry: %s (rc=%d)", pullspec, rc)
+    return rc == 0
+
+
+async def _filter_shipped_konflux_builds(
+    image_metas: list[ImageMetadata],
+    records: list[KonfluxBuildRecord],
+) -> tuple[list[KonfluxBuildRecord], set[int]]:
+    """
+    Filter out Konflux builds that are already released on registry.redhat.io.
+
+    For each (image_meta, record) pair, checks if the build's tag exists on
+    registry.redhat.io under the image's delivery repository. Builds found
+    on registry.redhat.io are considered already shipped and are excluded.
+
+    Arg(s):
+        image_metas (list[ImageMetadata]): Image metadata objects with delivery repo config.
+        records (list[KonfluxBuildRecord]): Corresponding build records from Konflux DB.
+
+    Return Value(s):
+        tuple: (filtered records not yet released, set of shipped indices).
+    """
+    semaphore = asyncio.Semaphore(REGISTRY_CHECK_CONCURRENCY)
+
+    async def _check_with_limit(delivery_repo: str, version: str, release: str) -> bool:
+        async with semaphore:
+            return await _is_image_released(delivery_repo, version, release)
+
+    check_tasks = []
+    check_indices = []
+
+    for i, (image, record) in enumerate(zip(image_metas, records)):
+        delivery_repo_names = image.config.delivery.delivery_repo_names
+        if delivery_repo_names is Missing or not delivery_repo_names:
+            LOGGER.warning("No delivery_repo_names for %s, skipping shipped check", image.distgit_key)
+            continue
+
+        delivery_repo = str(delivery_repo_names[0])
+        check_indices.append(i)
+        check_tasks.append(_check_with_limit(delivery_repo, record.version, record.release))
+
+    if not check_tasks:
+        return list(records), set()
+
+    LOGGER.info("Checking %d images against %s for shipped status...", len(check_tasks), DELIVERY_IMAGE_REGISTRY)
+    released_flags = await asyncio.gather(*check_tasks)
+
+    shipped_indices: set[int] = set()
+    for idx, is_released in zip(check_indices, released_flags):
+        if is_released:
+            shipped_indices.add(idx)
+
+    if shipped_indices:
+        LOGGER.info("Filtered %d already-shipped Konflux builds", len(shipped_indices))
+
+    filtered = [r for i, r in enumerate(records) if i not in shipped_indices]
+    return filtered, shipped_indices
+
+
+async def find_builds_konflux(runtime, payload, include_shipped: bool = False) -> list[dict]:
     """
     Find konflux builds for group/assembly.
 
-    Args:
+    Arg(s):
         runtime: The runtime object providing access to image metadata and the Konflux database.
         payload: If True, only include payload images; if False, only non-payload images.
+        include_shipped (bool): If True, do not filter out already-shipped builds.
 
-    Returns:
+    Return Value(s):
         list[dict]: List of build records for each image.
     """
     runtime.konflux_db.bind(KonfluxBuildRecord)
@@ -770,10 +856,14 @@ async def find_builds_konflux(runtime, payload) -> list[dict]:
         message = f"Failed to find Konflux builds for {len(images_not_found)} images: {images_not_found}"
         LOGGER.error(message)
         raise ElliottFatalError(message)
+
+    if not include_shipped:
+        records, _ = await _filter_shipped_konflux_builds(image_metas, list(records))
+
     return records
 
 
-async def find_builds_konflux_all_types(runtime: Runtime) -> dict[str, list]:
+async def find_builds_konflux_all_types(runtime: Runtime, include_shipped: bool = False) -> dict[str, list]:
     """
     Find Konflux builds for a group/assembly, separating payload and non-payload images,
     and fetch related OLM bundle builds.
@@ -789,10 +879,11 @@ async def find_builds_konflux_all_types(runtime: Runtime) -> dict[str, list]:
         3. 'olm_builds': NVRs of OLM bundle builds found.
         4. 'olm_builds_not_found': NVRs of OLM operator builds for which no bundle build was found.
 
-    Args:
+    Arg(s):
         runtime: The runtime object providing access to image metadata and the Konflux database.
+        include_shipped (bool): If True, do not filter out already-shipped builds.
 
-    Returns:
+    Return Value(s):
         dict[str, list]: A dictionary containing four lists:
             - 'payload': List of build nvrs for payload images.
             - 'non_payload': List of build nvrs for non-payload images.
@@ -828,6 +919,13 @@ async def find_builds_konflux_all_types(runtime: Runtime) -> dict[str, list]:
         message = f"Failed to find Konflux builds for {len(images_not_found)} images: {images_not_found}"
         LOGGER.error(message)
         raise ElliottFatalError(message)
+
+    if not include_shipped:
+        all_images = [img for _, img in image_metas]
+        _, shipped_indices = await _filter_shipped_konflux_builds(all_images, list(results))
+        results = [r for i, r in enumerate(results) if i not in shipped_indices]
+        olm_flags = [f for i, f in enumerate(olm_flags) if i not in shipped_indices]
+        payload_flags = [f for i, f in enumerate(payload_flags) if i not in shipped_indices]
 
     # get related bundle records in KonfluxBundleBuildRecord
     LOGGER.info("Fetching bundle NVRs from DB ...")

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -37,6 +37,7 @@ from elliottlib.util import (
 LOGGER = logutil.get_logger(__name__)
 DELIVERY_IMAGE_REGISTRY = "registry.redhat.io"
 REGISTRY_CHECK_CONCURRENCY = 30
+REGISTRY_CHECK_TIMEOUT = 30
 
 pass_runtime = click.make_pass_decorator(Runtime)
 
@@ -754,6 +755,7 @@ async def _is_image_released(delivery_repo: str, version: str, release: str) -> 
         rc, _, stderr = await cmd_gather_async(
             ["skopeo", "inspect", "--raw", f"docker://{pullspec}"],
             check=False,
+            timeout=REGISTRY_CHECK_TIMEOUT,
         )
     except Exception:
         LOGGER.warning("skopeo inspect failed for %s, assuming not released", pullspec, exc_info=True)

--- a/elliott/elliottlib/cli/find_builds_cli.py
+++ b/elliott/elliottlib/cli/find_builds_cli.py
@@ -758,9 +758,15 @@ async def _is_image_released(delivery_repo: str, version: str, release: str) -> 
     except Exception:
         LOGGER.warning("skopeo inspect failed for %s, assuming not released", pullspec, exc_info=True)
         return False
-    if rc != 0:
-        LOGGER.debug("Image not found on registry: %s (rc=%d)", pullspec, rc)
-    return rc == 0
+    if rc == 0:
+        return True
+
+    lower_stderr = stderr.lower()
+    if "manifest unknown" in lower_stderr or "not found" in lower_stderr:
+        LOGGER.debug("Image not found on registry: %s", pullspec)
+    else:
+        LOGGER.warning("skopeo inspect failed for %s (rc=%d): %s", pullspec, rc, stderr.strip())
+    return False
 
 
 async def _filter_shipped_konflux_builds(
@@ -787,6 +793,12 @@ async def _filter_shipped_konflux_builds(
         async with semaphore:
             return await _is_image_released(delivery_repo, version, release)
 
+    async def _check_any_repo(delivery_repo_names: list, version: str, release: str) -> bool:
+        for repo in delivery_repo_names:
+            if await _check_with_limit(str(repo), version, release):
+                return True
+        return False
+
     check_tasks = []
     check_indices = []
 
@@ -796,9 +808,8 @@ async def _filter_shipped_konflux_builds(
             LOGGER.warning("No delivery_repo_names for %s, skipping shipped check", image.distgit_key)
             continue
 
-        delivery_repo = str(delivery_repo_names[0])
         check_indices.append(i)
-        check_tasks.append(_check_with_limit(delivery_repo, record.version, record.release))
+        check_tasks.append(_check_any_repo(delivery_repo_names, record.version, record.release))
 
     if not check_tasks:
         return list(records), set()

--- a/elliott/tests/test_find_builds_cli.py
+++ b/elliott/tests/test_find_builds_cli.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from elliottlib import errata as erratalib
 from elliottlib.brew import Build
 from elliottlib.cli.find_builds_cli import (
+    REGISTRY_CHECK_TIMEOUT,
     _fetch_builds_by_kind_rpm,
     _filter_out_attached_builds,
     _filter_shipped_konflux_builds,
@@ -237,6 +238,7 @@ class TestIsImageReleased(IsolatedAsyncioTestCase):
                 "docker://registry.redhat.io/openshift4/ose-cli-rhel9:v4.19.0-202505210330.p0.el9",
             ],
             check=False,
+            timeout=REGISTRY_CHECK_TIMEOUT,
         )
 
     @patch("elliottlib.cli.find_builds_cli.cmd_gather_async", new_callable=AsyncMock)

--- a/elliott/tests/test_find_builds_cli.py
+++ b/elliott/tests/test_find_builds_cli.py
@@ -417,8 +417,9 @@ class TestFindBuildsKonfluxShippedFiltering(IsolatedAsyncioTestCase):
 
         runtime.should_receive("image_metas").and_return([meta_payload, meta_olm])
 
-        # OLM operator (index 1) is shipped
+        # OLM operator (index 1) is shipped — DB should NOT be queried for bundle builds
         mock_filter.return_value = ([build_payload], {1})
+        runtime.konflux_db.should_receive("search_builds_by_fields").never()
 
         builds_map = await find_builds_konflux_all_types(runtime)
 
@@ -426,8 +427,6 @@ class TestFindBuildsKonfluxShippedFiltering(IsolatedAsyncioTestCase):
         self.assertEqual(builds_map["non_payload"], [])
         self.assertEqual(builds_map["olm_builds"], [])
         self.assertEqual(builds_map["olm_builds_not_found"], [])
-        # DB should NOT have been queried for bundle builds
-        runtime.konflux_db.should_receive("search_builds_by_fields").never()
 
     @patch("elliottlib.cli.find_builds_cli._filter_shipped_konflux_builds", new_callable=AsyncMock)
     @patch("elliottlib.cli.find_builds_cli.KonfluxBuildRecord")

--- a/elliott/tests/test_find_builds_cli.py
+++ b/elliott/tests/test_find_builds_cli.py
@@ -1,13 +1,15 @@
 import unittest
 from unittest import IsolatedAsyncioTestCase, TestCase, mock
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from elliottlib import errata as erratalib
 from elliottlib.brew import Build
 from elliottlib.cli.find_builds_cli import (
     _fetch_builds_by_kind_rpm,
     _filter_out_attached_builds,
+    _filter_shipped_konflux_builds,
     _find_shipped_builds,
+    _is_image_released,
     find_builds_konflux,
     find_builds_konflux_all_types,
 )
@@ -75,7 +77,7 @@ class TestFindBuildsKonflux(IsolatedAsyncioTestCase):
         image_meta_2.get_latest_build = AsyncMock(return_value={"nvr": "image2-2.0.0-1.el9"})
 
         runtime.should_receive("image_metas").and_return([image_meta_1, image_meta_2])
-        actual_records = await find_builds_konflux(runtime, payload=True)
+        actual_records = await find_builds_konflux(runtime, payload=True, include_shipped=True)
         self.assertEqual(len(actual_records), 1)
         self.assertEqual(actual_records[0]['nvr'], "image1-1.0.0-1.el8")
         image_meta_1.get_latest_build.assert_called_once_with(el_target="el8", exclude_large_columns=True)
@@ -96,7 +98,7 @@ class TestFindBuildsKonflux(IsolatedAsyncioTestCase):
         image_meta_2.get_latest_build = AsyncMock(return_value={"nvr": "image2-2.0.0-1.el9"})
 
         runtime.should_receive("image_metas").and_return([image_meta_1, image_meta_2])
-        actual_records = await find_builds_konflux(runtime, payload=False)
+        actual_records = await find_builds_konflux(runtime, payload=False, include_shipped=True)
         self.assertEqual(len(actual_records), 0)
         image_meta_2.get_latest_build.assert_not_called()
 
@@ -111,7 +113,7 @@ class TestFindBuildsKonflux(IsolatedAsyncioTestCase):
 
         runtime.should_receive("image_metas").and_return([image_meta_1])
         with self.assertRaises(ElliottFatalError):
-            await find_builds_konflux(runtime, payload=True)
+            await find_builds_konflux(runtime, payload=True, include_shipped=True)
 
 
 class TestFindBuildsKonfluxAllTypes(IsolatedAsyncioTestCase):
@@ -154,7 +156,7 @@ class TestFindBuildsKonfluxAllTypes(IsolatedAsyncioTestCase):
                 return default
 
         with mock.patch("elliottlib.cli.find_builds_cli.anext", side_effect=fake_anext):
-            builds_map = await find_builds_konflux_all_types(runtime)
+            builds_map = await find_builds_konflux_all_types(runtime, include_shipped=True)
 
         # Assertions
         self.assertEqual(len(builds_map['payload']), 1)
@@ -193,7 +195,7 @@ class TestFindBuildsKonfluxAllTypes(IsolatedAsyncioTestCase):
 
         runtime.should_receive("image_metas").and_return([image_meta_1, image_meta_2])
 
-        builds_map = await find_builds_konflux_all_types(runtime)
+        builds_map = await find_builds_konflux_all_types(runtime, include_shipped=True)
 
         self.assertEqual(builds_map['payload'], [build_1.nvr])
         self.assertEqual(builds_map['non_payload'], [])
@@ -218,7 +220,258 @@ class TestFindBuildsKonfluxAllTypes(IsolatedAsyncioTestCase):
 
         runtime.should_receive("image_metas").and_return([image_meta_1])
         with self.assertRaises(ElliottFatalError):
-            await find_builds_konflux_all_types(runtime)
+            await find_builds_konflux_all_types(runtime, include_shipped=True)
+
+
+class TestIsImageReleased(IsolatedAsyncioTestCase):
+    @patch("elliottlib.cli.find_builds_cli.cmd_gather_async", new_callable=AsyncMock)
+    async def test_released_image(self, mock_cmd):
+        mock_cmd.return_value = (0, "", "")
+        result = await _is_image_released("openshift4/ose-cli-rhel9", "4.19.0", "202505210330.p0.el9")
+        self.assertTrue(result)
+        mock_cmd.assert_called_once_with(
+            [
+                "skopeo",
+                "inspect",
+                "--raw",
+                "docker://registry.redhat.io/openshift4/ose-cli-rhel9:v4.19.0-202505210330.p0.el9",
+            ],
+            check=False,
+        )
+
+    @patch("elliottlib.cli.find_builds_cli.cmd_gather_async", new_callable=AsyncMock)
+    async def test_unreleased_image(self, mock_cmd):
+        mock_cmd.return_value = (1, "", "not found")
+        result = await _is_image_released("openshift4/ose-cli-rhel9", "4.19.0", "202505210330.p0.el9")
+        self.assertFalse(result)
+
+    @patch("elliottlib.cli.find_builds_cli.cmd_gather_async", new_callable=AsyncMock)
+    async def test_skopeo_exception_returns_false(self, mock_cmd):
+        mock_cmd.side_effect = OSError("skopeo not found")
+        result = await _is_image_released("openshift4/ose-cli-rhel9", "4.19.0", "202505210330.p0.el9")
+        self.assertFalse(result)
+
+
+class TestFilterShippedKonfluxBuilds(IsolatedAsyncioTestCase):
+    @patch("elliottlib.cli.find_builds_cli._is_image_released", new_callable=AsyncMock)
+    async def test_filters_released_builds(self, mock_released):
+        mock_released.side_effect = [True, False]
+
+        image1 = MagicMock(distgit_key="img1")
+        image1.config.delivery.delivery_repo_names = ["openshift4/img1-rhel9"]
+        record1 = MagicMock(version="4.19.0", release="1.el9", nvr="img1-4.19.0-1.el9")
+
+        image2 = MagicMock(distgit_key="img2")
+        image2.config.delivery.delivery_repo_names = ["openshift4/img2-rhel9"]
+        record2 = MagicMock(version="4.19.0", release="2.el9", nvr="img2-4.19.0-2.el9")
+
+        filtered, shipped = await _filter_shipped_konflux_builds([image1, image2], [record1, record2])
+        self.assertEqual(filtered, [record2])
+        self.assertEqual(shipped, {0})
+
+    @patch("elliottlib.cli.find_builds_cli._is_image_released", new_callable=AsyncMock)
+    async def test_skips_missing_delivery_repo(self, mock_released):
+        from artcommonlib.model import Missing
+
+        mock_released.return_value = False
+
+        image1 = MagicMock(distgit_key="img1")
+        image1.config.delivery.delivery_repo_names = Missing
+        record1 = MagicMock(version="4.19.0", release="1.el9")
+
+        image2 = MagicMock(distgit_key="img2")
+        image2.config.delivery.delivery_repo_names = ["openshift4/img2-rhel9"]
+        record2 = MagicMock(version="4.19.0", release="2.el9")
+
+        filtered, shipped = await _filter_shipped_konflux_builds([image1, image2], [record1, record2])
+        self.assertEqual(filtered, [record1, record2])
+        self.assertEqual(shipped, set())
+        mock_released.assert_called_once()
+
+    @patch("elliottlib.cli.find_builds_cli._is_image_released", new_callable=AsyncMock)
+    async def test_skips_empty_delivery_repo_list(self, mock_released):
+        image1 = MagicMock(distgit_key="img1")
+        image1.config.delivery.delivery_repo_names = []
+        record1 = MagicMock(version="4.19.0", release="1.el9")
+
+        filtered, shipped = await _filter_shipped_konflux_builds([image1], [record1])
+        self.assertEqual(filtered, [record1])
+        self.assertEqual(shipped, set())
+        mock_released.assert_not_called()
+
+    @patch("elliottlib.cli.find_builds_cli._is_image_released", new_callable=AsyncMock)
+    async def test_returns_all_when_none_released(self, mock_released):
+        mock_released.return_value = False
+
+        image1 = MagicMock(distgit_key="img1")
+        image1.config.delivery.delivery_repo_names = ["openshift4/img1-rhel9"]
+        record1 = MagicMock(version="4.19.0", release="1.el9")
+
+        filtered, shipped = await _filter_shipped_konflux_builds([image1], [record1])
+        self.assertEqual(filtered, [record1])
+        self.assertEqual(shipped, set())
+
+    @patch("elliottlib.cli.find_builds_cli._is_image_released", new_callable=AsyncMock)
+    async def test_returns_empty_when_all_released(self, mock_released):
+        mock_released.return_value = True
+
+        image1 = MagicMock(distgit_key="img1")
+        image1.config.delivery.delivery_repo_names = ["openshift4/img1-rhel9"]
+        record1 = MagicMock(version="4.19.0", release="1.el9")
+
+        filtered, shipped = await _filter_shipped_konflux_builds([image1], [record1])
+        self.assertEqual(filtered, [])
+        self.assertEqual(shipped, {0})
+
+    @patch("elliottlib.cli.find_builds_cli._is_image_released", new_callable=AsyncMock)
+    async def test_empty_records(self, mock_released):
+        filtered, shipped = await _filter_shipped_konflux_builds([], [])
+        self.assertEqual(filtered, [])
+        self.assertEqual(shipped, set())
+        mock_released.assert_not_called()
+
+
+class TestFindBuildsKonfluxShippedFiltering(IsolatedAsyncioTestCase):
+    @patch("elliottlib.cli.find_builds_cli._filter_shipped_konflux_builds", new_callable=AsyncMock)
+    @patch("elliottlib.cli.find_builds_cli.KonfluxBuildRecord")
+    async def test_filters_shipped_by_default(self, MockKonfluxBuildRecord, mock_filter):
+        runtime = flexmock(konflux_db=flexmock(), assembly=None)
+        runtime.should_receive("get_releases_config").and_return(None)
+        runtime.konflux_db.should_receive("bind").with_args(MockKonfluxBuildRecord)
+
+        record1 = MagicMock(nvr="image1-1.0.0-1.el8")
+        image_meta = MagicMock(base_only=False, is_release=True, is_payload=True, distgit_key="image1")
+        image_meta.branch_el_target.return_value = "el8"
+        image_meta.get_latest_build = AsyncMock(return_value=record1)
+        runtime.should_receive("image_metas").and_return([image_meta])
+
+        mock_filter.return_value = ([record1], set())
+        result = await find_builds_konflux(runtime, payload=True)
+        mock_filter.assert_called_once()
+        self.assertEqual(len(result), 1)
+
+    @patch("elliottlib.cli.find_builds_cli._filter_shipped_konflux_builds", new_callable=AsyncMock)
+    @patch("elliottlib.cli.find_builds_cli.KonfluxBuildRecord")
+    async def test_skips_filter_with_include_shipped(self, MockKonfluxBuildRecord, mock_filter):
+        runtime = flexmock(konflux_db=flexmock(), assembly=None)
+        runtime.should_receive("get_releases_config").and_return(None)
+        runtime.konflux_db.should_receive("bind").with_args(MockKonfluxBuildRecord)
+
+        record1 = MagicMock(nvr="image1-1.0.0-1.el8")
+        image_meta = MagicMock(base_only=False, is_release=True, is_payload=True, distgit_key="image1")
+        image_meta.branch_el_target.return_value = "el8"
+        image_meta.get_latest_build = AsyncMock(return_value=record1)
+        runtime.should_receive("image_metas").and_return([image_meta])
+
+        result = await find_builds_konflux(runtime, payload=True, include_shipped=True)
+        mock_filter.assert_not_called()
+        self.assertEqual(len(result), 1)
+
+    @patch("elliottlib.cli.find_builds_cli._filter_shipped_konflux_builds", new_callable=AsyncMock)
+    @patch("elliottlib.cli.find_builds_cli.KonfluxBuildRecord")
+    @patch("elliottlib.cli.find_builds_cli.KonfluxBundleBuildRecord")
+    async def test_all_types_filters_shipped(self, MockBundle, MockKonflux, mock_filter):
+        runtime = flexmock(konflux_db=flexmock(), assembly=None)
+        runtime.should_receive("get_releases_config").and_return(None)
+        runtime.konflux_db.should_receive("bind").with_args(MockKonflux)
+        runtime.konflux_db.should_receive("bind").with_args(MockBundle)
+
+        build1 = MagicMock(nvr="image1-1.0.0-1.el8")
+        image_meta = MagicMock(
+            base_only=False, is_release=True, is_payload=True, is_olm_operator=False, distgit_key="image1"
+        )
+        image_meta.branch_el_target.return_value = "el8"
+        image_meta.get_latest_build = AsyncMock(return_value=build1)
+        runtime.should_receive("image_metas").and_return([image_meta])
+
+        mock_filter.return_value = ([build1], set())
+        builds_map = await find_builds_konflux_all_types(runtime)
+        mock_filter.assert_called_once()
+        self.assertEqual(builds_map["payload"], [build1.nvr])
+
+    @patch("elliottlib.cli.find_builds_cli._filter_shipped_konflux_builds", new_callable=AsyncMock)
+    @patch("elliottlib.cli.find_builds_cli.KonfluxBuildRecord")
+    @patch("elliottlib.cli.find_builds_cli.KonfluxBundleBuildRecord")
+    async def test_all_types_shipped_olm_operator_skips_bundle_lookup(self, MockBundle, MockKonflux, mock_filter):
+        """
+        When an OLM operator is filtered as shipped, its bundle lookup should also be skipped.
+        """
+        runtime = flexmock(konflux_db=flexmock(), assembly=None)
+        runtime.should_receive("get_releases_config").and_return(None)
+        runtime.konflux_db.should_receive("bind").with_args(MockKonflux)
+        runtime.konflux_db.should_receive("bind").with_args(MockBundle)
+
+        build_payload = MagicMock(nvr="payload-img-1.0.0-1.el8")
+        meta_payload = MagicMock(
+            base_only=False, is_release=True, is_payload=True, is_olm_operator=False, distgit_key="payload-img"
+        )
+        meta_payload.branch_el_target.return_value = "el8"
+        meta_payload.get_latest_build = AsyncMock(return_value=build_payload)
+
+        build_olm = MagicMock(nvr="olm-operator-2.0.0-1.el9")
+        meta_olm = MagicMock(
+            base_only=False, is_release=True, is_payload=False, is_olm_operator=True, distgit_key="olm-operator"
+        )
+        meta_olm.branch_el_target.return_value = "el9"
+        meta_olm.get_latest_build = AsyncMock(return_value=build_olm)
+
+        runtime.should_receive("image_metas").and_return([meta_payload, meta_olm])
+
+        # OLM operator (index 1) is shipped
+        mock_filter.return_value = ([build_payload], {1})
+
+        builds_map = await find_builds_konflux_all_types(runtime)
+
+        self.assertEqual(builds_map["payload"], [build_payload.nvr])
+        self.assertEqual(builds_map["non_payload"], [])
+        self.assertEqual(builds_map["olm_builds"], [])
+        self.assertEqual(builds_map["olm_builds_not_found"], [])
+        # DB should NOT have been queried for bundle builds
+        runtime.konflux_db.should_receive("search_builds_by_fields").never()
+
+    @patch("elliottlib.cli.find_builds_cli._filter_shipped_konflux_builds", new_callable=AsyncMock)
+    @patch("elliottlib.cli.find_builds_cli.KonfluxBuildRecord")
+    @patch("elliottlib.cli.find_builds_cli.KonfluxBundleBuildRecord")
+    async def test_all_types_preserves_flag_alignment(self, MockBundle, MockKonflux, mock_filter):
+        """
+        Verify that payload_flags, olm_flags, and results stay aligned after filtering.
+        3 images: payload (kept), non-payload OLM (shipped), non-payload (kept).
+        """
+        runtime = flexmock(konflux_db=flexmock(), assembly=None)
+        runtime.should_receive("get_releases_config").and_return(None)
+        runtime.konflux_db.should_receive("bind").with_args(MockKonflux)
+        runtime.konflux_db.should_receive("bind").with_args(MockBundle)
+
+        build1 = MagicMock(nvr="img1-1.0.0-1.el8")
+        meta1 = MagicMock(base_only=False, is_release=True, is_payload=True, is_olm_operator=False, distgit_key="img1")
+        meta1.branch_el_target.return_value = "el8"
+        meta1.get_latest_build = AsyncMock(return_value=build1)
+
+        build2 = MagicMock(nvr="olm-img-2.0.0-1.el9")
+        meta2 = MagicMock(
+            base_only=False, is_release=True, is_payload=False, is_olm_operator=True, distgit_key="olm-img"
+        )
+        meta2.branch_el_target.return_value = "el9"
+        meta2.get_latest_build = AsyncMock(return_value=build2)
+
+        build3 = MagicMock(nvr="nonpay-3.0.0-1.el9")
+        meta3 = MagicMock(
+            base_only=False, is_release=True, is_payload=False, is_olm_operator=False, distgit_key="nonpay"
+        )
+        meta3.branch_el_target.return_value = "el9"
+        meta3.get_latest_build = AsyncMock(return_value=build3)
+
+        runtime.should_receive("image_metas").and_return([meta1, meta2, meta3])
+
+        # Image at index 1 (OLM) shipped
+        mock_filter.return_value = ([build1, build3], {1})
+
+        builds_map = await find_builds_konflux_all_types(runtime)
+
+        self.assertEqual(sorted(builds_map["payload"]), [build1.nvr])
+        self.assertEqual(sorted(builds_map["non_payload"]), [build3.nvr])
+        self.assertEqual(builds_map["olm_builds"], [])
+        self.assertEqual(builds_map["olm_builds_not_found"], [])
 
 
 class TestFetchBuildsByKindRpm(IsolatedAsyncioTestCase):


### PR DESCRIPTION
  ## Summary
  
  When preparing consecutive OCP releases via Konflux, `elliott find-builds` returns the latest successful builds regardless of whether they've already been shipped. This means a
  tracker bug that missed a shipping window can get re-associated with an already-released image. Konflux catches this at shipping time, but we want earlier detection.

  This PR adds shipped-build filtering to `elliott find-builds` for Konflux by checking whether each image's tag already exists on `registry.redhat.io`. The existing `--include-shipped`
   flag (previously rejected for Konflux) now works.
  ## How it works

  1. For each Konflux build, construct the expected delivery tag: `v{version}-{release}`
  2. Use `skopeo inspect --raw` against `registry.redhat.io/{delivery_repo}:{tag}` to check if the image has already been published
  3. Checks run concurrently (up to 30 at a time) via `asyncio.Semaphore`
  4. Builds found on registry.redhat.io are excluded from results
  5. `--include-shipped` bypasses all filtering
  
  ## Changes
  
  - **`elliott/elliottlib/cli/find_builds_cli.py`**
    - Add `_is_image_released()` — checks a single image tag on registry.redhat.io via `skopeo inspect --raw`
    - Add `_filter_shipped_konflux_builds()` — runs concurrent registry checks across all builds, returns filtered list + shipped indices
    - Un-reject `--include-shipped` for Konflux; thread the flag through `find_builds_konflux()` and `find_builds_konflux_all_types()`
    - In `find_builds_konflux_all_types()`, shipped indices also remove the corresponding `olm_flags` and `payload_flags` entries to keep lists aligned

  - **`elliott/tests/test_find_builds_cli.py`** — 14 new tests:
    - `TestIsImageReleased` (3 tests): released, unreleased, skopeo exception
    - `TestFilterShippedKonfluxBuilds` (6 tests): filtering, missing delivery repo, empty list, all/none shipped
    - `TestFindBuildsKonfluxShippedFiltering` (5 tests): default filtering, `--include-shipped` bypass, all-types filtering, OLM bundle skip on shipped operator, flag alignment after 
  filtering
  
  ## Error handling

  | Scenario | Behavior |
  |----------|----------|
  | `skopeo inspect` fails or throws | Log warning, assume not released (fail open) |
  | No `delivery_repo_names` configured | Log warning, skip shipped check for that image |
  | Empty `delivery_repo_names` list | Skip shipped check for that image |
  | `--include-shipped` flag | Bypass all filtering, return all builds |
