### PR TITLE
Revert "Revert "ART-21641: Keep private fix content out of layered-product bundles and FBCs""

### DIFF
--- a/artcommon/artcommonlib/build_visibility.py
+++ b/artcommon/artcommonlib/build_visibility.py
@@ -48,6 +48,17 @@ def is_release_embargoed(release: str, build_system: str, default=True) -> bool:
     return default
 
 
+def is_nvr_embargoed(nvr: str, build_system: str = 'konflux') -> bool:
+    """
+    Determine embargo status directly from an NVR string, by inspecting its release field.
+    E.g. 'foo-1.0-1.p3' -> True (konflux, private), 'foo-1.0-1.p2' -> False (konflux, public)
+    """
+    from artcommonlib.rpm_utils import parse_nvr
+
+    release = parse_nvr(nvr)['release']
+    return is_release_embargoed(release, build_system)
+
+
 def get_visibility_suffix(build_system: str, visibility: BuildVisibility) -> str:
     """
     Get the p? flag based on the visibility status and the build system. E.g.:

--- a/artcommon/artcommonlib/build_visibility.py
+++ b/artcommon/artcommonlib/build_visibility.py
@@ -50,13 +50,18 @@ def is_release_embargoed(release: str, build_system: str, default=True) -> bool:
 
 def is_nvr_embargoed(nvr: str, build_system: str = 'konflux') -> bool:
     """
-    Determine embargo status directly from an NVR string, by inspecting its release field.
+    Determine embargo status directly from an NVR string.
     E.g. 'foo-1.0-1.p3' -> True (konflux, private), 'foo-1.0-1.p2' -> False (konflux, public)
-    """
-    from artcommonlib.rpm_utils import parse_nvr
 
-    release = parse_nvr(nvr)['release']
-    return is_release_embargoed(release, build_system)
+    Note: this deliberately searches the *entire* NVR string for a visibility suffix rather
+    than isolating the release field first. Not all NVR shapes put the p-flag in the release
+    field: e.g. OLM bundle "metadata-container" NVRs embed the referenced operator's full
+    release string (including its p-flag) in the *version* field instead
+    (bundle_version = f'{operator_version}.{operator_release}' in konflux_olm_bundler.py),
+    while the bundle's own release is just a trivial build counter like "1". Searching the
+    whole NVR finds the p-flag wherever it actually lives.
+    """
+    return is_release_embargoed(nvr, build_system)
 
 
 def get_visibility_suffix(build_system: str, visibility: BuildVisibility) -> str:

--- a/artcommon/artcommonlib/build_visibility.py
+++ b/artcommon/artcommonlib/build_visibility.py
@@ -60,7 +60,18 @@ def is_nvr_embargoed(nvr: str, build_system: str = 'konflux') -> bool:
     (bundle_version = f'{operator_version}.{operator_release}' in konflux_olm_bundler.py),
     while the bundle's own release is just a trivial build counter like "1". Searching the
     whole NVR finds the p-flag wherever it actually lives.
