### PR TITLE
ART-21639: preserve reinstall commands in Konflux Dockerfiles

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/dockerfile_transforms.py
+++ b/doozer/doozerlib/lockfile_prototype/dockerfile_transforms.py
@@ -76,13 +76,18 @@ def transform_reinstall_commands(df_content: str) -> str:
         str: Transformed Dockerfile text with reinstall commands wrapped.
     """
     reinstall_re = re.compile(
-        r"(\b(?:microdnf|dnf|yum)\s+(?:-\w+\s+)*reinstall\b[^&|;\\]*(?:\\\n[^&|;\\]*)*)"
+        r"(\b(?:microdnf|dnf|yum)\s+(?:-\w+\s+)*reinstall\b[^&|;\\\n]*(?:\\\n[^&|;\\\n]*)*)"
         r"(\s*&&\s*|\s*;\s*)?",
     )
 
     def _wrap(m: re.Match) -> str:
         cmd = m.group(1).rstrip()
+        if cmd.endswith("\\"):
+            cmd = cmd[:-1].rstrip()
         sep = m.group(2)
+        rest = m.string[m.end() :]
+        if not sep and rest.lstrip().startswith("||"):
+            return m.group(0)
         if sep:
             return f"({cmd} || true) {sep.lstrip()}"
         return f"({cmd} || true)"

--- a/doozer/doozerlib/lockfile_prototype/dockerfile_transforms.py
+++ b/doozer/doozerlib/lockfile_prototype/dockerfile_transforms.py
@@ -58,29 +58,36 @@ def strip_bare_updates_from_scripts(
                 logger.debug(f"Stripped bare updates from {script.relative_to(dest_dir)}")
 
 
-def strip_reinstall_commands(df_content: str) -> str:
+def transform_reinstall_commands(df_content: str) -> str:
     """
-    Remove microdnf/dnf/yum reinstall commands from a Dockerfile.
+    Make microdnf/dnf/yum reinstall commands fail-safe for hermetic builds.
 
-    In hermetic builds the base image packages are already at the exact
-    pinned version, so reinstalling them is redundant. The reinstall also
-    fails because the installed NEVRA is not available in the lockfile
-    repos (e.g. ``microdnf -y reinstall tzdata`` fails with
-    "Installed package tzdata-... not available").
-
-    Strips ``reinstall`` subcommands (with their package arguments) from
-    chained commands while preserving the rest of the chain.
+    In hermetic builds the installed NEVRA may not be available in the
+    lockfile repos, so ``reinstall`` can fail with "Installed package
+    not available". Rather than stripping the command entirely (which
+    drops semantically important re-extractions like ``reinstall
+    tzdata``), wrap each reinstall invocation in ``(cmd || true)`` so
+    it succeeds when the NEVRA matches and degrades gracefully when it
+    does not.
 
     Arg(s):
         df_content (str): Raw Dockerfile text.
     Return Value(s):
-        str: Transformed Dockerfile text with reinstall commands removed.
+        str: Transformed Dockerfile text with reinstall commands wrapped.
     """
     reinstall_re = re.compile(
-        r"\b(?:microdnf|dnf|yum)\s+(?:-\w+\s+)*reinstall\b[^&|;\\]*(?:\\\n[^&|;\\]*)*"
-        r"(?:\s*&&\s*|\s*;\s*)?",
+        r"(\b(?:microdnf|dnf|yum)\s+(?:-\w+\s+)*reinstall\b[^&|;\\]*(?:\\\n[^&|;\\]*)*)"
+        r"(\s*&&\s*|\s*;\s*)?",
     )
-    return reinstall_re.sub("", df_content)
+
+    def _wrap(m: re.Match) -> str:
+        cmd = m.group(1).rstrip()
+        sep = m.group(2)
+        if sep:
+            return f"({cmd} || true) {sep.lstrip()}"
+        return f"({cmd} || true)"
+
+    return reinstall_re.sub(_wrap, df_content)
 
 
 def fix_rpm_verify_commands(df_content: str) -> str:

--- a/doozer/doozerlib/lockfile_prototype/rebaser_hooks.py
+++ b/doozer/doozerlib/lockfile_prototype/rebaser_hooks.py
@@ -15,7 +15,7 @@ from doozerlib.lockfile_prototype.constants import DEFAULT_RPM_LOCKFILE_NAME
 from doozerlib.lockfile_prototype.dockerfile_transforms import (
     strip_bare_updates,
     strip_bare_updates_from_scripts,
-    strip_reinstall_commands,
+    transform_reinstall_commands,
 )
 from doozerlib.lockfile_prototype.generator import RpmLockfilePrototypeGenerator
 from doozerlib.lockfile_prototype.resolver import RpmResolver
@@ -126,5 +126,5 @@ def apply_dockerfile_transforms(
     if strip_updates:
         df_content = strip_bare_updates(df_content)
         strip_bare_updates_from_scripts(dest_dir, logger=_logger)
-    df_content = strip_reinstall_commands(df_content)
+    df_content = transform_reinstall_commands(df_content)
     df_path.write_text(df_content)

--- a/doozer/doozerlib/lockfile_prototype/rebaser_hooks.py
+++ b/doozer/doozerlib/lockfile_prototype/rebaser_hooks.py
@@ -104,12 +104,12 @@ def apply_dockerfile_transforms(
     logger: logging.Logger | None = None,
 ) -> None:
     """
