### PR TITLE
fix: lockfile builder stage handling, retry logic, and TMPDIR

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/constants.py
+++ b/doozer/doozerlib/lockfile_prototype/constants.py
@@ -2,6 +2,7 @@
 Constants and enums for the lockfile prototype package.
 """
 
+import re
 from enum import Enum
 from pathlib import Path
 
@@ -32,6 +33,8 @@ ARCH_KEYWORDS = ARCH_SUBSHELL_KEYWORDS + tuple(form for name in ARCH_VAR_NAMES f
 
 # RPM pseudo-packages that appear in rpmdb but are not installable via DNF
 RPM_PSEUDO_PACKAGES = frozenset({"gpg-pubkey"})
+
+VALID_PKG_NAME = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._+\-]*$")
 
 
 # rpm-lockfile-prototype stores extracted RPMDBs here. There is no env var

--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -436,6 +436,7 @@ class RpmLockfilePrototypeGenerator:
                     )
 
             reinstall_pkgs: list[str] | None = None
+            strippable: set[str] | None = None
             if stage_num == final_stage_num and not is_update_only and not has_bare_update:
                 if image_pullspec:
                     # --image mode: pass base image packages as reinstallPackages
@@ -451,6 +452,7 @@ class RpmLockfilePrototypeGenerator:
                     base_pkgs = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key)
                     if base_pkgs:
                         reinstall_pkgs = list(base_pkgs)
+                        strippable = set(base_pkgs) - set(packages) - set(upgrade_targets)
                         self.logger.info(
                             f"{distgit_key}: stage {stage_num}: {len(reinstall_pkgs)} base image "
                             "packages will be reinstalled into lockfile"
@@ -463,7 +465,24 @@ class RpmLockfilePrototypeGenerator:
                     if base_pkgs:
                         extra = [p for p in base_pkgs if p not in packages]
                         if extra:
+                            strippable = set(extra)
                             packages = packages + extra
+            elif stage_num != final_stage_num and not is_update_only:
+                # Non-final stage (builder): reinstall the Dockerfile packages
+                # so they appear in the lockfile even when already installed
+                # on some architectures, and add base image packages to the
+                # install list for conflict detection.
+                if image_pullspec:
+                    reinstall_pkgs = list(packages)
+                base_pkgs = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key)
+                if base_pkgs:
+                    extra = [p for p in base_pkgs if p not in packages]
+                    if extra:
+                        packages = packages + extra
+                        self.logger.info(
+                            f"{distgit_key}: stage {stage_num}: {len(extra)} base image "
+                            "packages added to install list for conflict detection"
+                        )
 
             enable_only = [s.split("/")[0] for s in stage_info.module_specs] if stage_info.module_specs else None
 
@@ -478,6 +497,7 @@ class RpmLockfilePrototypeGenerator:
                 stage_num,
                 module_enable=enable_only,
                 reinstall_packages=reinstall_pkgs,
+                strippable_packages=strippable,
             )
             if result:
                 stage_lockfiles.append(result)
@@ -663,9 +683,17 @@ class RpmLockfilePrototypeGenerator:
         stage_num: int,
         module_enable: list[str] | None = None,
         reinstall_packages: list[str] | None = None,
+        strippable_packages: set[str] | None = None,
     ) -> LockfileData | None:
         """
         Resolve a single stage, retrying after removing unavailable packages.
+
+        Arg(s):
+            strippable_packages (set[str] | None): Packages that may be
+                silently removed during retries (e.g. base image packages
+                added for conflict detection). If a missing package is NOT
+                in this set, it is a required Dockerfile package and the
+                error is raised immediately.
 
         Return Value(s):
             LockfileData | None: Lockfile data, or None if all packages filtered out.
@@ -679,15 +707,23 @@ class RpmLockfilePrototypeGenerator:
         # use the no-auth registry proxy instead.
         resolver_pullspec = ContainerImageHelper._proxy_pullspec(image_pullspec) if image_pullspec else None
 
