### PR TITLE
ART-18147 Fix RHEL version detection for multi-stage canonical builders

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -967,14 +967,12 @@ class ImageMetadata(Metadata):
                 dfp = DockerfileParser(fileobj=f)
                 parent_images = dfp.parent_images
 
-            # Iterate forward: the first FROM in a multi-stage Dockerfile is the primary builder,
-            # which reliably encodes the target RHEL version. Reverse iteration would incorrectly
-            # pick up compatibility builders (e.g. rhel-8-golang used only for upgrade shim binaries
-            # in ovn-kubernetes) before the primary rhel-9 builder.
-            # Also, some images (e.g. deployer) use image stream tags like :cli or :base that don't encode RHEL version. In these cases, we want to iterate through all parent images in case any of them encode RHEL version info in the tag.
-            # NOTE: the rhel version should be determined by the final layer. This is a hotfix and is probably wrong,
-            # but is needed to unblock canonical builders for now.
-            for pullspec in parent_images:
+            # Try the final parent first — it's the base image that determines the shipped RHEL version.
+            # Fall back to earlier parents (builders) in forward order if the base tag is ambiguous
+            # (e.g. :ovn-kubernetes-base, :cli). Forward fallback order picks the primary builder
+            # before any compatibility builders (e.g. rhel-8-golang used only for upgrade shims).
+            ordered = [parent_images[-1]] + parent_images[:-1]
+            for pullspec in ordered:
                 rhel_version, golang_version = extract_builder_info_from_pullspec(pullspec)
                 if rhel_version:
                     break

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1040,6 +1040,51 @@ RUN echo "test"
     @patch('doozerlib.image.SourceResolver')
     @patch('builtins.open', create=True)
     @patch('pathlib.Path.joinpath')
+    @patch('doozerlib.image.util.oc_image_info_for_arch', return_value={'config': {'config': {'Labels': {}}}})
+    def test_determine_upstream_rhel_version_compat_builder_before_primary(
+        self, mock_oc_image_info, mock_joinpath, mock_open, mock_source_resolver
+    ):
+        """Test that final base image RHEL version wins even when compat builder is listed first"""
+        extract_builder_info_from_pullspec.cache_clear()
+        metadata = self._create_image_metadata('openshift/test-reversed-builders')
+
+        metadata.config = Model(
+            {
+                'name': 'openshift/test-reversed-builders',
+                'distgit': {'branch': 'rhaos-5.0-rhel-9'},
+                'content': {'source': {'git': {'url': 'https://github.com/test/repo.git'}}},
+            }
+        )
+        metadata.branch_el_target = MagicMock(return_value=9)
+
+        mock_source_resolution = MagicMock()
+        metadata.runtime.source_resolver.resolve_source = MagicMock(return_value=mock_source_resolution)
+
+        mock_source_dir = MagicMock()
+        mock_source_resolver.get_source_dir = MagicMock(return_value=mock_source_dir)
+
+        mock_df_path = MagicMock()
+        mock_joinpath.return_value = mock_df_path
+
+        mock_open.return_value.__enter__.return_value = mock.mock_open(read_data="").return_value
+
+        with patch('doozerlib.image.DockerfileParser') as mock_dfp:
+            mock_dfp_instance = MagicMock()
+            # Compat builder listed BEFORE primary builder, base encodes RHEL version
+            mock_dfp_instance.parent_images = [
+                'registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.22',
+                'registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22',
+                'registry.ci.openshift.org/ocp/4.22:base-rhel9',
+            ]
+            mock_dfp.return_value = mock_dfp_instance
+            metadata.determine_targets = MagicMock(return_value=['target-1'])
+
+            # Should detect el9 from the final base image, not el8 from the first compat builder
+            metadata._apply_alternative_upstream_config()
+
+    @patch('doozerlib.image.SourceResolver')
+    @patch('builtins.open', create=True)
+    @patch('pathlib.Path.joinpath')
     @patch('doozerlib.image.util.oc_image_info_for_arch', side_effect=Exception('image not accessible'))
     def test_apply_alternative_upstream_config_undetermined_rhel_version(
         self, mock_oc_image_info, mock_joinpath, mock_open, mock_source_resolver


### PR DESCRIPTION
Right now running ocp4-scan-konflux in 5.0 with canonical builders config leads to several of these errors

```
OSError: [ose-operator-framework-tools] Upstream uses el8 but ART uses el9, and no matching alternative_upstream config was found. Please add an alternative_upstream config with "when: el8".
```

## Summary
- Fixes RHEL version detection in `_determine_upstream_builder_info` to prioritize the **final parent image** (the base layer that determines the shipped RHEL version) instead of the first parent
- Falls back to earlier parents (builders) in forward order only if the base tag doesn't encode RHEL version
- Adds test for the previously-unhandled case where a compat builder appears before the primary builder

## Context
The previous forward-iteration approach (`for pullspec in parent_images`) relied on the primary builder being listed first in the Dockerfile. This worked for ovn-kubernetes (rhel-9-golang before rhel-8-golang compat) by coincidence, but would break if a compat builder came first. The code itself acknowledged this with: *"the rhel version should be determined by the final layer. This is a hotfix and is probably wrong."*

The fix is minimal: `[parent_images[-1]] + parent_images[:-1]` — try the last parent first, then fall back to builders in forward order.

https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/49134/consoleFull

## Test plan
- [x] `test_determine_upstream_rhel_version_ubi_pattern` — single-stage ubi8 image
- [x] `test_determine_upstream_rhel_version_fallback_to_builder` — aws-efs pattern (base tag has no RHEL info, falls back to builder)
- [x] `test_determine_upstream_rhel_version_skips_compat_builder` — ovn-kubernetes pattern (rhel-9 primary, rhel-8 compat, ambiguous base)
- [x] `test_determine_upstream_rhel_version_compat_builder_before_primary` — **new**: compat builder listed before primary, base encodes RHEL version
- [x] `test_apply_alternative_upstream_config_undetermined_rhel_version` — deployer pattern (no RHEL info anywhere)
- [x] Full `test_image.py` suite: 81 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)