### PR TITLE
ART-18202: Fix rhel version mismatch lockfile

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -469,17 +469,24 @@ class RpmLockfilePrototypeGenerator:
                 # so they appear in the lockfile even when already installed
                 # on some architectures, and add base image packages to the
                 # install list for conflict detection.
-                if image_pullspec:
-                    reinstall_pkgs = list(packages)
-                base_pkgs = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key)
-                if base_pkgs:
-                    extra = [p for p in base_pkgs if p not in packages]
-                    if extra:
-                        packages = packages + extra
-                        self.logger.info(
-                            f"{distgit_key}: stage {stage_num}: {len(extra)} base image "
-                            "packages added to install list for conflict detection"
-                        )
+                #
+                # When the builder image RHEL version differs from the repos
+                # (e.g. el8 builder with el9 repos), skip --image mode and
+                # base image packages — cross-RHEL depsolve is unsolvable.
+                if self._has_rhel_version_mismatch(stage_num, repo_list, distgit_key):
+                    image_pullspec = None
+                else:
+                    if image_pullspec:
+                        reinstall_pkgs = list(packages)
+                    base_pkgs = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key)
+                    if base_pkgs:
+                        extra = [p for p in base_pkgs if p not in packages]
+                        if extra:
+                            packages = packages + extra
+                            self.logger.info(
+                                f"{distgit_key}: stage {stage_num}: {len(extra)} base image "
+                                "packages added to install list for conflict detection"
+                            )
 
             enable_only = [s.split("/")[0] for s in stage_info.module_specs] if stage_info.module_specs else None
 
@@ -600,6 +607,80 @@ class RpmLockfilePrototypeGenerator:
             else:
                 image_pullspec = resolved
         return image_pullspec
