### PR TITLE
feat(doozer): enrich base image Konflux Release annotations

### DIFF
--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -6,6 +6,7 @@ CLI lives in ``doozerlib.cli.images`` (see ``images:release-to-base-repo``).
 """
 
 import asyncio
+import os
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -105,7 +106,7 @@ class BaseImageHandler:
             self.logger.error("Failed to create snapshot")
             return None
 
-        release_name = await self._create_release_from_snapshot(snapshot_name, snapshot_input.nvr)
+        release_name = await self._create_release_from_snapshot(snapshot_name, snapshot_input)
         if not release_name:
             self.logger.error(f"Failed to create release (snapshot={snapshot_name})")
             return None
@@ -197,13 +198,15 @@ class BaseImageHandler:
             self.logger.error(f"Failed to create snapshot object (name={meta_name}): {type(e).__name__}: {e}")
             return None
 
-    async def _create_release_from_snapshot(self, snapshot_name: str, released_nvr: str) -> Optional[str]:
+    async def _create_release_from_snapshot(
+        self, snapshot_name: str, snapshot_input: BaseImageSnapshotInput
+    ) -> Optional[str]:
         """
         Create Konflux Release from snapshot using the product's silent base-image ReleasePlan.
 
         Args:
             snapshot_name: Snapshot resource name.
-            released_nvr: Single image NVR (stored on annotation ``art.redhat.com/nvrs`` for compatibility).
+            snapshot_input: Base-image component input (NVR and distgit key stored on Release annotations).
         """
         try:
             if not self.dry_run:
@@ -221,19 +224,24 @@ class BaseImageHandler:
                     raise RuntimeError(f"Snapshot {snapshot_name} did not become available in time")
 
             group_safe = normalize_group_name_for_k8s(self.runtime.group)
+            release_annotations = {
+                "art.redhat.com/kind": "image",
+                "art.redhat.com/group": self.runtime.group_config.name,
+                "art.redhat.com/assembly": getattr(self.runtime, "assembly", "stream"),
+                "art.redhat.com/env": "base-image-workflow",
+                "art.redhat.com/nvr": snapshot_input.nvr,
+                "art.redhat.com/distgit-key": snapshot_input.distgit_key,
+            }
+            if job_url := os.getenv("BUILD_URL"):
+                release_annotations["art.redhat.com/job-url"] = job_url
+
             release_metadata = {
                 "generateName": f"{group_safe}-base-image-release-",
                 "namespace": self.namespace,
                 "labels": {
                     "appstudio.openshift.io/application": self.base_image_application,
                 },
-                "annotations": {
-                    "art.redhat.com/kind": "image",
-                    "art.redhat.com/group": self.runtime.group_config.name,
-                    "art.redhat.com/assembly": getattr(self.runtime, "assembly", "stream"),
-                    "art.redhat.com/env": "base-image-workflow",
-                    "art.redhat.com/nvrs": released_nvr,
-                },
+                "annotations": release_annotations,
             }
 
             release_obj = {

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -166,7 +166,7 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
-    async def test_create_release_from_snapshot_sets_nvr_annotation(
+    async def test_create_release_from_snapshot_sets_release_annotations(
         self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
     ):
         mock_namespace.return_value = "ocp-art-tenant"
@@ -182,13 +182,44 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         handler = BaseImageHandler(self.runtime, dry_run=False)
 
         with patch.object(handler, "_wait_for_snapshot_availability", new=AsyncMock(return_value=True)):
-            await handler._create_release_from_snapshot("test-snapshot", self.nvr)
+            await handler._create_release_from_snapshot("test-snapshot", self.default_input)
 
         konflux_client._get.assert_awaited_once()
         konflux_client._create.assert_awaited_once()
         release_obj = konflux_client._create.await_args.args[0]
-        self.assertEqual(release_obj["metadata"]["annotations"]["art.redhat.com/nvrs"], self.nvr)
+        annotations = release_obj["metadata"]["annotations"]
+        self.assertEqual(annotations["art.redhat.com/nvr"], self.nvr)
+        self.assertEqual(annotations["art.redhat.com/distgit-key"], "test-base")
+        self.assertNotIn("art.redhat.com/job-url", annotations)
         self.assertEqual(release_obj["metadata"]["generateName"], "openshift-4-22-base-image-release-")
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_create_release_from_snapshot_sets_job_url_when_build_url_set(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+
+        konflux_client = AsyncMock()
+        created_release = MagicMock()
+        created_release.metadata.name = "test-release"
+        konflux_client._create.return_value = created_release
+        konflux_client.resource_url = MagicMock(return_value="https://konflux.example/releases/test-release")
+        mock_konflux_client_init.return_value = konflux_client
+
+        handler = BaseImageHandler(self.runtime, dry_run=False)
+
+        with patch.object(handler, "_wait_for_snapshot_availability", new=AsyncMock(return_value=True)):
+            with patch.dict("os.environ", {"BUILD_URL": "https://jenkins.example/job/123/"}):
+                await handler._create_release_from_snapshot("test-snapshot", self.default_input)
+
+        release_obj = konflux_client._create.await_args.args[0]
+        self.assertEqual(
+            release_obj["metadata"]["annotations"]["art.redhat.com/job-url"],
+            "https://jenkins.example/job/123/",
+        )
 
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
@@ -211,7 +242,7 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         handler = BaseImageHandler(self.runtime, dry_run=False)
 
         with patch.object(handler, "_wait_for_snapshot_availability", new=AsyncMock(return_value=True)):
-            await handler._create_release_from_snapshot("test-snapshot", self.nvr)
+            await handler._create_release_from_snapshot("test-snapshot", self.default_input)
 
         konflux_client._get.assert_awaited_once()
         self.assertEqual(konflux_client._get.await_args.args[2], "mtc-images-base-silent")


### PR DESCRIPTION
## Summary
Add meaningful, non-duplicated annotations to Konflux Release CRs created by the base image snapshot→release workflow.

## Problem
**Before:** Base image Releases only carried generic ART annotations (`kind`, `group`, `assembly`, `env`, `nvrs`). There was no distgit-key for filtering by ocp-build-data image, no Jenkins job provenance, and the `nvrs` key implied plural when only one NVR is ever released.

**After:** Releases include `art.redhat.com/nvr`, `art.redhat.com/distgit-key`, and optional `art.redhat.com/job-url` (from `BUILD_URL`). Snapshot input is passed through to release creation as the single source for annotation metadata.

## Implementation Details

### Key Changes
- Rename `art.redhat.com/nvrs` → `art.redhat.com/nvr`
- Add `art.redhat.com/distgit-key` from `BaseImageSnapshotInput.distgit_key`
- Add `art.redhat.com/job-url` when `BUILD_URL` is set (Jenkins runs)
- Pass full `snapshot_input` to `_create_release_from_snapshot` instead of bare NVR string
- Unit tests updated for new annotations and optional job-url behavior

## Test plan
- [x] `uv run pytest doozer/tests/backend/test_base_image_handler.py` — 8 passed