### PR TITLE
fix: add --base-image-release CLI override for open network mode

### DIFF
--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -412,6 +412,11 @@ class KonfluxBuildCli:
     is_flag=True,
     help='Skip enterprise-contract verification after builds.',
 )
+@click.option(
+    '--base-image-release/--no-base-image-release',
+    default=None,
+    help='Override base image release trigger. Takes precedence over image and group config settings.',
+)
 @pass_runtime
 @click_coroutine
 async def images_konflux_build(
@@ -427,9 +432,12 @@ async def images_konflux_build(
     build_priority: Optional[str],
     network_mode: Optional[str],
     skip_ec_verify: bool,
+    base_image_release: Optional[bool],
 ):
     if network_mode:
         runtime.network_mode_override = network_mode
+    if base_image_release is not None:
+        runtime.base_image_release_override = base_image_release
 
     cli = KonfluxBuildCli(
         runtime=runtime,

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1412,6 +1412,11 @@ class ImageMetadata(Metadata):
         if self.runtime.variant is BuildVariant.OKD:
             return False
 
+        base_image_release_override = getattr(self.runtime, "base_image_release_override", None)
+        if base_image_release_override is not None:
+            self.logger.info(f"Base image release override from CLI: {base_image_release_override}")
+            return base_image_release_override
+
         base_image_release_force_override = self.config.base_image_release.force
         if base_image_release_force_override not in [Missing, None] and bool(base_image_release_force_override):
             self.logger.info("Base image release force enabled from metadata config True")

--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -161,6 +161,7 @@ class Runtime(GroupRuntime):
             self.variant = BuildVariant(self.variant.lower())
 
         self.network_mode_override = None
+        self.base_image_release_override = None
 
         if self.latest_parent_version:
             self.ignore_missing_base = True

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1784,6 +1784,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         runtime.assembly = 'stream'
         runtime.product = 'ocp'
         runtime.group_config = Model({})
+        runtime.base_image_release_override = None
 
         # Test base image - should trigger workflow
         base_image = Model({'name': 'test-base', 'base_only': True})
@@ -1804,6 +1805,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         test_assembly_runtime.assembly = 'test'
         test_assembly_runtime.product = 'ocp'
         test_assembly_runtime.group_config = Model({})
+        test_assembly_runtime.base_image_release_override = None
         self.assertFalse(ImageMetadata(test_assembly_runtime, base_data).should_trigger_base_image_release())
         self.assertFalse(ImageMetadata(test_assembly_runtime, golang_data).should_trigger_base_image_release())
 
@@ -1814,6 +1816,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         named_runtime.assembly = '4.17.1'
         named_runtime.product = 'ocp'
         named_runtime.group_config = Model({})
+        named_runtime.base_image_release_override = None
         self.assertTrue(ImageMetadata(named_runtime, base_data).should_trigger_base_image_release())
         self.assertTrue(ImageMetadata(named_runtime, golang_data).should_trigger_base_image_release())
 
@@ -1870,6 +1873,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         runtime_group_off.assembly = 'stream'
         runtime_group_off.product = 'ocp'
         runtime_group_off.group_config = Model({'base_image_release': Model({'enabled': False})})
+        runtime_group_off.base_image_release_override = None
         group_off_base = Model({'name': 'g-off-base', 'base_only': True})
         group_off_data = Model({'key': 'g-off-base', 'data': group_off_base, 'filename': 'g-off-base.yaml'})
         group_off_metadata = ImageMetadata(runtime_group_off, group_off_data)
@@ -1882,6 +1886,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         runtime_both.assembly = 'stream'
         runtime_both.product = 'ocp'
         runtime_both.group_config = Model({'base_image_release': Model({'enabled': False})})
+        runtime_both.base_image_release_override = None
         base_override = Model(
             {
                 'name': 'override-base',
@@ -1900,6 +1905,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         layered_runtime.assembly = 'stream'
         layered_runtime.product = 'rhmtc'
         layered_runtime.group_config = Model({})
+        layered_runtime.base_image_release_override = None
         self.assertTrue(ImageMetadata(layered_runtime, base_data).should_trigger_base_image_release())
         self.assertTrue(ImageMetadata(layered_runtime, golang_data).should_trigger_base_image_release())
 
@@ -1929,12 +1935,34 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         test_assembly_forced_runtime.assembly = 'test'
         test_assembly_forced_runtime.product = 'ocp'
         test_assembly_forced_runtime.group_config = Model({})
+        test_assembly_forced_runtime.base_image_release_override = None
         test_assembly_forced = Model({'name': 'test-regular', 'base_image_release': Model({'force': True})})
         test_assembly_forced_metadata = ImageMetadata(
             test_assembly_forced_runtime,
             Model({'key': 'test-assembly-forced', 'data': test_assembly_forced, 'filename': 'taf.yaml'}),
         )
         self.assertTrue(test_assembly_forced_metadata.should_trigger_base_image_release())
+
+        # CLI override: base_image_release_override=False disables for base images
+        override_off_runtime = MagicMock()
+        override_off_runtime.logger = logging.getLogger('test_runtime')
+        override_off_runtime.variant = BuildVariant.OCP
+        override_off_runtime.assembly = 'stream'
+        override_off_runtime.product = 'ocp'
+        override_off_runtime.group_config = Model({})
+        override_off_runtime.base_image_release_override = False
+        self.assertFalse(ImageMetadata(override_off_runtime, base_data).should_trigger_base_image_release())
+        self.assertFalse(ImageMetadata(override_off_runtime, golang_data).should_trigger_base_image_release())
+
+        # CLI override: base_image_release_override=True enables even when group config disables
+        override_on_runtime = MagicMock()
+        override_on_runtime.logger = logging.getLogger('test_runtime')
+        override_on_runtime.variant = BuildVariant.OCP
+        override_on_runtime.assembly = 'stream'
+        override_on_runtime.product = 'ocp'
+        override_on_runtime.group_config = Model({'base_image_release': Model({'enabled': False})})
+        override_on_runtime.base_image_release_override = True
+        self.assertTrue(ImageMetadata(override_on_runtime, base_data).should_trigger_base_image_release())
 
     def test_base_image_release_quay_fallback_image_overrides_group(self):
         from artcommonlib.model import Model

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -932,6 +932,9 @@ class UpdateGolangPipeline:
             cmd.extend(['--konflux-kubeconfig', self.kubeconfig])
         if self.network_mode:
             cmd.extend(["--network-mode", self.network_mode])
+            if self.network_mode == "open":
+                # Base image release currently requires hermetic builds; this may change in the future
+                cmd.append("--no-base-image-release")
         if self.dry_run:
             cmd.append("--dry-run")
         await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars, log_stdout=True)


### PR DESCRIPTION
## Summary
- Adds `--base-image-release/--no-base-image-release` CLI flag to doozer's `beta:images:konflux:build` command, following the same pattern as `--network-mode`
- Adds `base_image_release_override` to Runtime, checked in `should_trigger_base_image_release()` with highest precedence (after OKD check)
- Wires `update_golang` pipeline to pass `--no-base-image-release` when `--network-mode open` is set, since base image release currently requires hermetic builds

## Test plan
- [x] Existing `test_should_trigger_base_image_release` tests pass
- [x] New test cases verify CLI override=False disables for base/golang images
- [x] New test cases verify CLI override=True enables even when group config disables
- [x] Full test suite passes (2720 tests across all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)