### PR TITLE
ART-19542: Remove deprecated separate golang branch logic, always use monobranch

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -189,7 +189,6 @@ class UpdateGolangPipeline:
         skip_pr: bool = False,
         external_golang_rpms: bool = False,
         network_mode: str | None = None,
-        use_new_golang_branch: bool = False,
         major_bump: bool = False,
     ):
         self.runtime = runtime
@@ -209,20 +208,11 @@ class UpdateGolangPipeline:
         self.skip_pr = skip_pr
         self.external_golang_rpms = external_golang_rpms
         self.network_mode = network_mode
-        self.use_new_golang_branch = use_new_golang_branch
         self.major_bump = major_bump
         self._slack_client = self.runtime.new_slack_client()
         self._doozer_working_dir = self.runtime.working_dir / "doozer-working"
         self._doozer_env_vars = os.environ.copy()
         self._branch_content = None
-
-        # Deprecation warning for separate golang branches
-        if not use_new_golang_branch:
-            _LOGGER.warning(
-                "Using unique golang version branches is deprecated. "
-                "Will use golang mono branch instead. "
-                "See: https://github.com/openshift-eng/ocp-build-data/tree/golang"
-            )
 
         # Get kubeconfig from environment variable if not provided
         if not kubeconfig:
@@ -634,22 +624,19 @@ class UpdateGolangPipeline:
 
     def should_sign_golang_rpm(self, el_v, go_version) -> bool:
         """Check sign_golang_rpm config for a specific golang version.
-        With monobranch: reads the per-image metadata (e.g. images/openshift-golang-builder-1-22.rhel9.yml)
-        since multiple golang versions share the same group.yml.
-        With separated branches: reads group.yml from the per-version branch.
+        Reads the per-image metadata (e.g. images/openshift-golang-builder-1-22.rhel9.yml)
+        since multiple golang versions share the same group.yml in the monobranch.
+        If not set in image config, falls back to group.yml.
         Defaults to False so that RHEL-shipped golang is never accidentally signed by us.
         """
-        if self.use_new_golang_branch:
-            default_branch = self.GOLANG_DATA_BRANCH
-            repo, branch = self._get_ocp_build_data_repo_and_branch(default_branch)
-            image_key = self.get_golang_image_key(el_v, go_version)
-            content = repo.get_contents(f"images/{image_key}.yml", ref=branch)
-            image_config = yaml.load(content.decoded_content)
-            if image_config.get('sign_golang_rpm') is not None:
-                return image_config.get('sign_golang_rpm', False)
-        else:
-            default_branch = self.get_golang_branch(el_v, go_version)
+        default_branch = self.GOLANG_DATA_BRANCH
         repo, branch = self._get_ocp_build_data_repo_and_branch(default_branch)
+        image_key = self.get_golang_image_key(el_v, go_version)
+        content = repo.get_contents(f"images/{image_key}.yml", ref=branch)
+        image_config = yaml.load(content.decoded_content)
+        if image_config.get('sign_golang_rpm') is not None:
+            return image_config.get('sign_golang_rpm', False)
+        # Fall back to group.yml
         content = repo.get_contents("group.yml", ref=branch)
         group_config = yaml.load(content.decoded_content)
         return group_config.get('sign_golang_rpm', False)
@@ -659,12 +646,8 @@ class UpdateGolangPipeline:
         _LOGGER.info("Building golang plashets for go %s, RHEL versions: %s", go_v, list(el_versions))
 
         for el_v in el_versions:
-            if self.use_new_golang_branch:
-                group = self.GOLANG_DATA_BRANCH
-                version = self.ocp_version
-            else:
-                group = self.get_golang_branch(el_v, go_version)
-                version = None
+            group = self.GOLANG_DATA_BRANCH
+            version = self.ocp_version
             repo_name = f"rhel-{el_v}-golang-rpms"
             _LOGGER.info("Triggering plashet build for group=%s, repo=%s", group, repo_name)
             await self._slack_client.say_in_thread(f"Building golang plashet: group={group}, repo={repo_name}")
@@ -1249,11 +1232,6 @@ class UpdateGolangPipeline:
     help='Override network mode for Konflux builds. Takes precedence over image and group config settings.',
 )
 @click.option(
-    '--use-new-golang-branch/--no-use-new-golang-branch',
-    default=False,
-    help='[DEPRECATED] This flag is now ignored. The pipeline always uses the unified "golang" monobranch layout.',
-)
-@click.option(
     '--major-bump',
     is_flag=True,
     default=False,
@@ -1280,7 +1258,6 @@ async def update_golang(
     skip_pr: bool,
     external_golang_rpms: bool,
     network_mode: str | None,
-    use_new_golang_branch: bool,
     major_bump: bool,
 ):
     if not runtime.dry_run and not confirm:
@@ -1289,10 +1266,6 @@ async def update_golang(
     cves_list = cves.split(',') if cves else None
     if force_update_tracker and not cves_list:
         raise ValueError('CVEs must be provided with --force-update-tracker')
-    if data_gitref and len(go_nvrs) > 1 and not use_new_golang_branch:
-        raise click.BadParameter(
-            '--data-gitref can only be used with a single NVR to ensure the git ref is coupled to the correct RHEL version branch'
-        )
     if network_mode and build_system == 'brew':
         raise click.BadParameter('--network-mode only applies when --build-system is "konflux" or "both".')
 
@@ -1313,18 +1286,6 @@ async def update_golang(
         skip_pr,
         external_golang_rpms,
         network_mode,
-        use_new_golang_branch,
         major_bump,
     )
-    try:
-        await pipeline.run()
-    except Exception as e:
-        if use_new_golang_branch:
-            _LOGGER.error("Golang monobranch build failed: %s", e)
-            slack_client = runtime.new_slack_client()
-            slack_client.bind_channel(ocp_version)
-            await slack_client.say(
-                f":warning: [GOLANG MONOBRANCH FAILURE] update-golang for {ocp_version} failed "
-                f"using the unified golang branch: {e}"
-            )
-        raise
+    await pipeline.run()

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -216,6 +216,14 @@ class UpdateGolangPipeline:
         self._doozer_env_vars = os.environ.copy()
         self._branch_content = None
 
+        # Deprecation warning for separate golang branches
+        if not use_new_golang_branch:
+            _LOGGER.warning(
+                "Using unique golang version branches is deprecated. "
+                "Will use golang mono branch instead. "
+                "See: https://github.com/openshift-eng/ocp-build-data/tree/golang"
+            )
+
         # Get kubeconfig from environment variable if not provided
         if not kubeconfig:
             kubeconfig = os.environ.get('KONFLUX_SA_KUBECONFIG')
@@ -1126,39 +1134,24 @@ class UpdateGolangPipeline:
     GOLANG_DATA_BRANCH = 'golang'
 
     @staticmethod
-    def get_golang_branch(el_v, go_version):
-        major_go, minor_go, _ = go_version.split('.')
-        go_v = f"{major_go}.{minor_go}"
-        return f'rhel-{el_v}-golang-{go_v}'
-
-    @staticmethod
     def get_golang_image_key(el_v, go_version):
         major_go, minor_go, _ = go_version.split('.')
         go_v = f"{major_go}-{minor_go}"
         return f'{GOLANG_BUILDER_IMAGE_NAME}-{go_v}.rhel{el_v}'
 
     def _get_doozer_var_args(self) -> list[str]:
-        if not self.use_new_golang_branch:
-            return []
         ocp_major, ocp_minor = self.ocp_version.split('.')
         return ['--var', f'MAJOR={ocp_major}', '--var', f'MINOR={ocp_minor}']
 
     def _get_doozer_group_and_image(self, el_v, go_version):
-        if self.use_new_golang_branch:
-            group = self.GOLANG_DATA_BRANCH
-            image_key = self.get_golang_image_key(el_v, go_version)
-        else:
-            group = self.get_golang_branch(el_v, go_version)
-            image_key = GOLANG_BUILDER_IMAGE_NAME
+        group = self.GOLANG_DATA_BRANCH
+        image_key = self.get_golang_image_key(el_v, go_version)
         if self.data_gitref:
             group += f'@{self.data_gitref}'
         return group, image_key
 
     def verify_golang_builder_repo(self, el_v, go_version):
-        if self.use_new_golang_branch:
-            default_branch = self.GOLANG_DATA_BRANCH
-        else:
-            default_branch = self.get_golang_branch(el_v, go_version)
+        default_branch = self.GOLANG_DATA_BRANCH
         filename = 'group.yml'
 
         repo, branch = self._get_ocp_build_data_repo_and_branch(default_branch)
@@ -1258,7 +1251,7 @@ class UpdateGolangPipeline:
 @click.option(
     '--use-new-golang-branch/--no-use-new-golang-branch',
     default=False,
-    help='Use the unified "golang" branch layout in ocp-build-data instead of per-variant branches (e.g. rhel-9-golang-1.26).',
+    help='[DEPRECATED] This flag is now ignored. The pipeline always uses the unified "golang" monobranch layout.',
 )
 @click.option(
     '--major-bump',

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -420,9 +420,8 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_doozer_var_args(self, mock_konflux_db):
-        """Test _get_doozer_var_args returns --var args when use_new_golang_branch is True"""
+        """Test _get_doozer_var_args returns --var args"""
         pipeline = self._make_pipeline()
-        pipeline.use_new_golang_branch = True
         self.assertEqual(pipeline._get_doozer_var_args(), ['--var', 'MAJOR=4', '--var', 'MINOR=16'])
 
         pipeline.ocp_version = "5.0"
@@ -1462,7 +1461,6 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             art_jira="ART-1234",
             tag_builds=True,
             build_system="konflux",
-            use_new_golang_branch=True,
         )
 
         async def mock_search_builds(*_args, **kwargs):
@@ -1546,7 +1544,6 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.20.12-2.el8"],
             art_jira="ART-1234",
             tag_builds=True,
-            use_new_golang_branch=True,
         )
 
         await pipeline._rebase_brew(8, "1.20.12", "golang-1.20.12-2.el8")
@@ -1805,7 +1802,6 @@ class TestShouldSignGolangRpm(unittest.TestCase):
             go_nvrs=["golang-1.22.9-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
-            use_new_golang_branch=True,
         )
 
         result = pipeline.should_sign_golang_rpm(9, "1.22.9")
@@ -1831,7 +1827,6 @@ class TestShouldSignGolangRpm(unittest.TestCase):
             go_nvrs=["golang-1.22.9-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
-            use_new_golang_branch=True,
         )
 
         result = pipeline.should_sign_golang_rpm(9, "1.22.9")
@@ -1859,35 +1854,11 @@ class TestShouldSignGolangRpm(unittest.TestCase):
             go_nvrs=["golang-1.25.3-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
-            use_new_golang_branch=True,
         )
 
         result = pipeline.should_sign_golang_rpm(9, "1.25.3")
 
         self.assertFalse(result)
-
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
-    def test_separated_branch_reads_group_yml(self, mock_get_github_client, mock_konflux_db):
-        mock_repo = Mock()
-        mock_repo.get_contents.return_value = Mock(decoded_content=b"sign_golang_rpm: true\n")
-        mock_get_github_client.return_value.get_repo.return_value = mock_repo
-
-        pipeline = UpdateGolangPipeline(
-            runtime=Mock(dry_run=False, working_dir=Path("/tmp/working")),
-            ocp_version="4.18",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.22.9-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-            use_new_golang_branch=False,
-        )
-
-        result = pipeline.should_sign_golang_rpm(9, "1.22.9")
-
-        self.assertTrue(result)
-        mock_repo.get_contents.assert_called_with("group.yml", ref="rhel-9-golang-1.22")
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
@@ -2024,7 +1995,7 @@ class TestIsRpmSigned(unittest.TestCase):
 class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
     """Test the _build_golang_plashets method"""
 
-    def _make_pipeline(self, use_new_golang_branch=False, dry_run=False):
+    def _make_pipeline(self, dry_run=False):
         mock_slack = Mock()
         mock_slack.say_in_thread = AsyncMock()
         mock_runtime = Mock(dry_run=dry_run, working_dir=Path("/tmp/working"))
@@ -2037,13 +2008,12 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.22.9-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
-            use_new_golang_branch=use_new_golang_branch,
         )
 
     @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     async def test_monobranch_triggers_jenkins_for_each_el_version(self, mock_konflux_db, mock_jenkins):
