### PR TITLE
ART-18732: feat(images) persist base image snapshot→release URLs on Konflux rows

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -68,6 +68,8 @@ class KonfluxRecord:
         'nvr',
         'ec_status',
         'ec_pipeline_url',
+        'released_pipeline',
+        'released_pullspec',
     ]
 
     TABLE_ID = None
@@ -292,6 +294,8 @@ class KonfluxBuildRecord(KonfluxRecord):
         build_priority: int = constants.KONFLUX_DEFAULT_BUILD_PRIORITY,
         ec_status: KonfluxECStatus = KonfluxECStatus.NOT_APPLICABLE,
         ec_pipeline_url: str = '',
+        released_pipeline: str = '',
+        released_pullspec: str = '',
     ):
         super().__init__(
             name,
@@ -332,6 +336,8 @@ class KonfluxBuildRecord(KonfluxRecord):
             else KonfluxECStatus(ec_status or KonfluxECStatus.NOT_APPLICABLE.value)
         )
         self.ec_pipeline_url = ec_pipeline_url
+        self.released_pipeline = released_pipeline
+        self.released_pullspec = released_pullspec
         self.init_uuids(record_id, build_id, nvr)
 
 

--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -68,7 +68,7 @@ class KonfluxRecord:
         'nvr',
         'ec_status',
         'ec_pipeline_url',
-        'released_pipeline',
+        'release_pipeline',
         'released_pullspec',
     ]
 
@@ -294,7 +294,7 @@ class KonfluxBuildRecord(KonfluxRecord):
         build_priority: int = constants.KONFLUX_DEFAULT_BUILD_PRIORITY,
         ec_status: KonfluxECStatus = KonfluxECStatus.NOT_APPLICABLE,
         ec_pipeline_url: str = '',
-        released_pipeline: str = '',
+        release_pipeline: str = '',
         released_pullspec: str = '',
     ):
         super().__init__(
@@ -336,7 +336,7 @@ class KonfluxBuildRecord(KonfluxRecord):
             else KonfluxECStatus(ec_status or KonfluxECStatus.NOT_APPLICABLE.value)
         )
         self.ec_pipeline_url = ec_pipeline_url
-        self.released_pipeline = released_pipeline
+        self.release_pipeline = release_pipeline
         self.released_pullspec = released_pullspec
         self.init_uuids(record_id, build_id, nvr)
 

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -660,7 +660,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             SchemaField('build_priority', 'INTEGER', 'REQUIRED'),
             SchemaField('ec_status', 'STRING', 'REQUIRED'),
             SchemaField('ec_pipeline_url', 'STRING', 'REQUIRED'),
-            SchemaField('released_pipeline', 'STRING', 'REQUIRED'),
+            SchemaField('release_pipeline', 'STRING', 'REQUIRED'),
             SchemaField('released_pullspec', 'STRING', 'REQUIRED'),
         ]
         self.db.bind(KonfluxBuildRecord)

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -660,6 +660,8 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             SchemaField('build_priority', 'INTEGER', 'REQUIRED'),
             SchemaField('ec_status', 'STRING', 'REQUIRED'),
             SchemaField('ec_pipeline_url', 'STRING', 'REQUIRED'),
+            SchemaField('released_pipeline', 'STRING', 'REQUIRED'),
+            SchemaField('released_pullspec', 'STRING', 'REQUIRED'),
         ]
         self.db.bind(KonfluxBuildRecord)
         self.assertEqual(self.db.generate_build_schema(), expected_fields)

--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -35,6 +35,17 @@ class BaseImageSnapshotInput:
     is_golang_builder: bool = False
 
 
+@dataclass(frozen=True)
+class BaseImageReleaseResult:
+    """Outputs from :meth:`BaseImageHandler.snapshot_release` after the Release succeeds."""
+
+    release_name: str
+    snapshot_name: str
+    nvr: str
+    released_pipeline: str
+    released_pullspec: str
+
+
 class BaseImageHandler:
     """
     Create a Konflux Snapshot for the product's base-image Application with **one** component, then a Release using
@@ -44,7 +55,6 @@ class BaseImageHandler:
     def __init__(self, runtime, dry_run: bool = False):
         self.runtime = runtime
         self.dry_run = dry_run
-        # Prefix until snapshot_release scopes `[entity]` to the image (same pattern as ImageMetadata).
         self.logger = logutil.EntityLoggingAdapter(self.runtime.logger, extra={'entity': 'base-image'})
 
         self.namespace = resolve_konflux_namespace_by_product(self.runtime.product, None)
@@ -68,14 +78,13 @@ class BaseImageHandler:
     def _scoped_logger(self, entity: str):
         return logutil.EntityLoggingAdapter(self.runtime.logger, extra={'entity': entity})
 
-    async def snapshot_release(self, snapshot_input: BaseImageSnapshotInput) -> Optional[Tuple[str, str]]:
+    async def snapshot_release(self, snapshot_input: BaseImageSnapshotInput) -> Optional[BaseImageReleaseResult]:
         """
         Run snapshot→release for exactly one base-image component.
 
         Returns:
-            ``(release_name, snapshot_name)`` on success, else ``None``.
+            :class:`BaseImageReleaseResult` on success, else ``None``.
         """
-        # Provisional entity (matches qualified_key for typical OCP images) until image_map lookup succeeds.
         self.logger = self._scoped_logger(f"containers/{snapshot_input.distgit_key}")
 
         if not snapshot_input.container_image:
@@ -106,20 +115,30 @@ class BaseImageHandler:
             self.logger.error("Failed to create snapshot")
             return None
 
-        release_name = await self._create_release_from_snapshot(snapshot_name, snapshot_input)
-        if not release_name:
+        result = await self._create_release_from_snapshot(snapshot_name, snapshot_input)
+        if not result:
             self.logger.error(f"Failed to create release (snapshot={snapshot_name})")
             return None
+
+        release_name, release_url = result
 
         if not await self._wait_for_release_completion(release_name):
             self.logger.error(f"Release did not complete successfully (release={release_name})")
             return None
 
+        released_pullspec = doozer_util.rh_art_images_base_pullspec(snapshot_input.nvr)
+
         self.logger.info(
             f"Snapshot-release completed (nvr={snapshot_input.nvr}, snapshot={snapshot_name}, release={release_name})"
         )
 
-        return release_name, snapshot_name
+        return BaseImageReleaseResult(
+            release_name=release_name,
+            snapshot_name=snapshot_name,
+            nvr=snapshot_input.nvr,
+            released_pipeline=release_url,
+            released_pullspec=released_pullspec,
+        )
 
     def _build_component_from_snapshot_input(self, snapshot_input: BaseImageSnapshotInput) -> dict:
         """One Konflux snapshot component dict from :class:`BaseImageSnapshotInput`."""
@@ -200,13 +219,16 @@ class BaseImageHandler:
 
     async def _create_release_from_snapshot(
         self, snapshot_name: str, snapshot_input: BaseImageSnapshotInput
-    ) -> Optional[str]:
+    ) -> Optional[Tuple[str, str]]:
         """
         Create Konflux Release from snapshot using the product's silent base-image ReleasePlan.
 
         Args:
             snapshot_name: Snapshot resource name.
             snapshot_input: Base-image component input (NVR and distgit key stored on Release annotations).
