### PR TITLE
Add build result summary to Layered Products Jenkins description

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -162,6 +162,7 @@ class BuildLayeredProductsPipeline:
             return
 
         await self._build(image_list, product, image_repo)
+        self._update_build_description()
 
     async def _rebase(self, image_list: str) -> str:
         """Rebase layered product images.
@@ -221,6 +222,26 @@ class BuildLayeredProductsPipeline:
             requested = [img.strip() for img in image_list.split(',') if img.strip()]
             remaining = [img for img in requested if img not in excluded]
             return ','.join(remaining)
+
+    def _update_build_description(self):
+        """Update Jenkins description with build results (succeeded/failed counts and failed image names)."""
+        record_log = self.parse_record_log()
+        if not record_log:
+            return
+
+        records = record_log.get('image_build_konflux', [])
+        built_images = [entry['name'] for entry in records if not int(entry['status'])]
+        failed_images = [entry['name'] for entry in records if int(entry['status'])]
+
+        desc_parts = [f'{len(built_images)} image(s) succeeded']
+        if failed_images:
+            desc_parts.append(f'{len(failed_images)} image(s) failed')
+        jenkins.update_description(f'{", ".join(desc_parts)}<br/>')
+
+        if 1 <= len(failed_images) <= 10:
+            jenkins.update_description(f'Failed images: {", ".join(failed_images)}<br/>')
+        elif len(failed_images) > 10:
+            jenkins.update_description(f'Check record.log for the full list of failed images<br/>')
 
     async def _build(self, image_list: str, product: str, image_repo: str):
         """Build layered product images."""

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -243,7 +243,7 @@ class BuildLayeredProductsPipeline:
         if 1 <= len(failed_images) <= 10:
             jenkins.update_description(f'Failed images: {", ".join(failed_images)}<br/>')
         elif len(failed_images) > 10:
-            jenkins.update_description(f'Check record.log for the full list of failed images<br/>')
+            jenkins.update_description('Check record.log for the full list of failed images<br/>')
 
     async def _build(self, image_list: str, product: str, image_repo: str):
         """Build layered product images."""

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -161,8 +161,10 @@ class BuildLayeredProductsPipeline:
             self._logger.warning('No buildable images remaining after rebase; skipping build')
             return
 
-        await self._build(image_list, product, image_repo)
-        self._update_build_description()
+        try:
+            await self._build(image_list, product, image_repo)
+        finally:
+            self._update_build_description()
 
     async def _rebase(self, image_list: str) -> str:
         """Rebase layered product images.

--- a/pyartcd/tests/pipelines/test_build_layered_products.py
+++ b/pyartcd/tests/pipelines/test_build_layered_products.py
@@ -231,10 +231,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
     def test_update_build_description_all_succeeded(self, mock_update_desc):
         """When all images succeed, description shows count with no failures."""
         record_log_path = Path(self.runtime.doozer_working, 'record.log')
-        record_log_path.write_text(
-            'image_build_konflux|name=img-a|status=0\n'
-            'image_build_konflux|name=img-b|status=0\n'
-        )
+        record_log_path.write_text('image_build_konflux|name=img-a|status=0\nimage_build_konflux|name=img-b|status=0\n')
         self.pipeline._update_build_description()
         mock_update_desc.assert_called_once_with('2 image(s) succeeded<br/>')
 

