### PR TITLE
ART-19365: Add pipeline job completion status fields to releases.yml

### DIFF
--- a/ocp-build-data-validator/validator/json_schemas/release.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/release.schema.json
@@ -7,6 +7,16 @@
   "properties": {
     "assembly": {
       "$ref": "assembly.schema.json"
+    },
+    "status": {
+      "type": "object",
+      "properties": {
+        "gen_assembly": { "type": "boolean" },
+        "prepare_release": { "type": "boolean" },
+        "build_sync": { "type": "boolean" },
+        "promoted": { "type": "boolean" }
+      },
+      "additionalProperties": false
     }
   },
   "required": [

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -237,6 +237,7 @@ class BuildSyncPipeline:
                     status_value=True,
                     working_dir=self.working_dir,
                     dry_run=self.runtime.dry_run,
+                    gitref=self.doozer_data_gitref,
                 )
 
         #  All good: delete fail counter

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -24,6 +24,7 @@ from opentelemetry import trace
 
 from pyartcd import constants, jenkins, locks
 from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.util import set_assembly_status
 from pyartcd.jenkins import get_build_url
 from pyartcd.runtime import GroupRuntime, Runtime
 from pyartcd.util import branch_arches
@@ -228,6 +229,15 @@ class BuildSyncPipeline:
                 f"`{self.build_system.capitalize()}` <{self.job_run}|build-sync> "
                 f"for assembly `{self.assembly}` succeeded!"
             )
+            if self.assembly != 'test':
+                await set_assembly_status(
+                    group=self.group,
+                    assembly=self.assembly,
+                    status_key="build_sync",
+                    status_value=True,
+                    working_dir=self.working_dir,
+                    dry_run=self.runtime.dry_run,
+                )
 
         #  All good: delete fail counter
         if self.assembly == 'stream' and not self.runtime.dry_run:

--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -393,6 +393,8 @@ class GenAssemblyPipeline:
         releases_yaml_path = build_data_path / "releases.yml"
         releases_yaml = yaml.load(releases_yaml_path) if releases_yaml_path.exists() else {}
         releases_yaml = merge_objects(assembly_definition, releases_yaml)
+        if self.assembly in releases_yaml.get("releases", {}):
+            releases_yaml["releases"][self.assembly].setdefault("status", {})["gen_assembly"] = True
         yaml.dump(releases_yaml, releases_yaml_path)
         pushed = await build_data.commit_push(f"{title}\n{body}")
         if not pushed:

--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -1468,6 +1468,7 @@ class PrepareReleaseKonfluxPipeline:
                 updated_group_config["advisories!"] = updated_group_config.pop("advisories")
 
         new_releases_config["releases"][self.assembly]["assembly"]["group"] = updated_group_config
+        new_releases_config["releases"][self.assembly].setdefault("status", {})["prepare_release"] = True
 
         out = StringIO()
         yaml.dump(new_releases_config, out)

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -687,6 +687,16 @@ class PromotePipeline:
 
         await self._slack_client.say_in_thread(f":white_check_mark: promote completed for {release_name}.")
 
+        if self.assembly not in ('stream', 'test'):
+            await util.set_assembly_status(
+                group=self.group,
+                assembly=self.assembly,
+                status_key="promoted",
+                status_value=True,
+                working_dir=self._working_dir,
+                dry_run=self.runtime.dry_run,
+            )
+
     def _get_release_stream_name(self, assembly_type: AssemblyTypes, arch: str):
         major, _ = isolate_major_minor_in_group(self.group)
         if major is None:

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -18,7 +18,8 @@ from artcommonlib.assembly import assembly_type
 from artcommonlib.exectools import limit_concurrency
 from artcommonlib.model import Missing, Model
 from artcommonlib.release_util import SoftwareLifecyclePhase, isolate_assembly_in_release
