### PR TITLE
fix: use registry proxy for parent image NVR extraction

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -1204,17 +1204,19 @@ class KonfluxImageBuilder:
         parent_image_nvrs = []
         for pullspec in parent_image_pullspecs:
             try:
+                # brew.registry.redhat.io requires auth that may not be available;
+                # use the no-auth registry proxy instead (image content is identical)
+                inspect_pullspec = pullspec.replace(constants.BREW_REGISTRY_BASE_URL, constants.REGISTRY_PROXY_BASE_URL)
                 # Use oc image info with optional auth file to get image labels
                 # Use --filter-by-os to handle manifest list images
                 try:
                     stdout = await oc_image_info__cached_async(
-                        pullspec,
+                        inspect_pullspec,
                         '--filter-by-os=amd64',
                         registry_config=registry_auth_file if registry_auth_file else None,
                     )
                 except ChildProcessError as e:
-                    # Could not access the image - this is unexpected and worth a warning
-                    logger.warning(f"Could not access parent image {pullspec}: {e}")
+                    logger.warning(f"Could not access parent image {inspect_pullspec}: {e}")
                     parent_image_nvrs.append(pullspec)
                     continue
 


### PR DESCRIPTION
## Summary
- `extract_parent_image_nvrs` in `konflux_image_builder.py` was using `brew.registry.redhat.io` pullspecs to inspect parent images via `oc image info`, which requires Customer Portal auth that may not be available during post-build metadata collection
- This caused NVR extraction to fail silently (with a warning), storing raw pullspecs instead of NVRs in BigQuery — degrading golang CVE tracking in Elliott
- Fix: convert `brew.registry.redhat.io` to `registry-proxy.engineering.redhat.com` before inspecting, matching the existing pattern in `lockfile_prototype/generator.py`

## Test plan
- [x] `make format` passes
- [x] All unit tests pass (artcommon, doozer, elliott, pyartcd, ocp-build-data-validator)
- [ ] Verify in a real build that parent image NVRs are extracted successfully for images previously failing with unauthorized errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)