### PR TITLE
fix: skip scratch base image in scan-sources builder checks

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -1027,6 +1027,10 @@ class ConfigScanSources:
                 # Member builder changes are already being propagated to descendants: skip
                 continue
 
+            if builder.stream == 'scratch':
+                # 'FROM scratch' has no parent image to check for updates
+                continue
+
             # Resolve builder build NVR
             if builder.image:
                 builder_image_name = builder.image


### PR DESCRIPTION
## Summary
- Images using `from: scratch` have no real parent image, so `oc image info` fails when scan-sources tries to check builder NVR
- Skip the builder change check for `scratch`-based images, since there is no upstream image to compare against

## Test plan
- [ ] Verify scan-sources no longer errors on images with `from: scratch`
- [ ] Verify scan-sources still correctly detects builder changes for normal images

🤖 Generated with [Claude Code](https://claude.com/claude-code)