+
+        Returns:
+            ``(release_name, release_console_url)`` or ``None`` on failure.
         """
         try:
             if not self.dry_run:
@@ -259,14 +281,14 @@ class BaseImageHandler:
                     f"[DRY-RUN] Would create release for snapshot={snapshot_name} plan={self.base_image_release_plan}"
                 )
                 self.logger.debug(f"[DRY-RUN] Release object: {release_obj}")
-                return f"dry-run-release-{snapshot_name}"
+                return f"dry-run-release-{snapshot_name}", "https://dry-run.invalid"
 
             created_release = await self.konflux_client._create(release_obj)
             release_name = created_release.metadata.name
             release_url = self.konflux_client.resource_url(created_release)
 
             self.logger.info(f"Created release {release_name} for snapshot {snapshot_name} ({release_url})")
-            return release_name
+            return release_name, release_url
 
         except Exception as e:
             self.logger.error(f"Failed to create release from snapshot {snapshot_name} ({type(e).__name__}: {e})")

--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -42,7 +42,7 @@ class BaseImageReleaseResult:
     release_name: str
     snapshot_name: str
     nvr: str
-    released_pipeline: str
+    release_pipeline: str
     released_pullspec: str
 
 
@@ -136,7 +136,7 @@ class BaseImageHandler:
             release_name=release_name,
             snapshot_name=snapshot_name,
             nvr=snapshot_input.nvr,
-            released_pipeline=release_url,
+            release_pipeline=release_url,
             released_pullspec=released_pullspec,
         )
 

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -30,7 +30,7 @@ from artcommonlib.rpm_utils import compare_nvr, parse_nvr
 from artcommonlib.util import fetch_slsa_attestation, get_konflux_data
 from dockerfile_parse import DockerfileParser
 from doozerlib import constants, util
-from doozerlib.backend.base_image_handler import BaseImageHandler, BaseImageSnapshotInput
+from doozerlib.backend.base_image_handler import BaseImageHandler, BaseImageReleaseResult, BaseImageSnapshotInput
 from doozerlib.backend.build_repo import BuildRepo
 from doozerlib.backend.konflux_client import ImageBuildParams, KonfluxClient
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
@@ -373,19 +373,17 @@ class KonfluxImageBuilder:
                 else:
                     # One completion record per attempt. Base images trigger snapshot→release (digest pullspec)
                     # before persisting SUCCESS or FAILURE so Jenkins/batch workflows can query SUCCESS rows.
+                    release_result: Optional[BaseImageReleaseResult] = None
                     if outcome is KonfluxBuildOutcome.SUCCESS and metadata.should_trigger_base_image_release():
-                        base_image_release_success = await self._trigger_base_image_release(
+                        release_result = await self._trigger_base_image_release(
                             metadata, nvr, definitive_image_pullspec, build_repo
                         )
-                        if base_image_release_success:
+                        if release_result:
                             logger.info("Base image release succeeded for %s, persisting build record", nvr)
                         else:
                             logger.error("Base image release failed for %s, persisting build record as FAILURE", nvr)
                             record["base_image_release_failed"] = "true"
-                        released_outcome = (
-                            KonfluxBuildOutcome.SUCCESS if base_image_release_success else KonfluxBuildOutcome.FAILURE
-                        )
-                        outcome = released_outcome
+                        outcome = KonfluxBuildOutcome.SUCCESS if release_result else KonfluxBuildOutcome.FAILURE
 
                     build_record = await self.update_konflux_db(
                         metadata,
@@ -396,6 +394,8 @@ class KonfluxImageBuilder:
                         build_priority,
                         ec_status=ec_status,
                         ec_pipeline_url=ec_pipeline_url,
+                        released_pipeline=release_result.released_pipeline if release_result else '',
+                        released_pullspec=release_result.released_pullspec if release_result else '',
                     )
                     if build_record:
                         record["record_id"] = build_record.record_id
@@ -893,6 +893,8 @@ class KonfluxImageBuilder:
         build_priority,
         ec_status=KonfluxECStatus.NOT_APPLICABLE,
         ec_pipeline_url='',
+        released_pipeline='',
+        released_pullspec='',
     ) -> Optional[KonfluxBuildRecord]:
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
         if not metadata.runtime.konflux_db:
@@ -959,6 +961,8 @@ class KonfluxImageBuilder:
             'build_priority': int(build_priority),
             'ec_status': ec_status,
             'ec_pipeline_url': ec_pipeline_url,
+            'released_pipeline': released_pipeline,
+            'released_pullspec': released_pullspec,
         }
 
         if outcome is KonfluxBuildOutcome.SUCCESS:
@@ -1220,7 +1224,7 @@ class KonfluxImageBuilder:
         nvr: str,
         container_image: str,
         build_repo: BuildRepo,
-    ) -> bool:
+    ) -> Optional[BaseImageReleaseResult]:
         """Run snapshot→release for one base image via :class:`BaseImageHandler` (no Jenkins job).
 
         Args:
@@ -1230,7 +1234,7 @@ class KonfluxImageBuilder:
             build_repo: Build repo (rebase git URL and commit for snapshot source)
 
         Returns:
