### PR TITLE
fix: use runtime working_dir for rpm-lockfile temp files instead of /tmp

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1024,6 +1024,7 @@ class KonfluxRebaser:
             base_dir=self._base_dir,
             downstream_parents=downstream_parents,
             parent_members=parent_members,
+            working_dir=Path(self._runtime.working_dir),
             shared_dnf_cache=self._shared_dnf_cache,
             logger=self._logger,
         )

--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -98,6 +98,7 @@ class RpmLockfilePrototypeGenerator:
     def __init__(
         self,
         repos: Repos,
+        working_dir: Path,
         logger: logging.Logger | None = None,
         container_helper: ContainerImageHelper | None = None,
         resolver: RpmResolver | None = None,
@@ -108,7 +109,7 @@ class RpmLockfilePrototypeGenerator:
         self.parent_source_dirs: dict[int, Path] = {}
         self.logger = logger or logutil.get_logger(__name__)
         self._container = container_helper or ContainerImageHelper(logger=self.logger)
-        self._resolver = resolver or RpmResolver(logger=self.logger)
+        self._resolver = resolver or RpmResolver(working_dir=working_dir, logger=self.logger)
 
     async def generate_lockfile(
         self,

--- a/doozer/doozerlib/lockfile_prototype/rebaser_hooks.py
+++ b/doozer/doozerlib/lockfile_prototype/rebaser_hooks.py
@@ -26,6 +26,7 @@ async def generate_lockfile(
     dest_dir: Path,
     repos,
     base_dir: Path,
+    working_dir: Path,
     downstream_parents: list[str] | None = None,
     parent_members: list | None = None,
     shared_dnf_cache: TemporaryDirectory | None = None,
@@ -42,6 +43,7 @@ async def generate_lockfile(
         dest_dir (Path): Build directory containing the Dockerfile.
         repos: Runtime Repos object for repository configuration.
         base_dir (Path): Base working directory for locating parent image sources.
+        working_dir (Path): Base directory for temp files (avoids filling /tmp).
         downstream_parents (list[str] | None): Parent image pullspecs per stage.
         parent_members (list | None): Parent ImageMetadata objects.
         shared_dnf_cache (TemporaryDirectory | None): Shared cache dir across images.
@@ -52,10 +54,10 @@ async def generate_lockfile(
     _logger = logger or logging.getLogger(__name__)
 
     if shared_dnf_cache is None:
-        shared_dnf_cache = TemporaryDirectory(prefix="rpm-lockfile-cache-")
+        shared_dnf_cache = TemporaryDirectory(prefix="rpm-lockfile-cache-", dir=str(working_dir))
 
-    resolver = RpmResolver(logger=_logger, cache_dir=shared_dnf_cache.name)
-    generator = RpmLockfilePrototypeGenerator(repos, resolver=resolver)
+    resolver = RpmResolver(working_dir=working_dir, logger=_logger, cache_dir=shared_dnf_cache.name)
+    generator = RpmLockfilePrototypeGenerator(repos, working_dir=working_dir, resolver=resolver)
 
     fallback: dict[int, list[str]] = {}
     parent_dirs: dict[int, Path] = {}

--- a/doozer/doozerlib/lockfile_prototype/resolver.py
+++ b/doozer/doozerlib/lockfile_prototype/resolver.py
@@ -38,9 +38,12 @@ class RpmResolver:
     (common during multi-image rebases) skip redundant downloads.
     """
 
-    def __init__(self, logger: logging.Logger | None = None, cache_dir: str | None = None):
+    def __init__(self, working_dir: Path, logger: logging.Logger | None = None, cache_dir: str | None = None):
         self.logger = logger or logutil.get_logger(__name__)
-        self._cache_dir_owner = None if cache_dir else TemporaryDirectory(prefix="rpm-lockfile-cache-")
+        self._working_dir = str(working_dir)
+        self._cache_dir_owner = (
+            None if cache_dir else TemporaryDirectory(prefix="rpm-lockfile-cache-", dir=self._working_dir)
+        )
         self._cache_path = cache_dir or self._cache_dir_owner.name
 
     async def resolve(
@@ -62,7 +65,7 @@ class RpmResolver:
         Return Value(s):
             LockfileData: Resolved lockfile.
         """
-        with TemporaryDirectory() as tmpdir:
+        with TemporaryDirectory(dir=self._working_dir) as tmpdir:
             in_file = Path(tmpdir) / DEFAULT_RPM_INFILE_NAME
             out_file = Path(tmpdir) / DEFAULT_RPM_LOCKFILE_NAME
 

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -3,6 +3,7 @@ Tests for doozerlib.lockfile_prototype.generator (orchestration).
 """
 
 import asyncio
+import tempfile
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -184,6 +185,7 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
     def _make_generator(self) -> RpmLockfilePrototypeGenerator:
         return RpmLockfilePrototypeGenerator(
             repos=self._make_mock_repos(),
+            working_dir=Path(tempfile.mkdtemp()),
             container_helper=self._make_mock_container(),
             resolver=self._make_mock_resolver(),
         )
@@ -825,7 +827,7 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         repos = MagicMock()
         repos.__getitem__ = lambda self_repos, key: repo_map[key]
 
-        generator = RpmLockfilePrototypeGenerator(repos=repos)
+        generator = RpmLockfilePrototypeGenerator(repos=repos, working_dir=Path(tempfile.mkdtemp()))
         result = generator._build_repo_list(enabled_repos={"rhel-9-rt-rpms"}, arches=["x86_64", "aarch64"])
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].repoid, "rhel-9-for-$basearch-rt-rpms")
@@ -864,7 +866,7 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         repos = MagicMock()
         repos.__getitem__ = lambda self_repos, key: repo_map[key]
 
-        generator = RpmLockfilePrototypeGenerator(repos=repos)
+        generator = RpmLockfilePrototypeGenerator(repos=repos, working_dir=Path(tempfile.mkdtemp()))
         result = generator._build_repo_list(enabled_repos={"rhel-9-golang-rpms"}, arches=["x86_64"])
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].options["includepkgs"], "module-build-macros golang* goversioninfo")
@@ -881,7 +883,7 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         repos = MagicMock()
         repos.__getitem__ = lambda self_repos, key: repo_map[key]
 
-        generator = RpmLockfilePrototypeGenerator(repos=repos)
+        generator = RpmLockfilePrototypeGenerator(repos=repos, working_dir=Path(tempfile.mkdtemp()))
         result = generator._build_repo_list(enabled_repos={"rhel-9-rt-rpms"}, arches=["x86_64"])
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].options, {})
@@ -898,7 +900,7 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         repos = MagicMock()
         repos.__getitem__ = lambda self_repos, key: repo_map[key]
 
-        generator = RpmLockfilePrototypeGenerator(repos=repos)
+        generator = RpmLockfilePrototypeGenerator(repos=repos, working_dir=Path(tempfile.mkdtemp()))
         result = generator._build_repo_list(enabled_repos={"rhel-9-baseos-rpms"}, arches=["x86_64", "aarch64"])
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].repoid, "rhel-9-for-$basearch-baseos-rpms")
@@ -1139,7 +1141,7 @@ class TestIsBuilddepRequirement(unittest.TestCase):
 class TestResolveBuilddepPackages(unittest.TestCase):
     def _make_gen(self):
         repos = MagicMock()
-        return RpmLockfilePrototypeGenerator(repos=repos)
+        return RpmLockfilePrototypeGenerator(repos=repos, working_dir=Path(tempfile.mkdtemp()))
 
     def test_no_matching_srpm(self):
         gen = self._make_gen()

--- a/doozer/tests/lockfile_prototype/test_resolver.py
+++ b/doozer/tests/lockfile_prototype/test_resolver.py
@@ -53,7 +53,7 @@ class TestRpmResolver(unittest.TestCase):
             return (0, "", "")
 
         mock_gather.side_effect = mock_cmd
-        resolver = RpmResolver()
+        resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
         config = RpmsInConfig(
             arches=["x86_64"],
             contentOrigin={"repos": []},
@@ -79,7 +79,7 @@ class TestRpmResolver(unittest.TestCase):
             return (0, "", "")
 
         mock_gather.side_effect = mock_cmd
-        resolver = RpmResolver()
+        resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
         config = RpmsInConfig(
             arches=["x86_64"],
             contentOrigin={"repos": []},
@@ -99,7 +99,7 @@ class TestRpmResolver(unittest.TestCase):
             return (1, "", "DNF dependency resolution failed")
 
         mock_gather.side_effect = mock_fail
-        resolver = RpmResolver()
+        resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
         config = RpmsInConfig(
             arches=["x86_64"],
             contentOrigin={"repos": []},
@@ -124,7 +124,7 @@ class TestRpmResolver(unittest.TestCase):
             return (0, "", "")
 
         mock_gather.side_effect = mock_cmd
-        resolver = RpmResolver()
+        resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
         config = RpmsInConfig(
             arches=["x86_64"],
             contentOrigin={"repos": []},
@@ -149,7 +149,7 @@ class TestRpmResolver(unittest.TestCase):
             return (0, "", "")
 
         mock_gather.side_effect = mock_cmd
-        resolver = RpmResolver()
+        resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
         config = RpmsInConfig(
             arches=["x86_64"],
             contentOrigin={"repos": []},
@@ -229,7 +229,7 @@ class TestIsRpmdbCorrupt(unittest.TestCase):
 
 class TestClearRpmdbCache(unittest.TestCase):
     def setUp(self):
-        self.resolver = RpmResolver()
+        self.resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
 
     def test_clears_cache_for_digest(self):
         """
@@ -325,7 +325,7 @@ class TestResolveRpmdbCorruptionRetry(unittest.TestCase):
         mock_gather.side_effect = mock_cmd
         mock_clear.return_value = True
 
-        resolver = RpmResolver()
+        resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
         config = RpmsInConfig(
             arches=["x86_64"],
             contentOrigin={"repos": []},
@@ -349,7 +349,7 @@ class TestResolveRpmdbCorruptionRetry(unittest.TestCase):
         mock_gather.side_effect = mock_fail
         mock_clear.return_value = True
 
-        resolver = RpmResolver()
+        resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
         config = RpmsInConfig(
             arches=["x86_64"],
             contentOrigin={"repos": []},
@@ -371,7 +371,7 @@ class TestResolveRpmdbCorruptionRetry(unittest.TestCase):
 
         mock_gather.side_effect = mock_fail
 
-        resolver = RpmResolver()
+        resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
         config = RpmsInConfig(
             arches=["x86_64"],
             contentOrigin={"repos": []},
@@ -393,7 +393,7 @@ class TestResolveRpmdbCorruptionRetry(unittest.TestCase):
 
         mock_gather.side_effect = mock_fail
 
-        resolver = RpmResolver()
+        resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
         config = RpmsInConfig(
             arches=["x86_64"],
             contentOrigin={"repos": []},


### PR DESCRIPTION
should fix issues like 

```
While writing extension cache /tmp/rpm-lockfile-cache-u63g9s5h/rhel-8-for-aarch64-baseos-rpms-filenames.solvx.wxMvEi (0): repowriter write failed: -1, error: write error blob: No space left on device
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved control over temporary file and cache directory placement by introducing a configurable working directory parameter throughout the RPM lockfile generation pipeline. Temporary files and caches are now created under the specified working directory instead of system defaults, enabling better isolation and resource management.

* **Tests**
  * Updated test fixtures to use isolated working directories for resolver and generator initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->