### PR TITLE
ART-18771: Register supplemental-tools product in Konflux constants

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -82,6 +82,7 @@ PRODUCT_NAMESPACE_MAP = {
     "openshift-logging": "art-logging-tenant",
     "quay": "art-quay-tenant",
     "rhmtc": "art-mtc-tenant",
+    "supplemental-tools": "ocp-art-tenant",
     "zero-trust": "art-oap-tenant",
 }
 
@@ -110,6 +111,7 @@ PRODUCT_KUBECONFIG_MAP = {
     "openshift-logging": "LOGGING_KONFLUX_SA_KUBECONFIG",
     "quay": "QUAY_KONFLUX_SA_KUBECONFIG",
     "rhmtc": "MTC_KONFLUX_SA_KUBECONFIG",
+    "supplemental-tools": "KONFLUX_SA_KUBECONFIG",
     "zero-trust": "OAP_KONFLUX_SA_KUBECONFIG",
 }
 


### PR DESCRIPTION
Adds supplemental-tools to PRODUCT_NAMESPACE_MAP and PRODUCT_KUBECONFIG_MAP so build_layered_products can resolve the correct Konflux namespace (ocp-art-tenant) and kubeconfig (KONFLUX_SA_KUBECONFIG).

Ref: [ART-18772](https://redhat.atlassian.net/browse/ART-18772)

Made with [Cursor](https://cursor.com)