### PR TITLE
sync-ci-images: fix --stream handling, add --images filter

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -125,6 +125,14 @@ def images_streams():
     help='If specified, only these stream names will be mirrored.',
 )
 @click.option(
+    '--image',
+    'images',
+    metavar='IMAGE_NAME',
+    default=[],
+    multiple=True,
+    help='If specified, only these image distgit keys will be mirrored (must have ci_alignment.upstream_image).',
+)
+@click.option(
     '--only-if-missing',
     default=False,
     is_flag=True,
@@ -145,6 +153,7 @@ def images_streams():
 def images_streams_mirror(
     runtime,
     streams: Tuple[str, ...],
+    images: Tuple[str, ...],
     only_if_missing: bool,
     live_test_mode: bool,
     force: bool,
@@ -163,7 +172,7 @@ def images_streams_mirror(
     elif runtime.registry_config_dir is not None:
         registry_config_file = get_docker_config_json(runtime.registry_config_dir)
 
-    def mirror_image(cmd_start: str, upstream_dest: str):
+    def mirror_image(cmd_start: str, upstream_dest: str, source_digest: Optional[str] = None):
         if upstream_dest.startswith('registry.ci.openshift.org/'):
             # Images targeting CI imagestreams must be mirrored to quay.io/openshift/ci (QCI) first,
             # then imagestreams updated to reference the QCI image by digest.
@@ -197,8 +206,12 @@ def images_streams_mirror(
                             f'Failed to mirror {upstream_entry_name}: {stderr}', (rc, stdout, stderr)
                         )
 
-                # Get digest of the newly mirrored image (handles manifest lists)
-                qci_digest = get_image_digest(floating_qci_dest, registry_config_file)
+                # Use source digest when available (oc image mirror preserves manifest digests).
+                # Falling back to get_image_digest for tag-based sources where digest isn't known.
+                if source_digest:
+                    qci_digest = source_digest
+                else:
+                    qci_digest = get_image_digest(floating_qci_dest, registry_config_file)
 
                 if qci_digest:
                     # Mirror to GC-prevention tag: art__<digest>
@@ -267,7 +280,7 @@ def images_streams_mirror(
                             f'Failed to mirror {upstream_entry_name}: {stderr}', (rc, stdout, stderr)
                         )
 
-    upstreaming_entries = _get_upstreaming_entries(runtime, streams)
+    upstreaming_entries = _get_upstreaming_entries(runtime, streams, image_names=images)
 
     for upstream_entry_name, config in upstreaming_entries.items():
         if config.mirror is True or force:
@@ -344,9 +357,13 @@ def images_streams_mirror(
             if registry_config_file is not None:
                 cmd += f" --registry-config={registry_config_file}"
 
+            # Extract digest from source pullspec when available (e.g. Konflux @sha256: refs).
+            # oc image mirror preserves manifest bytes, so source digest == destination digest.
+            src_digest = src_image_pullspec.split('@')[1] if '@' in src_image_pullspec else None
+
             # Mirror to main destination only if not in only-if-missing mode OR destination doesn't exist
             if not only_if_missing or not destinations_to_check.get(upstream_dest, False):
-                mirror_image(cmd, upstream_dest)
+                mirror_image(cmd, upstream_dest, source_digest=src_digest)
 
             # mirror arm64 builder and base images for CI
             if mirror_arm:
@@ -355,6 +372,7 @@ def images_streams_mirror(
                 if registry_config_file is not None:
                     arm_cmd += f" --registry-config={registry_config_file}"
                 # Mirror ARM64 only if not in only-if-missing mode OR destination doesn't exist
+                # ARM64 filter produces a single-arch image, not the original manifest list, so don't pass source_digest
                 if not only_if_missing or not destinations_to_check.get(f'{upstream_dest}-arm64', False):
                     mirror_image(arm_cmd, f'{upstream_dest}-arm64')
 
@@ -386,11 +404,19 @@ def images_streams_mirror(
     multiple=True,
     help='If specified, only check these streams',
 )
+@click.option(
+    '--image',
+    'images',
+    metavar='IMAGE_NAME',
+    default=[],
+    multiple=True,
+    help='If specified, only check these image distgit keys (must have ci_alignment.upstream_image).',
+)
 @click.option('--live-test-mode', default=False, is_flag=True, help='Scan for live-test mode buildconfigs')
 @click.option('--dry-run', default=False, is_flag=True, help='Do not actually mirror or update imagestreams')
 @option_registry_auth
 @pass_runtime
-def images_streams_check_upstream(runtime, streams, live_test_mode, dry_run, registry_auth: Optional[str]):
+def images_streams_check_upstream(runtime, streams, images, live_test_mode, dry_run, registry_auth: Optional[str]):
     runtime.initialize(clone_distgits=False, clone_source=False, prevent_cloning=True)
 
     # Determine which registry config to use
@@ -406,9 +432,7 @@ def images_streams_check_upstream(runtime, streams, live_test_mode, dry_run, reg
     istags_status = []
     qci_status = []
 
-    if not streams:
-        streams = runtime.get_stream_names()
-    upstreaming_entries = _get_upstreaming_entries(runtime, streams)
+    upstreaming_entries = _get_upstreaming_entries(runtime, streams, image_names=images)
 
     for upstream_entry_name, config in upstreaming_entries.items():
         upstream_dest = config.upstream_image
@@ -582,8 +606,8 @@ def images_streams_check_upstream(runtime, streams, live_test_mode, dry_run, reg
         print()
 
 
-def get_eligible_buildconfigs(runtime, streams, live_test_mode):
-    upstreaming_entries = _get_upstreaming_entries(runtime, streams)
+def get_eligible_buildconfigs(runtime, streams, live_test_mode, images=()):
+    upstreaming_entries = _get_upstreaming_entries(runtime, streams, image_names=images)
     buildconfig_names = []
     for upstream_entry_name, config in upstreaming_entries.items():
         transform = config.transform
@@ -614,6 +638,14 @@ def get_eligible_buildconfigs(runtime, streams, live_test_mode):
     help='If specified, only these stream names will be processed.',
 )
 @click.option(
+    '--image',
+    'images',
+    metavar='IMAGE_NAME',
+    default=[],
+    multiple=True,
+    help='If specified, only these image distgit keys will be processed (must have ci_alignment.upstream_image).',
+)
+@click.option(
     '--as',
     'as_user',
     metavar='CLUSTER_USERNAME',
@@ -625,7 +657,9 @@ def get_eligible_buildconfigs(runtime, streams, live_test_mode):
 @click.option('--dry-run', default=False, is_flag=True, help='Do not build anything, but only print build operations.')
 @option_registry_auth
 @pass_runtime
-def images_streams_start_buildconfigs(runtime, streams, as_user, live_test_mode, dry_run, registry_auth: Optional[str]):
+def images_streams_start_buildconfigs(
+    runtime, streams, images, as_user, live_test_mode, dry_run, registry_auth: Optional[str]
+):
     runtime.initialize(clone_distgits=False, clone_source=False, prevent_cloning=True)
 
     # Determine which registry config to use
@@ -650,7 +684,7 @@ def images_streams_start_buildconfigs(runtime, streams, as_user, live_test_mode,
         return
 
     buildconfigs = json.loads(bc_stdout).get('items', [])
-    eligible_bc_names = get_eligible_buildconfigs(runtime, streams, live_test_mode)
+    eligible_bc_names = get_eligible_buildconfigs(runtime, streams, live_test_mode, images=images)
 
     # Track triggered builds for post-build preservation
     triggered_builds = []
@@ -1043,52 +1077,67 @@ def images_streams_start_buildconfigs(runtime, streams, as_user, live_test_mode,
         print('\n=== Post-Build Preservation Complete ===')
 
 
-def _get_upstreaming_entries(runtime, stream_names=None):
+def _get_upstreaming_entry_for_image(runtime, image_meta):
+    """
+    Build an upstreaming entry from an image meta's ci_alignment config.
+    Returns the entry Model, or None if the image should be skipped (e.g. no build yet).
+    """
+    upstream_entry = Model(dict_to_model=image_meta.config.content.source.ci_alignment.primitive())
+
+    try:
+        upstream_entry['image'] = image_meta.pull_url()
+    except IOError as e:
+        runtime.logger.warning(f'Skipping {image_meta.distgit_key} for CI alignment: {e}')
+        return None
+
+    if upstream_entry.final_user is Missing:
+        upstream_entry.final_user = image_meta.config.final_stage_user
+    return upstream_entry
+
+
+def _get_upstreaming_entries(runtime, stream_names=None, image_names=None):
     """
     Looks through streams.yml entries and each image metadata for upstream
     transform information.
     :param runtime: doozer runtime
     :param stream_names: A list of streams to look for in streams.yml. If None or empty, all will be searched.
+    :param image_names: A list of image distgit keys to include. Each must have ci_alignment.upstream_image set.
     :return: Returns a map[name] => { transform: '...', upstream_image.... } where name is a stream name or distgit key.
     """
 
-    fetch_image_metas = False
-    if not stream_names:
-        # If not specified, use all.
+    fetch_all_image_metas = False
+    if not stream_names and not image_names:
         stream_names = runtime.get_stream_names()
-        fetch_image_metas = True
+        fetch_all_image_metas = True
 
     upstreaming_entries = {}
-    streams_config = runtime.streams
-    for stream in stream_names:
-        config = streams_config[stream]
-        if config is Missing:
-            raise IOError(f'Did not find stream {stream} in streams.yml for this group')
-        if config.upstream_image is not Missing:
-            upstreaming_entries[stream] = streams_config[stream]
 
-    if fetch_image_metas:
-        # Some images also have their own upstream information. This allows them to
-        # be mirrored out into upstream, optionally transformed, and made available as builder images for
-        # other images without being in streams.yml.
+    if stream_names:
+        streams_config = runtime.streams
+        for stream in stream_names:
+            config = streams_config[stream]
+            if config is Missing:
+                raise IOError(f'Did not find stream {stream} in streams.yml for this group')
+            if config.upstream_image is not Missing:
+                upstreaming_entries[stream] = streams_config[stream]
 
+    if fetch_all_image_metas:
         for image_meta in runtime.ordered_image_metas():
             if image_meta.config.content.source.ci_alignment.upstream_image is not Missing:
-                upstream_entry = Model(
-                    dict_to_model=image_meta.config.content.source.ci_alignment.primitive()
-                )  # Make a copy
+                entry = _get_upstreaming_entry_for_image(runtime, image_meta)
+                if entry is not None:
+                    upstreaming_entries[image_meta.distgit_key] = entry
 
-                # Use pull_url() which handles both Brew and Konflux build systems
-                try:
-                    upstream_entry['image'] = image_meta.pull_url()
-                except IOError as e:
-                    # Skip images that don't have builds yet (e.g., new images in Konflux)
-                    runtime.logger.warning(f'Skipping {image_meta.distgit_key} for CI alignment: {e}')
-                    continue
-
-                if upstream_entry.final_user is Missing:
-                    upstream_entry.final_user = image_meta.config.final_stage_user
-                upstreaming_entries[image_meta.distgit_key] = upstream_entry
+    elif image_names:
+        for name in image_names:
+            meta = runtime.image_map.get(name)
+            if not meta:
+                raise IOError(f'Image {name} not found in group metadata')
+            if meta.config.content.source.ci_alignment.upstream_image is Missing:
+                raise IOError(f'Image {name} does not have ci_alignment.upstream_image set; not eligible for CI sync')
+            entry = _get_upstreaming_entry_for_image(runtime, meta)
+            if entry is not None:
+                upstreaming_entries[name] = entry
 
     return upstreaming_entries
 
@@ -1105,6 +1154,14 @@ def _get_upstreaming_entries(runtime, stream_names=None):
     help='If specified, only these stream names will be processed.',
 )
 @click.option(
+    '--image',
+    'images',
+    metavar='IMAGE_NAME',
+    default=[],
+    multiple=True,
+    help='If specified, only these image distgit keys will be processed (must have ci_alignment.upstream_image).',
+)
+@click.option(
     '-o',
     '--output',
     metavar='FILENAME',
@@ -1117,7 +1174,7 @@ def _get_upstreaming_entries(runtime, stream_names=None):
 @click.option('--apply', default=False, is_flag=True, help='Apply the output if any buildconfigs are generated')
 @click.option('--live-test-mode', default=False, is_flag=True, help='Generate live-test mode buildconfigs')
 @pass_runtime
-def images_streams_gen_buildconfigs(runtime, streams, output, as_user, apply, live_test_mode):
+def images_streams_gen_buildconfigs(runtime, streams, images, output, as_user, apply, live_test_mode):
     """
     ART has a mandate to make "ART equivalent" images available usptream for CI workloads. This enables
     CI to compile with the same golang version ART is using and use identical UBI8 images, etc. To accomplish
@@ -1160,7 +1217,7 @@ def images_streams_gen_buildconfigs(runtime, streams, output, as_user, apply, li
 
     buildconfig_definitions = []
 
-    upstreaming_entries = _get_upstreaming_entries(runtime, streams)
+    upstreaming_entries = _get_upstreaming_entries(runtime, streams, image_names=images)
 
     for upstream_entry_name, config in upstreaming_entries.items():
         transform = config.transform

--- a/doozer/tests/cli/test_images_streams.py
+++ b/doozer/tests/cli/test_images_streams.py
@@ -278,6 +278,70 @@ def test_get_upstreaming_entries_with_final_user(mock_runtime, mock_image_meta):
     assert result['ose-test'].final_user == '1001'
 
 
+# Tests for --image filtering in _get_upstreaming_entries
+
+
+def test_get_upstreaming_entries_image_names_only(mock_runtime, mock_image_meta):
+    """Test filtering by image_names skips streams and only processes specified images."""
+    mock_image_meta.distgit_key = 'ci-openshift-base.rhel10'
+    mock_image_meta.pull_url.return_value = 'brew-registry.example.com/ci-openshift-base:latest'
+    mock_runtime.image_map = {'ci-openshift-base.rhel10': mock_image_meta}
+
+    result = images_streams._get_upstreaming_entries(mock_runtime, image_names=['ci-openshift-base.rhel10'])
+
+    assert len(result) == 1
+    assert 'ci-openshift-base.rhel10' in result
+    mock_runtime.ordered_image_metas.assert_not_called()
+    mock_runtime.get_stream_names.assert_not_called()
+
+
+def test_get_upstreaming_entries_image_not_found(mock_runtime):
+    """Test error when specified image_name is not in the group."""
+    mock_runtime.image_map = {}
+
+    with pytest.raises(IOError, match='Image nonexistent not found in group metadata'):
+        images_streams._get_upstreaming_entries(mock_runtime, image_names=['nonexistent'])
+
+
+def test_get_upstreaming_entries_image_not_eligible(mocker, mock_runtime):
+    """Test error when image lacks ci_alignment.upstream_image."""
+    ineligible_meta = mocker.MagicMock()
+    ineligible_meta.config.content.source.ci_alignment.upstream_image = Missing
+    mock_runtime.image_map = {'ose-cli': ineligible_meta}
+
+    with pytest.raises(IOError, match='not eligible for CI sync'):
+        images_streams._get_upstreaming_entries(mock_runtime, image_names=['ose-cli'])
+
+
+def test_get_upstreaming_entries_stream_and_image_union(mocker, mock_runtime, mock_image_meta):
+    """Test that providing both stream_names and image_names returns the union."""
+    mock_runtime.streams = {
+        'golang': Model({'upstream_image': 'registry.ci.openshift.org/ocp/4.17:golang'}),
+    }
+    mock_image_meta.distgit_key = 'ci-openshift-base.rhel10'
+    mock_image_meta.pull_url.return_value = 'brew-registry.example.com/ci-openshift-base:latest'
+    mock_runtime.image_map = {'ci-openshift-base.rhel10': mock_image_meta}
+
+    result = images_streams._get_upstreaming_entries(
+        mock_runtime, stream_names=['golang'], image_names=['ci-openshift-base.rhel10']
+    )
+
+    assert len(result) == 2
+    assert 'golang' in result
+    assert 'ci-openshift-base.rhel10' in result
+
+
+def test_get_upstreaming_entries_image_build_not_found_skips(mocker, mock_runtime, mock_image_meta):
+    """Test that an image with no build is gracefully skipped."""
+    mock_image_meta.distgit_key = 'ci-openshift-base.rhel10'
+    mock_image_meta.pull_url.side_effect = IOError('No build found')
+    mock_runtime.image_map = {'ci-openshift-base.rhel10': mock_image_meta}
+
+    result = images_streams._get_upstreaming_entries(mock_runtime, image_names=['ci-openshift-base.rhel10'])
+
+    assert result == {}
+
+
 # Tests for images:streams gen-buildconfigs command
 
 
@@ -295,7 +359,7 @@ def test_gen_buildconfigs_uses_get_upstreaming_entries():
     source = inspect.getsource(callback)
 
     # Verify it calls _get_upstreaming_entries
-    assert '_get_upstreaming_entries(runtime, streams)' in source
+    assert '_get_upstreaming_entries(runtime, streams' in source
 
     # Verify it uses the configuration fields from entries
     assert 'config.transform' in source

--- a/pyartcd/pyartcd/pipelines/sync_ci_images.py
+++ b/pyartcd/pyartcd/pipelines/sync_ci_images.py
@@ -511,24 +511,27 @@ class SyncCIImagesPipeline:
             f"--build-system {self.BUILD_SYSTEM} "
             f"--registry-config {auth_file}"
         )
-        if self.only_stream:
-            doozer_opts += f" --only-streams {self.only_stream}"
         return doozer_opts
+
+    @property
+    def _stream_arg(self) -> str:
+        """Return the --stream subcommand arg if only_stream is set, empty string otherwise."""
+        return f"--stream {self.only_stream}" if self.only_stream else ""
 
     async def _generate_and_apply_buildconfigs(self, doozer_opts: str) -> None:
         """Generate BuildConfigs and apply them to CI cluster."""
         self._logger.info(f"{self.version}: Generating BuildConfigs")
         apply_flag = "" if self.runtime.dry_run else "--apply"
         await self._run_doozer_command(
-            doozer_opts, "images:streams gen-buildconfigs", f"-o {self._working_dir}/buildconfigs.yaml {apply_flag}"
+            doozer_opts,
+            "images:streams gen-buildconfigs",
+            f"{self._stream_arg} -o {self._working_dir}/buildconfigs.yaml {apply_flag}",
         )
 
     async def _mirror_images_to_ci(self, doozer_opts: str, auth_file: str) -> None:
         """Mirror builder and base images to CI registries."""
         self._logger.info(f"{self.version}: Mirroring images")
-        # Pass --registry-auth at command level to work around doozer bug where
-        # global --registry-config doesn't get passed to oc image mirror commands
-        mirror_args = f"--registry-auth {auth_file} "
+        mirror_args = f"{self._stream_arg} --registry-auth {auth_file} "
         if self.update_images_only_when_missing:
             mirror_args += "--only-if-missing "
         if self.runtime.dry_run:
@@ -538,8 +541,7 @@ class SyncCIImagesPipeline:
     async def _trigger_ci_builds(self, doozer_opts: str, auth_file: str) -> None:
         """Start CI builds for updated images."""
         self._logger.info(f"{self.version}: Starting builds")
-        # Pass --registry-auth for image info and mirror operations in pre-build steps
-        start_builds_args = f"--registry-auth {auth_file} "
+        start_builds_args = f"{self._stream_arg} --registry-auth {auth_file} "
         if self.runtime.dry_run:
             start_builds_args += "--dry-run"
         await self._run_doozer_command(doozer_opts, "images:streams start-builds", start_builds_args.strip())
@@ -553,7 +555,9 @@ class SyncCIImagesPipeline:
     async def _verify_upstream_consistency(self, doozer_opts: str, auth_file: str) -> None:
         """Verify CI imagestreams match expected state."""
         self._logger.info(f"{self.version}: Checking upstream consistency")
-        await self._run_doozer_command(doozer_opts, "images:streams check-upstream", f"--registry-auth {auth_file}")
+        await self._run_doozer_command(
+            doozer_opts, "images:streams check-upstream", f"{self._stream_arg} --registry-auth {auth_file}"
+        )
 
     async def _open_reconciliation_prs(self, doozer_opts: str) -> int:
         """Open PRs to reconcile BuildConfig drift."""

--- a/pyartcd/pyartcd/pipelines/sync_ci_images.py
+++ b/pyartcd/pyartcd/pipelines/sync_ci_images.py
@@ -53,6 +53,7 @@ class SyncCIImagesPipeline:
         data_path: str = "",
         data_gitref: str = "",
         only_stream: str = "",
+        images: str = "",
         add_labels: str = "",
         assembly: str = "stream",
         skip_prs: bool = False,
@@ -69,6 +70,7 @@ class SyncCIImagesPipeline:
             data_path: ocp-build-data fork URL (default: official repo)
             data_gitref: ocp-build-data git branch/tag/sha (default: use version branch)
             only_stream: Specific stream from streams.yml.
+            images: Comma-separated distgit keys of images with ci_alignment.upstream_image.
             add_labels: Space-delimited labels to add to PRs
             assembly: Assembly name (default: "stream")
             skip_prs: Skip opening reconciliation PRs
@@ -82,6 +84,7 @@ class SyncCIImagesPipeline:
         self.data_path = data_path or OCP_BUILD_DATA_URL
         self.data_gitref = data_gitref
         self.only_stream = only_stream
+        self.images = [i.strip() for i in images.split(',') if i.strip()] if images else []
         self.add_labels = add_labels
         self.assembly = assembly
         self.skip_prs = skip_prs
@@ -106,9 +109,9 @@ class SyncCIImagesPipeline:
         if not re.match(r'^\d+\.\d+$', self.version):
             raise ValueError(f"Invalid FOR_RELEASE format: {self.version}. Expected format: X.Y (e.g., 4.17)")
 
-        # Auto-set SKIP_PRS if ONLY_STREAM is set.
-        if self.only_stream and not self.skip_prs:
-            self._logger.info("Setting SKIP_PRS to true because ONLY_STREAM is set")
+        # Auto-set SKIP_PRS if ONLY_STREAM or IMAGES is set.
+        if (self.only_stream or self.images) and not self.skip_prs:
+            self._logger.info("Setting SKIP_PRS to true because ONLY_STREAM or IMAGES is set")
             self.skip_prs = True
 
         # Validate assembly format (alphanumeric, dash, dot, underscore)
@@ -518,6 +521,16 @@ class SyncCIImagesPipeline:
         """Return the --stream subcommand arg if only_stream is set, empty string otherwise."""
         return f"--stream {self.only_stream}" if self.only_stream else ""
 
+    @property
+    def _image_args(self) -> str:
+        """Return --image args for each image distgit key, empty string if none."""
+        return " ".join(f"--image {img}" for img in self.images) if self.images else ""
+
+    @property
+    def _filter_args(self) -> str:
+        """Return combined --stream and --image subcommand args."""
+        return f"{self._stream_arg} {self._image_args}".strip()
+
     async def _generate_and_apply_buildconfigs(self, doozer_opts: str) -> None:
         """Generate BuildConfigs and apply them to CI cluster."""
         self._logger.info(f"{self.version}: Generating BuildConfigs")
@@ -525,13 +538,13 @@ class SyncCIImagesPipeline:
         await self._run_doozer_command(
             doozer_opts,
             "images:streams gen-buildconfigs",
-            f"{self._stream_arg} -o {self._working_dir}/buildconfigs.yaml {apply_flag}",
+            f"{self._filter_args} -o {self._working_dir}/buildconfigs.yaml {apply_flag}",
         )
 
     async def _mirror_images_to_ci(self, doozer_opts: str, auth_file: str) -> None:
         """Mirror builder and base images to CI registries."""
         self._logger.info(f"{self.version}: Mirroring images")
-        mirror_args = f"{self._stream_arg} --registry-auth {auth_file} "
+        mirror_args = f"{self._filter_args} --registry-auth {auth_file} "
         if self.update_images_only_when_missing:
             mirror_args += "--only-if-missing "
         if self.runtime.dry_run:
@@ -541,7 +554,7 @@ class SyncCIImagesPipeline:
     async def _trigger_ci_builds(self, doozer_opts: str, auth_file: str) -> None:
         """Start CI builds for updated images."""
         self._logger.info(f"{self.version}: Starting builds")
-        start_builds_args = f"{self._stream_arg} --registry-auth {auth_file} "
+        start_builds_args = f"{self._filter_args} --registry-auth {auth_file} "
         if self.runtime.dry_run:
             start_builds_args += "--dry-run"
         await self._run_doozer_command(doozer_opts, "images:streams start-builds", start_builds_args.strip())
@@ -556,7 +569,7 @@ class SyncCIImagesPipeline:
         """Verify CI imagestreams match expected state."""
         self._logger.info(f"{self.version}: Checking upstream consistency")
         await self._run_doozer_command(
-            doozer_opts, "images:streams check-upstream", f"{self._stream_arg} --registry-auth {auth_file}"
+            doozer_opts, "images:streams check-upstream", f"{self._filter_args} --registry-auth {auth_file}"
         )
 
     async def _open_reconciliation_prs(self, doozer_opts: str) -> int:
@@ -696,6 +709,12 @@ class SyncCIImagesPipeline:
     help='Process only specific stream from streams.yml. Automatically sets SKIP_PRS=true.',
 )
 @click.option(
+    '--images',
+    default='',
+    help='Comma-separated distgit keys to sync (e.g. ci-openshift-base.rhel10). '
+    'Each must have ci_alignment.upstream_image set. Automatically sets SKIP_PRS=true.',
+)
+@click.option(
     '--add-labels', default='', help='Space-delimited labels to add to reconciliation PRs (e.g., "backport candidate")'
 )
 @click.option('--assembly', default='stream', help='Assembly name to use for doozer operations (default: "stream")')
@@ -722,6 +741,7 @@ async def sync_ci_images_cli(
     data_path: str,
     data_gitref: str,
     only_stream: str,
+    images: str,
     add_labels: str,
     assembly: str,
     skip_prs: bool,
@@ -751,6 +771,7 @@ async def sync_ci_images_cli(
         data_path=data_path,
         data_gitref=data_gitref,
         only_stream=only_stream,
+        images=images,
         add_labels=add_labels,
         assembly=assembly,
         skip_prs=skip_prs,

--- a/pyartcd/tests/pipelines/test_sync_ci_images.py
+++ b/pyartcd/tests/pipelines/test_sync_ci_images.py
@@ -124,6 +124,66 @@ class TestSyncCIImagesPipeline:
 
         assert pipeline.skip_prs is True
 
+    def test_validate_auto_sets_skip_prs_for_images(self, mock_runtime):
+        """Test SKIP_PRS automatically set to true when IMAGES specified."""
+        pipeline = SyncCIImagesPipeline(
+            mock_runtime,
+            for_release="4.17",
+            images="ci-openshift-base.rhel10",
+            skip_prs=False,
+        )
+        assert pipeline.skip_prs is True
+
+    def test_images_parsed_as_list(self, mock_runtime):
+        """Test comma-separated IMAGES string is parsed into a list."""
+        pipeline = SyncCIImagesPipeline(
+            mock_runtime,
+            for_release="4.17",
+            images="ci-openshift-base.rhel10,ci-openshift-base.rhel9",
+        )
+        assert pipeline.images == ["ci-openshift-base.rhel10", "ci-openshift-base.rhel9"]
+
+    def test_images_empty_string_yields_empty_list(self, mock_runtime):
+        """Test empty IMAGES string yields empty list."""
+        pipeline = SyncCIImagesPipeline(mock_runtime, for_release="4.17", images="")
+        assert pipeline.images == []
+
+    def test_images_whitespace_handling(self, mock_runtime):
+        """Test IMAGES strips whitespace around entries."""
+        pipeline = SyncCIImagesPipeline(
+            mock_runtime,
+            for_release="4.17",
+            images=" ci-openshift-base.rhel10 , ci-openshift-base.rhel9 ",
+        )
+        assert pipeline.images == ["ci-openshift-base.rhel10", "ci-openshift-base.rhel9"]
+
+    def test_filter_args_with_stream_only(self, mock_runtime):
+        """Test _filter_args returns only --stream when no images."""
+        pipeline = SyncCIImagesPipeline(mock_runtime, for_release="4.17", only_stream="rhel10")
+        assert pipeline._filter_args == "--stream rhel10"
+
+    def test_filter_args_with_images_only(self, mock_runtime):
+        """Test _filter_args returns only --image args when no stream."""
+        pipeline = SyncCIImagesPipeline(mock_runtime, for_release="4.17", images="ci-openshift-base.rhel10")
+        assert pipeline._filter_args == "--image ci-openshift-base.rhel10"
+
+    def test_filter_args_with_both(self, mock_runtime):
+        """Test _filter_args returns both --stream and --image args."""
+        pipeline = SyncCIImagesPipeline(
+            mock_runtime,
+            for_release="4.17",
+            only_stream="rhel10",
+            images="ci-openshift-base.rhel10,ci-openshift-base.rhel9",
+        )
+        assert (
+            pipeline._filter_args == "--stream rhel10 --image ci-openshift-base.rhel10 --image ci-openshift-base.rhel9"
+        )
+
+    def test_filter_args_empty_when_neither(self, mock_runtime):
+        """Test _filter_args returns empty string when neither stream nor images."""
+        pipeline = SyncCIImagesPipeline(mock_runtime, for_release="4.17")
+        assert pipeline._filter_args == ""
+
     def test_init_with_custom_data_path(self, mock_runtime):
         """Test initialization with custom data path and gitref."""
         pipeline = SyncCIImagesPipeline(


### PR DESCRIPTION
## Summary

Two fixes for the `sync-ci-images` pipeline:

1. **Fix `--only-streams` → `--stream`**: The pipeline passed `--only-streams` as a global doozer option, but doozer has no such flag. Replaced with `--stream` at the subcommand level where doozer actually accepts it.

2. **Add `--images` filter**: New `--image` option on doozer's `images:streams` subcommands and a corresponding `--images` parameter on the pyartcd pipeline. Allows targeting specific distgit keys (e.g. `ci-openshift-base.rhel10`) without running a full sync.

## Test plan
- [x] All existing unit tests pass (`make test`)
- [x] New unit tests for `--image` filter parsing and selection behavior