### PR TITLE
ART-19363: Add --ocp-optional mode to release-from-fbc

### DIFF
--- a/artcommon/artcommonlib/gitlab.py
+++ b/artcommon/artcommonlib/gitlab.py
@@ -74,6 +74,26 @@ class GitLabClient:
         """
         return self._client.projects.get(project_path)
 
+    @staticmethod
+    def _parse_mr_url(mr_url: str) -> tuple[str, str]:
+        """
+        Extract the project path and MR IID from a full GitLab MR URL.
+
+        Arg(s):
+            mr_url (str): Full URL, e.g. "https://gitlab.example.com/group/project/-/merge_requests/42"
+        Return Value(s):
+            Tuple of (project_path, mr_iid) e.g. ("group/project", "42")
+        Raises:
+            ValueError: If the URL cannot be parsed as a GitLab MR URL
+        """
+        parsed = urlparse(mr_url)
+        path = parsed.path.strip("/")
+        if "/-/merge_requests/" not in path:
+            raise ValueError(f"Not a valid GitLab MR URL: {mr_url}")
+        project_path = path.split("/-/merge_requests")[0]
+        mr_iid = path.split("/")[-1]
+        return project_path, mr_iid
+
     def get_mr_from_url(self, mr_url: str):
         """
         Get MR object from URL.
@@ -86,12 +106,9 @@ class GitLabClient:
         if not mr_url:
             return None
 
-        parsed_url = urlparse(mr_url)
-        target_project_path = parsed_url.path.strip("/").split("/-/merge_requests")[0]
-        mr_id = parsed_url.path.split("/")[-1]
-
-        project = self._client.projects.get(target_project_path)
-        return project.mergerequests.get(mr_id)
+        project_path, mr_iid = self._parse_mr_url(mr_url)
+        project = self._client.projects.get(project_path)
+        return project.mergerequests.get(mr_iid)
 
     async def set_mr_ready(self, mr_url: str):
         """
@@ -223,6 +240,39 @@ class GitLabClient:
         pipeline_url = pipeline.web_url
         logger.info(f"CI MR pipeline triggered successfully: {pipeline_url}")
         return pipeline_url
+
+    def add_mr_dependency(self, mr_url: str, blocking_mr_url: str):
+        """
+        Set a native GitLab MR dependency so *mr_url* cannot be merged until
+        *blocking_mr_url* is merged first.
+
+        Uses the ``POST /projects/:id/merge_requests/:iid/blocks`` API.
+        Cross-project dependencies are supported by passing ``blocking_project_id``
+        when the two MRs belong to different projects.
+
+        Arg(s):
+            mr_url (str): Full URL of the merge request to be blocked
+            blocking_mr_url (str): Full URL of the merge request that must merge first
+        """
+        mr_project_path, mr_iid = self._parse_mr_url(mr_url)
+        blocking_project_path, blocking_mr_iid = self._parse_mr_url(blocking_mr_url)
+
+        project = self._client.projects.get(mr_project_path)
+
+        query: dict = {"blocking_merge_request_iid": int(blocking_mr_iid)}
+        if mr_project_path != blocking_project_path:
+            blocking_project = self._client.projects.get(blocking_project_path)
+            query["blocking_project_id"] = blocking_project.id
+
+        if self.dry_run:
+            logger.info("[DRY-RUN] Would add MR dependency: %s depends on %s", mr_url, blocking_mr_url)
+            return
+
+        self._client.http_post(
+            f"/projects/{project.id}/merge_requests/{mr_iid}/blocks",
+            query_data=query,
+        )
+        logger.info("Set MR dependency: %s depends on %s", mr_url, blocking_mr_url)
 
     def list_merge_requests(self, project_path: str, state: str = "opened", **kwargs):
         """

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -826,7 +826,11 @@ async def sync_to_quay(source_pullspec, destination_repo, tags=None):
 def _extract_images_from_catalog_json(catalog_path: str) -> list[str]:
     """Parse catalog.json (FBC format) and return relatedImages from olm.bundle entries.
 
-    Handles both NDJSON (one JSON object per line) and top-level JSON array formats.
+    Handles three catalog.json formats:
+      1. Single JSON document (array or object)
+      2. Compact NDJSON (one JSON object per line)
+      3. Pretty-printed concatenated JSON (multiple multi-line objects)
+
     Only extracts from entries where schema == "olm.bundle", mirroring:
         jq -r 'select(.schema == "olm.bundle") | .relatedImages[].image'
     """
@@ -854,6 +858,23 @@ def _extract_images_from_catalog_json(catalog_path: str) -> list[str]:
                     entries.append(obj)
             except json.JSONDecodeError:
                 continue
+
+    if not entries:
+        decoder = json.JSONDecoder()
+        idx = 0
+        content_len = len(content)
+        while idx < content_len:
+            remaining = content[idx:].lstrip()
+            if not remaining:
+                break
+            idx = content_len - len(remaining)
+            try:
+                obj, end_offset = decoder.raw_decode(content, idx)
+                if isinstance(obj, dict):
+                    entries.append(obj)
+                idx = end_offset
+            except json.JSONDecodeError:
+                break
 
     if not entries:
         raise RuntimeError(f"Failed to parse catalog.json: no valid JSON entries found in {catalog_path}")

--- a/artcommon/tests/test_gitlab_client.py
+++ b/artcommon/tests/test_gitlab_client.py
@@ -75,5 +75,82 @@ class TestGitLabClient(unittest.TestCase):
         self.assertIsInstance(client, GitLabClient)
 
 
+class TestParseMrUrl(unittest.TestCase):
+    def test_valid_url(self):
+        from artcommonlib.gitlab import GitLabClient
+
+        path, iid = GitLabClient._parse_mr_url(
+            "https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/549"
+        )
+        self.assertEqual(path, "hybrid-platforms/art/ocp-shipment-data")
+        self.assertEqual(iid, "549")
+
+    def test_invalid_url_raises(self):
+        from artcommonlib.gitlab import GitLabClient
+
+        with self.assertRaises(ValueError):
+            GitLabClient._parse_mr_url("https://gitlab.cee.redhat.com/group/project")
+
+
+class TestAddMrDependency(unittest.TestCase):
+    MR_URL = "https://gitlab.example.com/group/project/-/merge_requests/10"
+    BLOCKING_URL = "https://gitlab.example.com/group/project/-/merge_requests/5"
+    CROSS_PROJECT_URL = "https://gitlab.example.com/other/repo/-/merge_requests/7"
+
+    @patch("artcommonlib.gitlab.gitlab.Gitlab")
+    def test_same_project(self, mock_gitlab_class):
+        from artcommonlib.gitlab import GitLabClient
+
+        mock_gl = mock_gitlab_class.return_value
+        mock_project = MagicMock()
+        mock_project.id = 42
+        mock_gl.projects.get.return_value = mock_project
+
+        client = GitLabClient("https://gitlab.example.com", "fake-token")
+        client.add_mr_dependency(self.MR_URL, self.BLOCKING_URL)
+
+        mock_gl.http_post.assert_called_once_with(
+            "/projects/42/merge_requests/10/blocks",
+            query_data={"blocking_merge_request_iid": 5},
+        )
+
+    @patch("artcommonlib.gitlab.gitlab.Gitlab")
+    def test_cross_project(self, mock_gitlab_class):
+        from artcommonlib.gitlab import GitLabClient
+
+        mock_gl = mock_gitlab_class.return_value
+
+        project_a = MagicMock()
+        project_a.id = 42
+        project_b = MagicMock()
+        project_b.id = 99
+
+        def get_project(path):
+            if path == "group/project":
+                return project_a
+            return project_b
+
+        mock_gl.projects.get.side_effect = get_project
+
+        client = GitLabClient("https://gitlab.example.com", "fake-token")
+        client.add_mr_dependency(self.MR_URL, self.CROSS_PROJECT_URL)
+
+        mock_gl.http_post.assert_called_once_with(
+            "/projects/42/merge_requests/10/blocks",
+            query_data={"blocking_merge_request_iid": 7, "blocking_project_id": 99},
+        )
+
+    @patch("artcommonlib.gitlab.gitlab.Gitlab")
+    def test_dry_run_skips_api_call(self, mock_gitlab_class):
+        from artcommonlib.gitlab import GitLabClient
+
+        mock_gl = mock_gitlab_class.return_value
+
+        client = GitLabClient("https://gitlab.example.com", "fake-token", dry_run=True)
+        client.add_mr_dependency(self.MR_URL, self.BLOCKING_URL)
+
+        mock_gl.http_post.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -663,7 +663,7 @@ class TestExtractRelatedImagesFromFBC(unittest.TestCase):
             "quay.io/other/image@sha256:333",
         ]
 
