### PR TITLE
ART-21851: Include component name in base-image snapshot name

### DIFF
--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -24,6 +24,13 @@ from doozerlib.backend.konflux_client import API_VERSION, KIND_RELEASE, KIND_REL
 from kubernetes.dynamic import exceptions
 
 
+def _truncate_for_k8s_name(name: str, max_len: int) -> str:
+    """Truncate *name* to *max_len* chars, stripping any trailing dash."""
+    if len(name) <= max_len:
+        return name
+    return name[:max_len].rstrip('-')
+
+
 def _software_lifecycle_phase(runtime) -> Optional[str]:
     """Return group.yml software_lifecycle.phase when configured on the runtime."""
     group_config = getattr(runtime, 'group_config', None)
@@ -157,7 +164,7 @@ class BaseImageHandler:
             self.logger.error("Failed to create snapshot")
             return None
 
-        result = await self._create_release_from_snapshot(snapshot_name, snapshot_input)
+        result = await self._create_release_from_snapshot(snapshot_name, snapshot_input, component["name"])
         if not result:
             # Release creation failed, but we have the snapshot - return partial result with snapshot URL for tracking
             snapshot_url = self._get_snapshot_url(snapshot_name)
@@ -234,7 +241,8 @@ class BaseImageHandler:
                 raise ValueError(f"Group name '{self.runtime.group}' produces invalid normalized name for Kubernetes")
 
             timestamp = get_utc_now_formatted_str()
-            snapshot_name = f"{group_safe}-base-image-{timestamp}"
+            comp_name = _truncate_for_k8s_name(component["name"], 63 - len(group_safe) - len(timestamp) - 2)
+            snapshot_name = f"{group_safe}-{comp_name}-{timestamp}"
 
             if self.dry_run:
                 self.logger.info(f"[DRY-RUN] Would create snapshot {snapshot_name}")