-    Strip Dockerfile commands that fail in hermetic builds.
+    Transform Dockerfile commands for hermetic builds.
 
     Applied after lockfile generation so update targets are already
     resolved into the lockfile. Removes bare yum/dnf update commands
-    and reinstall commands (redundant when the base image already has
-    the pinned version).
+    and wraps reinstall commands in fail-safe ``(cmd || true)`` so
+    they degrade gracefully when the installed NEVRA is unavailable.
 
     Arg(s):
         dest_dir (Path): Build directory containing the Dockerfile.

--- a/doozer/doozerlib/lockfile_prototype/shell_parser.py
+++ b/doozer/doozerlib/lockfile_prototype/shell_parser.py
@@ -2,7 +2,8 @@
 Shell command parsing for RPM lockfile generation.
 
 Provides bashlex-based AST walking to extract package names from
-yum/dnf install and update commands in RUN bodies and shell scripts.
+yum/dnf install, update, and reinstall commands in RUN bodies and
+shell scripts.
 Handles variable assignments, arch-conditional blocks, subshell
 expansions, and bash-to-POSIX preprocessing.
 """
@@ -366,7 +367,7 @@ def _process_assignments(
 
 def _detect_pkg_action(word_values: list[str], ctx: _WalkContext) -> tuple[str | None, int]:
     """
-    Detect install/update/upgrade action in a dnf/yum command.
+    Detect install/update/upgrade/reinstall action in a dnf/yum command.
 
     Return Value(s):
         tuple[str | None, int]: (action, action_index) or (None, -1).

