### PR TITLE
ART-18202: use --image mode with reinstallPackages for lockfile resolution

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -980,7 +980,11 @@ class KonfluxRebaser:
             ):
                 from doozerlib.lockfile_prototype.rebaser_hooks import apply_dockerfile_transforms
 
-                apply_dockerfile_transforms(dest_dir, logger=self._logger)
+                apply_dockerfile_transforms(
+                    dest_dir,
+                    strip_updates=not downstream_parents,
+                    logger=self._logger,
+                )
 
             await self._update_csv(metadata, dest_dir, version, release)
 

--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -50,6 +50,7 @@ def build_rpms_in_yaml(
     arches: list[str],
     packages: list[str],
     arch_specific_packages: dict[str, list[str]] | None = None,
+    reinstall_packages: list[str] | None = None,
     upgrade_packages: list[str] | None = None,
     module_enable: list[str] | None = None,
 ) -> RpmsInConfig:
@@ -61,6 +62,8 @@ def build_rpms_in_yaml(
         arches (list[str]): Target architectures.
         packages (list[str]): Common package names for all arches.
         arch_specific_packages (dict[str, list[str]] | None): Per-arch packages.
+        reinstall_packages (list[str] | None): Installed packages to reinstall
+            from repos (ensures they appear in the lockfile).
         upgrade_packages (list[str] | None): Packages to upgrade.
         module_enable (list[str] | None): Module streams to enable
             (e.g., ["nodejs:18", "python36:3.6"]).
@@ -78,6 +81,7 @@ def build_rpms_in_yaml(
         arches=arches,
         contentOrigin={"repos": repos},
         packages=package_entries,
+        reinstallPackages=list(reinstall_packages) if reinstall_packages else [],
         upgradePackages=list(upgrade_packages) if upgrade_packages else [],
         moduleEnable=list(module_enable) if module_enable else [],
     )
@@ -419,19 +423,28 @@ class RpmLockfilePrototypeGenerator:
                     stage_num, analysis.stages[stage_num], distgit_key
                 )
 
+            reinstall_pkgs: list[str] | None = None
             if stage_num == last_stage_num:
-                # Final stage resolves in bare mode. Add base image packages
-                # to the install list so dependency conflicts (e.g.
-                # crypto-policies vs gnutls) are caught during resolution.
-                # Skip when upgrade_targets already include base image
-                # packages (e.g. update-only stages).
-                if not upgrade_targets:
+                if image_pullspec:
+                    # --image mode: pass base image packages as reinstallPackages
+                    # so they appear in the lockfile at repo versions. base.reinstall()
+                    # handles missing/renamed packages gracefully (warns, skips).
                     base_pkgs = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key)
+                    if base_pkgs:
+                        reinstall_pkgs = list(base_pkgs)
+                        self.logger.info(
+                            f"{distgit_key}: stage {stage_num}: {len(reinstall_pkgs)} base image "
+                            "packages will be reinstalled into lockfile"
+                        )
+                else:
+                    # No base image available — resolve in bare mode with
+                    # base image packages added to the install list for
+                    # conflict detection.
+                    base_pkgs = await self._get_base_image_packages(stage_num, None, distgit_key)
                     if base_pkgs:
                         extra = [p for p in base_pkgs if p not in packages]
                         if extra:
                             packages = packages + extra
-                image_pullspec = None
 
             enable_only = [s.split("/")[0] for s in stage_info.module_specs] if stage_info.module_specs else None
 
@@ -445,6 +458,7 @@ class RpmLockfilePrototypeGenerator:
                 distgit_key,
                 stage_num,
                 module_enable=enable_only,
+                reinstall_packages=reinstall_pkgs,
             )
             if result:
                 stage_lockfiles.append(result)
@@ -535,15 +549,10 @@ class RpmLockfilePrototypeGenerator:
             return stage_info.update_targets
         if stage_info.update_targets:
             return stage_info.update_targets
-        # Bare yum/dnf update (no named packages). The bare update
-        # command is stripped from the Dockerfile by strip_bare_updates()
-        # after lockfile generation, so there's no need to expand all
-        # base image packages as upgrade targets. Skipping avoids
-        # PackagesNotInstalledError when packages differ across arches.
-        self.logger.info(
-            f"{distgit_key}: stage {stage_num}: bare update command detected, "
-            "skipping upgrade target expansion (command will be stripped from Dockerfile)"
-        )
+        # Bare yum/dnf update (no named packages). Return empty here;
+        # _resolve_all_stages expands upgrade targets from the base
+        # image when --image mode is available.
+        self.logger.info(f"{distgit_key}: stage {stage_num}: bare update detected")
         return []
 
     @staticmethod
