### PR TITLE
WIP fix(doozer,pyartcd): capture parent-failure message in record and exc…

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -434,6 +434,16 @@ class KonfluxImageBuilder:
                 record["message"] = str(error)
                 raise error
 
+        except Exception as exc:
+            # Capture the actual error message for any exception that bypasses
+            # the build loop's error handling (e.g., parent build failures,
+            # NVR validation errors). Without this, record["message"] would
+            # remain "Unknown failure" and downstream counter logic couldn't
+            # distinguish failure types.
+            if record["message"] == "Unknown failure":
+                record["message"] = str(exc)
+            raise
+
         finally:
             if self._record_logger:
                 if 'okd' in self._config.group_name:

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -992,6 +992,81 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         mock_snap.assert_awaited_once()
 
 
+    async def test_build_parent_failure_captures_message_in_record(self):
+        """When parent images fail, the record message should capture the actual error, not 'Unknown failure'."""
+        metadata = self._metadata()
+        dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        build_repo = MagicMock()
+        build_repo.local_dir = dest_dir
+        build_repo.url = "https://github.com/test/repo.git"
+        build_repo.commit_hash = "test-commit"
+
+        # Simulate a parent member that failed to build
+        failed_parent = MagicMock()
+        failed_parent.distgit_key = "openshift-enterprise-base-rhel9"
+        failed_parent.build_status = False
+
+        record_logger = MagicMock()
+        self.builder._record_logger = record_logger
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=build_repo),
+            ),
+            patch.object(self.builder, "_parse_dockerfile", return_value=("test-uuid", "test-component", "1.0", "1")),
+            patch.object(
+                self.builder, "_wait_for_parent_members", new=AsyncMock(return_value=[failed_parent]),
+            ),
+        ):
+            with self.assertRaises(IOError) as ctx:
+                await self.builder.build(metadata)
+
+        # Verify the error message mentions the parent failure
+        self.assertIn("parent images failed to build", str(ctx.exception))
+        self.assertIn("openshift-enterprise-base-rhel9", str(ctx.exception))
+
+        # Verify the record message was captured (not left as "Unknown failure")
+        add_record_call = record_logger.add_record
+        add_record_call.assert_called_once()
+        _, kwargs = add_record_call.call_args
+        self.assertIn("parent images failed to build", kwargs["message"])
+        self.assertNotEqual(kwargs["message"], "Unknown failure")
+
+    async def test_build_unknown_exception_captures_message_in_record(self):
+        """Any exception before the build loop should capture its message in the record."""
+        metadata = self._metadata()
+        dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        build_repo = MagicMock()
+        build_repo.local_dir = dest_dir
+
+        record_logger = MagicMock()
+        self.builder._record_logger = record_logger
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=build_repo),
+            ),
+            patch.object(
+                self.builder, "_parse_dockerfile",
+                side_effect=ValueError("Target NVR 1.0-1 is not greater than the latest"),
+            ),
+        ):
+            with self.assertRaises(ValueError):
+                await self.builder.build(metadata)
+
+        add_record_call = record_logger.add_record
+        add_record_call.assert_called_once()
+        _, kwargs = add_record_call.call_args
+        self.assertIn("Target NVR", kwargs["message"])
+        self.assertNotEqual(kwargs["message"], "Unknown failure")
+
+
 class TestNormalizeVersion(unittest.TestCase):
     """
     Tests for _normalize_version.

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -257,11 +257,23 @@ class KonfluxOcpPipeline:
             entry['name']: entry for entry in record_log.get('image_build_konflux', []) if int(entry['status'])
         }
 
+        # Exclude images that failed only because their parent images failed to build.
+        # These children were never actually attempted, so incrementing their counters
+        # would be misleading.
+        real_failed_images = []
+        for image in failed_images:
+            entry = failed_entries.get(image, {})
+            message = entry.get('message', '')
+            if 'parent images failed to build' in message:
+                LOGGER.info(f'Excluding {image} from counter updates (parent build failure, not a real build issue)')
+            else:
+                real_failed_images.append(image)
+
         # Categorize failures by type (prefer granular outcome; fall back to legacy record flags)
         ec_failed_images = []
         release_failed_images = []
         build_failed_images = []
-        for image in failed_images:
+        for image in real_failed_images:
             entry = failed_entries.get(image, {})
             outcome = entry.get('outcome', '')
             if outcome == str(KonfluxBuildOutcome.ITS_ERROR):

--- a/pyartcd/tests/pipelines/test_ocp.py
+++ b/pyartcd/tests/pipelines/test_ocp.py
@@ -1256,3 +1256,116 @@ class TestKonfluxOcpPipelineBuildFailCounters(unittest.IsolatedAsyncioTestCase):
         await pipeline.update_build_fail_counters([], ['ironic'], record_log)
         mock_reset.assert_not_called()
         mock_incr.assert_not_called()
+
+    @patch('pyartcd.pipelines.ocp4_konflux.increment_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.reset_fail_counter', new_callable=AsyncMock)
+    async def test_build_fail_counters_exclude_parent_failures(self, mock_reset, mock_incr):
+        """Images that failed because their parent images failed should not increment counters."""
+        pipeline = self._make_pipeline()
+        record_log = {
+            'image_build_konflux': [
+                {
+                    'name': 'ose-baremetal-installer',
+                    'status': '-1',
+                    'nvrs': 'n/a',
+                    'outcome': '',
+                    'ec_pipeline_url': '',
+                    'build_pipeline_url': '',
+                    'release_pipeline': '',
+                    'base_image_release_failed': 'false',
+                    'task_id': 'n/a',
+                    'message': "Couldn't build ose-baremetal-installer because the following parent images failed to build: ose-etcd, openshift-enterprise-hyperkube",
+                },
+            ]
+        }
+        await pipeline.update_build_fail_counters([], ['ose-baremetal-installer'], record_log)
+        mock_incr.assert_not_called()
+
+    @patch('pyartcd.pipelines.ocp4_konflux.increment_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.reset_fail_counter', new_callable=AsyncMock)
+    async def test_build_fail_counters_mixed_real_and_parent_failures(self, mock_reset, mock_incr):
+        """Real failures should be counted, parent-failure children should not."""
+        pipeline = self._make_pipeline()
+        record_log = {
+            'image_build_konflux': [
+                {
+                    'name': 'openshift-enterprise-base-rhel9',
+                    'status': '-1',
+                    'nvrs': 'base-rhel9-1.0-1',
+                    'outcome': 'failure',
+                    'ec_pipeline_url': '',
+                    'build_pipeline_url': 'http://build/plr/base',
+                    'release_pipeline': '',
+                    'base_image_release_failed': 'false',
+                    'message': 'Build timed out',
+                },
+                {
+                    'name': 'ose-baremetal-installer',
+                    'status': '-1',
+                    'nvrs': 'n/a',
+                    'outcome': '',
+                    'ec_pipeline_url': '',
+                    'build_pipeline_url': '',
+                    'release_pipeline': '',
+                    'base_image_release_failed': 'false',
+                    'task_id': 'n/a',
+                    'message': "Couldn't build ose-baremetal-installer because the following parent images failed to build: openshift-enterprise-base-rhel9",
+                },
+                {
+                    'name': 'ose-network-tools',
+                    'status': '-1',
+                    'nvrs': 'n/a',
+                    'outcome': '',
+                    'ec_pipeline_url': '',
+                    'build_pipeline_url': '',
+                    'release_pipeline': '',
+                    'base_image_release_failed': 'false',
+                    'task_id': 'n/a',
+                    'message': "Couldn't build ose-network-tools because the following parent images failed to build: openshift-enterprise-base-rhel9",
+                },
+            ]
+        }
+        await pipeline.update_build_fail_counters(
+            [],
+            ['openshift-enterprise-base-rhel9', 'ose-baremetal-installer', 'ose-network-tools'],
+            record_log,
+        )
+        # Only the real failure (base-rhel9) should increment
+        incr_keys = [c.args[0] for c in mock_incr.call_args_list]
+        self.assertEqual(len(incr_keys), 1)
+        self.assertIn('openshift-enterprise-base-rhel9', incr_keys[0])
+        self.assertIn('build-failure', incr_keys[0])
+
+    @patch('pyartcd.pipelines.ocp4_konflux.increment_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.reset_fail_counter', new_callable=AsyncMock)
+    async def test_build_fail_counters_all_parent_failures_no_increments(self, mock_reset, mock_incr):
+        """When all failures are parent-caused, no counters should be incremented."""
+        pipeline = self._make_pipeline()
+        record_log = {
+            'image_build_konflux': [
+                {
+                    'name': 'child-a',
+                    'status': '-1',
+                    'nvrs': 'n/a',
+                    'outcome': '',
+                    'ec_pipeline_url': '',
+                    'build_pipeline_url': '',
+                    'release_pipeline': '',
+                    'base_image_release_failed': 'false',
+                    'message': "Couldn't build child-a because the following parent images failed to build: parent-x",
+                },
+                {
+                    'name': 'child-b',
+                    'status': '-1',
+                    'nvrs': 'n/a',
+                    'outcome': '',
+                    'ec_pipeline_url': '',
+                    'build_pipeline_url': '',
+                    'release_pipeline': '',
+                    'base_image_release_failed': 'false',
+                    'message': "Couldn't build child-b because the following parent images failed to build: parent-x, parent-y",
+                },
+            ]
+        }
+        await pipeline.update_build_fail_counters([], ['child-a', 'child-b'], record_log)
+        mock_incr.assert_not_called()


### PR DESCRIPTION
…lude from counters

When a parent image fails to build, its child images raise an IOError before the build loop starts. Previously this left record['message'] as 'Unknown failure', and update_build_fail_counters() couldn't distinguish these children from real build failures. This caused erroneous counter increments for images that were never attempted.

Changes:
- doozer/konflux_image_builder.py: add except clause before finally to capture the actual exception message in record['message'] when it would otherwise remain 'Unknown failure'
- pyartcd/ocp4_konflux.py: filter out entries whose message contains 'parent images failed to build' before categorizing failures and incrementing Redis counters
- Tests for both fixes in their respective test files