### PR TITLE
ART-14091: Add support for ignorable repos in scan-sources

### DIFF
--- a/artcommon/artcommonlib/config/repo.py
+++ b/artcommon/artcommonlib/config/repo.py
@@ -51,6 +51,10 @@ class RepoSync(BaseModel):
     latest_only: bool = True
 
 
+class ScanSources(BaseModel):
+    ignorable: bool = False
+
+
 class Repo(BaseModel):
     name: str
     disabled: bool = False
@@ -59,6 +63,7 @@ class Repo(BaseModel):
     conf: dict | None = None
     content_set: ContentSet | None = None
     reposync: RepoSync = RepoSync()
+    scan_sources: ScanSources | None = None
 
     def construct_download_url(
         self,

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -361,9 +361,86 @@ def is_release_next_week(group):
     )
     for release in release_schedules.json()['all_ga_tasks']:
         release_date = datetime.strptime(release['date_finish'], "%Y-%m-%d").date()
-        if release_date > date.today() and release_date <= date.today() + timedelta(days=7):
+        if release_date > date.today() and release_date <= date.today() + timedelta(days=2):
             return True
     return False
+
+
+def should_honor_ignorable_repos(runtime, force_ignore: bool = False) -> bool:
+    """
+    Determine whether ignorable repos should be honored based on lifecycle phase,
+    release scheduling, and force flag.
+
+    Logic:
+    1. If force_ignore=True, always honor ignorable repos (return True)
+    2. If software_lifecycle.phase != "release", always honor ignorable repos (return True)
+    3. If phase == "release", check if release is scheduled within 2 days:
+       - If release is imminent, DO NOT honor ignorable (return False) to allow rebuilds
+       - Otherwise, honor ignorable (return True)
+
+    :param runtime: Runtime object with group_config and group name
+    :param force_ignore: Manual override to force ignoring repos even during GA releases
+    :return: True if ignorable repos should be skipped, False if they should be processed
+    """
+    # Force flag always wins
+    if force_ignore:
+        LOGGER.info("Force ignore flag set: honoring ignorable repos regardless of lifecycle phase")
+        return True
+
+    # Check if we have lifecycle phase configured
+    group_config = getattr(runtime, 'group_config', None)
+    if not group_config:
+        LOGGER.warning("No group_config available; defaulting to NOT honoring ignorable repos")
+        return False
+
+    software_lifecycle = getattr(group_config, 'software_lifecycle', None)
+    if not software_lifecycle or software_lifecycle is Missing:
+        LOGGER.warning("No software_lifecycle configured; defaulting to NOT honoring ignorable repos")
+        return False
+
+    phase_name = getattr(software_lifecycle, 'phase', None)
+    if not phase_name or phase_name is Missing:
+        LOGGER.warning("No software_lifecycle.phase configured; defaulting to NOT honoring ignorable repos")
+        return False
+
+    try:
+        phase = SoftwareLifecyclePhase.from_name(phase_name)
+    except (ValueError, AttributeError) as e:
+        LOGGER.warning(
+            f"Invalid software_lifecycle.phase '{phase_name}': {e}; defaulting to NOT honoring ignorable repos"
+        )
+        return False
+
+    # Always honor ignorable for non-release phases
+    if phase != SoftwareLifecyclePhase.RELEASE:
+        LOGGER.info(f"Software lifecycle phase is '{phase_name}' (not 'release'): honoring ignorable repos")
+        return True
+
+    # Phase is 'release' - check if we're close to a GA release
+    # Cache the result on runtime to avoid repeated API calls
+    cache_key = '_cached_is_release_next_week'
+    if hasattr(runtime, cache_key):
+        is_release_soon = getattr(runtime, cache_key)
+        LOGGER.debug(f"Using cached release schedule check: is_release_soon={is_release_soon}")
+    else:
+        try:
+            group_name = runtime.group.split('@')[0]  # Remove commitish if present
+            is_release_soon = is_release_next_week(group_name)
+            setattr(runtime, cache_key, is_release_soon)
+            LOGGER.info(f"Release schedule check for {group_name}: release within 2 days = {is_release_soon}")
+        except Exception as e:
+            LOGGER.warning(
+                f"Failed to query release schedule from Product Pages: {e}; defaulting to NOT honoring ignorable repos for safety"
+            )
+            is_release_soon = True  # Fail safe: assume release is coming, don't skip repos
+            setattr(runtime, cache_key, is_release_soon)
+
+    if is_release_soon:
+        LOGGER.info("Release is scheduled within 2 days: NOT honoring ignorable repos to enable rebuilds for GA")
+        return False
+    else:
+        LOGGER.info("No release scheduled within 2 days: honoring ignorable repos")
+        return True
 
 
 def get_inflight(assembly, group, date=None):