-            bool: True if base image release completed successfully
+            :class:`BaseImageReleaseResult` when snapshot→release completes; ``None`` on failure or exception.
         """
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
 
@@ -1250,13 +1254,12 @@ class KonfluxImageBuilder:
                 dry_run=self._config.dry_run,
             )
             result = await handler.snapshot_release(snapshot_input)
-            success = result is not None
-            if success:
-                logger.info(f"Successfully triggered base image snapshot-release for {nvr}")
-                return True
-            logger.error("Base image snapshot-release did not complete successfully for %s", nvr)
-            return False
+            if result is None:
+                logger.error("Base image snapshot-release did not complete successfully for %s", nvr)
+                return None
+            logger.info(f"Successfully triggered base image snapshot-release for {nvr}")
+            return result
 
         except Exception as e:
             logger.error(f"Failed base image snapshot-release for {nvr}: {e}")
-            return False
+            return None

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -394,7 +394,7 @@ class KonfluxImageBuilder:
                         build_priority,
                         ec_status=ec_status,
                         ec_pipeline_url=ec_pipeline_url,
-                        released_pipeline=release_result.released_pipeline if release_result else '',
+                        release_pipeline=release_result.release_pipeline if release_result else '',
                         released_pullspec=release_result.released_pullspec if release_result else '',
                     )
                     if build_record:
@@ -893,7 +893,7 @@ class KonfluxImageBuilder:
         build_priority,
         ec_status=KonfluxECStatus.NOT_APPLICABLE,
         ec_pipeline_url='',
-        released_pipeline='',
+        release_pipeline='',
         released_pullspec='',
     ) -> Optional[KonfluxBuildRecord]:
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
@@ -961,7 +961,7 @@ class KonfluxImageBuilder:
             'build_priority': int(build_priority),
             'ec_status': ec_status,
             'ec_pipeline_url': ec_pipeline_url,
-            'released_pipeline': released_pipeline,
+            'release_pipeline': release_pipeline,
             'released_pullspec': released_pullspec,
         }
 

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -551,20 +551,24 @@ class KonfluxRebaser:
                 if not build:
                     raise IOError(f"A build of parent image {member} is not found.")
                 if parent_metadata.should_trigger_base_image_release():
+                    released_pullspec = (build.released_pullspec or "").strip()
+                    if released_pullspec:
+                        return released_pullspec, build.embargoed
+                    self._logger.warning(
+                        "Late-resolved parent %s: Konflux latest build has empty released_pullspec (nvr=%s); "
+                        "trying art-images-base URL",
+                        member,
+                        build.nvr,
+                    )
                     rh_pullspec = util.rh_art_images_base_pullspec(build.nvr)
                     if await self._registry_pullspec_exists(rh_pullspec):
                         return rh_pullspec, build.embargoed
-                    if parent_metadata.is_base_image_release_quay_fallback_enabled():
-                        self._logger.info(
-                            "art-images-base %s not reachable; using Konflux image_pullspec for late-resolved parent %s",
-                            rh_pullspec,
-                            member,
-                        )
-                        return build.image_pullspec, build.embargoed
-                    raise IOError(
-                        f"art-images-base pullspec not reachable for late-resolved parent {member} ({rh_pullspec!r}); "
-                        "base_image_release.quay_fallback is false"
+                    self._logger.warning(
+                        "Late-resolved parent %s: art-images-base unreachable (%s); using Konflux image_pullspec",
+                        member,
+                        rh_pullspec,
                     )
+                    return build.image_pullspec, build.embargoed
                 return build.image_pullspec, build.embargoed
 
             return original_parent, False

--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -1,3 +1,4 @@
+import copy
 import io
 import json
 import pathlib
@@ -38,42 +39,6 @@ from doozerlib.exceptions import DoozerFatalError
 from doozerlib.source_resolver import SourceResolver
 
 LOGGER = logutil.get_logger(__name__)
-
-
-async def _snapshot_input_from_konflux_success_build(runtime, nvr: str) -> Optional[BaseImageSnapshotInput]:
-    """Map a Konflux **SUCCESS** image row to :class:`BaseImageSnapshotInput`, or ``None`` if missing or unusable."""
-    nvr = (nvr or "").strip()
-    if not nvr:
-        return None
-
-    db = getattr(runtime, "konflux_db", None)
-    if not db:
-        return None
-
-    rec = await db.get_build_record_by_nvr(
-        nvr=nvr,
-        outcome=KonfluxBuildOutcome.SUCCESS,
-        strict=False,
-        exclude_large_columns=True,
-    )
-    if not rec or not rec.name or not rec.image_pullspec:
-        return None
-
-    image_metadata = runtime.image_map.get(rec.name)
-    if image_metadata is not None:
-        is_golang_builder = image_metadata.is_golang_builder()
-    else:
-        # NVR uses distgit-style openshift-golang-builder; keep substring check for older rows / missing image_map
-        is_golang_builder = GOLANG_BUILDER_IMAGE_NAME in nvr
-
-    return BaseImageSnapshotInput(
-        nvr=nvr,
-        distgit_key=rec.name,
-        container_image=rec.image_pullspec,
-        rebase_repo_url=rec.rebase_repo_url or "",
-        rebase_commitish=rec.rebase_commitish or "",
-        is_golang_builder=is_golang_builder,
-    )
 
 
 @cli.command("images:clone", help="Clone a group's image distgit repos locally.")
@@ -1511,7 +1476,10 @@ def query_rpm_version(runtime, repo_type):
 @click_coroutine
 @pass_runtime
 async def release_to_base_repo(runtime, nvr):
-    """Run Konflux snapshot→release for one NVR (row must exist and be SUCCESS for this group)."""
+    """Latest SUCCESS Konflux image row → snapshot/release, then INSERT follow-up with ``released_pipeline`` / ``released_pullspec``.
+
+    Golang builder is inferred from image metadata when present; otherwise from the openshift-golang-builder name in the NVR.
+    """
     logger = logutil.get_logger(__name__)
 
     runtime.initialize(mode='images', build_system='konflux', clone_distgits=False, prevent_cloning=True)
@@ -1522,16 +1490,42 @@ async def release_to_base_repo(runtime, nvr):
     if not image_nvr:
         raise DoozerFatalError("NVR is empty")
 
-    snapshot_input = await _snapshot_input_from_konflux_success_build(runtime, image_nvr)
-    if snapshot_input is None:
+    source_row = await runtime.konflux_db.get_build_record_by_nvr(
+        image_nvr,
+        outcome=KonfluxBuildOutcome.SUCCESS,
+        strict=False,
+        exclude_large_columns=False,
+    )
+    if not source_row:
         raise DoozerFatalError(f"No SUCCESS Konflux image row for {image_nvr}")
+
+    metadata = runtime.image_map.get(source_row.name)
+    is_golang_builder = metadata.is_golang_builder() if metadata else GOLANG_BUILDER_IMAGE_NAME in image_nvr
+
+    snapshot_input = BaseImageSnapshotInput(
+        nvr=image_nvr,
+        distgit_key=source_row.name,
+        container_image=source_row.image_pullspec,
+        rebase_repo_url=source_row.rebase_repo_url or "",
+        rebase_commitish=source_row.rebase_commitish or "",
+        is_golang_builder=is_golang_builder,
+    )
 
     handler = BaseImageHandler(runtime, dry_run=False)
     result = await handler.snapshot_release(snapshot_input)
 
     if result:
-        release_name, snapshot_name = result
-        logger.info("Done: release=%s snapshot=%s", release_name, snapshot_name)
+        logger.info(
+            "Done: release=%s snapshot=%s released_pipeline=%s",
+            result.release_name,
+            result.snapshot_name,
+            result.released_pipeline,
+        )
+        followup = copy.deepcopy(source_row)
+        followup.released_pipeline = result.released_pipeline
+        followup.released_pullspec = result.released_pullspec
+        followup.record_id = KonfluxBuildRecord.generate_record_id()
+        await runtime.konflux_db.add_builds([followup])
         return
 
     raise DoozerFatalError("snapshot_release returned no result")

--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -1476,7 +1476,7 @@ def query_rpm_version(runtime, repo_type):
 @click_coroutine
 @pass_runtime
 async def release_to_base_repo(runtime, nvr):
-    """Latest SUCCESS Konflux image row → snapshot/release, then INSERT follow-up with ``released_pipeline`` / ``released_pullspec``.
+    """Latest SUCCESS Konflux image row → snapshot/release, then INSERT follow-up with ``release_pipeline`` / ``released_pullspec``.
 
     Golang builder is inferred from image metadata when present; otherwise from the openshift-golang-builder name in the NVR.
     """
