### PR TITLE
ART-21487: Resolve binary RPM NVRs to source package NVRs via Brew at ingestion

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -888,7 +888,7 @@ class KonfluxImageBuilder:
                     continue
                 try:
                     purl = PackageURL.from_string(purl_string)
-                except Exception as e:
+                except ValueError as e:
                     LOGGER.warning(f"Failed to parse purl: {purl_string} {e}")
                     continue
 
@@ -989,9 +989,7 @@ class KonfluxImageBuilder:
                 unique_build_ids = list(set(nvr_to_build_id.values()))
                 with session.multicall(strict=True) as multicall:
                     build_tasks = [multicall.getBuild(bid) for bid in unique_build_ids]
-                bid_to_build = {
-                    bid: task.result for bid, task in zip(unique_build_ids, build_tasks) if task.result
-                }
+                bid_to_build = {bid: task.result for bid, task in zip(unique_build_ids, build_tasks) if task.result}
 
                 for nvr, bid in nvr_to_build_id.items():
                     build = bid_to_build.get(bid)
@@ -1126,7 +1124,9 @@ class KonfluxImageBuilder:
                 package_nvrs, source_rpms = await self.get_installed_packages(
                     definitive_image_pullspec, building_arches, self._config.registry_auth_file
                 )
-                source_rpms = self._resolve_source_package_nvrs(source_rpms, metadata.runtime)
+                source_rpms = await exectools.to_thread(
+                    self._resolve_source_package_nvrs, source_rpms, metadata.runtime
+                )
 
             build_record_params.update(
                 {

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -930,6 +930,80 @@ class KonfluxImageBuilder:
 
         return all_package_nvrs, all_source_rpms
 
+    @staticmethod
+    def _resolve_source_package_nvrs(source_rpms: set, runtime) -> set:
+        """
+        Resolve binary RPM NVRs to their source package NVRs via Brew.
+
+        When Mobster >=1.2.1 SBOMs lack the 'upstream' qualifier, the SBOM parser
+        falls back to using binary RPM names (e.g. kernel-core) as source package
+        names. These don't match actual Brew build NVRs (e.g. kernel). This method
+        resolves them by querying Koji: getBuild to identify valid builds, then
+        getRPM for those that aren't, to find the actual source package build.
+        """
+        if not source_rpms:
+            return source_rpms
+
+        with runtime.shared_koji_client_session() as session:
+            nvrs = sorted(source_rpms)
+
+            with session.multicall(strict=True) as multicall:
+                build_tasks = [multicall.getBuild(nvr) for nvr in nvrs]
+
+            resolved = set()
+            unresolved_nvrs = []
+            for nvr, task in zip(nvrs, build_tasks):
+                if task.result:
+                    resolved.add(nvr)
+                else:
+                    unresolved_nvrs.append(nvr)
+
+            if not unresolved_nvrs:
+                return resolved
+
+            # Binary NVRs need RPM lookup to find their source package build.
+            # getRPM needs NVRA, so try x86_64 first (most common), then noarch.
+            with session.multicall(strict=True) as multicall:
+                rpm_tasks = [multicall.getRPM(f"{nvr}.x86_64") for nvr in unresolved_nvrs]
+
+            still_unresolved = []
+            nvr_to_build_id: dict[str, int] = {}
+            for nvr, task in zip(unresolved_nvrs, rpm_tasks):
+                if task.result and task.result.get("build_id"):
+                    nvr_to_build_id[nvr] = task.result["build_id"]
+                else:
+                    still_unresolved.append(nvr)
+
+            # Retry unresolved with noarch
+            if still_unresolved:
+                with session.multicall(strict=True) as multicall:
+                    rpm_tasks = [multicall.getRPM(f"{nvr}.noarch") for nvr in still_unresolved]
+                for nvr, task in zip(still_unresolved, rpm_tasks):
+                    if task.result and task.result.get("build_id"):
+                        nvr_to_build_id[nvr] = task.result["build_id"]
+                    else:
+                        LOGGER.warning("Could not resolve source package for binary RPM NVR %s", nvr)
+                        resolved.add(nvr)
+
+            if nvr_to_build_id:
+                unique_build_ids = list(set(nvr_to_build_id.values()))
+                with session.multicall(strict=True) as multicall:
+                    build_tasks = [multicall.getBuild(bid) for bid in unique_build_ids]
+                bid_to_build = {
+                    bid: task.result for bid, task in zip(unique_build_ids, build_tasks) if task.result
+                }
+
+                for nvr, bid in nvr_to_build_id.items():
+                    build = bid_to_build.get(bid)
+                    if build:
+                        source_nvr = f"{build['name']}-{build['version']}-{build['release']}"
+                        resolved.add(source_nvr)
+                    else:
+                        LOGGER.warning("Could not find Brew build for build_id %s (from %s)", bid, nvr)
+                        resolved.add(nvr)
+
+            return resolved
+
     async def update_konflux_db(
         self,
         metadata,
@@ -1052,6 +1126,7 @@ class KonfluxImageBuilder:
                 package_nvrs, source_rpms = await self.get_installed_packages(
                     definitive_image_pullspec, building_arches, self._config.registry_auth_file
                 )
+                source_rpms = self._resolve_source_package_nvrs(source_rpms, metadata.runtime)
 
             build_record_params.update(
                 {

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -1389,7 +1389,7 @@ class TestGetInstalledPackages(unittest.IsolatedAsyncioTestCase):
         sbom = self._make_spdx_sbom(
             [
                 self._make_rpm_package(
-                    "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e?distro=rhel-9.8",
+                    "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e?arch=noarch&distro=rhel-9.8",
                     name="gpg-pubkey",
                 ),
                 self._make_rpm_package(
@@ -1541,7 +1541,6 @@ class TestResolveSourcePackageNvrs(unittest.TestCase):
 
         def make_multicall(*args, **kwargs):
             ctx = MagicMock()
-            idx = call_count[0]
             call_count[0] += 1
 
             def make_getBuild(nvr):

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -1519,3 +1519,178 @@ class TestGetInstalledPackages(unittest.IsolatedAsyncioTestCase):
             )
 
         self.assertEqual(package_nvrs, {"acl-2.3.1-4.el9", "bash-5.1.8-9.el9"})
+
+
+class TestResolveSourcePackageNvrs(unittest.TestCase):
+    """Tests for KonfluxImageBuilder._resolve_source_package_nvrs()."""
+
+    def test_empty_source_rpms(self):
+        """Empty set returns empty set."""
+        runtime = MagicMock()
+        result = KonfluxImageBuilder._resolve_source_package_nvrs(set(), runtime)
+        self.assertEqual(result, set())
+
+    def test_all_valid_build_nvrs(self):
+        """NVRs that are already valid Brew builds pass through unchanged."""
+        session = MagicMock()
+        runtime = MagicMock()
+        runtime.shared_koji_client_session.return_value.__enter__ = MagicMock(return_value=session)
+        runtime.shared_koji_client_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        call_count = [0]
+
+        def make_multicall(*args, **kwargs):
+            ctx = MagicMock()
+            idx = call_count[0]
+            call_count[0] += 1
+
+            def make_getBuild(nvr):
+                t = MagicMock()
+                t.result = {"name": "bash", "version": "5.1.8", "release": "9.el9", "build_id": 1}
+                return t
+
+            ctx.getBuild = make_getBuild
+            ctx.__enter__ = MagicMock(return_value=ctx)
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        session.multicall = make_multicall
+
+        result = KonfluxImageBuilder._resolve_source_package_nvrs({"bash-5.1.8-9.el9"}, runtime)
+        self.assertEqual(result, {"bash-5.1.8-9.el9"})
+
+    def test_binary_nvrs_resolved_to_source(self):
+        """Binary RPM NVR kernel-core resolved to source package NVR kernel."""
+        session = MagicMock()
+        runtime = MagicMock()
+        runtime.shared_koji_client_session.return_value.__enter__ = MagicMock(return_value=session)
+        runtime.shared_koji_client_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        call_count = [0]
+
+        def make_multicall(*args, **kwargs):
+            ctx = MagicMock()
+            idx = call_count[0]
+            call_count[0] += 1
+
+            def make_getBuild(nvr_or_id):
+                t = MagicMock()
+                if idx == 0:
+                    # First call: getBuild("kernel-core-4.18.0-372.el8") -> None
+                    t.result = None
+                else:
+                    # Third call: getBuild(42) -> source package
+                    t.result = {"name": "kernel", "version": "4.18.0", "release": "372.el8"}
+                return t
+
+            def make_getRPM(nvra):
+                t = MagicMock()
+                # Second call: getRPM("kernel-core-4.18.0-372.el8.x86_64") -> build_id
+                t.result = {"build_id": 42}
+                return t
+
+            ctx.getBuild = make_getBuild
+            ctx.getRPM = make_getRPM
+            ctx.__enter__ = MagicMock(return_value=ctx)
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        session.multicall = make_multicall
+
+        result = KonfluxImageBuilder._resolve_source_package_nvrs({"kernel-core-4.18.0-372.el8"}, runtime)
+        self.assertIn("kernel-4.18.0-372.el8", result)
+        self.assertNotIn("kernel-core-4.18.0-372.el8", result)
+
+    def test_noarch_fallback(self):
+        """Binary RPM not found as x86_64, resolved via noarch."""
+        session = MagicMock()
+        runtime = MagicMock()
+        runtime.shared_koji_client_session.return_value.__enter__ = MagicMock(return_value=session)
+        runtime.shared_koji_client_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        call_count = [0]
+
+        def make_multicall(*args, **kwargs):
+            ctx = MagicMock()
+            idx = call_count[0]
+            call_count[0] += 1
+
+            def make_getBuild(nvr_or_id):
+                t = MagicMock()
+                if idx == 0:
+                    t.result = None  # Not a build NVR
+                elif idx == 3:
+                    t.result = {"name": "basesystem", "version": "11", "release": "5.el8"}
+                else:
+                    t.result = None
+                return t
+
+            def make_getRPM(nvra):
+                t = MagicMock()
+                if idx == 1:
+                    t.result = None  # x86_64 not found
+                else:
+                    t.result = {"build_id": 77}  # noarch found
+                return t
+
+            ctx.getBuild = make_getBuild
+            ctx.getRPM = make_getRPM
+            ctx.__enter__ = MagicMock(return_value=ctx)
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        session.multicall = make_multicall
+
+        result = KonfluxImageBuilder._resolve_source_package_nvrs({"basesystem-11-5.el8"}, runtime)
+        self.assertIn("basesystem-11-5.el8", result)
+
+    def test_mixed_valid_and_binary_nvrs(self):
+        """Mix of valid build NVRs and binary NVRs both resolved correctly."""
+        session = MagicMock()
+        runtime = MagicMock()
+        runtime.shared_koji_client_session.return_value.__enter__ = MagicMock(return_value=session)
+        runtime.shared_koji_client_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        call_count = [0]
+
+        def make_multicall(*args, **kwargs):
+            ctx = MagicMock()
+            idx = call_count[0]
+            call_count[0] += 1
+            getBuild_calls = [0]
+
+            def make_getBuild(nvr_or_id):
+                t = MagicMock()
+                if idx == 0:
+                    # First multicall: getBuild for both NVRs
+                    call_idx = getBuild_calls[0]
+                    getBuild_calls[0] += 1
+                    if call_idx == 0:
+                        # bash is a valid build NVR
+                        t.result = {"name": "bash", "version": "5.1.8", "release": "9.el9"}
+                    else:
+                        # kernel-core is NOT a valid build NVR
+                        t.result = None
+                else:
+                    # Third multicall: getBuild(build_id) for source package
+                    t.result = {"name": "kernel", "version": "4.18.0", "release": "372.el8"}
+                return t
+
+            def make_getRPM(nvra):
+                t = MagicMock()
+                t.result = {"build_id": 42}
+                return t
+
+            ctx.getBuild = make_getBuild
+            ctx.getRPM = make_getRPM
+            ctx.__enter__ = MagicMock(return_value=ctx)
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        session.multicall = make_multicall
+
+        source_rpms = {"bash-5.1.8-9.el9", "kernel-core-4.18.0-372.el8"}
+        result = KonfluxImageBuilder._resolve_source_package_nvrs(source_rpms, runtime)
+        self.assertIn("bash-5.1.8-9.el9", result)
+        self.assertIn("kernel-4.18.0-372.el8", result)
+        self.assertNotIn("kernel-core-4.18.0-372.el8", result)

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -209,6 +209,11 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 "get_installed_packages",
                 new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
             ) as mock_get_installed_packages,
+            patch.object(
+                self.builder,
+                "_resolve_source_package_nvrs",
+                return_value={"srcpkg-1.0-1"},
+            ),
             patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
         ):
             mock_dockerfile = MagicMock()
@@ -270,6 +275,11 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 "get_installed_packages",
                 new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
             ) as mock_get_installed_packages,
+            patch.object(
+                self.builder,
+                "_resolve_source_package_nvrs",
+                return_value={"srcpkg-1.0-1"},
+            ),
             patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
         ):
             mock_dockerfile = MagicMock()
@@ -339,6 +349,11 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 "get_installed_packages",
                 new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
             ) as mock_get_installed_packages,
+            patch.object(
+                self.builder,
+                "_resolve_source_package_nvrs",
+                return_value={"srcpkg-1.0-1"},
+            ),
             patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
         ):
             mock_dockerfile = MagicMock()
@@ -404,6 +419,11 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 "get_installed_packages",
                 new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
             ),
