### PR TITLE
Update golang builder CVE component name to openshift4/openshift-golang-builder

### DIFF
--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -35,6 +35,7 @@ from elliottlib.util import (
     chunk,
     get_component_by_delivery_repo,
     isolate_timestamp_in_release,
+    normalize_component_by_ocp_delivery_repo,
 )
 
 logger = logutil.get_logger(__name__)
@@ -1730,6 +1731,7 @@ def get_cve_unfixed_components(runtime, cve_alias: str) -> Dict:
                     logger.warning(
                         f"Could not find component name for {pkg_name}! is it an art component? is the delivery repo defined?"
                     )
+                    unfixed_components.append(pkg_name)
                 else:
                     unfixed_components.append(comp_name)
             else:
@@ -1751,7 +1753,8 @@ def is_first_fix_for_tracker(runtime, flaw_bug: BugzillaBug, tracker_bug: JIRABu
         )
     alias = flaw_bug.alias[0]
     unfixed_components = get_cve_unfixed_components(runtime, alias)
-    first_fix = tracker_bug.whiteboard_component in unfixed_components
+    tracker_component = normalize_component_by_ocp_delivery_repo(runtime, tracker_bug.whiteboard_component)
+    first_fix = tracker_component in unfixed_components
     logger.info(
         f"Flaw bug {flaw_bug.id} is {'first-fix' if first_fix else 'second-fix'} for tracker bug {tracker_bug.id}"
     )
