### PR TITLE
fix: respect skip_nvr_check stream config in scan-sources-konflux

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -1030,14 +1030,19 @@ class ConfigScanSources:
             # Resolve builder build NVR
             if builder.image:
                 builder_image_name = builder.image
+                stream_config = None
             elif builder.stream:
-                builder_image_name = self.runtime.resolve_stream(builder.stream).image
+                stream_config = self.runtime.resolve_stream(builder.stream)
+                builder_image_name = stream_config.image
             else:
                 raise IOError(f'Unable to determine builder or parent image pullspec from {builder}')
             builder_build_nvr = await self.get_builder_build_nvr(builder_image_name)
 
             if not builder_build_nvr:
                 if builder.stream:
+                    if stream_config.get('skip_nvr_check', False):
+                        self.logger.info('Skipping NVR check for stream %s (skip_nvr_check is set)', builder.stream)
+                        continue
                     raise IOError(f'Unable to find nvr for {builder_image_name}')
                 # If it's a direct image reference, skip it (likely an external/upstream image)
                 continue


### PR DESCRIPTION
## Summary
- The `skip_nvr_check` field was defined in the streams schema but never read by `scan_sources_konflux`, causing spurious `OSError` when NVR resolution fails for streams (e.g. `rhel-coreos-base`) that don't have a corresponding Brew build
- Now checks `skip_nvr_check` on the stream config before raising, and skips the builder with an info log when set

## Test plan
- [x] Existing scan_sources tests pass (45 passed)
- [ ] Verify with a stream that has `skip_nvr_check: true` (e.g. `rhel-coreos-base`) that the error is no longer raised

🤖 Generated with [Claude Code](https://claude.com/claude-code)