+            patch.object(
+                self.builder,
+                "_resolve_source_package_nvrs",
+                return_value={"srcpkg-1.0-1"},
+            ),
             patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
         ):
             mock_dockerfile = MagicMock()
@@ -466,6 +486,11 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 self.builder,
                 "get_installed_packages",
                 new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
+            ),
+            patch.object(
+                self.builder,
+                "_resolve_source_package_nvrs",
+                return_value={"srcpkg-1.0-1"},
             ),
             patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
         ):
@@ -595,6 +620,11 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 "get_installed_packages",
                 new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
             ) as mock_get_installed_packages,
+            patch.object(
+                self.builder,
+                "_resolve_source_package_nvrs",
+                return_value={"srcpkg-1.0-1"},
+            ),
             patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
         ):
             mock_dockerfile = MagicMock()
@@ -659,6 +689,11 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
                 self.builder,
                 "get_installed_packages",
                 new=AsyncMock(return_value=({"pkg-1.0-1"}, {"srcpkg-1.0-1"})),
+            ),
+            patch.object(
+                self.builder,
+                "_resolve_source_package_nvrs",
+                return_value={"srcpkg-1.0-1"},
             ),
             patch("doozerlib.backend.konflux_image_builder.bigquery.BigQueryClient") as mock_bigquery_client,
         ):

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -132,8 +132,18 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
                 "ART_CLUSTER_ART_CD_PIPELINE_KUBECONFIG": "/path/to/kube/config",
             }
         )
