### PR TITLE
ART-21049: Add elliott verify-cve-trackers command 

### DIFF
--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -73,6 +73,7 @@ from elliottlib.cli.tarball_sources_cli import tarball_sources_cli
 from elliottlib.cli.validate_rhsa import validate_rhsa_cli
 from elliottlib.cli.verify_attached_bugs_cli import verify_attached_bugs_cli
 from elliottlib.cli.verify_attached_operators_cli import verify_attached_operators_cli
+from elliottlib.cli.verify_cve_trackers_cli import verify_cve_trackers_cli
 from elliottlib.cli.verify_cvp_cli import verify_cvp_cli
 from elliottlib.cli.verify_payload import verify_payload
 from elliottlib.exceptions import ElliottFatalError
@@ -323,6 +324,7 @@ cli.add_command(shipment_cli)
 cli.add_command(watch_release_cli)
 cli.add_command(find_bugs_second_fix_cli)
 cli.add_command(process_release_from_fbc_bugs_cli)
+cli.add_command(verify_cve_trackers_cli)
 
 # -----------------------------------------------------------------------------
 # CLI Entry point

--- a/elliott/elliottlib/cli/verify_cve_trackers_cli.py
+++ b/elliott/elliottlib/cli/verify_cve_trackers_cli.py
@@ -1,0 +1,397 @@
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Optional
+
+import click
+import yaml as pyyaml
+from artcommonlib.assembly import assembly_resolved
+from artcommonlib.github_auth import get_github_client_for_org
+from artcommonlib.gitlab import GitLabClient
+from artcommonlib.model import Missing, Model
+
+from elliottlib.cli.common import cli, click_coroutine
+from elliottlib.errata import get_bug_ids, get_raw_erratum
+
+LOGGER = logging.getLogger(__name__)
+
+ADVISORY_CVE_KINDS = ("rpm", "rhcos")
+SKIPPED_ADVISORY_IMPETUSES = frozenset({"microshift"})
+DROPPED_ADVISORY_STATUS = "DROPPED_NO_SHIP"
+JIRA_ISSUE_SOURCES = frozenset({"redhat.atlassian.net", "issues.redhat.com"})
+OCP_BUILD_DATA_URL = "https://github.com/openshift-eng/ocp-build-data"
+
+
+@dataclass
+class VerifyCveTrackersResult:
+    group: str
+    assembly: str
+    shipment_mr_url: Optional[str]
+    shipment_files: list[str] = field(default_factory=list)
+    missing_advisory_trackers: list[str] = field(default_factory=list)
+    missing_shipment_trackers: list[str] = field(default_factory=list)
+    advisory_elliott_trackers: list[str] = field(default_factory=list)
+    shipment_elliott_trackers: list[str] = field(default_factory=list)
+
+    @property
+    def missing_trackers(self) -> list[str]:
+        return sorted(set(self.missing_advisory_trackers + self.missing_shipment_trackers))
+
+    @property
+    def passed(self) -> bool:
+        return not self.missing_trackers
+
+
+def get_jira_issues_from_shipment_data(data: dict) -> set[str]:
+    shipment = data.get("shipment") or {}
+    release_notes = ((shipment.get("data") or {}).get("releaseNotes")) or {}
+    issues = release_notes.get("issues") or {}
+    fixed = issues.get("fixed") or []
+    jira_ids = set()
+    for issue in fixed:
+        if not isinstance(issue, dict):
+            continue
+        issue_id = issue.get("id")
+        source = issue.get("source", "")
+        if not issue_id:
+            continue
+        if source in JIRA_ISSUE_SOURCES or str(issue_id).startswith("OCPBUGS-"):
+            jira_ids.add(str(issue_id))
+    return jira_ids
+
+
+def parse_shipment_metadata_from_data(data: dict) -> tuple[str, str]:
+    shipment = data.get("shipment") or {}
+    metadata = shipment.get("metadata") or {}
+    group = metadata.get("group")
+    assembly = metadata.get("assembly")
+    if not group or not assembly:
+        raise ValueError("Shipment YAML must define shipment.metadata.group and shipment.metadata.assembly")
+    return group, assembly
+
+
+def get_jira_issues_from_shipment_mr(
+    mr_url: str,
+    gitlab_token: Optional[str] = None,
+) -> tuple[set[str], list[str], tuple[str, str]]:
+    token = gitlab_token or os.getenv("GITLAB_TOKEN")
+    if not token:
+        raise ValueError("GITLAB_TOKEN environment variable is required to read shipment MR")
+
+    client = GitLabClient.from_url(mr_url, gitlab_token=token)
+    project_path, _ = GitLabClient._parse_mr_url(mr_url)
+    mr = client.get_mr_from_url(mr_url)
+    project = client.get_project(project_path)
+    changes = mr.changes()
+    yaml_files = [
+        change["new_path"]
+        for change in changes.get("changes", [])
+        if change.get("new_path", "").lower().endswith(".yaml")
+    ]
+
+    if not yaml_files:
+        raise ValueError(f"No shipment YAML files found in MR {mr_url}")
+
+    jira_issues: set[str] = set()
+    processed_files: list[str] = []
+    group = None
+    assembly = None
+
+    for file_path in yaml_files:
+        try:
+            file_content = project.files.get(file_path=file_path, ref=mr.source_branch)
+            content = file_content.decode().decode("utf-8")
+            data = pyyaml.safe_load(content)
+            jira_issues.update(get_jira_issues_from_shipment_data(data))
+
+            file_group, file_assembly = parse_shipment_metadata_from_data(data)
+            processed_files.append(file_path)
+            if group is None:
+                group, assembly = file_group, file_assembly
+            elif (file_group, file_assembly) != (group, assembly):
+                raise ValueError(
+                    f"Shipment MR contains mixed assemblies: expected {group}/{assembly}, "
+                    f"found {file_group}/{file_assembly} in {file_path}"
+                )
+        except ValueError:
+            raise
+        except Exception:
+            LOGGER.warning(
+                "Failed to process shipment file %s in MR %s",
+                file_path,
+                mr_url,
+                exc_info=True,
+            )
+            continue
+
+    if group is None or assembly is None:
+        raise ValueError(f"No valid shipment YAML files found in MR {mr_url}")
+
+    return jira_issues, processed_files, (group, assembly)
+
+
+def _get_shipment_config(assembly_group: dict) -> dict:
+    for key in ("shipment", "shipment!"):
+        value = assembly_group.get(key)
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def get_shipment_mr_url(assembly_group: dict) -> str:
+    shipment_url = _get_shipment_config(assembly_group).get("url")
+    if not shipment_url:
+        raise RuntimeError("shipment.url not found in assembly group config")
+    return shipment_url
+
+
+def _load_releases_yaml_sync(group: str, data_path: str) -> Optional[dict]:
+    if not data_path.startswith("https://"):
+        releases_path = Path(data_path) / "releases.yml"
+        if not releases_path.is_file():
+            return None
+        return pyyaml.safe_load(releases_path.read_text(encoding="utf-8"))
+
+    parts = data_path.rstrip("/").removesuffix(".git").split("/")
+    if len(parts) < 2:
+        return None
+    owner, repo_name = parts[-2], parts[-1]
+    repo = get_github_client_for_org(owner).get_repo(f"{owner}/{repo_name}")
+    content = repo.get_contents("releases.yml", ref=group)
+    return pyyaml.safe_load(content.decoded_content)
+
+
+async def _load_releases_yaml(group: str, data_path: str) -> Optional[dict]:
+    return await asyncio.to_thread(_load_releases_yaml_sync, group, data_path)
+
+
+async def load_assembly_group(group: str, assembly: str, data_path: str) -> Optional[dict]:
+    releases = await _load_releases_yaml(group, data_path)
+    if not releases or assembly not in releases.get("releases", {}):
+        return None
+
+    releases_config = Model(dict_to_model=releases)
+    group_config = assembly_resolved(releases_config, assembly).group
+    if group_config is Missing:
+        return None
+    return group_config.primitive()
+
+
+def flatten_elliott_cve_trackers(elliott_output: dict, kinds: Optional[Iterable[str]] = None) -> list[str]:
+    trackers: set[str] = set()
+    if kinds is None:
+        values = elliott_output.values()
+    else:
+        values = (elliott_output.get(kind) for kind in kinds)
+
+    for value in values:
+        if isinstance(value, list):
+            trackers.update(str(item) for item in value)
+    return sorted(trackers)
+
+
+def find_missing_cve_trackers(elliott_trackers: Iterable[str], attached_jira_issues: Iterable[str]) -> list[str]:
+    attached = set(attached_jira_issues)
+    return sorted(tracker for tracker in elliott_trackers if tracker not in attached)
+
+
+def get_rhsa_jira_issues(advisories: dict) -> set[str]:
+    jira_issues: set[str] = set()
+
+    for impetus, advisory_id in advisories.items():
+        if impetus in SKIPPED_ADVISORY_IMPETUSES:
+            continue
+        if advisory_id is None or int(advisory_id) <= 0:
+            continue
+
+        raw_erratum = get_raw_erratum(advisory_id)
+        erratum = raw_erratum.get("errata") or {}
+        if erratum.get("status") == DROPPED_ADVISORY_STATUS:
+            continue
+        if erratum.get("type") != "RHSA":
+            continue
+
+        jira_issues.update(str(issue_id) for issue_id in get_bug_ids(advisory_id).get("jira", []))
+
+    return jira_issues
+
+
+async def verify_cve_trackers(
+    group: str,
+    assembly: str,
+    data_path: str,
+    advisory_trackers: dict,
+    shipment_trackers: dict,
+) -> VerifyCveTrackersResult:
+    assembly_group = await load_assembly_group(group, assembly, data_path)
+    if not assembly_group:
+        raise RuntimeError(f"Failed to load assembly group config for {group} {assembly}")
+
+    shipment_mr_url = get_shipment_mr_url(assembly_group)
+    result = VerifyCveTrackersResult(
+        group=group,
+        assembly=assembly,
+        shipment_mr_url=shipment_mr_url,
+    )
+
+    # Check RHSA advisories
+    rhsa_jira_issues = await asyncio.to_thread(
+        get_rhsa_jira_issues,
+        assembly_group.get("advisories", {}),
+    )
+    LOGGER.info("Found %s Jira issues on RHSA advisories", len(rhsa_jira_issues))
+
+    result.advisory_elliott_trackers = flatten_elliott_cve_trackers(advisory_trackers, kinds=ADVISORY_CVE_KINDS)
+    result.missing_advisory_trackers = find_missing_cve_trackers(
+        result.advisory_elliott_trackers,
+        rhsa_jira_issues,
+    )
+
+    # Check shipment MR
+    shipment_jira_issues, shipment_files, (mr_group, mr_assembly) = await asyncio.to_thread(
+        get_jira_issues_from_shipment_mr,
+        shipment_mr_url,
+    )
+    result.shipment_files = shipment_files
+
+    if (mr_group, mr_assembly) != (group, assembly):
+        raise ValueError(
+            f"Shipment MR metadata ({mr_group}, {mr_assembly}) does not match "
+            f"requested group/assembly ({group}, {assembly})"
+        )
+
+    LOGGER.info(
+        "Found %s Jira issues across %s shipment files in MR",
+        len(shipment_jira_issues),
+        len(shipment_files),
+    )
+
+    result.shipment_elliott_trackers = flatten_elliott_cve_trackers(shipment_trackers)
+    result.missing_shipment_trackers = find_missing_cve_trackers(
+        result.shipment_elliott_trackers,
+        shipment_jira_issues,
+    )
+
+    return result
+
+
+def render_result(result: VerifyCveTrackersResult, output: str) -> str:
+    if output == "json":
+        return json.dumps(
+            {
+                "group": result.group,
+                "assembly": result.assembly,
+                "shipment_mr_url": result.shipment_mr_url,
+                "shipment_files": result.shipment_files,
+                "passed": result.passed,
+                "missing_trackers": result.missing_trackers,
+                "missing_advisory_trackers": result.missing_advisory_trackers,
+                "missing_shipment_trackers": result.missing_shipment_trackers,
+                "advisory_elliott_trackers": result.advisory_elliott_trackers,
+                "shipment_elliott_trackers": result.shipment_elliott_trackers,
+            },
+            indent=2,
+        )
+
+    lines = [f"CVE tracker verification for {result.group} assembly {result.assembly}"]
+    if result.shipment_mr_url:
+        lines.append(f"Shipment MR: {result.shipment_mr_url}")
+        if result.shipment_files:
+            lines.append(f"Shipment files checked: {len(result.shipment_files)}")
+
+    if result.missing_advisory_trackers:
+        lines.append("")
+        lines.append("MISSING CVE TRACKER BUGS IN RHSA ADVISORIES:")
+        for tracker in result.missing_advisory_trackers:
+            lines.append(f"  - {tracker}")
+
+    if result.missing_shipment_trackers:
+        lines.append("")
+        lines.append("MISSING CVE TRACKER BUGS IN SHIPMENT MR:")
+        for tracker in result.missing_shipment_trackers:
+            lines.append(f"  - {tracker}")
+
+    if result.passed:
+        lines.append("")
+        lines.append("All CVE tracker bugs are covered.")
+
+    lines.append("")
+    overall = "PASS" if result.passed else "FAIL"
+    lines.append(f"Overall: {overall}")
+    return "\n".join(lines)
+
+
+@cli.command("verify-cve-trackers", short_help="Verify CVE tracker bugs are covered in advisories and shipment MR")
+@click.option(
+    "-g",
+    "--group",
+    metavar="GROUP",
+    required=True,
+    help="The group of components, e.g. openshift-4.20",
+)
+@click.option(
+    "--assembly",
+    metavar="ASSEMBLY",
+    required=True,
+    help="Assembly name, e.g. 4.20.1",
+)
+@click.option(
+    "--data-path",
+    required=False,
+    default=OCP_BUILD_DATA_URL,
+    help="ocp-build-data fork to use",
+)
+@click.option(
+    "--advisory-trackers-file",
+    required=True,
+    type=click.Path(exists=True),
+    help="JSON file with elliott find-bugs --cve-only output for Brew builds",
+)
+@click.option(
+    "--shipment-trackers-file",
+    required=True,
+    type=click.Path(exists=True),
+    help="JSON file with elliott find-bugs --cve-only output for Konflux builds",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    show_default=True,
+    help="Output format.",
+)
+@click_coroutine
+async def verify_cve_trackers_cli(
+    group: str,
+    assembly: str,
+    data_path: str,
+    advisory_trackers_file: str,
+    shipment_trackers_file: str,
+    output: str,
+):
+    """Verify CVE tracker bugs are covered in RHSA advisories and shipment MR.
+
+    Expects JSON output from `elliott find-bugs --cve-only` as input files:
+    one for Brew builds (advisory trackers) and one for Konflux builds
+    (shipment trackers). These are typically produced by the artcd
+    ert-verification pipeline.
+    """
+    with open(advisory_trackers_file) as f:
+        advisory_trackers = json.load(f)
+    with open(shipment_trackers_file) as f:
+        shipment_trackers = json.load(f)
+
+    result = await verify_cve_trackers(
+        group=group,
+        assembly=assembly,
+        data_path=data_path,
+        advisory_trackers=advisory_trackers,
+        shipment_trackers=shipment_trackers,
+    )
+    click.echo(render_result(result, output))
+    if not result.passed:
+        raise SystemExit(1)

