### PR TITLE
ART-21330: Fix FBC build crash on olm.deprecations blobs

### DIFF
--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -1574,7 +1574,8 @@ class KonfluxFbcRebaser:
                     raise IOError(f"Found unsupported schema: {schema}")
             if not package_name:
                 raise IOError(f"Couldn't determine package name for unknown schema: {schema}")
-            categorized_blobs.setdefault(package_name, {}).setdefault(schema, {})[blob["name"]] = blob
+            blob_key = package_name if schema == "olm.deprecations" else blob["name"]
+            categorized_blobs.setdefault(package_name, {}).setdefault(schema, {})[blob_key] = blob
         return categorized_blobs
 
 

--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -678,17 +678,27 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
         mock_render.assert_called_once_with("test-image-pullspec", migrate_level="none", auth=ANY)
 
     def test_categorize_catalog_blobs(self):
+        deprecation_blob = {
+            "schema": "olm.deprecations",
+            "package": "test-package",
+            "entries": [
+                {"reference": {"schema": "olm.bundle", "name": "test-bundle.v1.0.0"}, "message": "deprecated"},
+            ],
+        }
         catalog_blobs = [
             {"schema": "olm.package", "name": "test-package"},
             {"schema": "olm.channel", "name": "test-channel", "package": "test-package"},
             {"schema": "olm.bundle", "name": "test-bundle", "package": "test-package"},
+            deprecation_blob,
             {"schema": "olm.package", "name": "test-package2"},
             {"schema": "olm.channel", "name": "test-channel2", "package": "test-package2"},
             {"schema": "olm.bundle", "name": "test-bundle2", "package": "test-package2"},
         ]
         actual = self.rebaser._catagorize_catalog_blobs(catalog_blobs)
         self.assertEqual(actual.keys(), {"test-package", "test-package2"})
-        self.assertEqual(actual["test-package"].keys(), {"olm.package", "olm.channel", "olm.bundle"})
+        self.assertEqual(
+            actual["test-package"].keys(), {"olm.package", "olm.channel", "olm.bundle", "olm.deprecations"}
+        )
         self.assertEqual(
             actual["test-package"]["olm.package"]["test-package"], {"schema": "olm.package", "name": "test-package"}
         )
@@ -700,6 +710,7 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
             actual["test-package"]["olm.bundle"]["test-bundle"],
             {"schema": "olm.bundle", "name": "test-bundle", "package": "test-package"},
         )
+        self.assertEqual(actual["test-package"]["olm.deprecations"]["test-package"], deprecation_blob)
         self.assertEqual(actual["test-package2"].keys(), {"olm.package", "olm.channel", "olm.bundle"})
         self.assertEqual(
             actual["test-package2"]["olm.package"]["test-package2"], {"schema": "olm.package", "name": "test-package2"}


### PR DESCRIPTION
## Summary
- Fix `KeyError: 'name'` crash in `_catagorize_catalog_blobs` when processing `olm.deprecations` catalog blobs, which lack a top-level `name` field per the OLM FBC spec.
- Use `blob.get("name", package_name)` as the dictionary key so deprecation blobs fall back to `package_name` (correct since the OLM spec mandates one deprecation blob per package).
- First hit on the `multiclusterhub-operator` (ACM) FBC build because `redhat-operator-index:v4.18` contains deprecation entries for `advanced-cluster-management`.

Error seen in log: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-fbc/36186/

## Test plan
- [x] Unit test `test_categorize_catalog_blobs` extended to include `olm.deprecations` blob and passes
- [ ] Re-run `build-fbc` Jenkins job for `multiclusterhub-operator` to verify end-to-end

Jira: https://redhat.atlassian.net/browse/ART-21330


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed how catalog blobs are indexed for per-package storage, so `olm.deprecations` entries are keyed by package name and are retrieved correctly alongside other schema content.
* **Tests**
  * Expanded backend test coverage to include an `olm.deprecations` blob and updated assertions to verify it is categorized under the expected package output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->