### PR TITLE
fix(doozer,pyartcd): exclude parent-failure children from counters and description

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -434,6 +434,16 @@ class KonfluxImageBuilder:
                 record["message"] = str(error)
                 raise error
 
+        except Exception as exc:
+            # Capture the actual error message for any exception that bypasses
+            # the build loop's error handling (e.g., parent build failures,
+            # NVR validation errors). Without this, record["message"] would
+            # remain "Unknown failure" and downstream counter logic couldn't
+            # distinguish failure types.
+            if record["message"] == "Unknown failure":
+                record["message"] = str(exc)
+            raise
+
         finally:
             if self._record_logger:
                 if 'okd' in self._config.group_name:

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -991,7 +991,6 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(result)
         mock_snap.assert_awaited_once()
 
-
     async def test_build_parent_failure_captures_message_in_record(self):
         """When parent images fail, the record message should capture the actual error, not 'Unknown failure'."""
         metadata = self._metadata()
@@ -1018,7 +1017,9 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
             ),
             patch.object(self.builder, "_parse_dockerfile", return_value=("test-uuid", "test-component", "1.0", "1")),
             patch.object(
-                self.builder, "_wait_for_parent_members", new=AsyncMock(return_value=[failed_parent]),
+                self.builder,
+                "_wait_for_parent_members",
+                new=AsyncMock(return_value=[failed_parent]),
             ),
         ):
             with self.assertRaises(IOError) as ctx:
