### PR TITLE
Sign RHCOS containers for z-stream releases during promote

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -761,12 +761,13 @@ def start_build_microshift_bootc(
     )
 
 
-def start_rhcos_sync(release_tag_or_pullspec: str, dry_run: bool, **kwargs) -> Optional[str]:
+def start_rhcos_sync(release_tag_or_pullspec: str, dry_run: bool, sign_only: bool = False, **kwargs) -> Optional[str]:
     return start_build(
         job=Jobs.RHCOS_SYNC,
         params={
             'RELEASE_TAG': release_tag_or_pullspec,
             'DRY_RUN': dry_run,
+            'SIGN_ONLY': sign_only,
         },
         **kwargs,
     )

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -598,8 +598,9 @@ class PromotePipeline:
                         await self.sign_artifacts(release_name, client_type, release_infos, message_digests)
 
                 # publish rhcos on mirror via rhcos_sync job
-                # only if release is EC, RC, or a GA release (.0)
-                # job will not mirror & overwrite if destination already exists (sync already happened)
+                # EC, RC, GA(.0): full sync (mirror + sign)
+                # z-stream: sign RHCOS containers only (no mirror sync needed)
+                # full sync will not mirror & overwrite if destination already exists (sync already happened)
                 # if that is desired, run rhcos_sync with FORCE=true
                 is_ga = assembly_type == AssemblyTypes.STANDARD and self.assembly.endswith(".0")
                 if assembly_type in (AssemblyTypes.PREVIEW, AssemblyTypes.CANDIDATE) or is_ga:
@@ -608,9 +609,15 @@ class PromotePipeline:
                             continue
 
                         # '4.19.0-ec.0-aarch64' from 'quay.io/openshift-release-dev/ocp-release:4.19.0-ec.0-aarch64'
-                        # Since rhocs_sync does not take the quay URL as prefix
+                        # Since rhcos_sync does not take the quay URL as prefix
                         short_name = pullspec.split(":")[-1]
                         jenkins.start_rhcos_sync(short_name, dry_run=self.runtime.dry_run)
+                elif assembly_type == AssemblyTypes.STANDARD:
+                    for arch, pullspec in pullspecs.items():
+                        if arch == "multi":
+                            continue
+                        short_name = pullspec.split(":")[-1]
+                        jenkins.start_rhcos_sync(short_name, dry_run=self.runtime.dry_run, sign_only=True)
 
         except Exception as err:
             self._logger.exception(err)

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -734,6 +734,8 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         pipeline.wait_for_stable.assert_any_await("4.10.99", "aarch64", "4-stable-arm64")
         pipeline.send_image_list_email.assert_awaited_once_with("4.10.99", 2, ANY)
         sign_artifacts.assert_awaited_once_with("4.10.99", "ocp", ANY, [])
+        for arch in ["x86_64", "s390x", "ppc64le", "aarch64"]:
+            start_rhcos_sync.assert_any_call(f"4.10.99-{arch}", dry_run=False, sign_only=True)
 
     @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
     @patch("pyartcd.pipelines.promote.PromotePipeline.tag_release", return_value=None)

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -582,8 +582,10 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
     @patch("pyartcd.pipelines.promote.PromotePipeline.send_promote_complete_email")
     @patch("pyartcd.pipelines.promote.PromotePipeline.create_cincinnati_prs")
     @patch("pyartcd.pipelines.promote.PromotePipeline.verify_payload")
+    @patch("pyartcd.pipelines.promote.jenkins.start_rhcos_sync")
     async def test_run_with_standard_assembly(
         self,
+        start_rhcos_sync: Mock,
         verify_payload: AsyncMock,
         create_cincinnati_prs: AsyncMock,
         send_promote_complete_email: Mock,

--- a/pyartcd/tests/test_jenkins.py
+++ b/pyartcd/tests/test_jenkins.py
@@ -8,6 +8,14 @@ from pyartcd import jenkins
 
 
 class TestJenkinsStartBuild(unittest.TestCase):
+    def setUp(self):
+        jenkins.current_build_url = None
+        jenkins.current_job_name = None
+
+    def tearDown(self):
+        jenkins.current_build_url = None
+        jenkins.current_job_name = None
+
     @mock.patch("pyartcd.jenkins.init_jenkins")
     @mock.patch("pyartcd.jenkins.jenkins_client")
     def test_start_build_dont_block(self, mock_client, mock_init_jenkins):


### PR DESCRIPTION
## Summary
- Add `sign_only` parameter to `start_rhcos_sync()` in `jenkins.py`, passed through as `SIGN_ONLY` to the Jenkins job.
- Update promote pipeline to trigger `rhcos_sync` with `SIGN_ONLY=true` for z-stream STANDARD releases (assemblies not ending in `.0`), ensuring RHCOS container images are signed for all releases.

## Motivation
Previously, `rhcos_sync` was only triggered during promote for EC/RC/GA(.0) releases. Z-stream releases (4.x.1, 4.x.2, etc.) never got RHCOS container signing. This change adds an `elif` branch for z-stream STANDARD releases that triggers signing without the full mirror sync.

Companion PR for aos-cd-jobs: https://github.com/openshift-eng/aos-cd-jobs/pull/4738

## Test plan
- [ ] Verify promote for a z-stream assembly calls `start_rhcos_sync` with `sign_only=True`
- [ ] Verify promote for EC/RC/GA(.0) assemblies continues to call `start_rhcos_sync` without `sign_only` (full sync)
- [ ] Verify existing unit tests pass


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sign-only option for RHCOS sync Jenkins builds, passed as `sign_only` alongside existing dry-run and release tag settings.
  * Updated release promotion triggering to use full sync for standard/candidate/GA and sign-only for z-stream, with clearer skip behavior when destinations already exist.
* **Tests**
  * Enhanced promotion tests to verify sign-only sync is requested per architecture.
  * Improved Jenkins test reliability by resetting shared build/job state between test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->