### PR TITLE
fix(doozer): detect arch conditions in subshell package assignments

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/shell_parser.py
+++ b/doozer/doozerlib/lockfile_prototype/shell_parser.py
@@ -11,7 +11,7 @@ import logging
 import re
 
 import bashlex
-from artcommonlib.arch_util import brew_arch_for_go_arch
+from artcommonlib.arch_util import BREW_ARCHES, brew_arch_for_go_arch
 from pydantic import BaseModel, Field
 
 from doozerlib.lockfile_prototype.constants import ARCH_KEYWORDS
@@ -338,7 +338,16 @@ def _process_assignments(
         if has_cmdsub:
             extracted = _extract_subshell_packages(var_value)
             if extracted:
-                ctx.shell_vars[var_name] = extracted
+                target_arches = _extract_subshell_arch_condition(var_value)
+                if target_arches:
+                    per_arch = ctx.arch_shell_vars.setdefault(var_name, {})
+                    for arch in target_arches:
+                        if arch in per_arch:
+                            per_arch[arch] = f"{per_arch[arch]} {extracted}"
+                        else:
+                            per_arch[arch] = extracted
+                else:
+                    ctx.shell_vars[var_name] = extracted
         elif arch_context:
             per_arch = ctx.arch_shell_vars.setdefault(var_name, {})
             for arch in arch_context:
@@ -526,6 +535,40 @@ def _process_command_node(
         arch_resolved_tokens = _resolve_arch_specific_tokens(pkg_words, raw_args, all_vars, ctx)
 
     _classify_package_tokens(resolved_tokens, arch_resolved_tokens, action, ctx, arch_context)
+
+
+def _extract_subshell_arch_condition(subshell_body: str) -> list[str] | None:
+    """
+    Detect architecture conditions inside a subshell body and return
+    the list of arches where the subshell produces output.
+
+    Arg(s):
+        subshell_body (str): Text inside a $(...) subshell, e.g.
+            'if [ "$(uname -m)" != "s390x" ]; then echo -n mstflint; fi'
+    Return Value(s):
+        list[str] | None: Target arches (Brew names), or None if no
+            arch condition detected or pattern is ambiguous.
+    """
+    if not _has_arch_test(subshell_body):
+        return None
+
+    neq_arches = ARCH_NEQ_VALUE_RE.findall(subshell_body)
+    eq_arches = ARCH_VALUE_RE.findall(subshell_body)
+
+    if neq_arches and eq_arches:
+        return None
+
+    if neq_arches:
+        excluded = set(_normalize_arch_names(neq_arches))
+        target = sorted(set(BREW_ARCHES) - excluded)
+        return target if target else None
+
+    if eq_arches:
+        if len(eq_arches) > 1:
+            return None
+        return _normalize_arch_names(eq_arches)
+
+    return None
 
 
 def _extract_subshell_packages(subshell_body: str) -> str:

--- a/doozer/tests/lockfile_prototype/test_shell_parser.py
+++ b/doozer/tests/lockfile_prototype/test_shell_parser.py
@@ -133,11 +133,40 @@ class TestExtractPackagesFromRunCommands(unittest.TestCase):
             "yum -y install pciutils hwdata kmod $ARCH_DEP_PKGS"
         ]
         common, arch = extract_packages_from_run_commands(run_values)
-        self.assertIn("mstflint", common)
+        self.assertNotIn("mstflint", common)
         self.assertIn("pciutils", common)
         self.assertIn("hwdata", common)
         self.assertIn("kmod", common)
+        for a in ("x86_64", "aarch64", "ppc64le"):
+            self.assertIn("mstflint", arch.get(a, []))
+        self.assertNotIn("s390x", arch)
+
+    def test_subshell_arch_conditional_var_eq(self):
+        run_values = [
+            'SPECIAL=$(if [ "$(uname -m)" == "x86_64" ]; then echo -n intel-pkg ; fi) && '
+            "yum -y install base-pkg $SPECIAL"
+        ]
+        common, arch = extract_packages_from_run_commands(run_values)
+        self.assertNotIn("intel-pkg", common)
+        self.assertIn("base-pkg", common)
+        self.assertEqual(arch, {"x86_64": ["intel-pkg"]})
+
+    def test_subshell_no_arch_condition(self):
+        run_values = ['EXTRA=$(echo extra-pkg) && yum -y install base-pkg $EXTRA']
+        common, arch = extract_packages_from_run_commands(run_values)
+        self.assertIn("extra-pkg", common)
+        self.assertIn("base-pkg", common)
         self.assertEqual(arch, {})
+
+    def test_subshell_arch_conditional_var_go_arch(self):
+        run_values = [
+            'SPECIAL=$(if [ "$(go env GOARCH)" == "amd64" ]; then echo -n x86-only ; fi) && '
+            "yum -y install common-pkg $SPECIAL"
+        ]
+        common, arch = extract_packages_from_run_commands(run_values)
+        self.assertNotIn("x86-only", common)
+        self.assertIn("common-pkg", common)
+        self.assertEqual(arch, {"x86_64": ["x86-only"]})
 
     def test_if_else_var_with_nested_resolution(self):
         run_values = [


### PR DESCRIPTION
When a Dockerfile uses a subshell to conditionally set packages based on architecture (e.g. mstflint only on non-s390x), the shell parser was storing the packages as common to all arches. This caused rpm-lockfile-prototype to fail resolving unavailable packages, and the retry logic would strip them from all arches including where they exist.

Parse arch conditions (== / !=) inside subshell bodies and route the extracted packages to arch_shell_vars so downstream resolution correctly produces per-arch package lists.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-21/pipelineruns/ose-4-21-sriov-network-config-daemon-5pkw6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of architecture-specific package dependencies, now correctly identifying when packages are conditionally required for particular target architectures (x86_64, aarch64, ppc64le, s390x) rather than treating all packages as unconditional installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->