### PR TITLE
ART-18202: pass reinstall packages as upgrade targets to avoid PackagesNotAvailableError

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -660,14 +660,22 @@ class RpmLockfilePrototypeGenerator:
         # use the no-auth registry proxy instead.
         resolver_pullspec = ContainerImageHelper._proxy_pullspec(image_pullspec) if image_pullspec else None
 
+        # When reinstall_packages is set, also pass them as upgrade targets.
+        # base.reinstall() raises PackagesNotAvailableError when the installed
+        # version isn't in the configured repos — but rpm-lockfile-prototype
+        # swallows that error when the package is also in upgradePackages
+        # (the upgrade provides a replacement version).
+        remaining_reinstall = list(reinstall_packages) if reinstall_packages else []
+
         for attempt in range(MAX_RESOLUTION_RETRIES):
+            effective_upgrade = list(set(remaining_update_targets + remaining_reinstall)) if image_pullspec else None
             in_yaml = build_rpms_in_yaml(
                 repo_list,
                 arches,
                 remaining_packages,
                 arch_specific_packages=arch_pkgs,
-                reinstall_packages=reinstall_packages if image_pullspec else None,
-                upgrade_packages=remaining_update_targets if image_pullspec else None,
+                reinstall_packages=remaining_reinstall if image_pullspec else None,
+                upgrade_packages=effective_upgrade,
                 module_enable=module_enable,
             )
 
@@ -678,16 +686,23 @@ class RpmLockfilePrototypeGenerator:
                 if not missing:
                     raise
                 prev_count = (
-                    len(remaining_packages) + sum(len(v) for v in arch_pkgs.values()) + len(remaining_update_targets)
+                    len(remaining_packages)
+                    + sum(len(v) for v in arch_pkgs.values())
+                    + len(remaining_update_targets)
+                    + len(remaining_reinstall)
                 )
                 remaining_packages = [p for p in remaining_packages if p not in missing]
                 remaining_update_targets = [p for p in remaining_update_targets if p not in missing]
+                remaining_reinstall = [p for p in remaining_reinstall if p not in missing]
                 for arch in list(arch_pkgs.keys()):
                     arch_pkgs[arch] = [p for p in arch_pkgs[arch] if p not in missing]
                     if not arch_pkgs[arch]:
                         del arch_pkgs[arch]
                 new_count = (
-                    len(remaining_packages) + sum(len(v) for v in arch_pkgs.values()) + len(remaining_update_targets)
+                    len(remaining_packages)
+                    + sum(len(v) for v in arch_pkgs.values())
+                    + len(remaining_update_targets)
+                    + len(remaining_reinstall)
                 )
                 if new_count == prev_count:
                     raise

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -325,7 +325,7 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
             sorted(captured_configs[0].packages),
             ["bash", "coreutils", "glibc"],
         )
