### PR TITLE
Fix plashet job path

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -45,7 +45,7 @@ class Jobs(Enum):
     MICROSHIFT_SYNC = 'aos-cd-builds/build%2Fmicroshift_sync'
     CINCINNATI_PRS = 'aos-cd-builds/build%2Fcincinnati-prs'
     RHCOS_SYNC = 'aos-cd-builds/build%2Frhcos_sync'
-    BUILD_PLASHETS = 'aos-cd-jobs/build%2Fbuild-plashets'
+    BUILD_PLASHETS = 'aos-cd-builds/build%2Fbuild-plashets'
     BUILD_FBC = 'aos-cd-builds/build%2Fbuild-fbc'
     LAYERED_PRODUCTS = 'aos-cd-builds/build%2Flayered-products'
     LAYERED_PRODUCTS_SCAN = 'aos-cd-builds/build%2Flayered-products-scan'


### PR DESCRIPTION
This got erroneously changed in https://github.com/openshift-eng/art-tools/commit/406e4922de531a377acf76b34e234ff07447b93f 

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the build-plashets workflow integration to use the correct Jenkins job location.
  * Build-plashets requests can now be triggered successfully from the updated job path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->