### PR TITLE
Use dedicated conforma policies for test assembly EC verification

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -95,6 +95,7 @@ class KonfluxImageBuilderConfig:
     dry_run: bool = False
     build_priority: Optional[str] = None
     ec_policy_configuration: str = constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION
+    prega_ec_policy_configuration: str = constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION
     skip_ec_verify: bool = False
 
 
@@ -324,7 +325,7 @@ class KonfluxImageBuilder:
                         lifecycle_phase is not Missing
                         and SoftwareLifecyclePhase.from_name(lifecycle_phase) == SoftwareLifecyclePhase.PRE_RELEASE
                     ):
-                        ec_policy = constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION
+                        ec_policy = self._config.prega_ec_policy_configuration
                     else:
                         ec_policy = self._config.ec_policy_configuration
 

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -792,10 +792,19 @@ class KonfluxOlmBundleBuilder:
                         image_with_digest = f"{image_pullspec.split(':')[0]}@{image_digest}"
                         source_url = artlib_util.convert_remote_git_to_https(bundle_build_repo.url)
 
+                        is_test_assembly = self.assembly == "test"
                         if self.assembly_type == AssemblyTypes.PREVIEW:
-                            ec_policy = constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION
+                            ec_policy = (
+                                constants.KONFLUX_TEST_PREGA_EC_POLICY_CONFIGURATION
+                                if is_test_assembly
+                                else constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION
+                            )
                         else:
