### PR TITLE
ART-19485: fix(images): persist release_pipeline on Konflux RELEASE_ERROR rows

### DIFF
--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -37,13 +37,18 @@ class BaseImageSnapshotInput:
 
 @dataclass(frozen=True)
 class BaseImageReleaseResult:
-    """Outputs from :meth:`BaseImageHandler.snapshot_release` after the Release succeeds."""
+    """Outputs from :meth:`BaseImageHandler.snapshot_release`.
+
+    ``release_pipeline`` is set when the Release CR was created (even if the release pipeline failed).
+    ``released_pullspec`` is set only when the release completes successfully.
+    """
 
     release_name: str
     snapshot_name: str
     nvr: str
     release_pipeline: str
     released_pullspec: str
+    succeeded: bool = True
 
 
 class BaseImageHandler:
@@ -83,7 +88,8 @@ class BaseImageHandler:
         Run snapshot→release for exactly one base-image component.
 
         Returns:
-            :class:`BaseImageReleaseResult` on success, else ``None``.
+            :class:`BaseImageReleaseResult` when snapshot and Release CR succeed (``succeeded`` reflects
+            release pipeline outcome), else ``None`` when snapshot or Release CR creation fails.
         """
         self.logger = self._scoped_logger(f"containers/{snapshot_input.distgit_key}")
 
@@ -123,8 +129,17 @@ class BaseImageHandler:
         release_name, release_url = result
 
         if not await self._wait_for_release_completion(release_name):
-            self.logger.error(f"Release did not complete successfully (release={release_name})")
-            return None
+            self.logger.error(
+                f"Release did not complete successfully (release={release_name}, url={release_url})"
+            )
+            return BaseImageReleaseResult(
+                release_name=release_name,
+                snapshot_name=snapshot_name,
+                nvr=snapshot_input.nvr,
+                release_pipeline=release_url,
+                released_pullspec='',
+                succeeded=False,
+            )
 
         released_pullspec = doozer_util.rh_art_images_base_pullspec(snapshot_input.nvr)
 
@@ -138,6 +153,7 @@ class BaseImageHandler:
             nvr=snapshot_input.nvr,
             release_pipeline=release_url,
             released_pullspec=released_pullspec,
+            succeeded=True,
         )
 
     def _build_component_from_snapshot_input(self, snapshot_input: BaseImageSnapshotInput) -> dict:

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -43,6 +43,7 @@ from packageurl import PackageURL
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 LOGGER = logging.getLogger(__name__)
+RELEASE_PIPELINE_NOT_AVAILABLE = 'N/A'
 
 
 def _normalize_version(version: str) -> str:
@@ -375,7 +376,7 @@ class KonfluxImageBuilder:
                         release_result = await self._trigger_base_image_release(
                             metadata, nvr, definitive_image_pullspec, build_repo
                         )
-                        if release_result:
+                        if release_result and release_result.succeeded:
                             logger.info("Base image release succeeded for %s, persisting build record", nvr)
                         else:
                             logger.error(
@@ -384,7 +385,20 @@ class KonfluxImageBuilder:
                                 KonfluxBuildOutcome.RELEASE_ERROR,
                             )
                             record["base_image_release_failed"] = "true"
-                        outcome = KonfluxBuildOutcome.SUCCESS if release_result else KonfluxBuildOutcome.RELEASE_ERROR
+                        outcome = (
+                            KonfluxBuildOutcome.SUCCESS
+                            if release_result and release_result.succeeded
+                            else KonfluxBuildOutcome.RELEASE_ERROR
+                        )
+
+                    release_pipeline = ''
+                    released_pullspec = ''
+                    if release_result:
+                        release_pipeline = release_result.release_pipeline
+                        if release_result.succeeded:
+                            released_pullspec = release_result.released_pullspec
+                    elif metadata.should_trigger_base_image_release() and outcome is KonfluxBuildOutcome.RELEASE_ERROR:
+                        release_pipeline = RELEASE_PIPELINE_NOT_AVAILABLE
 
                     build_record = await self.update_konflux_db(
                         metadata,
@@ -394,8 +408,8 @@ class KonfluxImageBuilder:
                         building_arches,
                         build_priority,
                         ec_pipeline_url=ec_pipeline_url,
-                        release_pipeline=release_result.release_pipeline if release_result else '',
-                        released_pullspec=release_result.released_pullspec if release_result else '',
+                        release_pipeline=release_pipeline,
+                        released_pullspec=released_pullspec,
                     )
                     if build_record:
                         record["record_id"] = build_record.record_id
@@ -1235,7 +1249,8 @@ class KonfluxImageBuilder:
             build_repo: Build repo (rebase git URL and commit for snapshot source)
 
         Returns:
-            :class:`BaseImageReleaseResult` when snapshot→release completes; ``None`` on failure or exception.
+            :class:`BaseImageReleaseResult` when snapshot and Release CR are created (``succeeded`` reflects
+            release pipeline outcome); ``None`` when snapshot/Release CR creation fails or on exception.
         """
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
 
