### PR TITLE
Update validator to account for OKD arches override

### DIFF
--- a/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/assembly_group_config.schema.json
@@ -681,7 +681,30 @@
         "konflux?": {
           "$ref": "#/properties/okd/properties/konflux"
         },
-        "konflux-": {}
+        "konflux-": {},
+        "arches": {
+          "type": "array",
+          "items": {
+            "$ref": "arch.schema.json"
+          }
+        },
+        "arches!": {
+          "$ref": "#/properties/okd/properties/arches"
+        },
+        "arches?": {
+          "$ref": "#/properties/okd/properties/arches"
+        },
+        "arches-": {},
+        "enabled": {
+          "type": "boolean"
+        },
+        "enabled!": {
+          "$ref": "#/properties/okd/properties/enabled"
+        },
+        "enabled?": {
+          "$ref": "#/properties/okd/properties/enabled"
+        },
+        "enabled-": {}
       },
       "additionalProperties": false
     },


### PR DESCRIPTION
Fix validation error seen at https://github.com/openshift-eng/ocp-build-data/pull/11720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded validation for OKD Konflux configuration to support additional settings.
  * Added support for validating architecture lists and an enable/disable flag, including variant handling for different configuration states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->