@@ -1516,13 +1516,13 @@ async def release_to_base_repo(runtime, nvr):
 
     if result:
         logger.info(
-            "Done: release=%s snapshot=%s released_pipeline=%s",
+            "Done: release=%s snapshot=%s release_pipeline=%s",
             result.release_name,
             result.snapshot_name,
-            result.released_pipeline,
+            result.release_pipeline,
         )
         followup = copy.deepcopy(source_row)
-        followup.released_pipeline = result.released_pipeline
+        followup.release_pipeline = result.release_pipeline
         followup.released_pullspec = result.released_pullspec
         followup.record_id = KonfluxBuildRecord.generate_record_id()
         await runtime.konflux_db.add_builds([followup])

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -3,8 +3,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from artcommonlib.model import Model
 from artcommonlib.variants import BuildVariant
-from doozerlib.backend.base_image_handler import BaseImageHandler, BaseImageSnapshotInput
+from doozerlib.backend.base_image_handler import BaseImageHandler, BaseImageReleaseResult, BaseImageSnapshotInput
 from doozerlib.image import ImageMetadata
+from doozerlib.util import rh_art_images_base_pullspec
 
 
 class TestBaseImageHandler(IsolatedAsyncioTestCase):
@@ -52,12 +53,20 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         self.runtime.image_map = {"test-base": self.metadata}
 
         with patch.object(handler, "_snapshot_from_component", new=AsyncMock(return_value="test-snapshot")):
-            with patch.object(handler, "_create_release_from_snapshot", new=AsyncMock(return_value="test-release")):
+            with patch.object(
+                handler,
+                "_create_release_from_snapshot",
+                new=AsyncMock(return_value=("test-release", "https://konflux.example/releases/test-release")),
+            ):
                 with patch.object(handler, "_wait_for_release_completion", return_value=True):
                     result = await handler.snapshot_release(self.default_input)
 
         self.assertIsNotNone(result)
-        self.assertEqual(result, ("test-release", "test-snapshot"))
+        self.assertIsInstance(result, BaseImageReleaseResult)
+        self.assertEqual(result.release_name, "test-release")
+        self.assertEqual(result.snapshot_name, "test-snapshot")
+        self.assertEqual(result.released_pipeline, "https://konflux.example/releases/test-release")
+        self.assertEqual(result.released_pullspec, rh_art_images_base_pullspec(self.default_input.nvr))
 
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
@@ -73,7 +82,11 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         self.runtime.image_map = {"test-base": self.metadata}
 
         with patch.object(handler, "_snapshot_from_component", new=AsyncMock(return_value="snap")) as mock_snap:
-            with patch.object(handler, "_create_release_from_snapshot", new=AsyncMock(return_value="rel")):
+            with patch.object(
+                handler,
+                "_create_release_from_snapshot",
+                new=AsyncMock(return_value=("rel", "https://example.com/releases/rel")),
+            ):
                 with patch.object(handler, "_wait_for_release_completion", return_value=True):
                     await handler.snapshot_release(self.default_input)
 
@@ -156,12 +169,20 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         self.runtime.image_map = {"golang-builder": golang_metadata}
 
         with patch.object(handler, "_snapshot_from_component", new=AsyncMock(return_value="golang-snapshot")):
-            with patch.object(handler, "_create_release_from_snapshot", new=AsyncMock(return_value="golang-release")):
+            with patch.object(
+                handler,
+                "_create_release_from_snapshot",
+                new=AsyncMock(return_value=("golang-release", "https://konflux.example/releases/golang-release")),
+            ):
                 with patch.object(handler, "_wait_for_release_completion", return_value=True):
                     result = await handler.snapshot_release(inp)
 
         self.assertIsNotNone(result)
-        self.assertEqual(result, ("golang-release", "golang-snapshot"))
+        self.assertIsInstance(result, BaseImageReleaseResult)
+        self.assertEqual(result.release_name, "golang-release")
+        self.assertEqual(result.snapshot_name, "golang-snapshot")
+        self.assertEqual(result.released_pipeline, "https://konflux.example/releases/golang-release")
+        self.assertEqual(result.released_pullspec, rh_art_images_base_pullspec(golang_nvr))
 
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
@@ -182,8 +203,9 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         handler = BaseImageHandler(self.runtime, dry_run=False)
 
         with patch.object(handler, "_wait_for_snapshot_availability", new=AsyncMock(return_value=True)):
-            await handler._create_release_from_snapshot("test-snapshot", self.default_input)
+            name_url = await handler._create_release_from_snapshot("test-snapshot", self.default_input)
 
+        self.assertEqual(name_url, ("test-release", "https://konflux.example/releases/test-release"))
         konflux_client._get.assert_awaited_once()
         konflux_client._create.assert_awaited_once()
         release_obj = konflux_client._create.await_args.args[0]

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -65,7 +65,7 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         self.assertIsInstance(result, BaseImageReleaseResult)
         self.assertEqual(result.release_name, "test-release")
         self.assertEqual(result.snapshot_name, "test-snapshot")
-        self.assertEqual(result.released_pipeline, "https://konflux.example/releases/test-release")
+        self.assertEqual(result.release_pipeline, "https://konflux.example/releases/test-release")
         self.assertEqual(result.released_pullspec, rh_art_images_base_pullspec(self.default_input.nvr))
 
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
@@ -181,7 +181,7 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         self.assertIsInstance(result, BaseImageReleaseResult)
         self.assertEqual(result.release_name, "golang-release")
         self.assertEqual(result.snapshot_name, "golang-snapshot")
-        self.assertEqual(result.released_pipeline, "https://konflux.example/releases/golang-release")
+        self.assertEqual(result.release_pipeline, "https://konflux.example/releases/golang-release")
         self.assertEqual(result.released_pullspec, rh_art_images_base_pullspec(golang_nvr))
 
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -435,7 +435,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(persisted.image_pullspec, expected_pullspec)
 
     async def test_update_konflux_db_persists_released_fields_when_passed(self):
-        """released_pipeline and released_pullspec are forwarded to KonfluxBuildRecord."""
+        """release_pipeline and released_pullspec are forwarded to KonfluxBuildRecord."""
         metadata = self._metadata()
         build_repo = MagicMock()
         build_repo.https_url = "https://example.com/repo.git"
@@ -490,14 +490,14 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 KonfluxBuildOutcome.SUCCESS,
                 ["x86_64"],
                 "5",
-                released_pipeline="https://release.example/pipeline",
+                release_pipeline="https://release.example/pipeline",
                 released_pullspec="registry.redhat.io/foo:bar",
             )
 
         mock_add_build = metadata.runtime.konflux_db.add_build
         mock_add_build.assert_called_once()
         persisted = mock_add_build.call_args[0][0]
