### PR TITLE
fix(doozer): pass replace_vars when loading bug config for Jira Target Version

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -1030,7 +1030,9 @@ This ticket was created by ART pipline run [sync-ci-images|{jenkins_build_url}]
             )
             try:
                 # retrieve the target version string (e.g., 'z' or '4.21.0')
-                target_version_segment = Model(runtime.gitdata.load_data(key='bug').data).target_release[-1]
+                target_version_segment = Model(
+                    runtime.gitdata.load_data(key='bug', replace_vars=runtime.group_config.vars).data
+                ).target_release[-1]
 
                 # Build the update payload using the retrieved string
                 issue_update = {

--- a/doozer/tests/test_reconcile_jira_issues.py
+++ b/doozer/tests/test_reconcile_jira_issues.py
@@ -44,6 +44,7 @@ def _build_mocks(
     # Runtime mock
     runtime = MagicMock()
     runtime.get_major_minor_fields.return_value = (major, minor)
+    runtime.group_config.vars = {'MAJOR': major, 'MINOR': minor}
 
     # gitdata.load_data returns bug.yml with target_release
     bug_data = MagicMock()
@@ -228,6 +229,18 @@ class TestReconcileJiraIssuesCustomFields(unittest.TestCase):
         runtime.logger.error.assert_called_once()
         error_msg = runtime.logger.error.call_args[0][0]
         self.assertIn('Target Version', error_msg)
+
+    @patch('doozerlib.cli.images_streams.connect_issue_with_pr')
+    def test_load_data_passes_replace_vars(self, mock_connect):
+        """
+        Verify that load_data is called with replace_vars so that
+        template strings like {MAJOR}.{MINOR} are interpolated.
+        """
+        runtime, pr_map, mock_issue, mock_jira_client = _build_mocks()
+
+        reconcile_jira_issues(runtime, pr_map, dry_run=False)
+
+        runtime.gitdata.load_data.assert_called_with(key='bug', replace_vars=runtime.group_config.vars)
 
     @patch('doozerlib.cli.images_streams.connect_issue_with_pr')
     def test_version_below_4_16_skips_entirely(self, mock_connect):


### PR DESCRIPTION
## Summary
- Fixed `reconcile_jira_issues` in `images_streams.py` sending literal `{MAJOR}.{MINOR}` as the Jira Target Version instead of interpolated values (e.g. `4.18.z`)
- Root cause: `runtime.gitdata.load_data(key='bug')` was missing `replace_vars=runtime.group_config.vars`, so template strings in `bug.yml` were never substituted
- Added a test to verify `replace_vars` is always passed

## Test plan
- [x] New test `test_load_data_passes_replace_vars` asserts `replace_vars` is passed
- [x] All 2630 unit tests pass (`make test`)
- [x] `make format` and `make lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)