### PR TITLE
release-from-fbc: read mr_approvers from image config

### DIFF
--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -774,6 +774,21 @@
       "$ref": "#/properties/okd"
     },
     "okd-": {},
+    "mr_approvers": {
+      "description": "GitLab merge request approval rules mapping group names to lists of usernames",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {"type": "string"}
+      }
+    },
+    "mr_approvers!": {
+      "$ref": "#/properties/mr_approvers"
+    },
+    "mr_approvers?": {
+      "$ref": "#/properties/mr_approvers"
+    },
+    "mr_approvers-": {},
     "no_oit_comments": {
       "description": "Deprecated. Only used in 3.11 and 4.6",
       "type": "boolean"

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -777,9 +777,11 @@
     "mr_approvers": {
       "description": "GitLab merge request approval rules mapping group names to lists of usernames",
       "type": "object",
+      "propertyNames": { "minLength": 1 },
       "additionalProperties": {
         "type": "array",
-        "items": {"type": "string"}
+        "minItems": 1,
+        "items": { "type": "string", "minLength": 1 }
       }
     },
     "mr_approvers!": {

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -103,6 +103,7 @@ class ReleaseFromFbcPipeline:
         # Setup working directories
         self.working_dir = self.runtime.working_dir.absolute()
         self.elliott_working_dir = self.working_dir / "elliott-working"
+        self.doozer_working_dir = self.working_dir / "doozer-working"
         self._shipment_data_repo_dir = self.working_dir / "shipment-data-push"
 
         # Shipment repository configuration
@@ -349,6 +350,8 @@ class ReleaseFromFbcPipeline:
         self.working_dir.mkdir(parents=True, exist_ok=True)
         if self.elliott_working_dir.exists():
             shutil.rmtree(self.elliott_working_dir, ignore_errors=True)
+        if self.doozer_working_dir.exists():
+            shutil.rmtree(self.doozer_working_dir, ignore_errors=True)
         if self.create_mr and self._shipment_data_repo_dir.exists():
             shutil.rmtree(self._shipment_data_repo_dir, ignore_errors=True)
 
@@ -457,7 +460,7 @@ class ReleaseFromFbcPipeline:
                 nvr_dict = parse_nvr(self.extra_image_nvrs[0])
                 component = nvr_dict['name']
                 if component.endswith('-container'):
-                    component = component[:-len('-container')]
+                    component = component[: -len('-container')]
                 self.logger.info(f"Single extra NVR component: {component}")
                 return component
             else:
@@ -476,7 +479,16 @@ class ReleaseFromFbcPipeline:
         e.g. {"QE": ["user1", "user2"]}. Returns empty dict if not configured.
         """
         try:
-            cmd = ['doozer', f'--group={self.group}', '-i', doozer_key, 'config:print', '--key', 'mr_approvers']
+            cmd = [
+                'doozer',
+                f'--group={self.group}',
+                f'--working-dir={self.doozer_working_dir}',
+                '-i',
+                doozer_key,
+                'config:print',
+                '--key',
+                'mr_approvers',
+            ]
             _, output, _ = await exectools.cmd_gather_async(cmd)
             output = output.strip()
             if output and output not in ('None', 'null', '---'):

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -116,7 +116,7 @@ class ReleaseFromFbcPipeline:
         self.product = None
 
         # FBC operator doozer keys - populated during validate_fbc_related_images()
-        self._fbc_operator_keys: List[str] = []
+        self._fbc_operator_keys: list[str] = []
 
         # Set default shipment_path if not provided, using same logic as elliott
         self.shipment_path_was_defaulted = not shipment_path
@@ -407,7 +407,13 @@ class ReleaseFromFbcPipeline:
         e.g. {"QE": ["user1", "user2"]}. Returns empty dict if not configured.
         """
         try:
-            cmd = ['doozer', f'--group={self.group}', 'config:read-group', 'mr_approvers']
+            cmd = [
+                'doozer',
+                f'--group={self.group}',
+                f'--working-dir={self.doozer_working_dir}',
+                'config:read-group',
+                'mr_approvers',
+            ]
             _, output, _ = await exectools.cmd_gather_async(cmd)
             output = output.strip()
             if output and output not in ('None', 'null'):
@@ -420,19 +426,45 @@ class ReleaseFromFbcPipeline:
             self.logger.warning(f"Failed to load mr_approvers from group config: {e}")
         return {}
 
-    def _resolve_single_image_key(self) -> Optional[str]:
+    async def _resolve_doozer_key_from_component(self, component: str) -> Optional[str]:
+        """Resolve a Brew/Konflux component name to its doozer image key.
+
+        Uses `doozer images:print` with --short to query the authoritative
+        component-to-key mapping from ocp-build-data.
+        """
+        try:
+            cmd = [
+                'doozer',
+                f'--group={self.group}',
+                f'--working-dir={self.doozer_working_dir}',
+                '--load-disabled',
+                'images:print',
+                '--show-non-release',
+                '--short',
+                '{component}: {name}',
+            ]
+            _, output, _ = await exectools.cmd_gather_async(cmd)
+            for line in output.strip().splitlines():
+                parts = line.split(': ', 1)
+                if len(parts) == 2 and parts[0].strip() == component:
+                    return parts[1].strip()
+        except Exception as e:
+            self.logger.warning("Failed to resolve doozer key for component '%s': %s", component, e)
+        return None
+
+    async def _resolve_single_image_key(self) -> Optional[str]:
         """
         Determine the single unambiguous image config doozer key to query for mr_approvers.
 
         Returns the doozer key if exactly one image/operator can be identified, or None
-        if the situation is ambiguous. Ambiguous cases are logged as errors but do not
+        if the situation is ambiguous. Ambiguous cases are logged as warnings but do not
         block the pipeline.
         """
         has_fbc = bool(self._fbc_operator_keys)
         has_extras = bool(self.extra_image_nvrs)
 
         if has_fbc and has_extras:
-            self.logger.error(
+            self.logger.warning(
                 "Cannot resolve single image config for approvers: both FBC_PULLSPECS and "
                 "EXTRA_IMAGE_NVRS are provided. Falling back to group config."
             )
@@ -444,12 +476,12 @@ class ReleaseFromFbcPipeline:
             if len(valid_keys) == 1:
                 return valid_keys[0]
             elif len(valid_keys) == 0:
-                self.logger.error(
+                self.logger.warning(
                     "Cannot resolve single image config for approvers: no valid operator doozer keys "
                     "found from FBC images. Falling back to group config."
                 )
             else:
-                self.logger.error(
+                self.logger.warning(
                     "Cannot resolve single image config for approvers: multiple FBC operators found "
                     f"({valid_keys}). Falling back to group config."
                 )
@@ -457,14 +489,17 @@ class ReleaseFromFbcPipeline:
 
         if has_extras:
             if len(self.extra_image_nvrs) == 1:
-                nvr_dict = parse_nvr(self.extra_image_nvrs[0])
-                component = nvr_dict['name']
-                if component.endswith('-container'):
-                    component = component[: -len('-container')]
-                self.logger.info(f"Single extra NVR component: {component}")
-                return component
+                component = parse_nvr(self.extra_image_nvrs[0])['name']
+                key = await self._resolve_doozer_key_from_component(component)
+                if key:
+                    self.logger.info("Resolved doozer key '%s' from component '%s'", key, component)
+                    return key
+                self.logger.warning(
+                    "Could not resolve doozer key for component '%s', falling back to group config.", component
+                )
+                return None
             else:
-                self.logger.error(
+                self.logger.warning(
                     "Cannot resolve single image config for approvers: multiple EXTRA_IMAGE_NVRS "
                     f"provided ({len(self.extra_image_nvrs)}). Falling back to group config."
                 )
@@ -497,7 +532,14 @@ class ReleaseFromFbcPipeline:
             parsed = stdlib_yaml.safe_load(output)
             if not isinstance(parsed, dict):
                 return {}
-            mr_approvers = parsed.get('images', {}).get(doozer_key)
+            images = parsed.get('images')
+            if not isinstance(images, dict):
+                self.logger.debug(
+                    "Unexpected doozer config:print --yaml structure for '%s': missing 'images' key in envelope",
+                    doozer_key,
+                )
+                return {}
+            mr_approvers = images.get(doozer_key)
             if not isinstance(mr_approvers, dict) or not mr_approvers:
                 return {}
             self.logger.info(f"Loaded mr_approvers from image config '{doozer_key}': {mr_approvers}")
@@ -869,7 +911,7 @@ class ReleaseFromFbcPipeline:
 
         # Configure approval rules: try image config first, fall back to group.yml
         approvers_config: dict[str, list[str]] = {}
-        image_key = self._resolve_single_image_key()
+        image_key = await self._resolve_single_image_key()
         if image_key:
             approvers_config = await self._load_mr_approvers_from_image_config(image_key)
         if not approvers_config:

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -114,6 +114,9 @@ class ReleaseFromFbcPipeline:
         # Product configuration - initialized to None, will be loaded from group config in run()
         self.product = None
 
+        # FBC operator doozer keys - populated during validate_fbc_related_images()
+        self._fbc_operator_keys: List[str] = []
+
         # Set default shipment_path if not provided, using same logic as elliott
         self.shipment_path_was_defaulted = not shipment_path
         if not shipment_path:
@@ -412,6 +415,81 @@ class ReleaseFromFbcPipeline:
                 return parsed
         except Exception as e:
             self.logger.warning(f"Failed to load mr_approvers from group config: {e}")
+        return {}
+
+    def _resolve_single_image_key(self) -> Optional[str]:
+        """
+        Determine the single unambiguous image config doozer key to query for mr_approvers.
+
+        Returns the doozer key if exactly one image/operator can be identified, or None
+        if the situation is ambiguous. Ambiguous cases are logged as errors but do not
+        block the pipeline.
+        """
+        has_fbc = bool(self._fbc_operator_keys)
+        has_extras = bool(self.extra_image_nvrs)
+
+        if has_fbc and has_extras:
+            self.logger.error(
+                "Cannot resolve single image config for approvers: both FBC_PULLSPECS and "
+                "EXTRA_IMAGE_NVRS are provided. Falling back to group config."
+            )
+            return None
+
+        if has_fbc:
+            # Filter out UNKNOWN-* keys (fallback-generated when __doozer_key label was missing)
+            valid_keys = [k for k in self._fbc_operator_keys if not k.startswith("UNKNOWN-")]
+            if len(valid_keys) == 1:
+                return valid_keys[0]
+            elif len(valid_keys) == 0:
+                self.logger.error(
+                    "Cannot resolve single image config for approvers: no valid operator doozer keys "
+                    "found from FBC images. Falling back to group config."
+                )
+            else:
+                self.logger.error(
+                    "Cannot resolve single image config for approvers: multiple FBC operators found "
+                    f"({valid_keys}). Falling back to group config."
+                )
+            return None
+
+        if has_extras:
+            if len(self.extra_image_nvrs) == 1:
+                nvr_dict = parse_nvr(self.extra_image_nvrs[0])
+                component = nvr_dict['name']
+                self.logger.info(f"Single extra NVR component: {component}")
+                return component
+            else:
+                self.logger.error(
+                    "Cannot resolve single image config for approvers: multiple EXTRA_IMAGE_NVRS "
+                    f"provided ({len(self.extra_image_nvrs)}). Falling back to group config."
+                )
+                return None
+
+        return None
+
+    async def _load_mr_approvers_from_image_config(self, doozer_key: str) -> dict[str, list[str]]:
+        """
+        Load the mr_approvers field from a specific image configuration using doozer.
+        Returns a dict mapping approval group names to lists of GitLab usernames,
+        e.g. {"QE": ["user1", "user2"]}. Returns empty dict if not configured.
+        """
+        try:
+            cmd = ['doozer', f'--group={self.group}', '-i', doozer_key, 'config:print', '--key', 'mr_approvers']
+            _, output, _ = await exectools.cmd_gather_async(cmd)
+            output = output.strip()
+            if output and output not in ('None', 'null', '---'):
+                parsed = stdlib_yaml.safe_load(output)
+                if not isinstance(parsed, dict):
+                    self.logger.warning(
+                        "mr_approvers in image config '%s' is not a dict (got %s), ignoring",
+                        doozer_key,
+                        type(parsed).__name__,
+                    )
+                    return {}
+                self.logger.info(f"Loaded mr_approvers from image config '{doozer_key}': {parsed}")
+                return parsed
+        except Exception as e:
+            self.logger.warning(f"Failed to load mr_approvers from image config '{doozer_key}': {e}")
         return {}
 
     async def extract_fbc_labels(self, fbc_pullspec: str) -> Dict[str, Optional[str]]:
@@ -775,8 +853,14 @@ class ReleaseFromFbcPipeline:
             mr_url = mr.web_url
             self.logger.info("Created Merge Request: %s", mr_url)
 
-        # Configure approval rules from group.yml if defined
-        approvers_config = await self._load_mr_approvers_from_group_config()
+        # Configure approval rules: try image config first, fall back to group.yml
+        approvers_config: dict[str, list[str]] = {}
+        image_key = self._resolve_single_image_key()
+        if image_key:
+            approvers_config = await self._load_mr_approvers_from_image_config(image_key)
+        if not approvers_config:
+            approvers_config = await self._load_mr_approvers_from_group_config()
+
         if approvers_config:
             if self.dry_run:
                 self.logger.info("[DRY-RUN] Would set MR approval rules: %s", approvers_config)
@@ -936,6 +1020,9 @@ class ReleaseFromFbcPipeline:
         operator_groups = defaultdict(list)
         for fbc, operator in fbc_to_operator.items():
             operator_groups[operator].append(fbc)
+
+        # Store unique operator keys for approver resolution
+        self._fbc_operator_keys = sorted(operator_groups.keys())
 
         self.logger.info(f"Found {len(operator_groups)} operator group(s):")
         for operator, fbcs in operator_groups.items():

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -456,6 +456,8 @@ class ReleaseFromFbcPipeline:
             if len(self.extra_image_nvrs) == 1:
                 nvr_dict = parse_nvr(self.extra_image_nvrs[0])
                 component = nvr_dict['name']
+                if component.endswith('-container'):
+                    component = component[:-len('-container')]
                 self.logger.info(f"Single extra NVR component: {component}")
                 return component
             else:

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -488,20 +488,20 @@ class ReleaseFromFbcPipeline:
                 'config:print',
                 '--key',
                 'mr_approvers',
+                '--yaml',
             ]
             _, output, _ = await exectools.cmd_gather_async(cmd)
             output = output.strip()
-            if output and output not in ('None', 'null', '---'):
-                parsed = stdlib_yaml.safe_load(output)
-                if not isinstance(parsed, dict):
-                    self.logger.warning(
-                        "mr_approvers in image config '%s' is not a dict (got %s), ignoring",
-                        doozer_key,
-                        type(parsed).__name__,
-                    )
-                    return {}
-                self.logger.info(f"Loaded mr_approvers from image config '{doozer_key}': {parsed}")
-                return parsed
+            if not output:
+                return {}
+            parsed = stdlib_yaml.safe_load(output)
+            if not isinstance(parsed, dict):
+                return {}
+            mr_approvers = parsed.get('images', {}).get(doozer_key)
+            if not isinstance(mr_approvers, dict) or not mr_approvers:
+                return {}
+            self.logger.info(f"Loaded mr_approvers from image config '{doozer_key}': {mr_approvers}")
+            return mr_approvers
         except Exception as e:
             self.logger.warning(f"Failed to load mr_approvers from image config '{doozer_key}': {e}")
         return {}

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -1448,7 +1448,7 @@ class TestResolveSingleImageKey(unittest.TestCase):
     def test_single_extra_nvr_returns_component(self):
         pipeline = self._make_pipeline(extra_image_nvrs=["oadp-velero-container-1.4.5-1.el9"])
         result = pipeline._resolve_single_image_key()
-        self.assertEqual(result, "oadp-velero-container")
+        self.assertEqual(result, "oadp-velero")
 
     def test_multiple_extra_nvrs_returns_none(self):
         pipeline = self._make_pipeline(extra_image_nvrs=["foo-container-1.0-1.el9", "bar-container-2.0-1.el9"])
@@ -1503,7 +1503,7 @@ class TestLoadMrApproversFromImageConfig(unittest.TestCase):
 
     @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
     def test_valid_dict_returned(self, mock_cmd):
-        mock_cmd.return_value = (0, "QE:\n- user1\n- user2\n", "")
+        mock_cmd.return_value = (0, "images:\n  my-operator:\n    QE:\n    - user1\n    - user2\nrpms: {}\n", "")
         pipeline = self._make_pipeline()
         result = asyncio.run(pipeline._load_mr_approvers_from_image_config("my-operator"))
         self.assertEqual(result, {"QE": ["user1", "user2"]})
@@ -1512,24 +1512,25 @@ class TestLoadMrApproversFromImageConfig(unittest.TestCase):
         self.assertIn("-i", cmd_args)
         self.assertIn("my-operator", cmd_args)
         self.assertIn("mr_approvers", cmd_args)
+        self.assertIn("--yaml", cmd_args)
 
     @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
     def test_non_dict_returns_empty(self, mock_cmd):
-        mock_cmd.return_value = (0, "- user1\n- user2\n", "")
+        mock_cmd.return_value = (0, "images:\n  my-operator:\n  - user1\n  - user2\nrpms: {}\n", "")
         pipeline = self._make_pipeline()
         result = asyncio.run(pipeline._load_mr_approvers_from_image_config("my-operator"))
         self.assertEqual(result, {})
 
     @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
     def test_none_output_returns_empty(self, mock_cmd):
-        mock_cmd.return_value = (0, "None", "")
+        mock_cmd.return_value = (0, "images:\n  my-operator: null\nrpms: {}\n", "")
         pipeline = self._make_pipeline()
         result = asyncio.run(pipeline._load_mr_approvers_from_image_config("my-operator"))
         self.assertEqual(result, {})
 
     @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
     def test_null_output_returns_empty(self, mock_cmd):
-        mock_cmd.return_value = (0, "null", "")
+        mock_cmd.return_value = (0, "images:\n  my-operator: null\nrpms: {}\n", "")
         pipeline = self._make_pipeline()
         result = asyncio.run(pipeline._load_mr_approvers_from_image_config("my-operator"))
         self.assertEqual(result, {})
@@ -1542,8 +1543,8 @@ class TestLoadMrApproversFromImageConfig(unittest.TestCase):
         self.assertEqual(result, {})
 
     @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
-    def test_dashes_only_returns_empty(self, mock_cmd):
-        mock_cmd.return_value = (0, "---", "")
+    def test_empty_dict_returns_empty(self, mock_cmd):
+        mock_cmd.return_value = (0, "images:\n  my-operator: {}\nrpms: {}\n", "")
         pipeline = self._make_pipeline()
         result = asyncio.run(pipeline._load_mr_approvers_from_image_config("my-operator"))
         self.assertEqual(result, {})
@@ -1585,7 +1586,11 @@ class TestCreateShipmentMrImageConfigApprovers(unittest.TestCase):
         """When image config has mr_approvers, group.yml is not consulted."""
         # First call: _load_mr_approvers_from_image_config (returns valid config)
         # Second call would be group config but should not happen
-        mock_cmd.return_value = (0, "Release:\n- release_user\n", "")
+        mock_cmd.return_value = (
+            0,
+            "images:\n  cluster-logging-operator:\n    Release:\n    - release_user\nrpms: {}\n",
+            "",
+        )
 
         pipeline = self._make_pipeline(dry_run=False)
         pipeline._fbc_operator_keys = ["cluster-logging-operator"]
@@ -1616,7 +1621,7 @@ class TestCreateShipmentMrImageConfigApprovers(unittest.TestCase):
         async def mock_gather(cmd):
             call_count[0] += 1
             if "config:print" in cmd:
-                return (0, "None", "")
+                return (0, "images:\n  cluster-logging-operator: null\nrpms: {}\n", "")
             elif "config:read-group" in cmd:
                 return (0, "QE:\n- group_user\n", "")
             return (0, "", "")

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -1413,5 +1413,268 @@ class TestOcpOptionalMode(unittest.TestCase):
         pipeline._set_shipment_mr_dependency.assert_not_awaited()
 
 
+class TestResolveSingleImageKey(unittest.TestCase):
+    """Tests for _resolve_single_image_key."""
+
+    def _make_pipeline(self, fbc_pullspecs=None, extra_image_nvrs=None):
+        runtime = MagicMock()
+        runtime.dry_run = False
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        runtime.config = {}
+
+        pipeline = ReleaseFromFbcPipeline(
+            runtime=runtime,
+            group="logging-6.5",
+            assembly="6.5.1",
+            fbc_pullspecs=fbc_pullspecs or [],
+            extra_image_nvrs=extra_image_nvrs,
+            create_mr=False,
+        )
+        return pipeline
+
+    def test_single_fbc_operator_returns_key(self):
+        pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/test/fbc:latest"])
+        pipeline._fbc_operator_keys = ["cluster-logging-operator"]
+        result = pipeline._resolve_single_image_key()
+        self.assertEqual(result, "cluster-logging-operator")
+
+    def test_multiple_fbc_operators_returns_none(self):
+        pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/a:v1", "quay.io/b:v2"])
+        pipeline._fbc_operator_keys = ["operator-a", "operator-b"]
+        result = pipeline._resolve_single_image_key()
+        self.assertIsNone(result)
+
+    def test_single_extra_nvr_returns_component(self):
+        pipeline = self._make_pipeline(extra_image_nvrs=["oadp-velero-container-1.4.5-1.el9"])
+        result = pipeline._resolve_single_image_key()
+        self.assertEqual(result, "oadp-velero-container")
+
+    def test_multiple_extra_nvrs_returns_none(self):
+        pipeline = self._make_pipeline(extra_image_nvrs=["foo-container-1.0-1.el9", "bar-container-2.0-1.el9"])
+        result = pipeline._resolve_single_image_key()
+        self.assertIsNone(result)
+
+    def test_both_fbc_and_extras_returns_none(self):
+        pipeline = self._make_pipeline(
+            fbc_pullspecs=["quay.io/test/fbc:latest"],
+            extra_image_nvrs=["foo-container-1.0-1.el9"],
+        )
+        pipeline._fbc_operator_keys = ["my-operator"]
+        result = pipeline._resolve_single_image_key()
+        self.assertIsNone(result)
+
+    def test_unknown_fbc_keys_filtered_out(self):
+        pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/test/fbc:latest"])
+        pipeline._fbc_operator_keys = ["UNKNOWN-12345678", "cluster-logging-operator"]
+        result = pipeline._resolve_single_image_key()
+        self.assertEqual(result, "cluster-logging-operator")
+
+    def test_only_unknown_fbc_keys_returns_none(self):
+        pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/test/fbc:latest"])
+        pipeline._fbc_operator_keys = ["UNKNOWN-12345678"]
+        result = pipeline._resolve_single_image_key()
+        self.assertIsNone(result)
+
+    def test_no_fbc_no_extras_returns_none(self):
+        pipeline = self._make_pipeline()
+        result = pipeline._resolve_single_image_key()
+        self.assertIsNone(result)
+
+
+class TestLoadMrApproversFromImageConfig(unittest.TestCase):
+    """Tests for _load_mr_approvers_from_image_config."""
+
+    def _make_pipeline(self):
+        runtime = MagicMock()
+        runtime.dry_run = False
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        runtime.config = {}
+
+        pipeline = ReleaseFromFbcPipeline(
+            runtime=runtime,
+            group="logging-6.5",
+            assembly="6.5.1",
+            fbc_pullspecs=["quay.io/test/fbc:latest"],
+            create_mr=False,
+        )
+        return pipeline
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_valid_dict_returned(self, mock_cmd):
+        mock_cmd.return_value = (0, "QE:\n- user1\n- user2\n", "")
+        pipeline = self._make_pipeline()
+        result = asyncio.run(pipeline._load_mr_approvers_from_image_config("my-operator"))
+        self.assertEqual(result, {"QE": ["user1", "user2"]})
+        mock_cmd.assert_called_once()
+        cmd_args = mock_cmd.call_args[0][0]
+        self.assertIn("-i", cmd_args)
+        self.assertIn("my-operator", cmd_args)
+        self.assertIn("mr_approvers", cmd_args)
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_non_dict_returns_empty(self, mock_cmd):
+        mock_cmd.return_value = (0, "- user1\n- user2\n", "")
+        pipeline = self._make_pipeline()
+        result = asyncio.run(pipeline._load_mr_approvers_from_image_config("my-operator"))
+        self.assertEqual(result, {})
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_none_output_returns_empty(self, mock_cmd):
+        mock_cmd.return_value = (0, "None", "")
+        pipeline = self._make_pipeline()
+        result = asyncio.run(pipeline._load_mr_approvers_from_image_config("my-operator"))
+        self.assertEqual(result, {})
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_null_output_returns_empty(self, mock_cmd):
+        mock_cmd.return_value = (0, "null", "")
+        pipeline = self._make_pipeline()
+        result = asyncio.run(pipeline._load_mr_approvers_from_image_config("my-operator"))
+        self.assertEqual(result, {})
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_empty_output_returns_empty(self, mock_cmd):
+        mock_cmd.return_value = (0, "  \n", "")
+        pipeline = self._make_pipeline()
+        result = asyncio.run(pipeline._load_mr_approvers_from_image_config("my-operator"))
+        self.assertEqual(result, {})
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_dashes_only_returns_empty(self, mock_cmd):
+        mock_cmd.return_value = (0, "---", "")
+        pipeline = self._make_pipeline()
+        result = asyncio.run(pipeline._load_mr_approvers_from_image_config("my-operator"))
+        self.assertEqual(result, {})
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_exception_returns_empty(self, mock_cmd):
+        mock_cmd.side_effect = RuntimeError("doozer failed")
+        pipeline = self._make_pipeline()
+        result = asyncio.run(pipeline._load_mr_approvers_from_image_config("my-operator"))
+        self.assertEqual(result, {})
+
+
+class TestCreateShipmentMrImageConfigApprovers(unittest.TestCase):
+    """Tests for image-config-first approver resolution in create_shipment_mr."""
+
+    def _make_pipeline(self, dry_run=False, fbc_pullspecs=None, extra_image_nvrs=None):
+        runtime = MagicMock()
+        runtime.dry_run = dry_run
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        runtime.config = {"gitlab_url": "https://gitlab.example.com"}
+
+        pipeline = ReleaseFromFbcPipeline(
+            runtime=runtime,
+            group="logging-6.5",
+            assembly="6.5.1",
+            fbc_pullspecs=fbc_pullspecs or ["quay.io/test/fbc:latest"],
+            extra_image_nvrs=extra_image_nvrs,
+            create_mr=True,
+        )
+        pipeline.product = "logging"
+        pipeline.shipment_data_repo = AsyncMock()
+        pipeline.shipment_data_repo_push_url = "https://gitlab.example.com/user/ocp-shipment-data.git"
+        pipeline.shipment_data_repo_pull_url = "https://gitlab.example.com/org/ocp-shipment-data.git"
+        return pipeline
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_image_config_approvers_override_group(self, mock_cmd):
+        """When image config has mr_approvers, group.yml is not consulted."""
+        # First call: _load_mr_approvers_from_image_config (returns valid config)
+        # Second call would be group config but should not happen
+        mock_cmd.return_value = (0, "Release:\n- release_user\n", "")
+
+        pipeline = self._make_pipeline(dry_run=False)
+        pipeline._fbc_operator_keys = ["cluster-logging-operator"]
+        pipeline.update_shipment_data = AsyncMock(return_value=True)
+
+        mock_source_project = MagicMock()
+        mock_mr = MagicMock()
+        mock_mr.web_url = "https://gitlab.example.com/org/repo/-/merge_requests/10"
+        mock_source_project.mergerequests.create.return_value = mock_mr
+        pipeline._get_gitlab_project = MagicMock(return_value=mock_source_project)
+
+        mock_gitlab = MagicMock()
+        mock_gitlab.set_mr_approval_rules = AsyncMock()
+        pipeline.__dict__["_gitlab"] = mock_gitlab
+
+        asyncio.run(pipeline.create_shipment_mr({}, env="prod"))
+
+        mock_gitlab.set_mr_approval_rules.assert_awaited_once_with(
+            "https://gitlab.example.com/org/repo/-/merge_requests/10",
+            {"Release": ["release_user"]},
+        )
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_falls_back_to_group_when_image_config_empty(self, mock_cmd):
+        """When image config has no mr_approvers, falls back to group.yml."""
+        call_count = [0]
+
+        async def mock_gather(cmd):
+            call_count[0] += 1
+            if "config:print" in cmd:
+                return (0, "None", "")
+            elif "config:read-group" in cmd:
+                return (0, "QE:\n- group_user\n", "")
+            return (0, "", "")
+
+        mock_cmd.side_effect = mock_gather
+
+        pipeline = self._make_pipeline(dry_run=False)
+        pipeline._fbc_operator_keys = ["cluster-logging-operator"]
+        pipeline.update_shipment_data = AsyncMock(return_value=True)
+
+        mock_source_project = MagicMock()
+        mock_mr = MagicMock()
+        mock_mr.web_url = "https://gitlab.example.com/org/repo/-/merge_requests/11"
+        mock_source_project.mergerequests.create.return_value = mock_mr
+        pipeline._get_gitlab_project = MagicMock(return_value=mock_source_project)
+
+        mock_gitlab = MagicMock()
+        mock_gitlab.set_mr_approval_rules = AsyncMock()
+        pipeline.__dict__["_gitlab"] = mock_gitlab
+
+        asyncio.run(pipeline.create_shipment_mr({}, env="prod"))
+
+        mock_gitlab.set_mr_approval_rules.assert_awaited_once_with(
+            "https://gitlab.example.com/org/repo/-/merge_requests/11",
+            {"QE": ["group_user"]},
+        )
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_ambiguous_falls_back_to_group(self, mock_cmd):
+        """When both fbc_pullspecs and extra_image_nvrs are present, falls back to group."""
+        mock_cmd.return_value = (0, "QE:\n- group_user\n", "")
+
+        pipeline = self._make_pipeline(
+            dry_run=False,
+            fbc_pullspecs=["quay.io/test/fbc:latest"],
+            extra_image_nvrs=["foo-container-1.0-1.el9"],
+        )
+        pipeline._fbc_operator_keys = ["my-operator"]
+        pipeline.update_shipment_data = AsyncMock(return_value=True)
+
+        mock_source_project = MagicMock()
+        mock_mr = MagicMock()
+        mock_mr.web_url = "https://gitlab.example.com/org/repo/-/merge_requests/12"
+        mock_source_project.mergerequests.create.return_value = mock_mr
+        pipeline._get_gitlab_project = MagicMock(return_value=mock_source_project)
+
+        mock_gitlab = MagicMock()
+        mock_gitlab.set_mr_approval_rules = AsyncMock()
+        pipeline.__dict__["_gitlab"] = mock_gitlab
+
+        asyncio.run(pipeline.create_shipment_mr({}, env="prod"))
+
+        # Should use group config since it's ambiguous
+        mock_gitlab.set_mr_approval_rules.assert_awaited_once_with(
+            "https://gitlab.example.com/org/repo/-/merge_requests/12",
+            {"QE": ["group_user"]},
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -1436,23 +1436,42 @@ class TestResolveSingleImageKey(unittest.TestCase):
     def test_single_fbc_operator_returns_key(self):
         pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/test/fbc:latest"])
         pipeline._fbc_operator_keys = ["cluster-logging-operator"]
-        result = pipeline._resolve_single_image_key()
+        result = asyncio.run(pipeline._resolve_single_image_key())
         self.assertEqual(result, "cluster-logging-operator")
 
     def test_multiple_fbc_operators_returns_none(self):
         pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/a:v1", "quay.io/b:v2"])
         pipeline._fbc_operator_keys = ["operator-a", "operator-b"]
-        result = pipeline._resolve_single_image_key()
+        result = asyncio.run(pipeline._resolve_single_image_key())
         self.assertIsNone(result)
 
-    def test_single_extra_nvr_returns_component(self):
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_single_extra_nvr_resolves_via_doozer(self, mock_cmd):
+        """Single extra NVR resolves component to doozer key via images:print."""
+        mock_cmd.return_value = (0, "oadp-velero-container: oadp-velero\n", "")
         pipeline = self._make_pipeline(extra_image_nvrs=["oadp-velero-container-1.4.5-1.el9"])
-        result = pipeline._resolve_single_image_key()
+        result = asyncio.run(pipeline._resolve_single_image_key())
         self.assertEqual(result, "oadp-velero")
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_single_extra_nvr_no_container_suffix(self, mock_cmd):
+        """Extra NVR without -container suffix is resolved via doozer lookup."""
+        mock_cmd.return_value = (0, "my-custom-build: my-custom-image\n", "")
+        pipeline = self._make_pipeline(extra_image_nvrs=["my-custom-build-1.0.0-1.el9"])
+        result = asyncio.run(pipeline._resolve_single_image_key())
+        self.assertEqual(result, "my-custom-image")
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_single_extra_nvr_unresolvable_returns_none(self, mock_cmd):
+        """When doozer cannot resolve the component, returns None for group fallback."""
+        mock_cmd.return_value = (0, "other-component: other-image\n", "")
+        pipeline = self._make_pipeline(extra_image_nvrs=["unknown-component-1.0.0-1.el9"])
+        result = asyncio.run(pipeline._resolve_single_image_key())
+        self.assertIsNone(result)
 
     def test_multiple_extra_nvrs_returns_none(self):
         pipeline = self._make_pipeline(extra_image_nvrs=["foo-container-1.0-1.el9", "bar-container-2.0-1.el9"])
-        result = pipeline._resolve_single_image_key()
+        result = asyncio.run(pipeline._resolve_single_image_key())
         self.assertIsNone(result)
 
     def test_both_fbc_and_extras_returns_none(self):
@@ -1461,24 +1480,24 @@ class TestResolveSingleImageKey(unittest.TestCase):
             extra_image_nvrs=["foo-container-1.0-1.el9"],
         )
         pipeline._fbc_operator_keys = ["my-operator"]
-        result = pipeline._resolve_single_image_key()
+        result = asyncio.run(pipeline._resolve_single_image_key())
         self.assertIsNone(result)
 
     def test_unknown_fbc_keys_filtered_out(self):
         pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/test/fbc:latest"])
         pipeline._fbc_operator_keys = ["UNKNOWN-12345678", "cluster-logging-operator"]
-        result = pipeline._resolve_single_image_key()
+        result = asyncio.run(pipeline._resolve_single_image_key())
         self.assertEqual(result, "cluster-logging-operator")
 
     def test_only_unknown_fbc_keys_returns_none(self):
         pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/test/fbc:latest"])
         pipeline._fbc_operator_keys = ["UNKNOWN-12345678"]
-        result = pipeline._resolve_single_image_key()
+        result = asyncio.run(pipeline._resolve_single_image_key())
         self.assertIsNone(result)
 
     def test_no_fbc_no_extras_returns_none(self):
         pipeline = self._make_pipeline()
-        result = pipeline._resolve_single_image_key()
+        result = asyncio.run(pipeline._resolve_single_image_key())
         self.assertIsNone(result)
 
 
@@ -1529,8 +1548,9 @@ class TestLoadMrApproversFromImageConfig(unittest.TestCase):
         self.assertEqual(result, {})
 
     @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
-    def test_null_output_returns_empty(self, mock_cmd):
-        mock_cmd.return_value = (0, "images:\n  my-operator: null\nrpms: {}\n", "")
+    def test_missing_key_in_envelope_returns_empty(self, mock_cmd):
+        """When the requested doozer key is absent from the images envelope, returns empty."""
+        mock_cmd.return_value = (0, "images:\n  other-operator:\n    QE:\n    - user1\nrpms: {}\n", "")
         pipeline = self._make_pipeline()
         result = asyncio.run(pipeline._load_mr_approvers_from_image_config("my-operator"))
         self.assertEqual(result, {})
@@ -1678,6 +1698,45 @@ class TestCreateShipmentMrImageConfigApprovers(unittest.TestCase):
         mock_gitlab.set_mr_approval_rules.assert_awaited_once_with(
             "https://gitlab.example.com/org/repo/-/merge_requests/12",
             {"QE": ["group_user"]},
+        )
+
+    @patch("pyartcd.pipelines.release_from_fbc.exectools.cmd_gather_async")
+    def test_extras_only_resolves_image_config_approvers(self, mock_cmd):
+        """When only extra NVRs are provided, resolves doozer key and uses image config approvers."""
+
+        async def mock_gather(cmd):
+            if "images:print" in cmd:
+                return (0, "oadp-velero-container: oadp-velero\n", "")
+            elif "config:print" in cmd:
+                return (0, "images:\n  oadp-velero:\n    QE:\n    - image_user\nrpms: {}\n", "")
+            elif "config:read-group" in cmd:
+                return (0, "QE:\n- group_user\n", "")
+            return (0, "", "")
+
+        mock_cmd.side_effect = mock_gather
+
+        pipeline = self._make_pipeline(
+            dry_run=False,
+            fbc_pullspecs=[],
+            extra_image_nvrs=["oadp-velero-container-1.4.5-1.el9"],
+        )
+        pipeline.update_shipment_data = AsyncMock(return_value=True)
+
+        mock_source_project = MagicMock()
+        mock_mr = MagicMock()
+        mock_mr.web_url = "https://gitlab.example.com/org/repo/-/merge_requests/13"
+        mock_source_project.mergerequests.create.return_value = mock_mr
+        pipeline._get_gitlab_project = MagicMock(return_value=mock_source_project)
+
+        mock_gitlab = MagicMock()
+        mock_gitlab.set_mr_approval_rules = AsyncMock()
+        pipeline.__dict__["_gitlab"] = mock_gitlab
+
+        asyncio.run(pipeline.create_shipment_mr({}, env="prod"))
+
+        mock_gitlab.set_mr_approval_rules.assert_awaited_once_with(
+            "https://gitlab.example.com/org/repo/-/merge_requests/13",
+            {"QE": ["image_user"]},
         )
 
 


### PR DESCRIPTION
## Summary

- Extends the release-from-fbc pipeline to read `mr_approvers` from individual image configs (in ocp-build-data) when a single image/operator can be unambiguously identified
- Falls back to `group.yml` approvers when the situation is ambiguous (multiple operators, multiple extra NVRs, or both FBC_PULLSPECS and EXTRA_IMAGE_NVRS provided)
- Adds `mr_approvers` field to the image config JSON schema for validation

## Example image config usage

Add an `mr_approvers` field to the image YAML in ocp-build-data (e.g. `images/cluster-logging-operator.yml`):

```yaml
name: openshift/ose-cluster-logging-operator
distgit:
  component: cluster-logging-operator-container

owners:
  - logging-team@redhat.com

mr_approvers:
  QE:
    - gl_username1
    - gl_username2
  Release:
    - gl_username3

from:
  stream: rhel-9-golang
...
```

When the pipeline detects a single unambiguous operator (e.g. only one FBC pullspec mapping to `cluster-logging-operator`), it will use the image-level `mr_approvers` instead of the group-level one.

## Test plan

- [x] New unit tests for `_resolve_single_image_key()` (8 tests covering all ambiguity scenarios)
- [x] New unit tests for `_load_mr_approvers_from_image_config()` (7 tests covering valid/invalid/error outputs)
- [x] New integration tests for `create_shipment_mr()` image-config-first approver resolution (3 tests)
- [x] All 100 tests in `test_release_from_fbc.py` pass
- [ ] Functional test: Add `mr_approvers` to an image config in ocp-build-data and verify it is picked up during a release-from-fbc run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `mr_approvers` to the image configuration schema to specify per-image merge request approvers (with validation for non-empty group names and usernames).

* **Bug Fixes**
  * Improved merge request approver selection to prefer image-config approvers when a single valid image configuration can be determined, and reliably fall back to group-level settings when inputs are missing, ambiguous, or explicitly unset.

* **Tests**
  * Added unit coverage for image key resolution, loading `mr_approvers` from image configuration, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->