### PR TITLE
ART-14263: Add post-sync verification for S3 and Cloudflare R2 mirrors

### DIFF
--- a/pyartcd/pyartcd/s3.py
+++ b/pyartcd/pyartcd/s3.py
@@ -105,14 +105,18 @@ async def _verify_synced_to_mirrors(local_dir: str, s3_path: str):
     verify_cmd = ['aws', 's3', 'sync', '--no-progress', '--size-only', '--dryrun', local_dir, full_s3_path]
     env = os.environ.copy()
 
-    _, s3_out, _ = await exectools.cmd_gather_async(verify_cmd, env=env)
+    rc, s3_out, s3_err = await exectools.cmd_gather_async(verify_cmd, env=env)
+    if rc != 0:
+        raise IOError(f"S3 post-sync verification command failed (rc={rc}):\n{s3_err.strip()}")
     if s3_out.strip():
         raise IOError(f"S3 post-sync verification failed -- files missing or size mismatch:\n{s3_out.strip()}")
 
-    _, r2_out, _ = await exectools.cmd_gather_async(
+    rc, r2_out, r2_err = await exectools.cmd_gather_async(
         verify_cmd + ['--profile', 'cloudflare', '--endpoint-url', os.environ['CLOUDFLARE_ENDPOINT']],
         env=env,
     )
+    if rc != 0:
+        raise IOError(f"R2 post-sync verification command failed (rc={rc}):\n{r2_err.strip()}")
     if r2_out.strip():
         raise IOError(f"R2 post-sync verification failed -- files missing or size mismatch:\n{r2_out.strip()}")
 

--- a/pyartcd/pyartcd/s3.py
+++ b/pyartcd/pyartcd/s3.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 from typing import Optional
@@ -5,8 +6,14 @@ from typing import Optional
 from artcommonlib import exectools
 from tenacity import retry, stop_after_attempt, wait_fixed
 
+logger = logging.getLogger(__name__)
 
+
+@retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(30))
 async def sync_repo_to_s3_mirror(local_dir: str, s3_path: str, dry_run: bool = False, remove_old: bool = True):
+    """Sync a repo to S3 and R2 in three passes, then verify both destinations match.
+    Retries the entire sync+verify sequence up to 3 times.
+    """
     # Sync is not transactional. If we update repomd.xml before files it references are populated,
     # users of the repo will get a 404. So we run in three passes:
     # 1. On the first pass, exclude files like repomd.xml and do not delete any old files.