-        pipeline = self._make_pipeline(use_new_golang_branch=True)
+        pipeline = self._make_pipeline()
         mock_jenkins.start_build_plashets.return_value = "SUCCESS"
 
         await pipeline._build_golang_plashets("1.22.9", [8, 9])
@@ -2059,25 +2029,8 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_separated_branch_triggers_jenkins_per_el_and_go_version(self, mock_konflux_db, mock_jenkins):
-        pipeline = self._make_pipeline(use_new_golang_branch=False)
-        mock_jenkins.start_build_plashets.return_value = "SUCCESS"
-
-        await pipeline._build_golang_plashets("1.22.9", [8, 9])
-
-        self.assertEqual(mock_jenkins.start_build_plashets.call_count, 2)
-        calls = mock_jenkins.start_build_plashets.call_args_list
-        self.assertEqual(calls[0].kwargs["group"], "rhel-8-golang-1.22")
-        self.assertEqual(calls[0].kwargs["repos"], ["rhel-8-golang-rpms"])
-        self.assertIsNone(calls[0].kwargs["version"])
-        self.assertEqual(calls[1].kwargs["group"], "rhel-9-golang-1.22")
-        self.assertEqual(calls[1].kwargs["repos"], ["rhel-9-golang-rpms"])
-        self.assertIsNone(calls[1].kwargs["version"])
-
-    @patch("pyartcd.pipelines.update_golang.jenkins")
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     async def test_raises_on_jenkins_failure(self, mock_konflux_db, mock_jenkins):
-        pipeline = self._make_pipeline(use_new_golang_branch=True)
+        pipeline = self._make_pipeline()
         mock_jenkins.start_build_plashets.return_value = "FAILURE"
 
         with self.assertRaisesRegex(RuntimeError, "failed with result: FAILURE"):
