### PR TITLE
ART-21641: Keep private fix content out of layered-product bundles and FBCs

### DIFF
--- a/artcommon/artcommonlib/build_visibility.py
+++ b/artcommon/artcommonlib/build_visibility.py
@@ -48,6 +48,17 @@ def is_release_embargoed(release: str, build_system: str, default=True) -> bool:
     return default
 
 
+def is_nvr_embargoed(nvr: str, build_system: str = 'konflux') -> bool:
+    """
+    Determine embargo status directly from an NVR string, by inspecting its release field.
+    E.g. 'foo-1.0-1.p3' -> True (konflux, private), 'foo-1.0-1.p2' -> False (konflux, public)
+    """
+    from artcommonlib.rpm_utils import parse_nvr
+
+    release = parse_nvr(nvr)['release']
+    return is_release_embargoed(release, build_system)
+
+
 def get_visibility_suffix(build_system: str, visibility: BuildVisibility) -> str:
     """
     Get the p? flag based on the visibility status and the build system. E.g.:

--- a/artcommon/tests/test_build_visibility.py
+++ b/artcommon/tests/test_build_visibility.py
@@ -5,6 +5,7 @@ from artcommonlib.build_visibility import (
     get_all_visibility_suffixes,
     get_build_system,
     get_visibility_suffix,
+    is_nvr_embargoed,
     is_release_embargoed,
     isolate_pflag_in_release,
 )
@@ -41,6 +42,26 @@ class TestBuildVisibility(TestCase):
         # Wrong build system: KeyError is raised
         with self.assertRaises(KeyError):
             is_release_embargoed('v4.17.0-202503120643.p0', 'wrong')
+
+    def test_is_nvr_embargoed(self):
+        # Konflux (default build_system)
+        self.assertFalse(is_nvr_embargoed('foo-1.2.3-1.p2'))
+        self.assertTrue(is_nvr_embargoed('foo-1.2.3-1.p3'))
+
+        # Explicit konflux build_system
+        self.assertFalse(is_nvr_embargoed('foo-1.2.3-1.p2', 'konflux'))
+        self.assertTrue(is_nvr_embargoed('foo-1.2.3-1.p3', 'konflux'))
+
+        # Brew build_system
+        self.assertFalse(is_nvr_embargoed('foo-1.2.3-1.p0', 'brew'))
+        self.assertTrue(is_nvr_embargoed('foo-1.2.3-1.p1', 'brew'))
+
+        # No p? flag found: treat as embargoed
+        self.assertTrue(is_nvr_embargoed('foo-1.2.3-1'))
+
+        # Malformed NVR (no name/version/release separators): propagates ValueError from parse_nvr
+        with self.assertRaises(ValueError):
+            is_nvr_embargoed('not_an_nvr')
 
     def test_get_visibility_suffix(self):
         self.assertEqual(get_visibility_suffix('brew', BuildVisibility.PUBLIC), 'p0')

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -14,6 +14,7 @@ import yaml
 from artcommonlib import exectools
 from artcommonlib import util as artlib_util
 from artcommonlib.assembly import AssemblyTypes
+from artcommonlib.build_visibility import is_nvr_embargoed
 from artcommonlib.constants import KONFLUX_DEFAULT_IMAGE_SHARE_REPO
 from artcommonlib.konflux.konflux_build_record import (
     KonfluxBuildOutcome,
@@ -36,6 +37,13 @@ _LOGGER = logging.getLogger(__name__)
 
 
 BUNDLE_BUILD_PRIORITY = "3"
+
+
+class KonfluxOlmBundleRebaseError(Exception):
+    """Raised when an operator bundle cannot be safely rebased, e.g. an embargoed operand
+    image has no public substitute available."""
+
+    pass
 
 
 class KonfluxOlmBundleRebaser:
@@ -457,12 +465,58 @@ class KonfluxOlmBundleRebaser:
                 _delivery_override_map[_img_short] = _override_short
             except (yaml.YAMLError, OSError) as e:
                 self._logger.debug("Failed to parse image YAML %s: %s", _yml_path, e)
+        # Map component name (as it appears in the com.redhat.component label / NVR) to the
+        # ART ImageMetadata that builds it, so embargoed operands can be mapped back to a
+        # metadata object to query for a public substitute build. Computed lazily (only if an
+        # embargoed operand is actually encountered below) to avoid the cost of iterating every
+        # image metadata on the common (non-embargoed) path.
+        _component_to_meta: Optional[Dict[str, ImageMetadata]] = None
+
         for pullspec, image_info in zip(art_references, image_infos):
             image_labels = image_info['config']['config']['Labels']
             image_version = image_labels['version']
             image_release = image_labels['release']
             image_component_name = image_labels['com.redhat.component']
             image_nvr = f"{image_component_name}-{image_version}-{image_release}"
+
+            # Operator bundles are only ever shipped publicly, so they must never reference an
+            # embargoed (private-fix) operand image. If the resolved operand build is embargoed,
+            # substitute it with the latest public (non-embargoed) build of that same component.
+            # If no public build exists, fail the rebase rather than shipping embargoed content.
+            if engine is Engine.KONFLUX and is_nvr_embargoed(image_nvr):
+                if _component_to_meta is None:
+                    _component_to_meta = {im.get_component_name(): im for im in metadata.runtime.image_metas()}
+                operand_meta = _component_to_meta.get(image_component_name)
+                if operand_meta is None:
+                    raise KonfluxOlmBundleRebaseError(
+                        f"Operand image {image_nvr} referenced by operator {metadata.distgit_key} is "
+                        f"embargoed, but no ART image metadata could be found for component "
+                        f"'{image_component_name}' to look up a public substitute."
+                    )
+                public_build = await operand_meta.get_latest_konflux_build(
+                    default=None,
+                    el_target=operand_meta.branch_el_target(),
+                    embargoed=False,
+                    exclude_large_columns=True,
+                )
+                if not public_build:
+                    raise KonfluxOlmBundleRebaseError(
+                        f"Operand image {image_nvr} referenced by operator {metadata.distgit_key} is "
+                        f"embargoed, and no public (non-embargoed) build of '{operand_meta.distgit_key}' "
+                        f"is available to substitute. Cannot safely rebase this operator bundle."
+                    )
+                self._logger.warning(
+                    "Operand image %s referenced by operator %s is embargoed; substituting with public build %s",
+                    image_nvr,
+                    metadata.distgit_key,
+                    public_build.nvr,
+                )
+                image_info = await util.oc_image_info_for_arch_async(
+                    public_build.image_pullspec,
+                    registry_config=os.getenv("QUAY_AUTH_FILE"),
+                )
+                image_nvr = public_build.nvr
+
             namespace, image_short_name, image_tag = art_references[pullspec]
             image_sha = (
                 image_info['contentDigest']

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -150,7 +150,8 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
                     'Labels': {
                         'com.redhat.component': 'test-component',
                         'version': '1.0',
-                        'release': '1',
+                        # Public (non-embargoed) Konflux release.
+                        'release': '1.p2',
                     },
                 },
             },
@@ -186,7 +187,8 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
                     'Labels': {
                         'com.redhat.component': 'test-component',
                         'version': '1.0',
-                        'release': '1',
+                        # Public (non-embargoed) Konflux release.
+                        'release': '1.p2',
                     },
                 },
             },

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -8,9 +8,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import yaml
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBundleBuildRecord
 from artcommonlib.konflux.konflux_db import Engine
+from artcommonlib.model import Model
 from doozerlib import constants
 from doozerlib.backend.konflux_client import ImageBuildParams
-from doozerlib.backend.konflux_olm_bundler import KonfluxOlmBundleBuilder, KonfluxOlmBundleRebaser
+from doozerlib.backend.konflux_olm_bundler import (
+    KonfluxOlmBundleBuilder,
+    KonfluxOlmBundleRebaseError,
+    KonfluxOlmBundleRebaser,
+)
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
 
 
@@ -91,7 +96,9 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
                     'Labels': {
                         'com.redhat.component': 'test-brew-component',
                         'version': '1.0',
-                        'release': '1',
+                        # Public (non-embargoed) Konflux release, so the embargo-substitution
+                        # path introduced for layered-product bundles is not exercised here.
+                        'release': '1.p2',
                     },
                     'Env': {
                         '__doozer_key=test-component',
@@ -128,7 +135,7 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
             (
                 'registry.example.com/namespace/image:tag',
                 'registry.redhat.io/openshift4/image@sha256:1234567890abcdef',
-                'test-brew-component-1.0-1',
+                'test-brew-component-1.0-1.p2',
             ),
         )
 
@@ -992,3 +999,166 @@ class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
                 ["operand1-1.0-1", "operand2-1.0-1"],
             )
             self.assertIn('Failed writing record to the konflux DB', cm.output[0])
+
+
+class TestReplaceImageReferencesEmbargo(IsolatedAsyncioTestCase):
+    """Covers the embargoed-operand substitution logic added to _replace_image_references()
+    for layered-product operator bundles: embargoed operand references must never be shipped
+    in a public bundle, so they are substituted with the latest public build, or the rebase
+    fails clearly if no public substitute exists."""
+
+    def setUp(self):
+        self.rebaser = KonfluxOlmBundleRebaser(
+            base_dir=Path('/tmp/nonexistent-base-dir'),
+            group='openshift-4.18',
+            assembly='stream',
+            group_config=Model({}),
+            konflux_db=MagicMock(),
+            source_resolver=MagicMock(),
+            image_repo='quay.io/example/repo',
+            logger=MagicMock(),
+        )
+
+    def _make_metadata(self, image_metas=None):
+        metadata = MagicMock()
+        metadata.distgit_key = 'my-operator'
+        metadata.runtime.group = 'openshift-4.18'
+        metadata.runtime.data_dir = '/tmp/nonexistent-data-dir'
+        metadata.runtime.image_metas.return_value = image_metas or []
+        return metadata
+
+    @staticmethod
+    def _image_info(component, version, release, digest_suffix):
+        return {
+            'config': {
+                'config': {'Labels': {'version': version, 'release': release, 'com.redhat.component': component}}
+            },
+            'contentDigest': f'sha256:{digest_suffix}-content',
+            'listDigest': f'sha256:{digest_suffix}-list',
+        }
+
+    async def test_non_embargoed_operand_resolves_normally(self):
+        """A non-embargoed operand is resolved to its digest without any substitution."""
+        content = 'image: registry.redhat.io/openshift4/mypublic-operand-rhel9:v1.0'
+        metadata = self._make_metadata()
+
+        with patch(
+            'doozerlib.backend.konflux_olm_bundler.util.oc_image_info_for_arch_async',
+            new_callable=AsyncMock,
+            return_value=self._image_info('mypublic-operand-container', 'v1.0', '1.p2', 'public'),
+        ) as mock_oc_info:
+            new_content, found_images = await self.rebaser._replace_image_references(
+                'registry.redhat.io', content, Engine.KONFLUX, metadata
+            )
+
+        mock_oc_info.assert_awaited_once()
+        self.assertIn('registry.redhat.io/openshift4/mypublic-operand-rhel9@sha256:public-list', new_content)
+        self.assertEqual(
+            found_images['mypublic-operand-rhel9'][2],
+            'mypublic-operand-container-v1.0-1.p2',
+        )
+        # The lazy component-metadata map should never be built when nothing is embargoed.
+        metadata.runtime.image_metas.assert_not_called()
+
+    async def test_embargoed_operand_is_substituted_with_public_build(self):
+        """An embargoed operand is substituted with the latest public build of the same component."""
+        content = 'image: registry.redhat.io/openshift4/my-embargoed-operand-rhel9:v1.0'
+        metadata = self._make_metadata()
+
+        public_build = MagicMock()
+        public_build.nvr = 'my-embargoed-operand-container-v1.0-2.p2'
+        public_build.image_pullspec = 'quay.io/example/repo@sha256:public-build-digest'
+
+        operand_meta = MagicMock()
+        operand_meta.distgit_key = 'my-embargoed-operand'
+        operand_meta.get_component_name.return_value = 'my-embargoed-operand-container'
+        operand_meta.branch_el_target.return_value = 9
+        operand_meta.get_latest_konflux_build = AsyncMock(return_value=public_build)
+        metadata.runtime.image_metas.return_value = [operand_meta]
+
+        embargoed_info = self._image_info('my-embargoed-operand-container', 'v1.0', '1.p3', 'embargoed')
+        public_info = self._image_info('my-embargoed-operand-container', 'v1.0', '2.p2', 'public-sub')
+
+        async def fake_oc_image_info(pullspec, registry_config=None):
+            if pullspec == public_build.image_pullspec:
+                return public_info
+            return embargoed_info
+
+        with patch(
+            'doozerlib.backend.konflux_olm_bundler.util.oc_image_info_for_arch_async',
+            side_effect=fake_oc_image_info,
+        ) as mock_oc_info:
+            new_content, found_images = await self.rebaser._replace_image_references(
+                'registry.redhat.io', content, Engine.KONFLUX, metadata
+            )
+
+        self.assertEqual(mock_oc_info.call_count, 2)
+        operand_meta.get_latest_konflux_build.assert_awaited_once_with(
+            default=None, el_target=9, embargoed=False, exclude_large_columns=True
+        )
+        # The substituted (public) build's digest should be used in the final content, not the
+        # embargoed build's digest.
+        self.assertIn('registry.redhat.io/openshift4/my-embargoed-operand-rhel9@sha256:public-sub-list', new_content)
+        self.assertNotIn('embargoed-list', new_content)
+        self.assertEqual(
+            found_images['my-embargoed-operand-rhel9'][2],
+            public_build.nvr,
+        )
+
+    async def test_embargoed_operand_with_no_public_alternative_raises(self):
+        """When an embargoed operand has no public build to substitute, the rebase fails clearly."""
+        content = 'image: registry.redhat.io/openshift4/my-embargoed-operand-rhel9:v1.0'
+        metadata = self._make_metadata()
+
+        operand_meta = MagicMock()
+        operand_meta.distgit_key = 'my-embargoed-operand'
+        operand_meta.get_component_name.return_value = 'my-embargoed-operand-container'
+        operand_meta.branch_el_target.return_value = 9
+        operand_meta.get_latest_konflux_build = AsyncMock(return_value=None)
+        metadata.runtime.image_metas.return_value = [operand_meta]
+
+        embargoed_info = self._image_info('my-embargoed-operand-container', 'v1.0', '1.p3', 'embargoed')
+
+        with patch(
+            'doozerlib.backend.konflux_olm_bundler.util.oc_image_info_for_arch_async',
+            new_callable=AsyncMock,
+            return_value=embargoed_info,
+        ):
+            with self.assertRaises(KonfluxOlmBundleRebaseError):
+                await self.rebaser._replace_image_references('registry.redhat.io', content, Engine.KONFLUX, metadata)
+
+    async def test_embargoed_operand_with_unknown_component_raises(self):
+        """When an embargoed operand's component can't be mapped to any ART ImageMetadata, fail clearly."""
+        content = 'image: registry.redhat.io/openshift4/my-embargoed-operand-rhel9:v1.0'
+        metadata = self._make_metadata(image_metas=[])  # no metadata registered for this component
+
+        embargoed_info = self._image_info('my-embargoed-operand-container', 'v1.0', '1.p3', 'embargoed')
+
+        with patch(
+            'doozerlib.backend.konflux_olm_bundler.util.oc_image_info_for_arch_async',
+            new_callable=AsyncMock,
+            return_value=embargoed_info,
+        ):
+            with self.assertRaises(KonfluxOlmBundleRebaseError):
+                await self.rebaser._replace_image_references('registry.redhat.io', content, Engine.KONFLUX, metadata)
+
+    async def test_brew_engine_does_not_check_embargo(self):
+        """Embargo substitution is only applied for Konflux-engine operands; Brew engine is unaffected."""
+        content = 'image: registry.redhat.io/openshift4/my-embargoed-operand-rhel9:v1.0'
+        metadata = self._make_metadata()
+        embargoed_info = self._image_info('my-embargoed-operand-container', 'v1.0', '1.p3', 'embargoed')
+
+        with patch(
+            'doozerlib.backend.konflux_olm_bundler.util.oc_image_info_for_arch_async',
+            new_callable=AsyncMock,
+            return_value=embargoed_info,
+        ) as mock_oc_info:
+            new_content, found_images = await self.rebaser._replace_image_references(
+                'registry.redhat.io', content, Engine.BREW, metadata
+            )
+
+        # No substitution attempted; the (embargoed) build's own digest is used as-is.
+        mock_oc_info.assert_awaited_once()
+        self.assertIn('registry.redhat.io/openshift4/my-embargoed-operand-rhel9@sha256:embargoed-list', new_content)
+        # The lazy component-metadata map should never be built for the Brew engine.
+        metadata.runtime.image_metas.assert_not_called()

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 import traceback
 from pathlib import Path
 from typing import List, Optional
@@ -7,6 +8,7 @@ from typing import List, Optional
 import click
 import yaml
 from artcommonlib import exectools
+from artcommonlib.build_visibility import is_nvr_embargoed
 from artcommonlib.constants import PRODUCT_KUBECONFIG_MAP
 from artcommonlib.util import resolve_konflux_kubeconfig_by_product, resolve_konflux_namespace_by_product
 from doozerlib.constants import KONFLUX_DEFAULT_IMAGE_REPO
@@ -53,6 +55,9 @@ class BuildLayeredProductsPipeline:
         self.network_mode = network_mode
         self.plr_template = plr_template
         self._logger = logger or runtime.logger
+        # Operator NVRs that were dropped from the bundle build trigger because they are embargoed.
+        # The caller uses this to mark the Jenkins job UNSTABLE instead of a plain SUCCESS.
+        self.embargoed_operators_skipped: List[str] = []
 
         if self.image_build_strategy == BuildStrategy.ALL and self.image_list:
             raise ValueError("image_list must be empty when image_build_strategy is 'all'")
@@ -92,6 +97,23 @@ class BuildLayeredProductsPipeline:
             for record in records:
                 if record['has_olm_bundle'] == '1' and record['status'] == '0' and record.get('nvrs', None):
                     operator_nvrs.append(record['nvrs'].split(',')[0])
+
+            # Embargoed operators should not have a public bundle built for them. Drop them from
+            # the trigger; the previous public bundle remains the latest until a public rebuild
+            # happens. The caller marks the Jenkins job UNSTABLE when this list is non-empty.
+            non_embargoed_nvrs = []
+            for nvr in operator_nvrs:
+                if is_nvr_embargoed(nvr):
+                    self._logger.warning(
+                        'Operator NVR %s is embargoed; skipping bundle build trigger for it. '
+                        'The previous public bundle will remain the latest until a public rebuild.',
+                        nvr,
+                    )
+                    self.embargoed_operators_skipped.append(nvr)
+                else:
+                    non_embargoed_nvrs.append(nvr)
+            operator_nvrs = non_embargoed_nvrs
+
             if operator_nvrs:
                 # Automatically propagate parameters if set in environment
                 propagate_params = jenkins.get_propagatable_params()
@@ -139,6 +161,16 @@ class BuildLayeredProductsPipeline:
         image_repo = group_config.get('konflux', {}).get('image_repo') or KONFLUX_DEFAULT_IMAGE_REPO
         await self._rebase_and_build(product, image_repo)
         self.trigger_bundle_build()
+
+        if self.embargoed_operators_skipped:
+            self._logger.warning(
+                'Job completed, but skipped triggering bundle build for %d embargoed operator NVR(s): %s',
+                len(self.embargoed_operators_skipped),
+                ', '.join(self.embargoed_operators_skipped),
+            )
+            # Exit with code 2 to mark Jenkins job as UNSTABLE
+            # The Jenkinsfile should catch this exit code and set currentBuild.result = 'UNSTABLE'
+            sys.exit(2)
 
     def _group_param(self) -> str:
         if self.data_gitref:

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -15,6 +15,7 @@ from urllib.parse import urlparse
 import click
 import yaml as stdlib_yaml
 from artcommonlib import exectools
+from artcommonlib.build_visibility import is_nvr_embargoed
 from artcommonlib.constants import SHIPMENT_DATA_URL_TEMPLATE
 from artcommonlib.gitdata import SafeFormatter
 from artcommonlib.github_auth import get_github_client_for_org
@@ -1214,6 +1215,20 @@ class ReleaseFromFbcPipeline:
 
         if not all_nvrs and not self.extra_image_nvrs:
             raise RuntimeError("No NVRs extracted from FBC images and no extra image NVRs provided")
+
+        # Defensive check: bundle/FBC rebases (and the operator-level filter in
+        # build_layered_products.py) should already guarantee that FBC-derived NVRs are never
+        # embargoed. If an embargoed NVR reaches this point anyway - whether from the FBC
+        # pullspecs themselves or from a manual --extra-image-nvrs override - that signals a
+        # serious upstream bug (or misuse of --extra-image-nvrs), so fail the release rather than
+        # silently dropping it.
+        embargoed_nvrs = [nvr for nvr in all_nvrs + self.extra_image_nvrs if is_nvr_embargoed(nvr)]
+        if embargoed_nvrs:
+            raise RuntimeError(
+                f"Refusing to create a release referencing embargoed (private-fix) NVR(s): "
+                f"{embargoed_nvrs}. This should never happen for FBC-derived NVRs and likely "
+                f"indicates an upstream bug, or an embargoed NVR was passed via --extra-image-nvrs."
+            )
 
         # Categorize the extracted NVRs
         empty_categorized: Dict[str, List[str]]

--- a/pyartcd/tests/pipelines/test_build_layered_products.py
+++ b/pyartcd/tests/pipelines/test_build_layered_products.py
@@ -401,6 +401,108 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
         self.assertFalse(any(arg.startswith('--images=') for arg in cmd))
         self.assertFalse(any(arg.startswith('--exclude=') for arg in cmd))
 
+    def _write_image_build_record_log(self, entries):
+        """Write an image_build_konflux record.log with the given (name, nvr) entries, all successful with a bundle."""
+        record_log_path = Path(self.runtime.doozer_working, 'record.log')
+        lines = []
+        for name, nvr in entries:
+            lines.append(f'image_build_konflux|name={name}|has_olm_bundle=1|status=0|nvrs={nvr}\n')
+        record_log_path.write_text(''.join(lines))
+
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.start_olm_bundle_konflux')
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.get_propagatable_params', return_value={})
+    def test_trigger_bundle_build_filters_embargoed_operators(self, mock_get_params, mock_start_bundle):
+        """Embargoed operator NVRs are dropped from the trigger; non-embargoed ones proceed."""
+        self.pipeline.skip_bundle_build = False
+        self._write_image_build_record_log(
+            [
+                ('oadp-operator', 'oadp-operator-container-v1.4.9-1.p2'),
+                ('oadp-operator', 'oadp-operator-container-v1.4.9-2.p3'),
+            ]
+        )
+
+        self.pipeline.trigger_bundle_build()
+
+        mock_start_bundle.assert_called_once()
+        self.assertEqual(
+            mock_start_bundle.call_args.kwargs['operator_nvrs'],
+            ['oadp-operator-container-v1.4.9-1.p2'],
+        )
+        self.assertEqual(self.pipeline.embargoed_operators_skipped, ['oadp-operator-container-v1.4.9-2.p3'])
+
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.start_olm_bundle_konflux')
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.get_propagatable_params', return_value={})
+    def test_trigger_bundle_build_all_embargoed_skips_trigger(self, mock_get_params, mock_start_bundle):
+        """When every operator NVR is embargoed, the bundle build trigger is never called."""
+        self.pipeline.skip_bundle_build = False
+        self._write_image_build_record_log(
+            [
+                ('oadp-operator', 'oadp-operator-container-v1.4.9-1.p3'),
+            ]
+        )
+
+        self.pipeline.trigger_bundle_build()
+
+        mock_start_bundle.assert_not_called()
+        self.assertEqual(self.pipeline.embargoed_operators_skipped, ['oadp-operator-container-v1.4.9-1.p3'])
+
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.start_olm_bundle_konflux')
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.get_propagatable_params', return_value={})
+    def test_trigger_bundle_build_no_embargoed_calls_normally(self, mock_get_params, mock_start_bundle):
+        """When no operator NVRs are embargoed, the trigger proceeds normally with an empty skip list."""
+        self.pipeline.skip_bundle_build = False
+        self._write_image_build_record_log(
+            [
+                ('oadp-operator', 'oadp-operator-container-v1.4.9-1.p2'),
+            ]
+        )
+
+        self.pipeline.trigger_bundle_build()
+
+        mock_start_bundle.assert_called_once()
+        self.assertEqual(
+            mock_start_bundle.call_args.kwargs['operator_nvrs'],
+            ['oadp-operator-container-v1.4.9-1.p2'],
+        )
+        self.assertEqual(self.pipeline.embargoed_operators_skipped, [])
+
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.init_jenkins')
+    @patch('pyartcd.pipelines.build_layered_products.load_group_config')
+    async def test_run_exits_unstable_when_embargoed_operators_skipped(self, mock_load_config, mock_jenkins):
+        """run() exits with code 2 (UNSTABLE) when any embargoed operator NVRs were skipped."""
+        mock_load_config.return_value = {'product': 'oadp', 'version': '1.4.9'}
+        self.pipeline.skip_rebase = True
+        self.pipeline.skip_bundle_build = True
+
+        with (
+            patch.object(self.pipeline, '_rebase_and_build', new_callable=AsyncMock),
+            patch.object(self.pipeline, 'trigger_bundle_build') as mock_trigger,
+        ):
+
+            def fake_trigger():
+                self.pipeline.embargoed_operators_skipped.append('oadp-operator-container-v1.4.9-1.p3')
+
+            mock_trigger.side_effect = fake_trigger
+
+            with self.assertRaises(SystemExit) as ctx:
+                await self.pipeline.run()
+
+        self.assertEqual(ctx.exception.code, 2)
+
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.init_jenkins')
+    @patch('pyartcd.pipelines.build_layered_products.load_group_config')
+    async def test_run_succeeds_when_no_operators_skipped(self, mock_load_config, mock_jenkins):
+        """run() completes normally (no SystemExit) when no operator NVRs were skipped."""
+        mock_load_config.return_value = {'product': 'oadp', 'version': '1.4.9'}
+        self.pipeline.skip_rebase = True
+        self.pipeline.skip_bundle_build = True
+
+        with (
+            patch.object(self.pipeline, '_rebase_and_build', new_callable=AsyncMock),
+            patch.object(self.pipeline, 'trigger_bundle_build'),
+        ):
+            await self.pipeline.run()  # Should not raise
+
     async def test_build_all_strategy_with_exclusions(self):
         """When strategy is all with rebase exclusions, build uses --images= --exclude=."""
         with (

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -563,7 +563,7 @@ class TestExtraImageNvrsValidation(unittest.TestCase):
 
     def test_fbc_nvr_in_extra_image_nvrs_raises(self):
         """run() should raise RuntimeError when extra_image_nvrs contains an FBC build."""
-        pipeline = self._make_pipeline(extra_image_nvrs=["oadp-operator-fbc-1.5.3-1.el9"])
+        pipeline = self._make_pipeline(extra_image_nvrs=["oadp-operator-fbc-1.5.3-1.el9.p2"])
         pipeline.check_env_vars = MagicMock()
         pipeline.setup_working_dir = MagicMock()
         pipeline._load_product_from_group_config = AsyncMock(return_value="oadp")
@@ -586,6 +586,61 @@ class TestExtraImageNvrsValidation(unittest.TestCase):
             asyncio.run(pipeline.run())
         except RuntimeError as e:
             self.assertNotIn("FBC builds", str(e))
+
+
+class TestEmbargoedNvrDefensiveCheck(unittest.TestCase):
+    """run() must refuse to release if any embargoed (private-fix) NVR is found, whether it came
+    from an FBC pullspec or from a manual --extra-image-nvrs override."""
+
+    def _make_pipeline(self, extra_image_nvrs=None, fbc_pullspecs=None):
+        runtime = MagicMock()
+        runtime.config = {}
+        runtime.dry_run = False
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        pipeline = ReleaseFromFbcPipeline(
+            runtime=runtime,
+            group="oadp-1.5",
+            assembly="1.5.3",
+            fbc_pullspecs=fbc_pullspecs or [],
+            extra_image_nvrs=extra_image_nvrs,
+        )
+        pipeline.check_env_vars = MagicMock()
+        pipeline.setup_working_dir = MagicMock()
+        pipeline._load_product_from_group_config = AsyncMock(return_value="oadp")
+        return pipeline
+
+    def test_embargoed_fbc_nvr_raises(self):
+        """An embargoed NVR extracted from an FBC pullspec must fail the release."""
+        pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/example/fbc:v1"])
+        pipeline.validate_fbc_related_images = AsyncMock(return_value=[])
+        pipeline.extract_fbc_nvr = MagicMock(return_value="oadp-operator-fbc-1.5.3-1.p3")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(pipeline.run())
+        self.assertIn("embargoed", str(ctx.exception))
+        self.assertIn("oadp-operator-fbc-1.5.3-1.p3", str(ctx.exception))
+
+    def test_embargoed_extra_image_nvr_raises(self):
+        """An embargoed NVR passed via --extra-image-nvrs must fail the release."""
+        pipeline = self._make_pipeline(extra_image_nvrs=["oadp-velero-container-1.5.3-1.p3"])
+
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(pipeline.run())
+        self.assertIn("embargoed", str(ctx.exception))
+        self.assertIn("oadp-velero-container-1.5.3-1.p3", str(ctx.exception))
+
+    def test_non_embargoed_nvrs_do_not_raise_embargo_error(self):
+        """Public (non-embargoed) NVRs should not trigger the embargo defensive check."""
+        pipeline = self._make_pipeline(extra_image_nvrs=["oadp-velero-container-1.5.3-1.p2"])
+        pipeline.create_snapshot = AsyncMock(return_value=MagicMock())
+        pipeline.create_shipment_config = MagicMock(return_value=MagicMock())
+        pipeline.write_shipment_files_locally = AsyncMock()
+
+        try:
+            asyncio.run(pipeline.run())
+        except RuntimeError as e:
+            self.assertNotIn("embargoed", str(e))
 
 
 class TestSetShipmentMrReady(unittest.TestCase):
@@ -1228,7 +1283,7 @@ class TestOcpOptionalMode(unittest.TestCase):
     def test_extra_image_nvrs_merged_into_extras_key(self):
         """In OCP optional mode, extra_image_nvrs should merge into 'extras', not 'image'."""
         pipeline = self._make_pipeline(ocp_optional=True)
-        pipeline.extra_image_nvrs = ["extra-operator-container-v4.22.0-1.el9"]
+        pipeline.extra_image_nvrs = ["extra-operator-container-v4.22.0-1.el9.p2"]
         pipeline.fbc_pullspecs = []
         pipeline.check_env_vars = MagicMock()
         pipeline.setup_working_dir = MagicMock()
@@ -1241,7 +1296,7 @@ class TestOcpOptionalMode(unittest.TestCase):
         asyncio.run(pipeline.run())
 
         snapshot_call_args = pipeline.create_snapshot.call_args[0][0]
-        self.assertIn("extra-operator-container-v4.22.0-1.el9", snapshot_call_args)
+        self.assertIn("extra-operator-container-v4.22.0-1.el9.p2", snapshot_call_args)
 
         config_call_args = pipeline.create_shipment_config.call_args
         self.assertEqual(config_call_args[0][0], "extras")
@@ -1364,7 +1419,7 @@ class TestOcpOptionalMode(unittest.TestCase):
         pipeline = self._make_pipeline(ocp_optional=True)
         pipeline.create_mr = True
         pipeline.fbc_pullspecs = []
-        pipeline.extra_image_nvrs = ["extra-op-container-v4.22.0-1.el9"]
+        pipeline.extra_image_nvrs = ["extra-op-container-v4.22.0-1.el9.p2"]
         pipeline.check_env_vars = MagicMock()
         pipeline.setup_working_dir = MagicMock()
         pipeline.setup_shipment_repo = AsyncMock()
@@ -1393,7 +1448,7 @@ class TestOcpOptionalMode(unittest.TestCase):
         pipeline.product = "oadp"
         pipeline.create_mr = True
         pipeline.fbc_pullspecs = []
-        pipeline.extra_image_nvrs = ["oadp-container-v1.5.0-1.el9"]
+        pipeline.extra_image_nvrs = ["oadp-container-v1.5.0-1.el9.p2"]
         pipeline.check_env_vars = MagicMock()
         pipeline.setup_working_dir = MagicMock()
         pipeline.setup_shipment_repo = AsyncMock()


### PR DESCRIPTION
## Summary

Layered-product operator bundle rebase (`konflux_olm_bundler.py`) resolves every image reference in the CSV/manifests to a pinned digest, so embargoed (private-fix) content can be kept out of bundles/FBCs entirely, rather than needing to be filtered downstream. This PR implements that automatically, using the existing `doozer` commit-ancestry-based embargo detection (via NVR release `.p2`/`.p3` suffixes) - no data-model changes needed.

- **`artcommonlib/build_visibility.py`**: add `is_nvr_embargoed(nvr, build_system)` helper that checks embargo status directly from an NVR's release field.
- **`build_layered_products.py`**: drop any embargoed operator NVR before triggering its bundle build in `trigger_bundle_build()` (logging a warning; the previous public bundle stays latest until a public rebuild happens). `run()` now exits with code 2 when any operators were skipped this way, so the Jenkins job finishes UNSTABLE (visible warning) instead of a plain SUCCESS.
- **`konflux_olm_bundler.py`**: in `_replace_image_references()`, when a resolved operand image is embargoed, look up its `ImageMetadata` and substitute the latest public (non-embargoed) Konflux build of that same component. If no public build exists, the rebase fails with a new `KonfluxOlmBundleRebaseError` rather than silently shipping embargoed content. The component-metadata lookup map is built lazily (only when an embargoed operand is actually encountered) to avoid overhead on the common path.
- **`release_from_fbc.py`**: defensive check before shipment MR creation - raise a hard error if any embargoed NVR is found (from FBC pullspecs or a manual `--extra-image-nvrs` override). This should never trigger in practice since the two checkpoints above already guarantee clean output; if it does, it signals an upstream bug.

## Testing 

- Introduced manual .p3. pullspecs in https://github.com/openshift-priv/cluster-logging-operator/blob/art-logging-6.6-assembly-test-dgk-cluster-logging-operator/Dockerfile and https://github.com/openshift-priv/vector/blob/art-logging-6.6-assembly-test-dgk-vector/Dockerfile
- Triggered [build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Flayered-products/10500/console) while skipping rebase and running against this PR -> bundle build was successfully skipped

```
13:52:52  2026-07-15 17:52:52,197 pyartcd      WARNING Operator NVR ose-cluster-logging-operator-container-6.6.1-202607151535.p3.g678d2ac.assembly.test.el9 is embargoed; skipping bundle build trigger for it. The previous public bundle will remain the latest until a public rebuild.
13:52:52  2026-07-15 17:52:52,197 pyartcd      WARNING Job completed, but skipped triggering bundle build for 1 embargoed operator NVR(s): ose-cluster-logging-operator-container-6.6.1-202607151535.p3.g678d2ac.assembly.test.el9
```
- Job [failed](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Folm_bundle_konflux/28183/console) correctly when it couldn't pick a non-embargoed build as substitute

```
14:12:51      raise KonfluxOlmBundleRebaseError(
14:12:51  doozerlib.backend.konflux_olm_bundler.KonfluxOlmBundleRebaseError: Operand image vector-container-6.6.1-202607151535.p3.gca95fca.assembly.test.el9 referenced by operator cluster-logging-operator is embargoed, but no ART image metadata could be found for component 'vector-container' to look up a public substitute.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added embargo detection from NVRs to drive safer handling across pipelines.
  * Konflux layered-product bundle rebasing can substitute embargoed operands with the latest eligible public build when possible.

* **Bug Fixes**
  * Layered-product bundle triggering now skips embargoed operator builds and marks the job as unstable when any are skipped.
  * Release-from-FBC now refuses to create releases when embargoed/private-fix NVRs are provided or derived.

* **Tests**
  * Expanded coverage for embargo parsing, operand substitution behavior (including Brew scenarios), filtering/unstable logic, and defensive release validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->