### PR TITLE
skip external images in DB operand resolution

### DIFF
--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -294,8 +294,13 @@ class KonfluxOlmBundleRebaser:
         resolved_operands: dict[str, tuple[str, str, str]] = {}
         if operator_build.engine is Engine.KONFLUX and image_references and is_layered:
             delivery_override_map, delivery_namespace_map = self._build_delivery_maps(metadata)
+            external_image_names = self._get_external_image_names(operator_manifests_dir)
             resolved_operands = await self._resolve_operands_from_db(
-                metadata, image_references, delivery_override_map, delivery_namespace_map
+                metadata,
+                image_references,
+                delivery_override_map,
+                delivery_namespace_map,
+                external_image_names,
             )
 
         # Copy the operator's manifests to the bundle directory, replacing image
@@ -576,6 +581,7 @@ class KonfluxOlmBundleRebaser:
         image_references: dict[str, dict],
         delivery_override_map: dict[str, str],
         delivery_namespace_map: dict[str, str],
+        external_image_names: set[str] = frozenset(),
     ) -> dict[str, tuple[str, str, str]]:
         """
         Resolve ART-built operand images from Konflux DB instead of relying
@@ -608,13 +614,14 @@ class KonfluxOlmBundleRebaser:
 
             distgit_key = metadata.runtime.name_in_bundle_map.get(name)
             if not distgit_key:
-                logger.info(
-                    "Skipping %s (not in name_in_bundle_map for %s) -- likely an external image "
-                    "handled by _find_external_digest_images",
-                    name,
-                    metadata.distgit_key,
-                )
-                continue
+                if name in external_image_names:
+                    logger.info(
+                        "Skipping external image %s (defined in art.yaml external-images for %s)",
+                        name,
+                        metadata.distgit_key,
+                    )
+                    continue
+                raise ValueError(f"Unable to find {name} in name_in_bundle_map for {metadata.distgit_key}")
 
             meta = metadata.runtime.image_map.get(distgit_key)
             if not meta:
@@ -870,6 +877,32 @@ class KonfluxOlmBundleRebaser:
             if image_short_name not in already_resolved and image_short_name not in found:
                 found[image_short_name] = (pullspec, pullspec, "external")
         return found
+
+    @staticmethod
+    def _get_external_image_names(operator_manifests_dir: Path) -> set[str]:
+        """Get the set of image names defined in external-images config from art.yaml.
+
+        These images are not ART-built and will be handled separately by
+        _find_external_digest_images.
+
+        Args:
+            operator_manifests_dir: Path to the operator's manifests directory.
+
+        Returns:
+            Set of image names defined in external-images config, or empty set if none.
+        """
+        art_yaml_path = operator_manifests_dir / 'art.yaml'
+        if not art_yaml_path.is_file():
+            return set()
+        try:
+            with open(art_yaml_path, 'r', encoding='utf-8') as f:
+                art_yaml_data = yaml.safe_load(f.read())
+        except Exception:
+            return set()
+        external_images = art_yaml_data.get('external-images', [])
+        if not external_images:
+            return set()
+        return {ext_img.get('name') for ext_img in external_images if ext_img.get('name')}
 
     @cached_property
     def _operator_index_mode(self):

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -608,7 +608,13 @@ class KonfluxOlmBundleRebaser:
 
             distgit_key = metadata.runtime.name_in_bundle_map.get(name)
             if not distgit_key:
-                raise ValueError(f"Unable to find {name} in name_in_bundle_map for {metadata.distgit_key}")
+                logger.info(
+                    "Skipping %s (not in name_in_bundle_map for %s) -- likely an external image "
+                    "handled by _find_external_digest_images",
+                    name,
+                    metadata.distgit_key,
+                )
+                continue
 
             meta = metadata.runtime.image_map.get(distgit_key)
             if not meta:

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -704,8 +704,8 @@ spec:
 
     async def test_resolve_operands_from_db_skips_external_images(self):
         """
-        Verify that image-references entries not in name_in_bundle_map (external
-        images like postgresql) are gracefully skipped instead of raising an error.
+        Verify that image-references entries not in name_in_bundle_map are
+        gracefully skipped when they are declared as external in art.yaml.
         """
         metadata = MagicMock()
         metadata.distgit_key = "mta-operator"
@@ -720,8 +720,32 @@ spec:
             },
         }
 
-        resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
+        resolved = await self.rebaser._resolve_operands_from_db(
+            metadata, image_references, {}, {}, external_image_names={"postgresql"}
+        )
         self.assertEqual(resolved, {})
+
+    async def test_resolve_operands_from_db_unknown_image(self):
+        """
+        Verify ValueError when image-references has an image not in
+        name_in_bundle_map and not declared external in art.yaml.
+        """
+        metadata = MagicMock()
+        metadata.distgit_key = "test-operator"
+        metadata.runtime.group = "openshift-4.18"
+        metadata.runtime.data_dir = "/nonexistent/data/dir"
+        metadata.runtime.name_in_bundle_map = {}
+
+        image_references = {
+            "unknown-image": {
+                "name": "unknown-image",
+                "from": {"name": "registry.example.com/openshift/unknown:v4.18"},
+            },
+        }
+
+        with self.assertRaises(ValueError) as ctx:
+            await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {}, external_image_names=set())
+        self.assertIn("Unable to find unknown-image in name_in_bundle_map", str(ctx.exception))
 
     @patch("doozerlib.backend.konflux_olm_bundler.is_nvr_embargoed", return_value=False)
     @patch("doozerlib.util.oc_image_info_for_arch_async")
@@ -778,7 +802,9 @@ spec:
         self.rebaser._group_config.operator_image_ref_mode = "manifest-list"
         self.rebaser._group_config.vars = {"MAJOR": 8}
 
-        resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
+        resolved = await self.rebaser._resolve_operands_from_db(
+            metadata, image_references, {}, {}, external_image_names={"postgresql"}
+        )
 
         # mta-ui should be resolved, postgresql should be skipped
         self.assertIn("mta-ui-rhel9", resolved)

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -702,26 +702,91 @@ spec:
         _, new_pullspec, _ = resolved["ose-operand"]
         self.assertIn("sha256:content222", new_pullspec)
 
-    async def test_resolve_operands_from_db_unknown_image(self):
+    async def test_resolve_operands_from_db_skips_external_images(self):
         """
-        Verify ValueError when image-references has an image not in name_in_bundle_map.
+        Verify that image-references entries not in name_in_bundle_map (external
+        images like postgresql) are gracefully skipped instead of raising an error.
         """
         metadata = MagicMock()
-        metadata.distgit_key = "test-operator"
-        metadata.runtime.group = "openshift-4.18"
+        metadata.distgit_key = "mta-operator"
+        metadata.runtime.group = "mta-8.1"
         metadata.runtime.data_dir = "/nonexistent/data/dir"
         metadata.runtime.name_in_bundle_map = {}
 
         image_references = {
-            "unknown-image": {
-                "name": "unknown-image",
-                "from": {"name": "registry.example.com/openshift/unknown:v4.18"},
+            "postgresql": {
+                "name": "postgresql",
+                "from": {"name": "registry.redhat.io/rhel9/postgresql-15:latest"},
             },
         }
 
-        with self.assertRaises(ValueError) as ctx:
-            await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
-        self.assertIn("Unable to find unknown-image in name_in_bundle_map", str(ctx.exception))
+        resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
+        self.assertEqual(resolved, {})
+
+    @patch("doozerlib.backend.konflux_olm_bundler.is_nvr_embargoed", return_value=False)
+    @patch("doozerlib.util.oc_image_info_for_arch_async")
+    async def test_resolve_operands_from_db_mixed_internal_and_external(self, mock_oc_image_info, _mock_is_embargoed):
+        """
+        Verify that _resolve_operands_from_db resolves known ART-built operands
+        and skips external images not in name_in_bundle_map.
+        """
+        metadata = MagicMock()
+        metadata.distgit_key = "mta-operator"
+        metadata.runtime.group = "mta-8.1"
+        metadata.runtime.data_dir = "/tmp/test-data-dir"
+
+        operand_meta = MagicMock()
+        operand_meta.image_name_short = "mta-ui-rhel9"
+        operand_meta.distgit_key = "mta-ui"
+        operand_meta.branch_el_target.return_value = 9
+        operand_meta.config = {"delivery": {"delivery_repo_names": ["mta/mta-ui-rhel9"]}}
+
+        mock_build = MagicMock()
+        mock_build.version = "8.1.3"
+        mock_build.release = "202607170000.p0.gabcdef0.assembly.stream.el9"
+        mock_build.nvr = "mta-ui-container-8.1.3-202607170000.p0.gabcdef0.assembly.stream.el9"
+        operand_meta.get_latest_konflux_build = AsyncMock(return_value=mock_build)
+
+        metadata.runtime.name_in_bundle_map = {"mta-ui": "mta-ui"}
+        metadata.runtime.image_map = {"mta-ui": operand_meta}
+
+        image_references = {
+            "mta-ui": {
+                "name": "mta-ui",
+                "from": {"name": "quay.io/konveyor/mta-ui:latest"},
+            },
+            "postgresql": {
+                "name": "postgresql",
+                "from": {"name": "registry.redhat.io/rhel9/postgresql-15:latest"},
+            },
+        }
+
+        mock_oc_image_info.return_value = {
+            "config": {
+                "config": {
+                    "Labels": {
+                        "com.redhat.component": "mta-ui-container",
+                        "version": "8.1.3",
+                        "release": "202607170000.p0.gabcdef0.assembly.stream.el9",
+                    }
+                }
+            },
+            "listDigest": "sha256:aaa111bbb222",
+            "contentDigest": "sha256:ccc333ddd444",
+        }
+        self.rebaser._group_config.get.return_value = "mta"
+        self.rebaser._group_config.operator_image_ref_mode = "manifest-list"
+        self.rebaser._group_config.vars = {"MAJOR": 8}
+
+        resolved = await self.rebaser._resolve_operands_from_db(metadata, image_references, {}, {})
+
+        # mta-ui should be resolved, postgresql should be skipped
+        self.assertIn("mta-ui-rhel9", resolved)
+        self.assertNotIn("postgresql", resolved)
+        # Verify mta-ui was resolved correctly
+        _, new_pullspec, nvr = resolved["mta-ui-rhel9"]
+        self.assertIn("sha256:aaa111bbb222", new_pullspec)
+        self.assertEqual(nvr, "mta-ui-container-8.1.3-202607170000.p0.gabcdef0.assembly.stream.el9")
 
     async def test_resolve_operands_from_db_disabled_image(self):
         """