@@ -277,7 +285,7 @@ class BaseImageHandler:
             return None
 
     async def _create_release_from_snapshot(
-        self, snapshot_name: str, snapshot_input: BaseImageSnapshotInput
+        self, snapshot_name: str, snapshot_input: BaseImageSnapshotInput, component_name: str = ""
     ) -> Optional[Tuple[str, str]]:
         """
         Create Konflux Release from snapshot using the product's silent base-image ReleasePlan.
@@ -285,6 +293,7 @@ class BaseImageHandler:
         Args:
             snapshot_name: Snapshot resource name.
             snapshot_input: Base-image component input (NVR and distgit key stored on Release annotations).
+            component_name: Konflux component name, included in the Release generateName for traceability.
 
         Returns:
             ``(release_name, release_console_url)`` or ``None`` on failure.
@@ -316,8 +325,10 @@ class BaseImageHandler:
             if job_url := os.getenv("BUILD_URL"):
                 release_annotations["art.redhat.com/job-url"] = job_url
 
+            comp_safe = _truncate_for_k8s_name(component_name, 248 - len(group_safe) - 1) if component_name else ""
+            generate_name = f"{group_safe}-{comp_safe}-" if comp_safe else f"{group_safe}-base-image-release-"
             release_metadata = {
-                "generateName": f"{group_safe}-base-image-release-",
+                "generateName": generate_name,
                 "namespace": self.namespace,
                 "labels": {
                     "appstudio.openshift.io/application": self.base_image_application,

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -323,6 +323,92 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_snapshot_name_includes_component_name(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+        mock_konflux_client_init.return_value = AsyncMock()
+
+        handler = BaseImageHandler(self.runtime, dry_run=True)
+
+        component = {"name": "ose-4-22-openshift-base-rhel9", "containerImage": "quay.io/test:latest"}
+
+        with patch("doozerlib.backend.base_image_handler.get_utc_now_formatted_str", return_value="20260529104357"):
+            name = await handler._snapshot_from_component(component)
+
+        self.assertEqual(name, "openshift-4-22-ose-4-22-openshift-base-rhel9-20260529104357")
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_snapshot_name_within_63_char_limit(self, mock_kubeconfig, mock_namespace, mock_konflux_client_init):
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+        mock_konflux_client_init.return_value = AsyncMock()
+
+        handler = BaseImageHandler(self.runtime, dry_run=True)
+
+        component = {"name": "a" * 100, "containerImage": "quay.io/test:latest"}
+
+        with patch("doozerlib.backend.base_image_handler.get_utc_now_formatted_str", return_value="20260529104357"):
+            name = await handler._snapshot_from_component(component)
+
+        self.assertLessEqual(len(name), 63)
+        self.assertTrue(name.startswith("openshift-4-22-"))
+        self.assertTrue(name.endswith("-20260529104357"))
+        self.assertNotRegex(name, r'--')
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_different_components_produce_different_snapshot_names(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+        mock_konflux_client_init.return_value = AsyncMock()
+
+        handler = BaseImageHandler(self.runtime, dry_run=True)
+
+        comp1 = {"name": "ose-4-22-openshift-base-rhel9", "containerImage": "quay.io/test:latest"}
+        comp2 = {"name": "ose-4-22-openshift-base-nodejs-rhel9", "containerImage": "quay.io/test:latest"}
+
+        with patch("doozerlib.backend.base_image_handler.get_utc_now_formatted_str", return_value="20260529104357"):
+            name1 = await handler._snapshot_from_component(comp1)
+            name2 = await handler._snapshot_from_component(comp2)
+
+        self.assertNotEqual(name1, name2)
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_release_generate_name_includes_component(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+
+        konflux_client = AsyncMock()
+        created_release = MagicMock()
+        created_release.metadata.name = "test-release"
+        konflux_client._create.return_value = created_release
+        konflux_client.resource_url = MagicMock(return_value="https://konflux.example/releases/test-release")
+        mock_konflux_client_init.return_value = konflux_client
+
+        handler = BaseImageHandler(self.runtime, dry_run=False)
+
+        with patch.object(handler, "_wait_for_snapshot_availability", new=AsyncMock(return_value=True)):
+            await handler._create_release_from_snapshot(
+                "test-snapshot", self.default_input, "ose-4-22-openshift-base-rhel9"
+            )
+
+        release_obj = konflux_client._create.await_args.args[0]
+        self.assertEqual(release_obj["metadata"]["generateName"], "openshift-4-22-ose-4-22-openshift-base-rhel9-")
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
     async def test_create_release_from_snapshot_rhmtc_uses_product_plan_and_application(
         self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
     ):


### PR DESCRIPTION
## Summary
- When multiple base images were snapshotted within the same second, they got identical snapshot names (`{group}-base-image-{timestamp}`), causing 409 Conflict errors from the Kubernetes API
- Include the Konflux component name in the snapshot name (`{group}-{component}-{timestamp}`) so each image gets a unique name even at second-level timestamp granularity
- Component names are already k8s DNS label safe; only truncation is needed to stay within the 63-char limit

Example failure:
```
2026-05-29 10:43:57,111 doozerlib.backend.konflux_client INFO Creating appstudio.redhat.com/v1alpha1/Snapshot ocp-art-tenant/openshift-4-23-base-image-20260529104357...
2026-05-29 10:43:57,183 doozerlib.backend.konflux_client INFO Created appstudio.redhat.com/v1alpha1/Snapshot ocp-art-tenant/openshift-4-23-base-image-20260529104357
2026-05-29 10:43:57,183 artcommonlib INFO [containers/openshift-base-rhel9] Created snapshot openshift-4-23-base-image-20260529104357
2026-05-29 10:43:57,183 doozerlib.backend.konflux_client INFO Creating appstudio.redhat.com/v1alpha1/Snapshot ocp-art-tenant/openshift-4-23-base-image-20260529104357...
2026-05-29 10:43:57,237 artcommonlib ERROR [containers/openshift-base-nodejs.rhel9] Failed to create snapshot object (name=openshift-4-23-base-image-20260529104357): ConflictError: 409
```

## Test plan
- [x] New unit tests verify component name is included in the snapshot name
- [x] New unit test verifies the 63-char k8s DNS label limit is respected
- [x] New unit test verifies different components produce different names at the same timestamp
- [x] All existing tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot and release names now include the relevant component name when available.
  * Generated Kubernetes names remain within the 63-character limit and avoid trailing or duplicate separators.
  * Releases retain the existing generic naming format when no component name is provided.

* **Tests**
  * Added coverage for component-specific names, length limits, separator handling, and distinct names across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->