### PR TITLE
ART-20308: skip builder check when from object has no parent image

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -1035,7 +1035,9 @@ class ConfigScanSources:
                 stream_config = self.runtime.resolve_stream(builder.stream)
                 builder_image_name = stream_config.image
             else:
-                raise IOError(f'Unable to determine builder or parent image pullspec from {builder}')
+                # If neither image nor stream is defined (e.g., parent 'from' object with only 'builder' list),
+                # skip this entry as there's no parent/base image to check
+                continue
             builder_build_nvr = await self.get_builder_build_nvr(builder_image_name)
 
             if not builder_build_nvr:


### PR DESCRIPTION
For images with only multi-stage builders (e.g., rhcos-node-image), the from object contains only a 'builder' list with no parent 'image' or 'stream' field. Previously this would raise an IOError during builder change scanning.

This fix changes the exception to a continue statement, properly skipping the parent image change check when neither image nor stream is defined.

## Testing

- Build [#50474](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/50474/): Failed with the error (before fix): `ERROR Failed scanning image rhcos-node-image during builder checks`
- Build [#50476](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/50476/): SUCCESS - no errors found (after fix)
