### PR TITLE
Handle golang builder CVEs in release-from-fbc

### DIFF
--- a/elliott/elliottlib/cli/process_release_from_fbc_bugs_cli.py
+++ b/elliott/elliottlib/cli/process_release_from_fbc_bugs_cli.py
@@ -6,9 +6,10 @@ from typing import List, Optional
 import click
 from artcommonlib.jira_config import JIRA_SERVER_URL
 from artcommonlib.util import new_roundtrip_yaml_handler
+from doozerlib.util import konflux_application_name, konflux_image_component_name
 
 from elliottlib.bzutil import JIRABugTracker
-from elliottlib.cli.attach_cve_flaws_cli import get_konflux_component_by_component
+from elliottlib.cli.attach_cve_flaws_cli import _image_uses_builder, get_konflux_component_by_component
 from elliottlib.cli.common import cli, click_coroutine
 from elliottlib.runtime import Runtime
 from elliottlib.shipment_model import CveAssociation, ReleaseNotes
@@ -17,6 +18,8 @@ from elliottlib.util import get_component_by_delivery_repo
 
 YAML = new_roundtrip_yaml_handler()
 logger = logging.getLogger(__name__)
+
+GOLANG_BUILDER_DELIVERY_REPO = "openshift4/openshift-golang-builder"
 
 
 def _create_jira_tracker() -> JIRABugTracker:
@@ -53,6 +56,16 @@ def _extract_pscomponent_from_labels(labels: List[str]) -> Optional[str]:
         if label.startswith('pscomponent:'):
             return label[len('pscomponent:') :]
     return None
+
+
+def _get_golang_builder_components(runtime) -> list[str]:
+    """Find all Konflux component names in the group that use the golang builder."""
+    application = konflux_application_name(runtime.group)
+    components = []
+    for image_meta in runtime.image_metas():
+        if _image_uses_builder(image_meta, logger):
+            components.append(konflux_image_component_name(application, image_meta.distgit_key))
+    return sorted(components)
 
 
 async def process_bugs(runtime: Runtime, jira_ids: List[str]) -> ReleaseNotes:
@@ -109,9 +122,34 @@ async def process_bugs(runtime: Runtime, jira_ids: List[str]) -> ReleaseNotes:
 
         distgit_component = get_component_by_delivery_repo(runtime, pscomponent)
         if not distgit_component:
-            msg = f"JIRA {jira_id} (CVE {cve_id}): pscomponent '{pscomponent}' not found in delivery_repo_names"
-            logger.error(msg)
-            cve_mapping_errors.append(msg)
+            if pscomponent == GOLANG_BUILDER_DELIVERY_REPO:
+                builder_components = _get_golang_builder_components(runtime)
+                if not builder_components:
+                    msg = f"JIRA {jira_id} (CVE {cve_id}): golang builder CVE but no components use the builder"
+                    logger.error(msg)
+                    cve_mapping_errors.append(msg)
+                    continue
+                logger.info(
+                    "JIRA %s: CVE %s is a golang builder CVE, fanning out to %d components: %s",
+                    jira_id,
+                    cve_id,
+                    len(builder_components),
+                    builder_components,
+                )
+                for comp in builder_components:
+                    cve_associations.append(CveAssociation(key=cve_id, component=comp))
+            else:
+                msg = f"JIRA {jira_id} (CVE {cve_id}): pscomponent '{pscomponent}' not found in delivery_repo_names"
+                logger.error(msg)
+                cve_mapping_errors.append(msg)
+                continue
+
+            bug_flaw_ids = _extract_flaw_bug_ids_from_labels(labels)
+            if bug_flaw_ids:
+                logger.info("JIRA %s: found flaw bug IDs %s", jira_id, bug_flaw_ids)
+                flaw_bug_ids.extend(bug_flaw_ids)
+            else:
+                logger.warning("JIRA %s (CVE %s) has no flaw:bz# labels", jira_id, cve_id)
             continue
 
         konflux_component = get_konflux_component_by_component(runtime, distgit_component)

