### PR TITLE
Add cpe product name mapping for cert-manager

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -118,6 +118,9 @@ PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP = {
     "openshift-logging": ("logging-images-base-silent", "logging-images-base"),
     "acm": ("acm-images-base-silent", "acm-images-base"),
     "multicluster-engine": ("acm-images-base-silent", "acm-images-base"),
+    "external-secrets": ("oap-eso-images-base-silent", "oap-images-base"),
+    "cert-manager": ("oap-cm-images-base-silent", "oap-images-base"),
+    "zero-trust": ("oap-zt-images-base-silent", "oap-images-base"),
 }
 
 # Pre-release lifecycle (software_lifecycle.phase) — registry-ocp-art-base-ec-prod via ART-19498.

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -50,6 +50,9 @@ CPE_PRODUCT_NAME_MAPPING = {
     'mta': 'migration_toolkit_applications',
     'logging': 'logging',
     'openshift-logging': 'logging',
+    'cert-manager': 'cert_manager',
+    'external-secrets': 'external_secrets_operator',
+    'zero-trust': 'zero_trust_workload_identity_manager',
 }
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for recognizing `cert-manager`, `external-secrets`, and `zero-trust` product identifiers.
  * Updated base-image configuration so these products resolve to their corresponding release plans and shared base-image application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->