### PR TITLE
ART-21555: Two-pass resolution for bare-update lockfile stages

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -459,24 +459,34 @@ class RpmLockfilePrototypeGenerator:
                     )
 
             reinstall_pkgs: list[str] | None = None
+            pin_candidates: list[str] = []
             strippable: set[str] | None = None
             dockerfile_pkgs: set[str] | None = None
             if stage_num == final_stage_num and not is_update_only and has_bare_update:
                 if image_pullspec and packages:
-                    # Bare update + explicit installs in final stage: reinstall
-                    # the Dockerfile packages so they appear in the lockfile
-                    # even when already installed in the base image. Base image
-                    # packages use upgrade semantics via upgrade_targets (set
-                    # above), so we intentionally do NOT reinstall them here —
-                    # a Dockerfile package that's also a base image package
-                    # would otherwise get reinstalled at its currently-installed
-                    # EVR, which can win over the separate upgrade request and
-                    # silently keep an old version instead of upgrading.
-                    reinstall_pkgs = [p for p in packages if p not in base_pkgs]
-                    strippable = set()
+                    # Two-pass resolution for bare update + explicit installs.
+                    #
+                    # Pass 1 (this block): resolve with upgradePackages only,
+                    # NO reinstallPackages. Captures newly-installed Dockerfile
+                    # packages and base image packages with upgrades available.
+                    #
+                    # Pass 2 (after resolution): targeted reinstall for
+                    # Dockerfile packages that overlap with the base image but
+                    # produced no output in pass 1 (already installed at repo-
+                    # latest, so neither install nor upgrade captured them).
+                    #
+                    # Keeping reinstall and upgrade in the same DNF transaction
+                    # is unreliable: reinstall pins the installed EVR which can
+                    # win over an upgrade request for the same package, silently
+                    # keeping an old version. Separating them eliminates the
+                    # conflict entirely.
+                    pin_candidates = [p for p in packages if p in base_pkgs]
+                    strippable = set(upgrade_targets) - set(packages)
+                    dockerfile_pkgs = set(packages)
                     self.logger.info(
-                        f"{distgit_key}: stage {stage_num}: {len(reinstall_pkgs)} Dockerfile "
-                        "packages will be reinstalled into lockfile (bare update stage)"
+                        f"{distgit_key}: stage {stage_num}: bare update with "
+                        f"{len(packages)} Dockerfile packages ({len(pin_candidates)} "
+                        "overlap with base image, will use two-pass resolution)"
                     )
             elif stage_num == final_stage_num and not is_update_only and not has_bare_update:
                 if image_pullspec:
@@ -566,6 +576,23 @@ class RpmLockfilePrototypeGenerator:
                     )
                     if recovered:
                         result = merge_lockfiles([result, recovered])
+
+            # Pass 2 of two-pass resolution: pin Dockerfile packages that
+            # overlap with the base image but weren't captured by the
+            # upgrade pass (already installed at repo-latest version).
+            if pin_candidates and image_pullspec:
+                result = await self._pin_missing_dockerfile_packages(
+                    result,
+                    pin_candidates,
+                    repo_list,
+                    arches,
+                    image_pullspec,
+                    distgit_key,
+                    stage_num,
+                    enable_only,
+                )
+
+            if result:
                 stage_lockfiles.append(result)
 
         return stage_lockfiles
@@ -609,6 +636,86 @@ class RpmLockfilePrototypeGenerator:
         if not recovered:
             return None
         return merge_lockfiles(recovered) if len(recovered) > 1 else recovered[0]
