### PR TITLE
fix(lockfile): auto-clear corrupt RPMDB cache and retry

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/constants.py
+++ b/doozer/doozerlib/lockfile_prototype/constants.py
@@ -3,6 +3,7 @@ Constants and enums for the lockfile prototype package.
 """
 
 from enum import Enum
+from pathlib import Path
 
 DEFAULT_RPM_LOCKFILE_NAME = "rpms.lock.yaml"
 DEFAULT_RPM_INFILE_NAME = "rpms.in.yaml"
@@ -31,6 +32,19 @@ ARCH_KEYWORDS = ARCH_SUBSHELL_KEYWORDS + tuple(form for name in ARCH_VAR_NAMES f
 
 # RPM pseudo-packages that appear in rpmdb but are not installable via DNF
 RPM_PSEUDO_PACKAGES = frozenset({"gpg-pubkey"})
+
+
+# rpm-lockfile-prototype stores extracted RPMDBs here. There is no env var
+# to override this path — only RPM_LOCKFILE_PROTOTYPE_DNF_CACHE controls
+# the DNF repodata cache, not the RPMDB cache.
+RPMDB_CACHE_PATH = Path.home() / ".cache" / "rpm-lockfile-prototype" / "rpmdbs"
+
+# Patterns in rpm-lockfile-prototype stderr that indicate a broken RPMDB
+# cache entry. When matched, doozer clears the cached entry and retries.
+RPMDB_CACHE_ERROR_PATTERNS = [
+    "database disk image is malformed",
+    "failed loading RPMDB",
+]
 
 
 class LockfileBackend(str, Enum):

--- a/doozer/doozerlib/lockfile_prototype/resolver.py
+++ b/doozer/doozerlib/lockfile_prototype/resolver.py
@@ -9,6 +9,7 @@ dnf cannot be imported.
 
 import logging
 import re
+import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -20,6 +21,8 @@ from doozerlib.lockfile_prototype.constants import (
     DEFAULT_RPM_INFILE_NAME,
     DEFAULT_RPM_LOCKFILE_NAME,
     RPM_LOCKFILE_ENTRY_POINT,
+    RPMDB_CACHE_ERROR_PATTERNS,
+    RPMDB_CACHE_PATH,
     SYSTEM_PYTHON,
 )
 from doozerlib.lockfile_prototype.models import LockfileData, RpmsInConfig
@@ -49,6 +52,9 @@ class RpmResolver:
         Resolve RPM packages by running rpm-lockfile-prototype via
         system Python as a subprocess.
 
+        On RPMDB corruption errors, clears the cached RPMDB for the
+        image and retries once before raising.
+
         Arg(s):
             config (RpmsInConfig): Input configuration.
             image_pullspec (str | None): Base image for rpmdb context.
@@ -74,9 +80,65 @@ class RpmResolver:
             rc, _, stderr = await cmd_gather_async(cmd, check=False, env=env)
 
             if rc != 0:
+                if image_pullspec and self._is_rpmdb_corrupt(stderr):
+                    cleared = self._clear_rpmdb_cache(image_pullspec)
+                    if cleared:
+                        self.logger.info("Retrying rpm-lockfile-prototype after clearing corrupt RPMDB cache")
+                        retry_rc, _, retry_stderr = await cmd_gather_async(cmd, check=False, env=env)
+                        if retry_rc == 0:
+                            return LockfileData.model_validate(yaml.safe_load(out_file.read_text()))
+                        self.logger.warning("Retry also failed (exit code %d): %s", retry_rc, retry_stderr)
+
                 raise RuntimeError(f"rpm-lockfile-prototype failed (exit code {rc}): {stderr}")
 
             return LockfileData.model_validate(yaml.safe_load(out_file.read_text()))
+
+    @staticmethod
+    def _is_rpmdb_corrupt(stderr: str) -> bool:
+        """
+        Check if stderr indicates a corrupt RPMDB cache.
+
+        Arg(s):
+            stderr (str): Standard error output from rpm-lockfile-prototype.
+        Return Value(s):
+            bool: True if corruption patterns are detected.
+        """
+        return any(pattern in stderr for pattern in RPMDB_CACHE_ERROR_PATTERNS)
+
+    def _clear_rpmdb_cache(self, image_pullspec: str) -> bool:
+        """
+        Delete cached RPMDB entries for an image digest across all arches.
+
+        Arg(s):
+            image_pullspec (str): Image pullspec containing a digest
+                (e.g. "registry.example.com/repo@sha256:abc123...").
+        Return Value(s):
+            bool: True if any cache entries were deleted.
+        """
+        match = re.search(r"@(sha256:[a-f0-9]+)", image_pullspec)
+        if not match:
+            self.logger.warning("Cannot extract digest from pullspec %s, skipping RPMDB cache cleanup", image_pullspec)
+            return False
+
+        digest = match.group(1)
+        cleared = False
+
+        if not RPMDB_CACHE_PATH.is_dir():
+            return False
+
+        for arch_dir in RPMDB_CACHE_PATH.iterdir():
+            cache_entry = arch_dir / digest
+            if cache_entry.is_dir():
+                self.logger.warning("Clearing corrupt RPMDB cache: %s", cache_entry)
+                try:
+                    shutil.rmtree(cache_entry)
+                    cleared = True
+                except FileNotFoundError:
+                    continue
+                except OSError as ex:
+                    self.logger.warning("Failed to remove RPMDB cache %s: %s", cache_entry, ex)
+
+        return cleared
 
     @staticmethod
     def parse_missing_packages(error_text: str) -> set[str]:

--- a/doozer/tests/lockfile_prototype/test_resolver.py
+++ b/doozer/tests/lockfile_prototype/test_resolver.py
@@ -4,7 +4,9 @@ Tests for doozerlib.lockfile_prototype.resolver.
 
 import asyncio
 import os
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 import yaml
@@ -202,3 +204,201 @@ class TestParseMissingPackages(unittest.TestCase):
         error = "Some other error message\n"
         missing = RpmResolver.parse_missing_packages(error)
         self.assertEqual(missing, set())
+
+
+class TestIsRpmdbCorrupt(unittest.TestCase):
+    def test_detects_malformed_database(self):
+        stderr = (
+            "error: sqlite failure: CREATE TABLE IF NOT EXISTS 'Packages' "
+            "(hnum INTEGER PRIMARY KEY AUTOINCREMENT,blob BLOB NOT NULL): "
+            "database disk image is malformed"
+        )
+        self.assertTrue(RpmResolver._is_rpmdb_corrupt(stderr))
+
+    def test_detects_failed_loading_rpmdb(self):
+        stderr = "OSError: failed loading RPMDB\n"
+        self.assertTrue(RpmResolver._is_rpmdb_corrupt(stderr))
+
+    def test_no_false_positive(self):
+        stderr = "No match for argument: foo\n"
+        self.assertFalse(RpmResolver._is_rpmdb_corrupt(stderr))
+
+    def test_empty_stderr(self):
+        self.assertFalse(RpmResolver._is_rpmdb_corrupt(""))
+
+
+class TestClearRpmdbCache(unittest.TestCase):
+    def setUp(self):
+        self.resolver = RpmResolver()
+
+    def test_clears_cache_for_digest(self):
+        """
+        Should delete the cache directory matching the digest.
+        """
+        pullspec = "registry.example.com/repo@sha256:abc123def456"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_cache = Path(tmpdir) / "rpmdbs"
+            cache_entry = fake_cache / "amd64" / "sha256:abc123def456"
+            cache_entry.mkdir(parents=True)
+            (cache_entry / "Packages").touch()
+
+            other_entry = fake_cache / "amd64" / "sha256:other"
+            other_entry.mkdir(parents=True)
+            (other_entry / "Packages").touch()
+
+            with patch("doozerlib.lockfile_prototype.resolver.RPMDB_CACHE_PATH", fake_cache):
+                cleared = self.resolver._clear_rpmdb_cache(pullspec)
+
+            self.assertTrue(cleared)
+            self.assertFalse(cache_entry.exists())
+            self.assertTrue(other_entry.exists())
+
+    def test_clears_across_arches(self):
+        """
+        Should delete cache entries for the digest across all arch subdirectories.
+        """
+        pullspec = "registry.example.com/repo@sha256:abc123def456"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_cache = Path(tmpdir) / "rpmdbs"
+            for arch in ("amd64", "arm64", "s390x"):
+                entry = fake_cache / arch / "sha256:abc123def456"
+                entry.mkdir(parents=True)
+                (entry / "Packages").touch()
+
+            with patch("doozerlib.lockfile_prototype.resolver.RPMDB_CACHE_PATH", fake_cache):
+                cleared = self.resolver._clear_rpmdb_cache(pullspec)
+
+            self.assertTrue(cleared)
+            for arch in ("amd64", "arm64", "s390x"):
+                self.assertFalse((fake_cache / arch / "sha256:abc123def456").exists())
+
+    def test_no_digest_in_pullspec(self):
+        """
+        Should return False when pullspec has no digest.
+        """
+        cleared = self.resolver._clear_rpmdb_cache("registry.example.com/repo:latest")
+        self.assertFalse(cleared)
+
+    def test_cache_dir_missing(self):
+        """
+        Should return False when cache directory does not exist.
+        """
+        with patch("doozerlib.lockfile_prototype.resolver.RPMDB_CACHE_PATH", Path("/nonexistent/path")):
+            cleared = self.resolver._clear_rpmdb_cache("registry.example.com/repo@sha256:abc123")
+        self.assertFalse(cleared)
+
+
+class TestResolveRpmdbCorruptionRetry(unittest.TestCase):
+    FAKE_LOCKFILE_DATA = {
+        "lockfileVersion": 1,
+        "lockfileVendor": "redhat",
+        "arches": [
+            {
+                "arch": "x86_64",
+                "packages": [],
+                "source": [],
+                "module_metadata": [],
+            }
+        ],
+    }
+
+    CORRUPTION_STDERR = "error: sqlite failure: database disk image is malformed\nOSError: failed loading RPMDB\n"
+
+    @patch("doozerlib.lockfile_prototype.resolver.RpmResolver._clear_rpmdb_cache")
+    @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
+    def test_retries_on_rpmdb_corruption(self, mock_gather, mock_clear):
+        """
+        First call fails with corruption, cache cleared, second call succeeds.
+        """
+        call_count = 0
+
+        async def mock_cmd(cmd, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return (1, "", self.CORRUPTION_STDERR)
+            outfile_idx = cmd.index("--outfile") + 1
+            with open(cmd[outfile_idx], "w") as f:
+                yaml.safe_dump(self.FAKE_LOCKFILE_DATA, f)
+            return (0, "", "")
+
+        mock_gather.side_effect = mock_cmd
+        mock_clear.return_value = True
+
+        resolver = RpmResolver()
+        config = RpmsInConfig(
+            arches=["x86_64"],
+            contentOrigin={"repos": []},
+            packages=[],
+        )
+        result = asyncio.run(resolver.resolve(config, image_pullspec="registry.example.com/repo@sha256:abc123"))
+        self.assertIsInstance(result, LockfileData)
+        self.assertEqual(call_count, 2)
+        mock_clear.assert_called_once()
+
+    @patch("doozerlib.lockfile_prototype.resolver.RpmResolver._clear_rpmdb_cache")
+    @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
+    def test_raises_after_retry_fails(self, mock_gather, mock_clear):
+        """
+        Both calls fail with corruption — should raise RuntimeError.
+        """
+
+        async def mock_fail(cmd, **kwargs):
+            return (1, "", self.CORRUPTION_STDERR)
+
+        mock_gather.side_effect = mock_fail
+        mock_clear.return_value = True
+
+        resolver = RpmResolver()
+        config = RpmsInConfig(
+            arches=["x86_64"],
+            contentOrigin={"repos": []},
+            packages=[],
+        )
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(resolver.resolve(config, image_pullspec="registry.example.com/repo@sha256:abc123"))
+        self.assertIn("rpm-lockfile-prototype failed", str(ctx.exception))
+
+    @patch("doozerlib.lockfile_prototype.resolver.RpmResolver._clear_rpmdb_cache")
+    @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
+    def test_no_retry_without_image(self, mock_gather, mock_clear):
+        """
+        Bare mode (no image_pullspec) should not attempt cache clear.
+        """
+
+        async def mock_fail(cmd, **kwargs):
+            return (1, "", self.CORRUPTION_STDERR)
+
+        mock_gather.side_effect = mock_fail
+
+        resolver = RpmResolver()
+        config = RpmsInConfig(
+            arches=["x86_64"],
+            contentOrigin={"repos": []},
+            packages=[],
+        )
+        with self.assertRaises(RuntimeError):
+            asyncio.run(resolver.resolve(config))
+        mock_clear.assert_not_called()
+
+    @patch("doozerlib.lockfile_prototype.resolver.RpmResolver._clear_rpmdb_cache")
+    @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
+    def test_no_retry_on_other_errors(self, mock_gather, mock_clear):
+        """
+        Non-corruption errors should raise immediately without retry.
+        """
+
+        async def mock_fail(cmd, **kwargs):
+            return (1, "", "No match for argument: missing-pkg\n")
+
+        mock_gather.side_effect = mock_fail
+
+        resolver = RpmResolver()
+        config = RpmsInConfig(
+            arches=["x86_64"],
+            contentOrigin={"repos": []},
+            packages=[],
+        )
+        with self.assertRaises(RuntimeError):
+            asyncio.run(resolver.resolve(config, image_pullspec="registry.example.com/repo@sha256:abc123"))
+        mock_clear.assert_not_called()


### PR DESCRIPTION
  ## Summary
  
  When `rpm-lockfile-prototype` extracts an image's RPMDB to its persistent cache (`~/.cache/rpm-lockfile-prototype/rpmdbs/{arch}/{digest}`), a corrupted extraction (disk full, interrupted write, bad layer) is reused on every subsequent run, causing repeated failures with `database disk image is malformed` / `failed loading RPMDB`. The only fix today is manually deleting the cache entry on the Jenkins worker.

  This PR adds auto-detection and self-healing to doozer's `RpmResolver`:

  - Detect RPMDB corruption from stderr patterns
  - Clear the cached RPMDB for the failing image digest (all arches)
  - Retry the resolution once
  - If retry also fails, raise the original error (not the retry error)
  - Cache deletion is best-effort — filesystem errors are logged and don't crash the recovery path

  ## Changes

  - **`constants.py`** — Added `RPMDB_CACHE_PATH` and `RPMDB_CACHE_ERROR_PATTERNS` constants
  - **`resolver.py`** — Added `_is_rpmdb_corrupt()` and `_clear_rpmdb_cache()` methods; added retry-on-corruption logic to `resolve()` with original error preservation and best-effort cache deletion
  - **`test_resolver.py`** — 11 new tests covering corruption detection, cache cleanup (single/multi-arch, missing digest, missing cache dir), retry success/failure, bare-mode skip, and non-corruption error passthrough

  
  ## Context

  Triggered by `multus-networkpolicy` rebase failure on [ocp4-konflux/37047](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/37047) where the cached RPMDB for `openshift-enterprise-base-rhel9` (`sha256:b4558cf...`) was  corrupt. 
  The image itself was fine — verified locally with `podman run ... rpm -qa`.

```
[2026-06-07T13:28:19.377Z] 2026-06-07 13:28:14,147 doozerlib.cli.images_konflux ERROR Failed to rebase multus-networkpolicy: rpm-lockfile-prototype failed (exit code 1): error: sqlite failure: CREATE TABLE IF NOT EXISTS 'Packages' (hnum INTEGER PRIMARY KEY AUTOINCREMENT,blob BLOB NOT NULL): database disk image is malformed
[2026-06-07T13:28:19.377Z] error: cannot open Packages index using sqlite - No such file or directory (2)
[2026-06-07T13:28:19.377Z] error: cannot open Packages database in /tmp/tmpi1gr1dsp/var/lib/rpm
[2026-06-07T13:28:19.377Z] error: sqlite failure: CREATE TABLE IF NOT EXISTS 'Packages' (hnum INTEGER PRIMARY KEY AUTOINCREMENT,blob BLOB NOT NULL): database disk image is malformed
[2026-06-07T13:28:19.378Z] error: cannot open Packages index using sqlite - No such file or directory (2)
[2026-06-07T13:28:19.378Z] error: cannot open Packages database in 
[2026-06-07T13:28:19.378Z] Traceback (most recent call last):
[2026-06-07T13:28:19.378Z]   File "<string>", line 1, in <module>
[2026-06-07T13:28:19.378Z]   File "/home/jenkins/.local/lib/python3.9/site-packages/rpm_lockfile/__init__.py", line 502, in main
[2026-06-07T13:28:19.378Z]     process_arch(
[2026-06-07T13:28:19.378Z]   File "/home/jenkins/.local/lib/python3.9/site-packages/rpm_lockfile/__init__.py", line 283, in process_arch
[2026-06-07T13:28:19.378Z]     packages, sources, module_metadata = resolver(
[2026-06-07T13:28:19.378Z]   File "/home/jenkins/.local/lib/python3.9/site-packages/rpm_lockfile/__init__.py", line 159, in resolver
[2026-06-07T13:28:19.378Z]     base.fill_sack(load_system_repo=True)
[2026-06-07T13:28:19.378Z]   File "/usr/lib/python3.9/site-packages/dnf/base.py", line 400, in fill_sack
[2026-06-07T13:28:19.379Z]     self._sack.load_system_repo(build_cache=False)
[2026-06-07T13:28:19.379Z] OSError: failed loading RPMDB
```