### PR TITLE
ART-18202: Fix local RPM leak into reinstall/upgrade and rpmdb retry error propagation

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -87,6 +87,10 @@ def build_rpms_in_yaml(
         arch_specific_packages = {
             arch: [p for p in pkgs if not _is_local_rpm(p)] for arch, pkgs in arch_specific_packages.items()
         }
+    if reinstall_packages:
+        reinstall_packages = [p for p in reinstall_packages if not _is_local_rpm(p)]
+    if upgrade_packages:
+        upgrade_packages = [p for p in upgrade_packages if not _is_local_rpm(p)]
 
     package_entries: list[str | ArchSpecificPackage] = list(packages)
     if arch_specific_packages:

--- a/doozer/doozerlib/lockfile_prototype/resolver.py
+++ b/doozer/doozerlib/lockfile_prototype/resolver.py
@@ -88,12 +88,12 @@ class RpmResolver:
                 if image_pullspec and self._is_rpmdb_corrupt(stderr):
                     self._clear_rpmdb_cache(image_pullspec)
                     self.logger.info("Retrying rpm-lockfile-prototype after RPMDB cache error")
-                    retry_rc, _, retry_stderr = await cmd_gather_async(cmd, check=False, env=env)
-                    if retry_rc == 0:
+                    rc, _, stderr = await cmd_gather_async(cmd, check=False, env=env)
+                    if rc == 0:
                         return LockfileData.model_validate(yaml.safe_load(out_file.read_text()))
-                    error_summary = retry_stderr.strip().rsplit("\n", 1)[-1]
-                    self.logger.warning("Retry also failed (exit code %d): %s", retry_rc, error_summary)
-                    self.logger.debug("Full retry stderr:\n%s", retry_stderr)
+                    error_summary = stderr.strip().rsplit("\n", 1)[-1]
+                    self.logger.warning("Retry also failed (exit code %d): %s", rc, error_summary)
+                    self.logger.debug("Full retry stderr:\n%s", stderr)
 
                 raise RuntimeError(f"rpm-lockfile-prototype failed (exit code {rc}): {stderr}")
 

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -139,6 +139,22 @@ class TestIsLocalRpm(unittest.TestCase):
         pkg_names = [p if isinstance(p, str) else p.name for p in result.packages]
         self.assertEqual(pkg_names, ["nfs-utils", "jq", "librtas"])
 
+    def test_build_rpms_in_yaml_filters_local_rpms_from_reinstall_and_upgrade(self):
+        """
+        Local RPM tokens must also be filtered from reinstallPackages and
+        upgradePackages, not just from packages and arch_specific_packages.
+        """
+        repos = [RepoEntry(repoid="baseos", baseurl="https://example.com/$basearch/")]
+        result = build_rpms_in_yaml(
+            repos=repos,
+            arches=["x86_64"],
+            packages=["curl"],
+            reinstall_packages=["curl", "/tmp/extras/foo.rpm", "glibc"],
+            upgrade_packages=["bash", "/opt/rpms/*", "openssl"],
+        )
+        self.assertEqual(result.reinstallPackages, ["curl", "glibc"])
+        self.assertEqual(result.upgradePackages, ["bash", "openssl"])
+
 
 FAKE_LOCKFILE_DATA = LockfileData(
     lockfileVersion=1,

--- a/doozer/tests/lockfile_prototype/test_resolver.py
+++ b/doozer/tests/lockfile_prototype/test_resolver.py
@@ -469,3 +469,34 @@ class TestResolveRpmdbCorruptionRetry(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             asyncio.run(resolver.resolve(config, image_pullspec="registry.example.com/repo@sha256:abc123"))
         mock_clear.assert_not_called()
+
+    @patch("doozerlib.lockfile_prototype.resolver.RpmResolver._clear_rpmdb_cache")
+    @patch("doozerlib.lockfile_prototype.resolver.cmd_gather_async")
+    def test_retry_raises_retry_error_not_original(self, mock_gather, mock_clear):
+        """
+        When cache corruption triggers a retry and the retry fails with a
+        different error, the raised RuntimeError must contain the retry
+        stderr so the outer retry loop can parse it.
+        """
+        retry_stderr = "dnf.exceptions.PackagesNotInstalledError: No match for argument: nfs-utils: nfs-utils"
+        call_count = 0
+
+        async def mock_cmd(cmd, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return (1, "", self.CORRUPTION_STDERR)
+            return (1, "", retry_stderr)
+
+        mock_gather.side_effect = mock_cmd
+        mock_clear.return_value = True
+
+        resolver = RpmResolver(working_dir=Path(tempfile.mkdtemp()))
+        config = RpmsInConfig(
+            arches=["x86_64"],
+            contentOrigin={"repos": []},
+            packages=[],
+        )
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(resolver.resolve(config, image_pullspec="registry.example.com/repo@sha256:abc123"))
+        self.assertIn("nfs-utils", str(ctx.exception))


### PR DESCRIPTION
build_rpms_in_yaml was only filtering local RPM paths (.rpm files and path globs) from packages and arch_specific_packages. The same tokens could leak through reinstallPackages and upgradePackages when Dockerfile install commands contain local RPM paths that get copied into those lists by _resolve_all_stages. Apply _is_local_rpm filtering to both.

Also fix resolve() to propagate the retry error instead of the original when rpmdb cache corruption triggers a retry. Previously the original copytree error was raised, which _resolve_stage_with_retry couldn't parse for missing packages, causing it to raise immediately instead of stripping the problematic package and retrying.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local RPM entries are now consistently excluded from reinstall and upgrade package lists, matching existing filtering behavior elsewhere.
  * Improved retry error handling so the most recent failure details are surfaced when a retry still fails.

* **Tests**
  * Added coverage for filtering local RPMs from reinstall and upgrade lists.
  * Added coverage for retry failures to verify the correct error message is reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->