### PR TITLE
Fail release-from-fbc when CVE-to-component mapping fails

### DIFF
--- a/elliott/elliottlib/cli/process_release_from_fbc_bugs_cli.py
+++ b/elliott/elliottlib/cli/process_release_from_fbc_bugs_cli.py
@@ -109,10 +109,7 @@ async def process_bugs(runtime: Runtime, jira_ids: List[str]) -> ReleaseNotes:
 
         distgit_component = get_component_by_delivery_repo(runtime, pscomponent)
         if not distgit_component:
-            msg = (
-                f"JIRA {jira_id} (CVE {cve_id}): pscomponent '{pscomponent}' "
-                f"not found in delivery_repo_names"
-            )
+            msg = f"JIRA {jira_id} (CVE {cve_id}): pscomponent '{pscomponent}' not found in delivery_repo_names"
             logger.error(msg)
             cve_mapping_errors.append(msg)
             continue

--- a/elliott/elliottlib/cli/process_release_from_fbc_bugs_cli.py
+++ b/elliott/elliottlib/cli/process_release_from_fbc_bugs_cli.py
@@ -74,6 +74,7 @@ async def process_bugs(runtime: Runtime, jira_ids: List[str]) -> ReleaseNotes:
     cve_associations: list[CveAssociation] = []
     flaw_bug_ids: list[int] = []
     all_jira_ids: list[str] = []
+    cve_mapping_errors: list[str] = []
 
     for jira_id in jira_ids:
         jira_id = jira_id.strip()
@@ -94,32 +95,36 @@ async def process_bugs(runtime: Runtime, jira_ids: List[str]) -> ReleaseNotes:
 
         cve_id = _extract_cve_id_from_labels(labels)
         if not cve_id:
-            logger.warning("JIRA %s is Vulnerability but has no CVE label, skipping CVE association", jira_id)
+            msg = f"JIRA {jira_id} is Vulnerability but has no CVE label"
+            logger.error(msg)
+            cve_mapping_errors.append(msg)
             continue
 
         pscomponent = _extract_pscomponent_from_labels(labels)
         if not pscomponent:
-            logger.warning("JIRA %s (CVE %s) has no pscomponent label, skipping CVE association", jira_id, cve_id)
+            msg = f"JIRA {jira_id} (CVE {cve_id}) has no pscomponent label"
+            logger.error(msg)
+            cve_mapping_errors.append(msg)
             continue
 
         distgit_component = get_component_by_delivery_repo(runtime, pscomponent)
         if not distgit_component:
-            logger.warning(
-                "JIRA %s (CVE %s): pscomponent '%s' not found in delivery_repo_names, skipping",
-                jira_id,
-                cve_id,
-                pscomponent,
+            msg = (
+                f"JIRA {jira_id} (CVE {cve_id}): pscomponent '{pscomponent}' "
+                f"not found in delivery_repo_names"
             )
+            logger.error(msg)
+            cve_mapping_errors.append(msg)
             continue
 
         konflux_component = get_konflux_component_by_component(runtime, distgit_component)
         if not konflux_component:
-            logger.warning(
-                "JIRA %s (CVE %s): distgit component '%s' could not be mapped to a Konflux component, skipping",
-                jira_id,
-                cve_id,
-                distgit_component,
+            msg = (
+                f"JIRA {jira_id} (CVE {cve_id}): distgit component '{distgit_component}' "
+                f"could not be mapped to a Konflux component"
             )
+            logger.error(msg)
+            cve_mapping_errors.append(msg)
             continue
 
         logger.info(
@@ -138,6 +143,12 @@ async def process_bugs(runtime: Runtime, jira_ids: List[str]) -> ReleaseNotes:
             flaw_bug_ids.extend(bug_flaw_ids)
         else:
             logger.warning("JIRA %s (CVE %s) has no flaw:bz# labels", jira_id, cve_id)
+
+    if cve_mapping_errors:
+        raise RuntimeError(
+            f"Failed to map {len(cve_mapping_errors)} CVE(s) to components:\n"
+            + "\n".join(f"  - {e}" for e in cve_mapping_errors)
+        )
 
     advisory_type = "RHSA" if cve_associations else "RHBA"
     logger.info("Advisory type determined: %s (CVEs found: %d)", advisory_type, len(cve_associations))

--- a/elliott/tests/test_process_release_from_fbc_bugs_cli.py
+++ b/elliott/tests/test_process_release_from_fbc_bugs_cli.py
@@ -146,8 +146,8 @@ class TestProcessReleaseFromFbcBugs(unittest.IsolatedAsyncioTestCase):
     @patch(PATCH_GET_KONFLUX_COMPONENT)
     @patch(PATCH_GET_DELIVERY_REPO)
     @patch(PATCH_CREATE_TRACKER)
-    async def test_cve_without_cve_label_skipped(self, mock_create_tracker, mock_get_delivery, mock_get_konflux):
-        """A Vulnerability JIRA without a CVE label should be skipped for CVE association but still listed."""
+    async def test_cve_without_cve_label_raises(self, mock_create_tracker, mock_get_delivery, mock_get_konflux):
+        """A Vulnerability JIRA without a CVE label should raise RuntimeError."""
         bug = self._make_jira_bug(
             "OADP-9999",
             is_vulnerability=True,
@@ -158,22 +158,19 @@ class TestProcessReleaseFromFbcBugs(unittest.IsolatedAsyncioTestCase):
         mock_tracker.get_bug.return_value = bug
         mock_create_tracker.return_value = mock_tracker
 
-        result = await process_bugs(self.mock_runtime, ["OADP-9999"])
+        with self.assertRaises(RuntimeError) as ctx:
+            await process_bugs(self.mock_runtime, ["OADP-9999"])
 
-        self.assertEqual(result.type, "RHBA")
-        self.assertIsNone(result.cves)
-        fixed_ids = [i.id for i in result.issues.fixed]
-        self.assertIn("OADP-9999", fixed_ids)
-        mock_get_delivery.assert_not_called()
-        mock_get_konflux.assert_not_called()
+        self.assertIn("OADP-9999", str(ctx.exception))
+        self.assertIn("no CVE label", str(ctx.exception))
 
     @patch(PATCH_GET_KONFLUX_COMPONENT)
     @patch(PATCH_GET_DELIVERY_REPO)
     @patch(PATCH_CREATE_TRACKER)
-    async def test_cve_without_pscomponent_label_skipped(
+    async def test_cve_without_pscomponent_label_raises(
         self, mock_create_tracker, mock_get_delivery, mock_get_konflux
     ):
-        """A Vulnerability with CVE label but no pscomponent label should skip CVE association."""
+        """A Vulnerability with CVE label but no pscomponent label should raise RuntimeError."""
         bug = self._make_jira_bug(
             "OADP-8888",
             is_vulnerability=True,
@@ -184,18 +181,17 @@ class TestProcessReleaseFromFbcBugs(unittest.IsolatedAsyncioTestCase):
         mock_tracker.get_bug.return_value = bug
         mock_create_tracker.return_value = mock_tracker
 
-        result = await process_bugs(self.mock_runtime, ["OADP-8888"])
+        with self.assertRaises(RuntimeError) as ctx:
+            await process_bugs(self.mock_runtime, ["OADP-8888"])
 
-        self.assertEqual(result.type, "RHBA")
-        self.assertIsNone(result.cves)
-        mock_get_delivery.assert_not_called()
-        mock_get_konflux.assert_not_called()
+        self.assertIn("OADP-8888", str(ctx.exception))
+        self.assertIn("no pscomponent label", str(ctx.exception))
 
     @patch(PATCH_GET_KONFLUX_COMPONENT)
     @patch(PATCH_GET_DELIVERY_REPO)
     @patch(PATCH_CREATE_TRACKER)
-    async def test_unmapped_delivery_repo_skipped(self, mock_create_tracker, mock_get_delivery, mock_get_konflux):
-        """When pscomponent can't be found in delivery_repo_names, CVE association is skipped."""
+    async def test_unmapped_delivery_repo_raises(self, mock_create_tracker, mock_get_delivery, mock_get_konflux):
+        """When pscomponent can't be found in delivery_repo_names, should raise RuntimeError."""
         mock_get_delivery.return_value = None
 
         bug = self._make_jira_bug(
@@ -208,20 +204,17 @@ class TestProcessReleaseFromFbcBugs(unittest.IsolatedAsyncioTestCase):
         mock_tracker.get_bug.return_value = bug
         mock_create_tracker.return_value = mock_tracker
 
-        result = await process_bugs(self.mock_runtime, ["OADP-7777"])
+        with self.assertRaises(RuntimeError) as ctx:
+            await process_bugs(self.mock_runtime, ["OADP-7777"])
 
-        self.assertEqual(result.type, "RHBA")
-        self.assertIsNone(result.cves)
-        fixed_ids = [i.id for i in result.issues.fixed]
-        self.assertIn("OADP-7777", fixed_ids)
-        mock_get_delivery.assert_called_once_with(self.mock_runtime, "unknown/unknown-container")
-        mock_get_konflux.assert_not_called()
+        self.assertIn("OADP-7777", str(ctx.exception))
+        self.assertIn("unknown/unknown-container", str(ctx.exception))
 
     @patch(PATCH_GET_KONFLUX_COMPONENT)
     @patch(PATCH_GET_DELIVERY_REPO)
     @patch(PATCH_CREATE_TRACKER)
-    async def test_unmapped_konflux_component_skipped(self, mock_create_tracker, mock_get_delivery, mock_get_konflux):
-        """When distgit component can't be mapped to a Konflux component, CVE association is skipped."""
+    async def test_unmapped_konflux_component_raises(self, mock_create_tracker, mock_get_delivery, mock_get_konflux):
+        """When distgit component can't be mapped to a Konflux component, should raise RuntimeError."""
         mock_get_delivery.return_value = "some-container"
         mock_get_konflux.return_value = None
 
@@ -235,14 +228,41 @@ class TestProcessReleaseFromFbcBugs(unittest.IsolatedAsyncioTestCase):
         mock_tracker.get_bug.return_value = bug
         mock_create_tracker.return_value = mock_tracker
 
-        result = await process_bugs(self.mock_runtime, ["OADP-7777"])
+        with self.assertRaises(RuntimeError) as ctx:
+            await process_bugs(self.mock_runtime, ["OADP-7777"])
 
-        self.assertEqual(result.type, "RHBA")
-        self.assertIsNone(result.cves)
-        fixed_ids = [i.id for i in result.issues.fixed]
-        self.assertIn("OADP-7777", fixed_ids)
-        mock_get_delivery.assert_called_once_with(self.mock_runtime, "oadp/some-rhel9")
-        mock_get_konflux.assert_called_once_with(self.mock_runtime, "some-container")
+        self.assertIn("OADP-7777", str(ctx.exception))
+        self.assertIn("some-container", str(ctx.exception))
+
+    @patch(PATCH_GET_KONFLUX_COMPONENT)
+    @patch(PATCH_GET_DELIVERY_REPO)
+    @patch(PATCH_CREATE_TRACKER)
+    async def test_multiple_mapping_errors_all_reported(self, mock_create_tracker, mock_get_delivery, mock_get_konflux):
+        """All CVE mapping errors should be collected and reported in a single RuntimeError."""
+        mock_get_delivery.return_value = None
+
+        bug1 = self._make_jira_bug(
+            "OADP-1111",
+            is_vulnerability=True,
+            labels=["CVE-2025-00001", "pscomponent:unknown/repo-a"],
+        )
+        bug2 = self._make_jira_bug(
+            "OADP-2222",
+            is_vulnerability=True,
+            labels=["CVE-2025-00002", "pscomponent:unknown/repo-b"],
+        )
+
+        mock_tracker = Mock()
+        mock_tracker.get_bug.side_effect = lambda k: {"OADP-1111": bug1, "OADP-2222": bug2}[k]
+        mock_create_tracker.return_value = mock_tracker
+
+        with self.assertRaises(RuntimeError) as ctx:
+            await process_bugs(self.mock_runtime, ["OADP-1111", "OADP-2222"])
+
+        error_msg = str(ctx.exception)
+        self.assertIn("2 CVE(s)", error_msg)
+        self.assertIn("OADP-1111", error_msg)
+        self.assertIn("OADP-2222", error_msg)
 
     @patch(PATCH_GET_KONFLUX_COMPONENT)
     @patch(PATCH_GET_DELIVERY_REPO)

--- a/elliott/tests/test_process_release_from_fbc_bugs_cli.py
+++ b/elliott/tests/test_process_release_from_fbc_bugs_cli.py
@@ -167,9 +167,7 @@ class TestProcessReleaseFromFbcBugs(unittest.IsolatedAsyncioTestCase):
     @patch(PATCH_GET_KONFLUX_COMPONENT)
     @patch(PATCH_GET_DELIVERY_REPO)
     @patch(PATCH_CREATE_TRACKER)
-    async def test_cve_without_pscomponent_label_raises(
-        self, mock_create_tracker, mock_get_delivery, mock_get_konflux
-    ):
+    async def test_cve_without_pscomponent_label_raises(self, mock_create_tracker, mock_get_delivery, mock_get_konflux):
         """A Vulnerability with CVE label but no pscomponent label should raise RuntimeError."""
         bug = self._make_jira_bug(
             "OADP-8888",


### PR DESCRIPTION
## Summary
- `process_release_from_fbc_bugs` previously logged warnings and silently skipped CVEs when pscomponent could not be mapped to a Konflux component
- This caused missing CVE entries in shipment data that only surfaced later during validation (e.g., OADP 1.4.10 release-from-fbc build #109 silently dropped CVE-2026-32281 and CVE-2026-32282)
- Now all mapping failures are collected and a single `RuntimeError` is raised after processing all JIRAs, listing every failure so the job fails early with actionable context

## Test plan
- [x] Updated 4 existing tests from assert-skip to assert-raises
- [x] Added new test for multiple mapping errors being reported together
- [x] All 16 process_release_from_fbc_bugs tests pass
- [x] Full elliott test suite passes (409 tests)

## Jenkins validation
Tested with [release-from-fbc build #111](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Frelease-from-fbc/111/) (DRY_RUN=true, same OADP 1.4.10 parameters as build #109). Build correctly fails with:

```
RuntimeError: Failed to map 2 CVE(s) to components:
  - JIRA OADP-7902 (CVE CVE-2026-32281): pscomponent 'redhat-user-workloads/art-images' not found in delivery_repo_names
  - JIRA OADP-7788 (CVE CVE-2026-32282): pscomponent 'redhat-user-workloads/art-images' not found in delivery_repo_names
```