-                            ec_policy = constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION
+                            ec_policy = (
+                                constants.KONFLUX_TEST_EC_POLICY_CONFIGURATION
+                                if is_test_assembly
+                                else constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION
+                            )
 
                         ec_result = await konflux_client.verify_enterprise_contract(
                             namespace=self.konflux_namespace,

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -306,6 +306,13 @@ class KonfluxBuildCli:
         else:
             group = runtime.group
 
+        if runtime.assembly == "test":
+            ec_policy = constants.KONFLUX_TEST_EC_POLICY_CONFIGURATION
+            prega_ec_policy = constants.KONFLUX_TEST_PREGA_EC_POLICY_CONFIGURATION
+        else:
+            ec_policy = constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION
+            prega_ec_policy = constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION
+
         config = KonfluxImageBuilderConfig(
             base_dir=Path(runtime.working_dir, constants.WORKING_SUBDIR_KONFLUX_BUILD_SOURCES),
             group_name=group,
@@ -319,6 +326,8 @@ class KonfluxBuildCli:
             dry_run=self.dry_run,
             plr_template=self.plr_template,
             build_priority=self.build_priority,
+            ec_policy_configuration=ec_policy,
+            prega_ec_policy_configuration=prega_ec_policy,
             skip_ec_verify=self.skip_ec_verify,
         )
         builder = KonfluxImageBuilder(config=config, record_logger=runtime.record_logger)

--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -75,6 +75,11 @@ KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION = "ocp-art-tenant/conforma-build-stage"
 # PreGA (PREVIEW assembly) EC policy: same as stage but allows unsigned RPMs
 # https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/tenants-config/cluster/kflux-ocp-p01/tenants/ocp-art-tenant/ecp-build-ec-stage.yaml
 KONFLUX_PREGA_EC_POLICY_CONFIGURATION = "ocp-art-tenant/conforma-build-ec-stage"
+# Test assembly EC policies: base images are not released for test assemblies, so the
+# art-images base image registry rule is permanently excluded for build-time ITSs to pass.
+# https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/19219
+KONFLUX_TEST_EC_POLICY_CONFIGURATION = "ocp-art-tenant/conforma-build-stage-test"
+KONFLUX_TEST_PREGA_EC_POLICY_CONFIGURATION = "ocp-art-tenant/conforma-build-ec-stage-test"
 # Base image release EC policies (ReleasePlanAdmission policy name suffix). Selection is by
 # software_lifecycle.phase in resolve_konflux_base_image_release_targets — ART-19498.
 # Prod: registry-ocp-art-base-prod | Pre-release: registry-ocp-art-base-ec-prod

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1419,8 +1419,8 @@ class ImageMetadata(Metadata):
 
         The method checks preconditions in the following order:
         0. Variant must be OCP (not OKD); OKD never uses RH base-image snapshot→release
-        1. Image metadata ``base_image_release.force`` set to true enables workflow (OCP only)
-        2. Assembly must not be ``test``
+        1. Assembly must not be ``test`` (unconditional block, not bypassed by force)
+        2. Image metadata ``base_image_release.force`` set to true enables workflow (OCP only)
         3. Image must be ``base_only`` or a golang builder
         4. Base image release enabled override:
            - Image metadata configuration (``self.config.base_image_release.enabled``)
@@ -1433,13 +1433,14 @@ class ImageMetadata(Metadata):
         if self.runtime.variant is BuildVariant.OKD:
             return False
 
+        if self.runtime.assembly == "test":
+            self.logger.info("Skipping base image release for test assembly")
+            return False
+
         base_image_release_force_override = self.config.base_image_release.force
         if base_image_release_force_override not in [Missing, None] and bool(base_image_release_force_override):
             self.logger.info("Base image release force enabled from metadata config True")
             return True
-
-        if self.runtime.assembly == "test":
-            return False
 
         if not (self.is_base_image() or self.is_golang_builder()):
             return False

--- a/doozer/tests/backend/test_konflux_ec_verification.py
+++ b/doozer/tests/backend/test_konflux_ec_verification.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
 from artcommonlib.variants import BuildVariant
+from doozerlib import constants
 from doozerlib.backend.konflux_client import ECVerificationResult
 from doozerlib.backend.konflux_image_builder import (
     KonfluxImageBuilder,
@@ -292,3 +293,55 @@ class TestEcVerificationGating(IsolatedAsyncioTestCase):
 
         # Verify that all retries were attempted (exception path allows retries)
         self.assertEqual(builder._start_build.call_count, 3)
+
+    async def test_ec_uses_default_policy_for_release_phase(self, mock_kc_init):
+        """Default (non-test) assembly with release lifecycle uses the default stage policy."""
+        config = _make_config(group_name="openshift-4.18")
+        metadata = _make_metadata(for_release=True)
+        metadata.runtime.group_config.software_lifecycle.phase = "release"
+
+        verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+        verify_ec.assert_called_once()
+        call_kwargs = verify_ec.call_args
+        self.assertEqual(call_kwargs.kwargs["ec_policy"], constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION)
+
+    async def test_ec_uses_prega_policy_for_pre_release_phase(self, mock_kc_init):
+        """Pre-release lifecycle phase uses the prega policy from config."""
+        config = _make_config(group_name="openshift-4.18")
+        metadata = _make_metadata(for_release=True)
+        metadata.runtime.group_config.software_lifecycle.phase = "pre-release"
+
+        verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+        verify_ec.assert_called_once()
+        call_kwargs = verify_ec.call_args
+        self.assertEqual(call_kwargs.kwargs["ec_policy"], constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION)
+
+    async def test_ec_uses_test_policy_from_config(self, mock_kc_init):
+        """Test assembly builds use the test-specific EC policy passed via config."""
+        config = _make_config(
+            group_name="openshift-4.18",
+            ec_policy_configuration=constants.KONFLUX_TEST_EC_POLICY_CONFIGURATION,
+            prega_ec_policy_configuration=constants.KONFLUX_TEST_PREGA_EC_POLICY_CONFIGURATION,
+        )
+        metadata = _make_metadata(for_release=True)
+        metadata.runtime.group_config.software_lifecycle.phase = "release"
+
+        verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+        verify_ec.assert_called_once()
+        call_kwargs = verify_ec.call_args
+        self.assertEqual(call_kwargs.kwargs["ec_policy"], constants.KONFLUX_TEST_EC_POLICY_CONFIGURATION)
+
+    async def test_ec_uses_test_prega_policy_for_pre_release(self, mock_kc_init):
+        """Test assembly builds with pre-release lifecycle use the test prega policy from config."""
+        config = _make_config(
+            group_name="openshift-4.18",
+            ec_policy_configuration=constants.KONFLUX_TEST_EC_POLICY_CONFIGURATION,
+            prega_ec_policy_configuration=constants.KONFLUX_TEST_PREGA_EC_POLICY_CONFIGURATION,
+        )
+        metadata = _make_metadata(for_release=True)
+        metadata.runtime.group_config.software_lifecycle.phase = "pre-release"
+
+        verify_ec = await self._run_build_and_get_ec_calls(config, metadata, mock_kc_init)
+        verify_ec.assert_called_once()
+        call_kwargs = verify_ec.call_args
+        self.assertEqual(call_kwargs.kwargs["ec_policy"], constants.KONFLUX_TEST_PREGA_EC_POLICY_CONFIGURATION)

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1943,6 +1943,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         )
         self.assertFalse(okd_forced_metadata.should_trigger_base_image_release())
 
+        # Force=true does NOT bypass test assembly block (test assembly is unconditional skip)
         test_assembly_forced_runtime = MagicMock()
         test_assembly_forced_runtime.logger = logging.getLogger('test_runtime')
         test_assembly_forced_runtime.variant = BuildVariant.OCP
@@ -1954,7 +1955,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
             test_assembly_forced_runtime,
             Model({'key': 'test-assembly-forced', 'data': test_assembly_forced, 'filename': 'taf.yaml'}),
         )