+
+    async def _pin_missing_dockerfile_packages(
+        self,
+        result: LockfileData | None,
+        pin_candidates: list[str],
+        repo_list: list[RepoEntry],
+        arches: list[str],
+        image_pullspec: str,
+        distgit_key: str,
+        stage_num: int,
+        module_enable: list[str] | None,
+    ) -> LockfileData | None:
+        """
+        Pass 2 of two-pass bare-update resolution: pin Dockerfile
+        packages that overlap with the base image but weren't captured
+        by the upgrade pass.
+
+        These packages are already installed at the repo-latest version,
+        so neither install (already present) nor upgrade (nothing newer)
+        produced a lockfile entry. A targeted reinstall-only call pins
+        them at their installed version. No upgrade/reinstall EVR
+        conflict is possible because upgradePackages is not set here.
+
+        Arg(s):
+            result (LockfileData | None): Pass 1 result (may be None
+                if resolution produced nothing).
+            pin_candidates (list[str]): Dockerfile packages that overlap
+                with the base image and may need pinning.
+            repo_list (list[RepoEntry]): Repository entries.
+            arches (list[str]): Target architectures.
+            image_pullspec (str): Base image pullspec.
+            distgit_key (str): Image identifier for logging.
+            stage_num (int): Dockerfile stage number.
+            module_enable (list[str] | None): Module streams to enable.
+        Return Value(s):
+            LockfileData | None: The merged result, or None if both
+                passes produced nothing.
+        """
+        locked_names: set[str] = set()
+        if result:
+            for arch_entry in result.arches:
+                for pkg in arch_entry.packages:
+                    locked_names.add(pkg.name)
+
+        missing = sorted(p for p in pin_candidates if p not in locked_names)
+        if not missing:
+            return result
+
+        self.logger.info(
+            f"{distgit_key}: stage {stage_num}: pinning {len(missing)} Dockerfile "
+            f"packages not captured by upgrade pass: {missing}"
+        )
+        resolver_pullspec = ContainerImageHelper._proxy_pullspec(image_pullspec)
+        in_yaml = build_rpms_in_yaml(
+            repo_list,
+            arches,
+            missing,
+            reinstall_packages=missing,
+            module_enable=module_enable,
+        )
+        try:
+            pin_result = await self._resolver.resolve(in_yaml, image_pullspec=resolver_pullspec)
+        except RuntimeError as e:
+            self.logger.warning(
+                f"{distgit_key}: stage {stage_num}: pin pass failed, "
+                f"some Dockerfile packages may be unlocked: {e}"
+            )
+            return result
+
+        if pin_result and any(ae.packages for ae in pin_result.arches):
+            pinned = {pkg.name for ae in pin_result.arches for pkg in ae.packages}
+            self.logger.info(
+                f"{distgit_key}: stage {stage_num}: pin pass locked "
+                f"{len(pinned)} packages: {sorted(pinned)}"
+            )
+            if result:
+                return merge_lockfiles([result, pin_result])
+            return pin_result
+
+        return result
 
     async def _get_base_image_packages(self, stage_num: int, image_pullspec: str | None, distgit_key: str) -> list[str]:
         """

--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -674,48 +674,55 @@ class RpmLockfilePrototypeGenerator:
             LockfileData | None: The merged result, or None if both
                 passes produced nothing.
         """
-        locked_names: set[str] = set()
-        if result:
-            for arch_entry in result.arches:
-                for pkg in arch_entry.packages:
-                    locked_names.add(pkg.name)
+        locked_by_arch: dict[str, set[str]] = (
+            {entry.arch: {pkg.name for pkg in entry.packages} for entry in result.arches} if result else {}
+        )
 
-        missing = sorted(p for p in pin_candidates if p not in locked_names)
-        if not missing:
+        missing_by_arch: dict[str, list[str]] = {
+            arch: sorted(p for p in pin_candidates if p not in locked_by_arch.get(arch, set())) for arch in arches
+        }
+        missing_by_arch = {arch: missing for arch, missing in missing_by_arch.items() if missing}
+        if not missing_by_arch:
             return result
 
-        self.logger.info(
-            f"{distgit_key}: stage {stage_num}: pinning {len(missing)} Dockerfile "
-            f"packages not captured by upgrade pass: {missing}"
-        )
         resolver_pullspec = ContainerImageHelper._proxy_pullspec(image_pullspec)
