### PR TITLE
ART-18937: feat(konflux): expand KonfluxBuildOutcome with stage-specific failures

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -20,6 +20,18 @@ class KonfluxEnum(Enum):
 
 
 class KonfluxBuildOutcome(KonfluxEnum):
+    """Konflux build lifecycle outcome stored in BigQuery.
+
+    Taxonomy:
+    - SUCCESS: releasable build completed all required stages.
+    - PENDING: in-progress or awaiting further processing (intermediate row).
+    - BUILD_ERROR: build PipelineRun failed (canonical PLR failure; prefer over FAILURE).
+    - ITS_ERROR: Enterprise Contract / IntegrationTestScenario verification failed after a successful build.
+    - RELEASE_ERROR: base-image snapshot/release failed after a successful build.
+    - FAILURE: legacy generic failure; retained for old rows and out-of-scope writers (FBC/OLM may still emit it).
+    - TIMEOUT / CANCELLED: pipelinerun terminal states from Tekton Succeeded condition.
+    """
+
     FAILURE = 'failure'
     SUCCESS = 'success'
     PENDING = 'pending'
@@ -28,6 +40,19 @@ class KonfluxBuildOutcome(KonfluxEnum):
     BUILD_ERROR = 'build_error'
     ITS_ERROR = 'its_error'
     RELEASE_ERROR = 'release_error'
+
+    @classmethod
+    def db_filter_values(cls) -> tuple[str, ...]:
+        """Outcome values included in KonfluxDb default and cache queries."""
+        return (
+            cls.SUCCESS.value,
+            cls.FAILURE.value,
+            cls.BUILD_ERROR.value,
+            cls.ITS_ERROR.value,
+            cls.RELEASE_ERROR.value,
+            cls.TIMEOUT.value,
+            cls.CANCELLED.value,
+        )
 
     def is_success(self) -> bool:
         return self is KonfluxBuildOutcome.SUCCESS

--- a/artcommon/artcommonlib/konflux/konflux_build_record.py
+++ b/artcommon/artcommonlib/konflux/konflux_build_record.py
@@ -25,6 +25,22 @@ class KonfluxBuildOutcome(KonfluxEnum):
     PENDING = 'pending'
     TIMEOUT = 'timeout'
     CANCELLED = 'cancelled'
+    BUILD_ERROR = 'build_error'
+    ITS_ERROR = 'its_error'
+    RELEASE_ERROR = 'release_error'
+
+    def is_success(self) -> bool:
+        return self is KonfluxBuildOutcome.SUCCESS
+
+    def is_failure(self) -> bool:
+        return self in (
+            KonfluxBuildOutcome.FAILURE,
+            KonfluxBuildOutcome.BUILD_ERROR,
+            KonfluxBuildOutcome.ITS_ERROR,
+            KonfluxBuildOutcome.RELEASE_ERROR,
+            KonfluxBuildOutcome.TIMEOUT,
+            KonfluxBuildOutcome.CANCELLED,
+        )
 
     @classmethod
     def extract_from_pipelinerun_succeeded_condition(
@@ -34,13 +50,12 @@ class KonfluxBuildOutcome(KonfluxEnum):
             assert succeeded_condition.type == 'Succeeded'
             if succeeded_condition.is_status_true():
                 return cls.SUCCESS
-            else:
-                reason = succeeded_condition.reason
-                if reason == 'Cancelled':
-                    return cls.CANCELLED
-                if reason == 'Timeout':
-                    return cls.TIMEOUT
-                return cls.FAILURE
+            reason = succeeded_condition.reason
+            if reason == 'Cancelled':
+                return cls.CANCELLED
+            if reason == 'Timeout':
+                return cls.TIMEOUT
+            return cls.BUILD_ERROR
         return cls.PENDING
 
 

--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -543,7 +543,7 @@ class KonfluxDb:
             # Build query for last N days of builds in this group
             start_time = datetime.now(tz=timezone.utc) - timedelta(days=self.cache._cache_days)
             where_clauses = [
-                Column('outcome', String).in_(['success', 'failure']),
+                Column('outcome', String).in_(list(KonfluxBuildOutcome.db_filter_values())),
                 Column('start_time', DateTime) >= start_time,
             ]
 
@@ -754,9 +754,9 @@ class KonfluxDb:
             k: str(v) if isinstance(v, (KonfluxBuildOutcome, ArtifactType, Engine)) else v for k, v in where.items()
         }
 
