### PR TITLE
ART-21677: Push .repo files to public upstream for RHCOS images

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -18,13 +18,19 @@ import bashlex
 import bashlex.errors
 import semver
 import yaml
-from artcommonlib import exectools, release_util
+from artcommonlib import exectools, git_helper, release_util
 from artcommonlib.build_visibility import BuildVisibility, get_visibility_suffix, is_release_embargoed
 from artcommonlib.constants import GOLANG_NVR_ENV, GOLANG_NVR_LABEL
 from artcommonlib.konflux.konflux_build_record import Engine, KonfluxBuildRecord
 from artcommonlib.model import ListModel, Missing, Model
 from artcommonlib.telemetry import start_as_current_span_async
-from artcommonlib.util import deep_merge, detect_package_managers, is_cachito_enabled, oc_image_info_for_arch_async
+from artcommonlib.util import (
+    deep_merge,
+    detect_package_managers,
+    is_cachito_enabled,
+    isolate_major_minor_in_group,
+    oc_image_info_for_arch_async,
+)
 from artcommonlib.variants import BuildVariant
 from dockerfile_parse import DockerfileParser
 from doozerlib import constants, util
@@ -225,6 +231,10 @@ class KonfluxRebaser:
                 self._logger.info("Pushing changes to %s...", build_repo.url)
                 force = (self._runtime.assembly != "stream") or (build_repo.url != build_repo.pull_url)
                 await build_repo.push(force=force)
+
+                # Push .repo files to public upstream for RHCOS images
+                # This is called AFTER the push to ensure the commit exists and we can check if files changed
+                await self._push_repo_files_to_public_upstream(metadata, build_repo)
 
             self._rebased_nvr_info[metadata.distgit_key] = (actual_version, actual_release)
             metadata.rebase_status = True
@@ -1882,6 +1892,135 @@ class KonfluxRebaser:
 
             async with aiofiles.open(dest_dir.joinpath('cvp-owners.yml'), 'w', encoding='utf-8') as co:
                 await co.write(yaml_str)