--- a/elliott/elliottlib/cli/verify_cve_trackers_cli.py
+++ b/elliott/elliottlib/cli/verify_cve_trackers_cli.py
@@ -12,7 +12,7 @@ from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.gitlab import GitLabClient
 from artcommonlib.model import Missing, Model
 
-from elliottlib.cli.common import cli, click_coroutine
+from elliottlib.cli.common import cli, click_coroutine, pass_runtime
 from elliottlib.errata import get_bug_ids, get_raw_erratum
 
 LOGGER = logging.getLogger(__name__)
@@ -321,25 +321,6 @@ def render_result(result: VerifyCveTrackersResult, output: str) -> str:
 
 @cli.command("verify-cve-trackers", short_help="Verify CVE tracker bugs are covered in advisories and shipment MR")
 @click.option(
-    "-g",
-    "--group",
-    metavar="GROUP",
-    required=True,
-    help="The group of components, e.g. openshift-4.20",
-)
-@click.option(
-    "--assembly",
-    metavar="ASSEMBLY",
-    required=True,
-    help="Assembly name, e.g. 4.20.1",
-)
-@click.option(
-    "--data-path",
-    required=False,
-    default=OCP_BUILD_DATA_URL,
-    help="ocp-build-data fork to use",
-)
-@click.option(
     "--advisory-trackers-file",
     required=True,
     type=click.Path(exists=True),
@@ -359,21 +340,26 @@ def render_result(result: VerifyCveTrackersResult, output: str) -> str:
     show_default=True,
     help="Output format.",
 )
