### PR TITLE
ART-20948 elliott: gate golang CVE changelog parsing behind --parse-changelog flag

### DIFF
--- a/elliott/elliottlib/cli/find_bugs_golang_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_golang_cli.py
@@ -93,6 +93,7 @@ class FindBugsGolangCli:
         output_format: str = None,
         rpms_only: bool = False,
         skip_comment: bool = False,
+        parse_changelog: bool = False,
     ):
         self._runtime = runtime
         self._logger = LOGGER
@@ -110,6 +111,7 @@ class FindBugsGolangCli:
         self.output_format = output_format
         self.rpms_only = rpms_only
         self.skip_comment = skip_comment
+        self.parse_changelog = parse_changelog
 
         # cache
         self.pullspec = pullspec
@@ -423,7 +425,7 @@ class FindBugsGolangCli:
                 f"No fixed in NVRs specified, using golang versions from report as fixed in versions: {self.fixed_in_nvrs}"
             )
 
-        if not self.cve_ids:
+        if not self.cve_ids and self.parse_changelog:
             cves = self._get_cves_from_nvr_changelogs()
             if cves:
                 self.cve_ids = tuple(sorted(cves))
@@ -776,6 +778,14 @@ class FindBugsGolangCli:
     default=False,
     help="When updating tracker, skip adding comment with analysis and just update status. Only applicable if --update-tracker is set.",
 )
