### PR TITLE
Prevent duplicate image and bundle NVR builds

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -179,6 +179,20 @@ class KonfluxImageBuilder:
             uuid_tag, component_name, version, release = self._parse_dockerfile(metadata.distgit_key, df_path)
             nvr = f"{component_name}-{version}-{release}"
 
+            # get_latest_build() is assembly-aware and, for assemblies with a basis event,
+            # intentionally resolves to the stream build at the basis event. That behavior is
+            # useful for selecting assembly content, but it can miss an exact NVR that was
+            # already built for the current or another assembly. Check exact NVR existence
+            # without assembly or group scoping before applying the ordering check below.
+            existing_build = await self._get_successful_image_build_by_nvr(metadata, nvr)
+            if existing_build is not None:
+                raise ValueError(
+                    f"Successful image NVR {nvr} already exists in DB! "
+                    f"Existing build assembly: {existing_build.assembly}; "
+                    f"pullspec: {existing_build.image_pullspec}. "
+                    "To rebuild, please do another rebase to get a newer NVR"
+                )
+
             # Sanity check to ensure we're not rebuilding an existing or older NVR
             latest_build = await metadata.get_latest_build(
                 engine=Engine.KONFLUX.value,
@@ -469,6 +483,28 @@ class KonfluxImageBuilder:
                 self._record_logger.add_record(key, **record)
             metadata.build_event.set()
         return pipelinerun_name, pipelinerun_info.to_dict()
+
+    @staticmethod
+    async def _get_successful_image_build_by_nvr(metadata: ImageMetadata, nvr: str) -> Optional[KonfluxBuildRecord]:
+        """Find a successful Konflux image build by exact NVR, regardless of assembly or group."""
+        where = {
+            "nvr": nvr,
+            "outcome": KonfluxBuildOutcome.SUCCESS,
+            "artifact_type": ArtifactType.IMAGE,
+            "engine": Engine.KONFLUX,
+        }
+        build = await anext(
+            metadata.runtime.konflux_db.search_builds_by_fields(
+                where=where,
+                limit=1,
+                exclude_columns=["installed_rpms", "installed_packages"],
+            ),
+            None,
+        )
+        if build is None:
+            return None
+        assert isinstance(build, KonfluxBuildRecord)
+        return build
 
     def _parse_dockerfile(self, distgit_key: str, df_path: Path):
         """Parse the Dockerfile and return the UUID tag, component name, version, and release.

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -555,6 +555,18 @@ class KonfluxBundleCli:
         assert isinstance(bundle_build, KonfluxBundleBuildRecord)
         return bundle_build
 
+    async def _get_bundle_build_by_nvr(self, nvr: str) -> Optional[KonfluxBundleBuildRecord]:
+        """Find a successful bundle build by its exact NVR, regardless of assembly."""
+        where = {
+            "nvr": nvr,
+            "outcome": str(KonfluxBuildOutcome.SUCCESS),
+        }
+        bundle_build = await anext(self._db_for_bundles.search_builds_by_fields(where=where, limit=1), None)
+        if bundle_build is None:
+            return None
+        assert isinstance(bundle_build, KonfluxBundleBuildRecord)
+        return bundle_build
+
     async def _rebase_and_build(
         self,
         rebaser: KonfluxOlmBundleRebaser,
@@ -584,6 +596,21 @@ class KonfluxBundleCli:
 
         logger.info("Rebasing OLM bundle...")
         nvr = await rebaser.rebase(image_meta, operator_build, input_release)
+
+        # The assembly-scoped lookup above determines whether this assembly already has a
+        # bundle for the operator. The resulting NVR, however, is derived from the operator's
+        # labels and can collide with a bundle recorded under another assembly. Check the exact
+        # NVR globally before starting a PipelineRun so a cross-assembly invocation cannot
+        # create two successful builds with the same NVR.
+        existing_build = await self._get_bundle_build_by_nvr(nvr)
+        if existing_build is not None:
+            raise ValueError(
+                f"Successful bundle NVR {nvr} already exists in DB! "
+                f"Existing build assembly: {existing_build.assembly}; "
+                f"pullspec: {existing_build.image_pullspec}. "
+                "To rebuild, use a different bundle release."
+            )
+
         logger.info("Building OLM bundle...")
         await builder.build(image_meta, git_auth_secret=git_auth_secret)
         logger.info("Bundle build complete")

--- a/doozer/tests/backend/test_konflux_ec_verification.py
+++ b/doozer/tests/backend/test_konflux_ec_verification.py
@@ -81,7 +81,13 @@ def _make_metadata(distgit_key="test-image", for_release=True, is_base_image=Fal
     metadata.runtime.assembly = "stream"
     metadata.runtime.variant = variant if variant is not None else BuildVariant.OCP
     metadata.runtime.group_config.software_lifecycle.phase = "release"
-    metadata.runtime.konflux_db = None
+    metadata.runtime.konflux_db = MagicMock()
+
+    async def search_builds_by_fields(**_kwargs):
+        if False:
+            yield
+
+    metadata.runtime.konflux_db.search_builds_by_fields = MagicMock(side_effect=search_builds_by_fields)
     return metadata
 
 

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -3,7 +3,12 @@ import unittest
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
+from artcommonlib.konflux.konflux_build_record import (
+    ArtifactType,
+    Engine,
+    KonfluxBuildOutcome,
+    KonfluxBuildRecord,
+)
 from doozerlib.backend.konflux_image_builder import (
     KonfluxImageBuilder,
     KonfluxImageBuilderConfig,
@@ -48,6 +53,12 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         metadata.runtime = MagicMock()
         metadata.runtime.assembly = "test-assembly"
         metadata.runtime.konflux_db = MagicMock()
+
+        async def search_builds_by_fields(**_kwargs):
+            if False:
+                yield
+
+        metadata.runtime.konflux_db.search_builds_by_fields = MagicMock(side_effect=search_builds_by_fields)
         metadata.runtime.group_config.software_lifecycle.phase = "release"
         metadata.config.konflux.get.return_value = False
         metadata.for_release = True
@@ -59,6 +70,69 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         metadata.should_trigger_base_image_release.return_value = False
         metadata.is_golang_builder = MagicMock(return_value=False)
         return metadata
+
+    async def test_get_successful_image_build_by_nvr_is_not_assembly_scoped(self):
+        metadata = self._metadata()
+        existing_build = MagicMock(spec=KonfluxBuildRecord)
+
+        async def search_builds_by_fields(**_kwargs):
+            yield existing_build
+
+        metadata.runtime.konflux_db.search_builds_by_fields = MagicMock(side_effect=search_builds_by_fields)
+
+        result = await self.builder._get_successful_image_build_by_nvr(metadata, "test-component-1.0-1.assembly.test")
+
+        self.assertIs(result, existing_build)
+        metadata.runtime.konflux_db.search_builds_by_fields.assert_called_once_with(
+            where={
+                "nvr": "test-component-1.0-1.assembly.test",
+                "outcome": KonfluxBuildOutcome.SUCCESS,
+                "artifact_type": ArtifactType.IMAGE,
+                "engine": Engine.KONFLUX,
+            },
+            limit=1,
+            exclude_columns=["installed_rpms", "installed_packages"],
+        )
+
+    async def test_build_rejects_exact_nvr_before_assembly_scoped_latest_check(self):
+        metadata = self._metadata()
+        metadata.runtime.assembly = "4.17.1"
+        metadata.runtime.assembly_basis_event = "2026-07-01T00:00:00Z"
+        dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        existing_build = MagicMock(spec=KonfluxBuildRecord)
+        existing_build.assembly = "4.17.1"
+        existing_build.image_pullspec = "quay.io/example/image@sha256:existing"
+        build_repo = MagicMock()
+        start_build = AsyncMock()
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=build_repo),
+            ),
+            patch.object(
+                self.builder,
+                "_parse_dockerfile",
+                return_value=("test-uuid", "test-component", "1.0", "1.assembly.4.17.1"),
+            ),
+            patch.object(
+                self.builder,
+                "_get_successful_image_build_by_nvr",
+                new=AsyncMock(return_value=existing_build),
+            ) as exact_nvr_lookup,
+            patch.object(self.builder, "_start_build", new=start_build),
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "Successful image NVR test-component-1.0-1.assembly.4.17.1 already exists in DB",
+            ):
+                await self.builder.build(metadata)
+
+        exact_nvr_lookup.assert_awaited_once_with(metadata, "test-component-1.0-1.assembly.4.17.1")
+        metadata.get_latest_build.assert_not_awaited()
+        start_build.assert_not_awaited()
 
     async def test_build_uses_definitive_pullspec_for_attestation_validation(self):
         metadata = self._metadata()

--- a/doozer/tests/cli/test_images_konflux.py
+++ b/doozer/tests/cli/test_images_konflux.py
@@ -2,7 +2,11 @@ import json
 import unittest
 from unittest import mock
 
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord
+from artcommonlib.konflux.konflux_build_record import (
+    KonfluxBuildOutcome,
+    KonfluxBuildRecord,
+    KonfluxBundleBuildRecord,
+)
 from artcommonlib.model import Model
 from doozerlib.cli.images_konflux import KonfluxBundleCli, KonfluxRebaseCli
 from doozerlib.exceptions import DoozerFatalError, ParentRebaseFailedError
@@ -50,6 +54,49 @@ class TestKonfluxBundleCli(unittest.IsolatedAsyncioTestCase):
         build.name = name
         build.nvr = nvr
         return build
+
+    async def test_get_bundle_build_by_nvr_searches_without_assembly_filter(self):
+        existing_build = mock.Mock(spec=KonfluxBundleBuildRecord)
+
+        async def search_builds_by_fields(**_kwargs):
+            yield existing_build
+
+        self.mock_bundle_db.search_builds_by_fields = mock.Mock(side_effect=search_builds_by_fields)
+
+        result = await self.bundle_cli._get_bundle_build_by_nvr("test-operator-bundle-1.0.0-1")
+
+        self.assertIs(result, existing_build)
+        self.mock_bundle_db.search_builds_by_fields.assert_called_once_with(
+            where={
+                "nvr": "test-operator-bundle-1.0.0-1",
+                "outcome": str(KonfluxBuildOutcome.SUCCESS),
+            },
+            limit=1,
+        )
+
+    async def test_rebase_and_build_rejects_duplicate_nvr_from_another_assembly(self):
+        operator_build = self._create_operator_build("test-operator", "test-operator-1.0.0-1.assembly.stream")
+        image_meta = mock.Mock()
+        rebaser = mock.AsyncMock()
+        rebaser.rebase.return_value = "test-operator-bundle-1.0.0-1"
+        builder = mock.AsyncMock()
+
+        existing_build = mock.Mock(spec=KonfluxBundleBuildRecord)
+        existing_build.assembly = "stream"
+        existing_build.image_pullspec = "quay.io/example/bundle@sha256:existing"
+
+        self.bundle_cli._get_bundle_build_for = mock.AsyncMock(return_value=None)
+        self.bundle_cli._get_bundle_build_by_nvr = mock.AsyncMock(return_value=existing_build)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Successful bundle NVR test-operator-bundle-1.0.0-1 already exists in DB",
+        ):
+            await self.bundle_cli._rebase_and_build(rebaser, builder, image_meta, operator_build)
+
+        rebaser.rebase.assert_awaited_once_with(image_meta, operator_build, "1")
+        self.bundle_cli._get_bundle_build_by_nvr.assert_awaited_once_with("test-operator-bundle-1.0.0-1")
+        builder.build.assert_not_awaited()
 
     @mock.patch("doozerlib.cli.images_konflux.sys.exit", side_effect=SystemExit(1))
     @mock.patch("doozerlib.cli.images_konflux.click.echo")


### PR DESCRIPTION
Ref: https://redhat-internal.slack.com/archives/C0ARQM5UV88/p1784664373748309?thread_ts=1784310810.550789&cid=C0ARQM5UV88

We found a gap where duplicate NVRs can get built which caused release issues.

## What

- check the exact successful bundle NVR across all bundle assemblies before starting the bundle PipelineRun
- check the exact successful image NVR across all image assemblies and groups before starting the image PipelineRun
- retain the existing assembly-aware image NVR ordering check after exact-duplicate validation
- report the existing assembly and pullspec when rejecting a duplicate
- add regression coverage for cross-assembly bundle collisions and basis-event image assemblies

## Why

The bundle lookup is scoped to the current assembly and operator build. A bundle invocation under another assembly can therefore derive an NVR that already exists in the bundle records and start a second build with the same NVR. This happened when an `assembly=test` invocation used the same operator-derived bundle NVR as the earlier `assembly=stream` build.

The image guard similarly reused assembly content-selection semantics. For assemblies with a basis event, that lookup intentionally resolves to the stream build at the basis event and ignores successful builds recorded for the named assembly. Rerunning the same named-assembly image NVR could therefore pass the "newer than stream" comparison and create a duplicate. The new exact lookup omits assembly and group filters, restricts results to successful Konflux image records, and excludes the large package columns.

## Validation

- `make format`
- `make test PYTHON_VERSION=3.11` (3,067 tests passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate successful Konflux image and bundle builds when the same NVR already exists, including across different assemblies.
  * Added an early safety check to stop builds before proceeding when an exact-match successful build is found.

* **Tests**
  * Expanded coverage for NVR-based Konflux bundle lookup and for rejecting cross-assembly duplicate NVRs.
  * Added coverage for NVR-based Konflux image build detection, and updated test fixtures to mock Konflux DB queries appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->