### PR TITLE
fixed ART-19082

### DIFF
--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -1344,7 +1344,7 @@ class PrepareReleaseKonfluxPipeline:
         target_owner = self.build_data_repo_pull_url.split('/')[-2]
 
         head = f"{source_owner}:{branch}"
-        base = self.build_data_gitref or self.group
+        base = self.group
         gh_repo = get_github_client_for_org(target_owner).get_repo(f"{target_owner}/{target_repo}")
         existing_prs = list(gh_repo.get_pulls(state="open", head=head, base=base))
 


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

Original purpose (commit 1d4a63c1, May 2025): build_data_gitref was introduced to support passing --build-data-repo-url repo@branch to
  prepare-release-konflux. It serves two legitimate uses:

  1. --group=openshift-4.21@4.21.17 (line 86-87) — tells elliott/doozer to read assembly config from a specific gitref
  2. fetch_switch_branch(self.build_data_gitref or self.group) (line 267) — checks out the correct branch for reading releases.yml

  The bug was there from day one (line 551 in original commit). The author copy-pasted the self.build_data_gitref or self.group pattern from
  the checkout logic (where it's correct) into the PR base logic (where it's wrong). The intent was "use the same branch we checked out" — but
  for a PR merge target, the base should always be the group branch (openshift-4.21), not the gitref (4.21.17).

  Why it wasn't caught earlier: Before the Konflux pipeline was fully operational, the @assembly gitref syntax likely wasn't used in
  production. The bug only manifests when --build-data-repo-url includes @<assembly_name> AND the assembly branch already exists on the remote
  (from prior failed runs creating shipment update branches).

  Line 782 (build_commit = self.build_data_gitref or self.group in init_shipment) — added by 7dbeeda0 — is actually correct there because it's
  recording which commit/branch was used for the build data, not targeting a merge.