### PR TITLE
ART-18202: fix cross-arch lockfile reconciliation ignoring version pins

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -1366,6 +1366,17 @@ class RpmLockfilePrototypeGenerator:
             pins.append(format_version_pin(name, min_evr))
         return pins
 
+    @staticmethod
+    def _format_mismatches(mismatches: dict[str, dict[str, str]]) -> str:
+        """
+        Format cross-arch mismatches for error messages.
+        """
+        parts = []
+        for name, arch_evrs in sorted(mismatches.items()):
+            versions = ", ".join(f"{arch}={evr}" for arch, evr in sorted(arch_evrs.items()))
+            parts.append(f"{name} ({versions})")
+        return "; ".join(parts)
+
     async def _resolve_with_reconciliation(
         self,
         repo_list: list[RepoEntry],
@@ -1441,11 +1452,11 @@ class RpmLockfilePrototypeGenerator:
             f"{distgit_key}: stage {stage_num}: re-resolving with {len(version_pins)} version pins: {version_pins}"
         )
 
-        pinned_packages = list(packages) + version_pins
-        pinned_names = set(mismatches.keys())
-        pinned_update_targets = [t for t in update_targets if t not in pinned_names]
+        mismatched_names = set(mismatches.keys())
+        pinned_packages = [p for p in packages if p not in mismatched_names] + version_pins
+        pinned_update_targets = [p for p in update_targets if p not in mismatched_names]
         pinned_reinstall = (
-            [p for p in reinstall_packages if p not in pinned_names] if reinstall_packages else reinstall_packages
+            [p for p in reinstall_packages if p not in mismatched_names] if reinstall_packages else reinstall_packages
         )
 
         try:
@@ -1463,23 +1474,26 @@ class RpmLockfilePrototypeGenerator:
                 strippable_packages=strippable_packages,
                 dockerfile_packages=dockerfile_packages,
             )
-        except RuntimeError:
-            self.logger.warning(
-                f"{distgit_key}: stage {stage_num}: version-pinned re-resolution failed, "
-                "using original result with version mismatches"
-            )
-            return first_pass
+        except RuntimeError as e:
+            raise RuntimeError(
+                f"{distgit_key}: stage {stage_num}: cross-arch version reconciliation failed. "
+                f"Version-pinned re-resolution error: {e}. "
+                f"Mismatched packages: {self._format_mismatches(mismatches)}"
+            ) from e
 
         if not second_pass:
-            return first_pass
+            raise RuntimeError(
+                f"{distgit_key}: stage {stage_num}: cross-arch version reconciliation failed. "
+                f"Re-resolution returned no results. "
+                f"Mismatched packages: {self._format_mismatches(mismatches)}"
+            )
 
         remaining = self._detect_cross_arch_mismatches(second_pass)
         if remaining:
