### PR TITLE
ART-21305: run rpm-lockfile-prototype in podman container

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/constants.py
+++ b/doozer/doozerlib/lockfile_prototype/constants.py
@@ -20,9 +20,7 @@ MAX_RESOLUTION_RETRIES = 5
 MAX_REINSTALL_STRIP_RETRIES = 5
 DEFAULT_PLATFORM = "linux/amd64"
 
-SYSTEM_PYTHON = "/usr/bin/python3"
-RPM_LOCKFILE_ENTRY_POINT = "from rpm_lockfile import main; main()"
-
+RPM_LOCKFILE_IMAGE = "quay.io/redhat-user-workloads/ocp-art-tenant/art-cd:rpm-lockfile-v0.30.0"
 # RPM pseudo-packages that appear in rpmdb but are not installable via DNF
 RPM_PSEUDO_PACKAGES = frozenset({"gpg-pubkey"})
 

--- a/doozer/doozerlib/lockfile_prototype/resolver.py
+++ b/doozer/doozerlib/lockfile_prototype/resolver.py
@@ -1,10 +1,10 @@
 """
-RPM resolution via rpm-lockfile-prototype subprocess.
+RPM resolution via rpm-lockfile-prototype container.
 
-Invokes the rpm-lockfile-prototype tool through system Python so
-that python3-dnf (a system package built for the system Python) is
-available. The venv Python may be a different minor version where
-dnf cannot be imported.
+Invokes the rpm-lockfile-prototype tool inside a podman container
+so that python3-dnf and all system dependencies are self-contained.
+The container image is pulled from the art-cluster internal registry
+on first use if not already present locally.
 """
 
 import logging
@@ -22,45 +22,125 @@ from doozerlib.lockfile_prototype.constants import (
     DEFAULT_RPM_INFILE_NAME,
     DEFAULT_RPM_LOCKFILE_NAME,
     JENKINS_CACHE_DIR,
-    RPM_LOCKFILE_ENTRY_POINT,
+    RPM_LOCKFILE_IMAGE,
     RPMDB_CACHE_ERROR_PATTERNS,
     RPMDB_CACHE_SUBDIR,
-    SYSTEM_PYTHON,
     VALID_PKG_NAME,
 )
 from doozerlib.lockfile_prototype.models import LockfileData, RpmsInConfig
-from doozerlib.lockfile_prototype.utils import build_env
 
 
 class RpmResolver:
     """
-    Invokes rpm-lockfile-prototype via system Python subprocess.
+    Invokes rpm-lockfile-prototype via podman container.
 
     Maintains a persistent DNF repodata cache directory across
     resolve() calls so that repeated runs against the same repos
     (common during multi-image rebases) skip redundant downloads.
     """
 
-    def __init__(self, working_dir: Path, logger: logging.Logger | None = None, cache_dir: str | None = None):
+    def __init__(
+        self,
+        working_dir: Path | None = None,
+        logger: logging.Logger | None = None,
+        cache_dir: str | None = None,
+        image: str | None = None,
+    ):
         self.logger = logger or logutil.get_logger(__name__)
-        self._working_dir = str(working_dir)
+        self._working_dir = str(working_dir) if working_dir else None
         self._cache_dir_owner = (
             None if cache_dir else TemporaryDirectory(prefix="rpm-lockfile-cache-", dir=self._working_dir)
         )
         self._cache_path = cache_dir or self._cache_dir_owner.name
+        self._image = image or RPM_LOCKFILE_IMAGE
 
-        # In Jenkins, redirect the rpm-lockfile-prototype RPMDB cache to a
-        # persistent volume via XDG_CACHE_HOME so it survives across job runs
-        # and stays off the small root volume (~/.cache).
-        # Outside Jenkins, honour an existing XDG_CACHE_HOME if set.
+        # In Jenkins, preserve the pre-containerization RPMDB path
+        # (JENKINS_CACHE_DIR/rpmdbs) by mounting JENKINS_CACHE_DIR at
+        # XDG_CACHE_HOME/rpm-lockfile-prototype inside the container.
+        # Outside Jenkins, honour XDG_CACHE_HOME or ~/.cache.
         if os.environ.get("JENKINS_HOME"):
-            self._xdg_cache_home: Path | None = JENKINS_CACHE_DIR
+            self._rpmdb_cache_path = JENKINS_CACHE_DIR / "rpmdbs"
         else:
-            self._xdg_cache_home = None
-        xdg_env = os.environ.get("XDG_CACHE_HOME")
-        cache_root = self._xdg_cache_home or (Path(xdg_env) if xdg_env else Path.home() / ".cache")
-        self._rpmdb_cache_path = cache_root / RPMDB_CACHE_SUBDIR
+            xdg_env = os.environ.get("XDG_CACHE_HOME")
+            if xdg_env and Path(xdg_env).is_absolute():
+                xdg_cache_home = Path(xdg_env)
+            else:
+                if xdg_env:
+                    self.logger.warning("XDG_CACHE_HOME is not absolute (%r), falling back to ~/.cache", xdg_env)
+                xdg_cache_home = Path.home() / ".cache"
+            self._rpmdb_cache_path = xdg_cache_home / RPMDB_CACHE_SUBDIR
         self.logger.info("RPMDB cache path: %s", self._rpmdb_cache_path)
+
+    def _build_podman_cmd(
+        self,
+        tmpdir: str,
+        image_pullspec: str | None,
+        containerfile_path: str | None = None,
+    ) -> list[str]:
+        """
+        Build the podman run command with volume mounts and env vars.
+
+        Arg(s):
+            tmpdir (str): Host temp directory with rpms.in.yaml.
+            image_pullspec (str | None): Base image for rpmdb context.
+            containerfile_path (str | None): Host path to the Containerfile
+                to mount read-only at /work/Containerfile inside the container.
+        Return Value(s):
+            list[str]: Complete podman command.
+        """
+        cmd = ["podman", "run", "--rm"]
+
+        # Work directory: rpms.in.yaml input and rpms.lock.yaml output.
+        # :Z (exclusive SELinux label) is correct — each resolve() call gets its
+        # own unique TemporaryDirectory, so no other container shares this path.
+        cmd.extend(["-v", f"{tmpdir}:/work:Z"])
+
+        # DNF repodata cache — :z (shared) so parallel resolve() calls can read
+        # the same repodata without re-downloading.
+        cmd.extend(["-v", f"{self._cache_path}:/cache:z"])
+        cmd.extend(["-e", "RPM_LOCKFILE_PROTOTYPE_DNF_CACHE=/cache"])
+
+        # RPMDB cache via XDG_CACHE_HOME. The tool stores rpmdbs at
+        # $XDG_CACHE_HOME/rpm-lockfile-prototype/rpmdbs. In Jenkins, mount
+        # JENKINS_CACHE_DIR at XDG_CACHE_HOME/rpm-lockfile-prototype so rpmdbs
+        # land at JENKINS_CACHE_DIR/rpmdbs — same path as before containerization,
+        # no cold cache on upgrade. Outside Jenkins, mount the XDG_CACHE_HOME parent.
+        self._rpmdb_cache_path.mkdir(parents=True, exist_ok=True)
+        container_xdg = "/rpmdb-cache"
+        if os.environ.get("JENKINS_HOME"):
+            cmd.extend(["-v", f"{JENKINS_CACHE_DIR}:{container_xdg}/rpm-lockfile-prototype:z"])
+        else:
+            cmd.extend(["-v", f"{self._rpmdb_cache_path.parent.parent}:{container_xdg}:z"])
+        cmd.extend(["-e", f"XDG_CACHE_HOME={container_xdg}"])
+
+        # Mount host entitlement certs for accessing protected repos.
+        # Use :ro without :z — SELinux won't allow relabeling system dirs.
+        for host_path in ("/etc/pki/entitlement", "/etc/rhsm/ca", "/etc/pki/rpm-gpg"):
+            if Path(host_path).is_dir():
+                cmd.extend(["-v", f"{host_path}:{host_path}:ro"])
+
+        # Registry auth
+        auth_file = os.environ.get("QUAY_AUTH_FILE") or os.environ.get("REGISTRY_AUTH_FILE")
+        if auth_file:
+            cmd.extend(["-v", f"{auth_file}:/auth/auth.json:ro,z"])
+            cmd.extend(["-e", "REGISTRY_AUTH_FILE=/auth/auth.json"])
+
+        # Containerfile — mounted read-only so packagesFromContainerfile can read it.
+        # The config references it as "Containerfile" (relative to /work/rpms.in.yaml).
+        if containerfile_path:
+            cmd.extend(["-v", f"{containerfile_path}:/work/Containerfile:ro,Z"])
+
+        # Image name
+        cmd.append(self._image)
+
+        # Tool arguments
+        if image_pullspec:
+            cmd.extend(["--image", image_pullspec])
+        else:
+            cmd.append("--bare")
+        cmd.extend(["--outfile", "/work/" + DEFAULT_RPM_LOCKFILE_NAME, "/work/" + DEFAULT_RPM_INFILE_NAME])
+
+        return cmd
 
     async def resolve(
         self,
@@ -70,8 +150,8 @@ class RpmResolver:
         stage_num: int | None = None,
     ) -> LockfileData:
         """
-        Resolve RPM packages by running rpm-lockfile-prototype via
-        system Python as a subprocess.
+        Resolve RPM packages by running rpm-lockfile-prototype in a
+        podman container.
 
         When containerfile_path is set, the tool extracts packages from
         the Dockerfile's RUN commands via packagesFromContainerfile.
@@ -93,7 +173,10 @@ class RpmResolver:
             LockfileData: Resolved lockfile.
         """
         if containerfile_path:
