### PR TITLE
scan-sources: detect external image floating tag drift for layered products (ART-19441)

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -1075,7 +1075,7 @@ class ConfigScanSources:
 
         _, org, _ = artcommonlib.util.split_git_url(rebase_repo_url)
         manifests_dir = manifests_dir.strip('/')
-        art_yaml_path = f'{manifests_dir}/art.yaml'
+        art_yaml_path = '/'.join(part for part in (manifests_dir, 'art.yaml') if part)
 
         with tempfile.NamedTemporaryFile(delete=True, suffix='.yaml') as temp_file:
             try:
@@ -1107,13 +1107,13 @@ class ConfigScanSources:
         github_client = get_github_client_for_org(org)
         manifests_dir = manifests_dir.strip('/')
         bundle_dir = bundle_dir.strip('/')
-        bundle_manifests_dir = f'{manifests_dir}/{bundle_dir}' if bundle_dir else manifests_dir
+        bundle_manifests_dir = '/'.join(part for part in (manifests_dir, bundle_dir) if part)
         candidate_paths = [
-            f'{bundle_manifests_dir}/image-references',
-            f'{manifests_dir}/image-references',
+            '/'.join(part for part in (bundle_manifests_dir, 'image-references') if part),
+            '/'.join(part for part in (manifests_dir, 'image-references') if part),
+            '/'.join(part for part in (bundle_dir, 'image-references') if part),
         ]
-        if bundle_dir:
-            candidate_paths.append(f'{bundle_dir}/image-references')
+        candidate_paths = list(dict.fromkeys(candidate_paths))
 
         for ref_path in candidate_paths:
             with tempfile.NamedTemporaryFile(delete=True, suffix='.yaml') as temp_file:

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -1066,8 +1066,15 @@ class ConfigScanSources:
 
     @alru_cache
     async def _fetch_art_yaml_from_rebase(self, rebase_repo_url: str, rebase_commitish: str, manifests_dir: str):
-        """Fetch and parse art.yaml from an operator's rebase commit."""
+        """Fetch and parse art.yaml from an operator's rebase commit.
+
+        Returns the parsed YAML dict, or None if the file does not exist in the repo.
+        Raises on auth/network/parse errors so they surface as scan failures.
+        """
+        from github import UnknownObjectException
+
         _, org, _ = artcommonlib.util.split_git_url(rebase_repo_url)
+        manifests_dir = manifests_dir.strip('/')
         art_yaml_path = f'{manifests_dir}/art.yaml'
 
         with tempfile.NamedTemporaryFile(delete=True, suffix='.yaml') as temp_file:
@@ -1081,7 +1088,7 @@ class ConfigScanSources:
                 )
                 with open(temp_file.name) as f:
                     return yaml.safe_load(f.read())