+
+    def _get_public_repo_branch_name(self, metadata: ImageMetadata) -> str:
+        """
+        Get the branch name for pushing .repo files to public upstream.
+
+        Arg(s):
+            metadata (ImageMetadata): The image metadata.
+        Return Value(s):
+            str: Branch name in format: art-repos-{image-name}-{major}.{minor}
+        """
+        major, minor = isolate_major_minor_in_group(self._runtime.group)
+        if major is None or minor is None:
+            raise ValueError(f"Could not extract major.minor from group {self._runtime.group}")
+
+        return f"art-repos-{metadata.distgit_key}-{major}.{minor}"
+
+    @start_as_current_span_async(TRACER, "rebase.push_repo_files_to_public_upstream")
+    async def _push_repo_files_to_public_upstream(self, metadata: ImageMetadata, build_repo: BuildRepo) -> None:
+        """
+        Push .repo files to the public upstream repository for RHCOS images.
+        This creates a branch named art-repos-{IMAGE_NAME}-{MAJOR}.{MINOR} and
+        pushes art-signed.repo and art-unsigned.repo to it.
+
+        Only applies to images with content.source.git.web pointing to
+        https://github.com/openshift/os (i.e., RHCOS images)
+
+        Optimization: Only pushes if .repo files have changed in the rebase commit,
+        or if they don't yet exist on the public upstream.
+
+        Arg(s):
+            metadata (ImageMetadata): The image metadata.
+            build_repo (BuildRepo): The build repository object.
+        Return Value(s):
+            None
+        """
+        # Check if this is an RHCOS image that needs .repo files pushed to public upstream
+        if not metadata.config.get('content', {}).get('source', {}).get('git', {}).get('web'):
+            return
+
+        web_url = metadata.config.content.source.git.web
+        if web_url != "https://github.com/openshift/os":
+            return
+
+        # Check if .repo files were modified in the last commit (the rebase commit)
+        # This is an optimization to avoid cloning the public repo if nothing changed
+        local_dir = str(build_repo.local_dir)
+        rc, stdout, _ = await git_helper.gather_git_async(
+            ["-C", local_dir, "diff", "--name-only", "HEAD~1", "HEAD", "--", ".oit/*.repo"],
+            check=False,
+            github_url=build_repo.url,
+        )
+
+        repo_files_changed = bool(stdout.strip())
+
+        # If files haven't changed, we still need to check if this is the first time
+        # pushing to public upstream (files might not exist there yet)
+        # So we'll do a lightweight check: try to fetch the branch
+        # If branch doesn't exist, we need to push. If it exists and files unchanged, skip.
+        if not repo_files_changed:
+            # Quick check: does the branch exist on public upstream?
+            # We'll do a shallow ls-remote to avoid cloning
+            branch_name = self._get_public_repo_branch_name(metadata)
+            rc, stdout, _ = await git_helper.gather_git_async(
+                ["ls-remote", "--heads", web_url, branch_name], check=False, github_url=web_url
+            )
+
+            if stdout.strip():
+                # Branch exists and files unchanged, skip
+                self._logger.info(
+                    f"No changes to .repo files for {metadata.distgit_key} "
+                    f"and branch {branch_name} exists on public upstream, skipping push"
+                )
+                return
+            else:
+                # Branch doesn't exist yet, need to push for the first time
+                self._logger.info(
+                    f"Branch {branch_name} doesn't exist on public upstream yet, "
+                    f"will push .repo files for {metadata.distgit_key}"
+                )
+        else:
+            self._logger.info(f"Pushing updated .repo files to public upstream for {metadata.distgit_key}...")
+
+        # Get branch name
+        branch_name = self._get_public_repo_branch_name(metadata)
+
+        # Clone the PUBLIC upstream repository to a temporary directory
+        with TemporaryDirectory() as temp_dir:
+            upstream_dir = Path(temp_dir) / "upstream"
+
+            try:
+                git_helper.git_clone(web_url, str(upstream_dir))
+            except Exception as e:
+                self._logger.error(f"Failed to clone public upstream repo {web_url}: {e}")
+                raise
+
+            # Create or checkout the branch
+            with exectools.Dir(str(upstream_dir)):
+                # Try to checkout existing branch or create new one
+                rc, _, _ = exectools.cmd_gather(["git", "checkout", branch_name])
+                if rc != 0:
+                    # Branch doesn't exist, create it
+                    exectools.cmd_assert(["git", "checkout", "-b", branch_name])
+
+                # Copy .repo files from build repo to upstream repo root
+                repo_files = ["art-signed.repo", "art-unsigned.repo"]
+                for repo_file in repo_files:
+                    src_path = build_repo.local_dir / ".oit" / repo_file
+                    dst_path = upstream_dir / repo_file
+
+                    if not src_path.exists():
+                        self._logger.warning(f"Source file not found: {src_path}")
+                        continue
+
+                    shutil.copy2(src_path, dst_path)
+                    exectools.cmd_assert(["git", "add", repo_file])
+
+                # Commit changes
+                commit_message = (
+                    f"Update .repo files for {metadata.distgit_key}\n\n"
+                    f"Generated by ART during rebase for {self._runtime.group} assembly {self._runtime.assembly}"
+                )
+                rc, _, _ = exectools.cmd_gather(["git", "commit", "-m", commit_message])
+
+                if rc == 0:
+                    # Changes were committed, push to upstream
+                    exectools.cmd_assert(["git", "push", "origin", branch_name], retries=3)
+                    self._logger.info(f"Successfully pushed .repo files to {branch_name}")
+                else:
+                    self._logger.info(f"No changes to .repo files for {branch_name}")
 
     @start_as_current_span_async(TRACER, "rebase.write_fetch_artifacts")
     async def _write_fetch_artifacts(self, metadata: ImageMetadata, dest_dir: Path):

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1989,17 +1989,23 @@ class KonfluxRebaser:
         branch_name = self._get_public_repo_branch_name(metadata)
 
         # Clone the PUBLIC upstream repository to a temporary directory
