### PR TITLE
Skip oc-mirror binary sync for OCP 5.0+

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1020,9 +1020,9 @@ class PromotePipeline:
         )
 
         # Starting from 4.14, oc-mirror will be synced for all arches. See ART-6820 and ART-6863
-        # oc-mirror was introduced in 4.10, so skip for <= 4.9.
+        # oc-mirror was introduced in 4.10, so skip for <= 4.9. Not applicable for 5.0+.
         major, minor = isolate_major_minor_in_group(self.group)
-        if (major, minor) >= (4, 14) or ((major, minor) >= (4, 10) and build_arch == 'x86_64'):
+        if major < 5 and ((major, minor) >= (4, 14) or ((major, minor) >= (4, 10) and build_arch == 'x86_64')):
             # oc image  extract requires an empty destination directory. So do this before extracting tools.
             # oc adm release extract --tools does not require an empty directory.
             image_stat, oc_mirror_pullspec = get_release_image_pullspec(


### PR DESCRIPTION
## Summary

- `oc-mirror` is not applicable for OpenShift 5.0+
- The existing version gate used tuple comparison `(major, minor) >= (4, 14)`, which evaluates `True` for `(5, 0)`, causing `oc-mirror` to be incorrectly included in the sync
- Adds a `major < 5` guard to restrict the block to OCP 4.x only, covering any future 5.x versions automatically

## Test plan

- [ ] Existing `pyartcd/tests/pipelines/test_promote.py` — 26/26 pass (no dedicated test for this path; `publish_client` is mocked at a higher level in the test suite)
- [ ] Dry-run the promote pipeline against a 5.0 nightly and confirm the oc-mirror extraction block is skipped in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)