### PR TITLE
fix(doozer): fail rebase when art-images-base tag is unreachable

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -562,9 +562,7 @@ class KonfluxRebaser:
                     rh_pullspec = util.rh_art_images_base_pullspec(build.nvr)
                     if await self._registry_pullspec_exists(rh_pullspec):
                         return rh_pullspec, build.embargoed
-                    raise IOError(
-                        f"Late-resolved parent {member}: art-images-base tag unreachable at {rh_pullspec}"
-                    )
+                    raise IOError(f"Late-resolved parent {member}: art-images-base tag unreachable at {rh_pullspec}")
                 return build.image_pullspec, build.embargoed
 
             return original_parent, False

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -562,12 +562,9 @@ class KonfluxRebaser:
                     rh_pullspec = util.rh_art_images_base_pullspec(build.nvr)
                     if await self._registry_pullspec_exists(rh_pullspec):
                         return rh_pullspec, build.embargoed
-                    self._logger.warning(
-                        "Late-resolved parent %s: art-images-base unreachable (%s); using Konflux image_pullspec",
-                        member,
-                        rh_pullspec,
+                    raise IOError(
+                        f"Late-resolved parent {member}: art-images-base tag unreachable at {rh_pullspec}"
                     )
-                    return build.image_pullspec, build.embargoed
                 return build.image_pullspec, build.embargoed
 
             return original_parent, False

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1439,25 +1439,6 @@ class ImageMetadata(Metadata):
         self.logger.info(f"Base image release enabled set from {source} {base_image_release_enabled}")
         return base_image_release_enabled
 
-    def is_base_image_release_quay_fallback_enabled(self) -> bool:
-        """
-        When False and ``should_trigger_base_image_release()`` applies, late parent resolve
-        must not fall back to Konflux ``image_pullspec`` if ``registry.redhat.io`` art-images-base
-        is unreachable (rebase fails instead).
-
-        Image ``base_image_release.quay_fallback`` overrides group; default True
-        (same pattern as ``konflux.cachi2.lockfile.enabled``).
-        """
-        base_image_release_quay_fallback_config_override = self.config.base_image_release.quay_fallback
-        if base_image_release_quay_fallback_config_override not in [Missing, None]:
-            return bool(base_image_release_quay_fallback_config_override)
-        else:
-            base_image_release_quay_fallback_group_override = self.runtime.group_config.base_image_release.quay_fallback
-            if base_image_release_quay_fallback_group_override not in [Missing, None]:
-                return bool(base_image_release_quay_fallback_group_override)
-
-        return True
-
     def get_required_artifacts(self) -> list:
         """
         Get list of required artifacts from image config.

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -1384,7 +1384,6 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         parent.image_name_short = "golang-builder"
         parent.get_component_name.return_value = "openshift-golang-builder-container"
         parent.should_trigger_base_image_release.return_value = True
-        parent.is_base_image_release_quay_fallback_enabled.return_value = True
 
         runtime = MagicMock()
         runtime.resolve_image.return_value = parent
@@ -1404,11 +1403,10 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         )
 
     async def test_resolve_member_parent_late_resolve_uses_rh_art_base_tag(self):
-        """Late-resolve (DB) base/golang: RH art-images-base if tag is reachable, else Konflux digest from DB."""
+        """Late-resolve (DB) base/golang: RH art-images-base when tag is reachable."""
         parent = MagicMock()
         parent.distgit_key = "golang-builder"
         parent.should_trigger_base_image_release.return_value = True
-        parent.is_base_image_release_quay_fallback_enabled.return_value = True
         parent.branch_el_target.return_value = 9
         kb = MagicMock()
         kb.nvr = "openshift-golang-builder-container-v1.21-1.el9"
@@ -1437,12 +1435,11 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         )
         self.assertFalse(emb)
 
-    async def test_resolve_member_parent_late_resolve_falls_back_to_db_pullspec_when_art_base_missing(self):
-        """Late-resolved golang parent: use RH only if tag exists; otherwise Konflux digest from DB."""
+    async def test_resolve_member_parent_late_resolve_fails_when_art_base_missing(self):
+        """Late-resolved base-image-release parent fails when art-images-base tag is unreachable."""
         parent = MagicMock()
         parent.distgit_key = "golang-builder"
         parent.should_trigger_base_image_release.return_value = True
-        parent.is_base_image_release_quay_fallback_enabled.return_value = True
         parent.branch_el_target.return_value = 9
         kb = MagicMock()
         kb.nvr = "openshift-golang-builder-container-v1.21-1.el9"
@@ -1465,9 +1462,11 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         rebaser.derived_group = "openshift-4.18"
         rebaser._registry_pullspec_exists = AsyncMock(return_value=False)
 
-        resolved, emb = await rebaser._resolve_member_parent("golang-builder", "orig")
-        self.assertEqual(resolved, "quay.io/k@sha256:beef")
-        self.assertFalse(emb)
+        rh_pullspec = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.21-1.el9"
+        with self.assertRaises(IOError) as ctx:
+            await rebaser._resolve_member_parent("golang-builder", "orig")
+        self.assertIn("golang-builder", str(ctx.exception))
+        self.assertIn(rh_pullspec, str(ctx.exception))
 
     async def test_resolve_member_parent_late_resolve_uses_db_released_pullspec_when_set(self):
         parent = MagicMock()
@@ -1500,39 +1499,6 @@ class TestRebaserResolveMemberParentRegistryRedhat(IsolatedAsyncioTestCase):
         resolved, emb = await rebaser._resolve_member_parent("golang-builder", "orig")
         self.assertEqual(resolved, kb.released_pullspec)
         self.assertTrue(emb)
-
-    async def test_resolve_member_parent_late_resolve_falls_back_when_art_base_missing_even_if_quay_fallback_disabled(
-        self,
-    ):
-        parent = MagicMock()
-        parent.distgit_key = "golang-builder"
-        parent.should_trigger_base_image_release.return_value = True
-        parent.is_base_image_release_quay_fallback_enabled.return_value = False
-        parent.branch_el_target.return_value = 9
-        kb = MagicMock()
-        kb.nvr = "openshift-golang-builder-container-v1.21-1.el9"
-        kb.image_pullspec = "quay.io/k@sha256:beef"
-        kb.released_pullspec = ""
-        kb.embargoed = False
-        parent.get_latest_build = AsyncMock(return_value=kb)
-
-        runtime = MagicMock()
-        runtime.resolve_image.return_value = None
-        runtime.ignore_missing_base = True
-        runtime.latest_parent_version = True
-        runtime.late_resolve_image = MagicMock(return_value=parent)
-        runtime.group_config = Model({"konflux": Model({})})
-
-        rebaser = KonfluxRebaser(runtime, self.base_dir, MagicMock(), "unsigned")
-        rebaser.variant = BuildVariant.OCP
-        rebaser.image_repo = "quay.io/fake"
-        rebaser.uuid_tag = "v4.18-tag"
-        rebaser.derived_group = "openshift-4.18"
-        rebaser._registry_pullspec_exists = AsyncMock(return_value=False)
-
-        resolved, emb = await rebaser._resolve_member_parent("golang-builder", "orig")
-        self.assertEqual(resolved, "quay.io/k@sha256:beef")
-        self.assertFalse(emb)
 
     async def test_resolve_member_parent_keeps_quay_for_regular_member(self):
         parent = MagicMock()

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1936,26 +1936,6 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         )
         self.assertTrue(test_assembly_forced_metadata.should_trigger_base_image_release())
 
-    def test_base_image_release_quay_fallback_image_overrides_group(self):
-        from artcommonlib.model import Model
-
-        runtime = MagicMock()
-        runtime.logger = logging.getLogger('test_runtime')
-        runtime.group_config = Model({'base_image_release': Model({'quay_fallback': False})})
-        img_on = Model({'name': 't', 'base_image_release': Model({'quay_fallback': True})})
-        meta_on = ImageMetadata(runtime, Model({'key': 't', 'data': img_on, 'filename': 't.yaml'}))
-        self.assertTrue(meta_on.is_base_image_release_quay_fallback_enabled())
-
-        img_inherit = Model({'name': 't2'})
-        meta_inherit = ImageMetadata(runtime, Model({'key': 't2', 'data': img_inherit, 'filename': 't2.yaml'}))
-        self.assertFalse(meta_inherit.is_base_image_release_quay_fallback_enabled())
-
-        runtime_default = MagicMock()
-        runtime_default.logger = logging.getLogger('test_runtime')
-        runtime_default.group_config = Model({})
-        meta_default = ImageMetadata(runtime_default, Model({'key': 't2', 'data': img_inherit, 'filename': 't2.yaml'}))
-        self.assertTrue(meta_default.is_base_image_release_quay_fallback_enabled())
-
 
 class TestExtractBuilderInfoFromPullspec(unittest.TestCase):
     """

--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -358,18 +358,7 @@
         "enabled?": {
           "$ref": "#/properties/base_image_release/properties/enabled"
         },
-        "enabled-": {},
-        "quay_fallback": {
-          "description": "When false, late parent resolve fails if art-images-base is unreachable instead of Konflux fallback. Default true.",
-          "type": "boolean"
-        },
-        "quay_fallback!": {
-          "$ref": "#/properties/base_image_release/properties/quay_fallback"
-        },
-        "quay_fallback?": {
-          "$ref": "#/properties/base_image_release/properties/quay_fallback"
-        },
-        "quay_fallback-": {}
+        "enabled-": {}
       },
       "additionalProperties": false
     },

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -198,18 +198,7 @@
         "enabled?": {
           "$ref": "#/properties/base_image_release/properties/enabled"
         },