-        # When reinstall_packages is set, also pass them as upgrade targets.
-        # base.reinstall() raises PackagesNotAvailableError when the installed
-        # version isn't in the configured repos — but rpm-lockfile-prototype
-        # swallows that error when the package is also in upgradePackages
-        # (the upgrade provides a replacement version).
+        # When reinstall_packages comes from the base image (final stage),
+        # also pass them as upgrade targets. base.reinstall() raises
+        # PackagesNotAvailableError when the installed version isn't in
+        # the configured repos — but rpm-lockfile-prototype swallows that
+        # error when the package is also in upgradePackages (the upgrade
+        # provides a replacement version).
+        # For builder stages (strippable_packages is None), reinstall
+        # packages are Dockerfile packages that may not be installed in
+        # the base image — adding them to upgradePackages would cause
+        # PackagesNotInstalledError.
         remaining_reinstall = list(reinstall_packages) if reinstall_packages else []
+        promote_reinstall_to_upgrade = strippable_packages is not None
+        retries_exhausted = False
 
-        for attempt in range(MAX_RESOLUTION_RETRIES):
-            effective_upgrade = list(set(remaining_update_targets + remaining_reinstall)) if image_pullspec else None
+        for _attempt in range(MAX_RESOLUTION_RETRIES):
+            upgrade_extras = remaining_reinstall if promote_reinstall_to_upgrade else []
+            effective_upgrade = list(set(remaining_update_targets + upgrade_extras)) if image_pullspec else None
             in_yaml = build_rpms_in_yaml(
                 repo_list,
                 arches,
@@ -699,11 +735,23 @@ class RpmLockfilePrototypeGenerator:
             )
 
             try:
+                mode = "image" if resolver_pullspec else "bare"
+                self.logger.info(
+                    f"{distgit_key}: stage {stage_num}: resolving {len(remaining_packages)} packages in {mode} mode"
+                )
+                self.logger.debug(f"{distgit_key}: stage {stage_num}: full package list: {remaining_packages}")
                 return await self._resolver.resolve(in_yaml, image_pullspec=resolver_pullspec)
             except RuntimeError as e:
                 missing = RpmResolver.parse_missing_packages(str(e))
                 if not missing:
                     raise
+                if strippable_packages is not None:
+                    required_missing = missing - strippable_packages
+                    if required_missing:
+                        raise RuntimeError(
+                            f"{distgit_key}: stage {stage_num}: required packages not available "
+                            f"in configured repos: {sorted(required_missing)}"
+                        ) from e
                 prev_count = (
                     len(remaining_packages)
                     + sum(len(v) for v in arch_pkgs.values())
@@ -733,7 +781,44 @@ class RpmLockfilePrototypeGenerator:
                         f"{distgit_key}: stage {stage_num}: no packages remaining after filtering, skipping"
                     )
                     return None
