### PR TITLE
ART-18061: stop writing predicted operand NVRs for layered products + embargo check

### DIFF
--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import shutil
+import string
 from datetime import datetime, timezone
 from functools import cached_property, lru_cache
 from pathlib import Path
@@ -38,6 +39,44 @@ _LOGGER = logging.getLogger(__name__)
 
 
 BUNDLE_BUILD_PRIORITY = "3"
+
+# Characters that can appear inside a pullspec (registry/repo:tag or registry/repo@sha256:...)
+_PULLSPEC_CHARS = frozenset(string.ascii_letters + string.digits + "/:@._-")
+
+
+def _replace_pullspec(content: str, old_spec: str, new_spec: str) -> str:
+    """
+    Replace all occurrences of old_spec with new_spec in content, but only
+    when old_spec appears as a complete pullspec token — i.e. it is not a
+    substring of a longer pullspec.
+
+    Arg(s):
+        content (str): Text content (e.g. a CSV YAML file).
+        old_spec (str): Upstream pullspec to find.
+        new_spec (str): SHA-based pullspec to substitute.
+    Return Value(s):
+        str: Content with boundary-safe replacements applied.
+    """
+    if not isinstance(old_spec, str) or not old_spec:
+        raise ValueError("old_spec must be a non-empty string")
+    result = []
+    start = 0
+    while True:
+        idx = content.find(old_spec, start)
+        if idx == -1:
+            result.append(content[start:])
+            break
+        end = idx + len(old_spec)
+        before_ok = idx == 0 or content[idx - 1] not in _PULLSPEC_CHARS
+        after_ok = end == len(content) or content[end] not in _PULLSPEC_CHARS
+        if before_ok and after_ok:
+            result.append(content[start:idx])
+            result.append(new_spec)
+            start = end
+        else:
+            result.append(content[start:end])
+            start = end
+    return "".join(result)
 
 
 class KonfluxOlmBundleRebaseError(Exception):
@@ -279,8 +318,9 @@ class KonfluxOlmBundleRebaser:
                 # them directly with DB-resolved SHA pullspecs.
                 found_images: dict[str, tuple[str, str, str]] = {}
                 for delivery_name, (upstream_spec, new_pullspec, operand_nvr) in resolved_operands.items():
-                    if upstream_spec in content:
-                        content = content.replace(upstream_spec, new_pullspec)
+                    replaced_content = _replace_pullspec(content, upstream_spec, new_pullspec)
+                    if replaced_content != content:
+                        content = replaced_content
                         found_images[delivery_name] = (upstream_spec, new_pullspec, operand_nvr)
                 found_images.update(self._find_external_digest_images(content, found_images))
             else:

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -253,11 +253,9 @@ class KonfluxOlmBundleRebaser:
         # is validated with layered products first.
         is_layered = not metadata.runtime.group.startswith("openshift-")
         resolved_operands: dict[str, tuple[str, str, str]] = {}
-        rebased_name_map: dict[str, str] = {}
-        delivery_override_map: dict[str, str] = {}
         if operator_build.engine is Engine.KONFLUX and image_references and is_layered:
             delivery_override_map, delivery_namespace_map = self._build_delivery_maps(metadata)
