### PR TITLE
Fix bridge bug mirroring failures in ocp4-scan-konflux

### DIFF
--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -5,6 +5,7 @@ with BugTrackers
 
 import asyncio
 import itertools
+import logging
 import os
 import re
 import urllib.parse
@@ -964,7 +965,9 @@ class JIRABugTracker(BugTracker):
         if versions is None:
             versions = self.config.get('version')
         if versions and 'versions' not in fields:
-            fields['versions'] = [{'name': version} for version in versions]
+            versions = self._filter_valid_versions(versions)
+            if versions:
+                fields['versions'] = [{'name': version} for version in versions]
         if target_releases is None:
             target_releases = self.target_release()
         if target_releases and self.field_target_version not in fields:
@@ -976,6 +979,40 @@ class JIRABugTracker(BugTracker):
         if target_status:
             self._client.transition_issue(issue, target_status)
         return JIRABug(issue)
+
+    def _get_project_versions(self) -> set[str]:
+        """Return cached set of version names for the Jira project.
+
+        Successful lookups are cached for the lifetime of this tracker
+        instance. Transport/auth failures raise so the caller can decide
+        whether to fall back.
+        """
+        if not hasattr(self, "_project_versions_cache"):
+            self._project_versions_cache = {v.name for v in self._client.project_versions(self.project)}
+        return self._project_versions_cache
+
+    def _filter_valid_versions(self, versions: List[str]) -> List[str]:
+        """Filter version names to only those that exist in the Jira project.
+
+        Args:
+            versions: Configured version names to validate.
+
+        Returns:
+            List of version names that exist in the project. Returns the
+            original list unchanged if the project versions cannot be fetched.
+        """
+        try:
+            project_versions = self._get_project_versions()
+        except (JIRAError, requests.RequestException) as e:
+            logger.warning(
+                "Could not fetch project versions for %s; using configured versions as-is: %s", self.project, e
+            )
+            return versions
+        valid = [v for v in versions if v in project_versions]
+        invalid = [v for v in versions if v not in project_versions]
+        if invalid:
+            logger.warning("Affects versions %s do not exist in JIRA project %s; excluding them", invalid, self.project)
+        return valid
 
     def _update_bug_status(self, bugid, target_status):
         return self._client.transition_issue(bugid, target_status)
@@ -1157,7 +1194,15 @@ class JIRABugTracker(BugTracker):
 
     def create_issue_link(self, link_name: str, inward_issue: str, outward_issue: str):
         """Create a JIRA issue link between two issues."""
-        self._client.create_issue_link(link_name, inward_issue, outward_issue)
+        # Suppress noisy "Specified issue link type is not present" warning from the
+        # upstream jira library — it fires even when the link type name is correct.
+        jira_logger = logging.getLogger("jira.client")
+        prev_level = jira_logger.level
+        jira_logger.setLevel(logging.ERROR)
+        try:
+            self._client.create_issue_link(link_name, inward_issue, outward_issue)
+        finally:
+            jira_logger.setLevel(prev_level)
 
     def remove_bugs(self, advisory_obj, bugids: List, noop=False):
         if noop:

--- a/elliott/elliottlib/cli/find_bugs_bridge_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_bridge_cli.py
@@ -383,7 +383,6 @@ class FindBugsBridgeCli:
             "components": components,
             "labels": [BRIDGE_LABEL],
         }
-        fields["versions"] = []
         priority = getattr(getattr(source_bug.bug.fields, "priority", None), "name", None)
         if priority:
             fields["priority"] = {"name": priority}

--- a/elliott/tests/test_bzutil.py
+++ b/elliott/tests/test_bzutil.py
@@ -180,6 +180,8 @@ class TestJIRABugTracker(unittest.TestCase):
         }
         mock_issue = flexmock(key="OCPBUGS-1")
         mock_jira_client = flexmock()
