### PR TITLE
ART-19367: Refactor failure tracking: pipeline_url and full group names

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -141,6 +141,8 @@ class KonfluxImageBuilder:
             "has_olm_bundle": 1 if metadata.is_olm_operator else 0,
             "ec_failed": "false",
             "ec_pipeline_url": "",
+            "build_pipeline_url": "",
+            "release_pipeline": "",
             "base_image_release_failed": "false",
         }
         try:
@@ -249,6 +251,7 @@ class KonfluxImageBuilder:
                 pipelinerun_name = pipelinerun_info.name
                 record["task_id"] = pipelinerun_name
                 record["task_url"] = self._konflux_client.resource_url(pipelinerun_info.to_dict())
+                record["build_pipeline_url"] = record["task_url"]  # Store build pipeline URL for failure tracking
                 await self.update_konflux_db(
                     metadata,
                     build_repo,
@@ -377,6 +380,7 @@ class KonfluxImageBuilder:
                         )
                         if release_result:
                             logger.info("Base image release succeeded for %s, persisting build record", nvr)
+                            record["release_pipeline"] = release_result.release_pipeline
                         else:
                             logger.error(
                                 "Base image release failed for %s, persisting build record as %s",
@@ -384,6 +388,8 @@ class KonfluxImageBuilder:
                                 KonfluxBuildOutcome.RELEASE_ERROR,
                             )
                             record["base_image_release_failed"] = "true"
