### PR TITLE
ART-19367: Refactor images-health report to group failures by type

### DIFF
--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -49,11 +49,18 @@ class ImagesHealthPipeline:
         self.slack_client = self.runtime.new_slack_client()
         self.scanned_versions = []
         self.rebase_failures = {}  # version -> {image: {failure_count, url, build_system}}
+        self.ec_failures = {}  # version -> {image: {failure_count, jenkins_url, nvr, ec_pipeline_url, ...}}
+        self.release_failures = {}  # version -> {image: {failure_count, jenkins_url, nvr, ...}}
         self.jira_tickets: dict[tuple[str, str], str] = {}  # (image_name, group) -> ticket key
+        self._valid_images_cache: dict[str, set[str]] = {}
 
     async def run(self):
         await asyncio.gather(*(self.get_report(v) for v in self.versions))
-        await asyncio.gather(*(self.get_rebase_failures(v) for v in self.versions))
+        await asyncio.gather(
+            *(self.get_rebase_failures(v) for v in self.versions),
+            *(self.get_ec_failures(v) for v in self.versions),
+            *(self.get_release_failures(v) for v in self.versions),
+        )
         self.runtime.logger.info('Found %s concerns', len(self.report))
 
         if self._sync_jira and self.assembly == "stream":
@@ -185,6 +192,7 @@ class ImagesHealthPipeline:
     async def _get_valid_images(self, version: str, doozer_working: str) -> set[str]:
         """
         Get the set of valid image names for a given version from ocp-build-data.
+        Results are cached per version to avoid duplicate doozer subprocess calls.
 
         Arg(s):
             version (str): OCP version (e.g., "4.18")
@@ -192,6 +200,9 @@ class ImagesHealthPipeline:
         Return Value(s):
             set[str]: Set of valid image distgit keys
         """
+        if version in self._valid_images_cache:
+            return self._valid_images_cache[version]
+
         group_param = f'--group=openshift-{version}'
         if self.data_gitref:
             group_param += f'@{self.data_gitref}'
@@ -210,32 +221,146 @@ class ImagesHealthPipeline:
 
         try:
             _, out, _ = await exectools.cmd_gather_async(cmd, stderr=None)
-            # Parse the output - one image name per line
             valid_images = {line.strip() for line in out.strip().split('\n') if line.strip()}
             self.runtime.logger.info('Found %d valid images for openshift-%s', len(valid_images), version)
+            self._valid_images_cache[version] = valid_images
             return valid_images
         except Exception as e:
             self.runtime.logger.warning(
                 'Failed to fetch valid images for openshift-%s: %s. Proceeding without filtering.', version, e
             )
-            # On failure, return empty set to fail safe (don't process any images from Redis)
             return set()
+
+    async def _get_typed_failures(self, version: str, counter_type: str) -> dict:
+        """
+        Fetch failure data from Redis for a specific counter type and version.
+        Filters out images that don't exist in current ocp-build-data.
+
+        Arg(s):
+            version (str): OCP version (e.g., "4.18")
+            counter_type (str): Redis counter type (e.g., 'ec-failure', 'release-failure')
+        Return Value(s):
+            dict: {image_name: {failure_count, jenkins_url, nvr, ...}}
+        """
+        group = f'openshift-{version}'
+        all_failures = await util.get_counter_failures(counter_type, group=group, logger=self.runtime.logger)
+
+        if not all_failures:
+            return {}
+
+        doozer_working = f'{self.doozer_working}-{version}'
+        valid_images = await self._get_valid_images(version, doozer_working)
+
+        filtered_failures = {}
+        skipped_images = []
+
+        for image_name, failure_info in all_failures.items():
+            if image_name in valid_images:
+                filtered_failures[image_name] = failure_info
+            else:
+                skipped_images.append(image_name)
+
+        if skipped_images:
+            self.runtime.logger.warning(
+                'Filtered out %d %s(s) from Redis that do not exist in %s metadata: %s',
+                len(skipped_images),
+                counter_type,
+                group,
+                ', '.join(sorted(skipped_images)),
+            )
+
+        return filtered_failures
+
+    async def get_ec_failures(self, version: str):
+        """
+        Fetch EC verification failure data from Redis for a specific version.
+
+        Arg(s):
+            version (str): OCP version (e.g., "4.18")
+        """
+        self.ec_failures[version] = await self._get_typed_failures(version, 'ec-failure')
+
+    async def get_release_failures(self, version: str):
+        """
+        Fetch release-to-authz failure data from Redis for a specific version.
+
+        Arg(s):
+            version (str): OCP version (e.g., "4.18")
+        """
+        self.release_failures[version] = await self._get_typed_failures(version, 'release-failure')
 
     def sync_jira(self):
         jira_client = self.runtime.new_jira_client()
+        scanned_groups = {f"openshift-{v}" for v in self.scanned_versions}
 
-        # Build current failure set keyed by (image_name, group)
-        current_failures: dict[tuple[str, str], dict] = {}
+        # Sync build failure tickets (from doozer concerns)
+        build_failures: dict[tuple[str, str], dict] = {}
         for concern in self.report:
             if concern['code'] in FAILURE_CODES:
                 key = (concern['image_name'], concern['group'])
-                current_failures[key] = concern
+                build_failures[key] = concern
+        self._sync_jira_for_label(
+            jira_client,
+            'art:image-build-failure',
+            build_failures,
+            scanned_groups,
+            summary_prefix='Image build failure',
+            description_builder=self._build_description,
+            label_builder=self._build_failure_labels,
+            updater=self._update_build_failure_ticket,
+        )
 
-        # Fetch all open image-build-failure tickets
-        jql = 'project = ART AND labels = "art:image-build-failure" AND statusCategory != Done'
+        # Sync EC failure tickets (from Redis)
+        ec_failures = self._redis_failures_to_jira_dict(self.ec_failures)
+        self._sync_jira_for_label(
+            jira_client,
+            'art:image-ec-failure',
+            ec_failures,
+            scanned_groups,
+            summary_prefix='Image EC verification failure',
+            description_builder=self._build_redis_description,
+            label_builder=self._redis_failure_labels,
+        )
+
+        # Sync release failure tickets (from Redis)
+        release_failures = self._redis_failures_to_jira_dict(self.release_failures)
+        self._sync_jira_for_label(
+            jira_client,
+            'art:image-release-failure',
+            release_failures,
+            scanned_groups,
+            summary_prefix='Image release to authz failure',
+            description_builder=self._build_redis_description,
+            label_builder=self._redis_failure_labels,
+        )
+
+    def _sync_jira_for_label(
+        self,
+        jira_client: JIRAClient,
+        failure_label: str,
+        current_failures: dict[tuple[str, str], dict],
+        scanned_groups: set[str],
+        summary_prefix: str,
+        description_builder,
+        label_builder,
+        updater=None,
+    ):
+        """
+        Generic Jira ticket sync for a specific failure label type.
+
+        Arg(s):
+            jira_client (JIRAClient): Jira client instance
+            failure_label (str): Jira label for this failure type (e.g., 'art:image-build-failure')
+            current_failures (dict): {(image_name, group): failure_data}
+            scanned_groups (set[str]): Groups that were scanned this run
+            summary_prefix (str): Prefix for ticket summary
+            description_builder (callable): Function to build ticket description from failure data
+            label_builder (callable): Function to build labels list from failure data
+            updater (callable): Optional custom updater for existing tickets
+        """
+        jql = f'project = ART AND labels = "{failure_label}" AND statusCategory != Done'
         open_tickets = jira_client.search_issues(jql, maxResults=False)
 
