### PR TITLE
fix(doozer): improve images:streams mirror logging and check-upstream

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -306,6 +306,10 @@ def images_streams_check_upstream(runtime, streams, live_test_mode):
 
     for upstream_entry_name, config in upstreaming_entries.items():
         upstream_dest = config.upstream_image
+        if not upstream_dest.startswith('registry.ci.openshift.org/'):
+            istags_status.append(f'SKIP: {upstream_entry_name}\nNot an OpenShift imagestream target: {upstream_dest}')
+            continue
+
         _, dest_ns, dest_istag = upstream_dest.rsplit('/', maxsplit=2)
 
         if live_test_mode:

--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -306,7 +306,11 @@ def images_streams_check_upstream(runtime, streams, live_test_mode):
 
     for upstream_entry_name, config in upstreaming_entries.items():
         upstream_dest = config.upstream_image
-        if not upstream_dest.startswith('registry.ci.openshift.org/'):
+        openshift_imagestream_prefixes = (
+            'registry.ci.openshift.org/',
+            'registry.svc.ci.openshift.org/',
+        )
+        if not upstream_dest.startswith(openshift_imagestream_prefixes):
             istags_status.append(f'SKIP: {upstream_entry_name}\nNot an OpenShift imagestream target: {upstream_dest}')
             continue
 

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -398,6 +398,7 @@ class ImageMetadata(Metadata):
             build = asyncio.run(get_latest_konflux_build())
             if not build:
                 raise IOError(f'No Konflux build found for {self.distgit_key} in group {self.runtime.group}')
+            self.logger.info('Selected Konflux build %s', build.nvr)
             return build.image_pullspec
         else:
             # Brew build system (existing behavior)


### PR DESCRIPTION
## Summary
- Log the selected Konflux build NVR in `pull_url()` so operators can see which build was picked during `images:streams mirror`
- Skip `oc get istag` verification in `check-upstream` for non-OpenShift imagestream destinations (e.g. partner images on `quay.io`) — these were producing false `ERROR` reports since partner images don't live in OpenShift imagestreams

## Test plan
- [x] `make format` passes
- [x] `make test` passes (all 2655 tests)
- [x] Verified dry-run output shows the new NVR log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)