### PR TITLE
Fix rpm-lockfile-prototype ModuleNotFoundError in art-cd image

### DIFF
--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
@@ -16,8 +16,11 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin s
 ENV PATH="/usr/local/bin:$PATH"
 
 # Install necessary packages and Python libraries
+# python3-dnf is included so that the system python3 (RHEL 9's default
+# interpreter, distinct from python3.11 below) can resolve RPMs; see the
+# rpm-lockfile-prototype install step further down for why this matters.
 RUN dnf -y install python3.11 python3.11-pip python3.11-wheel python3.11-devel gcc krb5-devel wget tar gzip git krb5-workstation \
-    brewkoji rhpkg podman python3-rpm \
+    brewkoji rhpkg podman python3-rpm python3-pip python3-dnf \
     && uv pip install --system --upgrade setuptools \
     && dnf clean all
 
@@ -73,6 +76,17 @@ RUN uv pip install --python 3.11 --system setuptools==70.0.0
 
 # Install all art-tools packages in editable mode from the root pyproject.toml
 RUN uv pip install --python 3.11 --system -e .
+
+# doozer's RpmResolver (doozer/doozerlib/lockfile_prototype/resolver.py) shells
+# out to the system python3 (/usr/bin/python3) instead of the python3.11
+# interpreter above, because python3-dnf's compiled bindings are only
+# importable from the system Python. Install the same rpm-lockfile-prototype
+# revision pinned in uv.lock into that interpreter too, so the subprocess call
+# doesn't fail with "ModuleNotFoundError: No module named 'rpm_lockfile'".
+RUN LOCKFILE_REV=$(grep -A2 '^name = "rpm-lockfile-prototype"' uv.lock | grep 'source = ' | sed -n 's/.*#\([0-9a-f]\{40\}\).*/\1/p') \
+    && test -n "$LOCKFILE_REV" \
+    && /usr/bin/python3 -m pip install --no-cache-dir \
+       "rpm-lockfile-prototype @ git+https://github.com/konflux-ci/rpm-lockfile-prototype@${LOCKFILE_REV}"
 
 # Install check-payload tool for FIPS scanning, and copy to a location in PATH
 RUN git clone https://github.com/openshift/check-payload check-payload &&  \


### PR DESCRIPTION
## Problem

`build-layered-products` (and any other layered-products pipeline whose images use the `rpm-lockfile-prototype` backend) was silently skipping the rebase/build for affected images, with this error in the doozer logs:

```
Failed to rebase multiclusterhub-operator: rpm-lockfile-prototype failed (exit code 1):
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'rpm_lockfile'
```

The PipelineRun itself reported `Succeeded` because `pyartcd` treats a rebase failure as non-fatal per image — it logs a warning, excludes the image, and skips the build step if nothing buildable remains — so this failure mode is easy to miss.

## Root cause

`RpmResolver` (`doozer/doozerlib/lockfile_prototype/resolver.py`) intentionally shells out to the RHEL system Python (`/usr/bin/python3`, `SYSTEM_PYTHON` constant) rather than the app's own interpreter, because `python3-dnf`'s compiled bindings are only importable from the system Python:

```python
"""
Invokes the rpm-lockfile-prototype tool through system Python so
that python3-dnf (a system package built for the system Python) is
available. The venv Python may be a different minor version where
dnf cannot be imported.
"""
```

But the `art-cd` image installs a **second**, separate `python3.11` interpreter specifically for running doozer/artcd, and only installs `art-tools` (and its `rpm-lockfile-prototype` dependency) into that one via `uv pip install --python 3.11 --system -e .`. The RHEL default `/usr/bin/python3` (Python 3.9) never gets `rpm-lockfile-prototype` installed, so the subprocess call fails with `ModuleNotFoundError`.

## Fix

Install the same `rpm-lockfile-prototype` revision pinned in `uv.lock` into `/usr/bin/python3` as well, in `Containerfile.base`. The revision is extracted dynamically from `uv.lock` at build time (rather than hardcoded) so it can't silently drift out of sync with the python3.11 copy as the pin gets bumped over time.

## Note on alternative approach

While investigating, I found unused infrastructure in this same directory (`Containerfile.rpm_lockfile_prototype`, `rpm_lockfile_build.yaml` BuildConfig, `rpm_lockfile_pull_access.yaml` RBAC) that builds `rpm-lockfile-prototype` as its own standalone, root, DNF-capable image — apparently intended to run RPM resolution in an isolated container via `podman run` rather than in-process. `resolver.py` never references this image though, so it looks like orphaned infra from an earlier design iteration. Went with the smaller, self-contained Containerfile fix here since it doesn't require changing `resolver.py`'s execution model; happy to follow up on consolidating/removing the orphaned image+RBAC in a separate change if desired.

## Testing

Verified the revision-extraction one-liner against the current `uv.lock`:

```
$ grep -A2 '^name = "rpm-lockfile-prototype"' uv.lock | grep 'source = ' | sed -n 's/.*#\([0-9a-f]\{40\}\).*/\1/p'
11cc01cc906a144b83d2f0ff5dc06c5fad383721
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed base image setup to ensure required Python packaging tools are available.
  * Added installation of the pinned RPM lockfile utility, preventing failures in subsequent build steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->