### PR TITLE
ART-18202: Fix empty lockfile when final stage has bare update + install

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -438,7 +438,20 @@ class RpmLockfilePrototypeGenerator:
 
             reinstall_pkgs: list[str] | None = None
             strippable: set[str] | None = None
-            if stage_num == final_stage_num and not is_update_only and not has_bare_update:
+            if stage_num == final_stage_num and not is_update_only and has_bare_update:
+                if image_pullspec and packages:
+                    # Bare update + explicit installs in final stage: reinstall
+                    # the Dockerfile packages so they appear in the lockfile
+                    # even when already installed in the base image. Base image
+                    # packages use upgrade semantics via upgrade_targets (set
+                    # above), so we intentionally do NOT reinstall them here.
+                    reinstall_pkgs = list(packages)
+                    strippable = set()
+                    self.logger.info(
+                        f"{distgit_key}: stage {stage_num}: {len(reinstall_pkgs)} Dockerfile "
+                        "packages will be reinstalled into lockfile (bare update stage)"
+                    )
+            elif stage_num == final_stage_num and not is_update_only and not has_bare_update:
                 if image_pullspec:
                     # --image mode: pass base image packages as reinstallPackages
                     # so they appear in the lockfile at repo versions. base.reinstall()

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -541,12 +541,13 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         self.assertIn("libreswan", pkg_names)
         self.assertIn("openssl", pkg_names)
 
-    def test_bare_update_keeps_image_mode_without_upgrade_targets(self):
+    def test_bare_update_keeps_image_mode_reinstalls_dockerfile_packages(self):
         """
         Bare yum/dnf update with --image mode should NOT expand base
         image packages as upgrade targets (many are virtual provides or
-        renamed and cause resolution failures). Instead, dnf update is
-        kept in the Dockerfile and runs at build time with cachi2 RPMs.
+        renamed and cause resolution failures). Dockerfile install
+        packages must be reinstalled so they appear in the lockfile, and
+        also promoted to upgradePackages as a fallback if reinstall fails.
         """
         meta = self._make_mock_image_meta()
         meta.config.konflux.cachi2.lockfile.get.return_value = None
@@ -572,17 +573,20 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         self.assertEqual(len(captured_configs), 1)
         # --image mode preserved
         self.assertIsNotNone(captured_pullspecs[0])
-        # No upgrade targets — dnf update handled at build time
-        self.assertEqual(captured_configs[0].upgradePackages, [])
+        # Dockerfile packages reinstalled so they appear in lockfile
+        self.assertEqual(captured_configs[0].reinstallPackages, ["libreswan"])
+        # Dockerfile packages promoted to upgrade as reinstall fallback
+        self.assertEqual(captured_configs[0].upgradePackages, ["libreswan"])
 
-    def test_mixed_install_and_bare_update_skips_reinstall(self):
+    def test_mixed_install_and_bare_update_reinstalls_dockerfile_packages(self):
         """
         When a stage has both explicit installs and a bare update
         (e.g. microdnf update -y && microdnf install -y openssl),
-        reinstallPackages must be empty. Otherwise reinstall pins base
-        image versions and overrides upgrade semantics, preventing the
-        update from picking up latest RPMs — causing a perpetual
-        rebuild loop when scan-sources detects outdated packages.
+        Dockerfile install packages must appear in reinstallPackages
+        so they end up in the lockfile even when already installed in
+        the base image. Base image packages must NOT be reinstalled —
+        they use upgrade semantics via upgradePackages to pick up
+        latest versions without pinning.
         """
         meta = self._make_mock_image_meta()
         meta.config.konflux.cachi2.lockfile.get.return_value = None
@@ -606,15 +610,15 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
             asyncio.run(generator.generate_lockfile(meta, dest_dir))
 
         self.assertEqual(len(captured_configs), 1)
-        # reinstallPackages must be empty: bare update means we want
-        # upgrade semantics, and reinstall would pin old versions
-        self.assertEqual(captured_configs[0].reinstallPackages, [])
-        # Explicit install package must be present
+        # Dockerfile install packages must be reinstalled so they appear
+        # in the lockfile even when already installed in the base image
+        self.assertEqual(captured_configs[0].reinstallPackages, ["openssl"])
+        # Explicit install package must be present in packages list
         pkg_names = [p if isinstance(p, str) else p.name for p in captured_configs[0].packages]
         self.assertIn("openssl", pkg_names)
         # Base image packages must appear as upgrade targets so
         # dnf update picks up latest versions from repos
-        self.assertEqual(sorted(captured_configs[0].upgradePackages), ["audit", "bash", "glibc"])
+        self.assertEqual(sorted(captured_configs[0].upgradePackages), ["audit", "bash", "glibc", "openssl"])
 
     def test_reinstall_packages_also_passed_as_upgrade_targets(self):
         """


### PR DESCRIPTION
When a Dockerfile's final stage combines `yum update -y` with `yum install <pkg>`, the lockfile generator skipped reinstallPackages because has_bare_update was True. In --image mode, packages already installed in the base image were silently dropped by DNF ("already installed"), producing an empty lockfile. The hermetic build then failed because cachi2 had nothing prefetched.

Add a new branch that reinstalls the Dockerfile's explicit install packages (not base image packages) when has_bare_update is True in the final stage. Base packages continue using upgrade semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Final build stages now correctly keep Dockerfile-installed packages when a bare update is involved.
  * Packages explicitly requested in the Dockerfile will be reinstalled and included in the resolved upgrade set, improving consistency in generated lockfiles.
  * Mixed install and bare-update scenarios now preserve expected package behavior instead of skipping reinstalls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->