+                            if release_result and release_result.release_pipeline:
+                                record["release_pipeline"] = release_result.release_pipeline
                         outcome = KonfluxBuildOutcome.SUCCESS if release_result else KonfluxBuildOutcome.RELEASE_ERROR
 
                     build_record = await self.update_konflux_db(

--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -49,8 +49,8 @@ class ImagesHealthPipeline:
         self.slack_client = self.runtime.new_slack_client()
         self.scanned_versions = []
         self.rebase_failures = {}  # version -> {image: {failure_count, url, build_system}}
-        self.ec_failures = {}  # version -> {image: {failure_count, jenkins_url, nvr, ec_pipeline_url, ...}}
-        self.release_failures = {}  # version -> {image: {failure_count, jenkins_url, nvr, ...}}
+        self.ec_failures = {}  # version -> {image: {failure_count, jenkins_url, nvr, pipeline_url, ...}}
+        self.release_failures = {}  # version -> {image: {failure_count, jenkins_url, nvr, pipeline_url, ...}}
         self.jira_tickets: dict[tuple[str, str], str] = {}  # (image_name, group) -> ticket key
         self._valid_images_cache: dict[str, set[str]] = {}
 
@@ -158,8 +158,9 @@ class ImagesHealthPipeline:
             version (str): OCP version (e.g., "4.18")
         """
         # Fetch all rebase failures from Redis
+        group = f'openshift-{version}'
         all_failures = await util.get_rebase_failures(
-            version=version,
+            group=group,
             branches=['rebase-failure'],
             build_systems=['brew', 'konflux'],
             logger=self.runtime.logger,
@@ -527,9 +528,9 @@ class ImagesHealthPipeline:
         )
         if jenkins_url:
             description += f"*Last failure job:* {jenkins_url}\n"
-        ec_pipeline_url = failure_data.get('ec_pipeline_url', '')
-        if ec_pipeline_url:
-            description += f"*EC pipeline:* {ec_pipeline_url}\n"
+        pipeline_url = failure_data.get('pipeline_url', '')
+        if pipeline_url:
+            description += f"*Pipeline:* {pipeline_url}\n"
         return description
 
     def _jira_link(self, concern: dict) -> str:
@@ -592,9 +593,9 @@ class ImagesHealthPipeline:
             report += f'*EC Verification Failures ({len(ec_failures)}):*\n'
             for image_name, failure_info in sorted(ec_failures.items()):
                 report += self._format_redis_failure_line(image_name, failure_info)
-                ec_url = failure_info.get('ec_pipeline_url', '')
-                if ec_url:
-                    report += f' | {self.url_text(ec_url, "EC pipeline")}'
+                pipeline_url = failure_info.get('pipeline_url', '')
+                if pipeline_url:
+                    report += f' | {self.url_text(pipeline_url, "Pipeline")}'
                 report += '\n'
             report += '\n'
 
@@ -687,9 +688,9 @@ class ImagesHealthPipeline:
                 message += f'\n`{image_name}`:'
                 for failure in failures:
                     line = f'\n  • {self._format_forum_redis_failure_inline(failure)}'
-                    ec_url = failure.get('ec_pipeline_url', '')
-                    if ec_url:
-                        line += f' | {self.url_text(ec_url, "EC pipeline")}'
+                    pipeline_url = failure.get('pipeline_url', '')
+                    if pipeline_url:
+                        line += f' | {self.url_text(pipeline_url, "Pipeline")}'
                     message += line
             await self.slack_client.say(
                 message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False, unfurl_media=False

--- a/pyartcd/pyartcd/pipelines/ocp.py
+++ b/pyartcd/pyartcd/pipelines/ocp.py
@@ -495,13 +495,14 @@ class OcpPipeline:
             ]
         elif self.build_images.lower() == 'only':
             successful_images = [image for image in self.build_plan.images_included if image not in failed_images]
+        group = f'openshift-{self.version}'
         await asyncio.gather(
-            *[reset_fail_counter(f'count:rebase-failure:brew:{self.version}:{image}') for image in successful_images]
+            *[reset_fail_counter(f'count:rebase-failure:brew:{group}:{image}') for image in successful_images]
         )
 
         # Increment fail counters for failing images.
         await asyncio.gather(
-            *[increment_fail_counter(f'count:rebase-failure:brew:{self.version}:{image}') for image in failed_images]
+            *[increment_fail_counter(f'count:rebase-failure:brew:{group}:{image}') for image in failed_images]
         )
 
     def _handle_image_build_failures(self):

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -221,15 +221,16 @@ class KonfluxOcpPipeline:
                 raise ValueError(
                     f"Unknown build strategy: {self.build_plan.image_build_strategy}. Valid strategies: {[s.value for s in BuildStrategy]}"
                 )
+        group = f'openshift-{self.version}'
         await asyncio.gather(
-            *[reset_fail_counter(f'count:rebase-failure:konflux:{self.version}:{image}') for image in successful_images]
+            *[reset_fail_counter(f'count:rebase-failure:konflux:{group}:{image}') for image in successful_images]
         )
 
         # Increment fail counters only for images that failed rebase directly
         job_url = os.getenv('BUILD_URL')
         await asyncio.gather(
             *[
-                increment_fail_counter(f'count:rebase-failure:konflux:{self.version}:{image}', jenkins_url=job_url)
+                increment_fail_counter(f'count:rebase-failure:konflux:{group}:{image}', jenkins_url=job_url)
                 for image in failed_images
             ]
         )
@@ -298,6 +299,7 @@ class KonfluxOcpPipeline:
                     f'count:build-failure:konflux:{group}:{image}',
                     jenkins_url=job_url,
                     nvr=failed_entries.get(image, {}).get('nvrs'),
+                    pipeline_url=failed_entries.get(image, {}).get('build_pipeline_url'),
                 )
                 for image in build_failed_images
             ],
@@ -306,7 +308,7 @@ class KonfluxOcpPipeline:
                     f'count:ec-failure:konflux:{group}:{image}',
                     jenkins_url=job_url,
                     nvr=failed_entries.get(image, {}).get('nvrs'),
-                    ec_pipeline_url=failed_entries.get(image, {}).get('ec_pipeline_url'),
+                    pipeline_url=failed_entries.get(image, {}).get('ec_pipeline_url'),
                 )
                 for image in ec_failed_images
             ],
@@ -315,6 +317,7 @@ class KonfluxOcpPipeline:
                     f'count:release-failure:konflux:{group}:{image}',
                     jenkins_url=job_url,
                     nvr=failed_entries.get(image, {}).get('nvrs'),
+                    pipeline_url=failed_entries.get(image, {}).get('release_pipeline'),
                 )
                 for image in release_failed_images
             ],

--- a/pyartcd/pyartcd/pipelines/okd.py
+++ b/pyartcd/pyartcd/pipelines/okd.py
@@ -309,18 +309,16 @@ class KonfluxOkdPipeline:
                     f"Unknown build strategy: {self.build_plan.image_build_strategy}. Valid strategies: {[s.value for s in BuildStrategy]}"
                 )
 
+        group = f'okd-{self.version}'
         await asyncio.gather(
-            *[
-                reset_fail_counter(f'count:okd-rebase-failure:konflux:{self.version}:{image}')
-                for image in successful_images
-            ]
+            *[reset_fail_counter(f'count:okd-rebase-failure:konflux:{group}:{image}') for image in successful_images]
         )
 
         # Increment fail counters for failing images
         job_url = os.getenv('BUILD_URL')
         await asyncio.gather(
             *[
-                increment_fail_counter(f'count:okd-rebase-failure:konflux:{self.version}:{image}', jenkins_url=job_url)
+                increment_fail_counter(f'count:okd-rebase-failure:konflux:{group}:{image}', jenkins_url=job_url)
                 for image in failed_images
             ]
         )

--- a/pyartcd/pyartcd/pipelines/okd.py
+++ b/pyartcd/pyartcd/pipelines/okd.py
@@ -311,14 +311,14 @@ class KonfluxOkdPipeline:
 
         group = f'okd-{self.version}'
         await asyncio.gather(
-            *[reset_fail_counter(f'count:okd-rebase-failure:konflux:{group}:{image}') for image in successful_images]
+            *[reset_fail_counter(f'count:rebase-failure:konflux:{group}:{image}') for image in successful_images]
         )
 
         # Increment fail counters for failing images
         job_url = os.getenv('BUILD_URL')
         await asyncio.gather(
             *[
-                increment_fail_counter(f'count:okd-rebase-failure:konflux:{group}:{image}', jenkins_url=job_url)
+                increment_fail_counter(f'count:rebase-failure:konflux:{group}:{image}', jenkins_url=job_url)
                 for image in failed_images
             ]
         )

--- a/pyartcd/pyartcd/pipelines/okd_images_health.py
+++ b/pyartcd/pyartcd/pipelines/okd_images_health.py
@@ -131,8 +131,9 @@ class ImagesHealthPipeline:
             version (str): OKD version (e.g., "4.21")
         """
         # Fetch all rebase failures from Redis
+        group = f'okd-{version}'
         all_failures = await util.get_rebase_failures(
-            version=version,
+            group=group,
             branches=['okd-rebase-failure'],
             build_systems=['konflux'],
             logger=self.runtime.logger,

--- a/pyartcd/pyartcd/pipelines/okd_images_health.py
+++ b/pyartcd/pyartcd/pipelines/okd_images_health.py
@@ -134,7 +134,7 @@ class ImagesHealthPipeline:
         group = f'okd-{version}'
         all_failures = await util.get_rebase_failures(
             group=group,
-            branches=['okd-rebase-failure'],
+            branches=['rebase-failure'],
             build_systems=['konflux'],
             logger=self.runtime.logger,
         )

--- a/pyartcd/pyartcd/pipelines/seed_lockfile.py
+++ b/pyartcd/pyartcd/pipelines/seed_lockfile.py
@@ -228,8 +228,9 @@ class SeedLockfilePipeline:
             return
 
         LOGGER.info('Resetting rebase-fail counters for solved images: %s', ', '.join(solved))
+        group = f'openshift-{self.version}'
         results = await asyncio.gather(
-            *[reset_fail_counter(f'count:rebase-failure:konflux:{self.version}:{image}') for image in solved],
+            *[reset_fail_counter(f'count:rebase-failure:konflux:{group}:{image}') for image in solved],
             return_exceptions=True,
         )
         for image, result in zip(solved, results):

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -1061,9 +1061,11 @@ async def get_failures(pattern: str, entity_index: int = -2, logger=None, **cont
         # Get build failures
         await get_failures('count:build-failure:konflux:openshift-4.18:*:failure', build_system='konflux')
 
-        # Get rebase failures for multiple patterns
-        for branch in ['rebase-failure', 'okd-rebase-failure']:
-            await get_failures(f'count:{branch}:konflux:4.18:*:failure', branch=branch, build_system='konflux')
+        # Get rebase failures for OCP
+        await get_failures('count:rebase-failure:konflux:openshift-4.18:*:failure', branch='rebase-failure', build_system='konflux')
+
+        # Get rebase failures for OKD
+        await get_failures('count:rebase-failure:konflux:okd-4.18:*:failure', branch='rebase-failure', build_system='konflux')
     """
     failures = {}
 
@@ -1143,7 +1145,7 @@ async def get_rebase_failures(group: str, branches: list[str], build_systems: li
 
     Arg(s):
         group (str): Group name (e.g., "openshift-4.18", "okd-4.18")
-        branches (list[str]): Branch identifiers (e.g., ['rebase-failure'] or ['okd-rebase-failure'])
+        branches (list[str]): Branch identifiers (e.g., ['rebase-failure'])
         build_systems (list[str]): Build systems to check (e.g., ['brew', 'konflux'])
         logger (Logger): Optional logger for debugging
     Return Value(s):

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -1136,13 +1136,13 @@ async def get_failures(pattern: str, entity_index: int = -2, logger=None, **cont
     return failures
 
 
-async def get_rebase_failures(version: str, branches: list[str], build_systems: list[str], logger=None):
+async def get_rebase_failures(group: str, branches: list[str], build_systems: list[str], logger=None):
     """
-    Fetch rebase failure data from Redis for a specific version.
+    Fetch rebase failure data from Redis for a specific group.
     Checks multiple branch patterns and build systems.
 
     Arg(s):
-        version (str): Version (e.g., "4.18")
+        group (str): Group name (e.g., "openshift-4.18", "okd-4.18")
         branches (list[str]): Branch identifiers (e.g., ['rebase-failure'] or ['okd-rebase-failure'])
         build_systems (list[str]): Build systems to check (e.g., ['brew', 'konflux'])
         logger (Logger): Optional logger for debugging
@@ -1153,7 +1153,7 @@ async def get_rebase_failures(version: str, branches: list[str], build_systems: 
 
     for branch in branches:
         for build_system in build_systems:
-            pattern = f'count:{branch}:{build_system}:{version}:*:failure'
+            pattern = f'count:{branch}:{build_system}:{group}:*:failure'
             failures = await get_failures(
                 pattern, entity_index=-2, logger=logger, build_system=build_system, branch=branch
             )

--- a/pyartcd/tests/pipelines/test_images_health.py
+++ b/pyartcd/tests/pipelines/test_images_health.py
@@ -96,9 +96,7 @@ class TestNotifyPublicChannel(IsolatedAsyncioTestCase):
             _make_concern("build-fail", "openshift-4.22", ConcernCode.FAILING_AT_LEAST_FOR.value),
         ]
         pipeline.ec_failures = {
-            '4.22': {
-                'ec-fail-image': {'failure_count': 3, 'jenkins_url': 'http://j/1', 'ec_pipeline_url': 'http://ec/1'}
-            },
+            '4.22': {'ec-fail-image': {'failure_count': 3, 'jenkins_url': 'http://j/1', 'pipeline_url': 'http://ec/1'}},
         }
         pipeline.release_failures = {
             '4.22': {'release-fail-image': {'failure_count': 2, 'jenkins_url': 'http://j/2'}},
@@ -151,7 +149,7 @@ class TestNotifyPublicChannel(IsolatedAsyncioTestCase):
         pipeline = _make_pipeline(self.mock_runtime, public_channel="#forum-ocp-art")
         pipeline.report = []
         pipeline.ec_failures = {
-            '4.22': {'image-a': {'failure_count': 5, 'jenkins_url': '', 'ec_pipeline_url': 'http://ec/1'}},
+            '4.22': {'image-a': {'failure_count': 5, 'jenkins_url': '', 'pipeline_url': 'http://ec/1'}},
         }
         mock_slack_client.say.return_value = {"ts": ""}
 
@@ -189,7 +187,7 @@ class TestNotifyReleaseChannel(IsolatedAsyncioTestCase):
             _make_concern("build-fail-2", "openshift-4.18", ConcernCode.FAILING_AT_LEAST_FOR.value),
         ]
         pipeline.ec_failures = {
-            '4.18': {'ec-img': {'failure_count': 3, 'jenkins_url': 'http://j/1', 'ec_pipeline_url': 'http://ec/1'}},
+            '4.18': {'ec-img': {'failure_count': 3, 'jenkins_url': 'http://j/1', 'pipeline_url': 'http://ec/1'}},
         }
         pipeline.release_failures = {
             '4.18': {'rel-img': {'failure_count': 1, 'jenkins_url': 'http://j/2'}},
@@ -294,7 +292,7 @@ class TestGetTypedFailures(IsolatedAsyncioTestCase):
     @patch("pyartcd.pipelines.images_health.util.get_counter_failures", new_callable=AsyncMock)
     async def test_ec_failures_filtered_by_valid_images(self, mock_get_failures):
         mock_get_failures.return_value = {
-            'valid-image': {'failure_count': 3, 'jenkins_url': 'http://j/1', 'ec_pipeline_url': 'http://ec/1'},
+            'valid-image': {'failure_count': 3, 'jenkins_url': 'http://j/1', 'pipeline_url': 'http://ec/1'},
             'invalid-image': {'failure_count': 1, 'jenkins_url': 'http://j/2'},
         }
         runtime = _make_runtime()
@@ -503,7 +501,7 @@ class TestSyncJira(TestCase):
                     'failure_count': 4,
                     'jenkins_url': 'http://j/1',
                     'nvr': 'ec-image-1.0-1',
-                    'ec_pipeline_url': 'http://ec/1',
+                    'pipeline_url': 'http://ec/1',
                 },
             },
         }
@@ -519,7 +517,7 @@ class TestSyncJira(TestCase):
         self.assertIn("art:image-ec-failure", ec_call[1]["labels"])
         self.assertIn("art:package:ec-image", ec_call[1]["labels"])
         self.assertIn("art:fail-count:4", ec_call[1]["labels"])
-        self.assertIn("EC pipeline", ec_call[1]["description"])
+        self.assertIn("Pipeline:", ec_call[1]["description"])
 
     def test_creates_ticket_for_release_failure(self):
         pipeline = self._make_pipeline()

--- a/pyartcd/tests/pipelines/test_ocp.py
+++ b/pyartcd/tests/pipelines/test_ocp.py
@@ -1058,6 +1058,8 @@ class TestKonfluxOcpPipelineBuildFailCounters(unittest.IsolatedAsyncioTestCase):
                     'nvrs': 'ironic-1.0-1',
                     'ec_failed': 'true',
                     'ec_pipeline_url': 'http://its/plr/1',
+                    'build_pipeline_url': 'http://build/plr/1',
+                    'release_pipeline': '',
                     'base_image_release_failed': 'false',
                 },
             ]