+        # Note: git_clone will convert SSH to HTTPS by default (by design)
         with TemporaryDirectory() as temp_dir:
             upstream_dir = Path(temp_dir) / "upstream"
 
             try:
-                git_helper.git_clone(ssh_url, str(upstream_dir))
+                # Clone using HTTPS (git_clone converts SSH to HTTPS automatically)
+                git_helper.git_clone(web_url, str(upstream_dir))
             except Exception as e:
-                self._logger.error(f"Failed to clone public upstream repo {ssh_url}: {e}")
+                self._logger.error(f"Failed to clone public upstream repo {web_url}: {e}")
                 raise
 
             # Create or checkout the branch
             with exectools.Dir(str(upstream_dir)):
+                # Add SSH remote for pushing (we don't want to push to openshift/ via HTTPS)
+                self._logger.info(f"Adding SSH remote for push: {ssh_url}")
+                exectools.cmd_assert(["git", "remote", "add", "push_remote", ssh_url])
+
                 # Try to checkout existing branch or create new one
                 rc, _, _ = exectools.cmd_gather(["git", "checkout", branch_name])
                 if rc != 0:
@@ -2027,8 +2033,9 @@ class KonfluxRebaser:
                 rc, _, _ = exectools.cmd_gather(["git", "commit", "-m", commit_message])
 
                 if rc == 0:
-                    # Changes were committed, push to upstream
-                    exectools.cmd_assert(["git", "push", "origin", branch_name], retries=3)
+                    # Changes were committed, push to SSH remote
+                    self._logger.info(f"Pushing to SSH remote: {ssh_url}")
+                    exectools.cmd_assert(["git", "push", "push_remote", branch_name], retries=3)
                     self._logger.info(f"Successfully pushed .repo files to {branch_name}")
                 else:
                     self._logger.info(f"No changes to .repo files for {branch_name}")

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -2006,11 +2006,14 @@ class KonfluxRebaser:
                 self._logger.info(f"Adding SSH remote for push: {ssh_url}")
                 exectools.cmd_assert(["git", "remote", "add", "push_remote", ssh_url])
 
-                # Try to checkout existing branch or create new one
+                # Try to checkout existing branch or create orphan branch
                 rc, _, _ = exectools.cmd_gather(["git", "checkout", branch_name])
                 if rc != 0:
-                    # Branch doesn't exist, create it
-                    exectools.cmd_assert(["git", "checkout", "-b", branch_name])
+                    # Branch doesn't exist, create it as orphan (no parent commits)
+                    self._logger.info(f"Creating orphan branch {branch_name}")
+                    exectools.cmd_assert(["git", "checkout", "--orphan", branch_name])
+                    # Remove all files from the index (orphan branch starts with staged files from HEAD)
+                    exectools.cmd_assert(["git", "rm", "-rf", "."])
 
                 # Copy .repo files from build repo to upstream repo root
                 repo_files = ["art-signed.repo", "art-unsigned.repo"]

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -1935,6 +1935,17 @@ class KonfluxRebaser:
         if web_url != "https://github.com/openshift/os":
             return
 
+        # Convert HTTPS URL to SSH for push operations
+        # Format: https://github.com/org/repo -> git@github.com:org/repo.git
+        if web_url.startswith("https://github.com/"):
+            repo_path = web_url[len("https://github.com/") :]
+            if not repo_path.endswith(".git"):
+                repo_path += ".git"
+            ssh_url = f"git@github.com:{repo_path}"
+        else:
+            self._logger.warning(f"Unexpected web URL format: {web_url}, using as-is")
+            ssh_url = web_url
+
         # Check if .repo files were modified in the last commit (the rebase commit)
         # This is an optimization to avoid cloning the public repo if nothing changed
         local_dir = str(build_repo.local_dir)
