### PR TITLE
Honor distgit name overrides

### DIFF
--- a/artcommon/artcommonlib/metadata.py
+++ b/artcommon/artcommonlib/metadata.py
@@ -47,6 +47,8 @@ class MetadataBase(object):
         self.config = assembly_metadata_config(
             runtime.get_releases_config(), runtime.assembly, meta_type, self.distgit_key, self.raw_config
         )
+        if self.config.distgit.name is not Missing:
+            self.name = str(self.config.distgit.name)
         self.namespace, self._component_name = self.extract_component_info(meta_type, self.name, self.config)
         self.mode = self.config.get('mode', CONFIG_MODE_DEFAULT).lower()
         if self.mode not in CONFIG_MODES:

--- a/doozer/tests/test_metadata.py
+++ b/doozer/tests/test_metadata.py
@@ -53,6 +53,30 @@ class TestMetadata(TestCase):
             url, "http://distgit.example.com/cgit/containers/foo/plain/some_path/some_file.txt?h=some-branch&id=abcdefg"
         )
 
+    def test_distgit_name_override(self):
+        data_obj = MagicMock(
+            key="openshift-golang-builder-1-26.rhel8",
+            filename="openshift-golang-builder-1-26.rhel8.yml",
+            data={
+                "name": "openshift/golang-builder",
+                "distgit": {"name": "openshift-golang-builder"},
+            },
+        )
+        runtime = MagicMock(assembly=None, assembly_basis_event=None, user=None)
+        runtime.group_config = Model({"urls": {"pkgs_host": "pkgs.devel.redhat.com"}})
+
+        meta = Metadata("image", runtime, data_obj)
+
+        self.assertEqual(meta.distgit_key, "openshift-golang-builder-1-26.rhel8")
+        self.assertEqual(meta.name, "openshift-golang-builder")
+        self.assertEqual(meta.qualified_key, "containers/openshift-golang-builder-1-26.rhel8")
+        self.assertEqual(meta.qualified_name, "containers/openshift-golang-builder")
+        self.assertEqual(meta.get_component_name(), "openshift-golang-builder-container")
+        self.assertEqual(
+            meta.distgit_remote_url(),
+            "ssh://pkgs.devel.redhat.com/containers/openshift-golang-builder",
+        )
+
     def test_is_rpm_exempt(self):
         data_obj = MagicMock(key="foo", filename="foo.yml", data={"name": "foo"})
         runtime = MagicMock()


### PR DESCRIPTION
## What

- honor an image or RPM metadata `distgit.name` override when deriving the distgit repository name
- retain the versioned YAML key for metadata selection and working-directory identity
- cover the Golang monobranch naming case with a focused unit test

## Why

The Golang build-data monobranch uses versioned keys such as
`openshift-golang-builder-1-26.rhel8.yml`, while all variants build from the
existing `containers/openshift-golang-builder` distgit repository. Doozer
currently derives the repository from the YAML key and attempts to clone
`containers/openshift-golang-builder-1-26`, causing Brew operations to fail
before authentication can complete.

The image schema already defines `distgit.name` as the repository-name
override; this change makes metadata resolution honor it.

## Impact

Metadata without `distgit.name` is unchanged. When the override is present,
distgit URLs and component fallback use the configured repository name while
the original metadata key remains available as `distgit_key`.

## Verification

- `make format`
- `make test` (3,065 tests passed)
- focused regression test for
  `openshift-golang-builder-1-26.rhel8` resolving to
  `containers/openshift-golang-builder`

Follow-up metadata: https://github.com/openshift-eng/ocp-build-data/pull/12008
