### PR TITLE
Make sync-ci-images pipeline steps best-effort

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -1849,7 +1849,9 @@ def images_streams_prs(
     checked_upstream_images = (
         set()
     )  # A PR will not be opened unless the upstream image exists; keep track of ones we have checked.
+    missing_upstream_images = set()  # Track images that failed the check so we don't retry slow oc calls.
     errors_raised = False  # If failures are found when opening a PR, won't break the loop but will return an exit code to signal this event
+    images_skipped = False  # If images are skipped due to missing upstream manifests, exit 25 (unstable)
 
     for image_meta in runtime.ordered_image_metas():
         dgk = image_meta.distgit_key
@@ -1868,21 +1870,28 @@ def images_streams_prs(
             logger.info('Skipping PR check since there is no configured .from')
             continue
 
-        def check_if_upstream_image_exists(upstream_image):
-            if upstream_image not in checked_upstream_images:
-                # We don't know yet whether this image exists; perhaps a buildconfig is
-                # failing. Don't open PRs for images that don't yet exist.
-                try:
-                    util.oc_image_info_for_arch(upstream_image)
-                except:
-                    yellow_print(
-                        f'Unable to access upstream image {upstream_image} for {dgk}-- check whether buildconfigs are running successfully.'
-                    )
-                    if not ignore_missing_images:
-                        raise
-                checked_upstream_images.add(
-                    upstream_image
-                )  # Don't check this image again since it is a little slow to do so.
+        def check_if_upstream_image_exists(upstream_image) -> bool:
+            """Check if an upstream image exists. Returns False if missing.
+
+            We don't know yet whether this image exists; perhaps a buildconfig is
+            failing. Don't open PRs for images that don't yet exist.
+            """
+            if upstream_image in checked_upstream_images:
+                return upstream_image not in missing_upstream_images
+            try:
+                util.oc_image_info_for_arch(upstream_image)
+                checked_upstream_images.add(upstream_image)
+                return True
+            except Exception:
+                yellow_print(
+                    f'Unable to access upstream image {upstream_image} for {dgk}'
+                    ' -- check whether buildconfigs are running successfully.'
+                )
+                checked_upstream_images.add(upstream_image)
+                if ignore_missing_images:
+                    return True
+                missing_upstream_images.add(upstream_image)
+                return False
 
         desired_parents = []
 
@@ -1903,23 +1912,28 @@ def images_streams_prs(
                 try:
                     upstream_image = resolve_upstream_from(runtime, builder)
                 except Exception as e:
-                    message = f'Error while resolving upstream image for {builder} in {dgk} for {major}.{minor}: {e}'
-                    logger.error(message)
-                    raise IOError(message)
+                    yellow_print(f'Unable to resolve upstream image for {builder} in {dgk} for {major}.{minor}: {e}')
+                    images_skipped = True
+                    break
                 if not upstream_image:
                     logger.warning(f'Unable to resolve upstream image for: {builder}')
                     break
-                check_if_upstream_image_exists(upstream_image)
+                if not check_if_upstream_image_exists(upstream_image):
+                    images_skipped = True
+                    break
                 desired_parents.append(upstream_image)
 
             try:
                 parent_upstream_image = resolve_upstream_from(runtime, from_config)
             except Exception as e:
-                message = f'Error while resolving upstream image for {from_config} in {dgk} for {major}.{minor}: {e}'
-                logger.error(message)
-                raise IOError(message)
+                yellow_print(f'Unable to resolve upstream image for {from_config} in {dgk} for {major}.{minor}: {e}')
+                images_skipped = True
+                continue
             if len(desired_parents) != len(builders) or not parent_upstream_image:
                 logger.warning('Unable to find all ART equivalent upstream images for this image')
+                continue
+            if not check_if_upstream_image_exists(parent_upstream_image):
+                images_skipped = True
                 continue
 
             desired_parents.append(parent_upstream_image)
@@ -1933,10 +1947,14 @@ def images_streams_prs(
             try:
                 desired_ci_build_root_image = resolve_upstream_from(runtime, streams_pr_config.ci_build_root)
             except Exception as e:
-                message = f'Error while resolving ci_build_root {streams_pr_config.ci_build_root} in {dgk} for {major}.{minor}: {e}'
-                logger.error(message)
-                raise IOError(message)
-            check_if_upstream_image_exists(desired_ci_build_root_image)
+                yellow_print(
+                    f'Unable to resolve ci_build_root {streams_pr_config.ci_build_root} in {dgk} for {major}.{minor}: {e}'
+                )
+                images_skipped = True
+                continue
+            if not check_if_upstream_image_exists(desired_ci_build_root_image):
+                images_skipped = True
+                continue
 
             # Split the pullspec into an openshift namespace, imagestream, and tag.
             # e.g. registry.openshift.org:999/ocp/release:golang-1.16 => tag=golang-1.16, namespace=ocp, imagestream=release
@@ -2472,3 +2490,7 @@ If you have any questions about this pull request, please reach out in the `#for
     if errors_raised:
         print('Some errors were raised: see the log for details')
         exit(50)
+
+    if images_skipped:
+        print('Some images were skipped due to missing upstream manifests: see the log for details')
+        exit(25)

--- a/pyartcd/pyartcd/pipelines/sync_ci_images.py
+++ b/pyartcd/pyartcd/pipelines/sync_ci_images.py
@@ -612,37 +612,51 @@ class SyncCIImagesPipeline:
             shutil.rmtree(group_dir)
             self._logger.info(f"{self.version}: Cleaned up clone directory")
 
-    async def _run_step(self, name: str, coro) -> bool:
+    async def _run_step(self, name: str, coro, critical: bool = False) -> bool:
         """Run a pipeline step, catching and logging errors.
 
-        Returns True if the step succeeded, False if it failed.
+        Args:
+            name: Step name for logging
+            coro: Async coroutine to execute
+            critical: If True, re-raise exception after logging (hard failure)
+
+        Returns:
+            True if the step succeeded, False if it failed.
+
+        Raises:
+            Exception: If critical=True and step fails
         """
         try:
             await coro
             return True
         except Exception as e:
             self._logger.warning('%s: Step "%s" failed: %s', self.version, name, e, exc_info=True)
+            if critical:
+                self._logger.error('%s: Critical step "%s" failed, aborting pipeline', self.version, name)
+                raise
             return False
 
     async def run(self) -> int:
         """
         Main pipeline: sync CI images for a single OCP version.
 
-        Each doozer step is best-effort: if one fails (e.g. a missing Konflux
-        build), the pipeline continues with the remaining steps and returns 25
-        (partial/unstable) instead of crashing.
+        Critical steps (gen-buildconfigs, mirror) must succeed or the pipeline
+        aborts. Other steps (start-builds, check-upstream, prs-open) are
+        best-effort: if one fails (e.g. missing Konflux build, transient CI
+        issue), the pipeline continues with remaining steps and returns 25
+        (partial/unstable).
 
         Workflow:
         1. Check for changes in ocp-build-data
-        2. Generate and apply BuildConfigs to CI cluster
-        3. Mirror builder/base images to CI registries
-        4. Trigger CI builds
+        2. Generate and apply BuildConfigs to CI cluster [CRITICAL]
+        3. Mirror builder/base images to CI registries [CRITICAL]
+        4. Trigger CI builds [best-effort]
         5. Wait for builds to complete
-        6. Verify upstream imagestream consistency
-        7. Open PRs to reconcile any BuildConfig drift
+        6. Verify upstream imagestream consistency [best-effort]
+        7. Open PRs to reconcile any BuildConfig drift [best-effort]
 
         Returns:
-            Return code: 0=success, 25=partial (some steps failed), 50=failure
+            Return code: 0=success, 25=partial (non-critical steps failed), 50=failure
         """
         jenkins.update_title(f' [{self.version}]')
         self._logger.info(f"Starting sync-ci-images for {self.version}")
@@ -658,36 +672,44 @@ class SyncCIImagesPipeline:
             # Prepare build data
             group_dir = await self._prepare_build_data()
 
-            # Execute sync workflow - each step is best-effort
             failed_steps = []
             with self._create_registry_config() as auth_file:
                 self._logger.info(f"Created registry config: {auth_file}")
                 doozer_opts = self._build_doozer_options(group_dir, auth_file)
 
-                if not await self._run_step('gen-buildconfigs', self._generate_and_apply_buildconfigs(doozer_opts)):
-                    failed_steps.append('gen-buildconfigs')
+                # Critical steps - abort pipeline on failure
+                await self._run_step(
+                    'gen-buildconfigs', self._generate_and_apply_buildconfigs(doozer_opts), critical=True
+                )
+                await self._run_step('mirror', self._mirror_images_to_ci(doozer_opts, auth_file), critical=True)
 
-                if not await self._run_step('mirror', self._mirror_images_to_ci(doozer_opts, auth_file)):
-                    failed_steps.append('mirror')
-
-                if not await self._run_step('start-builds', self._trigger_ci_builds(doozer_opts)):
+                # Best-effort steps - continue on failure
+                if not await self._run_step('start-builds', self._trigger_ci_builds(doozer_opts, auth_file)):
                     failed_steps.append('start-builds')
 
                 await self._wait_for_builds()
 
-                if not await self._run_step('check-upstream', self._verify_upstream_consistency(doozer_opts)):
+                if not await self._run_step(
+                    'check-upstream', self._verify_upstream_consistency(doozer_opts, auth_file)
+                ):
                     failed_steps.append('check-upstream')
 
-                if not await self._run_step('prs-open', self._open_reconciliation_prs(doozer_opts)):
+                try:
+                    pr_rc = await self._open_reconciliation_prs(doozer_opts)
+                    if pr_rc == 25:
+                        failed_steps.append('prs-open')
+                except Exception as e:
+                    self._logger.warning('%s: Step "prs-open" failed: %s', self.version, e, exc_info=True)
                     failed_steps.append('prs-open')
 
-            # Record success even if partial - prevents re-running the same SHA
-            await self._record_successful_run(current_sha)
+            # Record success only if PRs didn't return partial (25) - retry on next run
+            if 'prs-open' not in failed_steps:
+                await self._record_successful_run(current_sha)
             self._cleanup(group_dir)
 
             if failed_steps:
                 self._logger.warning(
-                    '%s: Completed with errors in: %s',
+                    '%s: Completed with errors in non-critical steps: %s',
                     self.version,
                     ', '.join(failed_steps),
                 )

--- a/pyartcd/pyartcd/pipelines/sync_ci_images.py
+++ b/pyartcd/pyartcd/pipelines/sync_ci_images.py
@@ -612,9 +612,25 @@ class SyncCIImagesPipeline:
             shutil.rmtree(group_dir)
             self._logger.info(f"{self.version}: Cleaned up clone directory")
 
+    async def _run_step(self, name: str, coro) -> bool:
+        """Run a pipeline step, catching and logging errors.
+
+        Returns True if the step succeeded, False if it failed.
+        """
+        try:
+            await coro
+            return True
+        except Exception as e:
+            self._logger.warning('%s: Step "%s" failed: %s', self.version, name, e, exc_info=True)
+            return False
+
     async def run(self) -> int:
         """
         Main pipeline: sync CI images for a single OCP version.
+
+        Each doozer step is best-effort: if one fails (e.g. a missing Konflux
+        build), the pipeline continues with the remaining steps and returns 25
+        (partial/unstable) instead of crashing.
 
         Workflow:
         1. Check for changes in ocp-build-data
@@ -626,7 +642,7 @@ class SyncCIImagesPipeline:
         7. Open PRs to reconcile any BuildConfig drift
 
         Returns:
-            Return code: 0=success, 25=partial (PRs skipped), 50=failure
+            Return code: 0=success, 25=partial (some steps failed), 50=failure
         """
         jenkins.update_title(f' [{self.version}]')
         self._logger.info(f"Starting sync-ci-images for {self.version}")
@@ -642,24 +658,41 @@ class SyncCIImagesPipeline:
             # Prepare build data
             group_dir = await self._prepare_build_data()
 
-            # Execute sync workflow
+            # Execute sync workflow - each step is best-effort
+            failed_steps = []
             with self._create_registry_config() as auth_file:
                 self._logger.info(f"Created registry config: {auth_file}")
                 doozer_opts = self._build_doozer_options(group_dir, auth_file)
 
-                await self._generate_and_apply_buildconfigs(doozer_opts)
-                await self._mirror_images_to_ci(doozer_opts, auth_file)
-                await self._trigger_ci_builds(doozer_opts, auth_file)
+                if not await self._run_step('gen-buildconfigs', self._generate_and_apply_buildconfigs(doozer_opts)):
+                    failed_steps.append('gen-buildconfigs')
+
+                if not await self._run_step('mirror', self._mirror_images_to_ci(doozer_opts, auth_file)):
+                    failed_steps.append('mirror')
+
+                if not await self._run_step('start-builds', self._trigger_ci_builds(doozer_opts)):
+                    failed_steps.append('start-builds')
+
                 await self._wait_for_builds()
-                await self._verify_upstream_consistency(doozer_opts, auth_file)
 
-                rc = await self._open_reconciliation_prs(doozer_opts)
-                if rc == 25:
-                    return 25
+                if not await self._run_step('check-upstream', self._verify_upstream_consistency(doozer_opts)):
+                    failed_steps.append('check-upstream')
 
-            # Record success
+                if not await self._run_step('prs-open', self._open_reconciliation_prs(doozer_opts)):
+                    failed_steps.append('prs-open')
+
+            # Record success even if partial - prevents re-running the same SHA
             await self._record_successful_run(current_sha)
             self._cleanup(group_dir)
+
+            if failed_steps:
+                self._logger.warning(
+                    '%s: Completed with errors in: %s',
+                    self.version,
+                    ', '.join(failed_steps),
+                )
+                return 25
+
             return 0
 
         except Exception as e:


### PR DESCRIPTION
Each doozer step (gen-buildconfigs, mirror, start-builds, check-upstream, prs-open) now runs independently. If one fails (e.g. missing Konflux build, missing CI image), the pipeline continues with remaining steps and returns exit code 25 (partial) instead of crashing with exit code 50.

This prevents transient or data issues in one step from blocking the entire sync workflow.