### PR TITLE
Speed up pylint-imports by scanning only git-tracked source files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ lint: format-check pylint-imports
 	uv run ruff check --output-format concise
 
 pylint-imports:
-	uv run pylint --disable=all --enable=E0401,E0611 --score=no artcommon/ doozer/ elliott/ pyartcd/ ocp-build-data-validator/
+	uv run pylint --disable=all --enable=E0401,E0611 --score=no --jobs=0 artcommon/artcommonlib doozer/doozerlib elliott/elliottlib pyartcd/pyartcd ocp-build-data-validator/validator
 
 pylint:
 	uv run pylint --errors-only .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,3 +226,14 @@ skip-magic-trailing-comma = false
 
 # Like Black, automatically detect the appropriate line ending.
 line-ending = "auto"
+
+[tool.pylint.main]
+# Ignore generated/vendored directories that are not part of the source tree
+ignore-paths = [
+    ".*/\\.tox/.*",
+    ".*/\\.venv/.*",
+    ".*/\\.eggs/.*",
+    ".*/build/.*",
+    ".*/node_modules/.*",
+    ".*/site-packages/.*",
+]


### PR DESCRIPTION
## Summary
- The `pylint-imports` target was scanning entire top-level directories including `.tox/` (~5,900 files), `.venv/`, `.eggs/`, and other build artifacts — **16,020 Python files total**
- Now targets only source library directories (**285 files**), adds `--jobs=0` for parallel processing, and configures `ignore-paths` in `pyproject.toml`
- In CI, `pylint-imports` dropped from **~61s to 28s** (54% faster), and total `make test` from **~80s to 44s** (45% faster)

| | Before | After |
|---|---|---|
| `pylint-imports` | ~61s | 28s |
| `make test` (Run tests step) | ~80s | 44s |
| Files scanned | 16,020 | 285 |

## Test plan
- [x] `make pylint-imports` passes locally
- [x] CI passes — [tests job](https://github.com/openshift-eng/art-tools/actions/runs/26748622389/job/78830550497) completed in 2m52s

🤖 Generated with [Claude Code](https://claude.com/claude-code)