@@ -1053,7 +1054,8 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 new=AsyncMock(return_value=build_repo),
             ),
             patch.object(
-                self.builder, "_parse_dockerfile",
+                self.builder,
+                "_parse_dockerfile",
                 side_effect=ValueError("Target NVR 1.0-1 is not greater than the latest"),
             ),
         ):

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -992,6 +992,81 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         mock_snap.assert_awaited_once()
 
 
+    async def test_build_parent_failure_captures_message_in_record(self):
+        """When parent images fail, the record message should capture the actual error, not 'Unknown failure'."""
+        metadata = self._metadata()
+        dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        build_repo = MagicMock()
+        build_repo.local_dir = dest_dir
+        build_repo.url = "https://github.com/test/repo.git"
+        build_repo.commit_hash = "test-commit"
+
+        # Simulate a parent member that failed to build
+        failed_parent = MagicMock()
+        failed_parent.distgit_key = "openshift-enterprise-base-rhel9"
+        failed_parent.build_status = False
+
+        record_logger = MagicMock()
+        self.builder._record_logger = record_logger
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=build_repo),
+            ),
+            patch.object(self.builder, "_parse_dockerfile", return_value=("test-uuid", "test-component", "1.0", "1")),
+            patch.object(
+                self.builder, "_wait_for_parent_members", new=AsyncMock(return_value=[failed_parent]),
+            ),
+        ):
+            with self.assertRaises(IOError) as ctx:
+                await self.builder.build(metadata)
+
+        # Verify the error message mentions the parent failure
+        self.assertIn("parent images failed to build", str(ctx.exception))
+        self.assertIn("openshift-enterprise-base-rhel9", str(ctx.exception))
+
+        # Verify the record message was captured (not left as "Unknown failure")
+        add_record_call = record_logger.add_record
+        add_record_call.assert_called_once()
+        _, kwargs = add_record_call.call_args
+        self.assertIn("parent images failed to build", kwargs["message"])
+        self.assertNotEqual(kwargs["message"], "Unknown failure")
+
+    async def test_build_unknown_exception_captures_message_in_record(self):
+        """Any exception before the build loop should capture its message in the record."""
+        metadata = self._metadata()
+        dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        build_repo = MagicMock()
+        build_repo.local_dir = dest_dir
+
+        record_logger = MagicMock()
+        self.builder._record_logger = record_logger
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=build_repo),
+            ),
+            patch.object(
+                self.builder, "_parse_dockerfile",
+                side_effect=ValueError("Target NVR 1.0-1 is not greater than the latest"),
+            ),
+        ):
+            with self.assertRaises(ValueError):
+                await self.builder.build(metadata)
+
+        add_record_call = record_logger.add_record
+        add_record_call.assert_called_once()
+        _, kwargs = add_record_call.call_args
+        self.assertIn("Target NVR", kwargs["message"])
+        self.assertNotEqual(kwargs["message"], "Unknown failure")
+
+
 class TestNormalizeVersion(unittest.TestCase):
     """
     Tests for _normalize_version.

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -495,10 +495,37 @@ class KonfluxOcpPipeline:
             entry['name'] for entry in record_log.get('image_build_konflux', []) if not int(entry['status'])
         ]
         failed_images = [entry['name'] for entry in record_log.get('image_build_konflux', []) if int(entry['status'])]
-        if 1 <= len(failed_images) <= 10:
-            jenkins.update_description(f'Failed images: {", ".join(failed_images)}<br/>')
-        elif len(failed_images) > 10:
-            jenkins.update_description(f'{len(failed_images)} images failed. Check record.log for details<br/>')
+
+        # Separate real failures from parent-failure children
+        real_failed_images = []
+        skipped_due_to_parent_failure = []
+        for image in failed_images:
+            entry = next((e for e in record_log.get('image_build_konflux', []) if e['name'] == image), {})
+            message = entry.get('message', '')
+            if 'parent images failed to build' in message:
+                skipped_due_to_parent_failure.append(image)
+            else:
+                real_failed_images.append(image)
+
+        # Log skipped images
+        if skipped_due_to_parent_failure:
+            LOGGER.info(f'Skipped images due to parent build failures: {", ".join(skipped_due_to_parent_failure)}')
+
+        # Update description with real failures and skipped images
+        description_parts = []
+        if 1 <= len(real_failed_images) <= 10:
+            description_parts.append(f'Failed images: {", ".join(real_failed_images)}')
+        elif len(real_failed_images) > 10:
+            description_parts.append(f'{len(real_failed_images)} images failed. Check record.log for details')
+
+        if skipped_due_to_parent_failure:
+            if len(skipped_due_to_parent_failure) <= 10:
+                description_parts.append(f'Skipped (parent failure): {", ".join(skipped_due_to_parent_failure)}')
+            else:
+                description_parts.append(f'{len(skipped_due_to_parent_failure)} images skipped due to parent failures')
+
+        if description_parts:
+            jenkins.update_description('<br/>'.join(description_parts) + '<br/>')
 
         await self.update_build_fail_counters(built_images, failed_images, record_log)
 

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -257,11 +257,23 @@ class KonfluxOcpPipeline:
             entry['name']: entry for entry in record_log.get('image_build_konflux', []) if int(entry['status'])
         }
 
+        # Exclude images that failed only because their parent images failed to build.
+        # These children were never actually attempted, so incrementing their counters
+        # would be misleading.
+        real_failed_images = []
+        for image in failed_images:
+            entry = failed_entries.get(image, {})
+            message = entry.get('message', '')
+            if 'parent images failed to build' in message:
+                LOGGER.info(f'Excluding {image} from counter updates (parent build failure, not a real build issue)')
+            else:
+                real_failed_images.append(image)
+
         # Categorize failures by type (prefer granular outcome; fall back to legacy record flags)
         ec_failed_images = []
         release_failed_images = []
         build_failed_images = []
-        for image in failed_images:
+        for image in real_failed_images:
             entry = failed_entries.get(image, {})
             outcome = entry.get('outcome', '')
             if outcome == str(KonfluxBuildOutcome.ITS_ERROR):

--- a/pyartcd/tests/pipelines/test_ocp.py
+++ b/pyartcd/tests/pipelines/test_ocp.py
@@ -1256,3 +1256,116 @@ class TestKonfluxOcpPipelineBuildFailCounters(unittest.IsolatedAsyncioTestCase):
         await pipeline.update_build_fail_counters([], ['ironic'], record_log)
         mock_reset.assert_not_called()
         mock_incr.assert_not_called()
+
+    @patch('pyartcd.pipelines.ocp4_konflux.increment_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.reset_fail_counter', new_callable=AsyncMock)
+    async def test_build_fail_counters_exclude_parent_failures(self, mock_reset, mock_incr):
+        """Images that failed because their parent images failed should not increment counters."""
+        pipeline = self._make_pipeline()
+        record_log = {
+            'image_build_konflux': [
+                {
+                    'name': 'ose-baremetal-installer',
+                    'status': '-1',
+                    'nvrs': 'n/a',
+                    'outcome': '',
+                    'ec_pipeline_url': '',
+                    'build_pipeline_url': '',
+                    'release_pipeline': '',
+                    'base_image_release_failed': 'false',
+                    'task_id': 'n/a',
+                    'message': "Couldn't build ose-baremetal-installer because the following parent images failed to build: ose-etcd, openshift-enterprise-hyperkube",
+                },
+            ]
+        }
+        await pipeline.update_build_fail_counters([], ['ose-baremetal-installer'], record_log)
+        mock_incr.assert_not_called()
+
+    @patch('pyartcd.pipelines.ocp4_konflux.increment_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.reset_fail_counter', new_callable=AsyncMock)
+    async def test_build_fail_counters_mixed_real_and_parent_failures(self, mock_reset, mock_incr):
+        """Real failures should be counted, parent-failure children should not."""
+        pipeline = self._make_pipeline()
+        record_log = {
+            'image_build_konflux': [
+                {
+                    'name': 'openshift-enterprise-base-rhel9',
+                    'status': '-1',
+                    'nvrs': 'base-rhel9-1.0-1',
+                    'outcome': 'failure',
+                    'ec_pipeline_url': '',
+                    'build_pipeline_url': 'http://build/plr/base',
+                    'release_pipeline': '',
+                    'base_image_release_failed': 'false',
+                    'message': 'Build timed out',
+                },
+                {
+                    'name': 'ose-baremetal-installer',
+                    'status': '-1',
+                    'nvrs': 'n/a',
+                    'outcome': '',
+                    'ec_pipeline_url': '',
+                    'build_pipeline_url': '',
+                    'release_pipeline': '',
+                    'base_image_release_failed': 'false',
+                    'task_id': 'n/a',
+                    'message': "Couldn't build ose-baremetal-installer because the following parent images failed to build: openshift-enterprise-base-rhel9",
+                },
+                {
+                    'name': 'ose-network-tools',
+                    'status': '-1',
+                    'nvrs': 'n/a',
+                    'outcome': '',
+                    'ec_pipeline_url': '',
+                    'build_pipeline_url': '',
+                    'release_pipeline': '',
+                    'base_image_release_failed': 'false',
+                    'task_id': 'n/a',
+                    'message': "Couldn't build ose-network-tools because the following parent images failed to build: openshift-enterprise-base-rhel9",
+                },
+            ]
+        }
+        await pipeline.update_build_fail_counters(
+            [],
+            ['openshift-enterprise-base-rhel9', 'ose-baremetal-installer', 'ose-network-tools'],
+            record_log,
+        )
+        # Only the real failure (base-rhel9) should increment
+        incr_keys = [c.args[0] for c in mock_incr.call_args_list]
+        self.assertEqual(len(incr_keys), 1)
+        self.assertIn('openshift-enterprise-base-rhel9', incr_keys[0])
+        self.assertIn('build-failure', incr_keys[0])
+
+    @patch('pyartcd.pipelines.ocp4_konflux.increment_fail_counter', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.reset_fail_counter', new_callable=AsyncMock)
+    async def test_build_fail_counters_all_parent_failures_no_increments(self, mock_reset, mock_incr):
+        """When all failures are parent-caused, no counters should be incremented."""
+        pipeline = self._make_pipeline()
+        record_log = {
+            'image_build_konflux': [
+                {
+                    'name': 'child-a',
+                    'status': '-1',
+                    'nvrs': 'n/a',
+                    'outcome': '',
+                    'ec_pipeline_url': '',
+                    'build_pipeline_url': '',
+                    'release_pipeline': '',
+                    'base_image_release_failed': 'false',
+                    'message': "Couldn't build child-a because the following parent images failed to build: parent-x",
+                },
+                {
+                    'name': 'child-b',
+                    'status': '-1',
+                    'nvrs': 'n/a',
+                    'outcome': '',
+                    'ec_pipeline_url': '',
+                    'build_pipeline_url': '',
+                    'release_pipeline': '',
+                    'base_image_release_failed': 'false',
+                    'message': "Couldn't build child-b because the following parent images failed to build: parent-x, parent-y",
+                },
+            ]
+        }
+        await pipeline.update_build_fail_counters([], ['child-a', 'child-b'], record_log)
+        mock_incr.assert_not_called()

--- a/pyartcd/tests/pipelines/test_ocp.py
+++ b/pyartcd/tests/pipelines/test_ocp.py
@@ -1369,3 +1369,124 @@ class TestKonfluxOcpPipelineBuildFailCounters(unittest.IsolatedAsyncioTestCase):
         }
         await pipeline.update_build_fail_counters([], ['child-a', 'child-b'], record_log)
         mock_incr.assert_not_called()
+
+    @patch('pyartcd.pipelines.ocp4_konflux.jenkins')
+    @patch('pyartcd.pipelines.ocp4_konflux.KonfluxOcpPipeline.update_build_fail_counters', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.KonfluxOcpPipeline.parse_record_log')
+    async def test_sync_images_excludes_parent_failures_from_description(self, mock_parse, mock_counters, mock_jenkins):
+        """Parent-failure children should be logged as skipped, not shown in the description."""
+        pipeline = self._make_pipeline()
+
+        record_log = {
+            'image_build_konflux': [
+                {
+                    'name': 'ose-must-gather',
+                    'status': '-1',
+                    'nvrs': 'n/a',
+                    'outcome': 'failure',
+                    'message': 'Konflux image build for ose-must-gather failed with output=build_error',
+                },
+                {
+                    'name': 'local-storage-mustgather',
+                    'status': '-1',
+                    'nvrs': 'n/a',
+                    'outcome': '',
+                    'message': "Couldn't build local-storage-mustgather because the following parent images failed to build: ose-must-gather",
+                },
+                {
+                    'name': 'ose-cli',
+                    'status': '0',
+                    'nvrs': 'ose-cli-4.14.0-1',
+                    'outcome': 'success',
+                    'message': '',
+                },
+            ]
+        }
+        mock_parse.return_value = record_log
+
+        await pipeline.sync_images()
+
+        # Verify the description includes both the real failure and the skipped image
+        expected_description = (
+            'Failed images: ose-must-gather<br/>Skipped (parent failure): local-storage-mustgather<br/>'
+        )
+        mock_jenkins.update_description.assert_called_once_with(expected_description)
+
+    @patch('pyartcd.pipelines.ocp4_konflux.jenkins')
+    @patch('pyartcd.pipelines.ocp4_konflux.KonfluxOcpPipeline.update_build_fail_counters', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.KonfluxOcpPipeline.parse_record_log')
+    async def test_sync_images_all_parent_failures_no_description(self, mock_parse, mock_counters, mock_jenkins):
+        """When all failures are parent-caused, description should not show any failures."""
+        pipeline = self._make_pipeline()
+
+        record_log = {
+            'image_build_konflux': [
+                {
+                    'name': 'child-a',
+                    'status': '-1',
+                    'nvrs': 'n/a',
+                    'outcome': '',
+                    'message': "Couldn't build child-a because the following parent images failed to build: parent-x",
+                },
+                {
+                    'name': 'child-b',
+                    'status': '-1',
+                    'nvrs': 'n/a',
+                    'outcome': '',
+                    'message': "Couldn't build child-b because the following parent images failed to build: parent-x",
+                },
+                {
+                    'name': 'ose-cli',
+                    'status': '0',
+                    'nvrs': 'ose-cli-4.14.0-1',
+                    'outcome': 'success',
+                    'message': '',
+                },
+            ]
+        }
+        mock_parse.return_value = record_log
+
+        await pipeline.sync_images()
+
+        # When there are no real failures, only the skipped images description should be set
+        expected_description = 'Skipped (parent failure): child-a, child-b<br/>'
+        mock_jenkins.update_description.assert_called_once_with(expected_description)
+
+    @patch('pyartcd.pipelines.ocp4_konflux.jenkins')
+    @patch('pyartcd.pipelines.ocp4_konflux.KonfluxOcpPipeline.update_build_fail_counters', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.ocp4_konflux.KonfluxOcpPipeline.parse_record_log')
+    async def test_sync_images_many_skipped_uses_count(self, mock_parse, mock_counters, mock_jenkins):
+        """When there are >10 skipped images, show count instead of listing them."""
+        pipeline = self._make_pipeline()
+
+        # Create 12 skipped images
+        skipped_images = [
+            {
+                'name': f'child-{i}',
+                'status': '-1',
+                'nvrs': 'n/a',
+                'outcome': '',
+                'message': f"Couldn't build child-{i} because the following parent images failed to build: parent-x",
+            }
+            for i in range(12)
+        ]
+
+        record_log = {
+            'image_build_konflux': skipped_images
+            + [
+                {
+                    'name': 'ose-cli',
+                    'status': '0',
+                    'nvrs': 'ose-cli-4.14.0-1',
+                    'outcome': 'success',
+                    'message': '',
+                },
+            ]
+        }
+        mock_parse.return_value = record_log
+
+        await pipeline.sync_images()
+
+        # Should show count instead of listing all skipped images
+        expected_description = '12 images skipped due to parent failures<br/>'
+        mock_jenkins.update_description.assert_called_once_with(expected_description)


### PR DESCRIPTION
## Summary

This PR fixes how we handle child images that fail because their parent images failed to build. Previously, these children were:
1. Counted as real build failures (incorrectly incrementing Redis counters)
2. Listed in the Jenkins 'Failed images' description alongside actual failures

## Problem

When a parent image fails to build (e.g., ose-must-gather), its child images (e.g., local-storage-mustgather) raise an IOError **before** the build loop even starts. These children were never actually attempted, but:
- Their record['message'] was left as 'Unknown failure'
- update_build_fail_counters() couldn't distinguish them from real failures
- They appeared in the 'Failed images' description, creating confusion

## Solution

### Part 1: Capture parent-failure message in build record
**File**: `doozer/doozerlib/backend/konflux_image_builder.py`

Added an exception handler before the `finally` block that captures any exception message into `record['message']` if it would otherwise remain 'Unknown failure'. This ensures parent-failure messages are preserved in the build record.

### Part 2: Exclude parent-failure children from counters
**File**: `pyartcd/pyartcd/pipelines/ocp4_konflux.py` (`update_build_fail_counters` method)

Before incrementing Redis failure counters:
- Check each failed image's `message` field in the record log
- Exclude images whose message contains `'parent images failed to build'`
- Log: `'Excluding {image} from counter updates (parent build failure, not a real build issue)'`
- Only increment counters for "real" failures

### Part 3: Update Jenkins description
**File**: `pyartcd/pyartcd/pipelines/ocp4_konflux.py` (`sync_images` method)

Separate failed images into two categories:
- **Real failures**: Shown as `Failed images: ...`
- **Parent-failure children**: Shown as `Skipped (parent failure): ...`

## Example Output

### Before this PR
Jenkins description:
```
Failed images: ose-must-gather, local-storage-mustgather
```

Both images counted as failures in Redis.

### After this PR
Jenkins description:
```
Failed images: ose-must-gather
Skipped (parent failure): local-storage-mustgather
```

Only ose-must-gather counted as a failure in Redis.

## Testing

### Unit Tests
- `doozer/tests/backend/test_konflux_image_builder.py`:
  - `test_build_parent_failure_captures_message_in_record`
  - `test_build_unknown_exception_captures_message_in_record`
  
- `pyartcd/tests/pipelines/test_ocp.py`:
  - `test_build_fail_counters_exclude_parent_failures`
  - `test_build_fail_counters_mixed_real_and_parent_failures`
  - `test_build_fail_counters_all_parent_failures_no_increments`
  - `test_sync_images_excludes_parent_failures_from_description`
  - `test_sync_images_all_parent_failures_no_description`
  - `test_sync_images_many_skipped_uses_count`

### Manual Testing
Tested with Jenkins build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/36841/

Build attempted: ose-must-gather (failed), local-storage-mustgather (skipped due to parent failure)

Log output confirmed:
```
Failed to build local-storage-mustgather: Couldn't build local-storage-mustgather because the following parent images failed to build: ose-must-gather
```

## Related

- Fixes issue where child images incorrectly increment failure counters
- Improves Jenkins description clarity by separating real failures from skipped children