### PR TITLE
Fix test_ocp4_scan_konflux missing skip_rpms argument

### DIFF
--- a/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
+++ b/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
@@ -25,6 +25,7 @@ class TestOcp4ScanKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
             assembly='stream',
             data_gitref='',
             image_list='',
+            skip_rpms=False,
         )
 
     @patch.dict(os.environ, {'KUBECONFIG': '/path/to/kubeconfig'})
@@ -150,6 +151,7 @@ class TestBridgeBugMirroring(unittest.IsolatedAsyncioTestCase):
             assembly="stream",
             data_gitref="",
             image_list="",
+            skip_rpms=False,
         )
 
     async def test_run_invokes_bridge_bug_mirroring(self):


### PR DESCRIPTION
## Summary

- Add missing `skip_rpms` parameter to `Ocp4ScanPipeline` test fixtures

#3115 added a required `skip_rpms` parameter to `Ocp4ScanPipeline.__init__()` but did not update the two test instantiation sites, breaking all 8 tests in `test_ocp4_scan_konflux.py`.

## Test plan

- [x] All 8 tests in `pyartcd/tests/pipelines/test_ocp4_scan_konflux.py` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated pipeline test setup to explicitly include RPM processing in two test paths.
  * Improved coverage consistency for pipeline construction and bridge bug mirroring scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->