### PR TITLE
feat(pyartcd): add GA readiness check in prepare-release-konflux

### DIFF
--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse
 import aiohttp
 import asyncstdlib as a
 import click
+import ruamel.yaml
 import semver
 from artcommonlib import exectools
 from artcommonlib.assembly import (
@@ -1684,22 +1685,20 @@ class PrepareReleaseKonfluxPipeline:
         phase = (self.group_config.get('software_lifecycle') or {}).get('phase')
         if phase != 'release':
             errors.append(
-                f"group.yml software_lifecycle.phase must be 'release' for a standard assembly, "
-                f"but found '{phase}'"
+                f"group.yml software_lifecycle.phase must be 'release' for a standard assembly, but found '{phase}'"
             )
 
         # Check 2: bug.yml target_release must include .z
+        bug_config = None
         try:
             bug_config = yaml.load(await self.build_data_repo.read_file("bug.yml"))
+        except (OSError, ruamel.yaml.YAMLError):
+            self.logger.warning("bug.yml not found or unreadable; skipping target_release check.")
+        if bug_config is not None:
             target_release = (bug_config or {}).get('target_release', [])
             z_stream = f"{major}.{minor}.z"
             if z_stream not in target_release:
-                errors.append(
-                    f"bug.yml 'target_release' must include '{z_stream}', "
-                    f"but found: {target_release}"
-                )
-        except Exception:
-            self.logger.warning("bug.yml not found or unreadable; skipping target_release check.")
+                errors.append(f"bug.yml 'target_release' must include '{z_stream}', but found: {target_release}")
 
         if errors:
             raise ValueError(

--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -1692,8 +1692,10 @@ class PrepareReleaseKonfluxPipeline:
         bug_config = None
         try:
             bug_config = yaml.load(await self.build_data_repo.read_file("bug.yml"))
-        except (OSError, ruamel.yaml.YAMLError):
+        except OSError:
             self.logger.warning("bug.yml not found or unreadable; skipping target_release check.")
+        except ruamel.yaml.YAMLError as e:
+            errors.append(f"bug.yml could not be parsed: {e}")
         if bug_config is not None:
             target_release = (bug_config or {}).get('target_release', [])
             z_stream = f"{major}.{minor}.z"

--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -261,6 +261,7 @@ class PrepareReleaseKonfluxPipeline:
     async def _run_pipeline(self):
         # Check advisory stage policy early for fail-fast behavior
         await self.check_advisory_stage_policy(self.assembly_type)
+        await self.check_bug_config_for_ga()
 
         await self.check_blockers()
         err = None
@@ -1665,6 +1666,48 @@ class PrepareReleaseKonfluxPipeline:
             self.logger.info('Jira unchanged, not updating issue')
 
         return jira_changed
+
+    async def check_bug_config_for_ga(self):
+        """For standard (GA/z-stream) assemblies, verify that ocp-build-data is
+        correctly configured for post-GA releases:
+        - software_lifecycle.phase must be 'release'
+        - bug.yml target_release must include the z-stream entry (e.g. '4.22.z')
+        """
+        if self.assembly_type != AssemblyTypes.STANDARD:
+            self.logger.info("Assembly type is %s; skipping GA readiness check.", self.assembly_type)
+            return
+
+        errors = []
+        major, minor = self.release_name.split('.')[:2]
+
+        # Check 1: software_lifecycle.phase must be 'release'
+        phase = (self.group_config.get('software_lifecycle') or {}).get('phase')
+        if phase != 'release':
+            errors.append(
+                f"group.yml software_lifecycle.phase must be 'release' for a standard assembly, "
+                f"but found '{phase}'"
+            )
+
+        # Check 2: bug.yml target_release must include .z
+        try:
+            bug_config = yaml.load(await self.build_data_repo.read_file("bug.yml"))
+            target_release = (bug_config or {}).get('target_release', [])
+            z_stream = f"{major}.{minor}.z"
+            if z_stream not in target_release:
+                errors.append(
+                    f"bug.yml 'target_release' must include '{z_stream}', "
+                    f"but found: {target_release}"
+                )
+        except Exception:
+            self.logger.warning("bug.yml not found or unreadable; skipping target_release check.")
+
+        if errors:
+            raise ValueError(
+                "ocp-build-data is not configured for GA/z-stream releases:\n"
+                + "\n".join(f"  - {e}" for e in errors)
+                + "\nSee ocp-build-data PR #11046 for an example of the required changes."
+            )
+        self.logger.info("GA readiness check passed.")
 
     async def check_advisory_stage_policy(self, assembly_type: AssemblyTypes):
         """

--- a/pyartcd/tests/pipelines/test_prepare_release_konflux.py
+++ b/pyartcd/tests/pipelines/test_prepare_release_konflux.py
@@ -1183,9 +1183,7 @@ class TestCheckBugConfigForGa(unittest.IsolatedAsyncioTestCase):
         # Phase is correct, bug.yml is missing -> passes gracefully
         await pipeline.check_bug_config_for_ga()
 
-        pipeline.logger.warning.assert_called_with(
-            "bug.yml not found or unreadable; skipping target_release check."
-        )
+        pipeline.logger.warning.assert_called_with("bug.yml not found or unreadable; skipping target_release check.")
         pipeline.logger.info.assert_called_with("GA readiness check passed.")
 
     async def test_fails_phase_even_when_bug_yml_missing(self):
@@ -1199,3 +1197,17 @@ class TestCheckBugConfigForGa(unittest.IsolatedAsyncioTestCase):
             await pipeline.check_bug_config_for_ga()
 
         self.assertIn("software_lifecycle.phase must be 'release'", str(ctx.exception))
+
+    async def test_fails_when_bug_yml_is_malformed(self):
+        """If bug.yml exists but cannot be parsed, a validation error is raised (not silently skipped)."""
+        import ruamel.yaml
+
+        pipeline = self._make_pipeline()
+        pipeline.assembly_type = AssemblyTypes.STANDARD
+        pipeline.group_config = {'software_lifecycle': {'phase': 'release'}}
+        pipeline.build_data_repo.read_file.side_effect = ruamel.yaml.YAMLError("bad yaml")
+
+        with self.assertRaises(ValueError) as ctx:
+            await pipeline.check_bug_config_for_ga()
+
+        self.assertIn("bug.yml could not be parsed", str(ctx.exception))

--- a/pyartcd/tests/pipelines/test_prepare_release_konflux.py
+++ b/pyartcd/tests/pipelines/test_prepare_release_konflux.py
@@ -1068,3 +1068,134 @@ class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
 
         # Verify that execute_command_with_logging was not called
         pipeline.execute_command_with_logging.assert_not_called()
+
+
+class TestCheckBugConfigForGa(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.runtime = Mock(spec=Runtime)
+        self.runtime.working_dir = Path("/tmp/working-dir")
+        self.runtime.dry_run = False
+        self.runtime.config = {
+            "gitlab_url": "https://gitlab.example.com",
+            "build_config": {
+                "ocp_build_data_url": "https://github.com/user1/repo1",
+                "ocp_build_data_push_url": "https://github.com/user2/repo2",
+            },
+            "shipment_config": {
+                "shipment_data_url": "https://gitlab.example.com/user3/repo3",
+                "shipment_data_push_url": "https://gitlab.example.com/user4/repo4",
+            },
+        }
+        self.mock_slack_client = Mock(spec=SlackClient)
+
+    def _make_pipeline(self, group="openshift-4.22", assembly="4.22.1"):
+        pipeline = PrepareReleaseKonfluxPipeline(
+            slack_client=self.mock_slack_client,
+            runtime=self.runtime,
+            group=group,
+            assembly=assembly,
+        )
+        pipeline.gitlab_token = "gl_token"
+        pipeline.logger = Mock()
+        pipeline.build_data_repo = AsyncMock()
+        pipeline.releases_config = {
+            "releases": {
+                assembly: {
+                    "assembly": {
+                        "type": AssemblyTypes.STANDARD.value,
+                        "group": {"release_date": "2026-Jun-18"},
+                    }
+                }
+            }
+        }
+        return pipeline
+
+    async def test_passes_when_phase_release_and_z_stream_present(self):
+        """Standard assembly with correct phase and z-stream in bug.yml -> passes."""
+        pipeline = self._make_pipeline()
+        pipeline.assembly_type = AssemblyTypes.STANDARD
+        pipeline.group_config = {'software_lifecycle': {'phase': 'release'}}
+        pipeline.build_data_repo.read_file.return_value = "target_release:\n  - '4.22.0'\n  - '4.22.z'\n  - '4.22'\n"
+
+        await pipeline.check_bug_config_for_ga()
+
+        pipeline.logger.info.assert_called_with("GA readiness check passed.")
+
+    async def test_fails_when_phase_is_signing(self):
+        """Standard assembly with phase 'signing' -> raises ValueError."""
+        pipeline = self._make_pipeline()
+        pipeline.assembly_type = AssemblyTypes.STANDARD
+        pipeline.group_config = {'software_lifecycle': {'phase': 'signing'}}
+        pipeline.build_data_repo.read_file.return_value = "target_release:\n  - '4.22.0'\n  - '4.22.z'\n"
+
+        with self.assertRaises(ValueError) as ctx:
+            await pipeline.check_bug_config_for_ga()
+
+        self.assertIn("software_lifecycle.phase must be 'release'", str(ctx.exception))
+        self.assertIn("'signing'", str(ctx.exception))
+
+    async def test_fails_when_z_stream_absent_in_bug_yml(self):
+        """Standard assembly with correct phase but missing .z in target_release -> raises ValueError."""
+        pipeline = self._make_pipeline()
+        pipeline.assembly_type = AssemblyTypes.STANDARD
+        pipeline.group_config = {'software_lifecycle': {'phase': 'release'}}
+        pipeline.build_data_repo.read_file.return_value = "target_release:\n  - '4.22.0'\n  - '4.22'\n"
+
+        with self.assertRaises(ValueError) as ctx:
+            await pipeline.check_bug_config_for_ga()
+
+        self.assertIn("4.22.z", str(ctx.exception))
+
+    async def test_fails_with_both_errors_reported(self):
+        """Standard assembly with phase 'signing' and missing .z -> raises ValueError listing both issues."""
+        pipeline = self._make_pipeline()
+        pipeline.assembly_type = AssemblyTypes.STANDARD
+        pipeline.group_config = {'software_lifecycle': {'phase': 'signing'}}
+        pipeline.build_data_repo.read_file.return_value = "target_release:\n  - '4.22.0'\n"
+
+        with self.assertRaises(ValueError) as ctx:
+            await pipeline.check_bug_config_for_ga()
+
+        error_msg = str(ctx.exception)
+        self.assertIn("software_lifecycle.phase must be 'release'", error_msg)
+        self.assertIn("4.22.z", error_msg)
+
+    async def test_skips_for_non_standard_assembly(self):
+        """Preview/candidate assemblies are skipped -> no error raised."""
+        pipeline = self._make_pipeline()
+        pipeline.assembly_type = AssemblyTypes.PREVIEW
+        pipeline.group_config = {'software_lifecycle': {'phase': 'pre-release'}}
+
+        await pipeline.check_bug_config_for_ga()
+
+        pipeline.logger.info.assert_called_with(
+            "Assembly type is %s; skipping GA readiness check.", AssemblyTypes.PREVIEW
+        )
+        pipeline.build_data_repo.read_file.assert_not_called()
+
+    async def test_skips_target_release_check_when_bug_yml_missing(self):
+        """If bug.yml cannot be read, skip that check but still validate phase."""
+        pipeline = self._make_pipeline()
+        pipeline.assembly_type = AssemblyTypes.STANDARD
+        pipeline.group_config = {'software_lifecycle': {'phase': 'release'}}
+        pipeline.build_data_repo.read_file.side_effect = FileNotFoundError("bug.yml not found")
+
+        # Phase is correct, bug.yml is missing -> passes gracefully
+        await pipeline.check_bug_config_for_ga()
+
+        pipeline.logger.warning.assert_called_with(
+            "bug.yml not found or unreadable; skipping target_release check."
+        )
+        pipeline.logger.info.assert_called_with("GA readiness check passed.")
+
+    async def test_fails_phase_even_when_bug_yml_missing(self):
+        """If bug.yml is missing but phase is wrong, the phase error is still raised."""
+        pipeline = self._make_pipeline()
+        pipeline.assembly_type = AssemblyTypes.STANDARD
+        pipeline.group_config = {'software_lifecycle': {'phase': 'signing'}}
+        pipeline.build_data_repo.read_file.side_effect = FileNotFoundError("bug.yml not found")
+
+        with self.assertRaises(ValueError) as ctx:
+            await pipeline.check_bug_config_for_ga()
+
+        self.assertIn("software_lifecycle.phase must be 'release'", str(ctx.exception))

--- a/pyartcd/tests/pipelines/test_prepare_release_konflux.py
+++ b/pyartcd/tests/pipelines/test_prepare_release_konflux.py
@@ -926,6 +926,7 @@ class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
     @patch.object(PrepareReleaseKonfluxPipeline, 'sweep_et_builds', new_callable=AsyncMock)
     @patch.object(PrepareReleaseKonfluxPipeline, 'create_et_advisories', new_callable=AsyncMock)
     @patch.object(PrepareReleaseKonfluxPipeline, 'check_blockers', new_callable=AsyncMock)
+    @patch.object(PrepareReleaseKonfluxPipeline, 'check_bug_config_for_ga', new_callable=AsyncMock)
     @patch.object(PrepareReleaseKonfluxPipeline, 'check_advisory_stage_policy', new_callable=AsyncMock)
     @patch.object(PrepareReleaseKonfluxPipeline, 'initialize', new_callable=AsyncMock)
     @patch('pyartcd.pipelines.prepare_release_konflux.RegistryConfig')
@@ -934,6 +935,7 @@ class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
         mock_registry_config,
         mock_initialize,
         mock_check_advisory_stage_policy,
+        mock_check_bug_config_for_ga,
         mock_check_blockers,
         mock_create_et_advisories,
         mock_sweep_et_builds,


### PR DESCRIPTION
## Summary

- Adds `check_bug_config_for_ga()` to `PrepareReleaseKonfluxPipeline`, called early in `_run_pipeline()` as a fail-fast check for standard (GA/z-stream) assemblies
- Validates that `group.yml`'s `software_lifecycle.phase` is `'release'` and that `bug.yml`'s `target_release` includes the `.z` entry (e.g. `4.22.z`)
- Both conditions are checked independently and all errors are reported at once, so they can be fixed in a single ocp-build-data PR
- This check would have caught the missed configuration in ocp-build-data PR #11046 (4.22 GA transition)

## Test plan

- [ ] New `TestCheckBugConfigForGa` test class with 7 unit tests covering all cases (pass, phase wrong, z-stream missing, both wrong, non-standard assembly skipped, bug.yml missing)
- [ ] All 7 tests pass

Made with [Cursor](https://cursor.com)