-        raise RuntimeError(f"{distgit_key}: stage {stage_num}: exceeded {MAX_RESOLUTION_RETRIES} resolution retries")
+                if strippable_packages is not None:
+                    required_reinstall = [p for p in remaining_reinstall if p not in strippable_packages]
+                    if not required_reinstall and remaining_reinstall:
+                        self.logger.info(
+                            f"{distgit_key}: stage {stage_num}: all {len(remaining_reinstall)} "
+                            "remaining reinstall packages are optional, skipping retries"
+                        )
+                        break
+        else:
+            retries_exhausted = True
+        if strippable_packages is not None:
+            required_pkgs = set(remaining_packages) - strippable_packages
+            dropped = [p for p in remaining_reinstall if p not in required_pkgs]
+            remaining_reinstall = [p for p in remaining_reinstall if p in required_pkgs]
+            if retries_exhausted:
+                self.logger.warning(
+                    f"{distgit_key}: stage {stage_num}: exceeded {MAX_RESOLUTION_RETRIES} retries, "
+                    f"dropped {len(dropped)} optional reinstall packages, "
+                    f"keeping {len(remaining_reinstall)} required"
+                )
+        else:
+            self.logger.warning(
+                f"{distgit_key}: stage {stage_num}: exceeded {MAX_RESOLUTION_RETRIES} retries, "
+                "continuing without reinstall packages"
+            )
+            remaining_reinstall.clear()
+        fallback_upgrade_extras = remaining_reinstall if promote_reinstall_to_upgrade else []
+        effective_upgrade = list(set(remaining_update_targets + fallback_upgrade_extras)) if image_pullspec else None
+        in_yaml = build_rpms_in_yaml(
+            repo_list,
+            arches,
+            remaining_packages,
+            arch_specific_packages=arch_pkgs,
+            reinstall_packages=remaining_reinstall if image_pullspec else None,
+            upgrade_packages=effective_upgrade,
+            module_enable=module_enable,
+        )
+        return await self._resolver.resolve(in_yaml, image_pullspec=resolver_pullspec)
 
     def _assemble_lockfile(self, stage_lockfiles: list[LockfileData], image_meta: ImageMetadata) -> LockfileData:
         """
@@ -831,6 +916,7 @@ class RpmLockfilePrototypeGenerator:
         stage_num: int,
         module_enable: list[str] | None = None,
         reinstall_packages: list[str] | None = None,
+        strippable_packages: set[str] | None = None,
     ) -> LockfileData | None:
         """
         Resolve a stage with cross-arch version reconciliation.
@@ -851,6 +937,8 @@ class RpmLockfilePrototypeGenerator:
             module_enable (list[str] | None): Module streams to enable.
             reinstall_packages (list[str] | None): Base image packages to
                 reinstall from repos into the lockfile.
+            strippable_packages (set[str] | None): Packages that may be
+                silently removed during retries (conflict detection packages).
         Return Value(s):
             LockfileData | None: Resolved lockfile with consistent
                 versions, or None if no packages remain.
@@ -866,6 +954,7 @@ class RpmLockfilePrototypeGenerator:
             stage_num,
             module_enable=module_enable,
             reinstall_packages=reinstall_packages,
+            strippable_packages=strippable_packages,
         )
         if not first_pass:
             return None
@@ -885,6 +974,11 @@ class RpmLockfilePrototypeGenerator:
         )
 
         pinned_packages = list(packages) + version_pins