+@click.option(
+    "--parse-changelog",
+    is_flag=True,
+    default=False,
+    help="Parse changelogs of --fixed-in-nvr build(s) to automatically determine additional CVE ID(s) that are "
+    "fixed, merging them with any CVE ID(s) given via --cve-id. Disabled by default: by default the command "
+    "only considers CVE ID(s) explicitly given via --cve-id as fixed.",
+)
 @click.pass_obj
 @click_coroutine
 async def find_bugs_golang_cli(
@@ -795,6 +805,7 @@ async def find_bugs_golang_cli(
     output_format: str,
     rpms_only: bool,
     skip_comment: bool = False,
+    parse_changelog: bool = False,
 ):
     """Find golang security tracker bugs in jira and determine if they are fixed.
     Trackers are fetched from the OCPBUGS project
@@ -803,11 +814,14 @@ async def find_bugs_golang_cli(
 
     IMPORTANT: If --fixed-in-nvr isnot specified, then NVRs are automatically determined from builders defined in streams.yml and brew buildroots.
 
-    CVE fixes are determined from changelogs of these brew builds, in combination with CVE IDs specified with --cve-id.
+    By default, only CVE ID(s) explicitly specified with --cve-id are considered fixed. Pass --parse-changelog to
+    additionally determine CVE fixes from changelogs of the --fixed-in-nvr build(s); these are merged with any
+    CVE ID(s) given via --cve-id. This is useful in case you want to consider changelog entries as an additional
+    source of truth for CVE fixes, but changelog entries are not always accurate or present, so this is disabled
+    by default.
     Multiple NVRs can be specified e.g. "--fixed-in-nvr NVR1 --fixed-in-nvr NVR2"
 
-    Pass in --cve-id to specify additional CVE ID(s) that are fixed which may not be present in changelogs of the specified NVRs. This is useful in case changelog entries are not accurate or missing.
-    Multiple CVE IDs can be specified e.g. "--cve-id CVE-A --cve-id CVE-B"
+    Pass in --cve-id to specify CVE ID(s) that are fixed. Multiple CVE IDs can be specified e.g. "--cve-id CVE-A --cve-id CVE-B"
 
     Pass in --analyze to determine if found bugs are fixed against the computed target fixed versions.
 
@@ -831,6 +845,9 @@ async def find_bugs_golang_cli(
     --component: Only operate on trackers for these JIRA Bug components e.g. openshift-golang-builder-container.
 
     --rpms-only: Ignore builder container bugs and only analyze RPM trackers.
+
+    --parse-changelog: Parse changelogs of --fixed-in-nvr build(s) to determine additional CVE ID(s) that are fixed,
+    merged with any CVE ID(s) given via --cve-id. Disabled by default.
 
     --exclude-bug-statuses: Exclude bugs in these statuses. If you wanted to analyze and report on all open bugs
     you would pass --exclude-bug-statuses="". Only used when not using --tracker-id.
@@ -893,6 +910,9 @@ async def find_bugs_golang_cli(
     if force_update_tracker and not cve_ids:
         raise click.BadParameter('Cannot use --force-update-tracker without --cve-id')
 
+    if parse_changelog and not fixed_in_nvrs:
+        raise click.BadParameter('Cannot use --parse-changelog without --fixed-in-nvr')
+
     runtime.initialize(mode="both")
     if runtime.assembly != 'stream' and analyze and not pullspec:
         releases_config = runtime.get_releases_config()
@@ -921,5 +941,6 @@ async def find_bugs_golang_cli(
         output_format=output_format,
         rpms_only=rpms_only,
         skip_comment=skip_comment,
+        parse_changelog=parse_changelog,
     )
     await cli.run()

--- a/elliott/tests/test_find_bugs_golang_cli.py
+++ b/elliott/tests/test_find_bugs_golang_cli.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import MagicMock, patch
 
 from artcommonlib.release_util import get_patch_from_release
@@ -26,6 +26,51 @@ def _make_cli(**overrides):
     )
     defaults.update(overrides)
     return FindBugsGolangCli(**defaults)
+
+
+class TestChangelogParsingFlag(IsolatedAsyncioTestCase):
+    def test_parse_changelog_defaults_to_false(self):
+        cli = _make_cli()
+        self.assertFalse(cli.parse_changelog)
+
+    def _make_runnable_cli(self, **overrides):
+        """Build a CLI whose run() reaches the changelog-parsing decision point and
+        then exits early (no bugs found), so tests can assert on _get_cves_from_nvr_changelogs
+        without needing to mock the rest of the (heavy) bug-analysis pipeline.
+        """
+        runtime = MagicMock()
+        runtime.get_major_minor.return_value = (4, 17)
+        cli = _make_cli(
+            runtime=runtime,
+            fixed_in_nvrs=("golang-1.22.12-11.el9",),
+            tracker_ids=("OCPBUGS-1",),
+            **overrides,
+        )
+        cli.jira_tracker.get_bugs.return_value = []
+        return cli
+
+    @patch("elliottlib.cli.find_bugs_golang_cli.golang_report_for_version", return_value=[])
+    @patch.object(FindBugsGolangCli, "_get_cves_from_nvr_changelogs")
+    async def test_changelog_not_parsed_when_flag_disabled(self, mock_get_cves, _mock_report):
+        cli = self._make_runnable_cli(cve_ids=(), parse_changelog=False)
+        await cli.run()
+        mock_get_cves.assert_not_called()
+
+    @patch("elliottlib.cli.find_bugs_golang_cli.golang_report_for_version", return_value=[])
+    @patch.object(FindBugsGolangCli, "_get_cves_from_nvr_changelogs")
+    async def test_changelog_parsed_when_flag_enabled(self, mock_get_cves, _mock_report):
+        mock_get_cves.return_value = {"CVE-2024-1394"}
+        cli = self._make_runnable_cli(cve_ids=(), parse_changelog=True)
+        await cli.run()
+        mock_get_cves.assert_called_once()
+        self.assertEqual(cli.cve_ids, ("CVE-2024-1394",))
+
+    @patch("elliottlib.cli.find_bugs_golang_cli.golang_report_for_version", return_value=[])
+    @patch.object(FindBugsGolangCli, "_get_cves_from_nvr_changelogs")
+    async def test_changelog_not_parsed_when_cve_ids_explicitly_given(self, mock_get_cves, _mock_report):
+        cli = self._make_runnable_cli(cve_ids=("CVE-2024-1394",), parse_changelog=True)
+        await cli.run()
+        mock_get_cves.assert_not_called()
 
 
 def _make_bug(bug_id="OCPBUGS-99999", component="openshift-golang-builder-container"):


### PR DESCRIPTION
See: [ART-20948](https://redhat.atlassian.net/browse/ART-20948) for details on how changelog parsing can go wrong

## Summary
- `find-bugs:golang` previously always parsed brew build changelogs of `--fixed-in-nvr` builds to auto-detect additional fixed CVEs whenever `--cve-id` was not explicitly given.
- Changelog entries aren't always accurate/present, so this behavior is now gated behind a new `--parse-changelog` flag (disabled by default).
- By default, the command now only considers CVE ID(s) explicitly given via `--cve-id` as fixed.
- `--parse-changelog` requires `--fixed-in-nvr` to be set.

## Test plan
- [x] `uv run pytest --verbose --color=yes elliott/tests/test_find_bugs_golang_cli.py` passes, including new tests covering the flag's default-off behavior, opt-in behavior, and that explicit `--cve-id` values skip changelog parsing.
- [x] `ruff check` / `ruff format --check` pass on modified files.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional changelog parsing flag for the Golang bug-finding command.
  * When enabled, the command can automatically gather additional CVE IDs from related build changelogs and combine them with manually provided CVEs.

* **Bug Fixes**
  * Updated CVE detection behavior so changelog-based parsing no longer runs by default.
  * Added validation to ensure changelog parsing is only used when build information is available.

* **Tests**
  * Added coverage for the new flag’s default behavior and CVE selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->