### PR TITLE
fix: images-health missing base_only and non-release image failures

### DIFF
--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -202,6 +202,8 @@ class ImagesHealthPipeline:
             f'--data-path={self.data_path}',
             group_param,
             'images:print',
+            '--show-base',
+            '--show-non-release',
             '--short',
             '{name}',
         ]


### PR DESCRIPTION
`_get_valid_images()` calls `doozer images:print` to validate Redis failure keys against ocp-build-data metadata. The command defaults to excluding `base_only` and `for_release=false` images, causing failures like openshift-enterprise-base-rhel9 to be silently filtered out.

Add --show-base and --show-non-release flags so all images in metadata are considered valid for failure reporting.
