### PR TITLE
Add jq and yq to artcd-base image

### DIFF
--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
@@ -22,7 +22,7 @@ ENV PATH="/usr/local/bin:$PATH"
 # rpm-lockfile-prototype shells out to skopeo to copy a base image's rootfs
 # locally so it can inspect the RPM DB there.
 RUN dnf -y install python3.11 python3.11-pip python3.11-wheel python3.11-devel gcc krb5-devel wget tar gzip git krb5-workstation \
-    brewkoji rhpkg podman skopeo python3-rpm python3-pip python3-dnf \
+    brewkoji rhpkg podman skopeo python3-rpm python3-pip python3-dnf jq \
     && uv pip install --system --upgrade setuptools \
     && dnf clean all
 
@@ -40,6 +40,11 @@ RUN wget -O "awscliv2.zip" "https://awscli.amazonaws.com/awscli-exe-linux-x86_64
 # Install tkn client
 RUN curl -LO https://github.com/tektoncd/cli/releases/download/v0.37.0/tkn_0.37.0_Linux_x86_64.tar.gz &&  \
     tar xvzf tkn_0.37.0_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
+
+# Install yq
+ARG YQ_VERSION=v4.44.6
+RUN wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+    && chmod +x /usr/local/bin/yq
 
 # Install opm (Operator Package Manager) for FBC builds
 ARG OPM_VERSION=v1.47.0


### PR DESCRIPTION
## Summary
- Adds `jq` to the dnf install line for JSON processing in CI pipelines
- Installs `yq` v4.44.6 as a standalone binary (not available in RHEL repos)
- Both are needed by the shipment-ci pipeline for shipment file processing and validation

## Test plan
- [ ] Verify artcd-base image builds successfully
- [ ] Confirm `jq --version` and `yq --version` work in the built container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The base container image now includes the `jq` and `yq` command-line tools.
  * Scripts and workflows running in the image can now process JSON and YAML configuration data without additional setup.
  * The `yq` installation uses a configurable version for improved consistency across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->