--- a/doozer/doozerlib/lockfile_prototype/shell_parser.py
+++ b/doozer/doozerlib/lockfile_prototype/shell_parser.py
@@ -382,6 +382,8 @@ def _detect_pkg_action(word_values: list[str], ctx: _WalkContext) -> tuple[str |
         if wl in ("update", "upgrade"):
             ctx.has_update = True
             return "update", idx
+        if wl == "reinstall":
+            return "reinstall", idx
         if wl in ("builddep", "build-dep"):
             return "builddep", idx
         if wl == "module":

--- a/doozer/tests/lockfile_prototype/test_dockerfile_transforms.py
+++ b/doozer/tests/lockfile_prototype/test_dockerfile_transforms.py
@@ -6,7 +6,7 @@ from doozerlib.lockfile_prototype.dockerfile_transforms import (
     fix_rpm_verify_commands,
     strip_bare_updates,
     strip_bare_updates_from_scripts,
-    strip_reinstall_commands,
+    transform_reinstall_commands,
 )
 
 
@@ -145,40 +145,39 @@ class TestStripBareUpdatesFromScripts(unittest.TestCase):
             self.assertEqual(mtime_before, mtime_after)
 
 
-class TestStripReinstallCommands(unittest.TestCase):
-    def test_strips_microdnf_reinstall(self):
+class TestTransformReinstallCommands(unittest.TestCase):
+    def test_wraps_microdnf_reinstall(self):
         content = "RUN microdnf -y install openssl && microdnf -y reinstall tzdata && microdnf clean all\n"
-        result = strip_reinstall_commands(content)
-        self.assertNotIn("reinstall", result)
+        result = transform_reinstall_commands(content)
+        self.assertIn("(microdnf -y reinstall tzdata || true)", result)
         self.assertIn("microdnf -y install openssl", result)
         self.assertIn("microdnf clean all", result)
 
-    def test_strips_dnf_reinstall(self):
+    def test_wraps_dnf_reinstall(self):
         content = "RUN dnf -y reinstall tzdata && dnf clean all\n"
-        result = strip_reinstall_commands(content)
-        self.assertNotIn("reinstall", result)
-        self.assertIn("dnf clean all", result)
+        result = transform_reinstall_commands(content)
+        self.assertIn("(dnf -y reinstall tzdata || true) && dnf clean all", result)
 
-    def test_strips_yum_reinstall(self):
+    def test_wraps_yum_reinstall(self):
         content = "RUN yum reinstall -y glibc && yum clean all\n"
-        result = strip_reinstall_commands(content)
-        self.assertNotIn("reinstall", result)
+        result = transform_reinstall_commands(content)
+        self.assertIn("(yum reinstall -y glibc || true)", result)
         self.assertIn("yum clean all", result)
 
-    def test_strips_reinstall_multiple_packages(self):
+    def test_wraps_reinstall_multiple_packages(self):
         content = "RUN microdnf -y reinstall tzdata glibc && microdnf clean all\n"
-        result = strip_reinstall_commands(content)
-        self.assertNotIn("reinstall", result)
+        result = transform_reinstall_commands(content)
+        self.assertIn("(microdnf -y reinstall tzdata glibc || true)", result)
         self.assertIn("microdnf clean all", result)
 
     def test_preserves_install_commands(self):
         content = "RUN microdnf -y install openssl && microdnf clean all\n"
-        result = strip_reinstall_commands(content)
+        result = transform_reinstall_commands(content)
         self.assertEqual(result, content)
 
     def test_no_reinstall_unchanged(self):
         content = "FROM base\nRUN yum install -y wget\n"
-        result = strip_reinstall_commands(content)
+        result = transform_reinstall_commands(content)
         self.assertEqual(result, content)
 
     def test_real_world_oadp_pattern(self):
@@ -191,8 +190,8 @@ class TestStripReinstallCommands(unittest.TestCase):
             "microdnf -y reinstall tzdata && "
             "microdnf clean all\n"
         )
-        result = strip_reinstall_commands(content)
-        self.assertNotIn("reinstall", result)
+        result = transform_reinstall_commands(content)
+        self.assertIn("(microdnf -y reinstall tzdata || true)", result)
         self.assertIn("microdnf -y install openssl", result)
         self.assertIn("microdnf clean all", result)
 

--- a/doozer/tests/lockfile_prototype/test_dockerfile_transforms.py
+++ b/doozer/tests/lockfile_prototype/test_dockerfile_transforms.py
@@ -195,6 +195,38 @@ class TestTransformReinstallCommands(unittest.TestCase):
         self.assertIn("microdnf -y install openssl", result)
         self.assertIn("microdnf clean all", result)
 
+    def test_does_not_cross_newline(self):
+        """
+        Reinstall at end of RUN must not consume the next Dockerfile
+        instruction across an unescaped newline.
+        """
+        content = "RUN dnf -y reinstall tzdata\nCOPY foo bar\n"
+        result = transform_reinstall_commands(content)
+        self.assertEqual(
+            result,
+            "RUN (dnf -y reinstall tzdata || true)\nCOPY foo bar\n",
+        )
+
+    def test_multiline_continuation(self):
+        """
+        Backslash-newline continuation is collapsed into a single line.
+        """
+        content = "RUN dnf -y reinstall tzdata \\\n    && dnf clean all\n"
+        result = transform_reinstall_commands(content)
+        self.assertEqual(
+            result,
+            "RUN (dnf -y reinstall tzdata || true) && dnf clean all\n",
+        )
+
+    def test_existing_or_fallback_unchanged(self):
+        """
+        If the reinstall already has an || fallback, leave it unchanged
+        to avoid making the original fallback unreachable.
+        """
+        content = "RUN dnf -y reinstall tzdata || echo failed && dnf clean all\n"
+        result = transform_reinstall_commands(content)
+        self.assertEqual(result, content)
+
 
 class TestFixRpmVerifyCommands(unittest.TestCase):
     def test_transforms_variable_package_list(self):

