### PR TITLE
Resolve MAJOR/MINOR vars before validating bridge_release.basis_group

### DIFF
--- a/ocp-build-data-validator/tests/test_schema/test_group_schema.py
+++ b/ocp-build-data-validator/tests/test_schema/test_group_schema.py
@@ -59,3 +59,28 @@ class TestGroupSchema(unittest.TestCase):
             },
         }
         self.assertIn("must be 'openshift-5.0'", group_schema.validate("group.yml", invalid_data))
+
+    def test_validate_with_templated_group_name_and_valid_bridge_release(self):
+        # Real group.yml files always use an unresolved "{MAJOR}.{MINOR}" template for
+        # `name`, substituted at runtime by doozer/elliott. The validator must resolve
+        # it using `vars` before comparing against `bridge_release.basis_group`.
+        valid_data = {
+            "name": "openshift-{MAJOR}.{MINOR}",
+            "vars": {"MAJOR": 4, "MINOR": 23},
+            "bridge_release": {
+                "basis_group": "openshift-5.0",
+                "bug_mirroring": {"enabled": True},
+            },
+        }
+        self.assertEqual("", group_schema.validate("group.yml", valid_data))
+
+    def test_validate_with_templated_group_name_and_mismatched_bridge_release(self):
+        invalid_data = {
+            "name": "openshift-{MAJOR}.{MINOR}",
+            "vars": {"MAJOR": 4, "MINOR": 23},
+            "bridge_release": {
+                "basis_group": "openshift-5.1",
+                "bug_mirroring": {"enabled": True},
+            },
+        }
+        self.assertIn("must be 'openshift-5.0'", group_schema.validate("group.yml", invalid_data))

--- a/ocp-build-data-validator/validator/schema/group_schema.py
+++ b/ocp-build-data-validator/validator/schema/group_schema.py
@@ -12,6 +12,8 @@ from jsonschema import RefResolver, ValidationError
 from jsonschema.validators import validator_for
 from schema import SchemaError
 
+from validator.support import replace_vars
+
 if sys.version_info < (3, 9):
     # importlib.resources either doesn't exist or lacks the files()
     # function, so use the PyPI version:
@@ -80,7 +82,14 @@ def validate(_, data):
     bridge_release = demerged_data.get("bridge_release") or {}
     basis_group = bridge_release.get("basis_group")
     group_name = demerged_data.get("name")
+    vars_map = demerged_data.get("vars") or {}
     if basis_group and group_name:
+        # group.yml's `name` is normally an unresolved "{MAJOR}.{MINOR}" template
+        # (substituted at runtime by doozer/elliott). Resolve it here too, otherwise
+        # every group.yml with a templated name fails this check.
+        if "MAJOR" in vars_map and "MINOR" in vars_map:
+            group_name = replace_vars(group_name, vars_map)
+            basis_group = replace_vars(basis_group, vars_map)
         try:
             validate_bridge_release_basis_group(group_name, basis_group)
         except ValueError as e:


### PR DESCRIPTION
## Summary

- `group_schema.validate()` compared the raw, unresolved `name` field from `group.yml` (e.g. the literal template `openshift-{MAJOR}.{MINOR}`) against `bridge_release.basis_group`, so any `group.yml` with a templated `name` (which is how every real `group.yml` looks — the template is substituted at runtime by doozer/elliott) fails with `Invalid group name: openshift-{MAJOR}.{MINOR}`, even when the config is perfectly valid.
- This was caught because [openshift-eng/ocp-build-data#11880](https://github.com/openshift-eng/ocp-build-data/pull/11880) started failing CI ([job run](https://github.com/openshift-eng/ocp-build-data/actions/runs/29521247028/job/87699338821)) despite only adding an unrelated `plr_template_commitish` key to `group.yml`. Root cause traces back to `validate_bridge_release_basis_group`/`group_schema.py`, added in #2846.
- Fix: resolve `{MAJOR}`/`{MINOR}` in `name` (and defensively in `basis_group`) using the file's own `vars` section before calling `validate_bridge_release_basis_group`, reusing the existing `validator.support.replace_vars` helper (already used elsewhere in this validator for the same substitution).

## Test plan

- [x] Added `test_validate_with_templated_group_name_and_valid_bridge_release` and `test_validate_with_templated_group_name_and_mismatched_bridge_release` to `test_group_schema.py`, mirroring the real on-disk shape of `group.yml`.
- [x] `uv run --project . python -m pytest ocp-build-data-validator/tests/test_schema/test_group_schema.py -v` — 7/7 pass.
- [x] `uv run --project . python -m pytest ocp-build-data-validator/tests/ -v` — 91/91 pass, no regressions.
- [x] Re-ran `group_schema.validate()` directly against the real, unmodified `openshift-4.23/group.yml` fetched from GitHub: before the fix it returned `Invalid group name: openshift-{MAJOR}.{MINOR}`; after the fix it returns `''` (pass).
- [x] Confirmed the check still correctly flags a genuine mismatch (temporarily set `basis_group` to `openshift-5.1` against the same real file): returns `"bridge_release.basis_group for 'openshift-4.23' must be 'openshift-5.0', found 'openshift-5.1'"`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of group configurations using `{MAJOR}.{MINOR}` templates.
  * Resolved template values before checking that the configured basis group matches the group name.
  * Added clearer validation behavior for matching and mismatched resolved values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->