-            resolved_operands, rebased_name_map = await self._resolve_operands_from_db(
+            resolved_operands = await self._resolve_operands_from_db(
                 metadata, image_references, delivery_override_map, delivery_namespace_map
             )
 
@@ -275,20 +273,15 @@ class KonfluxOlmBundleRebaser:
                 content = await f.read()
 
             if operator_build.engine is Engine.KONFLUX and resolved_operands:
-                # The CSV content has predicted tags from operator rebase (e.g.
-                # registry/ns/image:4.18.0-release). Use regex to find them,
-                # then replace with DB-resolved SHA pullspecs.
-                pullspec_by_delivery = {name: new_ps for name, (_, new_ps, _) in resolved_operands.items()}
-                pattern = KonfluxOlmBundleRebaser._get_image_reference_pattern(str(csv_config["registry"]))
+                # Replace operand references using upstream specs from image-references.
+                # For layered products, operator rebase no longer writes predicted tags
+                # (ART-18061), so the CSV retains original upstream specs. We replace
+                # them directly with DB-resolved SHA pullspecs.
                 found_images: dict[str, tuple[str, str, str]] = {}
-                for match in pattern.finditer(content):
-                    old_pullspec = match.group(0)
-                    _, img_short = match.group(1).rsplit("/", maxsplit=1)
-                    delivery_name = rebased_name_map.get(img_short) or delivery_override_map.get(img_short, img_short)
-                    if delivery_name in pullspec_by_delivery:
-                        _, new_pullspec, operand_nvr = resolved_operands[delivery_name]
-                        content = content.replace(old_pullspec, new_pullspec)
-                        found_images[delivery_name] = (old_pullspec, new_pullspec, operand_nvr)
+                for delivery_name, (upstream_spec, new_pullspec, operand_nvr) in resolved_operands.items():
+                    if upstream_spec in content:
+                        content = content.replace(upstream_spec, new_pullspec)
+                        found_images[delivery_name] = (upstream_spec, new_pullspec, operand_nvr)
                 found_images.update(self._find_external_digest_images(content, found_images))
             else:
                 # Brew engine: use tag-based regex resolution (legacy path)
@@ -529,7 +522,7 @@ class KonfluxOlmBundleRebaser:
         image_references: dict[str, dict],
         delivery_override_map: dict[str, str],
         delivery_namespace_map: dict[str, str],
-    ) -> tuple[dict[str, tuple[str, str, str]], dict[str, str]]:
+    ) -> dict[str, tuple[str, str, str]]:
         """
         Resolve ART-built operand images from Konflux DB instead of relying
         on predicted v-r tags baked into the operator CSV at rebase time.
@@ -538,16 +531,16 @@ class KonfluxOlmBundleRebaser:
         (pipeline enforces: image rebase -> image build -> sync -> bundle rebase).
         So we query the DB for actual builds rather than trusting predicted tags.
 
+        Embargoed operand builds are automatically substituted with the latest
+        public build, since operator bundles must never ship embargoed content.
+
         Arg(s):
             metadata: ImageMetadata of the operator whose bundle is being rebased.
             image_references: Parsed image-references entries {name: {from: {name: spec}}}.
             delivery_override_map: Versioned-to-unversioned name overrides.
             delivery_namespace_map: Image-to-namespace overrides.
         Return Value(s):
-            tuple: (resolved, rebased_name_map) where
-                resolved: {delivery_image_short_name: (old_pullspec, new_pullspec, nvr)}
-                rebased_name_map: {image_name_short: delivery_short_name} mapping
-                    the rebased name used in CSV to the delivery key in resolved
+            dict: {delivery_image_short_name: (upstream_spec, new_pullspec, nvr)}
         """
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
         csv_namespace = self._group_config.get("csv_namespace", "openshift")
@@ -581,7 +574,7 @@ class KonfluxOlmBundleRebaser:
                 )
             )
 
-        # Phase 1b: Fetch all builds concurrently
+        # Phase 1b: Fetch all builds concurrently, then check embargo status
         builds = await asyncio.gather(*build_coros)
 
         operand_entries: list[tuple[str, str, str, ImageMetadata]] = []
@@ -589,6 +582,36 @@ class KonfluxOlmBundleRebaser:
         for (name, spec, meta), build in zip(entries_meta, builds, strict=True):
             if not build:
                 raise ValueError(f"Could not find latest Konflux build for {meta.distgit_key}")
+
+            # Operator bundles must never reference embargoed operand images.
+            # If the latest build is embargoed, substitute with the latest public build.
+            try:
+                embargoed = is_nvr_embargoed(build.nvr)
+            except ValueError as e:
+                raise KonfluxOlmBundleRebaseError(
+                    f"Unable to determine embargo status for operand {build.nvr} referenced "
+                    f"by operator {metadata.distgit_key}: {e}"
+                ) from e
+            if embargoed:
+                public_build = await meta.get_latest_konflux_build(
+                    default=None,
+                    el_target=f"el{meta.branch_el_target()}",
+                    embargoed=False,
+                    exclude_large_columns=True,
+                )
+                if not public_build:
+                    raise KonfluxOlmBundleRebaseError(
+                        f"Operand {build.nvr} referenced by operator {metadata.distgit_key} is "
+                        f"embargoed, and no public (non-embargoed) build of '{meta.distgit_key}' "
+                        f"is available to substitute. Cannot safely rebase this operator bundle."
+                    )
+                logger.warning(
+                    "Operand %s referenced by operator %s is embargoed; substituting with public build %s",
+                    build.nvr,
+                    metadata.distgit_key,
+                    public_build.nvr,
+                )
+                build = public_build
 
             build_pullspec = f"{self.image_repo}:{meta.image_name_short}-{build.version}-{build.release}"
             logger.info(f"Resolved {name} -> {build.nvr} (pullspec: {build_pullspec})")