+
+    @staticmethod
+    def _extract_rhel_version_from_pullspec(pullspec: str) -> int | None:
+        """
+        Extract RHEL major version from an image pullspec tag.
+
+        Handles two tag formats:
+        - rhel-8-golang-..., ubi-9-minimal, etc.
+        - NVR-style: openshift-golang-builder-container-v1.25.9-...el8
+
+        Arg(s):
+            pullspec (str): Image pullspec with tag or digest.
+        Return Value(s):
+            int | None: RHEL major version (e.g. 8, 9), or None if
+                not detectable.
+        """
+        if ":" not in pullspec:
+            return None
+        tag = pullspec.split("@")[0].split(":")[-1]
+        m = re.search(r"(?:rhel|ubi|centos|scos)-?(\d+)", tag)
+        if m:
+            return int(m.group(1))
+        m = re.search(r"\.el(\d+)", tag)
+        if m:
+            return int(m.group(1))
+        return None
+
+    @staticmethod
+    def _extract_rhel_version_from_repos(repo_list: list[RepoEntry]) -> int | None:
+        """
+        Extract RHEL major version from repo content set IDs.
+
+        Arg(s):
+            repo_list (list[RepoEntry]): Repository entries with repoid
+                fields like "rhel-9-for-x86_64-baseos-e4s-rpms__9_DOT_6".
+        Return Value(s):
+            int | None: RHEL major version, or None if not detectable.
+        """
+        for repo in repo_list:
+            m = re.search(r"rhel-(\d+)", repo.repoid)
+            if m:
+                return int(m.group(1))
+        return None
+
+    def _has_rhel_version_mismatch(self, stage_num: int, repo_list: list[RepoEntry], distgit_key: str) -> bool:
+        """
+        Check whether a builder stage's RHEL version differs from the
+        repos' RHEL version. Returns False when either version cannot
+        be determined (fail-open).
+
+        Arg(s):
+            stage_num (int): Dockerfile stage number.
+            repo_list (list[RepoEntry]): Repository entries.
+            distgit_key (str): Image identifier for logging.
+        Return Value(s):
+            bool: True if a RHEL version mismatch is detected.
+        """
+        if stage_num >= len(self.downstream_parents):
+            return False
+        pullspec = self.downstream_parents[stage_num]
+        if not pullspec or "/" not in pullspec:
+            return False
+        builder_rhel = self._extract_rhel_version_from_pullspec(pullspec)
+        repo_rhel = self._extract_rhel_version_from_repos(repo_list)
+        if builder_rhel is None or repo_rhel is None:
+            return False
+        if builder_rhel != repo_rhel:
+            self.logger.warning(
+                f"{distgit_key}: stage {stage_num}: RHEL version mismatch — "
+                f"builder image is el{builder_rhel} but repos are el{repo_rhel}; "
+                f"skipping base image packages and --image mode for this stage"
+            )
+            return True
+        return False
 
     async def _handle_update_only_stage(
         self, stage_num: int, image_pullspec: str | None, distgit_key: str

--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -762,6 +762,14 @@ class RpmLockfilePrototypeGenerator:
         resolved: set[str] = set()
 
         for pattern in builddep_patterns:
+            if pattern.endswith(".spec"):
+                self.logger.warning(
+                    f"{distgit_key}: builddep target '{pattern}' is a spec file — "
+                    "only SRPMs are supported for BuildRequires extraction; "
+                    "spec files cannot be parsed reliably due to macro resolution"
+                )
+                continue
+
             srpm_pattern = pattern if pattern.endswith(".src.rpm") else f"{pattern}.src.rpm"
             matching_srpms = [
                 f
@@ -770,17 +778,8 @@ class RpmLockfilePrototypeGenerator:
             ]
 
             if not matching_srpms:
-                matching_specs = [
-                    f
-                    for f in dest_dir.iterdir()
-                    if f.is_file() and f.name.endswith(".spec") and fnmatch.fnmatch(f.name, pattern)
-                ]
-                if matching_specs:
-                    matching_srpms = matching_specs
-
-            if not matching_srpms:
                 self.logger.warning(
-                    f"{distgit_key}: no SRPM or spec file matching '{pattern}' found in {dest_dir}, "
+                    f"{distgit_key}: no SRPM matching '{pattern}' found in {dest_dir}, "
                     "builddep packages will not be included in lockfile"
                 )
                 continue

--- a/doozer/doozerlib/lockfile_prototype/shell_parser.py
+++ b/doozer/doozerlib/lockfile_prototype/shell_parser.py
@@ -511,7 +511,10 @@ def _process_command_node(
         return
 
     word_values = [w.word for w in words]
-    action, action_idx = _detect_pkg_action(word_values, ctx)
+    all_vars = {**ctx.variables, **ctx.shell_vars}
+    resolved_first = resolve_bash_expansion(word_values[0], all_vars) if word_values else ""
+    resolved_word_values = [resolved_first] + word_values[1:] if word_values else word_values
+    action, action_idx = _detect_pkg_action(resolved_word_values, ctx)
     if not action:
         return
 

--- a/doozer/doozerlib/lockfile_prototype/shell_parser.py
+++ b/doozer/doozerlib/lockfile_prototype/shell_parser.py
@@ -382,7 +382,7 @@ def _detect_pkg_action(word_values: list[str], ctx: _WalkContext) -> tuple[str |
         if wl in ("update", "upgrade"):
             ctx.has_update = True
             return "update", idx
-        if wl == "builddep":
+        if wl in ("builddep", "build-dep"):
             return "builddep", idx
         if wl == "module":
             for sub_idx, sub_w in enumerate(word_values[idx + 1 :], idx + 1):

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -1663,3 +1663,205 @@ class TestResolveBuilddepPackages(unittest.TestCase):
                 gen_mod.cmd_gather_async = original
 
             self.assertEqual(result, ["gcc", "make"])
+
+
+class TestExtractRhelVersionFromPullspec(unittest.TestCase):
+    def test_rhel_8_golang_tag(self):
+        ps = "registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.21"
+        self.assertEqual(RpmLockfilePrototypeGenerator._extract_rhel_version_from_pullspec(ps), 8)
+
+    def test_rhel_9_golang_tag(self):
+        ps = "registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25"
+        self.assertEqual(RpmLockfilePrototypeGenerator._extract_rhel_version_from_pullspec(ps), 9)
+
+    def test_ubi_9_in_path_not_tag_returns_none(self):
+        ps = "registry.access.redhat.com/ubi9/ubi-minimal:latest"
+        self.assertIsNone(RpmLockfilePrototypeGenerator._extract_rhel_version_from_pullspec(ps))
+
+    def test_ubi_9_in_tag(self):
+        ps = "registry.access.redhat.com/ubi9/ubi-minimal:ubi-9-minimal"
+        self.assertEqual(RpmLockfilePrototypeGenerator._extract_rhel_version_from_pullspec(ps), 9)
+
+    def test_nvr_el8_tag(self):
+        ps = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.9-202605121249.p2.g2aa6a05.el8"
+        self.assertEqual(RpmLockfilePrototypeGenerator._extract_rhel_version_from_pullspec(ps), 8)
+
+    def test_nvr_el9_tag(self):
+        ps = "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.9-202605121249.p2.g2aa6a05.el9"
+        self.assertEqual(RpmLockfilePrototypeGenerator._extract_rhel_version_from_pullspec(ps), 9)
+
+    def test_digest_only_returns_none(self):
+        ps = "quay.io/test/builder@sha256:abc123def456"
+        self.assertIsNone(RpmLockfilePrototypeGenerator._extract_rhel_version_from_pullspec(ps))
+
+    def test_no_colon_returns_none(self):
+        self.assertIsNone(RpmLockfilePrototypeGenerator._extract_rhel_version_from_pullspec("builder_stage"))
+
+    def test_unrecognized_tag_returns_none(self):
+        ps = "quay.io/test/builder:latest"
+        self.assertIsNone(RpmLockfilePrototypeGenerator._extract_rhel_version_from_pullspec(ps))
+
+
+class TestExtractRhelVersionFromRepos(unittest.TestCase):
+    def test_rhel9_baseos_content_set(self):
+        repos = [
+            RepoEntry(repoid="rhel-9-for-x86_64-baseos-e4s-rpms__9_DOT_6", baseurl="https://example.com/baseos/"),
+        ]
+        self.assertEqual(RpmLockfilePrototypeGenerator._extract_rhel_version_from_repos(repos), 9)
+
+    def test_rhel8_content_set(self):
+        repos = [
+            RepoEntry(repoid="rhel-8-for-x86_64-baseos-rpms", baseurl="https://example.com/baseos/"),
+        ]
+        self.assertEqual(RpmLockfilePrototypeGenerator._extract_rhel_version_from_repos(repos), 8)
+
+    def test_no_rhel_in_repoid_returns_none(self):
+        repos = [
+            RepoEntry(repoid="custom-repo-rpms", baseurl="https://example.com/custom/"),
+        ]
+        self.assertIsNone(RpmLockfilePrototypeGenerator._extract_rhel_version_from_repos(repos))
+
+    def test_empty_repos_returns_none(self):
+        self.assertIsNone(RpmLockfilePrototypeGenerator._extract_rhel_version_from_repos([]))
+
+    def test_first_rhel_repo_wins(self):
+        repos = [
+            RepoEntry(repoid="custom-repo", baseurl="https://example.com/custom/"),
+            RepoEntry(repoid="rhel-9-for-x86_64-appstream-rpms", baseurl="https://example.com/appstream/"),
+        ]
+        self.assertEqual(RpmLockfilePrototypeGenerator._extract_rhel_version_from_repos(repos), 9)
+
+
+class TestHasRhelVersionMismatch(unittest.TestCase):
+    def _make_generator(self) -> RpmLockfilePrototypeGenerator:
+        repos = MagicMock()
+        return RpmLockfilePrototypeGenerator(
+            repos=repos,
+            working_dir=Path(tempfile.mkdtemp()),
+            container_helper=MagicMock(spec=ContainerImageHelper),
+            resolver=MagicMock(spec=RpmResolver),
+        )
+
+    def test_el8_builder_el9_repos_is_mismatch(self):
+        gen = self._make_generator()
+        gen.downstream_parents = [
+            "registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.9.el8",
+            "quay.io/test/base:rhel-9",
+        ]
+        repos = [RepoEntry(repoid="rhel-9-for-x86_64-baseos-rpms", baseurl="https://example.com/")]
+        self.assertTrue(gen._has_rhel_version_mismatch(0, repos, "test-img"))
+
+    def test_el9_builder_el9_repos_no_mismatch(self):
+        gen = self._make_generator()
+        gen.downstream_parents = [
+            "registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25",
+        ]
+        repos = [RepoEntry(repoid="rhel-9-for-x86_64-baseos-rpms", baseurl="https://example.com/")]
+        self.assertFalse(gen._has_rhel_version_mismatch(0, repos, "test-img"))
+
+    def test_undetectable_builder_returns_false(self):
+        gen = self._make_generator()
+        gen.downstream_parents = [
+            "quay.io/test/builder@sha256:abc123",
+        ]
+        repos = [RepoEntry(repoid="rhel-9-for-x86_64-baseos-rpms", baseurl="https://example.com/")]
+        self.assertFalse(gen._has_rhel_version_mismatch(0, repos, "test-img"))
+
+    def test_undetectable_repos_returns_false(self):
+        gen = self._make_generator()
+        gen.downstream_parents = [
+            "registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25",
+        ]
+        repos = [RepoEntry(repoid="custom-repo", baseurl="https://example.com/")]
+        self.assertFalse(gen._has_rhel_version_mismatch(0, repos, "test-img"))
+
+    def test_stage_alias_returns_false(self):
+        gen = self._make_generator()
+        gen.downstream_parents = ["builder_stage"]
+        repos = [RepoEntry(repoid="rhel-9-for-x86_64-baseos-rpms", baseurl="https://example.com/")]
+        self.assertFalse(gen._has_rhel_version_mismatch(0, repos, "test-img"))
+
+    def test_out_of_range_stage_returns_false(self):
+        gen = self._make_generator()
+        gen.downstream_parents = []
+        repos = [RepoEntry(repoid="rhel-9-for-x86_64-baseos-rpms", baseurl="https://example.com/")]
+        self.assertFalse(gen._has_rhel_version_mismatch(5, repos, "test-img"))
+
+
+class TestRhelMismatchEndToEnd(unittest.TestCase):
+    """
+    End-to-end: builder stage with el8 pullspec + el9 repos should skip
+    base image packages and resolve only Dockerfile packages in bare mode.
+    """
+
+    def _make_mock_repos(self) -> MagicMock:
+        repos = MagicMock()
+        baseos = MagicMock()
+        baseos.name = "rhel-9-baseos-rpms"
+        baseos.baseurl.return_value = "https://example.com/baseos/x86_64/os/"
+        baseos.content_set.return_value = "rhel-9-for-x86_64-baseos-rpms"
+        baseos.cs_optional = False
+        baseos._data.conf.get.return_value = {}
+        repo_map = {"rhel-9-baseos-rpms": baseos}
+        repos.__getitem__ = lambda self_repos, key: repo_map[key]
+        return repos
+
+    def _make_mock_image_meta(self) -> MagicMock:
+        meta = MagicMock()
+        meta.distgit_key = "hive"
+        meta.get_arches.return_value = ["x86_64"]
+        meta.get_enabled_repos.return_value = {"rhel-9-baseos-rpms"}
+        meta.is_lockfile_generation_enabled.return_value = True
+        lockfile_config = MagicMock()
+        lockfile_config.get.return_value = None
+        meta.config.konflux.cachi2.lockfile = lockfile_config
+        return meta
+
+    def test_el8_builder_skips_base_image_packages(self):
+        container = MagicMock(spec=ContainerImageHelper)
+        container.resolve_to_digest = AsyncMock(side_effect=lambda p: p.split(":")[0] + "@sha256:abc123")
+        container.get_installed_packages = AsyncMock(return_value=["gcc", "glibc", "readline"])
+        container.read_file_from_image = AsyncMock(return_value="")
+
+        resolver = MagicMock(spec=RpmResolver)
+        resolver.resolve = AsyncMock(return_value=FAKE_LOCKFILE_DATA.model_copy(deep=True))
+
+        generator = RpmLockfilePrototypeGenerator(
+            repos=self._make_mock_repos(),
+            working_dir=Path(tempfile.mkdtemp()),
+            container_helper=container,
+            resolver=resolver,
+        )
+        generator.downstream_parents = [
+            "registry.redhat.io/openshift/art-images-base:golang-builder-v1.25.el8",
+            "quay.io/test/base:rhel-9-base",
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest_dir = Path(tmpdir)
+            (dest_dir / "Dockerfile").write_text(
+                "FROM golang-builder AS builder_el8\n"
+                "RUN dnf install -y subscription-manager\n"
+                "\n"
+                "FROM base-rhel9\n"
+                "COPY --from=builder_el8 /bin/app /usr/bin/app\n"
+            )
+            asyncio.run(generator.generate_lockfile(self._make_mock_image_meta(), dest_dir))
+
+            # Resolver should have been called for stage 0 in bare mode
+            # (image_pullspec=None) because of RHEL mismatch
+            calls = resolver.resolve.call_args_list
+            stage0_call = calls[0]
+            self.assertIsNone(
+                stage0_call.kwargs.get("image_pullspec"),
+                "Stage 0 should use bare mode (image_pullspec=None) due to RHEL mismatch",
+            )
+
+            # Base image packages should NOT have been added to the install
+            # list — only the Dockerfile package should be present
+            config = stage0_call.args[0]
+            pkg_names = [p if isinstance(p, str) else p.name for p in config.packages]
+            self.assertIn("subscription-manager", pkg_names)
+            self.assertNotIn("gcc", pkg_names, "Base image packages should not be in install list")
+            self.assertNotIn("glibc", pkg_names, "Base image packages should not be in install list")
+            self.assertNotIn("readline", pkg_names, "Base image packages should not be in install list")

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -1644,25 +1644,13 @@ class TestResolveBuilddepPackages(unittest.TestCase):
 
             self.assertEqual(result, ["gcc", "make", "openssl-devel"])
 
-    def test_matching_spec_file(self):
+    def test_spec_file_skipped_with_warning(self):
         gen = self._make_gen()
         with TemporaryDirectory() as tmpdir:
-            spec_path = Path(tmpdir) / "pkcs11-helper.spec"
+            spec_path = Path(tmpdir) / "tuned.spec"
             spec_path.touch()
-
-            async def mock_gather(cmd, check=True, env=None):
-                return 0, "gcc\nmake\n", ""
-
-            import doozerlib.lockfile_prototype.generator as gen_mod
-
-            original = gen_mod.cmd_gather_async
-            gen_mod.cmd_gather_async = mock_gather
-            try:
-                result = asyncio.run(gen._resolve_builddep_packages(["pkcs11-helper*"], Path(tmpdir), "test-img"))
-            finally:
-                gen_mod.cmd_gather_async = original
-
-            self.assertEqual(result, ["gcc", "make"])
+            result = asyncio.run(gen._resolve_builddep_packages(["tuned.spec"], Path(tmpdir), "test-img"))
+            self.assertEqual(result, [])
 
 
 class TestExtractRhelVersionFromPullspec(unittest.TestCase):

--- a/doozer/tests/lockfile_prototype/test_shell_parser.py
+++ b/doozer/tests/lockfile_prototype/test_shell_parser.py
@@ -584,6 +584,17 @@ class TestBuilddepParsing(unittest.TestCase):
         _, _, _, _, builddep, _ = analyze_run_commands(run_values)
         self.assertEqual(builddep, ["mypackage.spec"])
 
+    def test_build_dep_hyphenated(self):
+        run_values = ["dnf build-dep tuned.spec -y"]
+        _, _, _, _, builddep, _ = analyze_run_commands(run_values)
+        self.assertEqual(builddep, ["tuned.spec"])
+
+    def test_build_dep_hyphenated_with_install(self):
+        run_values = ["dnf install -y gcc rpm-build && cd assets/tuned/daemon && dnf build-dep tuned.spec -y"]
+        common, _, _, _, builddep, _ = analyze_run_commands(run_values)
+        self.assertIn("gcc", common)
+        self.assertEqual(builddep, ["tuned.spec"])
+
 
 class TestModuleParsing(unittest.TestCase):
     def test_module_install(self):

--- a/doozer/tests/lockfile_prototype/test_shell_parser.py
+++ b/doozer/tests/lockfile_prototype/test_shell_parser.py
@@ -611,3 +611,25 @@ class TestModuleParsing(unittest.TestCase):
         run_values = ["dnf module enable -y nodejs"]
         _, _, _, _, _, modules = analyze_run_commands(run_values)
         self.assertEqual(modules, [])
+
+    def test_variable_package_manager(self):
+        run_values = ["${DNF} install -y openssh-clients"]
+        pkgs, _, _, _, _, _ = analyze_run_commands(run_values, env_vars={"DNF": "microdnf"})
+        self.assertEqual(pkgs, ["openssh-clients"])
+
+    def test_variable_package_manager_in_conditional(self):
+        run_values = [
+            "if ! rpm -q openssh-clients; then ${DNF} install -y openssh-clients "
+            "&& ${DNF} clean all && rm -rf /var/cache/dnf/*; fi"
+        ]
+        pkgs, _, _, _, _, _ = analyze_run_commands(run_values, env_vars={"DNF": "microdnf"})
+        self.assertEqual(pkgs, ["openssh-clients"])
+
+    def test_variable_package_manager_multiple_commands(self):
+        run_values = [
+            "if ! rpm -q openssh-clients; then ${DNF} install -y openssh-clients && ${DNF} clean all; fi",
+            "if ! rpm -q libvirt-libs; then ${DNF} install -y libvirt-libs && ${DNF} clean all; fi",
+            "if ! command -v tar; then ${DNF} install -y tar && ${DNF} clean all; fi",
+        ]
+        pkgs, _, _, _, _, _ = analyze_run_commands(run_values, env_vars={"DNF": "microdnf"})
+        self.assertEqual(pkgs, ["libvirt-libs", "openssh-clients", "tar"])


### PR DESCRIPTION
## Summary

  Fix three lockfile generator bugs discovered while debugging hive (mce-2.11) and cluster-node-tuning-operator (OCP 4.12) Konflux build failures.

  ### 1. RHEL version mismatch crash (hive)

  When a Dockerfile has an el8 builder stage but only el9 repos are configured, the generator crashed with an unsolvable depsolve error (el8 `@System` packages like readline-7.0
  conflict with el9 repo packages like readline-8.1). Now detects the mismatch by parsing the builder image pullspec and repo content set IDs, and gracefully falls back to bare mode for
  that stage.

  ### 2. `${DNF}` variable not recognized as package manager (hive)

  When the package manager command is a variable (`ARG DNF=${DNF:-microdnf}` then `${DNF} install -y openssh-clients`), the parser checked the literal unexpanded `${DNF}` against known
  names (`dnf`, `yum`, `microdnf`). Packages like `openssh-clients`, `libvirt-libs`, and `tar` were silently missing from lockfiles. Now resolves the first word through variable
  expansion before matching.

  ### 3. `dnf build-dep` not recognized + spec file cleanup (cluster-node-tuning-operator)

  - Parser only matched `builddep` but DNF also accepts `build-dep` (hyphenated). Commands like `dnf build-dep tuned.spec -y` were silently ignored.
  - Removed spec file handling from BuildRequires extraction — `rpmspec` resolves macros using host definitions that may not match the build environment, making it unreliable. Only
  `.src.rpm` files are supported; spec file patterns now log a clear warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package resolution for build stages when base images and configured repositories target different RHEL major versions.
  * Prevented fallback handling for explicit `.spec` build-dependency inputs, which now remain excluded with a warning.
  * Expanded command parsing to recognize `build-dep` and variable-based package manager commands in shell instructions.

* **Tests**
  * Added coverage for RHEL version detection, mismatch handling, and end-to-end builder-stage behavior.
  * Added parser tests for hyphenated build-dep commands and environment-variable package manager usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->