### PR TITLE
ART-14778: filter non-OCP MRs in shipment config parsing

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -57,6 +57,7 @@ FBCS_TABLE_ID = 'fbcs'
 TASKRUN_TABLE_ID = 'taskruns'
 
 SHIPMENT_DATA_URL_TEMPLATE = "https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data"
+SHIPMENT_CONFIG_KINDS = ("image", "extras", "metadata", "fbc", "microshift-bootc")
 
 # Redis related vars
 REDIS_HOST = 'master.redis.gwprhd.use1.cache.amazonaws.com'

--- a/elliott/elliottlib/cli/shipment_cli.py
+++ b/elliott/elliottlib/cli/shipment_cli.py
@@ -3,6 +3,7 @@ import sys
 import click
 from artcommonlib import logutil
 from artcommonlib.assembly import AssemblyTypes
+from artcommonlib.constants import SHIPMENT_CONFIG_KINDS
 from artcommonlib.gitdata import SafeFormatter
 from doozerlib.backend.konflux_fbc import KonfluxFbcBuilder
 from doozerlib.util import konflux_application_name
@@ -108,7 +109,7 @@ class InitShipmentCli:
 @click.argument(
     "kind",
     metavar="<KIND>",
-    type=click.Choice(["image", "extras", "metadata", "microshift-bootc", "fbc"]),
+    type=click.Choice(SHIPMENT_CONFIG_KINDS),
 )
 @click.pass_obj
 @click_coroutine