-            except Exception:
+            except (UnknownObjectException, FileNotFoundError):
                 return None
 
     async def _fetch_image_references_from_rebase(
@@ -1091,15 +1098,22 @@ class ConfigScanSources:
 
         Searches multiple candidate paths (bundle_manifests_dir, manifests_dir, bundle_dir)
         matching the pattern used by _find_image_refs_path in the rebaser.
+        Returns the parsed YAML dict, or None if the file is not found in any candidate path.
+        Raises on auth/network/parse errors so they surface as scan failures.
         """
+        from github import UnknownObjectException
+
         _, org, _ = artcommonlib.util.split_git_url(rebase_repo_url)
         github_client = get_github_client_for_org(org)
-        bundle_manifests_dir = f'{manifests_dir}/{bundle_dir}'
+        manifests_dir = manifests_dir.strip('/')
+        bundle_dir = bundle_dir.strip('/')
+        bundle_manifests_dir = f'{manifests_dir}/{bundle_dir}' if bundle_dir else manifests_dir
         candidate_paths = [
             f'{bundle_manifests_dir}/image-references',
             f'{manifests_dir}/image-references',
-            f'{bundle_dir}/image-references',
         ]
+        if bundle_dir:
+            candidate_paths.append(f'{bundle_dir}/image-references')
 
         for ref_path in candidate_paths:
             with tempfile.NamedTemporaryFile(delete=True, suffix='.yaml') as temp_file:
@@ -1113,7 +1127,7 @@ class ConfigScanSources:
                     )
                     with open(temp_file.name) as f:
                         return yaml.safe_load(f.read())
-                except Exception:
+                except (UnknownObjectException, FileNotFoundError):
                     continue
         return None
 

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -625,6 +625,10 @@ class ConfigScanSources:
             stage = 'builder checks'
             await self.scan_builders_changes(image_meta)
 
+            # Check for external image reference changes (floating tags) - layered products only
+            stage = 'external image checks'
+            await self.scan_external_image_changes(image_meta)
+
             # For OCP variant, perform additional checks that don't apply to OKD
             if self.variant != BuildVariant.OKD:
                 # Check for changes in image arches (skip for OKD - arch changes don't trigger OKD rebuilds)
@@ -1056,6 +1060,173 @@ class ConfigScanSources:
                         RebuildHintCode.BUILDER_CHANGING,
                         f'A builder or parent image build {builder_build_nvr} is newer than latest '
                         f'{image_meta.distgit_key} build',
+                    ),
+                )
+                return
+
+    @alru_cache
+    async def _fetch_art_yaml_from_rebase(self, rebase_repo_url: str, rebase_commitish: str, manifests_dir: str):
+        """Fetch and parse art.yaml from an operator's rebase commit."""
+        _, org, _ = artcommonlib.util.split_git_url(rebase_repo_url)
+        art_yaml_path = f'{manifests_dir}/art.yaml'
+
+        with tempfile.NamedTemporaryFile(delete=True, suffix='.yaml') as temp_file:
+            try:
+                await artcommonlib.util.download_file_from_github(
+                    repository=rebase_repo_url,
+                    branch=rebase_commitish,
+                    path=art_yaml_path,
+                    github_client=get_github_client_for_org(org),
+                    destination=temp_file.name,
+                )
+                with open(temp_file.name) as f:
+                    return yaml.safe_load(f.read())
+            except Exception:
+                return None
+
+    async def _fetch_image_references_from_rebase(
+        self, rebase_repo_url: str, rebase_commitish: str, manifests_dir: str, bundle_dir: str
+    ):
+        """Fetch and parse image-references from an operator's rebase commit.
+
+        Searches multiple candidate paths (bundle_manifests_dir, manifests_dir, bundle_dir)
+        matching the pattern used by _find_image_refs_path in the rebaser.
+        """
+        _, org, _ = artcommonlib.util.split_git_url(rebase_repo_url)
+        github_client = get_github_client_for_org(org)
+        bundle_manifests_dir = f'{manifests_dir}/{bundle_dir}'
+        candidate_paths = [
+            f'{bundle_manifests_dir}/image-references',
+            f'{manifests_dir}/image-references',
+            f'{bundle_dir}/image-references',
+        ]
+
+        for ref_path in candidate_paths:
+            with tempfile.NamedTemporaryFile(delete=True, suffix='.yaml') as temp_file:
+                try:
+                    await artcommonlib.util.download_file_from_github(
+                        repository=rebase_repo_url,
+                        branch=rebase_commitish,
+                        path=ref_path,
+                        github_client=github_client,
+                        destination=temp_file.name,
+                    )
+                    with open(temp_file.name) as f:
+                        return yaml.safe_load(f.read())
+                except Exception:
+                    continue
+        return None
+
+    @skip_check_if_changing
+    async def scan_external_image_changes(self, image_meta: ImageMetadata):
+        """Check if external image floating tags have drifted since the last operator build.
+
+        Only applicable to layered products (non-OCP). For operators that define
+        external-images in their art.yaml, resolves the current digest of each
+        floating tag and compares it to the digest pinned in the last rebase commit.
+        """
+        if self.runtime.product == "ocp":
+            return
+
+        if not image_meta.is_olm_operator:
+            return
+
+        build_record = self.latest_image_build_records_map.get(image_meta.distgit_key)
+        if not build_record or not build_record.rebase_repo_url or not build_record.rebase_commitish:
+            return
+
+        csv_config = image_meta.config.get('update-csv', None)
+        if not csv_config:
+            return
+
+        manifests_dir = csv_config.get('manifests-dir', 'manifests')
+        art_yaml_data = await self._fetch_art_yaml_from_rebase(
+            build_record.rebase_repo_url, build_record.rebase_commitish, manifests_dir
+        )
+        if not art_yaml_data:
+            return
+
+        external_images = art_yaml_data.get('external-images', [])
+        if not external_images:
+            return
+
+        # Filter to only entries with tag-based replace fields (not already digests)
+        tag_based_externals = []
+        for ext_img in external_images:
+            replace_ref = ext_img.get('replace', '')
+            if not replace_ref or '@' in replace_ref:
+                continue
+            tag_based_externals.append(ext_img)
+
+        if not tag_based_externals:
+            return
+
+        # Fetch image-references from the rebase commit to get pinned digests
+        gvars = self.runtime.group_config.vars
+        bundle_dir = csv_config.get('bundle-dir', f'{gvars["MAJOR"]}.{gvars["MINOR"]}')
+        ref_data = await self._fetch_image_references_from_rebase(
+            build_record.rebase_repo_url, build_record.rebase_commitish, manifests_dir, bundle_dir
+        )
+        if not ref_data:
+            self.logger.warning(
+                '%s: could not fetch image-references from rebase commit, skipping external image check',
+                image_meta.distgit_key,
+            )
+            return
+
+        # Build a map of image name -> pinned pullspec from image-references
+        pinned_pullspecs: Dict[str, str] = {}
+        for tag in ref_data.get('spec', {}).get('tags', []):
+            tag_name = tag.get('name', '')
+            pullspec = tag.get('from', {}).get('name', '')
+            if tag_name and pullspec:
+                pinned_pullspecs[tag_name] = pullspec
+
+        # Resolve current digests for all external images concurrently
+        registry_auth = os.getenv("KONFLUX_OPERATOR_INDEX_AUTH_FILE") or self.runtime.registry_config
+
+        async def resolve_current_digest(replace_ref: str) -> Optional[str]:
+            try:
+                image_info = await oc_image_info_for_arch_async(replace_ref, registry_config=registry_auth)
+                return image_info.get('listDigest') or image_info.get('digest')
+            except Exception as e:
+                self.logger.warning('Failed to resolve current digest for %s: %s', replace_ref, e)
+                return None
+
+        resolve_tasks = [resolve_current_digest(ext['replace']) for ext in tag_based_externals]
+        current_digests = await asyncio.gather(*resolve_tasks)
+
+        # Compare current digests to pinned digests
+        for ext_img, current_digest in zip(tag_based_externals, current_digests):
+            if not current_digest:
+                continue
+
+            name = ext_img.get('name', '')
+            pinned = pinned_pullspecs.get(name, '')
+            if not pinned:
+                continue
+
+            # Extract digest from pinned pullspec (format: registry/path@sha256:...)
+            if '@' in pinned:
+                pinned_digest = pinned.split('@', 1)[1]
+            else:
+                # Pinned pullspec doesn't have a digest -- possibly not yet resolved
+                continue
+
+            if current_digest != pinned_digest:
+                self.logger.info(
+                    '%s: external image %s (%s) has a new digest: pinned=%s current=%s',
+                    image_meta.distgit_key,
+                    name,
+                    ext_img.get('replace'),
+                    pinned_digest,
+                    current_digest,
+                )
+                self.add_image_meta_change(
+                    image_meta,
+                    RebuildHint(
+                        RebuildHintCode.EXTERNAL_IMAGE_CHANGE,
+                        f'External image {name} ({ext_img.get("replace")}) has a newer digest',
                     ),
                 )
                 return

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -28,7 +28,7 @@ from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import deep_merge, fetch_slsa_attestation, uses_konflux_imagestream_override
 from artcommonlib.variants import BuildVariant
 from async_lru import alru_cache
-from tenacity import retry, stop_after_attempt, wait_fixed
+from tenacity import retry, retry_if_not_exception_type, stop_after_attempt, wait_fixed
 
 from doozerlib import rhcos, util
 from doozerlib.build_info import KonfluxBuildRecordInspector
@@ -1073,23 +1073,26 @@ class ConfigScanSources:
         """
         from github import UnknownObjectException
 
-        _, org, _ = artcommonlib.util.split_git_url(rebase_repo_url)
+        _, org, repo_name = artcommonlib.util.split_git_url(rebase_repo_url)
         manifests_dir = manifests_dir.strip('/')
         art_yaml_path = '/'.join(part for part in (manifests_dir, 'art.yaml') if part)
+        github_client = get_github_client_for_org(org)
 
-        with tempfile.NamedTemporaryFile(delete=True, suffix='.yaml') as temp_file:
-            try:
-                await artcommonlib.util.download_file_from_github(
-                    repository=rebase_repo_url,
-                    branch=rebase_commitish,
-                    path=art_yaml_path,
-                    github_client=get_github_client_for_org(org),
-                    destination=temp_file.name,
-                )
-                with open(temp_file.name) as f:
-                    return yaml.safe_load(f.read())
-            except (UnknownObjectException, FileNotFoundError):
-                return None
+        @retry(
+            reraise=True,
+            wait=wait_fixed(10),
+            stop=stop_after_attempt(3),
+            retry=retry_if_not_exception_type(UnknownObjectException),
+        )
+        def _fetch():
+            repo = github_client.get_repo(f"{org}/{repo_name}")
+            return repo.get_contents(art_yaml_path, ref=rebase_commitish).decoded_content
+
+        try:
+            data = await asyncio.to_thread(_fetch)
+            return yaml.safe_load(data)
+        except UnknownObjectException:
+            return None
 
     async def _fetch_image_references_from_rebase(
         self, rebase_repo_url: str, rebase_commitish: str, manifests_dir: str, bundle_dir: str
@@ -1103,7 +1106,7 @@ class ConfigScanSources:
         """
         from github import UnknownObjectException
 
-        _, org, _ = artcommonlib.util.split_git_url(rebase_repo_url)
+        _, org, repo_name = artcommonlib.util.split_git_url(rebase_repo_url)
         github_client = get_github_client_for_org(org)
         manifests_dir = manifests_dir.strip('/')
         bundle_dir = bundle_dir.strip('/')
@@ -1115,20 +1118,24 @@ class ConfigScanSources:
         ]
         candidate_paths = list(dict.fromkeys(candidate_paths))
 