--- a/pyartcd/tests/pipelines/test_build_conforma_verify.py
+++ b/pyartcd/tests/pipelines/test_build_conforma_verify.py
@@ -219,22 +219,40 @@ class TestSlackReporting(unittest.TestCase):
 
         violations = {
             "ose-cluster-api": [
-                {"rule": "step_image_registries.allowed", "title": "Permitted registry",
-                 "image_ref": "quay.io/test@sha256:abc", "reason": "bad image"},
-                {"rule": "cve_results_found.cve_results", "title": "CVE scan results found",
-                 "image_ref": "quay.io/test@sha256:abc", "reason": "no scan"},
+                {
+                    "rule": "step_image_registries.allowed",
+                    "title": "Permitted registry",
+                    "image_ref": "quay.io/test@sha256:abc",
+                    "reason": "bad image",
+                },
+                {
+                    "rule": "cve_results_found.cve_results",
+                    "title": "CVE scan results found",
+                    "image_ref": "quay.io/test@sha256:abc",
+                    "reason": "no scan",
+                },
             ],
             "ose-mco": [
-                {"rule": "step_image_registries.allowed", "title": "Permitted registry",
-                 "image_ref": "quay.io/test@sha256:def", "reason": "bad image"},
+                {
+                    "rule": "step_image_registries.allowed",
+                    "title": "Permitted registry",
+                    "image_ref": "quay.io/test@sha256:def",
+                    "reason": "bad image",
+                },
             ],
         }
 
         import asyncio
 
-        asyncio.run(p._report_to_slack(
-            any_failed=True, image_failed=2, bundle_failed=0, fbc_failed=0, all_violations=violations,
-        ))
+        asyncio.run(
+            p._report_to_slack(
+                any_failed=True,
+                image_failed=2,
+                bundle_failed=0,
+                fbc_failed=0,
+                all_violations=violations,
+            )
+        )
 
         self.assertEqual(slack.say_in_thread.call_count, 2)
         rules_msg = slack.say_in_thread.call_args_list[1][0][0]


### PR DESCRIPTION
_resolve_operands_from_db() raised ValueError for image-references entries not in name_in_bundle_map (e.g. postgresql in mta-operator). These are external images not built by ART, consistent with how rebaser.py (line 2727) already skips them via external-images config.

Change the hard error to a skip-with-log. External images that are already digest-pinned in the CSV are still captured by _find_external_digest_images() and correctly appear in relatedImages.

Fixes mta-operator bundle build failures since PR #3109 ([ART-18061](https://redhat.atlassian.net/browse/ART-18061)).

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bundle processing now skips image references missing from the runtime bundle map when they’re configured as external in the operator’s `art.yaml`, instead of failing.
  * Internal/known operands continue resolving normally, while external/unmapped entries are omitted from results.

* **Tests**
  * Extended coverage for bundles containing only external images and mixed internal/external inputs, validating the new skip behavior and existing resolution logic.

* **Documentation**
  * None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->