### PR TITLE
ART-14778: Add registry.redhat.io credentials to prepare-release-konflux

### DIFF
--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -30,6 +30,7 @@ from artcommonlib.assembly import (
 from artcommonlib.constants import (
     OCP_RPA_BASE_URL,
     REGISTRY_QUAY_OCP_RELEASE_DEV,
+    REGISTRY_REDHAT_IO,
     SHIPMENT_DATA_URL_TEMPLATE,
 )
 from artcommonlib.github_auth import get_github_client_for_org
@@ -240,16 +241,16 @@ class PrepareReleaseKonfluxPipeline:
             )
 
         source_files = [quay_auth_file]
+        registries = [REGISTRY_QUAY_OCP_RELEASE_DEV]
         redhat_registry_auth_file = os.getenv('KONFLUX_OPERATOR_INDEX_AUTH_FILE')
         if redhat_registry_auth_file:
             source_files.append(redhat_registry_auth_file)
+            registries.append(REGISTRY_REDHAT_IO)
 
         with RegistryConfig(
             kubeconfig=os.environ.get('KUBECONFIG'),
             source_files=source_files,
-            registries=[
-                REGISTRY_QUAY_OCP_RELEASE_DEV,
-            ],
+            registries=registries,
         ) as global_auth_file:
             self._elliott_base_command.append(f'--registry-config={global_auth_file}')
             self._doozer_base_command.append(f'--registry-config={global_auth_file}')


### PR DESCRIPTION
## Summary
- The `RegistryConfig` in `prepare_release_konflux` only cherry-picked `REGISTRY_QUAY_OCP_RELEASE_DEV` from the source auth files, so `registry.redhat.io` credentials were discarded even though `KONFLUX_OPERATOR_INDEX_AUTH_FILE` (bound in the Jenkinsfile) contains them
- This caused all 241 skopeo inspects in `_filter_shipped_konflux_builds` (added in PR #2940) to fail with `unauthorized`, making the shipped-build filter assume every image was unreleased and filtering nothing
- Fix: add `REGISTRY_REDHAT_IO` to the `registries` list, matching what `ocp4_konflux.py` already does

## Test plan
- [ ] Verify prepare-release-konflux build logs show `Filtered N already-shipped Konflux builds` instead of 241 auth errors
- [ ] Confirm images already released (e.g. `golang-github-prometheus-prometheus` in 4.22.4) are excluded from the next assembly's builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the release pipeline’s authentication handling by supporting an additional container registry endpoint when the relevant auth setting is provided.
  * This helps ensure release preparation can access required images across supported registries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->