### PR TITLE
Add EFFECTIVE_TIME parameter to EC verification PipelineRuns

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -953,6 +953,7 @@ class KonfluxClient:
         ec_pipeline_url: str = constants.KONFLUX_EC_PIPELINE_GIT_URL,
         ec_pipeline_revision: str = constants.KONFLUX_EC_PIPELINE_REVISION,
         ec_pipeline_path: str = constants.KONFLUX_EC_PIPELINE_PATH,
+        effective_time: Optional[str] = None,
     ) -> dict:
         """Create a PipelineRun manifest for enterprise-contract verification.
 
@@ -1002,6 +1003,7 @@ class KonfluxClient:
                     {"name": "POLICY_CONFIGURATION", "value": policy_configuration},
                     {"name": "SINGLE_COMPONENT", "value": "true"},
                     {"name": "SNAPSHOT", "value": snapshot_json},
+                    *([{"name": "EFFECTIVE_TIME", "value": effective_time}] if effective_time else []),
                 ],
                 "taskRunTemplate": {
                     "serviceAccountName": f"build-pipeline-{component_name}",
@@ -1022,6 +1024,7 @@ class KonfluxClient:
         commit_sha: str,
         its_name: str,
         policy_configuration: str,
+        effective_time: Optional[str] = None,
     ) -> PipelineRunInfo:
         """Start an enterprise-contract verification PipelineRun.
 
@@ -1067,6 +1070,7 @@ class KonfluxClient:
             its_name=its_name,
             policy_configuration=policy_configuration,
             watch_labels=watch_labels,
+            effective_time=effective_time,
         )
 
         if self.dry_run:
@@ -1090,6 +1094,7 @@ class KonfluxClient:
         commit_sha: str,
         ec_policy: str,
         logger: logging.Logger,
