### PR TITLE
build-sync: Mirror RHCOS images to QCI

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -3,6 +3,7 @@ import glob
 import json
 import os
 import re
+from datetime import datetime
 
 import click
 import yaml
@@ -11,12 +12,13 @@ from artcommonlib.arch_util import go_arch_for_brew_arch, go_suffix_for_arch
 from artcommonlib.constants import (
     KONFLUX_DEFAULT_IMAGE_REPO,
     REGISTRY_CI_OPENSHIFT,
+    REGISTRY_QUAY_CI,
     REGISTRY_QUAY_OCP_RELEASE_DEV,
 )
 from artcommonlib.exectools import limit_concurrency
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.redis import RedisError
-from artcommonlib.registry_config import RegistryConfig
+from artcommonlib.registry_config import RegistryConfig, RegistryCredential
 from artcommonlib.release_util import SoftwareLifecyclePhase
 from artcommonlib.telemetry import start_as_current_span_async
 from artcommonlib.util import split_git_url, uses_konflux_imagestream_override
@@ -163,14 +165,29 @@ class BuildSyncPipeline:
 
         source_files = [quay_auth_file]
 
+        # Build credentials and registries lists
+        # QCI (quay.io/openshift/ci) is only added if credentials are available
+        credentials = []
+        registries = [
+            REGISTRY_QUAY_OCP_RELEASE_DEV,
+            KONFLUX_DEFAULT_IMAGE_REPO,
+            REGISTRY_CI_OPENSHIFT,
+        ]
+
+        qci_user = os.environ.get('QCI_USER')
+        qci_password = os.environ.get('QCI_PASSWORD')
+        if qci_user and qci_password:
+            # QCI credentials are added as explicit credentials, not to the registries list
+            # (registries list is for extracting from source files)
+            credentials.append(RegistryCredential(REGISTRY_QUAY_CI, qci_user, qci_password))
+        else:
+            self.logger.warning('QCI_USER/QCI_PASSWORD not set - RHCOS images will not be mirrored to QCI')
+
         with RegistryConfig(
             kubeconfig=os.environ.get('KUBECONFIG'),
             source_files=source_files,
-            registries=[
-                REGISTRY_QUAY_OCP_RELEASE_DEV,
-                KONFLUX_DEFAULT_IMAGE_REPO,
-                REGISTRY_CI_OPENSHIFT,
-            ],
+            registries=registries,
+            credentials=credentials,
         ) as global_auth_file:
             self._registry_config = global_auth_file
 
@@ -434,6 +451,119 @@ class BuildSyncPipeline:
         except (ChildProcessError, KeyError) as e:
             await self.slack_client.say(f'Unable to mirror CoreOS images to CI for {self.version}: {e}')
 
