### PR TITLE
Fix images-health report ordering: sort releases newest to oldest

### DIFF
--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -668,8 +668,22 @@ class ImagesHealthPipeline:
             summary_message, link_build_url=False, unfurl_links=False, unfurl_media=False
         )
 
-        # Send each group's summary as a thread response
-        for group in sorted(all_groups):
+        # Send each group's summary as a thread response, sorted by version (newest first)
+        def sort_key(group_name):
+            """
+            Extract version for sorting. Converts 'openshift-4.22' to (4, 22) tuple
+            for proper numeric sorting, with highest versions first.
+            """
+            version = group_name.replace('openshift-', '')
+            try:
+                parts = version.split('.')
+                # Return tuple of integers, negated for descending order
+                return tuple(-int(p) for p in parts)
+            except (ValueError, AttributeError):
+                # Fallback for malformed versions
+                return (0,)
+
+        for group in sorted(all_groups, key=sort_key):
             version = group.replace('openshift-', '')
             group_summary = []
 

--- a/pyartcd/tests/pipelines/test_images_health.py
+++ b/pyartcd/tests/pipelines/test_images_health.py
@@ -155,6 +155,32 @@ class TestNotifyPublicChannel(IsolatedAsyncioTestCase):
 
         mock_slack_client.bind_channel.assert_called_once_with("#my-custom-channel")
 
+    async def test_groups_sorted_by_version_descending(self):
+        """
+        Verify that releases are ordered from newest to oldest (e.g., 5.0, 4.23, 4.22).
+        """
+        mock_slack_client = self.mock_runtime.new_slack_client.return_value
+        pipeline = _make_pipeline(self.mock_runtime, public_channel="#forum-ocp-art")
+        pipeline.report = [
+            _make_concern("img-1", "openshift-4.22", ConcernCode.FAILING_AT_LEAST_FOR.value),
+            _make_concern("img-2", "openshift-5.0", ConcernCode.FAILING_AT_LEAST_FOR.value),
+            _make_concern("img-3", "openshift-4.23", ConcernCode.FAILING_AT_LEAST_FOR.value),
+        ]
+        mock_slack_client.say.return_value = {"ts": "thread-999"}
+
+        await pipeline.notify_public_channel()
+
+        calls = mock_slack_client.say.call_args_list
+        self.assertEqual(len(calls), 4)  # 1 summary + 3 groups
+
+        # Extract group names from thread messages (skipping the summary)
+        thread_messages = [calls[i][0][0] for i in range(1, 4)]
+
+        # Verify order: should be 5.0, 4.23, 4.22
+        self.assertIn("openshift-5.0", thread_messages[0])
+        self.assertIn("openshift-4.23", thread_messages[1])
+        self.assertIn("openshift-4.22", thread_messages[2])
+
     async def test_empty_report(self):
         mock_slack_client = self.mock_runtime.new_slack_client.return_value
         pipeline = _make_pipeline(self.mock_runtime, public_channel="#forum-ocp-art")


### PR DESCRIPTION
## Summary

Fix the release ordering in images-health reports sent to #forum-ocp-art. Releases are now displayed in descending version order (e.g., 5.0, 4.23, 4.22) instead of alphabetical order, making it easier to identify critical issues in newer releases.

## Changes

- Added `sort_key()` function in `notify_public_channel()` to convert version strings (e.g., "openshift-4.22") to numeric tuples for proper descending sort
- Applied the sort key to ensure groups appear newest-to-oldest
- Added test `test_groups_sorted_by_version_descending()` to verify correct ordering across multiple versions

## Test Plan

- [x] All existing tests pass (33/33)
- [x] New test verifies ordering with versions 4.22, 4.23, 5.0
- [x] Code formatting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Slack thread updates now appear in a consistent release-version order, with newer OpenShift versions shown before older ones.
  * Improved the ordering of per-version health notifications when multiple release groups are reported.
* **Tests**
  * Added coverage to verify the notification order across several release versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->