### PR TITLE
feat: add configurable prefetch_mode for prefetch-dependencies task

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -58,6 +58,7 @@ class ImageBuildParams:
     build_step_resources: Optional[dict[str, str]] = None
     workspace_storage: Optional[str] = None
     prefetch: Optional[list] = None
+    prefetch_mode: Optional[str] = None
     artifact_type: Optional[str] = None
     service_account: Optional[str] = None
     annotations: Optional[dict[str, str]] = None
@@ -1309,6 +1310,8 @@ class KonfluxClient:
                         _modify_param(task["params"], "PRIVILEGED_NESTED", str(build_params.privileged_nested).lower())
                 case "prefetch-dependencies":
                     _modify_param(task["params"], "sbom-type", "spdx")
+                    if build_params.prefetch_mode:
+                        _modify_param(task["params"], "mode", build_params.prefetch_mode)
                     if verbose_prefetch_enabled:
                         _modify_param(task["params"], "dev-package-managers", "true")
                         _modify_param(task["params"], "log-level", "debug")

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -771,10 +771,16 @@ class KonfluxImageBuilder:
         raw_symlink_check = _get_konflux_config(metadata, "enable_symlink_check")
         enable_symlink_check = bool(raw_symlink_check) if raw_symlink_check is not None else None
 
+        cachi2_config = _get_konflux_config(metadata, "cachi2", {})
+        prefetch_mode = (
+            str(cachi2_config.get("prefetch_mode")) if cachi2_config and cachi2_config.get("prefetch_mode") else None
+        )
+
         build_params = ImageBuildParams(
             hermetic=hermetic,
             enable_symlink_check=enable_symlink_check,
             prefetch=prefetch,
+            prefetch_mode=prefetch_mode,
             sast=sast,
             build_args=build_args,
             additional_secret=additional_secret,

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -51,6 +51,8 @@ spec:
       params:
       - name: ADDITIONAL_TAGS
         value: []
+    - name: prefetch-dependencies
+      params: []
     - name: clone-repository
       params: []
   taskRunTemplate:
@@ -993,3 +995,55 @@ class TestSkipTasks(IsolatedAsyncioTestCase):
         result = await self._build_plr(build_params=ImageBuildParams(skip_tasks=["nonexistent-task"]))
         task_names = [t["name"] for t in result["spec"]["pipelineSpec"]["tasks"]]
         self.assertEqual(len(task_names), 8)
+
+
+class TestNewPipelinerunPrefetchMode(IsolatedAsyncioTestCase):
+    """Tests for prefetch_mode in _new_pipelinerun_for_image_build."""
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_prefetch_mode_permissive_sets_mode_param(self, mock_get_template):
+        """Test that prefetch_mode='permissive' sets mode on the prefetch-dependencies task."""
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(prefetch_mode="permissive"),
+        )
+
+        tasks = result["spec"]["pipelineSpec"]["tasks"]
+        prefetch_task = next(t for t in tasks if t["name"] == "prefetch-dependencies")
+        task_param_dict = {p["name"]: p["value"] for p in prefetch_task["params"]}
+
+        self.assertEqual(task_param_dict["mode"], "permissive")
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_prefetch_mode_strict_sets_mode_param(self, mock_get_template):
+        """Test that prefetch_mode='strict' sets mode on the prefetch-dependencies task."""
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(prefetch_mode="strict"),
+        )
+
+        tasks = result["spec"]["pipelineSpec"]["tasks"]
+        prefetch_task = next(t for t in tasks if t["name"] == "prefetch-dependencies")
+        task_param_dict = {p["name"]: p["value"] for p in prefetch_task["params"]}
+
+        self.assertEqual(task_param_dict["mode"], "strict")
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
+    async def test_prefetch_mode_none_is_noop(self, mock_get_template):
+        """Test that None prefetch_mode doesn't add mode to the prefetch-dependencies task."""
+        client = _make_mock_client(mock_get_template)
+
+        result = await client._new_pipelinerun_for_image_build(
+            **_COMMON_KWARGS,
+            build_params=ImageBuildParams(prefetch_mode=None),
+        )
+
+        tasks = result["spec"]["pipelineSpec"]["tasks"]
+        prefetch_task = next(t for t in tasks if t["name"] == "prefetch-dependencies")
+        task_param_names = {p["name"] for p in prefetch_task["params"]}
+
+        self.assertNotIn("mode", task_param_names)