+        repo = github_client.get_repo(f"{org}/{repo_name}")
+
         for ref_path in candidate_paths:
-            with tempfile.NamedTemporaryFile(delete=True, suffix='.yaml') as temp_file:
-                try:
-                    await artcommonlib.util.download_file_from_github(
-                        repository=rebase_repo_url,
-                        branch=rebase_commitish,
-                        path=ref_path,
-                        github_client=github_client,
-                        destination=temp_file.name,
-                    )
-                    with open(temp_file.name) as f:
-                        return yaml.safe_load(f.read())
-                except (UnknownObjectException, FileNotFoundError):
-                    continue
+
+            @retry(
+                reraise=True,
+                wait=wait_fixed(10),
+                stop=stop_after_attempt(3),
+                retry=retry_if_not_exception_type(UnknownObjectException),
+            )
+            def _fetch(path=ref_path):
+                return repo.get_contents(path, ref=rebase_commitish).decoded_content
+
+            try:
+                data = await asyncio.to_thread(_fetch)
+                return yaml.safe_load(data)
+            except UnknownObjectException:
+                continue
         return None
 
     @skip_check_if_changing

--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -61,6 +61,7 @@ class RebuildHintCode(Enum):
     DEPENDENCY_NEWER = (True, 15)
     TASK_BUNDLE_OUTDATED = (True, 16)
     NETWORK_MODE_CHANGE = (True, 17)