-        self.assertEqual(persisted.released_pipeline, "https://release.example/pipeline")
+        self.assertEqual(persisted.release_pipeline, "https://release.example/pipeline")
         self.assertEqual(persisted.released_pullspec, "registry.redhat.io/foo:bar")
 
     async def test_trigger_base_image_release_success_flow(self):
@@ -559,7 +559,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 release_name="r",
                 snapshot_name="s",
                 nvr="test-nvr",
-                released_pipeline="https://example.com/rel",
+                release_pipeline="https://example.com/rel",
                 released_pullspec="registry.example/pull:test",
             )
             await self.builder.build(metadata)
@@ -571,7 +571,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         success_call_args = mock_update_db.await_args_list[1][0]
         self.assertEqual(success_call_args[3], KonfluxBuildOutcome.SUCCESS)
         success_call_kwargs = mock_update_db.await_args_list[1].kwargs
-        self.assertEqual(success_call_kwargs.get("released_pipeline"), "https://example.com/rel")
+        self.assertEqual(success_call_kwargs.get("release_pipeline"), "https://example.com/rel")
         self.assertEqual(success_call_kwargs.get("released_pullspec"), "registry.example/pull:test")
 
     async def test_trigger_base_image_release_failure_flow(self):
@@ -639,7 +639,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         failure_call_args = mock_update_db.await_args_list[1][0]
         self.assertEqual(failure_call_args[3], KonfluxBuildOutcome.FAILURE)
         failure_kw = mock_update_db.await_args_list[1].kwargs
-        self.assertEqual(failure_kw.get("released_pipeline", ""), "")
+        self.assertEqual(failure_kw.get("release_pipeline", ""), "")
         self.assertEqual(failure_kw.get("released_pullspec", ""), "")
 
     async def test_non_base_image_skips_release_trigger(self):
@@ -717,7 +717,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
             release_name="test-release",
             snapshot_name="test-snapshot",
             nvr="test-nvr",
-            released_pipeline="https://example.com/pipeline",
+            release_pipeline="https://example.com/pipeline",
             released_pullspec="example.com/openshift/foo:test-nvr",
         )
 
@@ -751,7 +751,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
             release_name="test-release",
             snapshot_name="test-snapshot",
             nvr="test-nvr",
-            released_pipeline="https://example.com/pipeline",
+            release_pipeline="https://example.com/pipeline",
             released_pullspec="example.com/openshift/foo:test-nvr",
         )
 

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -434,6 +434,72 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         persisted = mock_add_build.call_args[0][0]
         self.assertEqual(persisted.image_pullspec, expected_pullspec)
 
+    async def test_update_konflux_db_persists_released_fields_when_passed(self):
+        """released_pipeline and released_pullspec are forwarded to KonfluxBuildRecord."""
+        metadata = self._metadata()
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "test-commit-hash"
+        build_repo.local_dir = Path(self.temp_dir.name)
+
+        pipelinerun = PipelineRunInfo(
+            {
+                "metadata": {
+                    "name": "test-pipelinerun",
+                    "uid": "test-uid",
+                    "labels": {"appstudio.openshift.io/component": "test-component"},
+                },
+                "status": {
+                    "results": [
+                        {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                        {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                    ],
+                    "startTime": "2023-10-01T12:00:00Z",
+                    "completionTime": "2023-10-01T12:30:00Z",
+                },
+            },
+            {},
+        )
+
+        with (
+            patch("doozerlib.backend.konflux_image_builder.DockerfileParser") as mock_dockerfile_parser,
+            patch.object(self.builder, "extract_parent_image_nvrs", new=AsyncMock(return_value=[])),
+            patch.object(
+                self.builder,
+                "get_installed_packages",
+                new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
+            ),
+            patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
+        ):
+            mock_dockerfile = MagicMock()
+            mock_dockerfile.labels = {
+                "io.openshift.build.source-location": "https://example.com/source-repo.git",
+                "io.openshift.build.commit.id": "source-commit-id",
+                "com.redhat.component": "test-component",
+                "version": "1.0",
+                "release": "1.el9",
+            }
+            mock_dockerfile.parent_images = []
+            mock_dockerfile_parser.return_value = mock_dockerfile
+            mock_bigquery_client.return_value.client.insert_rows_json.return_value = None
+
+            await self.builder.update_konflux_db(
+                metadata,
+                build_repo,
+                pipelinerun,
+                KonfluxBuildOutcome.SUCCESS,
+                ["x86_64"],
+                "5",
+                released_pipeline="https://release.example/pipeline",
+                released_pullspec="registry.redhat.io/foo:bar",
+            )
+
+        mock_add_build = metadata.runtime.konflux_db.add_build
+        mock_add_build.assert_called_once()
+        persisted = mock_add_build.call_args[0][0]
+        self.assertEqual(persisted.released_pipeline, "https://release.example/pipeline")
+        self.assertEqual(persisted.released_pullspec, "registry.redhat.io/foo:bar")
+
     async def test_trigger_base_image_release_success_flow(self):
         """SUCCESS after base snapshot release refreshes Konflux DB without swapping image_pullspec to RH."""
         metadata = self._metadata()
@@ -475,9 +541,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
             patch.object(
                 self.builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))
             ) as mock_update_db,
-            patch.object(
-                self.builder, "_trigger_base_image_release", new=AsyncMock(return_value=True)
-            ) as mock_trigger_release,
+            patch.object(self.builder, "_trigger_base_image_release", new_callable=AsyncMock) as mock_trigger_release,
             patch.object(self.builder, "_validate_build_attestation_and_signature", new=AsyncMock()),
             patch.object(
                 self.builder._konflux_client,
@@ -489,6 +553,15 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 return_value=KonfluxBuildOutcome.SUCCESS,
             ),
         ):
+            from doozerlib.backend import base_image_handler
+
+            mock_trigger_release.return_value = base_image_handler.BaseImageReleaseResult(
+                release_name="r",
+                snapshot_name="s",
+                nvr="test-nvr",
+                released_pipeline="https://example.com/rel",
+                released_pullspec="registry.example/pull:test",
+            )
             await self.builder.build(metadata)
 
         mock_trigger_release.assert_awaited_once()
@@ -497,6 +570,9 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(mock_update_db.await_count, 2)
         success_call_args = mock_update_db.await_args_list[1][0]
         self.assertEqual(success_call_args[3], KonfluxBuildOutcome.SUCCESS)
+        success_call_kwargs = mock_update_db.await_args_list[1].kwargs
+        self.assertEqual(success_call_kwargs.get("released_pipeline"), "https://example.com/rel")
+        self.assertEqual(success_call_kwargs.get("released_pullspec"), "registry.example/pull:test")
 
     async def test_trigger_base_image_release_failure_flow(self):
         """Test base image release failure handling with FAILURE outcome update."""