+
+    Because the whole NVR is in scope, a p-flag-shaped token could theoretically turn up more
+    than once (e.g. an embedded operator release plus something else that happens to match).
+    Rather than silently trusting whichever match comes first, treat that as ambiguous and
+    raise, since we can't be sure which one (if any) reflects the actual embargo status.
     """
+    pflags = find_all_pflags_in_release(nvr)
+    if len(pflags) > 1:
+        raise ValueError(
+            f"NVR {nvr!r} contains multiple visibility-suffix matches {pflags!r}; refusing to "
+            "guess which one reflects the actual embargo status."
+        )
     return is_release_embargoed(nvr, build_system)
 
 
@@ -80,16 +91,23 @@ def get_all_visibility_suffixes() -> List[str]:
     return [suffix for d in VISIBILITY_SUFFIX.values() for suffix in d.values()]
 
 
+def find_all_pflags_in_release(release: str) -> List[str]:
+    """
+    Given a release (or NVR) string, return every visibility-suffix match found in it (e.g.
+    'p0', 'p1', 'p2', 'p3', or the wildcard 'p?'), in order of appearance. Usually 0 or 1
+    matches; more than one means the string is ambiguous.
+    """
+    suffixes = get_all_visibility_suffixes() + ['p?']
+    suffix_pattern = '|'.join(re.escape(suffix) for suffix in suffixes)
+    pattern = rf'\.({suffix_pattern})(?:\.|$)'
+    return re.findall(pattern, release)
+
+
 def isolate_pflag_in_release(release: str) -> Optional[str]:
     """
     Given a release field, determines whether it contains any of the visibility suffixes.
     If it does, it returns the matched suffix (e.g., 'p0', 'p1', 'p2', 'p3').
     If not found, returns None.
     """
-    suffixes = get_all_visibility_suffixes() + ['p?']
-    suffix_pattern = '|'.join(re.escape(suffix) for suffix in suffixes)
-    pattern = rf'\.({suffix_pattern})(?:\.|$)'
-    match = re.search(pattern, release)
-    if match:
-        return match.group(1)
-    return None
+    pflags = find_all_pflags_in_release(release)
+    return pflags[0] if pflags else None

--- a/artcommon/tests/test_build_visibility.py
+++ b/artcommon/tests/test_build_visibility.py
@@ -5,6 +5,7 @@ from artcommonlib.build_visibility import (
     get_all_visibility_suffixes,
     get_build_system,
     get_visibility_suffix,
+    is_nvr_embargoed,
     is_release_embargoed,
     isolate_pflag_in_release,
 )
@@ -41,6 +42,26 @@ class TestBuildVisibility(TestCase):
         # Wrong build system: KeyError is raised
         with self.assertRaises(KeyError):
             is_release_embargoed('v4.17.0-202503120643.p0', 'wrong')
+
+    def test_is_nvr_embargoed(self):
+        # Konflux (default build_system)
+        self.assertFalse(is_nvr_embargoed('foo-1.2.3-1.p2'))
+        self.assertTrue(is_nvr_embargoed('foo-1.2.3-1.p3'))
+
+        # Explicit konflux build_system
+        self.assertFalse(is_nvr_embargoed('foo-1.2.3-1.p2', 'konflux'))
+        self.assertTrue(is_nvr_embargoed('foo-1.2.3-1.p3', 'konflux'))
+
+        # Brew build_system
+        self.assertFalse(is_nvr_embargoed('foo-1.2.3-1.p0', 'brew'))
+        self.assertTrue(is_nvr_embargoed('foo-1.2.3-1.p1', 'brew'))
+
+        # No p? flag found: treat as embargoed
+        self.assertTrue(is_nvr_embargoed('foo-1.2.3-1'))
+
+        # Malformed NVR (no name/version/release separators): propagates ValueError from parse_nvr
+        with self.assertRaises(ValueError):
+            is_nvr_embargoed('not_an_nvr')
 
     def test_get_visibility_suffix(self):
         self.assertEqual(get_visibility_suffix('brew', BuildVisibility.PUBLIC), 'p0')

--- a/artcommon/tests/test_build_visibility.py
+++ b/artcommon/tests/test_build_visibility.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 
 from artcommonlib.build_visibility import (
     BuildVisibility,
+    find_all_pflags_in_release,
     get_all_visibility_suffixes,
     get_build_system,
     get_visibility_suffix,
@@ -79,6 +80,17 @@ class TestBuildVisibility(TestCase):
             )
         )
 
+        # Two distinct visibility-suffix matches in the same NVR: ambiguous, so refuse to
+        # guess which one applies and raise rather than silently trusting whichever comes first.
+        with self.assertRaises(ValueError):
+            is_nvr_embargoed('foo-1.0.p2.gabc123-1.p3')
+
+        # Even two matches of the *same* suffix are still treated as ambiguous: an NVR is
+        # never expected to carry a p-flag twice, so seeing it twice signals something
+        # unexpected about the NVR's shape that's worth investigating rather than papering over.
+        with self.assertRaises(ValueError):
+            is_nvr_embargoed('foo-1.0.p2.gabc123-1.p2')
+
     def test_get_visibility_suffix(self):
         self.assertEqual(get_visibility_suffix('brew', BuildVisibility.PUBLIC), 'p0')
         self.assertEqual(get_visibility_suffix('brew', BuildVisibility.PRIVATE), 'p1')
@@ -107,3 +119,9 @@ class TestBuildVisibility(TestCase):
         self.assertEqual(isolate_pflag_in_release('1.2.3-y.p4.p'), None)
         self.assertEqual(isolate_pflag_in_release('1.2.3-y.p.p?'), 'p?')
         self.assertEqual(isolate_pflag_in_release('1.2.3-y.p?.p4'), 'p?')
+
+    def test_find_all_pflags_in_release(self):
+        self.assertEqual(find_all_pflags_in_release('1.2.3-y.p.p1'), ['p1'])
+        self.assertEqual(find_all_pflags_in_release('1.2.3-y.p4.p'), [])
+        self.assertEqual(find_all_pflags_in_release('foo-1.0.p2.gabc123-1.p3'), ['p2', 'p3'])
+        self.assertEqual(find_all_pflags_in_release('foo-1.0.p2.gabc123-1.p2'), ['p2', 'p2'])

--- a/artcommon/tests/test_build_visibility.py
+++ b/artcommon/tests/test_build_visibility.py
@@ -56,12 +56,28 @@ class TestBuildVisibility(TestCase):
         self.assertFalse(is_nvr_embargoed('foo-1.2.3-1.p0', 'brew'))
         self.assertTrue(is_nvr_embargoed('foo-1.2.3-1.p1', 'brew'))
 
-        # No p? flag found: treat as embargoed
+        # No p? flag found anywhere in the NVR: treat as embargoed
         self.assertTrue(is_nvr_embargoed('foo-1.2.3-1'))
 
-        # Malformed NVR (no name/version/release separators): propagates ValueError from parse_nvr
-        with self.assertRaises(ValueError):
-            is_nvr_embargoed('not_an_nvr')
+        # Malformed NVR (no name/version/release separators): no p? flag found, so also
+        # defaults to embargoed. is_nvr_embargoed() searches the whole string for a p-flag
+        # pattern rather than parsing name/version/release, so it never raises here.
+        self.assertTrue(is_nvr_embargoed('not_an_nvr'))
+
+        # Bundle ("metadata-container") style NVRs embed the referenced operator's p-flag in
+        # the *version* segment (bundle_version = f'{operator_version}.{operator_release}'),
+        # not in the release segment, which is just a trivial build counter. Searching the
+        # whole NVR must still find it.
+        self.assertFalse(
+            is_nvr_embargoed(
+                'openshift-migration-operator-metadata-container-1.8.16.202607131859.p2.gafc12a7.assembly.stream.el8-1'
+            )
+        )
+        self.assertTrue(
+            is_nvr_embargoed(
+                'openshift-migration-operator-metadata-container-1.8.16.202607131859.p3.gafc12a7.assembly.stream.el8-1'
+            )
+        )
 
     def test_get_visibility_suffix(self):
         self.assertEqual(get_visibility_suffix('brew', BuildVisibility.PUBLIC), 'p0')

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -14,6 +14,7 @@ import yaml
 from artcommonlib import exectools
 from artcommonlib import util as artlib_util
 from artcommonlib.assembly import AssemblyTypes
+from artcommonlib.build_visibility import is_nvr_embargoed
 from artcommonlib.constants import KONFLUX_DEFAULT_IMAGE_SHARE_REPO
 from artcommonlib.konflux.konflux_build_record import (
     KonfluxBuildOutcome,
@@ -36,6 +37,13 @@ _LOGGER = logging.getLogger(__name__)
 
 
 BUNDLE_BUILD_PRIORITY = "3"
+
+
+class KonfluxOlmBundleRebaseError(Exception):
+    """Raised when an operator bundle cannot be safely rebased, e.g. an embargoed operand
+    image has no public substitute available."""
+
+    pass
 
 
 class KonfluxOlmBundleRebaser:
@@ -457,12 +465,58 @@ class KonfluxOlmBundleRebaser:
                 _delivery_override_map[_img_short] = _override_short
             except (yaml.YAMLError, OSError) as e:
                 self._logger.debug("Failed to parse image YAML %s: %s", _yml_path, e)
+        # Map component name (as it appears in the com.redhat.component label / NVR) to the
+        # ART ImageMetadata that builds it, so embargoed operands can be mapped back to a
+        # metadata object to query for a public substitute build. Computed lazily (only if an
+        # embargoed operand is actually encountered below) to avoid the cost of iterating every
+        # image metadata on the common (non-embargoed) path.
+        _component_to_meta: Optional[Dict[str, ImageMetadata]] = None
+
         for pullspec, image_info in zip(art_references, image_infos):
             image_labels = image_info['config']['config']['Labels']
             image_version = image_labels['version']
             image_release = image_labels['release']
             image_component_name = image_labels['com.redhat.component']
             image_nvr = f"{image_component_name}-{image_version}-{image_release}"
+
+            # Operator bundles are only ever shipped publicly, so they must never reference an
+            # embargoed (private-fix) operand image. If the resolved operand build is embargoed,
+            # substitute it with the latest public (non-embargoed) build of that same component.
+            # If no public build exists, fail the rebase rather than shipping embargoed content.
+            if engine is Engine.KONFLUX and is_nvr_embargoed(image_nvr):
+                if _component_to_meta is None:
+                    _component_to_meta = {im.get_component_name(): im for im in metadata.runtime.image_metas()}
+                operand_meta = _component_to_meta.get(image_component_name)
+                if operand_meta is None:
+                    raise KonfluxOlmBundleRebaseError(
+                        f"Operand image {image_nvr} referenced by operator {metadata.distgit_key} is "
+                        f"embargoed, but no ART image metadata could be found for component "
+                        f"'{image_component_name}' to look up a public substitute."
+                    )
+                public_build = await operand_meta.get_latest_konflux_build(
+                    default=None,
+                    el_target=operand_meta.branch_el_target(),
+                    embargoed=False,
+                    exclude_large_columns=True,
+                )
+                if not public_build:
+                    raise KonfluxOlmBundleRebaseError(
+                        f"Operand image {image_nvr} referenced by operator {metadata.distgit_key} is "
+                        f"embargoed, and no public (non-embargoed) build of '{operand_meta.distgit_key}' "
+                        f"is available to substitute. Cannot safely rebase this operator bundle."
+                    )
+                self._logger.warning(
+                    "Operand image %s referenced by operator %s is embargoed; substituting with public build %s",
+                    image_nvr,
+                    metadata.distgit_key,
+                    public_build.nvr,
+                )
+                image_info = await util.oc_image_info_for_arch_async(
+                    public_build.image_pullspec,
+                    registry_config=os.getenv("QUAY_AUTH_FILE"),
+                )
+                image_nvr = public_build.nvr
+
             namespace, image_short_name, image_tag = art_references[pullspec]
             image_sha = (
                 image_info['contentDigest']

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -483,7 +483,16 @@ class KonfluxOlmBundleRebaser:
             # embargoed (private-fix) operand image. If the resolved operand build is embargoed,
             # substitute it with the latest public (non-embargoed) build of that same component.
             # If no public build exists, fail the rebase rather than shipping embargoed content.
-            if engine is Engine.KONFLUX and is_nvr_embargoed(image_nvr):
+            try:
+                operand_is_embargoed = engine is Engine.KONFLUX and is_nvr_embargoed(image_nvr)
+            except ValueError as e:
+                # is_nvr_embargoed() raises when the NVR's embargo status is ambiguous (e.g. it
+                # matches more than one visibility suffix). Don't guess; fail the rebase.
+                raise KonfluxOlmBundleRebaseError(
+                    f"Unable to determine embargo status for operand image {image_nvr} referenced "
+                    f"by operator {metadata.distgit_key}: {e}"
+                ) from e
+            if operand_is_embargoed:
                 if _component_to_meta is None:
                     _component_to_meta = {im.get_component_name(): im for im in metadata.runtime.image_metas()}
                 operand_meta = _component_to_meta.get(image_component_name)

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -374,6 +374,29 @@ class KonfluxOlmBundleRebaser:
         pattern = r'([a-zA-Z0-9][-a-zA-Z0-9.]*(?::[0-9]+)?/[^@\s]+)@(sha256:[a-fA-F0-9]{64})'
         return re.compile(pattern)
 
+    @staticmethod
+    def _build_component_to_meta_map(runtime) -> Dict[str, "ImageMetadata"]:
+        """
+        Build a map of component name (as it appears in the com.redhat.component label / NVR) to
+        the ART ImageMetadata that builds it, covering every image declared in the group -- not
+        just the images actually loaded for this invocation.
+
+        `doozer beta:images:konflux:bundle <operator-nvr>` restricts `runtime.images` to just the
+        given operator(s) (see KonfluxBundleCli.get_operator_builds()), so `runtime.image_metas()`
+        alone would miss an embargoed operand image that belongs to a different (unloaded) image
+        in the same group, e.g. a dependent image referenced by the operator's CSV. Fall back to
+        `Runtime.late_resolve_image()`, which can resolve any image declared in the group's
+        `images/` directory on demand without adding it to `image_map` or triggering dependents.
+        """
+        component_to_meta = {im.get_component_name(): im for im in runtime.image_metas()}
+        for distgit_key in set(runtime.image_name_map.values()):
+            if distgit_key in runtime.image_map:
+                continue  # already covered by runtime.image_metas() above
+            other_meta = runtime.late_resolve_image(distgit_key, add=False, required=False)
+            if other_meta is not None:
+                component_to_meta.setdefault(other_meta.get_component_name(), other_meta)
+        return component_to_meta
+
     async def _replace_image_references(self, old_registry: str, content: str, engine: Engine, metadata):
         """
         Replace image references in the content by their corresponding SHA.
@@ -494,7 +517,7 @@ class KonfluxOlmBundleRebaser:
                 ) from e
             if operand_is_embargoed:
                 if _component_to_meta is None:
-                    _component_to_meta = {im.get_component_name(): im for im in metadata.runtime.image_metas()}
+                    _component_to_meta = self._build_component_to_meta_map(metadata.runtime)
                 operand_meta = _component_to_meta.get(image_component_name)
                 if operand_meta is None:
                     raise KonfluxOlmBundleRebaseError(

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -8,9 +8,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import yaml
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBundleBuildRecord
 from artcommonlib.konflux.konflux_db import Engine
+from artcommonlib.model import Model
 from doozerlib import constants
 from doozerlib.backend.konflux_client import ImageBuildParams
-from doozerlib.backend.konflux_olm_bundler import KonfluxOlmBundleBuilder, KonfluxOlmBundleRebaser
+from doozerlib.backend.konflux_olm_bundler import (
+    KonfluxOlmBundleBuilder,
+    KonfluxOlmBundleRebaseError,
+    KonfluxOlmBundleRebaser,
+)
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
 
 
@@ -91,7 +96,9 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
                     'Labels': {
                         'com.redhat.component': 'test-brew-component',
                         'version': '1.0',
-                        'release': '1',
+                        # Public (non-embargoed) Konflux release, so the embargo-substitution
+                        # path introduced for layered-product bundles is not exercised here.
+                        'release': '1.p2',
                     },
                     'Env': {
                         '__doozer_key=test-component',
@@ -128,7 +135,7 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
             (
                 'registry.example.com/namespace/image:tag',
                 'registry.redhat.io/openshift4/image@sha256:1234567890abcdef',
-                'test-brew-component-1.0-1',
+                'test-brew-component-1.0-1.p2',
             ),
         )
 
@@ -143,7 +150,8 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
                     'Labels': {
                         'com.redhat.component': 'test-component',
                         'version': '1.0',
-                        'release': '1',
+                        # Public (non-embargoed) Konflux release.
+                        'release': '1.p2',
                     },
                 },
             },