@@ -605,7 +628,6 @@ class KonfluxOlmBundleRebaser:
         image_infos = await asyncio.gather(*image_info_coros)
 
         resolved: dict[str, tuple[str, str, str]] = {}
-        rebased_name_map: dict[str, str] = {}
         for (_name, spec, _build_pullspec, meta), image_info in zip(operand_entries, image_infos, strict=True):
             image_labels = image_info["config"]["config"]["Labels"]
             image_nvr = f"{image_labels['com.redhat.component']}-{image_labels['version']}-{image_labels['release']}"
@@ -637,9 +659,8 @@ class KonfluxOlmBundleRebaser:
                 delivery_namespace_map,
             )
             resolved[delivery_short_name] = (spec, new_pullspec, image_nvr)
-            rebased_name_map[meta.image_name_short] = delivery_short_name
 
-        return resolved, rebased_name_map
+        return resolved
 
     async def _replace_image_references(self, old_registry: str, content: str, engine: Engine, metadata):
         """

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -3035,10 +3035,13 @@ class KonfluxRebaser:
         # Get external image names to skip in internal image replacement
         external_image_names = self._get_external_image_names(dest_dir, csv_config)
 
-        # Replace internal ART-built image references
-        await self._replace_internal_image_refs(
-            metadata, csv_file, image_refs, registry, image_map, external_image_names
-        )
+        # Replace internal ART-built image references with predicted v-r tags.
+        # For layered products, skip this — operand NVRs are resolved from Konflux DB
+        # at bundle rebase time instead (ART-18061).
+        if self._runtime.group.startswith("openshift-"):
+            await self._replace_internal_image_refs(
+                metadata, csv_file, image_refs, registry, image_map, external_image_names
+            )
 
         # Apply art.yaml search-and-replace updates and get parsed art.yaml data.
         # The returned art_yaml_data is passed to _replace_external_image_refs to avoid

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -583,8 +583,9 @@ spec:
             await self.rebaser._rebase_dir(metadata, operator_dir, bundle_dir, MagicMock(), input_release)
             self.assertIn("No files found in bundle directory", str(context.exception))
 
+    @patch("doozerlib.backend.konflux_olm_bundler.is_nvr_embargoed", return_value=False)
     @patch("doozerlib.util.oc_image_info_for_arch_async")
-    async def test_resolve_operands_from_db(self, mock_oc_image_info):
+    async def test_resolve_operands_from_db(self, mock_oc_image_info, _mock_is_embargoed):
         """
         Verify that _resolve_operands_from_db resolves operand NVRs from the
         Konflux DB and returns correctly-formed pullspecs and NVRs.
@@ -633,14 +634,13 @@ spec:
         self.rebaser._group_config.operator_image_ref_mode = "manifest-list"
         self.rebaser._group_config.vars = {"MAJOR": 4}
 
-        resolved, rebased_name_map = await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
+        resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
 
         self.assertIn("ose-operand", resolved)
         old_spec, new_pullspec, nvr = resolved["ose-operand"]
         self.assertEqual(old_spec, "registry.example.com/openshift/ose-operand:v4.18")
         self.assertIn("registry.redhat.io/openshift4/ose-operand@sha256:abc123def456", new_pullspec)
         self.assertEqual(nvr, "operand-container-4.18.0-202506120000.p0.g1234567.assembly.stream.el9")
-        self.assertEqual(rebased_name_map["ose-operand"], "ose-operand")
 
         # Verify DB query was made directly to Konflux
         operand_meta.get_latest_konflux_build.assert_called_once_with(
@@ -648,8 +648,9 @@ spec:
             exclude_large_columns=True,
         )
 
