### PR TITLE
ART-19847 Add --use-new-golang-branch support to update-golang pipeline

### DIFF
--- a/doozer/doozerlib/cli/__init__.py
+++ b/doozer/doozerlib/cli/__init__.py
@@ -210,6 +210,13 @@ def print_version(ctx, param, value):
     default=None,
     help="Whether to store & retrieve data in int / stage / prod database environment",
 )
+@click.option(
+    "--var",
+    "extra_vars",
+    metavar="KEY=VALUE",
+    multiple=True,
+    help="Override or inject a group.yml var at runtime (e.g. --var MAJOR=5 --var MINOR=0). [multiple]",
+)
 @click.option("--profile", metavar="NAME", default="", help="Name of build profile")
 @click.option(
     "--brew-event", metavar='EVENT', default=None, type=int, help="Lock koji clients from runtime to this brew event."

--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -93,6 +93,7 @@ class Runtime(GroupRuntime):
         self.variant = BuildVariant.OCP  # Default to OCP variant
         self.data_path = None
         self.data_dir = None
+        self.extra_vars: dict[str, str] = {}
         self.group_commitish = None
         self.latest_parent_version = False
         self.rhpkg_config = None
@@ -394,6 +395,16 @@ class Runtime(GroupRuntime):
                 # for example: replace_vars = {'CVES': 'None', 'IMPACT': 'Low', 'MAJOR': 4, 'MINOR': 12, 'RHCOS_EL_MAJOR': 8, 'RHCOS_EL_MINOR': 6, 'release_name': '4.12.77', 'runtime_assembly': '4.12.77'}
                 if 'PATCH' not in replace_vars:
                     replace_vars['PATCH'] = Version.parse(release_name).patch
+        if self.extra_vars:
+            for item in self.extra_vars:
+                if '=' not in item:
+                    raise ValueError(f"Invalid --var format '{item}', expected KEY=VALUE")
+                key, value = item.split('=', 1)
+                try:
+                    value = int(value)
+                except ValueError:
+                    pass
+                replace_vars[key] = value
         return replace_vars
 
     def init_state(self):

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -187,6 +187,7 @@ class UpdateGolangPipeline:
         skip_pr: bool = False,
         external_golang_rpms: bool = False,
         network_mode: str | None = None,
+        use_new_golang_branch: bool = False,
         major_bump: bool = False,
     ):
         self.runtime = runtime
@@ -206,6 +207,7 @@ class UpdateGolangPipeline:
         self.skip_pr = skip_pr
         self.external_golang_rpms = external_golang_rpms
         self.network_mode = network_mode
+        self.use_new_golang_branch = use_new_golang_branch
         self.major_bump = major_bump
         self._slack_client = self.runtime.new_slack_client()
         self._doozer_working_dir = self.runtime.working_dir / "doozer-working"
@@ -792,9 +794,7 @@ class UpdateGolangPipeline:
 
     async def _rebase_brew(self, el_v, go_version):
         _LOGGER.info("Rebasing for Brew...")
-        branch = self.get_golang_branch(el_v, go_version)
-        if self.data_gitref:
-            branch += f'@{self.data_gitref}'
+        group, image_key = self._get_doozer_group_and_image(el_v, go_version)
         version = f"v{go_version}"
         release = default_release_suffix()
         cmd = [
@@ -804,12 +804,13 @@ class UpdateGolangPipeline:
         ]
         if self.data_path:
             cmd.append(f"--data-path={self.data_path}")
