### PR TITLE
Add per-image sign_golang_rpm override for monobranch

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -594,11 +594,20 @@ class UpdateGolangPipeline:
         return False
 
     def should_sign_golang_rpm(self, el_v, go_version) -> bool:
-        """Check sign_golang_rpm in the golang branch group.yml.
+        """Check sign_golang_rpm config for a specific golang version.
+        With monobranch: reads the per-image metadata (e.g. images/openshift-golang-builder-1-22.rhel9.yml)
+        since multiple golang versions share the same group.yml.
+        With separated branches: reads group.yml from the per-version branch.
         Defaults to False so that RHEL-shipped golang is never accidentally signed by us.
         """
         if self.use_new_golang_branch:
             default_branch = self.GOLANG_DATA_BRANCH
+            repo, branch = self._get_ocp_build_data_repo_and_branch(default_branch)
+            image_key = self.get_golang_image_key(el_v, go_version)
+            content = repo.get_contents(f"images/{image_key}.yml", ref=branch)
+            image_config = yaml.load(content.decoded_content)
+            if image_config.get('sign_golang_rpm') is not None:
+                return image_config.get('sign_golang_rpm', False)
         else:
             default_branch = self.get_golang_branch(el_v, go_version)
         repo, branch = self._get_ocp_build_data_repo_and_branch(default_branch)

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1509,7 +1509,8 @@ class TestShouldSignGolangRpm(unittest.TestCase):
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
-    def test_returns_true_when_config_set(self, mock_get_github_client, mock_konflux_db):
+    def test_monobranch_image_override_takes_precedence(self, mock_get_github_client, mock_konflux_db):
+        """Image config sign_golang_rpm=true overrides group.yml default"""
         mock_repo = Mock()
         mock_repo.get_contents.return_value = Mock(decoded_content=b"sign_golang_rpm: true\n")
         mock_get_github_client.return_value.get_repo.return_value = mock_repo
@@ -1528,13 +1529,48 @@ class TestShouldSignGolangRpm(unittest.TestCase):
         result = pipeline.should_sign_golang_rpm(9, "1.22.9")
 
         self.assertTrue(result)
-        mock_repo.get_contents.assert_called_with("group.yml", ref="golang")
+        mock_repo.get_contents.assert_called_once_with(
+            "images/openshift-golang-builder-1-22.rhel9.yml", ref="golang"
+        )
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
-    def test_returns_false_when_config_not_set(self, mock_get_github_client, mock_konflux_db):
+    def test_monobranch_falls_back_to_group_yml(self, mock_get_github_client, mock_konflux_db):
+        """When image config has no sign_golang_rpm, falls back to group.yml"""
         mock_repo = Mock()
-        mock_repo.get_contents.return_value = Mock(decoded_content=b"name: rhel-9-golang-1.25\n")
+        image_content = Mock(decoded_content=b"name: openshift-golang-builder\n")
+        group_content = Mock(decoded_content=b"sign_golang_rpm: true\n")
+        mock_repo.get_contents.side_effect = [image_content, group_content]
+        mock_get_github_client.return_value.get_repo.return_value = mock_repo
+
+        pipeline = UpdateGolangPipeline(
+            runtime=Mock(dry_run=False, working_dir=Path("/tmp/working")),
+            ocp_version="4.18",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            use_new_golang_branch=True,
+        )
+
+        result = pipeline.should_sign_golang_rpm(9, "1.22.9")
+
+        self.assertTrue(result)
+        self.assertEqual(mock_repo.get_contents.call_count, 2)
+        mock_repo.get_contents.assert_any_call(
+            "images/openshift-golang-builder-1-22.rhel9.yml", ref="golang"
+        )
+        mock_repo.get_contents.assert_any_call("group.yml", ref="golang")
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    def test_monobranch_defaults_false_when_neither_set(self, mock_get_github_client, mock_konflux_db):
+        """When neither image config nor group.yml has sign_golang_rpm, defaults to False"""
+        mock_repo = Mock()
+        image_content = Mock(decoded_content=b"name: openshift-golang-builder\n")
+        group_content = Mock(decoded_content=b"name: golang\n")
+        mock_repo.get_contents.side_effect = [image_content, group_content]
         mock_get_github_client.return_value.get_repo.return_value = mock_repo
 
         pipeline = UpdateGolangPipeline(
@@ -1551,7 +1587,29 @@ class TestShouldSignGolangRpm(unittest.TestCase):
         result = pipeline.should_sign_golang_rpm(9, "1.25.3")
 
         self.assertFalse(result)
-        mock_repo.get_contents.assert_called_with("group.yml", ref="golang")
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    def test_separated_branch_reads_group_yml(self, mock_get_github_client, mock_konflux_db):
+        mock_repo = Mock()
+        mock_repo.get_contents.return_value = Mock(decoded_content=b"sign_golang_rpm: true\n")
+        mock_get_github_client.return_value.get_repo.return_value = mock_repo
+
+        pipeline = UpdateGolangPipeline(
+            runtime=Mock(dry_run=False, working_dir=Path("/tmp/working")),
+            ocp_version="4.18",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            use_new_golang_branch=False,
+        )
+
+        result = pipeline.should_sign_golang_rpm(9, "1.22.9")
+
+        self.assertTrue(result)
+        mock_repo.get_contents.assert_called_with("group.yml", ref="rhel-9-golang-1.22")
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1529,9 +1529,7 @@ class TestShouldSignGolangRpm(unittest.TestCase):
         result = pipeline.should_sign_golang_rpm(9, "1.22.9")
 
         self.assertTrue(result)
-        mock_repo.get_contents.assert_called_once_with(
-            "images/openshift-golang-builder-1-22.rhel9.yml", ref="golang"
-        )
+        mock_repo.get_contents.assert_called_once_with("images/openshift-golang-builder-1-22.rhel9.yml", ref="golang")
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
@@ -1558,9 +1556,7 @@ class TestShouldSignGolangRpm(unittest.TestCase):
 
         self.assertTrue(result)
         self.assertEqual(mock_repo.get_contents.call_count, 2)
-        mock_repo.get_contents.assert_any_call(
-            "images/openshift-golang-builder-1-22.rhel9.yml", ref="golang"
-        )
+        mock_repo.get_contents.assert_any_call("images/openshift-golang-builder-1-22.rhel9.yml", ref="golang")
         mock_repo.get_contents.assert_any_call("group.yml", ref="golang")
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")


### PR DESCRIPTION
## Summary
- When using the golang monobranch (`golang`), `should_sign_golang_rpm` now checks the per-image metadata (e.g. `images/openshift-golang-builder-1-22.rhel9.yml`) first for a `sign_golang_rpm` override, then falls back to `group.yml`
- This is needed because multiple golang versions share the same `group.yml` on the monobranch, but sustaining vs RHEL-shipped versions need different signing behavior
- For separated branches, behavior is unchanged — reads `sign_golang_rpm` from `group.yml` on the per-version branch

## Test plan
- [x] Unit tests for image-level override taking precedence
- [x] Unit tests for fallback to group.yml when image config has no override
- [x] Unit tests for defaults to False when neither is set
- [x] Unit tests for separated branch behavior unchanged
- [x] All 89 tests in `test_update_golang.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Go RPM signing configuration to respect per-image settings when available.
  * Preserved fallback behavior using group-level configuration when image settings are not defined.
  * Improved configuration handling for separated Go branches.
* **Tests**
  * Added coverage for configuration precedence, fallback behavior, defaults, and separated branch lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->