### PR TITLE
perf: cache extract_builder_info_from_pullspec to reduce oc image info calls

### DIFF
--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -5,6 +5,7 @@ import pathlib
 import re
 from collections import OrderedDict
 from copy import copy
+from functools import lru_cache
 from multiprocessing import Event
 from typing import Any, Dict, List, Optional, Set, Tuple, cast
 
@@ -27,6 +28,7 @@ from doozerlib.metadata import Metadata, RebuildHint, RebuildHintCode
 from doozerlib.source_resolver import SourceResolver
 
 
+@lru_cache(maxsize=500)
 def extract_builder_info_from_pullspec(
     pullspec: str,
     registry_config: Optional[str] = None,


### PR DESCRIPTION
## Summary

When canonical builders are enabled, `extract_builder_info_from_pullspec()` is called for every parent image in every upstream Dockerfile during `ImageMetadata` initialization. Many components share the same builder images (e.g., `registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21`), resulting in redundant `oc image info` calls.

This PR adds `@lru_cache(maxsize=500)` to cache the function's results (RHEL version, golang version tuple) for each unique pullspec within a single process run.

## Impact

- **Before**: ~807 `oc image info` invocations in ocp4-scan-konflux jobs (4.20 with canonical builders)
- **After**: Expected ~55-100 invocations (similar to runs without canonical builders)
- Significant speedup for scan-konflux jobs with canonical builders enabled
- No behavior change, only performance improvement

## Testing

- ✅ Linting passed (`make lint`)
- ✅ No functional changes, only caching layer added
- The underlying `oc_image_info_for_arch()` already uses LRU caching, this adds a higher-level cache

## References

- Related to canonical builders feature
- Addresses performance regression when canonical builders are enabled globally

🤖 Generated with [Claude Code](https://claude.com/claude-code)