@@ -1068,9 +1070,9 @@ class TestKonfluxOcpPipelineBuildFailCounters(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(incr_branches), 1)
         self.assertIn('count:ec-failure:konflux:openshift-4.18:ironic', incr_branches[0])
 
-        # Verify ec_pipeline_url is passed as metadata
+        # Verify pipeline_url is passed as metadata
         incr_kwargs = mock_incr.call_args_list[0].kwargs
-        self.assertEqual(incr_kwargs['ec_pipeline_url'], 'http://its/plr/1')
+        self.assertEqual(incr_kwargs['pipeline_url'], 'http://its/plr/1')
 
     @patch('pyartcd.pipelines.ocp4_konflux.increment_fail_counter', new_callable=AsyncMock)
     @patch('pyartcd.pipelines.ocp4_konflux.reset_fail_counter', new_callable=AsyncMock)
@@ -1085,6 +1087,8 @@ class TestKonfluxOcpPipelineBuildFailCounters(unittest.IsolatedAsyncioTestCase):
                     'nvrs': 'ose-base-1.0-1',
                     'ec_failed': 'false',
                     'ec_pipeline_url': '',
+                    'build_pipeline_url': 'http://build/plr/2',
+                    'release_pipeline': 'http://release/plr/1',
                     'base_image_release_failed': 'true',
                 },
             ]
