### PR TITLE
ART-21572: Add elliott verify-signatures command for image signed check

### DIFF
--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -75,6 +75,7 @@ from elliottlib.cli.verify_attached_bugs_cli import verify_attached_bugs_cli
 from elliottlib.cli.verify_attached_operators_cli import verify_attached_operators_cli
 from elliottlib.cli.verify_cvp_cli import verify_cvp_cli
 from elliottlib.cli.verify_payload import verify_payload
+from elliottlib.cli.verify_signatures_cli import verify_signatures_cli
 from elliottlib.exceptions import ElliottFatalError
 from elliottlib.util import pbar_header, progress_func
 
@@ -323,6 +324,7 @@ cli.add_command(shipment_cli)
 cli.add_command(watch_release_cli)
 cli.add_command(find_bugs_second_fix_cli)
 cli.add_command(process_release_from_fbc_bugs_cli)
+cli.add_command(verify_signatures_cli)
 
 # -----------------------------------------------------------------------------
 # CLI Entry point

--- a/elliott/elliottlib/cli/verify_signatures_cli.py
+++ b/elliott/elliottlib/cli/verify_signatures_cli.py
@@ -1,0 +1,218 @@
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+import aiohttp
+import click
+from artcommonlib import exectools
+
+from elliottlib.cli.common import cli, click_coroutine
+
+LOGGER = logging.getLogger(__name__)
+
+SIGNATURE_MIRROR_BASE = "https://mirror.openshift.com/pub/openshift-v4/signatures"
+DEV_MIRROR_PATH = "openshift-release-dev/ocp-release"
+PROD_MIRROR_PATH = "openshift/release"
+RELEASE_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-release"
+MAX_SIGNATURE_PROBES = 100
+
+
+@dataclass
+class SignatureCheckResult:
+    arch: str
+    pullspec: str
+    digest: str
+    dev_mirror: Optional[bool] = None
+    prod_mirror: Optional[bool] = None
+
+    @property
+    def passed(self) -> bool:
+        results = []
+        if self.dev_mirror is not None:
+            results.append(self.dev_mirror)
+        if self.prod_mirror is not None:
+            results.append(self.prod_mirror)
+        return bool(results) and all(results)
+
+
+@dataclass
+class VerifySignaturesResult:
+    release_name: str
+    arch_results: list[SignatureCheckResult] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        if self.errors:
+            return False
+        return bool(self.arch_results) and all(r.passed for r in self.arch_results)
+
+
+async def get_release_image_digest(pullspec: str) -> str:
+    cmd = ["oc", "image", "info", "-o", "json", pullspec]
+    rc, out, err = await exectools.cmd_gather_async(cmd)
+    if rc:
+        raise RuntimeError(f"oc image info failed for {pullspec}: {err.strip()}")
+    data = json.loads(out)
+    if isinstance(data, list):
+        data = data[0] if data else {}
+    digest = data.get("digest")
+    if not digest:
+        raise RuntimeError(f"No digest found for {pullspec}")
+    return digest
+
+
+async def check_signature_on_mirror(sha: str, mirror_path: str) -> bool:
+    base_url = f"{SIGNATURE_MIRROR_BASE}/{mirror_path}/sha256={sha}"
+    async with aiohttp.ClientSession() as session:
+        for sig_num in range(1, MAX_SIGNATURE_PROBES + 1):
+            url = f"{base_url}/signature-{sig_num}"
+            async with session.get(url) as response:
+                if response.status == 200:
+                    LOGGER.info("Found signature at %s", url)
+                    return True
+                if response.status == 404:
+                    return False
+                raise aiohttp.ClientResponseError(
+                    response.request_info,
+                    response.history,
+                    status=response.status,
+                    message=f"Unexpected status {response.status} from {url}",
+                )
+    LOGGER.warning("Reached max probes (%d) for %s — treating as unsigned", MAX_SIGNATURE_PROBES, sha)
+    return False
+
+
+async def verify_release_signatures(release_name, arches, check_dev, check_prod) -> VerifySignaturesResult:
+    result = VerifySignaturesResult(release_name=release_name)
+
+    for arch in arches:
+        pullspec = f"{RELEASE_IMAGE_REPO}:{release_name}-{arch}"
+        LOGGER.info("Checking signatures for %s", pullspec)
+
+        try:
+            digest = await get_release_image_digest(pullspec)
+        except Exception as e:
+            result.errors.append(f"{arch}: failed to get digest for {pullspec}: {e}")
+            continue
+
+        sha = digest.removeprefix("sha256:")
+        check = SignatureCheckResult(arch=arch, pullspec=pullspec, digest=digest)
+
+        if check_dev:
+            try:
+                check.dev_mirror = await check_signature_on_mirror(sha, DEV_MIRROR_PATH)
+            except Exception as e:
+                result.errors.append(f"{arch}: dev mirror check failed: {e}")
+            else:
+                status = "OK" if check.dev_mirror else "MISSING"
+                LOGGER.info("%s: dev mirror signature %s", arch, status)
+
+        if check_prod:
+            try:
+                check.prod_mirror = await check_signature_on_mirror(sha, PROD_MIRROR_PATH)
+            except Exception as e:
+                result.errors.append(f"{arch}: prod mirror check failed: {e}")
+            else:
+                status = "OK" if check.prod_mirror else "MISSING"
+                LOGGER.info("%s: prod mirror signature %s", arch, status)
+
+        result.arch_results.append(check)
+
+    return result
+
+
+def render_result(result: VerifySignaturesResult, output: str) -> str:
+    if output == "json":
+        data = {
+            "release": result.release_name,
+            "passed": result.passed,
+            "arch_results": [
+                {
+                    "arch": r.arch,
+                    "pullspec": r.pullspec,
+                    "digest": r.digest,
+                    "dev_mirror": r.dev_mirror,
+                    "prod_mirror": r.prod_mirror,
+                    "passed": r.passed,
+                }
+                for r in result.arch_results
+            ],
+            "errors": result.errors,
+        }
+        return json.dumps(data, indent=2)
+
+    lines = [f"Release: {result.release_name}", ""]
+    for r in result.arch_results:
+        status = "PASS" if r.passed else "FAIL"
+        lines.append(f"  {r.arch}: {status}")
+        lines.append(f"    pullspec: {r.pullspec}")
+        lines.append(f"    digest:   {r.digest}")
+        if r.dev_mirror is not None:
+            lines.append(f"    dev mirror:  {'OK' if r.dev_mirror else 'MISSING'}")
+        if r.prod_mirror is not None:
+            lines.append(f"    prod mirror: {'OK' if r.prod_mirror else 'MISSING'}")
+        lines.append("")
+
+    if result.errors:
+        lines.append("Errors:")
+        for err in result.errors:
+            lines.append(f"  - {err}")
+        lines.append("")
+
+    overall = "PASS" if result.passed else "FAIL"
+    lines.append(f"Overall: {overall}")
+    return "\n".join(lines)
+
+
+@cli.command("verify-signatures", short_help="Verify release image signatures on mirror")
+@click.option(
+    "--arch",
+    "arches",
+    multiple=True,
+    help="Architecture(s) to check. Can be specified multiple times. Defaults to group arches from ocp-build-data.",
+)
+@click.option(
+    "--check-dev-mirror/--no-check-dev-mirror",
+    default=True,
+    show_default=True,
+    help="Check signatures on dev mirror (openshift-release-dev/ocp-release).",
+)
+@click.option(
+    "--check-prod-mirror/--no-check-prod-mirror",
+    default=True,
+    show_default=True,
+    help="Check signatures on prod mirror (openshift/release).",
+)
+@click.option(
+    "-o", "--output", type=click.Choice(["text", "json"]), default="text", show_default=True, help="Output format."
+)
+@click.pass_obj
+@click_coroutine
+async def verify_signatures_cli(runtime, arches, check_dev_mirror, check_prod_mirror, output):
+    """Verify release image signatures on mirror.
+
+    Requires --group and --assembly global options. Uses the assembly name
+    as the release name and group arches as default architectures.
+
+    Example:
+        elliott --group openshift-4.18 --assembly 4.18.51 verify-signatures
+    """
+    runtime.initialize(config_only=True)
+    if not check_dev_mirror and not check_prod_mirror:
+        raise click.UsageError("At least one of --check-dev-mirror or --check-prod-mirror must be enabled.")
+
+    release_name = runtime.assembly
+    if not arches:
+        arches = runtime.group_config.get('arches', ['x86_64'])
+
+    result = await verify_release_signatures(
+        release_name=release_name,
+        arches=arches,
+        check_dev=check_dev_mirror,
+        check_prod=check_prod_mirror,
+    )
+    click.echo(render_result(result, output))
+    if not result.passed:
+        raise SystemExit(1)

