### PR TITLE
fix(doozer): skip outdated RPMs inherited from parent image in scan

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -24,7 +24,7 @@ from artcommonlib.model import Missing, Model
 from artcommonlib.pushd import Dir
 from artcommonlib.release_util import isolate_timestamp_in_release
 from artcommonlib.rhcos import get_latest_layered_rhcos_build, get_primary_container_name
-from artcommonlib.rpm_utils import parse_nvr
+from artcommonlib.rpm_utils import parse_nvr, to_nevra
 from artcommonlib.util import deep_merge, fetch_slsa_attestation, uses_konflux_imagestream_override
 from artcommonlib.variants import BuildVariant
 from async_lru import alru_cache
@@ -1276,6 +1276,10 @@ class ConfigScanSources:
         # Check for changes in non-ART RPMs
         build_record_inspector = KonfluxBuildRecordInspector(self.runtime, build_record)
         non_latest_rpms = await build_record_inspector.find_non_latest_rpms(self.package_rpm_finder)
+
+        if non_latest_rpms:
+            non_latest_rpms = await self._filter_parent_inherited_rpms(image_meta, non_latest_rpms)
+
         rebuild_hints = [
             f"Outdated RPM {installed_rpm} installed in {build_record.nvr} ({arch}) when {latest_rpm} was available in repo {repo}"
             for arch, non_latest in non_latest_rpms.items()
@@ -1287,6 +1291,51 @@ class ConfigScanSources:
             )
         else:
             self.logger.info('No package changes detected for %s', build_record.nvr)
+
+    async def _filter_parent_inherited_rpms(
+        self,
+        image_meta: ImageMetadata,
+        non_latest_rpms: dict[str, list[tuple[str, str, str]]],
+    ) -> dict[str, list[tuple[str, str, str]]]:
+        """
+        Filter out outdated RPMs inherited from the parent image.
+
+        If an outdated RPM is at the same version as in the parent image,
+        rebuilding this image cannot fix it — the parent must be updated
+        first. Suppressing these prevents pointless rebuild loops.
+        """
+        parent_key = image_meta.config["from"].member
+        if not parent_key:
+            return non_latest_rpms
+
+        parent_build = self.latest_image_build_records_map.get(parent_key)
+        if not parent_build:
+            return non_latest_rpms
+
+        parent_rpms = self.package_rpm_finder.get_brew_rpms_from_build_record(parent_build)
+        parent_nevras = {to_nevra(rpm) for rpm in parent_rpms}
+
+        filtered = {}
+        suppressed = 0
+        for arch, rpm_list in non_latest_rpms.items():
+            kept = []
+            for installed_rpm, latest_rpm, repo in rpm_list:
+                if installed_rpm in parent_nevras:
+                    suppressed += 1
+                else:
+                    kept.append((installed_rpm, latest_rpm, repo))
+            if kept:
+                filtered[arch] = kept
+
+        if suppressed:
+            self.logger.info(
+                "%s: suppressed %d outdated RPMs inherited from parent %s",
+                image_meta.distgit_key,
+                suppressed,
+                parent_key,
+            )
+
+        return filtered
 
     @skip_check_if_changing
     async def scan_extra_packages(self, image_meta: ImageMetadata):


### PR DESCRIPTION
  ## Summary
  - When the scan detects outdated RPMs in an image, it now checks if those RPMs are at the same version as in the parent image build. If so, they're suppressed — rebuilding this image cannot update them since they come from the base image layer and the Dockerfile doesn't touch them.
  - Fixes a rebuild loop for `openshift-enterprise-base-rhel94` on 4.15 where the scan checked inherited base image RPMs (acl, bash, bzip2, coreutils, audit, curl, etc. at `el9_2` versions) against RHEL 9.4 E4S repos (which have `el9_4` versions), triggering pointless rebuilds every scan cycle.

  ## How it works
  In `scan_rpm_changes()`, after finding outdated RPMs via `find_non_latest_rpms()`, a new `_filter_parent_inherited_rpms()` method:
  1. Gets the parent image's distgit key from `image_meta.config['from'].member`
  2. Looks up the parent's build record (already loaded in `latest_image_build_records_map`)
  3. Gets the parent's installed RPM NEVRAs via `PackageRpmFinder` (already cached)
  4. Filters out any outdated RPM whose installed NEVRA exists in the parent — it's inherited and unfixable by rebuild

  No new API calls or BigQuery queries — uses data already available in the scan context.


current implementation output https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/51371/console

```
12:33:32  2026-06-22 10:33:32,182 pyartcd.pipelines.ocp4_scan_konflux INFO Detected source changes:
12:33:32  images:
12:33:32  - local-storage-mustgather
12:33:32  - local-storage-diskmaker
12:33:32  - ose-network-tools
12:33:32  - local-storage-operator
12:33:32  - ose-agent-installer-api-server
12:33:32  - openshift-enterprise-operator-sdk
12:33:32  - openshift-base-nodejs
12:33:32  - openshift-enterprise-base-rhel94
12:33:32  - ose-must-gather-rhel9
12:33:32  - ose-tools
12:33:32  - openshift-enterprise-console
12:33:32  - openshift-enterprise-tests
```
with this fix https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/fgallott/job/ocp4-scan-konflux/6/console 

```
12:42:00  2026-06-22 10:41:59,321 pyartcd.pipelines.ocp4_scan_konflux INFO Detected source changes:
12:42:00  images:
12:42:00  - ose-agent-installer-api-server
12:42:00  - openshift-enterprise-tests
12:42:00  - ose-network-tools
12:42:00  - openshift-enterprise-operator-sdk
12:42:00  - ose-tools
12:42:00  - openshift-base-nodejs
12:42:00  - openshift-enterprise-console
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced RPM change detection to prevent unnecessary rebuilds when outdated packages are already inherited from parent images.
* Improved scanning efficiency by intelligently filtering parent-inherited RPMs that would not resolve issues.
* Reduced overall build time and system overhead through smarter change detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->