### PR TITLE
Refactor update_golang wait-repo and add timeout to async exec helpers

### DIFF
--- a/artcommon/artcommonlib/exectools.py
+++ b/artcommon/artcommonlib/exectools.py
@@ -719,13 +719,14 @@ async def manifest_tool(options, dry_run=False, auth_file: Optional[str] = None)
 
 @start_as_current_span_async(TRACER, "cmd_gather_async")
 async def cmd_gather_async(
-    cmd: Union[List[str], str], check: bool = True, log_stdout: bool = False, **kwargs
+    cmd: Union[List[str], str], check: bool = True, log_stdout: bool = False, timeout: Optional[int] = None, **kwargs
 ) -> Tuple[Optional[int], str, str]:
     """Runs a command asynchronously and returns rc,stdout,stderr as a tuple
     :param cmd <string|list>: A shell command
     :param check: If check is True and the exit code was non-zero, it raises a ChildProcessError
     :param log_stdout: If True, stream stdout lines to the logger in real time. Stderr is merged
         into stdout to avoid pipe deadlocks, so the returned stderr will be empty.
+    :param timeout: Kill the process if it does not terminate after timeout seconds.
     :param kwargs: Other arguments passing to asyncio.subprocess.create_subprocess_exec
     :return: rc, stdout, stderr
     """
