### PR TITLE
Add version parameter support to build-plashets for golang monobranch groups

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -278,32 +278,37 @@ class KonfluxImageBuilder:
                     image_pullspec = next((r['value'] for r in results if r['name'] == 'IMAGE_URL'), None)
                     image_digest = next((r['value'] for r in results if r['name'] == 'IMAGE_DIGEST'), None)
 
-                    definitive_image_pullspec = f"{image_pullspec.split(':')[0]}@{image_digest}"
-                    record["image_pullspec"] = definitive_image_pullspec
+                    # In dry-run mode, the simulated PipelineRun has no results, so skip operations requiring them
+                    if image_pullspec and image_digest:
+                        definitive_image_pullspec = f"{image_pullspec.split(':')[0]}@{image_digest}"
+                        record["image_pullspec"] = definitive_image_pullspec
 
-                    image_tag = image_pullspec.split(':')[-1]
-                    record["image_tag"] = image_tag
+                        image_tag = image_pullspec.split(':')[-1]
+                        record["image_tag"] = image_tag
 
-                    # Validate SLSA attestation and source image signature
-                    # Skip for non-OCP groups (e.g., OKD) as they may not have attestations/signatures
-                    is_ocp_group = self._config.group_name.startswith("openshift-")
-                    if is_ocp_group:
-                        try:
-                            # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
-                            await self._validate_build_attestation_and_signature(
-                                definitive_image_pullspec, metadata.distgit_key
+                        # Validate SLSA attestation and source image signature
+                        # Skip for non-OCP groups (e.g., OKD) as they may not have attestations/signatures
+                        is_ocp_group = self._config.group_name.startswith("openshift-")
+                        if is_ocp_group:
+                            try:
+                                # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
+                                await self._validate_build_attestation_and_signature(
+                                    definitive_image_pullspec, metadata.distgit_key
+                                )
+                            except Exception as e:
+                                logger.error(
+                                    f"Failed to get SLA attestation / source signature from konflux for image {definitive_image_pullspec}, marking build as {KonfluxBuildOutcome.BUILD_ERROR}. Error: {e}"
+                                )
+                                outcome = KonfluxBuildOutcome.BUILD_ERROR
+                        else:
+                            logger.info(
+                                "Skipping SLSA attestation validation for %s: non-OCP group '%s'",
+                                metadata.distgit_key,
+                                self._config.group_name,
                             )
-                        except Exception as e:
-                            logger.error(
-                                f"Failed to get SLA attestation / source signature from konflux for image {definitive_image_pullspec}, marking build as {KonfluxBuildOutcome.BUILD_ERROR}. Error: {e}"
-                            )
-                            outcome = KonfluxBuildOutcome.BUILD_ERROR
-                    else:
-                        logger.info(
-                            "Skipping SLSA attestation validation for %s: non-OCP group '%s'",
-                            metadata.distgit_key,
-                            self._config.group_name,
-                        )
+                    elif not self._config.dry_run:
+                        # This should never happen in real builds - only expected in dry-run mode
+                        raise IOError(f"PipelineRun succeeded but IMAGE_URL or IMAGE_DIGEST missing from results")
 
                 # Run enterprise-contract (EC) verification after a successful build
                 # TODO: Expand EC verification to layered products
@@ -315,6 +320,8 @@ class KonfluxImageBuilder:
                     and is_ocp_group
                     and not self._config.skip_ec_verify
                     and metadata.for_release
+                    and image_pullspec  # EC requires actual build results
+                    and image_digest
                 )
                 if should_run_ec:
                     app_name = util.konflux_application_name(self._config.group_name)
@@ -380,7 +387,12 @@ class KonfluxImageBuilder:
                     # One completion record per attempt. Base images trigger snapshot→release (digest pullspec)
                     # before persisting SUCCESS or FAILURE so Jenkins/batch workflows can query SUCCESS rows.
                     release_result: Optional[BaseImageReleaseResult] = None
-                    if outcome is KonfluxBuildOutcome.SUCCESS and metadata.should_trigger_base_image_release():
+                    if (
+                        outcome is KonfluxBuildOutcome.SUCCESS
+                        and metadata.should_trigger_base_image_release()
+                        and image_pullspec
+                        and image_digest
+                    ):
                         release_result = await self._trigger_base_image_release(
                             metadata, nvr, definitive_image_pullspec, build_repo
                         )

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -600,7 +600,7 @@ class KonfluxImageBuilder:
                 "path": lockfile_path,
             }
 
-            golang_pattern = re.compile(r'^golang-|^rhel-\d+-golang-\d+\.\d+')
+            golang_pattern = re.compile(r'^golang$|^golang-|^rhel-\d+-golang-\d+\.\d+')
             if group.startswith("openshift-") or golang_pattern.match(group):
                 # For groups like oadp, mta, logging we should always use signed repos
                 # For golang groups (golang-* and rhel-X-golang-Y.Z), always exclude gpg check regardless of lifecycle phase

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -308,7 +308,7 @@ class KonfluxImageBuilder:
                             )
                     elif not self._config.dry_run:
                         # This should never happen in real builds - only expected in dry-run mode
-                        raise IOError(f"PipelineRun succeeded but IMAGE_URL or IMAGE_DIGEST missing from results")
+                        raise IOError("PipelineRun succeeded but IMAGE_URL or IMAGE_DIGEST missing from results")
 
                 # Run enterprise-contract (EC) verification after a successful build
                 # TODO: Expand EC verification to layered products

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -45,7 +45,7 @@ class Jobs(Enum):
     MICROSHIFT_SYNC = 'aos-cd-builds/build%2Fmicroshift_sync'
     CINCINNATI_PRS = 'aos-cd-builds/build%2Fcincinnati-prs'
     RHCOS_SYNC = 'aos-cd-builds/build%2Frhcos_sync'
-    BUILD_PLASHETS = 'hack/bvizi/build%2Fbuild-plashets'
+    BUILD_PLASHETS = 'aos-cd-jobs/build%2Fbuild-plashets'
     BUILD_FBC = 'aos-cd-builds/build%2Fbuild-fbc'
     LAYERED_PRODUCTS = 'aos-cd-builds/build%2Flayered-products'
     LAYERED_PRODUCTS_SCAN = 'aos-cd-builds/build%2Flayered-products-scan'