+        effective_time: Optional[str] = None,
     ) -> ECVerificationResult:
         """Run enterprise-contract verification for a built image.
 
@@ -1123,6 +1128,7 @@ class KonfluxClient:
                 commit_sha=commit_sha,
                 its_name=its_name,
                 policy_configuration=ec_policy,
+                effective_time=effective_time,
             )
             ec_plr_name = ec_plr_info.name
 

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -97,6 +97,7 @@ class KonfluxImageBuilderConfig:
     ec_policy_configuration: str = constants.KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION
     prega_ec_policy_configuration: str = constants.KONFLUX_PREGA_EC_POLICY_CONFIGURATION
     skip_ec_verify: bool = False
+    effective_time: Optional[str] = None
 
 
 class KonfluxImageBuilder:
@@ -342,6 +343,7 @@ class KonfluxImageBuilder:
                         commit_sha=build_repo.commit_hash,
                         ec_policy=ec_policy,
                         logger=logger,
+                        effective_time=self._config.effective_time,
                     )
                     if ec_result.ec_failed:
                         ec_pipeline_url = ec_result.ec_pipeline_url

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -620,6 +620,7 @@ class KonfluxOlmBundleBuilder:
         assembly_type: Optional[AssemblyTypes] = None,
         record_logger: Optional[RecordLogger] = None,
         logger: logging.Logger = _LOGGER,
+        effective_time: Optional[str] = None,
     ) -> None:
         self.base_dir = base_dir
         self.group = group
@@ -636,6 +637,7 @@ class KonfluxOlmBundleBuilder:
         self.dry_run = dry_run
         self.skip_ec_verify = skip_ec_verify
         self.assembly_type = assembly_type
+        self.effective_time = effective_time
         self._record_logger = record_logger
         self._logger = logger
         self._konflux_client = KonfluxClient.from_kubeconfig(
@@ -815,6 +817,7 @@ class KonfluxOlmBundleBuilder:
                             commit_sha=bundle_build_repo.commit_hash,
                             ec_policy=ec_policy,
                             logger=logger,
+                            effective_time=self.effective_time,
                         )
                         ec_pipeline_url = ec_result.ec_pipeline_url
                         if ec_result.ec_failed:

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -268,6 +268,7 @@ class KonfluxBuildCli:
         build_priority: Optional[str],
         skip_ec_verify: bool = False,
         skip_tasks: tuple[str, ...] = (),
+        effective_time: Optional[str] = None,
     ):
         self.runtime = runtime
         self.konflux_kubeconfig = konflux_kubeconfig
@@ -281,6 +282,7 @@ class KonfluxBuildCli:
         self.plr_template = plr_template
         self.build_priority = build_priority
         self.skip_ec_verify = skip_ec_verify
+        self.effective_time = effective_time
 
         validate_build_priority(self.build_priority)
 
@@ -329,6 +331,7 @@ class KonfluxBuildCli:
             ec_policy_configuration=ec_policy,
             prega_ec_policy_configuration=prega_ec_policy,
             skip_ec_verify=self.skip_ec_verify,
+            effective_time=self.effective_time,
         )
         builder = KonfluxImageBuilder(config=config, record_logger=runtime.record_logger)
 
@@ -421,6 +424,12 @@ class KonfluxBuildCli:
     is_flag=True,
     help='Skip enterprise-contract verification after builds.',
 )
+@click.option(
+    '--effective-time',
+    default=None,
+    type=str,
+    help='Run EC policy checks at a future time. Expects RFC3339 format, e.g. "2026-07-10T00:00:00Z". Defaults to "now".',
+)
 @pass_runtime
 @click_coroutine
 async def images_konflux_build(
@@ -436,6 +445,7 @@ async def images_konflux_build(
     build_priority: Optional[str],
     network_mode: Optional[str],
     skip_ec_verify: bool,
+    effective_time: Optional[str],
 ):
     if network_mode:
         runtime.network_mode_override = network_mode
@@ -453,6 +463,7 @@ async def images_konflux_build(
         plr_template=plr_template,
         build_priority=build_priority,
         skip_ec_verify=skip_ec_verify,
+        effective_time=effective_time,
     )
     await cli.run()
 
@@ -473,6 +484,7 @@ class KonfluxBundleCli:
         plr_template: str,
         output: str,
         skip_tasks: tuple[str, ...] = (),
+        effective_time: Optional[str] = None,
     ):
         self.runtime = runtime
         self.operator_nvrs = list(operator_nvrs)
@@ -487,6 +499,7 @@ class KonfluxBundleCli:
         self.release = release
         self.output = output
         self.plr_template = plr_template
+        self.effective_time = effective_time
         self._db_for_bundles = KonfluxDb()
         self._db_for_bundles.bind(KonfluxBundleBuildRecord)
 
@@ -638,6 +651,7 @@ class KonfluxBundleCli:
             dry_run=self.dry_run,
             assembly_type=runtime.assembly_type,
             record_logger=runtime.record_logger,
+            effective_time=self.effective_time,
         )
 
         # Mint a per-invocation GitHub App token for git-clone auth
@@ -759,6 +773,12 @@ class KonfluxBundleCli:
     default='json',
     help='Output format for the build records.',
 )
+@click.option(
+    '--effective-time',
+    default=None,
+    type=str,
+    help='Run EC policy checks at a future time. Expects RFC3339 format, e.g. "2026-07-10T00:00:00Z". Defaults to "now".',
+)
 @pass_runtime
 @click_coroutine
 async def images_konflux_bundle(
@@ -775,6 +795,7 @@ async def images_konflux_bundle(
     release: Optional[str],
     plr_template: str,
     output: str,
+    effective_time: Optional[str],
 ):
     cli = KonfluxBundleCli(
         runtime=runtime,
@@ -790,5 +811,6 @@ async def images_konflux_bundle(
         release=release,
         plr_template=plr_template,
         output=output,
+        effective_time=effective_time,
     )
     await cli.run()

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -4,6 +4,7 @@ import logging
 import os
 import shutil
 import tempfile
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Optional, Tuple
@@ -470,6 +471,10 @@ class KonfluxOcpPipeline:
         if self.skip_ec_verify:
             LOGGER.info('Skipping EC verification as requested')
             cmd.append('--skip-ec-verify')
+
+        effective_time = (datetime.now(timezone.utc) + timedelta(days=14)).strftime("%Y-%m-%dT00:00:00Z")
+        LOGGER.info(f"Using EC effective time: {effective_time}")
+        cmd.extend(['--effective-time', effective_time])
 
         await exectools.cmd_assert_async(cmd)
 


### PR DESCRIPTION
## Summary

- Thread an `EFFECTIVE_TIME` parameter through the EC verification call chain so that policy rules with upcoming effective dates are caught **before** they become enforced.
- `ocp4_konflux.py` computes `utcnow + 14 days` as RFC3339 and passes `--effective-time` to the doozer build command.
- Doozer CLI (`beta:images:konflux:build` and `beta:images:konflux:bundle`) accepts `--effective-time` and wires it through `KonfluxImageBuilderConfig` / `KonfluxOlmBundleBuilder` to `KonfluxClient.verify_enterprise_contract()`.
- `KonfluxClient` adds `EFFECTIVE_TIME` to the EC PipelineRun params when provided.

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/39210/console --> ITS run: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-22/pipelineruns/openshift-4-22-ec-ose-4-22-cloud-event-proxy-kr2t8/

```
EFFECTIVE_TIME | 2026-07-11T00:00:00Z
```

## Dependencies

Depends on upstream pipeline change: https://github.com/konflux-ci/build-definitions/pull/3622 (merged)

## Test plan

- [x] All existing EC-related unit tests pass (47 tests in `test_konflux_ec_verification.py`, `test_konflux_client.py`, `test_konflux_image_builder.py`)
- [x] `ruff check` passes on all modified files
- [x] Verify in a dry-run build that `--effective-time` flag is accepted
- [x] Verify in a real ocp4-konflux run that EFFECTIVE_TIME appears in EC PipelineRun params


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `--effective-time` parameter for Konflux image and OLM bundle builds.
  * Enterprise Contract verification now accepts and forwards an effective time into the policy check.
  * On OCP Konflux pipelines, the effective time is automatically set to 14 days in the future at 00:00 UTC.
* **Bug Fixes**
  * Konflux verification flows now consistently carry the selected effective time through the related checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->