### PR TITLE
Include OCP version in base image release generateName

### DIFF
--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -220,8 +220,9 @@ class BaseImageHandler:
                 if not snapshot_available:
                     raise RuntimeError(f"Snapshot {snapshot_name} did not become available in time")
 
+            group_safe = normalize_group_name_for_k8s(self.runtime.group)
             release_metadata = {
-                "generateName": "ocp-base-image-release-",
+                "generateName": f"{group_safe}-base-image-release-",
                 "namespace": self.namespace,
                 "labels": {
                     "appstudio.openshift.io/application": self.base_image_application,

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -188,6 +188,7 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         konflux_client._create.assert_awaited_once()
         release_obj = konflux_client._create.await_args.args[0]
         self.assertEqual(release_obj["metadata"]["annotations"]["art.redhat.com/nvrs"], self.nvr)
+        self.assertEqual(release_obj["metadata"]["generateName"], "openshift-4-22-base-image-release-")
 
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")


### PR DESCRIPTION
The base image release was the only Konflux resource not embedding the OCP version in its name, making it hard to tell which release belongs to which version. Use the k8s-normalized group name (e.g. openshift-4-22) as prefix, consistent with how snapshots and shipment releases are already named.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED