### PR TITLE
ART-20053: fix bundle rebase using wrong registry namespace for OCP 5.0

### DIFF
--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -423,6 +423,7 @@ class KonfluxOlmBundleRebaser:
         # versioned internal name (e.g. ose-csi-livenessprobe-4.18-rhel9) while having them
         # replaced with the preferred unversioned delivery repo name (e.g. ose-csi-livenessprobe-rhel9).
         _delivery_override_map: Dict[str, str] = {}
+        _delivery_namespace_map: Dict[str, str] = {}
         _data_dir = metadata.runtime.data_dir
         for _yml_path in glob.glob(f"{_data_dir}/images/*.yml") + glob.glob(f"{_data_dir}/images/*.yaml"):
             try:
@@ -431,15 +432,17 @@ class KonfluxOlmBundleRebaser:
                 if not isinstance(_img_data, dict):
                     continue
                 _delivery = _img_data.get('delivery', {}) or {}
+                _repo_names = _delivery.get('delivery_repo_names') or []
+                _img_short = str(_img_data.get('name', '')).rsplit('/', 1)[-1]
+                if _repo_names and '/' in str(_repo_names[0]):
+                    _delivery_namespace_map[_img_short] = str(_repo_names[0]).rsplit('/', 1)[0]
                 if not _delivery.get('delivery_repo_name_override'):
                     continue
-                _repo_names = _delivery.get('delivery_repo_names') or []
                 if len(_repo_names) != 1:
                     raise IOError(
                         f"delivery_repo_name_override is set in {_yml_path} but delivery_repo_names has "
                         f"{len(_repo_names)} entries (expected exactly 1)"
                     )
-                _img_short = str(_img_data.get('name', '')).rsplit('/', 1)[-1]
                 _override_short = str(_repo_names[0]).rsplit('/', 1)[-1]
                 _delivery_override_map[_img_short] = _override_short
             except (yaml.YAMLError, OSError) as e:
@@ -459,7 +462,11 @@ class KonfluxOlmBundleRebaser:
             if not metadata.runtime.group.startswith("openshift-"):
                 new_namespace = namespace
             else:
-                new_namespace = 'openshift4' if namespace == csv_namespace else namespace
+                new_namespace = (
+                    _delivery_namespace_map.get(image_short_name, 'openshift4')
+                    if namespace == csv_namespace
+                    else namespace
+                )
             # If delivery_repo_name_override is set for this image, use the overridden short name
             # so the final pullspec uses the preferred delivery repo name (e.g. without a version tag).
             delivery_image_short_name = _delivery_override_map.get(image_short_name, image_short_name)


### PR DESCRIPTION
## Summary
- The Konflux bundle rebase in `konflux_olm_bundler.py` hardcoded `openshift4` as the registry namespace when replacing internal image references with production `registry.redhat.io` pullspecs
- For OCP 5.0, images are delivered under `openshift5/`, so relatedImages in the FBC catalog pointed to `registry.redhat.io/openshift4/...` instead of `registry.redhat.io/openshift5/...`
- This caused bundle unpacking failures in CI due to missing IDMS entries for the correct paths
- Fix: look up the delivery namespace from each image's `delivery_repo_names` in ocp-build-data instead of hardcoding `openshift4`

## Test plan
- [x] Existing unit tests pass (`test_konflux_olm_bundler.py` — 19/19)
- [ ] Verify that OCP 5.0 metallb FBC catalog relatedImages now reference `openshift5/` paths
- [ ] Verify that OCP 4.x bundles continue to use `openshift4/` paths (fallback default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenShift group image rebasing by refining how target namespaces are chosen for replaced images.
  * Namespace mapping can now be derived per image from delivery repository information, allowing more accurate namespace targeting instead of defaulting to a single fixed namespace.
  * When an image’s original namespace matches the CSV-derived namespace, replacements now use the computed mapped namespace for that image (falling back to the default when no mapping is available).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->