-from artcommonlib.util import convert_remote_git_to_ssh, new_roundtrip_yaml_handler
+from artcommonlib.github_auth import get_github_client_for_org
+from artcommonlib.util import convert_remote_git_to_ssh, new_roundtrip_yaml_handler, split_git_url
 from doozerlib import util as doozerutil
 from doozerlib.constants import ART_BUILD_HISTORY_URL
 from errata_tool import ErrataConnector
@@ -155,8 +156,14 @@ async def set_assembly_status(
     status_value: bool,
     working_dir: Path,
     dry_run: bool = False,
+    gitref: str = '',
 ):
-    """Update a status field for an assembly in releases.yml and push to the group branch.
+    """Update a status field for an assembly in releases.yml.
+
+    If gitref is provided (e.g. a PR branch like 'auto-gen-assembly-openshift-4.17-4.17.1'),
+    the commit is pushed directly to that branch, updating the existing open PR.
+
+    If gitref is empty, a new branch is created and a PR is opened against the group branch.
 
     :param group: Group name (e.g. 'openshift-4.17')
     :param assembly: Assembly name (e.g. '4.17.1')
@@ -164,7 +171,9 @@ async def set_assembly_status(
     :param status_value: Boolean value to set
     :param working_dir: Working directory for the temporary git clone
     :param dry_run: If True, do not push changes
+    :param gitref: Existing PR branch to push to. If empty, creates a new PR.
     """
+    from io import StringIO
     from pyartcd.git import GitRepository
 
     push_url = os.environ.get("OCP_BUILD_DATA_PUSH_URL", constants.OCP_BUILD_DATA_URL)
@@ -175,13 +184,19 @@ async def set_assembly_status(
     repo = GitRepository(clone_dir, dry_run=dry_run)
     await repo.setup(convert_remote_git_to_ssh(push_url))
 
+    target_branch = gitref or group
+    new_branch = f"auto-status-{status_key}-{group}-{assembly}" if not gitref else ""
+
     max_attempts = 3
     commit_msg = f"Update status.{status_key}={status_value} for assembly {assembly}"
     yaml_handler = new_roundtrip_yaml_handler()
     releases_path = clone_dir / "releases.yml"
 
     for attempt in range(1, max_attempts + 1):
-        await repo.fetch_switch_branch(group)
+        if new_branch:
+            await repo.fetch_switch_branch(new_branch, target_branch)
+        else:
+            await repo.fetch_switch_branch(target_branch)
 
         with open(releases_path, "r") as f:
             releases_config = yaml_handler.load(f)
@@ -199,7 +214,6 @@ async def set_assembly_status(
             release_entry["status"] = {}
         release_entry["status"][status_key] = status_value
 
-        from io import StringIO
         out = StringIO()
         yaml_handler.dump(releases_config, out)
         await repo.write_file("releases.yml", out.getvalue())
@@ -213,10 +227,27 @@ async def set_assembly_status(
             logger.error("Failed to push status update after %d attempts for assembly %s", max_attempts, assembly)
             raise
 
-        if pushed:
-            logger.info("Pushed status update: %s.%s=%s for assembly %s", "status", status_key, status_value, assembly)
-        else:
+        if not pushed:
             logger.info("No changes to push for status update of assembly %s", assembly)
+            return
+
+        logger.info("Pushed status update: %s.%s=%s for assembly %s", "status", status_key, status_value, assembly)
+
+        if new_branch:
+            _, owner, repo_name = split_git_url(push_url)
+            gh_repo = get_github_client_for_org(owner).get_repo(f"{owner}/{repo_name}")
+            head = f"{owner}:{new_branch}"
+            existing_prs = list(gh_repo.get_pulls(state="open", base=group, head=head))
+            if not existing_prs:
+                title = f"Update {status_key} status for assembly {assembly}"
+                if not dry_run:
+                    pr = gh_repo.create_pull(head=head, base=group, title=title, body=commit_msg, maintainer_can_modify=True)
+                    logger.info("Created PR: %s", pr.html_url)
+                else:
+                    logger.warning("[DRY RUN] Would have created PR with head=%s base=%s", head, group)
+            else:
+                logger.info("PR already exists: %s", existing_prs[0].html_url)
+
         return
 
 

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -174,37 +174,50 @@ async def set_assembly_status(
 
     repo = GitRepository(clone_dir, dry_run=dry_run)
     await repo.setup(convert_remote_git_to_ssh(push_url))
-    await repo.fetch_switch_branch(group)
 
+    max_attempts = 3
+    commit_msg = f"Update status.{status_key}={status_value} for assembly {assembly}"
     yaml_handler = new_roundtrip_yaml_handler()
     releases_path = clone_dir / "releases.yml"
-    with open(releases_path, "r") as f:
-        releases_config = yaml_handler.load(f)
 
-    if not releases_config or "releases" not in releases_config:
-        logger.warning("releases.yml is empty or missing 'releases' key; skipping status update")
+    for attempt in range(1, max_attempts + 1):
+        await repo.fetch_switch_branch(group)
+
+        with open(releases_path, "r") as f:
+            releases_config = yaml_handler.load(f)
+
+        if not releases_config or "releases" not in releases_config:
+            logger.warning("releases.yml is empty or missing 'releases' key; skipping status update")
+            return
+
+        release_entry = releases_config["releases"].get(assembly)
+        if release_entry is None:
+            logger.warning("Assembly %s not found in releases.yml; skipping status update", assembly)
+            return
+
+        if "status" not in release_entry:
+            release_entry["status"] = {}
+        release_entry["status"][status_key] = status_value
+
+        from io import StringIO
+        out = StringIO()
+        yaml_handler.dump(releases_config, out)
+        await repo.write_file("releases.yml", out.getvalue())
+
+        try:
+            pushed = await repo.commit_push(commit_msg, safe=True)
+        except Exception:
+            if attempt < max_attempts:
+                logger.warning("Push failed on attempt %d/%d, will re-fetch and retry", attempt, max_attempts)
+                continue
+            logger.error("Failed to push status update after %d attempts for assembly %s", max_attempts, assembly)
+            raise
+
+        if pushed:
+            logger.info("Pushed status update: %s.%s=%s for assembly %s", "status", status_key, status_value, assembly)
+        else:
+            logger.info("No changes to push for status update of assembly %s", assembly)
         return
-
-    release_entry = releases_config["releases"].get(assembly)
-    if release_entry is None:
-        logger.warning("Assembly %s not found in releases.yml; skipping status update", assembly)
-        return
-
-    if "status" not in release_entry:
-        release_entry["status"] = {}
-    release_entry["status"][status_key] = status_value
-
-    from io import StringIO
-    out = StringIO()
-    yaml_handler.dump(releases_config, out)
-    await repo.write_file("releases.yml", out.getvalue())
-
-    commit_msg = f"Update status.{status_key}={status_value} for assembly {assembly}"
-    pushed = await repo.commit_push(commit_msg, safe=True)
-    if pushed:
-        logger.info("Pushed status update: %s.%s=%s for assembly %s", "status", status_key, status_value, assembly)
-    else:
-        logger.info("No changes to push for status update of assembly %s", assembly)
 
 
 def get_assembly_type(releases_config: Dict, assembly_name: str):

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -18,6 +18,7 @@ from artcommonlib.assembly import assembly_type
 from artcommonlib.exectools import limit_concurrency
 from artcommonlib.model import Missing, Model
 from artcommonlib.release_util import SoftwareLifecyclePhase, isolate_assembly_in_release
+from artcommonlib.util import convert_remote_git_to_ssh, new_roundtrip_yaml_handler
 from doozerlib import util as doozerutil
 from doozerlib.constants import ART_BUILD_HISTORY_URL
 from errata_tool import ErrataConnector
@@ -145,6 +146,65 @@ async def load_assembly(
     except ChildProcessError as e:
         logger.error('Command "%s" failed: %s', ' '.join(cmd), e)
         return None
+
+
+async def set_assembly_status(
+    group: str,
+    assembly: str,
+    status_key: str,
+    status_value: bool,
+    working_dir: Path,
+    dry_run: bool = False,
+):
+    """Update a status field for an assembly in releases.yml and push to the group branch.
+
+    :param group: Group name (e.g. 'openshift-4.17')
+    :param assembly: Assembly name (e.g. '4.17.1')
+    :param status_key: Status field name (e.g. 'gen_assembly', 'build_sync', 'promoted')
+    :param status_value: Boolean value to set
+    :param working_dir: Working directory for the temporary git clone
+    :param dry_run: If True, do not push changes
+    """
+    from pyartcd.git import GitRepository
+
+    push_url = os.environ.get("OCP_BUILD_DATA_PUSH_URL", constants.OCP_BUILD_DATA_URL)
+    clone_dir = working_dir / "ocp-build-data-status"
+    if clone_dir.exists():
+        shutil.rmtree(clone_dir)
+
+    repo = GitRepository(clone_dir, dry_run=dry_run)
+    await repo.setup(convert_remote_git_to_ssh(push_url))
+    await repo.fetch_switch_branch(group)
+
+    yaml_handler = new_roundtrip_yaml_handler()
+    releases_path = clone_dir / "releases.yml"
+    with open(releases_path, "r") as f:
+        releases_config = yaml_handler.load(f)
+
+    if not releases_config or "releases" not in releases_config:
+        logger.warning("releases.yml is empty or missing 'releases' key; skipping status update")
+        return
+
+    release_entry = releases_config["releases"].get(assembly)
+    if release_entry is None:
+        logger.warning("Assembly %s not found in releases.yml; skipping status update", assembly)
+        return
+
+    if "status" not in release_entry:
+        release_entry["status"] = {}
+    release_entry["status"][status_key] = status_value
+
+    from io import StringIO
+    out = StringIO()
+    yaml_handler.dump(releases_config, out)
+    await repo.write_file("releases.yml", out.getvalue())
+
+    commit_msg = f"Update status.{status_key}={status_value} for assembly {assembly}"
+    pushed = await repo.commit_push(commit_msg, safe=True)
+    if pushed:
+        logger.info("Pushed status update: %s.%s=%s for assembly %s", "status", status_key, status_value, assembly)
+    else:
+        logger.info("No changes to push for status update of assembly %s", assembly)
 
 
 def get_assembly_type(releases_config: Dict, assembly_name: str):


### PR DESCRIPTION
## Summary
- Add `status` property to `release.schema.json` with boolean fields: `gen_assembly`, `prepare_release`, `build_sync`, `promoted`
- Add shared `set_assembly_status()` utility in `pyartcd/util.py` for pipelines that don't already write to releases.yml
- Update gen-assembly and prepare-release to set their status inline in existing releases.yml writes
- Update build-sync and promote to call `set_assembly_status()` on successful completion (non-stream assemblies only)

## Context
When release preparation jobs complete, there is no centralized tracking of which steps are done for a given assembly. This adds a top-level `status` block per assembly in `releases.yml`:
```yaml
releases:
  4.17.1:
    assembly: {...}
    status:
      gen_assembly: true
      prepare_release: true
      build_sync: true
      promoted: true
```

The dashboard reads these fields to show pipeline progress. Companion PRs for the dashboard backend and frontend are linked below.

## Test plan
- [ ] Run ocp-build-data-validator against a releases.yml with `status` fields -- verify pass
- [ ] Run ocp-build-data-validator against a releases.yml without `status` -- verify pass (backwards compat)
- [ ] Unit test `set_assembly_status()` with mocked GitRepository
- [ ] Verify gen-assembly PR includes `status.gen_assembly: true`
- [ ] Verify prepare-release commit includes `status.prepare_release: true`

Generated with [Claude Code](https://claude.com/claude-code)