### PR TITLE
Add lockfile backend property to validator schemas

### DIFF
--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -432,7 +432,18 @@
                 "force?": {
                   "$ref": "#/properties/konflux/properties/cachi2/properties/lockfile/properties/force"
                 },
-                "force-": {}
+                "force-": {},
+                "backend": {
+                  "description": "Lockfile generation backend to use (e.g., 'art-internal', 'rpm-lockfile-prototype')",
+                  "type": "string"
+                },
+                "backend!": {
+                  "$ref": "#/properties/konflux/properties/cachi2/properties/lockfile/properties/backend"
+                },
+                "backend?": {
+                  "$ref": "#/properties/konflux/properties/cachi2/properties/lockfile/properties/backend"
+                },
+                "backend-": {}
               },
               "additionalProperties": false
             },
@@ -541,7 +552,14 @@
                     "force": {"type": "boolean"},
                     "force!": {"$ref": "#/properties/okd/properties/konflux/properties/cachi2/properties/lockfile/properties/force"},
                     "force?": {"$ref": "#/properties/okd/properties/konflux/properties/cachi2/properties/lockfile/properties/force"},
-                    "force-": {}
+                    "force-": {},
+                    "backend": {
+                      "description": "Lockfile generation backend to use (e.g., 'art-internal', 'rpm-lockfile-prototype')",
+                      "type": "string"
+                    },
+                    "backend!": {"$ref": "#/properties/okd/properties/konflux/properties/cachi2/properties/lockfile/properties/backend"},
+                    "backend?": {"$ref": "#/properties/okd/properties/konflux/properties/cachi2/properties/lockfile/properties/backend"},
+                    "backend-": {}
                   },
                   "additionalProperties": false
                 },

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -1306,7 +1306,18 @@
                 "cross_arch!": {
                   "$ref": "#/properties/konflux/properties/cachi2/properties/lockfile/properties/cross_arch"
                 },
-                "cross_arch-": {}
+                "cross_arch-": {},
+                "backend": {
+                  "description": "Lockfile generation backend to use (e.g., 'art-internal', 'rpm-lockfile-prototype')",
+                  "type": "string"
+                },
+                "backend?": {
+                  "$ref": "#/properties/konflux/properties/cachi2/properties/lockfile/properties/backend"
+                },
+                "backend!": {
+                  "$ref": "#/properties/konflux/properties/cachi2/properties/lockfile/properties/backend"
+                },
+                "backend-": {}
               },
               "additionalProperties": false
             },


### PR DESCRIPTION
## Summary
- Add `backend` string property to `konflux.cachi2.lockfile` in group config and image config JSON schemas
- The `backend` property was introduced in #2852 but the validator schemas were not updated, causing validation failures in ocp-build-data (e.g., [ocp-build-data#10871](https://github.com/openshift-eng/ocp-build-data/pull/10871))

## Test plan
- [x] All 82 validator unit tests pass
- [x] Manually verified schema accepts `{"konflux": {"cachi2": {"lockfile": {"backend": "rpm-lockfile-prototype"}}}}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)