@@ -1258,6 +1273,14 @@ class KonfluxImageBuilder:
             if result is None:
                 logger.error("Base image snapshot-release did not complete successfully for %s", nvr)
                 return None
+            if not result.succeeded:
+                logger.error(
+                    "Base image release pipeline failed for %s (release=%s, url=%s)",
+                    nvr,
+                    result.release_name,
+                    result.release_pipeline,
+                )
+                return result
             logger.info(f"Successfully triggered base image snapshot-release for {nvr}")
             return result
 

--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -1514,7 +1514,7 @@ async def release_to_base_repo(runtime, nvr):
     handler = BaseImageHandler(runtime, dry_run=False)
     result = await handler.snapshot_release(snapshot_input)
 
-    if result:
+    if result and result.succeeded:
         logger.info(
             "Done: release=%s snapshot=%s release_pipeline=%s",
             result.release_name,
@@ -1527,5 +1527,11 @@ async def release_to_base_repo(runtime, nvr):
         followup.record_id = KonfluxBuildRecord.generate_record_id()
         await runtime.konflux_db.add_builds([followup])
         return
+
+    if result and not result.succeeded:
+        raise DoozerFatalError(
+            f"snapshot_release failed (release={result.release_name}, "
+            f"release_pipeline={result.release_pipeline})"
+        )
 
     raise DoozerFatalError("snapshot_release returned no result")

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -71,6 +71,36 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_snapshot_release_wait_failure_returns_partial_result_with_release_url(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+        mock_konflux_client_init.return_value = AsyncMock()
+
+        handler = BaseImageHandler(self.runtime, dry_run=True)
+        self.runtime.image_map = {"test-base": self.metadata}
+        release_url = "https://konflux.example/releases/failed-release"
+
+        with patch.object(handler, "_snapshot_from_component", new=AsyncMock(return_value="test-snapshot")):
+            with patch.object(
+                handler,
+                "_create_release_from_snapshot",
+                new=AsyncMock(return_value=("failed-release", release_url)),
+            ):
+                with patch.object(handler, "_wait_for_release_completion", return_value=False):
+                    result = await handler.snapshot_release(self.default_input)
+
+        self.assertIsNotNone(result)
+        self.assertFalse(result.succeeded)
+        self.assertEqual(result.release_name, "failed-release")
+        self.assertEqual(result.snapshot_name, "test-snapshot")
+        self.assertEqual(result.release_pipeline, release_url)
+        self.assertEqual(result.released_pullspec, "")
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
     async def test_snapshot_release_builds_one_component(
         self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
     ):

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -636,11 +636,86 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         mock_trigger_release.assert_awaited_once()
         self.assertEqual(mock_update_db.await_count, 2)
 
-        # Final update records RELEASE_ERROR outcome; released_* omitted when base release failed
+        # Final update records RELEASE_ERROR; N/A when Release CR was never created
         failure_call_args = mock_update_db.await_args_list[1][0]
         self.assertEqual(failure_call_args[3], KonfluxBuildOutcome.RELEASE_ERROR)
         failure_kw = mock_update_db.await_args_list[1].kwargs
-        self.assertEqual(failure_kw.get("release_pipeline", ""), "")
+        self.assertEqual(failure_kw.get("release_pipeline"), "N/A")
+        self.assertEqual(failure_kw.get("released_pullspec", ""), "")
+
+    async def test_trigger_base_image_release_failure_persists_release_pipeline(self):
+        """When Release CR exists but pipeline fails, persist release_pipeline for triage."""
+        metadata = self._metadata()
+        metadata.should_trigger_base_image_release.return_value = True
+        dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        build_repo = MagicMock()
+        build_repo.local_dir = dest_dir
+        build_repo.url = "https://github.com/test/repo.git"
+        build_repo.commit_hash = "test-commit"
+
+        initial_pipelinerun = MagicMock()
+        initial_pipelinerun.name = "test-pipelinerun"
+        initial_pipelinerun.to_dict.return_value = {"metadata": {"name": "test-pipelinerun"}}
+
+        completed_pipelinerun = MagicMock()
+        completed_pipelinerun.name = "test-pipelinerun"
+        completed_pipelinerun.find_condition.return_value = {"status": "True"}
+        completed_pipelinerun.to_dict.return_value = {
+            "metadata": {"name": "test-pipelinerun"},
+            "status": {
+                "results": [
+                    {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                    {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                ]
+            },
+        }
+        self.mock_konflux_client.wait_for_pipelinerun = AsyncMock(return_value=completed_pipelinerun)
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=build_repo),
+            ),
+            patch.object(self.builder, "_parse_dockerfile", return_value=("test-uuid", "test-component", "1.0", "1")),
+            patch.object(self.builder, "_wait_for_parent_members", new=AsyncMock(return_value=[])),
+            patch.object(self.builder, "_start_build", new=AsyncMock(return_value=initial_pipelinerun)),
+            patch.object(
+                self.builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))
+            ) as mock_update_db,
+            patch.object(self.builder, "_trigger_base_image_release", new_callable=AsyncMock) as mock_trigger_release,
+            patch.object(self.builder, "_validate_build_attestation_and_signature", new=AsyncMock()),
+            patch.object(
+                self.builder._konflux_client,
+                "verify_enterprise_contract",
+                new=AsyncMock(return_value=MagicMock(ec_status="PASSED", ec_pipeline_url="", ec_failed=False)),
+            ),
+            patch(
+                "doozerlib.backend.konflux_image_builder.KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition",
+                return_value=KonfluxBuildOutcome.SUCCESS,
+            ),
+        ):
+            from doozerlib.backend import base_image_handler
+
+            mock_trigger_release.return_value = base_image_handler.BaseImageReleaseResult(
+                release_name="failed-release",
+                snapshot_name="test-snapshot",
+                nvr="test-nvr",
+                release_pipeline="https://example.com/failed-release",
+                released_pullspec="",
+                succeeded=False,
+            )
+            with self.assertRaises(KonfluxImageBuildError):
+                await self.builder.build(metadata)
+
+        mock_trigger_release.assert_awaited_once()
+        self.assertEqual(mock_update_db.await_count, 2)
+
+        failure_call_args = mock_update_db.await_args_list[1][0]
+        self.assertEqual(failure_call_args[3], KonfluxBuildOutcome.RELEASE_ERROR)
+        failure_kw = mock_update_db.await_args_list[1].kwargs
+        self.assertEqual(failure_kw.get("release_pipeline"), "https://example.com/failed-release")
         self.assertEqual(failure_kw.get("released_pullspec", ""), "")
 
     async def test_non_base_image_skips_release_trigger(self):


### PR DESCRIPTION
## Summary
Konflux BigQuery `release_pipeline` was empty on `RELEASE_ERROR` rows because doozer only persisted it on full snapshot→release success. This change keeps triage links when a Release CR existed and uses `N/A` when it did not.

## Problem
**Before:** Any release-stage failure returned `None` from `snapshot_release()`, so `release_pipeline` was always empty on `RELEASE_ERROR` rows — even when a Konflux Release CR was created and the pipeline failed.

**After:** Partial release results persist the Konflux Release console URL on `RELEASE_ERROR` when the Release CR exists; pre-Release failures store `N/A`. `released_pullspec` remains success-only.

## Implementation Details

- `BaseImageReleaseResult` gains `succeeded`; wait failure returns partial result with `release_pipeline` URL
- `konflux_image_builder` sets outcome from `succeeded`, writes URL or `N/A` on `RELEASE_ERROR`
- `release-to-base-repo` CLI inserts follow-up rows only on full success
- Unit tests cover both failure buckets (no Release CR → `N/A`; Release CR + wait fail → URL)

## Test plan
- [x] `uv run pytest doozer/tests/backend/test_base_image_handler.py doozer/tests/backend/test_konflux_image_builder.py -k "release or snapshot_release"`