-        in_yaml = build_rpms_in_yaml(
-            repo_list,
-            arches,
-            missing,
-            reinstall_packages=missing,
-            module_enable=module_enable,
-        )
-        try:
-            pin_result = await self._resolver.resolve(in_yaml, image_pullspec=resolver_pullspec)
-        except RuntimeError as e:
-            self.logger.warning(
-                f"{distgit_key}: stage {stage_num}: pin pass failed, "
-                f"some Dockerfile packages may be unlocked: {e}"
+        pin_results: list[LockfileData] = []
+
+        for arch, missing in missing_by_arch.items():
+            self.logger.info(
+                f"{distgit_key}: stage {stage_num}: pinning {len(missing)} Dockerfile "
+                f"packages not captured by upgrade pass on {arch}: {missing}"
             )
+            in_yaml = build_rpms_in_yaml(
+                repo_list,
+                [arch],
+                missing,
+                reinstall_packages=missing,
+                module_enable=module_enable,
+            )
+            try:
+                pin_result = await self._resolver.resolve(in_yaml, image_pullspec=resolver_pullspec)
+            except RuntimeError as e:
+                self.logger.warning(
+                    f"{distgit_key}: stage {stage_num}: pin pass failed on {arch}, "
+                    f"some Dockerfile packages may be unlocked: {e}"
+                )
+                continue
+
+            if pin_result and any(ae.packages for ae in pin_result.arches):
+                pinned = {pkg.name for ae in pin_result.arches for pkg in ae.packages}
+                self.logger.info(
+                    f"{distgit_key}: stage {stage_num}: pin pass locked "
+                    f"{len(pinned)} packages on {arch}: {sorted(pinned)}"
+                )
+                pin_results.append(pin_result)
+
+        if not pin_results:
             return result
 
-        if pin_result and any(ae.packages for ae in pin_result.arches):
-            pinned = {pkg.name for ae in pin_result.arches for pkg in ae.packages}
-            self.logger.info(
-                f"{distgit_key}: stage {stage_num}: pin pass locked "
-                f"{len(pinned)} packages: {sorted(pinned)}"
-            )
-            if result:
-                return merge_lockfiles([result, pin_result])
-            return pin_result
-
-        return result
+        to_merge = [result] if result else []
+        to_merge.extend(pin_results)
+        return merge_lockfiles(to_merge)
 
     async def _get_base_image_packages(self, stage_num: int, image_pullspec: str | None, distgit_key: str) -> list[str]:
         """

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -588,13 +588,16 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         self.assertIn("libreswan", pkg_names)
         self.assertIn("openssl", pkg_names)
 
-    def test_bare_update_keeps_image_mode_reinstalls_dockerfile_packages(self):
+    def test_bare_update_keeps_image_mode_no_reinstall_in_upgrade_pass(self):
         """
-        Bare yum/dnf update with --image mode should NOT expand base
-        image packages as upgrade targets (many are virtual provides or
-        renamed and cause resolution failures). Dockerfile install
-        packages must be reinstalled so they appear in the lockfile, and
-        also promoted to upgradePackages as a fallback if reinstall fails.
+        Bare yum/dnf update with --image mode uses two-pass resolution:
+        the main pass resolves with upgradePackages only (no reinstall),
+        and a follow-up pin pass reinstalls Dockerfile packages that
+        overlap with the base image but had no upgrade available.
+
+        When no base image packages are available (empty list from
+        container query), the main pass just installs the Dockerfile
+        packages normally — no reinstall, no upgrade targets.
         """
         meta = self._make_mock_image_meta()
         meta.config.konflux.cachi2.lockfile.get.return_value = None
@@ -620,20 +623,20 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         self.assertEqual(len(captured_configs), 1)
         # --image mode preserved
         self.assertIsNotNone(captured_pullspecs[0])
-        # Dockerfile packages reinstalled so they appear in lockfile
-        self.assertEqual(captured_configs[0].reinstallPackages, ["libreswan"])
-        # Dockerfile packages promoted to upgrade as reinstall fallback
-        self.assertEqual(captured_configs[0].upgradePackages, ["libreswan"])
+        # No reinstall in two-pass design — libreswan is installed via packages
+        self.assertFalse(captured_configs[0].reinstallPackages)
+        pkg_names = [p if isinstance(p, str) else p.name for p in captured_configs[0].packages]
+        self.assertIn("libreswan", pkg_names)
+        # No upgrade targets (base image query returned empty)
+        self.assertFalse(captured_configs[0].upgradePackages)
 
-    def test_mixed_install_and_bare_update_reinstalls_dockerfile_packages(self):
+    def test_mixed_install_and_bare_update_two_pass_resolution(self):
         """
         When a stage has both explicit installs and a bare update
         (e.g. microdnf update -y && microdnf install -y openssl),
-        Dockerfile install packages must appear in reinstallPackages
-        so they end up in the lockfile even when already installed in
-        the base image. Base image packages must NOT be reinstalled —
-        they use upgrade semantics via upgradePackages to pick up
-        latest versions without pinning.
+        the main pass resolves with upgradePackages only (no reinstall).
+        Dockerfile packages not in the base image are installed normally
+        via the packages list. Base image packages use upgrade semantics.
         """
         meta = self._make_mock_image_meta()
         meta.config.konflux.cachi2.lockfile.get.return_value = None
@@ -657,26 +660,28 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
             asyncio.run(generator.generate_lockfile(meta, dest_dir))
 
         self.assertEqual(len(captured_configs), 1)
-        # Dockerfile install packages must be reinstalled so they appear
-        # in the lockfile even when already installed in the base image
-        self.assertEqual(captured_configs[0].reinstallPackages, ["openssl"])
-        # Explicit install package must be present in packages list
-        pkg_names = [p if isinstance(p, str) else p.name for p in captured_configs[0].packages]
+        # No reinstall in two-pass design
+        self.assertFalse(captured_configs[0].reinstallPackages)
+        # All packages (Dockerfile + base image) in packages list
+        pkg_names = sorted(p if isinstance(p, str) else p.name for p in captured_configs[0].packages)
         self.assertIn("openssl", pkg_names)
-        # Base image packages must appear as upgrade targets so
-        # dnf update picks up latest versions from repos
-        self.assertEqual(sorted(captured_configs[0].upgradePackages), ["audit", "bash", "glibc", "openssl"])
+        self.assertIn("audit", pkg_names)
+        # Only base image packages as upgrade targets (openssl is not
+        # in the base image, so it's installed via packages, not upgraded)
+        self.assertEqual(sorted(captured_configs[0].upgradePackages), ["audit", "bash", "glibc"])
 
-    def test_dockerfile_package_already_in_base_image_not_reinstalled(self):
+    def test_two_pass_no_reinstall_in_upgrade_pass_pin_pass_for_overlap(self):
         """
-        A Dockerfile package that's also already installed in the base
-        image (e.g. python3-setuptools, part of both the explicit install
-        list and the base image's package set) must NOT be reinstalled —
-        only upgraded. Reinstalling it can trivially match the
-        currently-installed EVR and win over the separate upgrade
-        request, silently keeping an old version (e.g. a non-modular
-        build from the base repos) instead of picking up the newer one
-        the upgrade would have found.
+        Two-pass resolution for bare update + explicit installs:
+
+        Pass 1 (upgrade): no reinstallPackages at all. Dockerfile
+        packages are installed via packages, base image packages are
+        upgraded via upgradePackages. This avoids the reinstall-vs-
+        upgrade EVR conflict.
+
+        Pass 2 (pin): Dockerfile packages that overlap with the base
+        image and weren't captured by pass 1 (no upgrade available)
+        are reinstalled to pin their installed version.
         """
         meta = self._make_mock_image_meta()
         meta.config.konflux.cachi2.lockfile.get.return_value = None
@@ -700,18 +705,25 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
             )
             asyncio.run(generator.generate_lockfile(meta, dest_dir))
 
-        self.assertEqual(len(captured_configs), 1)
-        # python3-setuptools must NOT be reinstalled — it's a base image
-        # package and must go through upgrade semantics only
-        self.assertNotIn("python3-setuptools", captured_configs[0].reinstallPackages)
-        # git is purely a Dockerfile package (not in the base image) and
-        # must still be reinstalled as before
-        self.assertIn("git", captured_configs[0].reinstallPackages)
-        # python3-setuptools must still be present as an upgrade target
-        self.assertIn("python3-setuptools", captured_configs[0].upgradePackages)
-        # And still present in the plain install list
-        pkg_names = [p if isinstance(p, str) else p.name for p in captured_configs[0].packages]
+        # Pass 1: upgrade pass — no reinstallPackages at all
+        self.assertGreaterEqual(len(captured_configs), 1)
+        main_config = captured_configs[0]
+        self.assertFalse(main_config.reinstallPackages)
+        # Both Dockerfile and base image packages in the install list
+        pkg_names = [p if isinstance(p, str) else p.name for p in main_config.packages]
         self.assertIn("python3-setuptools", pkg_names)
+        self.assertIn("git", pkg_names)
+        # Base image packages as upgrade targets
+        self.assertIn("python3-setuptools", main_config.upgradePackages)
+        self.assertIn("bash", main_config.upgradePackages)
+        # Pass 2: pin pass for python3-setuptools (base-image overlap
+        # not in FAKE_LOCKFILE_DATA output). git is NOT a pin candidate
+        # because it's not in the base image.
+        self.assertEqual(len(captured_configs), 2)
+        pin_config = captured_configs[1]
+        self.assertIn("python3-setuptools", pin_config.reinstallPackages)
+        self.assertNotIn("git", pin_config.reinstallPackages)
+        self.assertFalse(pin_config.upgradePackages)
 
     def test_base_image_overlap_package_survives_retry_exhaustion_fallback(self):
         """
@@ -759,14 +771,96 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         # Some later calls are _recover_stripped_per_arch attempts for the
         # noise packages (unrelated to this assertion), so check across all
         # calls rather than assuming a fixed index: python3-setuptools must
-        # have been offered as an upgrade target at some point post-fallback,
-        # never as a reinstall target.
+        # have been offered as an upgrade target at some point post-fallback.
         all_configs = [c.args[0] for c in generator._resolver.resolve.call_args_list]
         self.assertTrue(
             any("python3-setuptools" in (c.upgradePackages or []) for c in all_configs),
             "python3-setuptools should appear in upgradePackages in at least one resolve call",
         )
-        self.assertTrue(all("python3-setuptools" not in (c.reinstallPackages or []) for c in all_configs))
+        # No reinstallPackages in any upgrade pass call
+        main_configs = [c for c in all_configs if c.upgradePackages]
+        self.assertTrue(
+            all(not (c.reinstallPackages or []) for c in main_configs),
+            "no reinstallPackages should be set during upgrade pass",
+        )
+        # Pin pass should have fired for python3-setuptools since it's
+        # a base-image overlap package not in the resolver output
+        # (FAKE_LOCKFILE_DATA only has nfs-utils).
+        pin_configs = [c for c in all_configs if not c.upgradePackages]
+        self.assertTrue(
+            any("python3-setuptools" in (c.reinstallPackages or []) for c in pin_configs),
+            "python3-setuptools should be reinstalled in pin pass",
+        )
+
+    def test_all_dockerfile_packages_in_base_image_pin_pass_prevents_empty(self):
+        """
+        When ALL Dockerfile install packages are also base image packages
+        and no upgrades are available, the upgrade pass produces an empty
+        lockfile. The pin pass must reinstall them so the lockfile is not
+        empty (reproduces the ibm-vpc-node-label-updater scenario).
+        """
+        meta = self._make_mock_image_meta()
+        meta.config.konflux.cachi2.lockfile.get.return_value = None
+        generator = self._make_generator()
+        generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
+        # All Dockerfile packages are already in the base image
+        generator._container.get_installed_packages = AsyncMock(
+            return_value=["bash", "glibc", "ca-certificates", "openssl"]
+        )
+
+        # Simulate "no upgrades available": resolver returns empty lockfile
+        # on the main pass, and populated on the gap-fill pass.
+        empty_lockfile = LockfileData(
+            lockfileVersion=1,
+            lockfileVendor="redhat",
+            arches=[ArchResult(arch="x86_64", packages=[], source=[], module_metadata=[])],
+        )
+        gap_lockfile = LockfileData(
+            lockfileVersion=1,
+            lockfileVendor="redhat",
+            arches=[
+                ArchResult(
+                    arch="x86_64",
+                    packages=[
+                        PackageEntry(
+                            url="https://example.com/ca-certificates-2025.2.80.noarch.rpm",
+                            repoid="rhel-8-baseos-rpms",
+                            name="ca-certificates",
+                            evr="2025.2.80-80.1.el8_6",
+                        )
+                    ],
+                    source=[],
+                    module_metadata=[],
+                )
+            ],
+        )
+
+        call_count = 0
+
+        async def mock_resolve(config, image_pullspec=None):
+            nonlocal call_count
+            call_count += 1
+            if config.upgradePackages:
+                return empty_lockfile.model_copy(deep=True)
+            return gap_lockfile.model_copy(deep=True)
+
+        generator._resolver.resolve = AsyncMock(side_effect=mock_resolve)
+
+        with TemporaryDirectory() as tmpdir:
+            dest_dir = Path(tmpdir)
+            (dest_dir / "Dockerfile").write_text(
+                "FROM base\nRUN dnf update -y && dnf install -y ca-certificates\n"
+            )
+            asyncio.run(generator.generate_lockfile(meta, dest_dir))
+
+        # Should have been 2 resolver calls: main upgrade pass + gap-fill
+        self.assertEqual(call_count, 2)
+        all_configs = [c.args[0] for c in generator._resolver.resolve.call_args_list]
+        # First call: main upgrade pass (upgradePackages set)
+        self.assertTrue(all_configs[0].upgradePackages)
+        # Second call: gap-fill reinstall (no upgradePackages)
+        self.assertFalse(all_configs[1].upgradePackages)
+        self.assertIn("ca-certificates", all_configs[1].reinstallPackages)
 
     def test_reinstall_packages_also_passed_as_upgrade_targets(self):
         """

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -716,14 +716,118 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         # Base image packages as upgrade targets
         self.assertIn("python3-setuptools", main_config.upgradePackages)
         self.assertIn("bash", main_config.upgradePackages)
-        # Pass 2: pin pass for python3-setuptools (base-image overlap
-        # not in FAKE_LOCKFILE_DATA output). git is NOT a pin candidate
-        # because it's not in the base image.
-        self.assertEqual(len(captured_configs), 2)
-        pin_config = captured_configs[1]
-        self.assertIn("python3-setuptools", pin_config.reinstallPackages)
-        self.assertNotIn("git", pin_config.reinstallPackages)
-        self.assertFalse(pin_config.upgradePackages)
+        # Pass 2: per-arch pin passes for python3-setuptools (base-image
+        # overlap not in FAKE_LOCKFILE_DATA output). git is NOT a pin
+        # candidate because it's not in the base image. With per-arch
+        # resolution, one pin call per arch that's missing the package.
+        pin_configs = [c for c in captured_configs[1:] if c.reinstallPackages]
+        self.assertTrue(pin_configs, "at least one pin pass should have fired")
+        for pin_config in pin_configs:
+            self.assertIn("python3-setuptools", pin_config.reinstallPackages)
+            self.assertNotIn("git", pin_config.reinstallPackages)
+            self.assertFalse(pin_config.upgradePackages)
+
+    def test_two_pass_pin_per_arch_when_pass1_partial(self):
+        """
+        When pass 1 resolves an overlap package on only one arch (e.g.
+        x86_64 but not ppc64le), pass 2 must still pin it on the
+        missing arch. Regression test: the old code unioned locked
+        names across all arches, so a package present on any arch was
+        considered locked everywhere.
+        """
+        meta = self._make_mock_image_meta()
+        meta.config.konflux.cachi2.lockfile.get.return_value = None
+        generator = self._make_generator()
+        generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
+        generator._container.get_installed_packages = AsyncMock(return_value=["bash", "glibc", "python3-setuptools"])
+
+        # Pass 1 result has python3-setuptools on x86_64 only — not ppc64le
+        pass1_result = LockfileData(
+            lockfileVersion=1,
+            lockfileVendor="redhat",
+            arches=[
+                ArchResult(
+                    arch="x86_64",
+                    packages=[
+                        PackageEntry(
+                            url="https://example.com/python3-setuptools-53.0.0-12.el9.noarch.rpm",
+                            repoid="rhel-9-appstream-rpms",
+                            name="python3-setuptools",
+                            evr="53.0.0-12.el9",
+                        ),
+                        PackageEntry(
+                            url="https://example.com/git-2.43.0-1.el9.x86_64.rpm",
+                            repoid="rhel-9-appstream-rpms",
+                            name="git",
+                            evr="2.43.0-1.el9",
+                        ),
+                    ],
+                    source=[],
+                    module_metadata=[],
+                ),
+                ArchResult(
+                    arch="ppc64le",
+                    packages=[
+                        PackageEntry(
+                            url="https://example.com/git-2.43.0-1.el9.ppc64le.rpm",
+                            repoid="rhel-9-appstream-rpms",
+                            name="git",
+                            evr="2.43.0-1.el9",
+                        ),
+                    ],
+                    source=[],
+                    module_metadata=[],
+                ),
+            ],
+        )
+
+        pin_result = LockfileData(
+            lockfileVersion=1,
+            lockfileVendor="redhat",
+            arches=[
+                ArchResult(
+                    arch="ppc64le",
+                    packages=[
+                        PackageEntry(
+                            url="https://example.com/python3-setuptools-53.0.0-12.el9.noarch.rpm",
+                            repoid="rhel-9-appstream-rpms",
+                            name="python3-setuptools",
+                            evr="53.0.0-12.el9",
+                        ),
+                    ],
+                    source=[],
+                    module_metadata=[],
+                ),
+            ],
+        )
+
+        captured_configs: list[RpmsInConfig] = []
+
+        async def mock_resolve(config, image_pullspec=None):
+            captured_configs.append(config)
+            if config.reinstallPackages:
+                return pin_result.model_copy(deep=True)
+            return pass1_result.model_copy(deep=True)
+
+        generator._resolver.resolve = AsyncMock(side_effect=mock_resolve)
+
+        with TemporaryDirectory() as tmpdir:
+            dest_dir = Path(tmpdir)
+            (dest_dir / "Dockerfile").write_text(
+                "FROM base\nRUN dnf upgrade -y && dnf install -y python3-setuptools git\n"
+            )
+            asyncio.run(generator.generate_lockfile(meta, dest_dir))
+
+        # Pass 1: upgrade pass
+        self.assertGreaterEqual(len(captured_configs), 1)
+        self.assertFalse(captured_configs[0].reinstallPackages)
+
+        # Pass 2: pin pass should target only ppc64le (x86_64 already has it)
+        pin_configs = [c for c in captured_configs if c.reinstallPackages]
+        self.assertTrue(pin_configs, "pin pass should have fired")
+        self.assertEqual(len(pin_configs), 1, "only one arch should need pinning")
+        self.assertEqual(pin_configs[0].arches, ["ppc64le"], "pin pass should only target arch missing the package")
+        self.assertIn("python3-setuptools", pin_configs[0].reinstallPackages)
 
     def test_base_image_overlap_package_survives_retry_exhaustion_fallback(self):
         """
@@ -848,19 +952,21 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
 
         with TemporaryDirectory() as tmpdir:
             dest_dir = Path(tmpdir)
-            (dest_dir / "Dockerfile").write_text(
-                "FROM base\nRUN dnf update -y && dnf install -y ca-certificates\n"
-            )
+            (dest_dir / "Dockerfile").write_text("FROM base\nRUN dnf update -y && dnf install -y ca-certificates\n")
             asyncio.run(generator.generate_lockfile(meta, dest_dir))
 
-        # Should have been 2 resolver calls: main upgrade pass + gap-fill
-        self.assertEqual(call_count, 2)
+        # 1 upgrade pass + 1 per-arch pin call for each arch missing
+        # ca-certificates (both x86_64 and ppc64le are missing it)
+        self.assertGreaterEqual(call_count, 2)
         all_configs = [c.args[0] for c in generator._resolver.resolve.call_args_list]
         # First call: main upgrade pass (upgradePackages set)
         self.assertTrue(all_configs[0].upgradePackages)
-        # Second call: gap-fill reinstall (no upgradePackages)
-        self.assertFalse(all_configs[1].upgradePackages)
-        self.assertIn("ca-certificates", all_configs[1].reinstallPackages)
+        # Remaining calls: per-arch gap-fill reinstalls (no upgradePackages)
+        pin_configs = [c for c in all_configs[1:] if c.reinstallPackages]
+        self.assertTrue(pin_configs, "at least one pin pass should have fired")
+        for pc in pin_configs:
+            self.assertFalse(pc.upgradePackages)
+            self.assertIn("ca-certificates", pc.reinstallPackages)
 
     def test_reinstall_packages_also_passed_as_upgrade_targets(self):
         """


### PR DESCRIPTION
Separate upgrade and reinstall into independent DNF transactions to eliminate the EVR conflict where reinstall pins the installed version and wins over an upgrade request for the same package.

Pass 1 resolves with upgradePackages only (no reinstallPackages), capturing new installs and upgrades. Pass 2 runs a targeted reinstall for Dockerfile packages that overlap with the base image but produced no output in pass 1 (already installed at repo-latest, so neither install nor upgrade captured them).

This fixes empty lockfiles for images like ibm-vpc-node-label-updater where all Dockerfile packages are base-image overlaps with no upgrades available. Also makes the strippable set smarter — base-image-only upgrade targets are silently dropped instead of logging misleading "required Dockerfile packages" warnings.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image-mode package resolution with a two-pass process.
  * Ensures Dockerfile packages missing from the initial lockfile are restored automatically.
  * Handles package resolution correctly across architectures.
  * Prevents empty lockfiles when all requested packages already exist in the base image.

* **Tests**
  * Added regression coverage for partial, multi-architecture, and empty-result resolution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->