### PR TITLE
fix(doozer): skip shell cmds in Konflux injected lines for scratch stream images

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1273,7 +1273,9 @@ class KonfluxRebaser:
         df_lines = filtered_content
 
         # ART-8476 assert rhel version equivalence
-        if metadata.canonical_builders_enabled and self.variant != BuildVariant.OKD:
+        # Skip for scratch images — no shell available to run the check
+        _from_stream = metadata.config.get('from', {}).get('stream')
+        if metadata.canonical_builders_enabled and self.variant != BuildVariant.OKD and _from_stream != 'scratch':
             el_version = metadata.branch_el_target()
             df_lines.extend(
                 [

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1469,8 +1469,10 @@ class KonfluxRebaser:
         # files in the cache, and causing the rhel9 go build to make inappropriate decisions.
         # As a temporary guard against this cache pollution, clean the cache after every stage.
         # Use || true to prevent an error if this not a builder stage.
-        # Can be disabled via konflux.no_shell for build stages without /bin/sh
-        no_shell = metadata.config.konflux.get("no_shell", False)
+        # Can be disabled via konflux.no_shell for build stages without /bin/sh.
+        # Also auto-disabled when the base image is 'scratch' (no shell available).
+        from_stream = metadata.config.get('from', {}).get('stream')
+        no_shell = metadata.config.konflux.get("no_shell", False) or from_stream == 'scratch'
         if not no_shell:
             konflux_lines.append("RUN go clean -cache || true")
 

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -377,6 +377,43 @@ USER 3000
 
         self.assertEqual(dfp.content.strip(), expected.strip())
 
+    def test_add_build_repos_scratch_stream(self):
+        """
+        Test that RUN/USER shell commands are skipped when from.stream is 'scratch'.
+        """
+        from types import SimpleNamespace
+
+        metadata = MagicMock()
+        metadata.get_konflux_network_mode.return_value = "hermetic"
+        metadata.config.konflux = Model({})
+        metadata.config.konflux['cachito'] = SimpleNamespace(mode=Missing)
+        metadata.config.final_stage_user = Missing
+        metadata.is_lockfile_generation_enabled.return_value = False
+        # Simulate from: stream: scratch
+        metadata.config.get.return_value = {'stream': 'scratch'}
+
+        dfp = DockerfileParser(path=self.directory.name)
+        dfp.content = """
+FROM scratch
+COPY . /skills/
+"""
+        expected = """
+FROM scratch
+
+# Start Konflux-specific steps
+ENV ART_BUILD_ENGINE=konflux
+ENV ART_BUILD_DEPS_METHOD=cachi2
+ENV ART_BUILD_NETWORK=hermetic
+ENV ART_BUILD_DEPS_MODE=default
+# End Konflux-specific steps
+COPY . /skills/
+"""
+        rebaser = KonfluxRebaser(MagicMock(), MagicMock(), MagicMock(), "unsigned", "test-repo")
+        rebaser._add_build_repos(dfp=dfp, metadata=metadata, dest_dir=Path(self.directory.name))
+        self.assertEqual(expected.strip(), dfp.content.strip())
+        self.assertNotIn("RUN go clean", dfp.content)
+        self.assertNotIn("USER 0", dfp.content)
+
     def test_write_rpms_lock_file_enabled(self):
         metadata = MagicMock()
         metadata.distgit_key = "foo"


### PR DESCRIPTION
## Summary

- When an image uses `from: stream: scratch` (e.g. `agentic-skills`), the rebased Dockerfile has `FROM scratch` which has no shell
- Doozer was injecting `RUN go clean -cache || true` and `USER 0` into the Konflux-specific block, causing the build to fail
- Auto-detect `from.stream == 'scratch'` and treat it as `no_shell=True` so these shell-dependent lines are skipped

Related ocp-build-data PR: https://github.com/openshift-eng/ocp-build-data/pull/11034

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/36769/console

🤖 Generated with [Claude Code](https://claude.com/claude-code)