### PR TITLE
ART-21487: handle missing upstream qualifier in Mobster 1.2.1 SBOMs

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -866,47 +866,48 @@ class KonfluxImageBuilder:
             source_rpms = set()
             package_nvrs = set()
 
-            # we request konflux to generate sbom in spdx schema: https://spdx.dev/
-            # https://github.com/openshift-eng/art-tools/blob/fb172e73df248b1dbc09c3666b5229b4db705427/doozer/doozerlib/backend/konflux_client.py#L473
             for x in sbom_contents["packages"]:
                 purl_string = next(
                     (ref["referenceLocator"] for ref in x["externalRefs"] if ref["referenceType"] == "purl"), ""
                 )
 
-                # sbom uses purl or package-url convention https://github.com/package-url/purl-spec
-                # example: pkg:rpm/rhel/coreutils-single@8.32-35.el9?arch=x86_64&upstream=coreutils-8.32-35.el9.src.rpm&distro=rhel-9.4
                 # https://github.com/package-url/packageurl-python does not support purl schemes other than "pkg"
-                # so filter them out
-                if purl_string.startswith("pkg:"):
-                    try:
-                        purl = PackageURL.from_string(purl_string)
-                        # right now, we only care about rpms
-                        if purl.type == "rpm":
-                            # Only process packages actually installed in the image.
-                            # Skip packages that are only available in repository metadata.
-                            # Installed packages have the "upstream" qualifier, which points to the source RPM.
-                            # Packages without "upstream" (only having checksum/repository_id) are just
-                            # available in repository metadata. This prevents spurious entries like
-                            # kernel-rt-427.116.1 appearing when only kernel-rt-427.117.1 is actually installed.
-                            source_rpm = purl.qualifiers.get("upstream", None)
-                            if source_rpm:
-                                # get the installed package (name + version)
-                                if purl.name and purl.version:
-                                    package_nvrs.add(f"{purl.name}-{purl.version}")
+                if not purl_string.startswith("pkg:"):
+                    continue
+                try:
+                    purl = PackageURL.from_string(purl_string)
+                except Exception as e:
+                    LOGGER.warning(f"Failed to parse purl: {purl_string} {e}")
+                    continue
 
-                                # get the source rpm
-                                source_rpms.add(source_rpm.removesuffix(".src.rpm"))
-                    except Exception as e:
-                        LOGGER.warning(f"Failed to parse purl: {purl_string} {e}")
-                        continue
-            if not source_rpms:
+                if purl.type != "rpm":
+                    continue
+
+                arch_qual = purl.qualifiers.get("arch")
+                if not arch_qual or arch_qual == "src" or purl.name == "gpg-pubkey":
+                    continue
+
+                if purl.name and purl.version:
+                    package_nvrs.add(f"{purl.name}-{purl.version}")
+
+                # Old format (Mobster <1.2.1): upstream qualifier points to source RPM
+                # e.g. pkg:rpm/redhat/acl@2.3.1-4.el9?arch=x86_64&upstream=acl-2.3.1-4.el9.src.rpm&distro=rhel-9.8
+                # New format (Mobster >=1.2.1): upstream is stripped; only checksum+repository_id remain
+                # e.g. pkg:rpm/redhat/acl@2.3.1-4.el9?arch=x86_64&checksum=sha256:...&repository_id=...
+                source_rpm = purl.qualifiers.get("upstream")
+                if source_rpm:
+                    source_rpms.add(source_rpm.removesuffix(".src.rpm"))
+                elif purl.name and purl.version:
+                    source_rpms.add(f"{purl.name}-{purl.version}")
+
+            if not package_nvrs:
                 LOGGER.warning("No rpms found in sbom for arch %s. Please investigate", arch)
             return package_nvrs, source_rpms
 
         results = await asyncio.gather(*(_get_for_arch(arch) for arch in arches))
         for arch, result in zip(arches, results):
             package_nvrs, source_rpms = result