@@ -774,19 +775,28 @@ async def cmd_gather_async(
     proc = await asyncio.subprocess.create_subprocess_exec(cmd_list[0], *cmd_list[1:], **kwargs)
     span.set_attribute("process.pid", proc.pid)
 
-    if log_stdout and kwargs.get("stdout") == asyncio.subprocess.PIPE:
-        stdout_lines: list[str] = []
-        async for raw_line in proc.stdout:
-            line = raw_line.decode("utf-8", errors="replace").rstrip()
-            logger.info(line)
-            stdout_lines.append(line)
+    try:
+        if log_stdout and kwargs.get("stdout") == asyncio.subprocess.PIPE:
+            stdout_lines: list[str] = []
+
+            async def _stream_and_wait():
+                async for raw_line in proc.stdout:
+                    line = raw_line.decode("utf-8", errors="replace").rstrip()
+                    logger.info(line)
+                    stdout_lines.append(line)
+                await proc.wait()
+
+            await asyncio.wait_for(_stream_and_wait(), timeout=timeout)
+            stdout = "\n".join(stdout_lines)
+            stderr = ""
+        else:
+            stdout_raw, stderr_raw = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            stdout = stdout_raw.decode() if stdout_raw else ""
+            stderr = stderr_raw.decode() if stderr_raw else ""
+    except asyncio.TimeoutError:
+        proc.kill()
         await proc.wait()
-        stdout = "\n".join(stdout_lines)
-        stderr = ""
-    else:
-        stdout_raw, stderr_raw = await proc.communicate()
-        stdout = stdout_raw.decode() if stdout_raw else ""
-        stderr = stderr_raw.decode() if stderr_raw else ""
+        raise
     duration_seconds = time.time() - start_time
 
     span.set_attribute("result.exit_code", str(proc.returncode))
@@ -849,13 +859,19 @@ def _get_meaningful_span_name(cmd: Union[List[str], str]) -> str:
 
 @start_as_current_span_async(TRACER, "cmd_assert_async")
 async def cmd_assert_async(
-    cmd: Union[List[str], str], check: bool = True, suppress_output: bool = False, log_stdout: bool = False, **kwargs
+    cmd: Union[List[str], str],
+    check: bool = True,
+    suppress_output: bool = False,
+    log_stdout: bool = False,
+    timeout: Optional[int] = None,
+    **kwargs,
 ) -> int:
     """Runs a command and optionally raises an exception if the return code of the command indicates failure.
     :param cmd <string|list>: A shell command
     :param check: If check is True and the exit code was non-zero, it raises a ChildProcessError
     :param suppress_output: If True, stdout and stderr are discarded (/dev/null).
     :param log_stdout: If True, pipe and stream stdout lines to the logger in real time.
+    :param timeout: Kill the process if it does not terminate after timeout seconds.
     :param kwargs: Other arguments passing to asyncio.subprocess.create_subprocess_exec
     :return: return code of the command
     """
@@ -903,11 +919,21 @@ async def cmd_assert_async(
     proc = await asyncio.subprocess.create_subprocess_exec(cmd_list[0], *cmd_list[1:], **kwargs)
     span.set_attribute("process.pid", proc.pid)
 
-    if log_stdout and proc.stdout:
-        async for raw_line in proc.stdout:
-            logger.info(raw_line.decode("utf-8", errors="replace").rstrip())
+    try:
+        if log_stdout and proc.stdout:
 
-    returncode = await proc.wait()
+            async def _stream_and_wait():
+                async for raw_line in proc.stdout:
+                    logger.info(raw_line.decode("utf-8", errors="replace").rstrip())
+                return await proc.wait()
+
+            returncode = await asyncio.wait_for(_stream_and_wait(), timeout=timeout)
+        else:
+            returncode = await asyncio.wait_for(proc.wait(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        raise
     duration_seconds = time.time() - start_time
 
     span.set_attribute("result.exit_code", str(returncode))

--- a/artcommon/artcommonlib/exectools.py
+++ b/artcommon/artcommonlib/exectools.py
@@ -793,8 +793,11 @@ async def cmd_gather_async(
             stdout_raw, stderr_raw = await asyncio.wait_for(proc.communicate(), timeout=timeout)
             stdout = stdout_raw.decode() if stdout_raw else ""
             stderr = stderr_raw.decode() if stderr_raw else ""
-    except asyncio.TimeoutError:
-        proc.kill()
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
         await proc.wait()
         raise
     duration_seconds = time.time() - start_time
@@ -930,8 +933,11 @@ async def cmd_assert_async(
             returncode = await asyncio.wait_for(_stream_and_wait(), timeout=timeout)
         else:
             returncode = await asyncio.wait_for(proc.wait(), timeout=timeout)
-    except asyncio.TimeoutError:
-        proc.kill()
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
         await proc.wait()
         raise
     duration_seconds = time.time() - start_time

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -37,7 +37,7 @@ yaml = new_roundtrip_yaml_handler()
 PUBLISHED_GOLANG_BUILDER_REPO = f"{REGISTRY_REDHAT_IO}/openshift/{ART_IMAGES_BASE_APPLICATION}"
 
 
-def is_latest_build(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool:
+def is_latest(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool:
     build_tag = f'rhaos-{ocp_version}-rhel-{el_v}-build'
     parsed_nvr = parse_nvr(nvr)
     latest_build = koji_session.getLatestBuilds(build_tag, package=parsed_nvr['name'])
@@ -57,19 +57,24 @@ def get_latest_nvr_in_tag(tag: str, package: str, koji_session) -> str:
     return latest_build[0]['nvr']
 
 
-async def is_latest_and_available(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool:
-    if not is_latest_build(ocp_version, el_v, nvr, koji_session):
-        return False
-    # If regen repo has been run this would take a few seconds
-    # sadly --timeout cannot be less than 1 minute, so we wait for 1 minute
+async def is_available(ocp_version: str, el_v: int, nvr: str) -> bool:
+    # Not using --timeout because it can be unreliable; using Python-level timeout instead.
     build_tag = f'rhaos-{ocp_version}-rhel-{el_v}-build'
-    cmd = f'brew wait-repo {build_tag} --build {nvr} --timeout=1 --verbose'
-    rc = await exectools.cmd_assert_async(cmd, check=False, log_stdout=True)
+    cmd = f'brew wait-repo {build_tag} --build {nvr} --verbose'
+    try:
+        rc = await exectools.cmd_assert_async(cmd, check=False, log_stdout=True, timeout=60)
+    except asyncio.TimeoutError:
+        _LOGGER.info(f'{nvr} is not available in {build_tag}.')
+        return False
     if rc != 0:
         _LOGGER.info(f'Build {nvr} could not be confirmed available in {build_tag}.')
         return False
     _LOGGER.info(f'{nvr} is available in {build_tag}')
     return True
+
+
+async def is_latest_and_available(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool:
+    return is_latest(ocp_version, el_v, nvr, koji_session) and await is_available(ocp_version, el_v, nvr)
 
 
 def extract_and_validate_golang_nvrs(ocp_version: str, go_nvrs: List[str]):
@@ -355,7 +360,7 @@ class UpdateGolangPipeline:
         konflux_records: dict[int, KonfluxBuildRecord] = {}
         if not self.force_image_build:
             if self.build_system in ['both', 'brew']:
-                brew_nvrs = self.get_existing_builders(el_nvr_map_for_images, go_version)
+                brew_nvrs = self.get_existing_builders_brew(el_nvr_map_for_images, go_version)
             if self.build_system in ['both', 'konflux']:
                 konflux_records = await self.get_existing_builders_konflux(el_nvr_map_for_images, go_version)
 
@@ -387,7 +392,7 @@ class UpdateGolangPipeline:
 
             # Now all builders should be available, fetch again
             if self.build_system in ['both', 'brew']:
-                brew_nvrs = self.get_existing_builders(el_nvr_map_for_images, go_version)
+                brew_nvrs = self.get_existing_builders_brew(el_nvr_map_for_images, go_version)
             if self.build_system in ['both', 'konflux']:
                 konflux_records = await self.get_existing_builders_konflux(el_nvr_map_for_images, go_version)
 
@@ -462,32 +467,33 @@ class UpdateGolangPipeline:
         await self._slack_client.say_in_thread(f":white_check_mark: Updating golang for {self.ocp_version} complete.")
 
     async def process_build(self, el_v, nvr):
-        if await is_latest_and_available(self.ocp_version, el_v, nvr, self.koji_session):
-            return True
-        if not self.tag_builds:
-            return False
-        # Tag builds into override tag
-        await self.tag_build(el_v, nvr)
+        if not is_latest(self.ocp_version, el_v, nvr, self.koji_session):
+            if not self.tag_builds:
+                return False
+            await self.tag_build(el_v, nvr)
 
-        # Request a repo regen so the newly tagged build becomes available
-        build_tag = f'rhaos-{self.ocp_version}-rhel-{el_v}-build'
-        if self.dry_run:
-            _LOGGER.info(f"[DRY RUN] Would have run `brew regen-repo {build_tag}`")
-            _LOGGER.info(f"[DRY RUN] Would have waited for {nvr} to be available in build tags")
-            return True
-
-        regen_cmd = f'brew regen-repo {build_tag}'
-        _LOGGER.info("Requesting repo regen: %s", regen_cmd)
-        await exectools.cmd_assert_async(regen_cmd, log_stdout=True)
-
-        # Wait for repo to be available (5 hours max)
-        for _ in range(30):
-            await asyncio.sleep(600)  # 10 minutes
-            if await is_latest_and_available(self.ocp_version, el_v, nvr, self.koji_session):
+        # retry 5 times to request repo regen and check availability,
+        # which can take around 5 hours in worst case, before giving up and raise error
+        for _ in range(5):
+            if await is_available(self.ocp_version, el_v, nvr):
                 return True
-            _LOGGER.info("wait 10 mins...")
-        _LOGGER.info("build not available after 5 hours")
+            await self.request_repo(el_v, nvr)
+            if self.dry_run:
+                return True
+
+        _LOGGER.warning("build not available after 5 hours")
         return False
+
+    async def request_repo(self, el_v, nvr):
+        build_tag = f'rhaos-{self.ocp_version}-rhel-{el_v}-build'
+        # --request triggers a repo regen (like regen-repo) and waits for it to complete.
+        # Not using --timeout because it can be unreliable
+        # wait for 1hr
+        cmd = f'brew wait-repo {build_tag} --build={nvr} --request --verbose'
+        if self.dry_run:
+            _LOGGER.info(f"[DRY RUN] Would have run `{cmd}`")
+            return
+        await exectools.cmd_assert_async(cmd, log_stdout=True, timeout=3600)
 
     def brew_login(self):
         if not self.koji_session.logged_in:
@@ -512,9 +518,9 @@ class UpdateGolangPipeline:
             _LOGGER.info(f"Tagged {build} with {build_tag} tag")
             await self._slack_client.say_in_thread(f"Tagged {build} with {build_tag} tag")
 
-    def get_existing_builders(self, el_nvr_map, go_version):
+    def get_existing_builders_brew(self, el_nvr_map, go_version):
         component = GOLANG_BUILDER_CVE_COMPONENT
-        _LOGGER.info(f"Checking if {component} builds exist for given golang builds")
+        _LOGGER.info(f"Checking if {component} builds exist in Brew for given golang builds")
         package_info = self.koji_session.getPackage(component)
         if not package_info:
             raise IOError(f'Cannot find brew package info for {component}')
@@ -549,7 +555,7 @@ class UpdateGolangPipeline:
     ) -> dict[int, KonfluxBuildRecord]:
         """
         Check if openshift-golang-builder builds exist in Konflux for the provided compiler builds.
-        Similar to get_existing_builders but queries KonfluxDb instead of Brew.
+        Similar to get_existing_builders_brew but queries KonfluxDb instead of Brew.
         Returns {el_v: KonfluxBuildRecord} so callers have access to image_pullspec.
         """
         _LOGGER.info(f"Checking if {GOLANG_BUILDER_IMAGE_NAME} builds exist in Konflux for given golang builds")

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -481,6 +481,9 @@ class UpdateGolangPipeline:
             if self.dry_run:
                 return True
 
+        if await is_available(self.ocp_version, el_v, nvr):
+            return True
+
         _LOGGER.warning("build not available after 5 hours")
         return False
 

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -974,6 +974,34 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         self.assertFalse(result)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("pyartcd.pipelines.update_golang.is_available", new_callable=AsyncMock, side_effect=[False, False, True])
+    @patch("pyartcd.pipelines.update_golang.is_latest", return_value=True)
+    async def test_process_build_available_after_retries(self, mock_is_latest, mock_is_available, mock_konflux_db):
+        """Test process_build succeeds after retrying request_repo"""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.20.12-2.el8"],
+            art_jira="ART-1234",
+            tag_builds=True,
+        )
+        pipeline.request_repo = AsyncMock()
+
+        result = await pipeline.process_build(8, "golang-1.20.12-2.el8")
+
+        self.assertTrue(result)
+        self.assertEqual(mock_is_available.call_count, 3)
+        self.assertEqual(pipeline.request_repo.call_count, 2)
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     async def test_tag_build_dry_run(self, mock_konflux_db):
         """Test tag_build in dry-run mode"""
         mock_runtime = Mock(

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -12,8 +12,9 @@ from pyartcd.pipelines.update_golang import (
     UpdateGolangPipeline,
     extract_and_validate_golang_nvrs,
     get_latest_nvr_in_tag,
+    is_available,
+    is_latest,
     is_latest_and_available,
-    is_latest_build,
     move_golang_bugs,
 )
 
@@ -123,15 +124,15 @@ class TestGetLatestNvrInTag(unittest.TestCase):
         self.assertIsNone(result)
 
 
-class TestIsLatestBuild(unittest.TestCase):
-    """Test the is_latest_build function"""
+class TestIsLatest(unittest.TestCase):
+    """Test the is_latest function"""
 
     def test_build_is_latest(self):
         """Test when build is the latest"""
         mock_koji_session = Mock()
         mock_koji_session.getLatestBuilds.return_value = [{"nvr": "golang-1.20.12-2.el8"}]
 
-        result = is_latest_build("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session)
+        result = is_latest("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session)
 
         self.assertTrue(result)
         mock_koji_session.getLatestBuilds.assert_called_once_with("rhaos-4.16-rhel-8-build", package="golang")
@@ -141,7 +142,7 @@ class TestIsLatestBuild(unittest.TestCase):
         mock_koji_session = Mock()
         mock_koji_session.getLatestBuilds.return_value = [{"nvr": "golang-1.20.13-1.el8"}]
 
-        result = is_latest_build("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session)
+        result = is_latest("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session)
 
         self.assertFalse(result)
 
@@ -151,48 +152,54 @@ class TestIsLatestBuild(unittest.TestCase):
         mock_koji_session.getLatestBuilds.return_value = []
 
         with self.assertRaisesRegex(ValueError, "Cannot find latest golang build"):
-            is_latest_build("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session)
+            is_latest("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session)
+
+
+class TestIsAvailable(IsolatedAsyncioTestCase):
+    """Test the is_available async function"""
+
+    @patch("artcommonlib.exectools.cmd_assert_async", return_value=0)
+    async def test_build_is_available(self, mock_cmd_assert):
+        result = await is_available("4.16", 8, "golang-1.20.12-2.el8")
+
+        self.assertTrue(result)
+        mock_cmd_assert.assert_called_once()
+
+    @patch("artcommonlib.exectools.cmd_assert_async", return_value=1)
+    async def test_build_is_not_available(self, mock_cmd_assert):
+        with self.assertLogs("pyartcd.pipelines.update_golang", level="INFO") as cm:
+            result = await is_available("4.16", 8, "golang-1.20.12-2.el8")
+
+        self.assertFalse(result)
+        self.assertIn("could not be confirmed available", cm.output[0])
 
 
 class TestIsLatestAndAvailable(IsolatedAsyncioTestCase):
-    """Test the is_latest_and_available async function"""
+    """Test the is_latest_and_available wrapper"""
 
-    @patch("pyartcd.pipelines.update_golang.is_latest_build")
-    @patch("artcommonlib.exectools.cmd_assert_async", return_value=0)
-    async def test_build_is_latest_and_available(self, mock_cmd_assert, mock_is_latest):
-        """Test when build is latest and available"""
-        mock_is_latest.return_value = True
+    @patch("pyartcd.pipelines.update_golang.is_available", new_callable=AsyncMock, return_value=True)
+    @patch("pyartcd.pipelines.update_golang.is_latest", return_value=True)
+    async def test_latest_and_available(self, mock_is_latest, mock_is_available):
         mock_koji_session = Mock()
-
         result = await is_latest_and_available("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session)
-
         self.assertTrue(result)
         mock_is_latest.assert_called_once_with("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session)
-        mock_cmd_assert.assert_called_once()
+        mock_is_available.assert_called_once_with("4.16", 8, "golang-1.20.12-2.el8")
 
-    @patch("pyartcd.pipelines.update_golang.is_latest_build")
-    async def test_build_is_not_latest(self, mock_is_latest):
-        """Test when build is not latest"""
-        mock_is_latest.return_value = False
+    @patch("pyartcd.pipelines.update_golang.is_available", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.update_golang.is_latest", return_value=False)
+    async def test_not_latest_short_circuits(self, mock_is_latest, mock_is_available):
         mock_koji_session = Mock()
-
         result = await is_latest_and_available("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session)
-
         self.assertFalse(result)
+        mock_is_available.assert_not_called()
 
-    @patch("pyartcd.pipelines.update_golang.is_latest_build")
-    @patch("artcommonlib.exectools.cmd_assert_async", return_value=1)
-    async def test_build_is_latest_but_not_available(self, mock_cmd_assert, mock_is_latest):
-        """Test when build is latest but not available in repo"""
-        mock_is_latest.return_value = True
+    @patch("pyartcd.pipelines.update_golang.is_available", new_callable=AsyncMock, return_value=False)
+    @patch("pyartcd.pipelines.update_golang.is_latest", return_value=True)
+    async def test_latest_but_not_available(self, mock_is_latest, mock_is_available):
         mock_koji_session = Mock()
-
-        with self.assertLogs("pyartcd.pipelines.update_golang", level="INFO") as cm:
-            result = await is_latest_and_available("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session)
-
+        result = await is_latest_and_available("4.16", 8, "golang-1.20.12-2.el8", mock_koji_session)
         self.assertFalse(result)
-        self.assertEqual(len(cm.output), 1)
-        self.assertIn("could not be confirmed available", cm.output[0])
 
 
 class TestMoveGolangBugs(IsolatedAsyncioTestCase):
@@ -843,7 +850,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         )
         pipeline.validate_tag_builds_go_latest = Mock()
         pipeline.process_build = AsyncMock(return_value=True)
-        pipeline.get_existing_builders = Mock(
+        pipeline.get_existing_builders_brew = Mock(
             return_value={9: "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9"}
         )
         pipeline.update_golang_streams = AsyncMock()
@@ -916,10 +923,10 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         self.assertIsNone(tag)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    @patch("pyartcd.pipelines.update_golang.is_latest_and_available")
-    async def test_process_build_already_latest_and_available(self, mock_is_latest, mock_konflux_db):
+    @patch("pyartcd.pipelines.update_golang.is_available", new_callable=AsyncMock, return_value=True)
+    @patch("pyartcd.pipelines.update_golang.is_latest", return_value=True)
+    async def test_process_build_already_latest_and_available(self, mock_is_latest, mock_is_available, mock_konflux_db):
         """Test process_build when build is already latest and available"""
-        mock_is_latest.return_value = True
         mock_runtime = Mock(
             dry_run=False,
             working_dir=Path("/tmp/working"),
@@ -940,12 +947,12 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         self.assertTrue(result)
         mock_is_latest.assert_called_once_with("4.16", 8, "golang-1.20.12-2.el8", pipeline.koji_session)
+        mock_is_available.assert_called_once_with("4.16", 8, "golang-1.20.12-2.el8")
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    @patch("pyartcd.pipelines.update_golang.is_latest_and_available")
+    @patch("pyartcd.pipelines.update_golang.is_latest", return_value=False)
     async def test_process_build_not_latest_no_tag(self, mock_is_latest, mock_konflux_db):
         """Test process_build when build is not latest and tag_builds is False"""
-        mock_is_latest.return_value = False
         mock_runtime = Mock(
             dry_run=False,
             working_dir=Path("/tmp/working"),
@@ -1063,8 +1070,8 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("elliottlib.util.get_golang_container_nvrs_brew")
-    def test_get_existing_builders(self, mock_get_golang_nvrs, mock_konflux_db):
-        """Test get_existing_builders for Brew"""
+    def test_get_existing_builders_brew(self, mock_get_golang_nvrs, mock_konflux_db):
+        """Test get_existing_builders_brew for Brew"""
         mock_runtime = Mock(
             dry_run=False,
             working_dir=Path("/tmp/working"),
@@ -1098,7 +1105,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         }
 
         el_nvr_map = {8: "golang-1.20.12-2.el8"}
-        builder_nvrs = pipeline.get_existing_builders(el_nvr_map, "1.20.12")
+        builder_nvrs = pipeline.get_existing_builders_brew(el_nvr_map, "1.20.12")
 
         self.assertEqual(builder_nvrs, {8: "openshift-golang-builder-container-v1.20.12-202403212137.el8.g144a3f8"})
 


### PR DESCRIPTION
## Summary
- Add `timeout` parameter to `cmd_gather_async` and `cmd_assert_async` in exectools, using `asyncio.wait_for` to kill subprocess on expiry
- Split `is_latest_and_available` into separate `is_latest` and `is_available` functions; keep wrapper for `rebuild_golang_rpms`
- Refactor `process_build` to only tag when not latest, only request repo when not available
- Extract `request_repo` method using `brew wait-repo --request --build` with 1hr Python timeout (brew `--timeout` can be unreliable)
- Rename `get_existing_builders` → `get_existing_builders_brew`

## Test plan
- [x] All existing unit tests pass (79 tests across `test_update_golang.py` and `test_rebuild_golang_rpms.py`)
- [x] All exectools tests pass (34 tests in `test_exectools.py`)
- [x] `make format` and `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)