+        pinned_names = set(mismatches.keys())
+        pinned_update_targets = [t for t in update_targets if t not in pinned_names]
+        pinned_reinstall = (
+            [p for p in reinstall_packages if p not in pinned_names] if reinstall_packages else reinstall_packages
+        )
 
         try:
             second_pass = await self._resolve_stage_with_retry(
@@ -892,12 +986,13 @@ class RpmLockfilePrototypeGenerator:
                 arches,
                 pinned_packages,
                 arch_pkgs,
-                update_targets,
+                pinned_update_targets,
                 image_pullspec,
                 distgit_key,
                 stage_num,
                 module_enable=module_enable,
-                reinstall_packages=reinstall_packages,
+                reinstall_packages=pinned_reinstall,
+                strippable_packages=strippable_packages,
             )
         except RuntimeError:
             self.logger.warning(

--- a/doozer/doozerlib/lockfile_prototype/resolver.py
+++ b/doozer/doozerlib/lockfile_prototype/resolver.py
@@ -24,6 +24,7 @@ from doozerlib.lockfile_prototype.constants import (
     RPMDB_CACHE_ERROR_PATTERNS,
     RPMDB_CACHE_PATH,
     SYSTEM_PYTHON,
+    VALID_PKG_NAME,
 )
 from doozerlib.lockfile_prototype.models import LockfileData, RpmsInConfig
 from doozerlib.lockfile_prototype.utils import build_env
@@ -80,6 +81,7 @@ class RpmResolver:
 
             env = build_env()
             env["RPM_LOCKFILE_PROTOTYPE_DNF_CACHE"] = self._cache_path
+            env["TMPDIR"] = self._working_dir
             rc, _, stderr = await cmd_gather_async(cmd, check=False, env=env)
 
             if rc != 0:
@@ -164,4 +166,4 @@ class RpmResolver:
             m = re.search(r"No match for argument:\s*(\S+)", line.strip())
             if m:
                 missing.add(m.group(1).strip().rstrip(":"))
-        return missing
+        return {p for p in missing if VALID_PKG_NAME.match(p)}

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -290,12 +290,13 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         self.assertEqual(captured_pullspecs[0], "quay.io/test/builder@sha256:abc123")
         self.assertIsNone(captured_pullspecs[1])
 
-    def test_builder_stage_skips_reinstall_when_final_stage_has_no_installs(self):
+    def test_builder_stage_reinstalls_dockerfile_packages_and_adds_conflict_detection(self):
         """
         Multi-stage Dockerfile where only the builder stage installs
-        packages (e.g. thanos). reinstallPackages should NOT be added
-        to the builder stage — only the actual final Dockerfile stage
-        should get reinstallPackages.
+        packages (e.g. prometheus-promu). reinstallPackages should contain
+        the Dockerfile packages so they appear in the lockfile even when
+        already installed on some architectures. upgradePackages must NOT
+        include them (they may not be installed in the base image).
         """
         meta = self._make_mock_image_meta()
         meta.config.konflux.cachi2.lockfile.get.return_value = None
@@ -326,10 +327,65 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
             asyncio.run(generator.generate_lockfile(meta, dest_dir))
 
         self.assertEqual(len(captured_configs), 1)
-        # Builder stage should NOT have reinstallPackages
-        self.assertEqual(captured_configs[0].reinstallPackages, [])
-        # get_installed_packages should NOT be called for non-final stage
-        generator._container.get_installed_packages.assert_not_called()
+        # reinstallPackages should contain the Dockerfile packages
+        self.assertEqual(captured_configs[0].reinstallPackages, ["prometheus-promu"])
+        # Dockerfile packages must NOT be in upgradePackages (they may
+        # not be installed in the base image — upgrade would fail)
+        self.assertNotIn("prometheus-promu", captured_configs[0].upgradePackages or [])
+        # Base image packages should be queried for conflict detection
+        generator._container.get_installed_packages.assert_called_once()
+        # Base image packages should be in the install list
+        pkg_names = [p if isinstance(p, str) else p.name for p in captured_configs[0].packages]
+        for pkg in ["bash", "gcc", "golang", "glibc"]:
+            self.assertIn(pkg, pkg_names)
+
+    def test_builder_stage_conflict_detection_includes_base_deps(self):
+        """
+        Multi-stage Dockerfile like openshift-enterprise-pod where the
+        builder stage installs gcc and the builder's base image has
+        gcc-c++ pre-installed. The lockfile should include gcc-c++ in
+        the install list for conflict detection, and reinstallPackages
+        should contain only the Dockerfile packages.
+        """
+        meta = self._make_mock_image_meta()
+        meta.config.konflux.cachi2.lockfile.get.return_value = None
+        generator = self._make_generator()
+        generator.downstream_parents = [
+            "quay.io/test/golang-builder@sha256:abc123",
+            "quay.io/test/base@sha256:def456",
+        ]
+        generator._container.get_installed_packages = AsyncMock(
+            return_value=["gcc", "gcc-c++", "glibc", "glibc-static", "libgcc"]
+        )
+
+        captured_configs: list[RpmsInConfig] = []
+
+        async def capture_resolve(config, image_pullspec=None):
+            captured_configs.append(config)
+            return FAKE_LOCKFILE_DATA.model_copy(deep=True)
+
+        generator._resolver.resolve = AsyncMock(side_effect=capture_resolve)
+
+        with TemporaryDirectory() as tmpdir:
+            dest_dir = Path(tmpdir)
+            (dest_dir / "Dockerfile").write_text(
+                "FROM golang-builder AS builder\n"
+                "RUN dnf install -y gcc glibc-static\n"
+                "\n"
+                "FROM base-rhel9\n"
+                "COPY --from=builder /bin/pause /usr/bin/pod\n"
+            )
+            asyncio.run(generator.generate_lockfile(meta, dest_dir))
+
+        self.assertEqual(len(captured_configs), 1)
+        # reinstallPackages should contain only the Dockerfile packages
+        self.assertEqual(sorted(captured_configs[0].reinstallPackages), ["gcc", "glibc-static"])
+        pkg_names = [p if isinstance(p, str) else p.name for p in captured_configs[0].packages]
+        # gcc-c++ from the base image should be in the install list
+        self.assertIn("gcc-c++", pkg_names)
+        # Already-listed packages should not be duplicated
+        self.assertEqual(pkg_names.count("gcc"), 1)
+        self.assertEqual(pkg_names.count("glibc-static"), 1)
 
     def test_update_only_queries_base_image(self):
         """
@@ -602,11 +658,11 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         # Dockerfile install packages are NOT in reinstall or upgrade
         self.assertNotIn("curl", reinstall)
 
-    def test_reinstall_retry_removes_unavailable_packages(self):
+    def test_reinstall_retry_skips_retries_when_all_optional(self):
         """
-        When a reinstall/upgrade package fails resolution (e.g. package
-        not found in repos at all), the retry loop must remove it from
-        reinstallPackages and upgradePackages before retrying.
+        When a reinstall/upgrade package fails and all remaining reinstall
+        packages are optional (strippable), the retry loop should exit
+        early and fall back to resolving without reinstall packages.
         """
         meta = self._make_mock_image_meta()
         meta.config.konflux.cachi2.lockfile.get.return_value = None
@@ -630,15 +686,14 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
             (dest_dir / "Dockerfile").write_text("FROM base\nRUN dnf install -y curl\n")
             asyncio.run(generator.generate_lockfile(meta, dest_dir))
 
-        # Should have retried successfully
+        # First attempt fails, then early exit + fallback = 2 calls total
         self.assertEqual(call_count, 2)
-        # Second call should not have "nonexistent-pkg" in reinstall or upgrade
-        second_config = generator._resolver.resolve.call_args_list[1][0][0]
-        self.assertNotIn("nonexistent-pkg", second_config.reinstallPackages)
-        self.assertNotIn("nonexistent-pkg", second_config.upgradePackages)
-        # "glibc" should still be present
-        self.assertIn("glibc", second_config.reinstallPackages)
-        self.assertIn("glibc", second_config.upgradePackages)
+        # Fallback should drop all optional reinstall packages
+        fallback_config = generator._resolver.resolve.call_args_list[1][0][0]
+        self.assertEqual(fallback_config.reinstallPackages, [])
+        # Dockerfile package must still be in the install list
+        pkg_names = [p if isinstance(p, str) else p.name for p in fallback_config.packages]
+        self.assertIn("curl", pkg_names)
 
     def test_fallback_packages_used_when_image_unreachable(self):
         """
@@ -857,6 +912,248 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         self.assertEqual(call_count, 2)
         self.assertNotIn("policycoreutils-python-utils", captured_configs[1].packages)
         self.assertNotIn("policycoreutils-python-utils", captured_configs[1].upgradePackages)
+
+    def test_retry_raises_on_required_dockerfile_package_missing(self):
+        """
+        When a required Dockerfile package (not in strippable_packages) is
+        reported missing, _resolve_stage_with_retry must raise immediately
+        instead of silently stripping it.
+        """
+        generator = self._make_generator()
+        generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
+
+        async def mock_resolve(config, image_pullspec=None):
+            raise RuntimeError("No match for argument: glibc-static")
+
+        generator._resolver.resolve = AsyncMock(side_effect=mock_resolve)
+
+        repos = [
+            RepoEntry(
+                repoid="rhel-9-baseos-rpms",
+                baseurl="https://example.com/baseos/$basearch/os/",
+            )
+        ]
+
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(
+                generator._resolve_stage_with_retry(
+                    repo_list=repos,
+                    arches=["x86_64"],
+                    packages=["gcc", "glibc-static", "bash"],
+                    arch_pkgs={},
+                    update_targets=[],
+                    image_pullspec="quay.io/test/base@sha256:abc123",
+                    distgit_key="openshift-enterprise-pod",
+                    stage_num=0,
+                    strippable_packages={"bash"},
+                )
+            )
+        self.assertIn("required packages not available", str(ctx.exception))
+        self.assertIn("glibc-static", str(ctx.exception))
+        # Should fail on first attempt, no retries
+        self.assertEqual(generator._resolver.resolve.call_count, 1)
+
+    def test_retry_strips_only_conflict_detection_packages(self):
+        """
+        When strippable_packages is set, only those packages are removed
+        during retries. Original Dockerfile packages are preserved.
+        """
+        generator = self._make_generator()
+        generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
+
+        call_count = 0
+
+        async def mock_resolve(config, image_pullspec=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("No match for argument: libfoo-dev")
+            return FAKE_LOCKFILE_DATA.model_copy(deep=True)
+
+        generator._resolver.resolve = AsyncMock(side_effect=mock_resolve)
+
+        repos = [
+            RepoEntry(
+                repoid="rhel-9-baseos-rpms",
+                baseurl="https://example.com/baseos/$basearch/os/",
+            )
+        ]
+
+        result = asyncio.run(
+            generator._resolve_stage_with_retry(
+                repo_list=repos,
+                arches=["x86_64"],
+                packages=["gcc", "glibc-static", "libfoo-dev"],
+                arch_pkgs={},
+                update_targets=[],
+                image_pullspec="quay.io/test/base@sha256:abc123",
+                distgit_key="test-image",
+                stage_num=0,
+                strippable_packages={"libfoo-dev", "libbar"},
+            )
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(call_count, 2)
+        second_config = generator._resolver.resolve.call_args_list[1][0][0]
+        # Strippable package removed
+        self.assertNotIn("libfoo-dev", second_config.packages)
+        # Required packages preserved
+        self.assertIn("gcc", second_config.packages)
+        self.assertIn("glibc-static", second_config.packages)
+
+    def test_fallback_keeps_required_packages_in_reinstall(self):
+        """
+        When retry exhaustion fallback fires, required Dockerfile packages
+        that overlap with reinstallPackages must be preserved in reinstall.
+        Otherwise packages pre-installed in the base image disappear from
+        the lockfile (dnf says 'already installed', skips them).
+        """
+        generator = self._make_generator()
+        generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
+
+        failing_pkgs = [f"base-pkg-{i}" for i in range(5)]
+        call_count = 0
+
+        async def mock_resolve(config, image_pullspec=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 5:
+                raise RuntimeError(f"No match for argument: {failing_pkgs[call_count - 1]}")
+            return FAKE_LOCKFILE_DATA.model_copy(deep=True)
+
+        generator._resolver.resolve = AsyncMock(side_effect=mock_resolve)
+
+        repos = [
+            RepoEntry(
+                repoid="rhel-9-baseos-rpms",
+                baseurl="https://example.com/baseos/$basearch/os/",
+            )
+        ]
+
+        # Dockerfile packages: git, gzip, util-linux
+        # Base image packages (reinstall + strippable): git, gzip, + 5 failing base pkgs
+        # "git" and "gzip" are in both — they must stay in reinstall after fallback
+        all_packages = ["git", "gzip", "util-linux"] + failing_pkgs
+        reinstall = ["git", "gzip"] + failing_pkgs
+        strippable = set(failing_pkgs)
+
+        result = asyncio.run(
+            generator._resolve_stage_with_retry(
+                repo_list=repos,
+                arches=["x86_64", "aarch64"],
+                packages=all_packages,
+                arch_pkgs={},
+                update_targets=[],
+                image_pullspec="quay.io/test/base@sha256:abc123",
+                distgit_key="openshift-enterprise-tests",
+                stage_num=1,
+                reinstall_packages=reinstall,
+                strippable_packages=strippable,
+            )
+        )
+
+        self.assertIsNotNone(result)
+        # 5 retries (one failing pkg each) + 1 fallback = 6 calls
+        self.assertEqual(call_count, 6)
+        final_config = generator._resolver.resolve.call_args_list[5][0][0]
+        # Required Dockerfile packages must remain in reinstallPackages
+        self.assertIn("git", final_config.reinstallPackages)
+        self.assertIn("gzip", final_config.reinstallPackages)
+        # Strippable packages must be gone
+        for pkg in failing_pkgs:
+            self.assertNotIn(pkg, final_config.reinstallPackages)
+
+    def test_upgrade_targets_not_strippable_in_final_stage(self):
+        """
+        Dockerfile update targets (e.g. 'yum update -y python3-six') that
+        are also base image packages must not be strippable. Otherwise the
+        retry fallback drops them from reinstall and they disappear from
+        the lockfile on arches where the update has no newer version.
+        """
+        generator = self._make_generator()
+        generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
+
+        failing_pkgs = [f"base-pkg-{i}" for i in range(5)]
+        call_count = 0
+
+        async def mock_resolve(config, image_pullspec=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 5:
+                raise RuntimeError(f"No match for argument: {failing_pkgs[call_count - 1]}")
+            return FAKE_LOCKFILE_DATA.model_copy(deep=True)
+
+        generator._resolver.resolve = AsyncMock(side_effect=mock_resolve)
+
+        repos = [
+            RepoEntry(
+                repoid="rhel-9-baseos-rpms",
+                baseurl="https://example.com/baseos/$basearch/os/",
+            )
+        ]
+
+        # python3-six is a Dockerfile update target AND a base image package.
+        # It must NOT be strippable — it must survive the fallback in reinstall.
+        result = asyncio.run(
+            generator._resolve_stage_with_retry(
+                repo_list=repos,
+                arches=["x86_64", "aarch64"],
+                packages=["git", "python3-six"] + failing_pkgs,
+                arch_pkgs={},
+                update_targets=["python3-six"],
+                image_pullspec="quay.io/test/base@sha256:abc123",
+                distgit_key="openshift-enterprise-tests",
+                stage_num=1,
+                reinstall_packages=["git", "python3-six"] + failing_pkgs,
+                strippable_packages=set(failing_pkgs),
+            )
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(call_count, 6)
+        final_config = generator._resolver.resolve.call_args_list[5][0][0]
+        # python3-six must stay in reinstallPackages (not strippable)
+        self.assertIn("python3-six", final_config.reinstallPackages)
+        self.assertIn("git", final_config.reinstallPackages)
+        for pkg in failing_pkgs:
+            self.assertNotIn(pkg, final_config.reinstallPackages)
+
+    def test_builder_stage_strips_unavailable_packages_silently(self):
+        """
+        End-to-end: builder stage where glibc-static (Dockerfile package)
+        is not in repos. Builder stages use strippable=None (all packages
+        strippable) so unavailable packages are silently stripped rather
+        than raising.
+        """
+        meta = self._make_mock_image_meta()
+        meta.config.konflux.cachi2.lockfile.get.return_value = None
+        generator = self._make_generator()
+        generator.downstream_parents = [
+            "quay.io/test/golang-builder@sha256:abc123",
+            "quay.io/test/base@sha256:def456",
+        ]
+        generator._container.get_installed_packages = AsyncMock(return_value=["gcc", "gcc-c++", "glibc", "libgcc"])
+
+        async def mock_resolve(config, image_pullspec=None):
+            pkg_names = [p if isinstance(p, str) else p.name for p in config.packages]
+            if "glibc-static" in pkg_names:
+                raise RuntimeError("No match for argument: glibc-static")
+            return FAKE_LOCKFILE_DATA.model_copy(deep=True)
+
+        generator._resolver.resolve = AsyncMock(side_effect=mock_resolve)
+
+        with TemporaryDirectory() as tmpdir:
+            dest_dir = Path(tmpdir)
+            (dest_dir / "Dockerfile").write_text(
+                "FROM golang-builder AS builder\n"
+                "RUN dnf install -y gcc glibc-static\n"
+                "\n"
+                "FROM base-rhel9\n"
+                "COPY --from=builder /bin/pause /usr/bin/pod\n"
+            )
+            asyncio.run(generator.generate_lockfile(meta, dest_dir))
+            self.assertTrue((dest_dir / "rpms.lock.yaml").exists())
 
     def test_build_repo_list_keeps_literal_url_for_single_arch_repo(self):
         rt = MagicMock()
@@ -1219,6 +1516,45 @@ class TestCrossArchReconciliation(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(result, mismatched)
         self.assertEqual(gen._resolve_stage_with_retry.await_count, 2)
+
+    async def test_reconciliation_removes_mismatched_from_update_targets(self):
+        """
+        When a mismatched package is an update target (e.g. python3-six
+        from 'yum update -y python3-six'), the re-resolution must remove
+        it from update_targets so the upgrade doesn't override the
+        version pin.
+        """
+        gen = self._make_generator()
+        mismatched = self._make_lockfile(
+            {
+                "x86_64": [("python3-six", "1.12.0-2.el8ost", "https://x86/six.rpm")],
+                "aarch64": [("python3-six", "1.11.0-8.el8", "https://arm/six.rpm")],
+            }
+        )
+        reconciled = self._make_lockfile(
+            {
+                "x86_64": [("python3-six", "1.11.0-8.el8", "https://x86/six-old.rpm")],
+                "aarch64": [("python3-six", "1.11.0-8.el8", "https://arm/six.rpm")],
+            }
+        )
+        gen._resolve_stage_with_retry = AsyncMock(side_effect=[mismatched, reconciled])
+
+        result = await gen._resolve_with_reconciliation(
+            [],
+            ["x86_64", "aarch64"],
+            ["git", "python3-six"],
+            {},
+            ["python3-six"],
+            "quay.io/test/base@sha256:abc123",
+            "openshift-enterprise-tests",
+            1,
+        )
+        self.assertEqual(result, reconciled)
+        second_call = gen._resolve_stage_with_retry.call_args_list[1]
+        second_update_targets = second_call[0][4]
+        self.assertNotIn("python3-six", second_update_targets)
+        second_packages = second_call[0][2]
+        self.assertTrue(any("python3-six-1.11.0-8.el8" in p for p in second_packages))
 
 
 class TestIsBuilddepRequirement(unittest.TestCase):


### PR DESCRIPTION
Non-final (builder) stages now add base image packages to the install list for conflict detection and reinstall Dockerfile packages so they appear in the lockfile on arches where they're pre-installed.

Key fixes:
- Builder stage reinstall packages are not promoted to upgradePackages (prevents PackagesNotInstalledError for packages not in the base image)
- Retry logic distinguishes strippable (conflict detection) packages from required (Dockerfile) packages — raises immediately if a required package is unavailable instead of silently stripping it
- Final stage strippable set excludes Dockerfile packages so they survive the retry fallback and appear in the lockfile
- Early exit from retry loop when all remaining reinstall packages are optional — avoids burning retries one-by-one
- Bogus package names filtered from stderr via _VALID_PKG_NAME regex
- TMPDIR set to working_dir so rpm-lockfile-prototype internal skopeo copies don't fill /tmp on Jenkins

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lockfile generation retry behavior by distinguishing required vs optional (strippable) missing packages, with clearer fallback handling.
  * Enhanced multi-stage resolution so strippable package handling is applied correctly in the final stage and retried consistently across architectures.
  * Improved RPM missing-package parsing by validating package names and ignoring invalid entries; resolver now uses a deterministic working directory via a dedicated `TMPDIR`.
* **Tests**
  * Expanded generator and end-to-end coverage for multi-stage builds, builder-stage reinstall/conflict detection, retry/fallback behavior, and cross-architecture reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->