### PR TITLE
fix: prevent lockfile-related perpetual rebuild loops and empty lockfile build failures

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -974,9 +974,10 @@ class KonfluxRebaser:
             ):
                 from doozerlib.lockfile_prototype.rebaser_hooks import apply_dockerfile_transforms
 
+                lockfile_has_packages = bool(getattr(metadata, "lockfile_packages", None))
                 apply_dockerfile_transforms(
                     dest_dir,
-                    strip_updates=not downstream_parents,
+                    strip_updates=not downstream_parents or not lockfile_has_packages,
                     logger=self._logger,
                 )
 

--- a/doozer/doozerlib/lockfile_prototype/dockerfile_transforms.py
+++ b/doozer/doozerlib/lockfile_prototype/dockerfile_transforms.py
@@ -28,7 +28,7 @@ def strip_bare_updates(df_content: str) -> str:
         str: Transformed Dockerfile text with bare updates removed.
     """
     bare_update_re = re.compile(
-        r"\b(?:dnf|yum)\s+(?:-y\s+)?(?:update|upgrade)(?:\s+-y)?\s*(?:\\\n\s*&&\s*|&&\s*|;\s*|\n|(?=$))",
+        r"\b(?:microdnf|dnf|yum)\s+(?:-y\s+)?(?:update|upgrade)(?:\s+-y)?\s*(?:\\\n\s*&&\s*|&&\s*|;\s*|\n|(?=$))",
     )
     return bare_update_re.sub("", df_content)
 

--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -425,8 +425,18 @@ class RpmLockfilePrototypeGenerator:
                     stage_num, analysis.stages[stage_num], distgit_key
                 )
 
+            has_bare_update = stage_info.has_update and not stage_info.update_targets
+            if has_bare_update and not is_update_only and image_pullspec:
+                base_pkgs = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key)
+                if base_pkgs:
+                    upgrade_targets = list(base_pkgs)
+                    self.logger.info(
+                        f"{distgit_key}: stage {stage_num}: {len(upgrade_targets)} base image "
+                        "packages added as upgrade targets for bare update"
+                    )
+
             reinstall_pkgs: list[str] | None = None
-            if stage_num == final_stage_num and not is_update_only:
+            if stage_num == final_stage_num and not is_update_only and not has_bare_update:
                 if image_pullspec:
                     # --image mode: pass base image packages as reinstallPackages
                     # so they appear in the lockfile at repo versions. base.reinstall()
@@ -435,6 +445,9 @@ class RpmLockfilePrototypeGenerator:
                     # populates packages and upgrade_targets with all base image packages,
                     # so reinstall is redundant for coverage and would only pin them to
                     # the base image version, preventing updates from landing.
+                    # Also skipped when the stage has a bare update (e.g. microdnf update -y):
+                    # reinstall would pin base image versions and override upgrade semantics,
+                    # preventing the update from picking up latest RPMs from repos.
                     base_pkgs = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key)
                     if base_pkgs:
                         reinstall_pkgs = list(base_pkgs)

--- a/doozer/tests/lockfile_prototype/test_dockerfile_transforms.py
+++ b/doozer/tests/lockfile_prototype/test_dockerfile_transforms.py
@@ -23,6 +23,24 @@ class TestStripBareUpdates(unittest.TestCase):
         self.assertNotIn("dnf update -y", result)
         self.assertIn("dnf clean all", result)
 
+    def test_strips_bare_microdnf_update(self):
+        content = (
+            "RUN . /cachi2/cachi2.env &&     "
+            "echo 'skip_missing_names_on_install=0' >> /etc/yum.conf  "
+            "&& microdnf update -y   "
+            "&& microdnf clean all\n"
+        )
+        result = strip_bare_updates(content)
+        self.assertNotIn("microdnf update -y", result)
+        self.assertIn("microdnf clean all", result)
+        self.assertIn("cachi2.env", result)
+
+    def test_strips_microdnf_flag_before_action(self):
+        content = "RUN microdnf -y update && microdnf clean all\n"
+        result = strip_bare_updates(content)
+        self.assertNotIn("microdnf -y update", result)
+        self.assertIn("microdnf clean all", result)
+
     def test_strips_bare_dnf_upgrade(self):
         content = "RUN dnf upgrade -y && dnf clean all\n"
         result = strip_bare_updates(content)

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -526,6 +526,47 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         # No upgrade targets — dnf update handled at build time
         self.assertEqual(captured_configs[0].upgradePackages, [])
 
+    def test_mixed_install_and_bare_update_skips_reinstall(self):
+        """
+        When a stage has both explicit installs and a bare update
+        (e.g. microdnf update -y && microdnf install -y openssl),
+        reinstallPackages must be empty. Otherwise reinstall pins base
+        image versions and overrides upgrade semantics, preventing the
+        update from picking up latest RPMs — causing a perpetual
+        rebuild loop when scan-sources detects outdated packages.
+        """
+        meta = self._make_mock_image_meta()
+        meta.config.konflux.cachi2.lockfile.get.return_value = None
+        generator = self._make_generator()
+        generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
+        generator._container.get_installed_packages = AsyncMock(return_value=["audit", "bash", "glibc"])
+
+        captured_configs: list[RpmsInConfig] = []
+
+        async def capture_resolve(config, image_pullspec=None):
+            captured_configs.append(config)
+            return FAKE_LOCKFILE_DATA.model_copy(deep=True)
+
+        generator._resolver.resolve = AsyncMock(side_effect=capture_resolve)
+
+        with TemporaryDirectory() as tmpdir:
+            dest_dir = Path(tmpdir)
+            (dest_dir / "Dockerfile").write_text(
+                "FROM base\nRUN microdnf update -y && microdnf install -y openssl && microdnf clean all\n"
+            )
+            asyncio.run(generator.generate_lockfile(meta, dest_dir))
+
+        self.assertEqual(len(captured_configs), 1)
+        # reinstallPackages must be empty: bare update means we want
+        # upgrade semantics, and reinstall would pin old versions
+        self.assertEqual(captured_configs[0].reinstallPackages, [])
+        # Explicit install package must be present
+        pkg_names = [p if isinstance(p, str) else p.name for p in captured_configs[0].packages]
+        self.assertIn("openssl", pkg_names)
+        # Base image packages must appear as upgrade targets so
+        # dnf update picks up latest versions from repos
+        self.assertEqual(sorted(captured_configs[0].upgradePackages), ["audit", "bash", "glibc"])
+
     def test_reinstall_packages_also_passed_as_upgrade_targets(self):
         """
         Base image packages passed as reinstallPackages must also appear


### PR DESCRIPTION
Four fixes for hermetic build issues with rpm-lockfile-prototype:

1. dockerfile_transforms.py: Add microdnf to the strip_bare_updates regex so bare microdnf update commands are stripped when strip_updates=True.

2. generator.py: Skip reinstallPackages when a stage has a bare update (e.g. microdnf update -y) even when combined with install commands. Same root cause as https://github.com/openshift-eng/art-tools/pull/3063 — reinstall overrides upgrade in rpm-lockfile-prototype, pinning old base image versions and preventing the update from picking up latest RPMs from repos.

3. generator.py: For mixed install+bare-update stages, populate upgrade targets from base image packages. Without this, base image RPMs like `which` don't appear in the lockfile at all — _resolve_bare_update_targets returns empty for bare updates, so inherited packages are never upgraded and the scan keeps detecting them as outdated.

4. rebaser.py: Force strip_updates=True when the lockfile has no packages. When all base image RPMs are already at repo versions, rpm-lockfile-prototype returns an empty lockfile. Without stripping, the bare update tries to refresh unreachable external repos (e.g. cdn-ubi.redhat.com) in hermetic mode and fails with DNS errors.