### PR TITLE
fix(pyartcd,doozer): handle RHEL minor version suffix in golang NVR parsing

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -938,9 +938,14 @@ class KonfluxImageBuilder:
         build_pipeline_url = self._konflux_client.resource_url(pipelinerun_dict)
         build_component = pipelinerun_dict['metadata']['labels']['appstudio.openshift.io/component']
 
-        # Extract the el_target (e.g., 'el9' for OCP or 'scos9' for OKD) from the release string
+        # Extract the el_target (e.g., 'el9' for OCP or 'scos9' for OKD) from the release string.
+        # Strip RHEL minor version suffix (e.g., el8_10 -> el8) to keep el_target scoped to major version,
+        # consistent with how queries filter by el_target.
         _, el_suffix = split_el_suffix_in_release(release)
-        el_target_value = el_suffix if el_suffix else f'el{isolate_el_version_in_release(release)}'
+        if el_suffix:
+            el_target_value = re.sub(r'_\d+$', '', el_suffix)
+        else:
+            el_target_value = f'el{isolate_el_version_in_release(release)}'
 
         build_record_params = {
             'name': metadata.distgit_key,

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -365,6 +365,69 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         build_record = add_build_call.call_args[0][0]
         self.assertEqual(build_record.el_target, "el9")
 
+    async def test_update_konflux_db_preserves_scos_prefix_in_el_target(self):
+        """el_target should be 'scos9' for OKD builds, not 'el9'."""
+        metadata = self._metadata()
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "test-commit-hash"
+        build_repo.local_dir = Path(self.temp_dir.name)
+
+        pipelinerun = PipelineRunInfo(
+            {
+                "metadata": {
+                    "name": "test-pipelinerun",
+                    "uid": "test-uid",
+                    "labels": {"appstudio.openshift.io/component": "test-component"},
+                },
+                "status": {
+                    "results": [
+                        {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                        {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                    ],
+                    "startTime": "2023-10-01T12:00:00Z",
+                    "completionTime": "2023-10-01T12:30:00Z",
+                },
+            },
+            {},
+        )
+
+        with (
+            patch("doozerlib.backend.konflux_image_builder.DockerfileParser") as mock_dockerfile_parser,
+            patch.object(self.builder, "extract_parent_image_nvrs", new=AsyncMock(return_value=[])),
+            patch.object(
+                self.builder,
+                "get_installed_packages",
+                new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
+            ),
+            patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
+        ):
+            mock_dockerfile = MagicMock()
+            mock_dockerfile.labels = {
+                "io.openshift.build.source-location": "https://example.com/source-repo.git",
+                "io.openshift.build.commit.id": "source-commit-id",
+                "com.redhat.component": "test-component",
+                "version": "1.0",
+                "release": "1.scos9",
+            }
+            mock_dockerfile.parent_images = []
+            mock_dockerfile_parser.return_value = mock_dockerfile
+            mock_bigquery_client.return_value.client.insert_rows_json.return_value = None
+
+            await self.builder.update_konflux_db(
+                metadata,
+                build_repo,
+                pipelinerun,
+                KonfluxBuildOutcome.SUCCESS,
+                ["x86_64"],
+                "5",
+            )
+
+        add_build_call = metadata.runtime.konflux_db.add_build
+        add_build_call.assert_called_once()
+        build_record = add_build_call.call_args[0][0]
+        self.assertEqual(build_record.el_target, "scos9")
+
     async def test_ec_policy_selection_missing_lifecycle_phase(self):
         """Test that default EC policy is used when lifecycle phase is Missing."""
         from artcommonlib.model import Missing

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -302,6 +302,69 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(build_record.installed_rpms, [])
         self.assertEqual(build_record.image_pullspec, "quay.io/test/image@sha256:testdigest")
 
+    async def test_update_konflux_db_strips_rhel_minor_version_from_el_target(self):
+        """el_target should be 'el9' even when the release contains a minor version suffix like 'el9_6'."""
+        metadata = self._metadata()
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "test-commit-hash"
+        build_repo.local_dir = Path(self.temp_dir.name)
+
+        pipelinerun = PipelineRunInfo(
+            {
+                "metadata": {
+                    "name": "test-pipelinerun",
+                    "uid": "test-uid",
+                    "labels": {"appstudio.openshift.io/component": "test-component"},
+                },
+                "status": {
+                    "results": [
+                        {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                        {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                    ],
+                    "startTime": "2023-10-01T12:00:00Z",
+                    "completionTime": "2023-10-01T12:30:00Z",
+                },
+            },
+            {},
+        )
+
+        with (
+            patch("doozerlib.backend.konflux_image_builder.DockerfileParser") as mock_dockerfile_parser,
+            patch.object(self.builder, "extract_parent_image_nvrs", new=AsyncMock(return_value=[])),
+            patch.object(
+                self.builder,
+                "get_installed_packages",
+                new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
+            ),
+            patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
+        ):
+            mock_dockerfile = MagicMock()
+            mock_dockerfile.labels = {
+                "io.openshift.build.source-location": "https://example.com/source-repo.git",
+                "io.openshift.build.commit.id": "source-commit-id",
+                "com.redhat.component": "test-component",
+                "version": "1.0",
+                "release": "1.el9_6",
+            }
+            mock_dockerfile.parent_images = []
+            mock_dockerfile_parser.return_value = mock_dockerfile
+            mock_bigquery_client.return_value.client.insert_rows_json.return_value = None
+
+            await self.builder.update_konflux_db(
+                metadata,
+                build_repo,
+                pipelinerun,
+                KonfluxBuildOutcome.SUCCESS,
+                ["x86_64"],
+                "5",
+            )
+
+        add_build_call = metadata.runtime.konflux_db.add_build
+        add_build_call.assert_called_once()
+        build_record = add_build_call.call_args[0][0]
+        self.assertEqual(build_record.el_target, "el9")
+
     async def test_ec_policy_selection_missing_lifecycle_phase(self):
         """Test that default EC policy is used when lifecycle phase is Missing."""
         from artcommonlib.model import Missing

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -19,7 +19,7 @@ from artcommonlib.constants import (
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.konflux.konflux_db import KonfluxDb
-from artcommonlib.release_util import split_el_suffix_in_release
+from artcommonlib.release_util import isolate_el_version_in_release
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import new_roundtrip_yaml_handler
 from doozerlib.constants import ART_IMAGES_BASE_APPLICATION
@@ -105,11 +105,9 @@ def extract_and_validate_golang_nvrs(ocp_version: str, go_nvrs: List[str]):
             )
         go_version = parsed_nvr['version']
 
-        _, el_version = split_el_suffix_in_release(parsed_nvr['release'])
-        # el_version is either None or something like "el8"
-        if not el_version:
+        el_version = isolate_el_version_in_release(parsed_nvr['release'])
+        if el_version is None:
             raise ValueError(f'Cannot detect an el version in NVR {nvr}')
-        el_version = int(el_version[2:])
         if el_version not in supported_els:
             raise ValueError(
                 f'Unsupported RHEL version detected for nvr {nvr}, supported versions are: {supported_els}'

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -98,6 +98,19 @@ class TestExtractAndValidateGolangNvrs(unittest.TestCase):
             },
         )
 
+    def test_el_with_minor_version_suffix(self):
+        """Test NVRs with RHEL minor version suffix like el8_10, el9_5"""
+        go_version, el_nvr_map = extract_and_validate_golang_nvrs(
+            "4.16", ["golang-1.26.3-1.el8_10", "golang-1.26.3-1.el9_6"]
+        )
+        self.assertEqual(go_version, "1.26.3")
+        self.assertEqual(el_nvr_map, {8: "golang-1.26.3-1.el8_10", 9: "golang-1.26.3-1.el9_6"})
+
+    def test_el_minor_version_unsupported_major(self):
+        """Test that el7_9 is still rejected even with minor version suffix"""
+        with self.assertRaisesRegex(ValueError, "Unsupported RHEL version detected"):
+            extract_and_validate_golang_nvrs("4.16", ["golang-1.20.12-2.el7_9"])
+
 
 class TestGetLatestNvrInTag(unittest.TestCase):
     """Test the get_latest_nvr_in_tag function"""


### PR DESCRIPTION
## Summary

- Fixes `extract_and_validate_golang_nvrs` in `update_golang.py` failing on NVRs like `golang-1.26.3-1.el8_10`
- Fixes `update_konflux_db` in `konflux_image_builder.py` storing `el_target='el8_10'` instead of `el_target='el8'`
- Regression from #3011 which changed `split_el_suffix_in_release` to capture the full `el8_10` suffix
- `update_golang.py`: the previous code did `int("8_10")` → `810`, which isn't in `{8, 9, 10}`. Fix: use `isolate_el_version_in_release()` which already handles this correctly
- `konflux_image_builder.py`: raw `el8_10` suffix was stored as `el_target`, but queries filter by `el8`. Fix: strip minor version suffix with `re.sub(r'_\d+$', '', el_suffix)`

## Test plan

- [x] Unit tests for `extract_and_validate_golang_nvrs` with minor version suffixes (`el8_10`, `el9_6`)
- [x] Unit test verifying `el_target='el9'` for release `1.el9_6`
- [x] Unit test verifying `el_target='scos9'` preserved for OKD builds
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)