@@ -1781,7 +1784,8 @@ def is_first_fix_any(runtime, flaw_bug: BugzillaBug, tracker_bugs: Iterable[JIRA
     # and if not then second-fix close operation should be performed on them
     # but for now we will just return True if any of the trackers is a first fix
     for tracker_bug in tracker_bugs:
-        if tracker_bug.whiteboard_component in unfixed_components:
+        tracker_component = normalize_component_by_ocp_delivery_repo(runtime, tracker_bug.whiteboard_component)
+        if tracker_component in unfixed_components:
             logger.info(
                 f"Flaw bug {flaw_bug.id} is a first-fix for tracker bug {tracker_bug.id}. Other associated trackers of the flaw bug will not be checked."
             )

--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -537,7 +537,8 @@ class AttachCveFlaws:
                 raise ValueError(f"Bug {tracker.id} doesn't have a valid whiteboard component.")
 
             whiteboard_component = tracker.whiteboard_component
-            if is_ocp_delivery_repo(whiteboard_component):
+            is_golang_builder = whiteboard_component == constants.GOLANG_BUILDER_CVE_COMPONENT
+            if is_ocp_delivery_repo(whiteboard_component) and not is_golang_builder:
                 # this means the component here is the delivery repo name
                 # we need to translate it to build component name
                 new_component = get_component_by_delivery_repo(runtime, whiteboard_component)
@@ -548,10 +549,12 @@ class AttachCveFlaws:
             component_names = None  # Initialize to ensure it's always defined
 
             if konflux:
-                new_component = get_konflux_component_by_component(runtime, whiteboard_component)
+                new_component = (
+                    get_konflux_component_by_component(runtime, whiteboard_component) if not is_golang_builder else None
+                )
                 if not new_component:
                     # Special case for builder containers: they should map to all components that use this builder
-                    if whiteboard_component == "openshift-golang-builder-container":
+                    if is_golang_builder or whiteboard_component == constants.GOLANG_BUILDER_BREW_COMPONENT:
                         # Check which components actually use the golang builder
                         logger.info(f"Processing builder container CVE for '{whiteboard_component}' (golang builder)")
 

--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -537,7 +537,7 @@ class AttachCveFlaws:
                 raise ValueError(f"Bug {tracker.id} doesn't have a valid whiteboard component.")
 
             whiteboard_component = tracker.whiteboard_component
-            is_golang_builder = whiteboard_component == constants.GOLANG_BUILDER_CVE_COMPONENT
+            is_golang_builder = constants.is_golang_builder_component(whiteboard_component)
             if is_ocp_delivery_repo(whiteboard_component) and not is_golang_builder:
                 # this means the component here is the delivery repo name
                 # we need to translate it to build component name
@@ -554,7 +554,7 @@ class AttachCveFlaws:
                 )
                 if not new_component:
                     # Special case for builder containers: they should map to all components that use this builder
-                    if is_golang_builder or whiteboard_component == constants.GOLANG_BUILDER_BREW_COMPONENT:
+                    if is_golang_builder:
                         # Check which components actually use the golang builder
                         logger.info(f"Processing builder container CVE for '{whiteboard_component}' (golang builder)")
 

--- a/elliott/elliottlib/cli/find_bugs_golang_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_golang_cli.py
@@ -9,6 +9,7 @@ import requests
 from artcommonlib.release_util import get_patch_from_release, isolate_el_version_in_release
 from artcommonlib.rhcos import get_container_configs
 from artcommonlib.rpm_utils import parse_nvr
+from artcommonlib.util import is_ocp_delivery_repo
 from doozerlib.cli.get_nightlies import find_rc_nightlies
 from prettytable import PrettyTable
 from pyartcd.util import get_release_name_for_assembly
@@ -486,7 +487,9 @@ class FindBugsGolangCli:
             if comp in not_art:
                 logger.info(f"{b.id} is for a component that is not built by ART: {comp}. Skipping")
                 return False
-            if comp.endswith("-container") and not constants.is_golang_builder_component(comp):
+            if (
+                comp.endswith("-container") or is_ocp_delivery_repo(comp)
+            ) and not constants.is_golang_builder_component(comp):
                 logger.info(f"{b.id} is for a non-builder image: {comp}. Skipping")
                 return False
             return True

--- a/elliott/elliottlib/cli/find_bugs_golang_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_golang_cli.py
@@ -163,7 +163,7 @@ class FindBugsGolangCli:
         for go_build in go_nvr_map.keys():
             # if this is a builder image then fetch the golang rpm
             parent_go_build = go_build
-            if constants.GOLANG_BUILDER_BREW_COMPONENT in go_build:
+            if constants.GOLANG_BUILDER_COMPONENT in go_build:
                 parsed_nvr = parse_nvr(go_build)
                 go_builder_nvr_map = get_golang_container_nvrs(
                     [(parsed_nvr['name'], parsed_nvr['version'], parsed_nvr['release'])], self._logger, exact=True

--- a/elliott/elliottlib/cli/find_bugs_golang_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_golang_cli.py
@@ -210,13 +210,13 @@ class FindBugsGolangCli:
             # In case this is for builder image
             # and if vulnerable builds make up for less than 10% of total builds, consider it fixed
             # this is due to etcd and a few payload images lagging behind due to special reasons
-            if bug.whiteboard_component == constants.GOLANG_BUILDER_CVE_COMPONENT and vuln_builds / total_builds < 0.1:
+            if constants.is_golang_builder_component(bug.whiteboard_component) and vuln_builds / total_builds < 0.1:
                 self._logger.info("Vulnerable builds make up for less than 10% of total builds, considering it fixed")
                 fixed = True
         else:
             fixed = True
 
-        if bug.whiteboard_component == constants.GOLANG_BUILDER_CVE_COMPONENT:
+        if constants.is_golang_builder_component(bug.whiteboard_component):
             build_artifacts = f"Images in {self.pullspec}"
         else:
             nvrs = []
@@ -486,7 +486,7 @@ class FindBugsGolangCli:
             if comp in not_art:
                 logger.info(f"{b.id} is for a component that is not built by ART: {comp}. Skipping")
                 return False
-            if comp.endswith("-container") and comp != constants.GOLANG_BUILDER_CVE_COMPONENT:
+            if comp.endswith("-container") and not constants.is_golang_builder_component(comp):
                 logger.info(f"{b.id} is for a non-builder image: {comp}. Skipping")
                 return False
             return True
@@ -510,7 +510,7 @@ class FindBugsGolangCli:
             filtered_bugs_rpms_only = []
             for b in bugs:
                 # Skip builder container bugs
-                if b.whiteboard_component == constants.GOLANG_BUILDER_CVE_COMPONENT:
+                if constants.is_golang_builder_component(b.whiteboard_component):
                     continue
                 # Skip image components (those that start with "openshift<digit>/")
                 if re.match(r'^openshift\d+/', b.whiteboard_component):
@@ -648,7 +648,7 @@ class FindBugsGolangCli:
         fixed_bugs, unfixed_bugs, updated_bugs = [], [], []
         for bug in bugs:
             component = bug.whiteboard_component
-            art_managed = (component == constants.GOLANG_BUILDER_CVE_COMPONENT) or (component in self._runtime.rpm_map)
+            art_managed = constants.is_golang_builder_component(component) or (component in self._runtime.rpm_map)
             logger.info(f"{bug.id} has security component: {component}")
             fixed, comment, component_builds, parent_golang_builds = False, '', [], []
 
@@ -658,7 +658,7 @@ class FindBugsGolangCli:
                 continue
             logger.info(f"{bug.id} is fixed in: {[str(v) for v in tracker_fixed_in]}")
 
-            if component == constants.GOLANG_BUILDER_CVE_COMPONENT:
+            if constants.is_golang_builder_component(component):
                 fixed, comment, component_builds, parent_golang_builds = await self.is_fixed_golang_builder(
                     bug, tracker_fixed_in=tracker_fixed_in
                 )

--- a/elliott/elliottlib/cli/find_bugs_golang_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_golang_cli.py
@@ -162,7 +162,7 @@ class FindBugsGolangCli:
         for go_build in go_nvr_map.keys():
             # if this is a builder image then fetch the golang rpm
             parent_go_build = go_build
-            if constants.GOLANG_BUILDER_CVE_COMPONENT in go_build:
+            if constants.GOLANG_BUILDER_BREW_COMPONENT in go_build:
                 parsed_nvr = parse_nvr(go_build)
                 go_builder_nvr_map = get_golang_container_nvrs(
                     [(parsed_nvr['name'], parsed_nvr['version'], parsed_nvr['release'])], self._logger, exact=True
@@ -748,7 +748,7 @@ class FindBugsGolangCli:
     "--component",
     "components",
     multiple=True,
-    help="Only operate on trackers for these JIRA Bug components e.g. openshift-golang-builder-container",
+    help="Only operate on trackers for these JIRA Bug components e.g. openshift4/openshift-golang-builder",
 )
 @click.option('--art-jira', help='Related ART Jira ticket for reference e.g. ART-1234')
 @click.option(
@@ -815,7 +815,7 @@ async def find_bugs_golang_cli(
 
     Bugs are compared with latest builds in `stream` assembly by default. Pass --assembly to specify.
 
-    For openshift-golang-builder-container build, use --pullspec <payload_pullspec> to determine if fixed for builds in
+    For openshift-golang-builder build, use --pullspec <payload_pullspec> to determine if fixed for builds in
     given pullspec
 
     Note: rpm trackers cannot be processed if --pullspec is used, for that rely on --assembly.
@@ -828,7 +828,7 @@ async def find_bugs_golang_cli(
     bugs like openshift-golang-builder where we want to move the bug to VERIFIED after or close to when mass rebuild is
     triggered.
 
-    --component: Only operate on trackers for these JIRA Bug components e.g. openshift-golang-builder-container.
+    --component: Only operate on trackers for these JIRA Bug components e.g. openshift4/openshift-golang-builder.
 
     --rpms-only: Ignore builder container bugs and only analyze RPM trackers.
 

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -614,8 +614,8 @@ def categorize_bugs_by_type(
         if kind == 'image':
             # golang builder is a special tracker component
             # which applies to all our golang images
-            exception_packages.append(constants.GOLANG_BUILDER_CVE_COMPONENT)
-            exception_packages.append(constants.GOLANG_BUILDER_BREW_COMPONENT)
+            exception_packages.append(constants.GOLANG_BUILDER_OCP4_DELIVERY_REPO)
+            exception_packages.append(constants.GOLANG_BUILDER_COMPONENT)
 
         for bug in tracker_bugs:
             package_name = bug.whiteboard_component

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -96,7 +96,7 @@ def filter_art_managed_jira_trackers(
             continue
 
         if (
-            normalized_component == constants.GOLANG_BUILDER_CVE_COMPONENT
+            constants.is_golang_builder_component(normalized_component)
             or normalized_component in art_managed_image_components
         ):
             art_trackers.append(bug)

--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -615,6 +615,7 @@ def categorize_bugs_by_type(
             # golang builder is a special tracker component
             # which applies to all our golang images
             exception_packages.append(constants.GOLANG_BUILDER_CVE_COMPONENT)
+            exception_packages.append(constants.GOLANG_BUILDER_BREW_COMPONENT)
 
         for bug in tracker_bugs:
             package_name = bug.whiteboard_component

--- a/elliott/elliottlib/constants.py
+++ b/elliott/elliottlib/constants.py
@@ -22,7 +22,8 @@ BUG_SEVERITY_NUMBER_MAP = {
 }
 
 # Golang builder needs special treatment when associating security tracking bugs with builds:
-GOLANG_BUILDER_CVE_COMPONENT = 'openshift-golang-builder-container'
+GOLANG_BUILDER_CVE_COMPONENT = 'openshift4/openshift-golang-builder'
+GOLANG_BUILDER_BREW_COMPONENT = 'openshift-golang-builder-container'
 
 BUG_LOOKUP_CHUNK_SIZE = 100
 BUG_ATTACH_CHUNK_SIZE = 100

--- a/elliott/elliottlib/constants.py
+++ b/elliott/elliottlib/constants.py
@@ -25,6 +25,11 @@ BUG_SEVERITY_NUMBER_MAP = {
 GOLANG_BUILDER_CVE_COMPONENT = 'openshift4/openshift-golang-builder'
 GOLANG_BUILDER_BREW_COMPONENT = 'openshift-golang-builder-container'
 
+
+def is_golang_builder_component(component: str) -> bool:
+    """Accept both old (Brew) and new (JIRA) pscomponent names during migration."""
+    return component in (GOLANG_BUILDER_CVE_COMPONENT, GOLANG_BUILDER_BREW_COMPONENT)
+
 BUG_LOOKUP_CHUNK_SIZE = 100
 BUG_ATTACH_CHUNK_SIZE = 100
 

--- a/elliott/elliottlib/constants.py
+++ b/elliott/elliottlib/constants.py
@@ -22,13 +22,17 @@ BUG_SEVERITY_NUMBER_MAP = {
 }
 
 # Golang builder needs special treatment when associating security tracking bugs with builds:
-GOLANG_BUILDER_CVE_COMPONENT = 'openshift4/openshift-golang-builder'
-GOLANG_BUILDER_BREW_COMPONENT = 'openshift-golang-builder-container'
+GOLANG_BUILDER_COMPONENT = 'openshift-golang-builder-container'
+GOLANG_BUILDER_OCP4_DELIVERY_REPO = 'openshift4/openshift-golang-builder'
+
+
+def is_golang_builder_delivery_repo(name: str) -> bool:
+    return name in (GOLANG_BUILDER_OCP4_DELIVERY_REPO,)
 
 
 def is_golang_builder_component(component: str) -> bool:
-    """Accept both old (Brew) and new (JIRA) pscomponent names during migration."""
-    return component in (GOLANG_BUILDER_CVE_COMPONENT, GOLANG_BUILDER_BREW_COMPONENT)
+    """Accept both component name and delivery repo names during migration."""
+    return component == GOLANG_BUILDER_COMPONENT or is_golang_builder_delivery_repo(component)
 
 
 BUG_LOOKUP_CHUNK_SIZE = 100

--- a/elliott/elliottlib/constants.py
+++ b/elliott/elliottlib/constants.py
@@ -30,6 +30,7 @@ def is_golang_builder_component(component: str) -> bool:
     """Accept both old (Brew) and new (JIRA) pscomponent names during migration."""
     return component in (GOLANG_BUILDER_CVE_COMPONENT, GOLANG_BUILDER_BREW_COMPONENT)
 
+
 BUG_LOOKUP_CHUNK_SIZE = 100
 BUG_ATTACH_CHUNK_SIZE = 100
 

--- a/elliott/elliottlib/errata_async.py
+++ b/elliott/elliottlib/errata_async.py
@@ -380,13 +380,13 @@ class AsyncErrataUtils:
 
         # separate out golang CVEs and non-golang CVEs
         # expected_brew_components contain non-golang CVEs components for regular analysis
-        # All golang CVEs will have component as constants.GOLANG_BUILDER_CVE_COMPONENT
+        # All golang CVEs will have component as constants.GOLANG_BUILDER_OCP4_DELIVERY_REPO
         # which we do not attach to our advisories since it's a builder image
         # It requires special treatment
         expected_brew_components = set()
         golang_cve_names = set()
         for cve_name, components in expected_cve_components.items():
-            if constants.GOLANG_BUILDER_CVE_COMPONENT not in components:
+            if constants.GOLANG_BUILDER_OCP4_DELIVERY_REPO not in components:
                 expected_brew_components.update(components)
             else:
                 golang_cve_names.add(cve_name)
@@ -417,10 +417,10 @@ class AsyncErrataUtils:
             builder_nvr = parse_nvr(builder_nvr_string)
 
             # Make sure they are go builder nvrs (this should never happen)
-            if builder_nvr['name'] != constants.GOLANG_BUILDER_BREW_COMPONENT:
+            if builder_nvr['name'] != constants.GOLANG_BUILDER_COMPONENT:
                 raise ValueError(
                     f"Unexpected `name` value for nvr {builder_nvr}. Expected "
-                    f"{constants.GOLANG_BUILDER_BREW_COMPONENT}. Please investigate."
+                    f"{constants.GOLANG_BUILDER_COMPONENT}. Please investigate."
                 )
 
             if 'etcd' in list(go_nvr_map[builder_nvr_string])[0]:

--- a/elliott/elliottlib/errata_async.py
+++ b/elliott/elliottlib/errata_async.py
@@ -417,10 +417,10 @@ class AsyncErrataUtils:
             builder_nvr = parse_nvr(builder_nvr_string)
 
             # Make sure they are go builder nvrs (this should never happen)
-            if builder_nvr['name'] != constants.GOLANG_BUILDER_CVE_COMPONENT:
+            if builder_nvr['name'] != constants.GOLANG_BUILDER_BREW_COMPONENT:
                 raise ValueError(
                     f"Unexpected `name` value for nvr {builder_nvr}. Expected "
-                    f"{constants.GOLANG_BUILDER_CVE_COMPONENT}. Please investigate."
+                    f"{constants.GOLANG_BUILDER_BREW_COMPONENT}. Please investigate."
                 )
 
             if 'etcd' in list(go_nvr_map[builder_nvr_string])[0]:

--- a/elliott/elliottlib/errata_async.py
+++ b/elliott/elliottlib/errata_async.py
@@ -380,16 +380,16 @@ class AsyncErrataUtils:
 
         # separate out golang CVEs and non-golang CVEs
         # expected_brew_components contain non-golang CVEs components for regular analysis
-        # All golang CVEs will have component as constants.GOLANG_BUILDER_OCP4_DELIVERY_REPO
+        # Golang CVEs have a builder component (delivery repo or legacy name)
         # which we do not attach to our advisories since it's a builder image
         # It requires special treatment
         expected_brew_components = set()
         golang_cve_names = set()
         for cve_name, components in expected_cve_components.items():
-            if constants.GOLANG_BUILDER_OCP4_DELIVERY_REPO not in components:
-                expected_brew_components.update(components)
-            else:
+            if any(constants.is_golang_builder_component(c) for c in components):
                 golang_cve_names.add(cve_name)
+            else:
+                expected_brew_components.update(components)
 
         missing_brew_components = expected_brew_components - attached_brew_components
         if missing_brew_components:

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -488,7 +488,7 @@ def get_golang_container_nvrs_brew(nvrs: List[Tuple[str, str, str]], logger, exa
             logger.error(f'Error parsing {build}')
             raise
         name = nvr[0]
-        if name == 'openshift-golang-builder-container' or 'go-toolset' in name:
+        if name == constants.GOLANG_BUILDER_BREW_COMPONENT or 'go-toolset' in name:
             go_version = get_parent_golang_from_brew(nvr)
             if not go_version:
                 raise ValueError(f'Could not find go version for golang builder {nvr}')
@@ -591,7 +591,7 @@ def get_golang_container_nvrs_for_konflux_record(
             # NVRs never contain '/', so we can distinguish them from pullspecs.
             if '/' not in p:
                 # This is an NVR - look for golang builder (e.g. openshift-golang-builder-container-v1.24.4-...)
-                if p.startswith(f'{constants.GOLANG_BUILDER_CVE_COMPONENT}-'):
+                if p.startswith(f'{constants.GOLANG_BUILDER_BREW_COMPONENT}-'):
                     go_version = p
                     break
             else:
@@ -602,7 +602,7 @@ def get_golang_container_nvrs_for_konflux_record(
                     break
                 elif spec.startswith('art-images:golang-builder-'):
                     go_version = spec.replace(
-                        'art-images:golang-builder-', f'{constants.GOLANG_BUILDER_CVE_COMPONENT}-'
+                        'art-images:golang-builder-', f'{constants.GOLANG_BUILDER_BREW_COMPONENT}-'
                     )
                     break
 

--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -488,7 +488,7 @@ def get_golang_container_nvrs_brew(nvrs: List[Tuple[str, str, str]], logger, exa
             logger.error(f'Error parsing {build}')
             raise
         name = nvr[0]
-        if name == constants.GOLANG_BUILDER_BREW_COMPONENT or 'go-toolset' in name:
+        if name == constants.GOLANG_BUILDER_COMPONENT or 'go-toolset' in name:
             go_version = get_parent_golang_from_brew(nvr)
             if not go_version:
                 raise ValueError(f'Could not find go version for golang builder {nvr}')
@@ -591,7 +591,7 @@ def get_golang_container_nvrs_for_konflux_record(
             # NVRs never contain '/', so we can distinguish them from pullspecs.
             if '/' not in p:
                 # This is an NVR - look for golang builder (e.g. openshift-golang-builder-container-v1.24.4-...)
-                if p.startswith(f'{constants.GOLANG_BUILDER_BREW_COMPONENT}-'):
+                if p.startswith(f'{constants.GOLANG_BUILDER_COMPONENT}-'):
                     go_version = p
                     break
             else:
@@ -601,9 +601,7 @@ def get_golang_container_nvrs_for_konflux_record(
                     go_version = spec.replace(':', '-container-')
                     break
                 elif spec.startswith('art-images:golang-builder-'):
-                    go_version = spec.replace(
-                        'art-images:golang-builder-', f'{constants.GOLANG_BUILDER_BREW_COMPONENT}-'
-                    )
+                    go_version = spec.replace('art-images:golang-builder-', f'{constants.GOLANG_BUILDER_COMPONENT}-')
                     break
 
         if not go_version:

--- a/elliott/tests/test_bzutil.py
+++ b/elliott/tests/test_bzutil.py
@@ -740,36 +740,36 @@ class TestJIRABug(unittest.TestCase):
             flexmock(
                 key=1,
                 fields=flexmock(
-                    labels=["pscomponent:openshift-golang-builder-container/openshift-golang-builder-container"],
+                    labels=["pscomponent:some-component/some-component"],
                     issuetype=flexmock(name="Bug"),
                 ),
             )
         )
-        self.assertEqual(bug.whiteboard_component, "openshift-golang-builder-container")
+        self.assertEqual(bug.whiteboard_component, "some-component")
 
         # Non-duplicated component with slash should be left alone
         bug = JIRABug(
             flexmock(
                 key=2,
                 fields=flexmock(
-                    labels=["pscomponent:openshift4/ose-cli"],
+                    labels=["pscomponent:openshift4/openshift-golang-builder"],
                     issuetype=flexmock(name="Bug"),
                 ),
             )
         )
-        self.assertEqual(bug.whiteboard_component, "openshift4/ose-cli")
+        self.assertEqual(bug.whiteboard_component, "openshift4/openshift-golang-builder")
 
         # Component without slash should be unaffected
         bug = JIRABug(
             flexmock(
                 key=3,
                 fields=flexmock(
-                    labels=["pscomponent:openshift-golang-builder-container"],
+                    labels=["pscomponent:openshift-clients"],
                     issuetype=flexmock(name="Bug"),
                 ),
             )
         )
-        self.assertEqual(bug.whiteboard_component, "openshift-golang-builder-container")
+        self.assertEqual(bug.whiteboard_component, "openshift-clients")
 
 
 class TestBugzillaBug(unittest.TestCase):

--- a/elliott/tests/test_bzutil.py
+++ b/elliott/tests/test_bzutil.py
@@ -1344,6 +1344,91 @@ class TestBZUtil(unittest.IsolatedAsyncioTestCase):
         actual = bzutil.is_first_fix_any(mock_runtime, flaw_bug, tracker_bugs)
         self.assertEqual(expected, actual)
 
+    def test_is_first_fix_normalizes_delivery_repo_tracker(self):
+        """When tracker has delivery-repo pscomponent (openshift4/foo) and Hydra
+        returns the same name resolved to its Brew component, normalization
+        should make them match."""
+        mock_runtime = flexmock()
+        mock_runtime.should_receive("get_major_minor").and_return((4, 17))
+
+        mock_meta = flexmock()
+        mock_config = flexmock()
+        mock_delivery = flexmock()
+        mock_delivery.delivery_repo_names = ["openshift4/ose-cli"]
+        mock_config.delivery = mock_delivery
+        mock_meta.config = mock_config
+        mock_meta.should_receive("get_component_name").and_return("ose-cli-container")
+
+        mock_runtime.should_receive("image_metas").and_return([mock_meta])
+
+        hydra_data = {
+            "package_state": [
+                {
+                    "product_name": "Red Hat OpenShift Container Platform 4",
+                    "fix_state": "Affected",
+                    "package_name": "openshift4/ose-cli",
+                },
+            ],
+        }
+        flexmock(requests).should_receive("get").and_return(
+            flexmock(json=lambda: hydra_data, raise_for_status=lambda: None)
+        )
+
+        flaw_bug = BugzillaBug(flexmock(id=1, alias=["CVE-2024-999"]))
+        tracker_bugs = [flexmock(id=2, whiteboard_component="openshift4/ose-cli")]
+        actual = bzutil.is_first_fix_any(mock_runtime, flaw_bug, tracker_bugs)
+        self.assertTrue(actual)
+
+    def test_is_first_fix_fallback_when_delivery_repo_unresolved(self):
+        """When Hydra returns a delivery-repo name that can't be translated,
+        the raw name should be kept in unfixed_components so trackers using
+        that same delivery-repo pscomponent still match."""
+        mock_runtime = flexmock()
+        mock_runtime.should_receive("get_major_minor").and_return((4, 17))
+
+        # Provide a dummy image meta that does NOT match the golang builder,
+        # so get_component_by_delivery_repo returns None instead of raising.
+        dummy_meta = flexmock()
+        dummy_config = flexmock()
+        dummy_delivery = flexmock()
+        dummy_delivery.delivery_repo_names = ["openshift4/unrelated-image"]
+        dummy_config.delivery = dummy_delivery
+        dummy_meta.config = dummy_config
+        dummy_meta.should_receive("get_component_name").and_return("unrelated-container")
+        mock_runtime.should_receive("image_metas").and_return([dummy_meta])
+
+        hydra_data = {
+            "package_state": [
+                {
+                    "product_name": "Red Hat OpenShift Container Platform 4",
+                    "fix_state": "Affected",
+                    "package_name": "openshift4/openshift-golang-builder",
+                },
+            ],
+        }
+        flexmock(requests).should_receive("get").and_return(
+            flexmock(json=lambda: hydra_data, raise_for_status=lambda: None)
+        )
+
+        flaw_bug = BugzillaBug(flexmock(id=1, alias=["CVE-2024-888"]))
+        tracker_bugs = [flexmock(id=2, whiteboard_component="openshift4/openshift-golang-builder")]
+        actual = bzutil.is_first_fix_any(mock_runtime, flaw_bug, tracker_bugs)
+        self.assertTrue(actual)
+
+
+class TestIsGolangBuilderComponent(unittest.TestCase):
+    def test_matches_cve_component(self):
+        self.assertTrue(constants.is_golang_builder_component(constants.GOLANG_BUILDER_CVE_COMPONENT))
+
+    def test_matches_brew_component(self):
+        self.assertTrue(constants.is_golang_builder_component(constants.GOLANG_BUILDER_BREW_COMPONENT))
+
+    def test_rejects_unrelated(self):
+        self.assertFalse(constants.is_golang_builder_component("some-other-container"))
+
+    def test_rejects_empty(self):
+        self.assertFalse(constants.is_golang_builder_component(""))
+
 
 class TestSearchFilter(unittest.TestCase):
     def test_search_filter(self):

--- a/elliott/tests/test_bzutil.py
+++ b/elliott/tests/test_bzutil.py
@@ -1418,10 +1418,10 @@ class TestBZUtil(unittest.IsolatedAsyncioTestCase):
 
 class TestIsGolangBuilderComponent(unittest.TestCase):
     def test_matches_cve_component(self):
-        self.assertTrue(constants.is_golang_builder_component(constants.GOLANG_BUILDER_CVE_COMPONENT))
+        self.assertTrue(constants.is_golang_builder_component(constants.GOLANG_BUILDER_OCP4_DELIVERY_REPO))
 
     def test_matches_brew_component(self):
-        self.assertTrue(constants.is_golang_builder_component(constants.GOLANG_BUILDER_BREW_COMPONENT))
+        self.assertTrue(constants.is_golang_builder_component(constants.GOLANG_BUILDER_COMPONENT))
 
     def test_rejects_unrelated(self):
         self.assertFalse(constants.is_golang_builder_component("some-other-container"))

--- a/elliott/tests/test_errata_async.py
+++ b/elliott/tests/test_errata_async.py
@@ -162,7 +162,7 @@ class TestAsyncErrataUtils(IsolatedAsyncioTestCase):
         expected_cve_components = {
             "CVE-2099-1": {"a", "b"},
             "CVE-2099-2": {"c"},
-            "CVE-2099-3": {constants.GOLANG_BUILDER_CVE_COMPONENT},
+            "CVE-2099-3": {constants.GOLANG_BUILDER_OCP4_DELIVERY_REPO},
         }
         attached_builds = ["a-1.0.0-1.el8", "a-1.0.0-1.el9", "b-1.0.0-1.el9", "c-1.0.0-1.el8", "d-1.0.0-1.el8"]
         builder_el8 = 'openshift-golang-builder-container-v1.18.0-202204191948.sha1patch.el8.g4d4caca'
@@ -190,7 +190,7 @@ class TestAsyncErrataUtils(IsolatedAsyncioTestCase):
         cve_components = {
             "CVE-2099-1": {"a", "b"},
             "CVE-2099-2": {"c"},
-            "CVE-2099-3": {constants.GOLANG_BUILDER_CVE_COMPONENT},
+            "CVE-2099-3": {constants.GOLANG_BUILDER_OCP4_DELIVERY_REPO},
         }
         attached_builds = ["a-1.0.0-1.el8", "a-1.0.0-1.el7", "b-1.0.0-1.el8", "c-1.0.0-1.el8", "d-1.0.0-1.el8"]
         populate_golang_cve.return_value = {

--- a/elliott/tests/test_find_bugs_golang_cli.py
+++ b/elliott/tests/test_find_bugs_golang_cli.py
@@ -28,7 +28,7 @@ def _make_cli(**overrides):
     return FindBugsGolangCli(**defaults)
 
 
-def _make_bug(bug_id="OCPBUGS-99999", component=constants.GOLANG_BUILDER_CVE_COMPONENT):
+def _make_bug(bug_id="OCPBUGS-99999", component=constants.GOLANG_BUILDER_OCP4_DELIVERY_REPO):
     bug = MagicMock()
     bug.id = bug_id
     bug.whiteboard_component = component
@@ -103,7 +103,7 @@ class TestIsFixed(TestCase):
     def test_builder_container_10pct_threshold(self, mock_get_golang, mock_errata):
         mock_get_golang.return_value = {"golang-1.22.12-11.el9": []}
         cli = _make_cli()
-        bug = _make_bug(component=constants.GOLANG_BUILDER_CVE_COMPONENT)
+        bug = _make_bug(component=constants.GOLANG_BUILDER_OCP4_DELIVERY_REPO)
         tracker_fixed_in = {Version.parse("1.22.12-11"), Version.parse("1.22.12-13")}
         go_nvr_map = {
             "golang-1.22.12-11.el9": [("img", "1.0", "1.el9")] * 173,

--- a/elliott/tests/test_find_bugs_golang_cli.py
+++ b/elliott/tests/test_find_bugs_golang_cli.py
@@ -28,7 +28,7 @@ def _make_cli(**overrides):
     return FindBugsGolangCli(**defaults)
 
 
-def _make_bug(bug_id="OCPBUGS-99999", component="openshift-golang-builder-container"):
+def _make_bug(bug_id="OCPBUGS-99999", component=constants.GOLANG_BUILDER_CVE_COMPONENT):
     bug = MagicMock()
     bug.id = bug_id
     bug.whiteboard_component = component

--- a/elliott/tests/test_find_bugs_sweep_cli.py
+++ b/elliott/tests/test_find_bugs_sweep_cli.py
@@ -64,7 +64,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         builder_tracker = flexmock(
             id="OCPBUGS-5",
             is_tracker_bug=lambda: True,
-            whiteboard_component=constants.GOLANG_BUILDER_CVE_COMPONENT,
+            whiteboard_component=constants.GOLANG_BUILDER_OCP4_DELIVERY_REPO,
         )
         delivery_repo_tracker = flexmock(
             id="OCPBUGS-6", is_tracker_bug=lambda: True, whiteboard_component="openshift5/payload-image-rhel9"

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -24,7 +24,7 @@ from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import new_roundtrip_yaml_handler
 from doozerlib.constants import ART_IMAGES_BASE_APPLICATION
 from elliottlib import util as elliottutil
-from elliottlib.constants import GOLANG_BUILDER_CVE_COMPONENT
+from elliottlib.constants import GOLANG_BUILDER_BREW_COMPONENT, GOLANG_BUILDER_CVE_COMPONENT
 
 from pyartcd import constants, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
@@ -532,7 +532,7 @@ class UpdateGolangPipeline:
             await self._slack_client.say_in_thread(f"Tagged {build} with {build_tag} tag")
 
     def get_existing_builders_brew(self, el_nvr_map, go_version):
-        component = GOLANG_BUILDER_CVE_COMPONENT
+        component = GOLANG_BUILDER_BREW_COMPONENT
         _LOGGER.info(f"Checking if {component} builds exist in Brew for given golang builds")
         package_info = self.koji_session.getPackage(component)
         if not package_info:
@@ -574,7 +574,7 @@ class UpdateGolangPipeline:
         _LOGGER.info(f"Checking if {GOLANG_BUILDER_IMAGE_NAME} builds exist in Konflux for given golang builds")
 
         builder_records: dict[int, KonfluxBuildRecord] = {}
-        extra_patterns = {'nvr': f"{GOLANG_BUILDER_CVE_COMPONENT}-v{go_version}"}
+        extra_patterns = {'nvr': f"{GOLANG_BUILDER_BREW_COMPONENT}-v{go_version}"}
         build_records = await asyncio.gather(
             *(
                 anext(
@@ -624,8 +624,8 @@ class UpdateGolangPipeline:
         parsed_nvr = parse_nvr(builder_nvr)
         component_name = parsed_nvr["name"]
         if component_name == GOLANG_BUILDER_IMAGE_NAME:
-            component_name = GOLANG_BUILDER_CVE_COMPONENT
-        elif component_name != GOLANG_BUILDER_CVE_COMPONENT:
+            component_name = GOLANG_BUILDER_BREW_COMPONENT
+        elif component_name != GOLANG_BUILDER_BREW_COMPONENT:
             raise ValueError(f"Expected a golang builder image NVR, got: {builder_nvr}")
         published_nvr = f'{component_name}-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
         return f'{PUBLISHED_GOLANG_BUILDER_REPO}:{published_nvr}'

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -24,7 +24,7 @@ from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import new_roundtrip_yaml_handler
 from doozerlib.constants import ART_IMAGES_BASE_APPLICATION
 from elliottlib import util as elliottutil
-from elliottlib.constants import GOLANG_BUILDER_BREW_COMPONENT, GOLANG_BUILDER_CVE_COMPONENT
+from elliottlib.constants import GOLANG_BUILDER_COMPONENT, GOLANG_BUILDER_OCP4_DELIVERY_REPO
 
 from pyartcd import constants, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
@@ -470,7 +470,7 @@ class UpdateGolangPipeline:
             ocp_version=self.ocp_version,
             cves=self.cves,
             nvrs=self.go_nvrs if self.cves else None,
-            components=[GOLANG_BUILDER_CVE_COMPONENT],
+            components=[GOLANG_BUILDER_OCP4_DELIVERY_REPO],
             force_update_tracker=self.force_update_tracker,
             dry_run=self.dry_run,
         )
@@ -532,7 +532,7 @@ class UpdateGolangPipeline:
             await self._slack_client.say_in_thread(f"Tagged {build} with {build_tag} tag")
 
     def get_existing_builders_brew(self, el_nvr_map, go_version):
-        component = GOLANG_BUILDER_BREW_COMPONENT
+        component = GOLANG_BUILDER_COMPONENT
         _LOGGER.info(f"Checking if {component} builds exist in Brew for given golang builds")
         package_info = self.koji_session.getPackage(component)
         if not package_info:
@@ -574,7 +574,7 @@ class UpdateGolangPipeline:
         _LOGGER.info(f"Checking if {GOLANG_BUILDER_IMAGE_NAME} builds exist in Konflux for given golang builds")
 
         builder_records: dict[int, KonfluxBuildRecord] = {}
-        extra_patterns = {'nvr': f"{GOLANG_BUILDER_BREW_COMPONENT}-v{go_version}"}
+        extra_patterns = {'nvr': f"{GOLANG_BUILDER_COMPONENT}-v{go_version}"}
         build_records = await asyncio.gather(
             *(
                 anext(
@@ -624,8 +624,8 @@ class UpdateGolangPipeline:
         parsed_nvr = parse_nvr(builder_nvr)
         component_name = parsed_nvr["name"]
         if component_name == GOLANG_BUILDER_IMAGE_NAME:
-            component_name = GOLANG_BUILDER_BREW_COMPONENT
-        elif component_name != GOLANG_BUILDER_BREW_COMPONENT:
+            component_name = GOLANG_BUILDER_COMPONENT
+        elif component_name != GOLANG_BUILDER_COMPONENT:
             raise ValueError(f"Expected a golang builder image NVR, got: {builder_nvr}")
         published_nvr = f'{component_name}-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
         return f'{PUBLISHED_GOLANG_BUILDER_REPO}:{published_nvr}'

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -225,7 +225,7 @@ class TestMoveGolangBugs(IsolatedAsyncioTestCase):
             ocp_version="4.16",
             cves=["CVE-2024-1234", "CVE-2024-5678"],
             nvrs=["golang-1.20.12-2.el8"],
-            components=["openshift-golang-builder-container"],
+            components=["openshift4/openshift-golang-builder"],
             force_update_tracker=False,
             dry_run=False,
         )
@@ -246,7 +246,7 @@ class TestMoveGolangBugs(IsolatedAsyncioTestCase):
             "--fixed-in-nvr",
             "golang-1.20.12-2.el8",
             "--component",
-            "openshift-golang-builder-container",
+            "openshift4/openshift-golang-builder",
         ]
         mock_cmd_assert.assert_called_once_with(expected_cmd, log_stdout=True)
 


### PR DESCRIPTION
## Summary
- Update `GOLANG_BUILDER_CVE_COMPONENT` from `openshift-golang-builder-container` to `openshift4/openshift-golang-builder` to match the new JIRA pscomponent name for golang builder security trackers.
- Introduce `GOLANG_BUILDER_BREW_COMPONENT` (`openshift-golang-builder-container`) to preserve the Brew/Konflux package name which remains unchanged.
- Fix filtering logic in `attach_cve_flaws_cli` and `find_bugs_sweep_cli` to correctly handle the new `openshift4/` prefix format.
- Add `is_golang_builder_component()` helper that accepts both old and new pscomponent names for backward compatibility during migration.
- Fix `is_first_fix_for_tracker` / `is_first_fix_any` to normalize tracker `whiteboard_component` before comparing against Hydra unfixed components, preventing mismatches when the tracker uses a delivery-repo-format pscomponent.
- Add fallback in `get_cve_unfixed_components` to preserve raw delivery-repo names when translation fails.
- Extend `is_valid()` filter in `find_bugs_golang_cli` to also skip delivery-repo-format image trackers (`openshift4/...`), not just `-container` suffixed ones, while preserving the golang builder exemption.

## Test plan
- [x] All existing unit tests pass (71/71 in affected test files)
- [x] New tests for `is_golang_builder_component()` helper (4 cases)
- [x] New tests for `is_first_fix` normalization and fallback (2 cases)
- [x] Lint and format checks pass (`ruff check` clean)
- [ ] Verify golang bug sweep works correctly with new pscomponent in a dry-run against a stream assembly
- [ ] Verify `update-golang` pipeline correctly sweeps builder bugs with the new component name


Made with [Cursor](https://cursor.com)