-            if not source_rpms:
+            if not package_nvrs:
                 raise ChildProcessError(f"Could not get rpms from SBOM for arch {arch}")
 
         all_package_nvrs = set()

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -1280,3 +1280,242 @@ class TestKonfluxImageBuilderGolangComponent(unittest.TestCase):
         expected = "golang-builder-v1.25-rhel8"  # .el8 override takes precedence
         result = konflux_golang_builder_component_name(nvr)
         self.assertEqual(result, expected)
+
+
+class TestGetInstalledPackages(unittest.IsolatedAsyncioTestCase):
+    """Tests for KonfluxImageBuilder.get_installed_packages() SBOM parsing."""
+
+    def _make_spdx_sbom(self, packages):
+        """Build a minimal SPDX-2.3 SBOM with the given package dicts."""
+        return {
+            "spdxVersion": "SPDX-2.3",
+            "packages": packages,
+        }
+
+    def _make_rpm_package(self, purl_string, name="pkg"):
+        """Build a minimal SPDX package entry with a PURL external ref."""
+        return {
+            "SPDXID": f"SPDXRef-{name}",
+            "name": name,
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": purl_string,
+                    "referenceType": "purl",
+                }
+            ],
+        }
+
+    async def test_old_format_with_upstream(self):
+        """Mobster <1.2.1: PURLs include upstream qualifier -> source_rpms derived from upstream."""
+        sbom = self._make_spdx_sbom(
+            [
+                self._make_rpm_package(
+                    "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=x86_64&upstream=acl-2.3.1-4.el9.src.rpm&distro=rhel-9.8",
+                    name="acl",
+                ),
+                self._make_rpm_package(
+                    "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64&upstream=acl-2.3.1-4.el9.src.rpm&distro=rhel-9.8",
+                    name="libacl",
+                ),
+            ]
+        )
+
+        with patch("doozerlib.backend.konflux_image_builder.exectools.cmd_gather_async") as mock_cmd:
+            import json
+
+            mock_cmd.return_value = (0, json.dumps(sbom), "")
+            package_nvrs, source_rpms = await KonfluxImageBuilder.get_installed_packages(
+                "quay.io/test/image@sha256:abc", ["x86_64"]
+            )
+
+        self.assertEqual(package_nvrs, {"acl-2.3.1-4.el9", "libacl-2.3.1-4.el9"})
+        self.assertEqual(source_rpms, {"acl-2.3.1-4.el9"})
+
+    async def test_new_format_without_upstream(self):
+        """Mobster >=1.2.1: PURLs lack upstream -> binary NVR used as fallback for source_rpms."""
+        sbom = self._make_spdx_sbom(
+            [
+                self._make_rpm_package(
+                    "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=x86_64&checksum=sha256:150d7232&repository_id=rhel-9-baseos",
+                    name="acl",
+                ),
+                self._make_rpm_package(
+                    "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&checksum=sha256:d3adf8b0&repository_id=rhel-9-baseos",
+                    name="bash",
+                ),
+            ]
+        )
+
+        with patch("doozerlib.backend.konflux_image_builder.exectools.cmd_gather_async") as mock_cmd:
+            import json
+
+            mock_cmd.return_value = (0, json.dumps(sbom), "")
+            package_nvrs, source_rpms = await KonfluxImageBuilder.get_installed_packages(
+                "quay.io/test/image@sha256:abc", ["x86_64"]
+            )
+
+        self.assertEqual(package_nvrs, {"acl-2.3.1-4.el9", "bash-5.1.8-9.el9"})
+        self.assertEqual(source_rpms, {"acl-2.3.1-4.el9", "bash-5.1.8-9.el9"})
+
+    async def test_mixed_format(self):
+        """Some PURLs have upstream (old), some don't (new) -> both paths work."""
+        sbom = self._make_spdx_sbom(
+            [
+                self._make_rpm_package(
+                    "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=x86_64&upstream=acl-2.3.1-4.el9.src.rpm&distro=rhel-9.8",
+                    name="acl",
+                ),
+                self._make_rpm_package(
+                    "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&checksum=sha256:d3adf8b0&repository_id=rhel-9-baseos",
+                    name="bash",
+                ),
+            ]
+        )
+
+        with patch("doozerlib.backend.konflux_image_builder.exectools.cmd_gather_async") as mock_cmd:
+            import json
+
+            mock_cmd.return_value = (0, json.dumps(sbom), "")
+            package_nvrs, source_rpms = await KonfluxImageBuilder.get_installed_packages(
+                "quay.io/test/image@sha256:abc", ["x86_64"]
+            )
+
+        self.assertEqual(package_nvrs, {"acl-2.3.1-4.el9", "bash-5.1.8-9.el9"})
+        self.assertEqual(source_rpms, {"acl-2.3.1-4.el9", "bash-5.1.8-9.el9"})
+
+    async def test_gpg_pubkey_filtered_out(self):
+        """gpg-pubkey pseudo-packages should be skipped."""
+        sbom = self._make_spdx_sbom(
+            [
+                self._make_rpm_package(
+                    "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e?distro=rhel-9.8",
+                    name="gpg-pubkey",
+                ),
+                self._make_rpm_package(
+                    "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=x86_64&checksum=sha256:150d7232&repository_id=rhel-9-baseos",
+                    name="acl",
+                ),
+            ]
+        )
+
+        with patch("doozerlib.backend.konflux_image_builder.exectools.cmd_gather_async") as mock_cmd:
+            import json
+
+            mock_cmd.return_value = (0, json.dumps(sbom), "")
+            package_nvrs, source_rpms = await KonfluxImageBuilder.get_installed_packages(
+                "quay.io/test/image@sha256:abc", ["x86_64"]
+            )
+
+        self.assertEqual(package_nvrs, {"acl-2.3.1-4.el9"})
+        self.assertNotIn("gpg-pubkey-5a6340b3-6229229e", package_nvrs)
+
+    async def test_src_arch_filtered_out(self):
+        """Source RPM entries (arch=src) should be skipped."""
+        sbom = self._make_spdx_sbom(
+            [
+                self._make_rpm_package(
+                    "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=src",
+                    name="acl",
+                ),
+                self._make_rpm_package(
+                    "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&checksum=sha256:abc&repository_id=rhel-9-baseos",
+                    name="bash",
+                ),
+            ]
+        )
+
+        with patch("doozerlib.backend.konflux_image_builder.exectools.cmd_gather_async") as mock_cmd:
+            import json
+
+            mock_cmd.return_value = (0, json.dumps(sbom), "")
+            package_nvrs, source_rpms = await KonfluxImageBuilder.get_installed_packages(
+                "quay.io/test/image@sha256:abc", ["x86_64"]
+            )
+
+        self.assertEqual(package_nvrs, {"bash-5.1.8-9.el9"})
+        self.assertNotIn("acl-2.3.1-4.el9", package_nvrs)
+
+    async def test_empty_sbom_raises_error(self):
+        """An SBOM with no RPMs should raise ChildProcessError."""
+        sbom = self._make_spdx_sbom(
+            [
+                self._make_rpm_package(
+                    "pkg:npm/%40npmcli/agent@2.2.2",
+                    name="@npmcli/agent",
+                ),
+            ]
+        )
+
+        with patch("doozerlib.backend.konflux_image_builder.exectools.cmd_gather_async") as mock_cmd:
+            import json
+
+            mock_cmd.return_value = (0, json.dumps(sbom), "")
+            with self.assertRaises(ChildProcessError):
+                await KonfluxImageBuilder.get_installed_packages("quay.io/test/image@sha256:abc", ["x86_64"])
+
+    async def test_non_rpm_packages_ignored(self):
+        """Non-RPM packages (npm, oci) are ignored."""
+        sbom = self._make_spdx_sbom(
+            [
+                self._make_rpm_package(
+                    "pkg:npm/%40npmcli/agent@2.2.2",
+                    name="@npmcli/agent",
+                ),
+                self._make_rpm_package(
+                    "pkg:oci/art-images@sha256:abc?repository_url=quay.io/test",
+                    name="art-images",
+                ),
+                self._make_rpm_package(
+                    "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64&checksum=sha256:abc&repository_id=baseos",
+                    name="bash",
+                ),
+            ]
+        )
+
+        with patch("doozerlib.backend.konflux_image_builder.exectools.cmd_gather_async") as mock_cmd:
+            import json
+
+            mock_cmd.return_value = (0, json.dumps(sbom), "")
+            package_nvrs, source_rpms = await KonfluxImageBuilder.get_installed_packages(
+                "quay.io/test/image@sha256:abc", ["x86_64"]
+            )
+
+        self.assertEqual(package_nvrs, {"bash-5.1.8-9.el9"})
+
+    async def test_multiple_arches(self):
+        """Results are merged across arches."""
+        sbom_amd64 = self._make_spdx_sbom(
+            [
+                self._make_rpm_package(
+                    "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=x86_64&checksum=sha256:aaa&repository_id=baseos",
+                    name="acl",
+                ),
+            ]
+        )
+        sbom_arm64 = self._make_spdx_sbom(
+            [
+                self._make_rpm_package(
+                    "pkg:rpm/redhat/acl@2.3.1-4.el9?arch=aarch64&checksum=sha256:bbb&repository_id=baseos",
+                    name="acl",
+                ),
+                self._make_rpm_package(
+                    "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=aarch64&checksum=sha256:ccc&repository_id=baseos",
+                    name="bash",
+                ),
+            ]
+        )
+
+        import json
+
+        async def mock_cmd(cmd, env=None):
+            if "amd64" in " ".join(cmd):
+                return (0, json.dumps(sbom_amd64), "")
+            return (0, json.dumps(sbom_arm64), "")
+
+        with patch("doozerlib.backend.konflux_image_builder.exectools.cmd_gather_async", side_effect=mock_cmd):
+            package_nvrs, source_rpms = await KonfluxImageBuilder.get_installed_packages(
+                "quay.io/test/image@sha256:abc", ["x86_64", "aarch64"]
+            )
+
+        self.assertEqual(package_nvrs, {"acl-2.3.1-4.el9", "bash-5.1.8-9.el9"})


