### PR TITLE
Store pipeline_url for OKD build failures in Redis

### DIFF
--- a/pyartcd/pyartcd/pipelines/okd.py
+++ b/pyartcd/pyartcd/pipelines/okd.py
@@ -458,6 +458,7 @@ class KonfluxOkdPipeline:
                     f'count:build-failure:konflux:{group}:{image}',
                     jenkins_url=job_url,
                     nvr=failed_entries.get(image, {}).get('nvrs'),
+                    pipeline_url=failed_entries.get(image, {}).get('build_pipeline_url'),
                 )
                 for image in failed_images
             ]


### PR DESCRIPTION
Add pipeline_url parameter to increment_fail_counter for OKD build failures to achieve feature parity with OCP4-Konflux builds.

Previously, OKD build failures only stored jenkins_url and nvr in Redis, while OCP4-Konflux builds also stored the pipeline_url. This prevented OKD failures from having links to the Konflux pipeline runs in monitoring dashboards and failure reports.


## Test
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fokd/1324/ created `count:build-failure:konflux:okd-5.0:ose-machine-os-images:pipeline_url` in Redis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build-failure tracking for failed image builds, helping failure metrics and related reporting stay more accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->