### PR TITLE
Fix cross-major version comparison in images:streams prs

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -1162,7 +1162,7 @@ def images_streams_prs(
         exit(0)
 
     master_major, master_minor = extract_version_fields(what_is_in_master(), at_least=2)
-    if not ignore_ci_master and (major > master_major or minor > master_minor):
+    if not ignore_ci_master and (major, minor) > (master_major, master_minor):
         # ART building a release before it is in master. Too early to open PRs.
         runtime.logger.warning(
             f'Target {major}.{minor} has not been in master yet (it is tracking {master_major}.{master_minor}); skipping PRs'

--- a/doozer/tests/cli/test_images_streams.py
+++ b/doozer/tests/cli/test_images_streams.py
@@ -298,3 +298,49 @@ def test_gen_buildconfigs_uses_get_upstreaming_entries():
     assert 'config.transform' in source
     assert 'config.upstream_image' in source
     assert 'config.upstream_image_base' in source
+
+
+# Tests for master version comparison in images_streams_prs
+
+
+@pytest.mark.parametrize(
+    "target, master, expect_ahead",
+    [
+        # Same major, target ahead in minor — target is ahead
+        ((4, 18), (4, 17), True),
+        # Higher major — target is ahead
+        ((5, 0), (4, 17), True),
+        # Equal — target is not ahead
+        ((4, 17), (4, 17), False),
+        # Same major, target behind — target is not ahead
+        ((4, 16), (4, 17), False),
+        # Bug case: target has higher minor but lower major — target is NOT ahead
+        ((4, 23), (5, 0), False),
+        # Another cross-major case
+        ((4, 99), (5, 0), False),
+        # Next major with minor 0 vs high minor — target is ahead
+        ((5, 0), (4, 23), True),
+    ],
+    ids=[
+        "same-major-ahead",
+        "higher-major",
+        "equal",
+        "same-major-behind",
+        "cross-major-4.23-vs-5.0",
+        "cross-major-4.99-vs-5.0",
+        "next-major-5.0-vs-4.23",
+    ],
+)
+def test_master_version_comparison(target, master, expect_ahead):
+    """Regression test for the version comparison that decides whether to skip PRs.
+
+    Previously the check used ``major > master_major or minor > master_minor``
+    which incorrectly skipped e.g. 4.23 when master was 5.0 (because 23 > 0).
+    The fix uses tuple comparison: ``(major, minor) > (master_major, master_minor)``.
+    """
+    major, minor = target
+    master_major, master_minor = master
+
+    # This is the exact comparison from images_streams.py:1170
+    target_is_ahead = (major, minor) > (master_major, master_minor)
+    assert target_is_ahead == expect_ahead

--- a/doozer/tests/cli/test_images_streams.py
+++ b/doozer/tests/cli/test_images_streams.py
@@ -320,6 +320,10 @@ def test_gen_buildconfigs_uses_get_upstreaming_entries():
         ((4, 99), (5, 0), False),
         # Next major with minor 0 vs high minor — target is ahead
         ((5, 0), (4, 23), True),
+        # Same new major, target ahead — target is ahead
+        ((5, 2), (5, 1), True),
+        # Same new major, target behind — target is not ahead
+        ((5, 1), (5, 2), False),
     ],
     ids=[
         "same-major-ahead",
@@ -329,6 +333,8 @@ def test_gen_buildconfigs_uses_get_upstreaming_entries():
         "cross-major-4.23-vs-5.0",
         "cross-major-4.99-vs-5.0",
         "next-major-5.0-vs-4.23",
+        "same-major-5.2-vs-5.1",
+        "same-major-5.1-vs-5.2",
     ],
 )
 def test_master_version_comparison(target, master, expect_ahead):


### PR DESCRIPTION
## Summary
- Fix bug where `major > master_major or minor > master_minor` compared version fields independently, causing e.g. 4.23 to be skipped when master tracked 5.0 (because `23 > 0`)
- Use tuple comparison `(major, minor) > (master_major, master_minor)` which correctly handles cross-major boundaries
- Add parametrized regression test covering 7 cases including the cross-major scenario

## Test plan
- [x] `make format` passes
- [x] `make test` passes (all 2573 tests across all packages)
- [x] New `test_master_version_comparison` covers same-major, cross-major, equal, and behind cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)