### PR TITLE
ART-19655: Capitalize outcome names in Jenkins build history links

### DIFF
--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -777,7 +777,7 @@ class ImagesHealthPipeline:
 
         start_date = (datetime.now(timezone.utc) - timedelta(days=DELTA_DAYS)).strftime('%Y-%m-%d')
         end_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
-        art_dash_link = f'{ART_BUILD_HISTORY_URL}/?name=^{concern["image_name"]}$&group={group}&assembly=stream&engine=konflux&dateRange={start_date}+to+{end_date}&outcome=success&outcome=failure'
+        art_dash_link = f'{ART_BUILD_HISTORY_URL}/?name=^{concern["image_name"]}$&group={group}&assembly=stream&engine=konflux&dateRange={start_date}+to+{end_date}&outcome=Success&outcome=Failure'
         logs_link = self.url_text(self.get_logs_url(concern), "logs")
 
         message = f'{self.url_text(art_dash_link, f"{group}")}: '
@@ -820,7 +820,7 @@ class ImagesHealthPipeline:
         group = concern['group']
         start_date = (datetime.now(timezone.utc) - timedelta(days=DELTA_DAYS)).strftime('%Y-%m-%d')
         end_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
-        return f'{ART_BUILD_HISTORY_URL}/?name=^{image_name}$&group={group}&assembly=stream&engine=konflux&dateRange={start_date}+to+{end_date}&outcome=success&outcome=failure'
+        return f'{ART_BUILD_HISTORY_URL}/?name=^{image_name}$&group={group}&assembly=stream&engine=konflux&dateRange={start_date}+to+{end_date}&outcome=Success&outcome=Failure'
 
     def url_text(self, url, text):
         """

--- a/pyartcd/pyartcd/pipelines/okd_images_health.py
+++ b/pyartcd/pyartcd/pipelines/okd_images_health.py
@@ -327,7 +327,7 @@ class ImagesHealthPipeline:
         start_date = (datetime.now(timezone.utc) - timedelta(days=DELTA_DAYS)).strftime('%Y-%m-%d')
         end_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
         # Filter dashboard to show only OKD groups (okd-*)
-        dashboard_url = f'{ART_BUILD_HISTORY_URL}/?dateRange={start_date}+to+{end_date}&outcome=failure&engine=konflux'
+        dashboard_url = f'{ART_BUILD_HISTORY_URL}/?dateRange={start_date}+to+{end_date}&outcome=Failure&engine=konflux'
 
         message = (
             f':alert: There are some issues to look into for OKD builds:\n- {issues}\n\n'
@@ -386,7 +386,7 @@ class ImagesHealthPipeline:
 
         start_date = (datetime.now(timezone.utc) - timedelta(days=DELTA_DAYS)).strftime('%Y-%m-%d')
         end_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
-        art_dash_link = f'{ART_BUILD_HISTORY_URL}/?name=^{concern["image_name"]}$&group={okd_group}&assembly=stream&engine=konflux&dateRange={start_date}+to+{end_date}&outcome=success&outcome=failure'
+        art_dash_link = f'{ART_BUILD_HISTORY_URL}/?name=^{concern["image_name"]}$&group={okd_group}&assembly=stream&engine=konflux&dateRange={start_date}+to+{end_date}&outcome=Success&outcome=Failure'
         logs_link = self.url_text(self.get_logs_url(concern), "logs")
 
         message = f'{self.url_text(art_dash_link, f"{okd_group}")}: '
@@ -414,7 +414,7 @@ class ImagesHealthPipeline:
         okd_group = group.replace('openshift-', 'okd-')
         start_date = (datetime.now(timezone.utc) - timedelta(days=DELTA_DAYS)).strftime('%Y-%m-%d')
         end_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
-        return f'{ART_BUILD_HISTORY_URL}/?name=^{image_name}$&group={okd_group}&assembly=stream&engine=konflux&dateRange={start_date}+to+{end_date}&outcome=success&outcome=failure'
+        return f'{ART_BUILD_HISTORY_URL}/?name=^{image_name}$&group={okd_group}&assembly=stream&engine=konflux&dateRange={start_date}+to+{end_date}&outcome=Success&outcome=Failure'
 
     @staticmethod
     def get_logs_url(concern):

--- a/pyartcd/pyartcd/pipelines/seed_lockfile.py
+++ b/pyartcd/pyartcd/pipelines/seed_lockfile.py
@@ -395,7 +395,7 @@ class SeedLockfilePipeline:
         """Build a direct link to a build page in art-build-history."""
         nvr = entry.get('nvrs', '').split(',')[0]
         record_id = entry.get('record_id', '')
-        outcome = 'success' if int(entry.get('status', -1)) == 0 else 'failure'
+        outcome = 'Success' if int(entry.get('status', -1)) == 0 else 'Failure'
         if nvr and nvr != 'n/a' and record_id:
             return (
                 f'{ART_BUILD_HISTORY_URL}/build?nvr={nvr}&record_id={record_id}'
@@ -412,7 +412,7 @@ class SeedLockfilePipeline:
         end_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
         return (
             f'{ART_BUILD_HISTORY_URL}/?name=^{image_name}$&group={group}'
-            f'&engine=konflux&dateRange={start_date}+to+{end_date}&outcome=success&outcome=failure'
+            f'&engine=konflux&dateRange={start_date}+to+{end_date}&outcome=Success&outcome=Failure'
         )
 
     def _categorize_results(self) -> tuple[list[str], list[str], list[str]]:

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -463,7 +463,7 @@ def build_history_link_url(group: str, assembly: str, days: int = 2, job_url: st
     # Build URL with parameters in correct order and include empty parameters
     build_history_url = (
         f'{ART_BUILD_HISTORY_URL}/?name=&group={group}&assembly={assembly}'
-        f'&outcome=success&outcome=failure&engine=konflux'
+        f'&outcome=Success&outcome=Failure&engine=konflux'
         f'&dateRange={start_date}+to+{end_date}'
         f'&nvr=&record_id=&image_sha_tag=&source_repo=&commitish='
     )

--- a/pyartcd/tests/pipelines/test_seed_lockfile.py
+++ b/pyartcd/tests/pipelines/test_seed_lockfile.py
@@ -257,7 +257,7 @@ class TestSeedLockfilePipeline(unittest.IsolatedAsyncioTestCase):
         self.assertIn('/build?', url)
         self.assertIn('nvr=ironic-container', url)
         self.assertIn('record_id=abc-123', url)
-        self.assertIn('outcome=success', url)
+        self.assertIn('outcome=Success', url)
 
     def test_build_url_without_record_id(self):
         """_build_url falls back to search page when record_id is absent."""


### PR DESCRIPTION
## Summary
Links set by ocp4-konflux Jenkins runs had wrong outcome names ('failure' instead of 'Failure', 'success' instead of 'Success'). The art-build-history dashboard expects capitalized outcome values.

## Problem
Jenkins jobs were generating URLs like:
```
&outcome=success&outcome=failure
```

But the art-build-history dashboard expects:
```
&outcome=Success&outcome=Failure
```

## Solution
Updated all instances of lowercase outcome values to capitalized versions across:
- `pyartcd/util.py` - Root fix in `build_history_link_url()` function (used by ocp4_konflux.py)
- `pyartcd/pipelines/seed_lockfile.py` - Updated outcome values in URL generation
- `pyartcd/pipelines/images_health.py` - Updated outcome values in dashboard links
- `pyartcd/pipelines/okd_images_health.py` - Updated outcome values in OKD dashboard links
- `pyartcd/tests/pipelines/test_seed_lockfile.py` - Updated test assertion

## Testing
- ✅ All linting checks passed
- ✅ All 2,677 unit tests passed
- ✅ Pre-commit hooks passed

## Jira
Fixes: [ART-19655](https://redhat.atlassian.net/browse/ART-19655)