### PR TITLE
Restrict --data-gitref to a single NVR in update-golang

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -1062,6 +1062,10 @@ async def update_golang(
     cves_list = cves.split(',') if cves else None
     if force_update_tracker and not cves_list:
         raise ValueError('CVEs must be provided with --force-update-tracker')
+    if data_gitref and len(go_nvrs) > 1:
+        raise click.BadParameter(
+            '--data-gitref can only be used with a single NVR to ensure the git ref is coupled to the correct RHEL version branch'
+        )
     if network_mode and build_system == 'brew':
         raise click.BadParameter('--network-mode only applies when --build-system is "konflux" or "both".')
 


### PR DESCRIPTION
## Summary
- When `--data-gitref` is provided to the `update-golang` pipeline, require exactly one NVR
- This prevents the same git ref from being incorrectly applied to multiple per-RHEL branches (e.g. `rhel-8-golang-1.22@myref`, `rhel-9-golang-1.22@myref`), since the ref should be coupled to a specific RHEL version branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)