### PR TITLE
ART-18366 Add io.openshift.build.golang-nvr label to golang-builder images

### DIFF
--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -323,6 +323,12 @@ def images_covscan(
     default=False,
     help="Inject \"yum update -y\" in the final stage of an image build. This ensures the component image will be able to override RPMs it is inheriting from its parent image using RPMs in the rebuild plashet.",
 )
+@click.option(
+    '--extra-label',
+    multiple=True,
+    metavar='KEY=VALUE',
+    help='Extra labels to add to the Dockerfile. Can be specified multiple times. e.g. --extra-label io.openshift.build.golang-nvr=golang-1.25.3-1.el9',
+)
 @option_commit_message
 @option_push
 @pass_runtime
@@ -333,6 +339,7 @@ def images_rebase(
     embargoed: bool,
     repo_type: str,
     force_yum_updates: bool,
+    extra_label: tuple,
     message: str,
     push: bool,
 ):
@@ -353,6 +360,13 @@ def images_rebase(
     """
 
     runtime.initialize(validate_content_sets=True)
+
+    extra_labels = {}
+    for label in extra_label:
+        if '=' not in label:
+            raise click.BadParameter(f"Extra label must be in KEY=VALUE format, got: {label}")
+        key, value = label.split('=', 1)
+        extra_labels[key] = value
 
     if runtime.group_config.public_upstreams and (release is None or release != "+" and not release.endswith(".p?")):
         raise click.BadParameter(
@@ -388,7 +402,9 @@ def images_rebase(
             dgr = image_meta.distgit_repo()
             if embargoed:
                 dgr.private_fix = True
-            (real_version, real_release) = dgr.rebase_dir(version, release, terminate_event, force_yum_updates)
+            (real_version, real_release) = dgr.rebase_dir(
+                version, release, terminate_event, force_yum_updates, extra_labels=extra_labels
+            )
             sha = dgr.commit(message, log_diff=True)
             dgr.tag(real_version, real_release)
             runtime.record_logger.add_record(

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -1984,7 +1984,7 @@ class ImageDistGitRepo(DistGitRepo):
             all_stages=True,
         )
 
-    def update_distgit_dir(self, version, release, prev_release=None, force_yum_updates=False):
+    def update_distgit_dir(self, version, release, prev_release=None, force_yum_updates=False, extra_labels=None):
         dg_path = self.dg_path
         with Dir(self.distgit_dir):
             # Source or not, we should find a Dockerfile in the root at this point or something is wrong
@@ -2041,6 +2041,10 @@ class ImageDistGitRepo(DistGitRepo):
             if self.config.labels is not Missing:
                 for k, v in self.config.labels.items():
                     dfp.labels[k] = str(v)
+
+            if extra_labels:
+                for k, v in extra_labels.items():
+                    dfp.labels[k] = v
 
             # Set the image name
             dfp.labels["name"] = self.config.name
@@ -2956,7 +2960,9 @@ class ImageDistGitRepo(DistGitRepo):
             return version, prev_release, private_fix
         return None, None, None
 
-    def rebase_dir(self, version: str, release: str, terminate_event, force_yum_updates=False) -> Tuple[str, str]:
+    def rebase_dir(
+        self, version: str, release: str, terminate_event, force_yum_updates=False, extra_labels=None
+    ) -> Tuple[str, str]:
         """
         - Copies the checked out upstream source commit over the content the checked out distgit commit.
         - Runs any configured source modifications for the component.
@@ -3009,7 +3015,9 @@ class ImageDistGitRepo(DistGitRepo):
             if self.metadata.private_fix:
                 self.logger.warning("The source of this image contains embargoed fixes.")
 
-            real_version, real_release = self.update_distgit_dir(version, release, prev_release, force_yum_updates)
+            real_version, real_release = self.update_distgit_dir(
+                version, release, prev_release, force_yum_updates, extra_labels=extra_labels
+            )
             self.metadata.rebase_status = True
             return real_version, real_release
         except Exception:

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -380,9 +380,19 @@ class UpdateGolangPipeline:
             # Rebase and build missing images
             build_tasks = []
             if self.build_system in ['both', 'brew'] and brew_missing:
-                build_tasks.extend([self._rebase_and_build_brew(el_v, go_version) for el_v in brew_missing])
+                build_tasks.extend(
+                    [
+                        self._rebase_and_build_brew(el_v, go_version, el_nvr_map_for_images[el_v])
+                        for el_v in brew_missing
+                    ]
+                )
             if self.build_system in ['both', 'konflux'] and konflux_missing:
-                build_tasks.extend([self._rebase_and_build_konflux(el_v, go_version) for el_v in konflux_missing])
+                build_tasks.extend(
+                    [
+                        self._rebase_and_build_konflux(el_v, go_version, el_nvr_map_for_images[el_v])
+                        for el_v in konflux_missing
+                    ]
+                )
             if build_tasks:
                 results = await asyncio.gather(*build_tasks, return_exceptions=True)
             errors = [r for r in results if isinstance(r, Exception)]
@@ -790,7 +800,7 @@ class UpdateGolangPipeline:
             else:
                 _LOGGER.info(f"No update needed in {branch}")
 
-    async def _rebase_brew(self, el_v, go_version):
+    async def _rebase_brew(self, el_v, go_version, go_nvr: str):
         _LOGGER.info("Rebasing for Brew...")
         branch = self.get_golang_branch(el_v, go_version)
         if self.data_gitref:
@@ -815,6 +825,8 @@ class UpdateGolangPipeline:
                 version,
                 "--release",
                 release,
+                "--extra-label",
+                f"io.openshift.build.golang-nvr={go_nvr}",
                 "--message",
                 f"bumping to {version}-{release}",
             ]
