### PR TITLE
Query dev-preview stream in release controller for EC releases

### DIFF
--- a/artcommon/artcommonlib/ocp_version_ancestry.py
+++ b/artcommon/artcommonlib/ocp_version_ancestry.py
@@ -349,6 +349,46 @@ def _version_in_range(version: str, v_min: str, v_max: Optional[str]) -> bool:
     return v_info.major == min_info.major and v_info.minor == min_info.minor
 
 
+async def _fetch_release_controller_tags(
+    url: str,
+    major: int,
+    minor: int,
+    timeout: float,
+) -> list[str]:
+    """
+    Fetch tags from a single release controller stream URL and filter to major.minor.
+
+    :param url: Full URL to the release controller tags endpoint
+    :param major: Major version to filter for
+    :param minor: Minor version to filter for
+    :param timeout: HTTP request timeout in seconds
+    :return: List of matching version strings (unsorted)
+    """
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, timeout=timeout)
+            response.raise_for_status()
+    except httpx.HTTPError as e:
+        logger.warning('Failed to query release controller at %s: %s', url, e)
+        return []
+
+    data = response.json()
+    tags = data.get('tags') or []
+
+    version_pattern = re.compile(rf'^{major}\.{minor}\.')
+    versions = []
+    for tag in tags:
+        name = tag.get('name', '')
+        if version_pattern.match(name):
+            try:
+                semver.VersionInfo.parse(name)
+                versions.append(name)
+            except ValueError:
+                continue
+
+    return versions
+
+
 async def get_release_controller_versions_async(
     major: int,
     minor: int,
@@ -357,11 +397,15 @@ async def get_release_controller_versions_async(
     timeout: float = 30.0,
 ) -> list[str]:
     """
-    Query the release controller's stable stream to get all promoted versions for a major.minor.
+    Query the release controller's stable and dev-preview streams to get all promoted versions
+    for a major.minor.
 
-    The release controller tracks all versions that have been promoted to the 4-stable stream,
-    regardless of whether their cincinnati-graph-data PR has merged. This supplements Cincinnati
-    data to avoid missing recently-promoted z-streams.
+    The release controller tracks all versions that have been promoted, regardless of whether
+    their cincinnati-graph-data PR has merged. This supplements Cincinnati data to avoid missing
+    recently-promoted z-streams.
+
+    Both {major}-stable and {major}-dev-preview streams are queried because EC releases
+    (e.g., 5.0.0-ec.5) are promoted to dev-preview, not stable.
 
     :param major: Major version (e.g., 4 or 5)
     :param minor: Minor version (e.g., 18)
@@ -375,34 +419,15 @@ async def get_release_controller_versions_async(
         release_controller_url = f'https://{go_arch}.ocp.releases.ci.openshift.org'
 
     base_url = release_controller_url.rstrip('/')
-    url = f'{base_url}/api/v1/releasestream/{major}-stable/tags'
 
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(url, timeout=timeout)
-            response.raise_for_status()
-    except httpx.HTTPError as e:
-        logger.warning('Failed to query release controller at %s: %s', url, e)
-        return []
+    streams = [f'{major}-stable', f'{major}-dev-preview']
+    all_versions: set[str] = set()
+    for stream in streams:
+        url = f'{base_url}/api/v1/releasestream/{stream}/tags'
+        versions = await _fetch_release_controller_tags(url, major, minor, timeout)
+        all_versions.update(versions)
 
-    data = response.json()
-    tags = data.get('tags', [])
-
-    # Filter tags to only those matching the requested major.minor.
-    # Tag names are version strings like "4.18.3" or "4.18.0-rc.0".
-    version_pattern = re.compile(rf'^{major}\.{minor}\.')
-    versions = []
-    for tag in tags:
-        name = tag.get('name', '')
-        if version_pattern.match(name):
-            # Validate it's a proper semver string before including
-            try:
-                semver.VersionInfo.parse(name)
-                versions.append(name)
-            except ValueError:
-                continue
-
-    return sort_semver(versions)
+    return sort_semver(list(all_versions))
 
 
 async def calc_upgrade_sources_async(

--- a/artcommon/tests/test_ocp_version_ancestry.py
+++ b/artcommon/tests/test_ocp_version_ancestry.py
@@ -462,23 +462,34 @@ class TestGetCincinnatiChannels(unittest.TestCase):
 class TestGetReleaseControllerVersionsAsync(unittest.IsolatedAsyncioTestCase):
     """Test the get_release_controller_versions_async function"""
 
+    def _make_response(self, data):
+        """Helper to create a mock HTTP response."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = data
+        mock_response.raise_for_status = MagicMock()
+        return mock_response
+
+    def _make_stream_responses(self, stable_tags, dev_preview_tags):
+        """Helper to create side_effect for stable + dev-preview calls."""
+        stable_resp = self._make_response({"name": "4-stable", "tags": stable_tags})
+        dev_preview_resp = self._make_response({"name": "4-dev-preview", "tags": dev_preview_tags})
+        return [stable_resp, dev_preview_resp]
+
     async def test_filters_by_major_minor(self):
         """Only versions matching requested major.minor are returned"""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "name": "4-stable",
-            "tags": [
+        responses = self._make_stream_responses(
+            stable_tags=[
                 {"name": "4.18.3", "phase": "Accepted"},
                 {"name": "4.18.2", "phase": "Accepted"},
                 {"name": "4.18.1", "phase": "Accepted"},
                 {"name": "4.17.5", "phase": "Accepted"},
                 {"name": "4.17.4", "phase": "Accepted"},
             ],
-        }
-        mock_response.raise_for_status = MagicMock()
+            dev_preview_tags=[],
+        )
 
         with patch("httpx.AsyncClient") as mock_client:
-            mock_client.return_value.__aenter__.return_value.get = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(side_effect=responses)
 
             result = await get_release_controller_versions_async(4, 18, "amd64")
 
@@ -497,54 +508,53 @@ class TestGetReleaseControllerVersionsAsync(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, [])
 
     async def test_default_url_uses_go_arch(self):
-        """Default URL should be constructed from go_arch"""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"name": "4-stable", "tags": []}
-        mock_response.raise_for_status = MagicMock()
+        """Default URL should be constructed from go_arch, querying both streams"""
+        responses = self._make_stream_responses(stable_tags=[], dev_preview_tags=[])
 
         with patch("httpx.AsyncClient") as mock_client:
-            mock_get = AsyncMock(return_value=mock_response)
+            mock_get = AsyncMock(side_effect=responses)
             mock_client.return_value.__aenter__.return_value.get = mock_get
 
             await get_release_controller_versions_async(4, 18, "arm64")
 
-            called_url = mock_get.call_args[0][0]
+            calls = mock_get.call_args_list
+            self.assertEqual(len(calls), 2)
             self.assertEqual(
-                called_url, "https://arm64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/tags"
+                calls[0][0][0], "https://arm64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/tags"
+            )
+            self.assertEqual(
+                calls[1][0][0], "https://arm64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-dev-preview/tags"
             )
 
     async def test_custom_url(self):
-        """Custom release_controller_url should be used"""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"name": "4-stable", "tags": []}
-        mock_response.raise_for_status = MagicMock()
+        """Custom release_controller_url should be used for both streams"""
+        responses = self._make_stream_responses(stable_tags=[], dev_preview_tags=[])
 
         with patch("httpx.AsyncClient") as mock_client:
-            mock_get = AsyncMock(return_value=mock_response)
+            mock_get = AsyncMock(side_effect=responses)
             mock_client.return_value.__aenter__.return_value.get = mock_get
 
             await get_release_controller_versions_async(
                 4, 18, "amd64", release_controller_url="https://custom.example.com"
             )
 
-            called_url = mock_get.call_args[0][0]
-            self.assertEqual(called_url, "https://custom.example.com/api/v1/releasestream/4-stable/tags")
+            calls = mock_get.call_args_list
+            self.assertEqual(calls[0][0][0], "https://custom.example.com/api/v1/releasestream/4-stable/tags")
+            self.assertEqual(calls[1][0][0], "https://custom.example.com/api/v1/releasestream/4-dev-preview/tags")
 
     async def test_skips_invalid_semver_tags(self):
         """Tags with invalid semver names should be silently skipped"""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "name": "4-stable",
-            "tags": [
+        responses = self._make_stream_responses(
+            stable_tags=[
                 {"name": "4.18.1", "phase": "Accepted"},
                 {"name": "4.18.latest", "phase": "Accepted"},  # not valid semver (no patch number)
                 {"name": "4.18.0", "phase": "Accepted"},
             ],
-        }
-        mock_response.raise_for_status = MagicMock()
+            dev_preview_tags=[],
+        )
 
         with patch("httpx.AsyncClient") as mock_client:
-            mock_client.return_value.__aenter__.return_value.get = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(side_effect=responses)
 
             result = await get_release_controller_versions_async(4, 18, "amd64")
 