+    EXTERNAL_IMAGE_CHANGE = (True, 18)
 
 
 class RebuildHint(NamedTuple):

--- a/doozer/tests/cli/test_scan_sources_konflux.py
+++ b/doozer/tests/cli/test_scan_sources_konflux.py
@@ -73,6 +73,7 @@ class TestMinimalCrashIsolation(TestScanSourcesKonflux):
             patch.object(self.scanner, 'scan_for_upstream_changes', AsyncMock(side_effect=RuntimeError('boom'))),
             patch.object(self.scanner, 'scan_dependency_changes', AsyncMock()),
             patch.object(self.scanner, 'scan_builders_changes', AsyncMock()),
+            patch.object(self.scanner, 'scan_external_image_changes', AsyncMock()),
             patch.object(self.scanner, 'scan_arch_changes', AsyncMock()),
             patch.object(self.scanner, 'scan_network_mode_changes', AsyncMock()),
             patch.object(self.scanner, 'scan_for_config_changes', AsyncMock()),
@@ -688,3 +689,243 @@ class TestFindImagesWithDisabledDependencies(TestScanSourcesKonflux):
 
         result = self.scanner._find_images_with_disabled_dependencies()
         self.assertEqual(result, set())
+
+
+class TestScanExternalImageChanges(TestScanSourcesKonflux):
+    """Test the scan_external_image_changes method."""
+
+    def setUp(self):
+        super().setUp()
+        self.runtime.product = 'oadp'
+        self.scanner.runtime = self.runtime
+
+        self.image_meta.is_olm_operator = True
+        self.image_meta.config.get = MagicMock(
+            return_value={
+                'manifests-dir': 'manifests',
+                'bundle-dir': 'stable/',
+            }
+        )
+
+        self.build_record.rebase_repo_url = 'https://github.com/openshift-priv/oadp-operator.git'
+        self.build_record.rebase_commitish = 'abc123def'
+
+        self.runtime.group_config = MagicMock()
+        self.runtime.group_config.vars = {'MAJOR': '1', 'MINOR': '5'}
+
+    async def test_skips_for_ocp_product(self):
+        """Should early-return for OCP product."""
+        self.runtime.product = 'ocp'
+        with patch.object(self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock) as mock_fetch:
+            await self.scanner.scan_external_image_changes(self.image_meta)
+            mock_fetch.assert_not_called()
+
+    async def test_skips_non_olm_operator(self):
+        """Should early-return for non-OLM operator images."""
+        self.image_meta.is_olm_operator = False
+        with patch.object(self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock) as mock_fetch:
+            await self.scanner.scan_external_image_changes(self.image_meta)
+            mock_fetch.assert_not_called()
+
+    async def test_skips_no_build_record(self):
+        """Should early-return when no build record exists."""
+        self.scanner.latest_image_build_records_map = {}
+        with patch.object(self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock) as mock_fetch:
+            await self.scanner.scan_external_image_changes(self.image_meta)
+            mock_fetch.assert_not_called()
+
+    async def test_skips_no_art_yaml(self):
+        """Should skip when art.yaml cannot be fetched."""
+        with patch.object(self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = None
+            await self.scanner.scan_external_image_changes(self.image_meta)
+        self.assertEqual(len(self.scanner.changing_image_names), 0)
+
+    async def test_skips_no_external_images(self):
+        """Should skip when art.yaml has no external-images."""
+        with patch.object(self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = {'updates': []}
+            await self.scanner.scan_external_image_changes(self.image_meta)
+        self.assertEqual(len(self.scanner.changing_image_names), 0)
+
+    async def test_skips_digest_based_replace(self):
+        """Should skip external images that already use digest references."""
+        art_yaml = {
+            'external-images': [
+                {
+                    'name': 'postgresql',
+                    'search': 'RELATED_IMAGE_POSTGRESQL',
+                    'replace': 'registry.redhat.io/rhel9/postgresql-15@sha256:already_pinned',
+                }
+            ]
+        }
+        with (
+            patch.object(self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock, return_value=art_yaml),
+            patch.object(
+                self.scanner, '_fetch_image_references_from_rebase', new_callable=AsyncMock
+            ) as mock_fetch_refs,
+        ):
+            await self.scanner.scan_external_image_changes(self.image_meta)
+            mock_fetch_refs.assert_not_called()
+        self.assertEqual(len(self.scanner.changing_image_names), 0)
+
+    @patch('doozerlib.cli.scan_sources_konflux.oc_image_info_for_arch_async')
+    async def test_no_rebuild_when_digest_unchanged(self, mock_oc_image_info):
+        """Should not trigger rebuild when external image digest is the same."""
+        art_yaml = {
+            'external-images': [
+                {
+                    'name': 'postgresql',
+                    'search': 'RELATED_IMAGE_POSTGRESQL',
+                    'replace': 'registry.redhat.io/rhel9/postgresql-15:latest',
+                }
+            ]
+        }
+        image_refs = {
+            'spec': {
+                'tags': [
+                    {
+                        'name': 'postgresql',
+                        'from': {'name': 'registry.redhat.io/rhel9/postgresql-15@sha256:currentdigest123'},
+                    }
+                ]
+            }
+        }
+        mock_oc_image_info.return_value = {'listDigest': 'sha256:currentdigest123'}
+
+        with (
+            patch.object(self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock, return_value=art_yaml),
+            patch.object(
+                self.scanner, '_fetch_image_references_from_rebase', new_callable=AsyncMock, return_value=image_refs
+            ),
+            patch.object(self.scanner, 'add_image_meta_change') as mock_add_change,
+        ):
+            await self.scanner.scan_external_image_changes(self.image_meta)
+            mock_add_change.assert_not_called()
+
+    @patch('doozerlib.cli.scan_sources_konflux.oc_image_info_for_arch_async')
+    async def test_triggers_rebuild_when_digest_changed(self, mock_oc_image_info):
+        """Should trigger rebuild when external image has a new digest."""
+        art_yaml = {
+            'external-images': [
+                {
+                    'name': 'postgresql',
+                    'search': 'RELATED_IMAGE_POSTGRESQL',
+                    'replace': 'registry.redhat.io/rhel9/postgresql-15:latest',
+                }
+            ]
+        }
+        image_refs = {
+            'spec': {
+                'tags': [
+                    {
+                        'name': 'postgresql',
+                        'from': {'name': 'registry.redhat.io/rhel9/postgresql-15@sha256:olddigest456'},
+                    }
+                ]
+            }
+        }
+        mock_oc_image_info.return_value = {'listDigest': 'sha256:newdigest789'}
+
+        with (
+            patch.object(self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock, return_value=art_yaml),
+            patch.object(
+                self.scanner, '_fetch_image_references_from_rebase', new_callable=AsyncMock, return_value=image_refs
+            ),
+            patch.object(self.scanner, 'add_image_meta_change') as mock_add_change,
+        ):
+            await self.scanner.scan_external_image_changes(self.image_meta)
+            mock_add_change.assert_called_once()
+            call_args = mock_add_change.call_args[0]
+            self.assertEqual(call_args[0], self.image_meta)
+            self.assertEqual(call_args[1].code, RebuildHintCode.EXTERNAL_IMAGE_CHANGE)
+            self.assertIn('postgresql', call_args[1].reason)
+
+    @patch('doozerlib.cli.scan_sources_konflux.oc_image_info_for_arch_async')
+    async def test_graceful_handling_when_registry_unreachable(self, mock_oc_image_info):
+        """Should not crash when external registry is unreachable."""
+        art_yaml = {
+            'external-images': [
+                {
+                    'name': 'postgresql',
+                    'search': 'RELATED_IMAGE_POSTGRESQL',
+                    'replace': 'registry.redhat.io/rhel9/postgresql-15:latest',
+                }
+            ]
+        }
+        image_refs = {
+            'spec': {
+                'tags': [
+                    {
+                        'name': 'postgresql',
+                        'from': {'name': 'registry.redhat.io/rhel9/postgresql-15@sha256:olddigest456'},
+                    }
+                ]
+            }
+        }
+        mock_oc_image_info.side_effect = Exception('connection refused')
+
+        with (
+            patch.object(self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock, return_value=art_yaml),
+            patch.object(
+                self.scanner, '_fetch_image_references_from_rebase', new_callable=AsyncMock, return_value=image_refs
+            ),
+            patch.object(self.scanner, 'add_image_meta_change') as mock_add_change,
+        ):
+            await self.scanner.scan_external_image_changes(self.image_meta)
+            mock_add_change.assert_not_called()
+
+    @patch('doozerlib.cli.scan_sources_konflux.oc_image_info_for_arch_async')
+    async def test_multiple_external_images_first_changed(self, mock_oc_image_info):
+        """Should trigger rebuild and stop at the first changed external image."""
+        art_yaml = {
+            'external-images': [
+                {
+                    'name': 'postgresql',
+                    'search': 'RELATED_IMAGE_POSTGRESQL',
+                    'replace': 'registry.redhat.io/rhel9/postgresql-15:latest',
+                },
+                {
+                    'name': 'redis',
+                    'search': 'RELATED_IMAGE_REDIS',
+                    'replace': 'registry.redhat.io/rhel9/redis-7:latest',
+                },
+            ]
+        }
+        image_refs = {
+            'spec': {
+                'tags': [
+                    {
+                        'name': 'postgresql',
+                        'from': {'name': 'registry.redhat.io/rhel9/postgresql-15@sha256:oldpostgres'},
+                    },
+                    {
+                        'name': 'redis',
+                        'from': {'name': 'registry.redhat.io/rhel9/redis-7@sha256:oldredis'},
+                    },
+                ]
+            }
+        }
+        mock_oc_image_info.side_effect = [
+            {'listDigest': 'sha256:newpostgres'},
+            {'listDigest': 'sha256:oldredis'},
+        ]
+
+        with (
+            patch.object(self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock, return_value=art_yaml),
+            patch.object(
+                self.scanner, '_fetch_image_references_from_rebase', new_callable=AsyncMock, return_value=image_refs
+            ),
+            patch.object(self.scanner, 'add_image_meta_change') as mock_add_change,
+        ):
+            await self.scanner.scan_external_image_changes(self.image_meta)
+            mock_add_change.assert_called_once()
+            call_args = mock_add_change.call_args[0]
+            self.assertIn('postgresql', call_args[1].reason)
+
+    async def test_skip_check_if_already_changing(self):
+        """Should skip scan entirely if image is already marked for rebuild."""
+        self.scanner.changing_image_names = {'test-image'}
+        with patch.object(self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock) as mock_fetch:
+            await self.scanner.scan_external_image_changes(self.image_meta)
+            mock_fetch.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds scan_external_image_changes to the Konflux scan-sources pipeline for layered products (OADP, logging, MTA, MTC, etc.)
- For operators that define external-images in their art.yaml with floating tags (e.g. registry.redhat.io/rhel9/postgresql-15:latest), this check resolves the current digest behind each tag and compares it to the digest pinned in the last rebase commit
- If the tag points to a new image, the operator is automatically marked for rebuild, which triggers the downstream bundle and FBC builds

## Details

**Problem**: When a new image is pushed to a floating tag referenced by an operator external images, the operator bundle becomes stale. Previously there was no automated detection of this drift.

**Solution**: New scan check scan_external_image_changes that:
1. Gates on runtime.product != ocp (layered products only)
2. Fetches art.yaml and image-references from the last rebase commit via GitHub API
3. For each external image with a floating tag, resolves current digest via oc image info
4. Compares to the pinned digest - if different, marks operator for rebuild with EXTERNAL_IMAGE_CHANGE

**Performance**: Uses @skip_check_if_changing decorator, @alru_cache for art.yaml downloads, asyncio.gather for concurrent digest resolution, and direct `get_contents()` calls (bypassing the retry-decorated `download_file_from_github`) to avoid wasting ~20s retrying 404s when probing candidate paths for image-references. Transient network errors are still retried 3x via tenacity.

## Test plan

- [x] Unit tests cover: OCP product skip, non-OLM skip, no build record, no art.yaml, no external-images, digest-based replace skip, unchanged digest, changed digest triggers rebuild, registry unreachable graceful handling, multiple external images, skip-if-already-changing
- [x] ruff check and ruff format pass
- [x] Full doozer test suite passes (1194 tests)

## Jenkins test run

- **Build [#35978](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Flayered-products-scan/35978/console)**: Ran against `mta-8.1` / `mta-operator`. Scan completed successfully — no drift detected. External image check completed in ~1s.

### Local verification

Manually confirmed the scan result is correct by resolving current digests for all 3 MTA external images and comparing to the pinned digests in the rebase commit (`d89c5bd`):

| Image | Pinned digest | Current digest | Drift? |
|---|---|---|---|
| `registry.redhat.io/rhel9/postgresql-15:latest` | `sha256:327d89e4...` | `sha256:327d89e4...` | No |
| `registry.redhat.io/openshift4/ose-oauth-proxy:latest` | `sha256:ef10b2ec...` | `sha256:ef10b2ec...` | No |
| `registry.redhat.io/lightspeed-core/lightspeed-stack-rhel9:latest` | `sha256:99223794...` | `sha256:99223794...` | No |

Made with [Cursor](https://cursor.com)