### PR TITLE
ART-21561: Fix bundle CSV namespace references for OCP 5.0

### DIFF
--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -427,7 +427,7 @@ class KonfluxOlmBundleRebaser:
                 f"Invalid MAJOR version in group config for {metadata.runtime.group}: "
                 f"{self._group_config.vars.get('MAJOR')}"
             ) from e
-        default_delivery_namespace = f'openshift{major}' if major >= 5 else 'openshift4'
+        default_delivery_namespace = f'openshift{major}'
         # Build a map of image short name -> delivery override short name for images that have
         # delivery_repo_name_override set. This allows operators to reference images using a
         # versioned internal name (e.g. ose-csi-livenessprobe-4.18-rhel9) while having them

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -462,8 +462,11 @@ class KonfluxOlmBundleRebaser:
             if not metadata.runtime.group.startswith("openshift-"):
                 new_namespace = namespace
             else:
+                # Derive default delivery namespace from MAJOR version (openshift5 for OCP 5.x, openshift4 for older)
+                major = int(self._group_config.vars.get('MAJOR', 4))
+                default_delivery_namespace = f'openshift{major}' if major >= 5 else 'openshift4'
                 new_namespace = (
-                    _delivery_namespace_map.get(image_short_name, 'openshift4')
+                    _delivery_namespace_map.get(image_short_name, default_delivery_namespace)
                     if namespace == csv_namespace
                     else namespace
                 )

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -418,6 +418,16 @@ class KonfluxOlmBundleRebaser:
 
         # Replace ART-built image references in the content
         csv_namespace = self._group_config.get('csv_namespace', 'openshift')
+        # Derive default delivery namespace from MAJOR version (openshift5 for OCP 5.x, openshift4 for older)
+        try:
+            major = int(self._group_config.vars.get('MAJOR', 4))
+        except (ValueError, TypeError) as e:
+            # MAJOR should always be a valid integer in group.yml; if not, this is a config error
+            raise ValueError(
+                f"Invalid MAJOR version in group config for {metadata.runtime.group}: "
+                f"{self._group_config.vars.get('MAJOR')}"
+            ) from e
+        default_delivery_namespace = f'openshift{major}' if major >= 5 else 'openshift4'
         # Build a map of image short name -> delivery override short name for images that have
         # delivery_repo_name_override set. This allows operators to reference images using a
         # versioned internal name (e.g. ose-csi-livenessprobe-4.18-rhel9) while having them
@@ -462,9 +472,6 @@ class KonfluxOlmBundleRebaser:
             if not metadata.runtime.group.startswith("openshift-"):
                 new_namespace = namespace
             else:
-                # Derive default delivery namespace from MAJOR version (openshift5 for OCP 5.x, openshift4 for older)
-                major = int(self._group_config.vars.get('MAJOR', 4))
-                default_delivery_namespace = f'openshift{major}' if major >= 5 else 'openshift4'
                 new_namespace = (
                     _delivery_namespace_map.get(image_short_name, default_delivery_namespace)
                     if namespace == csv_namespace

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -146,28 +146,26 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
                     },
                 },
             },
-            'listDigest': 'sha256:abc123',
-            'contentDigest': 'sha256:abc123',
+            'listDigest': 'sha256:listdigest123',
+            'contentDigest': 'sha256:contentdigest456',
         }
         mock_oc_image_info.return_value = mock_image_info
 
         # Mock group_config with MAJOR=4
         self.rebaser._group_config.get.side_effect = lambda key, default=None: {
             'csv_namespace': 'namespace',
-            'operator_image_ref_mode': 'manifest-list'
         }.get(key, default)
         self.rebaser._group_config.vars = {'MAJOR': 4}
+        self.rebaser._group_config.operator_image_ref_mode = 'manifest-list'  # Uses listDigest
 
         metadata = MagicMock()
         metadata.runtime.group = "openshift-4.19"
         metadata.runtime.data_dir = "/tmp/nonexistent"
 
-        new_content, _ = await self.rebaser._replace_image_references(
-            old_registry, content, Engine.KONFLUX, metadata
-        )
+        new_content, _ = await self.rebaser._replace_image_references(old_registry, content, Engine.KONFLUX, metadata)
 
-        # Should use openshift4 namespace
-        self.assertIn('registry.redhat.io/openshift4/image@sha256:abc123', new_content)
+        # Should use openshift4 namespace and listDigest (manifest-list mode)
+        self.assertIn('registry.redhat.io/openshift4/image@sha256:listdigest123', new_content)
 
     @patch("doozerlib.util.oc_image_info_for_arch_async")
     async def test_replace_image_references_ocp5_namespace(self, mock_oc_image_info):
@@ -184,28 +182,26 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
                     },
                 },
             },
-            'listDigest': 'sha256:def456',
-            'contentDigest': 'sha256:def456',
+            'listDigest': 'sha256:listdigest789',
+            'contentDigest': 'sha256:contentdigestabc',
         }
         mock_oc_image_info.return_value = mock_image_info
 
         # Mock group_config with MAJOR=5
         self.rebaser._group_config.get.side_effect = lambda key, default=None: {
             'csv_namespace': 'namespace',
-            'operator_image_ref_mode': 'manifest-list'
         }.get(key, default)
         self.rebaser._group_config.vars = {'MAJOR': 5}
+        self.rebaser._group_config.operator_image_ref_mode = 'by-arch'  # Uses contentDigest
 
         metadata = MagicMock()
         metadata.runtime.group = "openshift-5.0"
         metadata.runtime.data_dir = "/tmp/nonexistent"
 
