### PR TITLE
Add enable-symlink-check param to Konflux image builds

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -48,6 +48,7 @@ class ImageBuildParams:
     """Optional build customization parameters for a Konflux PipelineRun."""
 
     hermetic: Optional[bool] = None
+    enable_symlink_check: Optional[bool] = None
     sast: Optional[bool] = None
     dockerfile: Optional[str] = None
     rebuild: Optional[bool] = None
@@ -1277,6 +1278,8 @@ class KonfluxClient:
             _modify_param(plr_params, "prefetch-input", build_params.prefetch)
         if build_params.hermetic is not None:
             _modify_param(plr_params, "hermetic", build_params.hermetic)
+        if build_params.enable_symlink_check is not None:
+            _modify_param(plr_params, "enable-symlink-check", build_params.enable_symlink_check)
 
         if build_params.rebuild is not None:
             _modify_param(plr_params, "rebuild", build_params.rebuild)

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -1328,6 +1328,8 @@ class KonfluxClient:
                         "refspec",
                         f"{commit_sha}:refs/remotes/origin/{target_branch} refs/tags/*:refs/tags/*",
                     )
+                    if build_params.enable_symlink_check is not None:
+                        _modify_param(task["params"], "enableSymlinkCheck", build_params.enable_symlink_check)
                 case "sast-snyk-check":
                     has_sast_task = True
                 case "ecosystem-cert-preflight-checks":

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -745,8 +745,12 @@ class KonfluxImageBuilder:
             annotations["art-overall-timeout-minutes"] = str(build_timeout_minutes)
             logger.info(f"Setting custom build timeout: {build_timeout_minutes} minutes")
 
+        raw_symlink_check = _get_konflux_config(metadata, "enable_symlink_check")
+        enable_symlink_check = bool(raw_symlink_check) if raw_symlink_check is not None else None
+
         build_params = ImageBuildParams(
             hermetic=hermetic,
+            enable_symlink_check=enable_symlink_check,
             prefetch=prefetch,
             sast=sast,
             build_args=build_args,

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -650,6 +650,36 @@ class TestNewPipelinerunBuildArgs(IsolatedAsyncioTestCase):
         self.assertEqual(param_dict["build-args"], [])
 
 
+class TestNewPipelinerunEnableSymlinkCheck(IsolatedAsyncioTestCase):
+    """Tests for enable_symlink_check in _new_pipelinerun_for_image_build."""
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_enable_symlink_check_false_sets_param(self, mock_get_template):
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(enable_symlink_check=False),
+        )
+
+        plr_params = result["spec"]["params"]
+        param_dict = {p["name"]: p["value"] for p in plr_params}
+        self.assertEqual(param_dict["enable-symlink-check"], "false")
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_enable_symlink_check_none_is_noop(self, mock_get_template):
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(enable_symlink_check=None),
+        )
+
+        plr_params = result["spec"]["params"]
+        param_dict = {p["name"]: p["value"] for p in plr_params}
+        self.assertNotIn("enable-symlink-check", param_dict)
+
+
 class TestNewPipelinerunAdditionalSecret(IsolatedAsyncioTestCase):
     """Tests for additional_secret in _new_pipelinerun_for_image_build."""
 

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -654,7 +654,7 @@ class TestNewPipelinerunEnableSymlinkCheck(IsolatedAsyncioTestCase):
     """Tests for enable_symlink_check in _new_pipelinerun_for_image_build."""
 
     @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
-    async def test_enable_symlink_check_false_sets_param(self, mock_get_template):
+    async def test_enable_symlink_check_false_sets_pipeline_and_task_param(self, mock_get_template):
         client = _make_mock_client(mock_get_template)
 
         result = await client._new_pipelinerun_for_image_build(
@@ -665,6 +665,11 @@ class TestNewPipelinerunEnableSymlinkCheck(IsolatedAsyncioTestCase):
         plr_params = result["spec"]["params"]
         param_dict = {p["name"]: p["value"] for p in plr_params}
         self.assertEqual(param_dict["enable-symlink-check"], "false")
+
+        tasks = result["spec"]["pipelineSpec"]["tasks"]
+        clone_task = next(t for t in tasks if t["name"] == "clone-repository")
+        task_param_dict = {p["name"]: p["value"] for p in clone_task["params"]}
+        self.assertEqual(task_param_dict["enableSymlinkCheck"], "false")
 
     @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
     async def test_enable_symlink_check_none_is_noop(self, mock_get_template):
@@ -678,6 +683,11 @@ class TestNewPipelinerunEnableSymlinkCheck(IsolatedAsyncioTestCase):
         plr_params = result["spec"]["params"]
         param_dict = {p["name"]: p["value"] for p in plr_params}
         self.assertNotIn("enable-symlink-check", param_dict)
+
+        tasks = result["spec"]["pipelineSpec"]["tasks"]
+        clone_task = next(t for t in tasks if t["name"] == "clone-repository")
+        task_param_names = {p["name"] for p in clone_task["params"]}
+        self.assertNotIn("enableSymlinkCheck", task_param_names)
 
 
 class TestNewPipelinerunAdditionalSecret(IsolatedAsyncioTestCase):

--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -533,6 +533,17 @@
           "$ref": "#/properties/konflux/properties/privileged_nested"
         },
         "privileged_nested-": {},
+        "enable_symlink_check": {
+          "description": "Enable symlink check in the build pipeline. Defaults to true if not specified.",
+          "type": "boolean"
+        },
+        "enable_symlink_check!": {
+          "$ref": "#/properties/konflux/properties/enable_symlink_check"
+        },
+        "enable_symlink_check?": {
+          "$ref": "#/properties/konflux/properties/enable_symlink_check"
+        },
+        "enable_symlink_check-": {},
         "build_step_resources": {
           "description": "Kubernetes resource requests/limits for the build step (e.g. memory, ephemeral-storage)",
           "type": "object",

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -1506,6 +1506,17 @@
           "$ref": "#/properties/konflux/properties/privileged_nested"
         },
         "privileged_nested-": {},
+        "enable_symlink_check": {
+          "description": "Enable symlink check in the build pipeline. Defaults to true if not specified.",
+          "type": "boolean"
+        },
+        "enable_symlink_check!": {
+          "$ref": "#/properties/konflux/properties/enable_symlink_check"
+        },
+        "enable_symlink_check?": {
+          "$ref": "#/properties/konflux/properties/enable_symlink_check"
+        },
+        "enable_symlink_check-": {},
         "build_step_resources": {
           "description": "Kubernetes resource requests/limits for the build step (e.g. memory, ephemeral-storage)",
           "type": "object",


### PR DESCRIPTION
## Summary
- Add `enable_symlink_check` as a configurable parameter in ocp-build-data (group and image level)
- When set, injects `enable-symlink-check` into the Konflux PipelineRun params
- When not specified, the param is not injected and defaults to `true` (pipeline default)

### Usage in ocp-build-data
```yaml
konflux:
  enable_symlink_check: false
```

## Test plan
- [x] Unit tests added for `enable-symlink-check` param injection (`test_enable_symlink_check_false_sets_param`, `test_enable_symlink_check_none_is_noop`)
- [x] All existing tests pass (`69 passed`)
- [x] Verify with a test build using an ocp-build-data image config that sets `enable_symlink_check: false`

Running against: https://github.com/openshift-eng/ocp-build-data/pull/10888

🤖 Generated with [Claude Code](https://claude.com/claude-code)