### PR TITLE
doozer: point reconciliation-PR upstream heuristic at quay-proxy.ci.registry.openshift.org

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -1467,6 +1467,8 @@ def resolve_upstream_from(runtime, image_entry):
             # tag name without the ose- prefix.
             image_name = remove_prefix(image_name, 'ose-')
             # e.g. quay-proxy.ci.registry.openshift.org/ocp/4.6:base
+            # TODO: temporary workaround for a registry.ci.openshift.org migration;
+            # revisit switching this back once the migration is complete.
             return f'quay-proxy.ci.registry.openshift.org/ocp/{major}.{minor}:{image_name}'
 
     if image_entry.image:

--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -1466,8 +1466,8 @@ def resolve_upstream_from(runtime, image_entry):
             # In release payloads, images are promoted into an imagestream
             # tag name without the ose- prefix.
             image_name = remove_prefix(image_name, 'ose-')
-            # e.g. registry.ci.openshift.org/ocp/4.6:base
-            return f'registry.ci.openshift.org/ocp/{major}.{minor}:{image_name}'
+            # e.g. quay-proxy.ci.registry.openshift.org/ocp/4.6:base
+            return f'quay-proxy.ci.registry.openshift.org/ocp/{major}.{minor}:{image_name}'
 
     if image_entry.image:
         # CI is on its own. We can't give them an image that isn't available outside the firewall.

--- a/doozer/tests/cli/test_images_streams.py
+++ b/doozer/tests/cli/test_images_streams.py
@@ -116,7 +116,7 @@ def test_resolve_upstream_from_with_member_using_heuristic(mocker, mock_runtime)
     result = images_streams.resolve_upstream_from(mock_runtime, image_entry)
 
     # Should strip 'ose-' prefix from image name
-    assert result == 'registry.ci.openshift.org/ocp/4.17:ansible'
+    assert result == 'quay-proxy.ci.registry.openshift.org/ocp/4.17:ansible'
 
 
 def test_resolve_upstream_from_with_member_using_payload_name(mocker, mock_runtime):
@@ -135,7 +135,7 @@ def test_resolve_upstream_from_with_member_using_payload_name(mocker, mock_runti
     result = images_streams.resolve_upstream_from(mock_runtime, image_entry)
 
     # Should use payload_name and strip path
-    assert result == 'registry.ci.openshift.org/ocp/4.18:custom-payload-name'
+    assert result == 'quay-proxy.ci.registry.openshift.org/ocp/4.18:custom-payload-name'
 
 
 def test_resolve_upstream_from_with_image_entry(mock_runtime):


### PR DESCRIPTION
## Summary

`resolve_upstream_from()` in `doozer/doozerlib/cli/images_streams.py` computes the desired upstream `FROM` pullspec used by `doozer images:streams prs open` when opening/updating reconciliation PRs against component repos. When an image `member` entry has no explicit `content.source.ci_alignment.upstream_image` override, it fell back to a hardcoded heuristic pointing at `registry.ci.openshift.org`. This switches that heuristic to `quay-proxy.ci.registry.openshift.org`, keeping the same `/ocp/{major}.{minor}:{image_name}` path structure.

Scope is intentionally narrow:
- Only the heuristic fallback branch of `resolve_upstream_from()` is changed. The `image_entry.stream` and explicit `ci_alignment.upstream_image` branches are driven by ocp-build-data config and are unaffected.
- The downstream `ci_build_root` coordinate parsing is host-agnostic (`rsplit` on `/` and `:`) and needs no change.
- Other unrelated `registry.ci.openshift.org` references elsewhere in the codebase (imagestream mirroring in this same file, `build_sync.py`, `promote.py`, `get_nightlies.py`, `sync_ci_images.py`, `rhcos.py`, `distgit.py`, `rebaser.py`, and the shared `REGISTRY_CI_OPENSHIFT` constant) are out of scope and untouched.

**Note:** This is expected to be a temporary change. We may need to switch this heuristic back to `registry.ci.openshift.org` (or another host) once the underlying registry migration this is working around is complete.

## Test plan

- [x] Updated `test_resolve_upstream_from_with_member_using_heuristic` and `test_resolve_upstream_from_with_member_using_payload_name` in `doozer/tests/cli/test_images_streams.py` to assert against the new host.
- [x] `uv run pytest --verbose --color=yes doozer/tests/cli/test_images_streams.py` -- 28/28 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated upstream CI image references to use the `quay-proxy.ci.registry.openshift.org` registry.
  * Improved compatibility when resolving upstream images from release payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->