### PR TITLE
fix(konflux): skip RPM extraction for scratch images in update_konflux_db

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -1010,11 +1010,17 @@ class KonfluxImageBuilder:
 
             definitive_image_pullspec = f"{image_pullspec.split(':')[0]}@{image_digest}"
 
-            # Skip RPM extraction for images that don't use RPMs (e.g. FROM scratch ISO builds).
+            # Skip RPM extraction for images that don't use RPMs (e.g. FROM scratch builds).
             # no_shell implies no /bin/sh and no RPMs installed in the image.
-            skip_rpm_extraction = metadata.config.konflux.get("no_shell", False)
+            # Also auto-skip when base image is 'scratch' (consistent with rebaser logic).
+            from_stream = metadata.config.get('from', {}).get('stream')
+            skip_rpm_extraction = metadata.config.konflux.get("no_shell", False) or from_stream == 'scratch'
             if skip_rpm_extraction:
-                logger.info("Skipping RPM extraction (no_shell=true): image does not use RPMs")
+                logger.info(
+                    "Skipping RPM extraction (no_shell=%s, from.stream=%s): image does not use RPMs",
+                    metadata.config.konflux.get("no_shell", False),
+                    from_stream,
+                )
                 package_nvrs: set = set()
                 source_rpms: set = set()
             else:

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -302,6 +302,73 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(build_record.installed_rpms, [])
         self.assertEqual(build_record.image_pullspec, "quay.io/test/image@sha256:testdigest")
 
+    async def test_update_konflux_db_skips_rpm_extraction_for_scratch_image(self):
+        """RPM extraction is auto-skipped when from.stream is 'scratch', even without explicit no_shell."""
+        metadata = self._metadata()
+        metadata.config.konflux.get.return_value = False  # no_shell not explicitly set
+        metadata.config.get.return_value = {'stream': 'scratch'}  # from.stream == 'scratch'
+        build_repo = MagicMock()
+        build_repo.https_url = "https://example.com/repo.git"
+        build_repo.commit_hash = "test-commit-hash"
+        build_repo.local_dir = Path(self.temp_dir.name)
+
+        pipelinerun = PipelineRunInfo(
+            {
+                "metadata": {
+                    "name": "test-pipelinerun",
+                    "uid": "test-uid",
+                    "labels": {"appstudio.openshift.io/component": "test-component"},
+                },
+                "status": {
+                    "results": [
+                        {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                        {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                    ],
+                    "startTime": "2023-10-01T12:00:00Z",
+                    "completionTime": "2023-10-01T12:30:00Z",
+                },
+            },
+            {},
+        )
+
+        with (
+            patch("doozerlib.backend.konflux_image_builder.DockerfileParser") as mock_dockerfile_parser,
+            patch.object(self.builder, "extract_parent_image_nvrs", new=AsyncMock(return_value=[])),
+            patch.object(
+                self.builder,
+                "get_installed_packages",
+                new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
+            ) as mock_get_installed_packages,
+            patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
+        ):
+            mock_dockerfile = MagicMock()
+            mock_dockerfile.labels = {
+                "io.openshift.build.source-location": "https://example.com/source-repo.git",
+                "io.openshift.build.commit.id": "source-commit-id",
+                "com.redhat.component": "test-component",
+                "version": "1.0",
+                "release": "1.el9",
+            }
+            mock_dockerfile.parent_images = []
+            mock_dockerfile_parser.return_value = mock_dockerfile
+            mock_bigquery_client.return_value.client.insert_rows_json.return_value = None
+
+            await self.builder.update_konflux_db(
+                metadata,
+                build_repo,
+                pipelinerun,
+                KonfluxBuildOutcome.SUCCESS,
+                ["x86_64"],
+                "5",
+            )
+
+        mock_get_installed_packages.assert_not_awaited()
+        add_build_call = metadata.runtime.konflux_db.add_build
+        add_build_call.assert_called_once()
+        build_record = add_build_call.call_args[0][0]
+        self.assertEqual(build_record.installed_packages, [])
+        self.assertEqual(build_record.installed_rpms, [])
+
     async def test_update_konflux_db_strips_rhel_minor_version_from_el_target(self):
         """el_target should be 'el9' even when the release contains a minor version suffix like 'el9_6'."""
         metadata = self._metadata()


### PR DESCRIPTION
## Summary

- Aligns `update_konflux_db` with the rebaser by auto-detecting `from.stream: scratch` and skipping RPM extraction
- Fixes `ChildProcessError: Could not get rpms from SBOM for arch x86_64` for scratch-based images like `agentic-skills`

## Root Cause

The rebaser (`rebaser.py:1477`) already auto-detects scratch:
```python
no_shell = metadata.config.konflux.get("no_shell", False) or from_stream == 'scratch'
```

But `update_konflux_db` only checked the explicit config flag:
```python
skip_rpm_extraction = metadata.config.konflux.get("no_shell", False)
```

So scratch images without explicit `konflux.no_shell: true` in ocp-build-data would fail when trying to extract RPMs from a SBOM that has none.

Fixes job [failure](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/37467/consoleFull)
```
22:55:11    File "/mnt/jenkins-workspace/aos-cd-builds_build_ocp4-konflux@7/art-tools/doozer/doozerlib/backend/konflux_image_builder.py", line 401, in build
22:55:11      build_record = await self.update_konflux_db(
22:55:11                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
22:55:11    File "/mnt/jenkins-workspace/aos-cd-builds_build_ocp4-konflux@7/art-tools/doozer/doozerlib/backend/konflux_image_builder.py", line 1022, in update_konflux_db
22:55:11      package_nvrs, source_rpms = await self.get_installed_packages(
22:55:11                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
22:55:11    File "/mnt/jenkins-workspace/aos-cd-builds_build_ocp4-konflux@7/art-tools/doozer/doozerlib/backend/konflux_image_builder.py", line 899, in get_installed_packages
22:55:11      raise ChildProcessError(f"Could not get rpms from SBOM for arch {arch}")
22:55:11  ChildProcessError: Could not get rpms from SBOM for arch x86_64
```
## Test plan

- [x] New test: `test_update_konflux_db_skips_rpm_extraction_for_scratch_image`
- [x] Existing test still passes: `test_update_konflux_db_skips_rpm_extraction_when_no_shell`
- [x] Full test file passes (34/34)
- [x] Ruff lint clean


Made with [Cursor](https://cursor.com)