### PR TITLE
Fix ocp-priv CoreOS tag race condition and add error logging

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -397,7 +397,13 @@ class BuildSyncPipeline:
             if self.runtime.dry_run:
                 self.logger.info('Would have executed: "%s"', cmd)
             else:
-                await exectools.cmd_gather_async(cmd)
+                try:
+                    await exectools.cmd_gather_async(cmd)
+                except ChildProcessError:
+                    # Concurrent oc tag calls may race to create the imagestream;
+                    # retry once so the second attempt tags into the now-existing imagestream.
+                    self.logger.warning('Retrying ocp-priv tag for %s-priv:%s after initial failure', self.version, tag)
+                    await exectools.cmd_gather_async(cmd)
 
     @start_as_current_span_async(TRACER, "build-sync.populate-ci-imagestreams")
     async def _populate_ci_imagestreams(self):
@@ -432,6 +438,7 @@ class BuildSyncPipeline:
             await asyncio.gather(*tasks)
 
         except (ChildProcessError, KeyError) as e:
+            self.logger.error('Unable to mirror CoreOS images to CI for %s: %s', self.version, e)
             await self.slack_client.say(f'Unable to mirror CoreOS images to CI for {self.version}: {e}')
 
     @start_as_current_span_async(TRACER, "build-sync.update-nightly-imagestreams")


### PR DESCRIPTION
## Summary
- Fix race condition where concurrent `oc tag` calls for the `ocp-priv` imagestream all try to create it simultaneously, causing `AlreadyExists` failures. Added a single retry so the second attempt tags into the now-existing imagestream.
- Log the error when CoreOS mirroring fails — previously it was only sent to Slack and never appeared in Jenkins console output.

## Test plan
- [x] `make unit` passes (3064 tests)
- [x] `ruff check` and `ruff format --check` pass on changed file
- [ ] Verify in next build-sync-konflux run that the ocp-priv tag no longer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when tagging private CI images by automatically retrying once after a tagging failure.
  * Added clearer error reporting when CoreOS image mirroring fails, including the affected version and failure details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->