--- a/pyartcd/tests/pipelines/test_build_layered_products.py
+++ b/pyartcd/tests/pipelines/test_build_layered_products.py
@@ -219,6 +219,51 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
         self.assertIn(f'--images={self.pipeline.image_list}', cmd)
         self.assertIn('beta:images:konflux:build', cmd)
 
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.update_description')
+    def test_update_build_description_no_record_log(self, mock_update_desc):
+        """When record.log does not exist, no description update is made."""
+        self.pipeline._update_build_description()
+        mock_update_desc.assert_not_called()
+
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.update_description')
+    def test_update_build_description_all_succeeded(self, mock_update_desc):
+        """When all images succeed, description shows count with no failures."""
+        record_log_path = Path(self.runtime.doozer_working, 'record.log')
+        record_log_path.write_text(
+            'image_build_konflux|name=img-a|status=0\n'
+            'image_build_konflux|name=img-b|status=0\n'
+        )
+        self.pipeline._update_build_description()
+        mock_update_desc.assert_called_once_with('2 image(s) succeeded<br/>')
+
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.update_description')
+    def test_update_build_description_some_failed(self, mock_update_desc):
+        """When some images fail, description shows succeeded/failed counts and lists failed names."""
+        record_log_path = Path(self.runtime.doozer_working, 'record.log')
+        record_log_path.write_text(
+            'image_build_konflux|name=img-a|status=0\n'
+            'image_build_konflux|name=img-b|status=1\n'
+            'image_build_konflux|name=img-c|status=1\n'
+        )
+        self.pipeline._update_build_description()
+        calls = [c[0][0] for c in mock_update_desc.call_args_list]
+        self.assertEqual(calls[0], '1 image(s) succeeded, 2 image(s) failed<br/>')
+        self.assertEqual(calls[1], 'Failed images: img-b, img-c<br/>')
+
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.update_description')
+    def test_update_build_description_many_failed(self, mock_update_desc):
+        """When more than 10 images fail, description omits individual names."""
+        record_log_path = Path(self.runtime.doozer_working, 'record.log')
+        lines = []
+        for i in range(12):
+            lines.append(f'image_build_konflux|name=img-{i}|status=1\n')
+        lines.append('image_build_konflux|name=img-ok|status=0\n')
+        record_log_path.write_text(''.join(lines))
+        self.pipeline._update_build_description()
+        calls = [c[0][0] for c in mock_update_desc.call_args_list]
+        self.assertEqual(calls[0], '1 image(s) succeeded, 12 image(s) failed<br/>')
+        self.assertEqual(calls[1], 'Check record.log for the full list of failed images<br/>')
+
     @patch('pyartcd.pipelines.build_layered_products.jenkins.init_jenkins')
     @patch('pyartcd.pipelines.build_layered_products.load_group_config')
     @patch('pyartcd.pipelines.build_layered_products.exectools.cmd_assert_async', new_callable=AsyncMock)

--- a/pyartcd/tests/pipelines/test_build_layered_products.py
+++ b/pyartcd/tests/pipelines/test_build_layered_products.py
@@ -192,6 +192,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
                 'pyartcd.pipelines.build_layered_products.resolve_konflux_kubeconfig_by_product',
                 return_value='/path/to/kubeconfig',
             ),
+            patch.object(self.pipeline, '_update_build_description'),
         ):
             await self.pipeline._rebase_and_build('oadp', KONFLUX_DEFAULT_IMAGE_REPO)
 
@@ -211,6 +212,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
                 'pyartcd.pipelines.build_layered_products.resolve_konflux_kubeconfig_by_product',
                 return_value='/path/to/kubeconfig',
             ),
+            patch.object(self.pipeline, '_update_build_description'),
         ):
             await self.pipeline._rebase_and_build('oadp', KONFLUX_DEFAULT_IMAGE_REPO)
 


### PR DESCRIPTION
## Summary
- Update the Layered Products Jenkins job description to show succeeded/failed image counts and list failed image names after builds complete
- Matches the existing pattern used by the ocp4-konflux pipeline (`sync_images()`)
- Shows individual failed image names when ≤10 failures, otherwise directs to record.log

## Test plan
- [x] Verify Jenkins description shows `"X image(s) succeeded"` when all images build successfully
- [x] Verify Jenkins description shows `"X image(s) succeeded, Y image(s) failed"` and lists failed image names when some fail
- [ ] Verify failed image names are omitted when >10 images fail
- [ ] Unit tests pass: `uv run pytest pyartcd/tests/pipelines/test_build_layered_products.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)