### PR TITLE
feat(doozer): capture RHEL minor version in NVR

### DIFF
--- a/artcommon/artcommonlib/release_util.py
+++ b/artcommon/artcommonlib/release_util.py
@@ -24,7 +24,7 @@ def split_el_suffix_in_release(release: str) -> Tuple[str, Optional[str]]:
     For OCP builds, this returns the el suffix (e.g., 'el9').
     """
 
-    el_suffix_match = re.match(r'(.*)[.+]((?:el|scos)\d+)(?:.*|$)', release)
+    el_suffix_match = re.match(r'(.*)[.+]((?:el|scos)\d+(?:_\d+)?)(?:.*|$)', release)
     if el_suffix_match:
         prefix = el_suffix_match.group(1)
         el_suffix = el_suffix_match.group(2)
@@ -62,11 +62,12 @@ def isolate_el_version_in_release(release: str) -> Optional[int]:
     """
     _, el_suffix = split_el_suffix_in_release(release)
     if el_suffix:
-        # Strip the prefix ('el' or 'scos') and return the numeric version
+        # Strip the prefix ('el' or 'scos') and return the major numeric version
         if el_suffix.startswith('scos'):
-            return int(el_suffix[4:])
+            numeric = el_suffix[4:]
         else:  # starts with 'el'
-            return int(el_suffix[2:])
+            numeric = el_suffix[2:]
+        return int(numeric.split('_')[0])
     return None
 
 

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -192,6 +192,10 @@ class TestUtil(unittest.TestCase):
             ),
             ('1.2.3-y.p.p1.assembly.4.9.99.scos8', '1.2.3-y.p.p1.assembly.4.9.99', 'scos8'),
             ('1.2.3-y.p.p1.assembly.art12398.scos10', '1.2.3-y.p.p1.assembly.art12398', 'scos10'),
+            # RHEL minor version test cases
+            ('202401221732.p0.g00c615b.el9_6', '202401221732.p0.g00c615b', 'el9_6'),
+            ('202401221732.p0.g00c615b.el9_4', '202401221732.p0.g00c615b', 'el9_4'),
+            ('1.2.3-y.p.p1.assembly.stream.el10_2', '1.2.3-y.p.p1.assembly.stream', 'el10_2'),
         ]
 
         for t in test_cases:
@@ -212,6 +216,10 @@ class TestUtil(unittest.TestCase):
             ('4.17.0-202407241200.p0.assembly.stream.gdeadbee.scos9', 9),
             ('1.2.3-y.p.p1.assembly.4.9.99.scos8', 8),
             ('1.2.3-y.p.p1.assembly.art12398.scos10', 10),
+            # RHEL minor version test cases (should still return major version only)
+            ('202401221732.p0.g00c615b.el9_6', 9),
+            ('202401221732.p0.g00c615b.el9_4', 9),
+            ('1.2.3-y.p.p1.assembly.stream.el10_2', 10),
         ]
 
         for t in test_cases:

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -36,7 +36,11 @@ from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, Konf
 from artcommonlib.lock import get_named_semaphore
 from artcommonlib.model import ListModel, Missing, Model
 from artcommonlib.pushd import Dir
-from artcommonlib.release_util import isolate_assembly_in_release, isolate_el_version_in_release
+from artcommonlib.release_util import (
+    isolate_assembly_in_release,
+    isolate_el_version_in_release,
+    split_el_suffix_in_release,
+)
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import (
     convert_remote_git_to_https,
@@ -1424,7 +1428,7 @@ class ImageDistGitRepo(DistGitRepo):
                 'nvr': nvr,
                 'version': version,
                 'release': release,
-                'el_target': f'el{isolate_el_version_in_release(release)}',
+                'el_target': split_el_suffix_in_release(release)[1] or f'el{isolate_el_version_in_release(release)}',
                 'embargoed': is_release_embargoed(release, self.runtime.build_system),
                 'arches': self.metadata.get_arches(),
                 'source_repo': source_repo,
@@ -2135,8 +2139,12 @@ class ImageDistGitRepo(DistGitRepo):
                 if self.runtime.assembly:
                     release += f'.assembly.{self.runtime.assembly}'
 
+                el_minor = self.metadata.config.get('el_minor', None)
                 if self.get_branch_el():
-                    release += ".el" + str(self.get_branch_el())
+                    el_suffix = "el" + str(self.get_branch_el())
+                    if el_minor is not Missing and el_minor is not None:
+                        el_suffix += "_" + str(el_minor)
+                    release += "." + el_suffix
 
                 dfp.labels['release'] = release
             else:

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -2136,6 +2136,9 @@ class ImageDistGitRepo(DistGitRepo):
                     release += f'.assembly.{self.runtime.assembly}'
 
                 el_minor = self.metadata.config.get('el_minor', None)
+                if el_minor is not Missing and el_minor is not None:
+                    if not isinstance(el_minor, int) or el_minor < 0:
+                        raise ValueError(f"el_minor must be a non-negative integer, got: {el_minor!r}")
                 if self.get_branch_el():
                     el_suffix = "el" + str(self.get_branch_el())
                     if el_minor is not Missing and el_minor is not None:

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -36,11 +36,7 @@ from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, Konf
 from artcommonlib.lock import get_named_semaphore
 from artcommonlib.model import ListModel, Missing, Model
 from artcommonlib.pushd import Dir
-from artcommonlib.release_util import (
-    isolate_assembly_in_release,
-    isolate_el_version_in_release,
-    split_el_suffix_in_release,
-)
+from artcommonlib.release_util import isolate_assembly_in_release, isolate_el_version_in_release
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import (
     convert_remote_git_to_https,
@@ -1428,7 +1424,7 @@ class ImageDistGitRepo(DistGitRepo):
                 'nvr': nvr,
                 'version': version,
                 'release': release,
-                'el_target': split_el_suffix_in_release(release)[1] or f'el{isolate_el_version_in_release(release)}',
+                'el_target': f'el{isolate_el_version_in_release(release)}',
                 'embargoed': is_release_embargoed(release, self.runtime.build_system),
                 'arches': self.metadata.get_arches(),
                 'source_repo': source_repo,


### PR DESCRIPTION
## Summary
- Adds support for `el_minor` field in image metadata config to include the RHEL minor version in the NVR release suffix (e.g., `.el9_6` instead of `.el9`)
- Updates `split_el_suffix_in_release` regex to correctly parse the `el<major>_<minor>` format
- `isolate_el_version_in_release` still returns the major version as `int` for backward compatibility
- The `el_target` stored in build DB is **not** changed — it remains major-version-only (e.g., `el9`)

## ocp-build-data changes (separate PR)
Add `el_minor` to golang-builder image configs in `rhel-9-golang-1.25/images/`:
- `openshift-golang-builder-96.yml`: `el_minor: 6`
- `openshift-golang-builder-94.yml`: `el_minor: 4`

## Test plan
- [x] `artcommon/tests/test_util.py` - added test cases for `el9_6`, `el9_4`, `el10_2` in both `split_el_suffix_in_release` and `isolate_el_version_in_release`
- [x] All 365 artcommon tests pass
- [x] All 79 distgit tests pass
- [ ] Verify with a real golang-builder rebase after ocp-build-data PR lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)