### PR TITLE
ART-21754: Detect RPM/image sibling source commit mismatch in payload generation

### DIFF
--- a/artcommon/artcommonlib/assembly.py
+++ b/artcommon/artcommonlib/assembly.py
@@ -78,6 +78,12 @@ class AssemblyIssueCode(Enum):
     # build was non-hermetic.
     MISMATCHED_NETWORK_MODE = 12
 
+    # An RPM and a container image are built from the same upstream repo
+    # but at different source commits, causing version skew between
+    # the RPM binaries (e.g. kubelet) and the image binaries
+    # (e.g. kube-apiserver from hyperkube).
+    MISMATCHED_RPM_IMAGE_SIBLINGS = 13
+
 
 class AssemblyIssue:
     """

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -56,6 +56,7 @@ from doozerlib.util import (
     extract_version_fields,
     find_manifest_list_sha,
     get_nightly_pullspec,
+    isolate_git_commit_in_release,
     isolate_nightly_name_components,
     what_is_in_master,
 )
@@ -829,6 +830,7 @@ class GenPayloadCli:
         self.logger.info("Checking assembly content for inconsistencies.")
         span.add_event("Checking assembly content for inconsistencies")
         self.detect_mismatched_siblings(assembly_inspector)
+        self.detect_rpm_image_sibling_mismatch(assembly_inspector)
 
         if self.runtime.build_system == 'brew':
             with rt.shared_build_status_detector() as bsd:
@@ -903,6 +905,76 @@ class GenPayloadCli:
 
         self.assembly_issues.extend(issues)
         span.set_attribute("doozer.result.issues", list(map(lambda it: it.to_dict(), issues)))
+
+    @TRACER.start_as_current_span("GenPayloadCli.detect_rpm_image_sibling_mismatch")
+    def detect_rpm_image_sibling_mismatch(self, assembly_inspector: AssemblyInspector):
+        """
+        Detect when an RPM and a container image are built from the same upstream
+        repo but at different source commits. This catches version skew like kubelet
+        (from the openshift RPM) running v1.33.11 while kube-apiserver (from the
+        hyperkube image) is at v1.33.10.
+        """
+        span = trace.get_current_span()
+        self.logger.debug("Checking for RPM/image sibling source mismatches...")
+
+        # Build a map of normalized source URL -> (distgit_key, source_commit) from payload images
+        image_source_commits: Dict[str, Tuple[str, str]] = {}
+        for img in assembly_inspector.get_group_release_images().values():
+            if not img:
+                continue
+            raw_source = img.get_image_meta().raw_config.content.source
+            source_url = raw_source.git.url
+            source_commit = img.get_source_git_commit()
+            if not source_url or not source_commit:
+                continue
+            normalized_url = convert_remote_git_to_https(source_url)
+            image_source_commits[normalized_url] = (img.get_image_meta().distgit_key, source_commit)
+
+        # Check each RPM's source against the image map
+        issues = []
+        rt = self.runtime
+        for rpm_meta in rt.rpm_metas():
+            rpm_source_url = rpm_meta.raw_config.content.source.git.url
+            if not rpm_source_url:
+                continue
+            normalized_rpm_url = convert_remote_git_to_https(rpm_source_url)
+
+            image_entry = image_source_commits.get(normalized_rpm_url)
+            if not image_entry:
+                continue
+
+            image_dgk, image_commit = image_entry
+
+            # Get the RPM build and extract its source commit from the NVR
+            for el_ver in rpm_meta.determine_rhel_targets():
+                rpm_build = assembly_inspector.get_group_rpm_build_dicts(el_ver).get(rpm_meta.distgit_key)
+                if not rpm_build:
+                    continue
+                rpm_commit = isolate_git_commit_in_release(rpm_build["release"])
+                if not rpm_commit:
+                    continue
+
+                # Short-prefix comparison: NVR embeds a 7-char prefix
+                min_len = min(len(rpm_commit), len(image_commit))
+                if rpm_commit[:min_len] == image_commit[:min_len]:
+                    continue
+
+                rpm_nvr = rpm_build["nvr"]
+                issue = AssemblyIssue(
+                    f"RPM {rpm_nvr} (commit {rpm_commit}) and image {image_dgk} "
+                    f"(commit {image_commit[:7]}) are built from the same upstream repo "
+                    f"({normalized_rpm_url}) but at different source commits. "
+                    f"This causes version skew between RPM binaries on nodes and "
+                    f"image binaries in the payload.",
+                    component=rpm_meta.distgit_key,
+                    code=AssemblyIssueCode.MISMATCHED_RPM_IMAGE_SIBLINGS,
+                )
+                issues.append(issue)
+                # Only need to flag once per RPM, not per el_ver
+                break
+
+        self.assembly_issues.extend(issues)
+        span.set_attribute("doozer.result.rpm_image_sibling_issues", list(map(lambda it: it.to_dict(), issues)))
 
     @staticmethod
     def generate_id_tags_list(assembly_inspector: AssemblyInspector) -> List[Tuple[int, str]]:

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -917,10 +917,11 @@ class GenPayloadCli:
         span = trace.get_current_span()
         self.logger.debug("Checking for RPM/image sibling source mismatches...")
 
-        # Build a map of normalized source URL -> (distgit_key, source_commit) from payload images
-        image_source_commits: Dict[str, Tuple[str, str]] = {}
+        # Build a map of normalized source URL -> list of (distgit_key, source_commit) from payload images.
+        # Multiple images can share the same upstream repo, so we store all of them.
+        image_source_commits: Dict[str, List[Tuple[str, str]]] = {}
         for img in assembly_inspector.get_group_release_images().values():
-            if not img:
+            if not img or not img.get_image_meta().is_payload:
                 continue
             raw_source = img.get_image_meta().raw_config.content.source
             source_url = raw_source.git.url
@@ -928,7 +929,9 @@ class GenPayloadCli:
             if not source_url or not source_commit:
                 continue
             normalized_url = convert_remote_git_to_https(source_url)
-            image_source_commits[normalized_url] = (img.get_image_meta().distgit_key, source_commit)
+            image_source_commits.setdefault(normalized_url, []).append(
+                (img.get_image_meta().distgit_key, source_commit)
+            )
 
         # Check each RPM's source against the image map
         issues = []
@@ -939,27 +942,31 @@ class GenPayloadCli:
                 continue
             normalized_rpm_url = convert_remote_git_to_https(rpm_source_url)
 
-            image_entry = image_source_commits.get(normalized_rpm_url)
-            if not image_entry:
+            image_entries = image_source_commits.get(normalized_rpm_url)
+            if not image_entries:
                 continue
 
-            image_dgk, image_commit = image_entry
-
             # Get the RPM build and extract its source commit from the NVR
+            rpm_commit = None
+            rpm_nvr = None
             for el_ver in rpm_meta.determine_rhel_targets():
                 rpm_build = assembly_inspector.get_group_rpm_build_dicts(el_ver).get(rpm_meta.distgit_key)
                 if not rpm_build:
                     continue
                 rpm_commit = isolate_git_commit_in_release(rpm_build["release"])
-                if not rpm_commit:
-                    continue
+                rpm_nvr = rpm_build["nvr"]
+                if rpm_commit:
+                    break
 
-                # Short-prefix comparison: NVR embeds a 7-char prefix
+            if not rpm_commit:
+                continue
+
+            # Compare against every sibling image from the same repo
+            for image_dgk, image_commit in image_entries:
                 min_len = min(len(rpm_commit), len(image_commit))
                 if rpm_commit[:min_len] == image_commit[:min_len]:
                     continue
 
-                rpm_nvr = rpm_build["nvr"]
                 issue = AssemblyIssue(
                     f"RPM {rpm_nvr} (commit {rpm_commit}) and image {image_dgk} "
                     f"(commit {image_commit[:7]}) are built from the same upstream repo "
@@ -970,8 +977,6 @@ class GenPayloadCli:
                     code=AssemblyIssueCode.MISMATCHED_RPM_IMAGE_SIBLINGS,
                 )
                 issues.append(issue)
-                # Only need to flag once per RPM, not per el_ver
-                break
 
         self.assembly_issues.extend(issues)
         span.set_attribute("doozer.result.rpm_image_sibling_issues", list(map(lambda it: it.to_dict(), issues)))

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -128,6 +128,7 @@ class TestGenPayloadCli(IsolatedAsyncioTestCase):
             rgp_cli.GenPayloadCli(runtime=MagicMock(assembly="stream", build_system="brew")),
             collect_assembly_build_ids=MagicMock(return_value={1, 2, 3}),
             detect_mismatched_siblings=None,
+            detect_rpm_image_sibling_mismatch=None,
             detect_non_latest_rpms=None,
             detect_inconsistent_images=Mock(),
             detect_installed_rpms_issues=None,
@@ -1252,3 +1253,122 @@ manifests:
         self.assertEqual('false', new_tag_annotations['release.openshift.io/rewrite'])
         self.assertEqual(os.getenv('BUILD_URL', ''), new_tag_annotations['release.openshift.io/build-url'])
         self.assertIn('release.openshift.io/runtime-brew-event', new_tag_annotations)
+
+    def _make_rpm_meta(self, source_url, distgit_key, el_targets=None):
+        """
+        Helper to build a mock RPMMetadata for RPM/image sibling tests.
+        """
+        if el_targets is None:
+            el_targets = [9]
+        raw_config = Model(dict(content=dict(source=dict(git=dict(url=source_url)))))
+        meta = MagicMock()
+        meta.raw_config = raw_config
+        meta.distgit_key = distgit_key
+        meta.determine_rhel_targets.return_value = el_targets
+        return meta
+
+    def test_detect_rpm_image_sibling_mismatch_flags_different_commits(self):
+        """
+        RPM and image from the same repo at different commits should be flagged.
+        """
+        gpcli = rgp_cli.GenPayloadCli(runtime=MagicMock(assembly="stream"))
+
+        img = self._make_sibling_inspector(
+            "git@github.com:openshift-priv/kubernetes.git", "aaa1234abcdef", "openshift-enterprise-hyperkube"
+        )
+        ai = MagicMock(AssemblyInspector)
+        ai.get_group_release_images.return_value = {"openshift-enterprise-hyperkube": img}
+
+        rpm_meta = self._make_rpm_meta("git@github.com:openshift-priv/kubernetes.git", "openshift")
+        gpcli.runtime.rpm_metas.return_value = [rpm_meta]
+        ai.get_group_rpm_build_dicts.return_value = {
+            "openshift": {
+                "nvr": "openshift-4.20.0-202605061218.p2.gbbb5678.assembly.stream.el9",
+                "release": "202605061218.p2.gbbb5678.assembly.stream.el9",
+            }
+        }
+
+        gpcli.detect_rpm_image_sibling_mismatch(ai)
+        self.assertEqual(len(gpcli.assembly_issues), 1)
+        self.assertEqual(gpcli.assembly_issues[0].code, AssemblyIssueCode.MISMATCHED_RPM_IMAGE_SIBLINGS)
+        self.assertEqual(gpcli.assembly_issues[0].component, "openshift")
+
+    def test_detect_rpm_image_sibling_mismatch_no_issue_same_commit(self):
+        """
+        RPM and image from the same repo at the same commit should not be flagged.
+        """
+        gpcli = rgp_cli.GenPayloadCli(runtime=MagicMock(assembly="stream"))
+
+        img = self._make_sibling_inspector(
+            "git@github.com:openshift-priv/kubernetes.git", "aaa1234abcdef", "openshift-enterprise-hyperkube"
+        )
+        ai = MagicMock(AssemblyInspector)
+        ai.get_group_release_images.return_value = {"openshift-enterprise-hyperkube": img}
+
+        rpm_meta = self._make_rpm_meta("git@github.com:openshift-priv/kubernetes.git", "openshift")
+        gpcli.runtime.rpm_metas.return_value = [rpm_meta]
+        ai.get_group_rpm_build_dicts.return_value = {
+            "openshift": {
+                "nvr": "openshift-4.20.0-202604241817.p2.gaaa1234.assembly.stream.el9",
+                "release": "202604241817.p2.gaaa1234.assembly.stream.el9",
+            }
+        }
+
+        gpcli.detect_rpm_image_sibling_mismatch(ai)
+        self.assertEqual(len(gpcli.assembly_issues), 0)
+
+    def test_detect_rpm_image_sibling_mismatch_different_repos_no_issue(self):
+        """
+        RPM and image from different repos should not be compared.
+        """
+        gpcli = rgp_cli.GenPayloadCli(runtime=MagicMock(assembly="stream"))
+
+        img = self._make_sibling_inspector(
+            "git@github.com:openshift-priv/kubernetes.git", "aaa1234abcdef", "openshift-enterprise-hyperkube"
+        )
+        ai = MagicMock(AssemblyInspector)
+        ai.get_group_release_images.return_value = {"openshift-enterprise-hyperkube": img}
+
+        rpm_meta = self._make_rpm_meta("git@github.com:openshift-priv/other-repo.git", "other-rpm")
+        gpcli.runtime.rpm_metas.return_value = [rpm_meta]
+
+        gpcli.detect_rpm_image_sibling_mismatch(ai)
+        self.assertEqual(len(gpcli.assembly_issues), 0)
+
+    def test_detect_rpm_image_sibling_mismatch_no_rpm_build(self):
+        """
+        RPM with no build available should be skipped without error.
+        """
+        gpcli = rgp_cli.GenPayloadCli(runtime=MagicMock(assembly="stream"))
+
+        img = self._make_sibling_inspector(
+            "git@github.com:openshift-priv/kubernetes.git", "aaa1234abcdef", "openshift-enterprise-hyperkube"
+        )
+        ai = MagicMock(AssemblyInspector)
+        ai.get_group_release_images.return_value = {"openshift-enterprise-hyperkube": img}
+
+        rpm_meta = self._make_rpm_meta("git@github.com:openshift-priv/kubernetes.git", "openshift")
+        gpcli.runtime.rpm_metas.return_value = [rpm_meta]
+        ai.get_group_rpm_build_dicts.return_value = {"openshift": None}
+
+        gpcli.detect_rpm_image_sibling_mismatch(ai)
+        self.assertEqual(len(gpcli.assembly_issues), 0)
+
+    def test_detect_rpm_image_sibling_mismatch_no_commit_in_release(self):
+        """
+        RPM whose release field has no extractable commit should be skipped.
+        """
+        gpcli = rgp_cli.GenPayloadCli(runtime=MagicMock(assembly="stream"))
+
+        img = self._make_sibling_inspector(
+            "git@github.com:openshift-priv/kubernetes.git", "aaa1234abcdef", "openshift-enterprise-hyperkube"
+        )
+        ai = MagicMock(AssemblyInspector)
+        ai.get_group_release_images.return_value = {"openshift-enterprise-hyperkube": img}
+
+        rpm_meta = self._make_rpm_meta("git@github.com:openshift-priv/kubernetes.git", "openshift")
+        gpcli.runtime.rpm_metas.return_value = [rpm_meta]
+        ai.get_group_rpm_build_dicts.return_value = {"openshift": {"nvr": "openshift-4.20.0-1.el9", "release": "1.el9"}}
+
+        gpcli.detect_rpm_image_sibling_mismatch(ai)
+        self.assertEqual(len(gpcli.assembly_issues), 0)

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -1372,3 +1372,56 @@ manifests:
 
         gpcli.detect_rpm_image_sibling_mismatch(ai)
         self.assertEqual(len(gpcli.assembly_issues), 0)
+
+    def test_detect_rpm_image_sibling_mismatch_skips_non_payload(self):
+        """
+        Non-payload images should be excluded from sibling comparison.
+        """
+        gpcli = rgp_cli.GenPayloadCli(runtime=MagicMock(assembly="stream"))
+
+        img = self._make_sibling_inspector(
+            "git@github.com:openshift-priv/kubernetes.git",
+            "aaa1234abcdef",
+            "openshift-enterprise-hyperkube",
+            is_payload=False,
+        )
+        ai = MagicMock(AssemblyInspector)
+        ai.get_group_release_images.return_value = {"openshift-enterprise-hyperkube": img}
+
+        rpm_meta = self._make_rpm_meta("git@github.com:openshift-priv/kubernetes.git", "openshift")
+        gpcli.runtime.rpm_metas.return_value = [rpm_meta]
+        ai.get_group_rpm_build_dicts.return_value = {
+            "openshift": {
+                "nvr": "openshift-4.20.0-202605061218.p2.gbbb5678.assembly.stream.el9",
+                "release": "202605061218.p2.gbbb5678.assembly.stream.el9",
+            }
+        }
+
+        gpcli.detect_rpm_image_sibling_mismatch(ai)
+        self.assertEqual(len(gpcli.assembly_issues), 0)
+
+    def test_detect_rpm_image_sibling_mismatch_multiple_images_same_repo(self):
+        """
+        When multiple payload images share the same repo, RPM should be compared
+        against all of them. A mismatch with any sibling should be flagged.
+        """
+        gpcli = rgp_cli.GenPayloadCli(runtime=MagicMock(assembly="stream"))
+
+        img_a = self._make_sibling_inspector("git@github.com:openshift-priv/kubernetes.git", "aaa1234abcdef", "image-a")
+        img_b = self._make_sibling_inspector("git@github.com:openshift-priv/kubernetes.git", "bbb5678abcdef", "image-b")
+        ai = MagicMock(AssemblyInspector)
+        ai.get_group_release_images.return_value = {"image-a": img_a, "image-b": img_b}
+
+        # RPM matches image-a but not image-b
+        rpm_meta = self._make_rpm_meta("git@github.com:openshift-priv/kubernetes.git", "openshift")
+        gpcli.runtime.rpm_metas.return_value = [rpm_meta]
+        ai.get_group_rpm_build_dicts.return_value = {
+            "openshift": {
+                "nvr": "openshift-4.20.0-202604241817.p2.gaaa1234.assembly.stream.el9",
+                "release": "202604241817.p2.gaaa1234.assembly.stream.el9",
+            }
+        }
+
+        gpcli.detect_rpm_image_sibling_mismatch(ai)
+        self.assertEqual(len(gpcli.assembly_issues), 1)
+        self.assertIn("image-b", gpcli.assembly_issues[0].msg)


### PR DESCRIPTION
Adds a new assembly consistency check that flags when an RPM and a container image built from the same upstream repo use different source commits. 

This prevents version skew like kubelet (RPM) running v1.33.11 while kube-apiserver (hyperkube image) is at v1.33.10, which was observed in OCP 4.20.22.

Jira: https://redhat.atlassian.net/browse/ART-21754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Assembly consistency reports now detect when RPM packages and container images from the same source repository were built from different commits, and flag them under a dedicated issue category.
- **Bug Fixes**
  - Improved release validation by preventing unnoticed source-version drift between related RPM and container image builds.
- **Tests**
  - Added coverage for the new RPM/image sibling mismatch detection, including matching, mismatching, skipped cases, and handling of multiple sibling images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->