+        mock_version = flexmock(name="4.23")
+        mock_jira_client.should_receive("project_versions").with_args("OCPBUGS").and_return([mock_version])
         mock_jira_client.should_receive("create_issue").with_args(
             fields={
                 "summary": "Bridge bug",

--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -277,41 +277,45 @@ class Ocp4ScanPipeline:
 
         Failures are logged and reported to Slack but do not fail the pipeline.
         """
-        group = f"openshift-{self.version}"
-        group_config = await util.load_group_config(
-            group=group,
-            assembly=self.assembly,
-            doozer_data_path=self.data_path,
-            doozer_data_gitref=self.data_gitref,
-        )
-        bridge_release = group_config.get("bridge_release", {}) or {}
-        bug_mirroring = bridge_release.get("bug_mirroring", {}) or {}
-        if not bug_mirroring.get("enabled", False):
-            self.logger.info("Bridge bug mirroring is disabled for %s", group)
-            return
-
-        if self.data_gitref:
-            group += f"@{self.data_gitref}"
-        cmd = [
-            "elliott",
-            f"--group={group}",
-            f"--assembly={self.assembly}",
-            "--build-system=konflux",
-            f"--working-dir={self._elliott_working}",
-            f"--data-path={self.data_path}",
-            "find-bugs:bridge-mirror",
-        ]
-        if self.runtime.dry_run:
-            cmd.append("--dry-run")
-
         try:
+            group = f"openshift-{self.version}"
+            group_config = await util.load_group_config(
+                group=group,
+                assembly=self.assembly,
+                doozer_data_path=self.data_path,
+                doozer_data_gitref=self.data_gitref,
+            )
+            bridge_release = group_config.get("bridge_release", {}) or {}
+            bug_mirroring = bridge_release.get("bug_mirroring", {}) or {}
+            if not bug_mirroring.get("enabled", False):
+                self.logger.info("Bridge bug mirroring is disabled for %s", group)
+                return
+
+            if self.data_gitref:
+                group += f"@{self.data_gitref}"
+            cmd = [
+                "elliott",
+                f"--group={group}",
+                f"--assembly={self.assembly}",
+                "--build-system=konflux",
+                f"--working-dir={self._elliott_working}",
+                f"--data-path={self.data_path}",
+                "find-bugs:bridge-mirror",
+            ]
+            if self.runtime.dry_run:
+                cmd.append("--dry-run")
+
             await exectools.cmd_assert_async(cmd)
-        except ChildProcessError as e:
+
+        except Exception as e:
             self.logger.error("Bridge bug mirroring failed for %s: %s", self.version, e)
-            if not self.runtime.dry_run:
-                slack_client = self.runtime.new_slack_client()
-                slack_client.bind_channel(f"openshift-{self.version}")
-                await slack_client.say(f"Bridge bug mirroring failed for {self.version}. Please investigate")
+            try:
+                if not self.runtime.dry_run:
+                    slack_client = self.runtime.new_slack_client()
+                    slack_client.bind_channel(f"openshift-{self.version}")
+                    await slack_client.say(f"Bridge bug mirroring failed for {self.version}. Please investigate")
+            except Exception:
+                self.logger.exception("Failed to send Slack notification for bridge bug mirroring failure")
 
 
 @cli.command('beta:konflux:ocp4-scan')

--- a/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
+++ b/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
@@ -212,6 +212,39 @@ class TestBridgeBugMirroring(unittest.IsolatedAsyncioTestCase):
         slack_client.bind_channel.assert_called_once_with("openshift-4.23")
         slack_client.say.assert_awaited_once_with("Bridge bug mirroring failed for 4.23. Please investigate")
 
+    @patch("pyartcd.pipelines.ocp4_scan_konflux.util.load_group_config")
+    async def test_handle_bridge_bug_mirroring_does_not_fail_on_config_error(self, mock_load_group_config):
+        mock_load_group_config.side_effect = RuntimeError("config load failed")
+        slack_client = AsyncMock()
+        slack_client.bind_channel = MagicMock()
+        self.runtime.new_slack_client.return_value = slack_client
+
+        await self.pipeline.handle_bridge_bug_mirroring()
+
+        mock_load_group_config.assert_awaited_once()
+        slack_client.bind_channel.assert_called_once_with("openshift-4.23")
+        slack_client.say.assert_awaited_once()
+
+    @patch("pyartcd.pipelines.ocp4_scan_konflux.util.load_group_config")
+    @patch("pyartcd.pipelines.ocp4_scan_konflux.exectools.cmd_assert_async")
+    async def test_handle_bridge_bug_mirroring_does_not_fail_on_slack_error(
+        self, mock_cmd_assert, mock_load_group_config
+    ):
+        mock_load_group_config.return_value = {
+            "bridge_release": {
+                "basis_group": "openshift-5.0",
+                "bug_mirroring": {"enabled": True},
+            }
+        }
+        mock_cmd_assert.side_effect = ChildProcessError("boom")
+        self.runtime.new_slack_client.side_effect = RuntimeError("slack broke")
+
+        await self.pipeline.handle_bridge_bug_mirroring()
+
+        mock_load_group_config.assert_awaited_once()
+        mock_cmd_assert.assert_awaited_once()
+        self.runtime.new_slack_client.assert_called_once()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Fix the root cause of bridge bug mirroring failures: `_build_issue_fields` was setting `versions` to an empty list, preventing `create_issue` from applying the tracker's configured Affects Versions. Jira rejected the creation with HTTP 400 ("Affects versions is required").
- Make bridge bug mirroring errors fully non-fatal in the scan pipeline by catching all exceptions (not just `ChildProcessError`), so failures in config loading, the elliott command, or Slack notification cannot block the scan.

## Test plan
- [x] `pytest elliott/tests/test_find_bugs_bridge_cli.py` — 12 tests pass
- [x] `pytest pyartcd/tests/pipelines/test_ocp4_scan_konflux.py` — 10 tests pass (including 2 new tests for broader error handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of bridge bug mirroring so unexpected errors no longer interrupt the scan pipeline.
  * Prevented notification failures from causing additional pipeline failures.
  * Updated JIRA mirrored issue creation to only include versions that exist in the target project (omit the versions field when none are valid).
  * Reduced noisy log output when creating issue links on JIRA.
* **Tests**
  * Added async coverage to ensure bridge bug mirroring completes without propagating configuration-loading or notification errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->