### PR TITLE
Revert "Revert "Revert "Temporarily skip RPMs in ocp4-scan-konflux due to distgit connection issues"""

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -102,7 +102,6 @@ class Ocp4ScanPipeline:
                 '--yaml',
                 f'--ci-kubeconfig={os.environ["KUBECONFIG"]}',
                 '--rebase-priv',
-                '--skip-rpms',
             ]
         )
         if self.runtime.dry_run:


### PR DESCRIPTION
Reverts openshift-eng/art-tools#3055

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated scan source configuration parameters to explicitly handle kubeconfig environment variables, enable YAML output formatting, and adjust rebase handling for improved scan pipeline reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->