-        # Index open tickets by (image_name, group) extracted from labels
         ticket_index: dict[tuple[str, str], object] = {}
         for ticket in open_tickets:
             image_name = None
@@ -248,19 +373,34 @@ class ImagesHealthPipeline:
             if image_name and group:
                 ticket_index[(image_name, group)] = ticket
 
-        # Record existing tickets and create missing ones
-        scanned_groups = {f"openshift-{v}" for v in self.scanned_versions}
-        for (image_name, group), concern in current_failures.items():
+        for (image_name, group), failure_data in current_failures.items():
             if (image_name, group) in ticket_index:
                 ticket = ticket_index[(image_name, group)]
                 self.jira_tickets[(image_name, group)] = ticket.key
                 _LOGGER.info("Ticket already exists for %s (%s): %s — updating", image_name, group, ticket.key)
-                self._update_existing_ticket(ticket, concern)
+                if updater:
+                    updater(ticket, failure_data)
+                else:
+                    ticket.update(
+                        fields={
+                            "labels": label_builder(failure_label, image_name, group, failure_data),
+                            "description": description_builder(failure_data),
+                        }
+                    )
                 continue
-            new_ticket = self._create_failure_ticket(jira_client, concern)
-            self.jira_tickets[(image_name, group)] = new_ticket.key
 
-        # Close resolved tickets (with scope guard)
+            labels = label_builder(failure_label, image_name, group, failure_data)
+            ticket = jira_client.create_issue(
+                project="ART",
+                issue_type="Task",
+                summary=f"{summary_prefix}: {image_name} ({group})",
+                description=description_builder(failure_data),
+                labels=labels,
+                components=["daily-ops"],
+            )
+            _LOGGER.info("Created ticket %s for %s (%s)", ticket.key, image_name, group)
+            self.jira_tickets[(image_name, group)] = ticket.key
+
         for (image_name, group), ticket in ticket_index.items():
             if group not in scanned_groups:
                 _LOGGER.info("Skipping close check for %s (%s): version not scanned", image_name, group)
@@ -273,8 +413,27 @@ class ImagesHealthPipeline:
                 jira_client.close_task(ticket.key)
 
     @staticmethod
+    def _redis_failures_to_jira_dict(failures_by_version: dict) -> dict[tuple[str, str], dict]:
+        """
+        Convert version-keyed Redis failures to (image_name, group) keyed dict for Jira sync.
+
+        Arg(s):
+            failures_by_version (dict): {version: {image: {failure_count, ...}}}
+        Return Value(s):
+            dict: {(image_name, group): failure_data}
+        """
+        result = {}
+        for version, failures in failures_by_version.items():
+            group = f'openshift-{version}'
+            for image_name, failure_info in failures.items():
+                result[(image_name, group)] = {**failure_info, 'image_name': image_name, 'group': group}
+        return result
+
+    @staticmethod
     def _get_fail_count(concern: dict) -> int:
-        """Return the number of consecutive build failures from a concern."""
+        """
+        Return the number of consecutive build failures from a concern.
+        """
         if concern['code'] == ConcernCode.FAILING_AT_LEAST_FOR.value:
             return LIMIT_BUILD_RESULTS
         return concern['latest_success_idx']
@@ -283,8 +442,37 @@ class ImagesHealthPipeline:
     def _fail_count_label(concern: dict) -> str:
         return f"art:fail-count:{ImagesHealthPipeline._get_fail_count(concern)}"
 
-    def _update_existing_ticket(self, ticket, concern: dict):
-        """Update fail-count label and description on an existing ticket."""
+    @staticmethod
+    def _build_failure_labels(failure_label: str, image_name: str, group: str, concern: dict) -> list[str]:
+        """
+        Build labels for a build failure Jira ticket.
+        """
+        return [
+            failure_label,
+            f"art:package:{image_name}",
+            f"art:group:{group}",
+            ImagesHealthPipeline._fail_count_label(concern),
+        ]
+
+    @staticmethod
+    def _redis_failure_labels(failure_label: str, image_name: str, group: str, failure_data: dict) -> list[str]:
+        """
+        Build labels for an EC or release failure Jira ticket.
+        """
+        labels = [
+            failure_label,
+            f"art:package:{image_name}",
+            f"art:group:{group}",
+        ]
+        failure_count = failure_data.get('failure_count', 0)
+        if failure_count:
+            labels.append(f"art:fail-count:{failure_count}")
+        return labels
+
+    def _update_build_failure_ticket(self, ticket, concern: dict):
+        """
+        Update fail-count label and description on an existing build failure ticket.
+        """
         new_label = self._fail_count_label(concern)
         labels = [label for label in ticket.fields.labels if not label.startswith("art:fail-count:")]
         if new_label not in labels:
@@ -319,27 +507,30 @@ class ImagesHealthPipeline:
             description += f"*Last successful build:* {last_good_url}\n"
         return description
 
-    def _create_failure_ticket(self, jira_client: JIRAClient, concern: dict):
-        image_name = concern['image_name']
-        group = concern['group']
+    @staticmethod
+    def _build_redis_description(failure_data: dict) -> str:
+        """
+        Build a Jira ticket description from Redis failure data (EC or release failures).
+        """
+        image_name = failure_data.get('image_name', 'N/A')
+        group = failure_data.get('group', 'N/A')
+        failure_count = failure_data.get('failure_count', 0)
+        nvr = failure_data.get('nvr', 'N/A')
+        jenkins_url = failure_data.get('jenkins_url', '')
 
-        labels = [
-            "art:image-build-failure",
-            f"art:package:{image_name}",
-            f"art:group:{group}",
-            self._fail_count_label(concern),
-        ]
-
-        ticket = jira_client.create_issue(
-            project="ART",
-            issue_type="Task",
-            summary=f"Image build failure: {image_name} ({group})",
-            description=self._build_description(concern),
-            labels=labels,
-            components=["daily-ops"],
+        description = (
+            f"Image failure detected by images-health.\n\n"
+            f"*Image:* {image_name}\n"
+            f"*Group:* {group}\n"
+            f"*NVR:* {nvr}\n"
+            f"*Consecutive failures:* {failure_count}\n"
         )
-        _LOGGER.info("Created ticket %s for %s (%s)", ticket.key, image_name, group)
-        return ticket
+        if jenkins_url:
+            description += f"*Last failure job:* {jenkins_url}\n"
+        ec_pipeline_url = failure_data.get('ec_pipeline_url', '')
+        if ec_pipeline_url:
+            description += f"*EC pipeline:* {ec_pipeline_url}\n"
+        return description
 
     def _jira_link(self, concern: dict) -> str:
         key = self.jira_tickets.get((concern['image_name'], concern['group']))
@@ -358,45 +549,64 @@ class ImagesHealthPipeline:
             and concern['code'] != ConcernCode.LATEST_BUILD_SUCCEEDED.value
         ]
 
-        # Get rebase failures for this version
         rebase_failures = self.rebase_failures.get(version, {})
+        ec_failures = self.ec_failures.get(version, {})
+        release_failures = self.release_failures.get(version, {})
 
         version_tag = f'`openshift-{version}`'
         if self.assembly != 'stream':
             version_tag += f' (assembly `{self.assembly}`)'
 
-        # If no concerns and no rebase failures, report all healthy
-        if not concerns and not rebase_failures:
+        if not concerns and not rebase_failures and not ec_failures and not release_failures:
             await self.slack_client.say(f':white_check_mark: All images are healthy for {version_tag}')
             return
 
