### PR TITLE
fix quay doomsday issue described in ART-18128

### DIFF
--- a/pyartcd/pyartcd/pipelines/quay_doomsday_backup.py
+++ b/pyartcd/pyartcd/pipelines/quay_doomsday_backup.py
@@ -99,13 +99,14 @@ class QuayDoomsdaySync:
             self.runtime.logger.info("[DRY RUN] Would have messaged Slack")
 
         # Synchronize individual arches sequentially to help with quay returning 502
-        results = []
+        failed_arches = []
         for arch in self.arches:
-            results.append(await self.sync_arch(arch))
+            if not await self.sync_arch(arch):
+                failed_arches.append(arch)
 
         # Report the results to Slack
         if not self.runtime.dry_run:
-            if all(results):
+            if not failed_arches:
                 await self.slack_client._client.reactions_add(
                     channel=slack_channel_id, timestamp=main_message_ts, name="done_it_is"
                 )
@@ -113,6 +114,11 @@ class QuayDoomsdaySync:
                 await self.slack_client.say_in_thread(":x: Failed to sync some arches", broadcast=True)
         else:
             self.runtime.logger.info("[DRY RUN] Would have messaged Slack")
+
+        if failed_arches:
+            raise RuntimeError(
+                f"Failed to sync arches for {self.version}: {', '.join(failed_arches)}"
+            )
 
 
 @cli.command(

--- a/pyartcd/pyartcd/pipelines/quay_doomsday_backup.py
+++ b/pyartcd/pyartcd/pipelines/quay_doomsday_backup.py
@@ -116,9 +116,7 @@ class QuayDoomsdaySync:
             self.runtime.logger.info("[DRY RUN] Would have messaged Slack")
 
         if failed_arches:
-            raise RuntimeError(
-                f"Failed to sync arches for {self.version}: {', '.join(failed_arches)}"
-            )
+            raise RuntimeError(f"Failed to sync arches for {self.version}: {', '.join(failed_arches)}")
 
 
 @cli.command(

--- a/pyartcd/tests/pipelines/test_quay_doomsday_backup.py
+++ b/pyartcd/tests/pipelines/test_quay_doomsday_backup.py
@@ -1,0 +1,59 @@
+"""Unit tests for quay_doomsday_backup pipeline."""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, Mock, patch
+
+from pyartcd.pipelines.quay_doomsday_backup import QuayDoomsdaySync
+from pyartcd.runtime import Runtime
+from pyartcd.slack import SlackClient
+
+
+class TestQuayDoomsdaySync(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.runtime = Mock(spec=Runtime)
+        self.runtime.dry_run = False
+        self.runtime.logger = Mock()
+        self.mock_slack_client = Mock(spec=SlackClient)
+        self.mock_slack_client.say_in_thread = AsyncMock(
+            return_value={"channel": "C123", "message": {"ts": "1234.5678"}}
+        )
+        self.mock_slack_client._client = Mock()
+        self.mock_slack_client._client.reactions_add = AsyncMock()
+        self.runtime.new_slack_client = Mock(return_value=self.mock_slack_client)
+        self.version = "4.15.5"
+        self.arches = "x86_64,s390x"
+
+    def _make_pipeline(self) -> QuayDoomsdaySync:
+        return QuayDoomsdaySync(runtime=self.runtime, version=self.version, arches=self.arches)
+
+    @patch("pyartcd.pipelines.quay_doomsday_backup.mkdirs")
+    async def test_run_succeeds_when_all_arches_sync(self, _mkdirs_mock):
+        pipeline = self._make_pipeline()
+        pipeline.sync_arch = AsyncMock(return_value=True)
+
+        await pipeline.run()
+
+        self.assertEqual(pipeline.sync_arch.await_count, 2)
+        self.mock_slack_client._client.reactions_add.assert_awaited_once()
+
+    @patch("pyartcd.pipelines.quay_doomsday_backup.mkdirs")
+    async def test_run_raises_when_some_arches_fail(self, _mkdirs_mock):
+        pipeline = self._make_pipeline()
+        pipeline.sync_arch = AsyncMock(side_effect=[True, False])
+
+        with self.assertRaisesRegex(RuntimeError, "Failed to sync arches for 4.15.5: s390x"):
+            await pipeline.run()
+
+        self.mock_slack_client.say_in_thread.assert_awaited()
+        self.mock_slack_client._client.reactions_add.assert_not_awaited()
+
+    @patch("pyartcd.pipelines.quay_doomsday_backup.mkdirs")
+    async def test_run_raises_when_all_arches_fail(self, _mkdirs_mock):
+        pipeline = self._make_pipeline()
+        pipeline.sync_arch = AsyncMock(return_value=False)
+
+        with self.assertRaisesRegex(RuntimeError, "Failed to sync arches for 4.15.5: x86_64, s390x"):
+            await pipeline.run()
+
+        self.mock_slack_client.say_in_thread.assert_awaited()
+        self.mock_slack_client._client.reactions_add.assert_not_awaited()


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Quay Doomsday backup pipeline to fail the run when one or more architecture sync operations fail, instead of only posting a notification.
  * Improved error reporting by tracking and surfacing the specific architectures that failed.

* **Tests**
  * Added unit tests covering the all-success path, partial failure path, and all-failures path, including expected Slack behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->