### PR TITLE
fix(locks): use get_build_path_or_random() for all lock identifiers

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -746,9 +746,8 @@ async def build_sync(
     try:
         # Only for stream assembly, lock the build to avoid parallel runs
         if assembly == 'stream':
-            # https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/40333/
-            # will return job/aos-cd-builds/job/build%252Fbuild-sync/40333
-            lock_identifier = get_build_url().replace(f'{constants.JENKINS_UI_URL}/', '')
+            # Use get_build_path_or_random() to handle cases where BUILD_URL is not set
+            lock_identifier = jenkins.get_build_path_or_random()
             runtime.logger.info('Lock identifier: %s', lock_identifier)
 
             await locks.run_with_lock(

--- a/pyartcd/pyartcd/pipelines/build_sync_multi.py
+++ b/pyartcd/pyartcd/pipelines/build_sync_multi.py
@@ -424,7 +424,7 @@ async def build_sync_multi(
     try:
         # Only for stream assembly, lock the build to avoid parallel runs
         if assembly == 'stream':
-            lock_identifier = get_build_url().replace(f'{constants.JENKINS_UI_URL}/', '')
+            lock_identifier = jenkins.get_build_path_or_random()
             runtime.logger.info('Lock identifier: %s', lock_identifier)
 
             await locks.run_with_lock(

--- a/pyartcd/pyartcd/pipelines/cleanup_locks.py
+++ b/pyartcd/pyartcd/pipelines/cleanup_locks.py
@@ -25,9 +25,17 @@ async def cleanup_locks(runtime: Runtime):
             # Lock ID is a build URL minus Jenkins server base URL
             build_path = await lock_manager.get_lock_id(lock_name)
 
+            # Skip locks with None or empty build_path
+            # These locks cannot be validated against Jenkins and cannot be safely deleted
+            if not build_path:
+                runtime.logger.warning(
+                    "Skipping lock %s with None or empty build path (cannot validate or delete)", lock_name
+                )
+                continue
+
             # Skip locks with random identifiers (created outside of Jenkins)
             # These locks cannot be validated against Jenkins builds and should not be cleaned up
-            if build_path and build_path.startswith('random-'):
+            if build_path.startswith('random-'):
                 runtime.logger.info(
                     "Skipping lock %s with random identifier %s (not a Jenkins build)", lock_name, build_path
                 )

--- a/pyartcd/pyartcd/pipelines/sync_ci_images.py
+++ b/pyartcd/pyartcd/pipelines/sync_ci_images.py
@@ -751,7 +751,7 @@ async def sync_ci_images_cli(
 
     # Run with per-version lock
     lock_name = locks.Lock.SYNC_CI_IMAGES.value.format(version=for_release)
-    lock_id = jenkins.get_build_url()  # Jenkins build identifier
+    lock_id = jenkins.get_build_path_or_random()  # Jenkins build identifier
 
     try:
         exit_code = await locks.run_with_lock(


### PR DESCRIPTION
## Summary
Fixed all pipelines that were incorrectly creating locks with potentially None identifiers, which caused cleanup-locks to crash.

## Root Cause
- `build_sync.py`, `build_sync_multi.py`, and `sync_ci_images.py` were using `get_build_url()` or `get_build_path()` directly for lock identifiers
- When `BUILD_URL` env var is not set, these return `None`
- Locks created with `None` identifiers cannot be validated or deleted by cleanup-locks
- cleanup-locks crashed with: `TypeError: args must not contain None`

## History
- Most pipelines were fixed in Feb 2026 (commit 4863817a)
- But `build_sync_multi.py` (created Dec 2025) and `sync_ci_images.py` were missed in that fix
- `build_sync.py` predates the fix but was also missed

## Changes

### 1. `pyartcd/pyartcd/pipelines/cleanup_locks.py`
- Added safety check to skip locks with None/empty build_path
- Prevents crashes when malformed locks exist in Redis
- Logs warning instead of crashing

### 2. `pyartcd/pyartcd/pipelines/build_sync.py`
- Changed from `get_build_url().replace(...)` to `get_build_path_or_random()`

### 3. `pyartcd/pyartcd/pipelines/build_sync_multi.py`
- Changed from `get_build_url().replace(...)` to `get_build_path_or_random()`

### 4. `pyartcd/pyartcd/pipelines/sync_ci_images.py`
- Changed from `get_build_url()` to `get_build_path_or_random()`

## Benefits
- ✅ cleanup-locks won't crash anymore
- ✅ No new locks with `None` identifiers will be created
- ✅ All pipelines now use consistent, safe lock identifier pattern

## Fixes
- https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/maintenance/job/maintenance%252Fcleanup-locks/77590/
- https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/maintenance/job/maintenance%252Fcleanup-locks/77584/

## Testing
- All 600 tests passing
- Linting checks passing