+    @patch("doozerlib.backend.konflux_olm_bundler.is_nvr_embargoed", return_value=False)
     @patch("doozerlib.util.oc_image_info_for_arch_async")
-    async def test_resolve_operands_from_db_by_arch_mode(self, mock_oc_image_info):
+    async def test_resolve_operands_from_db_by_arch_mode(self, mock_oc_image_info, _mock_is_embargoed):
         """
         Verify that by-arch mode uses contentDigest instead of listDigest.
         """
@@ -695,7 +696,7 @@ spec:
         self.rebaser._group_config.operator_image_ref_mode = "by-arch"
         self.rebaser._group_config.vars = {"MAJOR": 4}
 
-        resolved, _rebased_name_map = await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
+        resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
 
         _, new_pullspec, _ = resolved["ose-operand"]
         self.assertIn("sha256:content222", new_pullspec)
@@ -774,8 +775,9 @@ spec:
             await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
         self.assertIn("Could not find latest Konflux build", str(ctx.exception))
 
+    @patch("doozerlib.backend.konflux_olm_bundler.is_nvr_embargoed", return_value=False)
     @patch("doozerlib.util.oc_image_info_for_arch_async")
-    async def test_resolve_operands_with_delivery_override(self, mock_oc_image_info):
+    async def test_resolve_operands_with_delivery_override(self, mock_oc_image_info, _mock_is_embargoed):
         """
         Verify delivery_repo_name_override mapping works in _resolve_operands_from_db.
         """
@@ -841,7 +843,7 @@ spec:
             )
 
             delivery_override_map, delivery_namespace_map = self.rebaser._build_delivery_maps(metadata)