-        "enabled-": {},
-        "quay_fallback": {
-          "description": "When false, late parent resolve fails if registry.redhat.io art-images-base is unreachable instead of falling back to Konflux image_pullspec. Default true. Image overrides group.",
-          "type": "boolean"
-        },
-        "quay_fallback!": {
-          "$ref": "#/properties/base_image_release/properties/quay_fallback"
-        },
-        "quay_fallback?": {
-          "$ref": "#/properties/base_image_release/properties/quay_fallback"
-        },
-        "quay_fallback-": {}
+        "enabled-": {}
       },
       "additionalProperties": false
     },


### PR DESCRIPTION
## Summary

Remove the legacy quay.io Konflux pullspec fallback when late-resolving base-image-release parents. Rebase now fails with an explicit error if the `registry.redhat.io/openshift/art-images-base` tag is not reachable.

## Problem

**Before:** Late-resolved base-image-release parents silently fell back to the Konflux `quay.io` pullspec from the build DB when the art-images-base tag was missing.

**After:** Rebase raises `IOError` naming the member and expected art-images-base pullspec. The unused `base_image_release.quay_fallback` config knob and validator schema entries are removed.

## Test plan

- [x] `pytest doozer/tests/backend/test_rebaser.py::TestRebaserResolveMemberParentRegistryRedhat`
- [x] `pytest doozer/tests/test_image.py -k base_image_release`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Late-resolving member parents now fail with an error when the required `art-images-base` pullspec is unreachable, instead of falling back to an alternate pullspec.
* **Breaking Changes**
  * Removed the `base_image_release.quay_fallback` option from build-data validation schemas; fallback behavior is no longer configurable.
* **Tests**
  * Updated rebaser and image metadata tests to reflect the new “fail when art-base is missing/unreachable” expectations and removed obsolete fallback coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->