### PR TITLE
Expose effective resolved vars in group config

### DIFF
--- a/artcommon/artcommonlib/config/__init__.py
+++ b/artcommon/artcommonlib/config/__init__.py
@@ -202,6 +202,11 @@ class BuildDataLoader:
             if releases_config is None:
                 releases_config = self.load_releases_config(config_file=None)
             group_config = assembly_field(releases_config, assembly, "group", group_config)
+        if variables:
+            resolved_vars = group_config.get('vars')
+            if resolved_vars and not isinstance(resolved_vars, dict):
+                raise TypeError("The 'vars' field in group configuration must be a dictionary if present.")
+            group_config['vars'] = {**(resolved_vars or {}), **variables}
         return group_config
 
     def load_releases_config(self, config_file: str | None = None) -> dict:

--- a/artcommon/artcommonlib/config/__init__.py
+++ b/artcommon/artcommonlib/config/__init__.py
@@ -204,9 +204,9 @@ class BuildDataLoader:
             group_config = assembly_field(releases_config, assembly, "group", group_config)
         if variables:
             resolved_vars = group_config.get('vars')
-            if resolved_vars and not isinstance(resolved_vars, dict):
+            if 'vars' in group_config and not isinstance(resolved_vars, dict):
                 raise TypeError("The 'vars' field in group configuration must be a dictionary if present.")
-            group_config['vars'] = {**(resolved_vars or {}), **variables}
+            group_config['vars'] = {**(resolved_vars or {}), **(additional_vars or {})}
         return group_config
 
     def load_releases_config(self, config_file: str | None = None) -> dict:

--- a/artcommon/tests/test_build_data_loader.py
+++ b/artcommon/tests/test_build_data_loader.py
@@ -65,3 +65,39 @@ class TestBuildDataLoader(TestCase):
                 self.assertEqual(group_config["plashet"]["base_dir"], "4.21/$runtime_assembly/$slug")
                 self.assertEqual(group_config["plashet"]["plashet_dir"], "$yyyy-$MM/$revision")
                 self.assertTrue(group_config["plashet"]["create_symlinks"])
+
+    def test_load_group_config_exposes_effective_vars(self):
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            (data_dir / "group.yml").write_text(
+                "\n".join(
+                    [
+                        "name: golang",
+                        "vars:",
+                        "  MAJOR: major",
+                        "  MINOR: minor",
+                        "branch: rhaos-{MAJOR}.{MINOR}-rhel-9",
+                        "",
+                    ]
+                )
+            )
+
+            loader = BuildDataLoader(
+                data_path=str(data_dir),
+                clone_dir=str(data_dir),
+                commitish="golang",
+                build_system="brew",
+                gitdata=_StubGitData(data_dir),
+            )
+
+            group_config = loader.load_group_config(
+                assembly=None,
+                releases_config=None,
+                additional_vars={"MAJOR": 5, "MINOR": 0},
+            )
+
+            self.assertEqual(group_config["branch"], "rhaos-5.0-rhel-9")
+            self.assertEqual(group_config["vars"]["MAJOR"], 5)
+            self.assertEqual(group_config["vars"]["MINOR"], 0)


### PR DESCRIPTION
`uv run doozer --var MAJOR=5 --var MINOR=0 --group golang --assembly stream config:read-group --yaml`

## Summary
- make `BuildDataLoader.load_group_config()` write effective resolved vars back into `group_config["vars"]`
- preserve `--var` substitution visibility for `config:read-group --yaml` and other consumers of `runtime.group_config.vars`
- add a regression test for the golang-style `MAJOR`/`MINOR` override case

## Testing
- `make format`
- `uv run pytest --verbose --color=yes artcommon/tests/test_build_data_loader.py`
- `make test` *(fails in this environment during pyartcd test collection because `aioredlock` imports `distutils` under Python 3.12)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured group configuration variables consistently reflect assembly-specific updates while still honoring any caller-provided variable overrides.
  * Confirmed branch and related configuration values are rendered using the final effective variables.

* **Tests**
  * Added unit test coverage to verify overridden variables are correctly applied and exposed when loading group configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->