### PR TITLE
Add URL context to urlopen error messages

### DIFF
--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -1375,7 +1375,10 @@ def distgit_config_template(url):
     for a config yaml for the image.
     """
 
-    f = urllib.request.urlopen(url)
+    try:
+        f = urllib.request.urlopen(url)
+    except Exception as e:
+        raise click.ClickException(f"Failed to fetch {url}: {e}") from e
     if f.code != 200:
         click.echo("Error fetching {}: {}".format(url, f.code), err=True)
         exit(1)

--- a/doozer/doozerlib/rhcos.py
+++ b/doozer/doozerlib/rhcos.py
@@ -237,7 +237,7 @@ class RHCOSBuildFinder:
                 with request.urlopen(url, timeout=60) as req:
                     data = json.loads(req.read().decode())
             except Exception as e:
-                raise type(e)(f"Failed to fetch {url} for pullspec {pullspec}: {e}") from e
+                raise RuntimeError(f"Failed to fetch {url} for pullspec {pullspec}: {e}") from e
             return data['rpmostree.rpmdb.pkglist']
         else:
             return []

--- a/doozer/doozerlib/rhcos.py
+++ b/doozer/doozerlib/rhcos.py
@@ -233,8 +233,12 @@ class RHCOSBuildFinder:
             rhel_minor = build_id.split(".")[1]
             url = f"{RHCOS_RELEASES_STREAM_URL}/rhel-{rhel_major}.{rhel_minor}/builds/{build_id}/{self.brew_arch}/commitmeta.json"
             logger.info(f"Send request to {url}")
-            with request.urlopen(url, timeout=60) as req:
-                return json.loads(req.read().decode())['rpmostree.rpmdb.pkglist']
+            try:
+                with request.urlopen(url, timeout=60) as req:
+                    data = json.loads(req.read().decode())
+            except Exception as e:
+                raise type(e)(f"Failed to fetch {url} for pullspec {pullspec}: {e}") from e
+            return data['rpmostree.rpmdb.pkglist']
         else:
             return []
 

--- a/elliott/elliottlib/cli/rhcos_cli.py
+++ b/elliott/elliottlib/cli/rhcos_cli.py
@@ -140,7 +140,7 @@ def _get_non_layered_tags(runtime, build_id, arch, container_configs, art_repo):
         with request.urlopen(meta_url) as resp:
             meta = json.loads(resp.read().decode())
     except Exception as e:
-        raise type(e)(f"Failed to fetch {meta_url}: {e}") from e
+        raise RuntimeError(f"Failed to fetch {meta_url}: {e}") from e
 
     tags = {}
     for container_conf in container_configs:

--- a/elliott/elliottlib/cli/rhcos_cli.py
+++ b/elliott/elliottlib/cli/rhcos_cli.py
@@ -136,8 +136,11 @@ def _get_non_layered_tags(runtime, build_id, arch, container_configs, art_repo):
     meta_url = f"{RHCOS_RELEASES_STREAM_URL}/{url_key}/builds/{build_id}/{arch}/meta.json"
 
     LOGGER.info("Fetching RHCOS metadata: %s", meta_url)
-    with request.urlopen(meta_url) as resp:
-        meta = json.loads(resp.read().decode())
+    try:
+        with request.urlopen(meta_url) as resp:
+            meta = json.loads(resp.read().decode())
+    except Exception as e:
+        raise type(e)(f"Failed to fetch {meta_url}: {e}") from e
 
     tags = {}
     for container_conf in container_configs:

--- a/elliott/elliottlib/rhcos.py
+++ b/elliott/elliottlib/rhcos.py
@@ -45,8 +45,12 @@ def latest_build_id(runtime, version, arch="x86_64", private=False):
 def _latest_build_id(runtime, version, arch="x86_64", private=False):
     # returns the build id string or None (or raise exception)
     # (may want to return "schema-version" also if this ever gets more complex)
-    with request.urlopen(f"{release_url(runtime, version, arch, private)}/builds.json") as req:
-        data = json.loads(req.read().decode())
+    url = f"{release_url(runtime, version, arch, private)}/builds.json"
+    try:
+        with request.urlopen(url) as req:
+            data = json.loads(req.read().decode())
+    except Exception as e:
+        raise type(e)(f"Failed to fetch {url}: {e}") from e
     if not data["builds"]:
         return None
     build = data["builds"][0]
@@ -81,8 +85,11 @@ def _build_meta(runtime, build_id, version, arch="x86_64", private=False, meta_t
     # before 4.3 the arch was not included in the path
     vtuple = tuple(int(f) for f in version.split("."))
     url += f"{meta_type}.json" if vtuple < (4, 3) else f"{arch}/{meta_type}.json"
-    with request.urlopen(url) as req:
-        return json.loads(req.read().decode())
+    try:
+        with request.urlopen(url) as req:
+            return json.loads(req.read().decode())
+    except Exception as e:
+        raise type(e)(f"Failed to fetch {url}: {e}") from e
 
 
 def get_build_from_payload(runtime, payload_pullspec):

--- a/elliott/elliottlib/rhcos.py
+++ b/elliott/elliottlib/rhcos.py
@@ -50,7 +50,7 @@ def _latest_build_id(runtime, version, arch="x86_64", private=False):
         with request.urlopen(url) as req:
             data = json.loads(req.read().decode())
     except Exception as e:
-        raise type(e)(f"Failed to fetch {url}: {e}") from e
+        raise RuntimeError(f"Failed to fetch {url}: {e}") from e
     if not data["builds"]:
         return None
     build = data["builds"][0]
@@ -89,7 +89,7 @@ def _build_meta(runtime, build_id, version, arch="x86_64", private=False, meta_t
         with request.urlopen(url) as req:
             return json.loads(req.read().decode())
     except Exception as e:
-        raise type(e)(f"Failed to fetch {url}: {e}") from e
+        raise RuntimeError(f"Failed to fetch {url}: {e}") from e
 
 
 def get_build_from_payload(runtime, payload_pullspec):


### PR DESCRIPTION
build-sync-konflux failed with opaque urlopen failure: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync-konflux/21711/

## Summary
- Wrap bare `urlopen` calls in doozer and elliott rhcos modules with try/except that includes the URL in the error message
- Makes it easier to diagnose network or endpoint failures during RHCOS metadata fetches
- Affected files: `doozer/doozerlib/rhcos.py`, `doozer/doozerlib/cli/images.py`, `elliott/elliottlib/rhcos.py`, `elliott/elliottlib/cli/rhcos_cli.py`

## Test plan
- [x] `uv run pytest doozer/tests/ -k rhcos` — 22 passed
- [x] `uv run pytest elliott/tests/ -k rhcos` — 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)