### PR TITLE
ART-18202: fix RPMDB cache race condition in rpm-lockfile-prototype retry logic

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/constants.py
+++ b/doozer/doozerlib/lockfile_prototype/constants.py
@@ -47,6 +47,7 @@ RPMDB_CACHE_PATH = Path.home() / ".cache" / "rpm-lockfile-prototype" / "rpmdbs"
 RPMDB_CACHE_ERROR_PATTERNS = [
     "database disk image is malformed",
     "failed loading RPMDB",
+    "No such file or directory",
 ]
 
 

--- a/doozer/doozerlib/lockfile_prototype/resolver.py
+++ b/doozer/doozerlib/lockfile_prototype/resolver.py
@@ -86,13 +86,12 @@ class RpmResolver:
 
             if rc != 0:
                 if image_pullspec and self._is_rpmdb_corrupt(stderr):
-                    cleared = self._clear_rpmdb_cache(image_pullspec)
-                    if cleared:
-                        self.logger.info("Retrying rpm-lockfile-prototype after clearing corrupt RPMDB cache")
-                        retry_rc, _, retry_stderr = await cmd_gather_async(cmd, check=False, env=env)
-                        if retry_rc == 0:
-                            return LockfileData.model_validate(yaml.safe_load(out_file.read_text()))
-                        self.logger.warning("Retry also failed (exit code %d): %s", retry_rc, retry_stderr)
+                    self._clear_rpmdb_cache(image_pullspec)
+                    self.logger.info("Retrying rpm-lockfile-prototype after RPMDB cache error")
+                    retry_rc, _, retry_stderr = await cmd_gather_async(cmd, check=False, env=env)
+                    if retry_rc == 0:
+                        return LockfileData.model_validate(yaml.safe_load(out_file.read_text()))
+                    self.logger.warning("Retry also failed (exit code %d): %s", retry_rc, retry_stderr)
 
                 raise RuntimeError(f"rpm-lockfile-prototype failed (exit code {rc}): {stderr}")
 

--- a/doozer/tests/lockfile_prototype/test_resolver.py
+++ b/doozer/tests/lockfile_prototype/test_resolver.py
@@ -239,6 +239,15 @@ class TestIsRpmdbCorrupt(unittest.TestCase):
         stderr = "OSError: failed loading RPMDB\n"
         self.assertTrue(RpmResolver._is_rpmdb_corrupt(stderr))
 
+    def test_detects_no_such_file(self):
+        stderr = (
+            "shutil.Error: [('/home/jenkins/.cache/rpm-lockfile-prototype/rpmdbs/ppc64le/"
+            "sha256:abc123/var/lib/rpm/rpmdb.sqlite', '/tmp/xyz/var/lib/rpm/rpmdb.sqlite', "
+            "\"[Errno 2] No such file or directory: '/home/jenkins/.cache/rpm-lockfile-prototype/"
+            "rpmdbs/ppc64le/sha256:abc123/var/lib/rpm/rpmdb.sqlite'\")]"
+        )
+        self.assertTrue(RpmResolver._is_rpmdb_corrupt(stderr))
+
     def test_no_false_positive(self):
         stderr = "No match for argument: foo\n"
         self.assertFalse(RpmResolver._is_rpmdb_corrupt(stderr))
@@ -344,6 +353,44 @@ class TestResolveRpmdbCorruptionRetry(unittest.TestCase):
 
         mock_gather.side_effect = mock_cmd
         mock_clear.return_value = True
+
+        resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
+        config = RpmsInConfig(
+            arches=["x86_64"],
+            contentOrigin={"repos": []},
+            packages=[],
+        )
+        result = asyncio.run(resolver.resolve(config, image_pullspec="registry.example.com/repo@sha256:abc123"))
+        self.assertIsInstance(result, LockfileData)
+        self.assertEqual(call_count, 2)
+        mock_clear.assert_called_once()
+
+    @patch("doozerlib.lockfile_prototype.resolver.RpmResolver._clear_rpmdb_cache")
+    @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
+    def test_retries_when_cache_already_gone(self, mock_gather, mock_clear):
+        """
+        Cache deleted by another process (_clear returns False) — should still retry.
+        """
+        cache_race_stderr = (
+            "shutil.Error: [('/home/jenkins/.cache/rpm-lockfile-prototype/rpmdbs/ppc64le/"
+            "sha256:abc123/var/lib/rpm/rpmdb.sqlite', '/tmp/xyz/var/lib/rpm/rpmdb.sqlite', "
+            "\"[Errno 2] No such file or directory: '/home/jenkins/.cache/rpm-lockfile-prototype/"
+            "rpmdbs/ppc64le/sha256:abc123/var/lib/rpm/rpmdb.sqlite'\")]"
+        )
+        call_count = 0
+
+        async def mock_cmd(cmd, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return (1, "", cache_race_stderr)
+            outfile_idx = cmd.index("--outfile") + 1
+            with open(cmd[outfile_idx], "w") as f:
+                yaml.safe_dump(self.FAKE_LOCKFILE_DATA, f)
+            return (0, "", "")
+
+        mock_gather.side_effect = mock_cmd
+        mock_clear.return_value = False
 
         resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
         config = RpmsInConfig(


### PR DESCRIPTION
Concurrent rebase processes can delete the shared RPMDB cache while another process is mid-copytree, causing "No such file or directory" errors. Add this pattern to retry detection and always retry on cache errors regardless of whether _clear_rpmdb_cache found entries to delete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of RPM database cache errors, including a common “No such file or directory” failure.
  * Resolver now retries automatically even if the cache was already removed by another process, helping lockfile generation recover more reliably.
  * Better logging is shown when a retry still fails, making failures easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->