### PR TITLE
fix(sync-ci-images): fix oc wait, manifest-list digests, and IS import

### DIFF
--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -975,24 +975,28 @@ def images_streams_start_buildconfigs(
 
                 print(f'  Waiting for build {build_name}...')
 
-                # Wait for the specific build to complete or fail
-                # Use remaining time from overall timeout
-                wait_cmd = f"oc -n ci wait --for=jsonpath='{{.status.phase}}'=Complete --for=jsonpath='{{.status.phase}}'=Failed --timeout={int(remaining)}s build/{build_name}"
-                if as_user:
-                    wait_cmd += f' --as {as_user}'
+                # Poll for build completion (Complete or Failed).
+                # We cannot use `oc wait` with two --for=jsonpath conditions because
+                # multiple --for flags are ANDed, making Complete AND Failed impossible.
+                poll_interval = 15
+                phase = ''
+                while True:
+                    elapsed_wait = time.time() - overall_start_time
+                    if elapsed_wait >= overall_timeout:
+                        runtime.logger.warning(f'Overall timeout exceeded while waiting for {build_name}')
+                        break
 
-                rc, stdout, stderr = exectools.cmd_gather(wait_cmd)
-                if rc != 0:
-                    runtime.logger.warning(f'Build {build_name} did not complete: {stderr}')
-                    continue
+                    check_phase_cmd = f'oc -n ci get build/{build_name} -o jsonpath={{.status.phase}}'
+                    if as_user:
+                        check_phase_cmd += f' --as {as_user}'
 
-                # Check if build succeeded or failed
-                check_phase_cmd = f'oc -n ci get build/{build_name} -o jsonpath={{.status.phase}}'
-                if as_user:
-                    check_phase_cmd += f' --as {as_user}'
+                    rc_phase, phase_stdout, _ = exectools.cmd_gather(check_phase_cmd)
+                    if rc_phase == 0:
+                        phase = phase_stdout.strip()
+                        if phase in ('Complete', 'Failed', 'Cancelled', 'Error'):
+                            break
 
-                phase_stdout, _ = exectools.cmd_assert(check_phase_cmd, retries=1)
-                phase = phase_stdout.strip()
+                    time.sleep(poll_interval)
 
                 if phase != 'Complete':
                     runtime.logger.warning(

--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -206,10 +206,17 @@ def images_streams_mirror(
                             f'Failed to mirror {upstream_entry_name}: {stderr}', (rc, stdout, stderr)
                         )
 
-                # Always query the actual digest at QCI after mirroring.
-                # oc image mirror may convert manifest formats (OCI↔Docker v2s2),
-                # which changes the digest, so the source digest cannot be trusted.
-                qci_digest = get_image_digest(floating_qci_dest, registry_config_file)
+                # Determine the digest at QCI after mirroring.
+                # For manifest lists (--keep-manifest-list) with a digest-pinned source,
+                # the manifest list digest is preserved at the destination since the
+                # content is mirrored as-is. Use the source digest directly because
+                # `oc image info` cannot resolve manifest list tags.
+                qci_digest = None
+                if '--keep-manifest-list' in cmd_start and '@sha256:' in cmd_start:
+                    qci_digest = cmd_start.split('@sha256:', 1)[1].split()[0]
+                    qci_digest = f'sha256:{qci_digest}'
+                else:
+                    qci_digest = get_image_digest(floating_qci_dest, registry_config_file)
 
                 if qci_digest:
                     # Mirror to GC-prevention tag: art__<digest>

--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -231,7 +231,10 @@ def images_streams_mirror(
                         gc_mirror_cmd += f' --registry-config={registry_config_file}'
                     exectools.cmd_assert(gc_mirror_cmd, retries=3, realtime=True)
 
-                    # Update imagestream to reference QCI by digest via quay-proxy
+                    # Update imagestream to reference QCI by digest via quay-proxy.
+                    # Do NOT set reference=True; without it the image controller
+                    # imports the manifest into the integrated registry so that
+                    # oc image info / pulls against registry.ci work correctly.
                     istag_patch = {
                         'tag': {
                             'name': dest_tag,
@@ -239,7 +242,6 @@ def images_streams_mirror(
                                 'kind': 'DockerImage',
                                 'name': f'quay-proxy.ci.openshift.org/openshift/ci@{qci_digest}',
                             },
-                            'reference': True,
                             'referencePolicy': {'type': 'Source'},
                             'importPolicy': {'importMode': 'PreserveOriginal'},
                         }
@@ -545,7 +547,6 @@ def images_streams_check_upstream(runtime, streams, images, live_test_mode, dry_
                                             'kind': 'DockerImage',
                                             'name': f'quay-proxy.ci.openshift.org/openshift/ci@{current_digest}',
                                         },
-                                        'reference': True,
                                         'referencePolicy': {'type': 'Source'},
                                         'importPolicy': {'importMode': 'PreserveOriginal'},
                                     }
@@ -791,7 +792,6 @@ def images_streams_start_buildconfigs(
                                 'kind': 'DockerImage',
                                 'name': f'quay-proxy.ci.openshift.org/openshift/ci@{current_digest}',
                             },
-                            'reference': True,
                             'referencePolicy': {'type': 'Source'},
                             'importPolicy': {'importMode': 'PreserveOriginal'},
                         }
@@ -884,7 +884,6 @@ def images_streams_start_buildconfigs(
                                                 'kind': 'DockerImage',
                                                 'name': f'quay-proxy.ci.openshift.org/openshift/ci@{bootstrap_digest}',
                                             },
-                                            'reference': True,
                                             'referencePolicy': {'type': 'Source'},
                                             'importPolicy': {'importMode': 'PreserveOriginal'},
                                         }
@@ -1044,7 +1043,6 @@ def images_streams_start_buildconfigs(
                                     'kind': 'DockerImage',
                                     'name': f'quay-proxy.ci.openshift.org/openshift/ci@{new_digest}',
                                 },
-                                'reference': True,
                                 'referencePolicy': {'type': 'Source'},
                                 'importPolicy': {'importMode': 'PreserveOriginal'},
                             }

