### PR TITLE
fix(images): skip EC verification for OKD variant

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -27,6 +27,7 @@ from artcommonlib.oc_image_info import oc_image_info__cached_async
 from artcommonlib.release_util import SoftwareLifecyclePhase, isolate_el_version_in_release, split_el_suffix_in_release
 from artcommonlib.rpm_utils import compare_nvr, parse_nvr
 from artcommonlib.util import fetch_slsa_attestation, get_konflux_data
+from artcommonlib.variants import BuildVariant
 from dockerfile_parse import DockerfileParser
 from doozerlib import constants, util
 from doozerlib.backend.base_image_handler import BaseImageHandler, BaseImageReleaseResult, BaseImageSnapshotInput
@@ -307,6 +308,7 @@ class KonfluxImageBuilder:
                 is_ocp_group = self._config.group_name.startswith("openshift-")
                 should_run_ec = (
                     outcome is KonfluxBuildOutcome.SUCCESS
+                    and metadata.runtime.variant is not BuildVariant.OKD
                     and is_ocp_group
                     and not self._config.skip_ec_verify
                     and metadata.for_release
@@ -346,7 +348,12 @@ class KonfluxImageBuilder:
                         record["ec_pipeline_url"] = ec_pipeline_url
 
                 elif outcome is KonfluxBuildOutcome.SUCCESS:
-                    if self._config.skip_ec_verify:
+                    if metadata.runtime.variant is BuildVariant.OKD:
+                        logger.info(
+                            "Skipping EC verification for %s: OKD variant does not use RH EC workflow",
+                            metadata.distgit_key,
+                        )
+                    elif self._config.skip_ec_verify:
                         logger.info(
                             "Skipping EC verification for %s: --skip-ec-verify flag is set", metadata.distgit_key
                         )

--- a/doozer/tests/backend/test_konflux_ec_verification.py
+++ b/doozer/tests/backend/test_konflux_ec_verification.py
@@ -10,6 +10,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
+from artcommonlib.variants import BuildVariant
 from doozerlib.backend.konflux_client import ECVerificationResult
 from doozerlib.backend.konflux_image_builder import (
     KonfluxImageBuilder,
@@ -61,7 +62,7 @@ def _make_successful_pipelinerun_info():
     return plr_info
 
 
-def _make_metadata(distgit_key="test-image", for_release=True, is_base_image=False):
+def _make_metadata(distgit_key="test-image", for_release=True, is_base_image=False, variant=None):
     """Create a mock ImageMetadata."""
     metadata = MagicMock()
     metadata.distgit_key = distgit_key
@@ -77,6 +78,7 @@ def _make_metadata(distgit_key="test-image", for_release=True, is_base_image=Fal
     metadata.build_event = asyncio.Event()
     metadata.get_parent_members.return_value = {}
     metadata.runtime.assembly = "stream"
+    metadata.runtime.variant = variant if variant is not None else BuildVariant.OCP
     metadata.runtime.group_config.software_lifecycle.phase = "release"
     metadata.runtime.konflux_db = None
     return metadata
@@ -178,6 +180,14 @@ class TestEcVerificationGating(IsolatedAsyncioTestCase):
         """EC verification should be skipped for non-OCP groups (e.g. logging)."""
         config = _make_config(group_name="logging-6.2")
         metadata = _make_metadata(for_release=True)
+
+        verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+        verify_ec.assert_not_called()
+
+    async def test_ec_skipped_for_okd_variant(self, mock_kc_init):
+        """EC verification should be skipped for OKD variant (not OCP)."""
+        config = _make_config(group_name="openshift-5.0")
+        metadata = _make_metadata(for_release=True, variant=BuildVariant.OKD)
 
         verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
         verify_ec.assert_not_called()


### PR DESCRIPTION
## Summary

OKD Konflux builds no longer trigger RH Enterprise Contract (EC/ITS) verification when runtime variant is OKD. The OKD variant guard runs first in the `should_run_ec` condition, similar to how OKD is handled for `base_image_release` (PR #2995).

## Problem

**Before:** EC verification (IntegrationTestScenario pipeline) was triggered for OKD builds even though OKD does not use Red Hat's Enterprise Contract workflow.

**After:** OKD variant check is evaluated first in `should_run_ec` logic, preventing EC verification from running for OKD builds. Only OCP builds trigger EC verification.

## Implementation

- Add `BuildVariant` import to `konflux_image_builder.py`
- Add OKD variant check (`metadata.runtime.variant is not BuildVariant.OKD`) to `should_run_ec` condition before other guards
- Add logging when EC is skipped for OKD variant: `"Skipping EC verification for %s: OKD variant does not use RH EC workflow"`
- Add test case `test_ec_skipped_for_okd_variant` to verify the guard works correctly

## Testing

- All 8 EC verification tests pass
- All 28 Konflux image builder tests pass
- Linting and formatting checks pass

## Related

- Similar to PR #2995 which prevented OKD from triggering base image release
- Addresses the same issue for ITS (ec_pipeline) as #2995 did for base image release pipeline