### PR TITLE
ART-18202: support [ arch != X ] || dnf install pattern in lockfile parser

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/constants.py
+++ b/doozer/doozerlib/lockfile_prototype/constants.py
@@ -22,7 +22,7 @@ SYSTEM_PYTHON = "/usr/bin/python3"
 RPM_LOCKFILE_ENTRY_POINT = "from rpm_lockfile import main; main()"
 
 # Shell subshell expressions that evaluate to the current architecture
-ARCH_SUBSHELL_KEYWORDS = ("$(arch)", "$(uname -m)", "$(uname -p)")
+ARCH_SUBSHELL_KEYWORDS = ("$(arch)", "$(uname -m)", "$(uname -p)", "$(go env GOARCH)")
 
 # Shell variable names that hold the current architecture
 ARCH_VAR_NAMES = ("HOSTTYPE", "ARCH")

--- a/doozer/doozerlib/lockfile_prototype/constants.py
+++ b/doozer/doozerlib/lockfile_prototype/constants.py
@@ -25,7 +25,7 @@ RPM_LOCKFILE_ENTRY_POINT = "from rpm_lockfile import main; main()"
 ARCH_SUBSHELL_KEYWORDS = ("$(arch)", "$(uname -m)", "$(uname -p)", "$(go env GOARCH)")
 
 # Shell variable names that hold the current architecture
-ARCH_VAR_NAMES = ("HOSTTYPE", "ARCH")
+ARCH_VAR_NAMES = ("HOSTTYPE", "ARCH", "GOARCH")
 
 # All arch keywords: subshells + variables in both $VAR and ${VAR} forms
 ARCH_KEYWORDS = ARCH_SUBSHELL_KEYWORDS + tuple(form for name in ARCH_VAR_NAMES for form in (f"${name}", f"${{{name}}}"))

--- a/doozer/doozerlib/lockfile_prototype/shell_parser.py
+++ b/doozer/doozerlib/lockfile_prototype/shell_parser.py
@@ -39,6 +39,10 @@ ARCH_VALUE_RE = re.compile(
     rf"(?:{_ARCH_PATTERN})"
     r"[\"']?\s*==?\s*[\"']?(\w+)[\"']?"
 )
+ARCH_NEQ_VALUE_RE = re.compile(
+    rf"(?:{_ARCH_PATTERN})"
+    r"""[\"']?\s*!=\s*[\"']?(\w+)[\"']?"""
+)
 
 
 _MAX_EXPANSION_DEPTH = 10
@@ -148,6 +152,75 @@ def _extract_condition_arch(node) -> list[str]:
     return arches
 
 