-        # Sample catalog.json content -- FBC NDJSON with olm.bundle schema
+        # Sample catalog.json content -- FBC compact NDJSON with olm.bundle schema
         self.catalog_json_content = '\n'.join(
             [
                 json.dumps(
@@ -693,6 +693,45 @@ class TestExtractRelatedImagesFromFBC(unittest.TestCase):
                             {"name": "cli", "image": "registry.redhat.io/openshift4/ose-cli@sha256:555"},
                         ],
                     }
+                ),
+            ]
+        )
+
+        # Same catalog data but pretty-printed (multi-line concatenated JSON),
+        # matching the format produced by OCP FBC builds
+        # (e.g., ose-metallb-operator-fbc-4.22.0-20260528170921)
+        self.catalog_json_content_pretty = '\n'.join(
+            [
+                json.dumps(
+                    {
+                        "schema": "olm.package",
+                        "name": "test-operator",
+                        "defaultChannel": "stable",
+                    },
+                    indent=4,
+                ),
+                json.dumps(
+                    {
+                        "schema": "olm.channel",
+                        "name": "stable",
+                        "package": "test-operator",
+                        "entries": [
+                            {"name": "test-operator.v1.0.0", "skipRange": ">=0.0.1 <1.0.0"},
+                        ],
+                    },
+                    indent=4,
+                ),
+                json.dumps(
+                    {
+                        "schema": "olm.bundle",
+                        "name": "test-operator.v1.0.0",
+                        "package": "test-operator",
+                        "relatedImages": [
+                            {"name": "operator", "image": "registry.redhat.io/openshift4/ose-operator@sha256:444"},
+                            {"name": "cli", "image": "registry.redhat.io/openshift4/ose-cli@sha256:555"},
+                        ],
+                    },
+                    indent=4,
                 ),
             ]
         )
@@ -1015,3 +1054,26 @@ class TestExtractRelatedImagesFromFBC(unittest.TestCase):
         self.assertEqual(len(result), 2)
         self.assertIn('sha256:new222', str(result))
         self.assertIn('sha256:old111', str(result))
+
+    @patch('artcommonlib.util.cmd_gather_async', new_callable=AsyncMock)
+    @patch('builtins.open', new_callable=MagicMock)
+    @patch('os.path.exists')
+    @patch('os.listdir')
+    def test_catalog_json_pretty_printed_multiline(self, mock_listdir, mock_exists, mock_open, mock_cmd):
+        """Pretty-printed concatenated JSON (OCP FBC format) is parsed via raw_decode fallback"""
+        mock_cmd.side_effect = [
+            (0, self._create_discover_response(include_related_images=False, include_rendered_catalog=True), ''),
+            (0, 'Pulled artifact successfully', ''),
+        ]
+        mock_listdir.return_value = ['catalog.json']
+        mock_exists.side_effect = lambda path: 'catalog.json' in path
+
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.read.return_value = self.catalog_json_content_pretty
+        mock_open.return_value = mock_file
+
+        result = asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
+
+        self.assertEqual(len(result), 2)
+        self.assertIn('sha256:444', str(result))
+        self.assertIn('sha256:555', str(result))

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -66,6 +66,12 @@ class ReleaseFromFbcPipeline:
     This pipeline is designed for non-OpenShift products (e.g., OADP, MTA, MTC, logging)
     that need to create shipment files from FBC images. For OpenShift releases,
     use the PrepareReleaseKonfluxPipeline instead.
+
+    When --ocp-optional is set, the pipeline operates in OCP optional-operator mode:
+    it categorizes NVRs into extras/fbc kinds (matching the OCP shipment
+    structure) instead of the default image/fbc split. All FBC related images are
+    included by default, supporting the use case of shipping OCP optional operators
+    that were excluded from the main release due to dependency version conflicts.
     """
 
     def __init__(
@@ -80,6 +86,8 @@ class ReleaseFromFbcPipeline:
         jira_bugs: Optional[List[str]] = None,
         target_release_date: Optional[str] = None,
         extra_image_nvrs: Optional[List[str]] = None,
+        ocp_optional: bool = False,
+        exclude_nvr_components: Optional[List[str]] = None,
     ) -> None:
         self.logger = logging.getLogger(__name__)
         self.runtime = runtime
@@ -89,6 +97,8 @@ class ReleaseFromFbcPipeline:
         self.extra_image_nvrs = extra_image_nvrs or []
         self.create_mr = create_mr
         self.dry_run = self.runtime.dry_run
+        self.ocp_optional = ocp_optional
+        self.excluded_components = set(exclude_nvr_components) if exclude_nvr_components else set()
 
         # Setup working directories
         self.working_dir = self.runtime.working_dir.absolute()
@@ -480,32 +490,55 @@ class ReleaseFromFbcPipeline:
 
     def categorize_nvrs(self, nvrs: List[str]) -> Dict[str, List[str]]:
         """
-        Categorize NVRs into image builds, FBC builds, and external dependencies.
+        Categorize NVRs into build kinds.
+
+        In default mode: image / fbc / external (based on group version matching).
+        In OCP optional mode (--ocp-optional): extras / fbc / external.
+        All non-FBC images (including bundles) go into extras by default;
+        only explicitly listed --exclude-nvr-components are filtered out.
         """
         self.logger.info(f"Categorizing {len(nvrs)} extracted NVRs...")
 
-        categorized = {"image": [], "fbc": [], "external": []}
+        if self.ocp_optional:
+            categorized: Dict[str, List[str]] = {"extras": [], "fbc": [], "external": []}
 
-        for nvr in nvrs:
-            nvr_dict = parse_nvr(nvr)
-            component_name = nvr_dict['name']
+            for nvr in nvrs:
+                component_name = parse_nvr(nvr)['name']
 
-            if component_name.endswith('-fbc'):
-                categorized["fbc"].append(nvr)
-            elif self.is_nvr_from_current_group(nvr):
-                # All other builds from current group are considered image builds
-                categorized["image"].append(nvr)
-            else:
-                # External dependencies from other groups
-                categorized["external"].append(nvr)
+                if component_name.endswith('-fbc'):
+                    categorized["fbc"].append(nvr)
+                elif self.excluded_components and component_name in self.excluded_components:
+                    categorized["external"].append(nvr)
+                else:
+                    categorized["extras"].append(nvr)
 
-        self.logger.info("Categorization results:")
-        self.logger.info(f"  • Image builds: {len(categorized['image'])}")
-        self.logger.info(f"  • FBC builds: {len(categorized['fbc'])}")
-        if categorized['external']:
-            self.logger.info(f"  • External dependencies (filtered): {len(categorized['external'])}")
-            for ext_nvr in categorized['external']:
-                self.logger.info(f"    - {ext_nvr}")
+            self.logger.info("Categorization results (OCP optional mode):")
+            self.logger.info(f"  • Extras (all non-FBC images): {len(categorized['extras'])}")
+            self.logger.info(f"  • FBC builds: {len(categorized['fbc'])}")
+            if categorized['external']:
+                self.logger.info(f"  • Excluded: {len(categorized['external'])}")
+                for ext_nvr in categorized['external']:
+                    self.logger.info(f"    - {ext_nvr}")
+        else:
+            categorized = {"image": [], "fbc": [], "external": []}
+
+            for nvr in nvrs:
+                component_name = parse_nvr(nvr)['name']
+
+                if component_name.endswith('-fbc'):
+                    categorized["fbc"].append(nvr)
+                elif self.is_nvr_from_current_group(nvr):
+                    categorized["image"].append(nvr)
+                else:
+                    categorized["external"].append(nvr)
+
+            self.logger.info("Categorization results:")
+            self.logger.info(f"  • Image builds: {len(categorized['image'])}")
+            self.logger.info(f"  • FBC builds: {len(categorized['fbc'])}")
+            if categorized['external']:
+                self.logger.info(f"  • External dependencies (filtered): {len(categorized['external'])}")
+                for ext_nvr in categorized['external']:
+                    self.logger.info(f"    - {ext_nvr}")
 
         return categorized
 
@@ -603,13 +636,12 @@ class ReleaseFromFbcPipeline:
 
         self.logger.info(f"Creating shipment config for {kind}...")
 
-        # Create metadata - only set fbc=True for actual FBC catalog files
         metadata = Metadata(
-            product=self.product,  # Get product from group configuration
+            product=self.product,
             application=snapshot.spec.application if snapshot else "default-app",
             group=self.group,
             assembly=self.assembly,
-            fbc=kind == 'fbc',  # Only True for FBC catalog files, False for image shipments
+            fbc=kind == 'fbc',
         )
 
         # Create environments - read from shipment repo config if available
@@ -635,21 +667,21 @@ class ReleaseFromFbcPipeline:
 
         environments = Environments(stage=ShipmentEnv(releasePlan=stage_rpa), prod=ShipmentEnv(releasePlan=prod_rpa))
 
-        # Create release notes data
-        # If release_notes was provided (from JIRA bug processing), use it for image shipments
-        # Otherwise, set to null for release-from-fbc pipeline
-        # Exception: For OpenShift groups, provide minimal release notes to satisfy validation (required)
+        # Determine which kinds carry release notes.
+        # - 'fbc' shipments never carry release notes.
+        # - For openshift-* groups, ALL non-FBC shipments (image, extras)
+        #   require data.releaseNotes per shipment model validation.
+        # - For non-openshift groups, release notes are included only if provided.
         data = None
-        if kind == 'image' and release_notes:
-            self.logger.info("Using provided release notes (type=%s) for image shipment", release_notes.type)
+        if kind != 'fbc' and release_notes:
+            self.logger.info("Using provided release notes (type=%s) for %s shipment", release_notes.type, kind)
             data = Data(releaseNotes=release_notes)
-        elif kind == 'image' and self.group.startswith('openshift-'):
+        elif kind != 'fbc' and self.group.startswith('openshift-'):
             self.logger.info(
-                f"[Warning] Group '{self.group}' starts with 'openshift-' - generating minimal release notes "
-                f"to satisfy shipment validation requirements. This is a special situation case, "
-                f"PLEASE REVIEW!!"
+                f"Group '{self.group}' starts with 'openshift-' - generating minimal release notes "
+                f"for {kind} shipment to satisfy shipment validation requirements."
             )
-            rn = ReleaseNotes(type='RHBA', synopsis=f'FBC-derived image shipment for {self.product} {self.assembly}')
+            rn = ReleaseNotes(type='RHBA', synopsis=f'FBC-derived {kind} shipment for {self.product} {self.assembly}')
             data = Data(releaseNotes=rn)
 
         # Create shipment
@@ -926,9 +958,22 @@ class ReleaseFromFbcPipeline:
 
     async def run(self) -> None:
         """
