### PR TITLE
Install skopeo in art-cd image for rpm-lockfile-prototype

### DIFF
--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
@@ -16,11 +16,13 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin s
 ENV PATH="/usr/local/bin:$PATH"
 
 # Install necessary packages and Python libraries
-# python3-dnf is included so that the system python3 (RHEL 9's default
-# interpreter, distinct from python3.11 below) can resolve RPMs; see the
+# python3-dnf and skopeo are included for the system python3 (RHEL 9's
+# default interpreter, distinct from python3.11 below); see the
 # rpm-lockfile-prototype install step further down for why this matters.
+# rpm-lockfile-prototype shells out to skopeo to copy a base image's rootfs
+# locally so it can inspect the RPM DB there.
 RUN dnf -y install python3.11 python3.11-pip python3.11-wheel python3.11-devel gcc krb5-devel wget tar gzip git krb5-workstation \
-    brewkoji rhpkg podman python3-rpm python3-pip python3-dnf \
+    brewkoji rhpkg podman skopeo python3-rpm python3-pip python3-dnf \
     && uv pip install --system --upgrade setuptools \
     && dnf clean all
 


### PR DESCRIPTION
## Problem

Follow-up to #3155. After that fix (installing `rpm-lockfile-prototype` for the system python3), the `ModuleNotFoundError` is gone, but the next `build-layered-products` run hit a new, different failure in the same code path:

```
RuntimeError: rpm-lockfile-prototype failed (exit code 1): Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/rpm_lockfile/__init__.py", line 552, in main
    ...
  File "/usr/local/lib/python3.9/site-packages/rpm_lockfile/containers.py", line 41, in _copy_image
    utils.logged_run(cmd, check=True)
  ...
FileNotFoundError: [Errno 2] No such file or directory: 'skopeo'
```

(Confirms the earlier fix worked — execution now reaches `rpm_lockfile`'s own code instead of failing to import it.)

## Root cause

`rpm-lockfile-prototype` shells out to `skopeo` (`rpm_lockfile/containers.py::_copy_image`) to copy a base image's rootfs locally so it can inspect the RPM DB there. `skopeo` isn't installed in the `art-cd` image — only `podman` is.

The standalone `Containerfile.rpm_lockfile_prototype` image (built via the orphaned `rpm_lockfile_build.yaml`/`rpm_lockfile_pull_access.yaml` infra flagged in #3155) already installs `skopeo` alongside `python3-dnf` for exactly this reason, which independently confirms this is a real dependency of the tool.

## Fix

Add `skopeo` to the `dnf install` list in `Containerfile.base` alongside `python3-dnf`/`python3-pip`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Skopeo tooling to the base image for improved container image inspection and RPM dependency workflows.

* **Documentation**
  * Expanded setup comments to clarify the system Python and base image inspection requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->