### PR TITLE
art-cd: right-size artcd Task memory/cpu reservation

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/artcd-task.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/artcd-task.yaml
@@ -43,10 +43,10 @@ spec:
     - $(params.args[*])
     computeResources:
       limits:
-        memory: 16Gi
-      requests:
-        cpu: "1"
         memory: 8Gi
+      requests:
+        cpu: 500m
+        memory: 2Gi
     env:
     - name: SLACK_BOT_TOKEN
       valueFrom:


### PR DESCRIPTION
## Summary
- The shared `Task/artcd` (used by `build-fbc`, `build-layered-products`, `olm-bundle-konflux`, `release-from-fbc`, `layered-products-scan`, and `schedule-layered-products-scan`) requested `1 CPU / 8Gi memory` with a `16Gi` memory limit on its `invoke-artcd` step.
- These pipelines only run `doozer`/`artcd` to rebase Dockerfiles/FBC via git and trigger/poll remote Konflux builds -- they do not build images locally -- so the 8Gi request was reserving far more memory per pod than the workload actually needs.
- On the `artc2023` cluster, this was found to be a meaningful contributor to the worker `MachineSet` staying pinned at its autoscaler max (10/10 since May), since an 8Gi request already consumes most of a typical `m6a.xlarge` worker node's allocatable memory (~12.45Gi), so only ~1 such pod fits per node.
- Lowered the request to `500m CPU / 2Gi memory` and the limit to `8Gi`, based on comparable *unconstrained* orchestration pipelines in the same namespace (`doomsday-pipeline`, `fips-pipeline`) which peak at ~1-2Gi memory / ~0.5 CPU cores over the last 11 days of metrics (same kind of Python + git + Red Hat API orchestration workload).
- Confirmed via `oc get pipelines` on the live cluster and a repo-wide grep that no other pipeline references `Task/artcd`, so the blast radius is limited to these 6 layered-products pipelines.

## Test plan
- [ ] ArgoCD syncs the updated `Task/artcd` to the `art-cd` namespace on `artc2023`
- [ ] Trigger a `build-fbc`/`build-layered-products`/`olm-bundle-konflux`/`release-from-fbc` run and confirm it completes successfully under the new limits (watch for OOMKilled)
- [ ] Watch `oc adm top pod` during that run to capture real usage data for further tuning


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced resource limits for the ArtCD task to improve runtime efficiency.
  * Adjusted CPU allocation and retained the existing memory request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->