### PR TITLE
ART-21084: derive OKD enablement from group.yml okd.enabled

### DIFF
--- a/ocp-build-data-validator/tests/test_schema/test_group_schema.py
+++ b/ocp-build-data-validator/tests/test_schema/test_group_schema.py
@@ -61,9 +61,6 @@ class TestGroupSchema(unittest.TestCase):
         self.assertIn("must be 'openshift-5.0'", group_schema.validate("group.yml", invalid_data))
 
     def test_validate_with_templated_group_name_and_valid_bridge_release(self):
-        # Real group.yml files always use an unresolved "{MAJOR}.{MINOR}" template for
-        # `name`, substituted at runtime by doozer/elliott. The validator must resolve
-        # it using `vars` before comparing against `bridge_release.basis_group`.
         valid_data = {
             "name": "openshift-{MAJOR}.{MINOR}",
             "vars": {"MAJOR": 4, "MINOR": 23},
@@ -84,3 +81,24 @@ class TestGroupSchema(unittest.TestCase):
             },
         }
         self.assertIn("must be 'openshift-5.0'", group_schema.validate("group.yml", invalid_data))
+
+    def test_validate_with_okd_enabled_flag(self):
+        valid_data = {
+            "name": "openshift-4.21",
+            "vars": {"MAJOR": 4, "MINOR": 21},
+            "okd": {
+                "enabled": True,
+                "konflux": {"build_priority": 8},
+            },
+        }
+        self.assertEqual("", group_schema.validate("group.yml", valid_data))
+
+    def test_validate_with_invalid_okd_enabled_flag(self):
+        invalid_data = {
+            "name": "openshift-4.21",
+            "vars": {"MAJOR": 4, "MINOR": 21},
+            "okd": {
+                "enabled": "yes",
+            },
+        }
+        self.assertIn("'yes' is not of type 'boolean'", group_schema.validate("group.yml", invalid_data))

--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -647,6 +647,16 @@
           "$ref": "#/properties/okd/properties/branch"
         },
         "branch-": {},