@@ -634,6 +643,7 @@ class RpmLockfilePrototypeGenerator:
         distgit_key: str,
         stage_num: int,
         module_enable: list[str] | None = None,
+        reinstall_packages: list[str] | None = None,
     ) -> LockfileData | None:
         """
         Resolve a single stage, retrying after removing unavailable packages.
@@ -645,18 +655,24 @@ class RpmLockfilePrototypeGenerator:
         remaining_update_targets = list(update_targets)
         arch_pkgs = dict(arch_pkgs)
 
+        # rpm-lockfile-prototype uses skopeo to pull the base image rpmdb.
+        # brew.registry.redhat.io requires auth that skopeo may not have;
+        # use the no-auth registry proxy instead.
+        resolver_pullspec = ContainerImageHelper._proxy_pullspec(image_pullspec) if image_pullspec else None
+
         for attempt in range(MAX_RESOLUTION_RETRIES):
             in_yaml = build_rpms_in_yaml(
                 repo_list,
                 arches,
                 remaining_packages,
                 arch_specific_packages=arch_pkgs,
+                reinstall_packages=reinstall_packages if image_pullspec else None,
                 upgrade_packages=remaining_update_targets if image_pullspec else None,
                 module_enable=module_enable,
             )
 
             try:
-                return await self._resolver.resolve(in_yaml, image_pullspec=image_pullspec)
+                return await self._resolver.resolve(in_yaml, image_pullspec=resolver_pullspec)
             except RuntimeError as e:
                 missing = RpmResolver.parse_missing_packages(str(e))
                 if not missing:
@@ -780,6 +796,7 @@ class RpmLockfilePrototypeGenerator:
         distgit_key: str,
         stage_num: int,
         module_enable: list[str] | None = None,
+        reinstall_packages: list[str] | None = None,
     ) -> LockfileData | None:
         """
         Resolve a stage with cross-arch version reconciliation.
@@ -798,6 +815,8 @@ class RpmLockfilePrototypeGenerator:
             distgit_key (str): Image identifier for logging.
             stage_num (int): Dockerfile stage number.
             module_enable (list[str] | None): Module streams to enable.
+            reinstall_packages (list[str] | None): Base image packages to
+                reinstall from repos into the lockfile.
         Return Value(s):
             LockfileData | None: Resolved lockfile with consistent
                 versions, or None if no packages remain.
@@ -812,6 +831,7 @@ class RpmLockfilePrototypeGenerator:
             distgit_key,
             stage_num,
             module_enable=module_enable,
+            reinstall_packages=reinstall_packages,
         )
         if not first_pass:
             return None
@@ -843,6 +863,7 @@ class RpmLockfilePrototypeGenerator:
                 distgit_key,
                 stage_num,
                 module_enable=module_enable,