-        # Build summary message
         summary_parts = []
         if concerns:
-            summary_parts.append(self.get_component_tag(concerns))
+            n = len(concerns)
+            summary_parts.append(f'{n} image{"s" if n > 1 else ""} failed to build')
+        if ec_failures:
+            n = len(ec_failures)
+            summary_parts.append(f'{n} image{"s" if n > 1 else ""} failed EC verification')
+        if release_failures:
+            n = len(release_failures)
+            summary_parts.append(f'{n} image{"s" if n > 1 else ""} failed to be released to authz')
         if rebase_failures:
-            rebase_count = len(rebase_failures)
-            summary_parts.append(f'{rebase_count} image{"s" if rebase_count > 1 else ""} with rebase failures')
+            n = len(rebase_failures)
+            summary_parts.append(f'{n} image{"s" if n > 1 else ""} with rebase failures')
 
-        # Post parent message
         issues = '\n- '.join(summary_parts)
         response = await self.slack_client.say(
             f':alert: There are some issues to look into for {version_tag}:\n- {issues}'
         )
 
-        # Post detailed report in thread
         report = ''
 
-        # Add build concerns
         if concerns:
-            report += '*Build Issues:*\n'
+            report += f'*Build Failures ({len(concerns)}):*\n'
             for concern in concerns:
                 report += f'{self.get_message_for_release(concern)}\n'
             report += '\n'
 
-        # Add rebase failures
+        if ec_failures:
+            report += f'*EC Verification Failures ({len(ec_failures)}):*\n'
+            for image_name, failure_info in sorted(ec_failures.items()):
+                report += self._format_redis_failure_line(image_name, failure_info)
+                ec_url = failure_info.get('ec_pipeline_url', '')
+                if ec_url:
+                    report += f' | {self.url_text(ec_url, "EC pipeline")}'
+                report += '\n'
+            report += '\n'
+
+        if release_failures:
+            report += f'*Release to Authz Failures ({len(release_failures)}):*\n'
+            for image_name, failure_info in sorted(release_failures.items()):
+                report += self._format_redis_failure_line(image_name, failure_info)
+                report += '\n'
+            report += '\n'
+
         if rebase_failures:
-            report += '*Rebase Failures:*\n'
+            report += f'*Rebase Failures ({len(rebase_failures)}):*\n'
             for image_name, failure_info in sorted(rebase_failures.items()):
                 failure_count = failure_info.get('failure_count', 0)
                 jenkins_url = failure_info.get('jenkins_url', '')
@@ -414,45 +624,44 @@ class ImagesHealthPipeline:
         self.slack_client.bind_channel(self.public_channel)
 
         # Group build concerns by image name
-        image_concerns = {}
+        image_build_failures = {}
         for concern in self.report:
-            if (
-                concern['code'] == ConcernCode.NEVER_BUILT.value
-                or concern['code'] == ConcernCode.LATEST_BUILD_SUCCEEDED.value
-            ):
-                # We don't report NEVER_BUILT concerns to forum-ocp-art. Latest built succeeded is not a concern.
+            if concern['code'] in (ConcernCode.NEVER_BUILT.value, ConcernCode.LATEST_BUILD_SUCCEEDED.value):
                 continue
             image_name = concern['image_name']
-            image_concerns.setdefault(image_name, []).append(concern)
+            image_build_failures.setdefault(image_name, []).append(concern)
+
+        # Group EC failures by image name across all versions
+        image_ec_failures = self._group_failures_by_image(self.ec_failures)
+
+        # Group release failures by image name across all versions
+        image_release_failures = self._group_failures_by_image(self.release_failures)
 
         # Group rebase failures by image name across all versions
-        image_rebase_failures = {}
-        for version, failures in self.rebase_failures.items():
-            for image_name, failure_info in failures.items():
-                if image_name not in image_rebase_failures:
-                    image_rebase_failures[image_name] = []
-                image_rebase_failures[image_name].append(
-                    {
-                        'version': version,
-                        'failure_count': failure_info.get('failure_count', 0),
-                        'jenkins_url': failure_info.get('jenkins_url', ''),
-                        'build_system': failure_info.get('build_system', 'unknown'),
-                    }
-                )
+        image_rebase_failures = self._group_failures_by_image(self.rebase_failures)
 
-        # If no concerns and no rebase failures, report all healthy
-        if not image_concerns and not image_rebase_failures:
+        if (
+            not image_build_failures
+            and not image_ec_failures
+            and not image_release_failures
+            and not image_rebase_failures
+        ):
             await self.slack_client.say(':white_check_mark: All images are healthy for all monitored releases')
             return
 
-        # Build summary message
         summary_parts = []
-        if image_concerns:
-            n_build_issues = len(image_concerns)
-            summary_parts.append(f'{n_build_issues} image{"s" if n_build_issues > 1 else ""} with build issues')
+        if image_build_failures:
+            n = len(image_build_failures)
+            summary_parts.append(f'{n} image{"s" if n > 1 else ""} with build failures')
+        if image_ec_failures:
+            n = len(image_ec_failures)
+            summary_parts.append(f'{n} image{"s" if n > 1 else ""} with EC verification failures')
+        if image_release_failures:
+            n = len(image_release_failures)
+            summary_parts.append(f'{n} image{"s" if n > 1 else ""} with release to authz failures')
         if image_rebase_failures:
-            n_rebase_issues = len(image_rebase_failures)
-            summary_parts.append(f'{n_rebase_issues} image{"s" if n_rebase_issues > 1 else ""} with rebase failures')
+            n = len(image_rebase_failures)
+            summary_parts.append(f'{n} image{"s" if n > 1 else ""} with rebase failures')
 
         issues = '\n- '.join(summary_parts)
         response = await self.slack_client.say(
@@ -460,33 +669,109 @@ class ImagesHealthPipeline:
             link_build_url=False,
         )
 
-        # Post detailed report in thread
-        # Build concerns
-        for image_name, concerns in image_concerns.items():
-            image_message = f'`{image_name}` (build issues):'
-            for concern in concerns:
-                image_message += f'\n• {self.get_message_for_forum(concern)}'
+        if image_build_failures:
+            n = len(image_build_failures)
+            message = f'*Build Failures ({n} image{"s" if n > 1 else ""}):*'
+            for image_name, concerns in sorted(image_build_failures.items()):
+                message += f'\n`{image_name}`:'
+                for concern in concerns:
+                    message += f'\n  • {self.get_message_for_forum(concern)}'
             await self.slack_client.say(
-                image_message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False, unfurl_media=False
+                message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False, unfurl_media=False
             )
 
-        # Rebase failures
-        for image_name, failures in sorted(image_rebase_failures.items()):
-            image_message = f'`{image_name}` (rebase failures):'
-            for failure in failures:
-                version = failure['version']
-                failure_count = failure['failure_count']
-                jenkins_url = failure['jenkins_url']
-                build_system = failure['build_system']
-                image_message += (
-                    f'\n• openshift-{version} ({build_system}): '
-                    f'Failed {failure_count} time{"s" if failure_count != 1 else ""}'
-                )
-                if jenkins_url:
-                    image_message += f' ({self.url_text(jenkins_url, "Last failure job")})'
+        if image_ec_failures:
+            n = len(image_ec_failures)
+            message = f'*EC Verification Failures ({n} image{"s" if n > 1 else ""}):*'
+            for image_name, failures in sorted(image_ec_failures.items()):
+                message += f'\n`{image_name}`:'
+                for failure in failures:
+                    line = f'\n  • {self._format_forum_redis_failure_inline(failure)}'
+                    ec_url = failure.get('ec_pipeline_url', '')
+                    if ec_url:
+                        line += f' | {self.url_text(ec_url, "EC pipeline")}'
+                    message += line
             await self.slack_client.say(
-                image_message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False, unfurl_media=False
+                message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False, unfurl_media=False
             )