+        # GroupRuntime.create() calls util.load_group_config via pyartcd.runtime,
+        # which is a different reference than pyartcd.pipelines.promote.util.
+        # Patch it here so PromotePipeline.create() doesn't hit real ocp-build-data.
+        self._runtime_load_group_config_patcher = patch(
+            "pyartcd.runtime.util.load_group_config",
+            new_callable=AsyncMock,
+            return_value={},
+        )
+        self._runtime_load_group_config_patcher.start()
 
     def tearDown(self) -> None:
+        self._runtime_load_group_config_patcher.stop()
         for key, value in self._saved_env.items():
             if value is None:
                 os.environ.pop(key, None)
@@ -467,6 +477,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             runtime, group="openshift-4.10", assembly="4.10.99", signing_env="prod", skip_sigstore=True
         )
         pipeline.check_blocker_bugs = AsyncMock()
+        pipeline._drop_empty_advisories = AsyncMock()
         pipeline.change_advisory_state_qe = AsyncMock()
         pipeline.get_advisory_info = AsyncMock(
             return_value={
@@ -518,6 +529,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             runtime, group="openshift-4.10", assembly="4.10.99", signing_env="prod", skip_sigstore=True
         )
         pipeline.check_blocker_bugs = AsyncMock()
+        pipeline._drop_empty_advisories = AsyncMock()
         pipeline.change_advisory_state_qe = AsyncMock()
         pipeline.get_advisory_info = AsyncMock(
             return_value={"id": 2, "errata_id": 2222, "fulladvisory": "RHBA-2099:2222-02", "status": "NEW_FILES"}
@@ -636,6 +648,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             skip_sigstore=True,
         )
         pipeline.check_blocker_bugs = AsyncMock()
+        pipeline._drop_empty_advisories = AsyncMock()
         pipeline.change_advisory_state_qe = AsyncMock()
         pipeline.get_advisory_info = AsyncMock(
             return_value={
@@ -2226,6 +2239,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
             runtime, group="openshift-4.10", assembly="4.10.99", signing_env="prod", skip_sigstore=True
         )
         pipeline.check_blocker_bugs = AsyncMock()
+        pipeline._drop_empty_advisories = AsyncMock()
         pipeline.change_advisory_state_qe = AsyncMock()
         pipeline.get_advisory_info = AsyncMock(return_value={"id": 2, "errata_id": 2, "status": "QE"})
 


### PR DESCRIPTION
Mobster >=1.2.1 SBOMs lack the 'upstream' qualifier, so the SBOM parser falls back to binary RPM names (e.g. kernel-core) as source package names. These don't match Brew build NVRs (e.g. kernel), causing the RHCOS consistency check to fail for driver-toolkit's kernel package.

Add _resolve_source_package_nvrs() which queries Koji to map binary NVRs to their actual source package NVRs before storing in BigQuery. Uses multicall batching (getBuild, then getRPM for x86_64/noarch fallback) to minimize API overhead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Konflux build processing by resolving SBOM “source RPM” identifiers into corresponding source package NVRs via Koji-backed lookups.
  * Binary RPM identifiers are mapped to source NVRs, with `noarch` fallback when primary-arch resolution fails.
* **Bug Fixes**
  * Improved SBOM PURL parsing by tightening error handling for invalid PURL values.
  * Ensures unresolved identifiers are safely retained and that `gpg-pubkey` packages are still excluded.
* **Tests**
  * Added unit coverage for source-NVR resolution behaviors and updated/expanded pipeline promotion tests with additional mocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->