--- a/pyartcd/pyartcd/pipelines/sync_ci_images.py
+++ b/pyartcd/pyartcd/pipelines/sync_ci_images.py
@@ -559,14 +559,6 @@ class SyncCIImagesPipeline:
             start_builds_args += "--dry-run"
         await self._run_doozer_command(doozer_opts, "images:streams start-builds", start_builds_args.strip())
 
-    async def _wait_for_builds(self) -> None:
-        """Wait for CI builds to complete.
-
-        Note: start-builds now polls for build completion, so builds are
-        already finished by the time we reach here. This method is kept
-        as a no-op hook in case a short settling delay is ever needed.
-        """
-
     async def _verify_upstream_consistency(self, doozer_opts: str, auth_file: str) -> None:
         """Verify CI imagestreams match expected state."""
         self._logger.info(f"{self.version}: Checking upstream consistency")
@@ -669,7 +661,6 @@ class SyncCIImagesPipeline:
                 await self._generate_and_apply_buildconfigs(doozer_opts)
                 await self._mirror_images_to_ci(doozer_opts, auth_file)
                 await self._trigger_ci_builds(doozer_opts, auth_file)
-                await self._wait_for_builds()
                 await self._verify_upstream_consistency(doozer_opts, auth_file)
 
                 rc = await self._open_reconciliation_prs(doozer_opts)

--- a/pyartcd/pyartcd/pipelines/sync_ci_images.py
+++ b/pyartcd/pyartcd/pipelines/sync_ci_images.py
@@ -560,10 +560,12 @@ class SyncCIImagesPipeline:
         await self._run_doozer_command(doozer_opts, "images:streams start-builds", start_builds_args.strip())
 
     async def _wait_for_builds(self) -> None:
-        """Wait for CI builds to complete."""
-        if not self.skip_waits and not self.runtime.dry_run:
-            self._logger.info(f"{self.version}: Waiting {self.WAIT_TIME_MINUTES} minutes for builds")
-            await asyncio.sleep(self.WAIT_TIME_MINUTES * 60)
+        """Wait for CI builds to complete.
+
+        Note: start-builds now polls for build completion, so builds are
+        already finished by the time we reach here. This method is kept
+        as a no-op hook in case a short settling delay is ever needed.
+        """
 
     async def _verify_upstream_consistency(self, doozer_opts: str, auth_file: str) -> None:
         """Verify CI imagestreams match expected state."""


### PR DESCRIPTION
## Summary

Fixes three bugs in the sync-ci-images pipeline that were causing stale ImageStream tags, failed `oc image info` lookups, and outdated golang versions in CI images.

### 1. Replace impossible `oc wait` AND condition with polling
The post-build wait in `start-builds` used two `--for=jsonpath` flags (`phase=Complete` and `phase=Failed`). In modern `oc`/`kubectl`, multiple `--for` flags are ANDed, making this condition impossible to satisfy. The wait always timed out after 1 hour, preventing the post-build IS tag update from ever running.

**Fix:** Replaced with a polling loop that checks the build phase every 15s until it reaches a terminal state (`Complete`, `Failed`, `Cancelled`, `Error`).

### 2. Use source digest for manifest-list mirrors
For images mirrored with `--keep-manifest-list` from a digest-pinned source, `oc image info` cannot resolve the manifest list tag on Quay. This caused `get_image_digest` to fail, returning `None`, which skipped the IS tag update entirely — leaving stale digests and outdated image content (e.g. golang v1.25.9 instead of v1.25.11).

**Fix:** When `--keep-manifest-list` is used with a digest-pinned source (`@sha256:`), extract the source digest directly instead of calling `get_image_digest`. Manifest list digests are content-addressable and preserved during mirroring.

### 3. Remove `reference=True` from ImageStream tag patches
The QCI migration (`79f685261`) added `reference: true` to all IS tag patches. This tells the image controller not to import the image into the integrated registry, causing `oc image info registry.ci.openshift.org/...` to fail with "manifest unknown". Before the migration, images were natively in the integrated registry via BuildConfig pushes.

**Fix:** Removed `reference: true` from all five IS tag patch sites. The image controller now imports manifests from quay-proxy into the integrated registry. `referencePolicy: Source` and `importPolicy: PreserveOriginal` are retained.

### 4. Remove redundant 20-minute sleep
The `_wait_for_builds` method had a 20-minute sleep that was redundant now that build completion is polled in `start-builds`.

## Verified
```
$ oc image info registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.22 --filter-by-os amd64 | grep GO_VERSION
               GO_VERSION=v1.25.11
```

## Test plan
- [x] Existing unit tests pass (`doozer/tests/cli/test_images_streams.py`)
- [x] `oc image info` against registry.ci resolves correctly after fix
- [ ] Full `sync-ci-images` run for 4.22 completes without errors