--- a/elliott/elliottlib/cli/process_release_from_fbc_bugs_cli.py
+++ b/elliott/elliottlib/cli/process_release_from_fbc_bugs_cli.py
@@ -20,6 +20,8 @@ YAML = new_roundtrip_yaml_handler()
 logger = logging.getLogger(__name__)
 
 GOLANG_BUILDER_DELIVERY_REPO = "openshift4/openshift-golang-builder"
+GOLANG_BUILDER_COMPONENT = "openshift-golang-builder-container"
+GOLANG_BUILDER_PSCOMPONENTS = {GOLANG_BUILDER_DELIVERY_REPO, GOLANG_BUILDER_COMPONENT}
 
 
 def _create_jira_tracker() -> JIRABugTracker:
@@ -122,7 +124,7 @@ async def process_bugs(runtime: Runtime, jira_ids: List[str]) -> ReleaseNotes:
 
         distgit_component = get_component_by_delivery_repo(runtime, pscomponent)
         if not distgit_component:
-            if pscomponent == GOLANG_BUILDER_DELIVERY_REPO:
+            if pscomponent in GOLANG_BUILDER_PSCOMPONENTS:
                 builder_components = _get_golang_builder_components(runtime)
                 if not builder_components:
                     msg = f"JIRA {jira_id} (CVE {cve_id}): golang builder CVE but no components use the builder"

--- a/elliott/tests/test_process_release_from_fbc_bugs_cli.py
+++ b/elliott/tests/test_process_release_from_fbc_bugs_cli.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 from artcommonlib.jira_config import JIRA_DOMAIN_NAME
 from elliottlib.cli.process_release_from_fbc_bugs_cli import (
+    GOLANG_BUILDER_DELIVERY_REPO,
     _extract_cve_id_from_labels,
     _extract_flaw_bug_ids_from_labels,
     _extract_pscomponent_from_labels,
@@ -12,6 +13,7 @@ from elliottlib.cli.process_release_from_fbc_bugs_cli import (
 PATCH_CREATE_TRACKER = "elliottlib.cli.process_release_from_fbc_bugs_cli._create_jira_tracker"
 PATCH_GET_DELIVERY_REPO = "elliottlib.cli.process_release_from_fbc_bugs_cli.get_component_by_delivery_repo"
 PATCH_GET_KONFLUX_COMPONENT = "elliottlib.cli.process_release_from_fbc_bugs_cli.get_konflux_component_by_component"
+PATCH_GET_BUILDER_COMPONENTS = "elliottlib.cli.process_release_from_fbc_bugs_cli._get_golang_builder_components"
 
 
 class TestLabelExtraction(unittest.TestCase):
@@ -261,6 +263,113 @@ class TestProcessReleaseFromFbcBugs(unittest.IsolatedAsyncioTestCase):
         self.assertIn("2 CVE(s)", error_msg)
         self.assertIn("OADP-1111", error_msg)
         self.assertIn("OADP-2222", error_msg)
+
+    @patch(PATCH_GET_BUILDER_COMPONENTS)
+    @patch(PATCH_GET_KONFLUX_COMPONENT)
+    @patch(PATCH_GET_DELIVERY_REPO)
+    @patch(PATCH_CREATE_TRACKER)
+    async def test_golang_builder_cve_fans_out(
+        self, mock_create_tracker, mock_get_delivery, mock_get_konflux, mock_get_builder
+    ):
+        """A golang builder CVE should fan out to all components using the builder."""
+        mock_get_delivery.return_value = None
+        mock_get_builder.return_value = ["oadp-1-4-oadp-operator", "oadp-1-4-oadp-velero"]
+
+        bug = self._make_jira_bug(
+            "OADP-7902",
+            is_vulnerability=True,
+            labels=[
+                "CVE-2026-32281",
+                f"pscomponent:{GOLANG_BUILDER_DELIVERY_REPO}",
+                "flaw:bz#2456333",
+            ],
+        )
+
+        mock_tracker = Mock()
+        mock_tracker.get_bug.return_value = bug
+        mock_create_tracker.return_value = mock_tracker
+
+        result = await process_bugs(self.mock_runtime, ["OADP-7902"])
+
+        self.assertEqual(result.type, "RHSA")
+        self.assertEqual(len(result.cves), 2)
+        cve_components = {c.component for c in result.cves}
+        self.assertEqual(cve_components, {"oadp-1-4-oadp-operator", "oadp-1-4-oadp-velero"})
+        for cve in result.cves:
+            self.assertEqual(cve.key, "CVE-2026-32281")
+
+        flaw_ids = {i.id for i in result.issues.fixed if i.source == "bugzilla.redhat.com"}
+        self.assertIn("2456333", flaw_ids)
+
+    @patch(PATCH_GET_BUILDER_COMPONENTS)
+    @patch(PATCH_GET_KONFLUX_COMPONENT)
+    @patch(PATCH_GET_DELIVERY_REPO)
+    @patch(PATCH_CREATE_TRACKER)
+    async def test_golang_builder_cve_no_consumers_raises(
+        self, mock_create_tracker, mock_get_delivery, mock_get_konflux, mock_get_builder
+    ):
+        """A golang builder CVE with no builder-consuming components should raise RuntimeError."""
+        mock_get_delivery.return_value = None
+        mock_get_builder.return_value = []
+
+        bug = self._make_jira_bug(
+            "OADP-7902",
+            is_vulnerability=True,
+            labels=["CVE-2026-32281", f"pscomponent:{GOLANG_BUILDER_DELIVERY_REPO}"],
+        )
+
+        mock_tracker = Mock()
+        mock_tracker.get_bug.return_value = bug
+        mock_create_tracker.return_value = mock_tracker
+
+        with self.assertRaises(RuntimeError) as ctx:
+            await process_bugs(self.mock_runtime, ["OADP-7902"])
+
+        self.assertIn("OADP-7902", str(ctx.exception))
+        self.assertIn("no components use the builder", str(ctx.exception))
+
+    @patch(PATCH_GET_BUILDER_COMPONENTS)
+    @patch(PATCH_GET_KONFLUX_COMPONENT)
+    @patch(PATCH_GET_DELIVERY_REPO)
+    @patch(PATCH_CREATE_TRACKER)
+    async def test_golang_builder_cve_mixed_with_regular(
+        self, mock_create_tracker, mock_get_delivery, mock_get_konflux, mock_get_builder
+    ):
+        """A golang builder CVE and a regular CVE should both produce associations."""
+        mock_get_delivery.side_effect = lambda _rt, repo: {
+            "oadp/oadp-velero-rhel9": "oadp-velero-container",
+        }.get(repo)
+        mock_get_konflux.side_effect = lambda _rt, comp: {
+            "oadp-velero-container": "oadp-1-4-oadp-velero",
+        }.get(comp)
+        mock_get_builder.return_value = ["oadp-1-4-oadp-operator", "oadp-1-4-oadp-velero"]
+
+        builder_bug = self._make_jira_bug(
+            "OADP-7902",
+            is_vulnerability=True,
+            labels=["CVE-2026-32281", f"pscomponent:{GOLANG_BUILDER_DELIVERY_REPO}", "flaw:bz#2456333"],
+        )
+        regular_cve = self._make_jira_bug(
+            "OADP-7792",
+            is_vulnerability=True,
+            labels=["CVE-2026-32280", "pscomponent:oadp/oadp-velero-rhel9", "flaw:bz#2456339"],
+        )
+
+        mock_tracker = Mock()
+        mock_tracker.get_bug.side_effect = lambda k: {"OADP-7902": builder_bug, "OADP-7792": regular_cve}[k]
+        mock_create_tracker.return_value = mock_tracker
+
+        result = await process_bugs(self.mock_runtime, ["OADP-7902", "OADP-7792"])
+
+        self.assertEqual(result.type, "RHSA")
+        self.assertEqual(len(result.cves), 3)
+
+        builder_cves = [c for c in result.cves if c.key == "CVE-2026-32281"]
+        self.assertEqual(len(builder_cves), 2)
+
+        regular_cves = [c for c in result.cves if c.key == "CVE-2026-32280"]
+        self.assertEqual(len(regular_cves), 1)
+        self.assertEqual(regular_cves[0].component, "oadp-1-4-oadp-velero")
 
     @patch(PATCH_GET_KONFLUX_COMPONENT)
     @patch(PATCH_GET_DELIVERY_REPO)


### PR DESCRIPTION
## Summary
- When a CVE tracker JIRA has `pscomponent:openshift4/openshift-golang-builder` (or defensively, `openshift-golang-builder-container`), the release-from-fbc pipeline now fans out the CVE to all components in the group that use the golang builder
- This matches the existing behavior in the OCP `attach-cve-flaws` path (`attach_cve_flaws_cli.py:554-571`)
- Builder usage is detected by checking each image's `from.builder.stream` config for "golang" (reuses `_image_uses_builder()` from `attach_cve_flaws_cli`)
- Previously, these CVEs were silently skipped because `openshift4/openshift-golang-builder` is not in any layered product's `delivery_repo_names`

## Context
OADP 1.4.10 release had CVE-2026-32281 and CVE-2026-32282 dropped from the shipment because their JIRA trackers had `pscomponent:redhat-user-workloads/art-images`. Prodsec will standardize on `pscomponent:openshift4/openshift-golang-builder` going forward (ref: OCPBUGS-87945).

## Test plan
- [x] New test: golang builder CVE fans out to all builder-consuming components
- [x] New test: golang builder CVE with no consumers raises RuntimeError
- [x] New test: mixed golang builder + regular CVEs in same batch
- [x] All 19 process_release_from_fbc_bugs tests pass
- [x] Full elliott test suite passes (412 tests)
- [x] Format check and lint pass

## Jenkins validation
Tested with [release-from-fbc build #113](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Frelease-from-fbc/113/) (DRY_RUN=true, same OADP 1.4.10 parameters as build #109, with pscomponent labels on [OADP-7902](https://redhat.atlassian.net/browse/OADP-7902) and [OADP-7788](https://redhat.atlassian.net/browse/OADP-7788) updated to `openshift4/openshift-golang-builder`). Build completed successfully with both CVEs fanning out to all 10 golang-builder-consuming components:

```
JIRA OADP-7902: CVE CVE-2026-32281 is a golang builder CVE, fanning out to 10 components:
  ['oadp-1-4-oadp-kubevirt-velero-plugin', 'oadp-1-4-oadp-mustgather', 'oadp-1-4-oadp-operator',
   'oadp-1-4-oadp-velero', 'oadp-1-4-oadp-velero-plugin', 'oadp-1-4-oadp-velero-plugin-for-aws',
   'oadp-1-4-oadp-velero-plugin-for-gcp', 'oadp-1-4-oadp-velero-plugin-for-legacy-aws',
   'oadp-1-4-oadp-velero-plugin-for-microsoft-azure', 'oadp-1-4-oadp-velero-restic-restore-helper']

JIRA OADP-7788: CVE CVE-2026-32282 is a golang builder CVE, fanning out to 10 components:
  [same 10 components]
```

Includes defensive check for `openshift-golang-builder-container` pscomponent (the Brew/distgit component name used in OCP), though layered product JIRA trackers use `openshift4/openshift-golang-builder` in practice.

Previous test builds: [#112](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Frelease-from-fbc/112/) (pre-defensive-fix, also SUCCESS)