### PR TITLE
Fix distgit branch tracking in push_async for new RPM branches

### DIFF
--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -418,7 +418,8 @@ class DistGitRepo(object):
         # timeout value counterproductive. Limit to 5 simultaneous pushes.
         timeout = str(self.runtime.global_opts['rhpkg_push_timeout'])
         await exectools.cmd_assert_async(
-            ["timeout", f"{timeout}", "git", "push", "origin", "HEAD", "--follow-tags"], cwd=self.distgit_dir
+            ["timeout", f"{timeout}", "git", "push", "--set-upstream", "origin", self.branch, "--follow-tags"],
+            cwd=self.distgit_dir,
         )
 
     def get_branch_el(self) -> Optional[int]:


### PR DESCRIPTION
When doozer auto-creates a new distgit branch for RPMs (e.g., when building against a new RHEL version like rhel-10), the push_async() method was not setting up branch tracking. This caused rhpkg build to fail with:

  Branch rhaos-X.Y-rhel-Z does not track remote branch.

The synchronous push() method (used by images) correctly uses --set-upstream, but push_async() (used by RPMs) was missing this flag.

This fix aligns push_async() with push() by:
- Adding --set-upstream flag
- Changing "HEAD" to self.branch for clarity

Root cause identified from build failure:
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift/3923/

The first build (3923) created the new rhaos-5.0-rhel-9 branch and pushed it successfully, but rhpkg build failed due to missing tracking. The second build (3927) succeeded because the branch already existed and was cloned with automatic tracking.
