### PR TITLE
Sign multi-arch component manifest list digests

### DIFF
--- a/pyartcd/pyartcd/signatory.py
+++ b/pyartcd/pyartcd/signatory.py
@@ -469,8 +469,9 @@ class SigstoreSignatory:
             return need_signing, need_examining, errors
 
         if isinstance(img_info, list):
-            # Manifest list: examine each arch manifest
+            # Manifest list: sign the list itself AND examine each arch manifest
             self._logger.debug("%s is a manifest list", pullspec)
+            need_signing.add(pullspec)
             for manifest in img_info:
                 need_examining.add(self.redigest_pullspec(manifest["name"], manifest["digest"]))
         else:


### PR DESCRIPTION
## Summary
- Multi-arch component images (`ocp-v4.0-art-dev`) have their arch-specific digests cosign-signed but **not** their manifest list digest
- `_examine_component()` in `signatory.py` extracts arch manifests from a manifest list for signing but discards the manifest list digest itself
- This affects all release types (EC, RC, GA) equally
- Release images (`ocp-release`) are not affected — they use a different code path that correctly handles manifest lists

## Fix
Add the manifest list pullspec to the signing queue alongside the arch-specific manifests in `_examine_component()`.

## Test plan
- [x] All 19 signatory tests pass
- [ ] Verify on next promote that multi component manifest list digests have cosign signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)