### PR TITLE
ART-21639: preserve Dockerfile reinstall commands

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/dockerfile_parser.py
+++ b/doozer/doozerlib/lockfile_prototype/dockerfile_parser.py
@@ -314,6 +314,7 @@ def extract_packages_from_scripts(
     copy_map = copy_map or {}
     all_packages: set[str] = set()
     all_updates: set[str] = set()
+    all_reinstall: set[str] = set()
     all_arch_packages: dict[str, set[str]] = {}
     all_builddep: set[str] = set()
     all_modules: set[str] = set()
@@ -372,13 +373,14 @@ def extract_packages_from_scripts(
                     joined_lines.append(stripped)
             script_body = "\n".join(line for line in joined_lines if line.strip())
 
-            pkgs, script_arch_pkgs, updates, has_update, script_builddep, script_modules = analyze_run_commands(
-                [script_body]
+            pkgs, script_arch_pkgs, updates, has_update, script_builddep, script_modules, script_reinstall = (
+                analyze_run_commands([script_body])
             )
             all_packages.update(pkgs)
             for arch, arch_pkgs in script_arch_pkgs.items():
                 all_arch_packages.setdefault(arch, set()).update(arch_pkgs)
             all_updates.update(updates)
+            all_reinstall.update(script_reinstall)
             all_builddep.update(script_builddep)
             all_modules.update(script_modules)
             if has_update:
@@ -396,6 +398,7 @@ def extract_packages_from_scripts(
         has_update=scripts_have_bare_update,
         arch_packages={arch: sorted(pkgs) for arch, pkgs in sorted(all_arch_packages.items())},
         update_targets=sorted(all_updates),
+        reinstall_packages=sorted(all_reinstall),
         builddep_packages=sorted(all_builddep),
         module_specs=sorted(all_modules),
     )
@@ -457,7 +460,7 @@ def analyze_dockerfile_stages(
         stage_vars = collect_stage_vars(stage_entries, inherited_vars=global_args)
         run_values = [e["value"] for e in stage_entries if e["instruction"] == "RUN"]
 
-        common, arch_specific, update_targets, has_update, builddep, modules = analyze_run_commands(
+        common, arch_specific, update_targets, has_update, builddep, modules, reinstall = analyze_run_commands(
             run_values, env_vars=stage_vars
         )
         stage = StageInfo(
@@ -465,6 +468,7 @@ def analyze_dockerfile_stages(
             has_update=has_update,
             arch_packages=arch_specific,
             update_targets=update_targets,
+            reinstall_packages=reinstall,
             builddep_packages=builddep,
             module_specs=modules,
         )

--- a/doozer/doozerlib/lockfile_prototype/dockerfile_transforms.py
+++ b/doozer/doozerlib/lockfile_prototype/dockerfile_transforms.py
@@ -58,6 +58,48 @@ def strip_bare_updates_from_scripts(
                 logger.debug(f"Stripped bare updates from {script.relative_to(dest_dir)}")
 
 
+def rewrite_reinstall_commands(df_content: str) -> str:
+    """
+    Transform microdnf/dnf/yum reinstall commands into a two-step
+    rpmdb-remove + install sequence.
+
+    In hermetic builds ``reinstall`` fails when the exact installed
+    NEVRA is not available in the lockfile repos (common when the repo
+    has a newer version than the base image). The transform converts::
+
+        microdnf -y reinstall tzdata
+
+    into::
+
+        rpm -e --justdb --nodeps tzdata && microdnf -y install tzdata
+
+    ``rpm -e --justdb`` removes the package from the rpmdb **without
+    deleting files**, then the install sees it as missing and
+    re-extracts the full RPM payload from the lockfile-cached version.
+
+    Arg(s):
+        df_content (str): Raw Dockerfile text.
+    Return Value(s):
+        str: Transformed Dockerfile text with reinstall commands rewritten.
+    """
+    reinstall_re = re.compile(
+        r"\b(microdnf|dnf|yum)"  # group 1: package manager
+        r"((?:\s+-\w+)*)"  # group 2: pre-reinstall flags
+        r"\s+reinstall"  # literal reinstall action
+        r"((?:\s+-\w+)*)"  # group 3: post-reinstall flags
+        r"((?:\s+[^\s&|;\\-][^\s&|;\\]*)+)",  # group 4: package names
+    )
+
+    def _replace(m: re.Match) -> str:
+        pkgmgr = m.group(1)
+        flags = (m.group(2) + m.group(3)).strip()
+        flags_str = f" {flags}" if flags else ""
+        pkgs = m.group(4).strip()
+        return f"rpm -e --justdb --nodeps {pkgs} && {pkgmgr}{flags_str} install {pkgs}"
+
+    return reinstall_re.sub(_replace, df_content)
+
+
 def fix_rpm_verify_commands(df_content: str) -> str:
     """
     Transform rpm -V commands in Dockerfile RUN instructions so that

--- a/doozer/doozerlib/lockfile_prototype/dockerfile_transforms.py
+++ b/doozer/doozerlib/lockfile_prototype/dockerfile_transforms.py
@@ -58,31 +58,6 @@ def strip_bare_updates_from_scripts(
                 logger.debug(f"Stripped bare updates from {script.relative_to(dest_dir)}")
 
 
-def strip_reinstall_commands(df_content: str) -> str:
-    """
-    Remove microdnf/dnf/yum reinstall commands from a Dockerfile.
-
-    In hermetic builds the base image packages are already at the exact
-    pinned version, so reinstalling them is redundant. The reinstall also
-    fails because the installed NEVRA is not available in the lockfile
-    repos (e.g. ``microdnf -y reinstall tzdata`` fails with
-    "Installed package tzdata-... not available").
-
-    Strips ``reinstall`` subcommands (with their package arguments) from
-    chained commands while preserving the rest of the chain.
-
-    Arg(s):
-        df_content (str): Raw Dockerfile text.
-    Return Value(s):
-        str: Transformed Dockerfile text with reinstall commands removed.
-    """
-    reinstall_re = re.compile(
-        r"\b(?:microdnf|dnf|yum)\s+(?:-\w+\s+)*reinstall\b[^&|;\\]*(?:\\\n[^&|;\\]*)*"
-        r"(?:\s*&&\s*|\s*;\s*)?",
-    )
-    return reinstall_re.sub("", df_content)
-
-
 def fix_rpm_verify_commands(df_content: str) -> str:
     """
     Transform rpm -V commands in Dockerfile RUN instructions so that

--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -543,12 +543,12 @@ class RpmLockfilePrototypeGenerator:
                         )
 
             if stage_info.reinstall_packages:
-                df_reinstall = [p for p in stage_info.reinstall_packages if p not in (reinstall_pkgs or [])]
+                df_reinstall = [p for p in stage_info.reinstall_packages if p not in packages]
                 if df_reinstall:
-                    reinstall_pkgs = (reinstall_pkgs or []) + df_reinstall
+                    packages = list(packages) + df_reinstall
                     self.logger.info(
                         f"{distgit_key}: stage {stage_num}: {len(df_reinstall)} Dockerfile "
-                        "reinstall packages added to lockfile reinstallPackages"
+                        "reinstall packages added to install list"
                     )
 
             enable_only = [s.split("/")[0] for s in stage_info.module_specs] if stage_info.module_specs else None

--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -408,6 +408,7 @@ class RpmLockfilePrototypeGenerator:
             or stage.has_update
             or stage.builddep_packages
             or stage.module_specs
+            or stage.reinstall_packages
         ]
 
     async def _resolve_all_stages(
@@ -540,6 +541,15 @@ class RpmLockfilePrototypeGenerator:
                             f"{distgit_key}: stage {stage_num}: {len(extra)} base image "
                             "packages added to install list for conflict detection"
                         )
+
+            if stage_info.reinstall_packages:
+                df_reinstall = [p for p in stage_info.reinstall_packages if p not in (reinstall_pkgs or [])]
+                if df_reinstall:
+                    reinstall_pkgs = (reinstall_pkgs or []) + df_reinstall
+                    self.logger.info(
+                        f"{distgit_key}: stage {stage_num}: {len(df_reinstall)} Dockerfile "
+                        "reinstall packages added to lockfile reinstallPackages"
+                    )
 
             enable_only = [s.split("/")[0] for s in stage_info.module_specs] if stage_info.module_specs else None
 

--- a/doozer/doozerlib/lockfile_prototype/models.py
+++ b/doozer/doozerlib/lockfile_prototype/models.py
@@ -111,6 +111,7 @@ class StageInfo(BaseModel):
     has_update: bool = False
     arch_packages: dict[str, list[str]] = Field(default_factory=dict)
     update_targets: list[str] = Field(default_factory=list)
+    reinstall_packages: list[str] = Field(default_factory=list)
     builddep_packages: list[str] = Field(default_factory=list)
     module_specs: list[str] = Field(default_factory=list)
 
@@ -129,6 +130,7 @@ class StageInfo(BaseModel):
             has_update=self.has_update or other.has_update,
             arch_packages=merged_arch,
             update_targets=sorted(set(self.update_targets + other.update_targets)),
+            reinstall_packages=sorted(set(self.reinstall_packages + other.reinstall_packages)),
             builddep_packages=sorted(set(self.builddep_packages + other.builddep_packages)),
             module_specs=sorted(set(self.module_specs + other.module_specs)),
         )

--- a/doozer/doozerlib/lockfile_prototype/rebaser_hooks.py
+++ b/doozer/doozerlib/lockfile_prototype/rebaser_hooks.py
@@ -13,6 +13,7 @@ import yaml
 
 from doozerlib.lockfile_prototype.constants import DEFAULT_RPM_LOCKFILE_NAME
 from doozerlib.lockfile_prototype.dockerfile_transforms import (
+    rewrite_reinstall_commands,
     strip_bare_updates,
     strip_bare_updates_from_scripts,
 )
@@ -103,12 +104,12 @@ def apply_dockerfile_transforms(
     logger: logging.Logger | None = None,
 ) -> None:
     """
-    Strip Dockerfile commands that fail in hermetic builds.
+    Transform Dockerfile commands for hermetic builds.
 
     Applied after lockfile generation so update targets are already
     resolved into the lockfile. Removes bare yum/dnf update commands
-    and reinstall commands (redundant when the base image already has
-    the pinned version).
+    and rewrites reinstall commands into rpmdb-remove + install
+    sequences that work regardless of base image EVR.
 
     Arg(s):
         dest_dir (Path): Build directory containing the Dockerfile.
@@ -125,4 +126,5 @@ def apply_dockerfile_transforms(
     if strip_updates:
         df_content = strip_bare_updates(df_content)
         strip_bare_updates_from_scripts(dest_dir, logger=_logger)
+    df_content = rewrite_reinstall_commands(df_content)
     df_path.write_text(df_content)

--- a/doozer/doozerlib/lockfile_prototype/rebaser_hooks.py
+++ b/doozer/doozerlib/lockfile_prototype/rebaser_hooks.py
@@ -15,7 +15,6 @@ from doozerlib.lockfile_prototype.constants import DEFAULT_RPM_LOCKFILE_NAME
 from doozerlib.lockfile_prototype.dockerfile_transforms import (
     strip_bare_updates,
     strip_bare_updates_from_scripts,
-    strip_reinstall_commands,
 )
 from doozerlib.lockfile_prototype.generator import RpmLockfilePrototypeGenerator
 from doozerlib.lockfile_prototype.resolver import RpmResolver
@@ -126,5 +125,4 @@ def apply_dockerfile_transforms(
     if strip_updates:
         df_content = strip_bare_updates(df_content)
         strip_bare_updates_from_scripts(dest_dir, logger=_logger)
-    df_content = strip_reinstall_commands(df_content)
     df_path.write_text(df_content)

--- a/doozer/doozerlib/lockfile_prototype/shell_parser.py
+++ b/doozer/doozerlib/lockfile_prototype/shell_parser.py
@@ -30,6 +30,7 @@ class _WalkContext(BaseModel):
     packages: set[str] = Field(default_factory=set)
     arch_packages: dict[str, set[str]] = Field(default_factory=dict)
     update_targets: set[str] = Field(default_factory=set)
+    reinstall_packages: set[str] = Field(default_factory=set)
     has_update: bool = False
     builddep_packages: set[str] = Field(default_factory=set)
     module_specs: set[str] = Field(default_factory=set)
@@ -379,6 +380,8 @@ def _detect_pkg_action(word_values: list[str], ctx: _WalkContext) -> tuple[str |
         wl = w.lower()
         if wl == "install":
             return "install", idx
+        if wl == "reinstall":
+            return "reinstall", idx
         if wl in ("update", "upgrade"):
             ctx.has_update = True
             return "update", idx
@@ -476,6 +479,10 @@ def _classify_package_tokens(
         if not _is_valid_package_token(token):
             continue
         if token in arch_resolved_tokens:
+            continue
+
+        if action == "reinstall":
+            ctx.reinstall_packages.add(token)
             continue
 
         if action == "update":
@@ -593,7 +600,7 @@ def _extract_subshell_packages(subshell_body: str) -> str:
 def _parse_and_walk(
     run_values: list[str],
     env_vars: dict[str, str] | None = None,
-) -> tuple[set[str], dict[str, set[str]], set[str], bool, set[str], set[str]]:
+) -> tuple[set[str], dict[str, set[str]], set[str], bool, set[str], set[str], set[str]]:
     """
     Single pass: preprocess, parse with bashlex, and walk all RUN bodies.
 
@@ -601,13 +608,14 @@ def _parse_and_walk(
         run_values (list[str]): RUN command bodies.
         env_vars (dict[str, str] | None): Variables from ARG/ENV directives.
     Return Value(s):
-        tuple[set[str], dict[str, set[str]], set[str], bool, set[str], set[str]]:
+        tuple[set[str], dict[str, set[str]], set[str], bool, set[str], set[str], set[str]]:
             - Install packages (common to all arches).
             - Arch-specific install packages.
             - Update target packages.
             - Whether any update command was found.
             - Builddep package patterns.
             - Module specs (e.g., nodejs:18, nodejs:18/development).
+            - Reinstall packages.
     """
     logger = logging.getLogger(__name__)
     ctx = _WalkContext(variables=dict(env_vars or {}))
@@ -624,32 +632,41 @@ def _parse_and_walk(
         ctx.arch_shell_vars = {}
         _walk_nodes(ast_nodes, ctx)
 
-    return ctx.packages, ctx.arch_packages, ctx.update_targets, ctx.has_update, ctx.builddep_packages, ctx.module_specs
+    return (
+        ctx.packages,
+        ctx.arch_packages,
+        ctx.update_targets,
+        ctx.has_update,
+        ctx.builddep_packages,
+        ctx.module_specs,
+        ctx.reinstall_packages,
+    )
 
 
 def analyze_run_commands(
     run_values: list[str],
     env_vars: dict[str, str] | None = None,
-) -> tuple[list[str], dict[str, list[str]], list[str], bool, list[str], list[str]]:
+) -> tuple[list[str], dict[str, list[str]], list[str], bool, list[str], list[str], list[str]]:
     """
     Single-pass analysis of RUN command bodies. Returns all install
     packages, arch-specific packages, update targets, update flag,
-    builddep package patterns, and module specs.
+    builddep package patterns, module specs, and reinstall packages.
 
     Arg(s):
         run_values (list[str]): RUN command bodies.
         env_vars (dict[str, str] | None): Variables from ARG/ENV directives.
     Return Value(s):
-        tuple[list[str], dict[str, list[str]], list[str], bool, list[str], list[str]]:
+        tuple[list[str], dict[str, list[str]], list[str], bool, list[str], list[str], list[str]]:
             - Sorted common package names.
             - Dict mapping arch to sorted package names.
             - Sorted update target package names.
             - Whether any update command was found.
             - Sorted builddep package patterns.
             - Sorted module specs.
+            - Sorted reinstall package names.
     """
-    packages, arch_packages, update_targets, found_update, builddep_packages, module_specs = _parse_and_walk(
-        run_values, env_vars
+    packages, arch_packages, update_targets, found_update, builddep_packages, module_specs, reinstall_packages = (
+        _parse_and_walk(run_values, env_vars)
     )
     arch_result = {arch: sorted(pkgs) for arch, pkgs in sorted(arch_packages.items())}
     return (
@@ -659,6 +676,7 @@ def analyze_run_commands(
         found_update,
         sorted(builddep_packages),
         sorted(module_specs),
+        sorted(reinstall_packages),
     )
 
 
@@ -677,6 +695,6 @@ def extract_packages_from_run_commands(
             - Sorted unique list of common package names (all arches).
             - Dict mapping arch to sorted unique package names for that arch only.
     """
-    packages, arch_packages, _, _, _, _ = _parse_and_walk(run_values, env_vars)
+    packages, arch_packages, _, _, _, _, _ = _parse_and_walk(run_values, env_vars)
     arch_result = {arch: sorted(pkgs) for arch, pkgs in sorted(arch_packages.items())}
     return sorted(packages), arch_result

--- a/doozer/tests/lockfile_prototype/test_dockerfile_transforms.py
+++ b/doozer/tests/lockfile_prototype/test_dockerfile_transforms.py
@@ -4,6 +4,7 @@ from tempfile import TemporaryDirectory
 
 from doozerlib.lockfile_prototype.dockerfile_transforms import (
     fix_rpm_verify_commands,
+    rewrite_reinstall_commands,
     strip_bare_updates,
     strip_bare_updates_from_scripts,
 )
@@ -142,6 +143,60 @@ class TestStripBareUpdatesFromScripts(unittest.TestCase):
             strip_bare_updates_from_scripts(dest)
             mtime_after = script.stat().st_mtime_ns
             self.assertEqual(mtime_before, mtime_after)
+
+
+class TestRewriteReinstallCommands(unittest.TestCase):
+    def test_rewrites_microdnf_reinstall(self):
+        content = "RUN microdnf -y reinstall tzdata && microdnf clean all\n"
+        result = rewrite_reinstall_commands(content)
+        self.assertIn("rpm -e --justdb --nodeps tzdata", result)
+        self.assertIn("microdnf -y install tzdata", result)
+        self.assertNotIn("reinstall", result)
+        self.assertIn("microdnf clean all", result)
+
+    def test_rewrites_dnf_reinstall(self):
+        content = "RUN dnf -y reinstall tzdata && dnf clean all\n"
+        result = rewrite_reinstall_commands(content)
+        self.assertIn("rpm -e --justdb --nodeps tzdata", result)
+        self.assertIn("dnf -y install tzdata", result)
+        self.assertNotIn("reinstall", result)
+
+    def test_rewrites_yum_reinstall_flag_after_action(self):
+        content = "RUN yum reinstall -y glibc && yum clean all\n"
+        result = rewrite_reinstall_commands(content)
+        self.assertIn("rpm -e --justdb --nodeps glibc", result)
+        self.assertIn("install glibc", result)
+        self.assertNotIn("reinstall", result)
+
+    def test_rewrites_multiple_packages(self):
+        content = "RUN microdnf -y reinstall tzdata glibc && microdnf clean all\n"
+        result = rewrite_reinstall_commands(content)
+        self.assertIn("rpm -e --justdb --nodeps tzdata glibc", result)
+        self.assertIn("microdnf -y install tzdata glibc", result)
+
+    def test_preserves_install_commands(self):
+        content = "RUN microdnf -y install openssl && microdnf clean all\n"
+        result = rewrite_reinstall_commands(content)
+        self.assertEqual(result, content)
+
+    def test_no_reinstall_unchanged(self):
+        content = "FROM base\nRUN yum install -y wget\n"
+        result = rewrite_reinstall_commands(content)
+        self.assertEqual(result, content)
+
+    def test_real_world_oadp_pattern(self):
+        content = (
+            "RUN . /cachi2/cachi2.env && "
+            "    microdnf -y install openssl && "
+            "microdnf -y reinstall tzdata && "
+            "microdnf clean all\n"
+        )
+        result = rewrite_reinstall_commands(content)
+        self.assertIn("microdnf -y install openssl", result)
+        self.assertIn("rpm -e --justdb --nodeps tzdata", result)
+        self.assertIn("microdnf -y install tzdata", result)
+        self.assertNotIn("reinstall", result)
+        self.assertIn("microdnf clean all", result)
 
 
 class TestFixRpmVerifyCommands(unittest.TestCase):

--- a/doozer/tests/lockfile_prototype/test_dockerfile_transforms.py
+++ b/doozer/tests/lockfile_prototype/test_dockerfile_transforms.py
@@ -6,7 +6,6 @@ from doozerlib.lockfile_prototype.dockerfile_transforms import (
     fix_rpm_verify_commands,
     strip_bare_updates,
     strip_bare_updates_from_scripts,
-    strip_reinstall_commands,
 )
 
 
@@ -143,58 +142,6 @@ class TestStripBareUpdatesFromScripts(unittest.TestCase):
             strip_bare_updates_from_scripts(dest)
             mtime_after = script.stat().st_mtime_ns
             self.assertEqual(mtime_before, mtime_after)
-
-
-class TestStripReinstallCommands(unittest.TestCase):
-    def test_strips_microdnf_reinstall(self):
-        content = "RUN microdnf -y install openssl && microdnf -y reinstall tzdata && microdnf clean all\n"
-        result = strip_reinstall_commands(content)
-        self.assertNotIn("reinstall", result)
-        self.assertIn("microdnf -y install openssl", result)
-        self.assertIn("microdnf clean all", result)
-
-    def test_strips_dnf_reinstall(self):
-        content = "RUN dnf -y reinstall tzdata && dnf clean all\n"
-        result = strip_reinstall_commands(content)
-        self.assertNotIn("reinstall", result)
-        self.assertIn("dnf clean all", result)
-
-    def test_strips_yum_reinstall(self):
-        content = "RUN yum reinstall -y glibc && yum clean all\n"
-        result = strip_reinstall_commands(content)
-        self.assertNotIn("reinstall", result)
-        self.assertIn("yum clean all", result)
-
-    def test_strips_reinstall_multiple_packages(self):
-        content = "RUN microdnf -y reinstall tzdata glibc && microdnf clean all\n"
-        result = strip_reinstall_commands(content)
-        self.assertNotIn("reinstall", result)
-        self.assertIn("microdnf clean all", result)
-
-    def test_preserves_install_commands(self):
-        content = "RUN microdnf -y install openssl && microdnf clean all\n"
-        result = strip_reinstall_commands(content)
-        self.assertEqual(result, content)
-
-    def test_no_reinstall_unchanged(self):
-        content = "FROM base\nRUN yum install -y wget\n"
-        result = strip_reinstall_commands(content)
-        self.assertEqual(result, content)
-
-    def test_real_world_oadp_pattern(self):
-        """
-        Pattern from oadp-operator Dockerfile.
-        """
-        content = (
-            "RUN . /cachi2/cachi2.env && "
-            "    microdnf -y install openssl && "
-            "microdnf -y reinstall tzdata && "
-            "microdnf clean all\n"
-        )
-        result = strip_reinstall_commands(content)
-        self.assertNotIn("reinstall", result)
-        self.assertIn("microdnf -y install openssl", result)
-        self.assertIn("microdnf clean all", result)
 
 
 class TestFixRpmVerifyCommands(unittest.TestCase):

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -1967,8 +1967,10 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         """
         Packages explicitly reinstalled in the Dockerfile (e.g.
         ``microdnf -y reinstall tzdata``) must appear in the lockfile's
-        reinstallPackages so cachi2 pre-fetches them and the hermetic
-        build can execute the reinstall at build time.
+        install packages (not reinstallPackages) so cachi2 pre-fetches
+        them at whatever repo version is available. The Dockerfile
+        transform converts ``reinstall`` into a rpmdb-remove + install
+        sequence at build time.
         """
         meta = self._make_mock_image_meta()
         meta.config.konflux.cachi2.lockfile.get.return_value = None
@@ -1993,9 +1995,9 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
 
         self.assertGreaterEqual(len(captured_configs), 1)
         main_config = captured_configs[0]
-        self.assertIn("tzdata", main_config.reinstallPackages)
         pkg_names = [p if isinstance(p, str) else p.name for p in main_config.packages]
         self.assertIn("openssl", pkg_names)
+        self.assertIn("tzdata", pkg_names)
 
 
 class TestDetermineStagePullspec(unittest.IsolatedAsyncioTestCase):

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -1963,6 +1963,40 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
         self.assertTrue(result[0].options.get("skip_if_unavailable"))
         self.assertEqual(result[0].options["module_hotfixes"], 1)
 
+    def test_dockerfile_reinstall_packages_added_to_lockfile(self):
+        """
+        Packages explicitly reinstalled in the Dockerfile (e.g.
+        ``microdnf -y reinstall tzdata``) must appear in the lockfile's
+        reinstallPackages so cachi2 pre-fetches them and the hermetic
+        build can execute the reinstall at build time.
+        """
+        meta = self._make_mock_image_meta()
+        meta.config.konflux.cachi2.lockfile.get.return_value = None
+        generator = self._make_generator()
+        generator.downstream_parents = ["quay.io/test/base@sha256:abc123"]
+        generator._container.get_installed_packages = AsyncMock(return_value=["bash", "glibc", "tzdata"])
+
+        captured_configs: list[RpmsInConfig] = []
+
+        async def capture_resolve(config, image_pullspec=None):
+            captured_configs.append(config)
+            return FAKE_LOCKFILE_DATA.model_copy(deep=True)
+
+        generator._resolver.resolve = AsyncMock(side_effect=capture_resolve)
+
+        with TemporaryDirectory() as tmpdir:
+            dest_dir = Path(tmpdir)
+            (dest_dir / "Dockerfile").write_text(
+                "FROM base\nRUN microdnf -y install openssl && microdnf -y reinstall tzdata && microdnf clean all\n"
+            )
+            asyncio.run(generator.generate_lockfile(meta, dest_dir))
+
+        self.assertGreaterEqual(len(captured_configs), 1)
+        main_config = captured_configs[0]
+        self.assertIn("tzdata", main_config.reinstallPackages)
+        pkg_names = [p if isinstance(p, str) else p.name for p in main_config.packages]
+        self.assertIn("openssl", pkg_names)
+
 
 class TestDetermineStagePullspec(unittest.IsolatedAsyncioTestCase):
     """

--- a/doozer/tests/lockfile_prototype/test_shell_parser.py
+++ b/doozer/tests/lockfile_prototype/test_shell_parser.py
@@ -549,49 +549,49 @@ class TestListArchConditional(unittest.TestCase):
 class TestBuilddepParsing(unittest.TestCase):
     def test_simple_builddep(self):
         run_values = ["dnf builddep -y pkcs11-helper*"]
-        _, _, _, _, builddep, _ = analyze_run_commands(run_values)
+        _, _, _, _, builddep, _, _ = analyze_run_commands(run_values)
         self.assertEqual(builddep, ["pkcs11-helper*"])
 
     def test_builddep_with_flags(self):
         run_values = ["dnf builddep -y --skip-broken --nobest openvpn*"]
-        _, _, _, _, builddep, _ = analyze_run_commands(run_values)
+        _, _, _, _, builddep, _, _ = analyze_run_commands(run_values)
         self.assertEqual(builddep, ["openvpn*"])
 
     def test_builddep_multiple_patterns(self):
         run_values = ["dnf builddep -y pkcs11-helper* && dnf builddep -y openvpn*"]
-        _, _, _, _, builddep, _ = analyze_run_commands(run_values)
+        _, _, _, _, builddep, _, _ = analyze_run_commands(run_values)
         self.assertEqual(builddep, ["openvpn*", "pkcs11-helper*"])
 
     def test_builddep_does_not_interfere_with_install(self):
         run_values = ["dnf install -y gcc make && dnf builddep -y pkcs11-helper*"]
-        common, arch, _, _, builddep, _ = analyze_run_commands(run_values)
+        common, arch, _, _, builddep, _, _ = analyze_run_commands(run_values)
         self.assertEqual(common, ["gcc", "make"])
         self.assertEqual(arch, {})
         self.assertEqual(builddep, ["pkcs11-helper*"])
 
     def test_builddep_without_glob(self):
         run_values = ["dnf builddep -y pkcs11-helper"]
-        _, _, _, _, builddep, _ = analyze_run_commands(run_values)
+        _, _, _, _, builddep, _, _ = analyze_run_commands(run_values)
         self.assertEqual(builddep, ["pkcs11-helper"])
 
     def test_yum_builddep(self):
         run_values = ["yum builddep -y mypackage"]
-        _, _, _, _, builddep, _ = analyze_run_commands(run_values)
+        _, _, _, _, builddep, _, _ = analyze_run_commands(run_values)
         self.assertEqual(builddep, ["mypackage"])
 
     def test_builddep_spec_file(self):
         run_values = ["dnf builddep -y mypackage.spec"]
-        _, _, _, _, builddep, _ = analyze_run_commands(run_values)
+        _, _, _, _, builddep, _, _ = analyze_run_commands(run_values)
         self.assertEqual(builddep, ["mypackage.spec"])
 
     def test_build_dep_hyphenated(self):
         run_values = ["dnf build-dep tuned.spec -y"]
-        _, _, _, _, builddep, _ = analyze_run_commands(run_values)
+        _, _, _, _, builddep, _, _ = analyze_run_commands(run_values)
         self.assertEqual(builddep, ["tuned.spec"])
 
     def test_build_dep_hyphenated_with_install(self):
         run_values = ["dnf install -y gcc rpm-build && cd assets/tuned/daemon && dnf build-dep tuned.spec -y"]
-        common, _, _, _, builddep, _ = analyze_run_commands(run_values)
+        common, _, _, _, builddep, _, _ = analyze_run_commands(run_values)
         self.assertIn("gcc", common)
         self.assertEqual(builddep, ["tuned.spec"])
 
@@ -599,33 +599,33 @@ class TestBuilddepParsing(unittest.TestCase):
 class TestModuleParsing(unittest.TestCase):
     def test_module_install(self):
         run_values = ["dnf module install -y nodejs:18/development"]
-        _, _, _, _, _, modules = analyze_run_commands(run_values)
+        _, _, _, _, _, modules, _ = analyze_run_commands(run_values)
         self.assertEqual(modules, ["nodejs:18/development"])
 
     def test_module_enable(self):
         run_values = ["dnf module enable -y nodejs:18"]
-        _, _, _, _, _, modules = analyze_run_commands(run_values)
+        _, _, _, _, _, modules, _ = analyze_run_commands(run_values)
         self.assertEqual(modules, ["nodejs:18"])
 
     def test_module_with_install_does_not_interfere(self):
         run_values = ["dnf -y install gcc && dnf module install -y nodejs:18/development"]
-        common, _, _, _, _, modules = analyze_run_commands(run_values)
+        common, _, _, _, _, modules, _ = analyze_run_commands(run_values)
         self.assertEqual(common, ["gcc"])
         self.assertEqual(modules, ["nodejs:18/development"])
 
     def test_module_multiple(self):
         run_values = ["dnf module enable -y nodejs:18 python36:3.6"]
-        _, _, _, _, _, modules = analyze_run_commands(run_values)
+        _, _, _, _, _, modules, _ = analyze_run_commands(run_values)
         self.assertEqual(modules, ["nodejs:18", "python36:3.6"])
 
     def test_module_without_stream_ignored(self):
         run_values = ["dnf module enable -y nodejs"]
-        _, _, _, _, _, modules = analyze_run_commands(run_values)
+        _, _, _, _, _, modules, _ = analyze_run_commands(run_values)
         self.assertEqual(modules, [])
 
     def test_variable_package_manager(self):
         run_values = ["${DNF} install -y openssh-clients"]
-        pkgs, _, _, _, _, _ = analyze_run_commands(run_values, env_vars={"DNF": "microdnf"})
+        pkgs, _, _, _, _, _, _ = analyze_run_commands(run_values, env_vars={"DNF": "microdnf"})
         self.assertEqual(pkgs, ["openssh-clients"])
 
     def test_variable_package_manager_in_conditional(self):
@@ -633,7 +633,7 @@ class TestModuleParsing(unittest.TestCase):
             "if ! rpm -q openssh-clients; then ${DNF} install -y openssh-clients "
             "&& ${DNF} clean all && rm -rf /var/cache/dnf/*; fi"
         ]
-        pkgs, _, _, _, _, _ = analyze_run_commands(run_values, env_vars={"DNF": "microdnf"})
+        pkgs, _, _, _, _, _, _ = analyze_run_commands(run_values, env_vars={"DNF": "microdnf"})
         self.assertEqual(pkgs, ["openssh-clients"])
 
     def test_variable_package_manager_multiple_commands(self):
@@ -642,5 +642,49 @@ class TestModuleParsing(unittest.TestCase):
             "if ! rpm -q libvirt-libs; then ${DNF} install -y libvirt-libs && ${DNF} clean all; fi",
             "if ! command -v tar; then ${DNF} install -y tar && ${DNF} clean all; fi",
         ]
-        pkgs, _, _, _, _, _ = analyze_run_commands(run_values, env_vars={"DNF": "microdnf"})
+        pkgs, _, _, _, _, _, _ = analyze_run_commands(run_values, env_vars={"DNF": "microdnf"})
         self.assertEqual(pkgs, ["libvirt-libs", "openssh-clients", "tar"])
+
+
+class TestReinstallParsing(unittest.TestCase):
+    def test_microdnf_reinstall_tzdata(self):
+        run_values = ["microdnf -y reinstall tzdata && microdnf clean all"]
+        _, _, _, _, _, _, reinstall = analyze_run_commands(run_values)
+        self.assertEqual(reinstall, ["tzdata"])
+
+    def test_dnf_reinstall_tzdata(self):
+        run_values = ["dnf -y reinstall tzdata && dnf clean all"]
+        _, _, _, _, _, _, reinstall = analyze_run_commands(run_values)
+        self.assertEqual(reinstall, ["tzdata"])
+
+    def test_yum_reinstall(self):
+        run_values = ["yum reinstall -y glibc && yum clean all"]
+        _, _, _, _, _, _, reinstall = analyze_run_commands(run_values)
+        self.assertEqual(reinstall, ["glibc"])
+
+    def test_reinstall_multiple_packages(self):
+        run_values = ["microdnf -y reinstall tzdata glibc && microdnf clean all"]
+        _, _, _, _, _, _, reinstall = analyze_run_commands(run_values)
+        self.assertEqual(reinstall, ["glibc", "tzdata"])
+
+    def test_reinstall_does_not_interfere_with_install(self):
+        run_values = ["microdnf -y install openssl && microdnf -y reinstall tzdata && microdnf clean all"]
+        pkgs, _, _, _, _, _, reinstall = analyze_run_commands(run_values)
+        self.assertEqual(pkgs, ["openssl"])
+        self.assertEqual(reinstall, ["tzdata"])
+
+    def test_no_reinstall_returns_empty(self):
+        run_values = ["dnf install -y wget && dnf clean all"]
+        _, _, _, _, _, _, reinstall = analyze_run_commands(run_values)
+        self.assertEqual(reinstall, [])
+
+    def test_real_world_oadp_pattern(self):
+        run_values = [
+            ". /cachi2/cachi2.env && "
+            "    microdnf -y install openssl && "
+            "microdnf -y reinstall tzdata && "
+            "microdnf clean all"
+        ]
+        pkgs, _, _, _, _, _, reinstall = analyze_run_commands(run_values)
+        self.assertEqual(pkgs, ["openssl"])
+        self.assertEqual(reinstall, ["tzdata"])


### PR DESCRIPTION
UBI base images ship tzdata (and potentially other packages) with files stripped to save space. Downstream Dockerfiles use `dnf reinstall tzdata` to restore those files -- even when the version is identical, the reinstall re-extracts the full RPM payload. The rpm-lockfile-prototype rebase path was silently dropping these reinstall commands, causing missing timezone data at runtime (reported by OADP).

Three issues contributed:

1. The shell parser (_detect_pkg_action) did not recognize `reinstall` as a package manager action, so reinstall targets were never extracted from Dockerfiles into StageInfo.

2. The lockfile generator never included Dockerfile reinstall targets in reinstallPackages, so cachi2 never pre-fetched them.

3. strip_reinstall_commands() unconditionally removed all reinstall clauses from Dockerfile RUN instructions during rebase.

Fix by:
- Teaching the shell parser to recognize `reinstall` and route targets to a new StageInfo.reinstall_packages field
- Merging Dockerfile reinstall targets into the lockfile's reinstallPackages in the generator so they are resolved and pre-fetched for hermetic builds
- Removing strip_reinstall_commands() and its invocation from the Dockerfile transform pipeline

The net effect is that `RUN microdnf -y reinstall tzdata && microdnf clean all` is now preserved through rebase, the RPM is included in the lockfile, and the reinstall executes at build time.

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dockerfile package reinstallation is now handled more reliably across `dnf`, `microdnf`, and `yum`.
  * Reinstalled packages are detected and included in generated lockfiles.
  * Reinstall commands are rewritten to refresh package metadata while preserving installed files.

* **Bug Fixes**
  * Improved handling of multiple reinstall packages and mixed install/reinstall commands.
  * Prevented reinstall processing from interfering with regular package extraction.

* **Tests**
  * Added coverage for supported package managers, command patterns, and lockfile generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->