### PR TITLE
Use ocp_version for MAJOR/MINOR in verify_golang_builder_repo

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -994,11 +994,11 @@ class UpdateGolangPipeline:
                 "name please correct it."
             )
 
-        major, minor = group_config['vars']['MAJOR'], group_config['vars']['MINOR']
+        ocp_major, ocp_minor = self.ocp_version.split('.')
         err = False
         for arch, template_url in group_config['repos'][golang_repo]['conf']['baseurl'].items():
             expected_suffix = f'{content_repo_url_suffix}/{arch}/'
-            actual_url = template_url.format(MAJOR=major, MINOR=minor)
+            actual_url = template_url.format(MAJOR=ocp_major, MINOR=ocp_minor)
             if not actual_url.endswith(expected_suffix):
                 err = True
                 _LOGGER.error(f"{expected_suffix} not found in URL {actual_url}")


### PR DESCRIPTION
Follows https://github.com/openshift-eng/art-tools/pull/3003

## Summary
- Derives MAJOR/MINOR from `--ocp-version` instead of reading from the golang branch's `group.yml` vars
- The branch's `group.yml` may have placeholder values (e.g. for the unified golang branch), while `--ocp-version` is the authoritative source

Tested at https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgolang-builder/576/console

## Test plan
- [x] 69 pipeline tests pass
- [x] No behavior change for existing per-variant branches (MAJOR/MINOR in group.yml already match ocp_version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)