### PR TITLE
Detect and skip counter updates for infrastructure failures

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -245,6 +245,9 @@ class KonfluxOcpPipeline:
         - Base image release failures: count:release-failure:konflux:{group}:{image}
 
         Successfully built images reset all three counter types.
+
+        Infrastructure failures (where builds never started due to API/cluster issues)
+        are detected and skip individual image counter updates to avoid false inflation.
         """
         if self.assembly != 'stream':
             return
@@ -256,6 +259,29 @@ class KonfluxOcpPipeline:
         failed_entries = {
             entry['name']: entry for entry in record_log.get('image_build_konflux', []) if int(entry['status'])
         }
+
+        # A build failure only counts if a build was actually triggered.
+        # If task_id=n/a and task_url=n/a, no PipelineRun was created = not a build failure.
+        # Exclude "parent images failed to build" - those never attempted a build either.
+        if failed_images:
+            # Filter out images that never had a build attempt:
+            # 1. Parent dependency failures (never attempted)
+            # 2. Infrastructure failures (task_id=n/a, no PipelineRun created)
+            attempted_builds = [
+                image
+                for image in failed_images
+                if 'parent images failed to build' not in failed_entries.get(image, {}).get('message', '')
+                and failed_entries.get(image, {}).get('task_id') != 'n/a'
+            ]
+
+            # If NO builds were actually attempted, skip all counter updates
+            if not attempted_builds:
+                LOGGER.warning(
+                    f'No builds were actually attempted for {group}: all {len(failed_images)} failures '
+                    f'have task_id=n/a (infrastructure failure) or are parent-dependency failures. '
+                    f'Skipping individual image counter updates. Jenkins job: {job_url}'
+                )
+                return
 
         # Exclude images that failed only because their parent images failed to build.
         # These children were never actually attempted, so incrementing their counters


### PR DESCRIPTION
When Konflux API/cluster issues prevent builds from starting (e.g., Internal Server Error, webhook timeouts), all images get recorded with status=-1 and task_id=n/a in record.log. Previously, sync_images() would increment individual Redis failure counters for each image, causing false inflation where infrastructure failures appeared as hundreds of individual build failures.

Detection logic:
- A build failure only counts if a PipelineRun was actually created
- task_id=n/a and task_url=n/a means no PipelineRun = not a build failure
- Parent dependency failures are also excluded (never attempted)
- If NO builds were actually attempted, skip ALL Redis counter updates

This prevents Redis discrepancies where images-health reports differ from actual build status (e.g., Slack shows 2 failures, Redis has 227).

## Test
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/41116/