@@ -24,6 +31,9 @@ async def sync_repo_to_s3_mirror(local_dir: str, s3_path: str, dry_run: bool = F
     # 3. Everything should be synced in a consistent way -- delete anything old with --delete.
     if remove_old:
         await sync_dir_to_s3_mirror(local_dir, s3_path, exclude='', include_only='', dry_run=dry_run, remove_old=True)
+
+    if not dry_run:
+        await _verify_synced_to_mirrors(local_dir, s3_path)
 
 
 async def sync_dir_to_s3_mirror(
@@ -81,9 +91,29 @@ async def sync_dir_to_s3_mirror(
         + options
         + [local_dir, full_s3_path]
     )
-    # Sync temporarily to Cloudflare as well
+    # Sync to Cloudflare as well
     await retry(
         wait=wait_fixed(30),  # wait for 30 seconds between retries
         stop=(stop_after_attempt(3)),  # max 3 attempts
         reraise=True,
     )(exectools.cmd_assert_async)(full_command, env=env, stdout=sys.stderr)
+
+
+async def _verify_synced_to_mirrors(local_dir: str, s3_path: str):
+    """Run a size-only dry-run sync to verify all local files exist at both S3 and R2 destinations."""
+    full_s3_path = f's3://art-srv-enterprise{s3_path}'
+    verify_cmd = ['aws', 's3', 'sync', '--no-progress', '--size-only', '--dryrun', local_dir, full_s3_path]
+    env = os.environ.copy()
+
+    _, s3_out, _ = await exectools.cmd_gather_async(verify_cmd, env=env)
+    if s3_out.strip():
+        raise IOError(f"S3 post-sync verification failed -- files missing or size mismatch:\n{s3_out.strip()}")
+
+    _, r2_out, _ = await exectools.cmd_gather_async(
+        verify_cmd + ['--profile', 'cloudflare', '--endpoint-url', os.environ['CLOUDFLARE_ENDPOINT']],
+        env=env,
+    )
+    if r2_out.strip():
+        raise IOError(f"R2 post-sync verification failed -- files missing or size mismatch:\n{r2_out.strip()}")
+
+    logger.info("Verified: all local files present in S3 and R2 for %s", s3_path)

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -21,6 +21,7 @@ from artcommonlib.release_util import SoftwareLifecyclePhase, isolate_assembly_i
 from doozerlib import util as doozerutil
 from doozerlib.constants import ART_BUILD_HISTORY_URL
 from errata_tool import ErrataConnector
+from tenacity import retry, stop_after_attempt, wait_fixed
 
 from pyartcd import constants, record
 from pyartcd.mail import MailService
@@ -793,6 +794,7 @@ async def invalidate_cloudfront_cache(invalidation_path):
     await exectools.cmd_assert_async(cmd, env=os.environ.copy(), stdout=sys.stderr)
 
 
+@retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(30))
 async def mirror_to_s3(
     source: Union[str, Path],
     dest: str,
@@ -802,7 +804,8 @@ async def mirror_to_s3(
     delete: bool = False,
 ):
     """
-    Copy to AWS S3
+    Copy to AWS S3 and Cloudflare R2, then verify both destinations match.
+    Retries the entire sync+verify sequence up to 3 times.
     """
     cmd = ["aws", "s3", "sync", "--no-progress", "--exact-timestamps"]
     if delete:
@@ -822,6 +825,28 @@ async def mirror_to_s3(
         env=os.environ.copy(),
         stdout=sys.stderr,
     )
+
+    if not dry_run:
+        await _verify_synced_to_mirrors(source, dest)
+
+
+async def _verify_synced_to_mirrors(source: Union[str, Path], dest: str):
+    """Run a size-only dry-run sync to verify all local files exist at both S3 and R2 destinations."""
+    verify_cmd = ["aws", "s3", "sync", "--no-progress", "--size-only", "--dryrun"]
+    verify_paths = ['--', f'{source}', f'{dest}']
+
+    _, s3_out, _ = await exectools.cmd_gather_async(verify_cmd + verify_paths, env=os.environ.copy())
+    if s3_out.strip():
+        raise IOError(f"S3 post-sync verification failed -- files missing or size mismatch:\n{s3_out.strip()}")
+
+    _, r2_out, _ = await exectools.cmd_gather_async(
+        verify_cmd + ["--profile", "cloudflare", "--endpoint-url", os.environ["CLOUDFLARE_ENDPOINT"]] + verify_paths,
+        env=os.environ.copy(),
+    )
+    if r2_out.strip():
+        raise IOError(f"R2 post-sync verification failed -- files missing or size mismatch:\n{r2_out.strip()}")
+
+    logger.info("Verified: all local files present in S3 and R2 for %s", dest)
 
 
 async def mirror_to_google_cloud(source: Union[str, Path], dest: str, dry_run=False):

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -827,22 +827,35 @@ async def mirror_to_s3(
     )
 
     if not dry_run:
-        await _verify_synced_to_mirrors(source, dest)
+        await _verify_synced_to_mirrors(source, dest, exclude=exclude, include=include)
 
 
-async def _verify_synced_to_mirrors(source: Union[str, Path], dest: str):
+async def _verify_synced_to_mirrors(
+    source: Union[str, Path],
+    dest: str,
+    exclude: Optional[str] = None,
+    include: Optional[str] = None,
+):
     """Run a size-only dry-run sync to verify all local files exist at both S3 and R2 destinations."""
     verify_cmd = ["aws", "s3", "sync", "--no-progress", "--size-only", "--dryrun"]
+    if exclude is not None:
+        verify_cmd.append(f"--exclude={exclude}")
+    if include is not None:
+        verify_cmd.append(f"--include={include}")
     verify_paths = ['--', f'{source}', f'{dest}']
 
-    _, s3_out, _ = await exectools.cmd_gather_async(verify_cmd + verify_paths, env=os.environ.copy())
+    rc, s3_out, s3_err = await exectools.cmd_gather_async(verify_cmd + verify_paths, env=os.environ.copy())
+    if rc != 0:
+        raise IOError(f"S3 post-sync verification command failed (rc={rc}):\n{s3_err.strip()}")
     if s3_out.strip():
         raise IOError(f"S3 post-sync verification failed -- files missing or size mismatch:\n{s3_out.strip()}")
 
-    _, r2_out, _ = await exectools.cmd_gather_async(
+    rc, r2_out, r2_err = await exectools.cmd_gather_async(
         verify_cmd + ["--profile", "cloudflare", "--endpoint-url", os.environ["CLOUDFLARE_ENDPOINT"]] + verify_paths,
         env=os.environ.copy(),
     )
+    if rc != 0:
+        raise IOError(f"R2 post-sync verification command failed (rc={rc}):\n{r2_err.strip()}")
     if r2_out.strip():
         raise IOError(f"R2 post-sync verification failed -- files missing or size mismatch:\n{r2_out.strip()}")
 

--- a/pyartcd/tests/test_s3.py
+++ b/pyartcd/tests/test_s3.py
@@ -1,0 +1,119 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from pyartcd.s3 import _verify_synced_to_mirrors, sync_repo_to_s3_mirror
+from tenacity import wait_none
+
+# Disable retry wait for tests
+sync_repo_to_s3_mirror.retry.wait = wait_none()
+
+
+CLOUDFLARE_ENDPOINT = "https://fake-r2.cloudflarestorage.com"
+
+
+class TestVerifySyncedToMirrors(IsolatedAsyncioTestCase):
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.s3.exectools.cmd_gather_async", new_callable=AsyncMock)
+    async def test_passes_when_both_empty(self, mock_gather: AsyncMock):
+        mock_gather.return_value = (0, "", "")
+        await _verify_synced_to_mirrors("/local/dir", "/enterprise/reposync/5.0")
+        self.assertEqual(mock_gather.call_count, 2)
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.s3.exectools.cmd_gather_async", new_callable=AsyncMock)
+    async def test_raises_on_s3_mismatch(self, mock_gather: AsyncMock):
+        mock_gather.return_value = (0, "(dryrun) upload: ./foo.rpm to s3://art-srv-enterprise/path/foo.rpm\n", "")
+        with self.assertRaises(IOError) as ctx:
+            await _verify_synced_to_mirrors("/local/dir", "/enterprise/reposync/5.0")
+        self.assertIn("S3 post-sync verification failed", str(ctx.exception))
+        self.assertIn("foo.rpm", str(ctx.exception))
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.s3.exectools.cmd_gather_async", new_callable=AsyncMock)
+    async def test_raises_on_r2_mismatch(self, mock_gather: AsyncMock):
+        mock_gather.side_effect = [
+            (0, "", ""),  # S3 check passes
+            (0, "(dryrun) upload: ./bar.rpm to s3://art-srv-enterprise/path/bar.rpm\n", ""),  # R2 fails
+        ]
+        with self.assertRaises(IOError) as ctx:
+            await _verify_synced_to_mirrors("/local/dir", "/enterprise/reposync/5.0")
+        self.assertIn("R2 post-sync verification failed", str(ctx.exception))
+        self.assertIn("bar.rpm", str(ctx.exception))
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.s3.exectools.cmd_gather_async", new_callable=AsyncMock)
+    async def test_verify_uses_size_only_dryrun(self, mock_gather: AsyncMock):
+        mock_gather.return_value = (0, "", "")
+        await _verify_synced_to_mirrors("/local/dir", "/enterprise/reposync/5.0")
+        s3_cmd = mock_gather.call_args_list[0][0][0]
+        self.assertIn("--size-only", s3_cmd)
+        self.assertIn("--dryrun", s3_cmd)
+        self.assertNotIn("--exact-timestamps", s3_cmd)
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.s3.exectools.cmd_gather_async", new_callable=AsyncMock)
+    async def test_verify_checks_r2_with_cloudflare_profile(self, mock_gather: AsyncMock):
+        mock_gather.return_value = (0, "", "")
+        await _verify_synced_to_mirrors("/local/dir", "/enterprise/reposync/5.0")
+        r2_cmd = mock_gather.call_args_list[1][0][0]
+        self.assertIn("--profile", r2_cmd)
+        self.assertIn("cloudflare", r2_cmd)
+        self.assertIn("--endpoint-url", r2_cmd)
+        self.assertIn(CLOUDFLARE_ENDPOINT, r2_cmd)
+
+
+class TestSyncRepoToS3Mirror(IsolatedAsyncioTestCase):
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.s3._verify_synced_to_mirrors", new_callable=AsyncMock)
+    @patch("pyartcd.s3.sync_dir_to_s3_mirror", new_callable=AsyncMock)
+    async def test_calls_verify_after_sync(self, mock_sync_dir: AsyncMock, mock_verify: AsyncMock):
+        await sync_repo_to_s3_mirror.__wrapped__("/local", "/enterprise/reposync/5.0")
+        mock_verify.assert_awaited_once_with("/local", "/enterprise/reposync/5.0")
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.s3._verify_synced_to_mirrors", new_callable=AsyncMock)
+    @patch("pyartcd.s3.sync_dir_to_s3_mirror", new_callable=AsyncMock)
+    async def test_skips_verify_on_dry_run(self, mock_sync_dir: AsyncMock, mock_verify: AsyncMock):
+        await sync_repo_to_s3_mirror.__wrapped__("/local", "/enterprise/reposync/5.0", dry_run=True)
+        mock_verify.assert_not_awaited()
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.s3._verify_synced_to_mirrors", new_callable=AsyncMock)
+    @patch("pyartcd.s3.sync_dir_to_s3_mirror", new_callable=AsyncMock)
+    async def test_three_passes_with_remove_old(self, mock_sync_dir: AsyncMock, mock_verify: AsyncMock):
+        await sync_repo_to_s3_mirror.__wrapped__("/local", "/enterprise/reposync/5.0", remove_old=True)
+        self.assertEqual(mock_sync_dir.await_count, 3)
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.s3._verify_synced_to_mirrors", new_callable=AsyncMock)
+    @patch("pyartcd.s3.sync_dir_to_s3_mirror", new_callable=AsyncMock)
+    async def test_two_passes_without_remove_old(self, mock_sync_dir: AsyncMock, mock_verify: AsyncMock):
+        await sync_repo_to_s3_mirror.__wrapped__("/local", "/enterprise/reposync/5.0", remove_old=False)
+        self.assertEqual(mock_sync_dir.await_count, 2)
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.s3._verify_synced_to_mirrors", new_callable=AsyncMock)
+    @patch("pyartcd.s3.sync_dir_to_s3_mirror", new_callable=AsyncMock)
+    async def test_retries_on_verify_failure(self, mock_sync_dir: AsyncMock, mock_verify: AsyncMock):
+        mock_verify.side_effect = [IOError("R2 mismatch"), None]
+        await sync_repo_to_s3_mirror("/local", "/enterprise/reposync/5.0")
+        self.assertEqual(mock_verify.await_count, 2)
+        self.assertEqual(mock_sync_dir.await_count, 6)  # 3 passes x 2 attempts
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.s3._verify_synced_to_mirrors", new_callable=AsyncMock)
+    @patch("pyartcd.s3.sync_dir_to_s3_mirror", new_callable=AsyncMock)
+    async def test_retries_on_sync_failure(self, mock_sync_dir: AsyncMock, mock_verify: AsyncMock):
+        mock_sync_dir.side_effect = [Exception("S3 down"), None, None]
+        await sync_repo_to_s3_mirror("/local", "/enterprise/reposync/5.0", remove_old=False)
+        self.assertEqual(mock_sync_dir.await_count, 3)  # 1 fail + 2 passes on retry
+        mock_verify.assert_awaited_once()
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.s3._verify_synced_to_mirrors", new_callable=AsyncMock)
+    @patch("pyartcd.s3.sync_dir_to_s3_mirror", new_callable=AsyncMock)
+    async def test_raises_after_all_retries_exhausted(self, mock_sync_dir: AsyncMock, mock_verify: AsyncMock):
+        mock_verify.side_effect = IOError("R2 mismatch")
+        with self.assertRaises(IOError):
+            await sync_repo_to_s3_mirror("/local", "/enterprise/reposync/5.0", remove_old=False)
+        self.assertEqual(mock_verify.await_count, 3)  # 3 attempts then give up

--- a/pyartcd/tests/test_s3.py
+++ b/pyartcd/tests/test_s3.py
@@ -52,6 +52,26 @@ class TestVerifySyncedToMirrors(IsolatedAsyncioTestCase):
 
     @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
     @patch("pyartcd.s3.exectools.cmd_gather_async", new_callable=AsyncMock)
+    async def test_raises_on_s3_command_failure(self, mock_gather: AsyncMock):
+        mock_gather.return_value = (1, "", "An error occurred (AccessDenied)")
+        with self.assertRaises(IOError) as ctx:
+            await _verify_synced_to_mirrors("/local/dir", "/enterprise/reposync/5.0")
+        self.assertIn("S3 post-sync verification command failed", str(ctx.exception))
+        self.assertIn("rc=1", str(ctx.exception))
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.s3.exectools.cmd_gather_async", new_callable=AsyncMock)
+    async def test_raises_on_r2_command_failure(self, mock_gather: AsyncMock):
+        mock_gather.side_effect = [
+            (0, "", ""),
+            (1, "", "connection timeout"),
+        ]
+        with self.assertRaises(IOError) as ctx:
+            await _verify_synced_to_mirrors("/local/dir", "/enterprise/reposync/5.0")
+        self.assertIn("R2 post-sync verification command failed", str(ctx.exception))
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.s3.exectools.cmd_gather_async", new_callable=AsyncMock)
     async def test_verify_checks_r2_with_cloudflare_profile(self, mock_gather: AsyncMock):
         mock_gather.return_value = (0, "", "")
         await _verify_synced_to_mirrors("/local/dir", "/enterprise/reposync/5.0")

--- a/pyartcd/tests/test_util.py
+++ b/pyartcd/tests/test_util.py
@@ -399,6 +399,40 @@ class TestVerifySyncedToMirrors(IsolatedAsyncioTestCase):
         self.assertIn("--dryrun", s3_cmd)
         self.assertNotIn("--exact-timestamps", s3_cmd)
 
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.util.exectools.cmd_gather_async", new_callable=AsyncMock)
+    async def test_raises_on_s3_command_failure(self, mock_gather: AsyncMock):
+        mock_gather.return_value = (1, "", "An error occurred (AccessDenied)")
+        with self.assertRaises(IOError) as ctx:
+            await util._verify_synced_to_mirrors("/local/dir", "s3://art-srv-enterprise/path")
+        self.assertIn("S3 post-sync verification command failed", str(ctx.exception))
+        self.assertIn("rc=1", str(ctx.exception))
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.util.exectools.cmd_gather_async", new_callable=AsyncMock)
+    async def test_raises_on_r2_command_failure(self, mock_gather: AsyncMock):
+        mock_gather.side_effect = [
+            (0, "", ""),
+            (1, "", "connection timeout"),
+        ]
+        with self.assertRaises(IOError) as ctx:
+            await util._verify_synced_to_mirrors("/local/dir", "s3://art-srv-enterprise/path")
+        self.assertIn("R2 post-sync verification command failed", str(ctx.exception))
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.util.exectools.cmd_gather_async", new_callable=AsyncMock)
+    async def test_verify_applies_exclude_include_filters(self, mock_gather: AsyncMock):
+        mock_gather.return_value = (0, "", "")
+        await util._verify_synced_to_mirrors(
+            "/local/dir", "s3://art-srv-enterprise/path", exclude="*", include="sha256=*"
+        )
+        s3_cmd = mock_gather.call_args_list[0][0][0]
+        self.assertIn("--exclude=*", s3_cmd)
+        self.assertIn("--include=sha256=*", s3_cmd)
+        r2_cmd = mock_gather.call_args_list[1][0][0]
+        self.assertIn("--exclude=*", r2_cmd)
+        self.assertIn("--include=sha256=*", r2_cmd)
+
 
 class TestMirrorToS3(IsolatedAsyncioTestCase):
     CLOUDFLARE_ENDPOINT = "https://fake-r2.cloudflarestorage.com"
@@ -408,7 +442,14 @@ class TestMirrorToS3(IsolatedAsyncioTestCase):
     @patch("pyartcd.util.exectools.cmd_assert_async", new_callable=AsyncMock)
     async def test_calls_verify_after_sync(self, mock_assert: AsyncMock, mock_verify: AsyncMock):
         await util.mirror_to_s3.__wrapped__("/local", "s3://art-srv-enterprise/path")
-        mock_verify.assert_awaited_once_with("/local", "s3://art-srv-enterprise/path")
+        mock_verify.assert_awaited_once_with("/local", "s3://art-srv-enterprise/path", exclude=None, include=None)
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.util._verify_synced_to_mirrors", new_callable=AsyncMock)
+    @patch("pyartcd.util.exectools.cmd_assert_async", new_callable=AsyncMock)
+    async def test_passes_filters_to_verify(self, mock_assert: AsyncMock, mock_verify: AsyncMock):
+        await util.mirror_to_s3.__wrapped__("/local", "s3://art-srv-enterprise/path", exclude="*", include="sha256=*")
+        mock_verify.assert_awaited_once_with("/local", "s3://art-srv-enterprise/path", exclude="*", include="sha256=*")
 
     @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
     @patch("pyartcd.util._verify_synced_to_mirrors", new_callable=AsyncMock)

--- a/pyartcd/tests/test_util.py
+++ b/pyartcd/tests/test_util.py
@@ -1,7 +1,12 @@
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from tenacity import wait_none
+
 from pyartcd import util
+
+# Disable retry wait for tests
+util.mirror_to_s3.retry.wait = wait_none()
 
 
 class TestUtil(IsolatedAsyncioTestCase):
@@ -353,3 +358,88 @@ class TestUtil(IsolatedAsyncioTestCase):
         mock_get_keys.return_value = []
         result = await util.get_counter_failures('ec-failure', 'openshift-4.21')
         self.assertEqual(result, {})
+
+
+class TestVerifySyncedToMirrors(IsolatedAsyncioTestCase):
+    CLOUDFLARE_ENDPOINT = "https://fake-r2.cloudflarestorage.com"
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.util.exectools.cmd_gather_async", new_callable=AsyncMock)
+    async def test_passes_when_both_empty(self, mock_gather: AsyncMock):
+        mock_gather.return_value = (0, "", "")
+        await util._verify_synced_to_mirrors("/local/dir", "s3://art-srv-enterprise/path")
+        self.assertEqual(mock_gather.call_count, 2)
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.util.exectools.cmd_gather_async", new_callable=AsyncMock)
+    async def test_raises_on_s3_mismatch(self, mock_gather: AsyncMock):
+        mock_gather.return_value = (0, "(dryrun) upload: ./foo.rpm to s3://bucket/foo.rpm\n", "")
+        with self.assertRaises(IOError) as ctx:
+            await util._verify_synced_to_mirrors("/local/dir", "s3://art-srv-enterprise/path")
+        self.assertIn("S3 post-sync verification failed", str(ctx.exception))
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.util.exectools.cmd_gather_async", new_callable=AsyncMock)
+    async def test_raises_on_r2_mismatch(self, mock_gather: AsyncMock):
+        mock_gather.side_effect = [
+            (0, "", ""),  # S3 passes
+            (0, "(dryrun) upload: ./bar.rpm to s3://bucket/bar.rpm\n", ""),  # R2 fails
+        ]
+        with self.assertRaises(IOError) as ctx:
+            await util._verify_synced_to_mirrors("/local/dir", "s3://art-srv-enterprise/path")
+        self.assertIn("R2 post-sync verification failed", str(ctx.exception))
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.util.exectools.cmd_gather_async", new_callable=AsyncMock)
+    async def test_verify_uses_size_only_not_exact_timestamps(self, mock_gather: AsyncMock):
+        mock_gather.return_value = (0, "", "")
+        await util._verify_synced_to_mirrors("/local/dir", "s3://art-srv-enterprise/path")
+        s3_cmd = mock_gather.call_args_list[0][0][0]
+        self.assertIn("--size-only", s3_cmd)
+        self.assertIn("--dryrun", s3_cmd)
+        self.assertNotIn("--exact-timestamps", s3_cmd)
+
+
+class TestMirrorToS3(IsolatedAsyncioTestCase):
+    CLOUDFLARE_ENDPOINT = "https://fake-r2.cloudflarestorage.com"
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.util._verify_synced_to_mirrors", new_callable=AsyncMock)
+    @patch("pyartcd.util.exectools.cmd_assert_async", new_callable=AsyncMock)
+    async def test_calls_verify_after_sync(self, mock_assert: AsyncMock, mock_verify: AsyncMock):
+        await util.mirror_to_s3.__wrapped__("/local", "s3://art-srv-enterprise/path")
+        mock_verify.assert_awaited_once_with("/local", "s3://art-srv-enterprise/path")
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.util._verify_synced_to_mirrors", new_callable=AsyncMock)
+    @patch("pyartcd.util.exectools.cmd_assert_async", new_callable=AsyncMock)
+    async def test_skips_verify_on_dry_run(self, mock_assert: AsyncMock, mock_verify: AsyncMock):
+        await util.mirror_to_s3.__wrapped__("/local", "s3://art-srv-enterprise/path", dry_run=True)
+        mock_verify.assert_not_awaited()
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.util._verify_synced_to_mirrors", new_callable=AsyncMock)
+    @patch("pyartcd.util.exectools.cmd_assert_async", new_callable=AsyncMock)
+    async def test_retries_on_verify_failure(self, mock_assert: AsyncMock, mock_verify: AsyncMock):
+        mock_verify.side_effect = [IOError("R2 mismatch"), None]
+        await util.mirror_to_s3("/local", "s3://art-srv-enterprise/path")
+        self.assertEqual(mock_verify.await_count, 2)
+        self.assertEqual(mock_assert.await_count, 4)  # 2 syncs x 2 attempts
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.util._verify_synced_to_mirrors", new_callable=AsyncMock)
+    @patch("pyartcd.util.exectools.cmd_assert_async", new_callable=AsyncMock)
+    async def test_retries_on_sync_failure(self, mock_assert: AsyncMock, mock_verify: AsyncMock):
+        mock_assert.side_effect = [Exception("S3 down"), None, None]
+        await util.mirror_to_s3("/local", "s3://art-srv-enterprise/path")
+        self.assertEqual(mock_assert.await_count, 3)  # 1 fail + 2 syncs on retry
+        mock_verify.assert_awaited_once()
+
+    @patch.dict("os.environ", {"CLOUDFLARE_ENDPOINT": CLOUDFLARE_ENDPOINT})
+    @patch("pyartcd.util._verify_synced_to_mirrors", new_callable=AsyncMock)
+    @patch("pyartcd.util.exectools.cmd_assert_async", new_callable=AsyncMock)
+    async def test_raises_after_all_retries_exhausted(self, mock_assert: AsyncMock, mock_verify: AsyncMock):
+        mock_verify.side_effect = IOError("R2 mismatch")
+        with self.assertRaises(IOError):
+            await util.mirror_to_s3("/local", "s3://art-srv-enterprise/path")
+        self.assertEqual(mock_verify.await_count, 3)  # 3 attempts then give up


### PR DESCRIPTION
## Summary
- Adds post-sync verification to `mirror_to_s3` in `pyartcd/util.py` and `sync_repo_to_s3_mirror` in `pyartcd/s3.py`
- After syncing to both S3 and R2, runs a `--size-only --dryrun` sync to verify all local files exist at both destinations
- Wraps the entire sync+verify sequence in `tenacity.retry(stop_after_attempt(3))` so verification failures trigger retries of the full sync, matching the Groovy `retry(3)` behavior in aos-cd-jobs
- Catches silent partial upload failures where `aws s3 sync` exits 0 but does not upload all files to R2, which can leave files permanently S3-only when `doozer beta:reposync --delete` later removes them locally

Uses `--size-only` instead of `--exact-timestamps` to avoid false positives from timestamp precision differences between the local filesystem and Cloudflare R2.

Companion PR: https://github.com/openshift-eng/aos-cd-jobs/pull/4708

## Test plan
- [x] Unit tests for `_verify_synced_to_mirrors` in both `test_util.py` and `test_s3.py` (15 tests, all passing)
- [ ] Verify pipelines using `mirror_to_s3` complete successfully with verification
- [ ] Confirm verification does not produce false positives on a normal sync run