--- a/elliott/elliottlib/cli/verify_signatures_cli.py
+++ b/elliott/elliottlib/cli/verify_signatures_cli.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from dataclasses import dataclass, field
@@ -84,41 +85,51 @@ async def check_signature_on_mirror(sha: str, mirror_path: str) -> bool:
     return False
 
 
+async def _check_arch(arch, release_name, check_dev, check_prod) -> tuple[SignatureCheckResult | None, list[str]]:
+    errors = []
+    pullspec = f"{RELEASE_IMAGE_REPO}:{release_name}-{arch}"
+    LOGGER.info("Checking signatures for %s", pullspec)
+
+    try:
+        digest = await get_release_image_digest(pullspec)
+    except Exception as e:
+        errors.append(f"{arch}: failed to get digest for {pullspec}: {e}")
+        return None, errors
+
+    sha = digest.removeprefix("sha256:")
+    check = SignatureCheckResult(arch=arch, pullspec=pullspec, digest=digest)
+
+    if check_dev:
+        try:
+            check.dev_mirror = await check_signature_on_mirror(sha, DEV_MIRROR_PATH)
+        except Exception as e:
+            errors.append(f"{arch}: dev mirror check failed: {e}")
+        else:
+            status = "OK" if check.dev_mirror else "MISSING"
+            LOGGER.info("%s: dev mirror signature %s", arch, status)
+
+    if check_prod:
+        try:
+            check.prod_mirror = await check_signature_on_mirror(sha, PROD_MIRROR_PATH)
+        except Exception as e:
+            errors.append(f"{arch}: prod mirror check failed: {e}")
+        else:
+            status = "OK" if check.prod_mirror else "MISSING"
+            LOGGER.info("%s: prod mirror signature %s", arch, status)
+
+    return check, errors
+
+
 async def verify_release_signatures(release_name, arches, check_dev, check_prod) -> VerifySignaturesResult:
     result = VerifySignaturesResult(release_name=release_name)
 
