### PR TITLE
Skip external image references from embargo check

### DIFF
--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -1216,6 +1216,19 @@ class ReleaseFromFbcPipeline:
         if not all_nvrs and not self.extra_image_nvrs:
             raise RuntimeError("No NVRs extracted from FBC images and no extra image NVRs provided")
 
+        # Categorize NVRs first to separate external image references before the embargo check.
+        # External images (from the prod registry, e.g. postgresql) don't carry p-flags and
+        # would be incorrectly flagged as embargoed by is_nvr_embargoed() which defaults to True.
+        empty_categorized: Dict[str, List[str]]
+        if self.ocp_optional:
+            empty_categorized = {"extras": [], "fbc": [], "external": []}
+        else:
+            empty_categorized = {"image": [], "fbc": [], "external": []}
+        categorized_nvrs = self.categorize_nvrs(all_nvrs) if all_nvrs else empty_categorized
+
+        # The key for the primary non-FBC image shipment depends on mode
+        image_key = "extras" if self.ocp_optional else "image"
+
         # Defensive check: bundle rebases (and the operator-level filter in
         # build_layered_products.py) should already guarantee that the bundle/operand images
         # referenced by an FBC are never embargoed. If an embargoed NVR reaches this point
@@ -1223,13 +1236,12 @@ class ReleaseFromFbcPipeline:
         # override - that signals a serious upstream bug (or misuse of --extra-image-nvrs), so
         # fail the release rather than silently dropping it.
         #
-        # Note: this deliberately checks related_nvrs (the actual bundle/operand images
-        # referenced inside the FBC catalog), not fbc_nvrs (the FBC/catalog image's own NVR).
-        # The FBC image is just a catalog wrapper; its own NVR is never embargo-relevant and,
-        # by construction (see build_fbc.py), never carries a p-flag at all - so including it
-        # here would make this check fail unconditionally on every run.
+        # Note: this only checks non-external NVRs from the current group. External images
+        # (from the prod registry) and FBC catalog NVRs don't carry p-flags and are excluded.
         try:
-            embargoed_nvrs = [nvr for nvr in related_nvrs + self.extra_image_nvrs if is_nvr_embargoed(nvr)]
+            embargoed_nvrs = [
+                nvr for nvr in categorized_nvrs.get(image_key, []) + self.extra_image_nvrs if is_nvr_embargoed(nvr)
+            ]
         except ValueError as e:
             # is_nvr_embargoed() raises when an NVR's embargo status is ambiguous (e.g. it
             # matches more than one visibility suffix). Treat that the same as finding an
@@ -1241,17 +1253,6 @@ class ReleaseFromFbcPipeline:
                 f"{embargoed_nvrs}. This should never happen for FBC-derived NVRs and likely "
                 f"indicates an upstream bug, or an embargoed NVR was passed via --extra-image-nvrs."
             )
-
-        # Categorize the extracted NVRs
-        empty_categorized: Dict[str, List[str]]
-        if self.ocp_optional:
-            empty_categorized = {"extras": [], "fbc": [], "external": []}
-        else:
-            empty_categorized = {"image": [], "fbc": [], "external": []}
-        categorized_nvrs = self.categorize_nvrs(all_nvrs) if all_nvrs else empty_categorized
-
-        # The key for the primary non-FBC image shipment depends on mode
-        image_key = "extras" if self.ocp_optional else "image"
 
         # Merge extra image NVRs into the primary image category
         if self.extra_image_nvrs:

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -642,7 +642,7 @@ class TestEmbargoedNvrDefensiveCheck(unittest.TestCase):
     def test_ambiguous_nvr_raises(self):
         """An NVR whose embargo status is ambiguous (matches more than one visibility suffix)
         must fail the release rather than have is_nvr_embargoed() guess which one applies."""
-        ambiguous_nvr = "oadp-velero-container-1.5.3.202607151200.p2.g172d0b2.assembly.stream.el9.p3"
+        ambiguous_nvr = "oadp-velero-container-1.5.3-202607151200.p2.g172d0b2.assembly.stream.el9.p3"
         pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/example/fbc:v1"])
         pipeline.validate_fbc_related_images = AsyncMock(return_value=[ambiguous_nvr])
         pipeline.extract_fbc_nvr = MagicMock(return_value="oadp-operator-fbc-1.5.3-20260715174111.ocp4.19")
@@ -668,6 +668,20 @@ class TestEmbargoedNvrDefensiveCheck(unittest.TestCase):
         pipeline = self._make_pipeline(
             extra_image_nvrs=["oadp-velero-container-1.5.3-202607151200.p2.g172d0b2.assembly.stream.el9"]
         )
+        pipeline.create_snapshot = AsyncMock(return_value=MagicMock())
+        pipeline.create_shipment_config = MagicMock(return_value=MagicMock())
+        pipeline.write_shipment_files_locally = AsyncMock()
+
+        asyncio.run(pipeline.run())
+
+    def test_external_nvrs_skipped_from_embargo_check(self):
+        """External image NVRs (from the prod registry, e.g. postgresql) don't carry p-flags.
+        They must be excluded from the embargo check — is_nvr_embargoed() defaults to True
+        for NVRs without p-flags, which would incorrectly block the release."""
+        external_nvr = "postgresql-15-container-15.14-1.1733837256"
+        pipeline = self._make_pipeline(fbc_pullspecs=["quay.io/example/fbc:v1"])
+        pipeline.validate_fbc_related_images = AsyncMock(return_value=[external_nvr])
+        pipeline.extract_fbc_nvr = MagicMock(return_value="oadp-operator-fbc-1.5.3-20260715174111.ocp4.19")
         pipeline.create_snapshot = AsyncMock(return_value=MagicMock())
         pipeline.create_shipment_config = MagicMock(return_value=MagicMock())
         pipeline.write_shipment_files_locally = AsyncMock()


### PR DESCRIPTION
## Summary
- External images from the prod registry (e.g. `registry.redhat.io/rhel9/postgresql-15`) don't carry p-flag visibility suffixes. `is_nvr_embargoed()` defaults to `True` when no p-flag is found, incorrectly flagging these as embargoed.
- **Bundle builds**: `_resolve_operands_from_db()` now skips image-references entries not in `name_in_bundle_map` (external images) instead of raising `ValueError`. They are handled downstream by `_find_external_digest_images()` with NVR="external".
- **Release pipeline**: Moved NVR categorization before the embargo check in `release_from_fbc` so external dependencies are excluded from the check.

## Test plan
- [x] `test_resolve_operands_from_db_external_image_skipped` — verifies external images are silently skipped
- [x] `test_resolve_operands_from_db_mixed_art_and_external` — verifies ART images resolve while external images are skipped
- [x] `test_external_nvrs_skipped_from_embargo_check` — verifies external NVRs don't block the release
- [x] All existing embargo tests still pass (ambiguous, embargoed related, embargoed extra, FBC-only, non-embargoed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release validation by checking embargo status only for applicable primary and extra image builds.
  - External and catalog-only builds are now excluded from embargo checks, preventing unnecessary release failures.
  - Improved handling of ambiguous build identifiers during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->