### PR TITLE
fix: use registry proxy for digest resolution in lockfile generator

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/container_utils.py
+++ b/doozer/doozerlib/lockfile_prototype/container_utils.py
@@ -43,8 +43,9 @@ class ContainerImageHelper:
         if DIGEST_PREFIX in pullspec:
             return pullspec
 
+        inspect_pullspec = self._proxy_pullspec(pullspec)
         env = build_env()
-        cmd = ["skopeo", "inspect", "--no-tags", f"docker://{pullspec}"]
+        cmd = ["skopeo", "inspect", "--no-tags", f"docker://{inspect_pullspec}"]
         self.logger.debug(f"Resolving tag to digest: {pullspec}")
 
         rc, stdout, stderr = await cmd_gather_async(cmd, check=False, env=env)

--- a/doozer/tests/lockfile_prototype/test_container_utils.py
+++ b/doozer/tests/lockfile_prototype/test_container_utils.py
@@ -36,6 +36,25 @@ class TestContainerImageHelper(unittest.TestCase):
         self.assertEqual(result, "quay.io/test/img@sha256:def456")
 
     @patch("doozerlib.lockfile_prototype.container_utils.cmd_gather_async")
+    def test_resolve_to_digest_brew_registry_uses_proxy(self, mock_gather):
+        """
+        brew.registry.redhat.io pullspecs should be inspected via the registry proxy,
+        but the returned pullspec should keep the original brew.registry domain.
+        """
+        import json
+
+        async def mock_skopeo(cmd, **kwargs):
+            assert "registry-proxy.engineering.redhat.com" in cmd[-1], (
+                f"Expected proxy URL in skopeo command, got {cmd}"
+            )
+            return (0, json.dumps({"Digest": "sha256:abc123"}), "")
+
+        mock_gather.side_effect = mock_skopeo
+        helper = ContainerImageHelper()
+        result = asyncio.run(helper.resolve_to_digest("brew.registry.redhat.io/rh-osbs/ubi8:8.6-754"))
+        self.assertEqual(result, "brew.registry.redhat.io/rh-osbs/ubi8@sha256:abc123")
+
+    @patch("doozerlib.lockfile_prototype.container_utils.cmd_gather_async")
     def test_resolve_to_digest_skopeo_fails(self, mock_gather):
         """
         If skopeo fails, return the original pullspec.


### PR DESCRIPTION
## Summary
- `resolve_to_digest()` in `container_utils.py` was calling `skopeo inspect` directly on `brew.registry.redhat.io` pullspecs, which requires Customer Portal auth that may not be available
- This is the same class of bug fixed in #3042 for `extract_parent_image_nvrs`, but in a different code path (lockfile digest resolution)
- Fix: use the existing `_proxy_pullspec()` helper to convert to `registry-proxy.engineering.redhat.com` before inspecting, while preserving the original `brew.registry.redhat.io` domain in the returned pullspec

## Test plan
- [x] New test verifies skopeo is called with proxy URL and result preserves original domain
- [x] All existing tests pass
- [x] Full test suite passes (2721 tests across all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)