+        "enabled": {
+          "type": "boolean"
+        },
+        "enabled!": {
+          "$ref": "#/properties/okd/properties/enabled"
+        },
+        "enabled?": {
+          "$ref": "#/properties/okd/properties/enabled"
+        },
+        "enabled-": {},
         "konflux": {
           "type": "object",
           "properties": {

--- a/pyartcd/pyartcd/constants.py
+++ b/pyartcd/pyartcd/constants.py
@@ -41,10 +41,3 @@ GITHUB_OWNER = "openshift-eng"
 KONFLUX_IMAGE_BUILD_PLR_TEMPLATE_URL_FORMAT = "https://api.github.com/repos/{owner}/art-konflux-template/contents/.tekton/art-konflux-template-push.yaml?ref={branch_name}"  # Konflux PipelineRun (PLR) template for image builds
 KONFLUX_BUNDLE_BUILD_PLR_TEMPLATE_URL_FORMAT = "https://api.github.com/repos/{owner}/art-konflux-template/contents/.tekton/art-bundle-konflux-template-push.yaml?ref={branch_name}"  # Konflux PipelineRun (PLR) template for bundle builds
 KONFLUX_FBC_BUILD_PLR_TEMPLATE_URL_FORMAT = "https://api.github.com/repos/{owner}/art-konflux-template/contents/.tekton/art-fbc-konflux-template-push.yaml?ref={branch_name}"  # Konflux PipelineRun (PLR) template for FBC builds
-
-# OKD build triggering is enabled only for these OCP versions
-OKD_ENABLED_VERSIONS = [
-    '4.21',
-    '4.22',
-    '5.0',
-]

--- a/pyartcd/pyartcd/pipelines/okd_images_health.py
+++ b/pyartcd/pyartcd/pipelines/okd_images_health.py
@@ -6,12 +6,13 @@ from urllib.parse import quote
 
 import click
 from artcommonlib import exectools
+from artcommonlib.constants import ACTIVE_OCP_VERSIONS
 from doozerlib.cli.images_health import DELTA_DAYS, LIMIT_BUILD_RESULTS, ConcernCode
 from doozerlib.constants import ART_BUILD_FAILURES_URL, ART_BUILD_HISTORY_URL
 
 from pyartcd import util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
-from pyartcd.constants import OCP_BUILD_DATA_URL, OKD_ENABLED_VERSIONS
+from pyartcd.constants import OCP_BUILD_DATA_URL
 from pyartcd.runtime import Runtime
 
 OKD_GROUP_TEMPLATE = "okd-{}"
@@ -30,7 +31,7 @@ class ImagesHealthPipeline:
         assembly: str,
     ):
         self.runtime = runtime
-        self.versions = versions.split(',') if versions else OKD_ENABLED_VERSIONS
+        self._versions_param = versions
         self.doozer_working = self.runtime.working_dir / "doozer_working"
         self.send_to_release_channel = send_to_release_channel
         self.send_to_okd_channel = send_to_okd_channel
@@ -44,7 +45,46 @@ class ImagesHealthPipeline:
         self.scanned_versions = []
         self.rebase_failures = {}  # version -> {image: {failure_count, url}}
 
+    def _doozer_base_command(self, version: str) -> list[str]:
+        group_param = f'openshift-{version}'
+        if self.data_gitref:
+            group_param += f'@{self.data_gitref}'
+        return [
+            'doozer',
+            f'--working-dir={self.doozer_working}-{version}',
+            f'--data-path={self.data_path}',
+            f'--group={group_param}',
+            f'--assembly={self.assembly}',
+            '--build-system=konflux',
+            '--variant=okd',
+        ]
+
+    async def _resolve_versions(self) -> list[str]:
+        if self._versions_param:
+            candidates = [v.strip() for v in self._versions_param.split(',') if v.strip()]
+        else:
+            candidates = list(ACTIVE_OCP_VERSIONS)
+            self.runtime.logger.info(
+                'No --versions provided; probing ACTIVE_OCP_VERSIONS for okd.enabled in build-data'
+            )
+
+        enabled_versions = []
+        for version in candidates:
+            if await util.is_okd_version_enabled(self._doozer_base_command(version)):
+                enabled_versions.append(version)
+            else:
+                self.runtime.logger.info(
+                    'Version %s is not enabled for OKD (set okd.enabled: true in group.yml on openshift-%s). Skipping.',
+                    version,
+                    version,
+                )
+        return enabled_versions
+
     async def run(self):
+        self.versions = await self._resolve_versions()
+        if not self.versions:
+            self.runtime.logger.info('No OKD-enabled versions to monitor; skipping health report')
+            return
         await asyncio.gather(*(self.get_report(v) for v in self.versions))
         await asyncio.gather(*(self.get_rebase_failures(v) for v in self.versions))
         self.runtime.logger.info('Found %s concerns', len(self.report))

--- a/pyartcd/pyartcd/pipelines/okd_scan.py
+++ b/pyartcd/pyartcd/pipelines/okd_scan.py
@@ -29,7 +29,7 @@ import click
 import yaml
 from artcommonlib import exectools
 
-from pyartcd import constants, jenkins, locks
+from pyartcd import constants, jenkins, locks, util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.locks import Lock
 from pyartcd.runtime import Runtime
@@ -88,12 +88,14 @@ class OkdScanPipeline:
         # If we get here, lock could be acquired
         self.skipped = False
 
-        # Early exit if version not enabled for OKD
-        if self.version not in constants.OKD_ENABLED_VERSIONS:
+        self._check_params()
+
+        # Early exit if version not enabled for OKD in build-data
+        if not await util.is_okd_version_enabled(self.doozer_base_command):
             self.logger.info(
-                'Version %s is not enabled for OKD (enabled versions: %s). Skipping scan.',
+                'Version %s is not enabled for OKD (set okd.enabled: true in group.yml on openshift-%s). Skipping scan.',
                 self.version,
-                constants.OKD_ENABLED_VERSIONS,
+                self.version,
             )
             return
 
@@ -102,8 +104,6 @@ class OkdScanPipeline:
         if self.data_gitref:
             scan_info += f'@{self.data_gitref}'
         self.logger.info(scan_info)
-
-        self._check_params()
 
         # Scan for changes
         await self._scan_sources()

--- a/pyartcd/pyartcd/pipelines/scheduled/schedule_okd_scan.py
+++ b/pyartcd/pyartcd/pipelines/scheduled/schedule_okd_scan.py
@@ -14,8 +14,20 @@ from artcommonlib import redis
 
 from pyartcd import jenkins, util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.constants import OCP_BUILD_DATA_URL
 from pyartcd.locks import Lock, LockManager
 from pyartcd.runtime import Runtime
+
+
+async def _is_version_okd_enabled(runtime: Runtime, version: str) -> bool:
+    doozer_cmd = util.okd_doozer_base_command(
+        version=version,
+        assembly='stream',
+        data_path=OCP_BUILD_DATA_URL,
+        data_gitref='',
+        working_dir=runtime.working_dir / f'doozer_working-{version}',
+    )
+    return await util.is_okd_version_enabled(doozer_cmd)
 
 
 async def run_for(version: str, runtime: Runtime, lock_manager: LockManager):
@@ -46,25 +58,69 @@ async def run_for(version: str, runtime: Runtime, lock_manager: LockManager):
         runtime.logger.info('[%s] Not permitted, skipping', version)
         return
 
+    if not await _is_version_okd_enabled(runtime, version):
+        runtime.logger.info(
+            '[%s] OKD not enabled in build-data (okd.enabled); skipping okd-scan schedule',
+            version,
+        )
+        return
+
     # Schedule scan
     runtime.logger.info('[%s] Scheduling okd-scan', version)
     jenkins.start_okd_scan_konflux(version=version, block_until_building=False)
 
 
+async def resolve_schedule_versions(runtime: Runtime, version: tuple) -> list[str]:
+    if version:
+        enabled = []
+        for candidate in version:
+            if await _is_version_okd_enabled(runtime, candidate):
+                enabled.append(candidate)
+            else:
+                runtime.logger.info(
+                    'Version %s is not enabled for OKD (set okd.enabled: true in group.yml on openshift-%s). Skipping.',
+                    candidate,
+                    candidate,
+                )
+        return enabled
+    versions = await util.get_okd_enabled_versions(
+        working_dir=runtime.working_dir / 'doozer_working',
+    )
+    if not versions:
+        runtime.logger.info('No OKD-enabled versions found in build-data; nothing to schedule')
+    else:
+        runtime.logger.info('OKD-enabled versions from build-data: %s', ', '.join(versions))
+    return versions
+
+
 @cli.command('schedule-okd-scan')
-@click.option('--version', '-v', required=True, help='OCP/OKD version to scan', multiple=True)
+@click.option(
+    '--version',
+    '-v',
+    required=False,
+    help='OCP/OKD version to scan (omit to discover enabled versions from build-data)',
+    multiple=True,
+)
 @pass_runtime
 @click_coroutine
 async def okd_scan(runtime: Runtime, version: tuple):
     """
     Schedule OKD scans for specified versions.
 
+    When --version is omitted, probes ACTIVE_OCP_VERSIONS and schedules only versions
+    with okd.enabled in group.yml (merged via doozer --variant=okd).
+
     Example usage:
+        artcd schedule-okd-scan
         artcd schedule-okd-scan --version 4.21 --version 4.22
     """
+    versions = await resolve_schedule_versions(runtime, version)
+    if not versions:
+        return
+
     jenkins.init_jenkins()
     lock_manager = LockManager([redis.redis_url()])
     try:
-        await asyncio.gather(*[run_for(v, runtime, lock_manager) for v in version])
+        await asyncio.gather(*[run_for(v, runtime, lock_manager) for v in versions])
     finally:
         await lock_manager.destroy()

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os
@@ -16,6 +17,7 @@ import yaml
 from artcommonlib import exectools, redis
 from artcommonlib.arch_util import go_suffix_for_arch
 from artcommonlib.assembly import assembly_type
+from artcommonlib.constants import ACTIVE_OCP_VERSIONS
 from artcommonlib.exectools import limit_concurrency
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.model import Missing, Model
@@ -112,6 +114,75 @@ async def load_group_config(
     if not isinstance(group_config, dict):
         raise ValueError("ocp-build-data contains invalid group config.")
     return group_config
+
+
+def okd_doozer_base_command(
+    version: str,
+    assembly: str,
+    data_path: str,
+    data_gitref: str,
+    working_dir: Union[str, Path],
+) -> list[str]:
+    group_param = f'openshift-{version}'
+    if data_gitref:
+        group_param += f'@{data_gitref}'
+    return [
+        'doozer',
+        f'--working-dir={working_dir}',
+        f'--data-path={data_path}',
+        f'--group={group_param}',
+        f'--assembly={assembly}',
+        '--build-system=konflux',
+        '--variant=okd',
+    ]
+
+
+async def is_okd_version_enabled(doozer_base_command: list[str]) -> bool:
+    """
+    Check whether OKD is enabled for a version via merged group config.
+
+    The doozer command must include --variant=okd so Runtime merges group.yml okd:
+    into the group config (okd.enabled becomes top-level enabled), matching OKD builds.
+
+    Arg(s):
+        doozer_base_command (list[str]): Base doozer invocation for the target version.
+    Return Value(s):
+        bool: True when merged group config has enabled=true.
+    """
+    cmd = [*doozer_base_command, 'config:read-group', 'enabled', '--default=False']
+    _, out, _ = await exectools.cmd_gather_async(cmd, stderr=None)
+    return out.strip() == 'True'
+
+
+async def get_okd_enabled_versions(
+    assembly: str = 'stream',
+    data_path: str = constants.OCP_BUILD_DATA_URL,
+    data_gitref: str = '',
+    working_dir: Union[str, Path] = '.',
+    candidates: Optional[List[str]] = None,
+) -> List[str]:
+    """
+    Return OCP versions with okd.enabled in merged group config.
+
+    Probes each candidate via doozer --variant=okd (same gate as okd-scan).
+    """
+    versions_to_check = candidates if candidates is not None else ACTIVE_OCP_VERSIONS
+    enabled_versions: List[str] = []
+
+    async def check_version(version: str) -> Optional[str]:
+        base_cmd = okd_doozer_base_command(version, assembly, data_path, data_gitref, working_dir)
+        if await is_okd_version_enabled(base_cmd):
+            return version
+        logger.info(
+            'Version %s is not enabled for OKD (set okd.enabled: true in group.yml on openshift-%s)',
+            version,
+            version,
+        )
+        return None
+
+    results = await asyncio.gather(*[check_version(version) for version in versions_to_check])
+    enabled_versions.extend(v for v in results if v)
+    return enabled_versions
 
 
 async def load_releases_config(group: str, data_path: str = constants.OCP_BUILD_DATA_URL) -> Optional[Dict]:

--- a/pyartcd/tests/pipelines/test_okd_images_health.py
+++ b/pyartcd/tests/pipelines/test_okd_images_health.py
@@ -100,3 +100,57 @@ class TestGetReport(IsolatedAsyncioTestCase):
         mock_cmd.assert_not_called()
         self.assertEqual(len(pipeline.report), 0)
         self.assertIn('4.21', pipeline.scanned_versions)
+
+    @patch("pyartcd.pipelines.okd_images_health.util.is_okd_version_enabled", new_callable=AsyncMock)
+    async def test_filters_disabled_versions(self, mock_is_enabled):
+        """Requested versions without okd.enabled in build-data are skipped."""
+        mock_is_enabled.side_effect = [True, False]
+
+        pipeline = self._make_pipeline(versions="4.21,4.23")
+        pipeline.get_report = AsyncMock()
+        pipeline.get_rebase_failures = AsyncMock()
+
+        await pipeline.run()
+
+        self.assertEqual(pipeline.versions, ['4.21'])
+        self.assertEqual(mock_is_enabled.await_count, 2)
+        pipeline.get_report.assert_awaited_once_with('4.21')
+
+    @patch("pyartcd.pipelines.okd_images_health.util.is_okd_version_enabled", new_callable=AsyncMock)
+    async def test_discovers_enabled_versions_when_not_provided(self, mock_is_enabled):
+        """When --versions is omitted, probe ACTIVE_OCP_VERSIONS and keep okd.enabled versions."""
+
+        async def enabled_for_cmd(cmd):
+            return any(arg == '--group=openshift-4.21' for arg in cmd)
+
+        mock_is_enabled.side_effect = enabled_for_cmd
+
+        pipeline = self._make_pipeline(versions="")
+        pipeline.get_report = AsyncMock()
+        pipeline.get_rebase_failures = AsyncMock()
+
+        with patch(
+            'pyartcd.pipelines.okd_images_health.ACTIVE_OCP_VERSIONS',
+            ['4.21', '4.23'],
+        ):
+            await pipeline.run()
+
+        self.assertEqual(pipeline.versions, ['4.21'])
+        self.assertEqual(mock_is_enabled.await_count, 2)
+        pipeline.get_report.assert_awaited_once_with('4.21')
+
+    @patch(
+        "pyartcd.pipelines.okd_images_health.util.is_okd_version_enabled", new_callable=AsyncMock, return_value=False
+    )
+    async def test_skips_when_no_enabled_versions(self, _mock_is_enabled):
+        pipeline = self._make_pipeline(versions="4.23")
+        pipeline.get_report = AsyncMock()
+        pipeline.get_rebase_failures = AsyncMock()
+        pipeline.notify_release_channel = AsyncMock()
+        pipeline.notify_okd_channel = AsyncMock()
+
+        await pipeline.run()
+
+        self.assertEqual(pipeline.versions, [])
+        pipeline.get_report.assert_not_called()
+        pipeline.notify_okd_channel.assert_not_called()

--- a/pyartcd/tests/pipelines/test_okd_scan.py
+++ b/pyartcd/tests/pipelines/test_okd_scan.py
@@ -6,7 +6,7 @@ Unit tests for okd_scan pipeline.
 
 import os
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import yaml
 from pyartcd.pipelines.okd_scan import OkdScanPipeline
@@ -28,9 +28,10 @@ class TestOkdScanPipeline(unittest.IsolatedAsyncioTestCase):
         self.runtime.working_dir.__truediv__ = lambda self, x: MagicMock()
 
     @patch.dict(os.environ, {'KUBECONFIG': '/path/to/kubeconfig'})
+    @patch('pyartcd.pipelines.okd_scan.util.is_okd_version_enabled', new_callable=AsyncMock, return_value=True)
     @patch('pyartcd.pipelines.okd_scan.jenkins')
     @patch('pyartcd.pipelines.okd_scan.exectools.cmd_gather_async')
-    async def test_no_changes_detected(self, mock_cmd_gather, mock_jenkins):
+    async def test_no_changes_detected(self, mock_cmd_gather, mock_jenkins, _mock_is_enabled):
         """
         Test pipeline when no changes are detected.
         """
@@ -53,10 +54,10 @@ class TestOkdScanPipeline(unittest.IsolatedAsyncioTestCase):
         mock_jenkins.start_okd.assert_not_called()
 
     @patch.dict(os.environ, {'KUBECONFIG': '/path/to/kubeconfig'})
-    @patch('pyartcd.pipelines.okd_scan.constants.OKD_ENABLED_VERSIONS', ['4.21', '4.22'])
+    @patch('pyartcd.pipelines.okd_scan.util.is_okd_version_enabled', new_callable=AsyncMock, return_value=True)
     @patch('pyartcd.pipelines.okd_scan.jenkins')
     @patch('pyartcd.pipelines.okd_scan.exectools.cmd_gather_async')
-    async def test_valid_rebuild_reason_triggers_build(self, mock_cmd_gather, mock_jenkins):
+    async def test_valid_rebuild_reason_triggers_build(self, mock_cmd_gather, mock_jenkins, _mock_is_enabled):
         """
         Test that images with valid rebuild reasons trigger OKD builds.
         """
@@ -91,10 +92,10 @@ class TestOkdScanPipeline(unittest.IsolatedAsyncioTestCase):
         )
 
     @patch.dict(os.environ, {'KUBECONFIG': '/path/to/kubeconfig'})
-    @patch('pyartcd.pipelines.okd_scan.constants.OKD_ENABLED_VERSIONS', ['4.21', '4.22'])
+    @patch('pyartcd.pipelines.okd_scan.util.is_okd_version_enabled', new_callable=AsyncMock, return_value=True)
     @patch('pyartcd.pipelines.okd_scan.jenkins')
     @patch('pyartcd.pipelines.okd_scan.exectools.cmd_gather_async')
-    async def test_all_changed_images_trigger_build(self, mock_cmd_gather, mock_jenkins):
+    async def test_all_changed_images_trigger_build(self, mock_cmd_gather, mock_jenkins, _mock_is_enabled):
         """
         Test that all changed images from scan-sources trigger builds.
         Since we use --variant=okd, doozer only reports valid OKD rebuild reasons.
@@ -124,16 +125,16 @@ class TestOkdScanPipeline(unittest.IsolatedAsyncioTestCase):
         )
 
     @patch.dict(os.environ, {'KUBECONFIG': '/path/to/kubeconfig'})
-    @patch('pyartcd.pipelines.okd_scan.constants.OKD_ENABLED_VERSIONS', ['4.22'])
+    @patch('pyartcd.pipelines.okd_scan.util.is_okd_version_enabled', new_callable=AsyncMock, return_value=False)
     @patch('pyartcd.pipelines.okd_scan.jenkins')
     @patch('pyartcd.pipelines.okd_scan.exectools.cmd_gather_async')
-    async def test_version_not_enabled_skips_build(self, mock_cmd_gather, mock_jenkins):
+    async def test_version_not_enabled_skips_build(self, mock_cmd_gather, mock_jenkins, mock_is_enabled):
         """
-        Test that pipeline exits early for versions not in OKD_ENABLED_VERSIONS.
+        Test that pipeline exits early when group.yml okd.enabled is false or missing.
         """
         pipeline = OkdScanPipeline(
             runtime=self.runtime,
-            version='4.21',  # Not in enabled versions
+            version='4.23',
             data_path='https://github.com/openshift-eng/ocp-build-data',
             assembly='stream',
             data_gitref='',
@@ -142,15 +143,16 @@ class TestOkdScanPipeline(unittest.IsolatedAsyncioTestCase):
 
         await pipeline.run()
 
+        mock_is_enabled.assert_awaited_once()
         # Should exit early without scanning or triggering builds
         mock_cmd_gather.assert_not_called()
         mock_jenkins.start_okd.assert_not_called()
 
     @patch.dict(os.environ, {'KUBECONFIG': '/path/to/kubeconfig'})
-    @patch('pyartcd.pipelines.okd_scan.constants.OKD_ENABLED_VERSIONS', ['4.21'])
+    @patch('pyartcd.pipelines.okd_scan.util.is_okd_version_enabled', new_callable=AsyncMock, return_value=True)
     @patch('pyartcd.pipelines.okd_scan.jenkins')
     @patch('pyartcd.pipelines.okd_scan.exectools.cmd_gather_async')
-    async def test_multiple_changed_images(self, mock_cmd_gather, mock_jenkins):
+    async def test_multiple_changed_images(self, mock_cmd_gather, mock_jenkins, _mock_is_enabled):
         """
         Test that multiple changed images all trigger a build.
         With --variant=okd, all reported changes are valid OKD rebuild reasons.
@@ -188,10 +190,10 @@ class TestOkdScanPipeline(unittest.IsolatedAsyncioTestCase):
         )
 
     @patch.dict(os.environ, {'KUBECONFIG': '/path/to/kubeconfig'})
