### PR TITLE
ART-15595: scan-operator: detect and retry failed bundle/FBC builds

### DIFF
--- a/pyartcd/pyartcd/pipelines/scan_operator.py
+++ b/pyartcd/pyartcd/pipelines/scan_operator.py
@@ -191,18 +191,29 @@ class ScanOperatorPipeline:
             self.logger.info(f'  Bundle for {operator.nvr} exists: {bundle.nvr}')
             return bundle
 
-        # Check for pending bundle (avoid duplicate triggers)
-        pending = await self.bundle_db.get_latest_build(
-            name=bundle_name,
-            group=self.group,
-            outcome=KonfluxBuildOutcome.PENDING,
-            assembly=self.assembly,
+        # Query for the most recent non-SUCCESS record (PENDING or any failure).
+        # If the latest is PENDING, a build is in progress. If it's a failure, trigger a rebuild.
+        # Order by ingestion_time rather than start_time: PENDING records use datetime.now() as
+        # start_time while terminal records use the PipelineRun's actual startTime from Tekton,
+        # which can be slightly earlier. ingestion_time always reflects when the record was written
+        # to the DB, so the terminal record is correctly ordered after the PENDING record.
+        async for record in self.bundle_db.search_builds_by_fields(
+            where={
+                'name': bundle_name,
+                'group': self.group,
+                'outcome': [o for o in KonfluxBuildOutcome if not o.is_success()],
+                'assembly': self.assembly,
+            },
             extra_patterns={'operator_nvr': operator.nvr},
-        )
-
-        if pending:
-            self.logger.info(f'  Bundle build for {operator.nvr} in progress: {pending.nvr}')
-            return pending
+            limit=1,
+            order_by='ingestion_time',
+            sorting='DESC',
+        ):
+            if record.outcome.is_failure():
+                self.logger.info(f'  Bundle build for {operator.nvr} failed ({record.outcome.value}): {record.nvr}')
+                return None
+            self.logger.info(f'  Bundle build for {operator.nvr} in progress: {record.nvr}')
+            return record
 
         self.logger.info(f'  Bundle MISSING for {operator.nvr}')
         return None
@@ -229,19 +240,24 @@ class ScanOperatorPipeline:
             self.logger.info(f'  FBC build for {operator.nvr} exists: {fbc.nvr}')
             return fbc
 
-        # Check for pending FBC containing this specific bundle
+        # Query for the most recent non-SUCCESS record (PENDING or any failure).
+        # If the latest is PENDING, a build is in progress. If it's a failure, trigger a rebuild.
+        # Order by ingestion_time: see comment in check_bundle_exists for rationale.
         async for fbc in self.fbc_db.search_builds_by_fields(
             where={
                 'name': fbc_name,
                 'group': self.group,
-                'outcome': KonfluxBuildOutcome.PENDING,
+                'outcome': [o for o in KonfluxBuildOutcome if not o.is_success()],
                 'assembly': self.assembly,
             },
             array_contains={'bundle_nvrs': bundle.nvr},
             limit=1,
-            order_by='start_time',
+            order_by='ingestion_time',
             sorting='DESC',
         ):
+            if fbc.outcome.is_failure():
+                self.logger.info(f'  FBC build for {operator.nvr} failed ({fbc.outcome.value}): {fbc.nvr}')
+                return None
             self.logger.info(f'  FBC build for {operator.nvr} in progress: {fbc.nvr}')
             return fbc
 

--- a/pyartcd/pyartcd/pipelines/scan_operator.py
+++ b/pyartcd/pyartcd/pipelines/scan_operator.py
@@ -164,13 +164,11 @@ class ScanOperatorPipeline:
         """Check one operator for missing bundle/FBC builds."""
         bundle = await self.check_bundle_exists(operator)
 
-        if bundle is None:
-            # No bundle - trigger build
+        if bundle is None or bundle.outcome.is_failure():
             self.operators_without_bundles.append(operator)
         elif bundle.outcome == KonfluxBuildOutcome.SUCCESS:
-            # Bundle completed - check FBC
             fbc = await self.check_fbc_exists(operator, bundle)
-            if fbc is None:
+            if fbc is None or fbc.outcome.is_failure():
                 self.operators_without_fbcs.append(operator)
         # If bundle.outcome == PENDING, do nothing (auto-triggers when complete)
 
@@ -191,29 +189,28 @@ class ScanOperatorPipeline:
             self.logger.info(f'  Bundle for {operator.nvr} exists: {bundle.nvr}')
             return bundle
 
-        # Query for the most recent non-SUCCESS record (PENDING or any failure).
-        # If the latest is PENDING, a build is in progress. If it's a failure, trigger a rebuild.
-        # Order by ingestion_time rather than start_time: PENDING records use datetime.now() as
-        # start_time while terminal records use the PipelineRun's actual startTime from Tekton,
-        # which can be slightly earlier. ingestion_time always reflects when the record was written
-        # to the DB, so the terminal record is correctly ordered after the PENDING record.
-        async for record in self.bundle_db.search_builds_by_fields(
-            where={
-                'name': bundle_name,
-                'group': self.group,
-                'outcome': [o for o in KonfluxBuildOutcome if not o.is_success()],
-                'assembly': self.assembly,
-            },
+        # Check for the most recent PENDING build
+        pending = await self.bundle_db.get_latest_build(
+            name=bundle_name,
+            group=self.group,
+            outcome=KonfluxBuildOutcome.PENDING,
+            assembly=self.assembly,
             extra_patterns={'operator_nvr': operator.nvr},
-            limit=1,
-            order_by='ingestion_time',
-            sorting='DESC',
-        ):
-            if record.outcome.is_failure():
-                self.logger.info(f'  Bundle build for {operator.nvr} failed ({record.outcome.value}): {record.nvr}')
-                return None
-            self.logger.info(f'  Bundle build for {operator.nvr} in progress: {record.nvr}')
-            return record
+        )
+
+        if pending:
+            # Check if a failure record with the same NVR exists
+            async for failed_build in self.bundle_db.search_builds_by_fields(
+                where={'nvr': pending.nvr, 'outcome': [o for o in KonfluxBuildOutcome if o.is_failure()]},
+                limit=1,
+            ):
+                self.logger.info(
+                    f'  Bundle build for {operator.nvr} failed ({failed_build.outcome.value}): {failed_build.nvr}'
+                )
+                return failed_build
+
+            self.logger.info(f'  Bundle build for {operator.nvr} in progress: {pending.nvr}')
+            return pending
 
         self.logger.info(f'  Bundle MISSING for {operator.nvr}')
         return None
@@ -240,24 +237,29 @@ class ScanOperatorPipeline:
             self.logger.info(f'  FBC build for {operator.nvr} exists: {fbc.nvr}')
             return fbc
 
-        # Query for the most recent non-SUCCESS record (PENDING or any failure).
-        # If the latest is PENDING, a build is in progress. If it's a failure, trigger a rebuild.
-        # Order by ingestion_time: see comment in check_bundle_exists for rationale.
+        # Check for the most recent PENDING build
         async for fbc in self.fbc_db.search_builds_by_fields(
             where={
                 'name': fbc_name,
                 'group': self.group,
-                'outcome': [o for o in KonfluxBuildOutcome if not o.is_success()],
+                'outcome': KonfluxBuildOutcome.PENDING,
                 'assembly': self.assembly,
             },
             array_contains={'bundle_nvrs': bundle.nvr},
             limit=1,
-            order_by='ingestion_time',
+            order_by='start_time',
             sorting='DESC',
         ):
-            if fbc.outcome.is_failure():
-                self.logger.info(f'  FBC build for {operator.nvr} failed ({fbc.outcome.value}): {fbc.nvr}')
-                return None
+            # Check if a failure record with the same NVR exists
+            async for failed_build in self.fbc_db.search_builds_by_fields(
+                where={'nvr': fbc.nvr, 'outcome': [o for o in KonfluxBuildOutcome if o.is_failure()]},
+                limit=1,
+            ):
+                self.logger.info(
+                    f'  FBC build for {operator.nvr} failed ({failed_build.outcome.value}): {failed_build.nvr}'
+                )
+                return failed_build
+
             self.logger.info(f'  FBC build for {operator.nvr} in progress: {fbc.nvr}')
             return fbc
 


### PR DESCRIPTION
## Summary
- scan-operator's `check_bundle_exists()` and `check_fbc_exists()` now detect failed builds and trigger rebuilds
- Previously, only SUCCESS and PENDING outcomes were checked — a stale PENDING record masked failures, preventing retries
- Each method now queries for PENDING records separately, then checks if a failure record with the same NVR exists. If it does, the PENDING is stale and a rebuild is triggered. If not, the build is genuinely in progress

[Test run](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fscan-operator/35679/console)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection of failed operator and bundle scans by checking the most recent scan attempts and properly identifying failure cases, resulting in more accurate tracking of incomplete operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->