-    for arch in arches:
-        pullspec = f"{RELEASE_IMAGE_REPO}:{release_name}-{arch}"
-        LOGGER.info("Checking signatures for %s", pullspec)
+    tasks = [_check_arch(arch, release_name, check_dev, check_prod) for arch in arches]
+    arch_results = await asyncio.gather(*tasks)
 
-        try:
-            digest = await get_release_image_digest(pullspec)
-        except Exception as e:
-            result.errors.append(f"{arch}: failed to get digest for {pullspec}: {e}")
-            continue
-
-        sha = digest.removeprefix("sha256:")
-        check = SignatureCheckResult(arch=arch, pullspec=pullspec, digest=digest)
-
-        if check_dev:
-            try:
-                check.dev_mirror = await check_signature_on_mirror(sha, DEV_MIRROR_PATH)
-            except Exception as e:
-                result.errors.append(f"{arch}: dev mirror check failed: {e}")
-            else:
-                status = "OK" if check.dev_mirror else "MISSING"
-                LOGGER.info("%s: dev mirror signature %s", arch, status)
-
-        if check_prod:
-            try:
-                check.prod_mirror = await check_signature_on_mirror(sha, PROD_MIRROR_PATH)
-            except Exception as e:
-                result.errors.append(f"{arch}: prod mirror check failed: {e}")
-            else:
-                status = "OK" if check.prod_mirror else "MISSING"
-                LOGGER.info("%s: prod mirror signature %s", arch, status)
-
-        result.arch_results.append(check)
+    for check, errors in arch_results:
+        result.errors.extend(errors)
+        if check:
+            result.arch_results.append(check)
 
     return result
 