-            pfc_spec: dict = {"file": containerfile_path}
+            # Use the container-side path — the Containerfile is mounted at
+            # /work/Containerfile by _build_podman_cmd. "Containerfile" is
+            # relative to the input file at /work/rpms.in.yaml.
+            pfc_spec: dict = {"file": "Containerfile"}
             if stage_num is not None:
                 pfc_spec["stageNum"] = stage_num
             config.packagesFromContainerfile = pfc_spec
@@ -104,25 +187,14 @@ class RpmResolver:
 
             in_file.write_text(yaml.safe_dump(config.model_dump(exclude_none=True), sort_keys=False))
 
-            cmd = [SYSTEM_PYTHON, "-c", RPM_LOCKFILE_ENTRY_POINT]
-            if image_pullspec:
-                cmd.extend(["--image", image_pullspec])
-            else:
-                cmd.append("--bare")
-            cmd.extend(["--outfile", str(out_file), str(in_file)])
-
-            env = build_env()
-            env["RPM_LOCKFILE_PROTOTYPE_DNF_CACHE"] = self._cache_path
-            if self._xdg_cache_home:
-                env["XDG_CACHE_HOME"] = str(self._xdg_cache_home)
-            env["TMPDIR"] = self._working_dir
-            rc, _, stderr = await cmd_gather_async(cmd, check=False, env=env)
+            cmd = self._build_podman_cmd(tmpdir, image_pullspec, containerfile_path)
+            rc, _, stderr = await cmd_gather_async(cmd, check=False)
 
             if rc != 0:
                 if image_pullspec and self._is_rpmdb_corrupt(stderr):
                     self._clear_rpmdb_cache(image_pullspec)
                     self.logger.info("Retrying rpm-lockfile-prototype after RPMDB cache error")
-                    rc, _, stderr = await cmd_gather_async(cmd, check=False, env=env)
+                    rc, _, stderr = await cmd_gather_async(cmd, check=False)
                     if rc == 0:
                         return LockfileData.model_validate(yaml.safe_load(out_file.read_text()))
                     error_summary = stderr.strip().rsplit("\n", 1)[-1]

--- a/doozer/tests/lockfile_prototype/test_resolver.py
+++ b/doozer/tests/lockfile_prototype/test_resolver.py
@@ -10,7 +10,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 import yaml
-from doozerlib.lockfile_prototype.constants import RPM_LOCKFILE_ENTRY_POINT
+from doozerlib.lockfile_prototype.constants import (
+    DEFAULT_RPM_INFILE_NAME,
+    DEFAULT_RPM_LOCKFILE_NAME,
+    RPM_LOCKFILE_IMAGE,
+)
 from doozerlib.lockfile_prototype.models import (
     LockfileData,
     RpmsInConfig,
@@ -39,19 +43,45 @@ class TestRpmResolver(unittest.TestCase):
         ],
     }
 
+    def _mock_podman_run(self, cmd, expect_bare=False, expect_image=None, **kwargs):
+        """
+        Helper to create a mock for podman run that writes fake lockfile output.
+        Returns (rc, stdout, stderr).
+        """
+        self.assertEqual(cmd[0], "podman")
+        self.assertEqual(cmd[1], "run")
+        self.assertIn("--rm", cmd)
+
+        if expect_bare:
+            self.assertIn("--bare", cmd)
+            self.assertNotIn("--image", cmd)
+        if expect_image:
+            self.assertNotIn("--bare", cmd)
+            img_idx = cmd.index("--image") + 1
+            self.assertEqual(cmd[img_idx], expect_image)
+
+        host_tmpdir = None
+        for i, arg in enumerate(cmd):
+            if arg == "-v" and ":/work:" in cmd[i + 1]:
+                work_spec = cmd[i + 1]
+                options = work_spec.split(":")[2] if len(work_spec.split(":")) > 2 else ""
+                self.assertNotIn("ro", options.split(","), f"/work mount must be writable: {work_spec}")
+                host_tmpdir = work_spec.split(":")[0]
+                break
+        self.assertIsNotNone(host_tmpdir, "No /work mount found in podman command")
+        host_outfile = os.path.join(host_tmpdir, DEFAULT_RPM_LOCKFILE_NAME)
+        with open(host_outfile, "w") as f:
+            yaml.safe_dump(self.FAKE_LOCKFILE_DATA, f)
+        return (0, "", "")
+
     @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
     def test_resolve_bare_mode(self, mock_gather):
         """
-        Without image_pullspec, should pass --bare to the subprocess.
+        Without image_pullspec, should pass --bare.
         """
 
         async def mock_cmd(cmd, **kwargs):
