### PR TITLE
Temporarily skip RPMs in ocp4-scan-konflux due to distgit connection issues

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -100,6 +100,7 @@ class Ocp4ScanPipeline:
                 '--yaml',
                 f'--ci-kubeconfig={os.environ["KUBECONFIG"]}',
                 '--rebase-priv',
+                '--skip-rpms',
             ]
         )
         if self.runtime.dry_run:


### PR DESCRIPTION
## Summary

This PR temporarily disables RPM scanning in the `ocp4-scan-konflux` pipeline by unconditionally passing `--skip-rpms` to the doozer scan-sources command.

## Background

The ocp4-scan-konflux job has been failing due to SSH connection issues when attempting to clone RPM distgit repositories from `pkgs.devel.redhat.com`:

```
ssh: connect to host pkgs.devel.redhat.com port 22: Connection refused
fatal: Could not read from remote repository.
```

Example failure: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/49179/

## Changes

- Added `'--skip-rpms'` flag to the doozer command in the `get_changes()` method
- This makes the scan only check images and RHCOS, skipping RPM distgit repository checks

## Impact

This is a **temporary workaround** until the connectivity issues with pkgs.devel.redhat.com are resolved. The scan will still check:
- ✅ Image source changes
- ✅ RHCOS changes
- ❌ RPM source changes (skipped)

For the Konflux scan workflow, checking images and RHCOS is sufficient for most use cases.

## Testing

The change has been tested locally and verified to skip RPM distgit cloning attempts.

## Follow-up

Once pkgs.devel.redhat.com connectivity is stable, this change should be reverted to restore full RPM scanning capability.