@@ -179,7 +187,8 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
                     'Labels': {
                         'com.redhat.component': 'test-component',
                         'version': '1.0',
-                        'release': '1',
+                        # Public (non-embargoed) Konflux release.
+                        'release': '1.p2',
                     },
                 },
             },
@@ -992,3 +1001,166 @@ class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
                 ["operand1-1.0-1", "operand2-1.0-1"],
             )
             self.assertIn('Failed writing record to the konflux DB', cm.output[0])
+
+
+class TestReplaceImageReferencesEmbargo(IsolatedAsyncioTestCase):
+    """Covers the embargoed-operand substitution logic added to _replace_image_references()
+    for layered-product operator bundles: embargoed operand references must never be shipped
+    in a public bundle, so they are substituted with the latest public build, or the rebase
+    fails clearly if no public substitute exists."""
+
+    def setUp(self):
+        self.rebaser = KonfluxOlmBundleRebaser(
+            base_dir=Path('/tmp/nonexistent-base-dir'),
+            group='openshift-4.18',
+            assembly='stream',
+            group_config=Model({}),
+            konflux_db=MagicMock(),
+            source_resolver=MagicMock(),
+            image_repo='quay.io/example/repo',
+            logger=MagicMock(),
+        )
+
+    def _make_metadata(self, image_metas=None):
+        metadata = MagicMock()
+        metadata.distgit_key = 'my-operator'
+        metadata.runtime.group = 'openshift-4.18'
+        metadata.runtime.data_dir = '/tmp/nonexistent-data-dir'
+        metadata.runtime.image_metas.return_value = image_metas or []
+        return metadata
+
+    @staticmethod
+    def _image_info(component, version, release, digest_suffix):
+        return {
+            'config': {
+                'config': {'Labels': {'version': version, 'release': release, 'com.redhat.component': component}}
+            },
+            'contentDigest': f'sha256:{digest_suffix}-content',
+            'listDigest': f'sha256:{digest_suffix}-list',
+        }
+
+    async def test_non_embargoed_operand_resolves_normally(self):
+        """A non-embargoed operand is resolved to its digest without any substitution."""
+        content = 'image: registry.redhat.io/openshift4/mypublic-operand-rhel9:v1.0'
+        metadata = self._make_metadata()
+
+        with patch(
+            'doozerlib.backend.konflux_olm_bundler.util.oc_image_info_for_arch_async',
+            new_callable=AsyncMock,
+            return_value=self._image_info('mypublic-operand-container', 'v1.0', '1.p2', 'public'),
+        ) as mock_oc_info:
+            new_content, found_images = await self.rebaser._replace_image_references(
+                'registry.redhat.io', content, Engine.KONFLUX, metadata
+            )
+
+        mock_oc_info.assert_awaited_once()
+        self.assertIn('registry.redhat.io/openshift4/mypublic-operand-rhel9@sha256:public-list', new_content)
+        self.assertEqual(
+            found_images['mypublic-operand-rhel9'][2],
+            'mypublic-operand-container-v1.0-1.p2',
+        )
+        # The lazy component-metadata map should never be built when nothing is embargoed.
+        metadata.runtime.image_metas.assert_not_called()
+
+    async def test_embargoed_operand_is_substituted_with_public_build(self):
+        """An embargoed operand is substituted with the latest public build of the same component."""
+        content = 'image: registry.redhat.io/openshift4/my-embargoed-operand-rhel9:v1.0'
+        metadata = self._make_metadata()
+
+        public_build = MagicMock()
+        public_build.nvr = 'my-embargoed-operand-container-v1.0-2.p2'
+        public_build.image_pullspec = 'quay.io/example/repo@sha256:public-build-digest'
+
+        operand_meta = MagicMock()
+        operand_meta.distgit_key = 'my-embargoed-operand'
+        operand_meta.get_component_name.return_value = 'my-embargoed-operand-container'
+        operand_meta.branch_el_target.return_value = 9
+        operand_meta.get_latest_konflux_build = AsyncMock(return_value=public_build)
+        metadata.runtime.image_metas.return_value = [operand_meta]
+
+        embargoed_info = self._image_info('my-embargoed-operand-container', 'v1.0', '1.p3', 'embargoed')
+        public_info = self._image_info('my-embargoed-operand-container', 'v1.0', '2.p2', 'public-sub')
+
+        async def fake_oc_image_info(pullspec, registry_config=None):
+            if pullspec == public_build.image_pullspec:
+                return public_info
+            return embargoed_info
+
+        with patch(
+            'doozerlib.backend.konflux_olm_bundler.util.oc_image_info_for_arch_async',
+            side_effect=fake_oc_image_info,
+        ) as mock_oc_info:
+            new_content, found_images = await self.rebaser._replace_image_references(
+                'registry.redhat.io', content, Engine.KONFLUX, metadata
+            )
+
+        self.assertEqual(mock_oc_info.call_count, 2)
+        operand_meta.get_latest_konflux_build.assert_awaited_once_with(
+            default=None, el_target=9, embargoed=False, exclude_large_columns=True
+        )
+        # The substituted (public) build's digest should be used in the final content, not the
+        # embargoed build's digest.
+        self.assertIn('registry.redhat.io/openshift4/my-embargoed-operand-rhel9@sha256:public-sub-list', new_content)
+        self.assertNotIn('embargoed-list', new_content)
+        self.assertEqual(
+            found_images['my-embargoed-operand-rhel9'][2],
+            public_build.nvr,
+        )
+
+    async def test_embargoed_operand_with_no_public_alternative_raises(self):
+        """When an embargoed operand has no public build to substitute, the rebase fails clearly."""
+        content = 'image: registry.redhat.io/openshift4/my-embargoed-operand-rhel9:v1.0'
+        metadata = self._make_metadata()
+
+        operand_meta = MagicMock()
+        operand_meta.distgit_key = 'my-embargoed-operand'
+        operand_meta.get_component_name.return_value = 'my-embargoed-operand-container'
+        operand_meta.branch_el_target.return_value = 9
+        operand_meta.get_latest_konflux_build = AsyncMock(return_value=None)
+        metadata.runtime.image_metas.return_value = [operand_meta]
+
+        embargoed_info = self._image_info('my-embargoed-operand-container', 'v1.0', '1.p3', 'embargoed')
+
+        with patch(
+            'doozerlib.backend.konflux_olm_bundler.util.oc_image_info_for_arch_async',
+            new_callable=AsyncMock,
+            return_value=embargoed_info,
+        ):
+            with self.assertRaises(KonfluxOlmBundleRebaseError):
+                await self.rebaser._replace_image_references('registry.redhat.io', content, Engine.KONFLUX, metadata)
+
+    async def test_embargoed_operand_with_unknown_component_raises(self):
+        """When an embargoed operand's component can't be mapped to any ART ImageMetadata, fail clearly."""
+        content = 'image: registry.redhat.io/openshift4/my-embargoed-operand-rhel9:v1.0'
+        metadata = self._make_metadata(image_metas=[])  # no metadata registered for this component
+
+        embargoed_info = self._image_info('my-embargoed-operand-container', 'v1.0', '1.p3', 'embargoed')
+
+        with patch(
+            'doozerlib.backend.konflux_olm_bundler.util.oc_image_info_for_arch_async',
+            new_callable=AsyncMock,
+            return_value=embargoed_info,
+        ):
+            with self.assertRaises(KonfluxOlmBundleRebaseError):
+                await self.rebaser._replace_image_references('registry.redhat.io', content, Engine.KONFLUX, metadata)
+
+    async def test_brew_engine_does_not_check_embargo(self):
+        """Embargo substitution is only applied for Konflux-engine operands; Brew engine is unaffected."""
+        content = 'image: registry.redhat.io/openshift4/my-embargoed-operand-rhel9:v1.0'
+        metadata = self._make_metadata()
+        embargoed_info = self._image_info('my-embargoed-operand-container', 'v1.0', '1.p3', 'embargoed')
+
+        with patch(
+            'doozerlib.backend.konflux_olm_bundler.util.oc_image_info_for_arch_async',
+            new_callable=AsyncMock,
+            return_value=embargoed_info,
+        ) as mock_oc_info:
+            new_content, found_images = await self.rebaser._replace_image_references(
+                'registry.redhat.io', content, Engine.BREW, metadata
+            )
+
+        # No substitution attempted; the (embargoed) build's own digest is used as-is.
+        mock_oc_info.assert_awaited_once()
+        self.assertIn('registry.redhat.io/openshift4/my-embargoed-operand-rhel9@sha256:embargoed-list', new_content)
+        # The lazy component-metadata map should never be built for the Brew engine.
+        metadata.runtime.image_metas.assert_not_called()

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -98,7 +98,7 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
                         'version': '1.0',
                         # Public (non-embargoed) Konflux release, so the embargo-substitution
                         # path introduced for layered-product bundles is not exercised here.
-                        'release': '1.p2',
+                        'release': '202607151200.p2.g172d0b2.assembly.stream.el9',
                     },
                     'Env': {
                         '__doozer_key=test-component',
@@ -135,7 +135,7 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
             (
                 'registry.example.com/namespace/image:tag',
                 'registry.redhat.io/openshift4/image@sha256:1234567890abcdef',
-                'test-brew-component-1.0-1.p2',
+                'test-brew-component-1.0-202607151200.p2.g172d0b2.assembly.stream.el9',
             ),
         )
 
