### PR TITLE
ART-18202: Move local RPM filtering from parser to generator level

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -45,6 +45,18 @@ from doozerlib.lockfile_prototype.utils import format_version_pin, pick_minimum_
 from doozerlib.repos import Repos
 
 
+def _is_local_rpm(token: str) -> bool:
+    """
+    Return True if token is a local RPM file path or glob that can't
+    be resolved via lockfile repos (e.g. ``/path/*.rpm``, ``foo.rpm``).
+    """
+    if token.endswith(".rpm"):
+        return True
+    if "/" in token and "*" in token:
+        return True
+    return False
+
+
 def build_rpms_in_yaml(
     repos: list[RepoEntry],
     arches: list[str],
@@ -70,6 +82,12 @@ def build_rpms_in_yaml(
     Return Value(s):
         RpmsInConfig: Config ready for YAML serialization.
     """
+    packages = [p for p in packages if not _is_local_rpm(p)]
+    if arch_specific_packages:
+        arch_specific_packages = {
+            arch: [p for p in pkgs if not _is_local_rpm(p)] for arch, pkgs in arch_specific_packages.items()
+        }
+
     package_entries: list[str | ArchSpecificPackage] = list(packages)
     if arch_specific_packages:
         for arch, arch_pkgs in arch_specific_packages.items():
@@ -1010,11 +1028,11 @@ class RpmLockfilePrototypeGenerator:
                 "continuing without reinstall packages"
             )
             remaining_reinstall.clear()
-        # Clear all upgrade targets for the fallback — the retry loop
-        # already validated the install packages; upgrade targets that
-        # reference packages not in the base image's rpmdb would cause
-        # PackagesNotInstalledError from DNF.
+        # Clear all upgrade targets and disable reinstall→upgrade promotion
+        # for the fallback — upgrade targets that reference packages not in
+        # the base image's rpmdb cause PackagesNotInstalledError from DNF.
         remaining_update_targets.clear()
+        promote_reinstall_to_upgrade = False
         self.upgrades_dropped = True
         in_yaml = self._build_resolve_config(
             repo_list,

--- a/doozer/doozerlib/lockfile_prototype/shell_parser.py
+++ b/doozer/doozerlib/lockfile_prototype/shell_parser.py
@@ -108,19 +108,13 @@ def _preprocess_for_bashlex(text: str) -> str:
 def _is_valid_package_token(token: str) -> bool:
     """
     Return True if token looks like a package name, file path provide,
-    or glob pattern (e.g. golang-*1.23*). Rejects local RPM file paths
-    (globs like ``/path/*.rpm`` or explicit ``.rpm`` files) that can't
-    be resolved via lockfile repos.
+    or glob pattern (e.g. golang-*1.23*).
     """
     if not token or token.startswith("-") or token.endswith("-"):
         return False
     if "$" in token:
         return False
     if token in (">=", "<=", "==", ">", "<", "!="):
-        return False
-    if token.endswith(".rpm"):
-        return False
-    if "/" in token and "*" in token:
         return False
     return True
 

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -13,6 +13,7 @@ import yaml
 from doozerlib.lockfile_prototype.container_utils import ContainerImageHelper
 from doozerlib.lockfile_prototype.generator import (
     RpmLockfilePrototypeGenerator,
+    _is_local_rpm,
     build_rpms_in_yaml,
 )
 from doozerlib.lockfile_prototype.models import (
@@ -107,6 +108,36 @@ class TestBuildRpmsInYaml(unittest.TestCase):
         self.assertEqual(repo_dict["includepkgs"], "golang*")
         self.assertEqual(repo_dict["module_hotfixes"], 1)
         self.assertNotIn("options", repo_dict)
+
+
+class TestIsLocalRpm(unittest.TestCase):
+    def test_explicit_rpm_file(self):
+        self.assertTrue(_is_local_rpm("foo.rpm"))
+        self.assertTrue(_is_local_rpm("/tmp/bar-1.0.x86_64.rpm"))
+
+    def test_path_glob(self):
+        self.assertTrue(_is_local_rpm("/path/to/*.rpm"))
+        self.assertTrue(_is_local_rpm("/opt/rpms/*"))
+
+    def test_normal_packages(self):
+        self.assertFalse(_is_local_rpm("nfs-utils"))
+        self.assertFalse(_is_local_rpm("golang-*1.23*"))
+        self.assertFalse(_is_local_rpm("python3-six"))
+
+    def test_build_rpms_in_yaml_filters_local_rpms(self):
+        """
+        Local RPM file tokens extracted by the parser must be filtered
+        out before reaching rpm-lockfile-prototype.
+        """
+        repos = [RepoEntry(repoid="baseos", baseurl="https://example.com/$basearch/")]
+        result = build_rpms_in_yaml(
+            repos=repos,
+            arches=["x86_64"],
+            packages=["nfs-utils", "/tmp/extras/*.rpm", "jq", "local.rpm"],
+            arch_specific_packages={"x86_64": ["librtas", "/opt/rpms/*"]},
+        )
+        pkg_names = [p if isinstance(p, str) else p.name for p in result.packages]
+        self.assertEqual(pkg_names, ["nfs-utils", "jq", "librtas"])
 
 
 FAKE_LOCKFILE_DATA = LockfileData(
@@ -1100,6 +1131,66 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         # Strippable packages must be gone
         for pkg in failing_pkgs:
             self.assertNotIn(pkg, final_config.reinstallPackages)
+
+    def test_fallback_disables_reinstall_to_upgrade_promotion(self):
+        """
+        When the retry loop exhausts and the fallback fires, reinstall
+        packages must NOT be promoted to upgradePackages. Otherwise
+        base.upgrade() raises PackagesNotInstalledError for packages
+        that are in reinstall but not installed on all arches.
+        """
+        generator = self._make_generator()
+        generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
+
+        failing_pkgs = [f"base-pkg-{i}" for i in range(5)]
+        call_count = 0
+
+        async def mock_resolve(config, image_pullspec=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 5:
+                raise RuntimeError(f"No match for argument: {failing_pkgs[call_count - 1]}")
+            return FAKE_LOCKFILE_DATA.model_copy(deep=True)
+
+        generator._resolver.resolve = AsyncMock(side_effect=mock_resolve)
+
+        repos = [
+            RepoEntry(
+                repoid="rhel-9-baseos-rpms",
+                baseurl="https://example.com/baseos/$basearch/os/",
+            )
+        ]
+
+        # util-linux is a Dockerfile package AND a base image package.
+        # It must stay in reinstallPackages (graceful skip if missing)
+        # but NOT appear in upgradePackages (throws if not installed).
+        all_packages = ["util-linux", "curl"] + failing_pkgs
+        reinstall = ["util-linux", "curl"] + failing_pkgs
+        strippable = set(failing_pkgs)
+
+        result = asyncio.run(
+            generator._resolve_stage_with_retry(
+                repo_list=repos,
+                arches=["x86_64", "aarch64"],
+                packages=all_packages,
+                arch_pkgs={},
+                update_targets=[],
+                image_pullspec="quay.io/test/base@sha256:abc123",
+                distgit_key="ose-vmware-vsphere-csi-driver",
+                stage_num=0,
+                reinstall_packages=reinstall,
+                strippable_packages=strippable,
+            )
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(call_count, 6)
+        fallback_config = generator._resolver.resolve.call_args_list[5][0][0]
+        # Required packages must stay in reinstallPackages
+        self.assertIn("util-linux", fallback_config.reinstallPackages)
+        self.assertIn("curl", fallback_config.reinstallPackages)
+        # upgradePackages must be empty — promotion disabled in fallback
+        self.assertEqual(fallback_config.upgradePackages, [])
 
     def test_upgrade_targets_not_strippable_in_final_stage(self):
         """


### PR DESCRIPTION
Move local RPM filtering from parser to generator level

Also fix fallback path in _resolve_stage_with_retry: disable reinstall-to-upgrade promotion after retry exhaustion. Without this, reinstall packages were promoted to upgradePackages in the fallback resolve, causing PackagesNotInstalledError from base.upgrade() for packages not installed on all arches (e.g. util-linux, pciutils, python3-pecan).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local RPM paths and wildcard RPM patterns are now ignored when generating package lists, so only repository-resolvable packages are included.
  * Retry fallback behavior now avoids treating reinstall targets as upgrade targets after retries are exhausted, improving consistency in package handling.
* **Tests**
  * Added coverage for local RPM detection, package filtering, and retry fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->