### PR TITLE
Add el_minor to image config JSON schema

### DIFF
--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -402,6 +402,18 @@
       "$ref": "#/properties/final_stage_user"
     },
     "final_stage_user-": {},
+    "el_minor": {
+      "description": "RHEL minor version to include in the NVR release suffix (e.g., 6 produces .el9_6). When omitted, only the major version is used.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "el_minor!": {
+      "$ref": "#/properties/el_minor"
+    },
+    "el_minor?": {
+      "$ref": "#/properties/el_minor"
+    },
+    "el_minor-": {},
     "enabled_repos": {
       "description": "List of repositories that should be enabled at image build time. List of keys of group.yml's `repos`",
       "items": {


### PR DESCRIPTION
## Summary
- Adds `el_minor` field to the image config JSON schema so the ocp-build-data validator accepts it
- This is a follow-up to #3011 which added the `el_minor` support in doozer but was merged before the schema update

## Test plan
- [x] Schema validates correctly with `el_minor: 6` (integer, minimum 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)