### PR TITLE
Add acm,mce to base image release map

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -115,6 +115,8 @@ PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP = {
     "oadp": ("oadp-images-base-silent", "oadp-images-base"),
     "logging": ("logging-images-base-silent", "logging-images-base"),
     "openshift-logging": ("logging-images-base-silent", "logging-images-base"),
+    "acm": ("acm-images-base-silent", "acm-images-base"),
+    "mce": ("acm-images-base-silent", "acm-images-base"),
 }
 
 # Pre-release lifecycle (software_lifecycle.phase) — registry-ocp-art-base-ec-prod via ART-19498.


### PR DESCRIPTION
Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Konflux base-image support for the ACM and MCE products.
  * Both products now use the appropriate ACM base-image release configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->