### PR TITLE
Accept vulnerability-draft component as valid flaw bug

### DIFF
--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -91,9 +91,7 @@ class Bug:
         raise NotImplementedError
 
     def is_flaw_bug(self):
-        if self.product == "Security Response" and self.component == "vulnerability-draft":
-            raise ValueError(f'{self.id} has Component "vulnerability-draft". Consult ProdSec on how to proceed.')
-        return self.product == "Security Response" and self.component == "vulnerability"
+        return self.product == "Security Response" and self.component in ("vulnerability", "vulnerability-draft")
 
     def make_summary_with_target_version(self, major_version: int, minor_version: int) -> str:
         """Given an OCPBUGS bug summary and the major and minor version numbers,


### PR DESCRIPTION
## Summary
- The `is_flaw_bug()` method in `bzutil.py` previously raised a `ValueError` when encountering Bugzilla flaw bugs with the `vulnerability-draft` component, requiring manual ProdSec consultation
- This change treats `vulnerability-draft` the same as `vulnerability`, allowing these bugs to be processed in CVE workflows (e.g. `find-bugs`)

## Test plan
- [x] All 412 existing elliott unit tests pass
- [ ] Verify with a real `vulnerability-draft` flaw bug that it is now accepted by `find-bugs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Security Response bugs with a `vulnerability-draft` component are now treated the same as other flaw bugs.
  * This prevents errors in cases that previously failed and improves handling for draft vulnerability bugs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->