### PR TITLE
Fix get_nvr_root_log failing for noarch RPMs

### DIFF
--- a/elliott/elliottlib/brew.py
+++ b/elliott/elliottlib/brew.py
@@ -235,13 +235,17 @@ def get_nvr_root_log(name, version, release, arch='x86_64') -> Tuple[str, str]:
         logger.warning("Assuming rhel-8")
         rhel_version = 8
 
-    root_log_url = f'{constants.BREW_DOWNLOAD_URL}/vol/rhel-{rhel_version}/packages/{name}/{version}/{release}/data/logs/{arch}/root.log'
+    arches = [arch, 'noarch'] if arch != 'noarch' else ['noarch']
+    tried_urls = []
+    for a in arches:
+        root_log_url = f'{constants.BREW_DOWNLOAD_URL}/vol/rhel-{rhel_version}/packages/{name}/{version}/{release}/data/logs/{a}/root.log'
+        logger.debug(f"Trying {root_log_url}")
+        res = requests.get(root_log_url, verify=ssl.get_default_verify_paths().openssl_cafile)
+        if res.status_code == 200:
+            return res.text, root_log_url
+        tried_urls.append(root_log_url)
 
-    logger.debug(f"Trying {root_log_url}")
-    res = requests.get(root_log_url, verify=ssl.get_default_verify_paths().openssl_cafile)
-    if res.status_code != 200:
-        raise exceptions.BrewBuildException("Could not get root.log for {}-{}-{}".format(name, version, release))
-    return res.text, root_log_url
+    raise exceptions.BrewBuildException(f"Could not get root.log for {name}-{version}-{release}, tried: {tried_urls}")
 
 
 class Build(object):

--- a/elliott/elliottlib/brew.py
+++ b/elliott/elliottlib/brew.py
@@ -240,7 +240,11 @@ def get_nvr_root_log(name, version, release, arch='x86_64') -> Tuple[str, str]:
     for a in arches:
         root_log_url = f'{constants.BREW_DOWNLOAD_URL}/vol/rhel-{rhel_version}/packages/{name}/{version}/{release}/data/logs/{a}/root.log'
         logger.debug(f"Trying {root_log_url}")
-        res = requests.get(root_log_url, verify=ssl.get_default_verify_paths().openssl_cafile)
+        res = requests.get(
+            root_log_url,
+            verify=ssl.get_default_verify_paths().openssl_cafile,
+            timeout=30,
+        )
         if res.status_code == 200:
             return res.text, root_log_url
         tried_urls.append(root_log_url)

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -640,8 +640,9 @@ def get_golang_rpm_nvrs(nvrs, exact=False):
         root_log, log_url = brew.get_nvr_root_log(*nvr)
         try:
             go_version = get_golang_version_from_log(root_log, log_url)
-        except Exception as e:
-            raise ValueError(f'Could not find go version in root log for {nvr}: {e}') from e
+        except Exception:
+            LOGGER.warning(f'No golang version found in root log for {nvr}, skipping (not a golang RPM?)')
+            continue
 
         if exact:
             go_version = f'golang-{go_version}'

--- a/elliott/tests/test_brew.py
+++ b/elliott/tests/test_brew.py
@@ -434,6 +434,47 @@ class TestBrew(unittest.TestCase):
         actual = brew.get_latest_builds(tag_component_tuples, fake_session)
         self.assertListEqual(actual, expected)
 
