### PR TITLE
Hoist _get_microshift_rpm_commit() out of _rebase_and_build_bootc

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -224,9 +224,12 @@ class BuildMicroShiftBootcPipeline:
         variants = await self._get_bootc_variants()
         self._logger.info("Discovered bootc variants for group %s: %s", self.group, variants)
 
+        # Extract the upstream commit once (shared across all variants)
+        upstream_commit = await self._get_microshift_rpm_commit()
+
         # Build all variants in parallel
         build_results = await asyncio.gather(
-            *(self._rebase_and_build_bootc(variant) for variant in variants),
+            *(self._rebase_and_build_bootc(variant, upstream_commit) for variant in variants),
             return_exceptions=True,
         )
         builds: dict[str, KonfluxBuildRecord] = {}
@@ -567,11 +570,12 @@ class BuildMicroShiftBootcPipeline:
             )
         raise ValueError(f"Assembly type {self.assembly_type} is not supported for microshift-bootc builds")
 
-    async def _rebase_and_build_bootc(self, variant: dict) -> Optional[KonfluxBuildRecord]:
+    async def _rebase_and_build_bootc(self, variant: dict, upstream_commit: str) -> Optional[KonfluxBuildRecord]:
         """Rebase and build a single bootc image variant.
 
         Args:
             variant: Dict with keys "image_name" and "el_target".
+            upstream_commit: The microshift RPM commit to lock the build to.
         """
         bootc_image_name = variant["image_name"]
         el_target = variant["el_target"]
@@ -622,9 +626,6 @@ class BuildMicroShiftBootcPipeline:
             raise ValueError(
                 f"KONFLUX_SA_KUBECONFIG environment variable is required to build {bootc_image_name} image"
             )
-
-        # Extract the commit from the microshift RPM to ensure bootc is built from the same source
-        upstream_commit = await self._get_microshift_rpm_commit()
 
         # Determine the assembly label value based on assembly type
         assembly_label_value = self._get_assembly_label_value()

--- a/pyartcd/tests/pipelines/test_build_microshift_bootc.py
+++ b/pyartcd/tests/pipelines/test_build_microshift_bootc.py
@@ -377,14 +377,12 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.build_microshift_bootc.exectools.cmd_assert_async", new_callable=AsyncMock)
     @patch.object(BuildMicroShiftBootcPipeline, "get_latest_bootc_build", new_callable=AsyncMock)
-    @patch.object(BuildMicroShiftBootcPipeline, "_get_microshift_rpm_commit", new_callable=AsyncMock)
-    async def test_rebase_uses_two_segment_version(self, mock_get_commit, mock_get_build, mock_cmd):
+    async def test_rebase_uses_two_segment_version(self, mock_get_build, mock_cmd):
         """
         Test that _rebase_and_build_bootc passes --version v4.21 (2 segments)
         instead of v4.21.0 to avoid confusing tags on the container catalog
         (OCPBUGS-78040).
         """
-        mock_get_commit.return_value = "abc1234"
         mock_get_build.return_value = Mock(nvr="microshift-bootc-4.21.0-1.el9")
         pipeline = self._make_pipeline(group="openshift-4.21", assembly="4.21.7")
         pipeline.assembly_type = AssemblyTypes.STANDARD
@@ -394,7 +392,7 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
         try:
             variant = {"image_name": "microshift-bootc", "el_target": "el9"}
             with patch("asyncio.sleep", new_callable=AsyncMock):
-                await pipeline._rebase_and_build_bootc(variant)
+                await pipeline._rebase_and_build_bootc(variant, "abc1234")
 
             rebase_cmd = mock_cmd.call_args_list[0][0][0]
 
@@ -411,14 +409,12 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.build_microshift_bootc.exectools.cmd_assert_async", new_callable=AsyncMock)
     @patch.object(BuildMicroShiftBootcPipeline, "get_latest_bootc_build", new_callable=AsyncMock)
-    @patch.object(BuildMicroShiftBootcPipeline, "_get_microshift_rpm_commit", new_callable=AsyncMock)
-    async def test_rebase_and_build_bootc_uses_rpm_commit(self, mock_get_commit, mock_get_build, mock_cmd):
+    async def test_rebase_and_build_bootc_uses_rpm_commit(self, mock_get_build, mock_cmd):
         """
         Test that _rebase_and_build_bootc passes the RPM commit to --lock-upstream
         instead of HEAD.
         """
         # given
-        mock_get_commit.return_value = "0d0943b"
         mock_get_build.return_value = Mock(nvr="microshift-bootc-4.21.0-1.el9")
         pipeline = BuildMicroShiftBootcPipeline(
             runtime=self.runtime,
@@ -438,7 +434,7 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
             # when
             variant = {"image_name": "microshift-bootc", "el_target": "el9"}
             with patch("asyncio.sleep", new_callable=AsyncMock):
-                await pipeline._rebase_and_build_bootc(variant)
+                await pipeline._rebase_and_build_bootc(variant, "0d0943b")
 
             # then
             # Verify rebase command uses the RPM commit, not HEAD
@@ -459,14 +455,12 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.build_microshift_bootc.exectools.cmd_assert_async", new_callable=AsyncMock)
     @patch.object(BuildMicroShiftBootcPipeline, "get_latest_bootc_build", new_callable=AsyncMock)
-    @patch.object(BuildMicroShiftBootcPipeline, "_get_microshift_rpm_commit", new_callable=AsyncMock)
-    async def test_rebase_and_build_bootc_el10_variant(self, mock_get_commit, mock_get_build, mock_cmd):
+    async def test_rebase_and_build_bootc_el10_variant(self, mock_get_build, mock_cmd):
         """
         Test that _rebase_and_build_bootc correctly handles the el10 variant,
         using the microshift-bootc-rhel10 image name in doozer commands.
         """
         # given
-        mock_get_commit.return_value = "abc1234"
         mock_get_build.return_value = Mock(nvr="microshift-bootc-rhel10-container-v4.22-1.el10")
         pipeline = self._make_pipeline(group="openshift-4.22", assembly="4.22.0")
         pipeline.assembly_type = AssemblyTypes.STANDARD
@@ -476,7 +470,7 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
         try:
             variant = {"image_name": "microshift-bootc-rhel10", "el_target": "el10"}
             with patch("asyncio.sleep", new_callable=AsyncMock):
-                await pipeline._rebase_and_build_bootc(variant)
+                await pipeline._rebase_and_build_bootc(variant, "abc1234")
 
             # Verify rebase command uses the el10 image name
             rebase_cmd = mock_cmd.call_args_list[0][0][0]


### PR DESCRIPTION
- Move _get_microshift_rpm_commit() call to _run_pipeline so it runs once before parallel variant builds, avoiding concurrent elliott calls clashing on the shared working directory
- Pass upstream_commit as a parameter to _rebase_and_build_bootc
- Update tests to pass upstream_commit directly instead of mocking _get_microshift_rpm_commit

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the microshift bootc build pipeline to extract the upstream RPM source commit once during pipeline initialization instead of repeatedly for each variant, improving build efficiency while ensuring all variants are locked to the same commit source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->