-    @patch('pyartcd.pipelines.okd_scan.constants.OKD_ENABLED_VERSIONS', ['4.21'])
+    @patch('pyartcd.pipelines.okd_scan.util.is_okd_version_enabled', new_callable=AsyncMock, return_value=True)
     @patch('pyartcd.pipelines.okd_scan.jenkins')
     @patch('pyartcd.pipelines.okd_scan.exectools.cmd_gather_async')
-    async def test_scan_uses_variant_okd(self, mock_cmd_gather, mock_jenkins):
+    async def test_scan_uses_variant_okd(self, mock_cmd_gather, mock_jenkins, _mock_is_enabled):
         """
         Test that the pipeline calls doozer scan-sources with --variant=okd.
         This ensures filtering happens in doozer, not in Python.

--- a/pyartcd/tests/pipelines/test_schedule_okd_scan.py
+++ b/pyartcd/tests/pipelines/test_schedule_okd_scan.py
@@ -1,0 +1,101 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pyartcd.pipelines.scheduled.schedule_okd_scan import resolve_schedule_versions, run_for
+
+
+class TestResolveScheduleVersions(IsolatedAsyncioTestCase):
+    @patch(
+        'pyartcd.pipelines.scheduled.schedule_okd_scan._is_version_okd_enabled',
+        new_callable=AsyncMock,
+    )
+    async def test_explicit_versions_filters_disabled(self, is_enabled):
+        is_enabled.side_effect = [True, False]
+        runtime = MagicMock()
+        runtime.logger = MagicMock()
+
+        result = await resolve_schedule_versions(runtime, ('4.21', '4.23'))
+
+        self.assertEqual(result, ['4.21'])
+        self.assertEqual(is_enabled.await_count, 2)
+        runtime.logger.info.assert_any_call(
+            'Version %s is not enabled for OKD (set okd.enabled: true in group.yml on openshift-%s). Skipping.',
+            '4.23',
+            '4.23',
+        )
+
+    @patch('pyartcd.pipelines.scheduled.schedule_okd_scan.util.get_okd_enabled_versions', new_callable=AsyncMock)
+    async def test_discovers_from_build_data(self, get_enabled):
+        get_enabled.return_value = ['4.21', '4.22']
+        runtime = MagicMock()
+        runtime.working_dir = MagicMock()
+
+        result = await resolve_schedule_versions(runtime, tuple())
+
+        get_enabled.assert_awaited_once()
+        self.assertEqual(result, ['4.21', '4.22'])
+
+    @patch(
+        'pyartcd.pipelines.scheduled.schedule_okd_scan.util.get_okd_enabled_versions',
+        new_callable=AsyncMock,
+        return_value=[],
+    )
+    async def test_empty_when_none_enabled(self, _get_enabled):
+        runtime = MagicMock()
+        runtime.working_dir = MagicMock()
+        runtime.logger = MagicMock()
+
+        result = await resolve_schedule_versions(runtime, tuple())
+
+        self.assertEqual(result, [])
+        runtime.logger.info.assert_any_call('No OKD-enabled versions found in build-data; nothing to schedule')
+
+
+class TestRunFor(IsolatedAsyncioTestCase):
+    @patch('pyartcd.pipelines.scheduled.schedule_okd_scan.jenkins.start_okd_scan_konflux')
+    @patch(
+        'pyartcd.pipelines.scheduled.schedule_okd_scan._is_version_okd_enabled',
+        new_callable=AsyncMock,
+        return_value=False,
+    )
+    @patch(
+        'pyartcd.pipelines.scheduled.schedule_okd_scan.util.is_build_permitted',
+        new_callable=AsyncMock,
+        return_value=True,
+    )
+    async def test_skips_disabled_before_jenkins(self, _permitted, _enabled, start_scan):
+        runtime = MagicMock()
+        runtime.working_dir = MagicMock()
+        runtime.logger = MagicMock()
+        lock_manager = MagicMock()
+        lock_manager.is_locked = AsyncMock(return_value=False)
+
+        await run_for('4.23', runtime, lock_manager)
+
+        start_scan.assert_not_called()
+        runtime.logger.info.assert_any_call(
+            '[%s] OKD not enabled in build-data (okd.enabled); skipping okd-scan schedule',
+            '4.23',
+        )
+
+    @patch('pyartcd.pipelines.scheduled.schedule_okd_scan.jenkins.start_okd_scan_konflux')
+    @patch(
+        'pyartcd.pipelines.scheduled.schedule_okd_scan._is_version_okd_enabled',
+        new_callable=AsyncMock,
+        return_value=True,
+    )
+    @patch(
+        'pyartcd.pipelines.scheduled.schedule_okd_scan.util.is_build_permitted',
+        new_callable=AsyncMock,
+        return_value=True,
+    )
+    async def test_schedules_when_enabled(self, _permitted, _enabled, start_scan):
+        runtime = MagicMock()
+        runtime.working_dir = MagicMock()
+        runtime.logger = MagicMock()
+        lock_manager = MagicMock()
+        lock_manager.is_locked = AsyncMock(return_value=False)
+
+        await run_for('4.21', runtime, lock_manager)
+
+        start_scan.assert_called_once_with(version='4.21', block_until_building=False)

--- a/pyartcd/tests/test_util.py
+++ b/pyartcd/tests/test_util.py
@@ -174,6 +174,31 @@ class TestUtil(IsolatedAsyncioTestCase):
         res = await util.is_build_permitted(version='4.15')
         self.assertTrue(res)
 
+    @patch("pyartcd.util.exectools.cmd_gather_async", new_callable=AsyncMock)
+    async def test_is_okd_version_enabled(self, cmd_gather_async: AsyncMock):
+        cmd_gather_async.return_value = (0, 'True\n', '')
+
+        base_cmd = ['doozer', '--variant=okd', '--group=openshift-4.21']
+        self.assertTrue(await util.is_okd_version_enabled(base_cmd))
+        cmd_gather_async.assert_awaited_once()
+        cmd = cmd_gather_async.await_args.args[0]
+        self.assertIn('--variant=okd', cmd)
+        self.assertEqual(cmd[-3:], ['config:read-group', 'enabled', '--default=False'])
+
+        cmd_gather_async.return_value = (0, 'False\n', '')
+        self.assertFalse(await util.is_okd_version_enabled(base_cmd))
+
+    @patch("pyartcd.util.exectools.cmd_gather_async", new_callable=AsyncMock)
+    async def test_get_okd_enabled_versions(self, cmd_gather_async: AsyncMock):
+        cmd_gather_async.side_effect = [(0, 'True\n', ''), (0, 'False\n', '')]
+
+        enabled = await util.get_okd_enabled_versions(
+            working_dir='/tmp/wd',
+            candidates=['4.21', '4.23'],
+        )
+        self.assertEqual(enabled, ['4.21'])
+        self.assertEqual(cmd_gather_async.await_count, 2)
+
     @patch("pyartcd.util.load_group_config")
     async def test_get_signing_mode(self, load_group_config_mock: AsyncMock):
         group_config = {'software_lifecycle': {'phase': 'release'}}


### PR DESCRIPTION
## Summary

Move OKD version enablement from the hardcoded `OKD_ENABLED_VERSIONS` list to `okd.enabled` in ocp-build-data `group.yml`. Pipelines read merged group config through doozer `--variant=okd`.

## What changed

- Remove `OKD_ENABLED_VERSIONS` from `pyartcd/constants.py`
- Add `is_okd_version_enabled()`, `get_okd_enabled_versions()`, and `okd_doozer_base_command()` in `pyartcd/util.py`
- **okd-scan:** skip when `okd.enabled` is false or missing (still needed for manual Jenkins runs)
- **okd-images-health:** resolve `--versions` through the enablement gate; probe `ACTIVE_OCP_VERSIONS` when omitted; exit early when nothing is enabled
- **schedule-okd-scan:** discover enabled versions from build-data when `--version` is omitted; filter explicit `--version` args; check enablement in `run_for()` before `start_okd_scan_konflux` so disabled versions do not spawn skipped `build/okd-scan` jobs
- **Validator:** allow boolean `okd.enabled` under `okd:` in `assembly_group_config.schema.json`
- **Tests:** unit coverage for disabled 4.23 path, scheduler gating, and util helpers; `skip_rpms=False` in `test_ocp4_scan_konflux.py` after rebase onto main (#3115)

## Dependencies

- ocp-build-data: #11402, #11403, #11404 (merged — `okd.enabled: true` on 4.21, 4.22, 5.0; 4.23 stays disabled)
- aos-cd-jobs: #4742 (after this PR — removes `okdVersions` loop, calls `schedule-okd-scan` with no `--version`)

## Validation

- Unit tests: `pytest pyartcd/tests/pipelines/test_okd_scan.py pyartcd/tests/pipelines/test_okd_images_health.py pyartcd/tests/pipelines/test_schedule_okd_scan.py pyartcd/tests/test_util.py`
- Jenkins okd-scan dry-runs: 4.23 skips (#763); 4.21 with build-data fork passes gate and scan-sources (#765)

Jira: [ART-21084](https://redhat.atlassian.net/browse/ART-21084)