### PR TITLE
Skip ensure_repositories_loaded for rpm-lockfile-prototype images

### DIFF
--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -34,6 +34,7 @@ from doozerlib.cli import (
 )
 from doozerlib.exceptions import DoozerFatalError, ParentRebaseFailedError
 from doozerlib.image import ImageMetadata
+from doozerlib.lockfile_prototype.constants import LockfileBackend
 from doozerlib.runtime import Runtime
 
 TRACER = trace.get_tracer(__name__)
@@ -107,7 +108,10 @@ class KonfluxRebaseCli:
             extra_labels=self.extra_labels,
         )
 
-        await rebaser.rpm_lockfile_generator.ensure_repositories_loaded(metas, base_dir)
+        art_internal_metas = [
+            m for m in metas if m.get_lockfile_backend() != LockfileBackend.RPM_LOCKFILE_PROTOTYPE.value
+        ]
+        await rebaser.rpm_lockfile_generator.ensure_repositories_loaded(art_internal_metas, base_dir)
 
         tasks = []
         for image_meta in metas:

--- a/doozer/tests/cli/test_images_konflux.py
+++ b/doozer/tests/cli/test_images_konflux.py
@@ -130,8 +130,10 @@ class TestKonfluxRebaseCli(unittest.IsolatedAsyncioTestCase):
 
         parent = mock.Mock()
         parent.distgit_key = "parent-img"
+        parent.get_lockfile_backend.return_value = "art-internal"
         child = mock.Mock()
         child.distgit_key = "child-img"
+        child.get_lockfile_backend.return_value = "art-internal"
 
         runtime = mock.Mock(spec=Runtime)
         runtime.working_dir = "/tmp"
@@ -171,3 +173,52 @@ class TestKonfluxRebaseCli(unittest.IsolatedAsyncioTestCase):
             runtime.state["images:konflux:rebase"]["skipped-due-to-parent-rebase-failure"],
             ["child-img"],
         )
+
+    @mock.patch("doozerlib.cli.images_konflux.trace.get_current_span")
+    @mock.patch("doozerlib.cli.images_konflux.KonfluxRebaser")
+    async def test_ensure_repositories_loaded_skips_prototype_backend(self, mock_rebaser_cls, mock_get_span):
+        """ensure_repositories_loaded should only receive art-internal images, not rpm-lockfile-prototype ones."""
+        mock_get_span.return_value = mock.Mock()
+
+        art_internal_img = mock.Mock()
+        art_internal_img.distgit_key = "art-internal-img"
+        art_internal_img.get_lockfile_backend.return_value = "art-internal"
+
+        prototype_img = mock.Mock()
+        prototype_img.distgit_key = "prototype-img"
+        prototype_img.get_lockfile_backend.return_value = "rpm-lockfile-prototype"
+
+        runtime = mock.Mock(spec=Runtime)
+        runtime.working_dir = "/tmp"
+        runtime.upcycle = False
+        runtime.initialize = mock.Mock()
+        runtime.source_resolver = mock.Mock(spec=SourceResolver)
+        runtime.ordered_image_metas = mock.Mock(return_value=[art_internal_img, prototype_img])
+        runtime.state = {}
+
+        mock_rebaser = mock_rebaser_cls.return_value
+        mock_rebaser.rpm_lockfile_generator.ensure_repositories_loaded = mock.AsyncMock()
+        mock_rebaser.rebase_to = mock.AsyncMock(return_value=("4.14.0", "1"))
+
+        cli = KonfluxRebaseCli(
+            runtime=runtime,
+            version="4.14.0",
+            release="1",
+            embargoed=False,
+            force_yum_updates=False,
+            repo_type="unsigned",
+            image_repo="test-repo",
+            message="test",
+            push=False,
+        )
+
+        await cli.run()
+
+        mock_rebaser.rpm_lockfile_generator.ensure_repositories_loaded.assert_called_once()
+        loaded_metas = mock_rebaser.rpm_lockfile_generator.ensure_repositories_loaded.call_args[0][0]
+        self.assertEqual([m.distgit_key for m in loaded_metas], ["art-internal-img"])
+
+        self.assertEqual(mock_rebaser.rebase_to.call_count, 2)
+        rebased_keys = [call.args[0].distgit_key for call in mock_rebaser.rebase_to.call_args_list]
+        self.assertIn("art-internal-img", rebased_keys)
+        self.assertIn("prototype-img", rebased_keys)


### PR DESCRIPTION
## Summary
- Filter out `rpm-lockfile-prototype` images before calling `ensure_repositories_loaded` during Konflux rebase
- The art-internal `RPMLockfileGenerator` pre-loads repo metadata and queries the Konflux DB for seed NVRs — neither is needed for rpm-lockfile-prototype images, which resolve packages independently via their own DNF resolver
- Add test covering mixed-backend scenario: verifies only art-internal images are passed to `ensure_repositories_loaded` while both backends still get rebased

## Test plan
- [x] `make format` passes
- [x] `make test` passes (pyartcd failures are pre-existing `distutils` issue, unrelated)
- [x] New test `test_ensure_repositories_loaded_skips_prototype_backend` validates filtering logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)