### PR TITLE
ART-19498: feat(konflux): base image release plan by software lifecycle

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -98,7 +98,7 @@ PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP = {
     "openshift-logging": ("logging-images-base-silent", "logging-images-base"),
 }
 
-# Pre-release lifecycle (software_lifecycle.phase) — registry-ocp-art-base-ec-stage via ART-19498.
+# Pre-release lifecycle (software_lifecycle.phase) — registry-ocp-art-base-ec-prod via ART-19498.
 PRODUCT_BASE_IMAGE_KONFLUX_EC_RELEASE_MAP = {
     "ocp": ("ocp-art-images-base-silent-ec", "art-images-base"),
 }

--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -98,6 +98,11 @@ PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP = {
     "openshift-logging": ("logging-images-base-silent", "logging-images-base"),
 }
 
+# Pre-release lifecycle (software_lifecycle.phase) — registry-ocp-art-base-ec-stage via ART-19498.
+PRODUCT_BASE_IMAGE_KONFLUX_EC_RELEASE_MAP = {
+    "ocp": ("ocp-art-images-base-silent-ec", "art-images-base"),
+}
+
 PRODUCT_KUBECONFIG_MAP = {
     "acm": "ACM_KONFLUX_SA_KUBECONFIG",
     "mce": "ACM_KONFLUX_SA_KUBECONFIG",

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -20,6 +20,7 @@ from artcommonlib.constants import (
     GOLANG_BUILDER_IMAGE_NAME,
     KONFLUX_DEFAULT_IMAGE_REPO,
     KONFLUX_DEFAULT_NAMESPACE,
+    PRODUCT_BASE_IMAGE_KONFLUX_EC_RELEASE_MAP,
     PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP,
     PRODUCT_KUBECONFIG_MAP,
     PRODUCT_NAMESPACE_MAP,
@@ -31,7 +32,7 @@ from artcommonlib.oc_image_info import (
     oc_image_info__cached__lru,
     oc_image_info__cached_async__lru,
 )
-from artcommonlib.release_util import isolate_el_version_in_release
+from artcommonlib.release_util import SoftwareLifecyclePhase, isolate_el_version_in_release
 from ruamel.yaml import YAML
 from semver import VersionInfo
 from tenacity import before_sleep_log, retry, retry_if_exception_type, stop_after_attempt, wait_fixed
@@ -1197,7 +1198,10 @@ def resolve_konflux_namespace_by_product(product: str, provided_namespace: Optio
     return KONFLUX_DEFAULT_NAMESPACE
 
 
-def resolve_konflux_base_image_release_targets(product: str) -> Tuple[str, str]:
+def resolve_konflux_base_image_release_targets(
+    product: str,
+    lifecycle_phase: Optional[str] = None,
+) -> Tuple[str, str]:
     """
     Resolve the Konflux ReleasePlan name and Application for the silent base-image workflow.
 
@@ -1205,14 +1209,36 @@ def resolve_konflux_base_image_release_targets(product: str) -> Tuple[str, str]:
     spec.application and matching labels. These must match konflux-release-data for the product's tenant.
     Layered products use `<product>-images-base` (e.g. `mtc-images-base`). OCP keeps `art-images-base`.
 
+    When ``lifecycle_phase`` is ``pre-release`` and the product has an EC release plan configured
+    (OCP today), use the EC-stage base image ReleasePlan (``registry-ocp-art-base-ec-stage`` policy).
+    See https://redhat.atlassian.net/browse/ART-19498.
+
     Unknown products default to the OCP targets (same as resolve_konflux_namespace_by_product fallback).
 
     Args:
         product: Runtime product key (e.g. ocp, rhmtc, mta).
+        lifecycle_phase: ``group.yml`` ``software_lifecycle.phase`` value, if known.
 
     Returns:
         (release_plan_name, application_name)
     """
+    if lifecycle_phase not in (None, '', Missing):
+        try:
+            if SoftwareLifecyclePhase.from_name(lifecycle_phase) == SoftwareLifecyclePhase.PRE_RELEASE:
+                ec_targets = PRODUCT_BASE_IMAGE_KONFLUX_EC_RELEASE_MAP.get(product)
+                if ec_targets:
+                    plan, app = ec_targets
+                    KONFLUX_LOGGER.info(
+                        f"Using pre-release base-image Konflux releasePlan '{plan}' "
+                        f"and application '{app}' for product '{product}'"
+                    )
+                    return ec_targets
+        except ValueError:
+            KONFLUX_LOGGER.warning(
+                f"Unknown software_lifecycle.phase '{lifecycle_phase}' for product '{product}'; "
+                "using default base-image release plan"
+            )
+
     targets = PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP.get(product)
     if targets:
         plan, app = targets

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -1210,7 +1210,7 @@ def resolve_konflux_base_image_release_targets(
     Layered products use `<product>-images-base` (e.g. `mtc-images-base`). OCP keeps `art-images-base`.
 
     When ``lifecycle_phase`` is ``pre-release`` and the product has an EC release plan configured
-    (OCP today), use the EC-stage base image ReleasePlan (``registry-ocp-art-base-ec-stage`` policy).
+    (OCP today), use the EC base image ReleasePlan (``registry-ocp-art-base-ec-prod`` policy).
     See https://redhat.atlassian.net/browse/ART-19498.
 
     Unknown products default to the OCP targets (same as resolve_konflux_namespace_by_product fallback).

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -324,6 +324,24 @@ alternative_upstream:
             ("ocp-art-images-base-silent", "art-images-base"),
         )
 
+    def test_resolve_konflux_base_image_release_targets_pre_release_ocp_uses_ec_plan(self):
+        self.assertEqual(
+            util.resolve_konflux_base_image_release_targets("ocp", lifecycle_phase="pre-release"),
+            ("ocp-art-images-base-silent-ec", "art-images-base"),
+        )
+
+    def test_resolve_konflux_base_image_release_targets_release_phase_uses_prod_plan(self):
+        self.assertEqual(
+            util.resolve_konflux_base_image_release_targets("ocp", lifecycle_phase="release"),
+            ("ocp-art-images-base-silent", "art-images-base"),
+        )
+
+    def test_resolve_konflux_base_image_release_targets_pre_release_non_ocp_uses_prod_plan(self):
+        self.assertEqual(
+            util.resolve_konflux_base_image_release_targets("rhmtc", lifecycle_phase="pre-release"),
+            ("mtc-images-base-silent", "mtc-images-base"),
+        )
+
 
 class TestSoftwareLifecyclePhase(unittest.TestCase):
     def test_from_name_valid(self):

--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from artcommonlib import logutil
+from artcommonlib.model import Missing
 from artcommonlib.util import (
     get_utc_now_formatted_str,
     normalize_group_name_for_k8s,
@@ -21,6 +22,20 @@ from artcommonlib.util import (
 from doozerlib import util as doozer_util
 from doozerlib.backend.konflux_client import API_VERSION, KIND_RELEASE, KIND_RELEASE_PLAN, KIND_SNAPSHOT, KonfluxClient
 from kubernetes.dynamic import exceptions
+
+
+def _software_lifecycle_phase(runtime) -> Optional[str]:
+    """Return group.yml software_lifecycle.phase when configured on the runtime."""
+    group_config = getattr(runtime, 'group_config', None)
+    if group_config in (None, Missing):
+        return None
+    software_lifecycle = getattr(group_config, 'software_lifecycle', None)
+    if software_lifecycle in (None, Missing):
+        return None
+    phase = getattr(software_lifecycle, 'phase', None)
+    if phase in (None, Missing):
+        return None
+    return str(phase)
 
 
 @dataclass(frozen=True)
@@ -60,7 +75,11 @@ class BaseImageHandler:
         self.namespace = resolve_konflux_namespace_by_product(self.runtime.product, None)
         kubeconfig = resolve_konflux_kubeconfig_by_product(self.runtime.product, None)
 
-        resolved_plan, resolved_application = resolve_konflux_base_image_release_targets(self.runtime.product)
+        lifecycle_phase = _software_lifecycle_phase(self.runtime)
+        resolved_plan, resolved_application = resolve_konflux_base_image_release_targets(
+            self.runtime.product,
+            lifecycle_phase=lifecycle_phase,
+        )
         self.base_image_release_plan = resolved_plan
         self.base_image_application = resolved_application
         self.logger.info(

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -76,8 +76,8 @@ KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION = "ocp-art-tenant/conforma-build-stage"
 KONFLUX_PREGA_EC_POLICY_CONFIGURATION = "ocp-art-tenant/conforma-build-ec-stage"
 # Base image release EC policies (ReleasePlanAdmission policy name suffix). Selection is by
 # software_lifecycle.phase in resolve_konflux_base_image_release_targets — ART-19498.
-# Prod: registry-ocp-art-base-prod | Pre-release: registry-ocp-art-base-ec-stage
+# Prod: registry-ocp-art-base-prod | Pre-release: registry-ocp-art-base-ec-prod
 KONFLUX_BASE_IMAGE_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-base-prod"
-KONFLUX_BASE_IMAGE_PREGA_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-base-ec-stage"
+KONFLUX_BASE_IMAGE_PREGA_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-base-ec-prod"
 
 ART_IMAGES_BASE_APPLICATION = "art-images-base"

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -74,8 +74,10 @@ KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION = "ocp-art-tenant/conforma-build-stage"
 # PreGA (PREVIEW assembly) EC policy: same as stage but allows unsigned RPMs
 # https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/tenants-config/cluster/kflux-ocp-p01/tenants/ocp-art-tenant/ecp-build-ec-stage.yaml
 KONFLUX_PREGA_EC_POLICY_CONFIGURATION = "ocp-art-tenant/conforma-build-ec-stage"
-# Base image EC policy (base_only images use a dedicated prod policy for all assembly types)
-# https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/kflux-ocp-p01.7ayg.p1/product/EnterpriseContractPolicy/registry-ocp-art-base-prod.yaml
+# Base image release EC policies (ReleasePlanAdmission policy name suffix). Selection is by
+# software_lifecycle.phase in resolve_konflux_base_image_release_targets — ART-19498.
+# Prod: registry-ocp-art-base-prod | Pre-release: registry-ocp-art-base-ec-stage
 KONFLUX_BASE_IMAGE_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-base-prod"
+KONFLUX_BASE_IMAGE_PREGA_EC_POLICY_CONFIGURATION = "rhtap-releng-tenant/registry-ocp-art-base-ec-stage"
 
 ART_IMAGES_BASE_APPLICATION = "art-images-base"

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -246,6 +246,21 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_handler_pre_release_lifecycle_uses_ec_release_plan(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+        mock_konflux_client_init.return_value = AsyncMock()
+
+        self.runtime.group_config = Model({"software_lifecycle": Model({"phase": "pre-release"})})
+
+        handler = BaseImageHandler(self.runtime, dry_run=True)
+        self.assertEqual(handler.base_image_release_plan, "ocp-art-images-base-silent-ec")
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
     async def test_snapshot_release_failure_preserves_release_pipeline(
         self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
     ):


### PR DESCRIPTION
## Summary
Base image snapshot→release now picks the Konflux ReleasePlan from `group.yml` `software_lifecycle.phase`. Pre-release streams use `ocp-art-images-base-silent-ec` (`registry-ocp-art-base-ec-stage`). GA/stable streams keep `ocp-art-images-base-silent` (`registry-ocp-art-base-prod`).

## Problem
**Before:** All base images released through `registry-ocp-art-base-prod`, so 4.23/5.0 EC builds failed release Conforma on unsigned RPMs / unknown repo IDs while build and ITS looked fine.

**After:** Pre-release lifecycle uses the EC-stage base policy and release plan, aligned with non-base EC behavior (PR 2766 + `registry-ocp-art-ec-stage`).

**Depends on:** [konflux-release-data MR](https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/new?merge_request%5Bsource_branch%5D=[ART-19498](https://redhat.atlassian.net/browse/ART-19498)-base-image-ec-policy) for `registry-ocp-art-base-ec-stage`, RPA, and ReleasePlan — merge and deploy that first.

## Test plan
- [ ] `pytest artcommon/tests/test_util.py -k base_image_release_targets`
- [ ] `pytest doozer/tests/backend/test_base_image_handler.py`
- [ ] After kflux MR is live: rebuild a 4.23/stream base image (e.g. ose-ovn-kubernetes) with `software_lifecycle.phase: pre-release` and confirm release uses ec plan