+@pass_runtime
 @click_coroutine
 async def verify_cve_trackers_cli(
-    group: str,
-    assembly: str,
-    data_path: str,
+    runtime,
     advisory_trackers_file: str,
     shipment_trackers_file: str,
     output: str,
 ):
     """Verify CVE tracker bugs are covered in RHSA advisories and shipment MR.
 
+    Requires --group and --assembly global options.
+
     Expects JSON output from `elliott find-bugs --cve-only` as input files:
     one for Brew builds (advisory trackers) and one for Konflux builds
     (shipment trackers). These are typically produced by the artcd
     ert-verification pipeline.
+
+    Example:
+        elliott -g openshift-4.18 --assembly 4.18.51 verify-cve-trackers \\
+            --advisory-trackers-file brew.json --shipment-trackers-file konflux.json
     """
     with open(advisory_trackers_file) as f:
         advisory_trackers = json.load(f)
@@ -381,9 +367,9 @@ async def verify_cve_trackers_cli(
         shipment_trackers = json.load(f)
 
     result = await verify_cve_trackers(
-        group=group,
-        assembly=assembly,
-        data_path=data_path,
+        group=runtime.group,
+        assembly=runtime.assembly,
+        data_path=runtime.data_path,
         advisory_trackers=advisory_trackers,
         shipment_trackers=shipment_trackers,
     )

--- a/elliott/elliottlib/cli/verify_cve_trackers_cli.py
+++ b/elliott/elliottlib/cli/verify_cve_trackers_cli.py
@@ -1,13 +1,12 @@
 import asyncio
 import json
 import logging
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, Optional
 
 import click
-import yaml as pyyaml
+import yaml
 from artcommonlib.assembly import assembly_resolved
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.gitlab import GitLabClient
@@ -75,21 +74,17 @@ def parse_shipment_metadata_from_data(data: dict) -> tuple[str, str]:
 
 def get_jira_issues_from_shipment_mr(
     mr_url: str,
-    gitlab_token: Optional[str] = None,
 ) -> tuple[set[str], list[str], tuple[str, str]]:
-    token = gitlab_token or os.getenv("GITLAB_TOKEN")
-    if not token:
-        raise ValueError("GITLAB_TOKEN environment variable is required to read shipment MR")
+    gl = GitLabClient.from_url(mr_url)
+    mr = gl.get_mr_from_url(mr_url)
+    source_project = gl.get_project(mr.source_project_id)
 
-    client = GitLabClient.from_url(mr_url, gitlab_token=token)
-    project_path, _ = GitLabClient._parse_mr_url(mr_url)
-    mr = client.get_mr_from_url(mr_url)
-    project = client.get_project(project_path)
-    changes = mr.changes()
+    diff_info = mr.diffs.list(all=True)[0]
+    diff = mr.diffs.get(diff_info.id)
     yaml_files = [
-        change["new_path"]
-        for change in changes.get("changes", [])
-        if change.get("new_path", "").lower().endswith(".yaml")
+        file_diff.get("new_path") or file_diff.get("old_path")
+        for file_diff in diff.diffs
+        if (file_diff.get("new_path") or file_diff.get("old_path", "")).lower().endswith((".yaml", ".yml"))
     ]
 
     if not yaml_files:
@@ -102,9 +97,9 @@ def get_jira_issues_from_shipment_mr(
 
     for file_path in yaml_files:
         try:
-            file_content = project.files.get(file_path=file_path, ref=mr.source_branch)
+            file_content = source_project.files.get(file_path, mr.source_branch)
             content = file_content.decode().decode("utf-8")
-            data = pyyaml.safe_load(content)
+            data = yaml.safe_load(content)
             jira_issues.update(get_jira_issues_from_shipment_data(data))
 
             file_group, file_assembly = parse_shipment_metadata_from_data(data)
@@ -153,7 +148,7 @@ def _load_releases_yaml_sync(group: str, data_path: str) -> Optional[dict]:
         releases_path = Path(data_path) / "releases.yml"
         if not releases_path.is_file():
             return None
-        return pyyaml.safe_load(releases_path.read_text(encoding="utf-8"))
+        return yaml.safe_load(releases_path.read_text(encoding="utf-8"))
 
     parts = data_path.rstrip("/").removesuffix(".git").split("/")
     if len(parts) < 2:
@@ -161,7 +156,7 @@ def _load_releases_yaml_sync(group: str, data_path: str) -> Optional[dict]:
     owner, repo_name = parts[-2], parts[-1]
     repo = get_github_client_for_org(owner).get_repo(f"{owner}/{repo_name}")
     content = repo.get_contents("releases.yml", ref=group)
-    return pyyaml.safe_load(content.decoded_content)
+    return yaml.safe_load(content.decoded_content)
 
 
 async def _load_releases_yaml(group: str, data_path: str) -> Optional[dict]:

--- a/elliott/tests/test_verify_cve_trackers_cli.py
+++ b/elliott/tests/test_verify_cve_trackers_cli.py
@@ -1,0 +1,296 @@
+import json
+import unittest
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from elliottlib.cli.verify_cve_trackers_cli import (
+    VerifyCveTrackersResult,
+    find_missing_cve_trackers,
+    flatten_elliott_cve_trackers,
+    get_jira_issues_from_shipment_data,
+    get_jira_issues_from_shipment_mr,
+    get_rhsa_jira_issues,
+    get_shipment_mr_url,
+    parse_shipment_metadata_from_data,
+    render_result,
+    verify_cve_trackers,
+)
+
+SAMPLE_SHIPMENT = {
+    "shipment": {
+        "metadata": {
+            "group": "openshift-4.20",
+            "assembly": "4.20.1",
+        },
+        "data": {
+            "releaseNotes": {
+                "issues": {
+                    "fixed": [
+                        {"id": "OCPBUGS-11111", "source": "issues.redhat.com"},
+                        {"id": "OCPBUGS-22222", "source": "issues.redhat.com"},
+                        {"id": "1234567", "source": "bugzilla.redhat.com"},
+                    ]
+                }
+            }
+        },
+    }
+}
+
+
+class TestHelpers(unittest.TestCase):
+    def test_get_shipment_mr_url(self):
+        self.assertEqual(
+            get_shipment_mr_url({"shipment": {"url": "https://gitlab.example.com/mr/1"}}),
+            "https://gitlab.example.com/mr/1",
+        )
+
+    def test_get_shipment_mr_url_override_key(self):
+        self.assertEqual(
+            get_shipment_mr_url({"shipment!": {"url": "https://gitlab.example.com/mr/2"}}),
+            "https://gitlab.example.com/mr/2",
+        )
+
+    def test_get_shipment_mr_url_missing(self):
+        with self.assertRaises(RuntimeError):
+            get_shipment_mr_url({})
+
+    def test_get_jira_issues_from_shipment_data(self):
+        self.assertEqual(
+            get_jira_issues_from_shipment_data(SAMPLE_SHIPMENT),
+            {"OCPBUGS-11111", "OCPBUGS-22222"},
+        )
+
+    def test_get_jira_issues_from_shipment_data_empty(self):
+        self.assertEqual(get_jira_issues_from_shipment_data({}), set())
+
+    def test_get_jira_issues_ocpbugs_prefix(self):
+        data = {
+            "shipment": {
+                "data": {
+                    "releaseNotes": {
+                        "issues": {
+                            "fixed": [
+                                {"id": "OCPBUGS-99999", "source": "other.example.com"},
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        self.assertEqual(get_jira_issues_from_shipment_data(data), {"OCPBUGS-99999"})
+
+    def test_parse_shipment_metadata(self):
+        group, assembly = parse_shipment_metadata_from_data(SAMPLE_SHIPMENT)
+        self.assertEqual(group, "openshift-4.20")
+        self.assertEqual(assembly, "4.20.1")
+
+    def test_parse_shipment_metadata_missing(self):
+        with self.assertRaises(ValueError):
+            parse_shipment_metadata_from_data({"shipment": {"metadata": {}}})
+
+    def test_flatten_elliott_cve_trackers_all(self):
+        payload = {"rpm": ["OCPBUGS-1"], "image": ["OCPBUGS-2"]}
+        result = flatten_elliott_cve_trackers(payload)
+        self.assertEqual(result, ["OCPBUGS-1", "OCPBUGS-2"])
+
+    def test_flatten_elliott_cve_trackers_with_kinds(self):
+        payload = {
+            "rpm": ["OCPBUGS-1"],
+            "rhcos": ["OCPBUGS-2"],
+            "image": ["OCPBUGS-3"],
+        }
+        result = flatten_elliott_cve_trackers(payload, kinds=("rpm", "rhcos"))
+        self.assertEqual(result, ["OCPBUGS-1", "OCPBUGS-2"])
+
+    def test_flatten_elliott_cve_trackers_empty(self):
+        self.assertEqual(flatten_elliott_cve_trackers({}), [])
+
+    def test_find_missing_cve_trackers(self):
+        missing = find_missing_cve_trackers(
+            ["OCPBUGS-1", "OCPBUGS-2", "OCPBUGS-3"],
+            ["OCPBUGS-1", "OCPBUGS-3"],
+        )
+        self.assertEqual(missing, ["OCPBUGS-2"])
+
+    def test_find_missing_cve_trackers_none_missing(self):
+        missing = find_missing_cve_trackers(
+            ["OCPBUGS-1"],
+            ["OCPBUGS-1", "OCPBUGS-2"],
+        )
+        self.assertEqual(missing, [])
+
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_bug_ids")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_raw_erratum")
+    def test_get_rhsa_jira_issues(self, mock_get_raw_erratum, mock_get_bug_ids):
+        mock_get_raw_erratum.side_effect = [
+            {"errata": {"type": "RHSA", "status": "QE"}},
+            {"errata": {"type": "RHBA", "status": "QE"}},
+        ]
+        mock_get_bug_ids.return_value = {"jira": ["OCPBUGS-1"], "bugzilla": []}
+
+        advisories = {"rpm": 12345, "image": 12346}
+        result = get_rhsa_jira_issues(advisories)
+        self.assertEqual(result, {"OCPBUGS-1"})
+        mock_get_bug_ids.assert_called_once_with(12345)
+
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_bug_ids")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_raw_erratum")
+    def test_get_rhsa_jira_issues_skips_microshift(self, mock_get_raw_erratum, mock_get_bug_ids):
+        advisories = {"microshift": 99999}
+        result = get_rhsa_jira_issues(advisories)
+        self.assertEqual(result, set())
+        mock_get_raw_erratum.assert_not_called()
+
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_bug_ids")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_raw_erratum")
+    def test_get_rhsa_jira_issues_skips_dropped(self, mock_get_raw_erratum, mock_get_bug_ids):
+        mock_get_raw_erratum.return_value = {"errata": {"type": "RHSA", "status": "DROPPED_NO_SHIP"}}
+        advisories = {"rpm": 12345}
+        result = get_rhsa_jira_issues(advisories)
+        self.assertEqual(result, set())
+        mock_get_bug_ids.assert_not_called()
+
+
+class TestVerifyCveTrackersResult(unittest.TestCase):
+    def test_passed_no_missing(self):
+        r = VerifyCveTrackersResult(group="g", assembly="a", shipment_mr_url="url")
+        self.assertTrue(r.passed)
+
+    def test_failed_advisory_missing(self):
+        r = VerifyCveTrackersResult(
+            group="g",
+            assembly="a",
+            shipment_mr_url="url",
+            missing_advisory_trackers=["OCPBUGS-1"],
+        )
+        self.assertFalse(r.passed)
+
+    def test_failed_shipment_missing(self):
+        r = VerifyCveTrackersResult(
+            group="g",
+            assembly="a",
+            shipment_mr_url="url",
+            missing_shipment_trackers=["OCPBUGS-2"],
+        )
+        self.assertFalse(r.passed)
+
+    def test_missing_trackers_deduped(self):
+        r = VerifyCveTrackersResult(
+            group="g",
+            assembly="a",
+            shipment_mr_url="url",
+            missing_advisory_trackers=["OCPBUGS-1", "OCPBUGS-2"],
+            missing_shipment_trackers=["OCPBUGS-2", "OCPBUGS-3"],
+        )
+        self.assertEqual(r.missing_trackers, ["OCPBUGS-1", "OCPBUGS-2", "OCPBUGS-3"])
+
+
+class TestRenderResult(unittest.TestCase):
+    def test_text_pass(self):
+        r = VerifyCveTrackersResult(group="openshift-4.20", assembly="4.20.1", shipment_mr_url="https://mr")
+        text = render_result(r, "text")
+        self.assertIn("openshift-4.20", text)
+        self.assertIn("PASS", text)
+        self.assertIn("All CVE tracker bugs are covered", text)
+
+    def test_text_fail(self):
+        r = VerifyCveTrackersResult(
+            group="openshift-4.20",
+            assembly="4.20.1",
+            shipment_mr_url="https://mr",
+            missing_advisory_trackers=["OCPBUGS-1"],
+        )
+        text = render_result(r, "text")
+        self.assertIn("FAIL", text)
+        self.assertIn("OCPBUGS-1", text)
+
+    def test_json(self):
+        r = VerifyCveTrackersResult(
+            group="openshift-4.20",
+            assembly="4.20.1",
+            shipment_mr_url="https://mr",
+            advisory_elliott_trackers=["OCPBUGS-1"],
+        )
+        data = json.loads(render_result(r, "json"))
+        self.assertEqual(data["group"], "openshift-4.20")
+        self.assertTrue(data["passed"])
+        self.assertEqual(data["advisory_elliott_trackers"], ["OCPBUGS-1"])
+
+
+class TestVerifyCveTrackers(IsolatedAsyncioTestCase):
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_jira_issues_from_shipment_mr")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_rhsa_jira_issues")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.load_assembly_group", new_callable=AsyncMock)
+    async def test_all_pass(self, mock_load, mock_rhsa, mock_shipment):
+        mock_load.return_value = {
+            "advisories": {"rpm": 111},
+            "shipment": {"url": "https://gitlab/mr/1"},
+        }
+        mock_rhsa.return_value = {"OCPBUGS-1"}
+        mock_shipment.return_value = (
+            {"OCPBUGS-2"},
+            ["file.yaml"],
+            ("openshift-4.20", "4.20.1"),
+        )
+
+        result = await verify_cve_trackers(
+            "openshift-4.20",
+            "4.20.1",
+            "https://github.com/ocp-build-data",
+            advisory_trackers={"rpm": ["OCPBUGS-1"]},
+            shipment_trackers={"image": ["OCPBUGS-2"]},
+        )
+        self.assertTrue(result.passed)
+
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_jira_issues_from_shipment_mr")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_rhsa_jira_issues")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.load_assembly_group", new_callable=AsyncMock)
+    async def test_missing_advisory_tracker(self, mock_load, mock_rhsa, mock_shipment):
+        mock_load.return_value = {
+            "advisories": {"rpm": 111},
+            "shipment": {"url": "https://gitlab/mr/1"},
+        }
+        mock_rhsa.return_value = set()
+        mock_shipment.return_value = (set(), ["file.yaml"], ("openshift-4.20", "4.20.1"))
+
+        result = await verify_cve_trackers(
+            "openshift-4.20",
+            "4.20.1",
+            "https://github.com/ocp-build-data",
+            advisory_trackers={"rpm": ["OCPBUGS-1"]},
+            shipment_trackers={},
+        )
+        self.assertFalse(result.passed)
+        self.assertIn("OCPBUGS-1", result.missing_advisory_trackers)
+
+    @patch("elliottlib.cli.verify_cve_trackers_cli.load_assembly_group", new_callable=AsyncMock)
+    async def test_assembly_not_found(self, mock_load):
+        mock_load.return_value = None
+        with self.assertRaises(RuntimeError):
+            await verify_cve_trackers(
+                "openshift-4.20",
+                "4.20.1",
+                "https://github.com/ocp-build-data",
+                advisory_trackers={},
+                shipment_trackers={},
+            )
+
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_jira_issues_from_shipment_mr")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_rhsa_jira_issues")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.load_assembly_group", new_callable=AsyncMock)
+    async def test_shipment_mr_mismatch(self, mock_load, mock_rhsa, mock_shipment):
+        mock_load.return_value = {
+            "advisories": {},
+            "shipment": {"url": "https://gitlab/mr/1"},
+        }
+        mock_rhsa.return_value = set()
+        mock_shipment.return_value = (set(), ["file.yaml"], ("openshift-4.19", "4.19.5"))
+
+        with self.assertRaises(ValueError, msg="does not match"):
+            await verify_cve_trackers(
+                "openshift-4.20",
+                "4.20.1",
+                "https://github.com/ocp-build-data",
+                advisory_trackers={},
+                shipment_trackers={},
+            )


### PR DESCRIPTION
rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `verify-cve-trackers` command to verify CVE tracker coverage for a specified group and assembly using advisory-derived and shipment-derived Jira issue sources.
  * Supports loading `releases.yml` from a data path, including Git-based refs, and allows text or JSON output with pass/fail status and missing tracker details.
  * Enforces consistency between requested and shipment metadata; exits non-zero when coverage is incomplete.
  * Exposes `verify_cve_trackers` from the main module for programmatic use.
* **Tests**
  * Added unit and end-to-end tests for MR/YAML parsing, issue extraction, missing-tracker detection, and result rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->