@@ -853,11 +865,11 @@ class UpdateGolangPipeline:
             cmd.append("--scratch")
         await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars, log_stdout=True)
 
-    async def _rebase_and_build_brew(self, el_v, go_version):
-        await self._rebase_brew(el_v, go_version)
+    async def _rebase_and_build_brew(self, el_v, go_version, go_nvr: str):
+        await self._rebase_brew(el_v, go_version, go_nvr)
         await self._build_brew(el_v, go_version)
 
-    async def _rebase_konflux(self, el_v, go_version):
+    async def _rebase_konflux(self, el_v, go_version, go_nvr: str):
         """Rebase golang-builder image for Konflux"""
         _LOGGER.info("Rebasing for Konflux...")
         branch = self.get_golang_branch(el_v, go_version)
@@ -883,6 +895,8 @@ class UpdateGolangPipeline:
                 version,
                 "--release",
                 release,
+                "--extra-label",
+                f"io.openshift.build.golang-nvr={go_nvr}",
                 "--message",
                 f"bumping to {version}-{release}",
             ]
@@ -926,9 +940,9 @@ class UpdateGolangPipeline:
             cmd.append("--dry-run")
         await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars, log_stdout=True)
 
-    async def _rebase_and_build_konflux(self, el_v, go_version):
+    async def _rebase_and_build_konflux(self, el_v, go_version, go_nvr: str):
         """Rebase and build golang-builder image on Konflux"""
-        await self._rebase_konflux(el_v, go_version)
+        await self._rebase_konflux(el_v, go_version, go_nvr)
         await self._build_konflux(el_v, go_version)
 
     @staticmethod

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1243,7 +1243,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             tag_builds=True,
         )
 
-        await pipeline._rebase_brew(8, "1.20.12")
+        await pipeline._rebase_brew(8, "1.20.12", "golang-1.20.12-2.el8")
 
         mock_cmd_assert.assert_called_once()
         cmd = mock_cmd_assert.call_args[0][0]
@@ -1254,6 +1254,8 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         self.assertIn("--version", cmd)
         self.assertIn("v1.20.12", cmd)
         self.assertIn("--push", cmd)
+        self.assertIn("--extra-label", cmd)
+        self.assertIn("io.openshift.build.golang-nvr=golang-1.20.12-2.el8", cmd)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_assert_async")
@@ -1275,10 +1277,12 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             tag_builds=True,
         )
 
-        await pipeline._rebase_brew(8, "1.20.12")
+        await pipeline._rebase_brew(8, "1.20.12", "golang-1.20.12-2.el8")
 
         cmd = mock_cmd_assert.call_args[0][0]
         self.assertNotIn("--push", cmd)
+        self.assertIn("--extra-label", cmd)
+        self.assertIn("io.openshift.build.golang-nvr=golang-1.20.12-2.el8", cmd)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_assert_async")
@@ -1331,10 +1335,12 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             build_system="konflux",
         )
 
-        await pipeline._rebase_konflux(8, "1.20.12")
+        await pipeline._rebase_konflux(8, "1.20.12", "golang-1.20.12-2.el8")
 
         cmd = mock_cmd_assert.call_args[0][0]
         self.assertIn("beta:images:konflux:rebase", cmd)
+        self.assertIn("--extra-label", cmd)
+        self.assertIn("io.openshift.build.golang-nvr=golang-1.20.12-2.el8", cmd)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_assert_async")
@@ -1357,10 +1363,12 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             build_system="konflux",
         )
 
-        await pipeline._rebase_konflux(8, "1.20.12")
+        await pipeline._rebase_konflux(8, "1.20.12", "golang-1.20.12-2.el8")
 
         cmd = mock_cmd_assert.call_args[0][0]
         self.assertNotIn("--push", cmd)
+        self.assertIn("--extra-label", cmd)
+        self.assertIn("io.openshift.build.golang-nvr=golang-1.20.12-2.el8", cmd)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_assert_async")
@@ -1437,7 +1445,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             tag_builds=True,
         )
 
-        await pipeline._rebase_and_build_brew(8, "1.20.12")
+        await pipeline._rebase_and_build_brew(8, "1.20.12", "golang-1.20.12-2.el8")
 
         # Should call both rebase and build
         self.assertEqual(mock_cmd_assert.call_count, 2)
@@ -1463,7 +1471,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             build_system="konflux",
         )
 
-        await pipeline._rebase_and_build_konflux(8, "1.20.12")
+        await pipeline._rebase_and_build_konflux(8, "1.20.12", "golang-1.20.12-2.el8")
 
         # Should call both rebase and build
         self.assertEqual(mock_cmd_assert.call_count, 2)


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ART-18366

## Summary
- Adds `--extra-label KEY=VALUE` option to doozer's Brew `images:rebase` CLI, matching the existing Konflux equivalent
- Threads `extra_labels` through `distgit.py` `rebase_dir()` → `update_distgit_dir()` to apply labels to the Dockerfile
- Passes `--extra-label io.openshift.build.golang-nvr=<nvr>` from the `update_golang` pipeline for both Brew and Konflux builds
- Updates tests to verify the new label is included in doozer commands

## Test plan
- [x] `make lint` passes
- [x] `uv run pytest pyartcd/tests/pipelines/test_update_golang.py` — 68/68 pass
- [x] `uv run pytest doozer/tests/` — 1205/1205 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)