@@ -1108,6 +1112,8 @@ class TestKonfluxOcpPipelineBuildFailCounters(unittest.IsolatedAsyncioTestCase):
                     'nvrs': 'ceo-1.0-1',
                     'ec_failed': 'false',
                     'ec_pipeline_url': '',
+                    'build_pipeline_url': 'http://build/plr/3',
+                    'release_pipeline': '',
                     'base_image_release_failed': 'false',
                 },
             ]
@@ -1131,6 +1137,8 @@ class TestKonfluxOcpPipelineBuildFailCounters(unittest.IsolatedAsyncioTestCase):
                     'nvrs': 'ironic-1.0-1',
                     'ec_failed': 'true',
                     'ec_pipeline_url': 'http://its/1',
+                    'build_pipeline_url': 'http://build/plr/4',
+                    'release_pipeline': '',
                     'base_image_release_failed': 'false',
                 },
                 {
@@ -1139,6 +1147,8 @@ class TestKonfluxOcpPipelineBuildFailCounters(unittest.IsolatedAsyncioTestCase):
                     'nvrs': 'ose-base-1.0-1',
                     'ec_failed': 'false',
                     'ec_pipeline_url': '',
+                    'build_pipeline_url': 'http://build/plr/2',
+                    'release_pipeline': 'http://release/plr/1',
                     'base_image_release_failed': 'true',
                 },
                 {
@@ -1147,6 +1157,8 @@ class TestKonfluxOcpPipelineBuildFailCounters(unittest.IsolatedAsyncioTestCase):
                     'nvrs': 'ceo-1.0-1',
                     'ec_failed': 'false',
                     'ec_pipeline_url': '',
+                    'build_pipeline_url': 'http://build/plr/5',
+                    'release_pipeline': '',
                     'base_image_release_failed': 'false',
                 },
             ]
