### PR TITLE
ART-18202: Fix reinstall retry stripping packages from upgrade fallback

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -954,13 +954,24 @@ class RpmLockfilePrototypeGenerator:
                             f"{distgit_key}: stage {stage_num}: required Dockerfile packages not available "
                             f"in configured repos, stripping: {sorted(required_missing)}"
                         )
-                removed = self._strip_missing_packages(
-                    missing,
-                    remaining_packages,
-                    remaining_update_targets,
-                    remaining_reinstall,
-                    arch_pkgs,
-                )
+                reinstall_only = missing & set(remaining_reinstall)
+                fully_missing = missing - reinstall_only
+                removed = 0
+                if reinstall_only:
+                    remaining_reinstall[:] = [p for p in remaining_reinstall if p not in reinstall_only]
+                    removed += len(reinstall_only)
+                    self.logger.info(
+                        f"{distgit_key}: stage {stage_num}: stripped from reinstall only "
+                        f"(keeping in install/upgrade): {sorted(reinstall_only)}"
+                    )
+                if fully_missing:
+                    removed += self._strip_missing_packages(
+                        fully_missing,
+                        remaining_packages,
+                        remaining_update_targets,
+                        remaining_reinstall,
+                        arch_pkgs,
+                    )
                 if not removed:
                     raise
                 if stripped_tracker is not None:


### PR DESCRIPTION
When a package in reinstallPackages fails (installed version not in repos), _strip_missing_packages removed it from ALL lists including upgradePackages. This killed the upgrade fallback — the repos had a newer version but the retry never tried it.

Now when a missing package is in remaining_reinstall, only strip from reinstall. Keep in packages and upgradePackages so the next attempt can find the newer repo version via upgrade semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling for missing packages during dependency resolution.
  * Packages that only affect reinstall steps are now removed more precisely, reducing unnecessary changes to other install or update requests.
  * Packages missing from broader build inputs are still filtered out across the appropriate package lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->