-            self.logger.warning(
-                f"{distgit_key}: stage {stage_num}: {len(remaining)} mismatches persist after "
-                "re-resolution, using original result"
+            raise RuntimeError(
+                f"{distgit_key}: stage {stage_num}: cross-arch version reconciliation failed. "
+                f"Mismatches persist after re-resolution: {self._format_mismatches(remaining)}"
             )
-            return first_pass
 
         self.logger.info(f"{distgit_key}: stage {stage_num}: cross-arch versions reconciled successfully")
         return second_pass

--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -1454,6 +1454,7 @@ class RpmLockfilePrototypeGenerator:
 
         mismatched_names = set(mismatches.keys())
         pinned_packages = [p for p in packages if p not in mismatched_names] + version_pins
+        pinned_arch_pkgs = {arch: [p for p in pkgs if p not in mismatched_names] for arch, pkgs in arch_pkgs.items()}
         pinned_update_targets = [p for p in update_targets if p not in mismatched_names]
         pinned_reinstall = (
             [p for p in reinstall_packages if p not in mismatched_names] if reinstall_packages else reinstall_packages
@@ -1464,7 +1465,7 @@ class RpmLockfilePrototypeGenerator:
                 repo_list,
                 arches,
                 pinned_packages,
-                arch_pkgs,
+                pinned_arch_pkgs,
                 pinned_update_targets,
                 image_pullspec,
                 distgit_key,

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -2121,7 +2121,81 @@ class TestCrossArchReconciliation(unittest.IsolatedAsyncioTestCase):
         second_call_packages = gen._resolve_stage_with_retry.call_args_list[1][0][2]
         self.assertIn("libeconf-0.4.1-5.el9", second_call_packages)
 
-    async def test_reconciliation_falls_back_on_error(self):
+    async def test_reconciliation_excludes_unversioned_name_from_pinned_packages(self):
+        """
+        When the packages list contains an unversioned name that matches a
+        mismatched package, the second resolution must exclude the unversioned
+        name so DNF doesn't override the version pin.
+        """
+        gen = self._make_generator()
+        mismatched = self._make_lockfile(
+            {
+                "x86_64": [("libeconf", "0.4.1-7.el9_8", "https://x86/libeconf-7.rpm")],
+                "aarch64": [("libeconf", "0.4.1-5.el9", "https://arm/libeconf-5.rpm")],
+            }
+        )
+        reconciled = self._make_lockfile(
+            {
+                "x86_64": [("libeconf", "0.4.1-5.el9", "https://x86/libeconf-5.rpm")],
+                "aarch64": [("libeconf", "0.4.1-5.el9", "https://arm/libeconf-5.rpm")],
+            }
+        )
+        gen._resolve_stage_with_retry = AsyncMock(side_effect=[mismatched, reconciled])
+
+        result = await gen._resolve_with_reconciliation(
+            [],
+            ["x86_64", "aarch64"],
+            ["curl", "libeconf"],
+            {},
+            [],
+            None,
+            "test-image",
+            0,
+        )
+        self.assertEqual(result, reconciled)
+
+        second_call_packages = gen._resolve_stage_with_retry.call_args_list[1][0][2]
+        self.assertIn("libeconf-0.4.1-5.el9", second_call_packages)
+        self.assertNotIn("libeconf", second_call_packages)
+        self.assertIn("curl", second_call_packages)
+
+    async def test_reconciliation_excludes_mismatched_from_update_targets(self):
+        """
+        Update targets matching mismatched packages must be excluded from the
+        second resolution to prevent base.upgrade() from overriding pins.
+        """
+        gen = self._make_generator()
+        mismatched = self._make_lockfile(
+            {
+                "x86_64": [("libeconf", "0.4.1-7.el9_8", "https://x86/libeconf-7.rpm")],
+                "aarch64": [("libeconf", "0.4.1-5.el9", "https://arm/libeconf-5.rpm")],
+            }
+        )
+        reconciled = self._make_lockfile(
+            {
+                "x86_64": [("libeconf", "0.4.1-5.el9", "https://x86/libeconf-5.rpm")],
+                "aarch64": [("libeconf", "0.4.1-5.el9", "https://arm/libeconf-5.rpm")],
+            }
+        )
+        gen._resolve_stage_with_retry = AsyncMock(side_effect=[mismatched, reconciled])
+
+        result = await gen._resolve_with_reconciliation(
+            [],
+            ["x86_64", "aarch64"],
+            ["curl", "libeconf"],
+            {},
+            ["libeconf", "curl"],
+            None,
+            "test-image",
+            0,
+        )
+        self.assertEqual(result, reconciled)
+
+        second_call_update_targets = gen._resolve_stage_with_retry.call_args_list[1][0][4]
+        self.assertNotIn("libeconf", second_call_update_targets)
+        self.assertIn("curl", second_call_update_targets)
+
+    async def test_reconciliation_raises_on_resolution_error(self):
         gen = self._make_generator()
         mismatched = self._make_lockfile(
             {
@@ -2131,20 +2205,22 @@ class TestCrossArchReconciliation(unittest.IsolatedAsyncioTestCase):
         )
         gen._resolve_stage_with_retry = AsyncMock(side_effect=[mismatched, RuntimeError("DNF depsolve error")])
 
-        result = await gen._resolve_with_reconciliation(
-            [],
-            ["x86_64", "aarch64"],
-            ["curl"],
-            {},
-            [],
-            None,
-            "test-image",
-            0,
-        )
-        self.assertEqual(result, mismatched)
+        with self.assertRaises(RuntimeError) as ctx:
+            await gen._resolve_with_reconciliation(
+                [],
+                ["x86_64", "aarch64"],
+                ["curl"],
+                {},
+                [],
+                None,
+                "test-image",
+                0,
+            )
+        self.assertIn("reconciliation failed", str(ctx.exception))
+        self.assertIn("libeconf", str(ctx.exception))
         self.assertEqual(gen._resolve_stage_with_retry.await_count, 2)
 
-    async def test_reconciliation_falls_back_on_persistent_mismatch(self):
+    async def test_reconciliation_raises_on_persistent_mismatch(self):
         gen = self._make_generator()
         mismatched = self._make_lockfile(
             {
@@ -2154,17 +2230,19 @@ class TestCrossArchReconciliation(unittest.IsolatedAsyncioTestCase):
         )
         gen._resolve_stage_with_retry = AsyncMock(return_value=mismatched)
 
-        result = await gen._resolve_with_reconciliation(
-            [],
-            ["x86_64", "aarch64"],
-            ["curl"],
-            {},
-            [],
-            None,
-            "test-image",
-            0,
-        )
-        self.assertEqual(result, mismatched)
+        with self.assertRaises(RuntimeError) as ctx:
+            await gen._resolve_with_reconciliation(
+                [],
+                ["x86_64", "aarch64"],
+                ["curl"],
+                {},
+                [],
+                None,
+                "test-image",
+                0,
+            )
+        self.assertIn("reconciliation failed", str(ctx.exception))
+        self.assertIn("libeconf", str(ctx.exception))
         self.assertEqual(gen._resolve_stage_with_retry.await_count, 2)
 
     async def test_reconciliation_removes_mismatched_from_update_targets(self):

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -2159,6 +2159,44 @@ class TestCrossArchReconciliation(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("libeconf", second_call_packages)
         self.assertIn("curl", second_call_packages)
 
+    async def test_reconciliation_excludes_mismatched_from_arch_pkgs(self):
+        """
+        When arch_pkgs contains an unversioned name matching a mismatched
+        package, the second resolution must exclude it so DNF cannot override
+        the version pin via the per-arch package list.
+        """
+        gen = self._make_generator()
+        mismatched = self._make_lockfile(
+            {
+                "x86_64": [("libeconf", "0.4.1-7.el9_8", "https://x86/libeconf-7.rpm")],
+                "aarch64": [("libeconf", "0.4.1-5.el9", "https://arm/libeconf-5.rpm")],
+            }
+        )
+        reconciled = self._make_lockfile(
+            {
+                "x86_64": [("libeconf", "0.4.1-5.el9", "https://x86/libeconf-5.rpm")],
+                "aarch64": [("libeconf", "0.4.1-5.el9", "https://arm/libeconf-5.rpm")],
+            }
+        )
+        gen._resolve_stage_with_retry = AsyncMock(side_effect=[mismatched, reconciled])
+
+        result = await gen._resolve_with_reconciliation(
+            [],
+            ["x86_64", "aarch64"],
+            ["curl"],
+            {"x86_64": ["libeconf", "xz"], "aarch64": ["libeconf"]},
+            [],
+            None,
+            "test-image",
+            0,
+        )
+        self.assertEqual(result, reconciled)
+
+        second_call_arch_pkgs = gen._resolve_stage_with_retry.call_args_list[1][0][3]
+        self.assertNotIn("libeconf", second_call_arch_pkgs.get("x86_64", []))
+        self.assertNotIn("libeconf", second_call_arch_pkgs.get("aarch64", []))
+        self.assertIn("xz", second_call_arch_pkgs.get("x86_64", []))
+
     async def test_reconciliation_excludes_mismatched_from_update_targets(self):
         """
         Update targets matching mismatched packages must be excluded from the


### PR DESCRIPTION
When reconciling cross-arch RPM version mismatches, version pins were appended to the packages list without removing the unversioned package names. DNF saw both "libsemanage" (install latest) and "libsemanage-3.6-1.el9" (pin), picked the latest per arch, and the pin was effectively ignored. Same issue with update_targets where base.upgrade() would override pins.

Fix: exclude unversioned names of mismatched packages from both the packages list and update_targets before re-resolution. Also raise RuntimeError instead of silently falling back to the mismatched lockfile so builds fail early with a clear message instead of producing Conforma violations later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform package reconciliation by excluding mismatched packages from follow-up resolution and update steps.
  * Version-pinned package requirements are now preserved when architectures disagree.
  * Resolution failures, empty results, and unresolved mismatches now report clear errors identifying affected packages instead of silently using incomplete results.
* **Tests**
  * Expanded coverage for cross-platform mismatch handling, update targets, and reconciliation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->