### PR TITLE
ART-19485: preserve release_pipeline URL in BigQuery for failed base image releases

### DIFF
--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -124,7 +124,14 @@ class BaseImageHandler:
 
         if not await self._wait_for_release_completion(release_name):
             self.logger.error(f"Release did not complete successfully (release={release_name})")
-            return None
+            # Return partial result with release_pipeline URL for failure tracking
+            return BaseImageReleaseResult(
+                release_name=release_name,
+                snapshot_name=snapshot_name,
+                nvr=snapshot_input.nvr,
+                release_pipeline=release_url,
+                released_pullspec='',  # No pullspec on failure
+            )
 
         released_pullspec = doozer_util.rh_art_images_base_pullspec(snapshot_input.nvr)
 

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -373,7 +373,9 @@ class KonfluxImageBuilder:
                         release_result = await self._trigger_base_image_release(
                             metadata, nvr, definitive_image_pullspec, build_repo
                         )
-                        if release_result:
+                        # Success is indicated by having a released_pullspec (empty on failure)
+                        release_succeeded = release_result and release_result.released_pullspec
+                        if release_succeeded:
                             logger.info("Base image release succeeded for %s, persisting build record", nvr)
                             record["release_pipeline"] = release_result.release_pipeline
                         else:
@@ -385,7 +387,9 @@ class KonfluxImageBuilder:
                             record["base_image_release_failed"] = "true"
                             if release_result and release_result.release_pipeline:
                                 record["release_pipeline"] = release_result.release_pipeline