+def _extract_list_arch_context(test_node, operator: str) -> list[str] | None:
+    """
+    Compute effective arch context from a ``[ test ] || cmd`` or
+    ``[ test ] && cmd`` pattern.
+
+    Handles:
+        ``[ $(arch) != X ] || cmd`` → [X] (double negation = only on X)
+        ``[ $(arch) = X ] && cmd``  → [X] (direct match = only on X)
+        Other combos need full arch set → returns None (unconditional).
+    """
+    if not hasattr(test_node, "parts"):
+        return None
+    words = [p.word for p in test_node.parts if hasattr(p, "word")]
+    if not words or words[0] != "[":
+        return None
+    text = " ".join(words)
+    if not _has_arch_test(text):
+        return None
+
+    neq_arches = ARCH_NEQ_VALUE_RE.findall(text)
+    eq_arches = ARCH_VALUE_RE.findall(text)
+
+    if neq_arches and operator == "||":
+        return neq_arches
+    if eq_arches and operator == "&&":
+        return eq_arches
+
+    logger = logging.getLogger(__name__)
+    logger.debug(f"Unsupported arch-conditional pattern (needs full arch set): {text} {operator} cmd")
+    return None
+
+
+def _walk_list_node(
+    node,
+    ctx: _WalkContext,
+    arch_context: list[str] | None = None,
+    in_conditional: bool = False,
+):
+    """
+    Walk a list node, detecting ``[ test ] || cmd`` and
+    ``[ test ] && cmd`` arch-conditional patterns.
+    """
+    parts = node.parts
+    consumed: set[int] = set()
+
+    for i, part in enumerate(parts):
+        if part.kind != "command" or i in consumed:
+            continue
+        words = [p.word for p in part.parts if hasattr(p, "word")]
+        if not words or words[0] != "[":
+            continue
+        if i + 2 >= len(parts):
+            continue
+        op_node = parts[i + 1]
+        if not hasattr(op_node, "op") or op_node.op not in ("||", "&&"):
+            continue
+        arch_ctx = _extract_list_arch_context(part, op_node.op)
+        if arch_ctx is None:
+            continue
+        consumed.add(i)
+        consumed.add(i + 1)
+        consumed.add(i + 2)
+        _walk_nodes([parts[i + 2]], ctx, arch_ctx, in_conditional=False)
+
+    remaining = [p for idx, p in enumerate(parts) if idx not in consumed]
+    if remaining:
+        _walk_nodes(remaining, ctx, arch_context, in_conditional)
+
+
 def _walk_nodes(
     nodes: list,
     ctx: _WalkContext,
@@ -162,7 +235,7 @@ def _walk_nodes(
         kind = node.kind
 
         if kind == "list":
-            _walk_nodes(node.parts, ctx, arch_context, in_conditional)
+            _walk_list_node(node, ctx, arch_context, in_conditional)
 
         elif kind == "compound":
             for child in node.list:

--- a/doozer/doozerlib/lockfile_prototype/shell_parser.py
+++ b/doozer/doozerlib/lockfile_prototype/shell_parser.py
@@ -11,6 +11,7 @@ import logging
 import re
 
 import bashlex
+from artcommonlib.arch_util import brew_arch_for_go_arch
 from pydantic import BaseModel, Field
 
 from doozerlib.lockfile_prototype.constants import ARCH_KEYWORDS
@@ -148,8 +149,16 @@ def _extract_condition_arch(node) -> list[str]:
             words = [p.word for p in part.parts if hasattr(p, "word")]
             text = " ".join(words)
             if _has_arch_test(text):
-                arches.extend(_extract_arch_values(text))
+                arches.extend(_normalize_arch_names(_extract_arch_values(text)))
     return arches
+
+
+def _normalize_arch_names(arches: list[str]) -> list[str]:
+    """
+    Normalize Go-style arch names (amd64, arm64) to RPM/Brew names
+    (x86_64, aarch64). Names already in RPM form pass through unchanged.
+    """
+    return [brew_arch_for_go_arch(a) for a in arches]
 
 
 def _extract_list_arch_context(test_node, operator: str) -> list[str] | None:
@@ -175,9 +184,9 @@ def _extract_list_arch_context(test_node, operator: str) -> list[str] | None:
     eq_arches = ARCH_VALUE_RE.findall(text)
 
     if neq_arches and operator == "||":
-        return neq_arches
+        return _normalize_arch_names(neq_arches)
     if eq_arches and operator == "&&":
-        return eq_arches
+        return _normalize_arch_names(eq_arches)
 
     logger = logging.getLogger(__name__)
     logger.debug(f"Unsupported arch-conditional pattern (needs full arch set): {text} {operator} cmd")

--- a/doozer/tests/lockfile_prototype/test_shell_parser.py
+++ b/doozer/tests/lockfile_prototype/test_shell_parser.py
@@ -385,6 +385,8 @@ class TestExtractPackagesFromRunCommands(unittest.TestCase):
         ('[ ${ARCH} == x86_64 ]', "x86_64"),
         ('[ $(arch) == "x86_64" ]', "x86_64"),
         ("[ $(go env GOARCH) = amd64 ]", "amd64"),
+        ("[ $GOARCH = amd64 ]", "amd64"),
+        ('[ ${GOARCH} == arm64 ]', "arm64"),
     ],
 )
 def test_arch_value_regex_matches(text, expected):
