### PR TITLE
Report per-target success/failure summary for golang builder image builds

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -396,27 +396,38 @@ class UpdateGolangPipeline:
                     self.verify_golang_builder_repo(el_v, go_version)
 
             # Rebase and build missing images
-            build_tasks = []
+            build_targets = []  # list of (label, coroutine)
             if self.build_system in ['both', 'brew'] and brew_missing:
-                build_tasks.extend(
-                    [
-                        self._rebase_and_build_brew(el_v, go_version, el_nvr_map_for_images[el_v])
-                        for el_v in brew_missing
-                    ]
+                build_targets.extend(
+                    (
+                        f"RHEL {el_v} (brew)",
+                        self._rebase_and_build_brew(el_v, go_version, el_nvr_map_for_images[el_v]),
+                    )
+                    for el_v in sorted(brew_missing)
                 )
             if self.build_system in ['both', 'konflux'] and konflux_missing:
-                build_tasks.extend(
-                    [
-                        self._rebase_and_build_konflux(el_v, go_version, el_nvr_map_for_images[el_v])
-                        for el_v in konflux_missing
-                    ]
+                build_targets.extend(
+                    (
+                        f"RHEL {el_v} (konflux)",
+                        self._rebase_and_build_konflux(el_v, go_version, el_nvr_map_for_images[el_v]),
+                    )
+                    for el_v in sorted(konflux_missing)
                 )
-            if build_tasks:
-                results = await asyncio.gather(*build_tasks, return_exceptions=True)
-            errors = [r for r in results if isinstance(r, Exception)]
-            if errors:
-                error_msgs = "\n".join([str(e) for e in errors])
-                raise RuntimeError(f"{len(errors)} image build(s) failed:\n{error_msgs}")
+            if build_targets:
+                labels, coros = zip(*build_targets)
+                results = await asyncio.gather(*coros, return_exceptions=True)
+                succeeded = [label for label, r in zip(labels, results) if not isinstance(r, Exception)]
+                failed = [(label, r) for label, r in zip(labels, results) if isinstance(r, Exception)]
+
+                summary = "\n".join(
+                    ["Image build summary:"]
+                    + [f"  ✅ {label}: succeeded" for label in succeeded]
+                    + [f"  ❌ {label}: FAILED - {err}" for label, err in failed]
+                )
+                _LOGGER.info(summary)
+
+                if failed:
+                    raise RuntimeError(f"{len(failed)}/{len(build_targets)} image build(s) failed:\n{summary}")
 
             # Now all builders should be available, fetch again
             if self.build_system in ['both', 'brew']:


### PR DESCRIPTION
## Summary
- When multiple golang-builder image builds run in parallel (across RHEL versions and build systems), a failure previously surfaced only as an anonymous list of exception strings (`N image build(s) failed: ...`), with no indication of which RHEL version / build system each error belonged to, or which targets succeeded.
- Labels each build task by `RHEL {version} ({brew|konflux})` and logs/raises a clear per-target summary (✅ succeeded / ❌ failed with error) so the end of the job unambiguously shows what passed and what failed.

Prompted by triaging Jenkins job #641 (4.22, golang 1.25.11, el[9,8], both build systems), where el9 brew and el9 konflux builds failed while el8 (both systems) succeeded — this was hard to tell from the original error message.

## Test plan
- [x] `make unit` — all 2969 tests pass across artcommon, doozer, elliott, pyartcd, ocp-build-data-validator
- [x] `uv run ruff check` / `ruff format --check` pass on the changed file
- [x] Manually verified summary formatting with a scratch script simulating a mixed success/failure scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rebuilding of missing Golang builder images.
  * Build results now clearly identify each target as successful or failed.
  * Failures provide a consolidated summary and accurate failure count for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->