-        Execute the simplified FBC release workflow for non-OpenShift products.
+        Execute the FBC release workflow.
+
+        In default mode, produces image + fbc shipments for layered products.
+        In OCP optional mode (--ocp-optional), produces extras + fbc
+        shipments for OCP optional operators that were excluded from the main release.
         """
         self.logger.info(f"Starting FBC-based release workflow for {self.assembly}")
+        if self.ocp_optional:
+            self.logger.info("OCP optional-operator mode enabled (extras/fbc)")
+            if self.excluded_components:
+                self.logger.info(f"Excluding NVR components: {sorted(self.excluded_components)}")
+            if not self.group.startswith('openshift-'):
+                self.logger.warning(
+                    f"--ocp-optional is intended for openshift-* groups, but group is '{self.group}'. "
+                    "This will include ALL related images without group-version filtering."
+                )
         self.logger.info(f"Processing {len(self.fbc_pullspecs)} FBC pullspecs")
         if self.extra_image_nvrs:
             self.logger.info(f"Including {len(self.extra_image_nvrs)} extra image NVRs")
@@ -943,9 +988,6 @@ class ReleaseFromFbcPipeline:
         self.product = await self._load_product_from_group_config()
         self.logger.info(f"Loaded product '{self.product}' - continuing workflow for {self.product} {self.assembly}")
 
-        # Note: All products use the same shipment data repository
-        # No need to update shipment repository based on product
-
         related_nvrs = []
         fbc_nvrs = []
 
@@ -959,7 +1001,7 @@ class ReleaseFromFbcPipeline:
             ]
 
             if fbc_nvrs:
-                self.logger.info(f"✓ Extracted {len(fbc_nvrs)} FBC NVRs: {fbc_nvrs}")
+                self.logger.info(f"Extracted {len(fbc_nvrs)} FBC NVRs: {fbc_nvrs}")
             else:
                 self.logger.warning("Could not extract any FBC NVRs - FBC shipments will not be created")
 
@@ -970,22 +1012,30 @@ class ReleaseFromFbcPipeline:
             raise RuntimeError("No NVRs extracted from FBC images and no extra image NVRs provided")
 
         # Categorize the extracted NVRs
-        categorized_nvrs = self.categorize_nvrs(all_nvrs) if all_nvrs else {"image": [], "fbc": [], "external": []}
+        empty_categorized: Dict[str, List[str]]
+        if self.ocp_optional:
+            empty_categorized = {"extras": [], "fbc": [], "external": []}
+        else:
+            empty_categorized = {"image": [], "fbc": [], "external": []}
+        categorized_nvrs = self.categorize_nvrs(all_nvrs) if all_nvrs else empty_categorized
 
-        # Merge extra image NVRs into the image category so they end up in the same image shipment
+        # The key for the primary non-FBC image shipment depends on mode
+        image_key = "extras" if self.ocp_optional else "image"
+
+        # Merge extra image NVRs into the primary image category
         if self.extra_image_nvrs:
             fbc_extras = [nvr for nvr in self.extra_image_nvrs if parse_nvr(nvr)['name'].endswith('-fbc')]
             if fbc_extras:
                 raise RuntimeError(
                     f"--extra-image-nvrs contains FBC builds which belong in --fbc-pullspecs instead: {fbc_extras}"
                 )
-            self.logger.info(f"Adding {len(self.extra_image_nvrs)} extra image NVRs to image shipment")
-            categorized_nvrs['image'] = list(dict.fromkeys([*categorized_nvrs['image'], *self.extra_image_nvrs]))
+            self.logger.info(f"Adding {len(self.extra_image_nvrs)} extra image NVRs to {image_key} shipment")
+            categorized_nvrs[image_key] = list(dict.fromkeys([*categorized_nvrs[image_key], *self.extra_image_nvrs]))
 
-        # Create snapshots for image builds (only once since they're shared)
+        # Create snapshots for the primary image/extras builds
         image_snapshot = None
-        if categorized_nvrs.get('image'):
-            image_snapshot = await self.create_snapshot(categorized_nvrs['image'])
+        if categorized_nvrs.get(image_key):
+            image_snapshot = await self.create_snapshot(categorized_nvrs[image_key])
 
         # Create separate FBC snapshots for each FBC build
         fbc_snapshots = {}
@@ -1009,19 +1059,18 @@ class ReleaseFromFbcPipeline:
 
         # Create shipment configurations
         timestamp = datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
-        shipments_by_kind = {}
+        shipments_by_kind: Dict[str, ShipmentConfig] = {}
 
-        # Create image shipment (shared for all FBC builds)
+        # Create the primary image/extras shipment
         if image_snapshot:
-            shipment_config = self.create_shipment_config('image', image_snapshot, release_notes=release_notes)
-            shipments_by_kind['image'] = shipment_config
+            shipment_config = self.create_shipment_config(image_key, image_snapshot, release_notes=release_notes)
+            shipments_by_kind[image_key] = shipment_config
 
         # Create separate FBC shipment for each FBC build
         fbc_counter = 1
         for _, fbc_snapshot in fbc_snapshots.items():
             if fbc_snapshot:
                 shipment_config = self.create_shipment_config('fbc', fbc_snapshot)
-                # Use counter-based key for unique naming
                 shipment_kind = f"fbc{fbc_counter:02d}"
                 shipments_by_kind[shipment_kind] = shipment_config
                 fbc_counter += 1
@@ -1043,7 +1092,12 @@ class ReleaseFromFbcPipeline:
                     self.logger.info("Continuing with local files only")
 
         # Generate completion message
-        completion_msg = f"FBC-based release workflow completed for {self.product} {self.assembly}. Created {len(shipments_by_kind)} shipment files in repository: {self.shipment_data_repo._directory}"
+        completion_msg = (
+            f"FBC-based release workflow completed for {self.product} {self.assembly}. "
+            f"Created {len(shipments_by_kind)} shipment file(s) "
+            f"({', '.join(shipments_by_kind.keys())}) "
+            f"in repository: {self.shipment_data_repo._directory}"
+        )
 
         if self.shipment_mr_url:
             completion_msg += f". MR: {self.shipment_mr_url}"
@@ -1056,7 +1110,7 @@ class ReleaseFromFbcPipeline:
     "--group",
     metavar='NAME',
     required=True,
-    help="The group to operate on e.g. oadp-1.5, mta-7.0, mtc-1.8, logging-5.9 (NOTE: This command is intended for non-OpenShift products)",
+    help="The group to operate on e.g. oadp-1.5, mta-7.0, mtc-1.8, logging-5.9, or openshift-4.22 (with --ocp-optional)",
 )
 @click.option(
     "--assembly",
@@ -1103,6 +1157,20 @@ class ReleaseFromFbcPipeline:
     help='Target ship date for the release (e.g., 2026-Mar-31 or 2026-03-31). '
     'When provided, the date is included in the shipment MR title.',
 )
+@click.option(
+    '--ocp-optional',
+    is_flag=True,
+    default=False,
+    help='Enable OCP optional-operator mode. Categorizes NVRs into extras/fbc '
+    'kinds (matching the OCP shipment structure) instead of the default image/fbc split. '
+    'All FBC related images are included by default. Use with --group openshift-4.x.',
+)
+@click.option(
+    '--exclude-nvr-components',
+    default=None,
+    help='Comma-separated NVR component names to explicitly exclude from the shipment '
+    '(e.g., kube-rbac-proxy-container). Only needed in edge cases with --ocp-optional.',
+)
 @pass_runtime
 @click_coroutine
 async def release_from_fbc(
@@ -1116,47 +1184,53 @@ async def release_from_fbc(
     shipment_path: Optional[str],
     jira_bugs: Optional[str],
     target_release_date: Optional[str],
+    ocp_optional: bool,
+    exclude_nvr_components: Optional[str],
 ):
     """
-    Create shipment files from an FBC image for non-OpenShift products.
+    Create shipment files from an FBC image.
 
-    This command is designed for products other than OpenShift (e.g., OADP, MTA, MTC, logging).
-    It extracts NVRs from an FBC image and creates separate shipment files for
-    image builds and FBC builds. Extra image NVRs (not part of the FBC) can be
-    included in the same image shipment file.
+    This command extracts NVRs from an FBC image and creates separate shipment files.
+    It supports two modes:
+
+    \b
+    DEFAULT MODE (layered products):
+      For non-OpenShift products (OADP, MTA, MTC, logging). Creates image + fbc
+      shipment files. External dependencies from other groups are filtered out.
+
+    \b
+    OCP OPTIONAL MODE (--ocp-optional):
+      For OCP optional operators that were excluded from the main OCP release
+      (e.g., due to a dependency version conflict like kube-rbac-proxy). Creates
+      extras + fbc shipment files. ALL related images from the FBC are
+      included by default.
 
     At least one of --fbc-pullspecs or --extra-image-nvrs must be provided.
 
-    Note: For OpenShift releases, use the prepare-release-konflux command instead.
-
     \b
