### PR TITLE
Fix cross-arch RPM version reconciliation to pin max EVR instead of min

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -41,7 +41,7 @@ from doozerlib.lockfile_prototype.models import (
 )
 from doozerlib.lockfile_prototype.resolver import RpmResolver
 from doozerlib.lockfile_prototype.shell_parser import resolve_bash_expansion
-from doozerlib.lockfile_prototype.utils import format_version_pin, pick_minimum_evr
+from doozerlib.lockfile_prototype.utils import format_version_pin, pick_maximum_evr
 from doozerlib.repos import Repos
 
 
@@ -1200,18 +1200,26 @@ class RpmLockfilePrototypeGenerator:
     def _compute_version_pins(mismatches: dict[str, dict[str, str]]) -> list[str]:
         """
         Compute version-pinned DNF package specs from cross-arch mismatches.
-        Picks the minimum (oldest) version for each package.
+        Picks the maximum (newest) version for each package.
+
+        Pinning to the newest version (rather than the oldest) avoids
+        creating unsatisfiable dependencies on arches whose newer
+        transitive requirements (e.g. an arch-conditional Dockerfile
+        package pulling in a newer libxml2/libstdc++/etc.) demand it. The
+        newest version observed across arches is, by definition, already
+        available in the repos for at least one arch, and RHEL repos
+        typically carry the same latest package build for all arches.
 
         Arg(s):
             mismatches (dict[str, dict[str, str]]): From _detect_cross_arch_mismatches.
         Return Value(s):
             list[str]: Version-pinned package specs for DNF
-                (e.g., ["libeconf-0.4.1-5.el9"]).
+                (e.g., ["libeconf-0.4.1-7.el9_8"]).
         """
         pins: list[str] = []
         for name, arch_evrs in sorted(mismatches.items()):
