### PR TITLE
Add find-bugs:cutoff command to elliott

### DIFF
--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -43,6 +43,7 @@ from elliottlib.cli.create_placeholder_cli import create_placeholder_cli
 from elliottlib.cli.create_textonly_cli import create_textonly_cli
 from elliottlib.cli.find_bugs_blocker_cli import find_bugs_blocker_cli
 from elliottlib.cli.find_bugs_cli import find_bugs_cli
+from elliottlib.cli.find_bugs_cutoff_cli import find_bugs_cutoff_cli
 from elliottlib.cli.find_bugs_golang_cli import find_bugs_golang_cli
 from elliottlib.cli.find_bugs_kernel_cli import find_bugs_kernel_cli
 from elliottlib.cli.find_bugs_kernel_clones_cli import find_bugs_kernel_clones_cli
@@ -321,6 +322,7 @@ cli.add_command(shipment_cli)
 cli.add_command(watch_release_cli)
 cli.add_command(find_bugs_second_fix_cli)
 cli.add_command(process_release_from_fbc_bugs_cli)
+cli.add_command(find_bugs_cutoff_cli)
 
 # -----------------------------------------------------------------------------
 # CLI Entry point

--- a/elliott/elliottlib/cli/find_bugs_cutoff_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_cutoff_cli.py
@@ -1,0 +1,310 @@
+import json
+import sys
+from datetime import datetime, timezone
+from typing import List, Optional, Set
+
+import click
+from artcommonlib import logutil
+from artcommonlib.rpm_utils import parse_nvr
+
+from elliottlib import Runtime, constants
+from elliottlib.bzutil import Bug
+from elliottlib.cli.common import cli, click_coroutine
+from elliottlib.cli.find_bugs_sweep_cli import FindBugsSweep
+from elliottlib.util import chunk, isolate_timestamp_in_release, normalize_component_by_ocp_delivery_repo
+
+logger = logutil.get_logger(__name__)
+
+
+def get_timestamp_from_nvr(nvr: str) -> float:
+    """Extract a UTC unix timestamp from the embedded YYYYMMddHHmm in an NVR release field."""
+    parsed = parse_nvr(nvr)
+    ts_str = isolate_timestamp_in_release(parsed['release'])
+    if not ts_str:
+        raise click.BadParameter(
+            f"Cannot extract timestamp from NVR release field: {nvr}. "
+            "The release field must contain a YYYYMMddHHmm timestamp."
+        )
+    dt = datetime.strptime(ts_str, "%Y%m%d%H%M").replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+def parse_cutoff_time(time_str: str) -> float:
+    """Parse an ISO datetime string into a UTC unix timestamp."""
+    if time_str.endswith('Z'):
+        time_str = time_str[:-1] + '+00:00'
+    dt = datetime.fromisoformat(time_str)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+def get_component_names_from_nvrs(nvrs: List[str]) -> Set[str]:
+    """Extract package names from NVRs for component filtering."""
+    names = set()
+    for nvr in nvrs:
+        if nvr:
+            parsed = parse_nvr(nvr)
+            names.add(parsed['name'])
+    return names
+
+
+def filter_bugs_by_cutoff_chunked(bug_tracker, bugs, statuses, cutoff_ts):
+    """Filter bugs by cutoff in chunks to avoid Jira URL length limits."""
+    result = []
+    for bug_chunk in chunk(bugs, constants.BUG_LOOKUP_CHUNK_SIZE):
+        result.extend(bug_tracker.filter_bugs_by_cutoff_event(bug_chunk, statuses, cutoff_ts))
+    return result
+
+
+def get_delivery_repo_names(runtime: Runtime, component_name: str) -> Set[str]:
+    """Map a build component name to its delivery repo names using ocp-build-data metadata.
+
+    Tracker bugs use delivery repo names (e.g. openshift4/ose-kube-rbac-proxy-rhel9) in their
+    pscomponent labels. This function finds the matching image metadata and returns all
+    delivery repo names so we can query Jira directly.
+    """
+    for image_meta in runtime.image_metas():
+        if image_meta.get_component_name() == component_name:
+            repo_names = image_meta.config.delivery.get('delivery_repo_names', [])
+            if repo_names:
+                return set(repo_names)
+    return set()
+
+
+def search_tracker_bugs_at_cutoff(bug_tracker, component_names, statuses, cutoff_ts, runtime):
+    """Search for tracker bugs matching components that were in a qualifying status at cutoff time.
+
+    Builds a JQL query using pscomponent labels derived from delivery repo names in ocp-build-data.
+    """
+    dt = datetime.utcfromtimestamp(cutoff_ts).strftime("%Y/%m/%d %H:%M")
+    status_val = ','.join(f'"{s}"' for s in statuses)
+
+    # Build pscomponent label conditions from both component names and delivery repo names
+    label_conditions = []
+    for comp in component_names:
+        label_conditions.append(f'labels = "pscomponent:{comp}"')
+        label_conditions.append(f'labels = "art:pscomponent:{comp}"')
+        for repo_name in get_delivery_repo_names(runtime, comp):
+            label_conditions.append(f'labels = "pscomponent:{repo_name}"')
+            label_conditions.append(f'labels = "art:pscomponent:{repo_name}"')
+
+    if not label_conditions:
+        logger.warning(f"No pscomponent labels found for components: {component_names}")
+        return []
+
+    label_filter = f' and ({" or ".join(label_conditions)})'
+    cutoff_filter = f' and status was in ({status_val}) on("{dt}")'
+    query = bug_tracker._query(status=None, custom_query=label_filter + cutoff_filter)
+    if query is None:
+        return []
+    logger.info(f"JQL: {query}")
+    return bug_tracker._search(query)
+
+
+def filter_by_component(bugs: List[Bug], component_names: Set[str], runtime: Runtime) -> List[Bug]:
+    """Filter tracker bugs by whiteboard_component. Non-tracker bugs pass through unfiltered."""
+    filtered = []
+    for bug in bugs:
+        if not bug.is_tracker_bug():
+            filtered.append(bug)
+            continue
+        wb_component = bug.whiteboard_component
+        if wb_component:
+            wb_component = normalize_component_by_ocp_delivery_repo(runtime, wb_component)
+        if wb_component in component_names:
+            filtered.append(bug)
+    return filtered
+
+
+def validate_options(nvr, cutoff_time, from_nvr, to_nvr, from_time, to_time):
+    """Validate mutual exclusivity of single vs range mode options."""
+    single_opts = {'--nvr': nvr, '--cutoff-time': cutoff_time}
+    range_opts = {'--from-nvr': from_nvr, '--to-nvr': to_nvr, '--from-time': from_time, '--to-time': to_time}
+
+    has_single = any(single_opts.values())
+    has_range = any(range_opts.values())
+
+    if has_single and has_range:
+        raise click.BadParameter(
+            "Cannot mix single-mode options (--nvr, --cutoff-time) with "
+            "range-mode options (--from-nvr, --to-nvr, --from-time, --to-time)."
+        )
+
+    if not has_single and not has_range:
+        raise click.BadParameter(
+            "Must provide either single-mode (--nvr or --cutoff-time) or "
+            "range-mode (--from-nvr/--from-time + --to-nvr/--to-time) options."
+        )
+
+    if has_single:
+        if nvr and cutoff_time:
+            raise click.BadParameter("Cannot use both --nvr and --cutoff-time. Pick one.")
+        return 'single'
+
+    # Range mode validation
+    if from_nvr and from_time:
+        raise click.BadParameter("Cannot use both --from-nvr and --from-time. Pick one.")
+    if to_nvr and to_time:
+        raise click.BadParameter("Cannot use both --to-nvr and --to-time. Pick one.")
+    if not (from_nvr or from_time):
+        raise click.BadParameter("Range mode requires a 'from' source: --from-nvr or --from-time.")
+    if not (to_nvr or to_time):
+        raise click.BadParameter("Range mode requires a 'to' source: --to-nvr or --to-time.")
+
+    return 'range'
+
+
+@cli.command("find-bugs:cutoff", short_help="Find bugs by cutoff time or NVR")
+@click.option("--nvr", default=None, help="Image NVR to derive a single cutoff timestamp from")
+@click.option("--cutoff-time", default=None, help="ISO datetime for single cutoff (e.g. 2025-04-15T13:28:00Z)")
+@click.option("--from-nvr", default=None, help="Start NVR for range mode")
+@click.option("--to-nvr", default=None, help="End NVR for range mode")
+@click.option("--from-time", default=None, help="Start ISO datetime for range mode")
+@click.option("--to-time", default=None, help="End ISO datetime for range mode")
+@click.option(
+    "--component", default=None, help="Filter tracker bugs by whiteboard component (overrides NVR-derived component)"
+)
+@click.option(
+    "--include-status",
+    multiple=True,
+    default=None,
+    required=False,
+    type=click.Choice(constants.VALID_BUG_STATES),
+    help="Include bugs of this status (in addition to the default VERIFIED)",
+)
+@click.option(
+    "--exclude-status",
+    multiple=True,
+    default=None,
+    required=False,
+    type=click.Choice(constants.VALID_BUG_STATES),
+    help="Exclude bugs of this status",
+)
+@click.option("--output", "-o", type=click.Choice(["json", "text"]), default="text", help="Output format")
+@click.pass_obj
+@click_coroutine
+async def find_bugs_cutoff_cli(
+    runtime: Runtime,
+    nvr,
+    cutoff_time,
+    from_nvr,
+    to_nvr,
+    from_time,
+    to_time,
+    component,
+    include_status,
+    exclude_status,
+    output,
+):
+    """Find OCP bugs by cutoff time or NVR.
+
+    Supports two modes:
+
+    \b
+    Single cutoff: find bugs that were in qualifying status at a given time.
+        $ elliott -g openshift-4.18 find-bugs:cutoff --nvr <NVR> -o json
+        $ elliott -g openshift-4.18 find-bugs:cutoff --cutoff-time 2025-04-15T13:28:00Z
+
+    \b
+    Range: find bugs that entered qualifying status between two cutoff times.
+        $ elliott -g openshift-4.18 find-bugs:cutoff --from-nvr <NVR1> --to-nvr <NVR2>
+        $ elliott -g openshift-4.18 find-bugs:cutoff --from-time <T1> --to-time <T2>
+
+    When NVRs are provided, tracker bugs are automatically filtered to those
+    whose whiteboard_component matches the NVR package name. Use --component
+    to override this or to filter when using --cutoff-time/--from-time/--to-time.
+    """
+
+    mode = validate_options(nvr, cutoff_time, from_nvr, to_nvr, from_time, to_time)
+
+    runtime.initialize(mode="both")
+    bug_tracker = runtime.get_bug_tracker('jira')
+
+    find_bugs_obj = FindBugsSweep()
+    find_bugs_obj.include_status(include_status)
+    find_bugs_obj.exclude_status(exclude_status)
+
+    # Resolve timestamps
+    if mode == 'single':
+        cutoff_ts = get_timestamp_from_nvr(nvr) if nvr else parse_cutoff_time(cutoff_time)
+        nvrs_provided = [nvr] if nvr else []
+    else:
+        t1 = get_timestamp_from_nvr(from_nvr) if from_nvr else parse_cutoff_time(from_time)
+        t2 = get_timestamp_from_nvr(to_nvr) if to_nvr else parse_cutoff_time(to_time)
+        if t1 >= t2:
+            raise click.BadParameter(
+                f"'from' cutoff ({datetime.utcfromtimestamp(t1)}) must be before "
+                f"'to' cutoff ({datetime.utcfromtimestamp(t2)})."
+            )
+        nvrs_provided = [n for n in [from_nvr, to_nvr] if n]
+
+    # Determine component filter
+    component_names: Optional[Set[str]] = None
+    if component:
+        component_names = {component}
+    elif nvrs_provided:
+        component_names = get_component_names_from_nvrs(nvrs_provided)
+
+    statuses = sorted(find_bugs_obj.status)
+
+    if component_names:
+        # Fast path: query Jira directly for tracker bugs by pscomponent label + cutoff
+        logger.info(f"Searching for tracker bugs with component(s) {component_names} and status {statuses}")
+        if mode == 'single':
+            utc_ts = datetime.fromtimestamp(cutoff_ts, tz=timezone.utc)
+            logger.info(f"Finding tracker bugs in {statuses} at {utc_ts}...")
+            result_bugs = search_tracker_bugs_at_cutoff(
+                bug_tracker, component_names, find_bugs_obj.status, cutoff_ts, runtime
+            )
+        else:
+            utc_t1 = datetime.fromtimestamp(t1, tz=timezone.utc)
+            utc_t2 = datetime.fromtimestamp(t2, tz=timezone.utc)
+            logger.info(f"Finding tracker bugs that entered {statuses} between {utc_t1} and {utc_t2}...")
+            at_t2 = search_tracker_bugs_at_cutoff(bug_tracker, component_names, find_bugs_obj.status, t2, runtime)
+            at_t1 = search_tracker_bugs_at_cutoff(bug_tracker, component_names, find_bugs_obj.status, t1, runtime)
+            at_t1_ids = {b.id for b in at_t1}
+            result_bugs = [b for b in at_t2 if b.id not in at_t1_ids]
+    else:
+        # No component filter: broad search + chunked cutoff filtering
+        tr = bug_tracker.target_release()
+        logger.info(f"Searching for bugs currently in {statuses} with target releases: {tr}")
+        bugs = find_bugs_obj.search(bug_tracker_obj=bug_tracker, verbose=runtime.debug)
+
+        if not bugs:
+            logger.info("No bugs found matching current status criteria.")
+            if output == 'json':
+                click.echo(json.dumps([], indent=4))
+            else:
+                click.echo("No bugs found.")
+            sys.exit(0)
+
+        logger.info(f"Found {len(bugs)} bugs currently in qualifying status.")
+
+        if mode == 'single':
+            utc_ts = datetime.fromtimestamp(cutoff_ts, tz=timezone.utc)
+            logger.info(f"Filtering to bugs that were in {statuses} at {utc_ts}...")
+            result_bugs = filter_bugs_by_cutoff_chunked(bug_tracker, bugs, find_bugs_obj.status, cutoff_ts)
+        else:
+            utc_t1 = datetime.fromtimestamp(t1, tz=timezone.utc)
+            utc_t2 = datetime.fromtimestamp(t2, tz=timezone.utc)
+            logger.info(f"Finding bugs that entered {statuses} between {utc_t1} and {utc_t2}...")
+            at_t2 = filter_bugs_by_cutoff_chunked(bug_tracker, bugs, find_bugs_obj.status, t2)
+            at_t1 = filter_bugs_by_cutoff_chunked(bug_tracker, bugs, find_bugs_obj.status, t1)
+            at_t1_ids = {b.id for b in at_t1}
+            result_bugs = [b for b in at_t2 if b.id not in at_t1_ids]
+
+    logger.info(f"{len(result_bugs)} bugs found.")
+
+    # Output results
+    bug_ids = sorted([b.id for b in result_bugs])
+    if output == 'json':
+        click.echo(json.dumps(bug_ids, indent=4))
+    else:
+        if bug_ids:
+            click.echo(f"Found {len(bug_ids)} bugs:")
+            click.echo(", ".join(bug_ids))
+        else:
+            click.echo("No bugs found.")
+
+    sys.exit(0)