+
+        if image_release_failures:
+            n = len(image_release_failures)
+            message = f'*Release to Authz Failures ({n} image{"s" if n > 1 else ""}):*'
+            for image_name, failures in sorted(image_release_failures.items()):
+                message += f'\n`{image_name}`:'
+                for failure in failures:
+                    message += f'\n  • {self._format_forum_redis_failure_inline(failure)}'
+            await self.slack_client.say(
+                message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False, unfurl_media=False
+            )
+
+        if image_rebase_failures:
+            n = len(image_rebase_failures)
+            message = f'*Rebase Failures ({n} image{"s" if n > 1 else ""}):*'
+            for image_name, failures in sorted(image_rebase_failures.items()):
+                message += f'\n`{image_name}`:'
+                for failure in failures:
+                    message += f'\n  • {self._format_forum_redis_failure_inline(failure)}'
+            await self.slack_client.say(
+                message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False, unfurl_media=False
+            )
+
+    @staticmethod
+    def _group_failures_by_image(failures_by_version: dict) -> dict[str, list[dict]]:
+        """
+        Group version-keyed Redis failures into an image-keyed structure.
+
+        Arg(s):
+            failures_by_version (dict): {version: {image: {failure_count, ...}}}
+        Return Value(s):
+            dict: {image_name: [{version, failure_count, jenkins_url, build_system, ...}, ...]}
+        """
+        grouped = {}
+        for version, failures in failures_by_version.items():
+            for image_name, failure_info in failures.items():
+                grouped.setdefault(image_name, []).append(
+                    {
+                        'version': version,
+                        **failure_info,
+                    }
+                )
+        return grouped
+
+    def _format_redis_failure_line(self, image_name: str, failure_info: dict) -> str:
+        """
+        Format a single Redis failure entry for the release channel thread.
+
+        Arg(s):
+            image_name (str): Image distgit key
+            failure_info (dict): Redis failure data with failure_count, jenkins_url, etc.
+        Return Value(s):
+            str: Formatted line (without trailing newline)
+        """
+        failure_count = failure_info.get('failure_count', 0)
+        jenkins_url = failure_info.get('jenkins_url', '')
+        line = f'- `{image_name}`: Failed {failure_count} time{"s" if failure_count != 1 else ""}'
+        if jenkins_url:
+            line += f' ({self.url_text(jenkins_url, "Last failure job")})'
+        return line
+
+    def _format_forum_redis_failure_inline(self, failure: dict) -> str:
+        """
+        Format a single Redis failure entry as inline text (no leading bullet/newline).
+
+        Arg(s):
+            failure (dict): Failure data with version, failure_count, jenkins_url, etc.
+        Return Value(s):
+            str: Formatted text fragment
+        """
+        version = failure.get('version', '?')
+        failure_count = failure.get('failure_count', 0)
+        jenkins_url = failure.get('jenkins_url', '')
+        build_system = failure.get('build_system', 'unknown')
+        line = f'openshift-{version} ({build_system}): Failed {failure_count} time{"s" if failure_count != 1 else ""}'
+        if jenkins_url:
+            line += f' ({self.url_text(jenkins_url, "Last failure job")})'
+        return line
 
     def get_message_for_release(self, concern: dict):
         """
@@ -573,15 +858,6 @@ class ImagesHealthPipeline:
         end_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
         return f'{ART_BUILD_HISTORY_URL}/?name=^{image_name}$&group={group}&assembly=stream&engine=konflux&dateRange={start_date}+to+{end_date}&outcome=success&outcome=failure'
 
-    @staticmethod
-    def get_component_tag(report):
-        n_components = len(report)
-
-        if n_components > 1:
-            return f'{n_components} components have failed!'
-        else:
-            return '1 component has failed!'
-
     def url_text(self, url, text):
         """
         Slack requires URLs to be encoded in a specific way when using the <url|text> format.
@@ -604,7 +880,7 @@ class ImagesHealthPipeline:
     '--send-to-public-channel',
     required=False,
     default='',