--- a/doozer/tests/lockfile_prototype/test_shell_parser.py
+++ b/doozer/tests/lockfile_prototype/test_shell_parser.py
@@ -113,6 +113,23 @@ class TestExtractPackagesFromRunCommands(unittest.TestCase):
         self.assertEqual(common, ["make"])
         self.assertEqual(arch, {"x86_64": ["kernel-rt-devel", "kernel-rt-modules"]})
 
+    def test_reinstall_packages_parsed(self):
+        run_values = ["dnf -y reinstall tzdata && dnf clean all"]
+        common, arch = extract_packages_from_run_commands(run_values)
+        self.assertIn("tzdata", common)
+
+    def test_reinstall_multiple_packages_parsed(self):
+        run_values = ["microdnf -y reinstall tzdata glibc && microdnf clean all"]
+        common, arch = extract_packages_from_run_commands(run_values)
+        self.assertIn("tzdata", common)
+        self.assertIn("glibc", common)
+
+    def test_reinstall_mixed_with_install(self):
+        run_values = ["microdnf -y install openssl && microdnf -y reinstall tzdata && microdnf clean all"]
+        common, arch = extract_packages_from_run_commands(run_values)
+        self.assertIn("openssl", common)
+        self.assertIn("tzdata", common)
+
     def test_fallback_install_after_or(self):
         run_values = ["dnf -y install gcc-${GCC_VERSION} gcc-c++-${GCC_VERSION} || dnf -y install gcc gcc-c++"]
         common, arch = extract_packages_from_run_commands(run_values)

--- a/doozer/tests/lockfile_prototype/test_shell_parser.py
+++ b/doozer/tests/lockfile_prototype/test_shell_parser.py
@@ -117,18 +117,21 @@ class TestExtractPackagesFromRunCommands(unittest.TestCase):
         run_values = ["dnf -y reinstall tzdata && dnf clean all"]
         common, arch = extract_packages_from_run_commands(run_values)
         self.assertIn("tzdata", common)
+        self.assertEqual(arch, {})
 
     def test_reinstall_multiple_packages_parsed(self):
         run_values = ["microdnf -y reinstall tzdata glibc && microdnf clean all"]
         common, arch = extract_packages_from_run_commands(run_values)
         self.assertIn("tzdata", common)
         self.assertIn("glibc", common)
+        self.assertEqual(arch, {})
 
     def test_reinstall_mixed_with_install(self):
         run_values = ["microdnf -y install openssl && microdnf -y reinstall tzdata && microdnf clean all"]
         common, arch = extract_packages_from_run_commands(run_values)
         self.assertIn("openssl", common)
         self.assertIn("tzdata", common)
+        self.assertEqual(arch, {})
 
     def test_fallback_install_after_or(self):
         run_values = ["dnf -y install gcc-${GCC_VERSION} gcc-c++-${GCC_VERSION} || dnf -y install gcc gcc-c++"]


### PR DESCRIPTION
Previously, strip_reinstall_commands() unconditionally removed all dnf/microdnf/yum reinstall commands from Dockerfiles during Konflux builds. This caused semantically important re-extractions (e.g. reinstall tzdata for timezone data) to be silently dropped, breaking images that depend on the reinstalled package files.

Two fixes:
- Parse reinstall as a recognized action in the shell parser so reinstall packages are included in the lockfile resolution
- Transform reinstall commands to (cmd || true) instead of stripping them, so they succeed when the NEVRA matches and degrade gracefully when it does not

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reinstall package commands are no longer removed during hermetic builds; they are rewritten to fail safely when referenced packages aren’t available.
  * Package discovery now recognizes `reinstall` for `dnf`, `yum`, and `microdnf`, ensuring those packages are included in processing.
* **Tests**
  * Updated and expanded coverage to validate the new reinstall-command behavior, including single, multiple, and mixed install/reinstall flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->