@@ -1172,6 +1184,8 @@ class TestKonfluxOcpPipelineBuildFailCounters(unittest.IsolatedAsyncioTestCase):
                     'nvrs': 'ironic-1.0-1',
                     'ec_failed': 'false',
                     'ec_pipeline_url': '',
+                    'build_pipeline_url': '',
+                    'release_pipeline': '',
                     'base_image_release_failed': 'false',
                 },
             ]
@@ -1241,6 +1255,8 @@ class TestKonfluxOcpPipelineBuildFailCounters(unittest.IsolatedAsyncioTestCase):
                     'nvrs': 'ironic-1.0-1',
                     'ec_failed': 'true',
                     'ec_pipeline_url': 'http://its/1',
+                    'build_pipeline_url': 'http://build/plr/4',
+                    'release_pipeline': '',
                     'base_image_release_failed': 'false',
                 },
             ]

--- a/pyartcd/tests/pipelines/test_seed_lockfile.py
+++ b/pyartcd/tests/pipelines/test_seed_lockfile.py
@@ -443,7 +443,7 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
         with patch.object(pipeline, '_extract_stream_results_from_record_log', side_effect=populate_stream_results):
             await pipeline.run()
 
-        mock_reset.assert_awaited_once_with('count:rebase-failure:konflux:4.22:ironic')
+        mock_reset.assert_awaited_once_with('count:rebase-failure:konflux:openshift-4.22:ironic')
 
     @patch('pyartcd.pipelines.seed_lockfile.reset_fail_counter', new_callable=AsyncMock)
     @patch('pyartcd.pipelines.seed_lockfile.jenkins.init_jenkins')