-            resolved, _rebased_name_map = await self.rebaser._resolve_operands_from_db(
+            resolved = await self.rebaser._resolve_operands_from_db(
                 metadata, image_references, delivery_override_map, delivery_namespace_map
             )
 
@@ -850,8 +852,9 @@ spec:
         _, new_pullspec, _ = resolved["ose-csi-driver-rhel9"]
         self.assertIn("ose-csi-driver-rhel9", new_pullspec)
 
+    @patch("doozerlib.backend.konflux_olm_bundler.is_nvr_embargoed", return_value=False)
     @patch("doozerlib.util.oc_image_info_for_arch_async")
-    async def test_resolve_operands_from_db_layered_upstream_registry(self, mock_oc_image_info):
+    async def test_resolve_operands_from_db_layered_upstream_registry(self, mock_oc_image_info, _mock_is_embargoed):
         """
         Verify that for a layered product (e.g. OADP) whose image-references
         point to an upstream registry (quay.io/konveyor/*), the delivery
@@ -913,7 +916,7 @@ spec:
         self.rebaser._group_config.vars = {"MAJOR": 4}
 
         delivery_namespace_map = {"oadp-velero-rhel9": "oadp"}
-        resolved, rebased_name_map = await self.rebaser._resolve_operands_from_db(
+        resolved = await self.rebaser._resolve_operands_from_db(
             metadata,
             image_references,
             {},
@@ -926,7 +929,121 @@ spec:
         self.assertEqual(new_pullspec, "registry.redhat.io/oadp/oadp-velero-rhel9@sha256:oadpvelerodigest111")
         self.assertNotIn("konveyor", new_pullspec)
         self.assertEqual(nvr, "oadp-velero-container-1.5.8-202507160000.p0.g1234567.assembly.stream.el9")
-        self.assertEqual(rebased_name_map["oadp-velero-rhel9"], "oadp-velero-rhel9")
+
+    @patch("doozerlib.backend.konflux_olm_bundler.is_nvr_embargoed")
+    @patch("doozerlib.util.oc_image_info_for_arch_async")
+    async def test_resolve_operands_from_db_embargo_substitution(self, mock_oc_image_info, mock_is_embargoed):
+        """
+        Verify that embargoed operand builds are substituted with the latest
+        public (non-embargoed) build.
+        """
+        metadata = MagicMock()
+        metadata.distgit_key = "test-operator"
+        metadata.runtime.group = "mtc-1.8"
+        metadata.runtime.data_dir = "/nonexistent/data/dir"
+
+        operand_meta = MagicMock()
+        operand_meta.image_name_short = "ose-operand"
+        operand_meta.distgit_key = "operand"
+        operand_meta.branch_el_target.return_value = 9
+
+        # Latest build is embargoed (p3 suffix)
+        embargoed_build = MagicMock()
+        embargoed_build.version = "4.18.0"
+        embargoed_build.release = "202506120000.p3.g1234567.assembly.stream.el9"
+        embargoed_build.nvr = "operand-container-4.18.0-202506120000.p3.g1234567.assembly.stream.el9"
+
+        # Public substitute build
+        public_build = MagicMock()
+        public_build.version = "4.18.0"
+        public_build.release = "202506100000.p2.gabcdef0.assembly.stream.el9"
+        public_build.nvr = "operand-container-4.18.0-202506100000.p2.gabcdef0.assembly.stream.el9"
+
+        # First call returns embargoed, second (with embargoed=False) returns public
+        operand_meta.get_latest_konflux_build = AsyncMock(side_effect=[embargoed_build, public_build])
+
+        metadata.runtime.name_in_bundle_map = {"operand-image": "operand"}
+        metadata.runtime.image_map = {"operand": operand_meta}
+
+        image_references = {
+            "operand-image": {
+                "name": "operand-image",
+                "from": {"name": "registry.example.com/openshift/ose-operand:v4.18"},
+            },
+        }
+
+        mock_is_embargoed.return_value = True
+
+        mock_oc_image_info.return_value = {
+            "config": {
+                "config": {
+                    "Labels": {
+                        "com.redhat.component": "operand-container",
+                        "version": "4.18.0",
+                        "release": "202506100000.p2.gabcdef0.assembly.stream.el9",
+                    }
+                }
+            },
+            "listDigest": "sha256:publicdigest111",
+            "contentDigest": "sha256:publiccontent222",
+        }
+        self.rebaser._group_config.get.return_value = "openshift"
+        self.rebaser._group_config.operator_image_ref_mode = "manifest-list"
+        self.rebaser._group_config.vars = {"MAJOR": 4}
+
+        resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
+
+        self.assertIn("ose-operand", resolved)
+        _, new_pullspec, nvr = resolved["ose-operand"]
+        # Should use the public build's digest and NVR, not the embargoed one
+        self.assertIn("sha256:publicdigest111", new_pullspec)
+        self.assertEqual(nvr, "operand-container-4.18.0-202506100000.p2.gabcdef0.assembly.stream.el9")
+
+        # Verify the public build was fetched with embargoed=False
+        calls = operand_meta.get_latest_konflux_build.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[1].kwargs.get("embargoed"), False)
+
+    @patch("doozerlib.backend.konflux_olm_bundler.is_nvr_embargoed")
+    async def test_resolve_operands_from_db_embargo_no_public_build(self, mock_is_embargoed):
+        """
+        Verify that KonfluxOlmBundleRebaseError is raised when an embargoed operand
+        has no public build available to substitute.
+        """
+        metadata = MagicMock()
+        metadata.distgit_key = "test-operator"
+        metadata.runtime.group = "mtc-1.8"
+        metadata.runtime.data_dir = "/nonexistent/data/dir"
+
+        operand_meta = MagicMock()
+        operand_meta.image_name_short = "ose-operand"
+        operand_meta.distgit_key = "operand"
+        operand_meta.branch_el_target.return_value = 9
+
+        embargoed_build = MagicMock()
+        embargoed_build.version = "4.18.0"
+        embargoed_build.release = "202506120000.p3.g1234567.assembly.stream.el9"
+        embargoed_build.nvr = "operand-container-4.18.0-202506120000.p3.g1234567.assembly.stream.el9"
+
+        # First call returns embargoed, second returns None (no public build)
+        operand_meta.get_latest_konflux_build = AsyncMock(side_effect=[embargoed_build, None])
+
+        metadata.runtime.name_in_bundle_map = {"operand-image": "operand"}
+        metadata.runtime.image_map = {"operand": operand_meta}
+
+        image_references = {
+            "operand-image": {
+                "name": "operand-image",
+                "from": {"name": "registry.example.com/openshift/ose-operand:v4.18"},
+            },
+        }
+
+        mock_is_embargoed.return_value = True
+
+        with self.assertRaises(KonfluxOlmBundleRebaseError) as ctx:
+            await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
+        self.assertIn("embargoed", str(ctx.exception))
+        self.assertIn("no public", str(ctx.exception).lower())
 
     @patch("pathlib.Path.iterdir")
     @patch("pathlib.Path.exists", autospec=True)
@@ -953,8 +1070,8 @@ spec:
     ):
         """
         Verify that _rebase_dir uses _resolve_operands_from_db for Konflux engine
-        and that regex-based replacement correctly handles predicted tags in the CSV
-        (which differ from the original specs in image-references).
+        and that direct upstream spec replacement correctly replaces original specs
+        from image-references with DB-resolved SHA pullspecs.
         """
         metadata = MagicMock()
         metadata.config = {
@@ -983,7 +1100,7 @@ spec:
             {
                 "spec": {
                     "tags": [
-                        {"name": "operand-a", "from": {"name": "registry.example.com/openshift/ose-operand-a:v4.18"}},
+                        {"name": "operand-a", "from": {"name": "quay.io/upstream/operand-a:v1.8"}},
                     ]
                 }
             }
@@ -995,7 +1112,8 @@ spec:
             }
         )
 
-        # CSV content has PREDICTED tags from operator rebase, NOT the original specs
+        # CSV content retains ORIGINAL upstream specs (operator rebase no longer
+        # writes predicted tags for layered products — ART-18061)
         csv_content = (
             "apiVersion: operators.coreos.com/v1alpha1\n"
             "kind: ClusterServiceVersion\n"
@@ -1010,7 +1128,7 @@ spec:
             "          template:\n"
             "            spec:\n"
             "              containers:\n"
-            "              - image: registry.example.com/openshift/ose-operand-a:4.18.0-202506120000.p0.assembly.stream.el9\n"
+            "              - image: quay.io/upstream/operand-a:v1.8\n"
         )
 
         read_call_count = [0]
@@ -1038,23 +1156,19 @@ spec:
         mock_iterdir.side_effect = lambda: iter(bundle_files)
 
         mock_build_delivery_maps.return_value = ({}, {})
-        mock_resolve_operands.return_value = (
-            {
-                "ose-operand-a": (
-                    "registry.example.com/openshift/ose-operand-a:v4.18",
-                    "registry.redhat.io/openshift4/ose-operand-a@sha256:abc123",
-                    "operand-a-container-4.18.0-1.el9",
-                ),
-            },
-            {"ose-operand-a": "ose-operand-a"},
-        )
+        mock_resolve_operands.return_value = {
+            "ose-operand-a": (
+                "quay.io/upstream/operand-a:v1.8",
+                "registry.redhat.io/openshift4/ose-operand-a@sha256:abc123",
+                "operand-a-container-4.18.0-1.el9",
+            ),
+        }
 
         await self.rebaser._rebase_dir(metadata, operator_dir, bundle_dir, operator_build, input_release)
 
         mock_resolve_operands.assert_called_once()
 
-        # Verify the predicted tag was replaced with the DB-resolved SHA pullspec
-        # by checking what was written to the CSV file
+        # Verify the upstream spec was replaced with the DB-resolved SHA pullspec
         write_calls = mock_file.write.call_args_list
         csv_written = None
         for call in write_calls:
@@ -1064,7 +1178,7 @@ spec:
                 break
         self.assertIsNotNone(csv_written, "CSV content was not written")
         self.assertIn("sha256:abc123", csv_written)
-        self.assertNotIn("4.18.0-202506120000.p0.assembly.stream.el9", csv_written)
+        self.assertNotIn("quay.io/upstream/operand-a:v1.8", csv_written)
 
         # Verify operands passed to _create_oit_files include DB-resolved data
         mock_create_oit_files.assert_called_once()

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -15,6 +15,7 @@ from doozerlib.backend.konflux_olm_bundler import (
     KonfluxOlmBundleBuilder,
     KonfluxOlmBundleRebaseError,
     KonfluxOlmBundleRebaser,
+    _replace_pullspec,
 )
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
 
@@ -1956,3 +1957,51 @@ class TestReplaceImageReferencesEmbargo(IsolatedAsyncioTestCase):
         self.assertIn('registry.redhat.io/openshift4/my-embargoed-operand-rhel9@sha256:embargoed-list', new_content)
         # The lazy component-metadata map should never be built for the Brew engine.
         metadata.runtime.image_metas.assert_not_called()
+
+
+class TestReplacePullspec(IsolatedAsyncioTestCase):
+    """
+    Tests for the _replace_pullspec boundary-aware replacement helper.
+    """
+
+    def test_basic_replacement(self):
+        content = "image: registry.redhat.io/foo/bar:v1.0\n"
+        result = _replace_pullspec(
+            content, "registry.redhat.io/foo/bar:v1.0", "registry.redhat.io/foo/bar@sha256:abc123"
+        )
+        self.assertEqual(result, "image: registry.redhat.io/foo/bar@sha256:abc123\n")
+
+    def test_no_match(self):
+        content = "image: registry.redhat.io/foo/other:v2.0\n"
+        result = _replace_pullspec(
+            content, "registry.redhat.io/foo/bar:v1.0", "registry.redhat.io/foo/bar@sha256:abc123"
+        )
+        self.assertEqual(result, content)
+
+    def test_overlapping_tags_not_corrupted(self):
+        """
+        Replacing 'image:v1.0' must NOT corrupt 'image:v1.0.1' — the shorter
+        spec is a substring of the longer one.
+        """
+        content = "image: registry.redhat.io/foo/bar:v1.0.1\nimage: registry.redhat.io/foo/bar:v1.0\n"
+        result = _replace_pullspec(
+            content, "registry.redhat.io/foo/bar:v1.0", "registry.redhat.io/foo/bar@sha256:short"
+        )
+        self.assertIn("registry.redhat.io/foo/bar:v1.0.1", result, "longer tag must be preserved")
+        self.assertIn("registry.redhat.io/foo/bar@sha256:short", result, "exact match must be replaced")
+        self.assertNotIn("registry.redhat.io/foo/bar@sha256:short.1", result, "must not create corrupted pullspec")
+
+    def test_multiple_occurrences(self):
+        content = "a: registry.redhat.io/foo:v1\nb: registry.redhat.io/foo:v1\n"
+        result = _replace_pullspec(content, "registry.redhat.io/foo:v1", "registry.redhat.io/foo@sha256:xyz")
+        self.assertEqual(result.count("registry.redhat.io/foo@sha256:xyz"), 2)
+
+    def test_quoted_yaml_value(self):
+        content = 'image: "registry.redhat.io/foo/bar:v1.0"\n'
+        result = _replace_pullspec(content, "registry.redhat.io/foo/bar:v1.0", "registry.redhat.io/foo/bar@sha256:abc")
+        self.assertEqual(result, 'image: "registry.redhat.io/foo/bar@sha256:abc"\n')
+
+    def test_spec_at_start_and_end(self):
+        content = "registry.redhat.io/foo:v1"
+        result = _replace_pullspec(content, "registry.redhat.io/foo:v1", "registry.redhat.io/foo@sha256:abc")
+        self.assertEqual(result, "registry.redhat.io/foo@sha256:abc")


### PR DESCRIPTION
For layered products (non-OCP groups), operator rebase no longer writes predicted v-r tags into the CSV. Instead, the bundle rebaser resolves operand NVRs directly from Konflux DB using the original upstream specs from image-references.

This eliminates the stale NVR window for layered products and simplifies the replacement logic (direct string match instead of regex).

Also adds embargo handling to _resolve_operands_from_db: embargoed operand builds are automatically substituted with the latest public build, consistent with the legacy path behavior. (https://github.com/openshift-eng/art-tools/pull/3158)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Konflux layered bundle rebasing to use database-resolved digest pullspecs for operand images, avoiding incorrect tag/pattern substitutions.
  * Added safe pullspec replacement to prevent partial/overlapping matches.
  * When an operand build is embargoed, Konflux now substitutes the latest non-embargoed public build, or fails with a clearer error if none is available.
  * Limited an internal image-reference rewrite step to OpenShift runtimes only.

* **Tests**
  * Expanded and hardened Konflux operand-resolution and embargo-substitution coverage, including new safety checks for pullspec replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->