### PR TITLE
doozer: fix FBC base image namespace for OCP 5.x

### DIFF
--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -53,8 +53,8 @@ LOGGER = logging.getLogger(__name__)
 yaml = opm.yaml
 
 PRODUCTION_INDEX_PULLSPEC_FORMAT = "registry.redhat.io/redhat/redhat-operator-index:v{major}.{minor}"
-BASE_IMAGE_RHEL9_PULLSPEC_FORMAT = "registry.redhat.io/openshift4/ose-operator-registry-rhel9:v{major}.{minor}"
-BASE_IMAGE_RHEL8_PULLSPEC_FORMAT = "registry.redhat.io/openshift4/ose-operator-registry:v{major}.{minor}"
+BASE_IMAGE_RHEL9_PULLSPEC_FORMAT = "registry.redhat.io/openshift{major}/ose-operator-registry-rhel9:v{major}.{minor}"
+BASE_IMAGE_RHEL8_PULLSPEC_FORMAT = "registry.redhat.io/openshift{major}/ose-operator-registry:v{major}.{minor}"
 FBC_BUILD_PRIORITY = "2"
 
 

--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -9,6 +9,8 @@ from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, Konfl
 from doozerlib.backend.build_repo import BuildRepo
 from doozerlib.backend.konflux_client import ImageBuildParams, KonfluxClient
 from doozerlib.backend.konflux_fbc import (
+    BASE_IMAGE_RHEL8_PULLSPEC_FORMAT,
+    BASE_IMAGE_RHEL9_PULLSPEC_FORMAT,
     AssemblyBundleCsvInfo,
     KonfluxFbcBuilder,
     KonfluxFbcFragmentMerger,
@@ -590,8 +592,8 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
         mock_generate_dockerfile.assert_awaited_once_with(
             build_repo.local_dir,
             'catalog',
-            base_image='registry.redhat.io/openshift4/ose-operator-registry:v1.1',
-            builder_image='registry.redhat.io/openshift4/ose-operator-registry:v1.1',
+            base_image='registry.redhat.io/openshift1/ose-operator-registry:v1.1',
+            builder_image='registry.redhat.io/openshift1/ose-operator-registry:v1.1',
         )
 
     def test_generate_image_digest_mirror_set(self):
@@ -2972,6 +2974,26 @@ spec:
 
         result = await self.merger._merge_idms(["example.com/idm1", "example.com/idm2", "example.com/idm3"])
         self.assertEqual(result, expected)
+
+
+class TestBaseImagePullspecFormat(unittest.TestCase):
+    """Test that FBC base image pullspec format strings use the correct registry namespace."""
+
+    def test_ocp4_rhel9_base_image(self):
+        result = BASE_IMAGE_RHEL9_PULLSPEC_FORMAT.format(major=4, minor=17)
+        self.assertEqual(result, "registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.17")
+
+    def test_ocp5_rhel9_base_image(self):
+        result = BASE_IMAGE_RHEL9_PULLSPEC_FORMAT.format(major=5, minor=0)
+        self.assertEqual(result, "registry.redhat.io/openshift5/ose-operator-registry-rhel9:v5.0")
+
+    def test_ocp4_rhel8_base_image(self):
+        result = BASE_IMAGE_RHEL8_PULLSPEC_FORMAT.format(major=4, minor=14)
+        self.assertEqual(result, "registry.redhat.io/openshift4/ose-operator-registry:v4.14")
+
+    def test_ocp5_rhel8_base_image(self):
+        result = BASE_IMAGE_RHEL8_PULLSPEC_FORMAT.format(major=5, minor=0)
+        self.assertEqual(result, "registry.redhat.io/openshift5/ose-operator-registry:v5.0")
 
 
 class TestGenerateFbcBranchName(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Fix hardcoded `openshift4` namespace in FBC base image pullspec format strings (`BASE_IMAGE_RHEL9_PULLSPEC_FORMAT` and `BASE_IMAGE_RHEL8_PULLSPEC_FORMAT`) to use `openshift{major}`, so OCP 5.x correctly resolves to `registry.redhat.io/openshift5/ose-operator-registry-rhel9:v5.0` instead of `registry.redhat.io/openshift4/ose-operator-registry-rhel9:v5.0`.
- Update existing test assertion and add new `TestBaseImagePullspecFormat` tests covering OCP 4.x and 5.x.

## How it works

The `{major}` placeholder is populated at three call sites via `.format(major=..., minor=...)`. Each derives the major version from the OCP version tuple (sourced from group config `MAJOR`/`MINOR` vars or the `--major-minor` CLI override):

1. **`KonfluxFbcImporter._update_dir`** — uses `self.ocp_version[0]`
2. **`KonfluxFbcFragmentMerger.run`** — uses local `major` parsed from group config
3. **`KonfluxFbcRebaser._rebase_dir`** — uses `ocp_version[0]` from `self.ocp_version_override` or group config

No changes were needed at these call sites — they already pass `major=` as a named format argument.

## Test plan

- [x] All 80 existing tests in `doozer/tests/backend/test_konflux_fbc.py` pass
- [x] New `TestBaseImagePullspecFormat` tests verify correct namespace for both OCP 4.x and 5.x with RHEL8 and RHEL9 variants