### PR TITLE
fix: use upgrade semantics for update-only lockfile stages

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -412,7 +412,7 @@ class RpmLockfilePrototypeGenerator:
                 if extra:
                     packages = list(packages) + extra
 
-            is_update_only = not packages
+            is_update_only = stage_info.has_update and not packages
             if is_update_only:
                 packages, upgrade_targets, image_pullspec = await self._handle_update_only_stage(
                     stage_num, image_pullspec, distgit_key

--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -412,7 +412,8 @@ class RpmLockfilePrototypeGenerator:
                 if extra:
                     packages = list(packages) + extra
 
-            if not packages:
+            is_update_only = not packages
+            if is_update_only:
                 packages, upgrade_targets, image_pullspec = await self._handle_update_only_stage(
                     stage_num, image_pullspec, distgit_key
                 )
@@ -424,11 +425,15 @@ class RpmLockfilePrototypeGenerator:
                 )
 
             reinstall_pkgs: list[str] | None = None
-            if stage_num == final_stage_num:
+            if stage_num == final_stage_num and not is_update_only:
                 if image_pullspec:
                     # --image mode: pass base image packages as reinstallPackages
                     # so they appear in the lockfile at repo versions. base.reinstall()
                     # handles missing/renamed packages gracefully (warns, skips).
+                    # Skipped for update-only stages: _handle_update_only_stage already
+                    # populates packages and upgrade_targets with all base image packages,
+                    # so reinstall is redundant for coverage and would only pin them to
+                    # the base image version, preventing updates from landing.
                     base_pkgs = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key)
                     if base_pkgs:
                         reinstall_pkgs = list(base_pkgs)

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -356,8 +356,9 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
             (dest_dir / "Dockerfile").write_text("FROM base\nRUN yum update -y && yum clean all\n")
             asyncio.run(generator.generate_lockfile(meta, dest_dir))
 
-        # Called for update-only stage + reinstall expansion
-        self.assertGreaterEqual(generator._container.get_installed_packages.call_count, 1)
+        # _get_base_image_packages is called exactly once (for _handle_update_only_stage)
+        # The reinstall block is skipped for update-only final stages
+        self.assertEqual(generator._container.get_installed_packages.call_count, 1)
         self.assertEqual(len(captured_configs), 1)
         # Update-only stage uses --image mode with base image pullspec
         self.assertIsNotNone(captured_pullspecs[0])
@@ -367,6 +368,9 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
             ["bash", "coreutils", "glibc"],
         )
         self.assertEqual(sorted(captured_configs[0].upgradePackages), ["bash", "coreutils", "glibc"])
+        # reinstallPackages must be empty: reinstall overrides upgrade in DNF
+        # and would pin the base image version, preventing security updates
+        self.assertEqual(captured_configs[0].reinstallPackages, [])
 
     def test_mixed_install_and_bare_update_uses_image_mode(self):
         """


### PR DESCRIPTION
## Problem

4.23 was stuck in an infinite rebuild loop: ~252 images flagged as outdated every scan cycle, rebuilt, then flagged again. Root cause: the lockfile generator was pinning base image package versions instead of upgrading them, so `yum update -y` in hermetic builds had nothing to install.

Specifically, `openssl-3.5.5-3` (from `rhel9-8-els/rhel-minimal:latest`) was being locked into the lockfile even though `openssl-3.5.5-4` was available in `rhel-9-baseos-rpms`.

## Root Cause

For **update-only** stages (no explicit `dnf install`, just `yum update -y`), `_handle_update_only_stage` correctly sets base image packages as `upgradePackages` so DNF fetches the latest versions. However, the final-stage reinstall block then unconditionally called `_get_base_image_packages` again and set those same packages as `reinstallPackages`.

In `rpm-lockfile-prototype`, `base.reinstall()` runs **after** `base.upgrade()` and overrides it. Since the old version (`3.5.5-3`) is still present in the repos, reinstall succeeds and pins the old version. The `PackagesNotAvailableError` fallback to upgrade is never triggered.

The hermetic build then pre-fetches `3.5.5-3` via cachi2, `yum update -y` sees nothing to upgrade, the scan detects the outdated package, and the cycle repeats.

## Fix

Skip setting `reinstallPackages` when the final stage is update-only. The `_handle_update_only_stage` path already populates `packages` and `upgradePackages` with all base image packages, so reinstall is redundant for lockfile coverage and only adds harmful version-pinning.

Non-update-only final stages are unaffected — the `reinstall_pkgs` block still runs for stages with explicit package installs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary base-image package reinstall/extra package expansion for update-only final stages.

* **Tests**
  * Strengthened assertions to ensure update-only stages skip reinstallPackages behavior and that installed-package lookups occur with the expected frequency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->