### PR TITLE
ART-19484: fix(images): skip base image release for OKD before force check

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1391,8 +1391,8 @@ class ImageMetadata(Metadata):
         Determines whether this image should trigger the base image release workflow.
 
         The method checks preconditions in the following order:
-        0. Image metadata `base_image_release.force` set to true always enables workflow
-        1. Variant must be OCP (not OKD)
+        0. Variant must be OCP (not OKD); OKD never uses RH base-image snapshot→release
+        1. Image metadata ``base_image_release.force`` set to true enables workflow (OCP only)
         2. Assembly must not be ``test``
         3. Image must be ``base_only`` or a golang builder
         4. Base image release enabled override:
@@ -1403,13 +1403,13 @@ class ImageMetadata(Metadata):
         Returns:
             bool: True if base image release workflow should be triggered, False otherwise.
         """
+        if self.runtime.variant is BuildVariant.OKD:
+            return False
+
         base_image_release_force_override = self.config.base_image_release.force
         if base_image_release_force_override not in [Missing, None] and bool(base_image_release_force_override):
             self.logger.info("Base image release force enabled from metadata config True")
             return True
-
-        if self.runtime.variant is BuildVariant.OKD:
-            return False
 
         if self.runtime.assembly == "test":
             return False

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1921,12 +1921,12 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         okd_golang_metadata = ImageMetadata(okd_runtime, golang_data)
         self.assertFalse(okd_golang_metadata.should_trigger_base_image_release())
 
-        # Force=true bypasses OKD and test-assembly guards
+        # Force=true does not enable base image release on OKD (OCP-only workflow)
         okd_forced = Model({'name': 'test-regular', 'base_image_release': Model({'force': True})})
         okd_forced_metadata = ImageMetadata(
             okd_runtime, Model({'key': 'okd-forced', 'data': okd_forced, 'filename': 'okd-forced.yaml'})
         )
-        self.assertTrue(okd_forced_metadata.should_trigger_base_image_release())
+        self.assertFalse(okd_forced_metadata.should_trigger_base_image_release())
 
         test_assembly_forced_runtime = MagicMock()
         test_assembly_forced_runtime.logger = logging.getLogger('test_runtime')


### PR DESCRIPTION
## Summary

OKD Konflux builds no longer trigger RH base-image snapshot→release when image metadata has `base_image_release.force: true`. The OKD variant guard runs first in `should_trigger_base_image_release()`.

## Problem

**Before:** `base_image_release.force` was evaluated before `BuildVariant.OKD`, so OKD builds of openshift-5.0 images (e.g. `ose-installer` with `force: true` from ocp-build-data#10855) ran snapshot→release and persisted `release_error` in BigQuery.

**After:** OKD always returns `False` from `should_trigger_base_image_release()`; `force` applies only on OCP. Successful OKD PLRs persist as `success`.

## Implementation

- Move `if self.runtime.variant is BuildVariant.OKD: return False` to the top of `should_trigger_base_image_release()`
- Update docstring precondition order
- Test: OKD + `force: true` expects `False`

https://redhat.atlassian.net/browse/ART-19484