### PR TITLE
ART-21631: Prune dangling symlinks outside vendor/ during rebase

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -715,8 +715,12 @@ class KonfluxRebaser:
 
         self._logger.info("Resolving %d symlink(s) in vendor/ directory", len(symlinks))
         for link in symlinks:
-            target = link.resolve()
-            if not target.exists():
+            try:
+                target = link.resolve()
+                target_exists = target.exists()
+            except (OSError, RuntimeError):
+                target_exists = False
+            if not target_exists:
                 self._logger.warning("Pruning dangling vendor symlink %s -> %s", link, os.readlink(link))
                 link.unlink()
                 continue

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -637,6 +637,62 @@ class KonfluxRebaser:
         cmd = 'rsync -av {} {}/ {}/'.format(exclude, src, dest)
         await exectools.cmd_assert_async(cmd, suppress_output=True)
 
+    async def _cleanup_symlinks(self, dest_dir: Path, exclude: set[str] | None = None):
+        """
+        Single-pass cleanup of problematic symlinks in the destination tree.
+        Dangling symlinks (including loops) are removed. Symlinks whose targets
+        resolve outside dest_dir are replaced with copies of the target.
+        Konflux git-clone rejects both cases.
+
+        Arg(s):
+            dest_dir (Path): Root directory to walk.
+            exclude (set[str] | None): Top-level directory names to skip (e.g. {"vendor"}).
+        """
+        exclude = exclude or set()
+        resolved_dest = dest_dir.resolve()
+        pruned = 0
+        resolved = 0
+
+        for entry in dest_dir.rglob("*"):
+            if not entry.is_symlink():
+                continue
+            # Check exclusion before resolve() to avoid errors on symlink loops
+            try:
+                relative = entry.relative_to(dest_dir)
+            except ValueError:
+                continue
+            if relative.parts and relative.parts[0] in exclude:
+                continue
+
+            try:
+                target = entry.resolve()
+                target_exists = target.exists()
+            except (OSError, RuntimeError):
+                target_exists = False
+
+            if not target_exists:
+                self._logger.info("Pruning dangling symlink %s -> %s", entry, os.readlink(entry))
+                entry.unlink()
+                pruned += 1
+                continue
+
+            # Target exists but points outside dest_dir — replace with a copy
+            try:
+                target.relative_to(resolved_dest)
+            except ValueError:
+                self._logger.info("Resolving external symlink %s -> %s", entry, os.readlink(entry))
+                entry.unlink()
+                if target.is_dir():
+                    await exectools.to_thread(shutil.copytree, str(target), str(entry))
+                else:
+                    await exectools.to_thread(shutil.copy2, str(target), str(entry))
+                resolved += 1
+
+        if pruned:
+            self._logger.info("Pruned %d dangling symlink(s)", pruned)
+        if resolved:
+            self._logger.info("Resolved %d external symlink(s)", resolved)
+
     async def _resolve_vendor_symlinks(self, dest_dir: Path):
         """
         Replace symlinks in vendor/ with copies of their target directories.
@@ -661,7 +717,8 @@ class KonfluxRebaser:
         for link in symlinks:
             target = link.resolve()
             if not target.exists():
-                self._logger.warning("Vendor symlink %s points to non-existent target %s, skipping", link, target)
+                self._logger.warning("Pruning dangling vendor symlink %s -> %s", link, os.readlink(link))
+                link.unlink()
                 continue
 
             link.unlink()
@@ -801,6 +858,11 @@ class KonfluxRebaser:
         containerfile = dest_dir.joinpath('Containerfile')
         if containerfile.is_file():
             containerfile.unlink()
+
+        # Clean up dangling and external symlinks outside vendor/ (vendor/ handled separately above).
+        # Must run after Dockerfile.* cleanup since removing e.g. Dockerfile.ocp can leave
+        # symlinks like openshift/Dockerfile.openshift -> ../Dockerfile.ocp dangling.
+        await self._cleanup_symlinks(dest_dir, exclude={"vendor"})
 
         owners = []
         if metadata.config.owners is not Missing and isinstance(metadata.config.owners, list):

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -1254,14 +1254,15 @@ class TestResolveVendorSymlinks(TestCase):
         self.assertFalse(resolved.is_symlink())
         self.assertEqual(resolved.read_text(), "package real")
 
-    def test_skips_broken_symlinks(self):
+    def test_prunes_broken_symlinks(self):
         vendor = self.dest_dir / "vendor" / "k8s.io"
         vendor.mkdir(parents=True)
         (vendor / "missing").symlink_to("/nonexistent/path")
 
         asyncio.run(self.rebaser._resolve_vendor_symlinks(self.dest_dir))
 
-        self.assertTrue((vendor / "missing").is_symlink())
+        self.assertFalse((vendor / "missing").exists())
+        self.assertFalse((vendor / "missing").is_symlink())
         self.rebaser._logger.warning.assert_called_once()
 
     def test_resolves_multiple_symlinks(self):
@@ -1324,6 +1325,140 @@ class TestResolveVendorSymlinks(TestCase):
         mode = resolved.stat().st_mode
         exec_bits = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
         self.assertEqual(mode & exec_bits, 0, "Executable bits should be stripped")
+
+
+class TestCleanupSymlinks(TestCase):
+    def setUp(self):
+        self.directory = TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.dest_dir = Path(self.directory.name) / "dest"
+        self.dest_dir.mkdir()
+
+        self.external_dir = Path(self.directory.name) / "external"
+        self.external_dir.mkdir()
+
+        self.rebaser = KonfluxRebaser.__new__(KonfluxRebaser)
+        self.rebaser._logger = MagicMock()
+
+    def test_no_symlinks(self):
+        (self.dest_dir / "file.go").write_text("package main")
+        asyncio.run(self.rebaser._cleanup_symlinks(self.dest_dir))
+        self.assertTrue((self.dest_dir / "file.go").exists())
+        self.rebaser._logger.info.assert_not_called()
+
+    def test_prunes_dangling_symlink(self):
+        link = self.dest_dir / "broken"
+        link.symlink_to("/nonexistent/target")
+
+        asyncio.run(self.rebaser._cleanup_symlinks(self.dest_dir))
+
+        self.assertFalse(link.exists())
+        self.assertFalse(link.is_symlink())
+        self.rebaser._logger.info.assert_called()
+
+    def test_keeps_valid_internal_symlink(self):
+        real = self.dest_dir / "real.go"
+        real.write_text("package main")
+        link = self.dest_dir / "alias.go"
+        link.symlink_to(real)
+
+        asyncio.run(self.rebaser._cleanup_symlinks(self.dest_dir))
+
+        self.assertTrue(link.is_symlink())
+        self.assertEqual(link.read_text(), "package main")
+
+    def test_prunes_nested_dangling_symlink(self):
+        subdir = self.dest_dir / "pkg" / "util"
+        subdir.mkdir(parents=True)
+        link = subdir / "missing"
+        link.symlink_to("/nonexistent")
+
+        asyncio.run(self.rebaser._cleanup_symlinks(self.dest_dir))
+
+        self.assertFalse(link.exists())
+        self.assertFalse(link.is_symlink())
+
+    def test_excludes_vendor_directory(self):
+        vendor = self.dest_dir / "vendor" / "example.com"
+        vendor.mkdir(parents=True)
+        vendor_link = vendor / "broken"
+        vendor_link.symlink_to("/nonexistent")
+
+        non_vendor_link = self.dest_dir / "broken"
+        non_vendor_link.symlink_to("/nonexistent")
+
+        asyncio.run(self.rebaser._cleanup_symlinks(self.dest_dir, exclude={"vendor"}))
+
+        self.assertTrue(vendor_link.is_symlink(), "vendor/ symlinks should be left alone")
+        self.assertFalse(non_vendor_link.is_symlink(), "non-vendor symlinks should be pruned")
+
+    def test_prunes_multiple_dangling(self):
+        for name in ["a", "b", "c"]:
+            (self.dest_dir / name).symlink_to(f"/nonexistent/{name}")
+
+        asyncio.run(self.rebaser._cleanup_symlinks(self.dest_dir))
+
+        for name in ["a", "b", "c"]:
+            self.assertFalse((self.dest_dir / name).is_symlink())
+
+    def test_prunes_symlink_loop(self):
+        link_a = self.dest_dir / "loop_a"
+        link_b = self.dest_dir / "loop_b"
+        link_a.symlink_to(link_b)
+        link_b.symlink_to(link_a)
+
+        asyncio.run(self.rebaser._cleanup_symlinks(self.dest_dir))
+
+        self.assertFalse(link_a.is_symlink())
+        self.assertFalse(link_b.is_symlink())
+
+    def test_resolves_external_file_symlink(self):
+        external_file = self.external_dir / "Dockerfile.openshift"
+        external_file.write_text("FROM ubi9")
+        link = self.dest_dir / "openshift" / "Dockerfile.openshift"
+        link.parent.mkdir(parents=True)
+        link.symlink_to(external_file)
+
+        asyncio.run(self.rebaser._cleanup_symlinks(self.dest_dir))
+
+        self.assertFalse(link.is_symlink())
+        self.assertTrue(link.is_file())
+        self.assertEqual(link.read_text(), "FROM ubi9")
+
+    def test_resolves_external_dir_symlink(self):
+        ext_pkg = self.external_dir / "pkg"
+        ext_pkg.mkdir()
+        (ext_pkg / "main.go").write_text("package pkg")
+
+        link = self.dest_dir / "ext_pkg"
+        link.symlink_to(ext_pkg)
+
+        asyncio.run(self.rebaser._cleanup_symlinks(self.dest_dir))
+
+        self.assertFalse(link.is_symlink())
+        self.assertTrue(link.is_dir())
+        self.assertEqual((link / "main.go").read_text(), "package pkg")
+
+    def test_prunes_dangling_external(self):
+        link = self.dest_dir / "broken"
+        link.symlink_to(self.external_dir / "nonexistent")
+
+        asyncio.run(self.rebaser._cleanup_symlinks(self.dest_dir))
+
+        self.assertFalse(link.is_symlink(), "dangling external symlinks should be pruned")
+
+    def test_excludes_vendor_for_external(self):
+        external_file = self.external_dir / "module.go"
+        external_file.write_text("package mod")
+
+        vendor = self.dest_dir / "vendor" / "example.com"
+        vendor.mkdir(parents=True)
+        vendor_link = vendor / "module.go"
+        vendor_link.symlink_to(external_file)
+
+        asyncio.run(self.rebaser._cleanup_symlinks(self.dest_dir, exclude={"vendor"}))
+
+        self.assertTrue(vendor_link.is_symlink(), "vendor/ symlinks should be left alone")
 
 
 class TestCpeVersionExtraction(TestCase):

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -1265,6 +1265,17 @@ class TestResolveVendorSymlinks(TestCase):
         self.assertFalse((vendor / "missing").is_symlink())
         self.rebaser._logger.warning.assert_called_once()
 
+    def test_prunes_symlink_loop(self):
+        vendor = self.dest_dir / "vendor" / "k8s.io"
+        vendor.mkdir(parents=True)
+        (vendor / "loop_a").symlink_to(vendor / "loop_b")
+        (vendor / "loop_b").symlink_to(vendor / "loop_a")
+
+        asyncio.run(self.rebaser._resolve_vendor_symlinks(self.dest_dir))
+
+        self.assertFalse((vendor / "loop_a").is_symlink())
+        self.assertFalse((vendor / "loop_b").is_symlink())
+
     def test_resolves_multiple_symlinks(self):
         staging_base = self.dest_dir / "staging" / "src" / "k8s.io"
 


### PR DESCRIPTION
## Summary

  - Add `_cleanup_symlinks()` to handle two classes of problematic symlinks during rebase that cause Konflux build failures:
    - **Dangling symlinks** (broken targets, loops) — pruned
    - **External symlinks** (target resolves outside source dir) — replaced with file copies
  - Fix `_resolve_vendor_symlinks` to also prune dangling vendor symlinks instead of skipping them
  - Runs after all Dockerfile/Containerfile cleanup to catch symlinks orphaned by Dockerfile.* removal

  ## Motivation

  Two types of symlink failures observed in Konflux builds:

  1. Dangling symlinks left by rsync (e.g. `csi-driver-nfs/.travis.yml -> release-tools/travis.yml`)
  2. Symlinks pointing outside the source boundary rejected by Konflux git-clone symlink check (e.g. `openshift/Dockerfile.openshift -> ../Dockerfile`)

  level=error msg="Broken symlink found: /var/workdir/source/openshift/Dockerfile.openshift"
  level=fatal msg="symlink check: found 1 symlink(s) pointing outside the directory"


working builds:
- https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-5-0/pipelineruns/ose-5-0-csi-driver-nfs-68tkr
- https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-5-0/pipelineruns/ose-5-0-ose-baremetal-cluster-api-controllers-6fn44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **Bug Fixes**
  - Rebase operations now automatically prune broken symbolic links in the destination tree, including nested dangling links and symlink loops.
  - If a symbolic link resolves outside the destination tree, it is replaced with the resolved content (so the rebased result remains functional).
  - Vendor symlinks with missing targets are now pruned instead of left behind; vendor handling remains isolated from the general pruning logic.

- **Tests**
  - Expanded coverage for symlink cleanup and vendor symlink pruning scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->