### PR TITLE
ART-21554: gen-assembly: supplement Cincinnati with release controlle…

### DIFF
--- a/artcommon/artcommonlib/ocp_version_ancestry.py
+++ b/artcommon/artcommonlib/ocp_version_ancestry.py
@@ -11,10 +11,13 @@ Key components:
 - get_previous_minor_version_from_suggestions(): Extract the previous major.minor version
   from validated build-suggestions data
 - get_cincinnati_channels(): Get Cincinnati channel names for a version
+- get_release_controller_versions_async(): Fetch promoted versions from the release controller
 - calc_upgrade_sources_async(): Calculate which versions can upgrade to a target version
 """
 
 import functools
+import logging
+import re
 from typing import Any, Optional
 
 import httpx
@@ -23,6 +26,8 @@ import yaml
 from artcommonlib.arch_util import go_arch_for_brew_arch
 from artcommonlib.util import extract_version_fields
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
+
+logger = logging.getLogger(__name__)
 
 
 class SuggestionsSpec(BaseModel):
@@ -344,11 +349,68 @@ def _version_in_range(version: str, v_min: str, v_max: Optional[str]) -> bool:
     return v_info.major == min_info.major and v_info.minor == min_info.minor
 
 
+async def get_release_controller_versions_async(
+    major: int,
+    minor: int,
+    go_arch: str,
+    release_controller_url: str = '',
+    timeout: float = 30.0,
+) -> list[str]:
+    """
+    Query the release controller's stable stream to get all promoted versions for a major.minor.
+
+    The release controller tracks all versions that have been promoted to the 4-stable stream,
+    regardless of whether their cincinnati-graph-data PR has merged. This supplements Cincinnati
+    data to avoid missing recently-promoted z-streams.
+
+    :param major: Major version (e.g., 4 or 5)
+    :param minor: Minor version (e.g., 18)
+    :param go_arch: Go architecture name (e.g., 'amd64', 's390x', 'arm64', 'ppc64le', 'multi')
+    :param release_controller_url: Base URL for the release controller. If empty, defaults to
+        'https://{go_arch}.ocp.releases.ci.openshift.org'.
+    :param timeout: HTTP request timeout in seconds
+    :return: List of version strings matching major.minor, sorted descending by semver
+    """
+    if not release_controller_url:
+        release_controller_url = f'https://{go_arch}.ocp.releases.ci.openshift.org'
+
+    base_url = release_controller_url.rstrip('/')
+    url = f'{base_url}/api/v1/releasestream/{major}-stable/tags'
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, timeout=timeout)
+            response.raise_for_status()
+    except httpx.HTTPError as e:
+        logger.warning('Failed to query release controller at %s: %s', url, e)
+        return []
+
+    data = response.json()
+    tags = data.get('tags', [])
+
+    # Filter tags to only those matching the requested major.minor.
+    # Tag names are version strings like "4.18.3" or "4.18.0-rc.0".
+    version_pattern = re.compile(rf'^{major}\.{minor}\.')
+    versions = []
+    for tag in tags:
+        name = tag.get('name', '')
+        if version_pattern.match(name):
+            # Validate it's a proper semver string before including
+            try:
+                semver.VersionInfo.parse(name)
+                versions.append(name)
+            except ValueError:
+                continue
+
+    return sort_semver(versions)
+
+
 async def calc_upgrade_sources_async(
     version: str,
     arch: str,
     graph_url: str = 'https://api.openshift.com/api/upgrades_info/v1/graph',
     suggestions_url: str = 'https://raw.githubusercontent.com/openshift/cincinnati-graph-data/master/build-suggestions/',
+    release_controller_url: str = '',
 ) -> list[str]:
     """
     Calculate which previous release versions can upgrade to the specified version.
