### PR TITLE
ART-18202: Reject local RPM file globs from package token extraction

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/resolver.py
+++ b/doozer/doozerlib/lockfile_prototype/resolver.py
@@ -91,7 +91,9 @@ class RpmResolver:
                     retry_rc, _, retry_stderr = await cmd_gather_async(cmd, check=False, env=env)
                     if retry_rc == 0:
                         return LockfileData.model_validate(yaml.safe_load(out_file.read_text()))
-                    self.logger.warning("Retry also failed (exit code %d): %s", retry_rc, retry_stderr)
+                    error_summary = retry_stderr.strip().rsplit("\n", 1)[-1]
+                    self.logger.warning("Retry also failed (exit code %d): %s", retry_rc, error_summary)
+                    self.logger.debug("Full retry stderr:\n%s", retry_stderr)
 
                 raise RuntimeError(f"rpm-lockfile-prototype failed (exit code {rc}): {stderr}")
 

--- a/doozer/doozerlib/lockfile_prototype/shell_parser.py
+++ b/doozer/doozerlib/lockfile_prototype/shell_parser.py
@@ -108,13 +108,19 @@ def _preprocess_for_bashlex(text: str) -> str:
 def _is_valid_package_token(token: str) -> bool:
     """
     Return True if token looks like a package name, file path provide,
-    or glob pattern (e.g. golang-*1.23*).
+    or glob pattern (e.g. golang-*1.23*). Rejects local RPM file paths
+    (globs like ``/path/*.rpm`` or explicit ``.rpm`` files) that can't
+    be resolved via lockfile repos.
     """
     if not token or token.startswith("-") or token.endswith("-"):
         return False
     if "$" in token:
         return False
     if token in (">=", "<=", "==", ">", "<", "!="):
+        return False
+    if token.endswith(".rpm"):
+        return False
+    if "/" in token and "*" in token:
         return False
     return True
 


### PR DESCRIPTION
_is_valid_package_token accepted tokens like
/root/rpmbuild/RPMS/x86_64/pkcs11-helper* from yum install commands. These local RPM globs can't be resolved by rpm-lockfile-prototype and crash it with AttributeError: 'str' object has no attribute 'as_dict'.

Now reject tokens ending with .rpm or containing both / and * (local file globs) while preserving file provides like /usr/lib/udev/scsi_id (no glob, resolved via DNF provides).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry logging when RPM database corruption occurs, so failure messages are shorter and easier to read while still preserving detailed diagnostics for troubleshooting.
  * Tightened package token handling to avoid accepting invalid local RPM file paths and unsupported glob-style patterns, reducing false matches during package resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->