### PR TITLE
fix(doozer): parse DNF reinstall errors in lockfile retry loop

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/resolver.py
+++ b/doozer/doozerlib/lockfile_prototype/resolver.py
@@ -150,8 +150,9 @@ class RpmResolver:
         """
         Parse missing package names from rpm-lockfile-prototype error output.
 
-        Handles both the CLI format ("missing packages: X, Y") and the
-        DNF format ("No match for argument: X").
+        Handles the CLI format ("missing packages: X, Y"), DNF install/upgrade
+        errors ("No match for argument: X"), and DNF reinstall errors
+        ("no package matched: X").
 
         Arg(s):
             error_text (str): Error message from rpm-lockfile-prototype.
@@ -164,6 +165,9 @@ class RpmResolver:
             if m:
                 missing.update(pkg.strip() for pkg in m.group(1).split(","))
             m = re.search(r"No match for argument:\s*(\S+)", line.strip())
+            if m:
+                missing.add(m.group(1).strip().rstrip(":"))
+            m = re.search(r"no package matched:\s*(\S+)", line.strip())
             if m:
                 missing.add(m.group(1).strip().rstrip(":"))
         return {p for p in missing if VALID_PKG_NAME.match(p)}

--- a/doozer/tests/lockfile_prototype/test_resolver.py
+++ b/doozer/tests/lockfile_prototype/test_resolver.py
@@ -200,6 +200,16 @@ class TestParseMissingPackages(unittest.TestCase):
         missing = RpmResolver.parse_missing_packages(error)
         self.assertEqual(missing, {"policycoreutils-python-utils"})
 
+    def test_reinstall_not_available_format(self):
+        """
+        DNF PackagesNotAvailableError from base.reinstall() outputs
+        "no package matched: <pkg>" when the installed version is not
+        in the configured repos.
+        """
+        error = "dnf.exceptions.PackagesNotAvailableError: no package matched: git"
+        missing = RpmResolver.parse_missing_packages(error)
+        self.assertEqual(missing, {"git"})
+
     def test_no_match(self):
         error = "Some other error message\n"
         missing = RpmResolver.parse_missing_packages(error)


### PR DESCRIPTION
parse_missing_packages only handled "No match for argument:" (from dnf install/upgrade) and "missing packages:" (CLI format). DNF reinstall failures use a different format: "no package matched: X" from PackagesNotAvailableError. Without parsing this, the retry loop raised immediately instead of stripping the unavailable package.

Add the "no package matched:" pattern so reinstall failures for packages whose installed version is not in the configured repos (e.g. git) are handled gracefully.

[successful build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/fgallott/job/ocp4-konflux/877/console)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for package resolution to recognize additional error message formats, enhancing robustness when packages are unavailable.

* **Tests**
  * Added test coverage for newly supported error format parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->