-    # Create shipment files using default OCP shipment repository:
+    # Layered product (default mode):
     $ artcd release-from-fbc \\
         --group oadp-1.5 \\
         --assembly 1.5.3 \\
         --fbc-pullspecs quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc:oadp-operator-fbc-1.5.3-20251028153444
 
     \b
-    # Create shipment files with extra image NVRs:
+    # OCP optional operator (all related images included):
     $ artcd release-from-fbc \\
-        --group oadp-1.5 \\
-        --assembly 1.5.3 \\
-        --fbc-pullspecs quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc:oadp-operator-fbc-1.5.3-20251028153444 \\
-        --extra-image-nvrs oadp-velero-container-1.5.3-20251028.el9,oadp-helper-container-1.5.3-20251028.el9
+        --group openshift-4.22 \\
+        --assembly 4.22.0 \\
+        --fbc-pullspecs quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc:ose-metallb-operator-fbc-4.22.0-20260528170921 \\
+        --ocp-optional \\
+        --create-mr
 
     \b
-    # Ship only extra image NVRs (no FBC):
+    # OCP optional operator with explicit exclusion (edge case):
     $ artcd release-from-fbc \\
-        --group oadp-1.5 \\
-        --assembly 1.5.3 \\
-        --extra-image-nvrs oadp-velero-container-1.5.3-20251028.el9
-
-    \b
-    # Create shipment files and MR (requires GITLAB_TOKEN env var):
-    $ artcd release-from-fbc \\
-        --group oadp-1.5 \\
-        --assembly 1.5.3 \\
-        --fbc-pullspecs quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc:oadp-operator-fbc-1.5.3-20251028153444 \\
+        --group openshift-4.22 \\
+        --assembly 4.22.0 \\
+        --fbc-pullspecs quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc:ose-metallb-operator-fbc-4.22.0-20260528170921 \\
+        --ocp-optional \\
+        --exclude-nvr-components kube-rbac-proxy-container \\
         --create-mr
     """
     fbc_pullspecs_list = [spec.strip() for spec in fbc_pullspecs.split(',') if spec.strip()]
@@ -1177,6 +1251,11 @@ async def release_from_fbc(
     if target_release_date:
         normalized_date = _normalize_release_date(target_release_date)
 
+    # Parse comma-separated exclude NVR components
+    exclude_nvr_components_list = None
+    if exclude_nvr_components:
+        exclude_nvr_components_list = [c.strip() for c in exclude_nvr_components.split(',') if c.strip()]
+
     pipeline = ReleaseFromFbcPipeline(
         runtime=runtime,
         group=group,
@@ -1188,6 +1267,8 @@ async def release_from_fbc(
         jira_bugs=jira_bugs_list,
         target_release_date=normalized_date,
         extra_image_nvrs=extra_image_nvrs_list,
+        ocp_optional=ocp_optional,
+        exclude_nvr_components=exclude_nvr_components_list,
     )
 
     await pipeline.run()

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -293,6 +293,27 @@ class ReleaseFromFbcPipeline:
         project_path = parsed_url.path.strip('/').removesuffix('.git')
         return self._gitlab.get_project(project_path)
 
+    def _get_main_ocp_shipment_url(self) -> str | None:
+        """Read releases.yml from ocp-build-data and return the main OCP shipment MR URL
+        for the current assembly.
+
+        Path: releases.<assembly>.assembly.group.shipment.url
+        """
+        try:
+            content = self.get_file_from_branch(self.group, "releases.yml")
+            releases_config = stdlib_yaml.safe_load(content)
+            assembly_def = releases_config.get("releases", {}).get(self.assembly, {})
+            shipment = assembly_def.get("assembly", {}).get("group", {}).get("shipment", {})
+            url = shipment.get("url") if isinstance(shipment, dict) else None
+            if url:
+                self.logger.info("Found main OCP shipment MR: %s", url)
+            else:
+                self.logger.warning("No shipment URL in releases.yml for assembly '%s'", self.assembly)
+            return url
+        except Exception as e:
+            self.logger.warning("Failed to read main OCP shipment URL from releases.yml: %s", e)
+            return None
+
     def check_env_vars(self):
         """
         Check required environment variables for MR creation.
@@ -778,6 +799,24 @@ class ReleaseFromFbcPipeline:
             except Exception as e:
                 self.logger.warning(f"Failed to trigger CI MR pipeline for branch {mr.source_branch}: {e}")
 
+    async def _set_shipment_mr_dependency(self, blocking_mr_url: str):
+        """Set a native GitLab MR dependency so the shipment MR cannot merge
+        before *blocking_mr_url* is merged.
+
+        Failures are logged as warnings and do not block the pipeline.
+        """
+        if not self.shipment_mr_url or not blocking_mr_url:
+            return
+        try:
+            self._gitlab.add_mr_dependency(self.shipment_mr_url, blocking_mr_url)
+        except Exception as e:
+            self.logger.warning(
+                "Failed to set MR dependency (%s depends on %s): %s",
+                self.shipment_mr_url,
+                blocking_mr_url,
+                e,
+            )
+
     async def update_shipment_data(
         self, shipments_by_kind: Dict[str, ShipmentConfig], env: str, commit_message: str, branch: str
     ) -> bool:
@@ -1100,6 +1139,12 @@ class ReleaseFromFbcPipeline:
                 mr_url = await self.create_shipment_mr(shipments_by_kind, env="prod")
                 if mr_url:
                     self.logger.info(f"Created shipment MR: {mr_url}")
+
+                    if self.ocp_optional:
+                        main_ocp_mr_url = self._get_main_ocp_shipment_url()
+                        if main_ocp_mr_url:
+                            await self._set_shipment_mr_dependency(main_ocp_mr_url)
+
                     await self.set_shipment_mr_ready()
             except Exception as e:
                 self.logger.exception(f"Failed to create MR: {e}")

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -978,6 +978,13 @@ class ReleaseFromFbcPipeline:
                     "This flag is only for OCP optional operators excluded from the main OCP release. "
                     "Layered products (OADP, MTA, MTC, Logging) should use the default mode."
                 )
+        else:
+            if self.group.startswith('openshift-'):
+                raise ValueError(
+                    f"Group '{self.group}' is an openshift-* group but --ocp-optional was not set. "
+                    "OCP FBCs must use --ocp-optional to produce extras/fbc shipments. "
+                    "Without it, cross-group filtering may discard images and produce only FBC yaml."
+                )
         self.logger.info(f"Processing {len(self.fbc_pullspecs)} FBC pullspecs")
         if self.extra_image_nvrs:
             self.logger.info(f"Including {len(self.extra_image_nvrs)} extra image NVRs")

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -298,13 +298,24 @@ class ReleaseFromFbcPipeline:
         for the current assembly.
 
         Path: releases.<assembly>.assembly.group.shipment.url
+              (key may also be 'shipment!' or other merge-operator variant)
         """
         try:
             content = self.get_file_from_branch(self.group, "releases.yml")
             releases_config = stdlib_yaml.safe_load(content)
             assembly_def = releases_config.get("releases", {}).get(self.assembly, {})
-            shipment = assembly_def.get("assembly", {}).get("group", {}).get("shipment", {})
-            url = shipment.get("url") if isinstance(shipment, dict) else None
+            group = assembly_def.get("assembly", {}).get("group", {})
+            shipment = group.get("shipment")
+            if shipment is None:
+                # Handle assembly merge-operator suffixes (e.g. 'shipment!' override marker
+                # written by prepare-release-konflux for child assemblies with basis.assembly)
+                for key in group:
+                    if isinstance(key, str) and key.startswith("shipment") and len(key) == len("shipment") + 1:
+                        shipment = group[key]
+                        break
+            if not isinstance(shipment, dict):
+                shipment = {}
+            url = shipment.get("url")
             if url:
                 self.logger.info("Found main OCP shipment MR: %s", url)
             else:

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -499,46 +499,32 @@ class ReleaseFromFbcPipeline:
         """
         self.logger.info(f"Categorizing {len(nvrs)} extracted NVRs...")
 
-        if self.ocp_optional:
-            categorized: Dict[str, List[str]] = {"extras": [], "fbc": [], "external": []}
+        non_fbc_key = "extras" if self.ocp_optional else "image"
+        categorized: Dict[str, List[str]] = {non_fbc_key: [], "fbc": [], "external": []}
 
-            for nvr in nvrs:
-                component_name = parse_nvr(nvr)['name']
+        for nvr in nvrs:
+            component_name = parse_nvr(nvr)['name']
 
-                if component_name.endswith('-fbc'):
-                    categorized["fbc"].append(nvr)
-                elif self.excluded_components and component_name in self.excluded_components:
+            if component_name.endswith('-fbc'):
+                categorized["fbc"].append(nvr)
+            elif self.ocp_optional:
+                if self.excluded_components and component_name in self.excluded_components:
                     categorized["external"].append(nvr)
                 else:
-                    categorized["extras"].append(nvr)
+                    categorized[non_fbc_key].append(nvr)
+            elif self.is_nvr_from_current_group(nvr):
+                categorized[non_fbc_key].append(nvr)
+            else:
+                categorized["external"].append(nvr)
 