--- a/artcommon/tests/test_util_ignorable.py
+++ b/artcommon/tests/test_util_ignorable.py
@@ -1,0 +1,183 @@
+"""
+Tests for should_honor_ignorable_repos() function in artcommonlib.util
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from artcommonlib.model import Missing, Model
+from artcommonlib.util import should_honor_ignorable_repos
+
+
+class TestShouldHonorIgnorableRepos(unittest.TestCase):
+    """
+    Test suite for should_honor_ignorable_repos() decision logic
+    """
+
+    def test_force_flag_always_wins_during_release(self):
+        """Force flag should override all other logic, even during release phase with upcoming GA"""
+        runtime = MagicMock(spec=['group', 'group_config'])
+        runtime.group = 'openshift-4.17'
+        runtime.group_config = Model({'software_lifecycle': {'phase': 'release'}})
+
+        # Even during release phase with upcoming GA, force flag should win
+        with patch('artcommonlib.util.is_release_next_week', return_value=True):
+            self.assertTrue(should_honor_ignorable_repos(runtime, force_ignore=True))
+
+    def test_force_flag_wins_during_pre_release(self):
+        """Force flag should work during pre-release phase too"""
+        runtime = MagicMock()
+        runtime.group_config = Model({'software_lifecycle': {'phase': 'pre-release'}})
+
+        self.assertTrue(should_honor_ignorable_repos(runtime, force_ignore=True))
+
+    def test_pre_release_phase_honors_ignorable(self):
+        """Pre-release phase should always honor ignorable repos"""
+        runtime = MagicMock()
+        runtime.group_config = Model({'software_lifecycle': {'phase': 'pre-release'}})
+
+        self.assertTrue(should_honor_ignorable_repos(runtime, force_ignore=False))
+
+    def test_signing_phase_honors_ignorable(self):
+        """Signing phase should always honor ignorable repos"""
+        runtime = MagicMock()
+        runtime.group_config = Model({'software_lifecycle': {'phase': 'signing'}})
+
+        self.assertTrue(should_honor_ignorable_repos(runtime, force_ignore=False))
+
+    def test_eol_phase_honors_ignorable(self):
+        """End-of-life phase should always honor ignorable repos"""
+        runtime = MagicMock()
+        runtime.group_config = Model({'software_lifecycle': {'phase': 'eol'}})
+
+        self.assertTrue(should_honor_ignorable_repos(runtime, force_ignore=False))
+
+    def test_release_phase_with_upcoming_ga_does_not_honor(self):
+        """During release phase with GA within 2 days, should NOT honor ignorable"""
+        runtime = MagicMock(spec=['group', 'group_config'])
+        runtime.group = 'openshift-4.17'
+        runtime.group_config = Model({'software_lifecycle': {'phase': 'release'}})
+
+        with patch('artcommonlib.util.is_release_next_week', return_value=True):
+            self.assertFalse(should_honor_ignorable_repos(runtime, force_ignore=False))
+
+    def test_release_phase_without_upcoming_ga_honors(self):
+        """During release phase without upcoming GA (>2 days away), should honor ignorable"""
+        runtime = MagicMock(spec=['group', 'group_config'])
+        runtime.group = 'openshift-4.17'
+        runtime.group_config = Model({'software_lifecycle': {'phase': 'release'}})
+
+        with patch('artcommonlib.util.is_release_next_week', return_value=False):
+            self.assertTrue(should_honor_ignorable_repos(runtime, force_ignore=False))
+
+    def test_missing_group_config_defaults_to_not_honor(self):
+        """Missing group_config should default to NOT honoring (fail-safe)"""
+        runtime = MagicMock()
+        runtime.group_config = None
+
+        self.assertFalse(should_honor_ignorable_repos(runtime, force_ignore=False))
+
+    def test_missing_software_lifecycle_defaults_to_not_honor(self):
+        """Missing software_lifecycle should default to NOT honoring (fail-safe)"""
+        runtime = MagicMock()
+        runtime.group_config = Model({})
+
+        self.assertFalse(should_honor_ignorable_repos(runtime, force_ignore=False))
+
+    def test_software_lifecycle_is_missing_sentinel(self):
+        """software_lifecycle as Missing sentinel should default to NOT honoring"""
+        runtime = MagicMock()
+        runtime.group_config = MagicMock()
+        runtime.group_config.software_lifecycle = Missing
+
+        self.assertFalse(should_honor_ignorable_repos(runtime, force_ignore=False))
+
+    def test_missing_phase_defaults_to_not_honor(self):
+        """Missing phase value should default to NOT honoring (fail-safe)"""
+        runtime = MagicMock()
+        runtime.group_config = Model({'software_lifecycle': {}})
+
+        self.assertFalse(should_honor_ignorable_repos(runtime, force_ignore=False))
+
+    def test_phase_is_missing_sentinel(self):
+        """phase as Missing sentinel should default to NOT honoring"""
+        runtime = MagicMock()
+        runtime.group_config = MagicMock()
+        runtime.group_config.software_lifecycle = MagicMock()
+        runtime.group_config.software_lifecycle.phase = Missing
+
+        self.assertFalse(should_honor_ignorable_repos(runtime, force_ignore=False))
+
+    def test_invalid_phase_name_defaults_to_not_honor(self):
+        """Invalid phase name should default to NOT honoring (fail-safe)"""
+        runtime = MagicMock()
+        runtime.group_config = Model({'software_lifecycle': {'phase': 'invalid-phase'}})
+
+        self.assertFalse(should_honor_ignorable_repos(runtime, force_ignore=False))
+
+    def test_api_failure_defaults_to_not_honor(self):
+        """Product Pages API failure should default to NOT honoring (fail-safe)"""
+        runtime = MagicMock(spec=['group', 'group_config'])
+        runtime.group = 'openshift-4.17'
+        runtime.group_config = Model({'software_lifecycle': {'phase': 'release'}})
+
+        with patch('artcommonlib.util.is_release_next_week', side_effect=Exception("API down")):
+            self.assertFalse(should_honor_ignorable_repos(runtime, force_ignore=False))
+
+    def test_caching_on_runtime_works(self):
+        """Release schedule query should be cached on runtime to avoid repeated API calls"""
+        runtime = MagicMock(spec=['group', 'group_config'])
+        runtime.group = 'openshift-4.17'
+        runtime.group_config = Model({'software_lifecycle': {'phase': 'release'}})
+
+        with patch('artcommonlib.util.is_release_next_week', return_value=True) as mock_api:
+            # First call
+            result1 = should_honor_ignorable_repos(runtime, force_ignore=False)
+            self.assertFalse(result1)
+            self.assertEqual(mock_api.call_count, 1)
+
+            # Second call should use cache
+            result2 = should_honor_ignorable_repos(runtime, force_ignore=False)
+            self.assertFalse(result2)
+            self.assertEqual(mock_api.call_count, 1)  # Still 1, not 2
+
+            # Verify cache attribute exists
+            self.assertTrue(hasattr(runtime, '_cached_is_release_next_week'))
+            self.assertTrue(runtime._cached_is_release_next_week)
+
+    def test_caching_stores_api_failure_result(self):
+        """Even API failures should be cached to avoid hammering broken endpoint"""
+        runtime = MagicMock(spec=['group', 'group_config'])
+        runtime.group = 'openshift-4.17'
+        runtime.group_config = Model({'software_lifecycle': {'phase': 'release'}})
+
+        with patch('artcommonlib.util.is_release_next_week', side_effect=Exception("API down")) as mock_api:
+            # First call
+            result1 = should_honor_ignorable_repos(runtime, force_ignore=False)
+            self.assertFalse(result1)
+            self.assertEqual(mock_api.call_count, 1)
+
+            # Second call should not retry API
+            result2 = should_honor_ignorable_repos(runtime, force_ignore=False)
+            self.assertFalse(result2)
+            self.assertEqual(mock_api.call_count, 1)  # Still 1, not 2
+
+            # Verify cache stores the fail-safe value (True)
+            self.assertTrue(hasattr(runtime, '_cached_is_release_next_week'))
+            self.assertTrue(runtime._cached_is_release_next_week)
+
+    def test_group_with_commitish_is_stripped(self):
+        """Group name with @commitish should be stripped before API call"""
+        runtime = MagicMock(spec=['group', 'group_config'])
+        runtime.group = 'openshift-4.17@abc123def'
+        runtime.group_config = Model({'software_lifecycle': {'phase': 'release'}})
+
+        with patch('artcommonlib.util.is_release_next_week', return_value=False) as mock_api:
+            should_honor_ignorable_repos(runtime, force_ignore=False)
+
+            # Verify API was called with stripped group name
+            mock_api.assert_called_once_with('openshift-4.17')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/doozer/doozerlib/build_info.py
+++ b/doozer/doozerlib/build_info.py
@@ -11,6 +11,7 @@ from artcommonlib.konflux.package_rpm_finder import PackageRpmFinder
 from artcommonlib.model import Model
 from artcommonlib.release_util import isolate_el_version_in_release
 from artcommonlib.rpm_utils import to_nevra
+from artcommonlib.util import should_honor_ignorable_repos
 
 import doozerlib
 from doozerlib import brew, util
@@ -149,6 +150,37 @@ class BrewImageInspector(ImageInspector):
                 meta.distgit_key,
             )
             return []
+
+        # Filter out ignorable repos based on lifecycle phase and release schedule (ART-14091)
+        if should_honor_ignorable_repos(
+            self.runtime, force_ignore=getattr(self.runtime, 'ignore_all_ignorable_repos', False)
+        ):
+            non_ignorable_repos = []
+            for repo_name in enabled_repos:
+                repo = group_repos[repo_name]
+                # Check if repo has scan_sources.ignorable set to true
+                if repo._data.get('scan_sources', {}).get('ignorable', False):
+                    logger.info(
+                        f'Ignoring repo {repo_name} for RPM change detection in {meta.distgit_key} '
+                        f'(marked as ignorable and conditions allow skipping)'
+                    )
+                else:
+                    non_ignorable_repos.append(repo_name)
+
+            if not non_ignorable_repos:
+                logger.info(
+                    "All enabled repos for %s are marked as ignorable and skipped; no RPM change detection needed",
+                    meta.distgit_key,
+                )
+                return []
+
+            enabled_repos = non_ignorable_repos
+        else:
+            logger.info(
+                f"Lifecycle phase or release schedule requires processing all repos for {meta.distgit_key} "
+                f"(ignorable flag not honored)"
+            )
+
         logger.info(
             "Fetching repodatas for enabled repos %s", ", ".join(f"{repo_name}-{arch}" for repo_name in enabled_repos)
         )
@@ -751,6 +783,36 @@ class KonfluxBuildRecordInspector(BuildRecordInspector):
                 meta.distgit_key,
             )
             return {}
+
+        # Filter out ignorable repos based on lifecycle phase and release schedule (ART-14091)
+        if should_honor_ignorable_repos(
+            self.runtime, force_ignore=getattr(self.runtime, 'ignore_all_ignorable_repos', False)
+        ):
+            non_ignorable_repos = []
+            for repo_name in enabled_repos:
+                repo = group_repos[repo_name]
+                # Check if repo has scan_sources.ignorable set to true
+                if repo._data.get('scan_sources', {}).get('ignorable', False):
+                    logger.info(
+                        f'Ignoring repo {repo_name} for RPM change detection in {meta.distgit_key} '
+                        f'(marked as ignorable and conditions allow skipping)'
+                    )
+                else:
+                    non_ignorable_repos.append(repo_name)
+
+            if not non_ignorable_repos:
+                logger.info(
+                    "All enabled repos for %s are marked as ignorable and skipped; no RPM change detection needed",
+                    meta.distgit_key,
+                )
+                return {}
+
+            enabled_repos = non_ignorable_repos
+        else:
+            logger.info(
+                f"Lifecycle phase or release schedule requires processing all repos for {meta.distgit_key} "
+                f"(ignorable flag not honored)"
+            )
 
         for arch in self._build_record.arches:
             repodatas = await asyncio.gather(

--- a/doozer/doozerlib/cli/scan_sources.py
+++ b/doozer/doozerlib/cli/scan_sources.py
@@ -748,9 +748,17 @@ class ConfigScanSources:
 @click.option("--yaml", "as_yaml", default=False, is_flag=True, help='Print results in a yaml block')
 @click.option("--rebase-priv", default=False, is_flag=True, help='Try to reconcile public upstream into openshift-priv')
 @click.option('--dry-run', default=False, is_flag=True, help='Do not actually perform reconciliation, just log it')
+@click.option(
+    '--ignore-all-ignorable-repos',
+    default=False,
+    is_flag=True,
+    help='Force ignoring repos marked as ignorable even during GA releases (emergency override)',
+)
 @click_coroutine
 @pass_runtime
-async def config_scan_source_changes(runtime: Runtime, ci_kubeconfig, as_yaml, rebase_priv, dry_run):
+async def config_scan_source_changes(
+    runtime: Runtime, ci_kubeconfig, as_yaml, rebase_priv, dry_run, ignore_all_ignorable_repos
+):
     """
     Determine if any rpms / images need to be rebuilt.
 
