### PR TITLE
ART-19521: simplify health report to public channels

### DIFF
--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -622,6 +622,11 @@ class ImagesHealthPipeline:
         await self.slack_client.say(report, thread_ts=response['ts'], unfurl_links=False, unfurl_media=False)
 
     async def notify_public_channel(self):
+        """
+        Send a summary message to the public channel with a link to the dashboard.
+        Instead of posting detailed failure lists (which can overflow Jira API limits),
+        we now only post a summary and direct users to the art-build-failures dashboard.
+        """
         self.slack_client.bind_channel(self.public_channel)
 
         # Group build concerns by image name
@@ -665,58 +670,18 @@ class ImagesHealthPipeline:
             summary_parts.append(f'{n} image{"s" if n > 1 else ""} with rebase failures')
 
         issues = '\n- '.join(summary_parts)
-        response = await self.slack_client.say(
-            f':alert: There are some issues to look into for Openshift builds:\n- {issues}',
-            link_build_url=False,
+
+        # Build dashboard URL showing failures for all scanned versions
+        start_date = (datetime.now(timezone.utc) - timedelta(days=DELTA_DAYS)).strftime('%Y-%m-%d')
+        end_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+        dashboard_url = f'{ART_BUILD_HISTORY_URL}/?dateRange={start_date}+to+{end_date}&outcome=failure&engine=konflux'
+
+        message = (
+            f':alert: There are some issues to look into for Openshift builds:\n- {issues}\n\n'
+            f'For detailed information, please check the {self.url_text(dashboard_url, "ART Build Failures Dashboard")}'
         )
 
-        if image_build_failures:
-            n = len(image_build_failures)
-            message = f'*Build Failures ({n} image{"s" if n > 1 else ""}):*'
-            for image_name, concerns in sorted(image_build_failures.items()):
-                message += f'\n`{image_name}`:'
-                for concern in concerns:
-                    message += f'\n  • {self.get_message_for_forum(concern)}'
-            await self.slack_client.say(
-                message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False, unfurl_media=False
-            )
-
-        if image_ec_failures:
-            n = len(image_ec_failures)
-            message = f'*EC Verification Failures ({n} image{"s" if n > 1 else ""}):*'
-            for image_name, failures in sorted(image_ec_failures.items()):
-                message += f'\n`{image_name}`:'
-                for failure in failures:
-                    line = f'\n  • {self._format_forum_redis_failure_inline(failure)}'
-                    pipeline_url = failure.get('pipeline_url', '')
-                    if pipeline_url:
-                        line += f' | {self.url_text(pipeline_url, "Pipeline")}'
-                    message += line
-            await self.slack_client.say(
-                message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False, unfurl_media=False
-            )
-
-        if image_release_failures:
-            n = len(image_release_failures)
-            message = f'*Release to Authz Failures ({n} image{"s" if n > 1 else ""}):*'
-            for image_name, failures in sorted(image_release_failures.items()):
-                message += f'\n`{image_name}`:'
-                for failure in failures:
-                    message += f'\n  • {self._format_forum_redis_failure_inline(failure)}'
-            await self.slack_client.say(
-                message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False, unfurl_media=False
-            )
-
-        if image_rebase_failures:
-            n = len(image_rebase_failures)
-            message = f'*Rebase Failures ({n} image{"s" if n > 1 else ""}):*'
-            for image_name, failures in sorted(image_rebase_failures.items()):
-                message += f'\n`{image_name}`:'
-                for failure in failures:
-                    message += f'\n  • {self._format_forum_redis_failure_inline(failure)}'
-            await self.slack_client.say(
-                message, thread_ts=response['ts'], link_build_url=False, unfurl_links=False, unfurl_media=False
-            )
+        await self.slack_client.say(message, link_build_url=False, unfurl_links=False, unfurl_media=False)
 
     @staticmethod
     def _group_failures_by_image(failures_by_version: dict) -> dict[str, list[dict]]:

--- a/pyartcd/pyartcd/pipelines/okd_images_health.py
+++ b/pyartcd/pyartcd/pipelines/okd_images_health.py
@@ -275,9 +275,9 @@ class ImagesHealthPipeline:
 
     async def notify_okd_channel(self):
         """
-        Send aggregated notifications to #art-okd-release channel for all OKD versions.
-        Groups concerns and rebase failures by image name across all versions.
-        Excludes NEVER_BUILT and LATEST_BUILD_SUCCEEDED concerns.
+        Send a summary message to #art-okd-release channel with a link to the dashboard.
+        Instead of posting detailed failure lists (which can overflow Jira API limits),
+        we now only post a summary and direct users to the art-build-failures dashboard.
         """
         self.slack_client.bind_channel('#art-okd-release')
 
@@ -322,30 +322,19 @@ class ImagesHealthPipeline:
             summary_parts.append(f'{n_rebase_issues} image{"s" if n_rebase_issues > 1 else ""} with rebase failures')
 
         issues = '\n- '.join(summary_parts)
-        response = await self.slack_client.say(
-            f':alert: There are some issues to look into for OKD builds:\n- {issues}',
-            link_build_url=False,
+
+        # Build dashboard URL showing OKD failures
+        start_date = (datetime.now(timezone.utc) - timedelta(days=DELTA_DAYS)).strftime('%Y-%m-%d')
+        end_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+        # Filter dashboard to show only OKD groups (okd-*)
+        dashboard_url = f'{ART_BUILD_HISTORY_URL}/?dateRange={start_date}+to+{end_date}&outcome=failure&engine=konflux'
+
+        message = (
+            f':alert: There are some issues to look into for OKD builds:\n- {issues}\n\n'
+            f'For detailed information, please check the {self.url_text(dashboard_url, "ART Build Failures Dashboard")}'
         )
 
-        # Post detailed report in thread
-        # Build concerns
-        for image_name, concerns in image_concerns.items():
-            image_message = f'`{image_name}` (build issues):'
-            for concern in concerns:
-                image_message += f'\n• {self.get_message_for_okd_channel(concern)}'
-            await self.slack_client.say(image_message, thread_ts=response['ts'], link_build_url=False)
-
-        # Rebase failures
-        for image_name, failures in sorted(image_rebase_failures.items()):
-            image_message = f'`{image_name}` (rebase failures):'
-            for failure in failures:
-                version = failure['version']
-                failure_count = failure['failure_count']
-                jenkins_url = failure['jenkins_url']
-                image_message += f'\n• okd-{version}: Failed {failure_count} time{"s" if failure_count != 1 else ""}'
-                if jenkins_url:
-                    image_message += f' ({self.url_text(jenkins_url, "Last failure job")})'
-            await self.slack_client.say(image_message, thread_ts=response['ts'], link_build_url=False)
+        await self.slack_client.say(message, link_build_url=False, unfurl_links=False, unfurl_media=False)
 
     def get_message_for_release(self, concern: dict):
         """

--- a/pyartcd/tests/pipelines/test_images_health.py
+++ b/pyartcd/tests/pipelines/test_images_health.py
@@ -83,11 +83,13 @@ class TestNotifyPublicChannel(IsolatedAsyncioTestCase):
 
         await pipeline.notify_public_channel()
 
+        # Now only posts a single summary message with dashboard link
         calls = mock_slack_client.say.call_args_list
-        self.assertEqual(len(calls), 2)
+        self.assertEqual(len(calls), 1)
         first_call_args = calls[0][0][0]
         self.assertIn(":alert:", first_call_args)
         self.assertIn("build failures", first_call_args)
+        self.assertIn("ART Build Failures Dashboard", first_call_args)
 
     async def test_with_mixed_failure_types(self):
         mock_slack_client = self.mock_runtime.new_slack_client.return_value
@@ -108,21 +110,15 @@ class TestNotifyPublicChannel(IsolatedAsyncioTestCase):
 
         await pipeline.notify_public_channel()
 
+        # Now only posts a single summary message with dashboard link
         calls = mock_slack_client.say.call_args_list
-        # Summary + 4 thread messages (one per failure type)
-        self.assertEqual(len(calls), 5)
+        self.assertEqual(len(calls), 1)
         summary = calls[0][0][0]
         self.assertIn("build failures", summary)
         self.assertIn("EC verification failures", summary)
         self.assertIn("release to authz failures", summary)
         self.assertIn("rebase failures", summary)
-        # Thread messages: section header with image name, then group bullets below
-        build_thread = calls[1][0][0]
-        self.assertIn("Build Failures (1 image)", build_thread)
-        self.assertIn("`build-fail`:", build_thread)
-        ec_thread = calls[2][0][0]
-        self.assertIn("EC Verification Failures (1 image)", ec_thread)
-        self.assertIn("`ec-fail-image`:", ec_thread)
+        self.assertIn("ART Build Failures Dashboard", summary)
 
     async def test_binds_to_configured_channel(self):
         mock_slack_client = self.mock_runtime.new_slack_client.return_value
@@ -155,11 +151,13 @@ class TestNotifyPublicChannel(IsolatedAsyncioTestCase):
 
         await pipeline.notify_public_channel()
 
+        # Now only posts a single summary message with dashboard link
         calls = mock_slack_client.say.call_args_list
-        self.assertEqual(len(calls), 2)
+        self.assertEqual(len(calls), 1)
         summary = calls[0][0][0]
         self.assertIn("EC verification failures", summary)
         self.assertNotIn("build failures", summary)
+        self.assertIn("ART Build Failures Dashboard", summary)
 
 
 class TestNotifyReleaseChannel(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary

This PR simplifies the health report messages sent to public channels (e.g., `#forum-ocp-data`) to address verbosity issues and potential Jira API limit overflows.

## What Changed
**Before:**
- Posted a summary message with failure counts
- Posted detailed thread messages for each failure type (build, EC, release, rebase)
- Each thread message listed all failing images with links to logs and pipelines
- Could overflow Jira API limits with long lists

**After:**
- Posts only a summary message with failure counts
- Includes a link to the ART Build Failures Dashboard for detailed information
- No thread messages with verbose failure lists
- Significantly reduces Slack message volume

## Example Output
**New message format:**
```
:alert: There are some issues to look into for Openshift builds:
- 5 images with build failures
- 2 images with EC verification failures
- 1 image with release to authz failures

For detailed information, please check the <dashboard-url|ART Build Failures Dashboard>
```