--- a/elliott/elliottlib/shipment_utils.py
+++ b/elliott/elliottlib/shipment_utils.py
@@ -27,9 +27,9 @@ def get_shipment_configs_from_mr(
     Arg(s):
         mr_url (str): URL of the merge request.
         kinds (Tuple[str, ...]): Possible advisory kinds to fetch shipment configs for.
-        group (str | None): When provided, only files whose path contains this group
-            as a directory segment are parsed. Skips non-matching files entirely,
-            avoiding parse errors on unrelated products.
+        group (str | None): When provided, only files whose path has this group
+            at position 2 (shipment/{product}/{group}/...) are parsed. Skips
+            non-matching files entirely, avoiding parse errors on unrelated products.
 
     Return Value(s):
         Dict[str, ShipmentConfig]: Dict of {kind: ShipmentConfig}.
@@ -49,7 +49,8 @@ def get_shipment_configs_from_mr(
         if not file_path or not file_path.endswith(('.yaml', '.yml')):
             continue
 
-        if group and group not in file_path.split('/'):
+        path_parts = file_path.split('/')
+        if group and (len(path_parts) < 4 or path_parts[0] != "shipment" or path_parts[2] != group):
             continue
 
         filename = file_path.split('/')[-1]

--- a/elliott/elliottlib/shipment_utils.py
+++ b/elliott/elliottlib/shipment_utils.py
@@ -3,6 +3,7 @@ from typing import Dict, Iterable, List, Tuple
 from urllib.parse import urlparse
 
 from artcommonlib.assembly import assembly_config_struct
+from artcommonlib.constants import SHIPMENT_CONFIG_KINDS
 from artcommonlib.gitlab import GitLabClient
 from artcommonlib.jira_config import JIRA_DOMAIN_NAME
 from artcommonlib.model import Model
@@ -16,12 +17,22 @@ yaml = new_roundtrip_yaml_handler()
 
 
 def get_shipment_configs_from_mr(
-    mr_url: str, kinds: Tuple[str, ...] = ("image", "extras", "metadata", "fbc", "microshift-bootc")
+    mr_url: str,
+    kinds: Tuple[str, ...] = SHIPMENT_CONFIG_KINDS,
+    group: str | None = None,
 ) -> Dict[str, ShipmentConfig]:
-    """Fetch shipment configs from a merge request URL.
-    :param mr_url: URL of the merge request
-    :param kinds: List of all possible advisory kinds to fetch shipment configs for
-    :return: Dict of {kind: ShipmentConfig}
+    """
+    Fetch shipment configs from a merge request URL.
+
+    Arg(s):
+        mr_url (str): URL of the merge request.
+        kinds (Tuple[str, ...]): Possible advisory kinds to fetch shipment configs for.
+        group (str | None): When provided, only files whose path contains this group
+            as a directory segment are parsed. Skips non-matching files entirely,
+            avoiding parse errors on unrelated products.
+
+    Return Value(s):
+        Dict[str, ShipmentConfig]: Dict of {kind: ShipmentConfig}.
     """
 
     shipment_configs: Dict[str, ShipmentConfig] = {}
@@ -36,6 +47,9 @@ def get_shipment_configs_from_mr(
     for file_diff in diff.diffs:
         file_path = file_diff.get('new_path') or file_diff.get('old_path')
         if not file_path or not file_path.endswith(('.yaml', '.yml')):
+            continue
+
+        if group and group not in file_path.split('/'):
             continue
 
         filename = file_path.split('/')[-1]
@@ -138,7 +152,7 @@ def get_bug_ids_from_open_shipment_mrs(
     bug_ids: set[str] = set()
     for mr in open_mrs:
         try:
-            shipment_configs = get_shipment_configs_from_mr(mr.web_url)
+            shipment_configs = get_shipment_configs_from_mr(mr.web_url, group=group)
         except (ValueError, TypeError, KeyError):
             logger.warning("Failed to parse shipment configs from MR %s, skipping", mr.web_url, exc_info=True)
             continue

--- a/elliott/tests/test_shipment_utils.py
+++ b/elliott/tests/test_shipment_utils.py
@@ -295,6 +295,151 @@ shipment:
         self.assertEqual(set(result.keys()), expected_kinds)
 
 
+class TestGroupFiltering(unittest.TestCase):
+    """Test cases for group-based filtering in get_shipment_configs_from_mr"""
+
+    def setUp(self):
+        self.test_mr_url = "https://gitlab.com/test-project/-/merge_requests/123"
+        self.sample_yaml_content = """
+shipment:
+  metadata:
+    product: "openshift"
+    application: "openshift"
+    group: "openshift-4.18"
+    assembly: "4.18.40"
+    fbc: false
+  environments:
+    stage:
+      releasePlan: "stage-plan"
+    prod:
+      releasePlan: "prod-plan"
+  data:
+    releaseNotes:
+      type: "RHBA"
+      synopsis: "Test synopsis"
+      topic: "Test topic"
+      description: "Test description"
+      solution: "Test solution"
+      cves: []
+"""
+
+    @patch("artcommonlib.gitlab.gitlab.Gitlab")
+    @patch.dict(os.environ, {"GITLAB_TOKEN": "test-token"})
+    def test_group_filter_includes_matching_files(self, mock_gitlab_class):
+        """Files under the matching group directory are parsed."""
+        mock_gitlab = mock_gitlab_class.return_value
+        mock_project = Mock()
+        mock_source_project = Mock()
+        mock_gitlab.projects.get.side_effect = [mock_project, mock_source_project]
+
+        mock_mr = Mock()
+        mock_mr.source_project_id = "source-project-id"
+        mock_mr.source_branch = "test-branch"
+        mock_project.mergerequests.get.return_value = mock_mr
+
+        mock_diff_info = Mock()
+        mock_diff_info.id = "diff-id"
+        mock_mr.diffs.list.return_value = [mock_diff_info]
+        mock_diff = Mock()
+        mock_mr.diffs.get.return_value = mock_diff
+        mock_diff.diffs = [
+            {"new_path": "shipment/openshift/openshift-4.18/openshift/prod/image.yaml", "old_path": None},
+        ]
+
+        mock_file_content = Mock()
+        mock_file_content.decode.return_value.decode.return_value = self.sample_yaml_content
+        mock_source_project.files.get.return_value = mock_file_content
+
+        result = shipment_utils.get_shipment_configs_from_mr(self.test_mr_url, ("image",), group="openshift-4.18")
+        self.assertEqual(len(result), 1)
+        self.assertIn("image", result)
+
+    @patch("artcommonlib.gitlab.gitlab.Gitlab")
+    @patch.dict(os.environ, {"GITLAB_TOKEN": "test-token"})
+    def test_group_filter_excludes_non_matching_files(self, mock_gitlab_class):
+        """Files under a different group directory are skipped entirely."""
+        mock_gitlab = mock_gitlab_class.return_value
+        mock_project = Mock()
+        mock_source_project = Mock()
+        mock_gitlab.projects.get.side_effect = [mock_project, mock_source_project]
+
+        mock_mr = Mock()
+        mock_mr.source_project_id = "source-project-id"
+        mock_mr.source_branch = "test-branch"
+        mock_project.mergerequests.get.return_value = mock_mr
+
+        mock_diff_info = Mock()
+        mock_diff_info.id = "diff-id"
+        mock_mr.diffs.list.return_value = [mock_diff_info]
+        mock_diff = Mock()
+        mock_mr.diffs.get.return_value = mock_diff
+        mock_diff.diffs = [
+            {"new_path": "shipment/oadp/oadp-1.5/oadp/prod/fbc.yaml", "old_path": None},
+            {"new_path": "shipment/oadp/oadp-1.5/oadp/prod/fbc-extra.yaml", "old_path": None},
+        ]
+
+        result = shipment_utils.get_shipment_configs_from_mr(self.test_mr_url, ("fbc",), group="openshift-4.18")
+        self.assertEqual(result, {})
+        mock_source_project.files.get.assert_not_called()
+
+    @patch("artcommonlib.gitlab.gitlab.Gitlab")
+    @patch.dict(os.environ, {"GITLAB_TOKEN": "test-token"})
+    def test_group_filter_avoids_substring_match(self, mock_gitlab_class):
+        """Group filter uses exact path segment matching, not substring."""
+        mock_gitlab = mock_gitlab_class.return_value
+        mock_project = Mock()
+        mock_source_project = Mock()
+        mock_gitlab.projects.get.side_effect = [mock_project, mock_source_project]
+
+        mock_mr = Mock()
+        mock_mr.source_project_id = "source-project-id"
+        mock_mr.source_branch = "test-branch"
+        mock_project.mergerequests.get.return_value = mock_mr
+
+        mock_diff_info = Mock()
+        mock_diff_info.id = "diff-id"
+        mock_mr.diffs.list.return_value = [mock_diff_info]
+        mock_diff = Mock()
+        mock_mr.diffs.get.return_value = mock_diff
+        mock_diff.diffs = [
+            {"new_path": "shipment/openshift/openshift-4.18/openshift/prod/image.yaml", "old_path": None},
+        ]
+
+        result = shipment_utils.get_shipment_configs_from_mr(self.test_mr_url, ("image",), group="openshift-4.1")
+        self.assertEqual(result, {})
+        mock_source_project.files.get.assert_not_called()
+
+    @patch("artcommonlib.gitlab.gitlab.Gitlab")
+    @patch.dict(os.environ, {"GITLAB_TOKEN": "test-token"})
+    def test_no_group_filter_parses_all_files(self, mock_gitlab_class):
+        """Without group filter, all matching YAML files are parsed (existing behavior)."""
+        mock_gitlab = mock_gitlab_class.return_value
+        mock_project = Mock()
+        mock_source_project = Mock()
+        mock_gitlab.projects.get.side_effect = [mock_project, mock_source_project]
+
+        mock_mr = Mock()
+        mock_mr.source_project_id = "source-project-id"
+        mock_mr.source_branch = "test-branch"
+        mock_project.mergerequests.get.return_value = mock_mr
+
+        mock_diff_info = Mock()
+        mock_diff_info.id = "diff-id"
+        mock_mr.diffs.list.return_value = [mock_diff_info]
+        mock_diff = Mock()
+        mock_mr.diffs.get.return_value = mock_diff
+        mock_diff.diffs = [
+            {"new_path": "shipment/oadp/oadp-1.5/oadp/prod/image.yaml", "old_path": None},
+        ]
+
+        mock_file_content = Mock()
+        mock_file_content.decode.return_value.decode.return_value = self.sample_yaml_content
+        mock_source_project.files.get.return_value = mock_file_content
+
+        result = shipment_utils.get_shipment_configs_from_mr(self.test_mr_url, ("image",))
+        self.assertEqual(len(result), 1)
+
+
 @patch.dict(os.environ, {"GITLAB_TOKEN": "fake-token"})
 class TestGetBugIdsFromOpenShipmentMrs(unittest.TestCase):
     """Test cases for get_bug_ids_from_open_shipment_mrs"""
@@ -565,6 +710,23 @@ class TestGetBugIdsFromOpenShipmentMrs(unittest.TestCase):
 
         result = self._call(releases_config=self._make_releases_config("4.18.39", mr_url))
         self.assertEqual(result, {"OCPBUGS-1000"})
+
+    @patch("elliottlib.shipment_utils.get_shipment_configs_from_mr")
+    @patch("elliottlib.shipment_utils.GitLabClient")
+    def test_passes_group_to_get_shipment_configs(self, mock_gitlab_cls, mock_get_configs):
+        """get_shipment_configs_from_mr should be called with group kwarg for pre-filtering."""
+        mock_client = Mock()
+        mock_gitlab_cls.from_url.return_value = mock_client
+
+        mr_url = "https://gitlab.example.com/project/-/merge_requests/1"
+        mock_mr = Mock()
+        mock_mr.web_url = mr_url
+        mock_client.list_merge_requests.return_value = [mock_mr]
+
+        mock_get_configs.return_value = {}
+
+        self._call(group="openshift-4.18")
+        mock_get_configs.assert_called_once_with(mr_url, group="openshift-4.18")
 
 
 if __name__ == '__main__':

--- a/elliott/tests/test_shipment_utils.py
+++ b/elliott/tests/test_shipment_utils.py
@@ -411,6 +411,33 @@ shipment:
 
     @patch("artcommonlib.gitlab.gitlab.Gitlab")
     @patch.dict(os.environ, {"GITLAB_TOKEN": "test-token"})
+    def test_group_filter_checks_position_not_any_segment(self, mock_gitlab_class):
+        """Group appearing in a later path segment (not position 2) should not match."""
+        mock_gitlab = mock_gitlab_class.return_value
+        mock_project = Mock()
+        mock_source_project = Mock()
+        mock_gitlab.projects.get.side_effect = [mock_project, mock_source_project]
+
+        mock_mr = Mock()
+        mock_mr.source_project_id = "source-project-id"
+        mock_mr.source_branch = "test-branch"
+        mock_project.mergerequests.get.return_value = mock_mr
+
+        mock_diff_info = Mock()
+        mock_diff_info.id = "diff-id"
+        mock_mr.diffs.list.return_value = [mock_diff_info]
+        mock_diff = Mock()
+        mock_mr.diffs.get.return_value = mock_diff
+        mock_diff.diffs = [
+            {"new_path": "shipment/openshift/other-group/openshift-4.18/prod/image.yaml", "old_path": None},
+        ]
+
+        result = shipment_utils.get_shipment_configs_from_mr(self.test_mr_url, ("image",), group="openshift-4.18")
+        self.assertEqual(result, {})
+        mock_source_project.files.get.assert_not_called()
+
+    @patch("artcommonlib.gitlab.gitlab.Gitlab")
+    @patch.dict(os.environ, {"GITLAB_TOKEN": "test-token"})
     def test_no_group_filter_parses_all_files(self, mock_gitlab_class):
         """Without group filter, all matching YAML files are parsed (existing behavior)."""
         mock_gitlab = mock_gitlab_class.return_value


### PR DESCRIPTION
Add group-based path filtering to get_shipment_configs_from_mr() so that non-OCP shipment files (layered products like OADP, MTA) are skipped before parsing. Uses exact path segment matching against the shipment directory structure (shipment/{product}/{group}/...) to avoid ValueError crashes on MRs with duplicate kind files from other products.

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shipment configuration loading now supports optional group-based filtering, considering only YAML files in the expected `shipment/<kind>/<group>/...` path (with exact path-segment matching).
  * Open shipment MR bug-ID aggregation now honors the requested group when selecting shipment configs.
  * `shipment init` kind validation is now aligned with the shared supported kind list.

* **Tests**
  * Added unit tests covering exact group matching, skipping non-matching paths (no substring matches), and unchanged behavior when no group is provided.
  * Added test coverage ensuring the group argument is forwarded in the open MR bug-ID collection flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->