### PR TITLE
ART-19302: feat(images) add base_image_release.force override

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1393,6 +1393,7 @@ class ImageMetadata(Metadata):
         Determines whether this image should trigger the base image release workflow.
 
         The method checks preconditions in the following order:
+        0. Image metadata `base_image_release.force` set to true always enables workflow
         1. Variant must be OCP (not OKD)
         2. Assembly must not be ``test``
         3. Image must be ``base_only`` or a golang builder
@@ -1404,6 +1405,11 @@ class ImageMetadata(Metadata):
         Returns:
             bool: True if base image release workflow should be triggered, False otherwise.
         """
+        base_image_release_force_override = self.config.base_image_release.force
+        if base_image_release_force_override not in [Missing, None] and bool(base_image_release_force_override):
+            self.logger.info("Base image release force enabled from metadata config True")
+            return True
+
         if self.runtime.variant is BuildVariant.OKD:
             return False
 

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1783,6 +1783,20 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         regular_metadata = ImageMetadata(runtime, regular_data)
         self.assertFalse(regular_metadata.should_trigger_base_image_release())
 
+        # Regular image with force=true should trigger regardless of base/golang qualification
+        forced_regular = Model({'name': 'test-regular', 'base_image_release': Model({'force': True})})
+        forced_regular_data = Model(
+            {'key': 'forced-regular', 'data': forced_regular, 'filename': 'forced-regular.yaml'}
+        )
+        forced_regular_metadata = ImageMetadata(runtime, forced_regular_data)
+        self.assertTrue(forced_regular_metadata.should_trigger_base_image_release())
+
+        # Regular image with force=false should keep existing behavior
+        regular_force_off = Model({'name': 'test-regular', 'base_image_release': Model({'force': False})})
+        regular_force_off_data = Model({'key': 'regular-force-off', 'data': regular_force_off, 'filename': 'rfo.yaml'})
+        regular_force_off_metadata = ImageMetadata(runtime, regular_force_off_data)
+        self.assertFalse(regular_force_off_metadata.should_trigger_base_image_release())
+
         # Regular image with base_image_release.enabled: true does not qualify (not base/golang)
         snap_regular = Model({'name': 'test-regular', 'base_image_release': Model({'enabled': True})})
         snap_regular_data = Model({'key': 'test-snap', 'data': snap_regular, 'filename': 'test-snap.yaml'})
@@ -1800,6 +1814,14 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         golang_snap_off_data = Model({'key': 'go-off', 'data': golang_snap_off, 'filename': 'go-off.yaml'})
         golang_snap_off_metadata = ImageMetadata(runtime, golang_snap_off_data)
         self.assertFalse(golang_snap_off_metadata.should_trigger_base_image_release())
+
+        # Force=true overrides enabled=false
+        force_enabled_off = Model(
+            {'name': 'test-regular', 'base_image_release': Model({'enabled': False, 'force': True})}
+        )
+        force_enabled_off_data = Model({'key': 'force-enabled-off', 'data': force_enabled_off, 'filename': 'feo.yaml'})
+        force_enabled_off_metadata = ImageMetadata(runtime, force_enabled_off_data)
+        self.assertTrue(force_enabled_off_metadata.should_trigger_base_image_release())
 
         # Group base_image_release.enabled: false, image omits field (inherits group -> off)
         runtime_group_off = MagicMock()
@@ -1853,6 +1875,26 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
 
         okd_golang_metadata = ImageMetadata(okd_runtime, golang_data)
         self.assertFalse(okd_golang_metadata.should_trigger_base_image_release())
+
+        # Force=true bypasses OKD and test-assembly guards
+        okd_forced = Model({'name': 'test-regular', 'base_image_release': Model({'force': True})})
+        okd_forced_metadata = ImageMetadata(
+            okd_runtime, Model({'key': 'okd-forced', 'data': okd_forced, 'filename': 'okd-forced.yaml'})
+        )
+        self.assertTrue(okd_forced_metadata.should_trigger_base_image_release())
+
+        test_assembly_forced_runtime = MagicMock()
+        test_assembly_forced_runtime.logger = logging.getLogger('test_runtime')
+        test_assembly_forced_runtime.variant = BuildVariant.OCP
+        test_assembly_forced_runtime.assembly = 'test'
+        test_assembly_forced_runtime.product = 'ocp'
+        test_assembly_forced_runtime.group_config = Model({})
+        test_assembly_forced = Model({'name': 'test-regular', 'base_image_release': Model({'force': True})})
+        test_assembly_forced_metadata = ImageMetadata(
+            test_assembly_forced_runtime,
+            Model({'key': 'test-assembly-forced', 'data': test_assembly_forced, 'filename': 'taf.yaml'}),
+        )
+        self.assertTrue(test_assembly_forced_metadata.should_trigger_base_image_release())
 
     def test_base_image_release_quay_fallback_image_overrides_group(self):
         from artcommonlib.model import Model

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -174,9 +174,20 @@
     },
     "base_only-": {},
     "base_image_release": {
-      "description": "Controls Konflux base-image snapshot-to-release and rebaser RH art-images-base behavior for qualifying images. Per-image overrides group.",
+      "description": "Controls Konflux base-image snapshot-to-release and rebaser RH art-images-base behavior for this image. `force: true` bypasses normal qualification checks.",
       "type": "object",
       "properties": {
+        "force": {
+          "description": "When true, always run base-image release workflow for this image regardless of qualification checks.",
+          "type": "boolean"
+        },
+        "force!": {
+          "$ref": "#/properties/base_image_release/properties/force"
+        },
+        "force?": {
+          "$ref": "#/properties/base_image_release/properties/force"
+        },
+        "force-": {},
         "enabled": {
           "description": "If false, disables snapshot-to-release for this image when it qualifies as a base-image workflow target. Omitted: inherit group or default true.",
           "type": "boolean"


### PR DESCRIPTION
## Summary
Add image-level `base_image_release.force` so operators can always run the Konflux base-image snapshot-to-release workflow for a specific image, bypassing normal qualification guards.

## Problem
**Before:** Base-image release only triggered when an image passed all guards: OCP variant, non-test assembly, base_only or golang-builder, and enabled flag resolution.

**After:** Setting `base_image_release.force: true` in image metadata unconditionally triggers the release workflow, regardless of variant, assembly, image type, or enabled settings.

## Implementation Details
- Short-circuit `should_trigger_base_image_release()` when image metadata sets `base_image_release.force: true`
- Extend image config schema with `base_image_release.force` (image-level only, no group override)
- Add unit tests covering force precedence and unchanged behavior when force is unset or false

### Key Changes
- `doozer/doozerlib/image.py`: force check before existing guards
- `ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json`: schema support for `force`
- `doozer/tests/test_image.py`: coverage for bypass and control cases