### PR TITLE
fix: filter bugs from open shipment MRs in find-bugs using SHIPMENT_DATA_URL_TEMPLATE

### DIFF
--- a/elliott/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_sweep_cli.py
@@ -11,6 +11,7 @@ from artcommonlib.assembly import (
     assembly_own_issues_config,
     assembly_targeted_fixes_only,
 )
+from artcommonlib.constants import SHIPMENT_DATA_URL_TEMPLATE
 from artcommonlib.format_util import green_print
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import is_ocp_delivery_repo, new_roundtrip_yaml_handler
@@ -301,15 +302,12 @@ async def get_bugs_sweep(runtime: Runtime, find_bugs_obj, bug_tracker, filter_at
                 logger.info(f"Filtered {len(attached_bugs)} bugs since they are attached to other advisories")
 
             # filter bugs that are attached to open shipment MRs
-            shipment_data_url = runtime.shipment_path
-            shipment_bug_ids = set()
-            if shipment_data_url:
-                shipment_bug_ids = get_bug_ids_from_open_shipment_mrs(
-                    shipment_data_url=shipment_data_url,
-                    group=runtime.group,
-                    releases_config=releases_config,
-                    current_assembly=runtime.assembly,
-                )
+            shipment_bug_ids = get_bug_ids_from_open_shipment_mrs(
+                shipment_data_url=SHIPMENT_DATA_URL_TEMPLATE,
+                group=runtime.group,
+                releases_config=releases_config,
+                current_assembly=runtime.assembly,
+            )
             if shipment_bug_ids:
                 before_count = len(bugs)
                 bugs = [b for b in bugs if b.id not in shipment_bug_ids]

--- a/elliott/tests/test_find_bugs_sweep_cli.py
+++ b/elliott/tests/test_find_bugs_sweep_cli.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import elliottlib.cli.find_bugs_sweep_cli as sweep_cli
+from artcommonlib.constants import SHIPMENT_DATA_URL_TEMPLATE
 from click.testing import CliRunner
 from elliottlib import constants, errata
 from elliottlib.bzutil import JIRABugTracker
@@ -202,7 +203,6 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_get_bugs_sweep_filters_shipment_bugs(self, mock_cutoff, mock_bug_ids, mock_shipment_bugs):
         """When filter_attached_bugs=True, bugs in open shipment MRs should be filtered out."""
         runtime = MagicMock(debug=False, group="openshift-4.18", assembly="4.18.40")
-        runtime.shipment_path = "https://gitlab.example.com/project"
 
         bug_keep = flexmock(id="OCPBUGS-1")
         bug_filter = flexmock(id="OCPBUGS-2")
@@ -219,7 +219,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual([b.id for b in actual], ["OCPBUGS-1"])
         mock_shipment_bugs.assert_called_once_with(
-            shipment_data_url="https://gitlab.example.com/project",
+            shipment_data_url=SHIPMENT_DATA_URL_TEMPLATE,
             group="openshift-4.18",
             releases_config=runtime.get_releases_config(),
             current_assembly="4.18.40",


### PR DESCRIPTION
`get_bugs_sweep()` was skipping open-shipment-MR bug filtering because `runtime.shipment_path` was never set when `find-bugs` ran. Bugs already in an open shipment MR (e.g. 4.21.19) would leak into the next assembly (4.21.20).

Use `SHIPMENT_DATA_URL_TEMPLATE` directly at the call site so the filter always runs.