@@ -1955,7 +1966,7 @@ class KonfluxRebaser:
             # We'll do a shallow ls-remote to avoid cloning
             branch_name = self._get_public_repo_branch_name(metadata)
             rc, stdout, _ = await git_helper.gather_git_async(
-                ["ls-remote", "--heads", web_url, branch_name], check=False, github_url=web_url
+                ["ls-remote", "--heads", ssh_url, branch_name], check=False, github_url=ssh_url
             )
 
             if stdout.strip():
@@ -1982,9 +1993,9 @@ class KonfluxRebaser:
             upstream_dir = Path(temp_dir) / "upstream"
 
             try:
-                git_helper.git_clone(web_url, str(upstream_dir))
+                git_helper.git_clone(ssh_url, str(upstream_dir))
             except Exception as e:
-                self._logger.error(f"Failed to clone public upstream repo {web_url}: {e}")
+                self._logger.error(f"Failed to clone public upstream repo {ssh_url}: {e}")
                 raise
 
             # Create or checkout the branch

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -2195,3 +2195,134 @@ class TestPrivateFixDetectionE2E(IsolatedAsyncioTestCase):
             util.is_commit_in_public_upstream_async.assert_called_once()
         finally:
             util.is_commit_in_public_upstream_async = original_func
+
+
+class TestPublicRepoFilesPush(IsolatedAsyncioTestCase):
+    """
+    Tests for pushing .repo files to public upstream (openshift/os) for RHCOS images.
+    """
+
+    def setUp(self):
+        self.runtime = MagicMock()
+        self.runtime.group = "openshift-4.17"
+        self.runtime.assembly = "stream"
+
+        # Create rebaser with required arguments
+        base_dir = Path("/tmp/test")
+        source_resolver = MagicMock()
+        repo_type = "unsigned"
+        self.rebaser = KonfluxRebaser(self.runtime, base_dir, source_resolver, repo_type)
+
+    def test_get_public_repo_branch_name(self):
+        """
+        Test that _get_public_repo_branch_name generates correct branch names.
+        """
+        metadata = MagicMock()
+        metadata.distgit_key = "rhcos-node-image"
+
+        # Test for OCP 4.17
+        self.runtime.group = "openshift-4.17"
+        branch_name = self.rebaser._get_public_repo_branch_name(metadata)
+        self.assertEqual(branch_name, "art-repos-rhcos-node-image-4.17")
+
+        # Test for OCP 5.0
+        self.runtime.group = "openshift-5.0"
+        branch_name = self.rebaser._get_public_repo_branch_name(metadata)
+        self.assertEqual(branch_name, "art-repos-rhcos-node-image-5.0")
+
+        # Test for rhcos-node-extensions
+        metadata.distgit_key = "rhcos-node-extensions"
+        self.runtime.group = "openshift-4.18"
+        branch_name = self.rebaser._get_public_repo_branch_name(metadata)
+        self.assertEqual(branch_name, "art-repos-rhcos-node-extensions-4.18")
+
+    def test_get_public_repo_branch_name_invalid_group(self):
+        """
+        Test that _get_public_repo_branch_name raises ValueError for invalid group names.
+        """
+        metadata = MagicMock()
+        metadata.distgit_key = "rhcos-node-image"
+
+        self.runtime.group = "invalid-group"
+        with self.assertRaises(ValueError):
+            self.rebaser._get_public_repo_branch_name(metadata)
+
+    async def test_push_repo_files_skips_non_rhcos_images(self):
+        """
+        Test that _push_repo_files_to_public_upstream skips non-RHCOS images.
+        """
+        metadata = MagicMock()
+        metadata.config = Model({})
+        build_repo = MagicMock()
+
+        # Test with no web URL
+        await self.rebaser._push_repo_files_to_public_upstream(metadata, build_repo)
+
+        # Test with different web URL
+        metadata.config.content = Model(
+            {'source': Model({'git': Model({'web': 'https://github.com/openshift/different-repo'})})}
+        )
+        await self.rebaser._push_repo_files_to_public_upstream(metadata, build_repo)
+
+        # No git operations should have been called
+        # (we're just verifying it returns early without errors)
+
+    async def test_push_repo_files_rhcos_image_filtering(self):
+        """
+        Test that _push_repo_files_to_public_upstream only processes RHCOS images.
+        """
+        from unittest.mock import patch
+
+        from artcommonlib import git_helper
+
+        metadata = MagicMock()
+        metadata.distgit_key = "rhcos-node-image"
+        metadata.config = Model(
+            {'content': Model({'source': Model({'git': Model({'web': 'https://github.com/openshift/os'})})})}
+        )
+
+        build_repo = MagicMock()
+        build_repo.url = "git@github.com:openshift-priv/os.git"
+        build_repo.local_dir = Path("/tmp/build-repo")
+
+        # Mock git operations to check if they're called
+        with patch.object(git_helper, 'gather_git_async', new=AsyncMock()) as mock_gather:
+            # Mock that files haven't changed
+            mock_gather.return_value = (0, "", "")
+
+            # Mock ls-remote to say branch doesn't exist (empty output)
+            mock_gather.return_value = (0, "", "")
+
+            # Mock git_clone to prevent actual cloning
+            with patch.object(git_helper, 'git_clone') as mock_clone:
+                mock_clone.side_effect = FileNotFoundError("Expected - test should check before cloning")
+
+                # Should attempt to check if files changed (first call to gather_git_async)
+                # Then check if branch exists (second call via ls-remote)
+                # Then attempt to clone (which we mock to fail)
+                with self.assertRaises(FileNotFoundError):
+                    await self.rebaser._push_repo_files_to_public_upstream(metadata, build_repo)
+
+                # Verify ls-remote was called (indicates RHCOS image was detected)
+                self.assertTrue(mock_gather.called)
+
+    def test_branch_name_format_consistency(self):
+        """
+        Test that branch names follow the expected format across all RHCOS image variants.
+        """
+        rhcos_images = [
+            "rhcos-node-image",
+            "rhcos-node-image-rhel10",
+            "rhcos-node-extensions",
+            "rhcos-node-extensions-rhel10",
+        ]
+
+        self.runtime.group = "openshift-4.17"
+
+        for image_name in rhcos_images:
+            metadata = MagicMock()
+            metadata.distgit_key = image_name
+            branch_name = self.rebaser._get_public_repo_branch_name(metadata)
+            self.assertTrue(branch_name.startswith("art-repos-"))
+            self.assertTrue(branch_name.endswith("-4.17"))
+            self.assertIn(image_name, branch_name)


### PR DESCRIPTION
## Summary
Add support for pushing generated .repo files (art-signed.repo and art-unsigned.repo) to the public upstream repository (https://github.com/openshift/os) during RHCOS image rebase operations.

## Background
The upstream team does not have access to openshift-priv where .repo files are currently stored. They need these files in the public upstream repository to properly configure yum repositories during image builds.

## Changes

### Affected Images
- rhcos-node-image
- rhcos-node-image-rhel10
- rhcos-node-extensions
- rhcos-node-extensions-rhel10

All these images have `git@github.com:openshift-priv/os.git` as source URL and `https://github.com/openshift/os` as public web URL.

### Workflow
1. Generate .repo files and commit to openshift-priv/os (existing behavior)
2. Check if .repo files changed in the commit
3. If unchanged, check if branch exists on public upstream via `git ls-remote`
4. If changed OR branch doesn't exist:
   - Clone public upstream via HTTPS
   - Add SSH remote for push operations
   - Create or checkout orphan branch
   - Copy .repo files to repository root
   - Commit and push to public upstream via SSH

## Testing
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/41119/ created https://github.com/openshift/os/tree/art-repos-rhcos-node-extensions-5.0 with the generated .repo files in it.