### PR TITLE
Retry transient Brew repo requests

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -28,6 +28,7 @@ from doozerlib.cli.config_plashet import KNOWN_SIGNING_KEYS
 from doozerlib.constants import ART_IMAGES_BASE_APPLICATION
 from elliottlib import util as elliottutil
 from elliottlib.constants import GOLANG_BUILDER_CVE_COMPONENT
+from tenacity import before_sleep_log, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from pyartcd import constants, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
@@ -527,6 +528,13 @@ class UpdateGolangPipeline:
         _LOGGER.warning("build not available after 5 hours")
         return False
 
+    @retry(
+        retry=retry_if_exception_type(ChildProcessError),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=30, min=30, max=60),
+        before_sleep=before_sleep_log(_LOGGER, logging.WARNING),
+        reraise=True,
+    )
     async def request_repo(self, el_v, nvr):
         build_tag = f'rhaos-{self.ocp_version}-rhel-{el_v}-build'
         # --request triggers a repo regen (like regen-repo) and waits for it to complete.

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import tempfile
 import unittest
@@ -17,6 +18,7 @@ from pyartcd.pipelines.update_golang import (
     is_latest_and_available,
     move_golang_bugs,
 )
+from tenacity import wait_none
 
 
 class TestExtractAndValidateGolangNvrs(unittest.TestCase):
@@ -1023,6 +1025,61 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         self.assertTrue(result)
         self.assertEqual(mock_is_available.call_count, 3)
         self.assertEqual(pipeline.request_repo.call_count, 2)
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch(
+        "artcommonlib.exectools.cmd_assert_async",
+        new_callable=AsyncMock,
+        side_effect=[ChildProcessError("connection timed out"), ChildProcessError("connection timed out"), 0],
+    )
+    async def test_request_repo_retries_command_failures(self, mock_cmd_assert, mock_konflux_db):
+        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = Mock()
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.20.12-2.el8"],
+            art_jira="ART-1234",
+            tag_builds=True,
+        )
+        original_wait = UpdateGolangPipeline.request_repo.retry.wait
+        UpdateGolangPipeline.request_repo.retry.wait = wait_none()
+        self.addCleanup(setattr, UpdateGolangPipeline.request_repo.retry, "wait", original_wait)
+
+        await pipeline.request_repo(8, "golang-1.20.12-2.el8")
+
+        self.assertEqual(mock_cmd_assert.call_count, 3)
+        mock_cmd_assert.assert_called_with(
+            "brew wait-repo rhaos-4.16-rhel-8-build --build=golang-1.20.12-2.el8 --request --verbose",
+            log_stdout=True,
+            timeout=3600,
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch(
+        "artcommonlib.exectools.cmd_assert_async",
+        new_callable=AsyncMock,
+        side_effect=asyncio.TimeoutError,
+    )
+    async def test_request_repo_does_not_retry_python_timeout(self, mock_cmd_assert, mock_konflux_db):
+        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = Mock()
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.20.12-2.el8"],
+            art_jira="ART-1234",
+            tag_builds=True,
+        )
+
+        with self.assertRaises(asyncio.TimeoutError):
+            await pipeline.request_repo(8, "golang-1.20.12-2.el8")
+
+        mock_cmd_assert.assert_awaited_once()
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     async def test_tag_build_dry_run(self, mock_konflux_db):


### PR DESCRIPTION
## Summary

- retry `brew wait-repo --request` subprocess failures up to three times
- use 30/60-second exponential backoff and log before each retry
- preserve the existing one-hour Python timeout without retrying it

## Root cause

The Golang update pipeline aborted when Brewhub timed out during GSSAPI session creation. Koji reported the transport failure as a GSSAPI authentication error, and `request_repo` propagated the resulting `ChildProcessError` before the pipeline's repository-availability retry loop could continue.

## Impact

Transient Brewhub connection failures no longer fail the entire Golang pipeline immediately. Permanent command failures still surface after three attempts, and repo-generation timeouts retain their existing behavior.

## Validation

- `make format`
- `make test`
  - artcommon: 423 passed
  - doozer: 1,413 passed
  - elliott: 429 passed
  - pyartcd: 710 passed
  - ocp-build-data-validator: 91 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository requests now automatically retry up to three times after eligible command failures, using increasing delays between attempts.
  * Timeout errors continue to fail immediately without unnecessary retries.
  * Improved warning visibility when retry attempts occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->