### PR TITLE
ART-14019: validate snapshot components against RPA before release

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -139,10 +139,17 @@ PRODUCT_KUBECONFIG_MAP = {
 KONFLUX_DEFAULT_NAMESPACE = "ocp-art-tenant"
 
 # Base URL for fetching ReleasePlanAdmission YAMLs from konflux-release-data (GitLab raw)
-KONFLUX_RELEASE_DATA_RPA_BASE_URL = (
+OCP_RPA_BASE_URL = (
     "https://gitlab.cee.redhat.com/releng/konflux-release-data/-/raw/main/"
     "config/kflux-ocp-p01.7ayg.p1/product/ReleasePlanAdmission/ocp-art"
 )
+OCP_RPA_KINDS = {
+    "image": "ocp-art-advisory",
+    "metadata": "ocp-art-advisory",
+    "extras": "ocp-art-advisory",
+}
+OCP_RPA_ENVS = ["stage", "prod"]
+
 COREOS_RHEL10_STREAMS = [
     "rhel-coreos-10",
     "rhel-coreos-10-extensions",

--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -137,6 +137,12 @@ PRODUCT_KUBECONFIG_MAP = {
 
 # Default namespace for Konflux operations
 KONFLUX_DEFAULT_NAMESPACE = "ocp-art-tenant"
+
+# Base URL for fetching ReleasePlanAdmission YAMLs from konflux-release-data (GitLab raw)
+KONFLUX_RELEASE_DATA_RPA_BASE_URL = (
+    "https://gitlab.cee.redhat.com/releng/konflux-release-data/-/raw/main/"
+    "config/kflux-ocp-p01.7ayg.p1/product/ReleasePlanAdmission/ocp-art"
+)
 COREOS_RHEL10_STREAMS = [
     "rhel-coreos-10",
     "rhel-coreos-10-extensions",

--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Set
 import aiohttp
 import click
 from artcommonlib import logutil
-from artcommonlib.constants import KONFLUX_RELEASE_DATA_RPA_BASE_URL
+from artcommonlib.constants import OCP_RPA_BASE_URL, OCP_RPA_ENVS, OCP_RPA_KINDS
 from artcommonlib.util import (
     get_utc_now_formatted_str,
     new_roundtrip_yaml_handler,
@@ -34,7 +34,7 @@ LOGGER = logutil.get_logger(__name__)
 
 
 async def fetch_rpa(rpa_name: str) -> dict:
-    url = f"{KONFLUX_RELEASE_DATA_RPA_BASE_URL}/{rpa_name}.yaml"
+    url = f"{OCP_RPA_BASE_URL}/{rpa_name}.yaml"
     headers = {}
     gitlab_token = os.environ.get("GITLAB_TOKEN")
     if gitlab_token:
@@ -56,32 +56,7 @@ async def fetch_rpa(rpa_name: str) -> dict:
     return rpa_data
 
 
-SUPPORTED_RPA_KINDS = {
-    "image": "ocp-art-advisory",
-    "metadata": "ocp-art-advisory",
-    "extras": "ocp-art-advisory",
-}
-
-
-async def validate_snapshot_against_rpa(group: str, env: str, kind: str, snapshot_components: List[str]) -> None:
-    match = re.fullmatch(r"openshift-(\d+)\.(\d+)", group)
-    if group.startswith("openshift-") and not match:
-        raise ValueError(f"Unrecognized openshift group format, refusing to skip RPA validation: {group!r}")
-    if not match:
-        return
-    major, minor = match.group(1), match.group(2)
-
-    # FBC allowedPackages use OLM package names which don't match Konflux component names
-    if kind == "fbc":
-        LOGGER.info("Skipping RPA validation for FBC releases (different naming scheme)")
-        return
-
-    if kind not in SUPPORTED_RPA_KINDS:
-        raise ValueError(
-            f"Unsupported release kind for RPA validation: {kind!r}. Supported: {sorted(SUPPORTED_RPA_KINDS)}"
-        )
-    rpa_name = f"{SUPPORTED_RPA_KINDS[kind]}-{env}-{major}-{minor}"
-
+async def _validate_snapshot_against_single_rpa(rpa_name: str, snapshot_components: List[str]) -> None:
     LOGGER.info("Fetching RPA %s to validate snapshot components...", rpa_name)
     rpa_data = await fetch_rpa(rpa_name)
 
@@ -103,6 +78,29 @@ async def validate_snapshot_against_rpa(group: str, env: str, kind: str, snapsho
         )
 
     LOGGER.info("All %d snapshot components validated against RPA %s", len(snapshot_names), rpa_name)
+
+
+async def validate_snapshot_against_rpa(group: str, env: str, kind: str, snapshot_components: List[str]) -> None:
+    match = re.fullmatch(r"openshift-(\d+)\.(\d+)", group)
+    if group.startswith("openshift-") and not match:
+        raise ValueError(f"Unrecognized openshift group format, refusing to skip RPA validation: {group!r}")
+    if not match:
+        return
+    major, minor = match.group(1), match.group(2)
+
+    # FBC allowedPackages use OLM package names which don't match Konflux component names
+    if kind == "fbc":
+        LOGGER.info("Skipping RPA validation for FBC releases (different naming scheme)")
+        return
+
+    if kind not in OCP_RPA_KINDS:
+        raise ValueError(f"Unsupported release kind for RPA validation: {kind!r}. Supported: {sorted(OCP_RPA_KINDS)}")
+
+    # Validate against both prod and stage RPAs
+    envs_to_check = [env] + [e for e in OCP_RPA_ENVS if e != env]
+    for check_env in envs_to_check:
+        rpa_name = f"{OCP_RPA_KINDS[kind]}-{check_env}-{major}-{minor}"
+        await _validate_snapshot_against_single_rpa(rpa_name, snapshot_components)
 
 
 @dataclass

--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -56,8 +56,8 @@ async def fetch_rpa(rpa_name: str) -> dict:
     return rpa_data
 
 
-async def _validate_snapshot_against_single_rpa(rpa_name: str, snapshot_components: List[str]) -> None:
-    LOGGER.info("Fetching RPA %s to validate snapshot components...", rpa_name)
+async def _validate_snapshot_against_single_rpa(kind: str, rpa_name: str, snapshot_components: List[str]) -> None:
+    LOGGER.info("Validating %s shipment components against RPA %s...", kind, rpa_name)
     rpa_data = await fetch_rpa(rpa_name)
 
     allowed_names: Set[str] = set()
@@ -73,11 +73,16 @@ async def _validate_snapshot_against_single_rpa(rpa_name: str, snapshot_componen
     missing = snapshot_names - allowed_names
     if missing:
         raise ValueError(
-            f"The following snapshot components are not listed in RPA {rpa_name} "
+            f"The following {kind} shipment components are not listed in RPA {rpa_name} "
             f"and would be silently filtered out during release: {sorted(missing)}"
         )
 
-    LOGGER.info("All %d snapshot components validated against RPA %s", len(snapshot_names), rpa_name)
+    LOGGER.info(
+        "All %d snapshot components of %s shipment validated against RPA %s",
+        len(snapshot_names),
+        kind,
+        rpa_name,
+    )
 
 
 async def validate_snapshot_against_rpa(group: str, env: str, kind: str, snapshot_components: List[str]) -> None:
@@ -96,11 +101,13 @@ async def validate_snapshot_against_rpa(group: str, env: str, kind: str, snapsho
     if kind not in OCP_RPA_KINDS:
         raise ValueError(f"Unsupported release kind for RPA validation: {kind!r}. Supported: {sorted(OCP_RPA_KINDS)}")
 
-    # Validate against both prod and stage RPAs
+    if env not in OCP_RPA_ENVS:
+        raise ValueError(f"Unsupported release env for RPA validation: {env!r}. Supported: {OCP_RPA_ENVS}")
+
     envs_to_check = [env] + [e for e in OCP_RPA_ENVS if e != env]
     for check_env in envs_to_check:
         rpa_name = f"{OCP_RPA_KINDS[kind]}-{check_env}-{major}-{minor}"
-        await _validate_snapshot_against_single_rpa(rpa_name, snapshot_components)
+        await _validate_snapshot_against_single_rpa(kind, rpa_name, snapshot_components)
 
 
 @dataclass

--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -65,6 +65,8 @@ SUPPORTED_RPA_KINDS = {
 
 async def validate_snapshot_against_rpa(group: str, env: str, kind: str, snapshot_components: List[str]) -> None:
     match = re.fullmatch(r"openshift-(\d+)\.(\d+)", group)
+    if group.startswith("openshift-") and not match:
+        raise ValueError(f"Unrecognized openshift group format, refusing to skip RPA validation: {group!r}")
     if not match:
         return
     major, minor = match.group(1), match.group(2)

--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -56,16 +56,25 @@ async def fetch_rpa(rpa_name: str) -> dict:
     return rpa_data
 
 
+SUPPORTED_RPA_KINDS = {
+    "image": "ocp-art-advisory",
+    "metadata": "ocp-art-advisory",
+    "extras": "ocp-art-advisory",
+    "fbc": "ocp-art-fbc",
+}
+
+
 async def validate_snapshot_against_rpa(group: str, env: str, kind: str, snapshot_components: List[str]) -> None:
-    match = re.match(r"openshift-(\d+)\.(\d+)", group)
+    match = re.fullmatch(r"openshift-(\d+)\.(\d+)", group)
     if not match:
         return
     major, minor = match.group(1), match.group(2)
 
-    if kind == "fbc":
-        rpa_name = f"ocp-art-fbc-{env}-{major}-{minor}"
-    else:
-        rpa_name = f"ocp-art-advisory-{env}-{major}-{minor}"
+    if kind not in SUPPORTED_RPA_KINDS:
+        raise ValueError(
+            f"Unsupported release kind for RPA validation: {kind!r}. Supported: {sorted(SUPPORTED_RPA_KINDS)}"
+        )
+    rpa_name = f"{SUPPORTED_RPA_KINDS[kind]}-{env}-{major}-{minor}"
 
     LOGGER.info("Fetching RPA %s to validate snapshot components...", rpa_name)
     rpa_data = await fetch_rpa(rpa_name)
@@ -483,7 +492,8 @@ async def new_release_cli(
     '--kind',
     metavar='KIND',
     required=True,
-    help='The kind of release (e.g. "image", "metadata", "fbc")',
+    type=click.Choice(["image", "metadata", "extras", "fbc"]),
+    help='The kind of release',
 )
 @click.pass_obj
 @click_coroutine

--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -60,7 +60,6 @@ SUPPORTED_RPA_KINDS = {
     "image": "ocp-art-advisory",
     "metadata": "ocp-art-advisory",
     "extras": "ocp-art-advisory",
-    "fbc": "ocp-art-fbc",
 }
 
 
@@ -69,6 +68,11 @@ async def validate_snapshot_against_rpa(group: str, env: str, kind: str, snapsho
     if not match:
         return
     major, minor = match.group(1), match.group(2)
+
+    # FBC allowedPackages use OLM package names which don't match Konflux component names
+    if kind == "fbc":
+        LOGGER.info("Skipping RPA validation for FBC releases (different naming scheme)")
+        return
 
     if kind not in SUPPORTED_RPA_KINDS:
         raise ValueError(
@@ -80,14 +84,10 @@ async def validate_snapshot_against_rpa(group: str, env: str, kind: str, snapsho
     rpa_data = await fetch_rpa(rpa_name)
 
     allowed_names: Set[str] = set()
-    if kind == "fbc":
-        allowed_packages = rpa_data.get("spec", {}).get("data", {}).get("fbc", {}).get("allowedPackages", [])
-        allowed_names = set(allowed_packages)
-    else:
-        components = rpa_data.get("spec", {}).get("data", {}).get("mapping", {}).get("components", [])
-        for comp in components:
-            if isinstance(comp, dict) and "name" in comp:
-                allowed_names.add(comp["name"])
+    components = rpa_data.get("spec", {}).get("data", {}).get("mapping", {}).get("components", [])
+    for comp in components:
+        if isinstance(comp, dict) and "name" in comp:
+            allowed_names.add(comp["name"])
 
     if not allowed_names:
         raise ValueError(f"RPA {rpa_name} has no components/allowedPackages defined")
@@ -492,7 +492,7 @@ async def new_release_cli(
     '--kind',
     metavar='KIND',
     required=True,
-    type=click.Choice(["image", "metadata", "extras", "fbc"]),
+    type=click.Choice(["image", "metadata", "extras"]),
     help='The kind of release',
 )
 @click.pass_obj

--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -1,9 +1,13 @@
+import os
+import re
 import sys
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional, Set
 
+import aiohttp
 import click
 from artcommonlib import logutil
+from artcommonlib.constants import KONFLUX_RELEASE_DATA_RPA_BASE_URL
 from artcommonlib.util import (
     get_utc_now_formatted_str,
     new_roundtrip_yaml_handler,
@@ -27,6 +31,67 @@ from elliottlib.shipment_model import Shipment, ShipmentConfig, ShipmentEnv
 yaml = new_roundtrip_yaml_handler()
 
 LOGGER = logutil.get_logger(__name__)
+
+
+async def fetch_rpa(rpa_name: str) -> dict:
+    url = f"{KONFLUX_RELEASE_DATA_RPA_BASE_URL}/{rpa_name}.yaml"
+    headers = {}
+    gitlab_token = os.environ.get("GITLAB_TOKEN")
+    if gitlab_token:
+        headers["Private-Token"] = gitlab_token
+
+    timeout = aiohttp.ClientTimeout(total=30, sock_read=10)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.get(url, headers=headers) as response:
+            if response.status != 200:
+                error_msg = f"Failed to fetch RPA from {url}: HTTP {response.status}"
+                if response.status == 403:
+                    error_msg += ". 403 Forbidden may indicate missing GITLAB_TOKEN environment variable."
+                raise ValueError(error_msg)
+            content = await response.text()
+
+    rpa_data = yaml.load(content)
+    if not rpa_data:
+        raise ValueError(f"RPA file {rpa_name}.yaml is empty or invalid")
+    return rpa_data
+
+
+async def validate_snapshot_against_rpa(group: str, env: str, kind: str, snapshot_components: List[str]) -> None:
+    match = re.match(r"openshift-(\d+)\.(\d+)", group)
+    if not match:
+        return
+    major, minor = match.group(1), match.group(2)
+
+    if kind == "fbc":
+        rpa_name = f"ocp-art-fbc-{env}-{major}-{minor}"
+    else:
+        rpa_name = f"ocp-art-advisory-{env}-{major}-{minor}"
+
+    LOGGER.info("Fetching RPA %s to validate snapshot components...", rpa_name)
+    rpa_data = await fetch_rpa(rpa_name)
+
+    allowed_names: Set[str] = set()
+    if kind == "fbc":
+        allowed_packages = rpa_data.get("spec", {}).get("data", {}).get("fbc", {}).get("allowedPackages", [])
+        allowed_names = set(allowed_packages)
+    else:
+        components = rpa_data.get("spec", {}).get("data", {}).get("mapping", {}).get("components", [])
+        for comp in components:
+            if isinstance(comp, dict) and "name" in comp:
+                allowed_names.add(comp["name"])
+
+    if not allowed_names:
+        raise ValueError(f"RPA {rpa_name} has no components/allowedPackages defined")
+
+    snapshot_names = set(snapshot_components)
+    missing = snapshot_names - allowed_names
+    if missing:
+        raise ValueError(
+            f"The following snapshot components are not listed in RPA {rpa_name} "
+            f"and would be silently filtered out during release: {sorted(missing)}"
+        )
+
+    LOGGER.info("All %d snapshot components validated against RPA %s", len(snapshot_names), rpa_name)
 
 
 @dataclass
@@ -146,6 +211,12 @@ class CreateReleaseCli:
                 f"{env_config.model_dump()}. If you want to proceed, either remove the release metadata from the shipment config or use the --force flag."
             )
             return None
+
+        # Validate snapshot components against RPA before creating anything
+        if self.runtime.group.startswith("openshift-") and config.shipment.snapshot:
+            LOGGER.info("Validating snapshot components against RPA...")
+            component_names = [c.name for c in config.shipment.snapshot.spec.components]
+            await validate_snapshot_against_rpa(self.runtime.group, self.release_env, self.kind, component_names)
 
         # Create snapshot first using the spec from shipment config
         LOGGER.info("Creating snapshot from shipment config...")
@@ -389,3 +460,60 @@ async def new_release_cli(
     release = await pipeline.run()
     if release:
         yaml.dump(release.to_dict(), sys.stdout)
+
+
+@konflux_release_cli.command(
+    "validate-rpa",
+    short_help="Validate that snapshot components are listed in the ReleasePlanAdmission",
+)
+@click.option(
+    '--config',
+    metavar='CONFIG_PATH',
+    required=True,
+    help='Path of the shipment config file. The path should be from the root of the given shipment-data repo.',
+)
+@click.option(
+    '--env',
+    metavar='RELEASE_ENV',
+    required=True,
+    type=click.Choice(["stage", "prod"]),
+    help='Release environment to validate against',
+)
+@click.option(
+    '--kind',
+    metavar='KIND',
+    required=True,
+    help='The kind of release (e.g. "image", "metadata", "fbc")',
+)
+@click.pass_obj
+@click_coroutine
+async def validate_rpa_cli(runtime: Runtime, config, env, kind):
+    """
+    Validate that all snapshot components in a shipment config are present in the
+    ReleasePlanAdmission (RPA) for the given environment and kind.
+
+    Components not listed in the RPA are silently filtered out during release,
+    which can cause builds to be missed without any error.
+
+    \b
+    $ elliott -g openshift-4.18 --assembly 4.18.2 --shipment-path \\
+        "https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data@branch" \\
+        release validate-rpa --config shipment/ocp/openshift-4.18/openshift-4-18/4.18.2.yml \\
+        --env prod --kind image
+    """
+    runtime.initialize(build_system='konflux', with_shipment=True)
+
+    LOGGER.info("Loading %s...", config)
+    config_raw = runtime.shipment_gitdata.load_yaml_file(config)
+    if not config_raw:
+        raise ValueError(f"Error loading shipment config from {runtime.shipment_gitdata.data_path}/{config}")
+
+    shipment_config = ShipmentConfig.model_validate(config_raw)
+    if not (shipment_config.shipment.snapshot and shipment_config.shipment.snapshot.spec.components):
+        raise ValueError("Shipment config has no snapshot components to validate")
+
+    component_names = [c.name for c in shipment_config.shipment.snapshot.spec.components]
+    LOGGER.info("Validating %d components against RPA for %s/%s...", len(component_names), env, kind)
+
+    await validate_snapshot_against_rpa(runtime.group, env, kind, component_names)
+    LOGGER.info("Validation passed: all components are present in the RPA")

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -704,7 +704,9 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
         mock_fetch_rpa.return_value = rpa_data
 
         await validate_snapshot_against_rpa("openshift-4.18", "prod", "image", ["test-rpm", "test-container"])
-        mock_fetch_rpa.assert_awaited_once_with("ocp-art-advisory-prod-4-18")
+        self.assertEqual(mock_fetch_rpa.await_count, 2)
+        mock_fetch_rpa.assert_any_await("ocp-art-advisory-prod-4-18")
+        mock_fetch_rpa.assert_any_await("ocp-art-advisory-stage-4-18")
 
     @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
     async def test_validate_rpa_missing_components(self, mock_fetch_rpa):
@@ -716,7 +718,6 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
 
         self.assertIn("missing-component", str(ctx.exception))
         self.assertIn("silently filtered out", str(ctx.exception))
-        mock_fetch_rpa.assert_awaited_once_with("ocp-art-advisory-prod-4-18")
 
     @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
     async def test_validate_rpa_fbc_skipped(self, mock_fetch_rpa):
@@ -731,7 +732,17 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
             await validate_snapshot_against_rpa("openshift-4.18", "prod", "image", ["comp1"])
 
         self.assertIn("HTTP 404", str(ctx.exception))
-        mock_fetch_rpa.assert_awaited_once_with("ocp-art-advisory-prod-4-18")
+
+    @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
+    async def test_validate_rpa_checks_both_envs_stage_first(self, mock_fetch_rpa):
+        rpa_data = {"spec": {"data": {"mapping": {"components": [{"name": "comp1"}]}}}}
+        mock_fetch_rpa.return_value = rpa_data
+
+        await validate_snapshot_against_rpa("openshift-4.18", "stage", "image", ["comp1"])
+        self.assertEqual(mock_fetch_rpa.await_count, 2)
+        # When env is "stage", stage is checked first, then prod
+        calls = [c.args[0] for c in mock_fetch_rpa.await_args_list]
+        self.assertEqual(calls, ["ocp-art-advisory-stage-4-18", "ocp-art-advisory-prod-4-18"])
 
     @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
     async def test_validate_rpa_skipped_for_non_openshift(self, mock_fetch_rpa):

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -704,6 +704,7 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
         mock_fetch_rpa.return_value = rpa_data
 
         await validate_snapshot_against_rpa("openshift-4.18", "prod", "image", ["test-rpm", "test-container"])
+        mock_fetch_rpa.assert_awaited_once_with("ocp-art-advisory-prod-4-18")
 
     @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
     async def test_validate_rpa_missing_components(self, mock_fetch_rpa):
@@ -715,6 +716,7 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
 
         self.assertIn("missing-component", str(ctx.exception))
         self.assertIn("silently filtered out", str(ctx.exception))
+        mock_fetch_rpa.assert_awaited_once_with("ocp-art-advisory-prod-4-18")
 
     @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
     async def test_validate_rpa_fbc_success(self, mock_fetch_rpa):
@@ -722,6 +724,7 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
         mock_fetch_rpa.return_value = rpa_data
 
         await validate_snapshot_against_rpa("openshift-4.18", "prod", "fbc", ["sriov-network-operator"])
+        mock_fetch_rpa.assert_awaited_once_with("ocp-art-fbc-prod-4-18")
 
     @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
     async def test_validate_rpa_fbc_missing_packages(self, mock_fetch_rpa):
@@ -734,6 +737,7 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
             )
 
         self.assertIn("unknown-operator", str(ctx.exception))
+        mock_fetch_rpa.assert_awaited_once_with("ocp-art-fbc-prod-4-18")
 
     @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
     async def test_validate_rpa_fetch_failure(self, mock_fetch_rpa):
@@ -743,6 +747,7 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
             await validate_snapshot_against_rpa("openshift-4.18", "prod", "image", ["comp1"])
 
         self.assertIn("HTTP 404", str(ctx.exception))
+        mock_fetch_rpa.assert_awaited_once_with("ocp-art-advisory-prod-4-18")
 
     @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
     async def test_validate_rpa_skipped_for_non_openshift(self, mock_fetch_rpa):

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -719,25 +719,9 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
         mock_fetch_rpa.assert_awaited_once_with("ocp-art-advisory-prod-4-18")
 
     @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
-    async def test_validate_rpa_fbc_success(self, mock_fetch_rpa):
-        rpa_data = {"spec": {"data": {"fbc": {"allowedPackages": ["sriov-network-operator", "metallb-operator"]}}}}
-        mock_fetch_rpa.return_value = rpa_data
-
-        await validate_snapshot_against_rpa("openshift-4.18", "prod", "fbc", ["sriov-network-operator"])
-        mock_fetch_rpa.assert_awaited_once_with("ocp-art-fbc-prod-4-18")
-
-    @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
-    async def test_validate_rpa_fbc_missing_packages(self, mock_fetch_rpa):
-        rpa_data = {"spec": {"data": {"fbc": {"allowedPackages": ["sriov-network-operator"]}}}}
-        mock_fetch_rpa.return_value = rpa_data
-
-        with self.assertRaises(ValueError) as ctx:
-            await validate_snapshot_against_rpa(
-                "openshift-4.18", "prod", "fbc", ["sriov-network-operator", "unknown-operator"]
-            )
-
-        self.assertIn("unknown-operator", str(ctx.exception))
-        mock_fetch_rpa.assert_awaited_once_with("ocp-art-fbc-prod-4-18")
+    async def test_validate_rpa_fbc_skipped(self, mock_fetch_rpa):
+        await validate_snapshot_against_rpa("openshift-4.18", "prod", "fbc", ["fbc-ose-4-18-sriov-network-operator"])
+        mock_fetch_rpa.assert_not_called()
 
     @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
     async def test_validate_rpa_fetch_failure(self, mock_fetch_rpa):

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from artcommonlib.model import Model
 from doozerlib.backend.konflux_client import API_VERSION, KIND_APPLICATION, KIND_RELEASE, KIND_RELEASE_PLAN
-from elliottlib.cli.konflux_release_cli import CreateReleaseCli
+from elliottlib.cli.konflux_release_cli import CreateReleaseCli, validate_snapshot_against_rpa
 from elliottlib.cli.konflux_release_watch_cli import WatchReleaseCli
 from elliottlib.shipment_model import (
     ComponentSource,
@@ -183,10 +183,11 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
         self.konflux_client.verify_connection = MagicMock(return_value=True)
         self.konflux_client.resource_url = MagicMock()
 
+    @patch("elliottlib.cli.konflux_release_cli.validate_snapshot_against_rpa", new_callable=AsyncMock)
     @patch("elliottlib.cli.konflux_release_cli.get_utc_now_formatted_str", return_value="timestamp")
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
     @patch("elliottlib.runtime.Runtime")
-    async def test_run_prod_happy_path(self, mock_runtime, mock_konflux_client_init, _):
+    async def test_run_prod_happy_path(self, mock_runtime, mock_konflux_client_init, _, __mock_validate):
         mock_runtime.return_value = self.runtime
         mock_konflux_client_init.return_value = self.konflux_client
 
@@ -342,10 +343,11 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
         # Check result
         self.assertEqual(result, created_release)
 
+    @patch("elliottlib.cli.konflux_release_cli.validate_snapshot_against_rpa", new_callable=AsyncMock)
     @patch("elliottlib.cli.konflux_release_cli.get_utc_now_formatted_str", return_value="timestamp")
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
     @patch("elliottlib.runtime.Runtime")
-    async def test_run_stage_happy_path(self, mock_runtime, mock_konflux_client_init, _):
+    async def test_run_stage_happy_path(self, mock_runtime, mock_konflux_client_init, _, __mock_validate):
         mock_runtime.return_value = self.runtime
         mock_konflux_client_init.return_value = self.konflux_client
 
@@ -686,4 +688,130 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
         )
 
         # assert that release did not get created
+        self.assertEqual(self.konflux_client._create.call_count, 0)
+
+    @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
+    async def test_validate_rpa_success(self, mock_fetch_rpa):
+        rpa_data = {
+            "spec": {
+                "data": {
+                    "mapping": {
+                        "components": [{"name": "test-rpm"}, {"name": "test-container"}, {"name": "extra-component"}]
+                    }
+                }
+            }
+        }
+        mock_fetch_rpa.return_value = rpa_data
+
+        await validate_snapshot_against_rpa("openshift-4.18", "prod", "image", ["test-rpm", "test-container"])
+
+    @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
+    async def test_validate_rpa_missing_components(self, mock_fetch_rpa):
+        rpa_data = {"spec": {"data": {"mapping": {"components": [{"name": "test-rpm"}]}}}}
+        mock_fetch_rpa.return_value = rpa_data
+
+        with self.assertRaises(ValueError) as ctx:
+            await validate_snapshot_against_rpa("openshift-4.18", "prod", "image", ["test-rpm", "missing-component"])
+
+        self.assertIn("missing-component", str(ctx.exception))
+        self.assertIn("silently filtered out", str(ctx.exception))
+
+    @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
+    async def test_validate_rpa_fbc_success(self, mock_fetch_rpa):
+        rpa_data = {"spec": {"data": {"fbc": {"allowedPackages": ["sriov-network-operator", "metallb-operator"]}}}}
+        mock_fetch_rpa.return_value = rpa_data
+
+        await validate_snapshot_against_rpa("openshift-4.18", "prod", "fbc", ["sriov-network-operator"])
+
+    @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
+    async def test_validate_rpa_fbc_missing_packages(self, mock_fetch_rpa):
+        rpa_data = {"spec": {"data": {"fbc": {"allowedPackages": ["sriov-network-operator"]}}}}
+        mock_fetch_rpa.return_value = rpa_data
+
+        with self.assertRaises(ValueError) as ctx:
+            await validate_snapshot_against_rpa(
+                "openshift-4.18", "prod", "fbc", ["sriov-network-operator", "unknown-operator"]
+            )
+
+        self.assertIn("unknown-operator", str(ctx.exception))
+
+    @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
+    async def test_validate_rpa_fetch_failure(self, mock_fetch_rpa):
+        mock_fetch_rpa.side_effect = ValueError("HTTP 404")
+
+        with self.assertRaises(ValueError) as ctx:
+            await validate_snapshot_against_rpa("openshift-4.18", "prod", "image", ["comp1"])
+
+        self.assertIn("HTTP 404", str(ctx.exception))
+
+    @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
+    async def test_validate_rpa_skipped_for_non_openshift(self, mock_fetch_rpa):
+        await validate_snapshot_against_rpa("oadp-1.5", "prod", "image", ["comp1"])
+        mock_fetch_rpa.assert_not_called()
+
+    @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
+    @patch("elliottlib.cli.konflux_release_cli.get_utc_now_formatted_str", return_value="timestamp")
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    @patch("elliottlib.runtime.Runtime")
+    async def test_run_validates_rpa_before_snapshot(self, mock_runtime, mock_konflux_client_init, _, mock_fetch_rpa):
+        mock_runtime.return_value = self.runtime
+        mock_konflux_client_init.return_value = self.konflux_client
+
+        rpa_data = {"spec": {"data": {"mapping": {"components": [{"name": "test-rpm"}]}}}}
+        mock_fetch_rpa.return_value = rpa_data
+
+        shipment_config = ShipmentConfig(
+            shipment=Shipment(
+                metadata=Metadata(
+                    product="ocp", application="openshift-4-18", group="openshift-4.18", assembly="4.18.2"
+                ),
+                environments=Environments(
+                    stage=ShipmentEnv(releasePlan="test-stage-rp"),
+                    prod=ShipmentEnv(releasePlan="test-prod-rp"),
+                ),
+                snapshot=Snapshot(
+                    nvrs=["nvr1"],
+                    spec=SnapshotSpec(
+                        application="openshift-4-18",
+                        components=[
+                            SnapshotComponent(
+                                name="test-rpm",
+                                source=ComponentSource(
+                                    git=GitSource(url="https://github.com/test.git", revision="abc")
+                                ),
+                                containerImage="img1",
+                            ),
+                            SnapshotComponent(
+                                name="unauthorized-component",
+                                source=ComponentSource(
+                                    git=GitSource(url="https://github.com/test.git", revision="def")
+                                ),
+                                containerImage="img2",
+                            ),
+                        ],
+                    ),
+                ),
+                data=Data(
+                    releaseNotes=ReleaseNotes(type="RHBA", synopsis="s", topic="t", description="d", solution="s")
+                ),
+            ),
+        )
+        self.runtime.shipment_gitdata.load_yaml_file.return_value = shipment_config.model_dump(exclude_none=True)
+        self.konflux_client._get_api.return_value = MagicMock()
+        self.konflux_client._get.return_value = MagicMock()
+
+        cli = CreateReleaseCli(
+            runtime=self.runtime,
+            config_path=self.config_path,
+            release_env=self.release_env,
+            konflux_config=self.konflux_config,
+            image_repo_pull_secret={},
+            dry_run=self.dry_run,
+            kind="image",
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            await cli.run()
+
+        self.assertIn("unauthorized-component", str(ctx.exception))
         self.assertEqual(self.konflux_client._create.call_count, 0)

--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -28,7 +28,7 @@ from artcommonlib.assembly import (
     assembly_targeted_fixes_only,
 )
 from artcommonlib.constants import (
-    KONFLUX_RELEASE_DATA_RPA_BASE_URL,
+    OCP_RPA_BASE_URL,
     REGISTRY_QUAY_OCP_RELEASE_DEV,
     SHIPMENT_DATA_URL_TEMPLATE,
 )
@@ -1735,7 +1735,7 @@ class PrepareReleaseKonfluxPipeline:
         version_major = release_version[0]
         version_minor = release_version[1]
         policy_filename = f"ocp-art-advisory-stage-{version_major}-{version_minor}.yaml"
-        policy_url = f"{KONFLUX_RELEASE_DATA_RPA_BASE_URL}/{policy_filename}"
+        policy_url = f"{OCP_RPA_BASE_URL}/{policy_filename}"
 
         try:
             # Fetch the policy file

--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -28,6 +28,7 @@ from artcommonlib.assembly import (
     assembly_targeted_fixes_only,
 )
 from artcommonlib.constants import (
+    KONFLUX_RELEASE_DATA_RPA_BASE_URL,
     REGISTRY_QUAY_OCP_RELEASE_DEV,
     SHIPMENT_DATA_URL_TEMPLATE,
 )
@@ -46,6 +47,7 @@ from doozerlib.cli.release_gen_payload import (
     default_imagestream_namespace_base_name,
     payload_imagestream_namespace_and_name,
 )
+from elliottlib.cli.konflux_release_cli import validate_snapshot_against_rpa
 from elliottlib.errata import push_cdn_stage
 from elliottlib.errata_async import AsyncErrataAPI
 from elliottlib.shipment_model import Issue, ReleaseNotes, ShipmentConfig, Snapshot, SnapshotSpec, Tools
@@ -663,6 +665,12 @@ class PrepareReleaseKonfluxPipeline:
         # prepare snapshot from the found builds
         for kind, shipment in shipments_by_kind.items():
             shipment.shipment.snapshot = await self.get_snapshot(kind_to_builds[kind])
+
+        # Validate snapshot components against RPA before finalizing
+        for kind, shipment in shipments_by_kind.items():
+            if shipment.shipment.snapshot and shipment.shipment.snapshot.spec.components:
+                component_names = [c.name for c in shipment.shipment.snapshot.spec.components]
+                await validate_snapshot_against_rpa(self.group, env, kind, component_names)
 
         # Update shipment MR with found builds
         await self.update_shipment_mr(shipments_by_kind, env, shipment_url)
@@ -1727,7 +1735,7 @@ class PrepareReleaseKonfluxPipeline:
         version_major = release_version[0]
         version_minor = release_version[1]
         policy_filename = f"ocp-art-advisory-stage-{version_major}-{version_minor}.yaml"
-        policy_url = f"https://gitlab.cee.redhat.com/releng/konflux-release-data/-/raw/main/config/kflux-ocp-p01.7ayg.p1/product/ReleasePlanAdmission/ocp-art/{policy_filename}"
+        policy_url = f"{KONFLUX_RELEASE_DATA_RPA_BASE_URL}/{policy_filename}"
 
         try:
             # Fetch the policy file

--- a/pyartcd/tests/pipelines/test_prepare_release_konflux.py
+++ b/pyartcd/tests/pipelines/test_prepare_release_konflux.py
@@ -502,6 +502,7 @@ class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
     @patch.object(PrepareReleaseKonfluxPipeline, 'update_shipment_mr', new_callable=AsyncMock)
     @patch.object(PrepareReleaseKonfluxPipeline, 'create_shipment_mr', new_callable=AsyncMock)
     @patch.object(PrepareReleaseKonfluxPipeline, 'find_bugs', new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.prepare_release_konflux.validate_snapshot_against_rpa", new_callable=AsyncMock)
     @patch.object(PrepareReleaseKonfluxPipeline, 'find_or_build_fbc_builds', new_callable=AsyncMock)
     @patch.object(PrepareReleaseKonfluxPipeline, 'find_or_build_bundle_builds', new_callable=AsyncMock)
     @patch.object(PrepareReleaseKonfluxPipeline, 'find_builds_all', new_callable=AsyncMock)
@@ -514,6 +515,7 @@ class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
         mock_find_builds_all,
         mock_find_or_build_bundle_builds,
         mock_find_or_build_fbc_builds,
+        mock_validate_rpa,
         mock_find_bugs,
         mock_create_shipment_mr,
         mock_update_shipment_mr,

--- a/pyartcd/tests/pipelines/test_prepare_release_konflux.py
+++ b/pyartcd/tests/pipelines/test_prepare_release_konflux.py
@@ -807,6 +807,9 @@ class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
         mock_get_snapshot.assert_any_call(['fbc-nvr'])
         self.assertEqual(mock_get_snapshot.call_count, 4)
 
+        # Verify RPA validation was called for each shipment kind
+        self.assertTrue(mock_validate_rpa.await_count > 0, "validate_snapshot_against_rpa should have been called")
+
         # copy and modify mocks to what is expected after init and build finding, i.e., at create shipment MR time
         mock_shipment_image_create = copy.deepcopy(mock_shipment_image)
         mock_shipment_extras_create = copy.deepcopy(mock_shipment_extras)


### PR DESCRIPTION
[https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release-konflux/1070/console](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release-konflux/1070/console) 
```
12:35:01  2026-07-03 07:05:00,963 art_tools.elliottlib.cli.konflux_release_cli INFO Skipping RPA validation for FBC releases (different naming scheme)
12:35:01  2026-07-03 07:05:00,963 art_tools.elliottlib.cli.konflux_release_cli INFO Validating extras shipment components against RPA ocp-art-advisory-prod-4-19...
12:35:01  2026-07-03 07:05:01,475 art_tools.elliottlib.cli.konflux_release_cli INFO All 52 snapshot components of extras shipment validated against RPA ocp-art-advisory-prod-4-19
12:35:01  2026-07-03 07:05:01,486 art_tools.elliottlib.cli.konflux_release_cli INFO Validating extras shipment components against RPA ocp-art-advisory-stage-4-19...
12:35:01  2026-07-03 07:05:01,923 art_tools.elliottlib.cli.konflux_release_cli INFO All 52 snapshot components of extras shipment validated against RPA ocp-art-advisory-stage-4-19
12:35:01  2026-07-03 07:05:01,923 art_tools.elliottlib.cli.konflux_release_cli INFO Validating image shipment components against RPA ocp-art-advisory-prod-4-19...
12:35:02  2026-07-03 07:05:02,341 art_tools.elliottlib.cli.konflux_release_cli INFO All 187 snapshot components of image shipment validated against RPA ocp-art-advisory-prod-4-19
12:35:02  2026-07-03 07:05:02,341 art_tools.elliottlib.cli.konflux_release_cli INFO Validating image shipment components against RPA ocp-art-advisory-stage-4-19...
12:35:03  2026-07-03 07:05:02,767 art_tools.elliottlib.cli.konflux_release_cli INFO All 187 snapshot components of image shipment validated against RPA ocp-art-advisory-stage-4-19
12:35:03  2026-07-03 07:05:02,768 art_tools.elliottlib.cli.konflux_release_cli INFO Validating metadata shipment components against RPA ocp-art-advisory-prod-4-19...
12:35:03  2026-07-03 07:05:03,191 art_tools.elliottlib.cli.konflux_release_cli INFO All 15 snapshot components of metadata shipment validated against RPA ocp-art-advisory-prod-4-19
12:35:03  2026-07-03 07:05:03,192 art_tools.elliottlib.cli.konflux_release_cli INFO Validating metadata shipment components against RPA ocp-art-advisory-stage-4-19...
12:35:03  2026-07-03 07:05:03,692 art_tools.elliottlib.cli.konflux_release_cli INFO All 15 snapshot components of metadata shipment validated against RPA ocp-art-advisory-stage-4-19
```

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added RPA-backed validation of snapshot component names during Konflux release creation, with pre-check support via `konflux release validate-rpa`.
  * Release creation now validates snapshots for supported OpenShift runtime groups and kinds (skipping `fbc`), before creating Snapshot/Release resources.

* **Bug Fixes**
  * Switched advisory policy fetching to use the centralized Konflux release-data base URL.
  * Improved validation errors when RPA can’t be retrieved, is invalid/empty, or when components don’t match allowed mappings.

* **Tests**
  * Expanded unit and pipeline coverage for success, skips, and failure propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->