### PR TITLE
fix(doozer): accept glob patterns in VALID_PKG_NAME for retry parsing

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/constants.py
+++ b/doozer/doozerlib/lockfile_prototype/constants.py
@@ -34,7 +34,7 @@ ARCH_KEYWORDS = ARCH_SUBSHELL_KEYWORDS + tuple(form for name in ARCH_VAR_NAMES f
 # RPM pseudo-packages that appear in rpmdb but are not installable via DNF
 RPM_PSEUDO_PACKAGES = frozenset({"gpg-pubkey"})
 
-VALID_PKG_NAME = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._+\-]*$")
+VALID_PKG_NAME = re.compile(r"^[a-zA-Z0-9*][a-zA-Z0-9._+\-*]*$")
 
 
 # rpm-lockfile-prototype stores extracted RPMDBs here. There is no env var

--- a/doozer/tests/lockfile_prototype/test_resolver.py
+++ b/doozer/tests/lockfile_prototype/test_resolver.py
@@ -210,6 +210,16 @@ class TestParseMissingPackages(unittest.TestCase):
         missing = RpmResolver.parse_missing_packages(error)
         self.assertEqual(missing, {"git"})
 
+    def test_glob_pattern_in_missing_packages(self):
+        """
+        DNF glob patterns like *-server-ose* can appear in missing packages
+        errors. VALID_PKG_NAME must accept wildcards so the retry loop can
+        strip them.
+        """
+        error = "missing packages: *-server-ose*"
+        missing = RpmResolver.parse_missing_packages(error)
+        self.assertEqual(missing, {"*-server-ose*"})
+
     def test_no_match(self):
         error = "Some other error message\n"
         missing = RpmResolver.parse_missing_packages(error)


### PR DESCRIPTION
Dockerfiles can use DNF glob patterns like `*-server-ose*` in install commands. When these globs don't match anything in the configured repos, the retry loop needs to strip them. VALID_PKG_NAME rejected wildcards, so parse_missing_packages returned an empty set and the error was raised instead of retried.

Allow * in VALID_PKG_NAME so glob patterns are parsed and stripped during retry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package names now support wildcard glob patterns using asterisks (`*`), including asterisks as the first character in the name.

* **Tests**
  * Added test coverage to verify correct parsing of wildcard patterns in package names during dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->