### PR TITLE
fix(doozer): handle fallback resolve failure in lockfile retry loop

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -975,9 +975,10 @@ class KonfluxRebaser:
                 from doozerlib.lockfile_prototype.rebaser_hooks import apply_dockerfile_transforms
 
                 lockfile_has_packages = bool(getattr(metadata, "lockfile_packages", None))
+                upgrades_dropped = getattr(metadata, "lockfile_upgrades_dropped", False)
                 apply_dockerfile_transforms(
                     dest_dir,
-                    strip_updates=not downstream_parents or not lockfile_has_packages,
+                    strip_updates=not downstream_parents or not lockfile_has_packages or upgrades_dropped,
                     logger=self._logger,
                 )
 

--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -108,6 +108,7 @@ class RpmLockfilePrototypeGenerator:
         self.fallback_installed: dict[int, list[str]] = {}
         self.parent_source_dirs: dict[int, Path] = {}
         self.logger = logger or logutil.get_logger(__name__)
+        self.upgrades_dropped = False
         self._container = container_helper or ContainerImageHelper(logger=self.logger)
         self._resolver = resolver or RpmResolver(working_dir=working_dir, logger=self.logger)
 
@@ -721,6 +722,65 @@ class RpmLockfilePrototypeGenerator:
             self.logger.info(f"{distgit_key}: resolved {len(resolved)} builddep packages: {sorted(resolved)}")
         return sorted(resolved)
 
