### PR TITLE
switch to cyclonedx

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -1303,13 +1303,11 @@ class KonfluxClient:
                 case "build-images":
                     has_build_images_task = True
                     task["timeout"] = "12h"
-                    _modify_param(task["params"], "SBOM_TYPE", "spdx")
                     if build_params.additional_secret:
                         _modify_param(task["params"], "ADDITIONAL_SECRET", build_params.additional_secret)
                     if build_params.privileged_nested is not None:
                         _modify_param(task["params"], "PRIVILEGED_NESTED", str(build_params.privileged_nested).lower())
                 case "prefetch-dependencies":
-                    _modify_param(task["params"], "sbom-type", "spdx")
                     if build_params.prefetch_mode:
                         _modify_param(task["params"], "mode", build_params.prefetch_mode)
                     if verbose_prefetch_enabled:


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build job settings now only include optional overrides when they are actually provided.
  * Fixed an issue where an extra build parameter was being sent unconditionally, helping keep build behavior more consistent with the selected options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->