+                reinstall_packages=reinstall_packages,
             )
         except RuntimeError:
             self.logger.warning(

--- a/doozer/doozerlib/lockfile_prototype/models.py
+++ b/doozer/doozerlib/lockfile_prototype/models.py
@@ -42,6 +42,7 @@ class RpmsInConfig(BaseModel):
     arches: list[str]
     contentOrigin: dict[str, list[RepoEntry]]
     packages: list[str | ArchSpecificPackage] = Field(default_factory=list)
+    reinstallPackages: list[str] = Field(default_factory=list)
     upgradePackages: list[str] = Field(default_factory=list)
     moduleEnable: list[str] = Field(default_factory=list)
 

--- a/doozer/doozerlib/lockfile_prototype/rebaser_hooks.py
+++ b/doozer/doozerlib/lockfile_prototype/rebaser_hooks.py
@@ -96,6 +96,7 @@ async def generate_lockfile(
 
 def apply_dockerfile_transforms(
     dest_dir: Path,
+    strip_updates: bool = True,
     logger: logging.Logger | None = None,
 ) -> None:
     """
@@ -108,13 +109,18 @@ def apply_dockerfile_transforms(
 
     Arg(s):
         dest_dir (Path): Build directory containing the Dockerfile.
+        strip_updates (bool): Whether to strip bare dnf/yum update commands.
+            Set to False when the lockfile includes upgrade packages
+            (resolved with --image mode) so dnf update runs at build
+            time using the pre-fetched RPMs.
         logger (logging.Logger | None): Logger instance.
     """
     _logger = logger or logging.getLogger(__name__)
 
     df_path = dest_dir / "Dockerfile"
     df_content = df_path.read_text()
-    df_content = strip_bare_updates(df_content)
+    if strip_updates:
+        df_content = strip_bare_updates(df_content)
+        strip_bare_updates_from_scripts(dest_dir, logger=_logger)
     df_content = strip_reinstall_commands(df_content)
     df_path.write_text(df_content)
-    strip_bare_updates_from_scripts(dest_dir, logger=_logger)

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -315,27 +315,23 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
             (dest_dir / "Dockerfile").write_text("FROM base\nRUN yum update -y && yum clean all\n")
             asyncio.run(generator.generate_lockfile(meta, dest_dir))
 
-        generator._container.get_installed_packages.assert_called_once()
+        # Called for update-only stage + reinstall expansion
+        self.assertGreaterEqual(generator._container.get_installed_packages.call_count, 1)
         self.assertEqual(len(captured_configs), 1)
-        # Final stage uses bare mode (no rpmdb) for hermetic builds
-        self.assertIsNone(captured_pullspecs[0])
-        # upgrade_packages must be empty when image_pullspec is None:
-        # passing upgrade targets with --bare causes PackagesNotInstalledError
-        # because the installed sack is empty in bare mode.
-        self.assertEqual(captured_configs[0].upgradePackages, [])
-        # All installed packages should still appear as install targets
-        # so they end up in the lockfile
+        # Update-only stage uses --image mode with base image pullspec
+        self.assertIsNotNone(captured_pullspecs[0])
+        # All installed packages appear as both install and upgrade targets
         self.assertEqual(
             sorted(captured_configs[0].packages),
             ["bash", "coreutils", "glibc"],
         )
+        self.assertEqual(captured_configs[0].upgradePackages, ["bash", "coreutils", "glibc"])
 
-    def test_mixed_install_and_bare_update_skips_expansion(self):
+    def test_mixed_install_and_bare_update_uses_image_mode(self):
         """
-        Stage with both yum install and bare yum update -y should NOT
-        expand base image packages as upgrade targets. The bare update
-        command is stripped from the Dockerfile after lockfile generation,
-        so upgrade expansion is unnecessary and risks arch mismatches.
+        Stage with both yum install and bare yum update -y should resolve
+        in --image mode with upgradePackages=["*"] so base image packages
+        get upgraded to match build-time behavior.
         """
         meta = self._make_mock_image_meta()
         meta.config.konflux.cachi2.lockfile.get.return_value = None
@@ -343,9 +339,11 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
 
         captured_configs: list[RpmsInConfig] = []
+        captured_pullspecs: list[str | None] = []
 
         async def capture_resolve(config, image_pullspec=None):
             captured_configs.append(config)
+            captured_pullspecs.append(image_pullspec)
             return FAKE_LOCKFILE_DATA.model_copy(deep=True)
 
         generator._resolver.resolve = AsyncMock(side_effect=capture_resolve)
@@ -357,12 +355,10 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
             )
             asyncio.run(generator.generate_lockfile(meta, dest_dir))
 
-        # get_installed_packages is called once for final-stage conflict
-        # detection (not for bare update expansion)
-        generator._container.get_installed_packages.assert_called_once()
         self.assertEqual(len(captured_configs), 1)
-        self.assertEqual(captured_configs[0].upgradePackages, [])
-        # Only explicit install packages should be resolved
+        # --image mode: pullspec is preserved
+        self.assertIsNotNone(captured_pullspecs[0])
+        # Explicit install packages in the packages list
         pkg_names = [p if isinstance(p, str) else p.name for p in captured_configs[0].packages]
         self.assertIn("aws-efs-utils", pkg_names)
 
@@ -415,24 +411,23 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         self.assertIn("openvswitch3.5-ipsec", pkg_names)
         self.assertIn("ovn25.09-vtep", pkg_names)
 
-    def test_final_stage_queries_base_image_for_conflict_detection(self):
+    def test_final_stage_uses_image_mode_when_pullspec_available(self):
         """
-        For the final stage with packages but no bare update command,
-        base image packages must be added to the bare-mode resolution
-        so that dependency conflicts (e.g. crypto-policies EUS 9.8
-        conflicting with gnutls < 3.8.10) are detected and the lockfile
-        includes the required gnutls upgrade.
+        For the final stage with a base image pullspec, resolution uses
+        --image mode so DNF sees the base image's rpmdb. This ensures
+        lockfile versions match build-time behavior.
         """
         meta = self._make_mock_image_meta()
         meta.config.konflux.cachi2.lockfile.get.return_value = None
         generator = self._make_generator()
         generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
-        generator._container.get_installed_packages = AsyncMock(return_value=["gnutls", "glibc", "nss"])
 
         captured_configs: list[RpmsInConfig] = []
+        captured_pullspecs: list[str | None] = []
 
         async def capture_resolve(config, image_pullspec=None):
             captured_configs.append(config)
+            captured_pullspecs.append(image_pullspec)
             return FAKE_LOCKFILE_DATA.model_copy(deep=True)
 
         generator._resolver.resolve = AsyncMock(side_effect=capture_resolve)
@@ -442,34 +437,31 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
             (dest_dir / "Dockerfile").write_text("FROM base\nRUN dnf install -y libreswan openssl\n")
             asyncio.run(generator.generate_lockfile(meta, dest_dir))
 
-        # Must query base image even without bare update command
-        generator._container.get_installed_packages.assert_called_once()
         self.assertEqual(len(captured_configs), 1)
-        # Bare mode: image_pullspec is None and upgradePackages is empty
-        self.assertEqual(captured_configs[0].upgradePackages, [])
-        # Packages must include both Dockerfile packages AND base image packages
+        # --image mode: pullspec is preserved (not forced to None)
+        self.assertIsNotNone(captured_pullspecs[0])
+        # Only Dockerfile packages — base image packages come from rpmdb
         pkg_names = sorted(p if isinstance(p, str) else p.name for p in captured_configs[0].packages)
         self.assertIn("libreswan", pkg_names)
         self.assertIn("openssl", pkg_names)
-        self.assertIn("gnutls", pkg_names)
-        self.assertIn("glibc", pkg_names)
-        self.assertIn("nss", pkg_names)
 
-    def test_bare_update_does_not_query_base_image_for_upgrade_targets(self):
+    def test_bare_update_keeps_image_mode_without_upgrade_targets(self):
         """
-        Bare yum/dnf update should NOT expand base image packages as
-        upgrade targets. The bare update command is stripped after
-        lockfile generation, so expansion is unnecessary.
+        Bare yum/dnf update with --image mode should NOT expand base
+        image packages as upgrade targets (many are virtual provides or
+        renamed and cause resolution failures). Instead, dnf update is
+        kept in the Dockerfile and runs at build time with cachi2 RPMs.
         """
         meta = self._make_mock_image_meta()
         meta.config.konflux.cachi2.lockfile.get.return_value = None
         generator = self._make_generator()
-        generator._container.get_installed_packages = AsyncMock(return_value=["glibc", "gnutls"])
 
         captured_configs: list[RpmsInConfig] = []
+        captured_pullspecs: list[str | None] = []
 
         async def capture_resolve(config, image_pullspec=None):
             captured_configs.append(config)
+            captured_pullspecs.append(image_pullspec)
             return FAKE_LOCKFILE_DATA.model_copy(deep=True)
 
         generator._resolver.resolve = AsyncMock(side_effect=capture_resolve)
@@ -481,9 +473,10 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
                 generator.generate_lockfile(meta, dest_dir, downstream_parents=["quay.io/test/base@sha256:abc123"])
             )
 
