### PR TITLE
fix: Save EC pipeline URL on success, not just on failure

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -343,10 +343,11 @@ class KonfluxImageBuilder:
                         ec_policy=ec_policy,
                         logger=logger,
                     )
+                    # Always save EC pipeline URL for tracking, regardless of pass/fail
+                    ec_pipeline_url = ec_result.ec_pipeline_url
+                    record["ec_pipeline_url"] = ec_pipeline_url
                     if ec_result.ec_failed:
-                        ec_pipeline_url = ec_result.ec_pipeline_url
                         outcome = KonfluxBuildOutcome.ITS_ERROR
-                        record["ec_pipeline_url"] = ec_pipeline_url
 
                 elif outcome is KonfluxBuildOutcome.SUCCESS:
                     if metadata.runtime.variant is BuildVariant.OKD:


### PR DESCRIPTION
The EC pipeline URL was only being saved to the build record when Enterprise Contract verification failed. This meant successful ITS runs did not appear in the ART build history dashboard.

Now the ec_pipeline_url is always saved regardless of pass/fail status, allowing successful EC verifications to be tracked and linked from the build history UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * EC verification pipeline links are now always saved for build tracking, even when verification fails.
  * Build status only changes to an error state when EC verification actually fails, while the pipeline URL remains available for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->