### PR TITLE
Trigger build/rhcos_sync for RC releases

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -539,11 +539,11 @@ class PromotePipeline:
                         await self.sign_artifacts(release_name, client_type, release_infos, message_digests)
 
                 # publish rhcos on mirror via rhcos_sync job
-                # only if release is EC or a GA release (.0)
+                # only if release is EC, RC, or a GA release (.0)
                 # job will not mirror & overwrite if destination already exists (sync already happened)
                 # if that is desired, run rhcos_sync with FORCE=true
                 is_ga = assembly_type == AssemblyTypes.STANDARD and self.assembly.endswith(".0")
-                if assembly_type == AssemblyTypes.PREVIEW or is_ga:
+                if assembly_type in (AssemblyTypes.PREVIEW, AssemblyTypes.CANDIDATE) or is_ga:
                     for arch, pullspec in pullspecs.items():
                         if arch == "multi":
                             continue


### PR DESCRIPTION
## Summary
- Previously `rhcos_sync` was only triggered for EC (preview) and GA (`.0`) releases during promote
- RCs (`AssemblyTypes.CANDIDATE`) should also have RHCOS synced to the mirror from 4.22 onwards
- Added `AssemblyTypes.CANDIDATE` to the trigger condition in the promote pipeline

## Test plan
- [x] All 26 existing promote pipeline tests pass
- [ ] Verify on next RC promote that `rhcos_sync` job is triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)