@@ -540,7 +616,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 self.builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))
             ) as mock_update_db,
             patch.object(
-                self.builder, "_trigger_base_image_release", new=AsyncMock(return_value=False)
+                self.builder, "_trigger_base_image_release", new=AsyncMock(return_value=None)
             ) as mock_trigger_release,
             patch.object(self.builder, "_validate_build_attestation_and_signature", new=AsyncMock()),
             patch.object(
@@ -559,9 +635,12 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         mock_trigger_release.assert_awaited_once()
         self.assertEqual(mock_update_db.await_count, 2)
 
-        # Final update records FAILURE outcome
+        # Final update records FAILURE outcome; released_* omitted when base release failed
         failure_call_args = mock_update_db.await_args_list[1][0]
         self.assertEqual(failure_call_args[3], KonfluxBuildOutcome.FAILURE)
+        failure_kw = mock_update_db.await_args_list[1].kwargs
+        self.assertEqual(failure_kw.get("released_pipeline", ""), "")
+        self.assertEqual(failure_kw.get("released_pullspec", ""), "")
 
     async def test_non_base_image_skips_release_trigger(self):
         """Test that non-base images skip the release trigger logic entirely."""
@@ -634,14 +713,22 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         build_repo.commit_hash = "abc123"
         pullspec = "quay.io/test/img@sha256:deadbeef"
 
+        release_result = base_image_handler.BaseImageReleaseResult(
+            release_name="test-release",
+            snapshot_name="test-snapshot",
+            nvr="test-nvr",
+            released_pipeline="https://example.com/pipeline",
+            released_pullspec="example.com/openshift/foo:test-nvr",
+        )
+
         with patch.object(
             base_image_handler.BaseImageHandler,
             "snapshot_release",
-            new=AsyncMock(return_value=("test-release", "test-snapshot")),
+            new=AsyncMock(return_value=release_result),
         ) as mock_snap:
             result = await self.builder._trigger_base_image_release(metadata, "test-nvr", pullspec, build_repo)
 
-        self.assertTrue(result)
+        self.assertIs(result, release_result)
         mock_snap.assert_awaited_once()
         inp = mock_snap.await_args[0][0]
         self.assertEqual(inp.nvr, "test-nvr")
@@ -660,20 +747,28 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         build_repo.commit_hash = "abc123"
         pullspec = "quay.io/test/img@sha256:deadbeef"
 
+        release_result = base_image_handler.BaseImageReleaseResult(
+            release_name="test-release",
+            snapshot_name="test-snapshot",
+            nvr="test-nvr",
+            released_pipeline="https://example.com/pipeline",
+            released_pullspec="example.com/openshift/foo:test-nvr",
+        )
+
         with patch.object(
             base_image_handler.BaseImageHandler,
             "snapshot_release",
-            new=AsyncMock(return_value=("test-release", "test-snapshot")),
+            new=AsyncMock(return_value=release_result),
         ) as mock_snap:
             result = await self.builder._trigger_base_image_release(metadata, "test-nvr", pullspec, build_repo)
 
-        self.assertTrue(result)
+        self.assertIs(result, release_result)
         metadata.is_golang_builder.assert_called_once()
         inp = mock_snap.await_args[0][0]
         self.assertTrue(inp.is_golang_builder)
 
-    async def test_trigger_base_image_release_returns_false_when_handler_returns_none(self):
-        """When handler returns None, _trigger_base_image_release is False."""
+    async def test_trigger_base_image_release_returns_none_when_handler_returns_none(self):
+        """When handler returns None, _trigger_base_image_release returns None."""
         from doozerlib.backend import base_image_handler
 
         metadata = self._metadata()
@@ -690,7 +785,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 metadata, "test-nvr", "quay.io/x@sha256:y", build_repo
             )
 
-        self.assertFalse(result)
+        self.assertIsNone(result)
         mock_snap.assert_awaited_once()
 
 

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -1373,6 +1373,7 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         kb = MagicMock()
         kb.nvr = "openshift-golang-builder-container-v1.21-1.el9"
         kb.image_pullspec = "quay.io/k@sha256:abc"
+        kb.released_pullspec = ""
         kb.embargoed = False
         parent.get_latest_build = AsyncMock(return_value=kb)
 
@@ -1406,6 +1407,7 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         kb = MagicMock()
         kb.nvr = "openshift-golang-builder-container-v1.21-1.el9"
         kb.image_pullspec = "quay.io/k@sha256:beef"
+        kb.released_pullspec = ""
         kb.embargoed = False
         parent.get_latest_build = AsyncMock(return_value=kb)
 
@@ -1427,8 +1429,41 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         self.assertEqual(resolved, "quay.io/k@sha256:beef")
         self.assertFalse(emb)
 
-    async def test_resolve_member_parent_late_resolve_fails_when_art_base_missing_and_quay_fallback_disabled(self):
-        """Late-resolve: no Konflux fallback when base_image_release.quay_fallback is false."""
+    async def test_resolve_member_parent_late_resolve_uses_db_released_pullspec_when_set(self):
+        parent = MagicMock()
+        parent.distgit_key = "golang-builder"
+        parent.should_trigger_base_image_release.return_value = True
+        parent.branch_el_target.return_value = 9
+        kb = MagicMock()
+        kb.nvr = "openshift-golang-builder-container-v1.21-1.el9"
+        kb.image_pullspec = "quay.io/k@sha256:beef"
+        kb.released_pullspec = "registry.redhat.io/openshift/released@sha256:dead"
+        kb.embargoed = True
+        parent.get_latest_build = AsyncMock(return_value=kb)
+
+        runtime = MagicMock()
+        runtime.resolve_image.return_value = None
+        runtime.ignore_missing_base = True
+        runtime.latest_parent_version = True
+        runtime.late_resolve_image = MagicMock(return_value=parent)
+        runtime.group_config = Model({"konflux": Model({})})
+
+        rebaser = KonfluxRebaser(runtime, self.base_dir, MagicMock(), "unsigned")
+        rebaser.variant = BuildVariant.OCP
+        rebaser.image_repo = "quay.io/fake"
+        rebaser.uuid_tag = "v4.18-tag"
+        rebaser.derived_group = "openshift-4.18"
+        rebaser._registry_pullspec_exists = AsyncMock(
+            side_effect=AssertionError("_registry_pullspec_exists should not be consulted")
+        )
+
+        resolved, emb = await rebaser._resolve_member_parent("golang-builder", "orig")
+        self.assertEqual(resolved, kb.released_pullspec)
+        self.assertTrue(emb)
+
+    async def test_resolve_member_parent_late_resolve_falls_back_when_art_base_missing_even_if_quay_fallback_disabled(
+        self,
+    ):
         parent = MagicMock()
         parent.distgit_key = "golang-builder"
         parent.should_trigger_base_image_release.return_value = True
@@ -1437,6 +1472,7 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         kb = MagicMock()
         kb.nvr = "openshift-golang-builder-container-v1.21-1.el9"
         kb.image_pullspec = "quay.io/k@sha256:beef"
+        kb.released_pullspec = ""
         kb.embargoed = False
         parent.get_latest_build = AsyncMock(return_value=kb)
 
@@ -1451,12 +1487,12 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         rebaser.variant = BuildVariant.OCP
         rebaser.image_repo = "quay.io/fake"
         rebaser.uuid_tag = "v4.18-tag"
