### PR TITLE
Add microshift-bootc to OCP_RPA_KINDS for RPA validation

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -150,6 +150,7 @@ OCP_RPA_KINDS = {
     "image": "ocp-art-advisory",
     "metadata": "ocp-art-advisory",
     "extras": "ocp-art-advisory",
+    "microshift-bootc": "ocp-art-advisory",
 }
 OCP_RPA_ENVS = ["stage", "prod"]
 


### PR DESCRIPTION
## Summary
- microshift-bootc prod push was failing with `ValueError: Unsupported release kind for RPA validation: 'microshift-bootc'`
- microshift-bootc components (`ose-4-22-microshift-bootc`, `ose-4-22-microshift-bootc-rhel10`, etc.) are already listed in the `ocp-art-advisory` RPA
- Adding `microshift-bootc` to `OCP_RPA_KINDS` mapping it to `ocp-art-advisory` fixes the validation

## Test plan
- [ ] Verify the 4.22.4 microshift-bootc prod push pipeline succeeds after this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing `microshift-bootc` release plans as OpenShift art advisories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->