--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -409,6 +409,18 @@
               "$ref": "#/properties/konflux/properties/cachi2/properties/gomod_version_patch"
             },
             "gomod_version_patch-": {},
+            "prefetch_mode": {
+              "description": "Mode for the prefetch-dependencies task (e.g. 'strict', 'permissive')",
+              "type": "string",
+              "enum": ["strict", "permissive"]
+            },
+            "prefetch_mode!": {
+              "$ref": "#/properties/konflux/properties/cachi2/properties/prefetch_mode"
+            },
+            "prefetch_mode?": {
+              "$ref": "#/properties/konflux/properties/cachi2/properties/prefetch_mode"
+            },
+            "prefetch_mode-": {},
             "lockfile": {
               "type": "object",
               "properties": {
@@ -615,6 +627,14 @@
                 "enabled!": {"$ref": "#/properties/okd/properties/konflux/properties/cachi2/properties/enabled"},
                 "enabled?": {"$ref": "#/properties/okd/properties/konflux/properties/cachi2/properties/enabled"},
                 "enabled-": {},
+                "prefetch_mode": {
+                  "description": "Mode for the prefetch-dependencies task (e.g. 'strict', 'permissive')",
+                  "type": "string",
+                  "enum": ["strict", "permissive"]
+                },
+                "prefetch_mode!": {"$ref": "#/properties/okd/properties/konflux/properties/cachi2/properties/prefetch_mode"},
+                "prefetch_mode?": {"$ref": "#/properties/okd/properties/konflux/properties/cachi2/properties/prefetch_mode"},
+                "prefetch_mode-": {},
                 "lockfile": {
                   "type": "object",
                   "properties": {

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -1282,6 +1282,18 @@
               "$ref": "#/properties/konflux/properties/cachi2/properties/enabled"
             },
             "enabled-": {},
+            "prefetch_mode": {
+              "description": "Mode for the prefetch-dependencies task (e.g. 'strict', 'permissive')",
+              "type": "string",
+              "enum": ["strict", "permissive"]
+            },
+            "prefetch_mode?": {
+              "$ref": "#/properties/konflux/properties/cachi2/properties/prefetch_mode"
+            },
+            "prefetch_mode!": {
+              "$ref": "#/properties/konflux/properties/cachi2/properties/prefetch_mode"
+            },
+            "prefetch_mode-": {},
             "lockfile": {
               "type": "object",
               "properties": {


### PR DESCRIPTION
## Summary

- Adds a new `prefetch_mode` config field under `konflux.cachi2` (at both group and image level) that controls the `mode` parameter on the `prefetch-dependencies` Tekton task in PipelineRun YAMLs.
- Image-level config overrides group-level, following the existing `_get_konflux_config()` pattern.
- Supported values: `strict`, `permissive`.

## Usage

**Group-level default** (in `group.yml`):
```yaml
konflux:
  cachi2:
    prefetch_mode: permissive
```

**Per-image override** (in `images/my-image.yml`):
```yaml
konflux:
  cachi2:
    prefetch_mode: strict
```

## Changes

- **JSON schemas**: Added `prefetch_mode` to `konflux.cachi2` in both `assembly_group_config.schema.json` (including OKD mirror) and `image_config.base.schema.json`, with merge operator variants (`!`, `?`, `-`).
- **`ImageBuildParams`**: Added `prefetch_mode` field to the dataclass.
- **`konflux_image_builder.py`**: Reads `konflux.cachi2.prefetch_mode` from config and passes to `ImageBuildParams`.
- **`konflux_client.py`**: Injects `mode` param into the `prefetch-dependencies` task when `prefetch_mode` is set.
- **Tests**: 3 new tests covering permissive, strict, and None (noop) cases.

## Test plan

- [x] `make lint` passes (ruff check + format + pylint)
- [x] `uv run pytest doozer/tests/backend/test_konflux_client.py` - all 45 tests pass including 3 new prefetch_mode tests
- [x] `uv run pytest doozer/tests/backend/test_konflux_image_builder.py` - all 33 tests pass
- [x] Pre-existing pyartcd test failures (distutils on Python 3.12) are unrelated

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Users can now configure a new `prefetch_mode` setting in their Konflux image build configuration. This setting accepts `strict` or `permissive` values to control dependency prefetching behavior during the image build process. The configuration provides fine-grained control over how dependencies are resolved and cached, enabling users to optimize their build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->