### PR TITLE
Fix CoreOS image mirroring to use ocp-priv namespace

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -388,9 +388,9 @@ class BuildSyncPipeline:
 
         if not arch_suffix:
             # Tag the image into the imagestream for private CI from openshift-priv.
-            self.logger.info('Tagging ocp-private/%s-priv:%s with %s', self.version, tag, tag_pullspec)
+            self.logger.info('Tagging ocp-priv/%s-priv:%s with %s', self.version, tag, tag_pullspec)
             cmd = (
-                f'oc --kubeconfig {os.environ["KUBECONFIG"]} -n ocp-private '
+                f'oc --kubeconfig {os.environ["KUBECONFIG"]} -n ocp-priv '
                 f'tag {tag_pullspec} {self.version}-priv:{tag} --import-mode=PreserveOriginal'
             )
 


### PR DESCRIPTION
Test Platform moved from ocp-private to ocp-priv, causing build-sync-konflux to fail when tagging CoreOS images for private CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated private CI image tagging to use the correct `ocp-priv` image stream and namespace.
  * Improved related logging to accurately reflect the updated destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->