### PR TITLE
rebaser: Skip embargo check when source has no public upstream

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -280,7 +280,7 @@ class KonfluxRebaser:
 
         # Determine if this image contains private fixes
         if private_fix is None:
-            if source and source_dir and not source.is_fork_build:
+            if source and source_dir and source.has_public_upstream and not source.is_fork_build:
                 # If the private org branch commit doesn't exist in the public org,
                 # this image contains private fixes
                 is_commit_in_public_upstream = await util.is_commit_in_public_upstream_async(
@@ -288,8 +288,7 @@ class KonfluxRebaser:
                 )
 
                 if (
-                    source.has_public_upstream
-                    and not SourceResolver.is_branch_commit_hash(source.public_upstream_branch)
+                    not SourceResolver.is_branch_commit_hash(source.public_upstream_branch)
                     and not is_commit_in_public_upstream
                 ):
                     private_fix = True


### PR DESCRIPTION
## Summary

- Fix `is_commit_in_public_upstream_async` being called for images that don't have a private/public upstream relationship
- Prevents `git merge-base` failures with "Not a valid object name public_upstream/..." when the `public_upstream` remote doesn't exist

## Problem

The embargo detection logic in `rebaser.py` was calling `is_commit_in_public_upstream_async` for all images with source, regardless of whether they actually build from a private repo. Images that build from public repos (like those in openshift-eng/) don't have a `public_upstream` remote set up, causing the git command to fail.

The `has_public_upstream` flag indicates the source is from a private repo (e.g., openshift-priv) with a corresponding public repo to compare against. When `False`, there's no private/public distinction to verify.

## Fix

Move the `has_public_upstream` check from inside the nested `if` to the outer condition, preventing the git command from being called when there's no public upstream to check against.

## Test plan

- [x] Existing tests pass (`make test`)
- [x] E2E unit tests cover private fix detection logic