-        # Unless otherwise specified, only look for builds in 'success' or 'failure' state
+        # Unless otherwise specified, include terminal success and failure outcomes (incl. granular types)
         if 'outcome' not in where:
-            base_clauses.append(Column('outcome', String).in_(['success', 'failure']))
+            base_clauses.append(Column('outcome', String).in_(list(KonfluxBuildOutcome.db_filter_values())))
 
         for col_name, col_value in where.items():
             if col_value is not None:

--- a/artcommon/tests/test_konflux_build_record.py
+++ b/artcommon/tests/test_konflux_build_record.py
@@ -40,6 +40,15 @@ class TestKonfluxBuildOutcome(TestCase):
         self.assertFalse(KonfluxBuildOutcome.PENDING.is_failure())
         self.assertFalse(KonfluxBuildOutcome.PENDING.is_success())
 
+    def test_db_filter_values_includes_granular_outcomes(self):
+        values = KonfluxBuildOutcome.db_filter_values()
+        self.assertIn('success', values)
+        self.assertIn('failure', values)
+        self.assertIn('build_error', values)
+        self.assertIn('its_error', values)
+        self.assertIn('release_error', values)
+        self.assertNotIn('pending', values)
+
     def test_extract_from_pipelinerun_failed_plr(self):
         failed_condition = artlib_util.KubeCondition(
             {'type': 'Succeeded', 'status': 'False', 'reason': 'Failed', 'message': 'build failed'}

--- a/artcommon/tests/test_konflux_build_record.py
+++ b/artcommon/tests/test_konflux_build_record.py
@@ -1,12 +1,60 @@
 import json
 from unittest import TestCase
 
+from artcommonlib import util as artlib_util
 from artcommonlib.konflux.konflux_build_record import (
+    KonfluxBuildOutcome,
     KonfluxBuildRecord,
     KonfluxBundleBuildRecord,
     KonfluxECStatus,
     KonfluxFbcBuildRecord,
 )
+
+
+class TestKonfluxBuildOutcome(TestCase):
+    def test_granular_outcome_serialization(self):
+        for outcome, value in (
+            (KonfluxBuildOutcome.BUILD_ERROR, 'build_error'),
+            (KonfluxBuildOutcome.ITS_ERROR, 'its_error'),
+            (KonfluxBuildOutcome.RELEASE_ERROR, 'release_error'),
+        ):
+            build = KonfluxBuildRecord(outcome=outcome)
+            self.assertEqual(build.to_dict()['outcome'], value)
+            self.assertEqual(KonfluxBuildOutcome(value), outcome)
+
+    def test_is_success_and_is_failure(self):
+        self.assertTrue(KonfluxBuildOutcome.SUCCESS.is_success())
+        self.assertFalse(KonfluxBuildOutcome.SUCCESS.is_failure())
+
+        for outcome in (
+            KonfluxBuildOutcome.FAILURE,
+            KonfluxBuildOutcome.BUILD_ERROR,
+            KonfluxBuildOutcome.ITS_ERROR,
+            KonfluxBuildOutcome.RELEASE_ERROR,
+            KonfluxBuildOutcome.TIMEOUT,
+            KonfluxBuildOutcome.CANCELLED,
+        ):
+            self.assertTrue(outcome.is_failure(), outcome)
+            self.assertFalse(outcome.is_success(), outcome)
+
+        self.assertFalse(KonfluxBuildOutcome.PENDING.is_failure())
+        self.assertFalse(KonfluxBuildOutcome.PENDING.is_success())
+
+    def test_extract_from_pipelinerun_failed_plr(self):
+        failed_condition = artlib_util.KubeCondition(
+            {'type': 'Succeeded', 'status': 'False', 'reason': 'Failed', 'message': 'build failed'}
+        )
+        self.assertEqual(
+            KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition(failed_condition),
+            KonfluxBuildOutcome.BUILD_ERROR,
+        )
+        timeout_condition = artlib_util.KubeCondition(
+            {'type': 'Succeeded', 'status': 'False', 'reason': 'Timeout', 'message': 'timed out'}
+        )
+        self.assertEqual(
+            KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition(timeout_condition),
+            KonfluxBuildOutcome.TIMEOUT,
+        )
 
 
 class TestKonfluxBuild(TestCase):

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -761,6 +761,9 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
         test_cases = [
             ('success', KonfluxBuildOutcome.SUCCESS),
             ('failure', KonfluxBuildOutcome.FAILURE),
+            ('build_error', KonfluxBuildOutcome.BUILD_ERROR),
+            ('its_error', KonfluxBuildOutcome.ITS_ERROR),
+            ('release_error', KonfluxBuildOutcome.RELEASE_ERROR),
             ('konflux', Engine.KONFLUX),
             ('brew', Engine.BREW),
             ('image', ArtifactType.IMAGE),

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -97,7 +97,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
         await anext(self.db.search_builds_by_fields(start_search=start_search, where={}), None)
         # Default behavior is to NOT exclude large columns (exclude_large_columns=None by default)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure') AND "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure', 'build_error', 'its_error', 'release_error', 'timeout', 'cancelled') AND "
             f"start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' "
             "ORDER BY `start_time` DESC"
         )
@@ -106,7 +106,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
         end_search = start_search + timedelta(days=7)
         await anext(self.db.search_builds_by_fields(start_search=start_search, end_search=end_search, where={}), None)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure') AND "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure', 'build_error', 'its_error', 'release_error', 'timeout', 'cancelled') AND "
             f"start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' "
             f"ORDER BY `start_time` DESC"
         )
@@ -114,7 +114,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
         query_mock.reset_mock()
         await anext(self.db.search_builds_by_fields(start_search=start_search, where=None), None)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure') AND "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure', 'build_error', 'its_error', 'release_error', 'timeout', 'cancelled') AND "
             f"start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' "
             "ORDER BY `start_time` DESC"
         )
@@ -127,7 +127,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             None,
         )
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure') AND "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure', 'build_error', 'its_error', 'release_error', 'timeout', 'cancelled') AND "
             f"name = 'ironic' AND `group` = 'openshift-4.18' AND "
             f"start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00'"
             " ORDER BY `start_time` DESC"
@@ -136,7 +136,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
         query_mock.reset_mock()
         await anext(self.db.search_builds_by_fields(start_search=start_search, where={'name': None}), None)
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure') AND "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure', 'build_error', 'its_error', 'release_error', 'timeout', 'cancelled') AND "
             f"name IS NULL AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00'"
             " ORDER BY `start_time` DESC"
         )
@@ -146,7 +146,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             self.db.search_builds_by_fields(start_search=start_search, where={'name': None, 'group': None}), None
         )
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure') AND "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure', 'build_error', 'its_error', 'release_error', 'timeout', 'cancelled') AND "
             f"name IS NULL AND `group` IS NULL "
             "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' "
             "ORDER BY `start_time` DESC"
@@ -160,7 +160,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             None,
         )
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure') AND "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure', 'build_error', 'its_error', 'release_error', 'timeout', 'cancelled') AND "
             f"name = 'ironic' AND `group` = 'openshift-4.18' "
             "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' "
             "ORDER BY `start_time` DESC"
@@ -177,7 +177,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             None,
         )
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure') AND "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure', 'build_error', 'its_error', 'release_error', 'timeout', 'cancelled') AND "
             f"name = 'ironic' AND `group` = 'openshift-4.18' "
             "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' "
             "ORDER BY `start_time` ASC"
@@ -195,7 +195,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             None,
         )
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure') AND "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure', 'build_error', 'its_error', 'release_error', 'timeout', 'cancelled') AND "
             f"name = 'ironic' AND `group` = 'openshift-4.18' "
             "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' "
             "ORDER BY `start_time` ASC LIMIT 0"
@@ -213,7 +213,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             None,
         )
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure') AND "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure', 'build_error', 'its_error', 'release_error', 'timeout', 'cancelled') AND "
             f"name = 'ironic' AND `group` = 'openshift-4.18' "
             "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' "
             "ORDER BY `start_time` ASC LIMIT 10"
@@ -244,7 +244,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             None,
         )
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure') AND "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure', 'build_error', 'its_error', 'release_error', 'timeout', 'cancelled') AND "
             f"REGEXP_CONTAINS(name, 'installer') "
             "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' "
             "ORDER BY `start_time` ASC LIMIT 10"
@@ -262,7 +262,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             None,
         )
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure') AND "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure', 'build_error', 'its_error', 'release_error', 'timeout', 'cancelled') AND "
             f"REGEXP_CONTAINS(name, '^ose-installer$') "
             "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' "
             "ORDER BY `start_time` ASC LIMIT 10"
@@ -280,7 +280,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             None,
         )
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure') AND "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure', 'build_error', 'its_error', 'release_error', 'timeout', 'cancelled') AND "
             f"REGEXP_CONTAINS(name, 'installer') AND REGEXP_CONTAINS(`group`, 'openshift') "
             "AND start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' "
             "ORDER BY `start_time` ASC LIMIT 10"
@@ -301,7 +301,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             None,
         )
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure') AND "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure', 'build_error', 'its_error', 'release_error', 'timeout', 'cancelled') AND "
             "engine IN ('brew', 'konflux') AND name IN ('ironic', 'ose-installer') AND "
             "start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' "
             "ORDER BY `start_time` ASC LIMIT 10"
@@ -320,7 +320,7 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             None,
         )
         query_mock.assert_called_once_with(
-            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure') AND "
+            f"SELECT * FROM `{constants.BUILDS_TABLE_ID}` WHERE outcome IN ('success', 'failure', 'build_error', 'its_error', 'release_error', 'timeout', 'cancelled') AND "
             f"name = 'test-operator-fbc' AND `group` = 'openshift-4.18' AND "
             f"'test-operator-bundle-container-v4.18.0-123' IN UNNEST(bundle_nvrs) AND "
             f"start_time >= '2024-09-23 09:00:00+00:00' AND start_time < '2024-09-30 09:00:00+00:00' "

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -2130,7 +2130,7 @@ class KonfluxFbcBuilder:
                             'image_tag': image_pullspec.split(':')[-1],
                         }
                     )
-                case KonfluxBuildOutcome.FAILURE:
+                case KonfluxBuildOutcome.BUILD_ERROR | KonfluxBuildOutcome.FAILURE:
                     status = pipelinerun_dict.get('status', {})
                     start_time = status.get('startTime')
                     end_time = status.get('completionTime')

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -2130,17 +2130,17 @@ class KonfluxFbcBuilder:
                             'image_tag': image_pullspec.split(':')[-1],
                         }
                     )
-                case KonfluxBuildOutcome.BUILD_ERROR | KonfluxBuildOutcome.FAILURE:
-                    status = pipelinerun_dict.get('status', {})
-                    start_time = status.get('startTime')
-                    end_time = status.get('completionTime')
-                    build_record_params.update(
-                        {
-                            'start_time': datetime.strptime(start_time, '%Y-%m-%dT%H:%M:%SZ').replace(
-                                tzinfo=timezone.utc
-                            ),
-                            'end_time': datetime.strptime(end_time, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc),
-                        }
+            status = pipelinerun_dict.get('status', {})
+            if status:
+                start_time = status.get('startTime')
+                if start_time:
+                    build_record_params['start_time'] = datetime.strptime(start_time, '%Y-%m-%dT%H:%M:%SZ').replace(
+                        tzinfo=timezone.utc
+                    )
+                completion_time = status.get('completionTime')
+                if completion_time:
+                    build_record_params['end_time'] = datetime.strptime(completion_time, '%Y-%m-%dT%H:%M:%SZ').replace(
+                        tzinfo=timezone.utc
                     )
 
             build_record = KonfluxFbcBuildRecord(**build_record_params)

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -223,7 +223,6 @@ class KonfluxImageBuilder:
             logger.info(f"Building for arches: {building_arches}")
             error = None
             ec_failed = False
-            ec_status = KonfluxECStatus.NOT_APPLICABLE
             ec_pipeline_url = ''
             # Resolve build priority based on precedence rules
             if self._config.build_priority == "auto":
@@ -257,7 +256,6 @@ class KonfluxImageBuilder:
                     KonfluxBuildOutcome.PENDING,
                     building_arches,
                     build_priority,
-                    ec_status=KonfluxECStatus.NOT_APPLICABLE,
                 )
 
                 logger.info("Waiting for PipelineRun %s to complete...", pipelinerun_name)
@@ -293,9 +291,9 @@ class KonfluxImageBuilder:
                             )
                         except Exception as e:
                             logger.error(
-                                f"Failed to get SLA attestation / source signature from konflux for image {definitive_image_pullspec}, marking build as {KonfluxBuildOutcome.FAILURE}. Error: {e}"
+                                f"Failed to get SLA attestation / source signature from konflux for image {definitive_image_pullspec}, marking build as {KonfluxBuildOutcome.BUILD_ERROR}. Error: {e}"
                             )
-                            outcome = KonfluxBuildOutcome.FAILURE
+                            outcome = KonfluxBuildOutcome.BUILD_ERROR
                     else:
                         logger.info(
                             "Skipping SLSA attestation validation for %s: non-OCP group '%s'",
@@ -342,11 +340,10 @@ class KonfluxImageBuilder:
                         ec_policy=ec_policy,
                         logger=logger,
                     )
-                    ec_status = ec_result.ec_status
                     ec_pipeline_url = ec_result.ec_pipeline_url
                     ec_failed = ec_result.ec_failed
                     if ec_failed:
-                        outcome = KonfluxBuildOutcome.FAILURE
+                        outcome = KonfluxBuildOutcome.ITS_ERROR
                         record["ec_failed"] = "true"
                         record["ec_pipeline_url"] = ec_pipeline_url
 
@@ -381,9 +378,13 @@ class KonfluxImageBuilder:
                         if release_result:
                             logger.info("Base image release succeeded for %s, persisting build record", nvr)
                         else:
-                            logger.error("Base image release failed for %s, persisting build record as FAILURE", nvr)
+                            logger.error(
+                                "Base image release failed for %s, persisting build record as %s",
+                                nvr,
+                                KonfluxBuildOutcome.RELEASE_ERROR,
+                            )
                             record["base_image_release_failed"] = "true"
-                        outcome = KonfluxBuildOutcome.SUCCESS if release_result else KonfluxBuildOutcome.FAILURE
+                        outcome = KonfluxBuildOutcome.SUCCESS if release_result else KonfluxBuildOutcome.RELEASE_ERROR
 
                     build_record = await self.update_konflux_db(
                         metadata,
@@ -392,7 +393,6 @@ class KonfluxImageBuilder:
                         outcome,
                         building_arches,
                         build_priority,
-                        ec_status=ec_status,
                         ec_pipeline_url=ec_pipeline_url,
                         release_pipeline=release_result.release_pipeline if release_result else '',
                         released_pullspec=release_result.released_pullspec if release_result else '',
@@ -400,7 +400,8 @@ class KonfluxImageBuilder:
                     if build_record:
                         record["record_id"] = build_record.record_id
 
-                if outcome is not KonfluxBuildOutcome.SUCCESS:
+                if not outcome.is_success():
+                    record["outcome"] = str(outcome)
                     error = KonfluxImageBuildError(
                         f"Konflux image build for {metadata.distgit_key} failed with output={outcome}",
                         pipelinerun_name,

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -1023,17 +1023,17 @@ class KonfluxOlmBundleBuilder:
                             'image_tag': image_pullspec.split(':')[-1],
                         }
                     )
-                case KonfluxBuildOutcome.BUILD_ERROR | KonfluxBuildOutcome.FAILURE:
-                    status = pipelinerun_dict.get('status', {})
-                    start_time = status.get('startTime')
-                    end_time = status.get('completionTime')
-                    build_record_params.update(
-                        {
-                            'start_time': datetime.strptime(start_time, '%Y-%m-%dT%H:%M:%SZ').replace(
-                                tzinfo=timezone.utc
-                            ),
-                            'end_time': datetime.strptime(end_time, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc),
-                        }
+            status = pipelinerun_dict.get('status', {})
+            if status:
+                start_time = status.get('startTime')
+                if start_time:
+                    build_record_params['start_time'] = datetime.strptime(start_time, '%Y-%m-%dT%H:%M:%SZ').replace(
+                        tzinfo=timezone.utc
+                    )
+                completion_time = status.get('completionTime')
+                if completion_time:
+                    build_record_params['end_time'] = datetime.strptime(completion_time, '%Y-%m-%dT%H:%M:%SZ').replace(
+                        tzinfo=timezone.utc
                     )
 
             build_record = KonfluxBundleBuildRecord(**build_record_params)

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -805,7 +805,7 @@ class KonfluxOlmBundleBuilder:
                         ec_status = ec_result.ec_status
                         ec_pipeline_url = ec_result.ec_pipeline_url
                         if ec_result.ec_failed:
-                            outcome = KonfluxBuildOutcome.FAILURE
+                            outcome = KonfluxBuildOutcome.ITS_ERROR
                             ec_failed = True
                     elif outcome is KonfluxBuildOutcome.SUCCESS:
                         if self.skip_ec_verify:
@@ -1023,7 +1023,7 @@ class KonfluxOlmBundleBuilder:
                             'image_tag': image_pullspec.split(':')[-1],
                         }
                     )
-                case KonfluxBuildOutcome.FAILURE:
+                case KonfluxBuildOutcome.BUILD_ERROR | KonfluxBuildOutcome.FAILURE:
                     status = pipelinerun_dict.get('status', {})
                     start_time = status.get('startTime')
                     end_time = status.get('completionTime')

--- a/doozer/tests/backend/test_konflux_ec_verification.py
+++ b/doozer/tests/backend/test_konflux_ec_verification.py
@@ -183,7 +183,7 @@ class TestEcVerificationGating(IsolatedAsyncioTestCase):
 
     async def test_no_retry_when_ec_fails(self, mock_kc_init):
         """When EC verification fails, the build should NOT be retried."""
-        config = _make_config(group_name="openshift-4.18")
+        config = _make_config(group_name="openshift-4.18", dry_run=False)
         metadata = _make_metadata(for_release=True)
         metadata.get_konflux_build_attempts.return_value = 3
 
@@ -223,3 +223,6 @@ class TestEcVerificationGating(IsolatedAsyncioTestCase):
                         await builder.build(metadata)
 
         builder._start_build.assert_called_once()
+        self.assertEqual(builder.update_konflux_db.await_count, 2)
+        completion_call = builder.update_konflux_db.await_args_list[1]
+        self.assertEqual(completion_call.args[3], KonfluxBuildOutcome.ITS_ERROR)

--- a/doozer/tests/backend/test_konflux_ec_verification.py
+++ b/doozer/tests/backend/test_konflux_ec_verification.py
@@ -187,7 +187,8 @@ class TestEcVerificationGating(IsolatedAsyncioTestCase):
         metadata = _make_metadata(for_release=True)
         metadata.get_konflux_build_attempts.return_value = 3
 
-        builder = KonfluxImageBuilder(config)
+        record_logger = MagicMock()
+        builder = KonfluxImageBuilder(config, record_logger=record_logger)
 
         plr_info = _make_successful_pipelinerun_info()
         builder._start_build = AsyncMock(return_value=plr_info)
@@ -226,3 +227,8 @@ class TestEcVerificationGating(IsolatedAsyncioTestCase):
         self.assertEqual(builder.update_konflux_db.await_count, 2)
         completion_call = builder.update_konflux_db.await_args_list[1]
         self.assertEqual(completion_call.args[3], KonfluxBuildOutcome.ITS_ERROR)
+
+        record_logger.add_record.assert_called_once()
+        add_args, add_kwargs = record_logger.add_record.call_args
+        self.assertEqual(add_args[0], 'image_build_konflux')
+        self.assertEqual(add_kwargs['outcome'], str(KonfluxBuildOutcome.ITS_ERROR))

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -499,6 +499,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         persisted = mock_add_build.call_args[0][0]
         self.assertEqual(persisted.release_pipeline, "https://release.example/pipeline")
         self.assertEqual(persisted.released_pullspec, "registry.redhat.io/foo:bar")
+        self.assertEqual(persisted.ec_status.value, 'n/a')
 
     async def test_trigger_base_image_release_success_flow(self):
         """SUCCESS after base snapshot release refreshes Konflux DB without swapping image_pullspec to RH."""
@@ -635,9 +636,9 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         mock_trigger_release.assert_awaited_once()
         self.assertEqual(mock_update_db.await_count, 2)
 
-        # Final update records FAILURE outcome; released_* omitted when base release failed
+        # Final update records RELEASE_ERROR outcome; released_* omitted when base release failed
         failure_call_args = mock_update_db.await_args_list[1][0]
-        self.assertEqual(failure_call_args[3], KonfluxBuildOutcome.FAILURE)
+        self.assertEqual(failure_call_args[3], KonfluxBuildOutcome.RELEASE_ERROR)
         failure_kw = mock_update_db.await_args_list[1].kwargs
         self.assertEqual(failure_kw.get("release_pipeline", ""), "")
         self.assertEqual(failure_kw.get("released_pullspec", ""), "")

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -21,6 +21,7 @@ from artcommonlib.constants import (
     REGISTRY_QUAY_OPENSHIFT,
     REGISTRY_REDHAT_IO,
 )
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
 from artcommonlib.registry_config import RegistryConfig, RegistryCredential
 from artcommonlib.util import (
     new_roundtrip_yaml_handler,
@@ -255,13 +256,25 @@ class KonfluxOcpPipeline:
             entry['name']: entry for entry in record_log.get('image_build_konflux', []) if int(entry['status'])
         }
 
-        # Categorize failures by type
+        # Categorize failures by type (prefer granular outcome; fall back to legacy record flags)
         ec_failed_images = []
         release_failed_images = []
         build_failed_images = []
         for image in failed_images:
             entry = failed_entries.get(image, {})
-            if entry.get('ec_failed') == 'true':
+            outcome = entry.get('outcome', '')
+            if outcome == str(KonfluxBuildOutcome.ITS_ERROR):
+                ec_failed_images.append(image)
+            elif outcome == str(KonfluxBuildOutcome.RELEASE_ERROR):
+                release_failed_images.append(image)
+            elif outcome in (
+                str(KonfluxBuildOutcome.BUILD_ERROR),
+                str(KonfluxBuildOutcome.FAILURE),
+                str(KonfluxBuildOutcome.TIMEOUT),
+                str(KonfluxBuildOutcome.CANCELLED),
+            ):
+                build_failed_images.append(image)
+            elif entry.get('ec_failed') == 'true':
                 ec_failed_images.append(image)
             elif entry.get('base_image_release_failed') == 'true':
                 release_failed_images.append(image)

--- a/pyartcd/tests/pipelines/test_ocp.py
+++ b/pyartcd/tests/pipelines/test_ocp.py
@@ -1187,6 +1187,49 @@ class TestKonfluxOcpPipelineBuildFailCounters(unittest.IsolatedAsyncioTestCase):
 
     @patch('pyartcd.pipelines.ocp4_konflux.increment_fail_counter', new_callable=AsyncMock)
     @patch('pyartcd.pipelines.ocp4_konflux.reset_fail_counter', new_callable=AsyncMock)
+    async def test_build_fail_counters_categorize_by_outcome(self, mock_reset, mock_incr):
+        """Granular outcome values take precedence over legacy record flags."""
+        from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
+
+        pipeline = self._make_pipeline()
+        record_log = {
+            'image_build_konflux': [
+                {
+                    'name': 'ironic',
+                    'status': '-1',
+                    'nvrs': 'ironic-1.0-1',
+                    'outcome': str(KonfluxBuildOutcome.ITS_ERROR),
+                    'ec_failed': 'false',
+                    'base_image_release_failed': 'false',
+                },
+                {
+                    'name': 'ose-base',
+                    'status': '-1',
+                    'nvrs': 'ose-base-1.0-1',
+                    'outcome': str(KonfluxBuildOutcome.RELEASE_ERROR),
+                    'ec_failed': 'false',
+                    'base_image_release_failed': 'false',
+                },
+                {
+                    'name': 'ceo',
+                    'status': '-1',
+                    'nvrs': 'ceo-1.0-1',
+                    'outcome': str(KonfluxBuildOutcome.BUILD_ERROR),
+                    'ec_failed': 'true',
+                    'base_image_release_failed': 'true',
+                },
+            ]
+        }
+        await pipeline.update_build_fail_counters([], ['ironic', 'ose-base', 'ceo'], record_log)
+
+        incr_branches = {c.args[0] for c in mock_incr.call_args_list}
+        self.assertEqual(len(incr_branches), 3)
+        self.assertIn('count:ec-failure:konflux:openshift-4.18:ironic', incr_branches)
+        self.assertIn('count:release-failure:konflux:openshift-4.18:ose-base', incr_branches)
+        self.assertIn('count:build-failure:konflux:openshift-4.18:ceo', incr_branches)
+
+    @patch('pyartcd.pipelines.ocp4_konflux.increment_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.reset_fail_counter', new_callable=AsyncMock)
     async def test_build_fail_counters_non_stream_skipped(self, mock_reset, mock_incr):
         """Non-stream assemblies skip counter updates entirely."""
         pipeline = self._make_pipeline(assembly='4.18.1')


### PR DESCRIPTION
## Summary
Expand `KonfluxBuildOutcome` with granular failure types (`build_error`, `its_error`, `release_error`) so Konflux image build failures in BigQuery distinguish build PLR, EC/ITS, and base-image release stages.

## Problem
**Before:** Most Konflux image failures were stored as generic `failure`, and failure type was inferred from ephemeral Jenkins record flags (`ec_failed`, `base_image_release_failed`). New rows also wrote deprecated `ec_status`.

**After:** Failed build PLRs persist as `build_error`, EC failures as `its_error`, and base-image release failures as `release_error`. Pipeline URLs and release fields are written per stage; `ec_status` is no longer populated on new image build records. `ocp4-konflux` fail counters prefer the persisted `outcome` with fallback to legacy flags.

## Implementation Details
- Added `BUILD_ERROR`, `ITS_ERROR`, `RELEASE_ERROR` plus `is_success()` / `is_failure()` helpers on `KonfluxBuildOutcome`
- `extract_from_pipelinerun_succeeded_condition` maps failed build PLRs to `build_error`
- Updated `konflux_image_builder`, FBC/OLM bundler DB paths, and `ocp4_konflux` counter categorization
- Unit tests for enum serialization, image builder flows, EC failure outcome, and fail-counter routing

https://redhat.atlassian.net/browse/ART-18937