-        new_content, _ = await self.rebaser._replace_image_references(
-            old_registry, content, Engine.KONFLUX, metadata
-        )
+        new_content, _ = await self.rebaser._replace_image_references(old_registry, content, Engine.KONFLUX, metadata)
 
-        # Should use openshift5 namespace
-        self.assertIn('registry.redhat.io/openshift5/image@sha256:def456', new_content)
+        # Should use openshift5 namespace and contentDigest (by-arch mode)
+        self.assertIn('registry.redhat.io/openshift5/image@sha256:contentdigestabc', new_content)
 
     def test_operator_index_mode(self):
         # Test when operator_index_mode is 'pre-release'

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -131,6 +131,82 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
             ),
         )
 
+    @patch("doozerlib.util.oc_image_info_for_arch_async")
+    async def test_replace_image_references_ocp4_namespace(self, mock_oc_image_info):
+        """Test that OCP 4.x uses openshift4 namespace"""
+        old_registry = "registry.example.com"
+        content = """image: registry.example.com/namespace/image:tag"""
+        mock_image_info = {
+            'config': {
+                'config': {
+                    'Labels': {
+                        'com.redhat.component': 'test-component',
+                        'version': '1.0',
+                        'release': '1',
+                    },
+                },
+            },
+            'listDigest': 'sha256:abc123',
+            'contentDigest': 'sha256:abc123',
+        }
+        mock_oc_image_info.return_value = mock_image_info
+
+        # Mock group_config with MAJOR=4
+        self.rebaser._group_config.get.side_effect = lambda key, default=None: {
+            'csv_namespace': 'namespace',
+            'operator_image_ref_mode': 'manifest-list'
+        }.get(key, default)
+        self.rebaser._group_config.vars = {'MAJOR': 4}
+
+        metadata = MagicMock()
+        metadata.runtime.group = "openshift-4.19"
+        metadata.runtime.data_dir = "/tmp/nonexistent"
+
+        new_content, _ = await self.rebaser._replace_image_references(
+            old_registry, content, Engine.KONFLUX, metadata
+        )
+
+        # Should use openshift4 namespace
+        self.assertIn('registry.redhat.io/openshift4/image@sha256:abc123', new_content)
+
+    @patch("doozerlib.util.oc_image_info_for_arch_async")
+    async def test_replace_image_references_ocp5_namespace(self, mock_oc_image_info):
+        """Test that OCP 5.x uses openshift5 namespace"""
+        old_registry = "registry.example.com"
+        content = """image: registry.example.com/namespace/image:tag"""
+        mock_image_info = {
+            'config': {
+                'config': {
+                    'Labels': {
+                        'com.redhat.component': 'test-component',
+                        'version': '1.0',
+                        'release': '1',
+                    },
+                },
+            },
+            'listDigest': 'sha256:def456',
+            'contentDigest': 'sha256:def456',
+        }
+        mock_oc_image_info.return_value = mock_image_info
+
+        # Mock group_config with MAJOR=5
+        self.rebaser._group_config.get.side_effect = lambda key, default=None: {
+            'csv_namespace': 'namespace',
+            'operator_image_ref_mode': 'manifest-list'
+        }.get(key, default)
+        self.rebaser._group_config.vars = {'MAJOR': 5}
+
+        metadata = MagicMock()
+        metadata.runtime.group = "openshift-5.0"
+        metadata.runtime.data_dir = "/tmp/nonexistent"
+
+        new_content, _ = await self.rebaser._replace_image_references(
+            old_registry, content, Engine.KONFLUX, metadata
+        )
+
+        # Should use openshift5 namespace
+        self.assertIn('registry.redhat.io/openshift5/image@sha256:def456', new_content)
+
     def test_operator_index_mode(self):
         # Test when operator_index_mode is 'pre-release'
         self.rebaser._group_config.operator_index_mode = 'pre-release'

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -104,6 +104,7 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
         mock_oc_image_info.return_value = mock_image_info
         # operator_image_ref_mode defaults to 'manifest-list' (uses listDigest)
         self.rebaser._group_config.get.return_value = 'namespace'
+        self.rebaser._group_config.vars = {'MAJOR': 4}
         metadata = MagicMock()
         metadata.runtime.group = "openshift-4.19"
         new_content, found_images = await self.rebaser._replace_image_references(


### PR DESCRIPTION
  Auto-derive delivery namespace from MAJOR version in group.yml
  instead of using hardcoded 'openshift4' default.

  When building OLM bundles, placeholder images (e.g., origin-*) are
  not found in delivery_namespace_map and fall back to the default.
  Previously hardcoded 'openshift4', this caused OCP 5.0 bundles to
  reference wrong namespace, resulting in stage-testing timeouts.

  Solution:
  - Read MAJOR from group.yml vars
  - For OCP 5.x: use 'openshift5'
  - For OCP 4.x: use 'openshift4' (backward compatible)
  - Future: automatically use 'openshift{MAJOR}'

  After bundle rebuild, CSV will correctly reference:
    registry.redhat.io/openshift5/operator-name@sha256:... Instead of: registry.redhat.io/openshift4/operator-name@sha256:...

  Fixes: https://redhat.atlassian.net/browse/ART-21561
  Parent: https://redhat.atlassian.net/browse/ART-14465

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the OpenShift delivery-namespace fallback to derive `openshift{N}` from the configured platform major version, defaulting to `4` when unset.
  * Improved operator image reference rewriting to target the correct Red Hat registry pullspec format for major versions 4 vs 5 (including digest formatting differences).
  * Added clear validation and error reporting when the major version value cannot be parsed.
* **Tests**
  * Added async unit tests verifying major-version-specific image rewrite behavior for both 4.x and 5.x.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->