--- a/elliott/tests/test_find_bugs_cutoff_cli.py
+++ b/elliott/tests/test_find_bugs_cutoff_cli.py
@@ -1,0 +1,244 @@
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import click
+from elliottlib.cli.find_bugs_cutoff_cli import (
+    filter_by_component,
+    get_component_names_from_nvrs,
+    get_timestamp_from_nvr,
+    parse_cutoff_time,
+    validate_options,
+)
+from flexmock import flexmock
+
+
+class TestGetTimestampFromNvr(unittest.TestCase):
+    def test_valid_nvr(self):
+        nvr = "ose-installer-container-v4.18.0-202504151328.p0.g6666.assembly.stream"
+        ts = get_timestamp_from_nvr(nvr)
+        expected = datetime(2025, 4, 15, 13, 28, tzinfo=timezone.utc).timestamp()
+        self.assertEqual(ts, expected)
+
+    def test_valid_nvr_different_timestamp(self):
+        nvr = "logging-fluentd-container-v4.1.14-201908291507"
+        ts = get_timestamp_from_nvr(nvr)
+        expected = datetime(2019, 8, 29, 15, 7, tzinfo=timezone.utc).timestamp()
+        self.assertEqual(ts, expected)
+
+    def test_nvr_without_timestamp_raises(self):
+        nvr = "some-package-1.0-1.el8"
+        with self.assertRaises(click.BadParameter):
+            get_timestamp_from_nvr(nvr)
+
+
+class TestParseCutoffTime(unittest.TestCase):
+    def test_iso_with_z_suffix(self):
+        ts = parse_cutoff_time("2025-04-15T13:28:00Z")
+        expected = datetime(2025, 4, 15, 13, 28, tzinfo=timezone.utc).timestamp()
+        self.assertEqual(ts, expected)
+
+    def test_iso_with_offset(self):
+        ts = parse_cutoff_time("2025-04-15T13:28:00+00:00")
+        expected = datetime(2025, 4, 15, 13, 28, tzinfo=timezone.utc).timestamp()
+        self.assertEqual(ts, expected)
+
+    def test_naive_datetime_treated_as_utc(self):
+        ts = parse_cutoff_time("2025-04-15T13:28:00")
+        expected = datetime(2025, 4, 15, 13, 28, tzinfo=timezone.utc).timestamp()
+        self.assertEqual(ts, expected)
+
+
+class TestGetComponentNamesFromNvrs(unittest.TestCase):
+    def test_single_nvr(self):
+        names = get_component_names_from_nvrs(["ose-installer-container-v4.18.0-202504151328.p0.g6666.assembly.stream"])
+        self.assertEqual(names, {"ose-installer-container"})
+
+    def test_multiple_nvrs(self):
+        names = get_component_names_from_nvrs(
+            [
+                "ose-installer-container-v4.18.0-202504011000.p0.g1234.assembly.stream",
+                "ose-cli-container-v4.18.0-202504151328.p0.g5678.assembly.stream",
+            ]
+        )
+        self.assertEqual(names, {"ose-installer-container", "ose-cli-container"})
+
+    def test_same_package_different_versions(self):
+        names = get_component_names_from_nvrs(
+            [
+                "ose-installer-container-v4.18.0-202504011000.p0.g1234.assembly.stream",
+                "ose-installer-container-v4.18.0-202504151328.p0.g5678.assembly.stream",
+            ]
+        )
+        self.assertEqual(names, {"ose-installer-container"})
+
+    def test_none_values_skipped(self):
+        names = get_component_names_from_nvrs(
+            [None, "ose-installer-container-v4.18.0-202504151328.p0.g1234.assembly.stream"]
+        )
+        self.assertEqual(names, {"ose-installer-container"})
+
+    def test_empty_list(self):
+        names = get_component_names_from_nvrs([])
+        self.assertEqual(names, set())
+
+
+class TestFilterByComponent(unittest.TestCase):
+    def _make_bug(self, bug_id, is_tracker, whiteboard_component=None):
+        bug = flexmock(
+            id=bug_id,
+            is_tracker_bug=lambda: is_tracker,
+            whiteboard_component=whiteboard_component,
+        )
+        return bug
+
+    def test_non_tracker_bugs_pass_through(self):
+        runtime = MagicMock()
+        bugs = [
+            self._make_bug("OCPBUGS-1", False),
+            self._make_bug("OCPBUGS-2", False),
+        ]
+        result = filter_by_component(bugs, {"ose-installer-container"}, runtime)
+        self.assertEqual(len(result), 2)
+
+    def test_tracker_bugs_filtered_by_component(self):
+        runtime = MagicMock()
+        bugs = [
+            self._make_bug("OCPBUGS-1", True, "ose-installer-container"),
+            self._make_bug("OCPBUGS-2", True, "ose-cli-container"),
+            self._make_bug("OCPBUGS-3", False),
+        ]
+        with patch(
+            "elliottlib.cli.find_bugs_cutoff_cli.normalize_component_by_ocp_delivery_repo",
+            side_effect=lambda runtime, name: name,
+        ):
+            result = filter_by_component(bugs, {"ose-installer-container"}, runtime)
+        result_ids = [b.id for b in result]
+        self.assertIn("OCPBUGS-1", result_ids)
+        self.assertNotIn("OCPBUGS-2", result_ids)
+        self.assertIn("OCPBUGS-3", result_ids)
+
+    def test_tracker_with_no_whiteboard_excluded(self):
+        runtime = MagicMock()
+        bugs = [
+            self._make_bug("OCPBUGS-1", True, None),
+        ]
+        with patch(
+            "elliottlib.cli.find_bugs_cutoff_cli.normalize_component_by_ocp_delivery_repo",
+            side_effect=lambda runtime, name: name,
+        ):
+            result = filter_by_component(bugs, {"ose-installer-container"}, runtime)
+        self.assertEqual(len(result), 0)
+
+    def test_normalization_applied(self):
+        runtime = MagicMock()
+        bugs = [
+            self._make_bug("OCPBUGS-1", True, "openshift5/installer-rhel9"),
+        ]
+        with patch(
+            "elliottlib.cli.find_bugs_cutoff_cli.normalize_component_by_ocp_delivery_repo",
+            side_effect=lambda runtime, name: "ose-installer-container" if name.startswith("openshift5/") else name,
+        ):
+            result = filter_by_component(bugs, {"ose-installer-container"}, runtime)
+        self.assertEqual(len(result), 1)
+
+
+class TestValidateOptions(unittest.TestCase):
+    def test_single_nvr_mode(self):
+        mode = validate_options(
+            nvr="foo-1.0-1", cutoff_time=None, from_nvr=None, to_nvr=None, from_time=None, to_time=None
+        )
+        self.assertEqual(mode, "single")
+
+    def test_single_cutoff_time_mode(self):
+        mode = validate_options(
+            nvr=None, cutoff_time="2025-01-01T00:00:00Z", from_nvr=None, to_nvr=None, from_time=None, to_time=None
+        )
+        self.assertEqual(mode, "single")
+
+    def test_range_nvr_mode(self):
+        mode = validate_options(
+            nvr=None, cutoff_time=None, from_nvr="foo-1.0-1", to_nvr="foo-1.0-2", from_time=None, to_time=None
+        )
+        self.assertEqual(mode, "range")
+
+    def test_range_time_mode(self):
+        mode = validate_options(
+            nvr=None,
+            cutoff_time=None,
+            from_nvr=None,
+            to_nvr=None,
+            from_time="2025-01-01T00:00:00Z",
+            to_time="2025-02-01T00:00:00Z",
+        )
+        self.assertEqual(mode, "range")
+
+    def test_range_mixed_nvr_and_time(self):
+        mode = validate_options(
+            nvr=None,
+            cutoff_time=None,
+            from_nvr="foo-1.0-1",
+            to_nvr=None,
+            from_time=None,
+            to_time="2025-02-01T00:00:00Z",
+        )
+        self.assertEqual(mode, "range")
+
+    def test_no_options_raises(self):
+        with self.assertRaises(click.BadParameter):
+            validate_options(nvr=None, cutoff_time=None, from_nvr=None, to_nvr=None, from_time=None, to_time=None)
+
+    def test_both_nvr_and_cutoff_time_raises(self):
+        with self.assertRaises(click.BadParameter):
+            validate_options(
+                nvr="foo-1.0-1",
+                cutoff_time="2025-01-01T00:00:00Z",
+                from_nvr=None,
+                to_nvr=None,
+                from_time=None,
+                to_time=None,
+            )
+
+    def test_single_and_range_mixed_raises(self):
+        with self.assertRaises(click.BadParameter):
+            validate_options(
+                nvr="foo-1.0-1", cutoff_time=None, from_nvr="bar-1.0-1", to_nvr=None, from_time=None, to_time=None
+            )
+
+    def test_both_from_nvr_and_from_time_raises(self):
+        with self.assertRaises(click.BadParameter):
+            validate_options(
+                nvr=None,
+                cutoff_time=None,
+                from_nvr="foo-1.0-1",
+                to_nvr="bar-1.0-2",
+                from_time="2025-01-01T00:00:00Z",
+                to_time=None,
+            )
+
+    def test_both_to_nvr_and_to_time_raises(self):
+        with self.assertRaises(click.BadParameter):
+            validate_options(
+                nvr=None,
+                cutoff_time=None,
+                from_nvr="foo-1.0-1",
+                to_nvr="bar-1.0-2",
+                from_time=None,
+                to_time="2025-02-01T00:00:00Z",
+            )
+
+    def test_range_missing_from_raises(self):
+        with self.assertRaises(click.BadParameter):
+            validate_options(
+                nvr=None, cutoff_time=None, from_nvr=None, to_nvr="bar-1.0-2", from_time=None, to_time=None
+            )
+
+    def test_range_missing_to_raises(self):
+        with self.assertRaises(click.BadParameter):
+            validate_options(
+                nvr=None, cutoff_time=None, from_nvr="foo-1.0-1", to_nvr=None, from_time=None, to_time=None
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- New \`find-bugs:cutoff\` elliott command to find CVE tracker bugs by cutoff time or NVR
- Supports single cutoff (\`--nvr\` or \`--cutoff-time\`) and range mode (\`--from-nvr\`/\`--to-nvr\`) to find bugs that entered a qualifying status between two cutoff points
- When component filtering is active (via NVR or \`--component\`), queries Jira directly using \`pscomponent\` labels derived from ocp-build-data delivery repo names — fast, targeted query (~17s vs ~7min for broad searches)
- Without component filtering, falls back to the standard two-step search + chunked cutoff filtering

## Test plan
- [x] Unit tests (27 tests) covering timestamp parsing, validation, component filtering
- [x] Live tested — no tracker bugs for kube-rbac-proxy between two builds (expected, confirmed via direct Jira search):

```
$ elliott -g openshift-4.22 find-bugs:cutoff     --from-nvr kube-rbac-proxy-container-v4.22.0-202605210944.p2.gd12e274.assembly.stream.el9     --to-nvr kube-rbac-proxy-container-v4.22.0-202605260814.p2.gd12e274.assembly.stream.el9     -o json
[]
```

- [x] Live tested — found OCPBUGS-84163 and OCPBUGS-84175 (golang-builder CVEs verified May 29):

```
$ elliott -g openshift-4.22 find-bugs:cutoff     --from-time 2026-05-20T00:00:00Z     --to-time 2026-05-30T00:00:00Z     --component openshift-golang-builder-container     -o json
[
    "OCPBUGS-84163",
    "OCPBUGS-84175"
]
```

Results verified against direct Jira query — both bugs match CVEs for \`openshift-golang-builder-container\` that transitioned to VERIFIED in that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)