### PR TITLE
ART-21305: add BuildConfig for rpm-lockfile-prototype image

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/image/rpm_lockfile_build.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/image/rpm_lockfile_build.yaml
@@ -1,0 +1,26 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  labels:
+    build: rpm-lockfile-prototype
+  name: rpm-lockfile-prototype
+spec:
+  source:
+    dockerfile: art-cluster/pipelines/data/project/art-cd/image/Containerfile.rpm_lockfile_prototype
+    git:
+      ref: main
+      uri: https://github.com/openshift-eng/art-tools
+    type: Git
+  strategy:
+    dockerStrategy:
+      dockerfilePath: art-cluster/pipelines/data/project/art-cd/image/Containerfile.rpm_lockfile_prototype
+      pullSecret:
+        name: art-bot-docker-config
+    type: Docker
+  output:
+    to:
+      kind: ImageStreamTag
+      name: rpm-lockfile-prototype:v0.25.0
+  successfulBuildsHistoryLimit: 10
+  failedBuildsHistoryLimit: 5
+  runPolicy: Serial

--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/image/rpm_lockfile_image.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/image/rpm_lockfile_image.yaml
@@ -1,0 +1,4 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: rpm-lockfile-prototype

--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/image/rpm_lockfile_pull_access.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/image/rpm_lockfile_pull_access.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rpm-lockfile-image-puller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rpm-lockfile-image-puller-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:image-puller
+subjects:
+  - kind: ServiceAccount
+    name: rpm-lockfile-image-puller
+    namespace: art-cd

--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.rpm_lockfile_prototype
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.rpm_lockfile_prototype
@@ -1,0 +1,23 @@
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9:latest
+
+FROM ${BASE_IMAGE}
+RUN dnf install -y python3 python3-pip python3-dnf skopeo rpm git-core && dnf clean all
+
+# Install RH IT CA bundle so DNF can reach internal repos (rhsm-pulp.corp.redhat.com)
+RUN curl --silent --show-error --fail --insecure --output /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem \
+        https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem && \
+    curl --silent --show-error --fail --insecure --output /etc/pki/ca-trust/source/anchors/2015-IT-Root-CA.pem \
+        https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem && \
+    update-ca-trust
+
+WORKDIR /app
+
+ARG GIT_REF=tags/v0.25.0
+
+RUN python3 -m pip install https://github.com/konflux-ci/rpm-lockfile-prototype/archive/refs/${GIT_REF}.tar.gz
+
+WORKDIR /work
+
+# Runs as root: rpm-lockfile-prototype uses DNF's Python API for RPM dependency
+# resolution, which requires root access to the RPM database and cache directories.
+ENTRYPOINT ["/usr/local/bin/rpm-lockfile-prototype"]


### PR DESCRIPTION
  ## Summary

  Add art-cluster infrastructure to build and serve the `rpm-lockfile-prototype` container image from the `art-cd` namespace.

  - **ImageStream** for `rpm-lockfile-prototype`
  - **BuildConfig** that builds from bundled Containerfile (Fedora + python3-dnf + RH IT CAs, pinned to v0.23.0)
  - **ServiceAccount + RoleBinding** (`rpm-lockfile-image-puller`) for Jenkins pull access
  - **Containerfile** at `art-cluster/pipelines/data/project/art-cd/image/Containerfile.rpm_lockfile_prototype`
  
  This is part of the effort to containerize rpm-lockfile-prototype execution (see #3031), removing the dependency on host-installed python3-dnf.
  
  ## Post-merge steps

  After ArgoCD deploys these resources to `art-cd`:

  1. Generate a pull token (valid 1 year):
  oc create token rpm-lockfile-image-puller -n art-cd --duration=8760h
  2. Store the token in AWS Secrets Manager so Jenkins can sync it
  3. Configure Jenkins to use the token for podman login:
  podman login default-route-openshift-image-registry.apps.artc2023.pc3z.p1.openshiftapps.com \
    -u rpm-lockfile-image-puller -p <token>
  4. Set up GitHub webhook (optional) — add webhook URL in openshift-eng/art-tools repo settings pointing to the BuildConfig, so Containerfile changes auto-trigger rebuilds
  5. Follow-up PR in art-tools — update RpmResolver to pull from art-cluster registry instead of building on demand (#3031)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenShift `BuildConfig` for `rpm-lockfile-prototype` to build and publish a versioned image to an `ImageStreamTag`.
  * Added an `ImageStream` for `rpm-lockfile-prototype` and introduced a new container build definition that installs required tooling and the prototype tool.
* **Security / Access**
  * Added RBAC for `rpm-lockfile-image-puller` (service account + role binding) to allow controlled image pulls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->