### PR TITLE
ART-21515: strip quotes from pipe regex file path capture

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/dockerfile_parser.py
+++ b/doozer/doozerlib/lockfile_prototype/dockerfile_parser.py
@@ -232,7 +232,7 @@ def extract_packages_from_file_installs(
                 match = pipe_re.search(cmd_clean)
             if not match:
                 continue
-            raw_path = match.group(1)
+            raw_path = _strip_quotes(match.group(1))
             resolved_path = resolve_bash_expansion(raw_path, variables)
             if not resolved_path:
                 continue

--- a/doozer/tests/lockfile_prototype/test_dockerfile_parser.py
+++ b/doozer/tests/lockfile_prototype/test_dockerfile_parser.py
@@ -165,6 +165,26 @@ class TestExtractPackagesFromFileInstalls(unittest.TestCase):
             )
             self.assertEqual(result, ["dosfstools", "ipmitool"])
 
+    def test_pipe_with_quoted_env_var_in_path(self):
+        """
+        Pipe pattern with quoted env var (e.g. "/tmp/${PKGS_LIST}")
+        should strip quotes and resolve correctly.
+        """
+        with TemporaryDirectory() as tmpdir:
+            source_dir = Path(tmpdir)
+            pkg_file = source_dir / "main-packages-list.ocp"
+            pkg_file.write_text("coreos-installer\ndosfstools\n")
+            copy_map = {"/tmp/main-packages-list.ocp": "main-packages-list.ocp"}
+
+            run_values = ["grep -v '^#' \"/tmp/${PKGS_LIST}\" | xargs -rtd'\\n' dnf install -y"]
+            result, _ = extract_packages_from_file_installs(
+                run_values,
+                copy_map,
+                source_dir,
+                env_vars={"PKGS_LIST": "main-packages-list.ocp"},
+            )
+            self.assertEqual(result, ["coreos-installer", "dosfstools"])
+
     def test_arch_suffix_in_filename(self):
         """
         File path with $(arch) should resolve per-architecture and return


### PR DESCRIPTION
The pipe_re pattern in extract_packages_from_file_installs captures the file path including surrounding quotes (e.g. "/tmp/${PKGS_LIST}"), which breaks copy_map lookup after variable expansion. This caused packages like coreos-installer to be silently missing from lockfiles for images that switched from stdin redirect to grep pipe pattern (ironic-image in 4.23/5.0).


follows https://github.com/openshift/ironic-image/pull/749/changes#diff-d720986ad1d8ccfce6ee4cda67e3ca523d8f4eaf7b9ac301d9e7533c51297c84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package detection from install commands that reference input files with quoted paths or environment variables.
  - Ensured package lists are correctly extracted when paths include surrounding quotation marks.

- **Tests**
  - Added coverage for quoted environment-variable paths in piped install commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->