### PR TITLE
Fix git-clone-oci-ta 0.2 multi-refspec regression

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -1324,8 +1324,9 @@ class KonfluxClient:
                     _modify_param(
                         task["params"],
                         "refspec",
-                        f"{commit_sha}:refs/remotes/origin/{target_branch} refs/tags/*:refs/tags/*",
+                        f"{commit_sha}:refs/remotes/origin/{target_branch}",
                     )
+                    _modify_param(task["params"], "fetchTags", "true")
                     if build_params.enable_symlink_check is not None:
                         _modify_param(task["params"], "enableSymlinkCheck", build_params.enable_symlink_check)
                 case "sast-snyk-check":

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -905,7 +905,10 @@ class TestSkipTasks(IsolatedAsyncioTestCase):
                     "taskRunTemplate": {"serviceAccountName": "default"},
                     "pipelineSpec": {
                         "tasks": [
-                            {"name": "clone-repository", "params": [{"name": "refspec", "value": ""}]},
+                            {
+                                "name": "clone-repository",
+                                "params": [{"name": "refspec", "value": ""}, {"name": "fetchTags", "value": "false"}],
+                            },
                             {"name": "build-images", "params": [{"name": "SBOM_TYPE", "value": ""}]},
                             {"name": "clair-scan", "params": []},
                             {"name": "sast-snyk-check", "params": []},


### PR DESCRIPTION
## Summary

- The `konflux-build-cli` Go binary in `git-clone-oci-ta` 0.2 passes the `refspec` parameter as a single argument to `git fetch`, unlike v0.1 which split on whitespace. This caused our space-separated multi-refspec (`commit_sha:refs/remotes/origin/branch refs/tags/*:refs/tags/*`) to fail with exit code 128.
- Split the refspec into a single commit-SHA refspec and use the dedicated `fetchTags` parameter for tag fetching, which v0.2 handles as a separate `git fetch --tags` call.

Raised upstream issue since this is a minor regression https://github.com/konflux-ci/konflux-build-cli/issues/155

## Test plan

- [x] Unit tests pass (`uv run pytest doozer/tests/backend/test_konflux_client.py` -- 45/45 passed)
- [x] Lint passes (`ruff check` + `ruff format --check`)
- [ ] Verify fix on Konflux by re-running a test build against `openshift-priv/art-konflux-template` PR #161


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source fetch behavior for image builds so branch checkouts are handled more explicitly and tag retrieval is configured separately.
  * Updated related test coverage to reflect the new fetch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->