+    def _build_resolve_config(
+        self,
+        repo_list: list[RepoEntry],
+        arches: list[str],
+        packages: list[str],
+        arch_pkgs: dict[str, list[str]],
+        update_targets: list[str],
+        reinstall: list[str],
+        promote_reinstall_to_upgrade: bool,
+        image_pullspec: str | None,
+        module_enable: list[str] | None,
+    ) -> RpmsInConfig:
+        """
+        Build the rpms.in.yaml config for a resolve attempt.
+        """
+        upgrade_extras = reinstall if promote_reinstall_to_upgrade else []
+        effective_upgrade = list(set(update_targets + upgrade_extras)) if image_pullspec else None
+        return build_rpms_in_yaml(
+            repo_list,
+            arches,
+            packages,
+            arch_specific_packages=arch_pkgs,
+            reinstall_packages=reinstall if image_pullspec else None,
+            upgrade_packages=effective_upgrade,
+            module_enable=module_enable,
+        )
+
+    @staticmethod
+    def _strip_missing_packages(
+        missing: set[str],
+        remaining_packages: list[str],
+        remaining_update_targets: list[str],
+        remaining_reinstall: list[str],
+        arch_pkgs: dict[str, list[str]],
+    ) -> int:
+        """
+        Remove missing packages from all lists. Returns count of packages removed.
+        """
+        prev_count = (
+            len(remaining_packages)
+            + sum(len(v) for v in arch_pkgs.values())
+            + len(remaining_update_targets)
+            + len(remaining_reinstall)
+        )
+        remaining_packages[:] = [p for p in remaining_packages if p not in missing]
+        remaining_update_targets[:] = [p for p in remaining_update_targets if p not in missing]
+        remaining_reinstall[:] = [p for p in remaining_reinstall if p not in missing]
+        for arch in list(arch_pkgs.keys()):
+            arch_pkgs[arch] = [p for p in arch_pkgs[arch] if p not in missing]
+            if not arch_pkgs[arch]:
+                del arch_pkgs[arch]
+        new_count = (
+            len(remaining_packages)
+            + sum(len(v) for v in arch_pkgs.values())
+            + len(remaining_update_targets)
+            + len(remaining_reinstall)
+        )
+        return prev_count - new_count
+
     async def _resolve_stage_with_retry(
         self,
         repo_list: list[RepoEntry],
@@ -773,16 +833,16 @@ class RpmLockfilePrototypeGenerator:
         retries_exhausted = False
 
         for _attempt in range(MAX_RESOLUTION_RETRIES):
-            upgrade_extras = remaining_reinstall if promote_reinstall_to_upgrade else []
-            effective_upgrade = list(set(remaining_update_targets + upgrade_extras)) if image_pullspec else None
-            in_yaml = build_rpms_in_yaml(
+            in_yaml = self._build_resolve_config(
                 repo_list,
                 arches,
                 remaining_packages,
-                arch_specific_packages=arch_pkgs,
-                reinstall_packages=remaining_reinstall if image_pullspec else None,
-                upgrade_packages=effective_upgrade,
-                module_enable=module_enable,
+                arch_pkgs,
+                remaining_update_targets,
+                remaining_reinstall,
+                promote_reinstall_to_upgrade,
+                image_pullspec,
+                module_enable,
             )
 
             try:
@@ -801,26 +861,14 @@ class RpmLockfilePrototypeGenerator:
                             f"{distgit_key}: stage {stage_num}: required Dockerfile packages not available "
                             f"in configured repos, stripping: {sorted(required_missing)}"
                         )
-                prev_count = (
-                    len(remaining_packages)
-                    + sum(len(v) for v in arch_pkgs.values())
-                    + len(remaining_update_targets)
-                    + len(remaining_reinstall)
+                removed = self._strip_missing_packages(
+                    missing,
+                    remaining_packages,
+                    remaining_update_targets,
+                    remaining_reinstall,
+                    arch_pkgs,
                 )
-                remaining_packages = [p for p in remaining_packages if p not in missing]
-                remaining_update_targets = [p for p in remaining_update_targets if p not in missing]
-                remaining_reinstall = [p for p in remaining_reinstall if p not in missing]
-                for arch in list(arch_pkgs.keys()):
-                    arch_pkgs[arch] = [p for p in arch_pkgs[arch] if p not in missing]
-                    if not arch_pkgs[arch]:
-                        del arch_pkgs[arch]
-                new_count = (
-                    len(remaining_packages)
-                    + sum(len(v) for v in arch_pkgs.values())
-                    + len(remaining_update_targets)
-                    + len(remaining_reinstall)
-                )
-                if new_count == prev_count:
+                if not removed:
                     raise
                 if stripped_tracker is not None:
                     stripped_tracker.update(missing)
@@ -858,16 +906,22 @@ class RpmLockfilePrototypeGenerator:
                 "continuing without reinstall packages"
             )
             remaining_reinstall.clear()
-        fallback_upgrade_extras = remaining_reinstall if promote_reinstall_to_upgrade else []
-        effective_upgrade = list(set(remaining_update_targets + fallback_upgrade_extras)) if image_pullspec else None
-        in_yaml = build_rpms_in_yaml(
+        # Clear all upgrade targets for the fallback — the retry loop
+        # already validated the install packages; upgrade targets that
+        # reference packages not in the base image's rpmdb would cause
+        # PackagesNotInstalledError from DNF.
+        remaining_update_targets.clear()
+        self.upgrades_dropped = True
+        in_yaml = self._build_resolve_config(
             repo_list,
             arches,
             remaining_packages,
-            arch_specific_packages=arch_pkgs,
-            reinstall_packages=remaining_reinstall if image_pullspec else None,
-            upgrade_packages=effective_upgrade,
-            module_enable=module_enable,
+            arch_pkgs,
+            remaining_update_targets,
+            remaining_reinstall,
+            promote_reinstall_to_upgrade,
+            image_pullspec,
+            module_enable,
         )
         return await self._resolver.resolve(in_yaml, image_pullspec=resolver_pullspec)
 

--- a/doozer/doozerlib/lockfile_prototype/rebaser_hooks.py
+++ b/doozer/doozerlib/lockfile_prototype/rebaser_hooks.py
@@ -93,6 +93,8 @@ async def generate_lockfile(
                     pkg_names.add(name)
         metadata.lockfile_packages = sorted(pkg_names)
 
+    metadata.lockfile_upgrades_dropped = generator.upgrades_dropped
+
     return shared_dnf_cache
 
 

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -688,6 +688,40 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         pkg_names = [p if isinstance(p, str) else p.name for p in fallback_config.packages]
         self.assertIn("curl", pkg_names)
 
+    def test_fallback_sets_upgrades_dropped_flag(self):
+        """
+        When the retry loop exhausts retries and the fallback clears
+        upgrade targets, generator.upgrades_dropped must be True so
+        the rebaser strips dnf update from the Dockerfile.
+        """
+        meta = self._make_mock_image_meta()
+        meta.config.konflux.cachi2.lockfile.get.return_value = None
+        generator = self._make_generator()
+        generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
+        generator._container.get_installed_packages = AsyncMock(return_value=["bad-pkg", "glibc"])
+
+        call_count = 0
+
+        async def mock_resolve(config, image_pullspec=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("No match for argument: bad-pkg")
+            return FAKE_LOCKFILE_DATA.model_copy(deep=True)
+
+        generator._resolver.resolve = AsyncMock(side_effect=mock_resolve)
+
+        self.assertFalse(generator.upgrades_dropped)
+
+        with TemporaryDirectory() as tmpdir:
+            dest_dir = Path(tmpdir)
+            (dest_dir / "Dockerfile").write_text("FROM base\nRUN dnf install -y curl\n")
+            asyncio.run(generator.generate_lockfile(meta, dest_dir))
+
+        self.assertTrue(generator.upgrades_dropped)
+        fallback_config = generator._resolver.resolve.call_args_list[-1][0][0]
+        self.assertEqual(fallback_config.upgradePackages, [])
+
     def test_fallback_packages_used_when_image_unreachable(self):
         """
         When base image is unreachable but fallback_installed has data


### PR DESCRIPTION
this fixes [dpu-marvell-cp-agent](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/fgallott/job/ocp4-konflux/884/)

After exhausting retry attempts, the fallback resolve clears reinstall packages but kept upgrade targets that reference packages not installed in the base image (e.g. lld-libs, compiler-rt, ghc-srpm-macros). DNF threw PackagesNotInstalledError on base.upgrade() for these.

Three fixes:
1. Extract __build_resolve_config()_ and __strip_missing_packages()_ to reduce duplication between the retry loop and fallback
2. Clear all upgrade targets before the fallback resolve — without reinstall packages, promoted upgrade targets are meaningless and cause errors
3. Signal upgrades_dropped to the rebaser so it strips `dnf update -y` from the Dockerfile when the lockfile has no upgrade RPMs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of upgrade package resolution when fallback occurs. The system now properly tracks when upgrades are dropped and communicates this through metadata to ensure correct Dockerfile transformations are applied.

* **Tests**
  * Added test coverage for upgrade drop tracking during package resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->