@@ -527,7 +527,7 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
             # Should not raise despite Redis error
             await pipeline.run()
 
-        mock_reset.assert_awaited_once_with('count:rebase-failure:konflux:4.22:ironic')
+        mock_reset.assert_awaited_once_with('count:rebase-failure:konflux:openshift-4.22:ironic')
 
     def test_init_stores_jira_key(self):
         pipeline = self._create_pipeline(jira_key='ART-12345')

--- a/pyartcd/tests/test_util.py
+++ b/pyartcd/tests/test_util.py
@@ -308,7 +308,7 @@ class TestUtil(IsolatedAsyncioTestCase):
                 return [
                     'count:ec-failure:konflux:openshift-4.21:ironic:failure',
                     'count:ec-failure:konflux:openshift-4.21:ironic:jenkins_url',
-                    'count:ec-failure:konflux:openshift-4.21:ironic:ec_pipeline_url',
+                    'count:ec-failure:konflux:openshift-4.21:ironic:pipeline_url',
                 ]
             return []
 
@@ -316,12 +316,12 @@ class TestUtil(IsolatedAsyncioTestCase):
         mock_get_value.side_effect = lambda key: {
             'count:ec-failure:konflux:openshift-4.21:ironic:failure': '3',
             'count:ec-failure:konflux:openshift-4.21:ironic:jenkins_url': 'http://j/1',
-            'count:ec-failure:konflux:openshift-4.21:ironic:ec_pipeline_url': 'http://its/plr/1',
+            'count:ec-failure:konflux:openshift-4.21:ironic:pipeline_url': 'http://its/plr/1',
         }.get(key)
         result = await util.get_counter_failures('ec-failure', 'openshift-4.21')
         self.assertEqual(result['ironic']['failure_count'], 3)
         self.assertEqual(result['ironic']['jenkins_url'], 'http://j/1')