--- a/elliott/elliottlib/cli/verify_signatures_cli.py
+++ b/elliott/elliottlib/cli/verify_signatures_cli.py
@@ -199,7 +199,7 @@ async def verify_signatures_cli(runtime, arches, check_dev_mirror, check_prod_mi
     Example:
         elliott --group openshift-4.18 --assembly 4.18.51 verify-signatures
     """
-    runtime.initialize(config_only=True)
+    runtime.initialize()
     if not check_dev_mirror and not check_prod_mirror:
         raise click.UsageError("At least one of --check-dev-mirror or --check-prod-mirror must be enabled.")
 

--- a/elliott/tests/test_verify_signatures_cli.py
+++ b/elliott/tests/test_verify_signatures_cli.py
@@ -1,0 +1,267 @@
+import json
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+from elliottlib.cli.verify_signatures_cli import (
+    SignatureCheckResult,
+    VerifySignaturesResult,
+    check_signature_on_mirror,
+    get_release_image_digest,
+    render_result,
+    verify_release_signatures,
+)
+
+
+class TestSignatureCheckResult(TestCase):
+    def test_passed_dev_only_true(self):
+        r = SignatureCheckResult(arch="x86_64", pullspec="p", digest="d", dev_mirror=True)
+        self.assertTrue(r.passed)
+
+    def test_passed_dev_only_false(self):
+        r = SignatureCheckResult(arch="x86_64", pullspec="p", digest="d", dev_mirror=False)
+        self.assertFalse(r.passed)
+
+    def test_passed_both_true(self):
+        r = SignatureCheckResult(arch="x86_64", pullspec="p", digest="d", dev_mirror=True, prod_mirror=True)
+        self.assertTrue(r.passed)
+
+    def test_passed_mixed(self):
+        r = SignatureCheckResult(arch="x86_64", pullspec="p", digest="d", dev_mirror=True, prod_mirror=False)
+        self.assertFalse(r.passed)
+
+    def test_passed_no_checks(self):
+        r = SignatureCheckResult(arch="x86_64", pullspec="p", digest="d")
+        self.assertFalse(r.passed)
+
+
+class TestVerifySignaturesResult(TestCase):
+    def test_passed_all_good(self):
+        r = VerifySignaturesResult(
+            release_name="4.18.36",
+            arch_results=[
+                SignatureCheckResult(arch="x86_64", pullspec="p1", digest="d1", dev_mirror=True),
+                SignatureCheckResult(arch="aarch64", pullspec="p2", digest="d2", dev_mirror=True),
+            ],
+        )
+        self.assertTrue(r.passed)
+
+    def test_passed_one_fail(self):
+        r = VerifySignaturesResult(
+            release_name="4.18.36",
+            arch_results=[
+                SignatureCheckResult(arch="x86_64", pullspec="p1", digest="d1", dev_mirror=True),
+                SignatureCheckResult(arch="aarch64", pullspec="p2", digest="d2", dev_mirror=False),
+            ],
+        )
+        self.assertFalse(r.passed)
+
+    def test_passed_with_errors(self):
+        r = VerifySignaturesResult(
+            release_name="4.18.36",
+            arch_results=[
+                SignatureCheckResult(arch="x86_64", pullspec="p1", digest="d1", dev_mirror=True),
+            ],
+            errors=["something went wrong"],
+        )
+        self.assertFalse(r.passed)
+
+    def test_passed_empty(self):
+        r = VerifySignaturesResult(release_name="4.18.36")
+        self.assertFalse(r.passed)
+
+
+class TestCheckSignatureOnMirror(IsolatedAsyncioTestCase):
+    async def test_found_signature(self):
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("elliottlib.cli.verify_signatures_cli.aiohttp.ClientSession", return_value=mock_session):
+            result = await check_signature_on_mirror("abc123", "openshift-release-dev/ocp-release")
+        self.assertTrue(result)
+
+    async def test_not_found(self):
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("elliottlib.cli.verify_signatures_cli.aiohttp.ClientSession", return_value=mock_session):
+            result = await check_signature_on_mirror("abc123", "openshift-release-dev/ocp-release")
+        self.assertFalse(result)
+
+    async def test_server_error_raises(self):
+        mock_response = AsyncMock()
+        mock_response.status = 500
+        mock_response.request_info = MagicMock()
+        mock_response.history = ()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("elliottlib.cli.verify_signatures_cli.aiohttp.ClientSession", return_value=mock_session):
+            with self.assertRaises(aiohttp.ClientResponseError):
+                await check_signature_on_mirror("abc123", "openshift-release-dev/ocp-release")
+
+
+class TestGetReleaseImageDigest(IsolatedAsyncioTestCase):
+    async def test_success(self):
+        mock_output = json.dumps({"digest": "sha256:abc123"})
+        with patch(
+            "elliottlib.cli.verify_signatures_cli.exectools.cmd_gather_async", new_callable=AsyncMock
+        ) as mock_cmd:
+            mock_cmd.return_value = (0, mock_output, "")
+            result = await get_release_image_digest("quay.io/openshift-release-dev/ocp-release:4.18.36-x86_64")
+        self.assertEqual(result, "sha256:abc123")
+
+    async def test_list_response(self):
+        mock_output = json.dumps([{"digest": "sha256:def456"}])
+        with patch(
+            "elliottlib.cli.verify_signatures_cli.exectools.cmd_gather_async", new_callable=AsyncMock
+        ) as mock_cmd:
+            mock_cmd.return_value = (0, mock_output, "")
+            result = await get_release_image_digest("pullspec")
+        self.assertEqual(result, "sha256:def456")
+
+    async def test_command_failure(self):
+        with patch(
+            "elliottlib.cli.verify_signatures_cli.exectools.cmd_gather_async", new_callable=AsyncMock
+        ) as mock_cmd:
+            mock_cmd.return_value = (1, "", "error msg")
+            with self.assertRaises(RuntimeError):
+                await get_release_image_digest("pullspec")
+
+    async def test_missing_digest(self):
+        mock_output = json.dumps({"config": {}})
+        with patch(
+            "elliottlib.cli.verify_signatures_cli.exectools.cmd_gather_async", new_callable=AsyncMock
+        ) as mock_cmd:
+            mock_cmd.return_value = (0, mock_output, "")
+            with self.assertRaises(RuntimeError):
+                await get_release_image_digest("pullspec")
+
+
+class TestVerifyReleaseSignatures(IsolatedAsyncioTestCase):
+    async def test_single_arch_pass(self):
+        with (
+            patch(
+                "elliottlib.cli.verify_signatures_cli.get_release_image_digest", new_callable=AsyncMock
+            ) as mock_digest,
+            patch(
+                "elliottlib.cli.verify_signatures_cli.check_signature_on_mirror", new_callable=AsyncMock
+            ) as mock_check,
+        ):
+            mock_digest.return_value = "sha256:abc123"
+            mock_check.return_value = True
+            result = await verify_release_signatures("4.18.36", ["x86_64"], check_dev=True, check_prod=False)
+        self.assertTrue(result.passed)
+        self.assertEqual(len(result.arch_results), 1)
+        self.assertTrue(result.arch_results[0].dev_mirror)
+
+    async def test_single_arch_fail(self):
+        with (
+            patch(
+                "elliottlib.cli.verify_signatures_cli.get_release_image_digest", new_callable=AsyncMock
+            ) as mock_digest,
+            patch(
+                "elliottlib.cli.verify_signatures_cli.check_signature_on_mirror", new_callable=AsyncMock
+            ) as mock_check,
+        ):
+            mock_digest.return_value = "sha256:abc123"
+            mock_check.return_value = False
+            result = await verify_release_signatures("4.18.36", ["x86_64"], check_dev=True, check_prod=False)
+        self.assertFalse(result.passed)
+
+    async def test_digest_error(self):
+        with patch(
+            "elliottlib.cli.verify_signatures_cli.get_release_image_digest", new_callable=AsyncMock
+        ) as mock_digest:
+            mock_digest.side_effect = RuntimeError("oc failed")
+            result = await verify_release_signatures("4.18.36", ["x86_64"], check_dev=True, check_prod=False)
+        self.assertFalse(result.passed)
+        self.assertEqual(len(result.errors), 1)
+        self.assertIn("failed to get digest", result.errors[0])
+
+    async def test_multi_arch(self):
+        with (
+            patch(
+                "elliottlib.cli.verify_signatures_cli.get_release_image_digest", new_callable=AsyncMock
+            ) as mock_digest,
+            patch(
+                "elliottlib.cli.verify_signatures_cli.check_signature_on_mirror", new_callable=AsyncMock
+            ) as mock_check,
+        ):
+            mock_digest.return_value = "sha256:abc123"
+            mock_check.return_value = True
+            result = await verify_release_signatures("4.18.36", ["x86_64", "aarch64"], check_dev=True, check_prod=False)
+        self.assertTrue(result.passed)
+        self.assertEqual(len(result.arch_results), 2)
+
+    async def test_both_mirrors(self):
+        with (
+            patch(
+                "elliottlib.cli.verify_signatures_cli.get_release_image_digest", new_callable=AsyncMock
+            ) as mock_digest,
+            patch(
+                "elliottlib.cli.verify_signatures_cli.check_signature_on_mirror", new_callable=AsyncMock
+            ) as mock_check,
+        ):
+            mock_digest.return_value = "sha256:abc123"
+            mock_check.return_value = True
+            result = await verify_release_signatures("4.18.36", ["x86_64"], check_dev=True, check_prod=True)
+        self.assertTrue(result.passed)
+        self.assertTrue(result.arch_results[0].dev_mirror)
+        self.assertTrue(result.arch_results[0].prod_mirror)
+        self.assertEqual(mock_check.call_count, 2)
+
+
+class TestRenderResult(TestCase):
+    def test_text_output(self):
+        result = VerifySignaturesResult(
+            release_name="4.18.36",
+            arch_results=[
+                SignatureCheckResult(arch="x86_64", pullspec="p1", digest="sha256:abc", dev_mirror=True),
+            ],
+        )
+        text = render_result(result, "text")
+        self.assertIn("Release: 4.18.36", text)
+        self.assertIn("PASS", text)
+        self.assertIn("x86_64", text)
+
+    def test_json_output(self):
+        result = VerifySignaturesResult(
+            release_name="4.18.36",
+            arch_results=[
+                SignatureCheckResult(arch="x86_64", pullspec="p1", digest="sha256:abc", dev_mirror=True),
+            ],
+        )
+        text = render_result(result, "json")
+        data = json.loads(text)
+        self.assertEqual(data["release"], "4.18.36")
+        self.assertTrue(data["passed"])
+        self.assertEqual(len(data["arch_results"]), 1)
+
+    def test_text_with_errors(self):
+        result = VerifySignaturesResult(
+            release_name="4.18.36",
+            errors=["something broke"],
+        )
+        text = render_result(result, "text")
+        self.assertIn("FAIL", text)
+        self.assertIn("something broke", text)


### PR DESCRIPTION
rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `verify-release-signatures` CLI pipeline to verify release image signatures across selected architectures, with optional dev/prod sigstore mirror checks.
  * Added human-readable and JSON output showing overall PASS/FAIL and per-architecture mirror status.
  * Exposed signature verification as a public, importable entry point.
* **Bug Fixes**
  * Improved signature checking by using dedicated sigstore mirror probing and refactoring legacy verification logic for clearer pass/fail handling.
* **Tests**
  * Added end-to-end tests covering digest lookup failures, missing/invalid signatures, mirror-disabled behavior, error propagation, and both output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->