### PR TITLE
ART-21515: fixes for ose-baremetal-installer and ose-containernetworking-plugins

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -542,7 +542,12 @@ class RpmLockfilePrototypeGenerator:
                 stripped_tracker=stripped_tracker,
             )
             if result:
-                if stripped_tracker and image_pullspec and is_update_only:
+                # Any stage shape can inject base image packages (upgrade
+                # targets, reinstall packages, conflict-detection extras)
+                # that include arch-specific packages (e.g. dmidecode,
+                # x86-only) and get stripped during resolution. Try to
+                # recover them per-arch rather than dropping silently.
+                if stripped_tracker and image_pullspec:
                     recovered = await self._recover_stripped_per_arch(
                         repo_list,
                         arches,
@@ -1038,7 +1043,8 @@ class RpmLockfilePrototypeGenerator:
         remaining_update_targets.clear()
         promote_reinstall_to_upgrade = False
         self.upgrades_dropped = True
-        in_yaml = self._build_resolve_config(
+
+        return await self._resolve_fallback(
             repo_list,
             arches,
             remaining_packages,
@@ -1047,9 +1053,72 @@ class RpmLockfilePrototypeGenerator:
             remaining_reinstall,
             promote_reinstall_to_upgrade,
             image_pullspec,
+            resolver_pullspec,
             module_enable,
+            distgit_key,
+            stage_num,
+            stripped_tracker,
         )
-        return await self._resolver.resolve(in_yaml, image_pullspec=resolver_pullspec)
+
+    async def _resolve_fallback(
+        self,
+        repo_list: list[RepoEntry],
+        arches: list[str],
+        remaining_packages: list[str],
+        arch_pkgs: dict[str, list[str]],
+        remaining_update_targets: list[str],
+        remaining_reinstall: list[str],
+        promote_reinstall_to_upgrade: bool,
+        image_pullspec: str | None,
+        resolver_pullspec: str | None,
+        module_enable: list[str] | None,
+        distgit_key: str,
+        stage_num: int,
+        stripped_tracker: set[str] | None,
+    ) -> LockfileData | None:
+        """
+        Last-resort resolve after the main retry loop is exhausted.
+
+        Can still hit packages that are missing for a subset of arches
+        (e.g. base image packages like dmidecode that only exist on
+        x86_64) — keep stripping until it resolves instead of letting a
+        single unguarded call blow up the whole rebase.
+        """
+        for _attempt in range(MAX_RESOLUTION_RETRIES):
+            in_yaml = self._build_resolve_config(
+                repo_list,
+                arches,
+                remaining_packages,
+                arch_pkgs,
+                remaining_update_targets,
+                remaining_reinstall,
+                promote_reinstall_to_upgrade,
+                image_pullspec,
+                module_enable,
+            )
+            try:
+                return await self._resolver.resolve(in_yaml, image_pullspec=resolver_pullspec)
+            except RuntimeError as e:
+                missing = RpmResolver.parse_missing_packages(str(e))
+                if not missing:
+                    raise
+                removed = self._strip_missing_packages(
+                    missing, remaining_packages, remaining_update_targets, remaining_reinstall, arch_pkgs
+                )
+                if not removed:
+                    raise
+                if stripped_tracker is not None:
+                    stripped_tracker.update(missing)
+                self.logger.warning(
+                    f"{distgit_key}: stage {stage_num}: fallback retry without unavailable packages: "
+                    f"{sorted(missing)}"
+                )
+                if not remaining_packages and not arch_pkgs and not remaining_reinstall:
+                    self.logger.warning(
+                        f"{distgit_key}: stage {stage_num}: no packages remaining after fallback filtering, skipping"
+                    )
+                    return None
+        raise RuntimeError(f"{distgit_key}: stage {stage_num}: exceeded {MAX_RESOLUTION_RETRIES} fallback retries")
 
     def _assemble_lockfile(self, stage_lockfiles: list[LockfileData], image_meta: ImageMetadata) -> LockfileData:
         """

--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -506,22 +506,23 @@ class RpmLockfilePrototypeGenerator:
                 # install list for conflict detection.
                 #
                 # When the builder image RHEL version differs from the repos
-                # (e.g. el8 builder with el9 repos), skip --image mode and
-                # base image packages — cross-RHEL depsolve is unsolvable.
+                # (e.g. el8 builder with el9 repos), the stage's own packages
+                # can't be soundly resolved either — the only repos we have
+                # are for the wrong RHEL major, so skip locking this stage's
+                # packages entirely rather than pinning a mismatched RPM.
                 if self._has_rhel_version_mismatch(stage_num, repo_list, distgit_key):
-                    image_pullspec = None
-                else:
-                    if image_pullspec:
-                        reinstall_pkgs = list(packages)
-                    base_pkgs = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key)
-                    if base_pkgs:
-                        extra = [p for p in base_pkgs if p not in packages]
-                        if extra:
-                            packages = packages + extra
-                            self.logger.info(
-                                f"{distgit_key}: stage {stage_num}: {len(extra)} base image "
-                                "packages added to install list for conflict detection"
-                            )
+                    continue
+                if image_pullspec:
+                    reinstall_pkgs = list(packages)
+                base_pkgs = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key)
+                if base_pkgs:
+                    extra = [p for p in base_pkgs if p not in packages]
+                    if extra:
+                        packages = packages + extra
+                        self.logger.info(
+                            f"{distgit_key}: stage {stage_num}: {len(extra)} base image "
+                            "packages added to install list for conflict detection"
+                        )
 
             enable_only = [s.split("/")[0] for s in stage_info.module_specs] if stage_info.module_specs else None
 
@@ -717,7 +718,7 @@ class RpmLockfilePrototypeGenerator:
             self.logger.warning(
                 f"{distgit_key}: stage {stage_num}: RHEL version mismatch — "
                 f"builder image is el{builder_rhel} but repos are el{repo_rhel}; "
-                f"skipping base image packages and --image mode for this stage"
+                f"skipping package resolution for this stage entirely"
             )
             return True
         return False
@@ -1110,8 +1111,7 @@ class RpmLockfilePrototypeGenerator:
                 if stripped_tracker is not None:
                     stripped_tracker.update(missing)
                 self.logger.warning(
-                    f"{distgit_key}: stage {stage_num}: fallback retry without unavailable packages: "
-                    f"{sorted(missing)}"
+                    f"{distgit_key}: stage {stage_num}: fallback retry without unavailable packages: {sorted(missing)}"
                 )
                 if not remaining_packages and not arch_pkgs and not remaining_reinstall:
                     self.logger.warning(

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -714,12 +714,11 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
         generator._container.get_installed_packages = AsyncMock(return_value=["nonexistent-pkg", "glibc"])
 
-        call_count = 0
-
         async def mock_resolve(config, image_pullspec=None):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
+            pkg_names = [p if isinstance(p, str) else p.name for p in (config.packages or [])]
+            pkg_names += config.reinstallPackages or []
+            pkg_names += config.upgradePackages or []
+            if "nonexistent-pkg" in pkg_names:
                 raise RuntimeError("No match for argument: nonexistent-pkg")
             return FAKE_LOCKFILE_DATA.model_copy(deep=True)
 
@@ -730,8 +729,10 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
             (dest_dir / "Dockerfile").write_text("FROM base\nRUN dnf install -y curl\n")
             asyncio.run(generator.generate_lockfile(meta, dest_dir))
 
-        # First attempt fails, then early exit + fallback = 2 calls total
-        self.assertEqual(call_count, 2)
+        # First attempt fails, early exit + fallback succeeds, then per-arch
+        # recovery is attempted for the stripped package (2 arches, both fail
+        # since nonexistent-pkg is genuinely unavailable everywhere) = 4 calls.
+        self.assertEqual(generator._resolver.resolve.call_count, 4)
         # Fallback should drop all optional reinstall packages
         fallback_config = generator._resolver.resolve.call_args_list[1][0][0]
         self.assertEqual(fallback_config.reinstallPackages, [])
@@ -751,12 +752,11 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
         generator._container.get_installed_packages = AsyncMock(return_value=["bad-pkg", "glibc"])
 
-        call_count = 0
-
         async def mock_resolve(config, image_pullspec=None):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
+            pkg_names = [p if isinstance(p, str) else p.name for p in (config.packages or [])]
+            pkg_names += config.reinstallPackages or []
+            pkg_names += config.upgradePackages or []
+            if "bad-pkg" in pkg_names:
                 raise RuntimeError("No match for argument: bad-pkg")
             return FAKE_LOCKFILE_DATA.model_copy(deep=True)
 
@@ -770,7 +770,10 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
             asyncio.run(generator.generate_lockfile(meta, dest_dir))
 
         self.assertTrue(generator.upgrades_dropped)
-        fallback_config = generator._resolver.resolve.call_args_list[-1][0][0]
+        # Index 1 is the fallback call (index 0 fails, indices 2+ are the
+        # per-arch recovery attempts for the stripped bad-pkg, which also
+        # fail since it's genuinely unavailable everywhere).
+        fallback_config = generator._resolver.resolve.call_args_list[1][0][0]
         self.assertEqual(fallback_config.upgradePackages, [])
 
     def test_fallback_packages_used_when_image_unreachable(self):
@@ -875,12 +878,10 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         generator = self._make_generator()
         generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
 
-        call_count = 0
-
         async def mock_resolve(config, image_pullspec=None):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
+            pkg_names = [p if isinstance(p, str) else p.name for p in (config.packages or [])]
+            pkg_names += config.upgradePackages or []
+            if "dmidecode" in pkg_names:
                 raise RuntimeError("No match for argument: dmidecode")
             return FAKE_LOCKFILE_DATA.model_copy(deep=True)
 
@@ -891,7 +892,9 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
             (dest_dir / "Dockerfile").write_text("FROM base\nRUN yum -y install nfs-utils dmidecode\n")
             asyncio.run(generator.generate_lockfile(meta, dest_dir))
 
-            self.assertEqual(generator._resolver.resolve.call_count, 2)
+            # 1 failing attempt + 1 successful retry + 2 per-arch recovery
+            # attempts for dmidecode (both fail, genuinely unavailable) = 4.
+            self.assertEqual(generator._resolver.resolve.call_count, 4)
             self.assertTrue((dest_dir / "rpms.lock.yaml").exists())
 
     def test_resolve_stage_with_retry_no_upgrade_packages_when_bare(self):
@@ -1262,6 +1265,141 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         self.assertIn("git", final_config.reinstallPackages)
         for pkg in failing_pkgs:
             self.assertNotIn(pkg, final_config.reinstallPackages)
+
+    def test_fallback_strips_newly_discovered_missing_package(self):
+        """
+        A package that only surfaces as missing once the retry loop is
+        already exhausted (e.g. dmidecode, only on x86_64) must still be
+        stripped by the fallback instead of crashing the whole resolve
+        with an unguarded RuntimeError.
+        """
+        generator = self._make_generator()
+        generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
+
+        failing_pkgs = [f"base-pkg-{i}" for i in range(5)]
+        call_count = 0
+
+        async def mock_resolve(config, image_pullspec=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 5:
+                raise RuntimeError(f"No match for argument: {failing_pkgs[call_count - 1]}")
+            if call_count == 6:
+                raise RuntimeError("No match for argument: dmidecode")
+            return FAKE_LOCKFILE_DATA.model_copy(deep=True)
+
+        generator._resolver.resolve = AsyncMock(side_effect=mock_resolve)
+
+        repos = [
+            RepoEntry(
+                repoid="rhel-9-baseos-rpms",
+                baseurl="https://example.com/baseos/$basearch/os/",
+            )
+        ]
+
+        result = asyncio.run(
+            generator._resolve_stage_with_retry(
+                repo_list=repos,
+                arches=["x86_64", "aarch64"],
+                packages=["git", "dmidecode"] + failing_pkgs,
+                arch_pkgs={},
+                update_targets=[],
+                image_pullspec="quay.io/test/base@sha256:abc123",
+                distgit_key="ose-baremetal-installer",
+                stage_num=0,
+                strippable_packages=set(failing_pkgs),
+            )
+        )
+
+        self.assertIsNotNone(result)
+        # 5 main-loop retries + 1 fallback failure on dmidecode + 1 successful fallback retry
+        self.assertEqual(call_count, 7)
+        final_config = generator._resolver.resolve.call_args_list[6][0][0]
+        pkg_names = [p if isinstance(p, str) else p.name for p in final_config.packages]
+        self.assertNotIn("dmidecode", pkg_names)
+        self.assertIn("git", pkg_names)
+
+    def test_fallback_raises_after_exhausting_its_own_retries(self):
+        """
+        If the fallback itself keeps hitting new missing packages beyond
+        its retry budget, it must raise a clear RuntimeError rather than
+        looping forever or crashing with a raw parse failure.
+        """
+        generator = self._make_generator()
+        generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
+
+        # 5 distinct packages for the main loop, then 5 more distinct
+        # packages that only ever surface during the fallback loop.
+        main_failing = [f"base-pkg-{i}" for i in range(5)]
+        fallback_failing = [f"arch-only-pkg-{i}" for i in range(5)]
+        call_count = 0
+
+        async def mock_resolve(config, image_pullspec=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 5:
+                raise RuntimeError(f"No match for argument: {main_failing[call_count - 1]}")
+            raise RuntimeError(f"No match for argument: {fallback_failing[call_count - 6]}")
+
+        generator._resolver.resolve = AsyncMock(side_effect=mock_resolve)
+
+        repos = [
+            RepoEntry(
+                repoid="rhel-9-baseos-rpms",
+                baseurl="https://example.com/baseos/$basearch/os/",
+            )
+        ]
+
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(
+                generator._resolve_stage_with_retry(
+                    repo_list=repos,
+                    arches=["x86_64", "aarch64"],
+                    packages=["git"] + main_failing + fallback_failing,
+                    arch_pkgs={},
+                    update_targets=[],
+                    image_pullspec="quay.io/test/base@sha256:abc123",
+                    distgit_key="ose-baremetal-installer",
+                    stage_num=0,
+                    strippable_packages=set(main_failing),
+                )
+            )
+
+        self.assertIn("exceeded", str(ctx.exception))
+        # 5 main-loop attempts + 5 fallback attempts, no more calls after that
+        self.assertEqual(call_count, 10)
+
+    def test_bare_update_final_stage_triggers_per_arch_recovery(self):
+        """
+        End-to-end: final stage with a bare 'dnf upgrade -y' plus an
+        explicit install (has_bare_update=True, is_update_only=False)
+        strips an arch-specific base image package (e.g. dmidecode).
+        Per-arch recovery must still be attempted for this stage shape,
+        not just for is_update_only stages.
+        """
+        meta = self._make_mock_image_meta()
+        generator = self._make_generator()
+        generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
+        generator._container.get_installed_packages = AsyncMock(return_value=["curl", "dmidecode"])
+        generator._recover_stripped_per_arch = AsyncMock(return_value=None)
+
+        async def mock_resolve(config, image_pullspec=None):
+            pkg_names = [p if isinstance(p, str) else p.name for p in (config.packages or [])]
+            pkg_names += config.upgradePackages or []
+            if "dmidecode" in pkg_names:
+                raise RuntimeError("No match for argument: dmidecode")
+            return FAKE_LOCKFILE_DATA.model_copy(deep=True)
+
+        generator._resolver.resolve = AsyncMock(side_effect=mock_resolve)
+
+        with TemporaryDirectory() as tmpdir:
+            dest_dir = Path(tmpdir)
+            (dest_dir / "Dockerfile").write_text("FROM base-rhel9\nRUN dnf upgrade -y && dnf install -y curl\n")
+            asyncio.run(generator.generate_lockfile(meta, dest_dir))
+
+        generator._recover_stripped_per_arch.assert_awaited_once()
+        stripped_arg = generator._recover_stripped_per_arch.call_args[0][2]
+        self.assertIn("dmidecode", stripped_arg)
 
     def test_builder_stage_strips_unavailable_packages_silently(self):
         """

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -2027,8 +2027,11 @@ class TestHasRhelVersionMismatch(unittest.TestCase):
 
 class TestRhelMismatchEndToEnd(unittest.TestCase):
     """
-    End-to-end: builder stage with el8 pullspec + el9 repos should skip
-    base image packages and resolve only Dockerfile packages in bare mode.
+    End-to-end: builder stage with el8 pullspec + el9 repos has no repos
+    that can soundly resolve its packages (mixing el8 and el9 repos in
+    one rpm-lockfile-prototype call breaks module resolution), so the
+    whole stage's packages must be skipped rather than resolved against
+    the wrong RHEL major.
     """
 
     def _make_mock_repos(self) -> MagicMock:
@@ -2054,7 +2057,7 @@ class TestRhelMismatchEndToEnd(unittest.TestCase):
         meta.config.konflux.cachi2.lockfile = lockfile_config
         return meta
 
-    def test_el8_builder_skips_base_image_packages(self):
+    def test_el8_builder_skips_entire_stage(self):
         container = MagicMock(spec=ContainerImageHelper)
         container.resolve_to_digest = AsyncMock(side_effect=lambda p: p.split(":")[0] + "@sha256:abc123")
         container.get_installed_packages = AsyncMock(return_value=["gcc", "glibc", "readline"])
@@ -2085,20 +2088,10 @@ class TestRhelMismatchEndToEnd(unittest.TestCase):
             )
             asyncio.run(generator.generate_lockfile(self._make_mock_image_meta(), dest_dir))
 
-            # Resolver should have been called for stage 0 in bare mode
-            # (image_pullspec=None) because of RHEL mismatch
-            calls = resolver.resolve.call_args_list
-            stage0_call = calls[0]
-            self.assertIsNone(
-                stage0_call.kwargs.get("image_pullspec"),
-                "Stage 0 should use bare mode (image_pullspec=None) due to RHEL mismatch",
-            )
-
-            # Base image packages should NOT have been added to the install
-            # list — only the Dockerfile package should be present
-            config = stage0_call.args[0]
-            pkg_names = [p if isinstance(p, str) else p.name for p in config.packages]
-            self.assertIn("subscription-manager", pkg_names)
-            self.assertNotIn("gcc", pkg_names, "Base image packages should not be in install list")
-            self.assertNotIn("glibc", pkg_names, "Base image packages should not be in install list")
-            self.assertNotIn("readline", pkg_names, "Base image packages should not be in install list")
+            # Stage 0 (el8 builder, el9-only repos) must be skipped entirely —
+            # no repos exist that could soundly resolve its packages, so it's
+            # dropped from the lockfile rather than pinning a mismatched RPM.
+            # The final stage has no install/update commands, so no stage
+            # ever reaches the resolver.
+            resolver.resolve.assert_not_called()
+            self.assertTrue((dest_dir / "rpms.lock.yaml").exists())


### PR DESCRIPTION
https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-ose-containernetworking-plugins-rbgz2

https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-ose-baremetal-installer-6b2gh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of RHEL major-version mismatches by skipping package resolution for the affected builder stage instead of switching to a less complete mode.
  * Broadened stripped-package recovery so per-architecture recovery can run whenever recovery tracking is enabled and an image source is available.
  * Refined fallback retry behavior with bounded retries to avoid unhandled errors and to retry missing packages more consistently.
* **Tests**
  * Updated and expanded generator retry/fallback coverage, including resolver-call expectations and mismatch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->