+    @mock.patch("requests.get")
+    @mock.patch("ssl.get_default_verify_paths", return_value=mock.MagicMock(openssl_cafile="/my/cert.pem"))
+    def test_get_nvr_root_log_falls_back_to_noarch(self, _, mock_get):
+        def fake_get(url, **kwargs):
+            resp = mock.MagicMock()
+            if '/noarch/root.log' in url:
+                resp.status_code = 200
+                resp.text = 'fake root log content'
+            else:
+                resp.status_code = 404
+            return resp
+
+        mock_get.side_effect = fake_get
+        text, url = brew.get_nvr_root_log(
+            'openshift4-aws-iso', '4.19.0', '202506111249.p0.gd2acdd5.assembly.stream.el8'
+        )
+        self.assertEqual(text, 'fake root log content')
+        self.assertIn('/noarch/root.log', url)
+
+    @mock.patch("requests.get")
+    @mock.patch("ssl.get_default_verify_paths", return_value=mock.MagicMock(openssl_cafile="/my/cert.pem"))
+    def test_get_nvr_root_log_prefers_given_arch(self, _, mock_get):
+        def fake_get(url, **kwargs):
+            resp = mock.MagicMock()
+            resp.status_code = 200
+            resp.text = 'x86_64 root log'
+            return resp
+
+        mock_get.side_effect = fake_get
+        text, url = brew.get_nvr_root_log('openshift', '4.19.0', '202506111249.p0.gd2acdd5.assembly.stream.el8')
+        self.assertEqual(text, 'x86_64 root log')
+        self.assertIn('/x86_64/root.log', url)
+        mock_get.assert_called_once()
+
+    @mock.patch("requests.get")
+    @mock.patch("ssl.get_default_verify_paths", return_value=mock.MagicMock(openssl_cafile="/my/cert.pem"))
+    def test_get_nvr_root_log_raises_when_all_arches_fail(self, _, mock_get):
+        mock_get.return_value = mock.MagicMock(status_code=404)
+        with self.assertRaises(exceptions.BrewBuildException):
+            brew.get_nvr_root_log('nonexistent', '1.0', '1.el8')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/elliott/tests/test_util.py
+++ b/elliott/tests/test_util.py
@@ -126,6 +126,25 @@ class TestUtil(unittest.TestCase):
         actual = util.get_golang_container_nvrs(nvrs, None)
         self.assertEqual(expected, actual)
 
+    def test_get_golang_rpm_nvrs_skips_non_golang_rpms(self):
+        golang_nvr = ('openshift', '4.19.0', '202506111249.p0.gd2acdd5.assembly.stream.el8')
+        non_golang_nvr = ('openshift4-aws-iso', '4.19.0', '202506111249.p0.gd2acdd5.assembly.stream.el8')
+        golang_root_log = 'golang-bin               x86_64  1.23.6-2.module+el8.11.0+22775+e8b271ec'
+        non_golang_root_log = 'ansible-core             noarch  2.16.3-2.el8'
+
+        flexmock(brew).should_receive("get_nvr_root_log").with_args(*golang_nvr).and_return(
+            (golang_root_log, 'http://fake/golang/root.log')
+        ).once()
+        flexmock(brew).should_receive("get_nvr_root_log").with_args(*non_golang_nvr).and_return(
+            (non_golang_root_log, 'http://fake/noarch/root.log')
+        ).once()
+
+        result = util.get_golang_rpm_nvrs([golang_nvr, non_golang_nvr])
+        self.assertIn('1.23.6-2.module+el8.11.0+22775+e8b271ec', result)
+        self.assertEqual(result['1.23.6-2.module+el8.11.0+22775+e8b271ec'], {golang_nvr})
+        for nvrs in result.values():
+            self.assertNotIn(non_golang_nvr, nvrs)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- `get_nvr_root_log` now falls back to `noarch` when the default `x86_64` arch returns 404, fixing failures for noarch builds like `openshift4-aws-iso`
- `get_golang_rpm_nvrs` skips RPMs where no Go version is found in root.log instead of raising, so `rebuild-golang-rpms --all` no longer crashes on non-Go RPMs
- Error message now includes the URLs that were tried for easier debugging

## Test plan
- [x] Added test: `get_nvr_root_log` falls back to noarch when x86_64 404s
- [x] Added test: `get_nvr_root_log` prefers the given arch when it succeeds
- [x] Added test: `get_nvr_root_log` raises when all arches fail
- [x] Added test: `get_golang_rpm_nvrs` skips non-Go RPMs gracefully
- [x] All 373 elliott tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)