-            self.assertIn("--bare", cmd)
-            self.assertNotIn("--image", cmd)
-            outfile_idx = cmd.index("--outfile") + 1
-            with open(cmd[outfile_idx], "w") as f:
-                yaml.safe_dump(self.FAKE_LOCKFILE_DATA, f)
-            return (0, "", "")
+            return self._mock_podman_run(cmd, expect_bare=True)
 
         mock_gather.side_effect = mock_cmd
         resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
@@ -67,17 +97,11 @@ class TestRpmResolver(unittest.TestCase):
     @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
     def test_resolve_with_image(self, mock_gather):
         """
-        With image_pullspec, should pass --image to the subprocess.
+        With image_pullspec, should pass --image.
         """
 
         async def mock_cmd(cmd, **kwargs):
-            self.assertIn("--image", cmd)
-            image_idx = cmd.index("--image") + 1
-            self.assertEqual(cmd[image_idx], "quay.io/test/img@sha256:abc")
-            outfile_idx = cmd.index("--outfile") + 1
-            with open(cmd[outfile_idx], "w") as f:
-                yaml.safe_dump(self.FAKE_LOCKFILE_DATA, f)
-            return (0, "", "")
+            return self._mock_podman_run(cmd, expect_image="quay.io/test/img@sha256:abc")
 
         mock_gather.side_effect = mock_cmd
         resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
@@ -111,18 +135,15 @@ class TestRpmResolver(unittest.TestCase):
         self.assertIn("rpm-lockfile-prototype failed", str(ctx.exception))
 
     @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
-    def test_resolve_uses_system_python(self, mock_gather):
+    def test_resolve_uses_podman(self, mock_gather):
         """
-        Should invoke /usr/bin/python3 -c to use system Python.
+        Should invoke podman run, not system python.
         """
 
         async def mock_cmd(cmd, **kwargs):
-            self.assertEqual(cmd[0], "/usr/bin/python3")
-            self.assertEqual(cmd[1], "-c")
-            outfile_idx = cmd.index("--outfile") + 1
-            with open(cmd[outfile_idx], "w") as f:
-                yaml.safe_dump(self.FAKE_LOCKFILE_DATA, f)
-            return (0, "", "")
+            self.assertEqual(cmd[0], "podman")
+            self.assertEqual(cmd[1], "run")
+            return self._mock_podman_run(cmd, expect_bare=True)
 
         mock_gather.side_effect = mock_cmd
         resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
@@ -135,42 +156,15 @@ class TestRpmResolver(unittest.TestCase):
         mock_gather.assert_called_once()
 
     @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
-    def test_resolve_uses_entry_point(self, mock_gather):
+    def test_resolve_mounts_dnf_cache(self, mock_gather):
         """
-        resolve() always invokes the tool via -c RPM_LOCKFILE_ENTRY_POINT.
+        Should mount DNF cache and set env var.
         """
+        captured_cmds = []
 
         async def mock_cmd(cmd, **kwargs):
-            self.assertEqual(cmd[2], RPM_LOCKFILE_ENTRY_POINT)
-            outfile_idx = cmd.index("--outfile") + 1
-            with open(cmd[outfile_idx], "w") as f:
-                yaml.safe_dump(self.FAKE_LOCKFILE_DATA, f)
-            return (0, "", "")
-
-        mock_gather.side_effect = mock_cmd
-        resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
-        config = RpmsInConfig(
-            arches=["x86_64"],
-            contentOrigin={"repos": []},
-            packages=[],
-        )
-        asyncio.run(resolver.resolve(config))
-        mock_gather.assert_called_once()
-
-    @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
-    def test_resolve_sets_dnf_cache_env(self, mock_gather):
-        """
-        RPM_LOCKFILE_PROTOTYPE_DNF_CACHE should be set in the subprocess
-        env and point to the same directory across multiple resolve() calls.
-        """
-        captured_envs: list[dict] = []
-
-        async def mock_cmd(cmd, **kwargs):
-            captured_envs.append(dict(kwargs.get("env", {})))
-            outfile_idx = cmd.index("--outfile") + 1
-            with open(cmd[outfile_idx], "w") as f:
-                yaml.safe_dump(self.FAKE_LOCKFILE_DATA, f)
-            return (0, "", "")
+            captured_cmds.append(cmd)
+            return self._mock_podman_run(cmd, expect_bare=True)
 
         mock_gather.side_effect = mock_cmd
         resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