@@ -454,6 +456,8 @@ class TestListArchConditional(unittest.TestCase):
     def test_arch_context_only_applies_to_next_command(self):
         """
         In ``[ test ] || cmd1 && cmd2``, only cmd1 gets the arch context.
+        bashlex parses this as ``(test || cmd1) && cmd2`` (left-associative),
+        so only cmd1 is ``parts[i+2]`` and cmd2 falls into remaining nodes.
         """
         pkgs, arch_pkgs = extract_packages_from_run_commands(
             ['[ $(arch) != x86_64 ] || dnf install -y special-pkg && dnf install -y common-pkg']
@@ -483,23 +487,34 @@ class TestListArchConditional(unittest.TestCase):
     def test_go_env_goarch_neq_or(self):
         """
         ``[ $(go env GOARCH) != "amd64" ] || yum install -y pkg``
+        Go arch name ``amd64`` is normalized to RPM name ``x86_64``.
         """
         pkgs, arch_pkgs = extract_packages_from_run_commands(
             ['[ $(go env GOARCH) != "amd64" ] || yum install -y special-pkg']
         )
         self.assertEqual(pkgs, [])
-        self.assertEqual(arch_pkgs, {"amd64": ["special-pkg"]})
+        self.assertEqual(arch_pkgs, {"x86_64": ["special-pkg"]})
 
     def test_go_env_goarch_neq_or_subshell(self):
         """
         ``[ $(go env GOARCH) != "amd64" ] || (yum install -y pkg1 pkg2 && other)``
         — subshell grouping after ``||`` should still extract arch packages.
+        Go arch name ``amd64`` is normalized to RPM name ``x86_64``.
         """
         pkgs, arch_pkgs = extract_packages_from_run_commands(
             ['[ $(go env GOARCH) != "amd64" ] || (yum install -y llvm-toolset cmake3 gcc-c++ && tar zfx cross.tar.gz)']
         )
         self.assertEqual(pkgs, [])
-        self.assertEqual(arch_pkgs, {"amd64": ["cmake3", "gcc-c++", "llvm-toolset"]})
+        self.assertEqual(arch_pkgs, {"x86_64": ["cmake3", "gcc-c++", "llvm-toolset"]})
+
+    def test_goarch_var_neq_or(self):
+        """
+        ``[ $GOARCH != "arm64" ] || dnf install -y pkg``
+        Go arch name ``arm64`` is normalized to RPM name ``aarch64``.
+        """
+        pkgs, arch_pkgs = extract_packages_from_run_commands(['[ $GOARCH != "arm64" ] || dnf install -y arm-only-pkg'])
+        self.assertEqual(pkgs, [])
+        self.assertEqual(arch_pkgs, {"aarch64": ["arm-only-pkg"]})
 
 
 class TestBuilddepParsing(unittest.TestCase):

--- a/doozer/tests/lockfile_prototype/test_shell_parser.py
+++ b/doozer/tests/lockfile_prototype/test_shell_parser.py
@@ -384,6 +384,7 @@ class TestExtractPackagesFromRunCommands(unittest.TestCase):
         ("[ $ARCH = aarch64 ]", "aarch64"),
         ('[ ${ARCH} == x86_64 ]', "x86_64"),
         ('[ $(arch) == "x86_64" ]', "x86_64"),
+        ("[ $(go env GOARCH) = amd64 ]", "amd64"),
     ],
 )
 def test_arch_value_regex_matches(text, expected):