-            min_evr = pick_minimum_evr(list(arch_evrs.values()))
-            pins.append(format_version_pin(name, min_evr))
+            max_evr = pick_maximum_evr(list(arch_evrs.values()))
+            pins.append(format_version_pin(name, max_evr))
         return pins
 
     async def _resolve_with_reconciliation(

--- a/doozer/doozerlib/lockfile_prototype/utils.py
+++ b/doozer/doozerlib/lockfile_prototype/utils.py
@@ -66,6 +66,22 @@ def pick_minimum_evr(evrs: list[str]) -> str:
     return result
 
 
+def pick_maximum_evr(evrs: list[str]) -> str:
+    """
+    Return the newest EVR from a list using RPM version comparison.
+
+    Arg(s):
+        evrs (list[str]): EVR strings to compare.
+    Return Value(s):
+        str: The maximum (newest) EVR.
+    """
+    result = evrs[0]
+    for evr in evrs[1:]:
+        if compare_evr(evr, result) > 0:
+            result = evr
+    return result
+
+
 def format_version_pin(name: str, evr: str) -> str:
     """
     Format a version-pinned DNF package spec from name and EVR.

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -1797,7 +1797,7 @@ class TestCrossArchReconciliation(unittest.IsolatedAsyncioTestCase):
         }
         gen = self._make_generator()
         pins = gen._compute_version_pins(mismatches)
-        self.assertEqual(sorted(pins), ["curl-7.76-1.el9", "libeconf-0.4.1-5.el9"])
+        self.assertEqual(sorted(pins), ["curl-7.76-2.el9", "libeconf-0.4.1-7.el9_8"])
 
     async def test_reconciliation_skips_when_consistent(self):
         gen = self._make_generator()
@@ -1852,7 +1852,7 @@ class TestCrossArchReconciliation(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(gen._resolve_stage_with_retry.await_count, 2)
 
         second_call_packages = gen._resolve_stage_with_retry.call_args_list[1][0][2]
-        self.assertIn("libeconf-0.4.1-5.el9", second_call_packages)
+        self.assertIn("libeconf-0.4.1-7.el9_8", second_call_packages)
 
     async def test_reconciliation_falls_back_on_error(self):
         gen = self._make_generator()
@@ -1937,7 +1937,7 @@ class TestCrossArchReconciliation(unittest.IsolatedAsyncioTestCase):
         second_update_targets = second_call[0][4]
         self.assertNotIn("python3-six", second_update_targets)
         second_packages = second_call[0][2]
-        self.assertTrue(any("python3-six-1.11.0-8.el8" in p for p in second_packages))
+        self.assertTrue(any("python3-six-1.12.0-2.el8ost" in p for p in second_packages))
 
 
 class TestIsBuilddepRequirement(unittest.TestCase):

--- a/doozer/tests/lockfile_prototype/test_utils.py
+++ b/doozer/tests/lockfile_prototype/test_utils.py
@@ -10,6 +10,7 @@ from doozerlib.lockfile_prototype.utils import (
     compare_evr,
     format_version_pin,
     parse_evr,
+    pick_maximum_evr,
     pick_minimum_evr,
 )
 
@@ -78,6 +79,19 @@ class TestPickMinimumEvr(unittest.TestCase):
     def test_with_epoch(self):
         evrs = ["1:2.0-3.el9", "0.9-1.el9"]
         self.assertEqual(pick_minimum_evr(evrs), "0.9-1.el9")
+
+
+class TestPickMaximumEvr(unittest.TestCase):
+    def test_single(self):
+        self.assertEqual(pick_maximum_evr(["0.4.1-5.el9"]), "0.4.1-5.el9")
+
+    def test_picks_newest(self):
+        evrs = ["0.4.1-7.el9_8", "0.4.1-5.el9", "0.4.1-6.el9"]
+        self.assertEqual(pick_maximum_evr(evrs), "0.4.1-7.el9_8")
+
+    def test_with_epoch(self):
+        evrs = ["1:2.0-3.el9", "0.9-1.el9"]
+        self.assertEqual(pick_maximum_evr(evrs), "1:2.0-3.el9")
 
 
 class TestFormatVersionPin(unittest.TestCase):


### PR DESCRIPTION
## Summary

Fixes the `rpm_packages.unique_version` Conforma violation on the golang builder image (and any other image with arch-conditional Dockerfile installs) by fixing how cross-arch RPM version mismatches are reconciled.

## Root cause

The golang builder Dockerfile has an x86_64-only conditional block that installs `libxml2-devel`, `gcc-c++`, etc. Their transitive dependencies (`libxml2`, `libstdc++`, `libsemanage`) resolve to newer versions on x86_64 than on the other arches, since those arches never run that block.

The lockfile generator's `_resolve_with_reconciliation()` correctly *detects* this mismatch, but `_compute_version_pins()` pinned to the **minimum (oldest)** EVR across arches. Pinning down to the older version creates an unsatisfiable dependency on x86_64 (which needs the newer version), so the re-resolution pass fails with `RuntimeError`, and the code silently falls back to the original, mismatched lockfile. The image builds successfully, but the release later fails Conforma:

```
✕ [Violation] rpm_packages.unique_version
  Reason: Mismatched versions of the "libxml2" RPM were found across different arches.
  Platform linux/x86_64 has libxml2-2.9.13-13.el9_4. Platforms linux/arm64, linux/ppc64le, linux/s390x have libxml2-2.9.13-6.el9_4.
```

(same pattern for `libsemanage` and `libstdc++`)

## Fix

Pin to the **maximum (newest)** EVR instead of the minimum in `_compute_version_pins()`. The newest version satisfies the arch-specific dependency's requirement and is available for all arches in the repos, so the re-resolution succeeds and all arches converge on the same version.

## Risk

Low risk — this only changes behavior on the reconciliation path that already runs when a cross-arch mismatch is detected (most images never hit it). If the max-pinned re-resolution still fails for some reason, the existing `except RuntimeError` safety net falls back to the original mismatched lockfile — i.e. the current (broken) behavior — so there's no new failure mode introduced.

## Test plan

- [x] Added `pick_maximum_evr()` to `utils.py` with unit tests
- [x] Updated `_compute_version_pins()` to use it, updated existing reconciliation tests to reflect max-EVR pinning
- [x] `doozer/tests/lockfile_prototype/test_utils.py` and `test_generator.py` pass (119/119)
- [x] `ruff check` / `ruff format --check` pass
- [ ] Re-run the golang-builder Konflux release and confirm the `rpm_packages.unique_version` Conforma violation is resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package version reconciliation so mismatched cross-architecture builds now align to the newest available version, reducing unexpected downgrades during dependency resolution.
  * Updated resolution behavior to better handle version differences across architectures and epochs.

* **Tests**
  * Expanded coverage for version selection and reconciliation scenarios to reflect the new highest-version matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->