-            self.logger.info("Categorization results (OCP optional mode):")
-            self.logger.info(f"  • Extras (all non-FBC images): {len(categorized['extras'])}")
-            self.logger.info(f"  • FBC builds: {len(categorized['fbc'])}")
-            if categorized['external']:
-                self.logger.info(f"  • Excluded: {len(categorized['external'])}")
-                for ext_nvr in categorized['external']:
-                    self.logger.info(f"    - {ext_nvr}")
-        else:
-            categorized = {"image": [], "fbc": [], "external": []}
-
-            for nvr in nvrs:
-                component_name = parse_nvr(nvr)['name']
-
-                if component_name.endswith('-fbc'):
-                    categorized["fbc"].append(nvr)
-                elif self.is_nvr_from_current_group(nvr):
-                    categorized["image"].append(nvr)
-                else:
-                    categorized["external"].append(nvr)
-
-            self.logger.info("Categorization results:")
-            self.logger.info(f"  • Image builds: {len(categorized['image'])}")
-            self.logger.info(f"  • FBC builds: {len(categorized['fbc'])}")
-            if categorized['external']:
-                self.logger.info(f"  • External dependencies (filtered): {len(categorized['external'])}")
-                for ext_nvr in categorized['external']:
-                    self.logger.info(f"    - {ext_nvr}")
+        self.logger.info(f"Categorization results{' (OCP optional mode)' if self.ocp_optional else ''}:")
+        self.logger.info(f"  • {non_fbc_key.title()} builds: {len(categorized[non_fbc_key])}")
+        self.logger.info(f"  • FBC builds: {len(categorized['fbc'])}")
+        if categorized['external']:
+            label = "Excluded" if self.ocp_optional else "External dependencies (filtered)"
+            self.logger.info(f"  • {label}: {len(categorized['external'])}")
+            for ext_nvr in categorized['external']:
+                self.logger.info(f"    - {ext_nvr}")
 
         return categorized
 
