### PR TITLE
Include base_only images in OKD imagestream tagging

### DIFF
--- a/pyartcd/pyartcd/pipelines/okd.py
+++ b/pyartcd/pyartcd/pipelines/okd.py
@@ -616,9 +616,11 @@ class KonfluxOkdPipeline:
                 continue
 
             # Determine payload tag name
-            # Note: Only images with for_payload=true should be tagged into imagestreams
-            if not image_metadata.get('for_payload', False):
-                self.logger.debug('Skipping non-payload image %s from imagestream tagging', image_name)
+            # Tag payload images and base_only images (which other images depend on)
+            is_payload = image_metadata.get('for_payload', False)
+            is_base_only = image_metadata.get('base_only', False)
+            if not (is_payload or is_base_only):
+                self.logger.debug('Skipping non-payload, non-base image %s from imagestream tagging', image_name)
                 continue
 
             payload_tag = self._get_payload_tag_name(image_name, image_metadata)


### PR DESCRIPTION
## Summary
Fixes OKD 5.0 nightly failures caused by missing base images in the imagestream.

## Problem
The OKD pipeline was filtering out all non-payload images when tagging into imagestreams. This caused base images like `ose-haproxy-router-base` to be missing from `registry.ci.openshift.org/origin/scos-5.0-art`, which caused payload images that depend on them (like `haproxy-router`) to fall back to outdated bases from 4.22.

From the Slack thread: the `haproxy-router` image was getting templates from OKD 5.0 source but using a binary from the outdated 4.22 base (built May 19), creating a binary/template version mismatch.

## Root Cause
`pyartcd/pyartcd/pipelines/okd.py` lines 619-621:
```python
if not image_metadata.get('for_payload', False):
    self.logger.debug('Skipping non-payload image %s from imagestream tagging', image_name)
    continue
```

This excluded all base images (`base_only: true`, `for_payload: false`) from imagestream tagging.

## Solution
Now tags both:
- Payload images (`for_payload: true`)
- Base images (`base_only: true`) that other images depend on

This ensures the full dependency chain is available in the imagestream.

## Testing
After this merges and the next OKD build runs, verify that:
```bash
oc image info registry.ci.openshift.org/origin/scos-5.0-art:haproxy-router-base
```
returns a valid image (not "manifest unknown").

## Related
Slack thread: https://redhat-internal.slack.com/archives/CB95J6R4N/p1780561497756919

🤖 Generated with [Claude Code](https://claude.com/claude-code)