### PR TITLE
Revert "Revert "Temporarily skip RPMs in ocp4-scan-konflux due to distgit connection issues""

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -102,6 +102,7 @@ class Ocp4ScanPipeline:
                 '--yaml',
                 f'--ci-kubeconfig={os.environ["KUBECONFIG"]}',
                 '--rebase-priv',
+                '--skip-rpms',
             ]
         )
         if self.runtime.dry_run:


### PR DESCRIPTION
Reverts openshift-eng/art-tools#2973

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the OCP4 scan configuration to skip RPMs during change detection, affecting which sources are evaluated in scan operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->