@@ -781,6 +789,9 @@ async def config_scan_source_changes(runtime: Runtime, ci_kubeconfig, as_yaml, r
         runtime.initialize(mode="both", clone_distgits=True)
     else:
         runtime.initialize(mode='both', clone_distgits=False)
+
+    # Store CLI flag on runtime for use by helper functions (ART-14091)
+    runtime.ignore_all_ignorable_repos = ignore_all_ignorable_repos
 
     await ConfigScanSources(runtime, ci_kubeconfig, as_yaml, rebase_priv, dry_run).run()
 

--- a/doozer/doozerlib/repos.py
+++ b/doozer/doozerlib/repos.py
@@ -96,6 +96,10 @@ class Repo(object):
         if repo_config.reposync:
             repo_dict['reposync'] = repo_config.reposync.model_dump(exclude_none=True)
 
+        # Add scan_sources if present (ART-14091)
+        if repo_config.scan_sources:
+            repo_dict['scan_sources'] = repo_config.scan_sources.model_dump(exclude_none=True)
+
         return Repo(repo_config.name, repo_dict, list(arches), gpgcheck)
 
     def __init__(self, name: str, data: Dict, valid_arches: List[str], gpgcheck: bool = True):

--- a/doozer/doozerlib/rhcos.py
+++ b/doozer/doozerlib/rhcos.py
@@ -13,6 +13,7 @@ from artcommonlib.constants import COREOS_RHEL10_STREAMS, RHCOS_RELEASES_BASE_UR
 from artcommonlib.model import Missing, Model
 from artcommonlib.release_util import isolate_el_version_in_release
 from artcommonlib.rhcos import get_build_id_from_rhcos_pullspec
+from artcommonlib.util import should_honor_ignorable_repos
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from doozerlib import brew
@@ -548,11 +549,38 @@ class RHCOSBuildInspector:
             raise ValueError("RHCOS build repos need to be defined in group config rhcos.enabled_repos.")
         enabled_repos = enabled_repos.primitive()
 
-        enabled_repos_rhel10 = [repo for repo in enabled_repos if "rhel-10" in repo]
-        enabled_repos_rhel9 = [repo for repo in enabled_repos if "rhel-10" not in repo]
-
         group_repos = self.runtime.repos
         arch = self.brew_arch
+
+        # Filter out ignorable repos based on lifecycle phase and release schedule (ART-14091)
+        if should_honor_ignorable_repos(
+            self.runtime, force_ignore=getattr(self.runtime, 'ignore_all_ignorable_repos', False)
+        ):
+            non_ignorable_repos = []
+            for repo_name in enabled_repos:
+                repo = group_repos[repo_name]
+                if repo._data.get('scan_sources', {}).get('ignorable', False):
+                    logger.info(
+                        f'Ignoring repo {repo_name} for RHCOS RPM change detection '
+                        f'(marked as ignorable and conditions allow skipping)'
+                    )
+                else:
+                    non_ignorable_repos.append(repo_name)
+
+            if not non_ignorable_repos:
+                logger.warning(
+                    "All RHCOS enabled repos are marked as ignorable and skipped; no RPM change detection needed"
+                )
+                return []
+
+            enabled_repos = non_ignorable_repos
+        else:
+            logger.info(
+                "Lifecycle phase or release schedule requires processing all RHCOS repos (ignorable flag not honored)"
+            )
+
+        enabled_repos_rhel10 = [repo for repo in enabled_repos if "rhel-10" in repo]
+        enabled_repos_rhel9 = [repo for repo in enabled_repos if "rhel-10" not in repo]
 
         logger.info(
             "Fetching repodatas for enabled repos %s", ", ".join(f"{repo_name}-{arch}" for repo_name in enabled_repos)

--- a/doozer/doozerlib/runtime.py
+++ b/doozer/doozerlib/runtime.py
@@ -25,7 +25,7 @@ from artcommonlib.assembly import (
 )
 from artcommonlib.config import BuildDataLoader
 from artcommonlib.config.plashet import PlashetConfig
-from artcommonlib.config.repo import ContentSet, Repo, RepoList, RepoSync
+from artcommonlib.config.repo import ContentSet, Repo, RepoList, RepoSync, ScanSources
 from artcommonlib.model import Missing, Model
 from artcommonlib.pushd import Dir
 from artcommonlib.runtime import GroupRuntime
@@ -356,7 +356,7 @@ class Runtime(GroupRuntime):
             new_repos = []
 
             for repo_name, repo_data in old_repos.items():
-                # Parse content_set and reposync if present
+                # Parse content_set, reposync, and scan_sources if present
                 content_set = None
                 if 'content_set' in repo_data:
                     content_set = ContentSet.model_validate(repo_data['content_set'])
@@ -364,6 +364,10 @@ class Runtime(GroupRuntime):
                 reposync = RepoSync()
                 if 'reposync' in repo_data:
                     reposync = RepoSync.model_validate(repo_data['reposync'])
+
+                scan_sources = None
+                if 'scan_sources' in repo_data:
+                    scan_sources = ScanSources.model_validate(repo_data['scan_sources'])
 
                 # Create Repo object using constructor
                 repo = Repo(
@@ -373,6 +377,7 @@ class Runtime(GroupRuntime):
                     conf=repo_data.get('conf'),
                     content_set=content_set,
                     reposync=reposync,
+                    scan_sources=scan_sources,
                 )
                 new_repos.append(repo)
 

--- a/doozer/tests/test_rhcos_optimized.py
+++ b/doozer/tests/test_rhcos_optimized.py
@@ -32,7 +32,9 @@ class TestRhcosOptimized(unittest.TestCase):
 
             # Mock repos
             repo9 = MagicMock()
+            repo9._data.get.return_value = {}  # scan_sources not set, so not ignorable
             repo10 = MagicMock()
+            repo10._data.get.return_value = {}  # scan_sources not set, so not ignorable
             self.runtime.repos = {"rhel-9-baseos": repo9, "rhel-10-baseos": repo10}
 
             # Mock repodata


### PR DESCRIPTION
## Summary
This PR adds support for marking repos as ignorable in scan-sources to prevent mass rebuilds from routine RHEL updates.

## Config
Needs to go along with ocp-build-data changes to `group.yml` in the `repos` stanza, e.g.
```
   rhel-9-baseos-rpms:
     scan_sources:
       ignorable: true
```

## Testing
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/56178/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying per-repository scan sources in configuration, including an `ignorable` flag to control whether a repository participates in scan comparisons.

* **Bug Fixes**
  * Outdated RPM detection now ignores repositories marked as ignorable in both image and build/architecture inspection paths.
  * When all enabled repositories are ignorable, RPM checks now return empty results immediately to avoid unnecessary repodata scanning.

* **Tests**
  * Updated related tests to reflect the new `scan_sources`/`ignorable` handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->