-                        outcome = KonfluxBuildOutcome.SUCCESS if release_result else KonfluxBuildOutcome.RELEASE_ERROR
+                        outcome = (
+                            KonfluxBuildOutcome.SUCCESS if release_succeeded else KonfluxBuildOutcome.RELEASE_ERROR
+                        )
 
                     build_record = await self.update_konflux_db(
                         metadata,

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -1261,7 +1261,10 @@ class KonfluxImageBuilder:
             if result is None:
                 logger.error("Base image snapshot-release did not complete successfully for %s", nvr)
                 return None
-            logger.info(f"Successfully triggered base image snapshot-release for {nvr}")
+            if not result.released_pullspec:
+                logger.error(f"Base image release failed to complete for {nvr} - see {result.release_pipeline}")
+            else:
+                logger.info(f"Successfully triggered base image snapshot-release for {nvr}")
             return result
 
         except Exception as e:

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -246,6 +246,37 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_snapshot_release_failure_preserves_release_pipeline(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        """Test that release_pipeline URL is preserved even when release fails."""
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+        mock_konflux_client_init.return_value = AsyncMock()
+
+        handler = BaseImageHandler(self.runtime, dry_run=True)
+        self.runtime.image_map = {"test-base": self.metadata}
+
+        with patch.object(handler, "_snapshot_from_component", new=AsyncMock(return_value="test-snapshot")):
+            with patch.object(
+                handler,
+                "_create_release_from_snapshot",
+                new=AsyncMock(return_value=("failed-release", "https://konflux.example/releases/failed-release")),
+            ):
+                with patch.object(handler, "_wait_for_release_completion", return_value=False):
+                    result = await handler.snapshot_release(self.default_input)
+
+        # Should return a result with release_pipeline but empty released_pullspec
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, BaseImageReleaseResult)
+        self.assertEqual(result.release_name, "failed-release")
+        self.assertEqual(result.snapshot_name, "test-snapshot")
+        self.assertEqual(result.release_pipeline, "https://konflux.example/releases/failed-release")
+        self.assertEqual(result.released_pullspec, "")  # Empty on failure
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
     async def test_create_release_from_snapshot_rhmtc_uses_product_plan_and_application(
         self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
     ):

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -573,7 +573,7 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(success_call_kwargs.get("released_pullspec"), "registry.example/pull:test")
 
     async def test_trigger_base_image_release_failure_flow(self):
-        """Test base image release failure handling with FAILURE outcome update."""
+        """Test base image release failure handling when _trigger_base_image_release returns None."""
         metadata = self._metadata()
         metadata.should_trigger_base_image_release.return_value = True
         dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
@@ -638,6 +638,85 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(failure_call_args[3], KonfluxBuildOutcome.RELEASE_ERROR)
         failure_kw = mock_update_db.await_args_list[1].kwargs
         self.assertEqual(failure_kw.get("release_pipeline", ""), "")
+        self.assertEqual(failure_kw.get("released_pullspec", ""), "")
+
+    async def test_trigger_base_image_release_failure_preserves_pipeline_url(self):
+        """Test base image release failure preserves release_pipeline URL when available."""
+        metadata = self._metadata()
+        metadata.should_trigger_base_image_release.return_value = True
+        dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        build_repo = MagicMock()
+        build_repo.local_dir = dest_dir
+        build_repo.url = "https://github.com/test/repo.git"
+        build_repo.commit_hash = "test-commit"
+
+        initial_pipelinerun = MagicMock()
+        initial_pipelinerun.name = "test-pipelinerun"
+        initial_pipelinerun.to_dict.return_value = {"metadata": {"name": "test-pipelinerun"}}
+
+        completed_pipelinerun = MagicMock()
+        completed_pipelinerun.name = "test-pipelinerun"
+        completed_pipelinerun.find_condition.return_value = {"status": "True"}
+        completed_pipelinerun.to_dict.return_value = {
+            "metadata": {"name": "test-pipelinerun"},
+            "status": {
+                "results": [
+                    {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                    {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                ]
+            },
+        }
+        self.mock_konflux_client.wait_for_pipelinerun = AsyncMock(return_value=completed_pipelinerun)
+
+        # Create a failed release result with release_pipeline but no released_pullspec
+        from doozerlib.backend.base_image_handler import BaseImageReleaseResult
+
+        failed_result = BaseImageReleaseResult(
+            release_name="failed-release",
+            snapshot_name="test-snapshot",
+            nvr="test-nvr",
+            release_pipeline="https://example.com/failed-release",
+            released_pullspec="",  # Empty indicates failure
+        )
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=build_repo),
+            ),
+            patch.object(self.builder, "_parse_dockerfile", return_value=("test-uuid", "test-component", "1.0", "1")),
+            patch.object(self.builder, "_wait_for_parent_members", new=AsyncMock(return_value=[])),
+            patch.object(self.builder, "_start_build", new=AsyncMock(return_value=initial_pipelinerun)),
+            patch.object(
+                self.builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))
+            ) as mock_update_db,
+            patch.object(
+                self.builder, "_trigger_base_image_release", new=AsyncMock(return_value=failed_result)
+            ) as mock_trigger_release,
+            patch.object(self.builder, "_validate_build_attestation_and_signature", new=AsyncMock()),
+            patch.object(
+                self.builder._konflux_client,
+                "verify_enterprise_contract",
+                new=AsyncMock(return_value=MagicMock(ec_pipeline_url="", ec_failed=False)),
+            ),
+            patch(
+                "doozerlib.backend.konflux_image_builder.KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition",
+                return_value=KonfluxBuildOutcome.SUCCESS,
+            ),
+        ):
+            with self.assertRaises(KonfluxImageBuildError):
+                await self.builder.build(metadata)
+
+        mock_trigger_release.assert_awaited_once()
+        self.assertEqual(mock_update_db.await_count, 2)
+
+        # Final update records RELEASE_ERROR outcome with release_pipeline preserved
+        failure_call_args = mock_update_db.await_args_list[1][0]
+        self.assertEqual(failure_call_args[3], KonfluxBuildOutcome.RELEASE_ERROR)
+        failure_kw = mock_update_db.await_args_list[1].kwargs
+        self.assertEqual(failure_kw.get("release_pipeline"), "https://example.com/failed-release")
         self.assertEqual(failure_kw.get("released_pullspec", ""), "")
 
     async def test_non_base_image_skips_release_trigger(self):


### PR DESCRIPTION
## Summary

Fixes an issue where the `release_pipeline` field in BigQuery was empty for failed base image releases, making it difficult to debug release failures.

## Problem

When a base image release failed (outcome = `release_error`), the `release_pipeline` URL was not being stored in BigQuery because:
1. `BaseImageHandler.snapshot_release()` returned `None` when `_wait_for_release_completion()` returned `False`
2. The caller in `KonfluxImageBuilder` then stored an empty string for `release_pipeline`

This meant we couldn't query BigQuery to find the Konflux release URL for debugging failed releases.

## Solution

**Modified `BaseImageHandler.snapshot_release()`:**
- Now returns a `BaseImageReleaseResult` even when the release fails
- Sets `release_pipeline` to the URL (for debugging)
- Sets `released_pullspec` to empty string (to indicate failure)

**Modified `KonfluxImageBuilder`:**
- Checks `released_pullspec` presence (not just `release_result` truthiness) to determine success
- Preserves `release_pipeline` URL from the result even when the release fails

## Testing
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/36563/