@@ -151,7 +151,7 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
                         'com.redhat.component': 'test-component',
                         'version': '1.0',
                         # Public (non-embargoed) Konflux release.
-                        'release': '1.p2',
+                        'release': '202607151200.p2.g172d0b2.assembly.stream.el9',
                     },
                 },
             },
@@ -188,7 +188,7 @@ class TestKonfluxOlmBundleRebaser(IsolatedAsyncioTestCase):
                         'com.redhat.component': 'test-component',
                         'version': '1.0',
                         # Public (non-embargoed) Konflux release.
-                        'release': '1.p2',
+                        'release': '202607151200.p2.g172d0b2.assembly.stream.el9',
                     },
                 },
             },
@@ -1047,7 +1047,9 @@ class TestReplaceImageReferencesEmbargo(IsolatedAsyncioTestCase):
         with patch(
             'doozerlib.backend.konflux_olm_bundler.util.oc_image_info_for_arch_async',
             new_callable=AsyncMock,
-            return_value=self._image_info('mypublic-operand-container', 'v1.0', '1.p2', 'public'),
+            return_value=self._image_info(
+                'mypublic-operand-container', 'v1.0', '202607151200.p2.g172d0b2.assembly.stream.el9', 'public'
+            ),
         ) as mock_oc_info:
             new_content, found_images = await self.rebaser._replace_image_references(
                 'registry.redhat.io', content, Engine.KONFLUX, metadata
@@ -1057,7 +1059,7 @@ class TestReplaceImageReferencesEmbargo(IsolatedAsyncioTestCase):
         self.assertIn('registry.redhat.io/openshift4/mypublic-operand-rhel9@sha256:public-list', new_content)
         self.assertEqual(
             found_images['mypublic-operand-rhel9'][2],
-            'mypublic-operand-container-v1.0-1.p2',
+            'mypublic-operand-container-v1.0-202607151200.p2.g172d0b2.assembly.stream.el9',
         )
         # The lazy component-metadata map should never be built when nothing is embargoed.
         metadata.runtime.image_metas.assert_not_called()
@@ -1068,7 +1070,7 @@ class TestReplaceImageReferencesEmbargo(IsolatedAsyncioTestCase):
         metadata = self._make_metadata()
 
         public_build = MagicMock()
-        public_build.nvr = 'my-embargoed-operand-container-v1.0-2.p2'
+        public_build.nvr = 'my-embargoed-operand-container-v1.0-202607151201.p2.g8a1f3c4.assembly.stream.el9'
         public_build.image_pullspec = 'quay.io/example/repo@sha256:public-build-digest'
 
         operand_meta = MagicMock()
@@ -1078,8 +1080,12 @@ class TestReplaceImageReferencesEmbargo(IsolatedAsyncioTestCase):
         operand_meta.get_latest_konflux_build = AsyncMock(return_value=public_build)
         metadata.runtime.image_metas.return_value = [operand_meta]
 
-        embargoed_info = self._image_info('my-embargoed-operand-container', 'v1.0', '1.p3', 'embargoed')
-        public_info = self._image_info('my-embargoed-operand-container', 'v1.0', '2.p2', 'public-sub')
+        embargoed_info = self._image_info(
+            'my-embargoed-operand-container', 'v1.0', '202607151200.p3.g172d0b2.assembly.stream.el9', 'embargoed'
+        )
+        public_info = self._image_info(
+            'my-embargoed-operand-container', 'v1.0', '202607151201.p2.g8a1f3c4.assembly.stream.el9', 'public-sub'
+        )
 
         async def fake_oc_image_info(pullspec, registry_config=None):
             if pullspec == public_build.image_pullspec:
@@ -1119,7 +1125,9 @@ class TestReplaceImageReferencesEmbargo(IsolatedAsyncioTestCase):
         operand_meta.get_latest_konflux_build = AsyncMock(return_value=None)
         metadata.runtime.image_metas.return_value = [operand_meta]
 
-        embargoed_info = self._image_info('my-embargoed-operand-container', 'v1.0', '1.p3', 'embargoed')
+        embargoed_info = self._image_info(
+            'my-embargoed-operand-container', 'v1.0', '202607151200.p3.g172d0b2.assembly.stream.el9', 'embargoed'
+        )
 
         with patch(
             'doozerlib.backend.konflux_olm_bundler.util.oc_image_info_for_arch_async',
@@ -1134,7 +1142,9 @@ class TestReplaceImageReferencesEmbargo(IsolatedAsyncioTestCase):
         content = 'image: registry.redhat.io/openshift4/my-embargoed-operand-rhel9:v1.0'
         metadata = self._make_metadata(image_metas=[])  # no metadata registered for this component
 
-        embargoed_info = self._image_info('my-embargoed-operand-container', 'v1.0', '1.p3', 'embargoed')
+        embargoed_info = self._image_info(
+            'my-embargoed-operand-container', 'v1.0', '202607151200.p3.g172d0b2.assembly.stream.el9', 'embargoed'
+        )
 
         with patch(
             'doozerlib.backend.konflux_olm_bundler.util.oc_image_info_for_arch_async',
@@ -1148,7 +1158,9 @@ class TestReplaceImageReferencesEmbargo(IsolatedAsyncioTestCase):
         """Embargo substitution is only applied for Konflux-engine operands; Brew engine is unaffected."""
         content = 'image: registry.redhat.io/openshift4/my-embargoed-operand-rhel9:v1.0'
         metadata = self._make_metadata()
-        embargoed_info = self._image_info('my-embargoed-operand-container', 'v1.0', '1.p3', 'embargoed')
+        embargoed_info = self._image_info(
+            'my-embargoed-operand-container', 'v1.0', '202607151200.p3.g172d0b2.assembly.stream.el9', 'embargoed'
+        )
 
         with patch(
             'doozerlib.backend.konflux_olm_bundler.util.oc_image_info_for_arch_async',

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -1027,6 +1027,13 @@ class TestReplaceImageReferencesEmbargo(IsolatedAsyncioTestCase):
         metadata.runtime.group = 'openshift-4.18'
         metadata.runtime.data_dir = '/tmp/nonexistent-data-dir'
         metadata.runtime.image_metas.return_value = image_metas or []
+        # By default, simulate a fully-loaded runtime where image_metas() already covers every
+        # image in the group, so the late_resolve_image() fallback in
+        # _build_component_to_meta_map() has nothing extra to find. Tests that specifically
+        # exercise that fallback (e.g. because `doozer beta:images:konflux:bundle <nvr>` restricts
+        # image_metas() to just the given operator) override these explicitly.
+        metadata.runtime.image_map = {im.distgit_key: im for im in (image_metas or [])}
+        metadata.runtime.image_name_map = {}
         return metadata
 
     @staticmethod
@@ -1136,6 +1143,75 @@ class TestReplaceImageReferencesEmbargo(IsolatedAsyncioTestCase):
         ):
             with self.assertRaises(KonfluxOlmBundleRebaseError):
                 await self.rebaser._replace_image_references('registry.redhat.io', content, Engine.KONFLUX, metadata)
+
+    async def test_embargoed_operand_not_in_restricted_image_metas_is_found_via_late_resolve(self):
+        """Reproduces a real production failure: `doozer beta:images:konflux:bundle <operator-nvr>`
+        restricts runtime.image_metas() to just the given operator (see
+        KonfluxBundleCli.get_operator_builds()), so an embargoed operand belonging to a different,
+        unloaded image in the same group (e.g. a dependent image referenced by the operator's CSV)
+        is invisible to image_metas() alone. _build_component_to_meta_map() must fall back to
+        Runtime.late_resolve_image() to find it rather than failing with "no ART image metadata
+        could be found"."""
+        content = 'image: registry.redhat.io/openshift4/log-file-metric-exporter-rhel9:v1.0'
+        # Only the operator itself is loaded into image_metas(); the operand ("dependent" image)
+        # is not, mirroring the restricted `--images`-style loading done for bundle builds.
+        metadata = self._make_metadata(image_metas=[])
+        metadata.runtime.image_name_map = {
+            'openshift-logging/log-file-metric-exporter-rhel9': 'log-file-metric-exporter',
+            'log-file-metric-exporter-rhel9': 'log-file-metric-exporter',
+        }
+        metadata.runtime.image_map = {}  # not loaded for this invocation
+
+        public_build = MagicMock()
+        public_build.nvr = 'log-file-metric-exporter-container-6.6.1-202607160200.p2.g3c1201f.assembly.test.el9'
+        public_build.image_pullspec = 'quay.io/example/repo@sha256:public-build-digest'
+
+        operand_meta = MagicMock()
+        operand_meta.distgit_key = 'log-file-metric-exporter'
+        operand_meta.get_component_name.return_value = 'log-file-metric-exporter-container'
+        operand_meta.branch_el_target.return_value = 9
+        operand_meta.get_latest_konflux_build = AsyncMock(return_value=public_build)
+        metadata.runtime.late_resolve_image = MagicMock(return_value=operand_meta)
+
+        embargoed_info = self._image_info(
+            'log-file-metric-exporter-container',
+            '6.6.1',
+            '202607160122.p3.g3c1201f.assembly.test.el9',
+            'embargoed',
+        )
+        public_info = self._image_info(
+            'log-file-metric-exporter-container',
+            '6.6.1',
+            '202607160200.p2.g3c1201f.assembly.test.el9',
+            'public-sub',
+        )
+
+        async def fake_oc_image_info(pullspec, registry_config=None):
+            if pullspec == public_build.image_pullspec:
+                return public_info
+            return embargoed_info
+
+        with patch(
+            'doozerlib.backend.konflux_olm_bundler.util.oc_image_info_for_arch_async',
+            side_effect=fake_oc_image_info,
+        ):
+            new_content, found_images = await self.rebaser._replace_image_references(
+                'registry.redhat.io', content, Engine.KONFLUX, metadata
+            )
+
+        metadata.runtime.late_resolve_image.assert_called_once_with(
+            'log-file-metric-exporter', add=False, required=False
+        )
+        operand_meta.get_latest_konflux_build.assert_awaited_once_with(
+            default=None, el_target=9, embargoed=False, exclude_large_columns=True
+        )
+        self.assertIn(
+            'registry.redhat.io/openshift4/log-file-metric-exporter-rhel9@sha256:public-sub-list', new_content
+        )
+        self.assertEqual(
+            found_images['log-file-metric-exporter-rhel9'][2],
+            public_build.nvr,
+        )
 
     async def test_embargoed_operand_with_unknown_component_raises(self):
         """When an embargoed operand's component can't be mapped to any ART ImageMetadata, fail clearly."""

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -1154,6 +1154,29 @@ class TestReplaceImageReferencesEmbargo(IsolatedAsyncioTestCase):
             with self.assertRaises(KonfluxOlmBundleRebaseError):
                 await self.rebaser._replace_image_references('registry.redhat.io', content, Engine.KONFLUX, metadata)
 
+    async def test_operand_with_ambiguous_embargo_status_raises(self):
+        """When an operand's NVR matches more than one visibility suffix (ambiguous embargo
+        status), the rebase fails clearly rather than guessing which suffix applies."""
+        content = 'image: registry.redhat.io/openshift4/my-ambiguous-operand-rhel9:v1.0'
+        metadata = self._make_metadata()
+
+        # Synthetic/defensive case: version and release combine into an NVR carrying two
+        # visibility suffixes (real ART NVRs never carry more than one).
+        ambiguous_info = self._image_info(
+            'my-ambiguous-operand-container',
+            '1.0.202607151200.p2.g172d0b2.assembly.stream.el9',
+            '1.p3',
+            'ambiguous',
+        )
+
+        with patch(
+            'doozerlib.backend.konflux_olm_bundler.util.oc_image_info_for_arch_async',
+            new_callable=AsyncMock,
+            return_value=ambiguous_info,
+        ):
+            with self.assertRaises(KonfluxOlmBundleRebaseError):
+                await self.rebaser._replace_image_references('registry.redhat.io', content, Engine.KONFLUX, metadata)
+
     async def test_brew_engine_does_not_check_embargo(self):
         """Embargo substitution is only applied for Konflux-engine operands; Brew engine is unaffected."""
         content = 'image: registry.redhat.io/openshift4/my-embargoed-operand-rhel9:v1.0'

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 import traceback
 from pathlib import Path
 from typing import List, Optional
@@ -7,6 +8,7 @@ from typing import List, Optional
 import click
 import yaml
 from artcommonlib import exectools
+from artcommonlib.build_visibility import is_nvr_embargoed
 from artcommonlib.constants import PRODUCT_KUBECONFIG_MAP
 from artcommonlib.util import resolve_konflux_kubeconfig_by_product, resolve_konflux_namespace_by_product
 from doozerlib.constants import KONFLUX_DEFAULT_IMAGE_REPO
@@ -53,6 +55,9 @@ class BuildLayeredProductsPipeline:
         self.network_mode = network_mode
         self.plr_template = plr_template
         self._logger = logger or runtime.logger
+        # Operator NVRs that were dropped from the bundle build trigger because they are embargoed.
+        # The caller uses this to mark the Jenkins job UNSTABLE instead of a plain SUCCESS.
+        self.embargoed_operators_skipped: List[str] = []
 
         if self.image_build_strategy == BuildStrategy.ALL and self.image_list:
             raise ValueError("image_list must be empty when image_build_strategy is 'all'")
@@ -92,6 +97,23 @@ class BuildLayeredProductsPipeline:
             for record in records:
                 if record['has_olm_bundle'] == '1' and record['status'] == '0' and record.get('nvrs', None):
                     operator_nvrs.append(record['nvrs'].split(',')[0])
+
+            # Embargoed operators should not have a public bundle built for them. Drop them from
+            # the trigger; the previous public bundle remains the latest until a public rebuild
+            # happens. The caller marks the Jenkins job UNSTABLE when this list is non-empty.
+            non_embargoed_nvrs = []
+            for nvr in operator_nvrs:
+                if is_nvr_embargoed(nvr):
+                    self._logger.warning(
+                        'Operator NVR %s is embargoed; skipping bundle build trigger for it. '
+                        'The previous public bundle will remain the latest until a public rebuild.',
+                        nvr,
+                    )
+                    self.embargoed_operators_skipped.append(nvr)
+                else:
+                    non_embargoed_nvrs.append(nvr)
+            operator_nvrs = non_embargoed_nvrs
+
             if operator_nvrs:
                 # Automatically propagate parameters if set in environment
                 propagate_params = jenkins.get_propagatable_params()
@@ -139,6 +161,16 @@ class BuildLayeredProductsPipeline:
         image_repo = group_config.get('konflux', {}).get('image_repo') or KONFLUX_DEFAULT_IMAGE_REPO
         await self._rebase_and_build(product, image_repo)
         self.trigger_bundle_build()
+
+        if self.embargoed_operators_skipped:
+            self._logger.warning(
+                'Job completed, but skipped triggering bundle build for %d embargoed operator NVR(s): %s',
+                len(self.embargoed_operators_skipped),
+                ', '.join(self.embargoed_operators_skipped),
+            )
+            # Exit with code 2 to mark Jenkins job as UNSTABLE
+            # The Jenkinsfile should catch this exit code and set currentBuild.result = 'UNSTABLE'
+            sys.exit(2)
 
     def _group_param(self) -> str:
         if self.data_gitref:

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -103,7 +103,19 @@ class BuildLayeredProductsPipeline:
             # happens. The caller marks the Jenkins job UNSTABLE when this list is non-empty.
             non_embargoed_nvrs = []
             for nvr in operator_nvrs:
-                if is_nvr_embargoed(nvr):
+                try:
+                    embargoed = is_nvr_embargoed(nvr)
+                except ValueError:
+                    # is_nvr_embargoed() raises when the NVR's embargo status is ambiguous
+                    # (e.g. it matches more than one visibility suffix). Treat that the same
+                    # as embargoed: don't guess, just skip the bundle trigger and warn.
+                    self._logger.exception(
+                        'Unable to determine visibility for operator NVR %s; skipping bundle build trigger for it.',
+                        nvr,
+                    )
+                    self.embargoed_operators_skipped.append(nvr)
+                    continue
+                if embargoed:
                     self._logger.warning(
                         'Operator NVR %s is embargoed; skipping bundle build trigger for it. '
                         'The previous public bundle will remain the latest until a public rebuild.',

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -15,6 +15,7 @@ from urllib.parse import urlparse
 import click
 import yaml as stdlib_yaml
 from artcommonlib import exectools
+from artcommonlib.build_visibility import is_nvr_embargoed
 from artcommonlib.constants import SHIPMENT_DATA_URL_TEMPLATE
 from artcommonlib.gitdata import SafeFormatter
 from artcommonlib.github_auth import get_github_client_for_org
@@ -1214,6 +1215,20 @@ class ReleaseFromFbcPipeline:
 
         if not all_nvrs and not self.extra_image_nvrs:
             raise RuntimeError("No NVRs extracted from FBC images and no extra image NVRs provided")
+
+        # Defensive check: bundle/FBC rebases (and the operator-level filter in
+        # build_layered_products.py) should already guarantee that FBC-derived NVRs are never
+        # embargoed. If an embargoed NVR reaches this point anyway - whether from the FBC
+        # pullspecs themselves or from a manual --extra-image-nvrs override - that signals a
+        # serious upstream bug (or misuse of --extra-image-nvrs), so fail the release rather than
+        # silently dropping it.
+        embargoed_nvrs = [nvr for nvr in all_nvrs + self.extra_image_nvrs if is_nvr_embargoed(nvr)]
+        if embargoed_nvrs:
+            raise RuntimeError(
+                f"Refusing to create a release referencing embargoed (private-fix) NVR(s): "
+                f"{embargoed_nvrs}. This should never happen for FBC-derived NVRs and likely "
+                f"indicates an upstream bug, or an embargoed NVR was passed via --extra-image-nvrs."
+            )
 
         # Categorize the extracted NVRs
         empty_categorized: Dict[str, List[str]]

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -1228,7 +1228,13 @@ class ReleaseFromFbcPipeline:
         # The FBC image is just a catalog wrapper; its own NVR is never embargo-relevant and,
         # by construction (see build_fbc.py), never carries a p-flag at all - so including it
         # here would make this check fail unconditionally on every run.
-        embargoed_nvrs = [nvr for nvr in related_nvrs + self.extra_image_nvrs if is_nvr_embargoed(nvr)]
+        try:
+            embargoed_nvrs = [nvr for nvr in related_nvrs + self.extra_image_nvrs if is_nvr_embargoed(nvr)]
+        except ValueError as e:
+            # is_nvr_embargoed() raises when an NVR's embargo status is ambiguous (e.g. it
+            # matches more than one visibility suffix). Treat that the same as finding an
+            # embargoed NVR: refuse to guess and fail the release.
+            raise RuntimeError(f"Refusing to create a release: unable to determine embargo status: {e}") from e
         if embargoed_nvrs:
             raise RuntimeError(
                 f"Refusing to create a release referencing embargoed (private-fix) NVR(s): "

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -1216,13 +1216,19 @@ class ReleaseFromFbcPipeline:
         if not all_nvrs and not self.extra_image_nvrs:
             raise RuntimeError("No NVRs extracted from FBC images and no extra image NVRs provided")
 
-        # Defensive check: bundle/FBC rebases (and the operator-level filter in
-        # build_layered_products.py) should already guarantee that FBC-derived NVRs are never
-        # embargoed. If an embargoed NVR reaches this point anyway - whether from the FBC
-        # pullspecs themselves or from a manual --extra-image-nvrs override - that signals a
-        # serious upstream bug (or misuse of --extra-image-nvrs), so fail the release rather than
-        # silently dropping it.
-        embargoed_nvrs = [nvr for nvr in all_nvrs + self.extra_image_nvrs if is_nvr_embargoed(nvr)]
+        # Defensive check: bundle rebases (and the operator-level filter in
+        # build_layered_products.py) should already guarantee that the bundle/operand images
+        # referenced by an FBC are never embargoed. If an embargoed NVR reaches this point
+        # anyway - whether from the FBC's related images or from a manual --extra-image-nvrs
+        # override - that signals a serious upstream bug (or misuse of --extra-image-nvrs), so
+        # fail the release rather than silently dropping it.
+        #
+        # Note: this deliberately checks related_nvrs (the actual bundle/operand images
+        # referenced inside the FBC catalog), not fbc_nvrs (the FBC/catalog image's own NVR).
+        # The FBC image is just a catalog wrapper; its own NVR is never embargo-relevant and,
+        # by construction (see build_fbc.py), never carries a p-flag at all - so including it
+        # here would make this check fail unconditionally on every run.
+        embargoed_nvrs = [nvr for nvr in related_nvrs + self.extra_image_nvrs if is_nvr_embargoed(nvr)]
         if embargoed_nvrs:
             raise RuntimeError(
                 f"Refusing to create a release referencing embargoed (private-fix) NVR(s): "

--- a/pyartcd/tests/pipelines/test_build_layered_products.py
+++ b/pyartcd/tests/pipelines/test_build_layered_products.py
@@ -401,6 +401,108 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
         self.assertFalse(any(arg.startswith('--images=') for arg in cmd))
         self.assertFalse(any(arg.startswith('--exclude=') for arg in cmd))
 
+    def _write_image_build_record_log(self, entries):
+        """Write an image_build_konflux record.log with the given (name, nvr) entries, all successful with a bundle."""
+        record_log_path = Path(self.runtime.doozer_working, 'record.log')
+        lines = []
+        for name, nvr in entries:
+            lines.append(f'image_build_konflux|name={name}|has_olm_bundle=1|status=0|nvrs={nvr}\n')
+        record_log_path.write_text(''.join(lines))
+
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.start_olm_bundle_konflux')
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.get_propagatable_params', return_value={})
+    def test_trigger_bundle_build_filters_embargoed_operators(self, mock_get_params, mock_start_bundle):
+        """Embargoed operator NVRs are dropped from the trigger; non-embargoed ones proceed."""
+        self.pipeline.skip_bundle_build = False
+        self._write_image_build_record_log(
+            [
+                ('oadp-operator', 'oadp-operator-container-v1.4.9-1.p2'),
+                ('oadp-operator', 'oadp-operator-container-v1.4.9-2.p3'),
+            ]
+        )
+
+        self.pipeline.trigger_bundle_build()
+
+        mock_start_bundle.assert_called_once()
+        self.assertEqual(
+            mock_start_bundle.call_args.kwargs['operator_nvrs'],
+            ['oadp-operator-container-v1.4.9-1.p2'],
+        )
+        self.assertEqual(self.pipeline.embargoed_operators_skipped, ['oadp-operator-container-v1.4.9-2.p3'])
+
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.start_olm_bundle_konflux')
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.get_propagatable_params', return_value={})
+    def test_trigger_bundle_build_all_embargoed_skips_trigger(self, mock_get_params, mock_start_bundle):
+        """When every operator NVR is embargoed, the bundle build trigger is never called."""
+        self.pipeline.skip_bundle_build = False
+        self._write_image_build_record_log(
+            [
+                ('oadp-operator', 'oadp-operator-container-v1.4.9-1.p3'),
+            ]
+        )
+
+        self.pipeline.trigger_bundle_build()
+
+        mock_start_bundle.assert_not_called()
+        self.assertEqual(self.pipeline.embargoed_operators_skipped, ['oadp-operator-container-v1.4.9-1.p3'])
+
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.start_olm_bundle_konflux')
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.get_propagatable_params', return_value={})
+    def test_trigger_bundle_build_no_embargoed_calls_normally(self, mock_get_params, mock_start_bundle):
+        """When no operator NVRs are embargoed, the trigger proceeds normally with an empty skip list."""
+        self.pipeline.skip_bundle_build = False
+        self._write_image_build_record_log(
+            [
+                ('oadp-operator', 'oadp-operator-container-v1.4.9-1.p2'),
+            ]
+        )
+
+        self.pipeline.trigger_bundle_build()
+
+        mock_start_bundle.assert_called_once()
+        self.assertEqual(
+            mock_start_bundle.call_args.kwargs['operator_nvrs'],
+            ['oadp-operator-container-v1.4.9-1.p2'],
+        )
+        self.assertEqual(self.pipeline.embargoed_operators_skipped, [])
+
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.init_jenkins')
+    @patch('pyartcd.pipelines.build_layered_products.load_group_config')
+    async def test_run_exits_unstable_when_embargoed_operators_skipped(self, mock_load_config, mock_jenkins):
+        """run() exits with code 2 (UNSTABLE) when any embargoed operator NVRs were skipped."""
+        mock_load_config.return_value = {'product': 'oadp', 'version': '1.4.9'}
+        self.pipeline.skip_rebase = True
+        self.pipeline.skip_bundle_build = True
+
+        with (
+            patch.object(self.pipeline, '_rebase_and_build', new_callable=AsyncMock),
+            patch.object(self.pipeline, 'trigger_bundle_build') as mock_trigger,
+        ):
+
+            def fake_trigger():
+                self.pipeline.embargoed_operators_skipped.append('oadp-operator-container-v1.4.9-1.p3')
+
+            mock_trigger.side_effect = fake_trigger
+
+            with self.assertRaises(SystemExit) as ctx:
+                await self.pipeline.run()
+
+        self.assertEqual(ctx.exception.code, 2)
+
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.init_jenkins')
+    @patch('pyartcd.pipelines.build_layered_products.load_group_config')
+    async def test_run_succeeds_when_no_operators_skipped(self, mock_load_config, mock_jenkins):
+        """run() completes normally (no SystemExit) when no operator NVRs were skipped."""
+        mock_load_config.return_value = {'product': 'oadp', 'version': '1.4.9'}
+        self.pipeline.skip_rebase = True
+        self.pipeline.skip_bundle_build = True
+
+        with (
+            patch.object(self.pipeline, '_rebase_and_build', new_callable=AsyncMock),
+            patch.object(self.pipeline, 'trigger_bundle_build'),
+        ):
+            await self.pipeline.run()  # Should not raise
+
     async def test_build_all_strategy_with_exclusions(self):
         """When strategy is all with rebase exclusions, build uses --images= --exclude=."""
         with (

--- a/pyartcd/tests/pipelines/test_build_layered_products.py
+++ b/pyartcd/tests/pipelines/test_build_layered_products.py
@@ -435,6 +435,31 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
 
     @patch('pyartcd.pipelines.build_layered_products.jenkins.start_olm_bundle_konflux')
     @patch('pyartcd.pipelines.build_layered_products.jenkins.get_propagatable_params', return_value={})
+    def test_trigger_bundle_build_ambiguous_nvr_skips_and_warns(self, mock_get_params, mock_start_bundle):
+        """An NVR whose embargo status is ambiguous (matches more than one visibility suffix)
+        is treated like an embargoed NVR: skip its bundle trigger and record it as skipped,
+        rather than letting the ValueError bubble up and get silently swallowed by the
+        broader except-Exception handler around this method."""
+        self.pipeline.skip_bundle_build = False
+        ambiguous_nvr = 'oadp-operator-container-v1.4.9.202607151200.p2.g172d0b2.assembly.stream.el9.p3'
+        self._write_image_build_record_log(
+            [
+                ('oadp-operator', ambiguous_nvr),
+                ('oadp-operator', 'oadp-operator-container-v1.4.9-202607151201.p2.g8a1f3c4.assembly.stream.el9'),
+            ]
+        )
+
+        self.pipeline.trigger_bundle_build()
+
+        mock_start_bundle.assert_called_once()
+        self.assertEqual(
+            mock_start_bundle.call_args.kwargs['operator_nvrs'],
+            ['oadp-operator-container-v1.4.9-202607151201.p2.g8a1f3c4.assembly.stream.el9'],
+        )
+        self.assertEqual(self.pipeline.embargoed_operators_skipped, [ambiguous_nvr])
+
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.start_olm_bundle_konflux')
+    @patch('pyartcd.pipelines.build_layered_products.jenkins.get_propagatable_params', return_value={})
     def test_trigger_bundle_build_all_embargoed_skips_trigger(self, mock_get_params, mock_start_bundle):
         """When every operator NVR is embargoed, the bundle build trigger is never called."""
         self.pipeline.skip_bundle_build = False

--- a/pyartcd/tests/pipelines/test_build_layered_products.py
+++ b/pyartcd/tests/pipelines/test_build_layered_products.py
@@ -416,8 +416,8 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
         self.pipeline.skip_bundle_build = False
         self._write_image_build_record_log(
             [
-                ('oadp-operator', 'oadp-operator-container-v1.4.9-1.p2'),
-                ('oadp-operator', 'oadp-operator-container-v1.4.9-2.p3'),
+                ('oadp-operator', 'oadp-operator-container-v1.4.9-202607151200.p2.g172d0b2.assembly.stream.el9'),
+                ('oadp-operator', 'oadp-operator-container-v1.4.9-202607151201.p3.g8a1f3c4.assembly.stream.el9'),
             ]
         )
 
@@ -426,9 +426,12 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
         mock_start_bundle.assert_called_once()
         self.assertEqual(
             mock_start_bundle.call_args.kwargs['operator_nvrs'],
-            ['oadp-operator-container-v1.4.9-1.p2'],
+            ['oadp-operator-container-v1.4.9-202607151200.p2.g172d0b2.assembly.stream.el9'],
         )
-        self.assertEqual(self.pipeline.embargoed_operators_skipped, ['oadp-operator-container-v1.4.9-2.p3'])
+        self.assertEqual(
+            self.pipeline.embargoed_operators_skipped,
+            ['oadp-operator-container-v1.4.9-202607151201.p3.g8a1f3c4.assembly.stream.el9'],
+        )
 
     @patch('pyartcd.pipelines.build_layered_products.jenkins.start_olm_bundle_konflux')
     @patch('pyartcd.pipelines.build_layered_products.jenkins.get_propagatable_params', return_value={})
@@ -437,14 +440,17 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
         self.pipeline.skip_bundle_build = False
         self._write_image_build_record_log(
             [
-                ('oadp-operator', 'oadp-operator-container-v1.4.9-1.p3'),
+                ('oadp-operator', 'oadp-operator-container-v1.4.9-202607151200.p3.g172d0b2.assembly.stream.el9'),
             ]
         )
 
         self.pipeline.trigger_bundle_build()
 
         mock_start_bundle.assert_not_called()
-        self.assertEqual(self.pipeline.embargoed_operators_skipped, ['oadp-operator-container-v1.4.9-1.p3'])
+        self.assertEqual(
+            self.pipeline.embargoed_operators_skipped,
+            ['oadp-operator-container-v1.4.9-202607151200.p3.g172d0b2.assembly.stream.el9'],
+        )
 
     @patch('pyartcd.pipelines.build_layered_products.jenkins.start_olm_bundle_konflux')
     @patch('pyartcd.pipelines.build_layered_products.jenkins.get_propagatable_params', return_value={})
@@ -453,7 +459,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
         self.pipeline.skip_bundle_build = False
         self._write_image_build_record_log(
             [
-                ('oadp-operator', 'oadp-operator-container-v1.4.9-1.p2'),
+                ('oadp-operator', 'oadp-operator-container-v1.4.9-202607151200.p2.g172d0b2.assembly.stream.el9'),
             ]
         )
 
@@ -462,7 +468,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
         mock_start_bundle.assert_called_once()
         self.assertEqual(
             mock_start_bundle.call_args.kwargs['operator_nvrs'],
-            ['oadp-operator-container-v1.4.9-1.p2'],
+            ['oadp-operator-container-v1.4.9-202607151200.p2.g172d0b2.assembly.stream.el9'],
         )
         self.assertEqual(self.pipeline.embargoed_operators_skipped, [])
 
@@ -480,7 +486,9 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
         ):
 
             def fake_trigger():
-                self.pipeline.embargoed_operators_skipped.append('oadp-operator-container-v1.4.9-1.p3')
+                self.pipeline.embargoed_operators_skipped.append(
+                    'oadp-operator-container-v1.4.9-202607151200.p3.g172d0b2.assembly.stream.el9'
+                )
 
             mock_trigger.side_effect = fake_trigger
 

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -563,7 +563,7 @@ class TestExtraImageNvrsValidation(unittest.TestCase):
 
     def test_fbc_nvr_in_extra_image_nvrs_raises(self):
         """run() should raise RuntimeError when extra_image_nvrs contains an FBC build."""
-        pipeline = self._make_pipeline(extra_image_nvrs=["oadp-operator-fbc-1.5.3-1.el9"])
+        pipeline = self._make_pipeline(extra_image_nvrs=["oadp-operator-fbc-1.5.3-1.el9.p2"])
         pipeline.check_env_vars = MagicMock()
         pipeline.setup_working_dir = MagicMock()
         pipeline._load_product_from_group_config = AsyncMock(return_value="oadp")
@@ -586,6 +586,61 @@ class TestExtraImageNvrsValidation(unittest.TestCase):
             asyncio.run(pipeline.run())
         except RuntimeError as e:
             self.assertNotIn("FBC builds", str(e))
+
+
+class TestEmbargoedNvrDefensiveCheck(unittest.TestCase):
+    """run() must refuse to release if any embargoed (private-fix) NVR is found, whether it came
+    from an FBC pullspec or from a manual --extra-image-nvrs override."""
+
+    def _make_pipeline(self, extra_image_nvrs=None, fbc_pullspecs=None):
+        runtime = MagicMock()
+        runtime.config = {}
+        runtime.dry_run = False
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        pipeline = ReleaseFromFbcPipeline(
+            runtime=runtime,
+            group="oadp-1.5",
+            assembly="1.5.3",
+            fbc_pullspecs=fbc_pullspecs or [],
+            extra_image_nvrs=extra_image_nvrs,
+        )
+        pipeline.check_env_vars = MagicMock()
+        pipeline.setup_working_dir = MagicMock()
+        pipeline._load_product_from_group_config = AsyncMock(return_value="oadp")
+        return pipeline
+
+    def test_embargoed_fbc_nvr_raises(self):
+        """An embargoed NVR extracted from an FBC pullspec must fail the release."""
+        pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/example/fbc:v1"])
+        pipeline.validate_fbc_related_images = AsyncMock(return_value=[])
+        pipeline.extract_fbc_nvr = MagicMock(return_value="oadp-operator-fbc-1.5.3-1.p3")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(pipeline.run())
+        self.assertIn("embargoed", str(ctx.exception))
+        self.assertIn("oadp-operator-fbc-1.5.3-1.p3", str(ctx.exception))
+
+    def test_embargoed_extra_image_nvr_raises(self):
+        """An embargoed NVR passed via --extra-image-nvrs must fail the release."""
+        pipeline = self._make_pipeline(extra_image_nvrs=["oadp-velero-container-1.5.3-1.p3"])
+
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(pipeline.run())
+        self.assertIn("embargoed", str(ctx.exception))
+        self.assertIn("oadp-velero-container-1.5.3-1.p3", str(ctx.exception))
+
+    def test_non_embargoed_nvrs_do_not_raise_embargo_error(self):
+        """Public (non-embargoed) NVRs should not trigger the embargo defensive check."""
+        pipeline = self._make_pipeline(extra_image_nvrs=["oadp-velero-container-1.5.3-1.p2"])
+        pipeline.create_snapshot = AsyncMock(return_value=MagicMock())
+        pipeline.create_shipment_config = MagicMock(return_value=MagicMock())
+        pipeline.write_shipment_files_locally = AsyncMock()
+
+        try:
+            asyncio.run(pipeline.run())
+        except RuntimeError as e:
+            self.assertNotIn("embargoed", str(e))
 
 
 class TestSetShipmentMrReady(unittest.TestCase):
@@ -1228,7 +1283,7 @@ class TestOcpOptionalMode(unittest.TestCase):
     def test_extra_image_nvrs_merged_into_extras_key(self):
         """In OCP optional mode, extra_image_nvrs should merge into 'extras', not 'image'."""
         pipeline = self._make_pipeline(ocp_optional=True)
-        pipeline.extra_image_nvrs = ["extra-operator-container-v4.22.0-1.el9"]
+        pipeline.extra_image_nvrs = ["extra-operator-container-v4.22.0-1.el9.p2"]
         pipeline.fbc_pullspecs = []
         pipeline.check_env_vars = MagicMock()
         pipeline.setup_working_dir = MagicMock()
@@ -1241,7 +1296,7 @@ class TestOcpOptionalMode(unittest.TestCase):
         asyncio.run(pipeline.run())
 
         snapshot_call_args = pipeline.create_snapshot.call_args[0][0]
-        self.assertIn("extra-operator-container-v4.22.0-1.el9", snapshot_call_args)
+        self.assertIn("extra-operator-container-v4.22.0-1.el9.p2", snapshot_call_args)
 
         config_call_args = pipeline.create_shipment_config.call_args
         self.assertEqual(config_call_args[0][0], "extras")
@@ -1364,7 +1419,7 @@ class TestOcpOptionalMode(unittest.TestCase):
         pipeline = self._make_pipeline(ocp_optional=True)
         pipeline.create_mr = True
         pipeline.fbc_pullspecs = []
-        pipeline.extra_image_nvrs = ["extra-op-container-v4.22.0-1.el9"]
+        pipeline.extra_image_nvrs = ["extra-op-container-v4.22.0-1.el9.p2"]
         pipeline.check_env_vars = MagicMock()
         pipeline.setup_working_dir = MagicMock()
         pipeline.setup_shipment_repo = AsyncMock()
@@ -1393,7 +1448,7 @@ class TestOcpOptionalMode(unittest.TestCase):
         pipeline.product = "oadp"
         pipeline.create_mr = True
         pipeline.fbc_pullspecs = []
-        pipeline.extra_image_nvrs = ["oadp-container-v1.5.0-1.el9"]
+        pipeline.extra_image_nvrs = ["oadp-container-v1.5.0-1.el9.p2"]
         pipeline.check_env_vars = MagicMock()
         pipeline.setup_working_dir = MagicMock()
         pipeline.setup_shipment_repo = AsyncMock()

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -610,16 +610,31 @@ class TestEmbargoedNvrDefensiveCheck(unittest.TestCase):
         pipeline._load_product_from_group_config = AsyncMock(return_value="oadp")
         return pipeline
 
-    def test_embargoed_fbc_nvr_raises(self):
-        """An embargoed NVR extracted from an FBC pullspec must fail the release."""
+    def test_embargoed_fbc_nvr_alone_does_not_raise(self):
+        """The FBC (catalog) image's own NVR is excluded from the embargo check: it's just a
+        catalog wrapper and, by construction, never carries a p-flag at all (see
+        build_fbc.py, which tags it with a bare timestamp). An embargoed-looking fbc_nvr alone
+        (no embargoed related/extra image NVRs) must not raise the embargo defensive check."""
         pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/example/fbc:v1"])
         pipeline.validate_fbc_related_images = AsyncMock(return_value=[])
         pipeline.extract_fbc_nvr = MagicMock(return_value="oadp-operator-fbc-1.5.3-1.p3")
+        pipeline.create_snapshot = AsyncMock(return_value=MagicMock())
+        pipeline.create_shipment_config = MagicMock(return_value=MagicMock())
+        pipeline.write_shipment_files_locally = AsyncMock()
+
+        asyncio.run(pipeline.run())
+
+    def test_embargoed_related_nvr_raises(self):
+        """An embargoed NVR among the FBC's related images (the actual bundle/operand images
+        referenced inside the catalog) must fail the release."""
+        pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/example/fbc:v1"])
+        pipeline.validate_fbc_related_images = AsyncMock(return_value=["oadp-velero-container-1.5.3-1.p3"])
+        pipeline.extract_fbc_nvr = MagicMock(return_value="oadp-operator-fbc-1.5.3-20260715120000")
 
         with self.assertRaises(RuntimeError) as ctx:
             asyncio.run(pipeline.run())
         self.assertIn("embargoed", str(ctx.exception))
-        self.assertIn("oadp-operator-fbc-1.5.3-1.p3", str(ctx.exception))
+        self.assertIn("oadp-velero-container-1.5.3-1.p3", str(ctx.exception))
 
     def test_embargoed_extra_image_nvr_raises(self):
         """An embargoed NVR passed via --extra-image-nvrs must fail the release."""
@@ -631,16 +646,15 @@ class TestEmbargoedNvrDefensiveCheck(unittest.TestCase):
         self.assertIn("oadp-velero-container-1.5.3-1.p3", str(ctx.exception))
 
     def test_non_embargoed_nvrs_do_not_raise_embargo_error(self):
-        """Public (non-embargoed) NVRs should not trigger the embargo defensive check."""
+        """Public (non-embargoed) NVRs should not trigger the embargo defensive check. The
+        mocked workflow should complete normally, so require the run to fully succeed rather
+        than suppressing any RuntimeError (which would mask unrelated regressions)."""
         pipeline = self._make_pipeline(extra_image_nvrs=["oadp-velero-container-1.5.3-1.p2"])
         pipeline.create_snapshot = AsyncMock(return_value=MagicMock())
         pipeline.create_shipment_config = MagicMock(return_value=MagicMock())
         pipeline.write_shipment_files_locally = AsyncMock()
 
-        try:
-            asyncio.run(pipeline.run())
-        except RuntimeError as e:
-            self.assertNotIn("embargoed", str(e))
+        asyncio.run(pipeline.run())
 
 
 class TestSetShipmentMrReady(unittest.TestCase):

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -612,12 +612,14 @@ class TestEmbargoedNvrDefensiveCheck(unittest.TestCase):
 
     def test_embargoed_fbc_nvr_alone_does_not_raise(self):
         """The FBC (catalog) image's own NVR is excluded from the embargo check: it's just a
-        catalog wrapper and, by construction, never carries a p-flag at all (see
-        build_fbc.py, which tags it with a bare timestamp). An embargoed-looking fbc_nvr alone
-        (no embargoed related/extra image NVRs) must not raise the embargo defensive check."""
+        catalog wrapper and, by construction, never carries a p-flag at all (see build_fbc.py,
+        which tags it with a bare timestamp, e.g.
+        'openshift-migration-operator-fbc-1.8.16-20260715174111.ocp4.19'). Since is_nvr_embargoed()
+        defaults to treating an NVR with no p-flag as embargoed, checking the FBC's own NVR would
+        make this defensive check fail unconditionally on every run - confirm it's excluded."""
         pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/example/fbc:v1"])
         pipeline.validate_fbc_related_images = AsyncMock(return_value=[])
-        pipeline.extract_fbc_nvr = MagicMock(return_value="oadp-operator-fbc-1.5.3-1.p3")
+        pipeline.extract_fbc_nvr = MagicMock(return_value="oadp-operator-fbc-1.5.3-20260715174111.ocp4.19")
         pipeline.create_snapshot = AsyncMock(return_value=MagicMock())
         pipeline.create_shipment_config = MagicMock(return_value=MagicMock())
         pipeline.write_shipment_files_locally = AsyncMock()
@@ -627,29 +629,33 @@ class TestEmbargoedNvrDefensiveCheck(unittest.TestCase):
     def test_embargoed_related_nvr_raises(self):
         """An embargoed NVR among the FBC's related images (the actual bundle/operand images
         referenced inside the catalog) must fail the release."""
+        embargoed_nvr = "oadp-velero-container-1.5.3-202607151200.p3.g172d0b2.assembly.stream.el9"
         pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/example/fbc:v1"])
-        pipeline.validate_fbc_related_images = AsyncMock(return_value=["oadp-velero-container-1.5.3-1.p3"])
-        pipeline.extract_fbc_nvr = MagicMock(return_value="oadp-operator-fbc-1.5.3-20260715120000")
+        pipeline.validate_fbc_related_images = AsyncMock(return_value=[embargoed_nvr])
+        pipeline.extract_fbc_nvr = MagicMock(return_value="oadp-operator-fbc-1.5.3-20260715174111.ocp4.19")
 
         with self.assertRaises(RuntimeError) as ctx:
             asyncio.run(pipeline.run())
         self.assertIn("embargoed", str(ctx.exception))
-        self.assertIn("oadp-velero-container-1.5.3-1.p3", str(ctx.exception))
+        self.assertIn(embargoed_nvr, str(ctx.exception))
 
     def test_embargoed_extra_image_nvr_raises(self):
         """An embargoed NVR passed via --extra-image-nvrs must fail the release."""
-        pipeline = self._make_pipeline(extra_image_nvrs=["oadp-velero-container-1.5.3-1.p3"])
+        embargoed_nvr = "oadp-velero-container-1.5.3-202607151200.p3.g172d0b2.assembly.stream.el9"
+        pipeline = self._make_pipeline(extra_image_nvrs=[embargoed_nvr])
 
         with self.assertRaises(RuntimeError) as ctx:
             asyncio.run(pipeline.run())
         self.assertIn("embargoed", str(ctx.exception))
-        self.assertIn("oadp-velero-container-1.5.3-1.p3", str(ctx.exception))
+        self.assertIn(embargoed_nvr, str(ctx.exception))
 
     def test_non_embargoed_nvrs_do_not_raise_embargo_error(self):
         """Public (non-embargoed) NVRs should not trigger the embargo defensive check. The
         mocked workflow should complete normally, so require the run to fully succeed rather
         than suppressing any RuntimeError (which would mask unrelated regressions)."""
-        pipeline = self._make_pipeline(extra_image_nvrs=["oadp-velero-container-1.5.3-1.p2"])
+        pipeline = self._make_pipeline(
+            extra_image_nvrs=["oadp-velero-container-1.5.3-202607151200.p2.g172d0b2.assembly.stream.el9"]
+        )
         pipeline.create_snapshot = AsyncMock(return_value=MagicMock())
         pipeline.create_shipment_config = MagicMock(return_value=MagicMock())
         pipeline.write_shipment_files_locally = AsyncMock()

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -639,6 +639,18 @@ class TestEmbargoedNvrDefensiveCheck(unittest.TestCase):
         self.assertIn("embargoed", str(ctx.exception))
         self.assertIn(embargoed_nvr, str(ctx.exception))
 
+    def test_ambiguous_nvr_raises(self):
+        """An NVR whose embargo status is ambiguous (matches more than one visibility suffix)
+        must fail the release rather than have is_nvr_embargoed() guess which one applies."""
+        ambiguous_nvr = "oadp-velero-container-1.5.3.202607151200.p2.g172d0b2.assembly.stream.el9.p3"
+        pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/example/fbc:v1"])
+        pipeline.validate_fbc_related_images = AsyncMock(return_value=[ambiguous_nvr])
+        pipeline.extract_fbc_nvr = MagicMock(return_value="oadp-operator-fbc-1.5.3-20260715174111.ocp4.19")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(pipeline.run())
+        self.assertIn("embargo status", str(ctx.exception))
+
     def test_embargoed_extra_image_nvr_raises(self):
         """An embargoed NVR passed via --extra-image-nvrs must fail the release."""
         embargoed_nvr = "oadp-velero-container-1.5.3-202607151200.p3.g172d0b2.assembly.stream.el9"


### PR DESCRIPTION
Reverts openshift-eng/art-tools#3164


https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Frelease-from-fbc/140/console
```
15:04:36  RuntimeError: Refusing to create a release referencing embargoed
(private-fix) NVR(s):
['openshift-migration-operator-metadata-container-1.8.16.202607131859.p2.gafc12a7.assembly.stream.el8-1',
'openshift-migration-operator-fbc-1.8.16-20260715174111.ocp4.19']. This should
never happen for FBC-derived NVRs and likely indicates an upstream bug, or an
embargoed NVR was passed via --extra-image-nvrs.0
```

Need to work on this to address the above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved NVR embargo detection (including multi-match visibility marker handling) and applied it to layered product bundle triggering and release-from-FBC validation.
  * Konflux operator bundle rebasing now substitutes embargoed operands with the latest compatible public builds when available.
* **Bug Fixes**
  * Layered product builds now skip embargoed operator NVRs, log warnings, and exit with code `2` to mark jobs unstable.
  * Release-from-FBC now aborts when embargoed images are detected, including ambiguous determination cases.
* **Tests**
  * Added/expanded coverage for embargo detection, substitution behavior (including BREW/late-resolve paths), and defensive pipeline validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->