### PR TITLE
Add image build strategy (all/only) to layered-products pipeline

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -834,6 +834,7 @@ def start_layered_products(
     group: str,
     assembly: str,
     image_list: list = None,
+    image_build_strategy: str = None,
     **kwargs,
 ) -> Optional[str]:
     params = {
@@ -844,6 +845,8 @@ def start_layered_products(
     # Build only changed images or none
     if image_list:
         params['IMAGE_LIST'] = ','.join(image_list)
+    if image_build_strategy:
+        params['IMAGE_BUILD_STRATEGY'] = image_build_strategy
 
     return start_build(
         job=Jobs.LAYERED_PRODUCTS,

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -15,6 +15,7 @@ from pyartcd import constants, jenkins, locks
 from pyartcd import record as record_util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.locks import Lock
+from pyartcd.pipelines.ocp4_konflux import BuildStrategy
 from pyartcd.runtime import Runtime
 from pyartcd.util import default_release_suffix, load_group_config
 
@@ -31,6 +32,7 @@ class BuildLayeredProductsPipeline:
         image_list: str,
         data_path: str,
         skip_bundle_build: bool,
+        image_build_strategy: str = 'only',
         skip_rebase: bool = False,
         kubeconfig: Optional[str] = None,
         data_gitref: Optional[str] = None,
@@ -42,7 +44,8 @@ class BuildLayeredProductsPipeline:
         self.group = group
         self.version = version
         self.assembly = assembly
-        self.image_list = image_list
+        self.image_list = image_list or ''
+        self.image_build_strategy = BuildStrategy(image_build_strategy)
         self.skip_bundle_build = skip_bundle_build
         self.skip_rebase = skip_rebase
         self.kubeconfig = kubeconfig
@@ -50,6 +53,11 @@ class BuildLayeredProductsPipeline:
         self.network_mode = network_mode
         self.plr_template = plr_template
         self._logger = logger or runtime.logger
+
+        if self.image_build_strategy == BuildStrategy.ALL and self.image_list:
+            raise ValueError("image_list must be empty when image_build_strategy is 'all'")
+        if self.image_build_strategy == BuildStrategy.ONLY and not self.image_list:
+            raise ValueError("image_list is required when image_build_strategy is 'only'")
 
         self._working_dir = self.runtime.working_dir.absolute()
 
@@ -149,37 +157,47 @@ class BuildLayeredProductsPipeline:
         ]
 
     async def _rebase_and_build(self, product: str, image_repo: str):
-        """Rebase and build layered product image"""
-        image_list = self.image_list
+        """Rebase and build layered product images."""
+        strategy = self.image_build_strategy
+        rebase_image_list = self.image_list if strategy == BuildStrategy.ONLY else None
+        excluded: List[str] = []
 
         if not self.skip_rebase:
-            image_list = await self._rebase(image_list)
+            excluded = await self._rebase(rebase_image_list)
         else:
             self._logger.warning("Skipping rebase step because --skip-rebase flag is set")
 
-        if not image_list:
-            self._logger.warning('No buildable images remaining after rebase; skipping build')
-            return
+        if strategy == BuildStrategy.ONLY:
+            requested = [img.strip() for img in self.image_list.split(',') if img.strip()]
+            remaining = [img for img in requested if img not in excluded]
+            if not remaining:
+                self._logger.warning('No buildable images remaining after rebase; skipping build')
+                return
+            build_image_list = ','.join(remaining)
+        else:
+            build_image_list = None
 
         try:
-            await self._build(image_list, product, image_repo)
+            await self._build(strategy, build_image_list, excluded, product, image_repo)
         finally:
             self._update_build_description()
 
-    async def _rebase(self, image_list: str) -> str:
+    async def _rebase(self, image_list: Optional[str]) -> List[str]:
         """Rebase layered product images.
 
-        Returns the (possibly reduced) comma-separated image list after
-        excluding images that failed to rebase, following the same pattern
-        used by the OCP4 pipeline.
+        Returns the list of images excluded due to rebase failure.
         """
         release = default_release_suffix()
-        self._logger.info(f"Rebasing {image_list} image(s) for assembly {self.assembly}")
+        if image_list:
+            self._logger.info(f"Rebasing {image_list} image(s) for assembly {self.assembly}")
+        else:
+            self._logger.info(f"Rebasing all images for assembly {self.assembly}")
 
         rebase_cmd = self._doozer_base_command()
+        if image_list:
+            rebase_cmd.append(f"--images={image_list}")
         rebase_cmd.extend(
             [
-                f"--images={image_list}",
                 "beta:images:konflux:rebase",
                 f"--version={self.version}",
                 f"--release={release}",
@@ -193,8 +211,11 @@ class BuildLayeredProductsPipeline:
 
         try:
             await exectools.cmd_assert_async(rebase_cmd, env=self._doozer_env_vars)
-            self._logger.info(f"Successfully rebased {image_list}")
-            return image_list
+            if image_list:
+                self._logger.info(f"Successfully rebased {image_list}")
+            else:
+                self._logger.info("Successfully rebased all images")
+            return []
 
         except ChildProcessError:
             state_path = Path(self.runtime.doozer_working, 'state.yaml')
@@ -221,9 +242,7 @@ class BuildLayeredProductsPipeline:
                     ','.join(skipped_due_to_parent),
                 )
 
-            requested = [img.strip() for img in image_list.split(',') if img.strip()]
-            remaining = [img for img in requested if img not in excluded]
-            return ','.join(remaining)
+            return excluded
 
     def _update_build_description(self):
         """Update Jenkins description with build results (succeeded/failed counts and failed image names)."""
@@ -245,14 +264,27 @@ class BuildLayeredProductsPipeline:
         elif len(failed_images) > 10:
             jenkins.update_description('Check record.log for the full list of failed images<br/>')
 
-    async def _build(self, image_list: str, product: str, image_repo: str):
+    async def _build(
+        self,
+        strategy: BuildStrategy,
+        image_list: Optional[str],
+        excluded: List[str],
+        product: str,
+        image_repo: str,
+    ):
         """Build layered product images."""
-        self._logger.info(f"Building {image_list} image(s) for assembly {self.assembly}")
+        if image_list:
+            self._logger.info(f"Building {image_list} image(s) for assembly {self.assembly}")
+        else:
+            self._logger.info(f"Building all images for assembly {self.assembly}")
 
         build_cmd = self._doozer_base_command()
+        if strategy == BuildStrategy.ONLY:
+            build_cmd.append(f"--images={image_list}")
+        elif excluded:
+            build_cmd.extend(["--images=", f"--exclude={','.join(excluded)}"])
         build_cmd.extend(
             [
-                f"--images={image_list}",
                 "beta:images:konflux:build",
                 f"--image-repo={image_repo}",
                 "--build-priority=1",
@@ -290,7 +322,10 @@ class BuildLayeredProductsPipeline:
             build_env["QUAY_AUTH_FILE"] = konflux_registry_auth_file
 
         await exectools.cmd_assert_async(build_cmd, env=build_env)
-        self._logger.info(f"Successfully built {image_list}")
+        if image_list:
+            self._logger.info(f"Successfully built {image_list}")
+        else:
+            self._logger.info("Successfully built all images")
 
 
 @cli.command("build-layered-products")
@@ -320,9 +355,15 @@ class BuildLayeredProductsPipeline:
     help="The name of an assembly to rebase & build for. e.g. 4.9.1",
 )
 @click.option(
+    "--image-build-strategy",
+    type=click.Choice(['all', 'only']),
+    default='only',
+    help="'all' builds every image in the group; 'only' builds IMAGE_LIST images only",
+)
+@click.option(
     "--image-list",
     metavar="IMAGE_NAME",
-    help="List of images to build",
+    help="List of images to build (required when --image-build-strategy=only)",
 )
 @click.option("--skip-bundle-build", is_flag=True, default=False, help="(For testing) Skip the bundle build step")
 @click.option("--skip-rebase", is_flag=True, default=False, help="(For testing) Skip the rebase step")
@@ -353,6 +394,7 @@ async def build_layered_products(
     group: str,
     version: Optional[str],
     assembly: str,
+    image_build_strategy: str,
     image_list: str,
     skip_bundle_build: bool,
     skip_rebase: bool,
@@ -370,6 +412,7 @@ async def build_layered_products(
             version=version,
             assembly=assembly,
             image_list=image_list,
+            image_build_strategy=image_build_strategy,
             data_path=data_path,
             skip_bundle_build=skip_bundle_build,
             skip_rebase=skip_rebase,

--- a/pyartcd/tests/pipelines/test_build_layered_products.py
+++ b/pyartcd/tests/pipelines/test_build_layered_products.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import yaml
 from doozerlib.constants import KONFLUX_DEFAULT_IMAGE_REPO
 from pyartcd.pipelines.build_layered_products import BuildLayeredProductsPipeline
+from pyartcd.pipelines.ocp4_konflux import BuildStrategy
 from pyartcd.runtime import Runtime
 
 
@@ -66,14 +67,14 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
             )
         mock_update_title.assert_not_called()
 
-    async def test_rebase_success_returns_original_image_list(self):
-        """When rebase succeeds, the full image list is returned unchanged."""
+    async def test_rebase_success_returns_no_excluded_images(self):
+        """When rebase succeeds, no images are excluded."""
         with patch('pyartcd.pipelines.build_layered_products.exectools.cmd_assert_async', new_callable=AsyncMock):
             result = await self.pipeline._rebase('img-a,img-b')
-        self.assertEqual(result, 'img-a,img-b')
+        self.assertEqual(result, [])
 
-    async def test_rebase_failure_excludes_failed_images(self):
-        """When rebase fails and state.yaml records failed images, those images are excluded."""
+    async def test_rebase_failure_returns_excluded_images(self):
+        """When rebase fails and state.yaml records failed images, those images are returned as excluded."""
         state = {'images:konflux:rebase': {'failed-images': ['oadp-operator']}}
         state_path = Path(self.runtime.doozer_working, 'state.yaml')
         with state_path.open('w') as f:
@@ -86,10 +87,10 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
         ):
             result = await self.pipeline._rebase('oadp-velero-restic-restore-helper,oadp-operator')
 
-        self.assertEqual(result, 'oadp-velero-restic-restore-helper')
+        self.assertEqual(result, ['oadp-operator'])
 
-    async def test_rebase_failure_excludes_skipped_due_to_parent_images(self):
-        """Images listed only as skipped due to parent rebase failure are excluded from the build list."""
+    async def test_rebase_failure_returns_skipped_due_to_parent_images(self):
+        """Images listed as skipped due to parent rebase failure are included in the excluded list."""
         state = {
             'images:konflux:rebase': {
                 'failed-images': ['parent-image'],
@@ -107,10 +108,10 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
         ):
             result = await self.pipeline._rebase('parent-image,child-image,other-image')
 
-        self.assertEqual(result, 'other-image')
+        self.assertEqual(result, ['parent-image', 'child-image'])
 
-    async def test_rebase_failure_all_images_failed(self):
-        """When all requested images fail rebase, an empty string is returned."""
+    async def test_rebase_failure_all_images_excluded(self):
+        """When all requested images fail rebase, all are returned as excluded."""
         state = {'images:konflux:rebase': {'failed-images': ['img-a', 'img-b']}}
         state_path = Path(self.runtime.doozer_working, 'state.yaml')
         with state_path.open('w') as f:
@@ -123,7 +124,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
         ):
             result = await self.pipeline._rebase('img-a,img-b')
 
-        self.assertEqual(result, '')
+        self.assertEqual(result, ['img-a', 'img-b'])
 
     async def test_rebase_failure_no_state_file_reraises(self):
         """When rebase fails but state.yaml does not exist, the error is re-raised."""
@@ -338,3 +339,84 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
         image_repo_args = [arg for arg in build_cmd if arg.startswith('--image-repo=')]
         self.assertEqual(len(image_repo_args), 1)
         self.assertEqual(image_repo_args[0], f'--image-repo={KONFLUX_DEFAULT_IMAGE_REPO}')
+
+    def test_all_strategy_with_image_list_raises(self):
+        """When strategy is all and image_list is non-empty, ValueError is raised."""
+        with patch('pyartcd.pipelines.build_layered_products.jenkins.init_jenkins'):
+            with self.assertRaises(ValueError) as ctx:
+                BuildLayeredProductsPipeline(
+                    runtime=self.runtime,
+                    group='oadp-1.4',
+                    version='1.4.9',
+                    assembly='stream',
+                    image_list='oadp-operator',
+                    image_build_strategy='all',
+                    data_path='https://github.com/openshift-eng/ocp-build-data',
+                    skip_bundle_build=True,
+                )
+        self.assertIn("image_list must be empty", str(ctx.exception))
+
+    async def test_rebase_all_strategy_no_images_flag(self):
+        """When strategy is all, rebase command does not include --images=."""
+        with patch(
+            'pyartcd.pipelines.build_layered_products.exectools.cmd_assert_async',
+            new_callable=AsyncMock,
+        ) as mock_cmd:
+            await self.pipeline._rebase(None)
+
+        cmd = mock_cmd.call_args[0][0]
+        self.assertFalse(any(arg.startswith('--images=') for arg in cmd))
+
+    async def test_rebase_all_strategy_returns_excluded_on_failure(self):
+        """When all-strategy rebase fails, excluded images are returned."""
+        state = {'images:konflux:rebase': {'failed-images': ['img-a']}}
+        state_path = Path(self.runtime.doozer_working, 'state.yaml')
+        with state_path.open('w') as f:
+            yaml.safe_dump(state, f)
+
+        with patch(
+            'pyartcd.pipelines.build_layered_products.exectools.cmd_assert_async',
+            new_callable=AsyncMock,
+            side_effect=ChildProcessError('exit code 1'),
+        ):
+            result = await self.pipeline._rebase(None)
+
+        self.assertEqual(result, ['img-a'])
+
+    async def test_build_all_strategy_no_exclusions(self):
+        """When strategy is all with no exclusions, build command has no --images= flag."""
+        with (
+            patch(
+                'pyartcd.pipelines.build_layered_products.exectools.cmd_assert_async',
+                new_callable=AsyncMock,
+            ) as mock_cmd,
+            patch(
+                'pyartcd.pipelines.build_layered_products.resolve_konflux_kubeconfig_by_product',
+                return_value='/path/to/kubeconfig',
+            ),
+        ):
+            await self.pipeline._build(BuildStrategy.ALL, None, [], 'oadp', KONFLUX_DEFAULT_IMAGE_REPO)
+
+        cmd = mock_cmd.call_args[0][0]
+        self.assertFalse(any(arg.startswith('--images=') for arg in cmd))
+        self.assertFalse(any(arg.startswith('--exclude=') for arg in cmd))
+
+    async def test_build_all_strategy_with_exclusions(self):
+        """When strategy is all with rebase exclusions, build uses --images= --exclude=."""
+        with (
+            patch(
+                'pyartcd.pipelines.build_layered_products.exectools.cmd_assert_async',
+                new_callable=AsyncMock,
+            ) as mock_cmd,
+            patch(
+                'pyartcd.pipelines.build_layered_products.resolve_konflux_kubeconfig_by_product',
+                return_value='/path/to/kubeconfig',
+            ),
+        ):
+            await self.pipeline._build(
+                BuildStrategy.ALL, None, ['img-a', 'img-b'], 'oadp', KONFLUX_DEFAULT_IMAGE_REPO
+            )
+
+        cmd = mock_cmd.call_args[0][0]
+        self.assertIn('--images=', cmd)
+        self.assertIn('--exclude=img-a,img-b', cmd)

--- a/pyartcd/tests/pipelines/test_build_layered_products.py
+++ b/pyartcd/tests/pipelines/test_build_layered_products.py
@@ -413,9 +413,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
                 return_value='/path/to/kubeconfig',
             ),
         ):
-            await self.pipeline._build(
-                BuildStrategy.ALL, None, ['img-a', 'img-b'], 'oadp', KONFLUX_DEFAULT_IMAGE_REPO
-            )
+            await self.pipeline._build(BuildStrategy.ALL, None, ['img-a', 'img-b'], 'oadp', KONFLUX_DEFAULT_IMAGE_REPO)
 
         cmd = mock_cmd.call_args[0][0]
         self.assertIn('--images=', cmd)


### PR DESCRIPTION
## Summary
- Add `--image-build-strategy=all|only` to `build-layered-products`, reusing `BuildStrategy` from `ocp4_konflux`
- For `all`, rebase/build omit `--images=`; rebase failures use `--exclude=` on build
- For `only`, behavior matches existing image-list flow with post-rebase exclusion
- Validate `image_list` is empty for `all` and required for `only`
- Update `start_layered_products()` Jenkins helper and unit tests

## Test plan
- [x] `uv run pytest pyartcd/tests/pipelines/test_build_layered_products.py` (22 passed)
- [ ] Trigger `build-layered-products` with `--image-build-strategy=only --image-list=...`
- [ ] Trigger with `--image-build-strategy=all` and no `--image-list`
- [ ] Confirm `ValueError` when `--image-build-strategy=all` is used with a non-empty `--image-list`


Made with [Cursor](https://cursor.com)