@@ -400,6 +401,105 @@ def test_arch_value_regex_no_match():
     ARCH_VALUE_RE should not match plain text.
     """
     assert ARCH_VALUE_RE.search("echo hello") is None
+
+
+class TestListArchConditional(unittest.TestCase):
+    """
+    Tests for ``[ test ] || cmd`` and ``[ test ] && cmd`` arch-conditional
+    patterns in list nodes.
+    """
+
+    def test_neq_or_extracts_arch_packages(self):
+        """
+        ``[ $(arch) != x86_64 ] || dnf install -y pkg`` installs only on x86_64.
+        """
+        pkgs, arch_pkgs = extract_packages_from_run_commands(['[ $(arch) != x86_64 ] || dnf install -y special-pkg'])
+        self.assertEqual(pkgs, [])
+        self.assertEqual(arch_pkgs, {"x86_64": ["special-pkg"]})
+
+    def test_eq_and_extracts_arch_packages(self):
+        """
+        ``[ $(arch) = x86_64 ] && dnf install -y pkg`` installs only on x86_64.
+        """
+        pkgs, arch_pkgs = extract_packages_from_run_commands(['[ $(arch) = x86_64 ] && dnf install -y special-pkg'])
+        self.assertEqual(pkgs, [])
+        self.assertEqual(arch_pkgs, {"x86_64": ["special-pkg"]})
+
+    def test_double_bracket_neq_or(self):
+        """
+        ``[[ $(arch) != aarch64 ]] || yum install -y arm-pkg`` with [[ ]] preprocessing.
+        """
+        pkgs, arch_pkgs = extract_packages_from_run_commands(['[[ $(arch) != aarch64 ]] || yum install -y arm-pkg'])
+        self.assertEqual(pkgs, [])
+        self.assertEqual(arch_pkgs, {"aarch64": ["arm-pkg"]})
+
+    def test_eq_or_treated_as_unconditional(self):
+        """
+        ``[ $(arch) = x86_64 ] || dnf install -y pkg`` means "all except x86_64"
+        which needs the full arch set — treated as unconditional.
+        """
+        pkgs, arch_pkgs = extract_packages_from_run_commands(['[ $(arch) = x86_64 ] || dnf install -y pkg'])
+        self.assertIn("pkg", pkgs)
+        self.assertEqual(arch_pkgs, {})
+
+    def test_neq_and_treated_as_unconditional(self):
+        """
+        ``[ $(arch) != x86_64 ] && dnf install -y pkg`` means "all except x86_64"
+        — treated as unconditional.
+        """
+        pkgs, arch_pkgs = extract_packages_from_run_commands(['[ $(arch) != x86_64 ] && dnf install -y pkg'])
+        self.assertIn("pkg", pkgs)
+        self.assertEqual(arch_pkgs, {})
+
+    def test_arch_context_only_applies_to_next_command(self):
+        """
+        In ``[ test ] || cmd1 && cmd2``, only cmd1 gets the arch context.
+        """
+        pkgs, arch_pkgs = extract_packages_from_run_commands(
+            ['[ $(arch) != x86_64 ] || dnf install -y special-pkg && dnf install -y common-pkg']
+        )
+        self.assertIn("common-pkg", pkgs)
+        self.assertEqual(arch_pkgs, {"x86_64": ["special-pkg"]})
+
+    def test_regular_or_fallback_unchanged(self):
+        """
+        Regular ``cmd1 || cmd2`` without [ test ] stays unconditional.
+        """
+        pkgs, arch_pkgs = extract_packages_from_run_commands(
+            ['dnf install -y preferred-pkg || dnf install -y fallback-pkg']
+        )
+        self.assertIn("preferred-pkg", pkgs)
+        self.assertIn("fallback-pkg", pkgs)
+        self.assertEqual(arch_pkgs, {})
+
+    def test_uname_m_neq_or(self):
+        """
+        ``[ $(uname -m) != s390x ] || dnf install -y s390x-pkg``
+        """
+        pkgs, arch_pkgs = extract_packages_from_run_commands(['[ $(uname -m) != s390x ] || dnf install -y s390x-pkg'])
+        self.assertEqual(pkgs, [])
+        self.assertEqual(arch_pkgs, {"s390x": ["s390x-pkg"]})
+
+    def test_go_env_goarch_neq_or(self):
+        """
+        ``[ $(go env GOARCH) != "amd64" ] || yum install -y pkg``
+        """
+        pkgs, arch_pkgs = extract_packages_from_run_commands(
+            ['[ $(go env GOARCH) != "amd64" ] || yum install -y special-pkg']
+        )
+        self.assertEqual(pkgs, [])
+        self.assertEqual(arch_pkgs, {"amd64": ["special-pkg"]})
+
+    def test_go_env_goarch_neq_or_subshell(self):
+        """
+        ``[ $(go env GOARCH) != "amd64" ] || (yum install -y pkg1 pkg2 && other)``
+        — subshell grouping after ``||`` should still extract arch packages.
+        """
+        pkgs, arch_pkgs = extract_packages_from_run_commands(
+            ['[ $(go env GOARCH) != "amd64" ] || (yum install -y llvm-toolset cmake3 gcc-c++ && tar zfx cross.tar.gz)']
+        )
+        self.assertEqual(pkgs, [])
+        self.assertEqual(arch_pkgs, {"amd64": ["cmake3", "gcc-c++", "llvm-toolset"]})
 
 
 class TestBuilddepParsing(unittest.TestCase):


### PR DESCRIPTION
  ## Summary

  Support `[ arch != X ] || cmd` and `[ arch = X ] && cmd` conditional patterns in the lockfile shell parser, including `$(go env GOARCH)` as an architecture keyword.

  ### Problem

  Some Dockerfiles use list-style arch conditionals instead of `if/then/fi`:

  ```dockerfile
  RUN [ $(go env GOARCH) != "amd64" ] || (\
      yum install -y llvm-toolset-17* cmake3 gcc-c++ libxml2-devel \
      glibc mingw64-gcc && ...)
```
  The parser didn't recognize this pattern, causing arch-specific packages to be treated as unconditional — they'd appear in lockfiles for all architectures.

  ### Changes

  - `shell_parser.py`: Add `ARCH_NEQ_VALUE_RE` regex for `!=` operator. Add `_extract_list_arch_context()` to compute effective arch from `[ test ] || cmd / [ test ] && cmd` patterns. Add `_walk_list_node()` to detect these patterns in bashlex list nodes before falling through to regular walking.
  - `constants.py`: Add `$(go env GOARCH) `to `ARCH_SUBSHELL_KEYWORDS`.


  Supported patterns

  | Pattern | Meaning | Result |
  |---------|---------|--------|
  | `[ $(arch) != X ] \|\| cmd` | double negation → only on X | arch-specific to X |
  | `[ $(arch) = X ] && cmd` | direct match → only on X | arch-specific to X |
  | `[ $(arch) = X ] \|\| cmd` | all except X (needs full arch set) | treated as unconditional |
  | `[ $(arch) != X ] && cmd` | all except X (needs full arch set) | treated as unconditional |


  Works with all existing arch keywords` ($(arch), $(uname -m), $HOSTTYPE, etc.)` plus the new `$(go env GOARCH).`