-        # get_installed_packages is called once for final-stage conflict
-        # detection, but NOT for bare update expansion
-        generator._container.get_installed_packages.assert_called_once()
+        self.assertEqual(len(captured_configs), 1)
+        # --image mode preserved
+        self.assertIsNotNone(captured_pullspecs[0])
+        # No upgrade targets — dnf update handled at build time
         self.assertEqual(captured_configs[0].upgradePackages, [])
 
     def test_fallback_packages_used_when_image_unreachable(self):


### PR DESCRIPTION
The final stage was forced to bare mode (image_pullspec = None) which resolves without the base image's rpmdb. This causes two problems:

- Version conflicts: lockfile resolves gcc-11.5.0 from repos but the base image (e.g. golang-builder) has gcc-c++-11.4.1 requiring gcc = 11.4.1 — build fails with dependency conflict
- Cross-arch mismatches: base image packages not in lockfile, so different base image versions per arch produce Conforma violations

Now the final stage keeps --image mode when a base image pullspec is available. rpm-lockfile-prototype extracts the rpmdb per-arch via skopeo, so DNF sees what's already installed and resolves compatible versions. Pullspec is translated to registry-proxy for skopeo auth.

ALL base image packages are passed as reinstallPackages — base.reinstall() puts them in the lockfile at consistent versions across arches, ensuring packages like tar, libsemanage, and python3-cloud-what appear for every arch. reinstall handles virtual provides and renamed packages gracefully (warns, skips). Packages in both the Dockerfile install list and the base image are included so --image mode doesn't skip them as "already installed."

Bare dnf update -y is kept in the Dockerfile (not stripped) when downstream_parents are present. Falls back to bare mode with manual base image package addition only when the base image is unreachable.

Verified locally with 4 arches (x86_64, aarch64, ppc64le, s390x) — all previously-mismatched packages resolve consistently.