-        self.assertTrue(test_assembly_forced_metadata.should_trigger_base_image_release())
+        self.assertFalse(test_assembly_forced_metadata.should_trigger_base_image_release())
 
 
 class TestExtractGolangVersionFromPullspec(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Use `conforma-build-stage-test` and `conforma-build-ec-stage-test` policies for test assembly builds instead of the default stage policies
- Base images are not released for test assemblies, so the art-images base image registry rule is permanently excluded in these policies for build-time ITSs to pass
- Policies added in [KRD MR 19219](https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/19219)
- Block base image releases unconditionally for test assemblies by moving the `assembly == "test"` check before `base_image_release.force` in `should_trigger_base_image_release()`

## Changes
- **constants.py**: Add `KONFLUX_TEST_EC_POLICY_CONFIGURATION` and `KONFLUX_TEST_PREGA_EC_POLICY_CONFIGURATION`
- **konflux_image_builder.py**: Add `prega_ec_policy_configuration` field to `KonfluxImageBuilderConfig` so both policies are configurable (builder stays assembly-agnostic)
- **images_konflux.py**: Select test vs default policy pair based on `runtime.assembly == "test"`
- **konflux_olm_bundler.py**: Select test policies when `self.assembly == "test"` for OLM bundle builds
- **test_konflux_ec_verification.py**: Add 4 tests verifying policy selection for default, pre-release, test, and test+pre-release scenarios
- **image.py**: Reorder checks in `should_trigger_base_image_release()` so test assembly is an unconditional block (not bypassed by `force: true`)
- **test_image.py**: Update test to assert `force: true` + test assembly returns `False`

## Test plan
- [x] All 12 EC verification tests pass (8 existing + 4 new)
- [x] All 34 image builder tests pass
- [x] Base image release gate test passes with new assertion
- [x] Ruff lint passes on all changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable pre-GA Enterprise Contract policy settings for build verification flexibility.
  * Test assemblies now use dedicated EC and pre-GA EC policy configurations during verification.
  * EC policy selection now adapts to both assembly type and software lifecycle phase.
* **Bug Fixes**
  * Base image release triggering now correctly blocks the `"test"` assembly even when `force=true` is set.
* **Tests**
  * Added coverage to verify correct EC policy behavior across lifecycle phases and test/default assemblies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->