### PR TITLE
ART-18061: resolve operand NVRs from Konflux DB at bundle rebase time

### DIFF
--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -29,6 +29,7 @@ from doozerlib import constants, util
 from doozerlib.backend.build_repo import BuildRepo
 from doozerlib.backend.konflux_client import ImageBuildParams, KonfluxClient
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
+from doozerlib.exceptions import DoozerFatalError
 from doozerlib.image import ImageMetadata
 from doozerlib.record_logger import RecordLogger
 from doozerlib.source_resolver import SourceResolution, SourceResolver
@@ -204,67 +205,28 @@ class KonfluxOlmBundleRebaser:
         channel_name = str(channel['name'])
         csv_name = str(channel['currentCSV'])
 
-        # Copy the operator's manifests to the bundle directory
-        bundle_manifests_dir.mkdir(parents=True, exist_ok=True)
-        # Iterate through all bundle manifests files, replacing any image reference tag by its
-        # corresponding SHA.
-        # That is used to allow disconnected installs, where a cluster can't reach external registries
-        # in order to translate image tags into something "pullable"
-        all_found_operands: Dict[
-            str, Tuple[str, str, str]
-        ] = {}  # map of image name to (old_pullspec, new_pullspec, nvr)
-        for src in operator_bundle_dir.iterdir():
-            if src.name == "image-references":
-                continue  # skip image-references file
-            logger.info(f"Processing {src}...")
-            # Read the file content and replace image references
-            async with aiofiles.open(src, 'r') as f:
-                content = await f.read()
-            content, found_images = await self._replace_image_references(
-                str(csv_config['registry']), content, operator_build.engine, metadata
-            )
-            for _, (old_pullspec, new_pullspec, operand_nvr) in found_images.items():
-                logger.info(f"Replaced image reference {old_pullspec} ({operand_nvr}) by {new_pullspec}")
-            all_found_operands.update(found_images)
-            # Write the content to the dest bundle directory
-            dest = bundle_manifests_dir / src.name
-            async with aiofiles.open(dest, 'w') as f:
-                if "clusterserviceversion.yaml" in src.name:
-                    csv = yaml.safe_load(content)
-                    csv['metadata']['annotations']['operators.openshift.io/valid-subscription'] = csv_config[
-                        'valid-subscription-label'
-                    ]
-                    if found_images:
-                        csv["spec"]["relatedImages"] = [
-                            {"name": name, "image": new_pullspec} for name, (_, new_pullspec, _) in found_images.items()
-                        ]
-                    content = yaml.safe_dump(csv)
-                await f.write(content)
-
         # Read image references from the operator's image-references file
-        image_references = {}
+        image_references: dict[str, dict] = {}
         refs_path = operator_bundle_dir / "image-references"
         if not metadata.runtime.group.startswith("openshift-"):
             refs_path = operator_manifests_dir / "../image-references"
         if refs_path.exists():
-            async with aiofiles.open(refs_path, 'r') as f:
+            async with aiofiles.open(refs_path, "r") as f:
                 image_refs = yaml.safe_load(await f.read())
-            for entry in image_refs.get('spec', {}).get('tags', []):
+            for entry in image_refs.get("spec", {}).get("tags", []):
                 image_references[entry["name"]] = entry
 
         # Validate that containerImage annotation in CSV matches an entry in image-references
-        # This catches cases where the upstream CSV has an outdated tag that doesn't match image-references
-        csv_files = list(operator_bundle_dir.glob('*.clusterserviceversion.yaml'))
+        csv_files = list(operator_bundle_dir.glob("*.clusterserviceversion.yaml"))
         if csv_files:
             csv_file = csv_files[0]
-            async with aiofiles.open(csv_file, 'r') as f:
+            async with aiofiles.open(csv_file, "r") as f:
                 csv_content = await f.read()
             csv_data = yaml.safe_load(csv_content)
-            container_image = csv_data.get('metadata', {}).get('annotations', {}).get('containerImage')
+            container_image = csv_data.get("metadata", {}).get("annotations", {}).get("containerImage")
 
             if container_image and image_references:
-                # Check if containerImage matches any spec from image-references
-                specs_from_refs = {ref['from']['name'] for ref in image_references.values()}
+                specs_from_refs = {ref["from"]["name"] for ref in image_references.values()}
                 if container_image not in specs_from_refs:
                     logger.warning(
                         f"CSV containerImage annotation '{container_image}' does not match any entry in image-references file. "
@@ -272,6 +234,69 @@ class KonfluxOlmBundleRebaser:
                         f"Expected one of: {specs_from_refs}. "
                         f"Please update the upstream CSV to use the correct tag from image-references."
                     )
+
+        # For Konflux engine on layered products (non-OCP), resolve operand NVRs
+        # from DB instead of relying on predicted tags from operator rebase.
+        # OCP operators still use the legacy tag-based resolution until this
+        # is validated with layered products first.
+        is_layered = not metadata.runtime.group.startswith("openshift-")
+        resolved_operands: dict[str, tuple[str, str, str]] = {}
+        delivery_override_map: dict[str, str] = {}
+        if operator_build.engine is Engine.KONFLUX and image_references and is_layered:
+            delivery_override_map, _ = self._build_delivery_maps(metadata)
+            resolved_operands = await self._resolve_operands_from_db(metadata, image_references)
+
+        # Copy the operator's manifests to the bundle directory, replacing image
+        # reference tags by their corresponding SHA for disconnected installs
+        bundle_manifests_dir.mkdir(parents=True, exist_ok=True)
+        all_found_operands: Dict[
+            str, Tuple[str, str, str]
+        ] = {}  # map of image name to (old_pullspec, new_pullspec, nvr)
+        for src in operator_bundle_dir.iterdir():
+            if src.name == "image-references":
+                continue
+            logger.info(f"Processing {src}...")
+            async with aiofiles.open(src, "r") as f:
+                content = await f.read()
+
+            if operator_build.engine is Engine.KONFLUX and resolved_operands:
+                # The CSV content has predicted tags from operator rebase (e.g.
+                # registry/ns/image:4.18.0-release). Use regex to find them,
+                # then replace with DB-resolved SHA pullspecs.
+                pullspec_by_delivery = {name: new_ps for name, (_, new_ps, _) in resolved_operands.items()}
+                pattern = KonfluxOlmBundleRebaser._get_image_reference_pattern(str(csv_config["registry"]))
+                found_images: dict[str, tuple[str, str, str]] = {}
+                for match in pattern.finditer(content):
+                    old_pullspec = match.group(0)
+                    _, img_short = match.group(1).rsplit("/", maxsplit=1)
+                    delivery_name = delivery_override_map.get(img_short, img_short)
+                    if delivery_name in pullspec_by_delivery:
+                        content = content.replace(old_pullspec, pullspec_by_delivery[delivery_name])
+                        found_images[delivery_name] = resolved_operands[delivery_name]
+                found_images.update(self._find_external_digest_images(content, found_images))
+            else:
+                # Brew engine: use tag-based regex resolution (legacy path)
+                content, found_images = await self._replace_image_references(
+                    str(csv_config["registry"]), content, operator_build.engine, metadata
+                )
+
+            for _, (old_pullspec, new_pullspec, operand_nvr) in found_images.items():
+                logger.info(f"Replaced image reference {old_pullspec} ({operand_nvr}) by {new_pullspec}")
+            all_found_operands.update(found_images)
+
+            dest = bundle_manifests_dir / src.name
+            async with aiofiles.open(dest, "w") as f:
+                if "clusterserviceversion.yaml" in src.name:
+                    csv = yaml.safe_load(content)
+                    csv["metadata"]["annotations"]["operators.openshift.io/valid-subscription"] = csv_config[
+                        "valid-subscription-label"
+                    ]
+                    if found_images:
+                        csv["spec"]["relatedImages"] = [
+                            {"name": name, "image": new_pullspec} for name, (_, new_pullspec, _) in found_images.items()
+                        ]
+                    content = yaml.safe_dump(csv)
+                await f.write(content)
 
         # Warn if the number of images found in the bundle doesn't match the image-references file
         if len(all_found_operands) != len(image_references):
@@ -354,6 +379,90 @@ class KonfluxOlmBundleRebaser:
         async with aiofiles.open(oit_dir / 'olm_bundle_info.yaml', 'w') as f:
             await f.write(content)
 