@@ -180,73 +174,161 @@ class TestRpmResolver(unittest.TestCase):
             packages=["nfs-utils"],
         )
         asyncio.run(resolver.resolve(config))
-        asyncio.run(resolver.resolve(config))
+        cmd = captured_cmds[0]
+        dnf_cache_env = any(
+            arg == "-e" and i + 1 < len(cmd) and cmd[i + 1] == "RPM_LOCKFILE_PROTOTYPE_DNF_CACHE=/cache"
+            for i, arg in enumerate(cmd)
+        )
+        self.assertTrue(dnf_cache_env, "RPM_LOCKFILE_PROTOTYPE_DNF_CACHE=/cache env not set")
+        dnf_cache_mount = any(
+            arg == "-v"
+            and i + 1 < len(cmd)
+            and cmd[i + 1].split(":")[1] == "/cache"
+            and "ro" not in cmd[i + 1].split(":")[2].split(",")
+            for i, arg in enumerate(cmd)
+        )
+        self.assertTrue(dnf_cache_mount, "No writable volume mount targeting /cache found in podman command")
 
-        self.assertEqual(len(captured_envs), 2)
-        cache_dir_1 = captured_envs[0]["RPM_LOCKFILE_PROTOTYPE_DNF_CACHE"]
-        cache_dir_2 = captured_envs[1]["RPM_LOCKFILE_PROTOTYPE_DNF_CACHE"]
-        self.assertEqual(cache_dir_1, cache_dir_2)
-        self.assertTrue(os.path.isdir(cache_dir_1))
-
+    @patch.dict(os.environ, {"REGISTRY_AUTH_FILE": "/run/containers/auth.json"})
     @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
-    def test_sets_xdg_cache_home_in_jenkins(self, mock_gather):
+    def test_resolve_mounts_auth_file(self, mock_gather):
         """
-        When JENKINS_HOME is set, XDG_CACHE_HOME should point to the
-        persistent Jenkins cache directory.
+        When REGISTRY_AUTH_FILE is set, should mount it and set env var.
         """
-        captured_envs: list[dict] = []
+        captured_cmds = []
 
         async def mock_cmd(cmd, **kwargs):