+    @start_as_current_span_async(TRACER, "build-sync.mirror-rhcos-to-qci")
+    async def _mirror_rhcos_to_qci(self):
+        """
+        Mirror RHCOS images to quay.io/openshift/ci (QCI) for external CI consumption.
+
+        Uses the same tag convention as images:streams mirror:
+        - Prunable: {timestamp}_prune_art__ocp_{version}_{tag}
+        - Floating: art__ocp_{version}_{tag}
+        """
+        current_span = trace.get_current_span()
+        current_span.set_attribute("build-sync.version", self.version)
+        current_span.set_attribute("build-sync.assembly", self.assembly)
+
+        # Same guards as _populate_ci_imagestreams
+        major, minor = [int(n) for n in self.version.split('.')]
+        if major <= 4 and minor < 12:
+            self.logger.info('Skipping QCI mirror for version %s (< 4.12)', self.version)
+            return
+
+        if not self.assembly == 'stream' or self.doozer_data_gitref:
+            self.logger.info('Skipping QCI mirror for non-stream assembly or custom gitref')
+            return
+
+        # Check if QCI credentials are available
+        if not os.environ.get('QCI_USER') or not os.environ.get('QCI_PASSWORD'):
+            self.logger.warning('QCI_USER/QCI_PASSWORD not set - skipping QCI mirror')
+            return
+
+        try:
+            tags_to_transfer = rhcos.get_container_names(self.group_runtime)
+            prune_timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+
+            self.logger.info('Mirroring RHCOS images to QCI: %s', tags_to_transfer)
+
+            tasks = []
+            for tag in tags_to_transfer:
+                # Mirror to public QCI
+                tasks.append(self._mirror_single_rhcos_to_qci(tag, prune_timestamp, private=False))
+                # Mirror to private QCI (for openshift-priv CI)
+                tasks.append(self._mirror_single_rhcos_to_qci(tag, prune_timestamp, private=True))
+
+            await asyncio.gather(*tasks)
+            self.logger.info('Successfully mirrored RHCOS images to QCI')
+
+        except Exception as e:
+            self.logger.error('Failed to mirror RHCOS images to QCI: %s', e)
+            await self.slack_client.say(f'Unable to mirror CoreOS images to QCI for {self.version}: {e}')
+
+    @start_as_current_span_async(TRACER, "build-sync.mirror-single-rhcos-to-qci")
+    @limit_concurrency(10)
+    async def _mirror_single_rhcos_to_qci(self, tag: str, prune_timestamp: str, private: bool):
+        """
+        Mirror a single RHCOS image to QCI using oc image mirror.
+
+        Creates both a prunable tag (for cleanup) and a floating tag (always points to latest).
+        Uses oc image mirror with --keep-manifest-list to preserve multi-arch manifests.
+
+        For private mirroring, we use the same source pullspec from the public ART imagestream
+        (consistent with how _tag_into_ci_imagestream handles private CI).
+
+        Args:
+            tag: RHCOS container name (e.g., 'rhel-coreos', 'rhel-coreos-extensions')
+            prune_timestamp: Timestamp string for prunable tag naming
+            private: Whether to add _priv suffix for private CI consumption
+        """
+        current_span = trace.get_current_span()
+        current_span.set_attribute("build-sync.tag", tag)
+        current_span.set_attribute("build-sync.private", private)
+
+        # Always get pullspec from public ART imagestream (same source for both public and private,
+        # consistent with _tag_into_ci_imagestream which uses the same pullspec for private CI)
+        namespace = 'ocp'
+        is_name = self.is_base_name
+
+        # Get the pullspec from the ART imagestream (already multi-arch)
+        cmd = (
+            f'oc --kubeconfig {os.environ["KUBECONFIG"]} -n {namespace} '
+            f'get istag/{is_name}:{tag} -o=jsonpath={{.tag.from.name}}'
+        )
+        rc, tag_pullspec, stderr = await exectools.cmd_gather_async(cmd, check=False)
+        tag_pullspec = tag_pullspec.strip()
+
+        if rc != 0 or not tag_pullspec:
+            self.logger.warning(
+                'No pullspec found for %s/%s:%s (rc=%d, stderr=%s)', namespace, is_name, tag, rc, stderr
+            )
+            return
+
+        # Build QCI tag names following the images:streams mirror convention
+        priv_suffix = '_priv' if private else ''
+        qci_tag_base = f"ocp_{self.version}{priv_suffix}_{tag}"
+
+        prunable_tag = f"{prune_timestamp}_prune_art__{qci_tag_base}"
+        floating_tag = f"art__{qci_tag_base}"
+
+        self.logger.info('Mirroring %s/%s:%s to QCI: %s', namespace, is_name, tag, floating_tag)
+
+        if self.runtime.dry_run:
+            self.logger.info('[DRY RUN] Would mirror %s -> %s, %s', tag_pullspec, prunable_tag, floating_tag)
+            return
+
+        # Mirror to QCI using oc image mirror with --keep-manifest-list for multi-arch
+        for qci_tag in [prunable_tag, floating_tag]:
+            dest = f"{REGISTRY_QUAY_CI}:{qci_tag}"
+            cmd = (
+                f'oc image mirror --keep-manifest-list --registry-config={self._registry_config} {tag_pullspec} {dest}'
+            )
+            try:
+                await exectools.cmd_assert_async(cmd)
+            except ChildProcessError as e:
+                self.logger.error('Failed to mirror %s to %s: %s', tag_pullspec, dest, e)
+                raise
+
     @start_as_current_span_async(TRACER, "build-sync.update-nightly-imagestreams")
     async def _update_nightly_imagestreams(self):
         """
@@ -490,6 +620,9 @@ class BuildSyncPipeline:
 
         # Populate CI imagestreams
         await self._populate_ci_imagestreams()
+
+        # Mirror RHCOS images to QCI for external CI consumption
+        await self._mirror_rhcos_to_qci()
 
         if self.publish:
             # Run 'oc adm release new' in parallel

--- a/pyartcd/tests/pipelines/test_build_sync.py
+++ b/pyartcd/tests/pipelines/test_build_sync.py
@@ -1,0 +1,336 @@
+"""Tests for build_sync pipeline QCI mirroring functionality."""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestMirrorRhcosToQci(unittest.IsolatedAsyncioTestCase):
+    """Tests for _mirror_rhcos_to_qci functionality."""
+
+    def _create_pipeline(self, version='4.17', assembly='stream', doozer_data_gitref=''):
+        """Create a BuildSyncPipeline instance with mocked dependencies."""
+        with patch('pyartcd.pipelines.build_sync.GroupRuntime'):
+            from pyartcd.pipelines.build_sync import BuildSyncPipeline
+
+            runtime = MagicMock()
+            runtime.logger = MagicMock()
+            runtime.dry_run = False
+            runtime.working_dir = '/tmp/test'
+            runtime.config = MagicMock()
+
+            pipeline = BuildSyncPipeline(
+                runtime=runtime,
+                version=version,
+                assembly=assembly,
+                publish=False,
+                data_path='https://github.com/openshift-eng/ocp-build-data',
+                emergency_ignore_issues=False,
+                retrigger_current_nightly=False,
+                doozer_data_gitref=doozer_data_gitref,
+                images='',
+                exclude_arches='',
+                skip_multiarch_payload=False,
+                embargo_permit_ack=False,
+                build_system='konflux',
+            )
+            pipeline.group_runtime = MagicMock()
+            pipeline.slack_client = AsyncMock()
+            pipeline._registry_config = '/tmp/auth.json'
+            return pipeline
+
+    @patch.dict('os.environ', {'QCI_USER': 'test_user', 'QCI_PASSWORD': 'test_pass'})
+    @patch('pyartcd.pipelines.build_sync.rhcos')
+    async def test_mirror_rhcos_to_qci_success(self, mock_rhcos):
+        """Test successful mirroring of RHCOS images to QCI."""
+        pipeline = self._create_pipeline()
+        mock_rhcos.get_container_names.return_value = {'rhel-coreos', 'rhel-coreos-extensions'}
+
+        with patch.object(pipeline, '_mirror_single_rhcos_to_qci', new_callable=AsyncMock) as mock_mirror:
+            await pipeline._mirror_rhcos_to_qci()
+
+            # Should be called for each tag, both public and private
+            assert mock_mirror.call_count == 4  # 2 tags * 2 (public + private)
+
+    @patch.dict('os.environ', {}, clear=True)
+    async def test_mirror_rhcos_to_qci_skips_without_credentials(self):
+        """Test QCI mirroring is skipped when credentials not available."""
+        pipeline = self._create_pipeline()
+
+        with patch.object(pipeline, '_mirror_single_rhcos_to_qci', new_callable=AsyncMock) as mock_mirror:
+            await pipeline._mirror_rhcos_to_qci()
+
+            # Should not attempt to mirror without credentials
+            mock_mirror.assert_not_called()
+
+    async def test_mirror_rhcos_to_qci_skips_old_versions(self):
+        """Test QCI mirroring is skipped for versions < 4.12."""
+        pipeline = self._create_pipeline(version='4.11')
+
+        with patch.dict('os.environ', {'QCI_USER': 'user', 'QCI_PASSWORD': 'pass'}):
+            with patch.object(pipeline, '_mirror_single_rhcos_to_qci', new_callable=AsyncMock) as mock_mirror:
+                await pipeline._mirror_rhcos_to_qci()
+
+                mock_mirror.assert_not_called()
+
+    async def test_mirror_rhcos_to_qci_skips_non_stream_assembly(self):
+        """Test QCI mirroring is skipped for non-stream assemblies."""
+        pipeline = self._create_pipeline(assembly='4.17.1')
+
+        with patch.dict('os.environ', {'QCI_USER': 'user', 'QCI_PASSWORD': 'pass'}):
+            with patch.object(pipeline, '_mirror_single_rhcos_to_qci', new_callable=AsyncMock) as mock_mirror:
+                await pipeline._mirror_rhcos_to_qci()
+
+                mock_mirror.assert_not_called()
+
+    async def test_mirror_rhcos_to_qci_skips_custom_gitref(self):
+        """Test QCI mirroring is skipped when custom data gitref is specified."""
+        pipeline = self._create_pipeline(doozer_data_gitref='custom-branch')
+
+        with patch.dict('os.environ', {'QCI_USER': 'user', 'QCI_PASSWORD': 'pass'}):
+            with patch.object(pipeline, '_mirror_single_rhcos_to_qci', new_callable=AsyncMock) as mock_mirror:
+                await pipeline._mirror_rhcos_to_qci()
+
+                mock_mirror.assert_not_called()
+
+
+class TestMirrorSingleRhcosToQci(unittest.IsolatedAsyncioTestCase):
+    """Tests for _mirror_single_rhcos_to_qci functionality."""
+
+    def _create_pipeline(self, dry_run=False):
+        """Create a BuildSyncPipeline instance with mocked dependencies."""
+        with patch('pyartcd.pipelines.build_sync.GroupRuntime'):
+            from pyartcd.pipelines.build_sync import BuildSyncPipeline
+
+            runtime = MagicMock()
+            runtime.logger = MagicMock()
+            runtime.dry_run = dry_run
+            runtime.working_dir = '/tmp/test'
+            runtime.config = MagicMock()
+
+            pipeline = BuildSyncPipeline(
+                runtime=runtime,
+                version='4.17',
+                assembly='stream',
+                publish=False,
+                data_path='https://github.com/openshift-eng/ocp-build-data',
+                emergency_ignore_issues=False,
+                retrigger_current_nightly=False,
+                doozer_data_gitref='',
+                images='',
+                exclude_arches='',
+                skip_multiarch_payload=False,
+                embargo_permit_ack=False,
+                build_system='konflux',
+            )
+            pipeline.group_runtime = MagicMock()
+            pipeline.slack_client = AsyncMock()
+            pipeline._registry_config = '/tmp/auth.json'
+            return pipeline
+
+    @patch.dict('os.environ', {'KUBECONFIG': '/tmp/kubeconfig'})
+    @patch('pyartcd.pipelines.build_sync.exectools.cmd_gather_async', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.build_sync.exectools.cmd_assert_async', new_callable=AsyncMock)
+    async def test_mirror_single_rhcos_public(self, mock_cmd_assert, mock_cmd_gather):
+        """Test mirroring a single RHCOS tag to public QCI."""
+        pipeline = self._create_pipeline()
+
+        # Mock getting the pullspec from imagestream
+        mock_cmd_gather.return_value = (0, 'quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123', '')
+
+        await pipeline._mirror_single_rhcos_to_qci('rhel-coreos', '20240101120000', private=False)
+
+        # Verify oc get istag was called for public namespace
+        mock_cmd_gather.assert_called_once()
+        assert '-n ocp ' in mock_cmd_gather.call_args[0][0]
+        assert 'art-latest:rhel-coreos' in mock_cmd_gather.call_args[0][0]
+
+        # Verify oc image mirror was called twice (prunable + floating)
+        assert mock_cmd_assert.call_count == 2
+
+    @patch.dict('os.environ', {'KUBECONFIG': '/tmp/kubeconfig'})
+    @patch('pyartcd.pipelines.build_sync.exectools.cmd_gather_async', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.build_sync.exectools.cmd_assert_async', new_callable=AsyncMock)
+    async def test_mirror_single_rhcos_private(self, mock_cmd_assert, mock_cmd_gather):
+        """Test mirroring a single RHCOS tag to private QCI."""
+        pipeline = self._create_pipeline()
+
+        mock_cmd_gather.return_value = (0, 'quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123', '')
+
+        await pipeline._mirror_single_rhcos_to_qci('rhel-coreos', '20240101120000', private=True)
+
+        # Private uses same public ART imagestream as source
+        mock_cmd_gather.assert_called_once()
+        assert '-n ocp ' in mock_cmd_gather.call_args[0][0]
+
+        # Should still mirror to QCI with _priv suffix
+        assert mock_cmd_assert.call_count == 2
+        first_call = mock_cmd_assert.call_args_list[0][0][0]
+        assert '_priv_' in first_call
+
+    @patch.dict('os.environ', {'KUBECONFIG': '/tmp/kubeconfig'})
+    @patch('pyartcd.pipelines.build_sync.exectools.cmd_gather_async', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.build_sync.exectools.cmd_assert_async', new_callable=AsyncMock)
+    async def test_mirror_single_rhcos_dry_run(self, mock_cmd_assert, mock_cmd_gather):
+        """Test dry run mode doesn't actually mirror."""
+        pipeline = self._create_pipeline(dry_run=True)
+
+        mock_cmd_gather.return_value = (0, 'quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123', '')
+
+        await pipeline._mirror_single_rhcos_to_qci('rhel-coreos', '20240101120000', private=False)
+
+        # Verify oc get istag was called (to get pullspec)
+        mock_cmd_gather.assert_called_once()
+
+        # Verify oc image mirror was NOT called in dry run
+        mock_cmd_assert.assert_not_called()
+
+    @patch.dict('os.environ', {'KUBECONFIG': '/tmp/kubeconfig'})
+    @patch('pyartcd.pipelines.build_sync.exectools.cmd_gather_async', new_callable=AsyncMock)
+    async def test_mirror_single_rhcos_missing_pullspec(self, mock_cmd_gather):
+        """Test handling when pullspec is not found."""
+        pipeline = self._create_pipeline()
+
+        # Simulate failed oc get istag
+        mock_cmd_gather.return_value = (1, '', 'not found')
+
+        # Should not raise, just log warning and return
+        await pipeline._mirror_single_rhcos_to_qci('rhel-coreos', '20240101120000', private=False)
+
+    @patch.dict('os.environ', {'KUBECONFIG': '/tmp/kubeconfig'})
+    @patch('pyartcd.pipelines.build_sync.exectools.cmd_gather_async', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.build_sync.exectools.cmd_assert_async', new_callable=AsyncMock)
+    async def test_mirror_qci_tag_naming(self, mock_cmd_assert, mock_cmd_gather):
+        """Test QCI tag naming convention and oc image mirror command."""
+        pipeline = self._create_pipeline()
+        pipeline._registry_config = '/tmp/registry_config.json'
+
+        mock_cmd_gather.return_value = (0, 'quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123', '')
+
+        await pipeline._mirror_single_rhcos_to_qci('rhel-coreos-extensions', '20240101120000', private=False)
+
+        # Verify correct tag naming pattern and oc image mirror command
+        calls = mock_cmd_assert.call_args_list
+        prunable_call = calls[0][0][0]
+        assert 'oc image mirror' in prunable_call
+        assert '--keep-manifest-list' in prunable_call
+        assert '--registry-config=' in prunable_call
+        assert 'quay.io/openshift/ci:20240101120000_prune_art__ocp_4.17_rhel-coreos-extensions' in prunable_call
+
+        floating_call = calls[1][0][0]
+        assert 'quay.io/openshift/ci:art__ocp_4.17_rhel-coreos-extensions' in floating_call
+
+
+class TestRegistryConfigWithQci(unittest.IsolatedAsyncioTestCase):
+    """Tests for RegistryConfig setup with QCI credentials."""
+
+    @patch('pyartcd.pipelines.build_sync.RegistryConfig')
+    @patch('pyartcd.pipelines.build_sync.GroupRuntime')
+    @patch.dict(
+        'os.environ',
+        {
+            'QUAY_AUTH_FILE': '/tmp/quay_auth.json',
+            'KUBECONFIG': '/tmp/kubeconfig',
+            'QCI_USER': 'test_user',
+            'QCI_PASSWORD': 'test_pass',
+        },
+    )
+    async def test_registry_config_includes_qci_credentials(self, mock_group_runtime, mock_registry_config):
+        """Test RegistryConfig is created with QCI credentials."""
+        from pyartcd.pipelines.build_sync import BuildSyncPipeline
+
+        runtime = MagicMock()
+        runtime.logger = MagicMock()
+        runtime.dry_run = False
+        runtime.working_dir = '/tmp/test'
+        runtime.config = MagicMock()
+
+        # Setup mock context manager
+        mock_registry_config.return_value.__enter__ = MagicMock(return_value='/tmp/merged_auth.json')
+        mock_registry_config.return_value.__exit__ = MagicMock(return_value=False)
+
+        pipeline = BuildSyncPipeline(
+            runtime=runtime,
+            version='4.17',
+            assembly='stream',
+            publish=False,
+            data_path='https://github.com/openshift-eng/ocp-build-data',
+            emergency_ignore_issues=False,
+            retrigger_current_nightly=False,
+            doozer_data_gitref='',
+            images='',
+            exclude_arches='',
+            skip_multiarch_payload=False,
+            embargo_permit_ack=False,
+            build_system='konflux',
+        )
+        pipeline.group_runtime = MagicMock()
+        pipeline._run_pipeline = AsyncMock()
+
+        await pipeline.run()
+
+        # Verify RegistryConfig was called with QCI credentials
+        mock_registry_config.assert_called_once()
+        call_kwargs = mock_registry_config.call_args.kwargs
+
+        from artcommonlib.constants import REGISTRY_QUAY_CI
+
+        # QCI should NOT be in the registries list (it's for source file extraction)
+        assert REGISTRY_QUAY_CI not in call_kwargs['registries']
+
+        # QCI should be in the credentials list (explicit credentials)
+        assert len(call_kwargs['credentials']) == 1
+        cred = call_kwargs['credentials'][0]
+        assert cred.registry == REGISTRY_QUAY_CI
+
+    @patch('pyartcd.pipelines.build_sync.RegistryConfig')
+    @patch('pyartcd.pipelines.build_sync.GroupRuntime')
+    @patch.dict(
+        'os.environ',
+        {
+            'QUAY_AUTH_FILE': '/tmp/quay_auth.json',
+            'KUBECONFIG': '/tmp/kubeconfig',
+        },
+        clear=True,
+    )
+    async def test_registry_config_without_qci_credentials(self, mock_group_runtime, mock_registry_config):
+        """Test RegistryConfig is created without QCI credentials when not available."""
+        from pyartcd.pipelines.build_sync import BuildSyncPipeline
+
+        runtime = MagicMock()
+        runtime.logger = MagicMock()
+        runtime.dry_run = False
+        runtime.working_dir = '/tmp/test'
+        runtime.config = MagicMock()
+
+        mock_registry_config.return_value.__enter__ = MagicMock(return_value='/tmp/merged_auth.json')
+        mock_registry_config.return_value.__exit__ = MagicMock(return_value=False)
+
+        pipeline = BuildSyncPipeline(
+            runtime=runtime,
+            version='4.17',
+            assembly='stream',
+            publish=False,
+            data_path='https://github.com/openshift-eng/ocp-build-data',
+            emergency_ignore_issues=False,
+            retrigger_current_nightly=False,
+            doozer_data_gitref='',
+            images='',
+            exclude_arches='',
+            skip_multiarch_payload=False,
+            embargo_permit_ack=False,
+            build_system='konflux',
+        )
+        pipeline.group_runtime = MagicMock()
+        pipeline._run_pipeline = AsyncMock()
+
+        await pipeline.run()
+
+        # Verify RegistryConfig was called without QCI credentials
+        mock_registry_config.assert_called_once()
+        call_kwargs = mock_registry_config.call_args.kwargs
+
+        # Should have empty credentials list
+        assert call_kwargs['credentials'] == []
+
+        # Should have logged a warning
+        runtime.logger.warning.assert_called()


### PR DESCRIPTION
## Summary

Tag RHCOS container images to QCI (`quay.io/openshift/ci`) during build-sync for external CI consumption.

Uses `oc tag` with reference mode (as suggested by reviewer) to create image references without copying bytes:
- `--reference-policy='source'` - Reference points to source location
- `--import-mode='PreserveOriginal'` - Preserve original manifest format  
- `--reference` - Create reference without importing image

## QCI Pullspec Format

Images are tagged with:
- **Prunable tags** (for cleanup): `quay.io/openshift/ci:<timestamp>_prune_art__ocp_<version>_<tag>`
- **Floating tags** (latest): `quay.io/openshift/ci:art__ocp_<version>_<tag>`

### Examples for OCP 4.17

Public images:
```
quay.io/openshift/ci:20260603120000_prune_art__ocp_4.17_rhel-coreos
quay.io/openshift/ci:art__ocp_4.17_rhel-coreos
quay.io/openshift/ci:art__ocp_4.17_rhel-coreos-extensions
quay.io/openshift/ci:art__ocp_4.17_machine-os-content
quay.io/openshift/ci:art__ocp_4.17_rhel-coreos-10
quay.io/openshift/ci:art__ocp_4.17_rhel-coreos-10-extensions
```

Private images (for openshift-priv CI):
```
quay.io/openshift/ci:art__ocp_4.17_priv_rhel-coreos
quay.io/openshift/ci:art__ocp_4.17_priv_rhel-coreos-extensions
```

## Implementation Details

- Added `_mirror_rhcos_to_qci()` orchestration method with guards for version ≥4.12, stream assembly, and QCI credentials
- Added `_mirror_single_rhcos_to_qci()` to fetch ART imagestream pullspecs and tag to QCI
- Uses same public ART imagestream source for both public and private (consistent with `_tag_into_ci_imagestream`)
- QCI credentials via `QCI_USER`/`QCI_PASSWORD` environment variables (requires Jenkinsfile update in aos-cd-jobs)
- Errors are logged and sent to Slack but don't fail the build (non-critical mirror)

## Test Plan

- [x] Unit tests for success, skip conditions, dry-run, tag naming
- [ ] Integration test with actual QCI credentials