### PR TITLE
ART-20918: fix(doozer): fail release-to-base-repo when released_pullspec is empty

### DIFF
--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -1530,18 +1530,23 @@ async def release_to_base_repo(runtime, nvr):
     handler = BaseImageHandler(runtime, dry_run=False)
     result = await handler.snapshot_release(snapshot_input)
 
-    if result:
-        logger.info(
-            "Done: release=%s snapshot=%s release_pipeline=%s",
-            result.release_name,
-            result.snapshot_name,
-            result.release_pipeline,
-        )
-        followup = copy.deepcopy(source_row)
-        followup.release_pipeline = result.release_pipeline
-        followup.released_pullspec = result.released_pullspec
-        followup.record_id = KonfluxBuildRecord.generate_record_id()
-        await runtime.konflux_db.add_builds([followup])
-        return
+    if not result:
+        raise DoozerFatalError("snapshot_release returned no result")
 
-    raise DoozerFatalError("snapshot_release returned no result")
+    if not result.released_pullspec:
+        msg = f"Base image release did not complete successfully for {image_nvr}"
+        if result.release_pipeline:
+            msg += f" (release_pipeline={result.release_pipeline})"
+        raise DoozerFatalError(msg)
+
+    logger.info(
+        "Done: release=%s snapshot=%s release_pipeline=%s",
+        result.release_name,
+        result.snapshot_name,
+        result.release_pipeline,
+    )
+    followup = copy.deepcopy(source_row)
+    followup.release_pipeline = result.release_pipeline
+    followup.released_pullspec = result.released_pullspec
+    followup.record_id = KonfluxBuildRecord.generate_record_id()
+    await runtime.konflux_db.add_builds([followup])

--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -1494,6 +1494,8 @@ def query_rpm_version(runtime, repo_type):
 async def release_to_base_repo(runtime, nvr):
     """Latest SUCCESS Konflux image row → snapshot/release, then INSERT follow-up with ``release_pipeline`` / ``released_pullspec``.
 
+    Raises DoozerFatalError (non-zero exit) if ``released_pullspec`` is empty after release.
+
     Golang builder is inferred from image metadata when present; otherwise from the openshift-golang-builder name in the NVR.
     """
     logger = logutil.get_logger(__name__)

--- a/doozer/tests/cli/test_images.py
+++ b/doozer/tests/cli/test_images.py
@@ -256,6 +256,46 @@ class TestReleaseToBaseRepo(unittest.TestCase):
 
         kb.add_builds.assert_awaited_once()
 
+    def test_release_to_base_repo_raises_when_released_pullspec_empty(self):
+        """Release failure (empty pullspec) must fail CLI — matches konflux_image_builder semantics."""
+        runtime = self._runtime_with_base_image()
+        nvr = "ose-base-container-v4.22-1.el9"
+        source = KonfluxBuildRecord(
+            name="openshift-enterprise-base-rhel9",
+            group=runtime.group,
+            nvr=nvr,
+            outcome=KonfluxBuildOutcome.SUCCESS,
+            engine=Engine.KONFLUX,
+            image_pullspec="quay.io/base@sha256:abc",
+            rebase_repo_url="https://git.example/r.git",
+            rebase_commitish="deadbeef",
+        )
+
+        kb = MagicMock()
+        kb.get_build_record_by_nvr = AsyncMock(return_value=source)
+        kb.bind = MagicMock()
+        kb.add_builds = AsyncMock()
+        runtime.konflux_db = kb
+        runtime.initialize = MagicMock()
+
+        failed_out = BaseImageReleaseResult(
+            release_name="r-failed",
+            snapshot_name="s1",
+            nvr=nvr,
+            release_pipeline="https://konflux.example/releases/r-failed",
+            released_pullspec="",
+        )
+
+        with patch("doozerlib.cli.images.BaseImageHandler") as bh_cls:
+            bh_cls.return_value.snapshot_release = AsyncMock(return_value=failed_out)
+
+            with self.assertRaises(DoozerFatalError) as ctx:
+                _invoke_release_to_base_repo_inner(runtime, nvr)
+
+        self.assertIn("did not complete successfully", str(ctx.exception))
+        self.assertIn("https://konflux.example/releases/r-failed", str(ctx.exception))
+        kb.add_builds.assert_not_awaited()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

The manual `build/base-image-release` Jenkins job reported SUCCESS when Konflux release failed because `images:release-to-base-repo` exited 0 on partial results. This change aligns CLI failure semantics with `konflux_image_builder`.

## Problem

**Before:** When `snapshot_release` returned a tracking result with empty `released_pullspec`, the CLI logged errors, wrote a DB follow-up row, and exited 0 — so Jenkins stayed green.

**After:** Empty `released_pullspec` raises `DoozerFatalError` (non-zero exit) with the `release_pipeline` URL in the message. Success path and DB follow-up write are unchanged.

## Test plan

- [x] `python3 -m pytest doozer/tests/cli/test_images.py::TestReleaseToBaseRepo -v`
- [x] `python3 -m pytest doozer/tests/backend/test_konflux_image_builder.py -k base_image_release -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error reporting for failed release operations to include pipeline information when available.
  * Enhanced validation prevents incomplete release operations from being incorrectly marked as successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->