@@ -2086,7 +2039,7 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
     @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     async def test_dry_run_passes_dry_run_flag(self, mock_konflux_db, mock_jenkins):
-        pipeline = self._make_pipeline(use_new_golang_branch=True, dry_run=True)
+        pipeline = self._make_pipeline(dry_run=True)
         mock_jenkins.start_build_plashets.return_value = "SUCCESS"
 
         await pipeline._build_golang_plashets("1.22.9", [9])
@@ -2096,9 +2049,9 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
 
 
 class TestMonobranchDispatch(IsolatedAsyncioTestCase):
-    """Test that branch-dependent methods dispatch correctly based on use_new_golang_branch"""
+    """Test that doozer group and image methods work with monobranch"""
 
-    def _make_pipeline(self, use_new_golang_branch):
+    def _make_pipeline(self):
         mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
         mock_runtime.new_slack_client.return_value = Mock()
         return UpdateGolangPipeline(
@@ -2109,30 +2062,18 @@ class TestMonobranchDispatch(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.22.9-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
-            use_new_golang_branch=use_new_golang_branch,
         )
 
-    def test_doozer_group_uses_monobranch_when_flag_is_true(self):
-        pipeline = self._make_pipeline(use_new_golang_branch=True)
+    def test_doozer_group_uses_monobranch(self):
+        pipeline = self._make_pipeline()
         group, image_key = pipeline._get_doozer_group_and_image(9, "1.22.9")
         self.assertEqual(group, "golang")
         self.assertEqual(image_key, "openshift-golang-builder-1-22.rhel9")
 
-    def test_doozer_group_uses_separated_branch_when_flag_is_false(self):
-        pipeline = self._make_pipeline(use_new_golang_branch=False)
-        group, image_key = pipeline._get_doozer_group_and_image(9, "1.22.9")
-        self.assertEqual(group, "rhel-9-golang-1.22")
-        self.assertEqual(image_key, "openshift-golang-builder")
-
     def test_doozer_var_args_with_monobranch(self):
-        pipeline = self._make_pipeline(use_new_golang_branch=True)
+        pipeline = self._make_pipeline()
         args = pipeline._get_doozer_var_args()
         self.assertEqual(args, ['--var', 'MAJOR=4', '--var', 'MINOR=18'])
-
-    def test_doozer_var_args_with_separated_branch(self):
-        pipeline = self._make_pipeline(use_new_golang_branch=False)
-        args = pipeline._get_doozer_var_args()
-        self.assertEqual(args, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR removes the deprecated separate golang branch logic from the `update-golang` pipeline and makes it always use the unified `golang` monobranch layout.

## Changes

### Update Golang Pipeline (`update_golang.py`)

- **Added deprecation warning**: When `--use-new-golang-branch` flag is not set (default), a warning is logged directing users to the golang monobranch
- **Removed `get_golang_branch()` method**: No longer needed since we always use `'golang'` monobranch
- **Simplified `_get_doozer_var_args()`**: Always returns MAJOR/MINOR OCP version variables (needed for monobranch template substitution)
- **Simplified `_get_doozer_group_and_image()`**: Always uses `GOLANG_DATA_BRANCH = 'golang'` and versioned image keys
- **Simplified `verify_golang_builder_repo()`**: Always checks the `'golang'` monobranch
- **Simplified `should_sign_golang_rpm()`**: Always reads from `'golang'` monobranch group.yml
- **Updated `_build_golang_plashets()`**: Now uses monobranch group name
- **Updated CLI help text**: Marked `--use-new-golang-branch` as deprecated

### Test Updates

- Removed `test_get_golang_branch` (method no longer exists)
- Updated `test_get_doozer_var_args` to expect vars are always returned
- Updated `test_rebase_brew` to expect monobranch group name and --var arguments
- Updated `test_returns_true_when_config_set` and related tests to expect `ref='golang'` instead of separate branch names
- Updated plashet tests to expect monobranch group name

## Backward Compatibility

The `--use-new-golang-branch` parameter is kept to:
1. Show deprecation warnings to users still using the old default
2. Maintain CLI compatibility (no breaking changes)

The flag is now effectively ignored - the pipeline always uses the monobranch approach.

Unused `--var` arguments passed to doozer are harmless - they're simply ignored if the group.yml doesn't have corresponding template placeholders.

## Dependencies

This PR depends on the plashet support for golang groups being merged first. See related PR for adding version parameter support to build-plashets pipeline.

## Testing

- [x] All unit tests pass
- [x] Verified deprecation warning appears when flag is not set
- [x] Confirmed monobranch group name is used throughout

## Related

- ocp-build-data golang monobranch: https://github.com/openshift-eng/ocp-build-data/tree/golang