-        rebaser.group = "openshift-4.18"
+        rebaser.derived_group = "openshift-4.18"
         rebaser._registry_pullspec_exists = AsyncMock(return_value=False)
 
-        with self.assertRaises(IOError) as ctx:
-            await rebaser._resolve_member_parent("golang-builder", "orig")
-        self.assertIn("quay_fallback is false", str(ctx.exception))
+        resolved, emb = await rebaser._resolve_member_parent("golang-builder", "orig")
+        self.assertEqual(resolved, "quay.io/k@sha256:beef")
+        self.assertFalse(emb)
 
     async def test_resolve_member_parent_keeps_quay_for_regular_member(self):
         parent = MagicMock()

--- a/doozer/tests/cli/test_images.py
+++ b/doozer/tests/cli/test_images.py
@@ -1,18 +1,25 @@
+import asyncio
 import unittest
-from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
-from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
 from artcommonlib.gitdata import DataObj
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
+from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.model import Model
 from artcommonlib.variants import BuildVariant
 from click.testing import CliRunner
 from doozerlib import Runtime
-from doozerlib.cli import images as images_cli
-from doozerlib.cli.images import images_show_ancestors
+from doozerlib.backend.base_image_handler import BaseImageReleaseResult
+from doozerlib.cli.images import images_show_ancestors, release_to_base_repo
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.image import ImageMetadata
+
+
+def _invoke_release_to_base_repo_inner(runtime, nvr: str):
+    """Call the bare async handler (avoid Click/pass_runtime context in unit tests)."""
+    fn = release_to_base_repo.callback
+    while hasattr(fn, '__wrapped__'):
+        fn = fn.__wrapped__
+    return asyncio.run(fn(runtime, nvr))
 
 
 class TestImagesCli(unittest.TestCase):
@@ -111,8 +118,8 @@ class TestImagesCli(unittest.TestCase):
         self.assertIn("Image 'non-existent' not found in group.", str(result.exception))
 
 
-class TestSnapshotInputFromKonfluxSuccessBuild(IsolatedAsyncioTestCase):
-    def _base_runtime_and_md(self):
+class TestReleaseToBaseRepo(unittest.TestCase):
+    def _runtime_with_base_image(self):
         runtime = MagicMock()
         runtime.group = "openshift-4.22"
         runtime.product = "ocp"
@@ -129,89 +136,76 @@ class TestSnapshotInputFromKonfluxSuccessBuild(IsolatedAsyncioTestCase):
         data = Model({"key": "openshift-enterprise-base-rhel9", "data": image_model, "filename": "base.yaml"})
         md = ImageMetadata(runtime, data)
         md.distgit_key = "openshift-enterprise-base-rhel9"
-        return runtime, md
+        runtime.image_map = {md.distgit_key: md}
+        return runtime
 