@@ -357,13 +419,17 @@ async def calc_upgrade_sources_async(
     1. Fetching build-suggestions to determine the previous minor version
     2. Using get_previous_minor_version_from_suggestions to extract previous version
     3. Querying Cincinnati for versions from both previous and current minor releases
-    4. Filtering based on build-suggestions constraints (minor_min/max, z_min/max, block lists)
-    5. Including eligible hotfix releases
+    4. Supplementing Cincinnati data with release controller versions (catches recently-promoted
+       z-streams whose cincinnati-graph-data PR hasn't merged yet)
+    5. Filtering based on build-suggestions constraints (minor_min/max, z_min/max, block lists)
+    6. Including eligible hotfix releases
 
     :param version: Version string (e.g., "5.0.0-rc.0")
     :param arch: Architecture (brew arch name, e.g., "x86_64")
     :param graph_url: Cincinnati API endpoint
     :param suggestions_url: Base URL to Cincinnati build-suggestions directory
+    :param release_controller_url: Base URL for the release controller. If empty, defaults to
+        'https://{go_arch}.ocp.releases.ci.openshift.org'.
     :return: Sorted list of version strings that can upgrade to the target version
     :raises IOError: If the version string cannot be parsed into major.minor fields
     :raises ValueError: If build-suggestions are invalid or previous version cannot be determined
@@ -391,6 +457,21 @@ async def calc_upgrade_sources_async(
     # STEP 4: Query Cincinnati for version lists
     prev_versions, _ = await get_channel_versions_async(prev_candidate_channel, go_arch, graph_url)
     curr_versions, current_edges = await get_channel_versions_async(candidate_channel, go_arch, graph_url)
+
+    # STEP 4.5: Supplement Cincinnati data with release controller versions.
+    # If a z-stream was promoted but its cincinnati-graph-data PR hasn't merged yet,
+    # it will be invisible to Cincinnati. The release controller tracks all promoted
+    # versions in the {major}-stable stream, so we union those in.
+    rc_prev_versions = await get_release_controller_versions_async(
+        prev_major, prev_minor, go_arch, release_controller_url
+    )
+    rc_curr_versions = await get_release_controller_versions_async(major, minor, go_arch, release_controller_url)
+
+    prev_versions_set = set(prev_versions) | set(rc_prev_versions)
+    prev_versions = sort_semver(list(prev_versions_set))
+
+    curr_versions_set = set(curr_versions) | set(rc_curr_versions)
+    curr_versions = sort_semver(list(curr_versions_set))
 
     upgrade_from = set()
 

--- a/artcommon/tests/test_ocp_version_ancestry.py
+++ b/artcommon/tests/test_ocp_version_ancestry.py
@@ -12,6 +12,7 @@ from artcommonlib.ocp_version_ancestry import (
     calc_upgrade_sources_async,
     get_build_suggestions_async,
     get_cincinnati_channels,
+    get_release_controller_versions_async,
 )
 from pydantic import ValidationError
 
@@ -458,6 +459,118 @@ class TestGetCincinnatiChannels(unittest.TestCase):
         self.assertIn('3.11', str(ctx.exception))
 
 
+class TestGetReleaseControllerVersionsAsync(unittest.IsolatedAsyncioTestCase):
+    """Test the get_release_controller_versions_async function"""
+
+    async def test_filters_by_major_minor(self):
+        """Only versions matching requested major.minor are returned"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "name": "4-stable",
+            "tags": [
+                {"name": "4.18.3", "phase": "Accepted"},
+                {"name": "4.18.2", "phase": "Accepted"},
+                {"name": "4.18.1", "phase": "Accepted"},
+                {"name": "4.17.5", "phase": "Accepted"},
+                {"name": "4.17.4", "phase": "Accepted"},
+            ],
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(return_value=mock_response)
+
+            result = await get_release_controller_versions_async(4, 18, "amd64")
+
+        # Only 4.18.x versions should be returned
+        self.assertEqual(result, ['4.18.3', '4.18.2', '4.18.1'])
+
+    async def test_returns_empty_on_http_error(self):
+        """HTTP errors should be logged and return empty list (non-fatal)"""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                side_effect=httpx.HTTPStatusError("503", request=MagicMock(), response=MagicMock(status_code=503))
+            )
+
+            result = await get_release_controller_versions_async(4, 18, "amd64")
+
+        self.assertEqual(result, [])
+
+    async def test_default_url_uses_go_arch(self):
+        """Default URL should be constructed from go_arch"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"name": "4-stable", "tags": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_get = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.get = mock_get
+
+            await get_release_controller_versions_async(4, 18, "arm64")
+
+            called_url = mock_get.call_args[0][0]
+            self.assertEqual(
+                called_url, "https://arm64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/tags"
+            )
+
+    async def test_custom_url(self):
+        """Custom release_controller_url should be used"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"name": "4-stable", "tags": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_get = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.get = mock_get
+
+            await get_release_controller_versions_async(
+                4, 18, "amd64", release_controller_url="https://custom.example.com"
+            )
+
+            called_url = mock_get.call_args[0][0]
+            self.assertEqual(called_url, "https://custom.example.com/api/v1/releasestream/4-stable/tags")
+
+    async def test_skips_invalid_semver_tags(self):
+        """Tags with invalid semver names should be silently skipped"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "name": "4-stable",
+            "tags": [
+                {"name": "4.18.1", "phase": "Accepted"},
+                {"name": "4.18.latest", "phase": "Accepted"},  # not valid semver (no patch number)
+                {"name": "4.18.0", "phase": "Accepted"},
+            ],
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(return_value=mock_response)
+
+            result = await get_release_controller_versions_async(4, 18, "amd64")
+
+        self.assertEqual(result, ['4.18.1', '4.18.0'])
+
+    async def test_sorted_descending(self):
+        """Results should be sorted in descending semver order"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "name": "4-stable",
+            "tags": [
+                {"name": "4.18.0", "phase": "Accepted"},
+                {"name": "4.18.2", "phase": "Accepted"},
+                {"name": "4.18.1", "phase": "Accepted"},
+            ],
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(return_value=mock_response)
+
+            result = await get_release_controller_versions_async(4, 18, "amd64")
+
+        self.assertEqual(result, ['4.18.2', '4.18.1', '4.18.0'])
+
+
 class TestCalcUpgradeSourcesAsync(unittest.IsolatedAsyncioTestCase):
     """Test the calc_upgrade_sources_async function"""
 
@@ -475,9 +588,10 @@ class TestCalcUpgradeSourcesAsync(unittest.IsolatedAsyncioTestCase):
             }
         return BuildSuggestions.model_validate(data)
 
+    @patch("artcommonlib.ocp_version_ancestry.get_release_controller_versions_async", new_callable=AsyncMock)
     @patch("artcommonlib.ocp_version_ancestry.get_channel_versions_async")
     @patch("artcommonlib.ocp_version_ancestry.get_build_suggestions_async")
-    async def test_5_0_queries_4_22_channel(self, mock_suggestions, mock_channel):
+    async def test_5_0_queries_4_22_channel(self, mock_suggestions, mock_channel, mock_rc):
         """5.0 should query candidate-4.22 (not candidate-5.-1)"""
         mock_suggestions.return_value = self._make_suggestions()
         mock_channel.side_effect = [
@@ -486,6 +600,7 @@ class TestCalcUpgradeSourcesAsync(unittest.IsolatedAsyncioTestCase):
             # Second call: candidate-5.0
             (['5.0.0-rc.0', '5.0.0-ec.1', '5.0.0-ec.0'], {}),
         ]
+        mock_rc.return_value = []  # release controller returns nothing extra
 
         result = await calc_upgrade_sources_async("5.0.0-rc.0", "x86_64")
 
@@ -503,9 +618,10 @@ class TestCalcUpgradeSourcesAsync(unittest.IsolatedAsyncioTestCase):
         self.assertIn('5.0.0-ec.0', result)
         self.assertIn('5.0.0-ec.1', result)
 
+    @patch("artcommonlib.ocp_version_ancestry.get_release_controller_versions_async", new_callable=AsyncMock)
     @patch("artcommonlib.ocp_version_ancestry.get_channel_versions_async")
     @patch("artcommonlib.ocp_version_ancestry.get_build_suggestions_async")
-    async def test_standard_minor_bump_4_18(self, mock_suggestions, mock_channel):
+    async def test_standard_minor_bump_4_18(self, mock_suggestions, mock_channel, mock_rc):
         """Standard 4.18 should query candidate-4.17"""
         mock_suggestions.return_value = self._make_suggestions(
             {
@@ -523,6 +639,7 @@ class TestCalcUpgradeSourcesAsync(unittest.IsolatedAsyncioTestCase):
             (['4.17.12', '4.17.11', '4.17.10'], {}),
             (['4.18.1', '4.18.0'], {}),
         ]
+        mock_rc.return_value = []
 
         result = await calc_upgrade_sources_async("4.18.2", "x86_64")
 
@@ -533,9 +650,10 @@ class TestCalcUpgradeSourcesAsync(unittest.IsolatedAsyncioTestCase):
         # 4.17.10 < minor_min (4.17.11), should be excluded
         self.assertNotIn('4.17.10', result)
 
+    @patch("artcommonlib.ocp_version_ancestry.get_release_controller_versions_async", new_callable=AsyncMock)
     @patch("artcommonlib.ocp_version_ancestry.get_channel_versions_async")
     @patch("artcommonlib.ocp_version_ancestry.get_build_suggestions_async")
-    async def test_block_list_excludes_versions(self, mock_suggestions, mock_channel):
+    async def test_block_list_excludes_versions(self, mock_suggestions, mock_channel, mock_rc):
         """Versions in block lists should be excluded"""
         mock_suggestions.return_value = self._make_suggestions(
             {
@@ -553,6 +671,7 @@ class TestCalcUpgradeSourcesAsync(unittest.IsolatedAsyncioTestCase):
             (['4.22.2', '4.22.1', '4.22.0'], {}),
             (['5.0.0-ec.1', '5.0.0-ec.0'], {}),
         ]
+        mock_rc.return_value = []
 
         result = await calc_upgrade_sources_async("5.0.0-rc.0", "x86_64")
 
@@ -562,9 +681,10 @@ class TestCalcUpgradeSourcesAsync(unittest.IsolatedAsyncioTestCase):
         self.assertIn('5.0.0-ec.0', result)
         self.assertNotIn('5.0.0-ec.1', result)  # blocked
 
+    @patch("artcommonlib.ocp_version_ancestry.get_release_controller_versions_async", new_callable=AsyncMock)
     @patch("artcommonlib.ocp_version_ancestry.get_channel_versions_async")
     @patch("artcommonlib.ocp_version_ancestry.get_build_suggestions_async")
-    async def test_hotfix_included_for_standard_release(self, mock_suggestions, mock_channel):
+    async def test_hotfix_included_for_standard_release(self, mock_suggestions, mock_channel, mock_rc):
         """Hotfixes with < 2 outgoing edges should be included for standard releases"""
         mock_suggestions.return_value = self._make_suggestions()
         mock_channel.side_effect = [
@@ -574,14 +694,16 @@ class TestCalcUpgradeSourcesAsync(unittest.IsolatedAsyncioTestCase):
                 {'5.0.0-ec.0': [], '5.0.0-0.hotfix-2024-09-30-133631': ['5.0.0-ec.0']},  # 1 edge < 2
             ),
         ]
+        mock_rc.return_value = []
 
         result = await calc_upgrade_sources_async("5.0.1", "x86_64")
 
         self.assertIn('5.0.0-0.hotfix-2024-09-30-133631', result)
 
+    @patch("artcommonlib.ocp_version_ancestry.get_release_controller_versions_async", new_callable=AsyncMock)
     @patch("artcommonlib.ocp_version_ancestry.get_channel_versions_async")
     @patch("artcommonlib.ocp_version_ancestry.get_build_suggestions_async")
-    async def test_hotfix_excluded_with_2_edges(self, mock_suggestions, mock_channel):
+    async def test_hotfix_excluded_with_2_edges(self, mock_suggestions, mock_channel, mock_rc):
         """Hotfixes with >= 2 outgoing edges should NOT be added by step 7"""
         mock_suggestions.return_value = self._make_suggestions()
         mock_channel.side_effect = [
@@ -594,14 +716,16 @@ class TestCalcUpgradeSourcesAsync(unittest.IsolatedAsyncioTestCase):
                 },
             ),
         ]
+        mock_rc.return_value = []
 
         result = await calc_upgrade_sources_async("5.0.2", "x86_64")
 
         self.assertNotIn('5.0.0-0.hotfix-2024-09-30-133631', result)
 
+    @patch("artcommonlib.ocp_version_ancestry.get_release_controller_versions_async", new_callable=AsyncMock)
     @patch("artcommonlib.ocp_version_ancestry.get_channel_versions_async")
     @patch("artcommonlib.ocp_version_ancestry.get_build_suggestions_async")
-    async def test_hotfix_in_block_list_not_readded(self, mock_suggestions, mock_channel):
+    async def test_hotfix_in_block_list_not_readded(self, mock_suggestions, mock_channel, mock_rc):
         """Step 7 must not re-add hotfixes excluded by z_block_list"""
         mock_suggestions.return_value = self._make_suggestions(
             {
@@ -622,14 +746,16 @@ class TestCalcUpgradeSourcesAsync(unittest.IsolatedAsyncioTestCase):
                 {'5.0.0-0.hotfix-2024-09-30-133631': ['5.0.0-ec.0']},
             ),
         ]
+        mock_rc.return_value = []
 
         result = await calc_upgrade_sources_async("5.0.1", "x86_64")
 
         self.assertNotIn('5.0.0-0.hotfix-2024-09-30-133631', result)
 
+    @patch("artcommonlib.ocp_version_ancestry.get_release_controller_versions_async", new_callable=AsyncMock)
     @patch("artcommonlib.ocp_version_ancestry.get_channel_versions_async")
     @patch("artcommonlib.ocp_version_ancestry.get_build_suggestions_async")
-    async def test_hotfix_edges_count_only_standard_targets(self, mock_suggestions, mock_channel):
+    async def test_hotfix_edges_count_only_standard_targets(self, mock_suggestions, mock_channel, mock_rc):
         """Step 7 should count only edges to standard releases toward the 2-edge limit"""
         mock_suggestions.return_value = self._make_suggestions()
         mock_channel.side_effect = [
@@ -650,14 +776,16 @@ class TestCalcUpgradeSourcesAsync(unittest.IsolatedAsyncioTestCase):
                 },
             ),
         ]
+        mock_rc.return_value = []
 
         result = await calc_upgrade_sources_async("5.0.1", "x86_64")
 
         self.assertIn('5.0.0-0.hotfix-2024-09-30-133631', result)
 
+    @patch("artcommonlib.ocp_version_ancestry.get_release_controller_versions_async", new_callable=AsyncMock)
     @patch("artcommonlib.ocp_version_ancestry.get_channel_versions_async")
     @patch("artcommonlib.ocp_version_ancestry.get_build_suggestions_async")
-    async def test_hotfix_not_included_for_hotfix_release(self, mock_suggestions, mock_channel):
+    async def test_hotfix_not_included_for_hotfix_release(self, mock_suggestions, mock_channel, mock_rc):
         """When calculating for a hotfix release, don't include other hotfixes"""
         mock_suggestions.return_value = self._make_suggestions()
         mock_channel.side_effect = [
@@ -667,28 +795,32 @@ class TestCalcUpgradeSourcesAsync(unittest.IsolatedAsyncioTestCase):
                 {'5.0.0-ec.0': [], '5.0.0-0.hotfix-2024-09-30-133631': []},
             ),
         ]
+        mock_rc.return_value = []
 
         result = await calc_upgrade_sources_async("5.0.0-0.hotfix-2024-10-01-120000", "x86_64")
 
         self.assertNotIn('5.0.0-0.hotfix-2024-09-30-133631', result)
 
+    @patch("artcommonlib.ocp_version_ancestry.get_release_controller_versions_async", new_callable=AsyncMock)
     @patch("artcommonlib.ocp_version_ancestry.get_channel_versions_async")
     @patch("artcommonlib.ocp_version_ancestry.get_build_suggestions_async")
-    async def test_result_sorted_descending(self, mock_suggestions, mock_channel):
+    async def test_result_sorted_descending(self, mock_suggestions, mock_channel, mock_rc):
         """Result should be sorted in descending semver order"""
         mock_suggestions.return_value = self._make_suggestions()
         mock_channel.side_effect = [
             (['4.22.0', '4.22.1', '4.22.2'], {}),
             (['5.0.0-ec.0', '5.0.0-ec.1'], {}),
         ]
+        mock_rc.return_value = []
 
         result = await calc_upgrade_sources_async("5.0.0-rc.0", "x86_64")
 
         self.assertEqual(result, ['5.0.0-ec.1', '5.0.0-ec.0', '4.22.2', '4.22.1', '4.22.0'])
 
+    @patch("artcommonlib.ocp_version_ancestry.get_release_controller_versions_async", new_callable=AsyncMock)
     @patch("artcommonlib.ocp_version_ancestry.get_channel_versions_async")
     @patch("artcommonlib.ocp_version_ancestry.get_build_suggestions_async")
-    async def test_no_max_includes_same_minor(self, mock_suggestions, mock_channel):
+    async def test_no_max_includes_same_minor(self, mock_suggestions, mock_channel, mock_rc):
         """When minor_max/z_max are omitted, include all versions >= min with same major.minor"""
         mock_suggestions.return_value = self._make_suggestions(
             {
@@ -708,6 +840,7 @@ class TestCalcUpgradeSourcesAsync(unittest.IsolatedAsyncioTestCase):
             # candidate-5.0
             (['5.0.0-ec.0', '5.0.0-rc.0', '5.0.9999'], {}),
         ]
+        mock_rc.return_value = []
 
         result = await calc_upgrade_sources_async("5.0.0-rc.0", "x86_64")
 
@@ -719,6 +852,84 @@ class TestCalcUpgradeSourcesAsync(unittest.IsolatedAsyncioTestCase):
         # All 5.0 versions >= z_min should be included (no upper bound)
         self.assertIn('5.0.0-ec.0', result)
         self.assertIn('5.0.9999', result)
+
+    @patch("artcommonlib.ocp_version_ancestry.get_release_controller_versions_async", new_callable=AsyncMock)
+    @patch("artcommonlib.ocp_version_ancestry.get_channel_versions_async")
+    @patch("artcommonlib.ocp_version_ancestry.get_build_suggestions_async")
+    async def test_release_controller_supplements_cincinnati(self, mock_suggestions, mock_channel, mock_rc):
+        """Versions on release controller but NOT in Cincinnati should be included"""
+        mock_suggestions.return_value = self._make_suggestions(
+            {
+                "default": {
+                    "minor_min": "4.17.0",
+                    "minor_max": "4.17.9999",
+                    "minor_block_list": [],
+                    "z_min": "4.18.0",
+                    "z_max": "4.18.9999",
+                    "z_block_list": [],
+                },
+            }
+        )
+        # Cincinnati only knows about 4.17.1 and 4.18.0
+        mock_channel.side_effect = [
+            (['4.17.1', '4.17.0'], {}),
+            (['4.18.0'], {}),
+        ]
+        # Release controller also has 4.17.2 (recently promoted, graph-data PR not merged)
+        # and 4.18.1 (recently promoted z-stream)
+        mock_rc.side_effect = [
+            ['4.17.2', '4.17.1', '4.17.0'],  # prev minor versions from RC
+            ['4.18.1', '4.18.0'],  # curr minor versions from RC
+        ]
+
+        result = await calc_upgrade_sources_async("4.18.2", "x86_64")
+
+        # 4.17.2 should be included even though Cincinnati didn't have it
+        self.assertIn('4.17.2', result)
+        self.assertIn('4.17.1', result)
+        self.assertIn('4.17.0', result)
+        # 4.18.1 should be included even though Cincinnati didn't have it
+        self.assertIn('4.18.1', result)
+        self.assertIn('4.18.0', result)
+
+    @patch("artcommonlib.ocp_version_ancestry.get_release_controller_versions_async", new_callable=AsyncMock)
+    @patch("artcommonlib.ocp_version_ancestry.get_channel_versions_async")
+    @patch("artcommonlib.ocp_version_ancestry.get_build_suggestions_async")
+    async def test_release_controller_versions_still_filtered(self, mock_suggestions, mock_channel, mock_rc):
+        """Versions from release controller should still be filtered by build-suggestions constraints"""
+        mock_suggestions.return_value = self._make_suggestions(
+            {
+                "default": {
+                    "minor_min": "4.17.2",
+                    "minor_max": "4.17.9999",
+                    "minor_block_list": ["4.17.3"],
+                    "z_min": "4.18.0",
+                    "z_max": "4.18.9999",
+                    "z_block_list": [],
+                },
+            }
+        )
+        mock_channel.side_effect = [
+            (['4.17.2'], {}),
+            (['4.18.0'], {}),
+        ]
+        # Release controller has versions outside build-suggestions range and blocked versions
+        mock_rc.side_effect = [
+            ['4.17.4', '4.17.3', '4.17.2', '4.17.1', '4.17.0'],
+            ['4.18.1', '4.18.0'],
+        ]
+
+        result = await calc_upgrade_sources_async("4.18.2", "x86_64")
+
+        # 4.17.4 is >= minor_min and not blocked -> included
+        self.assertIn('4.17.4', result)
+        # 4.17.2 is >= minor_min and not blocked -> included
+        self.assertIn('4.17.2', result)
+        # 4.17.3 is in block list -> excluded
+        self.assertNotIn('4.17.3', result)
+        # 4.17.1 and 4.17.0 are < minor_min -> excluded
+        self.assertNotIn('4.17.1', result)
+        self.assertNotIn('4.17.0', result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…r data for upgrade edges

When calculating upgrade edges in calc_upgrade_sources_async, Cincinnati candidate channels may not include recently-promoted z-streams whose cincinnati-graph-data PR hasn't merged yet. This causes the assembly generator to miss valid upgrade sources.

Add get_release_controller_versions_async() to query the release controller's {major}-stable stream, which tracks all promoted versions regardless of graph-data PR status. The function queries the architecture-specific release controller endpoint and filters tags by major.minor.

In calc_upgrade_sources_async, after querying Cincinnati (STEP 4), union the release controller versions with Cincinnati versions for both prev_versions and curr_versions. The existing build-suggestions filtering (z_min/z_max, block lists) still applies, and Cincinnati edges are still used for hotfix logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgrade source calculations now include additional OpenShift versions from the release controller, helping surface promoted z-stream updates sooner.
  * Version results are more comprehensive across adjacent minor streams while still respecting existing upgrade rules.

* **Bug Fixes**
  * Improved handling for versions that are available in the release controller but not yet in other version data sources.
  * Non-available or invalid version entries are safely ignored, keeping upgrade recommendations clean and sorted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->