@@ -552,23 +562,91 @@ class TestGetReleaseControllerVersionsAsync(unittest.IsolatedAsyncioTestCase):
 
     async def test_sorted_descending(self):
         """Results should be sorted in descending semver order"""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "name": "4-stable",
-            "tags": [
+        responses = self._make_stream_responses(
+            stable_tags=[
                 {"name": "4.18.0", "phase": "Accepted"},
                 {"name": "4.18.2", "phase": "Accepted"},
                 {"name": "4.18.1", "phase": "Accepted"},
             ],
-        }
-        mock_response.raise_for_status = MagicMock()
+            dev_preview_tags=[],
+        )
 
         with patch("httpx.AsyncClient") as mock_client:
-            mock_client.return_value.__aenter__.return_value.get = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(side_effect=responses)
 
             result = await get_release_controller_versions_async(4, 18, "amd64")
 
         self.assertEqual(result, ['4.18.2', '4.18.1', '4.18.0'])
+
+    async def test_null_tags_returns_empty(self):
+        """When the release controller returns {"tags": null}, should return [] instead of crashing"""
+        responses = [
+            self._make_response({"name": "5-stable", "tags": None}),
+            self._make_response({"name": "5-dev-preview", "tags": None}),
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(side_effect=responses)
+
+            result = await get_release_controller_versions_async(5, 0, "amd64")
+
+        self.assertEqual(result, [])
+
+    async def test_dev_preview_versions_included(self):
+        """EC releases from dev-preview stream should be included in results"""
+        responses = [
+            # stable stream has no 5.0 versions
+            self._make_response({"name": "5-stable", "tags": []}),
+            # dev-preview has EC releases
+            self._make_response(
+                {
+                    "name": "5-dev-preview",
+                    "tags": [
+                        {"name": "5.0.0-ec.5", "phase": "Accepted"},
+                        {"name": "5.0.0-ec.4", "phase": "Accepted"},
+                        {"name": "5.0.0-ec.3", "phase": "Accepted"},
+                        {"name": "4.22.0-ec.2", "phase": "Accepted"},  # different minor, should be filtered
+                    ],
+                }
+            ),
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(side_effect=responses)
+
+            result = await get_release_controller_versions_async(5, 0, "amd64")
+
+        self.assertEqual(result, ['5.0.0-ec.5', '5.0.0-ec.4', '5.0.0-ec.3'])
+
+    async def test_union_of_stable_and_dev_preview(self):
+        """Versions from both stable and dev-preview should be unioned and deduplicated"""
+        responses = [
+            self._make_response(
+                {
+                    "name": "5-stable",
+                    "tags": [
+                        {"name": "5.0.1", "phase": "Accepted"},
+                        {"name": "5.0.0", "phase": "Accepted"},
+                    ],
+                }
+            ),
+            self._make_response(
+                {
+                    "name": "5-dev-preview",
+                    "tags": [
+                        {"name": "5.0.0-ec.3", "phase": "Accepted"},
+                        {"name": "5.0.0", "phase": "Accepted"},  # duplicate with stable
+                    ],
+                }
+            ),
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(side_effect=responses)
+
+            result = await get_release_controller_versions_async(5, 0, "amd64")
+
+        self.assertEqual(result, ['5.0.1', '5.0.0', '5.0.0-ec.3'])
 
 
 class TestCalcUpgradeSourcesAsync(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- Fix `TypeError: 'NoneType' object is not iterable` crash in `get_release_controller_versions_async()` when the release controller returns `{"tags": null}` (e.g. for `5-stable` which has no releases yet)
- Query both `{major}-stable` and `{major}-dev-preview` release controller streams, since EC releases (e.g. `5.0.0-ec.5`) are promoted to dev-preview, not stable
- Extract HTTP+parse logic into `_fetch_release_controller_tags()` helper to avoid duplication

## Test plan
- [x] Existing tests updated to account for two HTTP calls (stable + dev-preview)
- [x] New test: `test_null_tags_returns_empty` — verifies `{"tags": null}` returns `[]`
- [x] New test: `test_dev_preview_versions_included` — verifies EC releases from dev-preview are returned
- [x] New test: `test_union_of_stable_and_dev_preview` — verifies deduplication across streams
- [x] All 3067 unit tests pass (`make unit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release version discovery by checking both stable and developer-preview release streams.
  - Filters results to valid semantic versions matching the requested major and minor release.
  - Combines and deduplicates versions, including eligible EC releases, in descending version order.
  - Handles unavailable or empty tag data gracefully without failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->