-    async def test_builds_inputs_from_success_rows(self):
-        runtime, md = self._base_runtime_and_md()
-
-        record = MagicMock()
-        record.nvr = "ose-base-container-v4.22-1.el9"
-        record.name = "openshift-enterprise-base-rhel9"
-        record.image_pullspec = "quay.io/x@sha256:abc"
-        record.rebase_repo_url = "https://git.example/r.git"
-        record.rebase_commitish = "deadbeef"
-
-        runtime.konflux_db = MagicMock()
-        runtime.konflux_db.get_build_record_by_nvr = AsyncMock(return_value=record)
-        runtime.image_map = {record.name: md}
-
-        inp = await images_cli._snapshot_input_from_konflux_success_build(runtime, record.nvr)
-
-        runtime.konflux_db.get_build_record_by_nvr.assert_awaited_once_with(
-            nvr=record.nvr,
+    def test_inserts_followup_row_after_snapshot_release(self):
+        runtime = self._runtime_with_base_image()
+        nvr = "ose-base-container-v4.22-1.el9"
+        source = KonfluxBuildRecord(
+            name="openshift-enterprise-base-rhel9",
+            group=runtime.group,
+            nvr=nvr,
             outcome=KonfluxBuildOutcome.SUCCESS,
-            strict=False,
-            exclude_large_columns=True,
+            engine=Engine.KONFLUX,
+            record_id="prior-id",
+            build_id="shared-bid",
+            image_pullspec="quay.io/base@sha256:abc",
+            rebase_repo_url="https://git.example/r.git",
+            rebase_commitish="deadbeef",
         )
-        self.assertIsNotNone(inp)
-        assert inp is not None
-        self.assertEqual(inp.nvr, record.nvr)
-        self.assertEqual(inp.distgit_key, record.name)
-        self.assertEqual(inp.container_image, record.image_pullspec)
-        self.assertEqual(inp.rebase_repo_url, record.rebase_repo_url)
-        self.assertFalse(inp.is_golang_builder)
 
-    async def test_skips_unknown_nvr(self):
-        runtime, _ = self._base_runtime_and_md()
+        kb = MagicMock()
+        kb.get_build_record_by_nvr = AsyncMock(return_value=source)
+        kb.bind = MagicMock()
 
-        runtime.konflux_db = MagicMock()
-        runtime.konflux_db.get_build_record_by_nvr = AsyncMock(return_value=None)
+        captured = []
 
-        inp = await images_cli._snapshot_input_from_konflux_success_build(runtime, "nosuch-container-v1-1.el9")
-        self.assertIsNone(inp)
+        async def capture_builds(builds):
+            captured.extend(builds)
 
-    async def test_golang_builder_flag_from_metadata(self):
-        runtime = MagicMock()
-        runtime.group = "openshift-4.22"
-        runtime.product = "ocp"
-        runtime.variant = BuildVariant.OCP
-        runtime.assembly = "stream"
+        kb.add_builds = AsyncMock(side_effect=capture_builds)
 
-        image_model = Model(
-            {
-                "name": GOLANG_BUILDER_IMAGE_NAME,
-                "base_image_release": {"enabled": True},
-                "distgit": {"component": "ose-golang-builder-container"},
-            }
+        runtime.konflux_db = kb
+        runtime.initialize = MagicMock()
+
+        release_out = BaseImageReleaseResult(
+            release_name="r1",
+            snapshot_name="s1",
+            nvr=nvr,
+            released_pipeline="https://pipeline",
+            released_pullspec="registry.example/img:tag",
         )
-        data = Model({"key": "openshift-golang-builder", "data": image_model, "filename": "golang.yaml"})
-        md = ImageMetadata(runtime, data)
-        md.distgit_key = "openshift-golang-builder"
 
-        record = MagicMock()
-        record.nvr = "openshift-golang-builder-container-v1-1.el9"
-        record.name = "openshift-golang-builder"
-        record.image_pullspec = "quay.io/golang@sha256:x"
-        record.rebase_repo_url = ""
-        record.rebase_commitish = ""
+        with patch("doozerlib.cli.images.BaseImageHandler") as bh_cls:
 
-        runtime.konflux_db = MagicMock()
-        runtime.konflux_db.get_build_record_by_nvr = AsyncMock(return_value=record)
-        runtime.image_map = {record.name: md}
+            async def snap_release(inp):
+                self.assertFalse(inp.is_golang_builder)
+                self.assertEqual(inp.distgit_key, source.name)
+                self.assertEqual(inp.container_image, source.image_pullspec)
+                self.assertEqual(inp.rebase_repo_url, source.rebase_repo_url)
+                self.assertEqual(inp.rebase_commitish, source.rebase_commitish)
+                return release_out
 
-        inp = await images_cli._snapshot_input_from_konflux_success_build(runtime, record.nvr)
-        self.assertIsNotNone(inp)
-        assert inp is not None
-        self.assertTrue(inp.is_golang_builder)
+            bh_cls.return_value.snapshot_release = snap_release
 
-    async def test_golang_builder_flag_slash_name_in_metadata(self):
-        """config.name openshift/golang-builder must match ImageMetadata.is_golang_builder (ART-18934)."""
+            _invoke_release_to_base_repo_inner(runtime, nvr)
+
+        kb.get_build_record_by_nvr.assert_awaited_once()
+        self.assertEqual(len(captured), 1)
+        followup = captured[0]
+        self.assertEqual(followup.build_id, "shared-bid")
+        self.assertEqual(followup.released_pipeline, release_out.released_pipeline)
+        self.assertEqual(followup.released_pullspec, release_out.released_pullspec)
+        self.assertNotEqual(followup.record_id, "prior-id")
+
+    def test_golang_builder_snapshot_input_openshift_slash_builder_name(self):
+        """Regression: openshift/golang-builder in metadata marks golang (ART-18934)."""
         runtime = MagicMock()
         runtime.group = "rhel-9-golang-1.23"
         runtime.product = "ocp"
         runtime.variant = BuildVariant.OCP
         runtime.assembly = "stream"
-
         image_model = Model(
             {
                 "name": "openshift/golang-builder",
@@ -222,22 +216,45 @@ class TestSnapshotInputFromKonfluxSuccessBuild(IsolatedAsyncioTestCase):
         data = Model({"key": "openshift-golang-builder", "data": image_model, "filename": "golang.yaml"})
         md = ImageMetadata(runtime, data)
         md.distgit_key = "openshift-golang-builder"
+        runtime.image_map = {"openshift-golang-builder": md}
 
-        record = MagicMock()
-        record.nvr = "openshift-golang-builder-container-v1.23.10-1.el9"
-        record.name = "openshift-golang-builder"
-        record.image_pullspec = "quay.io/golang@sha256:x"
-        record.rebase_repo_url = ""
-        record.rebase_commitish = ""
+        nvr = "openshift-golang-builder-container-v1.23.10-1.el9"
+        source = KonfluxBuildRecord(
+            name="openshift-golang-builder",
+            group=runtime.group,
+            nvr=nvr,
+            outcome=KonfluxBuildOutcome.SUCCESS,
+            engine=Engine.KONFLUX,
+            image_pullspec="quay.io/g@sha256:x",
+            rebase_repo_url="",
+            rebase_commitish="",
+        )
+        kb = MagicMock()
+        kb.get_build_record_by_nvr = AsyncMock(return_value=source)
+        kb.bind = MagicMock()
+        kb.add_builds = AsyncMock()
+        runtime.konflux_db = kb
+        runtime.initialize = MagicMock()
 
-        runtime.konflux_db = MagicMock()
-        runtime.konflux_db.get_build_record_by_nvr = AsyncMock(return_value=record)
-        runtime.image_map = {record.name: md}
+        release_out = BaseImageReleaseResult(
+            release_name="r1",
+            snapshot_name="s1",
+            nvr=nvr,
+            released_pipeline="https://p",
+            released_pullspec="registry.io/i:t",
+        )
 
-        inp = await images_cli._snapshot_input_from_konflux_success_build(runtime, record.nvr)
-        self.assertIsNotNone(inp)
-        assert inp is not None
-        self.assertTrue(inp.is_golang_builder)
+        with patch("doozerlib.cli.images.BaseImageHandler") as bh_cls:
+
+            async def snap_release(inp):
+                self.assertTrue(inp.is_golang_builder)
+                return release_out
+
+            bh_cls.return_value.snapshot_release = snap_release
+
+            _invoke_release_to_base_repo_inner(runtime, nvr)
+
+        kb.add_builds.assert_awaited_once()
 
 
 if __name__ == '__main__':

--- a/doozer/tests/cli/test_images.py
+++ b/doozer/tests/cli/test_images.py
@@ -173,7 +173,7 @@ class TestReleaseToBaseRepo(unittest.TestCase):
             release_name="r1",
             snapshot_name="s1",
             nvr=nvr,
-            released_pipeline="https://pipeline",
+            release_pipeline="https://pipeline",
             released_pullspec="registry.example/img:tag",
         )
 
@@ -195,7 +195,7 @@ class TestReleaseToBaseRepo(unittest.TestCase):
         self.assertEqual(len(captured), 1)
         followup = captured[0]
         self.assertEqual(followup.build_id, "shared-bid")
-        self.assertEqual(followup.released_pipeline, release_out.released_pipeline)
+        self.assertEqual(followup.release_pipeline, release_out.release_pipeline)
         self.assertEqual(followup.released_pullspec, release_out.released_pullspec)
         self.assertNotEqual(followup.record_id, "prior-id")
 
@@ -240,7 +240,7 @@ class TestReleaseToBaseRepo(unittest.TestCase):
             release_name="r1",
             snapshot_name="s1",
             nvr=nvr,
-            released_pipeline="https://p",
+            release_pipeline="https://p",
             released_pullspec="registry.io/i:t",
         )
 


### PR DESCRIPTION
## Summary

- Add `released_pipeline` and `released_pullspec` on `KonfluxBuildRecord`, excluded from `build_id` hashing alongside other follow-up metadata.
- Konflux image builder writes a single completion row: after optional snapshot→release it passes those fields into `update_konflux_db` (no separate follow-up insert from the trigger path).
- `BaseImageHandler.snapshot_release` returns structured `BaseImageReleaseResult`; CLI `release_to_base_repo` clones the source row for the follow-up record after snapshot→release.
- Tests updated for schema, builder, handler, and CLI.

Related prior draft (authz/base-image release workflow): #2887 — closing in favor of this PR for the current persistence approach.

## Problem

**Before:** Base-image release follow-up metadata was split across paths (e.g. extra DB writes or reads), and snapshot→release outputs were not modeled clearly for the builder vs CLI.

**After:** One completion record pattern with explicit `released_*` columns, a single structured handler result type, and CLI follow-up built from the NVR row without a second `get_latest_build`.

## Test plan

- [ ] `make lint` / `make unit` (or package-scoped pytest on touched tests)
- [ ] Confirm BigQuery/Konflux schemas that consume `KonfluxBuildRecord` tolerate new required string columns (empty allowed where written today).