-        self.assertEqual(result['ironic']['ec_pipeline_url'], 'http://its/plr/1')
+        self.assertEqual(result['ironic']['pipeline_url'], 'http://its/plr/1')
 
     @patch("artcommonlib.redis.get_value", new_callable=AsyncMock)
     @patch("artcommonlib.redis.get_keys", new_callable=AsyncMock)


### PR DESCRIPTION
## Summary

This PR makes two related improvements to failure tracking in Redis:

1. **Standardize pipeline URL storage** - Replace `ec_pipeline_url` with a generic `pipeline_url` field
2. **Use full group names in rebase counters** - Change from version-only (e.g., `4.18`) to full group names (e.g., `openshift-4.18`, `okd-4.18`)

## Changes

### 1. Pipeline URL Standardization

**Problem**: Different failure types stored pipeline URLs inconsistently, and only EC failures had a dedicated pipeline URL field in Redis.

**Solution**: 
- Introduce a generic `pipeline_url` field in Redis for all failure types
- Build failures: store `build_pipeline_url` as `pipeline_url`
- EC failures: store `ec_pipeline_url` as `pipeline_url`
- Release failures: store `release_pipeline` as `pipeline_url`
- Rebase failures: keep `jenkins_url` only (no pipeline_url needed per requirements)

**Benefits**:
- Consistent naming across all failure types
- Clear separation between Jenkins job URL (`jenkins_url`) and Konflux/pipeline URL (`pipeline_url`)
- Easier for images-health reports to display relevant pipeline links

### 2. Full Group Names in Rebase Failure Counters

**Problem**: Rebase failure counters used just the version (e.g., `4.18`) instead of the full group name, making it unclear which pipeline should handle these failures.

**Before**:
```
count:rebase-failure:konflux:4.18:ironic
count:okd-rebase-failure:konflux:4.21:ironic
```

**After**:
```
count:rebase-failure:konflux:openshift-4.18:ironic
count:okd-rebase-failure:konflux:okd-4.21:ironic
```

**Benefits**:
- Consistent with build/EC/release failure patterns
- Clear ownership: `images-health` handles `openshift-*`, `okd-images-health` handles `okd-*`
- Easier to query and filter failures by group