-            captured_envs.append(dict(kwargs.get("env", {})))
-            outfile_idx = cmd.index("--outfile") + 1
-            with open(cmd[outfile_idx], "w") as f:
-                yaml.safe_dump(self.FAKE_LOCKFILE_DATA, f)
-            return (0, "", "")
+            captured_cmds.append(list(cmd))
+            return self._mock_podman_run(cmd, expect_bare=True)
+
+        mock_gather.side_effect = mock_cmd
+        resolver = RpmResolver()
+        config = RpmsInConfig(
+            arches=["x86_64"],
+            contentOrigin={"repos": []},
+            packages=[],
+        )
+        asyncio.run(resolver.resolve(config))
+        cmd = captured_cmds[0]
+        auth_mount = "/run/containers/auth.json:/auth/auth.json:ro,z"
+        self.assertTrue(
+            any(arg == "-v" and cmd[i + 1] == auth_mount for i, arg in enumerate(cmd) if i + 1 < len(cmd)),
+            f"Expected auth file mount {auth_mount} in command",
+        )
+        auth_env_set = any(
+            arg == "-e" and i + 1 < len(cmd) and cmd[i + 1] == "REGISTRY_AUTH_FILE=/auth/auth.json"
+            for i, arg in enumerate(cmd)
+        )
+        self.assertTrue(auth_env_set)
+
+    @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
+    def test_custom_image_parameter(self, mock_gather):
+        """
+        Image parameter should override default and be passed to podman run.
+        """
+        captured_cmds = []
+
+        async def mock_cmd(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return self._mock_podman_run(cmd, expect_bare=True)
+
+        mock_gather.side_effect = mock_cmd
+        custom_image = "quay.io/custom/rpm-lockfile:v1.0"
+        resolver = RpmResolver(image=custom_image, working_dir=Path(tempfile.mkdtemp()))
+        self.assertEqual(resolver._image, custom_image)
+        config = RpmsInConfig(arches=["x86_64"], contentOrigin={"repos": []}, packages=[])
+        asyncio.run(resolver.resolve(config))
+        self.assertIn(custom_image, captured_cmds[0])
+
+    @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
+    def test_default_image(self, mock_gather):
+        """
+        Default image should match constant and be passed to podman run.
+        """
+        captured_cmds = []
+
+        async def mock_cmd(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return self._mock_podman_run(cmd, expect_bare=True)
+
+        mock_gather.side_effect = mock_cmd
+        resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
+        self.assertEqual(resolver._image, RPM_LOCKFILE_IMAGE)
+        config = RpmsInConfig(arches=["x86_64"], contentOrigin={"repos": []}, packages=[])
+        asyncio.run(resolver.resolve(config))
+        self.assertIn(RPM_LOCKFILE_IMAGE, captured_cmds[0])
+
+    def test_rpmdb_cache_path_in_jenkins(self):
+        """
+        When JENKINS_HOME is set, _rpmdb_cache_path should point directly to
+        JENKINS_CACHE_DIR/rpmdbs (preserving the pre-containerization path).
+        """
+        with patch.dict(os.environ, {"JENKINS_HOME": "/var/jenkins"}):
+            resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
+        self.assertEqual(
+            str(resolver._rpmdb_cache_path),
+            "/mnt/jenkins-workspace/rpm-lockfile-cache/rpmdbs",
+        )
+
+    @patch("doozerlib.lockfile_prototype.resolver.Path.mkdir")
+    @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
+    def test_rpmdb_cache_mount_in_jenkins(self, mock_gather, mock_mkdir):
+        """
+        In Jenkins, JENKINS_CACHE_DIR must be mounted at
+        XDG_CACHE_HOME/rpm-lockfile-prototype so rpmdbs land at
+        JENKINS_CACHE_DIR/rpmdbs (same path as before containerization).
+        """
+        captured_cmds = []
+
+        async def mock_cmd(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return self._mock_podman_run(cmd, expect_bare=True)
 
         mock_gather.side_effect = mock_cmd
         with patch.dict(os.environ, {"JENKINS_HOME": "/var/jenkins"}):
             resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
-            config = RpmsInConfig(
-                arches=["x86_64"],
-                contentOrigin={"repos": []},
-                packages=["nfs-utils"],
-            )
+            config = RpmsInConfig(arches=["x86_64"], contentOrigin={"repos": []}, packages=[])
             asyncio.run(resolver.resolve(config))
 
-        self.assertEqual(len(captured_envs), 1)
-        xdg = captured_envs[0]["XDG_CACHE_HOME"]
-        self.assertEqual(xdg, "/mnt/jenkins-workspace/rpm-lockfile-cache")
+        cmd = captured_cmds[0]
+        expected_mount = "/mnt/jenkins-workspace/rpm-lockfile-cache:/rpmdb-cache/rpm-lockfile-prototype:z"
+        self.assertTrue(
+            any(arg == "-v" and cmd[i + 1] == expected_mount for i, arg in enumerate(cmd) if i + 1 < len(cmd)),
+            f"Expected Jenkins RPMDB mount {expected_mount!r} in command",
+        )
+        self.assertTrue(
+            any(
+                arg == "-e" and i + 1 < len(cmd) and cmd[i + 1] == "XDG_CACHE_HOME=/rpmdb-cache"
+                for i, arg in enumerate(cmd)
+            ),
+            "Expected XDG_CACHE_HOME=/rpmdb-cache in podman command",
+        )
 
-    @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
-    def test_no_xdg_cache_home_outside_jenkins(self, mock_gather):
+    def test_rpmdb_cache_path_outside_jenkins(self):
         """
-        When JENKINS_HOME is not set, XDG_CACHE_HOME should not be
-        overridden in the subprocess env.
+        When JENKINS_HOME is not set, _rpmdb_cache_path should fall
+        back to ~/.cache.
         """
-        captured_envs: list[dict] = []
+        env = os.environ.copy()
+        env.pop("JENKINS_HOME", None)
+        env.pop("XDG_CACHE_HOME", None)
+        with patch.dict(os.environ, env, clear=True):
+            resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
+        expected = Path.home() / ".cache" / "rpm-lockfile-prototype" / "rpmdbs"
+        self.assertEqual(resolver._rpmdb_cache_path, expected)
 
-        async def mock_cmd(cmd, **kwargs):
-            captured_envs.append(dict(kwargs.get("env", {})))
-            outfile_idx = cmd.index("--outfile") + 1
-            with open(cmd[outfile_idx], "w") as f:
-                yaml.safe_dump(self.FAKE_LOCKFILE_DATA, f)
-            return (0, "", "")
-
-        mock_gather.side_effect = mock_cmd
-        with patch.dict(os.environ, {}, clear=False):
-            env = os.environ.copy()
-            env.pop("JENKINS_HOME", None)
-            with patch.dict(os.environ, env, clear=True):
-                resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
-                config = RpmsInConfig(
-                    arches=["x86_64"],
-                    contentOrigin={"repos": []},
-                    packages=["nfs-utils"],
-                )
-                asyncio.run(resolver.resolve(config))
-
-        self.assertEqual(len(captured_envs), 1)
-        self.assertNotIn("XDG_CACHE_HOME", captured_envs[0])
+    def test_relative_xdg_cache_home_falls_back(self):
+        """
+        A relative XDG_CACHE_HOME must be rejected and fall back to ~/.cache
+        so that podman -v never receives a relative mount source.
+        """
+        env = os.environ.copy()
+        env.pop("JENKINS_HOME", None)
+        env["XDG_CACHE_HOME"] = "."
+        with patch.dict(os.environ, env, clear=True):
+            resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
+        expected = Path.home() / ".cache" / "rpm-lockfile-prototype" / "rpmdbs"
+        self.assertEqual(resolver._rpmdb_cache_path, expected)
 
 
 class TestPackagesFromContainerfile(unittest.TestCase):
@@ -260,13 +342,20 @@ class TestPackagesFromContainerfile(unittest.TestCase):
         with the file path and 1-indexed stageNum.
         """
         captured_configs: list[dict] = []
+        captured_cmds: list[list] = []
 
         async def mock_cmd(cmd, **kwargs):
-            infile = cmd[-1]
-            with open(infile) as f:
+            captured_cmds.append(list(cmd))
+            for i, arg in enumerate(cmd):
+                if arg == "-v" and ":/work:" in cmd[i + 1]:
+                    work_spec = cmd[i + 1]
+                    options = work_spec.split(":")[2] if len(work_spec.split(":")) > 2 else ""
+                    assert "ro" not in options.split(","), f"/work mount must be writable: {work_spec}"
+                    host_tmpdir = work_spec.split(":")[0]
+                    break
+            with open(os.path.join(host_tmpdir, DEFAULT_RPM_INFILE_NAME)) as f:
                 captured_configs.append(yaml.safe_load(f))
-            outfile_idx = cmd.index("--outfile") + 1
-            with open(cmd[outfile_idx], "w") as f:
+            with open(os.path.join(host_tmpdir, DEFAULT_RPM_LOCKFILE_NAME), "w") as f:
                 yaml.safe_dump(self.FAKE_LOCKFILE_DATA, f)
             return (0, "", "")
 
@@ -289,8 +378,17 @@ class TestPackagesFromContainerfile(unittest.TestCase):
         self.assertEqual(len(captured_configs), 1)
         pfc = captured_configs[0].get("packagesFromContainerfile")
         self.assertIsNotNone(pfc)
-        self.assertEqual(pfc["file"], "/path/to/Dockerfile")
+        # Container-side path — the host Containerfile is mounted at /work/Containerfile
+        self.assertEqual(pfc["file"], "Containerfile")
         self.assertEqual(pfc["stageNum"], 2)
+
+        # Host Containerfile must be mounted into the container
+        cmd = captured_cmds[0]
+        expected_mount = "/path/to/Dockerfile:/work/Containerfile:ro,Z"
+        self.assertTrue(
+            any(arg == "-v" and cmd[i + 1] == expected_mount for i, arg in enumerate(cmd) if i + 1 < len(cmd)),
+            f"Expected Containerfile mount {expected_mount!r} in command",
+        )
 
     @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
     def test_no_packages_from_containerfile_when_not_set(self, mock_gather):
@@ -301,11 +399,16 @@ class TestPackagesFromContainerfile(unittest.TestCase):
         captured_configs: list[dict] = []
 
         async def mock_cmd(cmd, **kwargs):
-            infile = cmd[-1]
-            with open(infile) as f:
+            for i, arg in enumerate(cmd):
+                if arg == "-v" and ":/work:" in cmd[i + 1]:
+                    work_spec = cmd[i + 1]
+                    options = work_spec.split(":")[2] if len(work_spec.split(":")) > 2 else ""
+                    assert "ro" not in options.split(","), f"/work mount must be writable: {work_spec}"
+                    host_tmpdir = work_spec.split(":")[0]
+                    break
+            with open(os.path.join(host_tmpdir, DEFAULT_RPM_INFILE_NAME)) as f:
                 captured_configs.append(yaml.safe_load(f))
-            outfile_idx = cmd.index("--outfile") + 1
-            with open(cmd[outfile_idx], "w") as f:
+            with open(os.path.join(host_tmpdir, DEFAULT_RPM_LOCKFILE_NAME), "w") as f:
                 yaml.safe_dump(self.FAKE_LOCKFILE_DATA, f)
             return (0, "", "")
 
@@ -522,8 +625,15 @@ class TestResolveRpmdbCorruptionRetry(unittest.TestCase):
             call_count += 1
             if call_count == 1:
                 return (1, "", self.CORRUPTION_STDERR)
-            outfile_idx = cmd.index("--outfile") + 1
-            with open(cmd[outfile_idx], "w") as f:
+            for i, arg in enumerate(cmd):
+                if arg == "-v" and ":/work:" in cmd[i + 1]:
+                    work_spec = cmd[i + 1]
+                    options = work_spec.split(":")[2] if len(work_spec.split(":")) > 2 else ""
+                    assert "ro" not in options.split(","), f"/work mount must be writable: {work_spec}"
+                    host_tmpdir = work_spec.split(":")[0]
+                    break
+            host_outfile = os.path.join(host_tmpdir, DEFAULT_RPM_LOCKFILE_NAME)
+            with open(host_outfile, "w") as f:
                 yaml.safe_dump(self.FAKE_LOCKFILE_DATA, f)
             return (0, "", "")
 
@@ -560,8 +670,15 @@ class TestResolveRpmdbCorruptionRetry(unittest.TestCase):
             call_count += 1
             if call_count == 1:
                 return (1, "", cache_race_stderr)
-            outfile_idx = cmd.index("--outfile") + 1
-            with open(cmd[outfile_idx], "w") as f:
+            for i, arg in enumerate(cmd):
+                if arg == "-v" and ":/work:" in cmd[i + 1]:
+                    work_spec = cmd[i + 1]
+                    options = work_spec.split(":")[2] if len(work_spec.split(":")) > 2 else ""
+                    assert "ro" not in options.split(","), f"/work mount must be writable: {work_spec}"
+                    host_tmpdir = work_spec.split(":")[0]
+                    break
+            host_outfile = os.path.join(host_tmpdir, DEFAULT_RPM_LOCKFILE_NAME)
+            with open(host_outfile, "w") as f:
                 yaml.safe_dump(self.FAKE_LOCKFILE_DATA, f)
             return (0, "", "")
 


### PR DESCRIPTION
  ## Summary

  Replaces the system Python subprocess invocation of rpm-lockfile-prototype with `podman run`, removing the dependency on host-installed `python3-dnf` and `python3-rpm`. All DNF dependencies are now self-contained in the container image.

  **Image:** `quay.io/redhat-user-workloads/ocp-art-tenant/art-cd:rpm-lockfile-v0.30.0` (public — no pull authentication required)

  ### Volume mounts

  | Host path | Container path | Purpose |
  |---|---|---|
  |  per-resolve `TemporaryDirectory` (inside `working_dir` if set, else system tmp)| `/work` | `rpms.in.yaml` input + `rpms.lock.yaml` output |
  | `_cache_path` | `/cache` | DNF repodata cache (shared, `:z`) |
  | see RPMDB section below | `/rpmdb-cache/rpm-lockfile-prototype` or `/rpmdb-cache` | RPMDB cache via `XDG_CACHE_HOME` |
  | `/etc/pki/entitlement`, `/etc/rhsm/ca`, `/etc/pki/rpm-gpg` | same | RH entitlement certs for CDN repo access (`:ro`, no SELinux relabel) |
  | `$REGISTRY_AUTH_FILE` / `$QUAY_AUTH_FILE` | `/auth/auth.json` | Registry auth for base image pulls inside the container |

  ### RPMDB cache persistence

  rpm-lockfile-prototype v0.30.0 respects `XDG_CACHE_HOME`, storing extracted RPMDBs at
  `$XDG_CACHE_HOME/rpm-lockfile-prototype/rpmdbs`. The container is given `XDG_CACHE_HOME=/rpmdb-cache`.

  - **Jenkins:** `JENKINS_CACHE_DIR` (`/mnt/jenkins-workspace/rpm-lockfile-cache`) is mounted
    at `/rpmdb-cache/rpm-lockfile-prototype`, so the tool writes rpmdbs to
    `JENKINS_CACHE_DIR/rpmdbs` — the same path used before containerization (previously
    reached via the `~/.cache/rpm-lockfile-prototype → JENKINS_CACHE_DIR` symlink).
    No cold cache on upgrade.
  - **Elsewhere:** `$XDG_CACHE_HOME` (or `~/.cache`) is mounted as `/rpmdb-cache`.

  ### Corrupt RPMDB recovery

  On stderr patterns indicating a broken RPMDB (`database disk image is malformed`, `failed loading RPMDB`), doozer clears the cached RPMDB entry for that image digest and retries once automatically.

  ## Follow-up (after merge)

  - Remove Jenkins symlink `/home/jenkins/.cache/rpm-lockfile-prototype`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- RPM lockfile resolution now runs in a containerized environment.
- A default container image is provided, with support for selecting a custom image.
- Package metadata and RPM database caches can persist between runs.
- Registry authentication, entitlement certificates, working files, and optional Containerfiles are supported.

## Bug Fixes

- Improved recovery from corrupted RPM database caches, including automatic retry support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->