### PR TITLE
Fix Jira security level field to use name instead of numeric ID

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -1021,7 +1021,7 @@ This ticket was created by ART pipline run [sync-ci-images|{jenkins_build_url}]
             'components': [{'name': component}],
             'summary': summary,
             'description': description,
-            "security": {"id": "11697"},  # Restrict to Red Hat Employee
+            "security": {"name": "Red Hat Employee"},
         }
 
         if not dry_run:

--- a/doozer/doozerlib/cli/scan_osh.py
+++ b/doozer/doozerlib/cli/scan_osh.py
@@ -494,7 +494,7 @@ class ScanOshCli:
             "issuetype": {"name": "Bug"},
             "versions": [{"name": self.jira_target_version}],  # Affects Version/s
             "components": [{"name": potential_component}],
-            "security": {"id": "11697"},  # Restrict to Red Hat Employee
+            "security": {"name": "Red Hat Employee"},
             "summary": summary,
             "description": description,
             "labels": ["art:sast", f"art:package:{build['package_name']}"],


### PR DESCRIPTION
## Summary
- The hardcoded Jira security level ID `"11697"` is not valid on the Atlassian Cloud instance (`redhat.atlassian.net`), causing `JIRAError HTTP 400: Specify a valid value for Security Level` when creating issues
- Changed `images_streams.py` and `scan_osh.py` to reference the security level by name (`"Red Hat Employee"`) instead of by numeric ID, matching the pattern already used in `find_bugs_kernel_cli.py`

## Test plan
- [ ] Verify `sync-ci-images` pipeline can create Jira issues without the 400 error
- [ ] Verify `scan_osh` Jira issue creation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)