### PR DESCRIPTION
## Summary

- Adapts `get_installed_packages()` SBOM parsing to handle Mobster >=1.2.1 which no longer includes the `upstream` qualifier on RPM PURLs ([konflux-ci/mobster#435](https://github.com/konflux-ci/mobster/issues/435))
- Falls back to binary NVR (`name-version`) for `source_rpms` when `upstream` is absent, maintaining backward compatibility with older SBOMs
- Only raises `ChildProcessError` when `package_nvrs` is empty (not when `source_rpms` is empty), preventing false failures

## Test plan

- [x] Added 8 unit tests covering: old format (with upstream), new format (without upstream), mixed format, gpg-pubkey filtering, arch=src filtering, empty SBOM error, non-RPM package filtering, multi-arch merging
- [x] All existing backend tests pass with no regressions
- [ ] Verify with a live Konflux build using Mobster >=1.2.1 (e.g. `ocp4-konflux` pipeline)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installed package detection from SBOM data, including more reliable RPM-only parsing and stricter filtering of package entries.
  * Correctly derives source package information when upstream metadata is missing, and avoids counting pseudo-packages and `arch=src` entries.
  * Updated behavior when SBOMs contain no valid RPM package entries to ensure failures are surfaced appropriately.
* **Tests**
  * Added thorough coverage for SBOM extraction across multiple architectures and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->