### PR TITLE
fix(konflux): reduce BigQuery log noise for unexpected fields

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -1279,10 +1279,10 @@ class KonfluxDb:
             row_fields = set(row.keys())
             filtered_fields = {field: row[field] for field in row_fields if field in valid_params}
 
-            # Log warning if any fields were ignored
+            # Log debug message if any fields were ignored
             ignored_fields = row_fields - valid_params
             if ignored_fields:
-                self.logger.warning(
+                self.logger.debug(
                     'Ignoring unexpected fields from BigQuery row for %s: %s',
                     self.record_cls.__name__,
                     sorted(ignored_fields),


### PR DESCRIPTION
## Summary
- Changed log level from `warning` to `debug` for unexpected BigQuery fields in KonfluxDb
- Prevents log flooding when BigQuery returns new fields like `ec_status` that aren't yet defined in `KonfluxBuildRecord`
- Debug level still provides visibility for troubleshooting while keeping production logs clean