-    help='Slack channel to send public notification to (e.g. #forum-ocp-art). Leave blank to skip.',
+    help='Slack channel to send public notification to (e.g. #forum-ocp-art)',
 )
 @click.option(
     '--data-path',

--- a/pyartcd/tests/pipelines/test_images_health.py
+++ b/pyartcd/tests/pipelines/test_images_health.py
@@ -28,179 +28,197 @@ def _make_concern(image_name, group, code, **kwargs):
     return concern
 
 
-class TestImagesHealthPipeline(IsolatedAsyncioTestCase):
+def _make_pipeline(runtime, versions="4.22", public_channel="", image_list="", assembly="stream", sync_jira=False):
+    return ImagesHealthPipeline(
+        runtime=runtime,
+        versions=versions,
+        send_to_release_channel=False,
+        public_channel=public_channel,
+        data_path=DATA_PATH,
+        data_gitref="",
+        image_list=image_list,
+        assembly=assembly,
+        sync_jira=sync_jira,
+    )
+
+
+def _make_runtime():
+    runtime = MagicMock()
+    runtime.working_dir = MagicMock()
+    runtime.logger = MagicMock()
+    mock_slack_client = MagicMock()
+    mock_slack_client.say = AsyncMock()
+    runtime.new_slack_client = MagicMock(return_value=mock_slack_client)
+    return runtime
+
+
+class TestNotifyPublicChannel(IsolatedAsyncioTestCase):
     def setUp(self):
-        self.mock_runtime = MagicMock()
-        self.mock_runtime.working_dir = MagicMock()
-        self.mock_runtime.logger = MagicMock()
+        self.mock_runtime = _make_runtime()
 
-        mock_slack_client = MagicMock()
-        mock_slack_client.say = AsyncMock()
-
-        self.mock_runtime.new_slack_client = MagicMock(return_value=mock_slack_client)
-
-    async def test_notify_public_channel_with_no_concerns_after_filtering(self):
-        # given
+    async def test_no_concerns_after_filtering(self):
         mock_slack_client = self.mock_runtime.new_slack_client.return_value
-        pipeline = ImagesHealthPipeline(
-            runtime=self.mock_runtime,
-            versions="4.22",
-            send_to_release_channel=False,
-            public_channel="#forum-ocp-art",
-            data_path=DATA_PATH,
-            data_gitref="",
-            image_list="",
-            assembly="stream",
-        )
+        pipeline = _make_pipeline(self.mock_runtime, public_channel="#forum-ocp-art")
         pipeline.report = [
-            {
-                "code": ConcernCode.NEVER_BUILT.value,
-                "image_name": "never-built-image",
-                "group": "openshift-4.22",
-            },
-            {
-                "code": ConcernCode.LATEST_BUILD_SUCCEEDED.value,
-                "image_name": "succeeded-image",
-                "group": "openshift-4.22",
-            },
+            {"code": ConcernCode.NEVER_BUILT.value, "image_name": "never-built-image", "group": "openshift-4.22"},
+            {"code": ConcernCode.LATEST_BUILD_SUCCEEDED.value, "image_name": "ok-image", "group": "openshift-4.22"},
         ]
-        # when
+
         await pipeline.notify_public_channel()
-        # then
+
         mock_slack_client.say.assert_called_once_with(
             ":white_check_mark: All images are healthy for all monitored releases"
         )
 
-    async def test_notify_public_channel_with_concerns(self):
-        # given
+    async def test_with_build_concerns(self):
         mock_slack_client = self.mock_runtime.new_slack_client.return_value
-        pipeline = ImagesHealthPipeline(
-            runtime=self.mock_runtime,
-            versions="4.21",
-            send_to_release_channel=False,
-            public_channel="#forum-ocp-art",
-            data_path=DATA_PATH,
-            data_gitref="",
-            image_list="",
-            assembly="stream",
-        )
+        pipeline = _make_pipeline(self.mock_runtime, versions="4.21", public_channel="#forum-ocp-art")
         pipeline.report = [
-            {
-                "code": ConcernCode.FAILING_AT_LEAST_FOR.value,
-                "image_name": "failing-image",
-                "group": "openshift-4.21",
-                "latest_failed_build_time": "2025-12-17T10:00:00+00:00",
-                "latest_failed_nvr": "failing-image-1.0-1",
-                "latest_failed_build_record_id": "12345",
-            },
-            {
-                "code": ConcernCode.LATEST_ATTEMPT_FAILED.value,
-                "image_name": "failing-image",
-                "group": "openshift-4.20",
-                "latest_success_idx": 3,
-                "latest_failed_build_time": "2025-12-17T11:00:00+00:00",
-                "latest_failed_nvr": "failing-image-2.0-1",
-                "latest_failed_build_record_id": "12346",
-            },
+            _make_concern("failing-image", "openshift-4.21", ConcernCode.FAILING_AT_LEAST_FOR.value),
+            _make_concern(
+                "failing-image", "openshift-4.20", ConcernCode.LATEST_ATTEMPT_FAILED.value, latest_success_idx=3
+            ),
         ]
-        mock_response = {"ts": ""}
-        mock_slack_client.say.return_value = mock_response
-        # when
-        await pipeline.notify_public_channel()
-        # then
-        calls = mock_slack_client.say.call_args_list
-        self.assertEqual(len(calls), 2)
-        first_call_args = calls[0][0][0]
-        self.assertIn(":alert: There are some issues to look into for Openshift builds:", first_call_args)
+        mock_slack_client.say.return_value = {"ts": ""}
 
-    async def test_notify_public_channel_with_mixed_concerns(self):
-        # given
-        mock_slack_client = self.mock_runtime.new_slack_client.return_value
-        pipeline = ImagesHealthPipeline(
-            runtime=self.mock_runtime,
-            versions="4.22",
-            send_to_release_channel=False,
-            public_channel="#forum-ocp-art",
-            data_path=DATA_PATH,
-            data_gitref="",
-            image_list="",
-            assembly="stream",
-        )
-
-        # Create a report with mixed concerns
-        pipeline.report = [
-            {
-                "code": ConcernCode.NEVER_BUILT.value,
-                "image_name": "never-built-image",
-                "group": "openshift-4.22",
-            },
-            {
-                "code": ConcernCode.LATEST_BUILD_SUCCEEDED.value,
-                "image_name": "succeeded-image",
-                "group": "openshift-4.22",
-            },
-            {
-                "code": ConcernCode.FAILING_AT_LEAST_FOR.value,
-                "image_name": "failing-image",
-                "group": "openshift-4.22",
-                "latest_failed_build_time": "2025-12-17T10:00:00+00:00",
-                "latest_failed_nvr": "failing-image-1.0-1",
-                "latest_failed_build_record_id": "12345",
-            },
-        ]
-        mock_response = {"ts": ""}
-        mock_slack_client.say.return_value = mock_response
-        # when
         await pipeline.notify_public_channel()
-        # then
+
         calls = mock_slack_client.say.call_args_list
         self.assertEqual(len(calls), 2)
         first_call_args = calls[0][0][0]
         self.assertIn(":alert:", first_call_args)
+        self.assertIn("build failures", first_call_args)
 
-    async def test_notify_public_channel_with_empty_report(self):
+    async def test_with_mixed_failure_types(self):
         mock_slack_client = self.mock_runtime.new_slack_client.return_value
-        pipeline = ImagesHealthPipeline(
-            runtime=self.mock_runtime,
-            versions="4.22",
-            send_to_release_channel=False,
-            public_channel="#forum-ocp-art",
-            data_path=DATA_PATH,
-            data_gitref="",
-            image_list="",
-            assembly="stream",
-        )
-        pipeline.report = []
-        # when
+        pipeline = _make_pipeline(self.mock_runtime, public_channel="#test-channel")
+        pipeline.report = [
+            _make_concern("build-fail", "openshift-4.22", ConcernCode.FAILING_AT_LEAST_FOR.value),
+        ]
+        pipeline.ec_failures = {
+            '4.22': {
+                'ec-fail-image': {'failure_count': 3, 'jenkins_url': 'http://j/1', 'ec_pipeline_url': 'http://ec/1'}
+            },
+        }
+        pipeline.release_failures = {
+            '4.22': {'release-fail-image': {'failure_count': 2, 'jenkins_url': 'http://j/2'}},
+        }
+        pipeline.rebase_failures = {
+            '4.22': {'rebase-fail-image': {'failure_count': 1, 'jenkins_url': 'http://j/3', 'build_system': 'konflux'}},
+        }
+        mock_slack_client.say.return_value = {"ts": ""}
+
         await pipeline.notify_public_channel()
-        # then
+
+        calls = mock_slack_client.say.call_args_list
+        # Summary + 4 thread messages (one per failure type)
+        self.assertEqual(len(calls), 5)
+        summary = calls[0][0][0]
+        self.assertIn("build failures", summary)
+        self.assertIn("EC verification failures", summary)
+        self.assertIn("release to authz failures", summary)
+        self.assertIn("rebase failures", summary)
+        # Thread messages: section header with image name, then group bullets below
+        build_thread = calls[1][0][0]
+        self.assertIn("Build Failures (1 image)", build_thread)
+        self.assertIn("`build-fail`:", build_thread)
+        ec_thread = calls[2][0][0]
+        self.assertIn("EC Verification Failures (1 image)", ec_thread)
+        self.assertIn("`ec-fail-image`:", ec_thread)
+
+    async def test_binds_to_configured_channel(self):
+        mock_slack_client = self.mock_runtime.new_slack_client.return_value
+        pipeline = _make_pipeline(self.mock_runtime, public_channel="#my-custom-channel")
+        pipeline.report = []
+
+        await pipeline.notify_public_channel()
+
+        mock_slack_client.bind_channel.assert_called_once_with("#my-custom-channel")
+
+    async def test_empty_report(self):
+        mock_slack_client = self.mock_runtime.new_slack_client.return_value
+        pipeline = _make_pipeline(self.mock_runtime, public_channel="#forum-ocp-art")
+        pipeline.report = []
+
+        await pipeline.notify_public_channel()
+
         mock_slack_client.say.assert_called_once_with(
             ":white_check_mark: All images are healthy for all monitored releases"
         )
 
+    async def test_only_ec_failures(self):
+        mock_slack_client = self.mock_runtime.new_slack_client.return_value
+        pipeline = _make_pipeline(self.mock_runtime, public_channel="#forum-ocp-art")
+        pipeline.report = []
+        pipeline.ec_failures = {
+            '4.22': {'image-a': {'failure_count': 5, 'jenkins_url': '', 'ec_pipeline_url': 'http://ec/1'}},
+        }
+        mock_slack_client.say.return_value = {"ts": ""}
+
+        await pipeline.notify_public_channel()
+
+        calls = mock_slack_client.say.call_args_list
+        self.assertEqual(len(calls), 2)
+        summary = calls[0][0][0]
+        self.assertIn("EC verification failures", summary)
+        self.assertNotIn("build failures", summary)
+
+
+class TestNotifyReleaseChannel(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.mock_runtime = _make_runtime()
+
+    async def test_all_healthy(self):
+        mock_slack_client = self.mock_runtime.new_slack_client.return_value
+        pipeline = _make_pipeline(self.mock_runtime, versions="4.18")
+        pipeline.report = []
+        pipeline.scanned_versions = ["4.18"]
+
+        await pipeline.notify_release_channel("4.18")
+
+        mock_slack_client.say.assert_called_once()
+        self.assertIn("healthy", mock_slack_client.say.call_args[0][0])
+
+    async def test_grouped_failure_summary(self):
+        mock_slack_client = self.mock_runtime.new_slack_client.return_value
+        pipeline = _make_pipeline(self.mock_runtime, versions="4.18")
+        pipeline.report = [
+            _make_concern(
+                "build-fail-1", "openshift-4.18", ConcernCode.LATEST_ATTEMPT_FAILED.value, latest_success_idx=2
+            ),
+            _make_concern("build-fail-2", "openshift-4.18", ConcernCode.FAILING_AT_LEAST_FOR.value),
+        ]
+        pipeline.ec_failures = {
+            '4.18': {'ec-img': {'failure_count': 3, 'jenkins_url': 'http://j/1', 'ec_pipeline_url': 'http://ec/1'}},
+        }
+        pipeline.release_failures = {
+            '4.18': {'rel-img': {'failure_count': 1, 'jenkins_url': 'http://j/2'}},
+        }
+        mock_slack_client.say.return_value = {"ts": ""}
+
+        await pipeline.notify_release_channel("4.18")
+
+        calls = mock_slack_client.say.call_args_list
+        summary = calls[0][0][0]
+        self.assertIn("2 images failed to build", summary)
+        self.assertIn("1 image failed EC verification", summary)
+        self.assertIn("1 image failed to be released to authz", summary)
+
+        thread_detail = calls[1][0][0]
+        self.assertIn("Build Failures (2)", thread_detail)
+        self.assertIn("EC Verification Failures (1)", thread_detail)
+        self.assertIn("Release to Authz Failures (1)", thread_detail)
+
 
 class TestGetReport(IsolatedAsyncioTestCase):
     def _make_pipeline(self, versions="4.18", image_list=""):
-        runtime = MagicMock()
-        runtime.working_dir = MagicMock()
-        runtime.logger = MagicMock()
-        runtime.new_slack_client.return_value = MagicMock()
-        return ImagesHealthPipeline(
-            runtime=runtime,
-            versions=versions,
-            send_to_release_channel=False,
-            public_channel="",
-            data_path=DATA_PATH,
-            data_gitref="",
-            image_list=image_list,
-            assembly="stream",
-        )
+        runtime = _make_runtime()
+        return _make_pipeline(runtime, versions=versions, image_list=image_list)
 
     @patch("pyartcd.pipelines.images_health.exectools.cmd_gather_async", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.images_health.util.is_build_permitted", new_callable=AsyncMock, return_value=True)
     @patch("pyartcd.pipelines.images_health.util.get_counter_failures", new_callable=AsyncMock)
     async def test_redis_pre_filters_doozer_call(self, mock_get_failures, _mock_permitted, mock_cmd):
-        """Redis failures scope the --images flag on the doozer subprocess."""
         mock_get_failures.return_value = {
             'ironic': {'failure_count': 3, 'url': '', 'nvr': ''},
             'hypershift': {'failure_count': 5, 'url': '', 'nvr': ''},
@@ -214,7 +232,6 @@ class TestGetReport(IsolatedAsyncioTestCase):
         mock_cmd.return_value = (0, json.dumps(doozer_report), '')
 
         pipeline = self._make_pipeline()
-        # Mock _get_valid_images to return all images as valid
         pipeline._get_valid_images = AsyncMock(return_value={'ironic', 'hypershift'})
 
         await pipeline.get_report('4.18')
@@ -233,7 +250,6 @@ class TestGetReport(IsolatedAsyncioTestCase):
     @patch("pyartcd.pipelines.images_health.util.is_build_permitted", new_callable=AsyncMock, return_value=True)
     @patch("pyartcd.pipelines.images_health.util.get_counter_failures", new_callable=AsyncMock)
     async def test_image_list_intersects_with_redis(self, mock_get_failures, _mock_permitted, mock_cmd):
-        """When --image-list is provided, only images in BOTH lists are queried."""
         mock_get_failures.return_value = {
             'ironic': {'failure_count': 3, 'url': '', 'nvr': ''},
             'hypershift': {'failure_count': 5, 'url': '', 'nvr': ''},
@@ -244,7 +260,6 @@ class TestGetReport(IsolatedAsyncioTestCase):
         mock_cmd.return_value = (0, json.dumps(doozer_report), '')
 
         pipeline = self._make_pipeline(image_list="ironic")
-        # Mock _get_valid_images to return ironic as valid
         pipeline._get_valid_images = AsyncMock(return_value={'ironic', 'hypershift'})
 
         await pipeline.get_report('4.18')
@@ -266,7 +281,6 @@ class TestGetReport(IsolatedAsyncioTestCase):
     @patch("pyartcd.pipelines.images_health.util.is_build_permitted", new_callable=AsyncMock, return_value=True)
     @patch("pyartcd.pipelines.images_health.util.get_counter_failures", new_callable=AsyncMock, return_value={})
     async def test_skips_bigquery_when_no_redis_failures(self, _mock_get_failures, _mock_permitted, mock_cmd):
-        """When Redis reports no failures, doozer images:health is not called at all."""
         pipeline = self._make_pipeline()
 
         await pipeline.get_report('4.18')
@@ -276,27 +290,72 @@ class TestGetReport(IsolatedAsyncioTestCase):
         self.assertIn('4.18', pipeline.scanned_versions)
 
 
+class TestGetTypedFailures(IsolatedAsyncioTestCase):
+    @patch("pyartcd.pipelines.images_health.util.get_counter_failures", new_callable=AsyncMock)
+    async def test_ec_failures_filtered_by_valid_images(self, mock_get_failures):
+        mock_get_failures.return_value = {
+            'valid-image': {'failure_count': 3, 'jenkins_url': 'http://j/1', 'ec_pipeline_url': 'http://ec/1'},
+            'invalid-image': {'failure_count': 1, 'jenkins_url': 'http://j/2'},
+        }
+        runtime = _make_runtime()
+        pipeline = _make_pipeline(runtime, versions="4.18")
+        pipeline._get_valid_images = AsyncMock(return_value={'valid-image', 'other-image'})
+
+        await pipeline.get_ec_failures('4.18')
+
+        self.assertIn('valid-image', pipeline.ec_failures['4.18'])
+        self.assertNotIn('invalid-image', pipeline.ec_failures['4.18'])
+        mock_get_failures.assert_called_once_with('ec-failure', group='openshift-4.18', logger=runtime.logger)
+
+    @patch("pyartcd.pipelines.images_health.util.get_counter_failures", new_callable=AsyncMock)
+    async def test_release_failures_filtered_by_valid_images(self, mock_get_failures):
+        mock_get_failures.return_value = {
+            'ose-base': {'failure_count': 2, 'jenkins_url': 'http://j/1'},
+        }
+        runtime = _make_runtime()
+        pipeline = _make_pipeline(runtime, versions="4.18")
+        pipeline._get_valid_images = AsyncMock(return_value={'ose-base'})
+
+        await pipeline.get_release_failures('4.18')
+
+        self.assertEqual(pipeline.release_failures['4.18']['ose-base']['failure_count'], 2)
+
+    @patch("pyartcd.pipelines.images_health.util.get_counter_failures", new_callable=AsyncMock)
+    async def test_empty_redis_returns_empty(self, mock_get_failures):
+        mock_get_failures.return_value = {}
+        runtime = _make_runtime()
+        pipeline = _make_pipeline(runtime, versions="4.18")
+
+        await pipeline.get_ec_failures('4.18')
+
+        self.assertEqual(pipeline.ec_failures['4.18'], {})
+
+    @patch("pyartcd.pipelines.images_health.util.get_counter_failures", new_callable=AsyncMock)
+    async def test_valid_images_cache(self, mock_get_failures):
+        mock_get_failures.return_value = {
+            'img': {'failure_count': 1, 'jenkins_url': ''},
+        }
+        runtime = _make_runtime()
+        pipeline = _make_pipeline(runtime, versions="4.18")
+        mock_get_valid = AsyncMock(return_value={'img'})
+        pipeline._get_valid_images = mock_get_valid
+
+        await pipeline.get_ec_failures('4.18')
+        await pipeline.get_release_failures('4.18')
+
+        # _get_valid_images is called twice because _get_typed_failures calls it,
+        # but _get_valid_images itself has caching so doozer would only be called once
+        self.assertEqual(mock_get_valid.call_count, 2)
+
+
 class TestSyncJira(TestCase):
     def _make_pipeline(self, image_list=""):
-        runtime = MagicMock()
-        runtime.working_dir = MagicMock()
-        runtime.logger = MagicMock()
-        runtime.new_slack_client.return_value = MagicMock()
-        pipeline = ImagesHealthPipeline(
-            runtime=runtime,
-            versions="5.0",
-            send_to_release_channel=False,
-            public_channel="",
-            data_path=DATA_PATH,
-            data_gitref="",
-            image_list=image_list,
-            assembly="stream",
-            sync_jira=True,
-        )
+        runtime = _make_runtime()
+        pipeline = _make_pipeline(runtime, versions="5.0", image_list=image_list, sync_jira=True)
         pipeline.scanned_versions = ["5.0"]
         return pipeline
 
-    def test_creates_ticket_for_new_failure(self):
+    def test_creates_ticket_for_new_build_failure(self):
         pipeline = self._make_pipeline()
         pipeline.report = [
             _make_concern("ironic", "openshift-5.0", ConcernCode.FAILING_AT_LEAST_FOR.value),
@@ -309,15 +368,13 @@ class TestSyncJira(TestCase):
 
         pipeline.sync_jira()
 
-        mock_jira.create_issue.assert_called_once()
-        kwargs = mock_jira.create_issue.call_args
-        self.assertEqual(kwargs[1]["project"], "ART")
-        self.assertEqual(kwargs[1]["summary"], "Image build failure: ironic (openshift-5.0)")
-        self.assertIn("art:image-build-failure", kwargs[1]["labels"])
-        self.assertIn("art:package:ironic", kwargs[1]["labels"])
-        self.assertIn("art:group:openshift-5.0", kwargs[1]["labels"])
-        self.assertIn("art:fail-count:100", kwargs[1]["labels"])
-        mock_jira.close_task.assert_not_called()
+        create_calls = [c for c in mock_jira.create_issue.call_args_list]
+        build_call = next(c for c in create_calls if "build failure" in c[1]["summary"].lower())
+        self.assertEqual(build_call[1]["project"], "ART")
+        self.assertIn("art:image-build-failure", build_call[1]["labels"])
+        self.assertIn("art:package:ironic", build_call[1]["labels"])
+        self.assertIn("art:group:openshift-5.0", build_call[1]["labels"])
+        self.assertIn("art:fail-count:100", build_call[1]["labels"])
 
     def test_creates_ticket_with_fail_count_from_latest_success_idx(self):
         pipeline = self._make_pipeline()
@@ -332,10 +389,12 @@ class TestSyncJira(TestCase):
 
         pipeline.sync_jira()
 
-        kwargs = mock_jira.create_issue.call_args
-        self.assertIn("art:fail-count:7", kwargs[1]["labels"])
+        build_call = next(
+            c for c in mock_jira.create_issue.call_args_list if "build failure" in c[1]["summary"].lower()
+        )
+        self.assertIn("art:fail-count:7", build_call[1]["labels"])
 
-    def test_updates_existing_ticket(self):
+    def test_updates_existing_build_ticket(self):
         pipeline = self._make_pipeline()
         pipeline.report = [
             _make_concern("ironic", "openshift-5.0", ConcernCode.FAILING_AT_LEAST_FOR.value),
@@ -352,7 +411,6 @@ class TestSyncJira(TestCase):
         pipeline.sync_jira()
 
         mock_jira.create_issue.assert_not_called()
-        mock_jira.close_task.assert_not_called()
         existing_ticket.update.assert_called_once()
         updated_fields = existing_ticket.update.call_args[1]["fields"]
         updated_labels = updated_fields["labels"]
@@ -385,9 +443,8 @@ class TestSyncJira(TestCase):
         self.assertIn("art:image-build-failure", updated_labels)
         self.assertIn("ironic-1.0-1", updated_fields["description"])
 
-    def test_closes_resolved_ticket(self):
+    def test_closes_resolved_build_ticket(self):
         pipeline = self._make_pipeline()
-        # Report only has a success — no failures
         pipeline.report = [
             _make_concern("ironic", "openshift-5.0", ConcernCode.LATEST_BUILD_SUCCEEDED.value),
         ]
@@ -402,15 +459,13 @@ class TestSyncJira(TestCase):
 
         pipeline.sync_jira()
 
-        mock_jira.create_issue.assert_not_called()
-        mock_jira.close_task.assert_called_once_with("ART-50")
+        mock_jira.close_task.assert_called_with("ART-50")
 
     def test_skips_close_for_unscanned_version(self):
         pipeline = self._make_pipeline()
         pipeline.scanned_versions = ["5.0"]
         pipeline.report = []
 
-        # Ticket for a version we did NOT scan
         ticket_4_18 = _make_ticket(
             "ART-60",
             ["art:image-build-failure", "art:package:ironic", "art:group:openshift-4.18"],
@@ -439,6 +494,76 @@ class TestSyncJira(TestCase):
 
         mock_jira.close_task.assert_not_called()
 
+    def test_creates_ticket_for_ec_failure(self):
+        pipeline = self._make_pipeline()
+        pipeline.report = []
+        pipeline.ec_failures = {
+            '5.0': {
+                'ec-image': {
+                    'failure_count': 4,
+                    'jenkins_url': 'http://j/1',
+                    'nvr': 'ec-image-1.0-1',
+                    'ec_pipeline_url': 'http://ec/1',
+                },
+            },
+        }
+
+        mock_jira = MagicMock()
+        mock_jira.search_issues.return_value = []
+        mock_jira.create_issue.return_value = MagicMock(key="ART-200")
+        pipeline.runtime.new_jira_client.return_value = mock_jira
+
+        pipeline.sync_jira()
+
+        ec_call = next(c for c in mock_jira.create_issue.call_args_list if "EC verification failure" in c[1]["summary"])
+        self.assertIn("art:image-ec-failure", ec_call[1]["labels"])
+        self.assertIn("art:package:ec-image", ec_call[1]["labels"])
+        self.assertIn("art:fail-count:4", ec_call[1]["labels"])
+        self.assertIn("EC pipeline", ec_call[1]["description"])
+
+    def test_creates_ticket_for_release_failure(self):
+        pipeline = self._make_pipeline()
+        pipeline.report = []
+        pipeline.release_failures = {
+            '5.0': {
+                'ose-base': {
+                    'failure_count': 2,
+                    'jenkins_url': 'http://j/1',
+                    'nvr': 'ose-base-1.0-1',
+                },
+            },
+        }
+
+        mock_jira = MagicMock()
+        mock_jira.search_issues.return_value = []
+        mock_jira.create_issue.return_value = MagicMock(key="ART-300")
+        pipeline.runtime.new_jira_client.return_value = mock_jira
+
+        pipeline.sync_jira()
+
+        release_call = next(
+            c for c in mock_jira.create_issue.call_args_list if "release to authz failure" in c[1]["summary"].lower()
+        )
+        self.assertIn("art:image-release-failure", release_call[1]["labels"])
+        self.assertIn("art:package:ose-base", release_call[1]["labels"])
+
+    def test_closes_resolved_ec_ticket(self):
+        pipeline = self._make_pipeline()
+        pipeline.report = []
+        pipeline.ec_failures = {'5.0': {}}
+
+        stale_ticket = _make_ticket(
+            "ART-201",
+            ["art:image-ec-failure", "art:package:ec-image", "art:group:openshift-5.0"],
+        )
+        mock_jira = MagicMock()
+        mock_jira.search_issues.return_value = [stale_ticket]
+        pipeline.runtime.new_jira_client.return_value = mock_jira
+
+        pipeline.sync_jira()
+
+        mock_jira.close_task.assert_called_with("ART-201")
+
     def test_fetches_all_pages(self):
         pipeline = self._make_pipeline()
         pipeline.report = []
@@ -449,17 +574,16 @@ class TestSyncJira(TestCase):
 
         pipeline.sync_jira()
 
-        mock_jira.search_issues.assert_called_once()
-        _, kwargs = mock_jira.search_issues.call_args
-        self.assertFalse(kwargs.get("maxResults", True))
+        # sync_jira now calls search_issues 3 times (build, ec, release)
+        self.assertEqual(mock_jira.search_issues.call_count, 3)
+        for call in mock_jira.search_issues.call_args_list:
+            _, kwargs = call
+            self.assertFalse(kwargs.get("maxResults", True))
 
 
 class TestSyncJiraIntegration(IsolatedAsyncioTestCase):
     def _make_pipeline(self, assembly="stream"):
-        runtime = MagicMock()
-        runtime.working_dir = MagicMock()
-        runtime.logger = MagicMock()
-        runtime.new_slack_client.return_value = MagicMock()
+        runtime = _make_runtime()
         pipeline = ImagesHealthPipeline(
             runtime=runtime,
             versions="5.0",
@@ -476,7 +600,9 @@ class TestSyncJiraIntegration(IsolatedAsyncioTestCase):
 
     @patch.object(ImagesHealthPipeline, "get_report", new_callable=AsyncMock)
     @patch.object(ImagesHealthPipeline, "get_rebase_failures", new_callable=AsyncMock)
-    async def test_skips_jira_sync_for_non_stream_assembly(self, _mock_rebase, _mock_report):
+    @patch.object(ImagesHealthPipeline, "get_ec_failures", new_callable=AsyncMock)
+    @patch.object(ImagesHealthPipeline, "get_release_failures", new_callable=AsyncMock)
+    async def test_skips_jira_sync_for_non_stream_assembly(self, _mock_release, _mock_ec, _mock_rebase, _mock_report):
         pipeline = self._make_pipeline(assembly="4.18.5")
         pipeline.report = [
             _make_concern("ironic", "openshift-5.0", ConcernCode.FAILING_AT_LEAST_FOR.value),
@@ -491,7 +617,9 @@ class TestSyncJiraIntegration(IsolatedAsyncioTestCase):
 
     @patch.object(ImagesHealthPipeline, "get_report", new_callable=AsyncMock)
     @patch.object(ImagesHealthPipeline, "get_rebase_failures", new_callable=AsyncMock)
-    async def test_jira_failure_does_not_block_notifications(self, _mock_rebase, _mock_report):
+    @patch.object(ImagesHealthPipeline, "get_ec_failures", new_callable=AsyncMock)
+    @patch.object(ImagesHealthPipeline, "get_release_failures", new_callable=AsyncMock)
+    async def test_jira_failure_does_not_block_notifications(self, _mock_release, _mock_ec, _mock_rebase, _mock_report):
         pipeline = self._make_pipeline()
         pipeline.report = []
         pipeline.send_to_release_channel = True
@@ -508,3 +636,46 @@ class TestSyncJiraIntegration(IsolatedAsyncioTestCase):
         await pipeline.run()
 
         mock_slack.say.assert_called()
+
+
+class TestGroupFailuresByImage(TestCase):
+    def test_groups_across_versions(self):
+        failures_by_version = {
+            '4.18': {
+                'img-a': {'failure_count': 3, 'jenkins_url': 'http://j/1', 'build_system': 'konflux'},
+            },
+            '4.19': {
+                'img-a': {'failure_count': 1, 'jenkins_url': 'http://j/2', 'build_system': 'konflux'},
+                'img-b': {'failure_count': 2, 'jenkins_url': 'http://j/3', 'build_system': 'brew'},
+            },
+        }
+
+        result = ImagesHealthPipeline._group_failures_by_image(failures_by_version)
+
+        self.assertEqual(len(result['img-a']), 2)
+        self.assertEqual(len(result['img-b']), 1)
+        self.assertEqual(result['img-a'][0]['version'], '4.18')
+        self.assertEqual(result['img-a'][1]['version'], '4.19')
+
+    def test_empty_input(self):
+        result = ImagesHealthPipeline._group_failures_by_image({})
+        self.assertEqual(result, {})
+
+
+class TestRedisFailuresToJiraDict(TestCase):
+    def test_converts_version_keyed_to_tuple_keyed(self):
+        failures = {
+            '4.18': {
+                'img-a': {'failure_count': 3, 'jenkins_url': 'http://j/1'},
+            },
+            '4.19': {
+                'img-b': {'failure_count': 1, 'jenkins_url': 'http://j/2'},
+            },
+        }
+
+        result = ImagesHealthPipeline._redis_failures_to_jira_dict(failures)
+
+        self.assertIn(('img-a', 'openshift-4.18'), result)
+        self.assertIn(('img-b', 'openshift-4.19'), result)
+        self.assertEqual(result[('img-a', 'openshift-4.18')]['image_name'], 'img-a')
+        self.assertEqual(result[('img-a', 'openshift-4.18')]['group'], 'openshift-4.18')


### PR DESCRIPTION
Instead of reporting all image failures as generic "build issues", the report now groups them by failure type: build failures, EC verification failures, release-to-authz failures, and rebase failures.

The public channel notification groups by failure type first, then lists affected components within each type section.


## Testing
- https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/dpaolell/job/images-health/46/
- https://redhat-internal.slack.com/archives/CB95J6R4N/p1780322560993979