### PR TITLE
Fix image filtering to use distgit_key instead of name

### DIFF
--- a/doozer/doozerlib/cli/images.py
+++ b/doozer/doozerlib/cli/images.py
@@ -1221,6 +1221,7 @@ def images_print(runtime, short, show_non_release, only_for_payload, show_base, 
     \b
     {type} - The type of the distgit (e.g. rpms)
     {name} - The name of the distgit repository (e.g. openshift-enterprise)
+    {distgit_key} - The full distgit key including any suffix (e.g. openshift-enterprise-console.rhel9)
     {image_name} - The container registry image name (e.g. openshift3/ose-ansible)
     {image_name_short} - The container image name without the registry (e.g. ose-ansible)
     {component} - The component identified in the Dockerfile
@@ -1303,6 +1304,7 @@ def images_print(runtime, short, show_non_release, only_for_payload, show_base, 
         s = s.replace("{build}", "{component}-{version}-{release}")
         s = s.replace("{repository}", "{image}:{version}-{release}")
         s = s.replace("{namespace}", image.namespace)
+        s = s.replace("{distgit_key}", image.distgit_key)
         s = s.replace("{name}", image.name)
         s = s.replace("{image_name}", image.image_name)
         s = s.replace("{image_name_short}", image.image_name_short)

--- a/pyartcd/pyartcd/pipelines/images_health.py
+++ b/pyartcd/pyartcd/pipelines/images_health.py
@@ -192,14 +192,14 @@ class ImagesHealthPipeline:
 
     async def _get_valid_images(self, version: str, doozer_working: str) -> set[str]:
         """
-        Get the set of valid image names for a given version from ocp-build-data.
+        Get the set of valid image distgit keys for a given version from ocp-build-data.
         Results are cached per version to avoid duplicate doozer subprocess calls.
 
         Arg(s):
             version (str): OCP version (e.g., "4.18")
             doozer_working (str): Doozer working directory path
         Return Value(s):
-            set[str]: Set of valid image distgit keys
+            set[str]: Set of valid image distgit keys (e.g. "ose-console.rhel9")
         """
         if version in self._valid_images_cache:
             return self._valid_images_cache[version]
@@ -217,7 +217,7 @@ class ImagesHealthPipeline:
             '--show-base',
             '--show-non-release',
             '--short',
-            '{name}',
+            '{distgit_key}',
         ]
 
         try:

--- a/pyartcd/pyartcd/pipelines/okd_images_health.py
+++ b/pyartcd/pyartcd/pipelines/okd_images_health.py
@@ -185,7 +185,7 @@ class ImagesHealthPipeline:
             group_param,
             'images:print',
             '--short',
-            '{name}',
+            '{distgit_key}',
         ]
 
         try:


### PR DESCRIPTION
The {name} format field in doozer strips dot suffixes (e.g. "image.rhel9" becomes "image"), causing images with RHEL variant suffixes to be incorrectly filtered out as non-existent. Add {distgit_key} format field to images:print and use it in both OCP and OKD images-health pipelines so Redis keys match correctly.

example https://redhat-internal.slack.com/archives/GTDLQU9LH/p1783500150370479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image filtering to use full distgit keys, which helps match reported failures against the correct image metadata.
  * `images:print` now supports a `{distgit_key}` placeholder, making output more consistent for downstream tooling.
* **Documentation**
  * Clarified the description of valid image output to better reflect the identifiers returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->