### PR TITLE
Fix missing --add-auto-labels and hardcoded labels in sync-ci-images PRs

### DIFF
--- a/pyartcd/pyartcd/pipelines/sync_ci_images.py
+++ b/pyartcd/pyartcd/pipelines/sync_ci_images.py
@@ -572,8 +572,11 @@ class SyncCIImagesPipeline:
             )
 
         pr_args = f"--github-access-token {github_token} --interstitial {self.PR_INTERSTITIAL_SECONDS}"
+        pr_args += ' --add-auto-labels'
+        pr_args += ' --add-label "jira/valid-bug" --add-label "verified"'
         if self.add_labels:
-            pr_args += f" --add-labels {self.add_labels}"
+            for label in self.add_labels.split():
+                pr_args += f' --add-label "{label}"'
         if self.runtime.dry_run:
             pr_args += " --moist-run"  # doozer's dry-run equivalent for PRs
 


### PR DESCRIPTION
## Summary
- The Groovy → pyartcd migration of sync-ci-images (PR #2877) dropped three flags from the `doozer images:streams prs open` invocation:
  1. **`--add-auto-labels`**: applies per-image `auto_label` config from ocp-build-data (e.g. `approved`, `lgtm`, `verified`, `jira/valid-reference`). Without this, images like `ose-ibm-vpc-block-csi-driver` that configure auto-merge labels no longer get them ([example PR missing labels](https://github.com/openshift/ibm-vpc-block-csi-driver/pull/153))
  2. **`--add-label "jira/valid-bug"`**: hardcoded on all PRs for versions >= 4.12 in the old Groovy job
  3. **`--add-label "verified"`**: hardcoded on all PRs for versions >= 4.12 in the old Groovy job
- Also fixes `--add-labels` (nonexistent doozer flag) to `--add-label` (singular, repeatable) matching the actual [doozer CLI definition](https://github.com/openshift-eng/art-tools/blob/main/doozer/doozerlib/cli/images_streams.py#L1717)

Old Groovy invocation ([source](https://github.com/openshift-eng/aos-cd-jobs/blob/4d112769b2b20409d201024419e8999c93fc471d/scheduled-jobs/build/sync-ci-images/Jenkinsfile#L195)):
```groovy
other_args = '--add-label "jira/valid-bug" --add-label "verified"'
doozer ... images:streams prs open --interstitial 840 --add-auto-labels ${other_args} --github-access-token ${GITHUB_TOKEN}
```

## Test plan
- [ ] Run sync-ci-images in dry-run mode and verify doozer command includes `--add-auto-labels`, `--add-label "jira/valid-bug"`, and `--add-label "verified"`
- [ ] Verify PRs for images with `auto_label` config (e.g. `ose-ibm-vpc-block-csi-driver`) get labels applied