+    def _build_delivery_maps(
+        self,
+        metadata: ImageMetadata,
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        """
+        Build delivery override and namespace maps from ocp-build-data image YAMLs.
+
+        Arg(s):
+            metadata: ImageMetadata providing runtime.data_dir.
+        Return Value(s):
+            tuple: (delivery_override_map, delivery_namespace_map)
+                override_map: {versioned_short_name: unversioned_delivery_short_name}
+                namespace_map: {image_short_name: delivery_namespace}
+        """
+        delivery_override_map: dict[str, str] = {}
+        delivery_namespace_map: dict[str, str] = {}
+        data_dir = metadata.runtime.data_dir
+        for yml_path in glob.glob(f"{data_dir}/images/*.yml") + glob.glob(f"{data_dir}/images/*.yaml"):
+            try:
+                with open(yml_path) as yf:
+                    img_data = yaml.safe_load(yf)
+                if not isinstance(img_data, dict):
+                    continue
+                delivery = img_data.get("delivery", {}) or {}
+                repo_names = delivery.get("delivery_repo_names") or []
+                img_short = str(img_data.get("name", "")).rsplit("/", 1)[-1]
+                if repo_names and "/" in str(repo_names[0]):
+                    delivery_namespace_map[img_short] = str(repo_names[0]).rsplit("/", 1)[0]
+                if not delivery.get("delivery_repo_name_override"):
+                    continue
+                if len(repo_names) != 1:
+                    raise ValueError(
+                        f"delivery_repo_name_override is set in {yml_path} but delivery_repo_names has "
+                        f"{len(repo_names)} entries (expected exactly 1)"
+                    )
+                override_short = str(repo_names[0]).rsplit("/", 1)[-1]
+                delivery_override_map[img_short] = override_short
+            except (yaml.YAMLError, OSError) as e:
+                self._logger.debug("Failed to parse image YAML %s: %s", yml_path, e)
+        return delivery_override_map, delivery_namespace_map
+
+    def _build_delivery_pullspec(
+        self,
+        image_short_name: str,
+        image_sha: str,
+        original_namespace: str,
+        metadata: ImageMetadata,
+        delivery_override_map: dict[str, str],
+        delivery_namespace_map: dict[str, str],
+    ) -> tuple[str, str]:
+        """
+        Build the final delivery pullspec for an operand image.
+
+        Arg(s):
+            image_short_name: Short name of the image (e.g. "ose-csi-driver-4.18-rhel9").
+            image_sha: SHA digest (e.g. "sha256:abc123...").
+            original_namespace: Namespace from the original pullspec.
+            metadata: ImageMetadata for group context.
+            delivery_override_map: Versioned-to-unversioned name overrides.
+            delivery_namespace_map: Image-to-namespace overrides.
+        Return Value(s):
+            tuple: (delivery_short_name, new_pullspec)
+        """
+        csv_namespace = self._group_config.get("csv_namespace", "openshift")
+        try:
+            major = int(self._group_config.vars.get("MAJOR", 4))
+        except (ValueError, TypeError) as e:
+            raise ValueError(
+                f"Invalid MAJOR version in group config for {metadata.runtime.group}: "
+                f"{self._group_config.vars.get('MAJOR')}"
+            ) from e
+        default_delivery_namespace = f"openshift{major}"
+        if not metadata.runtime.group.startswith("openshift-"):
+            new_namespace = original_namespace
+        else:
+            new_namespace = (
+                delivery_namespace_map.get(image_short_name, default_delivery_namespace)
+                if original_namespace == csv_namespace
+                else original_namespace
+            )
+        delivery_short_name = delivery_override_map.get(image_short_name, image_short_name)
+        new_pullspec = f"registry.redhat.io/{new_namespace}/{delivery_short_name}@{image_sha}"
+        return delivery_short_name, new_pullspec
+
     @lru_cache
     @staticmethod
     def _get_image_reference_pattern(registry: str):
@@ -397,110 +506,162 @@ class KonfluxOlmBundleRebaser:
                 component_to_meta.setdefault(other_meta.get_component_name(), other_meta)
         return component_to_meta
 
+    async def _resolve_operands_from_db(
+        self,
+        metadata: ImageMetadata,
+        image_references: dict[str, dict],
+    ) -> dict[str, tuple[str, str, str]]:
+        """
+        Resolve ART-built operand images from Konflux DB instead of relying
+        on predicted v-r tags baked into the operator CSV at rebase time.
+
+        At bundle rebase time, all image builds are guaranteed complete
+        (pipeline enforces: image rebase -> image build -> sync -> bundle rebase).
+        So we query the DB for actual builds rather than trusting predicted tags.
+
+        Arg(s):
+            metadata: ImageMetadata of the operator whose bundle is being rebased.
+            image_references: Parsed image-references entries {name: {from: {name: spec}}}.
+        Return Value(s):
+            dict: {delivery_image_short_name: (old_pullspec, new_pullspec, nvr)}
+        """
+        logger = self._logger.getChild(f"[{metadata.distgit_key}]")
+        csv_namespace = self._group_config.get("csv_namespace", "openshift")
+        delivery_override_map, delivery_namespace_map = self._build_delivery_maps(metadata)
+
+        # Phase 1: Query DB for latest builds and collect oc image info coroutines
+        operand_entries: list[tuple[str, str, str]] = []  # (name, spec, build_pullspec)
+        image_info_coros = []
+
+        for name, ref_entry in image_references.items():
+            spec = ref_entry["from"]["name"]
+
+            distgit_key = metadata.runtime.name_in_bundle_map.get(name)
+            if not distgit_key:
+                raise ValueError(f"Unable to find {name} in name_in_bundle_map for {metadata.distgit_key}")
+
+            meta = metadata.runtime.image_map.get(distgit_key)
+            if not meta:
+                meta = metadata.runtime.late_resolve_image(distgit_key, required=False)
+                if meta is None:
+                    raise DoozerFatalError(
+                        f"Attempted to load image {distgit_key} but it has mode disabled; "
+                        f"{metadata.distgit_key} references it in image-references"
+                    )
+
+            el_target = f"el{meta.branch_el_target()}"
+            # Call get_latest_konflux_build directly — this method inherently
+            # requires Konflux DB results regardless of runtime.build_system
+            build = await meta.get_latest_konflux_build(
+                el_target=el_target,
+                exclude_large_columns=True,
+            )
+            if not build:
+                raise ValueError(f"Could not find latest Konflux build for {meta.distgit_key}")
+
+            build_pullspec = f"{self.image_repo}:{meta.image_name_short}-{build.version}-{build.release}"
+            logger.info(f"Resolved {name} -> {build.nvr} (pullspec: {build_pullspec})")
+
+            operand_entries.append((name, spec, build_pullspec))
+            image_info_coros.append(
+                util.oc_image_info_for_arch_async(
+                    build_pullspec,
+                    registry_config=os.getenv("QUAY_AUTH_FILE"),
+                )
+            )
+
+        # Phase 2: Fetch all image infos concurrently
+        image_infos = await asyncio.gather(*image_info_coros)
+
+        resolved: dict[str, tuple[str, str, str]] = {}
+        for (_name, spec, _build_pullspec), image_info in zip(operand_entries, image_infos, strict=True):
+            image_labels = image_info["config"]["config"]["Labels"]
+            image_nvr = f"{image_labels['com.redhat.component']}-{image_labels['version']}-{image_labels['release']}"
+
+            image_sha = (
+                image_info["contentDigest"]
+                if self._group_config.operator_image_ref_mode == "by-arch"
+                else image_info["listDigest"]
+            )
+
+            # Parse the original spec to get namespace and short name
+            # spec format: registry/namespace/image_short:tag
+            parts = spec.rsplit("/", 1)
+            if len(parts) == 2:
+                original_namespace = parts[0].split("/", 1)[-1] if "/" in parts[0] else parts[0]
+                image_short_name = parts[1].split(":")[0].split("@")[0]
+            else:
+                original_namespace = csv_namespace
+                image_short_name = spec.split(":")[0].split("@")[0]
+
+            delivery_short_name, new_pullspec = self._build_delivery_pullspec(
+                image_short_name,
+                image_sha,
+                original_namespace,
+                metadata,
+                delivery_override_map,
+                delivery_namespace_map,
+            )
+            resolved[delivery_short_name] = (spec, new_pullspec, image_nvr)
+
+        return resolved
+
     async def _replace_image_references(self, old_registry: str, content: str, engine: Engine, metadata):
         """
         Replace image references in the content by their corresponding SHA.
-        Returns the content with the replacements and a map of found images in format of {image_name: (old_pullspec, new_pullspec, nvr)}
 
-        This function handles two types of image references:
-        1. ART-built images matching the registry pattern (e.g., registry.redhat.io/openshift/image:tag)
-           - These are resolved via Konflux/Brew to get the SHA digest
-        2. Digest-pinned images (e.g., registry.redhat.io/rhel9/postgresql-15@sha256:...)
-           - These are already pinned and are included in found_images without modification
+        Legacy path used by Brew engine. For Konflux, _resolve_operands_from_db
+        is used instead.
+
+        Arg(s):
+            old_registry: Registry prefix to match (e.g. "registry.redhat.io").
+            content: File content to process.
+            engine: Build engine (KONFLUX or BREW).
+            metadata: ImageMetadata for the operator.
+        Return Value(s):
+            tuple: (new_content, found_images) where found_images is
+                {image_name: (old_pullspec, new_pullspec, nvr)}
         """
         new_content = content
         found_images: Dict[str, Tuple[str, str, str]] = {}
 
         # Step 1: Find and process ART-built images matching the registry pattern
         pattern = KonfluxOlmBundleRebaser._get_image_reference_pattern(old_registry)
-        matches = pattern.finditer(content)
-        art_references = {}  # map of image pullspec to (namespace, image_short_name, image_tag)
-        image_info_tasks = []
-        for match in matches:
+        art_references = {}
+        image_info_coros = []
+        for match in pattern.finditer(content):
             pullspec = match.group(0)
             namespace, image_short_name = match.group(1).rsplit('/', maxsplit=1)
             image_tag = match.group(2)
             art_references[pullspec] = (namespace, image_short_name, image_tag)
 
-        # Get image infos for ART-built images
         for pullspec, (namespace, image_short_name, image_tag) in art_references.items():
             if engine is Engine.KONFLUX:
                 build_pullspec = f"{self.image_repo}:{image_short_name}-{image_tag}"
-                image_info_tasks.append(
-                    asyncio.create_task(
-                        util.oc_image_info_for_arch_async(
-                            build_pullspec,
-                            registry_config=os.getenv("QUAY_AUTH_FILE"),
-                        )
+                image_info_coros.append(
+                    util.oc_image_info_for_arch_async(
+                        build_pullspec,
+                        registry_config=os.getenv("QUAY_AUTH_FILE"),
                     )
                 )
             elif engine is Engine.BREW:
                 build_pullspec = (
                     f"{constants.REGISTRY_PROXY_BASE_URL}/rh-osbs/{namespace}-{image_short_name}:{image_tag}"
                 )
-                image_info_tasks.append(
-                    asyncio.create_task(
-                        util.oc_image_info_for_arch_async(
-                            build_pullspec,
-                        )
+                image_info_coros.append(
+                    util.oc_image_info_for_arch_async(
+                        build_pullspec,
                     )
                 )
-        image_infos = await asyncio.gather(*image_info_tasks)
+        image_infos = await asyncio.gather(*image_info_coros)
 
-        # Replace ART-built image references in the content
-        csv_namespace = self._group_config.get('csv_namespace', 'openshift')
-        # Derive default delivery namespace from MAJOR version (openshift5 for OCP 5.x, openshift4 for older)
-        try:
-            major = int(self._group_config.vars.get('MAJOR', 4))
-        except (ValueError, TypeError) as e:
-            # MAJOR should always be a valid integer in group.yml; if not, this is a config error
-            raise ValueError(
-                f"Invalid MAJOR version in group config for {metadata.runtime.group}: "
-                f"{self._group_config.vars.get('MAJOR')}"
-            ) from e
-        default_delivery_namespace = f'openshift{major}'
-        # Build a map of image short name -> delivery override short name for images that have
-        # delivery_repo_name_override set. This allows operators to reference images using a
-        # versioned internal name (e.g. ose-csi-livenessprobe-4.18-rhel9) while having them
-        # replaced with the preferred unversioned delivery repo name (e.g. ose-csi-livenessprobe-rhel9).
-        _delivery_override_map: Dict[str, str] = {}
-        _delivery_namespace_map: Dict[str, str] = {}
-        _data_dir = metadata.runtime.data_dir
-        for _yml_path in glob.glob(f"{_data_dir}/images/*.yml") + glob.glob(f"{_data_dir}/images/*.yaml"):
-            try:
-                with open(_yml_path) as _yf:
-                    _img_data = yaml.safe_load(_yf)
-                if not isinstance(_img_data, dict):
-                    continue
-                _delivery = _img_data.get('delivery', {}) or {}
-                _repo_names = _delivery.get('delivery_repo_names') or []
-                _img_short = str(_img_data.get('name', '')).rsplit('/', 1)[-1]
-                if _repo_names and '/' in str(_repo_names[0]):
-                    _delivery_namespace_map[_img_short] = str(_repo_names[0]).rsplit('/', 1)[0]
-                if not _delivery.get('delivery_repo_name_override'):
-                    continue
-                if len(_repo_names) != 1:
-                    raise IOError(
-                        f"delivery_repo_name_override is set in {_yml_path} but delivery_repo_names has "
-                        f"{len(_repo_names)} entries (expected exactly 1)"
-                    )
-                _override_short = str(_repo_names[0]).rsplit('/', 1)[-1]
-                _delivery_override_map[_img_short] = _override_short
-            except (yaml.YAMLError, OSError) as e:
-                self._logger.debug("Failed to parse image YAML %s: %s", _yml_path, e)
-        # Map component name (as it appears in the com.redhat.component label / NVR) to the
-        # ART ImageMetadata that builds it, so embargoed operands can be mapped back to a
-        # metadata object to query for a public substitute build. Computed lazily (only if an
-        # embargoed operand is actually encountered below) to avoid the cost of iterating every
-        # image metadata on the common (non-embargoed) path.
-        _component_to_meta: Optional[Dict[str, ImageMetadata]] = None
+        delivery_override_map, delivery_namespace_map = self._build_delivery_maps(metadata)
+        _component_to_meta: Optional[Dict[str, "ImageMetadata"]] = None
 
         for pullspec, image_info in zip(art_references, image_infos):
             image_labels = image_info['config']['config']['Labels']
-            image_version = image_labels['version']
-            image_release = image_labels['release']
             image_component_name = image_labels['com.redhat.component']
-            image_nvr = f"{image_component_name}-{image_version}-{image_release}"
+            image_nvr = f"{image_component_name}-{image_labels['version']}-{image_labels['release']}"
 
             # Operator bundles are only ever shipped publicly, so they must never reference an
             # embargoed (private-fix) operand image. If the resolved operand build is embargoed,
@@ -509,8 +670,6 @@ class KonfluxOlmBundleRebaser:
             try:
                 operand_is_embargoed = engine is Engine.KONFLUX and is_nvr_embargoed(image_nvr)
             except ValueError as e:
-                # is_nvr_embargoed() raises when the NVR's embargo status is ambiguous (e.g. it
-                # matches more than one visibility suffix). Don't guess; fail the rebase.
                 raise KonfluxOlmBundleRebaseError(
                     f"Unable to determine embargo status for operand image {image_nvr} referenced "
                     f"by operator {metadata.distgit_key}: {e}"
@@ -549,52 +708,52 @@ class KonfluxOlmBundleRebaser:
                 )
                 image_nvr = public_build.nvr
 
-            namespace, image_short_name, image_tag = art_references[pullspec]
+            namespace, image_short_name, _image_tag = art_references[pullspec]
             image_sha = (
                 image_info['contentDigest']
                 if self._group_config.operator_image_ref_mode == 'by-arch'
                 else image_info['listDigest']
             )
-            if not metadata.runtime.group.startswith("openshift-"):
-                new_namespace = namespace
-            else:
-                new_namespace = (
-                    _delivery_namespace_map.get(image_short_name, default_delivery_namespace)
-                    if namespace == csv_namespace
-                    else namespace
-                )
-            # If delivery_repo_name_override is set for this image, use the overridden short name
-            # so the final pullspec uses the preferred delivery repo name (e.g. without a version tag).
-            delivery_image_short_name = _delivery_override_map.get(image_short_name, image_short_name)
-            new_pullspec = '{}/{}@{}'.format(
-                'registry.redhat.io',  # hardcoded until appregistry is dead
-                f'{new_namespace}/{delivery_image_short_name}',
+            delivery_short_name, new_pullspec = self._build_delivery_pullspec(
+                image_short_name,
                 image_sha,
+                namespace,
+                metadata,
+                delivery_override_map,
+                delivery_namespace_map,
             )
             new_content = new_content.replace(pullspec, new_pullspec)
-            found_images[delivery_image_short_name] = (pullspec, new_pullspec, image_nvr)
+            found_images[delivery_short_name] = (pullspec, new_pullspec, image_nvr)
 
-        # Step 2: Find digest-pinned images that are already resolved (e.g., external images)
-        # These don't need resolution but should be included in found_images for relatedImages
-        digest_pattern = KonfluxOlmBundleRebaser._get_digest_image_pattern()
-        for match in digest_pattern.finditer(new_content):
-            image_path = match.group(1)  # e.g., registry.redhat.io/rhel9/postgresql-15
-            digest = match.group(2)  # e.g., sha256:abc123...
-            pullspec = f"{image_path}@{digest}"
-
-            # Extract image short name from the path
-            image_short_name = image_path.rsplit('/', 1)[-1]
-
-            # Skip if this image was already processed as an ART-built image
-            if image_short_name in found_images:
-                continue
-
-            # Add to found_images with pullspec as both old and new (no change needed)
-            # Use "external" as NVR since we don't have version info for external images
-            found_images[image_short_name] = (pullspec, pullspec, "external")
-            self._logger.debug(f"Found digest-pinned external image: {pullspec}")
+        # Step 2: Find digest-pinned images (external, already resolved)
+        found_images.update(self._find_external_digest_images(new_content, found_images))
 
         return new_content, found_images
+
+    @staticmethod
+    def _find_external_digest_images(
+        content: str,
+        already_resolved: dict[str, tuple[str, str, str]],
+    ) -> dict[str, tuple[str, str, str]]:
+        """
+        Scan content for digest-pinned external images not already in already_resolved.
+
+        Arg(s):
+            content: File content to scan.
+            already_resolved: Images already resolved (to skip).
+        Return Value(s):
+            dict: {image_short_name: (pullspec, pullspec, "external")}
+        """
+        found: dict[str, tuple[str, str, str]] = {}
+        digest_pattern = KonfluxOlmBundleRebaser._get_digest_image_pattern()
+        for match in digest_pattern.finditer(content):
+            image_path = match.group(1)
+            digest = match.group(2)
+            pullspec = f"{image_path}@{digest}"
+            image_short_name = image_path.rsplit("/", 1)[-1]
+            if image_short_name not in already_resolved and image_short_name not in found:
+                found[image_short_name] = (pullspec, pullspec, "external")
+        return found
 
     @cached_property
     def _operator_index_mode(self):

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -253,10 +253,11 @@ class KonfluxOlmBundleRebaser:
         # is validated with layered products first.
         is_layered = not metadata.runtime.group.startswith("openshift-")
         resolved_operands: dict[str, tuple[str, str, str]] = {}
+        rebased_name_map: dict[str, str] = {}
         delivery_override_map: dict[str, str] = {}
         if operator_build.engine is Engine.KONFLUX and image_references and is_layered:
             delivery_override_map, delivery_namespace_map = self._build_delivery_maps(metadata)
-            resolved_operands = await self._resolve_operands_from_db(
+            resolved_operands, rebased_name_map = await self._resolve_operands_from_db(
                 metadata, image_references, delivery_override_map, delivery_namespace_map
             )
 
@@ -283,7 +284,7 @@ class KonfluxOlmBundleRebaser:
                 for match in pattern.finditer(content):
                     old_pullspec = match.group(0)
                     _, img_short = match.group(1).rsplit("/", maxsplit=1)
-                    delivery_name = delivery_override_map.get(img_short, img_short)
+                    delivery_name = rebased_name_map.get(img_short) or delivery_override_map.get(img_short, img_short)
                     if delivery_name in pullspec_by_delivery:
                         _, new_pullspec, operand_nvr = resolved_operands[delivery_name]
                         content = content.replace(old_pullspec, new_pullspec)
@@ -528,7 +529,7 @@ class KonfluxOlmBundleRebaser:
         image_references: dict[str, dict],
         delivery_override_map: dict[str, str],
         delivery_namespace_map: dict[str, str],
-    ) -> dict[str, tuple[str, str, str]]:
+    ) -> tuple[dict[str, tuple[str, str, str]], dict[str, str]]:
         """
         Resolve ART-built operand images from Konflux DB instead of relying
         on predicted v-r tags baked into the operator CSV at rebase time.
@@ -543,7 +544,10 @@ class KonfluxOlmBundleRebaser:
             delivery_override_map: Versioned-to-unversioned name overrides.
             delivery_namespace_map: Image-to-namespace overrides.
         Return Value(s):
-            dict: {delivery_image_short_name: (old_pullspec, new_pullspec, nvr)}
+            tuple: (resolved, rebased_name_map) where
+                resolved: {delivery_image_short_name: (old_pullspec, new_pullspec, nvr)}
+                rebased_name_map: {image_name_short: delivery_short_name} mapping
+                    the rebased name used in CSV to the delivery key in resolved
         """
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
         csv_namespace = self._group_config.get("csv_namespace", "openshift")
@@ -580,7 +584,7 @@ class KonfluxOlmBundleRebaser:
         # Phase 1b: Fetch all builds concurrently
         builds = await asyncio.gather(*build_coros)
 
-        operand_entries: list[tuple[str, str, str]] = []  # (name, spec, build_pullspec)
+        operand_entries: list[tuple[str, str, str, ImageMetadata]] = []
         image_info_coros = []
         for (name, spec, meta), build in zip(entries_meta, builds, strict=True):
             if not build:
@@ -589,7 +593,7 @@ class KonfluxOlmBundleRebaser:
             build_pullspec = f"{self.image_repo}:{meta.image_name_short}-{build.version}-{build.release}"
             logger.info(f"Resolved {name} -> {build.nvr} (pullspec: {build_pullspec})")
 
-            operand_entries.append((name, spec, build_pullspec))
+            operand_entries.append((name, spec, build_pullspec, meta))
             image_info_coros.append(
                 util.oc_image_info_for_arch_async(
                     build_pullspec,
@@ -601,7 +605,8 @@ class KonfluxOlmBundleRebaser:
         image_infos = await asyncio.gather(*image_info_coros)
 
         resolved: dict[str, tuple[str, str, str]] = {}
-        for (_name, spec, _build_pullspec), image_info in zip(operand_entries, image_infos, strict=True):
+        rebased_name_map: dict[str, str] = {}
+        for (_name, spec, _build_pullspec, meta), image_info in zip(operand_entries, image_infos, strict=True):
             image_labels = image_info["config"]["config"]["Labels"]
             image_nvr = f"{image_labels['com.redhat.component']}-{image_labels['version']}-{image_labels['release']}"
 
@@ -630,8 +635,9 @@ class KonfluxOlmBundleRebaser:
                 delivery_namespace_map,
             )
             resolved[delivery_short_name] = (spec, new_pullspec, image_nvr)
+            rebased_name_map[meta.image_name_short] = delivery_short_name
 
-        return resolved
+        return resolved, rebased_name_map
 
     async def _replace_image_references(self, old_registry: str, content: str, engine: Engine, metadata):
         """

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -469,7 +469,7 @@ class KonfluxOlmBundleRebaser:
             ) from e
         default_delivery_namespace = f"openshift{major}"
         if not metadata.runtime.group.startswith("openshift-"):
-            new_namespace = original_namespace
+            new_namespace = delivery_namespace_map.get(image_short_name, original_namespace)
         else:
             new_namespace = (
                 delivery_namespace_map.get(image_short_name, default_delivery_namespace)
@@ -616,15 +616,17 @@ class KonfluxOlmBundleRebaser:
                 else image_info["listDigest"]
             )
 
-            # Parse the original spec to get namespace and short name
-            # spec format: registry/namespace/image_short:tag
-            parts = spec.rsplit("/", 1)
-            if len(parts) == 2:
-                original_namespace = parts[0].split("/", 1)[-1] if "/" in parts[0] else parts[0]
-                image_short_name = parts[1].split(":")[0].split("@")[0]
+            # Derive namespace and image name from the operand's delivery
+            # config in ocp-build-data rather than from the upstream spec in
+            # image-references (which may point to an unrelated upstream
+            # registry, e.g. quay.io/konveyor/* for OADP).
+            repo_names = meta.config.get("delivery", {}).get("delivery_repo_names") or []
+            if repo_names and "/" in str(repo_names[0]):
+                original_namespace = str(repo_names[0]).rsplit("/", 1)[0]
+                image_short_name = str(repo_names[0]).rsplit("/", 1)[-1]
             else:
+                image_short_name = meta.image_name_short
                 original_namespace = csv_namespace
-                image_short_name = spec.split(":")[0].split("@")[0]
 
             delivery_short_name, new_pullspec = self._build_delivery_pullspec(
                 image_short_name,

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -205,16 +205,28 @@ class KonfluxOlmBundleRebaser:
         channel_name = str(channel['name'])
         csv_name = str(channel['currentCSV'])
 
-        # Read image references from the operator's image-references file
+        # Read image references from the operator's image-references file.
+        # Different operators place the file in different directories, so
+        # search multiple candidates (same order as rebaser.py).
+        refs_path = None
+        for candidate in [operator_bundle_dir, operator_manifests_dir, operator_manifests_dir.parent]:
+            if (candidate / "image-references").exists():
+                refs_path = candidate / "image-references"
+                break
+
         image_references: dict[str, dict] = {}
-        refs_path = operator_bundle_dir / "image-references"
-        if not metadata.runtime.group.startswith("openshift-"):
-            refs_path = operator_manifests_dir.parent / "image-references"
-        if refs_path.exists():
+        if refs_path is not None:
             async with aiofiles.open(refs_path, "r") as f:
                 image_refs = yaml.safe_load(await f.read())
             for entry in image_refs.get("spec", {}).get("tags", []):
                 image_references[entry["name"]] = entry
+        else:
+            logger.warning(
+                f"No image-references file found for {metadata.distgit_key}; "
+                f"searched: {[str(c / 'image-references') for c in [operator_bundle_dir, operator_manifests_dir, operator_manifests_dir.parent]]}. "
+                f"Falling back to legacy tag-based resolution. "
+                f"This fallback will be removed in a future release."
+            )
 
         # Validate that containerImage annotation in CSV matches an entry in image-references
         csv_files = list(operator_bundle_dir.glob("*.clusterserviceversion.yaml"))
@@ -303,7 +315,8 @@ class KonfluxOlmBundleRebaser:
         # Warn if the number of images found in the bundle doesn't match the image-references file
         if len(all_found_operands) != len(image_references):
             logger.warning(
-                f"Found {len(all_found_operands)} images in the bundle, but {len(image_references)} at {refs_path}"
+                f"Found {len(all_found_operands)} images in the bundle, but {len(image_references)} in image-references"
+                f" ({refs_path or 'file not found'})"
             )
             logger.warning(f"Found operands: {all_found_operands}")
 

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -209,7 +209,7 @@ class KonfluxOlmBundleRebaser:
         image_references: dict[str, dict] = {}
         refs_path = operator_bundle_dir / "image-references"
         if not metadata.runtime.group.startswith("openshift-"):
-            refs_path = operator_manifests_dir / "../image-references"
+            refs_path = operator_manifests_dir.parent / "image-references"
         if refs_path.exists():
             async with aiofiles.open(refs_path, "r") as f:
                 image_refs = yaml.safe_load(await f.read())
@@ -243,8 +243,10 @@ class KonfluxOlmBundleRebaser:
         resolved_operands: dict[str, tuple[str, str, str]] = {}
         delivery_override_map: dict[str, str] = {}
         if operator_build.engine is Engine.KONFLUX and image_references and is_layered:
-            delivery_override_map, _ = self._build_delivery_maps(metadata)
-            resolved_operands = await self._resolve_operands_from_db(metadata, image_references)
+            delivery_override_map, delivery_namespace_map = self._build_delivery_maps(metadata)
+            resolved_operands = await self._resolve_operands_from_db(
+                metadata, image_references, delivery_override_map, delivery_namespace_map
+            )
 
         # Copy the operator's manifests to the bundle directory, replacing image
         # reference tags by their corresponding SHA for disconnected installs
@@ -417,7 +419,7 @@ class KonfluxOlmBundleRebaser:
                 override_short = str(repo_names[0]).rsplit("/", 1)[-1]
                 delivery_override_map[img_short] = override_short
             except (yaml.YAMLError, OSError) as e:
-                self._logger.debug("Failed to parse image YAML %s: %s", yml_path, e)
+                self._logger.warning("Failed to parse image YAML %s: %s", yml_path, e)
         return delivery_override_map, delivery_namespace_map
 
     def _build_delivery_pullspec(
@@ -510,6 +512,8 @@ class KonfluxOlmBundleRebaser:
         self,
         metadata: ImageMetadata,
         image_references: dict[str, dict],
+        delivery_override_map: dict[str, str],
+        delivery_namespace_map: dict[str, str],
     ) -> dict[str, tuple[str, str, str]]:
         """
         Resolve ART-built operand images from Konflux DB instead of relying
@@ -522,16 +526,17 @@ class KonfluxOlmBundleRebaser:
         Arg(s):
             metadata: ImageMetadata of the operator whose bundle is being rebased.
             image_references: Parsed image-references entries {name: {from: {name: spec}}}.
+            delivery_override_map: Versioned-to-unversioned name overrides.
+            delivery_namespace_map: Image-to-namespace overrides.
         Return Value(s):
             dict: {delivery_image_short_name: (old_pullspec, new_pullspec, nvr)}
         """
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
         csv_namespace = self._group_config.get("csv_namespace", "openshift")
-        delivery_override_map, delivery_namespace_map = self._build_delivery_maps(metadata)
 
-        # Phase 1: Query DB for latest builds and collect oc image info coroutines
-        operand_entries: list[tuple[str, str, str]] = []  # (name, spec, build_pullspec)
-        image_info_coros = []
+        # Phase 1a: Validate metadata and collect DB query coroutines
+        entries_meta: list[tuple[str, str, ImageMetadata]] = []  # (name, spec, meta)
+        build_coros = []
 
         for name, ref_entry in image_references.items():
             spec = ref_entry["from"]["name"]
@@ -549,13 +554,21 @@ class KonfluxOlmBundleRebaser:
                         f"{metadata.distgit_key} references it in image-references"
                     )
 
+            entries_meta.append((name, spec, meta))
             el_target = f"el{meta.branch_el_target()}"
-            # Call get_latest_konflux_build directly — this method inherently
-            # requires Konflux DB results regardless of runtime.build_system
-            build = await meta.get_latest_konflux_build(
-                el_target=el_target,
-                exclude_large_columns=True,
+            build_coros.append(
+                meta.get_latest_konflux_build(
+                    el_target=el_target,
+                    exclude_large_columns=True,
+                )
             )
+
+        # Phase 1b: Fetch all builds concurrently
+        builds = await asyncio.gather(*build_coros)
+
+        operand_entries: list[tuple[str, str, str]] = []  # (name, spec, build_pullspec)
+        image_info_coros = []
+        for (name, spec, meta), build in zip(entries_meta, builds, strict=True):
             if not build:
                 raise ValueError(f"Could not find latest Konflux build for {meta.distgit_key}")
 
@@ -635,7 +648,7 @@ class KonfluxOlmBundleRebaser:
             image_tag = match.group(2)
             art_references[pullspec] = (namespace, image_short_name, image_tag)
 
-        for pullspec, (namespace, image_short_name, image_tag) in art_references.items():
+        for _pullspec, (namespace, image_short_name, image_tag) in art_references.items():
             if engine is Engine.KONFLUX:
                 build_pullspec = f"{self.image_repo}:{image_short_name}-{image_tag}"
                 image_info_coros.append(
@@ -658,7 +671,7 @@ class KonfluxOlmBundleRebaser:
         delivery_override_map, delivery_namespace_map = self._build_delivery_maps(metadata)
         _component_to_meta: Optional[Dict[str, "ImageMetadata"]] = None
 
-        for pullspec, image_info in zip(art_references, image_infos):
+        for pullspec, image_info in zip(art_references, image_infos, strict=True):
             image_labels = image_info['config']['config']['Labels']
             image_component_name = image_labels['com.redhat.component']
             image_nvr = f"{image_component_name}-{image_labels['version']}-{image_labels['release']}"

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -285,8 +285,9 @@ class KonfluxOlmBundleRebaser:
                     _, img_short = match.group(1).rsplit("/", maxsplit=1)
                     delivery_name = delivery_override_map.get(img_short, img_short)
                     if delivery_name in pullspec_by_delivery:
-                        content = content.replace(old_pullspec, pullspec_by_delivery[delivery_name])
-                        found_images[delivery_name] = resolved_operands[delivery_name]
+                        _, new_pullspec, operand_nvr = resolved_operands[delivery_name]
+                        content = content.replace(old_pullspec, new_pullspec)
+                        found_images[delivery_name] = (old_pullspec, new_pullspec, operand_nvr)
                 found_images.update(self._find_external_digest_images(content, found_images))
             else:
                 # Brew engine: use tag-based regex resolution (legacy path)

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -583,6 +583,493 @@ spec:
             await self.rebaser._rebase_dir(metadata, operator_dir, bundle_dir, MagicMock(), input_release)
             self.assertIn("No files found in bundle directory", str(context.exception))
 
+    @patch("doozerlib.util.oc_image_info_for_arch_async")
+    async def test_resolve_operands_from_db(self, mock_oc_image_info):
+        """
+        Verify that _resolve_operands_from_db resolves operand NVRs from the
+        Konflux DB and returns correctly-formed pullspecs and NVRs.
+        """
+        metadata = MagicMock()
+        metadata.distgit_key = "test-operator"
+        metadata.runtime.group = "openshift-4.18"
+        metadata.runtime.data_dir = "/nonexistent/data/dir"
+
+        # Set up name_in_bundle_map and image_map
+        operand_meta = MagicMock()
+        operand_meta.image_name_short = "ose-operand"
+        operand_meta.distgit_key = "operand"
+        operand_meta.branch_el_target.return_value = 9
+
+        mock_build = MagicMock()
+        mock_build.version = "4.18.0"
+        mock_build.release = "202506120000.p0.g1234567.assembly.stream.el9"
+        mock_build.nvr = "operand-container-4.18.0-202506120000.p0.g1234567.assembly.stream.el9"
+        operand_meta.get_latest_konflux_build = AsyncMock(return_value=mock_build)
+
+        metadata.runtime.name_in_bundle_map = {"operand-image": "operand"}
+        metadata.runtime.image_map = {"operand": operand_meta}
+
+        image_references = {
+            "operand-image": {
+                "name": "operand-image",
+                "from": {"name": "registry.example.com/openshift/ose-operand:v4.18"},
+            },
+        }
+
+        mock_oc_image_info.return_value = {
+            "config": {
+                "config": {
+                    "Labels": {
+                        "com.redhat.component": "operand-container",
+                        "version": "4.18.0",
+                        "release": "202506120000.p0.g1234567.assembly.stream.el9",
+                    }
+                }
+            },
+            "listDigest": "sha256:abc123def456",
+            "contentDigest": "sha256:789xyz000111",
+        }
+        self.rebaser._group_config.get.return_value = "openshift"
+        self.rebaser._group_config.operator_image_ref_mode = "manifest-list"
+        self.rebaser._group_config.vars = {"MAJOR": 4}
+
+        with patch("glob.glob", return_value=[]):
+            resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references)
+
+        self.assertIn("ose-operand", resolved)
+        old_spec, new_pullspec, nvr = resolved["ose-operand"]
+        self.assertEqual(old_spec, "registry.example.com/openshift/ose-operand:v4.18")
+        self.assertIn("registry.redhat.io/openshift4/ose-operand@sha256:abc123def456", new_pullspec)
+        self.assertEqual(nvr, "operand-container-4.18.0-202506120000.p0.g1234567.assembly.stream.el9")
+
+        # Verify DB query was made directly to Konflux
+        operand_meta.get_latest_konflux_build.assert_called_once_with(
+            el_target="el9",
+            exclude_large_columns=True,
+        )
+
+    @patch("doozerlib.util.oc_image_info_for_arch_async")
+    async def test_resolve_operands_from_db_by_arch_mode(self, mock_oc_image_info):
+        """
+        Verify that by-arch mode uses contentDigest instead of listDigest.
+        """
+        metadata = MagicMock()
+        metadata.distgit_key = "test-operator"
+        metadata.runtime.group = "openshift-4.18"
+        metadata.runtime.data_dir = "/nonexistent/data/dir"
+
+        operand_meta = MagicMock()
+        operand_meta.image_name_short = "ose-operand"
+        operand_meta.distgit_key = "operand"
+        operand_meta.branch_el_target.return_value = 9
+        mock_build = MagicMock()
+        mock_build.version = "4.18.0"
+        mock_build.release = "1.el9"
+        mock_build.nvr = "operand-container-4.18.0-1.el9"
+        operand_meta.get_latest_konflux_build = AsyncMock(return_value=mock_build)
+
+        metadata.runtime.name_in_bundle_map = {"operand-image": "operand"}
+        metadata.runtime.image_map = {"operand": operand_meta}
+
+        image_references = {
+            "operand-image": {
+                "name": "operand-image",
+                "from": {"name": "registry.example.com/openshift/ose-operand:v4.18"},
+            },
+        }
+
+        mock_oc_image_info.return_value = {
+            "config": {
+                "config": {
+                    "Labels": {
+                        "com.redhat.component": "operand-container",
+                        "version": "4.18.0",
+                        "release": "1.el9",
+                    }
+                }
+            },
+            "listDigest": "sha256:list111",
+            "contentDigest": "sha256:content222",
+        }
+        self.rebaser._group_config.get.return_value = "openshift"
+        self.rebaser._group_config.operator_image_ref_mode = "by-arch"
+        self.rebaser._group_config.vars = {"MAJOR": 4}
+
+        with patch("glob.glob", return_value=[]):
+            resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references)
+
+        _, new_pullspec, _ = resolved["ose-operand"]
+        self.assertIn("sha256:content222", new_pullspec)
+
+    async def test_resolve_operands_from_db_unknown_image(self):
+        """
+        Verify ValueError when image-references has an image not in name_in_bundle_map.
+        """
+        metadata = MagicMock()
+        metadata.distgit_key = "test-operator"
+        metadata.runtime.group = "openshift-4.18"
+        metadata.runtime.data_dir = "/nonexistent/data/dir"
+        metadata.runtime.name_in_bundle_map = {}
+
+        image_references = {
+            "unknown-image": {
+                "name": "unknown-image",
+                "from": {"name": "registry.example.com/openshift/unknown:v4.18"},
+            },
+        }
+
+        with patch("glob.glob", return_value=[]):
+            with self.assertRaises(ValueError) as ctx:
+                await self.rebaser._resolve_operands_from_db(metadata, image_references)
+        self.assertIn("Unable to find unknown-image in name_in_bundle_map", str(ctx.exception))
+
+    async def test_resolve_operands_from_db_disabled_image(self):
+        """
+        Verify DoozerFatalError when operand image has mode disabled.
+        """
+        from doozerlib.exceptions import DoozerFatalError
+
+        metadata = MagicMock()
+        metadata.distgit_key = "test-operator"
+        metadata.runtime.group = "openshift-4.18"
+        metadata.runtime.data_dir = "/nonexistent/data/dir"
+        metadata.runtime.name_in_bundle_map = {"disabled-image": "disabled-operand"}
+        metadata.runtime.image_map = {}
+        metadata.runtime.late_resolve_image.return_value = None
+
+        image_references = {
+            "disabled-image": {
+                "name": "disabled-image",
+                "from": {"name": "registry.example.com/openshift/disabled:v4.18"},
+            },
+        }
+
+        with patch("glob.glob", return_value=[]):
+            with self.assertRaises(DoozerFatalError):
+                await self.rebaser._resolve_operands_from_db(metadata, image_references)
+
+    async def test_resolve_operands_from_db_no_build(self):
+        """
+        Verify ValueError when no build found in DB for an operand.
+        """
+        metadata = MagicMock()
+        metadata.distgit_key = "test-operator"
+        metadata.runtime.group = "openshift-4.18"
+        metadata.runtime.data_dir = "/nonexistent/data/dir"
+
+        operand_meta = MagicMock()
+        operand_meta.image_name_short = "ose-operand"
+        operand_meta.distgit_key = "operand"
+        operand_meta.branch_el_target.return_value = 9
+        operand_meta.get_latest_konflux_build = AsyncMock(return_value=None)
+
+        metadata.runtime.name_in_bundle_map = {"operand-image": "operand"}
+        metadata.runtime.image_map = {"operand": operand_meta}
+
+        image_references = {
+            "operand-image": {
+                "name": "operand-image",
+                "from": {"name": "registry.example.com/openshift/ose-operand:v4.18"},
+            },
+        }
+
+        with patch("glob.glob", return_value=[]):
+            with self.assertRaises(ValueError) as ctx:
+                await self.rebaser._resolve_operands_from_db(metadata, image_references)
+        self.assertIn("Could not find latest Konflux build", str(ctx.exception))
+
+    @patch("doozerlib.util.oc_image_info_for_arch_async")
+    async def test_resolve_operands_with_delivery_override(self, mock_oc_image_info):
+        """
+        Verify delivery_repo_name_override mapping works in _resolve_operands_from_db.
+        """
+        metadata = MagicMock()
+        metadata.distgit_key = "test-operator"
+        metadata.runtime.group = "openshift-4.18"
+        metadata.runtime.data_dir = "/tmp/test-data-dir"
+
+        operand_meta = MagicMock()
+        operand_meta.image_name_short = "ose-csi-driver-4.18-rhel9"
+        operand_meta.distgit_key = "ose-csi-driver"
+        operand_meta.branch_el_target.return_value = 9
+        mock_build = MagicMock()
+        mock_build.version = "4.18.0"
+        mock_build.release = "1.el9"
+        mock_build.nvr = "ose-csi-driver-container-4.18.0-1.el9"
+        operand_meta.get_latest_konflux_build = AsyncMock(return_value=mock_build)
+
+        metadata.runtime.name_in_bundle_map = {"csi-driver": "ose-csi-driver"}
+        metadata.runtime.image_map = {"ose-csi-driver": operand_meta}
+
+        image_references = {
+            "csi-driver": {
+                "name": "csi-driver",
+                "from": {"name": "registry.example.com/openshift/ose-csi-driver-4.18-rhel9:v4.18"},
+            },
+        }
+
+        mock_oc_image_info.return_value = {
+            "config": {
+                "config": {
+                    "Labels": {
+                        "com.redhat.component": "ose-csi-driver-container",
+                        "version": "4.18.0",
+                        "release": "1.el9",
+                    }
+                }
+            },
+            "listDigest": "sha256:abc123",
+            "contentDigest": "sha256:def456",
+        }
+        self.rebaser._group_config.get.return_value = "openshift"
+        self.rebaser._group_config.operator_image_ref_mode = "manifest-list"
+
+        # Create a temporary YAML file with delivery_repo_name_override
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            metadata.runtime.data_dir = tmpdir
+            images_dir = Path(tmpdir) / "images"
+            images_dir.mkdir()
+            img_yaml = images_dir / "ose-csi-driver.yml"
+            img_yaml.write_text(
+                yaml.safe_dump(
+                    {
+                        "name": "ose-csi-driver-4.18-rhel9",
+                        "delivery": {
+                            "delivery_repo_names": ["openshift4/ose-csi-driver-rhel9"],
+                            "delivery_repo_name_override": True,
+                        },
+                    }
+                )
+            )
+
+            resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references)
+
+        # Should use the override name, not the versioned name
+        self.assertIn("ose-csi-driver-rhel9", resolved)
+        _, new_pullspec, _ = resolved["ose-csi-driver-rhel9"]
+        self.assertIn("ose-csi-driver-rhel9", new_pullspec)
+
+    @patch("pathlib.Path.iterdir")
+    @patch("pathlib.Path.exists", autospec=True)
+    @patch("pathlib.Path.glob")
+    @patch("aiofiles.open")
+    @patch("pathlib.Path.mkdir")
+    @patch("glob.glob")
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxOlmBundleRebaser._build_delivery_maps")
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxOlmBundleRebaser._resolve_operands_from_db")
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxOlmBundleRebaser._create_dockerfile")
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxOlmBundleRebaser._create_oit_files")
+    async def test_rebase_dir_konflux_uses_db_resolution(
+        self,
+        mock_create_oit_files,
+        mock_create_dockerfile,
+        mock_resolve_operands,
+        mock_build_delivery_maps,
+        mock_glob,
+        mock_mkdir,
+        mock_open,
+        mock_path_glob,
+        mock_path_exists,
+        mock_iterdir,
+    ):
+        """
+        Verify that _rebase_dir uses _resolve_operands_from_db for Konflux engine
+        and that regex-based replacement correctly handles predicted tags in the CSV
+        (which differ from the original specs in image-references).
+        """
+        metadata = MagicMock()
+        metadata.config = {
+            "update-csv": {
+                "manifests-dir": "manifests",
+                "bundle-dir": "bundle",
+                "valid-subscription-label": "valid-subscription",
+                "registry": "registry.example.com",
+            },
+        }
+        metadata.distgit_key = "test-operator"
+        # Use a layered product group — DB resolution is gated to non-OCP groups
+        metadata.runtime.group = "mtc-1.8"
+
+        operator_dir = Path("/path/to/operator/dir")
+        bundle_dir = Path("/path/to/bundle/dir")
+        input_release = "1.0-1"
+
+        operator_build = MagicMock()
+        operator_build.engine = Engine.KONFLUX
+        operator_build.nvr = "test-operator-1.0-1"
+
+        mock_glob.return_value = ["/path/to/operator/dir/manifests/package.yaml"]
+
+        image_refs_yaml = yaml.safe_dump(
+            {
+                "spec": {
+                    "tags": [
+                        {"name": "operand-a", "from": {"name": "registry.example.com/openshift/ose-operand-a:v4.18"}},
+                    ]
+                }
+            }
+        )
+        package_yaml = yaml.safe_dump(
+            {
+                "packageName": "test-package",
+                "channels": [{"name": "test-channel", "currentCSV": "test-operator.v1.0.0"}],
+            }
+        )
+
+        # CSV content has PREDICTED tags from operator rebase, NOT the original specs
+        csv_content = (
+            "apiVersion: operators.coreos.com/v1alpha1\n"
+            "kind: ClusterServiceVersion\n"
+            "metadata:\n"
+            "  annotations: {}\n"
+            "  name: test-operator.v1.0.1\n"
+            "spec:\n"
+            "  install:\n"
+            "    spec:\n"
+            "      deployments:\n"
+            "      - spec:\n"
+            "          template:\n"
+            "            spec:\n"
+            "              containers:\n"
+            "              - image: registry.example.com/openshift/ose-operand-a:4.18.0-202506120000.p0.assembly.stream.el9\n"
+        )
+
+        read_call_count = [0]
+        file_contents = [package_yaml, image_refs_yaml, csv_content]
+
+        async def mock_read():
+            idx = read_call_count[0]
+            read_call_count[0] += 1
+            if idx < len(file_contents):
+                return file_contents[idx]
+            return ""
+
+        mock_file = mock_open.return_value.__aenter__.return_value
+        mock_file.read = mock_read
+        mock_file.write = AsyncMock()
+
+        # Only image-references path should "exist"; dependencies/properties paths should not
+        mock_path_exists.side_effect = lambda path_self: "image-references" in str(path_self)
+        mock_path_glob.return_value = []
+
+        bundle_files = [
+            Path("/path/to/operator/dir/manifests/bundle/test.clusterserviceversion.yaml"),
+            Path("/path/to/operator/dir/manifests/bundle/image-references"),
+        ]
+        mock_iterdir.side_effect = lambda: iter(bundle_files)
+
+        mock_build_delivery_maps.return_value = ({}, {})
+        mock_resolve_operands.return_value = {
+            "ose-operand-a": (
+                "registry.example.com/openshift/ose-operand-a:v4.18",
+                "registry.redhat.io/openshift4/ose-operand-a@sha256:abc123",
+                "operand-a-container-4.18.0-1.el9",
+            ),
+        }
+
+        await self.rebaser._rebase_dir(metadata, operator_dir, bundle_dir, operator_build, input_release)
+
+        mock_resolve_operands.assert_called_once()
+
+        # Verify the predicted tag was replaced with the DB-resolved SHA pullspec
+        # by checking what was written to the CSV file
+        write_calls = mock_file.write.call_args_list
+        csv_written = None
+        for call in write_calls:
+            written = call[0][0]
+            if "ose-operand-a" in written or "sha256:abc123" in written:
+                csv_written = written
+                break
+        self.assertIsNotNone(csv_written, "CSV content was not written")
+        self.assertIn("sha256:abc123", csv_written)
+        self.assertNotIn("4.18.0-202506120000.p0.assembly.stream.el9", csv_written)
+
+        # Verify operands passed to _create_oit_files include DB-resolved data
+        mock_create_oit_files.assert_called_once()
+        operands_arg = mock_create_oit_files.call_args[0][4]
+        self.assertIn("ose-operand-a", operands_arg)
+        self.assertEqual(operands_arg["ose-operand-a"][2], "operand-a-container-4.18.0-1.el9")
+
+    @patch("pathlib.Path.iterdir")
+    @patch("pathlib.Path.exists")
+    @patch("pathlib.Path.glob")
+    @patch("aiofiles.open")
+    @patch("pathlib.Path.mkdir")
+    @patch("glob.glob")
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxOlmBundleRebaser._replace_image_references")
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxOlmBundleRebaser._create_dockerfile")
+    @patch("doozerlib.backend.konflux_olm_bundler.KonfluxOlmBundleRebaser._create_oit_files")
+    async def test_rebase_dir_brew_uses_legacy_resolution(
+        self,
+        mock_create_oit_files,
+        mock_create_dockerfile,
+        mock_replace_image_references,
+        mock_glob,
+        mock_mkdir,
+        mock_open,
+        mock_path_glob,
+        mock_path_exists,
+        mock_iterdir,
+    ):
+        """
+        Verify that _rebase_dir still uses _replace_image_references for Brew engine.
+        """
+        metadata = MagicMock()
+        metadata.config = {
+            "update-csv": {
+                "manifests-dir": "manifests",
+                "bundle-dir": "bundle",
+                "valid-subscription-label": "valid-subscription",
+                "registry": "registry.example.com",
+            },
+        }
+        metadata.distgit_key = "test-operator"
+        metadata.runtime.group = "openshift-4.18"
+
+        operator_dir = Path("/path/to/operator/dir")
+        bundle_dir = Path("/path/to/bundle/dir")
+        input_release = "1.0-1"
+
+        # Operator build with Brew engine
+        operator_build = MagicMock()
+        operator_build.engine = Engine.BREW
+        operator_build.nvr = "test-operator-1.0-1"
+
+        mock_glob.return_value = ["/path/to/operator/dir/manifests/package.yaml"]
+
+        package_yaml = yaml.safe_dump(
+            {
+                "packageName": "test-package",
+                "channels": [{"name": "test-channel", "currentCSV": "test-operator.v1.0.0"}],
+            }
+        )
+
+        mock_file = mock_open.return_value.__aenter__.return_value
+        mock_file.read.return_value = package_yaml
+        mock_file.write = AsyncMock()
+
+        mock_path_exists.return_value = False
+        mock_path_glob.return_value = []
+
+        bundle_files = [
+            Path("/path/to/operator/dir/manifests/bundle/file.yaml"),
+            Path("/path/to/operator/dir/manifests/bundle/image-references"),
+        ]
+        mock_iterdir.side_effect = lambda: iter(bundle_files)
+
+        content = "apiVersion: v1\nkind: Pod\n"
+        mock_replace_image_references.return_value = (
+            content,
+            {"image": ("old_pullspec", "new_pullspec", "test-component-1.0-1")},
+        )
+
+        await self.rebaser._rebase_dir(metadata, operator_dir, bundle_dir, operator_build, input_release)
+
+        # Verify _replace_image_references was called (Brew path)
+        mock_replace_image_references.assert_called()
+
 
 class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
     def setUp(self):

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -633,13 +633,14 @@ spec:
         self.rebaser._group_config.operator_image_ref_mode = "manifest-list"
         self.rebaser._group_config.vars = {"MAJOR": 4}
 
-        resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
+        resolved, rebased_name_map = await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
 
         self.assertIn("ose-operand", resolved)
         old_spec, new_pullspec, nvr = resolved["ose-operand"]
         self.assertEqual(old_spec, "registry.example.com/openshift/ose-operand:v4.18")
         self.assertIn("registry.redhat.io/openshift4/ose-operand@sha256:abc123def456", new_pullspec)
         self.assertEqual(nvr, "operand-container-4.18.0-202506120000.p0.g1234567.assembly.stream.el9")
+        self.assertEqual(rebased_name_map["ose-operand"], "ose-operand")
 
         # Verify DB query was made directly to Konflux
         operand_meta.get_latest_konflux_build.assert_called_once_with(
@@ -694,7 +695,7 @@ spec:
         self.rebaser._group_config.operator_image_ref_mode = "by-arch"
         self.rebaser._group_config.vars = {"MAJOR": 4}
 
-        resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
+        resolved, _rebased_name_map = await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
 
         _, new_pullspec, _ = resolved["ose-operand"]
         self.assertIn("sha256:content222", new_pullspec)
@@ -840,7 +841,7 @@ spec:
             )
 
             delivery_override_map, delivery_namespace_map = self.rebaser._build_delivery_maps(metadata)
-            resolved = await self.rebaser._resolve_operands_from_db(
+            resolved, _rebased_name_map = await self.rebaser._resolve_operands_from_db(
                 metadata, image_references, delivery_override_map, delivery_namespace_map
             )
 
@@ -959,13 +960,16 @@ spec:
         mock_iterdir.side_effect = lambda: iter(bundle_files)
 
         mock_build_delivery_maps.return_value = ({}, {})
-        mock_resolve_operands.return_value = {
-            "ose-operand-a": (
-                "registry.example.com/openshift/ose-operand-a:v4.18",
-                "registry.redhat.io/openshift4/ose-operand-a@sha256:abc123",
-                "operand-a-container-4.18.0-1.el9",
-            ),
-        }
+        mock_resolve_operands.return_value = (
+            {
+                "ose-operand-a": (
+                    "registry.example.com/openshift/ose-operand-a:v4.18",
+                    "registry.redhat.io/openshift4/ose-operand-a@sha256:abc123",
+                    "operand-a-container-4.18.0-1.el9",
+                ),
+            },
+            {"ose-operand-a": "ose-operand-a"},
+        )
 
         await self.rebaser._rebase_dir(metadata, operator_dir, bundle_dir, operator_build, input_release)
 

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -633,8 +633,7 @@ spec:
         self.rebaser._group_config.operator_image_ref_mode = "manifest-list"
         self.rebaser._group_config.vars = {"MAJOR": 4}
 
-        with patch("glob.glob", return_value=[]):
-            resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references)
+        resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
 
         self.assertIn("ose-operand", resolved)
         old_spec, new_pullspec, nvr = resolved["ose-operand"]
@@ -695,8 +694,7 @@ spec:
         self.rebaser._group_config.operator_image_ref_mode = "by-arch"
         self.rebaser._group_config.vars = {"MAJOR": 4}
 
-        with patch("glob.glob", return_value=[]):
-            resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references)
+        resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
 
         _, new_pullspec, _ = resolved["ose-operand"]
         self.assertIn("sha256:content222", new_pullspec)
@@ -718,9 +716,8 @@ spec:
             },
         }
 
-        with patch("glob.glob", return_value=[]):
-            with self.assertRaises(ValueError) as ctx:
-                await self.rebaser._resolve_operands_from_db(metadata, image_references)
+        with self.assertRaises(ValueError) as ctx:
+            await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
         self.assertIn("Unable to find unknown-image in name_in_bundle_map", str(ctx.exception))
 
     async def test_resolve_operands_from_db_disabled_image(self):
@@ -744,9 +741,8 @@ spec:
             },
         }
 
-        with patch("glob.glob", return_value=[]):
-            with self.assertRaises(DoozerFatalError):
-                await self.rebaser._resolve_operands_from_db(metadata, image_references)
+        with self.assertRaises(DoozerFatalError):
+            await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
 
     async def test_resolve_operands_from_db_no_build(self):
         """
@@ -773,9 +769,8 @@ spec:
             },
         }
 
-        with patch("glob.glob", return_value=[]):
-            with self.assertRaises(ValueError) as ctx:
-                await self.rebaser._resolve_operands_from_db(metadata, image_references)
+        with self.assertRaises(ValueError) as ctx:
+            await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
         self.assertIn("Could not find latest Konflux build", str(ctx.exception))
 
     @patch("doozerlib.util.oc_image_info_for_arch_async")
@@ -844,7 +839,10 @@ spec:
                 )
             )
 
-            resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references)
+            delivery_override_map, delivery_namespace_map = self.rebaser._build_delivery_maps(metadata)
+            resolved = await self.rebaser._resolve_operands_from_db(
+                metadata, image_references, delivery_override_map, delivery_namespace_map
+            )
 
         # Should use the override name, not the versioned name
         self.assertIn("ose-csi-driver-rhel9", resolved)

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -850,6 +850,84 @@ spec:
         _, new_pullspec, _ = resolved["ose-csi-driver-rhel9"]
         self.assertIn("ose-csi-driver-rhel9", new_pullspec)
 
+    @patch("doozerlib.util.oc_image_info_for_arch_async")
+    async def test_resolve_operands_from_db_layered_upstream_registry(self, mock_oc_image_info):
+        """
+        Verify that for a layered product (e.g. OADP) whose image-references
+        point to an upstream registry (quay.io/konveyor/*), the delivery
+        pullspec uses the namespace and image name from ocp-build-data
+        delivery_repo_names, not the upstream spec.
+
+        Regression test: without the fix, the result would be
+        registry.redhat.io/konveyor/velero@sha256:... instead of the correct
+        registry.redhat.io/oadp/oadp-velero-rhel9@sha256:...
+        """
+        metadata = MagicMock()
+        metadata.distgit_key = "oadp-operator"
+        metadata.runtime.group = "oadp-1.5"
+        metadata.runtime.data_dir = "/tmp/test-oadp-data"
+
+        operand_meta = MagicMock()
+        operand_meta.image_name_short = "oadp-velero-rhel9"
+        operand_meta.distgit_key = "oadp-velero"
+        operand_meta.branch_el_target.return_value = 9
+        operand_meta.config = Model(
+            {
+                "delivery": {
+                    "delivery_repo_names": ["oadp/oadp-velero-rhel9"],
+                },
+            }
+        )
+
+        mock_build = MagicMock()
+        mock_build.version = "1.5.8"
+        mock_build.release = "202507160000.p0.g1234567.assembly.stream.el9"
+        mock_build.nvr = "oadp-velero-container-1.5.8-202507160000.p0.g1234567.assembly.stream.el9"
+        operand_meta.get_latest_konflux_build = AsyncMock(return_value=mock_build)
+
+        metadata.runtime.name_in_bundle_map = {"oadp-velero-rhel9": "oadp-velero"}
+        metadata.runtime.image_map = {"oadp-velero": operand_meta}
+
+        image_references = {
+            "oadp-velero-rhel9": {
+                "name": "oadp-velero-rhel9",
+                "from": {"name": "quay.io/konveyor/velero:oadp-1.5"},
+            },
+        }
+
+        mock_oc_image_info.return_value = {
+            "config": {
+                "config": {
+                    "Labels": {
+                        "com.redhat.component": "oadp-velero-container",
+                        "version": "1.5.8",
+                        "release": "202507160000.p0.g1234567.assembly.stream.el9",
+                    }
+                }
+            },
+            "listDigest": "sha256:oadpvelerodigest111",
+            "contentDigest": "sha256:oadpvelerocontentdigest222",
+        }
+        self.rebaser._group_config.get.return_value = "oadp"
+        self.rebaser._group_config.operator_image_ref_mode = "manifest-list"
+        self.rebaser._group_config.vars = {"MAJOR": 4}
+
+        delivery_namespace_map = {"oadp-velero-rhel9": "oadp"}
+        resolved, rebased_name_map = await self.rebaser._resolve_operands_from_db(
+            metadata,
+            image_references,
+            {},
+            delivery_namespace_map,
+        )
+
+        self.assertIn("oadp-velero-rhel9", resolved)
+        old_spec, new_pullspec, nvr = resolved["oadp-velero-rhel9"]
+        self.assertEqual(old_spec, "quay.io/konveyor/velero:oadp-1.5")
+        self.assertEqual(new_pullspec, "registry.redhat.io/oadp/oadp-velero-rhel9@sha256:oadpvelerodigest111")
+        self.assertNotIn("konveyor", new_pullspec)
+        self.assertEqual(nvr, "oadp-velero-container-1.5.8-202507160000.p0.g1234567.assembly.stream.el9")
+        self.assertEqual(rebased_name_map["oadp-velero-rhel9"], "oadp-velero-rhel9")
+
     @patch("pathlib.Path.iterdir")
     @patch("pathlib.Path.exists", autospec=True)
     @patch("pathlib.Path.glob")


### PR DESCRIPTION
  ## Summary

Phase 1 of [ART-18061](https://redhat.atlassian.net/browse/ART-18061): resolve operand NVRs from Konflux DB at bundle rebase time instead of relying on predicted v-r tags from operator rebase.

Currently, operator rebase predicts operand NVRs and bakes them into the CSV. Bundle and FBC builds consume these predictions — but predicted NVRs can go stale when operands are rebuilt between rebase and prepare-release. This causes recurring prepare-release failures (most recently hit on 4.14.64).

**Gated to layered products only** (non-`openshift-*` groups) as a POC. OCP operators continue using the legacy tag-based resolution until validated.

  ## What changes

- **`_resolve_operands_from_db()`** — new method that queries Konflux DB for latest successful build of each operand via `get_latest_konflux_build()`, then resolves SHA digests via `oc image info`
- **`_rebase_dir()`** — for layered Konflux operators, uses regex to match predicted tags in CSV content, replaces with DB-resolved SHA pullspecs
- **`_build_delivery_maps()`** / **`_build_delivery_pullspec()`** / **`_find_external_digest_images()`** — extracted shared helpers, eliminating duplication between the new DB path and legacy `_replace_image_references()`
- **`_replace_image_references()`** — refactored to use shared helpers, kept as fallback for Brew engine and OCP Konflux operators

## What stays the same

- Operator rebase still writes predicted tags (cleanup in Phase 2)
- Brew engine path unchanged
- OCP operators (`openshift-*` groups) unchanged
- `olm_bundle_info.yaml`, bundle DB records, FBC rebase, prepare-release validation — all consume the same data structures

## Jira

[ART-18061](https://issues.redhat.com/browse/ART-18061)

## Test plan

- [x] 8 new unit tests covering DB resolution, error cases, delivery overrides, by-arch mode
- [x] 2 new integration tests verifying Konflux path uses DB resolution and Brew path uses legacy
- [x] Test verifies predicted tags (not original specs) are correctly replaced in CSV content
- [x] All 1336 existing doozer tests pass, lint clean
- [ ] Dry-run with a real layered product operator (MTC or OADP) to compare `olm_bundle_info.yaml` output against production

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Konflux-based bundle rebasing now reads the operator’s `image-references`, resolves operand images from Konflux build data, and rewrites bundle/CSV images to use digest-pinned pullspecs.
  * For layered products, delivery pullspec resolution is now DB-backed, including support for delivery repository overrides.
* **Bug Fixes**
  * Warns when the CSV container image doesn’t match parsed `image-references`, improves handling for disabled/unknown operands, and better preserves existing external digest-pinned images.
  * Non-layered/legacy flows retain previous behavior.
* **Tests**
  * Expanded async unit coverage for DB resolution, overrides, and engine-specific rebasing/error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->