### PR TITLE
ART-21305: fix lockfile image certs

### DIFF
--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.rpm_lockfile_prototype
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.rpm_lockfile_prototype
@@ -4,10 +4,8 @@ FROM ${BASE_IMAGE}
 RUN dnf install -y python3 python3-pip python3-dnf skopeo rpm git-core && dnf clean all
 
 # Install RH IT CA bundle so DNF can reach internal repos (rhsm-pulp.corp.redhat.com)
-RUN curl --silent --show-error --fail --insecure --output /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem \
-        https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem && \
-    curl --silent --show-error --fail --insecure --output /etc/pki/ca-trust/source/anchors/2015-IT-Root-CA.pem \
-        https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem && \
+RUN curl --silent --show-error --fail --insecure --output /etc/pki/ca-trust/source/anchors/Current-IT-Root-CAs.pem \
+        https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem && \
     update-ca-trust
 
 WORKDIR /app


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the RPM-based container image to use the current trusted certificate bundle.
  * Improves certificate validation reliability during image builds and runtime connections.
  * No changes to application behavior or dependency installation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->