### PR TITLE
ART-18366: feat(doozer): inject exact golang NVR during builder image rebase

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -82,6 +82,9 @@ KONFLUX_DEFAULT_BUILD_PRIORITY = 5
 GOLANG_BUILDER_IMAGE_NAME = 'openshift-golang-builder'
 # Golang rpm package name
 GOLANG_RPM_PACKAGE_NAME = 'golang'
+# Label and env var for injecting exact golang NVR into builder images
+GOLANG_NVR_LABEL = 'io.openshift.build.golang-nvr'
+GOLANG_NVR_ENV = '__doozer_golang_nvr'
 
 # Product-based mappings for Konflux tenant namespaces and kubeconfigs
 PRODUCT_NAMESPACE_MAP = {

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -20,6 +20,7 @@ import semver
 import yaml
 from artcommonlib import exectools, release_util
 from artcommonlib.build_visibility import BuildVisibility, get_visibility_suffix, is_release_embargoed
+from artcommonlib.constants import GOLANG_NVR_ENV, GOLANG_NVR_LABEL
 from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildRecord
 from artcommonlib.model import ListModel, Missing, Model
 from artcommonlib.telemetry import start_as_current_span_async
@@ -1304,6 +1305,10 @@ class KonfluxRebaser:
         if metadata.config.envs:
             # Allow environment variables to be specified in the ART image metadata
             metadata_envs.update(metadata.config.envs.primitive())
+
+        golang_nvr = self.extra_labels.get(GOLANG_NVR_LABEL)
+        if golang_nvr:
+            metadata_envs[GOLANG_NVR_ENV] = golang_nvr
 
         if self._runtime.group_config.build_profiles.enable_go_cover is True:
             # This must be implemented by the ART golang wrappers

--- a/doozer/doozerlib/distgit.py
+++ b/doozer/doozerlib/distgit.py
@@ -29,7 +29,7 @@ from artcommonlib.build_visibility import (
     is_release_embargoed,
     isolate_pflag_in_release,
 )
-from artcommonlib.constants import GIT_NO_PROMPTS
+from artcommonlib.constants import GIT_NO_PROMPTS, GOLANG_NVR_ENV, GOLANG_NVR_LABEL
 from artcommonlib.format_util import yellow_print
 from artcommonlib.git_helper import gather_git, git_clone
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
@@ -2248,6 +2248,11 @@ class ImageDistGitRepo(DistGitRepo):
             if self.config.envs:
                 # Allow environment variables to be specified in the ART image metadata
                 metadata_envs.update(self.config.envs.primitive())
+
+            if extra_labels:
+                golang_nvr = extra_labels.get(GOLANG_NVR_LABEL)
+                if golang_nvr:
+                    metadata_envs[GOLANG_NVR_ENV] = golang_nvr
 
             if self.runtime.group_config.build_profiles.enable_go_cover is True:
                 # This must be implemented by the ART golang wrappers

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -13,6 +13,7 @@ from artcommonlib.brew import BuildStates
 from artcommonlib.constants import (
     BREW_HUB,
     GOLANG_BUILDER_IMAGE_NAME,
+    GOLANG_NVR_LABEL,
     KONFLUX_DEFAULT_IMAGE_REPO,
     PRODUCT_NAMESPACE_MAP,
     REGISTRY_REDHAT_IO,
@@ -908,7 +909,7 @@ class UpdateGolangPipeline:
                 "--release",
                 release,
                 "--extra-label",
-                f"io.openshift.build.golang-nvr={go_nvr}",
+                f"{GOLANG_NVR_LABEL}={go_nvr}",
                 "--message",
                 f"bumping to {version}-{release}",
             ]
@@ -976,7 +977,7 @@ class UpdateGolangPipeline:
                 "--release",
                 release,
                 "--extra-label",
-                f"io.openshift.build.golang-nvr={go_nvr}",
+                f"{GOLANG_NVR_LABEL}={go_nvr}",
                 "--message",
                 f"bumping to {version}-{release}",
             ]


### PR DESCRIPTION
## Summary

- Adds `GOLANG_NVR_LABEL` / `GOLANG_NVR_ENV` constants to artcommon
- When `--extra-label io.openshift.build.golang-nvr=<NVR>` is passed during rebase, doozer now injects `__doozer_golang_nvr` as an env var into the Dockerfile (both Brew and Konflux paths)
- Updates `update_golang.py` pipeline to use the shared constant instead of a hardcoded string

This enables golang-builder Dockerfiles in ocp-build-data to use:
```dockerfile
dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}"
```
to install the exact golang RPM when available, falling back to the wildcard for manual builds.

### ocp-build-data Dockerfile change (follow-up PR)

Once this lands, the golang-builder Dockerfiles in ocp-build-data need a one-line change on each branch. Replace:
```dockerfile
dnf install -y "golang-*$VERSION*" && \
```
with:
```dockerfile
dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
```

### Dry-run verification

```bash
doozer \
  --working-dir=/tmp/doozer-test-konflux-rebase \
  --build-system=konflux \
  --data-path=<ocp-build-data-path> \
  --group rhel-9-golang-1.25 \
  -i openshift-golang-builder \
  beta:images:konflux:rebase \
  --version v1.25.3 \
  --release 202406041800.test.el9 \
  --extra-label io.openshift.build.golang-nvr=golang-1.25.3-1.el9 \
  --message "dry-run test rebase"
```

## Test plan

- [x] `make format` — no changes needed
- [x] `make test` — all 2629 tests pass (365 artcommon + 1210 doozer + 393 elliott + 575 pyartcd + 86 validator)
- [ ] Verify env var injection with a doozer dry-run rebase of golang-builder image (requires Kerberos/network)
- [ ] After ocp-build-data Dockerfile update: trigger a `--scratch` golang-builder build and confirm exact NVR appears in build logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for passing an exact Go build version into builder image updates.
  * The Go version value is now carried through rebasing flows and applied automatically when available.

* **Bug Fixes**
  * Improved consistency in how builder image metadata is updated during rebases.
  * Ensured the Go version label is used uniformly across supported image update paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->