### PR TITLE
Require reposync.enabled in repo schema validation

### DIFF
--- a/ocp-build-data-validator/tests/test_schema/test_group_schema.py
+++ b/ocp-build-data-validator/tests/test_schema/test_group_schema.py
@@ -26,6 +26,29 @@ class TestGroupSchema(unittest.TestCase):
         }
         self.assertIn("'yes' is not of type 'boolean'", group_schema.validate("group.yml", invalid_data))
 
+    def test_validate_reposync_requires_enabled(self):
+        data_missing_enabled = {
+            "repos": {
+                "my-repo": {
+                    "conf": {"baseurl": {"x86_64": "https://example.com/repo/"}},
+                    "reposync": {"latest_only": False},
+                }
+            }
+        }
+        result = group_schema.validate("group.yml", data_missing_enabled)
+        self.assertIn("'enabled' is a required property", result)
+
+    def test_validate_reposync_with_enabled(self):
+        data_with_enabled = {
+            "repos": {
+                "my-repo": {
+                    "conf": {"baseurl": {"x86_64": "https://example.com/repo/"}},
+                    "reposync": {"enabled": False},
+                }
+            }
+        }
+        self.assertEqual("", group_schema.validate("group.yml", data_with_enabled))
+
     def test_validate_with_mismatched_bridge_release_basis_group(self):
         invalid_data = {
             "name": "openshift-4.23",

--- a/ocp-build-data-validator/validator/json_schemas/repos.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/repos.schema.json
@@ -47,6 +47,7 @@
                             "type": "boolean"
                         }
                     },
+                    "required": ["enabled"],
                     "additionalProperties": false
                 },
                 "reposync!": {


### PR DESCRIPTION
## Summary
- Makes `enabled` a required field inside the `reposync` object in `repos.schema.json`
- When a repo specifies `reposync:`, it must now explicitly set `enabled: true` or `enabled: false`
- Adds tests for both valid and invalid cases

## Context
We are standardizing `reposync: enabled: <bool>` across all `ocp-build-data` branches. This validator change enforces that any new or modified repo definition includes the field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened repository validation so `reposync` entries must include an `enabled` field.
  * Validation now correctly rejects incomplete repository definitions and accepts valid boolean `enabled` values.
* **Tests**
  * Added coverage for both failing and passing validation cases to verify the updated schema behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->