### PR TITLE
Fix missing release_pipeline URL for base image release failures

### DIFF
--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -97,6 +97,29 @@ class BaseImageHandler:
     def _scoped_logger(self, entity: str):
         return logutil.EntityLoggingAdapter(self.runtime.logger, extra={'entity': entity})
 
+    def _get_snapshot_url(self, snapshot_name: str) -> str:
+        """
+        Construct the Konflux UI URL for a snapshot.
+
+        Args:
+            snapshot_name: The name of the snapshot resource.
+
+        Returns:
+            The Konflux UI URL for the snapshot.
+        """
+        # Build a minimal resource dict to pass to resource_url()
+        resource_dict = {
+            'kind': 'Snapshot',
+            'metadata': {
+                'name': snapshot_name,
+                'namespace': self.namespace,
+                'labels': {
+                    'appstudio.openshift.io/application': self.base_image_application,
+                },
+            },
+        }
+        return self.konflux_client.resource_url(resource_dict)
+
     async def snapshot_release(self, snapshot_input: BaseImageSnapshotInput) -> Optional[BaseImageReleaseResult]:
         """
         Run snapshot→release for exactly one base-image component.
@@ -136,8 +159,18 @@ class BaseImageHandler:
 
         result = await self._create_release_from_snapshot(snapshot_name, snapshot_input)
         if not result:
-            self.logger.error(f"Failed to create release (snapshot={snapshot_name})")
-            return None
+            # Release creation failed, but we have the snapshot - return partial result with snapshot URL for tracking
+            snapshot_url = self._get_snapshot_url(snapshot_name)
+            self.logger.error(
+                f"Failed to create release (snapshot={snapshot_name}), returning partial result with snapshot URL"
+            )
+            return BaseImageReleaseResult(
+                release_name='',
+                snapshot_name=snapshot_name,
+                nvr=snapshot_input.nvr,
+                release_pipeline=snapshot_url,  # Use snapshot URL as fallback when release wasn't created
+                released_pullspec='',  # No pullspec on failure
+            )
 
         release_name, release_url = result
 

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -292,6 +292,37 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_snapshot_release_creation_failure_returns_snapshot_url(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        """Test that when release creation fails, snapshot URL is returned for tracking."""
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+
+        # Create a mock konflux client that will be used to build snapshot URL
+        mock_client = AsyncMock()
+        mock_client.resource_url = MagicMock(return_value="https://konflux.example/snapshots/test-snapshot")
+        mock_konflux_client_init.return_value = mock_client
+
+        handler = BaseImageHandler(self.runtime, dry_run=False)
+        self.runtime.image_map = {"test-base": self.metadata}
+
+        with patch.object(handler, "_snapshot_from_component", new=AsyncMock(return_value="test-snapshot")):
+            # Release creation fails and returns None
+            with patch.object(handler, "_create_release_from_snapshot", new=AsyncMock(return_value=None)):
+                result = await handler.snapshot_release(self.default_input)
+
+        # Should return a partial result with snapshot URL as release_pipeline fallback
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, BaseImageReleaseResult)
+        self.assertEqual(result.release_name, "")  # Empty since release wasn't created
+        self.assertEqual(result.snapshot_name, "test-snapshot")
+        self.assertEqual(result.release_pipeline, "https://konflux.example/snapshots/test-snapshot")
+        self.assertEqual(result.released_pullspec, "")  # Empty on failure
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
     async def test_create_release_from_snapshot_rhmtc_uses_product_plan_and_application(
         self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
     ):


### PR DESCRIPTION
When base image release fails during the Konflux Release creation phase (e.g., API errors, missing ReleasePlan), the code was returning None instead of capturing diagnostic information. This resulted in:
- Empty release_pipeline field in database records
- Missing release_pipeline field in record.log
- Empty pipeline_url in Redis failure counters

The fix returns a partial BaseImageReleaseResult with the Snapshot URL as a fallback when Release creation fails. Since the Release object is never created in this scenario, we use the successfully-created Snapshot URL as a diagnostic breadcrumb for failure tracking.

Changes:
- Added _get_snapshot_url() helper method to construct Snapshot URLs
- Modified snapshot_release() to return partial result on release creation failure
- Added test coverage for the new code path

This ensures the database, record.log, and Redis counters all capture diagnostic URLs even when Release creation fails early.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of release creation failures to provide snapshot tracking information instead of returning empty results.

* **Tests**
  * Added test coverage for release creation failure scenarios to ensure snapshot metadata is properly retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->