@@ -795,7 +795,6 @@ def start_build_plashets(
         'COPY_LINKS': copy_links,
         'DRY_RUN': dry_run,
         'VERSION': version,
-        'ART_TOOLS_COMMIT': "kopero2000@plashet-build-mono-golang-support",
     }
 
     return start_build(

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -45,7 +45,7 @@ class Jobs(Enum):
     MICROSHIFT_SYNC = 'aos-cd-builds/build%2Fmicroshift_sync'
     CINCINNATI_PRS = 'aos-cd-builds/build%2Fcincinnati-prs'
     RHCOS_SYNC = 'aos-cd-builds/build%2Frhcos_sync'
-    BUILD_PLASHETS = 'aos-cd-builds/build%2Fbuild-plashets'
+    BUILD_PLASHETS = 'hack/bvizi/build%2Fbuild-plashets'
     BUILD_FBC = 'aos-cd-builds/build%2Fbuild-fbc'
     LAYERED_PRODUCTS = 'aos-cd-builds/build%2Flayered-products'
     LAYERED_PRODUCTS_SCAN = 'aos-cd-builds/build%2Flayered-products-scan'
@@ -774,7 +774,16 @@ def start_rhcos_sync(release_tag_or_pullspec: str, dry_run: bool, sign_only: boo
 
 
 def start_build_plashets(
-    group, release, assembly, repos=None, data_path='', data_gitref='', copy_links=False, dry_run=False, **kwargs
+    group,
+    release,
+    assembly,
+    repos=None,
+    data_path='',
+    data_gitref='',
+    copy_links=False,
+    dry_run=False,
+    version=None,
+    **kwargs,
 ) -> Optional[str]:
     params = {
         'GROUP': group,
@@ -785,6 +794,8 @@ def start_build_plashets(
         'DATA_GITREF': data_gitref,
         'COPY_LINKS': copy_links,
         'DRY_RUN': dry_run,
+        'VERSION': version,
+        'ART_TOOLS_COMMIT': "kopero2000@cleanup-logic-for-seperate-golang-versions",
     }
 
     return start_build(

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -795,7 +795,7 @@ def start_build_plashets(
         'COPY_LINKS': copy_links,
         'DRY_RUN': dry_run,
         'VERSION': version,
-        'ART_TOOLS_COMMIT': "kopero2000@cleanup-logic-for-seperate-golang-versions",
+        'ART_TOOLS_COMMIT': "kopero2000@plashet-build-mono-golang-support",
     }
 
     return start_build(

--- a/pyartcd/pyartcd/pipelines/build_plashets.py
+++ b/pyartcd/pyartcd/pipelines/build_plashets.py
@@ -22,7 +22,16 @@ class RpmMirror:
 
 class BuildPlashetsPipeline:
     def __init__(
-        self, runtime: Runtime, group, release, assembly, repos=None, data_path='', data_gitref='', copy_links=False
+        self,
+        runtime: Runtime,
+        group,
+        release,
+        assembly,
+        repos=None,
+        data_path='',
+        data_gitref='',
+        copy_links=False,
+        version=None,
     ):
         self.runtime = runtime
         self.group = group
@@ -32,6 +41,7 @@ class BuildPlashetsPipeline:
         self.data_path = data_path
         self.data_gitref = data_gitref
         self.copy_links = copy_links
+        self.version = version
 
         self.slack_client = runtime.new_slack_client()
 
@@ -72,6 +82,7 @@ class BuildPlashetsPipeline:
                 data_gitref=self.data_gitref,
                 copy_links=self.copy_links,
                 dry_run=self.runtime.dry_run,
+                version=self.version,
             )
             self.runtime.logger.info('Built plashets: %s', json.dumps(plashets_built, indent=4))
 
@@ -143,6 +154,12 @@ class BuildPlashetsPipeline:
 )
 @click.option('--data-gitref', required=False, default='', help='Doozer data path git [branch / tag / sha] to use')
 @click.option('--copy-links', is_flag=True, default=False, help='Call rsync with --copy-links instead of --links')
+@click.option(
+    '--version',
+    required=False,
+    default='',
+    help='OCP version for resolving MAJOR/MINOR vars in golang groups (e.g. 4.18). Required for golang groups, ignored for other groups.',
+)
 @pass_runtime
 @click_coroutine
 async def build_plashets_cli(
@@ -154,11 +171,26 @@ async def build_plashets_cli(
     data_path: str,
     data_gitref: str,
     copy_links: bool,
+    version: str,
 ):
     # Auto-generate release timestamp if not provided
     if not release:
         release = util.default_release_suffix()
         runtime.logger.info(f'Auto-generated release timestamp: {release}')
+
+    # Validate version parameter for golang groups
+    is_golang_group = group.startswith('golang')
+    if is_golang_group and not version:
+        raise click.BadParameter(
+            f"Version parameter is required for golang groups (group: {group}). "
+            "Please provide --version (e.g., --version 4.18)"
+        )
+
+    if not is_golang_group and version:
+        runtime.logger.warning(
+            f"Version parameter '{version}' will be ignored for non-golang group '{group}'. "
+            "Version is only used for golang groups."
+        )
 
     pipeline = BuildPlashetsPipeline(
         runtime=runtime,
@@ -169,6 +201,7 @@ async def build_plashets_cli(
         data_path=data_path,
         data_gitref=data_gitref,
         copy_links=copy_links,
+        version=version or None,
     )
 
     lock = Lock.PLASHET

--- a/pyartcd/pyartcd/pipelines/build_plashets.py
+++ b/pyartcd/pyartcd/pipelines/build_plashets.py
@@ -102,16 +102,15 @@ class BuildPlashetsPipeline:
         Otherwise, return False
         """
 
-        extra_vars = []
-        if self.group.startswith('golang') and self.version:
-            major, minor = self.version.split('.')
-            extra_vars = [f"MAJOR={major}", f"MINOR={minor}"]
+        if self.group.startswith('golang'):
+            self.runtime.logger.info('Skipping freeze automation check for golang group %s', self.group)
+            return True
+
         automation_freeze_state: str = await get_freeze_automation(
             group=self.group,
             doozer_data_path=self.data_path,
             doozer_working=self.runtime.doozer_working,
             doozer_data_gitref=self.data_gitref,
-            extra_vars=extra_vars,
         )
         self.runtime.logger.info('Automation freeze state for %s: %s', self.group, automation_freeze_state)
 

--- a/pyartcd/pyartcd/pipelines/build_plashets.py
+++ b/pyartcd/pyartcd/pipelines/build_plashets.py
@@ -102,12 +102,16 @@ class BuildPlashetsPipeline:
         Otherwise, return False
         """
 
-        # pass group instead of version to get_freeze_automation
+        extra_vars = []
+        if self.group.startswith('golang') and self.version:
+            major, minor = self.version.split('.')
+            extra_vars = [f"MAJOR={major}", f"MINOR={minor}"]
         automation_freeze_state: str = await get_freeze_automation(
             group=self.group,
             doozer_data_path=self.data_path,
             doozer_working=self.runtime.doozer_working,
             doozer_data_gitref=self.data_gitref,
+            extra_vars=extra_vars,
         )
         self.runtime.logger.info('Automation freeze state for %s: %s', self.group, automation_freeze_state)
 

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -623,6 +623,8 @@ class UpdateGolangPipeline:
                 version=self.ocp_version,
                 block_until_complete=True,
                 dry_run=self.dry_run,
+                data_path=self.data_path,
+                data_gitref=self.data_gitref
             )
             if result != "SUCCESS":
                 raise RuntimeError(f"Plashet build for {group} failed with result: {result}")

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -597,7 +597,10 @@ class UpdateGolangPipeline:
         """Check sign_golang_rpm in the golang branch group.yml.
         Defaults to False so that RHEL-shipped golang is never accidentally signed by us.
         """
-        default_branch = self.get_golang_branch(el_v, go_version)
+        if self.use_new_golang_branch:
+            default_branch = self.GOLANG_DATA_BRANCH
+        else:
+            default_branch = self.get_golang_branch(el_v, go_version)
         repo, branch = self._get_ocp_build_data_repo_and_branch(default_branch)
         content = repo.get_contents("group.yml", ref=branch)
         group_config = yaml.load(content.decoded_content)

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -608,23 +608,26 @@ class UpdateGolangPipeline:
         _LOGGER.info("Building golang plashets for go %s, RHEL versions: %s", go_v, list(el_versions))
 
         for el_v in el_versions:
-            group = self.GOLANG_DATA_BRANCH
+            if self.use_new_golang_branch:
+                group = self.GOLANG_DATA_BRANCH
+                version = self.ocp_version
+            else:
+                group = self.get_golang_branch(el_v, go_version)
+                version = None
             repo_name = f"rhel-{el_v}-golang-rpms"
             _LOGGER.info("Triggering plashet build for group=%s, repo=%s", group, repo_name)
             await self._slack_client.say_in_thread(f"Building golang plashet: group={group}, repo={repo_name}")
 
-            # Pass OCP version as VERSION param so build-plashets can resolve MAJOR/MINOR vars
-            # The monobranch golang group.yml uses {MAJOR}/{MINOR} placeholders that need to be resolved
             result = jenkins.start_build_plashets(
                 group=group,
                 release=default_release_suffix(),
                 assembly="stream",
                 repos=[repo_name],
-                version=self.ocp_version,
+                version=version,
                 block_until_complete=True,
                 dry_run=self.dry_run,
                 data_path=self.data_path,
-                data_gitref=self.data_gitref
+                data_gitref=self.data_gitref,
             )
             if result != "SUCCESS":
                 raise RuntimeError(f"Plashet build for {group} failed with result: {result}")
@@ -1173,9 +1176,8 @@ class UpdateGolangPipeline:
     help='Override network mode for Konflux builds. Takes precedence over image and group config settings.',
 )
 @click.option(
-    '--use-new-golang-branch',
-    is_flag=True,
-    default=False,
+    '--use-new-golang-branch/--no-use-new-golang-branch',
+    default=True,
     help='Use the unified "golang" branch layout in ocp-build-data instead of per-variant branches (e.g. rhel-9-golang-1.26).',
 )
 @click.option(
@@ -1221,7 +1223,7 @@ async def update_golang(
     if network_mode and build_system == 'brew':
         raise click.BadParameter('--network-mode only applies when --build-system is "konflux" or "both".')
 
-    await UpdateGolangPipeline(
+    pipeline = UpdateGolangPipeline(
         runtime,
         ocp_version,
         cves_list,
@@ -1240,4 +1242,16 @@ async def update_golang(
         network_mode,
         use_new_golang_branch,
         major_bump,
-    ).run()
+    )
+    try:
+        await pipeline.run()
+    except Exception as e:
+        if use_new_golang_branch:
+            _LOGGER.error("Golang monobranch build failed: %s", e)
+            slack_client = runtime.new_slack_client()
+            slack_client.bind_channel(ocp_version)
+            await slack_client.say(
+                f":warning: [GOLANG MONOBRANCH FAILURE] update-golang for {ocp_version} failed "
+                f"using the unified golang branch: {e}"
+            )
+        raise

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -608,23 +608,26 @@ class UpdateGolangPipeline:
         _LOGGER.info("Building golang plashets for go %s, RHEL versions: %s", go_v, list(el_versions))
 
         for el_v in el_versions:
-            group = self.GOLANG_DATA_BRANCH
+            if self.use_new_golang_branch:
+                group = self.GOLANG_DATA_BRANCH
+                version = self.ocp_version
+            else:
+                group = self.get_golang_branch(el_v, go_version)
+                version = None
             repo_name = f"rhel-{el_v}-golang-rpms"
             _LOGGER.info("Triggering plashet build for group=%s, repo=%s", group, repo_name)
             await self._slack_client.say_in_thread(f"Building golang plashet: group={group}, repo={repo_name}")
 
-            # Pass OCP version as VERSION param so build-plashets can resolve MAJOR/MINOR vars
-            # The monobranch golang group.yml uses {MAJOR}/{MINOR} placeholders that need to be resolved
             result = jenkins.start_build_plashets(
                 group=group,
                 release=default_release_suffix(),
                 assembly="stream",
                 repos=[repo_name],
-                version=self.ocp_version,
+                version=version,
                 block_until_complete=True,
                 dry_run=self.dry_run,
                 data_path=self.data_path,
-                data_gitref=self.data_gitref
+                data_gitref=self.data_gitref,
             )
             if result != "SUCCESS":
                 raise RuntimeError(f"Plashet build for {group} failed with result: {result}")
@@ -1173,10 +1176,11 @@ class UpdateGolangPipeline:
     help='Override network mode for Konflux builds. Takes precedence over image and group config settings.',
 )
 @click.option(
-    '--use-new-golang-branch',
-    is_flag=True,
-    default=False,
-    help='Use the unified "golang" branch layout in ocp-build-data instead of per-variant branches (e.g. rhel-9-golang-1.26).',
+    '--use-new-golang-branch/--no-use-new-golang-branch',
+    default=True,
+    help='Use the unified "golang" branch layout in ocp-build-data (default). '
+    'Falls back to per-variant branches (e.g. rhel-9-golang-1.26) automatically on failure. '
+    'Use --no-use-new-golang-branch to force per-variant branches.',
 )
 @click.option(
     '--major-bump',
@@ -1221,23 +1225,33 @@ async def update_golang(
     if network_mode and build_system == 'brew':
         raise click.BadParameter('--network-mode only applies when --build-system is "konflux" or "both".')
 
-    await UpdateGolangPipeline(
-        runtime,
-        ocp_version,
-        cves_list,
-        force_update_tracker,
-        go_nvrs,
-        art_jira,
-        tag_builds,
-        scratch,
-        force_image_build,
-        build_system,
-        kubeconfig,
-        data_path,
-        data_gitref,
-        skip_pr,
-        external_golang_rpms,
-        network_mode,
-        use_new_golang_branch,
-        major_bump,
-    ).run()
+    pipeline_kwargs = dict(
+        ocp_version=ocp_version,
+        cves=cves_list,
+        force_update_tracker=force_update_tracker,
+        go_nvrs=go_nvrs,
+        art_jira=art_jira,
+        tag_builds=tag_builds,
+        scratch=scratch,
+        force_image_build=force_image_build,
+        build_system=build_system,
+        kubeconfig=kubeconfig,
+        data_path=data_path,
+        data_gitref=data_gitref,
+        skip_pr=skip_pr,
+        external_golang_rpms=external_golang_rpms,
+        network_mode=network_mode,
+        major_bump=major_bump,
+    )
+
+    try:
+        await UpdateGolangPipeline(
+            runtime, use_new_golang_branch=use_new_golang_branch, **pipeline_kwargs,
+        ).run()
+    except Exception as e:
+        if not use_new_golang_branch:
+            raise
+        _LOGGER.warning("Golang build with monobranch failed, falling back to separated branches: %s", e)
+        await UpdateGolangPipeline(
+            runtime, use_new_golang_branch=False, **pipeline_kwargs,
+        ).run()

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -608,19 +608,21 @@ class UpdateGolangPipeline:
         _LOGGER.info("Building golang plashets for go %s, RHEL versions: %s", go_v, list(el_versions))
 
         for el_v in el_versions:
-            group = f"rhel-{el_v}-golang-{go_v}"
+            group = self.GOLANG_DATA_BRANCH
             repo_name = f"rhel-{el_v}-golang-rpms"
             _LOGGER.info("Triggering plashet build for group=%s, repo=%s", group, repo_name)
             await self._slack_client.say_in_thread(f"Building golang plashet: group={group}, repo={repo_name}")
-            if self.dry_run:
-                _LOGGER.info("[DRY RUN] Would have triggered build-plashets for %s", group)
-                continue
+
+            # Pass OCP version as VERSION param so build-plashets can resolve MAJOR/MINOR vars
+            # The monobranch golang group.yml uses {MAJOR}/{MINOR} placeholders that need to be resolved
             result = jenkins.start_build_plashets(
                 group=group,
                 release=default_release_suffix(),
                 assembly="stream",
                 repos=[repo_name],
+                version=self.ocp_version,
                 block_until_complete=True,
+                dry_run=self.dry_run,
             )
             if result != "SUCCESS":
                 raise RuntimeError(f"Plashet build for {group} failed with result: {result}")

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -608,26 +608,23 @@ class UpdateGolangPipeline:
         _LOGGER.info("Building golang plashets for go %s, RHEL versions: %s", go_v, list(el_versions))
 
         for el_v in el_versions:
-            if self.use_new_golang_branch:
-                group = self.GOLANG_DATA_BRANCH
-                version = self.ocp_version
-            else:
-                group = self.get_golang_branch(el_v, go_version)
-                version = None
+            group = self.GOLANG_DATA_BRANCH
             repo_name = f"rhel-{el_v}-golang-rpms"
             _LOGGER.info("Triggering plashet build for group=%s, repo=%s", group, repo_name)
             await self._slack_client.say_in_thread(f"Building golang plashet: group={group}, repo={repo_name}")
 
+            # Pass OCP version as VERSION param so build-plashets can resolve MAJOR/MINOR vars
+            # The monobranch golang group.yml uses {MAJOR}/{MINOR} placeholders that need to be resolved
             result = jenkins.start_build_plashets(
                 group=group,
                 release=default_release_suffix(),
                 assembly="stream",
                 repos=[repo_name],
-                version=version,
+                version=self.ocp_version,
                 block_until_complete=True,
                 dry_run=self.dry_run,
                 data_path=self.data_path,
-                data_gitref=self.data_gitref,
+                data_gitref=self.data_gitref
             )
             if result != "SUCCESS":
                 raise RuntimeError(f"Plashet build for {group} failed with result: {result}")
@@ -1176,11 +1173,10 @@ class UpdateGolangPipeline:
     help='Override network mode for Konflux builds. Takes precedence over image and group config settings.',
 )
 @click.option(
-    '--use-new-golang-branch/--no-use-new-golang-branch',
-    default=True,
-    help='Use the unified "golang" branch layout in ocp-build-data (default). '
-    'Falls back to per-variant branches (e.g. rhel-9-golang-1.26) automatically on failure. '
-    'Use --no-use-new-golang-branch to force per-variant branches.',
+    '--use-new-golang-branch',
+    is_flag=True,
+    default=False,
+    help='Use the unified "golang" branch layout in ocp-build-data instead of per-variant branches (e.g. rhel-9-golang-1.26).',
 )
 @click.option(
     '--major-bump',
@@ -1225,33 +1221,23 @@ async def update_golang(
     if network_mode and build_system == 'brew':
         raise click.BadParameter('--network-mode only applies when --build-system is "konflux" or "both".')
 
-    pipeline_kwargs = dict(
-        ocp_version=ocp_version,
-        cves=cves_list,
-        force_update_tracker=force_update_tracker,
-        go_nvrs=go_nvrs,
-        art_jira=art_jira,
-        tag_builds=tag_builds,
-        scratch=scratch,
-        force_image_build=force_image_build,
-        build_system=build_system,
-        kubeconfig=kubeconfig,
-        data_path=data_path,
-        data_gitref=data_gitref,
-        skip_pr=skip_pr,
-        external_golang_rpms=external_golang_rpms,
-        network_mode=network_mode,
-        major_bump=major_bump,
-    )
-
-    try:
-        await UpdateGolangPipeline(
-            runtime, use_new_golang_branch=use_new_golang_branch, **pipeline_kwargs,
-        ).run()
-    except Exception as e:
-        if not use_new_golang_branch:
-            raise
-        _LOGGER.warning("Golang build with monobranch failed, falling back to separated branches: %s", e)
-        await UpdateGolangPipeline(
-            runtime, use_new_golang_branch=False, **pipeline_kwargs,
-        ).run()
+    await UpdateGolangPipeline(
+        runtime,
+        ocp_version,
+        cves_list,
+        force_update_tracker,
+        go_nvrs,
+        art_jira,
+        tag_builds,
+        scratch,
+        force_image_build,
+        build_system,
+        kubeconfig,
+        data_path,
+        data_gitref,
+        skip_pr,
+        external_golang_rpms,
+        network_mode,
+        use_new_golang_branch,
+        major_bump,
+    ).run()

--- a/pyartcd/pyartcd/plashets.py
+++ b/pyartcd/pyartcd/plashets.py
@@ -259,7 +259,7 @@ async def build_plashets(
     is_golang_group = group.startswith('golang')
     if is_golang_group and version:
         major, minor = version.split('.')
-        extra_vars = [f"MAJOR=${major}", f"MINOR={minor}"]
+        extra_vars = [f"MAJOR={major}", f"MINOR={minor}"]
 
     # Load group config
     group_config = await util.load_group_config(

--- a/pyartcd/pyartcd/plashets.py
+++ b/pyartcd/pyartcd/plashets.py
@@ -217,16 +217,18 @@ async def build_plashets(
     data_gitref: str = '',
     copy_links: bool = False,
     dry_run: bool = False,
+    version: str | None = None,
 ) -> dict:
     """
     Unless no RPMs have changed, create multiple yum repos (one for each arch) of RPMs
     based on -candidate tags. Based on release state, those repos can be signed
     (release state) or unsigned (pre-release state)
 
-    :param group: e.g. openshift-4.14
+    :param group: e.g. openshift-4.14 or golang
     :param release: e.g. 202304181947.p?
     :param assembly: e.g. assembly name, defaults to 'stream'
     :param repos: (optional) limit the repos to build to this list. If empty, build all repos. e.g. ['rhel-8-server-ose-rpms']
+    :param version: (optional) OCP version for resolving MAJOR/MINOR vars in golang groups (e.g. '4.18'). Required for golang groups.
     :param doozer_working: Doozer working dir
     :param data_path: ocp-build-data fork to use
     :param data_gitref: Doozer data path git [branch / tag / sha] to use
@@ -250,11 +252,22 @@ async def build_plashets(
     """
 
     # major, minor = stream.split('.')  # e.g. ('4', '14') from '4.14'
+    extra_vars = []
     revision = release.replace('.p?', '')  # e.g. '202304181947' from '202304181947.p?'
+
+    # For golang groups, use version parameter to inject MAJOR/MINOR vars
+    is_golang_group = group.startswith('golang')
+    if is_golang_group and version:
+        major, minor = version.split('.')
+        extra_vars = [f"MAJOR=${major}", f"MINOR={minor}"]
 
     # Load group config
     group_config = await util.load_group_config(
-        group=group, assembly=assembly, doozer_data_path=data_path, doozer_data_gitref=data_gitref
+        group=group,
+        assembly=assembly,
+        doozer_data_path=data_path,
+        doozer_data_gitref=data_gitref,
+        extra_vars=extra_vars,
     )
 
     # Check if assemblies are enabled for current group
@@ -371,6 +384,7 @@ async def build_plashets(
             data_path=data_path,
             dry_run=dry_run,
             doozer_working=doozer_working,
+            version=version,
         )
 
         logger.info('Plashet repo for %s created: %s', repo.name, local_path)
@@ -419,6 +433,7 @@ async def build_plashet_from_tags(
     data_path: str = constants.OCP_BUILD_DATA_URL,
     doozer_working: str = 'doozer-working',
     dry_run: bool = False,
+    version: str | None = None,
 ):
     """
     Builds Plashet repo with "from-tags"
@@ -432,16 +447,28 @@ async def build_plashet_from_tags(
         f'--data-path={data_path}',
         "--working-dir",
         doozer_working,
-        "--group",
-        group_param,
-        "--assembly",
-        assembly,
-        "config:plashet",
-        "--base-dir",
-        str(base_dir),
-        "--name",
-        name,
     ]
+
+    # Add MAJOR/MINOR vars for golang groups when version is provided
+    # This is used by golang update pipeline to inject version for monobranch groups
+    is_golang_group = group_param.startswith('golang')  # Handle group@gitref format
+    if is_golang_group and version:
+        major, minor = version.split('.')
+        cmd.extend(['--var', f'MAJOR={major}', '--var', f'MINOR={minor}'])
+
+    cmd.extend(
+        [
+            "--group",
+            group_param,
+            "--assembly",
+            assembly,
+            "config:plashet",
+            "--base-dir",
+            str(base_dir),
+            "--name",
+            name,
+        ]
+    )
     if repo_subdir:
         cmd.extend(["--repo-subdir", repo_subdir])
     for arch in arches:

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -289,6 +289,7 @@ async def get_freeze_automation(
     doozer_data_path: str = constants.OCP_BUILD_DATA_URL,
     doozer_working: str = '',
     doozer_data_gitref: str = '',
+    extra_vars: list = [],
 ) -> str:
     """
     Returns freeze_automation flag for a specific group
@@ -303,6 +304,7 @@ async def get_freeze_automation(
         f'--working-dir={doozer_working}' if doozer_working else '',
         '--assembly=stream',
         f'--data-path={doozer_data_path}',
+        *[param for extra_var in extra_vars for param in ['--var', extra_var]],
         group_param,
         'config:read-group',
         '--default=no',

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -89,7 +89,7 @@ async def load_group_config(
     cmd = [
         "doozer",
         f"--data-path={doozer_data_path}",
-        *[param for extra_var in extra_vars for param in ['--var', extra_var]],
+        *[param for extra_var in (extra_vars or []) for param in ['--var', extra_var]],
         "--group",
         group,
         "--assembly",
@@ -304,7 +304,7 @@ async def get_freeze_automation(
         f'--working-dir={doozer_working}' if doozer_working else '',
         '--assembly=stream',
         f'--data-path={doozer_data_path}',
-        *[param for extra_var in extra_vars for param in ['--var', extra_var]],
+        *[param for extra_var in (extra_vars or []) for param in ['--var', extra_var]],
         group_param,
         'config:read-group',
         '--default=no',

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -89,8 +89,8 @@ async def load_group_config(
     cmd = [
         "doozer",
         f"--data-path={doozer_data_path}",
-        "--group",
         *[param for extra_var in extra_vars for param in ['--var', extra_var]],
+        "--group",
         group,
         "--assembly",
         assembly,

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -82,6 +82,7 @@ async def load_group_config(
     env=None,
     doozer_data_path: str = constants.OCP_BUILD_DATA_URL,
     doozer_data_gitref: str = '',
+    extra_vars: List = [],
 ) -> Dict:
     if doozer_data_gitref:
         group += f'@{doozer_data_gitref}'
@@ -89,6 +90,7 @@ async def load_group_config(
         "doozer",
         f"--data-path={doozer_data_path}",
         "--group",
+        *[param for extra_var in extra_vars for param in ['--var', extra_var]],
         group,
         "--assembly",
         assembly,

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -82,7 +82,7 @@ async def load_group_config(
     env=None,
     doozer_data_path: str = constants.OCP_BUILD_DATA_URL,
     doozer_data_gitref: str = '',
-    extra_vars: List = [],
+    extra_vars: List = None,
 ) -> Dict:
     if doozer_data_gitref:
         group += f'@{doozer_data_gitref}'
@@ -289,7 +289,7 @@ async def get_freeze_automation(
     doozer_data_path: str = constants.OCP_BUILD_DATA_URL,
     doozer_working: str = '',
     doozer_data_gitref: str = '',
-    extra_vars: list = [],
+    extra_vars: list = None,
 ) -> str:
     """
     Returns freeze_automation flag for a specific group

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -415,21 +415,13 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         self.assertEqual(pipeline.data_path, "/custom/data/path")
         self.assertEqual(pipeline.data_gitref, "my-branch")
 
-    def test_get_golang_branch(self):
-        """Test get_golang_branch static method"""
-        branch = UpdateGolangPipeline.get_golang_branch(8, "1.20.12")
-        self.assertEqual(branch, "rhel-8-golang-1.20")
-
-        branch = UpdateGolangPipeline.get_golang_branch(9, "1.21.5")
-        self.assertEqual(branch, "rhel-9-golang-1.21")
-
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_doozer_var_args(self, mock_konflux_db):
-        """Test _get_doozer_var_args returns --var args when use_new_golang_branch is set"""
+        """Test _get_doozer_var_args always returns --var args for MAJOR/MINOR"""
         pipeline = self._make_pipeline()
-        self.assertEqual(pipeline._get_doozer_var_args(), [])
+        # Now always returns vars regardless of use_new_golang_branch flag
+        self.assertEqual(pipeline._get_doozer_var_args(), ['--var', 'MAJOR=4', '--var', 'MINOR=16'])
 
-        pipeline.use_new_golang_branch = True
         pipeline.ocp_version = "5.0"
         self.assertEqual(pipeline._get_doozer_var_args(), ['--var', 'MAJOR=5', '--var', 'MINOR=0'])
 
@@ -1279,8 +1271,11 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         mock_cmd_assert.assert_called_once()
         cmd = mock_cmd_assert.call_args[0][0]
         self.assertIn("doozer", cmd)
+        self.assertIn("--var", cmd)
+        self.assertIn("MAJOR=4", cmd)
+        self.assertIn("MINOR=16", cmd)
         self.assertIn("--group", cmd)
-        self.assertIn("rhel-8-golang-1.20", cmd)
+        self.assertIn("golang", cmd)  # Now uses monobranch
         self.assertIn("images:rebase", cmd)
         self.assertIn("--version", cmd)
         self.assertIn("v1.20.12", cmd)
@@ -1531,7 +1526,7 @@ class TestShouldSignGolangRpm(unittest.TestCase):
         result = pipeline.should_sign_golang_rpm(9, "1.22.9")
 
         self.assertTrue(result)
-        mock_repo.get_contents.assert_called_with("group.yml", ref="rhel-9-golang-1.22")
+        mock_repo.get_contents.assert_called_with("group.yml", ref="golang")
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
@@ -1553,6 +1548,7 @@ class TestShouldSignGolangRpm(unittest.TestCase):
         result = pipeline.should_sign_golang_rpm(9, "1.25.3")
 
         self.assertFalse(result)
+        mock_repo.get_contents.assert_called_with("group.yml", ref="golang")
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
@@ -1712,10 +1708,13 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
 
         self.assertEqual(mock_jenkins.start_build_plashets.call_count, 2)
         calls = mock_jenkins.start_build_plashets.call_args_list
-        self.assertEqual(calls[0].kwargs["group"], "rhel-8-golang-1.22")
+        # Both calls now use the 'golang' monobranch
+        self.assertEqual(calls[0].kwargs["group"], "golang")
         self.assertEqual(calls[0].kwargs["repos"], ["rhel-8-golang-rpms"])
-        self.assertEqual(calls[1].kwargs["group"], "rhel-9-golang-1.22")
+        self.assertEqual(calls[0].kwargs["version"], "4.18")
+        self.assertEqual(calls[1].kwargs["group"], "golang")
         self.assertEqual(calls[1].kwargs["repos"], ["rhel-9-golang-rpms"])
+        self.assertEqual(calls[1].kwargs["version"], "4.18")
 
     @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1685,15 +1685,12 @@ class TestIsRpmSigned(unittest.TestCase):
 class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
     """Test the _build_golang_plashets method"""
 
-    @patch("pyartcd.pipelines.update_golang.jenkins")
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_triggers_jenkins_for_each_el_version(self, mock_konflux_db, mock_jenkins):
+    def _make_pipeline(self, use_new_golang_branch=False, dry_run=False):
         mock_slack = Mock()
         mock_slack.say_in_thread = AsyncMock()
-        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
+        mock_runtime = Mock(dry_run=dry_run, working_dir=Path("/tmp/working"))
         mock_runtime.new_slack_client.return_value = mock_slack
-
-        pipeline = UpdateGolangPipeline(
+        return UpdateGolangPipeline(
             runtime=mock_runtime,
             ocp_version="4.18",
             cves=None,
@@ -1701,14 +1698,19 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.22.9-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
+            use_new_golang_branch=use_new_golang_branch,
         )
+
+    @patch("pyartcd.pipelines.update_golang.jenkins")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_monobranch_triggers_jenkins_for_each_el_version(self, mock_konflux_db, mock_jenkins):
+        pipeline = self._make_pipeline(use_new_golang_branch=True)
         mock_jenkins.start_build_plashets.return_value = "SUCCESS"
 
         await pipeline._build_golang_plashets("1.22.9", [8, 9])
 
         self.assertEqual(mock_jenkins.start_build_plashets.call_count, 2)
         calls = mock_jenkins.start_build_plashets.call_args_list
-        # Both calls now use the 'golang' monobranch
         self.assertEqual(calls[0].kwargs["group"], "golang")
         self.assertEqual(calls[0].kwargs["repos"], ["rhel-8-golang-rpms"])
         self.assertEqual(calls[0].kwargs["version"], "4.18")
@@ -1718,21 +1720,25 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_raises_on_jenkins_failure(self, mock_konflux_db, mock_jenkins):
-        mock_slack = Mock()
-        mock_slack.say_in_thread = AsyncMock()
-        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
-        mock_runtime.new_slack_client.return_value = mock_slack
+    async def test_separated_branch_triggers_jenkins_per_el_and_go_version(self, mock_konflux_db, mock_jenkins):
+        pipeline = self._make_pipeline(use_new_golang_branch=False)
+        mock_jenkins.start_build_plashets.return_value = "SUCCESS"
 
-        pipeline = UpdateGolangPipeline(
-            runtime=mock_runtime,
-            ocp_version="4.18",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.22.9-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-        )
+        await pipeline._build_golang_plashets("1.22.9", [8, 9])
+
+        self.assertEqual(mock_jenkins.start_build_plashets.call_count, 2)
+        calls = mock_jenkins.start_build_plashets.call_args_list
+        self.assertEqual(calls[0].kwargs["group"], "rhel-8-golang-1.22")
+        self.assertEqual(calls[0].kwargs["repos"], ["rhel-8-golang-rpms"])
+        self.assertIsNone(calls[0].kwargs["version"])
+        self.assertEqual(calls[1].kwargs["group"], "rhel-9-golang-1.22")
+        self.assertEqual(calls[1].kwargs["repos"], ["rhel-9-golang-rpms"])
+        self.assertIsNone(calls[1].kwargs["version"])
+
+    @patch("pyartcd.pipelines.update_golang.jenkins")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_raises_on_jenkins_failure(self, mock_konflux_db, mock_jenkins):
+        pipeline = self._make_pipeline(use_new_golang_branch=True)
         mock_jenkins.start_build_plashets.return_value = "FAILURE"
 
         with self.assertRaisesRegex(RuntimeError, "failed with result: FAILURE"):
@@ -1740,13 +1746,23 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_dry_run_skips_jenkins(self, mock_konflux_db, mock_jenkins):
-        mock_slack = Mock()
-        mock_slack.say_in_thread = AsyncMock()
-        mock_runtime = Mock(dry_run=True, working_dir=Path("/tmp/working"))
-        mock_runtime.new_slack_client.return_value = mock_slack
+    async def test_dry_run_passes_dry_run_flag(self, mock_konflux_db, mock_jenkins):
+        pipeline = self._make_pipeline(use_new_golang_branch=True, dry_run=True)
+        mock_jenkins.start_build_plashets.return_value = "SUCCESS"
 
-        pipeline = UpdateGolangPipeline(
+        await pipeline._build_golang_plashets("1.22.9", [9])
+
+        mock_jenkins.start_build_plashets.assert_called_once()
+        self.assertTrue(mock_jenkins.start_build_plashets.call_args.kwargs["dry_run"])
+
+
+class TestMonobranchDispatch(IsolatedAsyncioTestCase):
+    """Test that branch-dependent methods dispatch correctly based on use_new_golang_branch"""
+
+    def _make_pipeline(self, use_new_golang_branch):
+        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = Mock()
+        return UpdateGolangPipeline(
             runtime=mock_runtime,
             ocp_version="4.18",
             cves=None,
@@ -1754,11 +1770,30 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.22.9-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
+            use_new_golang_branch=use_new_golang_branch,
         )
 
-        await pipeline._build_golang_plashets("1.22.9", [9])
+    def test_doozer_group_uses_monobranch_when_flag_is_true(self):
+        pipeline = self._make_pipeline(use_new_golang_branch=True)
+        group, image_key = pipeline._get_doozer_group_and_image(9, "1.22.9")
+        self.assertEqual(group, "golang")
+        self.assertEqual(image_key, "openshift-golang-builder-1-22.rhel9")
 
-        mock_jenkins.start_build_plashets.assert_not_called()
+    def test_doozer_group_uses_separated_branch_when_flag_is_false(self):
+        pipeline = self._make_pipeline(use_new_golang_branch=False)
+        group, image_key = pipeline._get_doozer_group_and_image(9, "1.22.9")
+        self.assertEqual(group, "rhel-9-golang-1.22")
+        self.assertEqual(image_key, "openshift-golang-builder")
+
+    def test_doozer_var_args_with_monobranch(self):
+        pipeline = self._make_pipeline(use_new_golang_branch=True)
+        args = pipeline._get_doozer_var_args()
+        self.assertEqual(args, ['--var', 'MAJOR=4', '--var', 'MINOR=18'])
+
+    def test_doozer_var_args_with_separated_branch(self):
+        pipeline = self._make_pipeline(use_new_golang_branch=False)
+        args = pipeline._get_doozer_var_args()
+        self.assertEqual(args, [])
 
 
 if __name__ == "__main__":

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1687,7 +1687,7 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_monobranch_triggers_jenkins_for_each_el_version(self, mock_konflux_db, mock_jenkins):
+    async def test_triggers_jenkins_for_each_el_version(self, mock_konflux_db, mock_jenkins):
         mock_slack = Mock()
         mock_slack.say_in_thread = AsyncMock()
         mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
@@ -1701,7 +1701,6 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.22.9-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
-            use_new_golang_branch=True,
         )
         mock_jenkins.start_build_plashets.return_value = "SUCCESS"
 
@@ -1709,43 +1708,13 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
 
         self.assertEqual(mock_jenkins.start_build_plashets.call_count, 2)
         calls = mock_jenkins.start_build_plashets.call_args_list
+        # Both calls now use the 'golang' monobranch
         self.assertEqual(calls[0].kwargs["group"], "golang")
         self.assertEqual(calls[0].kwargs["repos"], ["rhel-8-golang-rpms"])
         self.assertEqual(calls[0].kwargs["version"], "4.18")
         self.assertEqual(calls[1].kwargs["group"], "golang")
         self.assertEqual(calls[1].kwargs["repos"], ["rhel-9-golang-rpms"])
         self.assertEqual(calls[1].kwargs["version"], "4.18")
-
-    @patch("pyartcd.pipelines.update_golang.jenkins")
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_separated_branch_triggers_jenkins_per_el_and_go_version(self, mock_konflux_db, mock_jenkins):
-        mock_slack = Mock()
-        mock_slack.say_in_thread = AsyncMock()
-        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
-        mock_runtime.new_slack_client.return_value = mock_slack
-
-        pipeline = UpdateGolangPipeline(
-            runtime=mock_runtime,
-            ocp_version="4.18",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.22.9-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-            use_new_golang_branch=False,
-        )
-        mock_jenkins.start_build_plashets.return_value = "SUCCESS"
-
-        await pipeline._build_golang_plashets("1.22.9", [8, 9])
-
-        self.assertEqual(mock_jenkins.start_build_plashets.call_count, 2)
-        calls = mock_jenkins.start_build_plashets.call_args_list
-        self.assertEqual(calls[0].kwargs["group"], "rhel-8-golang-1.22")
-        self.assertEqual(calls[0].kwargs["repos"], ["rhel-8-golang-rpms"])
-        self.assertIsNone(calls[0].kwargs["version"])
-        self.assertEqual(calls[1].kwargs["group"], "rhel-9-golang-1.22")
-        self.assertEqual(calls[1].kwargs["repos"], ["rhel-9-golang-rpms"])
-        self.assertIsNone(calls[1].kwargs["version"])
 
     @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -1763,7 +1732,6 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.22.9-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
-            use_new_golang_branch=True,
         )
         mock_jenkins.start_build_plashets.return_value = "FAILURE"
 
@@ -1772,7 +1740,7 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_dry_run_passes_dry_run_flag(self, mock_konflux_db, mock_jenkins):
+    async def test_dry_run_skips_jenkins(self, mock_konflux_db, mock_jenkins):
         mock_slack = Mock()
         mock_slack.say_in_thread = AsyncMock()
         mock_runtime = Mock(dry_run=True, working_dir=Path("/tmp/working"))
@@ -1786,88 +1754,11 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.22.9-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
-            use_new_golang_branch=True,
         )
-        mock_jenkins.start_build_plashets.return_value = "SUCCESS"
 
         await pipeline._build_golang_plashets("1.22.9", [9])
 
-        mock_jenkins.start_build_plashets.assert_called_once()
-        self.assertTrue(mock_jenkins.start_build_plashets.call_args.kwargs["dry_run"])
-
-
-class TestMonobranchFallback(IsolatedAsyncioTestCase):
-    """Test that monobranch failure creates a new pipeline with separated branches"""
-
-    @patch("pyartcd.pipelines.update_golang.jenkins")
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_plashets_use_separated_branch_when_flag_is_false(self, mock_konflux_db, mock_jenkins):
-        """Verify that the fallback pipeline (use_new_golang_branch=False) uses separated branches"""
-        mock_slack = Mock()
-        mock_slack.say_in_thread = AsyncMock()
-        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
-        mock_runtime.new_slack_client.return_value = mock_slack
-
-        # Simulate the fallback pipeline
-        pipeline = UpdateGolangPipeline(
-            runtime=mock_runtime,
-            ocp_version="4.18",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.22.9-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-            use_new_golang_branch=False,
-        )
-        mock_jenkins.start_build_plashets.return_value = "SUCCESS"
-
-        await pipeline._build_golang_plashets("1.22.9", [9])
-
-        calls = mock_jenkins.start_build_plashets.call_args_list
-        self.assertEqual(calls[0].kwargs["group"], "rhel-9-golang-1.22")
-        self.assertIsNone(calls[0].kwargs["version"])
-
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_doozer_group_uses_separated_branch_when_flag_is_false(self, mock_konflux_db):
-        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
-        mock_runtime.new_slack_client.return_value = Mock()
-
-        pipeline = UpdateGolangPipeline(
-            runtime=mock_runtime,
-            ocp_version="4.18",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.22.9-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-            use_new_golang_branch=False,
-        )
-
-        group, image_key = pipeline._get_doozer_group_and_image(9, "1.22.9")
-        self.assertEqual(group, "rhel-9-golang-1.22")
-        self.assertEqual(image_key, "openshift-golang-builder")
-        self.assertEqual(pipeline._get_doozer_var_args(), [])
-
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_doozer_group_uses_monobranch_when_flag_is_true(self, mock_konflux_db):
-        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
-        mock_runtime.new_slack_client.return_value = Mock()
-
-        pipeline = UpdateGolangPipeline(
-            runtime=mock_runtime,
-            ocp_version="4.18",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.22.9-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-            use_new_golang_branch=True,
-        )
-
-        group, image_key = pipeline._get_doozer_group_and_image(9, "1.22.9")
-        self.assertEqual(group, "golang")
-        self.assertEqual(image_key, "openshift-golang-builder-1-22.rhel9")
-        self.assertEqual(pipeline._get_doozer_var_args(), ['--var', 'MAJOR=4', '--var', 'MINOR=18'])
+        mock_jenkins.start_build_plashets.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -417,9 +417,9 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_doozer_var_args(self, mock_konflux_db):
-        """Test _get_doozer_var_args always returns --var args for MAJOR/MINOR"""
+        """Test _get_doozer_var_args returns --var args when use_new_golang_branch is True"""
         pipeline = self._make_pipeline()
-        # Now always returns vars regardless of use_new_golang_branch flag
+        pipeline.use_new_golang_branch = True
         self.assertEqual(pipeline._get_doozer_var_args(), ['--var', 'MAJOR=4', '--var', 'MINOR=16'])
 
         pipeline.ocp_version = "5.0"
@@ -1264,6 +1264,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.20.12-2.el8"],
             art_jira="ART-1234",
             tag_builds=True,
+            use_new_golang_branch=True,
         )
 
         await pipeline._rebase_brew(8, "1.20.12", "golang-1.20.12-2.el8")
@@ -1275,7 +1276,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         self.assertIn("MAJOR=4", cmd)
         self.assertIn("MINOR=16", cmd)
         self.assertIn("--group", cmd)
-        self.assertIn("golang", cmd)  # Now uses monobranch
+        self.assertIn("golang", cmd)
         self.assertIn("images:rebase", cmd)
         self.assertIn("--version", cmd)
         self.assertIn("v1.20.12", cmd)
@@ -1521,6 +1522,7 @@ class TestShouldSignGolangRpm(unittest.TestCase):
             go_nvrs=["golang-1.22.9-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
+            use_new_golang_branch=True,
         )
 
         result = pipeline.should_sign_golang_rpm(9, "1.22.9")
@@ -1543,6 +1545,7 @@ class TestShouldSignGolangRpm(unittest.TestCase):
             go_nvrs=["golang-1.25.3-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
+            use_new_golang_branch=True,
         )
 
         result = pipeline.should_sign_golang_rpm(9, "1.25.3")

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1687,7 +1687,7 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_triggers_jenkins_for_each_el_version(self, mock_konflux_db, mock_jenkins):
+    async def test_monobranch_triggers_jenkins_for_each_el_version(self, mock_konflux_db, mock_jenkins):
         mock_slack = Mock()
         mock_slack.say_in_thread = AsyncMock()
         mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
@@ -1701,6 +1701,7 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.22.9-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
+            use_new_golang_branch=True,
         )
         mock_jenkins.start_build_plashets.return_value = "SUCCESS"
 
@@ -1708,13 +1709,43 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
 
         self.assertEqual(mock_jenkins.start_build_plashets.call_count, 2)
         calls = mock_jenkins.start_build_plashets.call_args_list
-        # Both calls now use the 'golang' monobranch
         self.assertEqual(calls[0].kwargs["group"], "golang")
         self.assertEqual(calls[0].kwargs["repos"], ["rhel-8-golang-rpms"])
         self.assertEqual(calls[0].kwargs["version"], "4.18")
         self.assertEqual(calls[1].kwargs["group"], "golang")
         self.assertEqual(calls[1].kwargs["repos"], ["rhel-9-golang-rpms"])
         self.assertEqual(calls[1].kwargs["version"], "4.18")
+
+    @patch("pyartcd.pipelines.update_golang.jenkins")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_separated_branch_triggers_jenkins_per_el_and_go_version(self, mock_konflux_db, mock_jenkins):
+        mock_slack = Mock()
+        mock_slack.say_in_thread = AsyncMock()
+        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = mock_slack
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.18",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            use_new_golang_branch=False,
+        )
+        mock_jenkins.start_build_plashets.return_value = "SUCCESS"
+
+        await pipeline._build_golang_plashets("1.22.9", [8, 9])
+
+        self.assertEqual(mock_jenkins.start_build_plashets.call_count, 2)
+        calls = mock_jenkins.start_build_plashets.call_args_list
+        self.assertEqual(calls[0].kwargs["group"], "rhel-8-golang-1.22")
+        self.assertEqual(calls[0].kwargs["repos"], ["rhel-8-golang-rpms"])
+        self.assertIsNone(calls[0].kwargs["version"])
+        self.assertEqual(calls[1].kwargs["group"], "rhel-9-golang-1.22")
+        self.assertEqual(calls[1].kwargs["repos"], ["rhel-9-golang-rpms"])
+        self.assertIsNone(calls[1].kwargs["version"])
 
     @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -1732,6 +1763,7 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.22.9-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
+            use_new_golang_branch=True,
         )
         mock_jenkins.start_build_plashets.return_value = "FAILURE"
 
@@ -1740,7 +1772,7 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_dry_run_skips_jenkins(self, mock_konflux_db, mock_jenkins):
+    async def test_dry_run_passes_dry_run_flag(self, mock_konflux_db, mock_jenkins):
         mock_slack = Mock()
         mock_slack.say_in_thread = AsyncMock()
         mock_runtime = Mock(dry_run=True, working_dir=Path("/tmp/working"))
@@ -1754,11 +1786,88 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.22.9-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
+            use_new_golang_branch=True,
         )
+        mock_jenkins.start_build_plashets.return_value = "SUCCESS"
 
         await pipeline._build_golang_plashets("1.22.9", [9])
 
-        mock_jenkins.start_build_plashets.assert_not_called()
+        mock_jenkins.start_build_plashets.assert_called_once()
+        self.assertTrue(mock_jenkins.start_build_plashets.call_args.kwargs["dry_run"])
+
+
+class TestMonobranchFallback(IsolatedAsyncioTestCase):
+    """Test that monobranch failure creates a new pipeline with separated branches"""
+
+    @patch("pyartcd.pipelines.update_golang.jenkins")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_plashets_use_separated_branch_when_flag_is_false(self, mock_konflux_db, mock_jenkins):
+        """Verify that the fallback pipeline (use_new_golang_branch=False) uses separated branches"""
+        mock_slack = Mock()
+        mock_slack.say_in_thread = AsyncMock()
+        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = mock_slack
+
+        # Simulate the fallback pipeline
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.18",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            use_new_golang_branch=False,
+        )
+        mock_jenkins.start_build_plashets.return_value = "SUCCESS"
+
+        await pipeline._build_golang_plashets("1.22.9", [9])
+
+        calls = mock_jenkins.start_build_plashets.call_args_list
+        self.assertEqual(calls[0].kwargs["group"], "rhel-9-golang-1.22")
+        self.assertIsNone(calls[0].kwargs["version"])
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_doozer_group_uses_separated_branch_when_flag_is_false(self, mock_konflux_db):
+        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.18",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            use_new_golang_branch=False,
+        )
+
+        group, image_key = pipeline._get_doozer_group_and_image(9, "1.22.9")
+        self.assertEqual(group, "rhel-9-golang-1.22")
+        self.assertEqual(image_key, "openshift-golang-builder")
+        self.assertEqual(pipeline._get_doozer_var_args(), [])
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_doozer_group_uses_monobranch_when_flag_is_true(self, mock_konflux_db):
+        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.18",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            use_new_golang_branch=True,
+        )
+
+        group, image_key = pipeline._get_doozer_group_and_image(9, "1.22.9")
+        self.assertEqual(group, "golang")
+        self.assertEqual(image_key, "openshift-golang-builder-1-22.rhel9")
+        self.assertEqual(pipeline._get_doozer_var_args(), ['--var', 'MAJOR=4', '--var', 'MINOR=18'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR adds support for passing an OCP version parameter to the build-plashets pipeline to enable building plashets for golang monobranch groups. This is required because golang groups (like `golang` instead of `rhel-9-golang-1.22`) cannot have their MAJOR/MINOR version derived from the group name.

## Changes

### Plashet Pipeline (`plashets.py`)

- **Added `version` parameter** to `build_plashets()` function
  - Accepts OCP version string (e.g., `'4.18'`)
  - Used to inject `--var MAJOR=X --var MINOR=Y` into doozer command
- **Added `version` parameter** to `build_plashet_from_tags()` function
  - Conditionally injects MAJOR/MINOR vars only when version is provided
  - Allows doozer to resolve `{MAJOR}` and `{MINOR}` template placeholders in golang monobranch group.yml

### Build Plashets Pipeline (`build_plashets.py`)

- **Added `--version` CLI option**
  - Optional parameter for specifying OCP version
  - Required for golang groups, ignored for standard openshift-X.Y groups
  - Added validation: raises error if golang group is used without version
  - Added warning if version is provided for non-golang groups
- **Updated `BuildPlashetsPipeline`** to accept and pass through version parameter

### Jenkins Integration (`jenkins.py`)

- **Updated `start_build_plashets()`** to accept `version` parameter
  - Passes as `VERSION` parameter to Jenkins job
  - Allows golang update pipeline to trigger plashet builds with explicit version

### Golang Update Pipeline (`update_golang.py`)

- **Updated `_build_golang_plashets()`** to pass version when calling Jenkins
  - Ensures golang plashet builds receive the OCP version for MAJOR/MINOR resolution

### Test Updates

- Updated plashet-related tests to verify version parameter is passed correctly

## How It Works

### Problem
Golang monobranch groups (e.g., `golang`) cannot derive MAJOR/MINOR from the group name:
- Standard groups: `openshift-4.18` → `MAJOR=4, MINOR=18` ✅
- Golang groups: `golang` → Cannot derive version ❌

### Solution
When building plashets for golang groups:
1. Caller passes `--version 4.18` parameter
2. Plashet pipeline injects `--var MAJOR=4 --var MINOR=18` into doozer command
3. Doozer uses these vars to resolve `{MAJOR}` and `{MINOR}` placeholders in group.yml
4. Group config is loaded with resolved values
5. Plashet builds proceed normally

### Command Flow
```bash
# Golang update pipeline calls:
jenkins.start_build_plashets(group='golang', version='4.18', ...)

# Which triggers Jenkins job with:
VERSION=4.18

# Which calls artcd with:
artcd build-plashets --group golang --version 4.18 ...

# Which calls doozer with:
doozer --var MAJOR=4 --var MINOR=18 --group golang config:plashet ...
```

## Backward Compatibility

- ✅ **Existing groups unaffected**: Standard `openshift-X.Y` groups continue to work without the version parameter
- ✅ **Optional parameter**: Version is only required for golang groups
- ✅ **Validation included**: Clear error messages guide users when version is missing for golang groups

## Testing

- [x] All unit tests pass
- [x] Version parameter is correctly passed through the call chain
- [x] Validation enforces version requirement for golang groups
- [x] Warning shown when version provided for non-golang groups

## Related Issues

- Part of golang monobranch migration effort
- Enables golang update pipeline to build plashets with monobranch layout
- ocp-build-data golang monobranch: https://github.com/openshift-eng/ocp-build-data/tree/golang

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--version` support for Go plashet builds (required for Go groups) and new `golang` monobranch targeting; non-Go groups ignore it.
  * `update-golang` now defaults to `--use-new-golang-branch` (paired flag) for unified `golang` layout.
* **Bug Fixes**
  * Tightened build-result gating for verification and snapshot-to-release: both image pullspec and digest are now required; dry runs skip result-dependent validation.
  * Compose-permission freeze automation is bypassed for Go groups.
* **Other**
  * Updated Jenkins plashets job path/trigger parameters and expanded Go prefetch matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->