@@ -1254,6 +1240,8 @@ async def release_from_fbc(
     # Parse comma-separated exclude NVR components
     exclude_nvr_components_list = None
     if exclude_nvr_components:
+        if not ocp_optional:
+            raise click.ClickException("--exclude-nvr-components requires --ocp-optional to be set")
         exclude_nvr_components_list = [c.strip() for c in exclude_nvr_components.split(',') if c.strip()]
 
     pipeline = ReleaseFromFbcPipeline(

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -175,23 +175,35 @@ class ReleaseFromFbcPipeline:
         except GithubException as e:
             raise ValueError(f"Failed to fetch {filename} from {data_path} branch {branch}: {e}")
 
-    def _load_release_notes_template(self) -> dict | None:
+    def _load_release_notes_template(self, kind: str | None = None) -> dict | None:
         """
-        Load and populate release notes template from ocp-build-data using get_advisory_boilerplate(),
-        matching the pattern used by get_advisory_boilerplate().
+        Load and populate release notes template from ocp-build-data advisory_templates.yml.
 
-        Return Value(s):
+        Two modes:
+        - OCP optional (kind provided): Uses kind (e.g., 'extras') as template key,
+          populates {MAJOR}/{MINOR}/{PATCH} from group.yml vars section.
+        - Layered product (kind=None): Uses self.product as template key,
+          populates {PRODUCT_MAJOR}/{PRODUCT_MINOR}/{PRODUCT_PATCH} from assembly
+          and {OCP_RELEASE_NOTES_VERSION} from group.yml.
+
+        Args:
+            kind: When provided, used as the boilerplate lookup key (OCP optional mode).
+                  When None, self.product is used (layered product mode).
+
+        Returns:
             dict | None: Template dict with synopsis, topic, description, solution, or None if not found.
         """
+        art_advisory_key = kind if kind else self.product
+
         try:
             boilerplate = get_advisory_boilerplate(
                 runtime=self,
                 et_data={},
-                art_advisory_key=self.product,
+                art_advisory_key=art_advisory_key,
                 errata_type="RHBA",
             )
         except (ValueError, KeyError):
-            self.logger.debug("No release notes template found for product '%s'", self.product)
+            self.logger.debug("No release notes template found for key '%s'", art_advisory_key)
             return None
         except Exception as e:
             self.logger.warning("Failed to load release notes template: %s", e)
@@ -201,21 +213,31 @@ class ReleaseFromFbcPipeline:
             group_content = self.get_file_from_branch(self.group, "group.yml")
             group_config = stdlib_yaml.safe_load(group_content)
 
-            ocp_version = str(group_config.get("OCP_RELEASE_NOTES_VERSION", ""))
-            if not ocp_version:
-                self.logger.warning("OCP_RELEASE_NOTES_VERSION not found in group.yml for group '%s'", self.group)
-                return None
-
-            ocp_version_dashed = ocp_version.replace(".", "-")
-
-            assembly_parts = self.assembly.split(".")
-            replace_vars = {
-                "OCP_RELEASE_NOTES_VERSION": ocp_version,
-                "OCP_RELEASE_NOTES_VERSION_DASHED": ocp_version_dashed,
-                "PRODUCT_MAJOR": assembly_parts[0] if len(assembly_parts) > 0 else "",
-                "PRODUCT_MINOR": assembly_parts[1] if len(assembly_parts) > 1 else "",
-                "PRODUCT_PATCH": assembly_parts[2] if len(assembly_parts) > 2 else "",
-            }
+            if kind:
+                # OCP optional mode: use {MAJOR}, {MINOR}, {PATCH} from vars section
+                vars_section = group_config.get("vars", {})
+                major = str(vars_section.get("MAJOR", ""))
+                minor = str(vars_section.get("MINOR", ""))
+                assembly_parts = self.assembly.split(".")
+                patch = assembly_parts[2] if len(assembly_parts) > 2 else "0"
+                if not major or not minor:
+                    self.logger.warning("MAJOR/MINOR not found in group.yml vars for group '%s'", self.group)
+                    return None
+                replace_vars = {"MAJOR": major, "MINOR": minor, "PATCH": patch}
+            else:
+                # Layered product mode: use {PRODUCT_*} and {OCP_RELEASE_NOTES_VERSION}
+                ocp_version = str(group_config.get("OCP_RELEASE_NOTES_VERSION", ""))
+                if not ocp_version:
+                    self.logger.warning("OCP_RELEASE_NOTES_VERSION not found in group.yml for group '%s'", self.group)
+                    return None
+                assembly_parts = self.assembly.split(".")
+                replace_vars = {
+                    "OCP_RELEASE_NOTES_VERSION": ocp_version,
+                    "OCP_RELEASE_NOTES_VERSION_DASHED": ocp_version.replace(".", "-"),
+                    "PRODUCT_MAJOR": assembly_parts[0] if len(assembly_parts) > 0 else "",
+                    "PRODUCT_MINOR": assembly_parts[1] if len(assembly_parts) > 1 else "",
+                    "PRODUCT_PATCH": assembly_parts[2] if len(assembly_parts) > 2 else "",
+                }
 
             formatter = SafeFormatter()
             result = {}
@@ -223,12 +245,7 @@ class ReleaseFromFbcPipeline:
                 value = boilerplate.get(field, "")
                 result[field] = formatter.format(value, **replace_vars)
 
-            self.logger.info(
-                "Loaded release notes template for '%s' (OCP_RELEASE_NOTES_VERSION=%s, assembly=%s)",
-                self.product,
-                ocp_version,
-                self.assembly,
-            )
+            self.logger.info("Loaded release notes template for key '%s'", art_advisory_key)
             return result
 
         except Exception as e:
@@ -1034,7 +1051,11 @@ class ReleaseFromFbcPipeline:
             release_notes = self.generate_release_notes()
 
         # Load release notes template from ocp-build-data
-        template = self._load_release_notes_template()
+        if self.ocp_optional:
+            template = self._load_release_notes_template(kind=image_key)
+        else:
+            template = self._load_release_notes_template()
+
         if template:
             if release_notes is None:
                 release_notes = ReleaseNotes(type="RHBA")

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -973,9 +973,10 @@ class ReleaseFromFbcPipeline:
             if self.excluded_components:
                 self.logger.info(f"Excluding NVR components: {sorted(self.excluded_components)}")
             if not self.group.startswith('openshift-'):
-                self.logger.warning(
-                    f"--ocp-optional is intended for openshift-* groups, but group is '{self.group}'. "
-                    "This will include ALL related images without group-version filtering."
+                raise ValueError(
+                    f"--ocp-optional requires an openshift-* group, but got '{self.group}'. "
+                    "This flag is only for OCP optional operators excluded from the main OCP release. "
+                    "Layered products (OADP, MTA, MTC, Logging) should use the default mode."
                 )
         self.logger.info(f"Processing {len(self.fbc_pullspecs)} FBC pullspecs")
         if self.extra_image_nvrs:

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -1288,6 +1288,105 @@ class TestOcpOptionalMode(unittest.TestCase):
         self.assertTrue(config.shipment.metadata.fbc)
         self.assertIsNone(config.shipment.data)
 
+    # -- _get_main_ocp_shipment_url tests --
+
+    def test_get_main_ocp_shipment_url_found(self):
+        """Should return URL when releases.yml has shipment.url for the assembly."""
+        pipeline = self._make_pipeline(ocp_optional=True, assembly="rc.5")
+        releases_yml = {
+            "releases": {
+                "rc.5": {
+                    "assembly": {
+                        "group": {
+                            "shipment": {
+                                "url": "https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/549"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        import yaml as stdlib_yaml
+
+        pipeline.get_file_from_branch = MagicMock(return_value=stdlib_yaml.dump(releases_yml).encode())
+        result = pipeline._get_main_ocp_shipment_url()
+        self.assertEqual(
+            result,
+            "https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/549",
+        )
+
+    def test_get_main_ocp_shipment_url_missing(self):
+        """Should return None when assembly exists but has no shipment URL."""
+        pipeline = self._make_pipeline(ocp_optional=True, assembly="rc.5")
+        releases_yml = {"releases": {"rc.5": {"assembly": {"group": {"release_jira": "ART-12345"}}}}}
+        import yaml as stdlib_yaml
+
+        pipeline.get_file_from_branch = MagicMock(return_value=stdlib_yaml.dump(releases_yml).encode())
+        result = pipeline._get_main_ocp_shipment_url()
+        self.assertIsNone(result)
+
+    def test_get_main_ocp_shipment_url_error(self):
+        """Should return None and log warning on fetch failure."""
+        pipeline = self._make_pipeline(ocp_optional=True)
+        pipeline.get_file_from_branch = MagicMock(side_effect=ValueError("GitHub auth failed"))
+        result = pipeline._get_main_ocp_shipment_url()
+        self.assertIsNone(result)
+
+    # -- MR dependency wiring in run() --
+
+    def test_mr_dependency_set_in_ocp_optional_run(self):
+        """run() should call _set_shipment_mr_dependency when ocp_optional and MR created."""
+        pipeline = self._make_pipeline(ocp_optional=True)
+        pipeline.create_mr = True
+        pipeline.fbc_pullspecs = []
+        pipeline.extra_image_nvrs = ["extra-op-container-v4.22.0-1.el9"]
+        pipeline.check_env_vars = MagicMock()
+        pipeline.setup_working_dir = MagicMock()
+        pipeline.setup_shipment_repo = AsyncMock()
+        pipeline._load_product_from_group_config = AsyncMock(return_value="ocp")
+        pipeline._load_release_notes_template = MagicMock(return_value=None)
+        pipeline.create_snapshot = AsyncMock(return_value=_make_snapshot(app="openshift-4-22"))
+        pipeline.create_shipment_config = MagicMock(return_value=MagicMock())
+        pipeline.create_shipment_mr = AsyncMock(return_value="https://gitlab.example.com/g/p/-/merge_requests/100")
+        pipeline.shipment_mr_url = "https://gitlab.example.com/g/p/-/merge_requests/100"
+        pipeline._get_main_ocp_shipment_url = MagicMock(
+            return_value="https://gitlab.example.com/g/p/-/merge_requests/50"
+        )
+        pipeline._set_shipment_mr_dependency = AsyncMock()
+        pipeline.set_shipment_mr_ready = AsyncMock()
+
+        asyncio.run(pipeline.run())
+
+        pipeline._get_main_ocp_shipment_url.assert_called_once()
+        pipeline._set_shipment_mr_dependency.assert_awaited_once_with(
+            "https://gitlab.example.com/g/p/-/merge_requests/50"
+        )
+
+    def test_mr_dependency_not_set_for_default_mode(self):
+        """run() should NOT call _set_shipment_mr_dependency in default (non-ocp-optional) mode."""
+        pipeline = self._make_pipeline(ocp_optional=False, group="oadp-1.5", assembly="1.5.0")
+        pipeline.product = "oadp"
+        pipeline.create_mr = True
+        pipeline.fbc_pullspecs = []
+        pipeline.extra_image_nvrs = ["oadp-container-v1.5.0-1.el9"]
+        pipeline.check_env_vars = MagicMock()
+        pipeline.setup_working_dir = MagicMock()
+        pipeline.setup_shipment_repo = AsyncMock()
+        pipeline._load_product_from_group_config = AsyncMock(return_value="oadp")
+        pipeline._load_release_notes_template = MagicMock(return_value=None)
+        pipeline.create_snapshot = AsyncMock(return_value=_make_snapshot(app="oadp-1-5"))
+        pipeline.create_shipment_config = MagicMock(return_value=MagicMock())
+        pipeline.create_shipment_mr = AsyncMock(return_value="https://gitlab.example.com/g/p/-/merge_requests/200")
+        pipeline.shipment_mr_url = "https://gitlab.example.com/g/p/-/merge_requests/200"
+        pipeline._get_main_ocp_shipment_url = MagicMock()
+        pipeline._set_shipment_mr_dependency = AsyncMock()
+        pipeline.set_shipment_mr_ready = AsyncMock()
+
+        asyncio.run(pipeline.run())
+
+        pipeline._get_main_ocp_shipment_url.assert_not_called()
+        pipeline._set_shipment_mr_dependency.assert_not_awaited()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -976,5 +976,182 @@ class TestRunWithTemplate(unittest.TestCase):
         self.assertIsNone(release_notes)
 
 
+class TestOcpOptionalMode(unittest.TestCase):
+    """Tests for OCP optional-operator mode (--ocp-optional)."""
+
+    def _make_pipeline(
+        self, ocp_optional=False, exclude_nvr_components=None, group="openshift-4.22", assembly="4.22.0"
+    ):
+        runtime = MagicMock()
+        runtime.dry_run = False
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        runtime.config = {}
+
+        pipeline = ReleaseFromFbcPipeline(
+            runtime=runtime,
+            group=group,
+            assembly=assembly,
+            fbc_pullspecs=["quay.io/test/fbc:latest"],
+            create_mr=False,
+            ocp_optional=ocp_optional,
+            exclude_nvr_components=exclude_nvr_components,
+        )
+        pipeline.product = "ocp"
+        return pipeline
+
+    def test_ocp_optional_flag_stored(self):
+        pipeline = self._make_pipeline(ocp_optional=True)
+        self.assertTrue(pipeline.ocp_optional)
+
+    def test_ocp_optional_default_false(self):
+        pipeline = self._make_pipeline()
+        self.assertFalse(pipeline.ocp_optional)
+
+    def test_exclude_nvr_components_stored_as_set(self):
+        pipeline = self._make_pipeline(
+            ocp_optional=True,
+            exclude_nvr_components=["kube-rbac-proxy-container", "other-container"],
+        )
+        self.assertEqual(pipeline.excluded_components, {"kube-rbac-proxy-container", "other-container"})
+
+    def test_exclude_nvr_components_default_empty_set(self):
+        pipeline = self._make_pipeline(ocp_optional=True)
+        self.assertEqual(pipeline.excluded_components, set())
+
+    # -- categorize_nvrs tests --
+
+    def test_categorize_ocp_optional_all_included(self):
+        """In OCP optional mode, all non-FBC images (including bundles and payload deps) go to extras."""
+        pipeline = self._make_pipeline(ocp_optional=True)
+        nvrs = [
+            "ose-metallb-operator-container-v4.22.0-202605281227.el9",
+            "ose-metallb-container-v4.22.0-202605281227.el9",
+            "ose-frr-container-v4.22.0-202605281227.el9",
+            "kube-rbac-proxy-container-v4.22.0-202605281227.el9",
+            "ose-metallb-operator-bundle-container-v4.22.0.202605281227.el9-1",
+            "ose-metallb-operator-fbc-4.22.0-20260528170921",
+        ]
+        result = pipeline.categorize_nvrs(nvrs)
+
+        self.assertEqual(
+            result["extras"],
+            [
+                "ose-metallb-operator-container-v4.22.0-202605281227.el9",
+                "ose-metallb-container-v4.22.0-202605281227.el9",
+                "ose-frr-container-v4.22.0-202605281227.el9",
+                "kube-rbac-proxy-container-v4.22.0-202605281227.el9",
+                "ose-metallb-operator-bundle-container-v4.22.0.202605281227.el9-1",
+            ],
+        )
+        self.assertNotIn("metadata", result)
+        self.assertEqual(
+            result["fbc"],
+            [
+                "ose-metallb-operator-fbc-4.22.0-20260528170921",
+            ],
+        )
+        self.assertEqual(result["external"], [])
+
+    def test_categorize_ocp_optional_with_exclusion(self):
+        """Explicitly excluded components go to external."""
+        pipeline = self._make_pipeline(
+            ocp_optional=True,
+            exclude_nvr_components=["kube-rbac-proxy-container"],
+        )
+        nvrs = [
+            "ose-metallb-operator-container-v4.22.0-202605281227.el9",
+            "kube-rbac-proxy-container-v4.22.0-202605281227.el9",
+            "ose-metallb-operator-fbc-4.22.0-20260528170921",
+        ]
+        result = pipeline.categorize_nvrs(nvrs)
+
+        self.assertEqual(
+            result["extras"],
+            [
+                "ose-metallb-operator-container-v4.22.0-202605281227.el9",
+            ],
+        )
+        self.assertEqual(
+            result["external"],
+            [
+                "kube-rbac-proxy-container-v4.22.0-202605281227.el9",
+            ],
+        )
+        self.assertEqual(
+            result["fbc"],
+            [
+                "ose-metallb-operator-fbc-4.22.0-20260528170921",
+            ],
+        )
+
+    def test_categorize_default_mode_unchanged(self):
+        """Default (non-OCP-optional) mode still uses image/fbc/external."""
+        pipeline = self._make_pipeline(ocp_optional=False)
+        nvrs = [
+            "ose-metallb-operator-container-v4.22.0-202605281227.el9",
+            "ose-metallb-operator-fbc-4.22.0-20260528170921",
+        ]
+        result = pipeline.categorize_nvrs(nvrs)
+
+        self.assertIn("image", result)
+        self.assertIn("fbc", result)
+        self.assertNotIn("extras", result)
+        self.assertNotIn("metadata", result)
+
+    def test_categorize_bundles_go_to_extras(self):
+        """Bundle NVRs go to extras alongside all other non-FBC images."""
+        pipeline = self._make_pipeline(ocp_optional=True)
+        nvrs = [
+            "ose-metallb-operator-bundle-container-v4.22.0.202605281227.el9-1",
+            "some-other-bundle-thing-container-v1.0.0-1.el9",
+        ]
+        result = pipeline.categorize_nvrs(nvrs)
+        self.assertNotIn("metadata", result)
+        self.assertEqual(len(result["extras"]), 2)
+
+    # -- create_shipment_config tests --
+
+    def test_create_shipment_config_extras_with_release_notes(self):
+        """extras kind should include release notes when provided."""
+        pipeline = self._make_pipeline(ocp_optional=True)
+        snapshot = _make_snapshot(app="openshift-4-22")
+        release_notes = ReleaseNotes(type="RHBA", synopsis="test")
+        config = pipeline.create_shipment_config("extras", snapshot, release_notes=release_notes)
+
+        self.assertIsNotNone(config.shipment.data)
+        self.assertEqual(config.shipment.data.releaseNotes.type, "RHBA")
+        self.assertFalse(config.shipment.metadata.fbc)
+
+    def test_create_shipment_config_extras_openshift_minimal_notes(self):
+        """extras kind for openshift-* group gets minimal release notes automatically."""
+        pipeline = self._make_pipeline(ocp_optional=True)
+        snapshot = _make_snapshot(app="openshift-4-22")
+        config = pipeline.create_shipment_config("extras", snapshot)
+
+        self.assertIsNotNone(config.shipment.data)
+        self.assertEqual(config.shipment.data.releaseNotes.type, "RHBA")
+        self.assertIn("extras", config.shipment.data.releaseNotes.synopsis)
+
+    def test_create_shipment_config_extras_no_notes_for_non_openshift(self):
+        """extras kind for non-openshift group should have no data when no release notes provided."""
+        pipeline = self._make_pipeline(ocp_optional=True, group="oadp-1.4", assembly="1.4.5")
+        pipeline.product = "oadp"
+        snapshot = _make_snapshot(app="oadp-1-4")
+        config = pipeline.create_shipment_config("extras", snapshot)
+
+        self.assertIsNone(config.shipment.data)
+        self.assertFalse(config.shipment.metadata.fbc)
+
+    def test_create_shipment_config_fbc_still_works(self):
+        """fbc kind in OCP optional mode should still set fbc=True and no data."""
+        pipeline = self._make_pipeline(ocp_optional=True)
+        snapshot = _make_snapshot(app="fbc-openshift-4-22")
+        config = pipeline.create_shipment_config("fbc", snapshot)
+
+        self.assertTrue(config.shipment.metadata.fbc)
+        self.assertIsNone(config.shipment.data)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -1110,6 +1110,29 @@ class TestOcpOptionalMode(unittest.TestCase):
         self.assertNotIn("metadata", result)
         self.assertEqual(len(result["extras"]), 2)
 
+    # -- run() integration tests --
+
+    def test_extra_image_nvrs_merged_into_extras_key(self):
+        """In OCP optional mode, extra_image_nvrs should merge into 'extras', not 'image'."""
+        pipeline = self._make_pipeline(ocp_optional=True)
+        pipeline.extra_image_nvrs = ["extra-operator-container-v4.22.0-1.el9"]
+        pipeline.fbc_pullspecs = []
+        pipeline.check_env_vars = MagicMock()
+        pipeline.setup_working_dir = MagicMock()
+        pipeline._load_product_from_group_config = AsyncMock(return_value="ocp")
+        pipeline._load_release_notes_template = MagicMock(return_value=None)
+        pipeline.create_snapshot = AsyncMock(return_value=_make_snapshot(app="openshift-4-22"))
+        pipeline.create_shipment_config = MagicMock(return_value=MagicMock())
+        pipeline.write_shipment_files_locally = AsyncMock()
+
+        asyncio.run(pipeline.run())
+
+        snapshot_call_args = pipeline.create_snapshot.call_args[0][0]
+        self.assertIn("extra-operator-container-v4.22.0-1.el9", snapshot_call_args)
+
+        config_call_args = pipeline.create_shipment_config.call_args
+        self.assertEqual(config_call_args[0][0], "extras")
+
     # -- create_shipment_config tests --
 
     def test_create_shipment_config_extras_with_release_notes(self):

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -1315,6 +1315,31 @@ class TestOcpOptionalMode(unittest.TestCase):
             "https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/549",
         )
 
+    def test_get_main_ocp_shipment_url_found_override_suffix(self):
+        """Should return URL when releases.yml uses 'shipment!' override marker."""
+        pipeline = self._make_pipeline(ocp_optional=True, assembly="4.22.0")
+        releases_yml = {
+            "releases": {
+                "4.22.0": {
+                    "assembly": {
+                        "group": {
+                            "shipment!": {
+                                "url": "https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/562"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        import yaml as stdlib_yaml
+
+        pipeline.get_file_from_branch = MagicMock(return_value=stdlib_yaml.dump(releases_yml).encode())
+        result = pipeline._get_main_ocp_shipment_url()
+        self.assertEqual(
+            result,
+            "https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/562",
+        )
+
     def test_get_main_ocp_shipment_url_missing(self):
         """Should return None when assembly exists but has no shipment URL."""
         pipeline = self._make_pipeline(ocp_optional=True, assembly="rc.5")

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -785,7 +785,7 @@ class TestGetFileFromBranch(unittest.TestCase):
 class TestLoadReleaseNotesTemplate(unittest.TestCase):
     """Tests for _load_release_notes_template method."""
 
-    def _make_pipeline(self, group="logging-6.5", assembly="6.5.0"):
+    def _make_pipeline(self, group="openshift-4.22", assembly="4.22.0"):
         runtime = MagicMock()
         runtime.dry_run = False
         runtime.working_dir = MagicMock()
@@ -798,48 +798,49 @@ class TestLoadReleaseNotesTemplate(unittest.TestCase):
             assembly=assembly,
             fbc_pullspecs=["quay.io/test/fbc:latest"],
         )
-        pipeline.product = "openshift-logging"
+        pipeline.product = "ocp"
         return pipeline
 
     @patch("pyartcd.pipelines.release_from_fbc.get_advisory_boilerplate")
     @patch.object(ReleaseFromFbcPipeline, "get_file_from_branch")
     def test_template_found_with_placeholder_substitution(self, mock_get_file, mock_get_boilerplate):
-        """Template is found via get_advisory_boilerplate and all placeholders are substituted."""
+        """Template is found via get_advisory_boilerplate using kind as key, placeholders substituted."""
         mock_get_boilerplate.return_value = {
-            "synopsis": "Logging {PRODUCT_MAJOR}.{PRODUCT_MINOR}.{PRODUCT_PATCH}",
-            "topic": "Logging {PRODUCT_MAJOR}.{PRODUCT_MINOR}.{PRODUCT_PATCH}",
-            "description": "Logging {PRODUCT_MAJOR}.{PRODUCT_MINOR}.{PRODUCT_PATCH} update",
-            "solution": "For OCP {OCP_RELEASE_NOTES_VERSION} see ocp-{OCP_RELEASE_NOTES_VERSION_DASHED}-release-notes",
+            "synopsis": "OpenShift Container Platform 4.{MINOR}.{PATCH} extras update",
+            "topic": "Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available.",
+            "description": "This advisory contains updates for OCP 4.{MINOR}.{PATCH}.",
+            "solution": "For OCP 4.{MINOR} see the docs.",
         }
         mock_get_file.return_value = b"""
-OCP_RELEASE_NOTES_VERSION: "4.21"
+vars:
+  MAJOR: 4
+  MINOR: 22
 """
 
         pipeline = self._make_pipeline()
-        result = pipeline._load_release_notes_template()
+        result = pipeline._load_release_notes_template(kind="extras")
 
         self.assertIsNotNone(result)
-        self.assertEqual(result["synopsis"], "Logging 6.5.0")
-        self.assertEqual(result["topic"], "Logging 6.5.0")
-        self.assertEqual(result["description"], "Logging 6.5.0 update")
-        self.assertEqual(result["solution"], "For OCP 4.21 see ocp-4-21-release-notes")
+        self.assertEqual(result["synopsis"], "OpenShift Container Platform 4.22.0 extras update")
+        self.assertEqual(result["topic"], "Red Hat OpenShift Container Platform release 4.22.0 is now available.")
+        self.assertEqual(result["description"], "This advisory contains updates for OCP 4.22.0.")
+        self.assertEqual(result["solution"], "For OCP 4.22 see the docs.")
 
         mock_get_boilerplate.assert_called_once_with(
             runtime=pipeline,
             et_data={},
-            art_advisory_key="openshift-logging",
+            art_advisory_key="extras",
             errata_type="RHBA",
         )
-        mock_get_file.assert_called_once_with("logging-6.5", "group.yml")
+        mock_get_file.assert_called_once_with("openshift-4.22", "group.yml")
 
     @patch("pyartcd.pipelines.release_from_fbc.get_advisory_boilerplate")
     def test_template_not_found_returns_none(self, mock_get_boilerplate):
         """When get_advisory_boilerplate raises ValueError, return None."""
-        mock_get_boilerplate.side_effect = ValueError("Boilerplate mta not found")
+        mock_get_boilerplate.side_effect = ValueError("Boilerplate ocp not found")
 
         pipeline = self._make_pipeline()
-        pipeline.product = "mta"
-        result = pipeline._load_release_notes_template()
+        result = pipeline._load_release_notes_template(kind="extras")
 
         self.assertIsNone(result)
 
@@ -849,14 +850,14 @@ OCP_RELEASE_NOTES_VERSION: "4.21"
         mock_get_boilerplate.side_effect = Exception("GitHub API failure")
 
         pipeline = self._make_pipeline()
-        result = pipeline._load_release_notes_template()
+        result = pipeline._load_release_notes_template(kind="extras")
 
         self.assertIsNone(result)
 
     @patch("pyartcd.pipelines.release_from_fbc.get_advisory_boilerplate")
     @patch.object(ReleaseFromFbcPipeline, "get_file_from_branch")
-    def test_missing_ocp_release_notes_version_returns_none(self, mock_get_file, mock_get_boilerplate):
-        """When group.yml has no OCP_RELEASE_NOTES_VERSION, return None."""
+    def test_missing_major_minor_in_group_yml_returns_none(self, mock_get_file, mock_get_boilerplate):
+        """When group.yml has no MAJOR/MINOR in vars section, return None."""
         mock_get_boilerplate.return_value = {
             "synopsis": "Synopsis",
             "topic": "Topic",
@@ -868,29 +869,141 @@ product: logging
 """
 
         pipeline = self._make_pipeline()
-        result = pipeline._load_release_notes_template()
+        result = pipeline._load_release_notes_template(kind="extras")
 
         self.assertIsNone(result)
 
     @patch("pyartcd.pipelines.release_from_fbc.get_advisory_boilerplate")
     @patch.object(ReleaseFromFbcPipeline, "get_file_from_branch")
     def test_assembly_version_parsing_two_components(self, mock_get_file, mock_get_boilerplate):
-        """Assembly with only major.minor (no PRODUCT_PATCH) uses empty string for PRODUCT_PATCH."""
+        """Assembly with only major.minor (no patch) defaults patch to '0'."""
         mock_get_boilerplate.return_value = {
-            "synopsis": "Version {PRODUCT_MAJOR}.{PRODUCT_MINOR}.{PRODUCT_PATCH}",
+            "synopsis": "Version {MAJOR}.{MINOR}.{PATCH}",
             "topic": "Topic",
             "description": "Description",
             "solution": "Solution",
         }
         mock_get_file.return_value = b"""
+vars:
+  MAJOR: 4
+  MINOR: 22
+"""
+
+        pipeline = self._make_pipeline(assembly="4.22")
+        result = pipeline._load_release_notes_template(kind="extras")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["synopsis"], "Version 4.22.0")
+
+    @patch("pyartcd.pipelines.release_from_fbc.get_advisory_boilerplate")
+    @patch.object(ReleaseFromFbcPipeline, "get_file_from_branch")
+    def test_unresolved_placeholders_left_as_is(self, mock_get_file, mock_get_boilerplate):
+        """SafeFormatter leaves unrecognized placeholders (like {IMAGE_ADVISORY}) intact."""
+        mock_get_boilerplate.return_value = {
+            "synopsis": "OCP 4.{MINOR}.{PATCH} extras update",
+            "topic": "Topic",
+            "description": "See https://access.redhat.com/errata/{IMAGE_ADVISORY}",
+            "solution": "Solution",
+        }
+        mock_get_file.return_value = b"""
+vars:
+  MAJOR: 4
+  MINOR: 22
+"""
+
+        pipeline = self._make_pipeline()
+        result = pipeline._load_release_notes_template(kind="extras")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["synopsis"], "OCP 4.22.0 extras update")
+        self.assertEqual(result["description"], "See https://access.redhat.com/errata/{IMAGE_ADVISORY}")
+
+    # -- Layered product mode tests (kind=None, uses self.product as key) --
+
+    @patch("pyartcd.pipelines.release_from_fbc.get_advisory_boilerplate")
+    @patch.object(ReleaseFromFbcPipeline, "get_file_from_branch")
+    def test_layered_product_template_with_product_vars(self, mock_get_file, mock_get_boilerplate):
+        """Layered product path uses self.product as key and PRODUCT_* placeholders."""
+        mock_get_boilerplate.return_value = {
+            "synopsis": "Logging for Red Hat OpenShift - {PRODUCT_MAJOR}.{PRODUCT_MINOR}.{PRODUCT_PATCH}",
+            "topic": "Logging for Red Hat OpenShift - {PRODUCT_MAJOR}.{PRODUCT_MINOR}.{PRODUCT_PATCH}",
+            "description": "Red Hat OpenShift Logging {PRODUCT_MAJOR}.{PRODUCT_MINOR}.{PRODUCT_PATCH} update",
+            "solution": "For OCP {OCP_RELEASE_NOTES_VERSION} see ocp-{OCP_RELEASE_NOTES_VERSION_DASHED}-release-notes",
+        }
+        mock_get_file.return_value = b"""
+OCP_RELEASE_NOTES_VERSION: "4.18"
+"""
+
+        pipeline = self._make_pipeline(group="logging-6.2", assembly="6.2.1")
+        pipeline.product = "openshift-logging"
+        result = pipeline._load_release_notes_template()
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["synopsis"], "Logging for Red Hat OpenShift - 6.2.1")
+        self.assertEqual(result["topic"], "Logging for Red Hat OpenShift - 6.2.1")
+        self.assertEqual(result["description"], "Red Hat OpenShift Logging 6.2.1 update")
+        self.assertEqual(result["solution"], "For OCP 4.18 see ocp-4-18-release-notes")
+
+        mock_get_boilerplate.assert_called_once_with(
+            runtime=pipeline,
+            et_data={},
+            art_advisory_key="openshift-logging",
+            errata_type="RHBA",
+        )
+        mock_get_file.assert_called_once_with("logging-6.2", "group.yml")
+
+    @patch("pyartcd.pipelines.release_from_fbc.get_advisory_boilerplate")
+    @patch.object(ReleaseFromFbcPipeline, "get_file_from_branch")
+    def test_layered_product_missing_ocp_release_notes_version_returns_none(self, mock_get_file, mock_get_boilerplate):
+        """Layered product without OCP_RELEASE_NOTES_VERSION in group.yml returns None."""
+        mock_get_boilerplate.return_value = {
+            "synopsis": "Synopsis",
+            "topic": "Topic",
+            "description": "Description",
+            "solution": "Solution",
+        }
+        mock_get_file.return_value = b"""
+product: openshift-logging
+"""
+
+        pipeline = self._make_pipeline(group="logging-6.3", assembly="6.3.5")
+        pipeline.product = "openshift-logging"
+        result = pipeline._load_release_notes_template()
+
+        self.assertIsNone(result)
+
+    @patch("pyartcd.pipelines.release_from_fbc.get_advisory_boilerplate")
+    def test_layered_product_no_template_key_returns_none(self, mock_get_boilerplate):
+        """Layered product whose product name has no template key returns None."""
+        mock_get_boilerplate.side_effect = ValueError("Boilerplate mta not found")
+
+        pipeline = self._make_pipeline(group="mta-7.2", assembly="7.2.0")
+        pipeline.product = "mta"
+        result = pipeline._load_release_notes_template()
+
+        self.assertIsNone(result)
+
+    @patch("pyartcd.pipelines.release_from_fbc.get_advisory_boilerplate")
+    @patch.object(ReleaseFromFbcPipeline, "get_file_from_branch")
+    def test_layered_product_assembly_two_components(self, mock_get_file, mock_get_boilerplate):
+        """Layered product with major.minor assembly (no patch) uses empty string for PRODUCT_PATCH."""
+        mock_get_boilerplate.return_value = {
+            "synopsis": "Version {PRODUCT_MAJOR}.{PRODUCT_MINOR}.{PRODUCT_PATCH}",
+            "topic": "Topic",
+            "description": "Description",
+            "solution": "Solution for {OCP_RELEASE_NOTES_VERSION}",
+        }
+        mock_get_file.return_value = b"""
 OCP_RELEASE_NOTES_VERSION: "4.21"
 """
 
-        pipeline = self._make_pipeline(assembly="6.5")
+        pipeline = self._make_pipeline(group="logging-6.5", assembly="6.5")
+        pipeline.product = "openshift-logging"
         result = pipeline._load_release_notes_template()
 
         self.assertIsNotNone(result)
         self.assertEqual(result["synopsis"], "Version 6.5.")
+        self.assertEqual(result["solution"], "Solution for 4.21")
 
 
 class TestRunWithTemplate(unittest.TestCase):


### PR DESCRIPTION
Extend release-from-fbc to support shipping OCP optional operators that are excluded from the main release due to dependency version conflicts (e.g., metallb needing a different kube-rbac-proxy).

When --ocp-optional is set, NVRs are categorized into extras/fbc kinds matching the OCP shipment structure, instead of the default image/fbc split. All FBC related images (including bundles and payload dependencies) are included in the extras shipment by default. An --exclude-nvr-components escape hatch is available for edge cases.

Changes:
- Add ocp_optional and exclude_nvr_components to pipeline constructor
- Extend categorize_nvrs() with extras/fbc categorization for OCP mode
- Generalize create_shipment_config() release notes logic for any non-FBC kind
- Update run() to use mode-appropriate category keys (extras vs image)
- Add --ocp-optional and --exclude-nvr-components CLI options
- Add tests covering OCP optional mode categorization and exclusion

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED