### PR TITLE
ART-19367: Use cache for images:health instead of per-image BigQuery queries

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -325,6 +325,47 @@ class BuildCache:
             )
             return None
 
+    def get_builds_by_name(
+        self,
+        name: str,
+        group: str,
+        assembly: typing.Optional[str] = None,
+        limit: typing.Optional[int] = None,
+        cache_type: CacheRecordsType = CacheRecordsType.SMALL_COLUMNS,
+    ) -> typing.List[KonfluxRecord]:
+        """
+        Get all cached builds for a name, sorted newest-first, with optional filtering.
+
+        Arg(s):
+            name (str): Component name (e.g., 'ironic')
+            group (str): Group name (e.g., 'openshift-4.18')
+            assembly (str): Optional assembly filter (e.g., 'stream')
+            limit (int): Optional max number of builds to return
+            cache_type (CacheRecordsType): Type of cache to search
+        Return Value(s):
+            list[KonfluxRecord]: Matching builds sorted by start_time descending, or empty list
+        """
+        with self._lock:
+            groups = self.cache_groups[cache_type]
+            if group not in groups:
+                self._increment_miss(cache_type)
+                return []
+
+            builds = groups[group]['by_name'].get(name, [])
+            if not builds:
+                self._increment_miss(cache_type)
+                return []
+
+            self._increment_hit(cache_type)
+
+            if assembly is not None:
+                builds = [b for b in builds if b.assembly == assembly]
+
+            if limit is not None:
+                builds = builds[:limit]
+
+            return builds
+
     def is_group_loaded(self, group: str, cache_type: CacheRecordsType = CacheRecordsType.SMALL_COLUMNS) -> bool:
         """
         Check if group is already loaded in cache.

--- a/doozer/doozerlib/cli/images_health.py
+++ b/doozer/doozerlib/cli/images_health.py
@@ -1,4 +1,3 @@
-import asyncio
 import datetime
 import json
 import logging
@@ -8,7 +7,6 @@ import click
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.model import Missing
 from artcommonlib.variants import BuildVariant
-from tenacity import retry, stop_after_attempt, wait_fixed
 
 from doozerlib import Runtime
 from doozerlib.cli import cli, click_coroutine, pass_runtime
@@ -78,22 +76,22 @@ class ImagesHealthPipeline:
         self.variant = variant
 
     async def run(self):
-        # Gather concerns for all images we build with Konflux
-        tasks = []
+        # Pre-load the build cache for this group in a single BigQuery query
+        await self.runtime.konflux_db._ensure_group_cached(self.group)
+        self.logger.info('Build cache loaded for group %s', self.group)
 
         # Filter out images that are disabled for this variant
+        image_metas = []
         for image_meta in self.runtime.image_metas():
             if self.variant is BuildVariant.OKD:
-                # For OKD variant, determine effective mode: okd.mode overrides general mode
-                effective_mode = image_meta.mode  # Default to general mode
+                effective_mode = image_meta.mode
                 if image_meta.config.okd is not Missing and image_meta.config.okd.mode is not Missing:
-                    effective_mode = image_meta.config.okd.mode  # Override with OKD-specific mode if present
+                    effective_mode = image_meta.config.okd.mode
 
                 if effective_mode == 'disabled':
                     self.logger.info('Skipping OKD disabled image: %s', image_meta.distgit_key)
                     continue
 
-                # For OKD, skip non-payload images (they are not built/released)
                 for_payload = image_meta.config.for_payload
                 if for_payload is Missing:
                     for_payload = False
@@ -103,23 +101,23 @@ class ImagesHealthPipeline:
             elif image_meta.config.konflux.mode == 'disabled' or image_meta.mode == 'disabled':
                 self.logger.info('Skipping disabled image: %s', image_meta.distgit_key)
                 continue
-            tasks.append(self.get_concerns(image_meta))
+            image_metas.append(image_meta)
 
-        await asyncio.gather(*tasks)
+        for image_meta in image_metas:
+            self.get_concerns(image_meta)
 
-        # We should now have a dict of qualified_key => [concern, ...]
         if not self.concerns:
             self.logger.info('No concerns to report!')
         click.echo(
             json.dumps(self.concerns, indent=4, default=lambda o: o.to_dict() if isinstance(o, Concern) else str(o))
         )
 
-    async def get_concerns(self, image_meta):
+    def get_concerns(self, image_meta):
         for_release = image_meta.config.for_release
         if for_release is Missing:
             for_release = True
 
-        builds = await self.query(image_meta)
+        builds = self._query_cache(image_meta)
         if not builds:
             message = f'Image build for {image_meta.distgit_key} has never been attempted during last {DELTA_DAYS} days'
             self.logger.info(message)
@@ -189,28 +187,16 @@ class ImagesHealthPipeline:
         concern.group = self.runtime.group
         self.concerns.append(concern)
 
-    @retry(reraise=True, stop=stop_after_attempt(10), wait=wait_fixed(3))
-    async def query(self, image_meta):
+    def _query_cache(self, image_meta):
         """
-        For 'stream' assembly only, query 'builds' table  for component 'name' from BigQuery
+        Look up build records from the pre-loaded cache instead of querying BigQuery per image.
         """
-
-        self.logger.info('Querying builds for image: %s', image_meta.distgit_key)
-        results = [
-            build
-            async for build in self.runtime.konflux_db.search_builds_by_fields(
-                start_search=self.start_search,
-                where={
-                    'name': image_meta.distgit_key,
-                    'group': self.group,
-                    'engine': 'konflux',
-                    'assembly': self.assembly,
-                },
-                order_by='start_time',
-                limit=self.limit,
-            )
-        ]
-        return results
+        return self.runtime.konflux_db.cache.get_builds_by_name(
+            name=image_meta.distgit_key,
+            group=self.group,
+            assembly=self.assembly,
+            limit=self.limit,
+        )
 
 
 @cli.command("images:health", short_help="Create a health report for this image group (requires DB read)")

--- a/doozer/tests/cli/test_images_health.py
+++ b/doozer/tests/cli/test_images_health.py
@@ -24,6 +24,7 @@ class TestImagesHealthOKDModeFiltering(unittest.IsolatedAsyncioTestCase):
         self.mock_runtime.group = "openshift-4.20"
         self.mock_runtime.konflux_db = MagicMock()
         self.mock_runtime.konflux_db.bind = MagicMock()
+        self.mock_runtime.konflux_db._ensure_group_cached = AsyncMock()
 
     def _create_image_meta(self, distgit_key: str, mode: str, okd_mode=Missing, for_payload=True):
         """
@@ -63,7 +64,7 @@ class TestImagesHealthOKDModeFiltering(unittest.IsolatedAsyncioTestCase):
 
         pipeline = ImagesHealthPipeline(runtime=self.mock_runtime, limit=100, variant=BuildVariant.OKD)
 
-        with patch.object(pipeline, 'get_concerns', new=AsyncMock()) as mock_get_concerns:
+        with patch.object(pipeline, 'get_concerns', new=MagicMock()) as mock_get_concerns:
             await pipeline.run()
             # Image should be skipped, so get_concerns should not be called
             mock_get_concerns.assert_not_called()
@@ -79,7 +80,7 @@ class TestImagesHealthOKDModeFiltering(unittest.IsolatedAsyncioTestCase):
 
         pipeline = ImagesHealthPipeline(runtime=self.mock_runtime, limit=100, variant=BuildVariant.OKD)
 
-        with patch.object(pipeline, 'get_concerns', new=AsyncMock()) as mock_get_concerns:
+        with patch.object(pipeline, 'get_concerns', new=MagicMock()) as mock_get_concerns:
             await pipeline.run()
             # Image should NOT be skipped, so get_concerns should be called once
             mock_get_concerns.assert_called_once_with(image_meta)
@@ -95,7 +96,7 @@ class TestImagesHealthOKDModeFiltering(unittest.IsolatedAsyncioTestCase):
 
         pipeline = ImagesHealthPipeline(runtime=self.mock_runtime, limit=100, variant=BuildVariant.OKD)
 
-        with patch.object(pipeline, 'get_concerns', new=AsyncMock()) as mock_get_concerns:
+        with patch.object(pipeline, 'get_concerns', new=MagicMock()) as mock_get_concerns:
             await pipeline.run()
             # Image should be skipped, so get_concerns should not be called
             mock_get_concerns.assert_not_called()
@@ -111,7 +112,7 @@ class TestImagesHealthOKDModeFiltering(unittest.IsolatedAsyncioTestCase):
 
         pipeline = ImagesHealthPipeline(runtime=self.mock_runtime, limit=100, variant=BuildVariant.OKD)
 
-        with patch.object(pipeline, 'get_concerns', new=AsyncMock()) as mock_get_concerns:
+        with patch.object(pipeline, 'get_concerns', new=MagicMock()) as mock_get_concerns:
             await pipeline.run()
             # Image should NOT be skipped, so get_concerns should be called once
             mock_get_concerns.assert_called_once_with(image_meta)
@@ -127,7 +128,7 @@ class TestImagesHealthOKDModeFiltering(unittest.IsolatedAsyncioTestCase):
 
         pipeline = ImagesHealthPipeline(runtime=self.mock_runtime, limit=100, variant=BuildVariant.OCP)
 
-        with patch.object(pipeline, 'get_concerns', new=AsyncMock()) as mock_get_concerns:
+        with patch.object(pipeline, 'get_concerns', new=MagicMock()) as mock_get_concerns:
             await pipeline.run()
             # Image should be skipped, so get_concerns should not be called
             mock_get_concerns.assert_not_called()
@@ -143,7 +144,7 @@ class TestImagesHealthOKDModeFiltering(unittest.IsolatedAsyncioTestCase):
 
         pipeline = ImagesHealthPipeline(runtime=self.mock_runtime, limit=100, variant=BuildVariant.OCP)
 
-        with patch.object(pipeline, 'get_concerns', new=AsyncMock()) as mock_get_concerns:
+        with patch.object(pipeline, 'get_concerns', new=MagicMock()) as mock_get_concerns:
             await pipeline.run()
             # Image should NOT be skipped, so get_concerns should be called once
             mock_get_concerns.assert_called_once_with(image_meta)
@@ -159,7 +160,7 @@ class TestImagesHealthOKDModeFiltering(unittest.IsolatedAsyncioTestCase):
 
         pipeline = ImagesHealthPipeline(runtime=self.mock_runtime, limit=100, variant=BuildVariant.OKD)
 
-        with patch.object(pipeline, 'get_concerns', new=AsyncMock()) as mock_get_concerns:
+        with patch.object(pipeline, 'get_concerns', new=MagicMock()) as mock_get_concerns:
             await pipeline.run()
             # Non-payload image should be skipped for OKD
             mock_get_concerns.assert_not_called()
@@ -175,7 +176,7 @@ class TestImagesHealthOKDModeFiltering(unittest.IsolatedAsyncioTestCase):
 
         pipeline = ImagesHealthPipeline(runtime=self.mock_runtime, limit=100, variant=BuildVariant.OKD)
 
-        with patch.object(pipeline, 'get_concerns', new=AsyncMock()) as mock_get_concerns:
+        with patch.object(pipeline, 'get_concerns', new=MagicMock()) as mock_get_concerns:
             await pipeline.run()
             # Payload image should be processed for OKD
             mock_get_concerns.assert_called_once_with(image_meta)
@@ -195,7 +196,7 @@ class TestImagesHealthOKDModeFiltering(unittest.IsolatedAsyncioTestCase):
 
         pipeline = ImagesHealthPipeline(runtime=self.mock_runtime, limit=100, variant=BuildVariant.OKD)
 
-        with patch.object(pipeline, 'get_concerns', new=AsyncMock()) as mock_get_concerns:
+        with patch.object(pipeline, 'get_concerns', new=MagicMock()) as mock_get_concerns:
             await pipeline.run()
             # Only image2 and image4 should be processed
             self.assertEqual(mock_get_concerns.call_count, 2)
@@ -217,7 +218,7 @@ class TestImagesHealthOKDModeFiltering(unittest.IsolatedAsyncioTestCase):
 
         pipeline = ImagesHealthPipeline(runtime=self.mock_runtime, limit=100, variant=BuildVariant.OKD)
 
-        with patch.object(pipeline, 'get_concerns', new=AsyncMock()) as mock_get_concerns:
+        with patch.object(pipeline, 'get_concerns', new=MagicMock()) as mock_get_concerns:
             await pipeline.run()
             # Only image1 and image3 should be processed (both are payload images with effective mode 'enabled')
             self.assertEqual(mock_get_concerns.call_count, 2)


### PR DESCRIPTION
## Summary
- Pre-load the entire group's build cache with a single BigQuery query via `_ensure_group_cached()`, then read per-image build history from the in-memory cache
- Replaces the previous approach where each image fired its own `search_builds_by_fields()` call with exponential window search (N × up to 7 BigQuery round-trips)
- Adds `get_builds_by_name()` to `BuildCache` for retrieving the full build history list for a given image name (the existing `get_by_name()` only returns the latest)

**Context:** Jenkins build [#3945](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/scanning/job/scanning%252Fimages-health/3945/) took 18 minutes because groups like 4.18 had ~250 build-failure keys in Redis, causing doozer to fire ~1700 BigQuery queries. With this change, each group is loaded in 1 query regardless of failing image count.

## Test plan
- [x] `make lint` passes
- [x] `pytest doozer/tests/cli/test_images_health.py` — 10 tests pass
- [ ] Run images-health pipeline in Jenkins to verify end-to-end performance improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)