+        cmd.extend(self._get_doozer_var_args())
         cmd.extend(
             [
                 "--group",
-                branch,
+                group,
                 "-i",
-                GOLANG_BUILDER_IMAGE_NAME,
+                image_key,
                 "images:rebase",
                 "--version",
                 version,
@@ -825,9 +826,7 @@ class UpdateGolangPipeline:
 
     async def _build_brew(self, el_v, go_version):
         _LOGGER.info("Building on Brew...")
-        branch = self.get_golang_branch(el_v, go_version)
-        if self.data_gitref:
-            branch += f'@{self.data_gitref}'
+        group, image_key = self._get_doozer_group_and_image(el_v, go_version)
         cmd = [
             "doozer",
             f"--working-dir={self._doozer_working_dir}-brew-{el_v}",
@@ -835,12 +834,13 @@ class UpdateGolangPipeline:
         ]
         if self.data_path:
             cmd.append(f"--data-path={self.data_path}")
+        cmd.extend(self._get_doozer_var_args())
         cmd.extend(
             [
                 "--group",
-                branch,
+                group,
                 "-i",
-                GOLANG_BUILDER_IMAGE_NAME,
+                image_key,
                 "images:build",
                 "--repo-type",
                 "unsigned",
@@ -860,9 +860,7 @@ class UpdateGolangPipeline:
     async def _rebase_konflux(self, el_v, go_version):
         """Rebase golang-builder image for Konflux"""
         _LOGGER.info("Rebasing for Konflux...")
-        branch = self.get_golang_branch(el_v, go_version)
-        if self.data_gitref:
-            branch += f'@{self.data_gitref}'
+        group, image_key = self._get_doozer_group_and_image(el_v, go_version)
         version = f"v{go_version}"
         release = default_release_suffix()
         cmd = [
@@ -872,12 +870,13 @@ class UpdateGolangPipeline:
         ]
         if self.data_path:
             cmd.append(f"--data-path={self.data_path}")
+        cmd.extend(self._get_doozer_var_args())
         cmd.extend(
             [
                 "--group",
-                branch,
+                group,
                 "-i",
-                GOLANG_BUILDER_IMAGE_NAME,
+                image_key,
                 "beta:images:konflux:rebase",
                 "--version",
                 version,
@@ -896,9 +895,7 @@ class UpdateGolangPipeline:
     async def _build_konflux(self, el_v, go_version):
         """Build golang-builder image on Konflux"""
         _LOGGER.info("Building on Konflux...")
-        branch = self.get_golang_branch(el_v, go_version)
-        if self.data_gitref:
-            branch += f'@{self.data_gitref}'
+        group, image_key = self._get_doozer_group_and_image(el_v, go_version)
         konflux_namespace = PRODUCT_NAMESPACE_MAP["ocp"]
         cmd = [
             "doozer",
@@ -907,12 +904,13 @@ class UpdateGolangPipeline:
         ]
         if self.data_path:
             cmd.append(f"--data-path={self.data_path}")
+        cmd.extend(self._get_doozer_var_args())
         cmd.extend(
             [
                 "--group",
-                branch,
+                group,
                 "-i",
-                GOLANG_BUILDER_IMAGE_NAME,
+                image_key,
                 "beta:images:konflux:build",
                 f"--konflux-namespace={konflux_namespace}",
                 "--skip-ec-verify",
@@ -931,14 +929,42 @@ class UpdateGolangPipeline:
         await self._rebase_konflux(el_v, go_version)
         await self._build_konflux(el_v, go_version)
 
+    GOLANG_DATA_BRANCH = 'golang'
+
     @staticmethod
     def get_golang_branch(el_v, go_version):
         major_go, minor_go, _ = go_version.split('.')
         go_v = f"{major_go}.{minor_go}"
         return f'rhel-{el_v}-golang-{go_v}'
 
+    @staticmethod
+    def get_golang_image_key(el_v, go_version):
+        major_go, minor_go, _ = go_version.split('.')
+        go_v = f"{major_go}-{minor_go}"
+        return f'{GOLANG_BUILDER_IMAGE_NAME}-{go_v}.rhel{el_v}'
+
+    def _get_doozer_var_args(self) -> list[str]:
+        if not self.use_new_golang_branch:
+            return []
+        ocp_major, ocp_minor = self.ocp_version.split('.')
+        return ['--var', f'MAJOR={ocp_major}', '--var', f'MINOR={ocp_minor}']
+
+    def _get_doozer_group_and_image(self, el_v, go_version):
+        if self.use_new_golang_branch:
+            group = self.GOLANG_DATA_BRANCH
+            image_key = self.get_golang_image_key(el_v, go_version)
+        else:
+            group = self.get_golang_branch(el_v, go_version)
+            image_key = GOLANG_BUILDER_IMAGE_NAME
+        if self.data_gitref:
+            group += f'@{self.data_gitref}'
+        return group, image_key
+
     def verify_golang_builder_repo(self, el_v, go_version):
-        branch = self.get_golang_branch(el_v, go_version)
+        if self.use_new_golang_branch:
+            branch = self.GOLANG_DATA_BRANCH
+        else:
+            branch = self.get_golang_branch(el_v, go_version)
         filename = 'group.yml'
 
         repo = get_github_client_for_org("openshift-eng").get_repo("openshift-eng/ocp-build-data")
@@ -1037,6 +1063,12 @@ class UpdateGolangPipeline:
     help='Override network mode for Konflux builds. Takes precedence over image and group config settings.',
 )
 @click.option(
+    '--use-new-golang-branch',
+    is_flag=True,
+    default=False,
+    help='Use the unified "golang" branch layout in ocp-build-data instead of per-variant branches (e.g. rhel-9-golang-1.26).',
+)
+@click.option(
     '--major-bump',
     is_flag=True,
     default=False,
@@ -1063,6 +1095,7 @@ async def update_golang(
     skip_pr: bool,
     external_golang_rpms: bool,
     network_mode: str | None,
+    use_new_golang_branch: bool,
     major_bump: bool,
 ):
     if not runtime.dry_run and not confirm:
@@ -1095,5 +1128,6 @@ async def update_golang(
         skip_pr,
         external_golang_rpms,
         network_mode,
+        use_new_golang_branch,
         major_bump,
     ).run()

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -410,6 +410,16 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         branch = UpdateGolangPipeline.get_golang_branch(9, "1.21.5")
         self.assertEqual(branch, "rhel-9-golang-1.21")
 
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_get_doozer_var_args(self, mock_konflux_db):
+        """Test _get_doozer_var_args returns --var args when use_new_golang_branch is set"""
+        pipeline = self._make_pipeline()
+        self.assertEqual(pipeline._get_doozer_var_args(), [])
+
+        pipeline.use_new_golang_branch = True
+        pipeline.ocp_version = "5.0"
+        self.assertEqual(pipeline._get_doozer_var_args(), ['--var', 'MAJOR=5', '--var', 'MINOR=0'])
+
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_validate_tag_builds_go_latest_accepts_matching_major_minor(self, mock_konflux_db, mock_get_github_client):


### PR DESCRIPTION
## Summary
- Adds `--use-new-golang-branch` flag to `update-golang` pipeline for building golang-builder images from the unified `golang` branch in ocp-build-data instead of per-variant branches (e.g. rhel-9-golang-1.26)
- Adds doozer `--var KEY=VALUE` CLI option for runtime group.yml var injection (e.g. `--var MAJOR=5 --var MINOR=0`)
- Pipeline passes `--var` args to doozer when `--use-new-golang-branch` is set, injecting MAJOR/MINOR from `--ocp-version`
- Refactors doozer command builders to use `_get_doozer_group_and_image()` for consistent group/image-key resolution

## Test plan
- [x] Unit tests: 69 pipeline tests pass
- [x] Dry-run tested: `artcd --dry-run update-golang --use-new-golang-branch` with local ocp-build-data worktree — doozer rebase completed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)