-        self.assertEqual(captured_configs[0].upgradePackages, ["bash", "coreutils", "glibc"])
+        self.assertEqual(sorted(captured_configs[0].upgradePackages), ["bash", "coreutils", "glibc"])
 
     def test_mixed_install_and_bare_update_uses_image_mode(self):
         """
@@ -478,6 +478,79 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         self.assertIsNotNone(captured_pullspecs[0])
         # No upgrade targets — dnf update handled at build time
         self.assertEqual(captured_configs[0].upgradePackages, [])
+
+    def test_reinstall_packages_also_passed_as_upgrade_targets(self):
+        """
+        Base image packages passed as reinstallPackages must also appear
+        in upgradePackages so rpm-lockfile-prototype skips
+        PackagesNotAvailableError (installed version not in repos) instead
+        of crashing.
+        """
+        meta = self._make_mock_image_meta()
+        meta.config.konflux.cachi2.lockfile.get.return_value = None
+        generator = self._make_generator()
+        generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
+        generator._container.get_installed_packages = AsyncMock(return_value=["sed", "glibc", "libnghttp2"])
+
+        captured_configs: list[RpmsInConfig] = []
+
+        async def capture_resolve(config, image_pullspec=None):
+            captured_configs.append(config)
+            return FAKE_LOCKFILE_DATA.model_copy(deep=True)
+
+        generator._resolver.resolve = AsyncMock(side_effect=capture_resolve)
+
+        with TemporaryDirectory() as tmpdir:
+            dest_dir = Path(tmpdir)
+            (dest_dir / "Dockerfile").write_text("FROM base\nRUN dnf install -y curl\n")
+            asyncio.run(generator.generate_lockfile(meta, dest_dir))
+
+        self.assertEqual(len(captured_configs), 1)
+        reinstall = captured_configs[0].reinstallPackages
+        upgrade = captured_configs[0].upgradePackages
+        # All reinstall packages must also be in upgrade targets
+        for pkg in reinstall:
+            self.assertIn(pkg, upgrade)
+        # Dockerfile install packages are NOT in reinstall or upgrade
+        self.assertNotIn("curl", reinstall)
+
+    def test_reinstall_retry_removes_unavailable_packages(self):
+        """
+        When a reinstall/upgrade package fails resolution (e.g. package
+        not found in repos at all), the retry loop must remove it from
+        reinstallPackages and upgradePackages before retrying.
+        """
+        meta = self._make_mock_image_meta()
+        meta.config.konflux.cachi2.lockfile.get.return_value = None
+        generator = self._make_generator()
+        generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
+        generator._container.get_installed_packages = AsyncMock(return_value=["nonexistent-pkg", "glibc"])
+
+        call_count = 0
+
+        async def mock_resolve(config, image_pullspec=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("No match for argument: nonexistent-pkg")
+            return FAKE_LOCKFILE_DATA.model_copy(deep=True)
+
+        generator._resolver.resolve = AsyncMock(side_effect=mock_resolve)
+
+        with TemporaryDirectory() as tmpdir:
+            dest_dir = Path(tmpdir)
+            (dest_dir / "Dockerfile").write_text("FROM base\nRUN dnf install -y curl\n")
+            asyncio.run(generator.generate_lockfile(meta, dest_dir))
+
+        # Should have retried successfully
+        self.assertEqual(call_count, 2)
+        # Second call should not have "nonexistent-pkg" in reinstall or upgrade
+        second_config = generator._resolver.resolve.call_args_list[1][0][0]
+        self.assertNotIn("nonexistent-pkg", second_config.reinstallPackages)
+        self.assertNotIn("nonexistent-pkg", second_config.upgradePackages)
+        # "glibc" should still be present
+        self.assertIn("glibc", second_config.reinstallPackages)
+        self.assertIn("glibc", second_config.upgradePackages)
 
     def test_fallback_packages_used_when_image_unreachable(self):
         """


### PR DESCRIPTION
  ### Problem

  After #2999, `base.reinstall(pkg)` crashes with `PackagesNotAvailableError` when a base image package's installed version isn't in the configured EUS repos (e.g. `sed`, `libnghttp2`).
  This happens because the base image was built from a different repo set than what's configured for lockfile resolution.

  ### Root cause

  rpm-lockfile-prototype's `base.reinstall()` handler swallows `PackagesNotAvailableError` **only** when the package is also in `upgradePackages`:

  ```python
  except dnf.exceptions.PackagesNotAvailableError:
      if pkg not in upgrade_packages:
          raise  # <-- crashes here
```
  We were passing base image packages as reinstallPackages but not as upgradePackages.

   ### Fix

  Pass all reinstallPackages as upgradePackages too. When the installed version isn't in repos, the reinstall error is swallowed (because the package IS in upgrade targets), and the
  upgrade provides a replacement version from the repos. This is the intended design of the rpm-lockfile-prototype handler.

  Also makes remaining_reinstall mutable in the retry loop so unavailable packages are filtered on retry (same as remaining_packages and remaining_update_targets).