### PR TITLE
Fix monobranch Konflux builder lookup

### DIFF
--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -565,7 +565,7 @@ def get_golang_container_nvrs_for_konflux_record(
         # because we need to look at included golang rpms instead of parent images.
         # Unlike `get_golang_container_nvrs_brew`, we don't accept 'go-toolset*' containers
         # because they don't exist in KonfluxDB.
-        if build.name == GOLANG_BUILDER_IMAGE_NAME:
+        if nvr_dict['name'] == constants.GOLANG_BUILDER_CVE_COMPONENT:
             go_package = next(
                 (
                     pkg_nvr

--- a/elliott/tests/test_util.py
+++ b/elliott/tests/test_util.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import Mock
 
 from elliottlib import brew, util
 from elliottlib.bzutil import Bug
@@ -125,6 +126,29 @@ class TestUtil(unittest.TestCase):
         expected = {go_version: {nvrs[0]}}
         actual = util.get_golang_container_nvrs(nvrs, None)
         self.assertEqual(expected, actual)
+
+    def test_get_golang_container_nvrs_for_monobranch_builder_record(self):
+        build = flexmock(
+            name='openshift-golang-builder-1-26.rhel8',
+            nvr='openshift-golang-builder-container-v1.26.5-202607272002.p2.g5a9ab9d.el8',
+            installed_packages=['golang-1.26.5-1.module+el8.10.0+24506+6809f2d9'],
+            parent_images=[],
+        )
+
+        actual = util.get_golang_container_nvrs_for_konflux_record([build], Mock(), exact=True)
+
+        self.assertEqual(
+            actual,
+            {
+                'golang-1.26.5-1.module+el8.10.0+24506+6809f2d9': {
+                    (
+                        'openshift-golang-builder-container',
+                        'v1.26.5',
+                        '202607272002.p2.g5a9ab9d.el8',
+                    )
+                }
+            },
+        )
 
     def test_get_golang_rpm_nvrs_skips_non_golang_rpms(self):
         golang_nvr = ('openshift', '4.19.0', '202506111249.p0.gd2acdd5.assembly.stream.el8')

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -728,6 +728,9 @@ class UpdateGolangPipeline:
                 _LOGGER,
                 exact=True,
             )
+            if not go_nvr_map:
+                _LOGGER.warning("Could not determine installed Golang RPM for %s", build_record.nvr)
+                continue
             actual_go_nvr, _ = next(iter(go_nvr_map.items()))
             expected_go_nvr = el_nvr_map[el_v]
             if actual_go_nvr != expected_go_nvr:

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -702,7 +702,7 @@ class UpdateGolangPipeline:
                 anext(
                     self.konflux_db.search_builds_by_fields(
                         where={
-                            "name": GOLANG_BUILDER_IMAGE_NAME,
+                            "name": self._get_doozer_group_and_image(el_v, go_version)[1],
                             "el_target": f'el{el_v}',
                             "artifact_type": str(ArtifactType.IMAGE),
                             "outcome": str(KonfluxBuildOutcome.SUCCESS),

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import click
 import koji
+from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord
 from pyartcd.pipelines.update_golang import (
     UpdateGolangPipeline,
@@ -1261,6 +1262,54 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         mock_get_golang_nvrs.assert_called_once()
         self.assertEqual(mock_get_golang_nvrs.call_args.args[0], [mock_build_record])
         self.assertEqual(mock_get_golang_nvrs.call_args.kwargs, {"exact": True})
+        self.assertEqual(
+            mock_db_instance.search_builds_by_fields.call_args.kwargs["where"]["name"],
+            GOLANG_BUILDER_IMAGE_NAME,
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_get_existing_builders_konflux_monobranch_names(self, mock_konflux_db_class):
+        """Test Konflux builder lookup uses versioned metadata keys for the Golang monobranch."""
+        mock_runtime = Mock(
+            dry_run=False,
+            working_dir=Path("/tmp/working"),
+        )
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        mock_db_instance = Mock()
+        mock_konflux_db_class.return_value = mock_db_instance
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="5.0",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.26.5-1.el8", "golang-1.26.5-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="konflux",
+            use_new_golang_branch=True,
+        )
+
+        async def mock_search_builds(*_args, **_kwargs):
+            for build_record in ():
+                yield build_record
+
+        mock_db_instance.search_builds_by_fields = Mock(side_effect=mock_search_builds)
+
+        builder_records = await pipeline.get_existing_builders_konflux(
+            {8: "golang-1.26.5-1.el8", 9: "golang-1.26.5-1.el9"},
+            "1.26.5",
+        )
+
+        self.assertEqual(builder_records, {})
+        self.assertEqual(
+            [call.kwargs["where"]["name"] for call in mock_db_instance.search_builds_by_fields.call_args_list],
+            [
+                "openshift-golang-builder-1-26.rhel8",
+                "openshift-golang-builder-1-26.rhel9",
+            ],
+        )
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("pyartcd.pipelines.update_golang.elliottutil.get_golang_container_nvrs_for_konflux_record")

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1268,7 +1268,8 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         )
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_get_existing_builders_konflux_monobranch_names(self, mock_konflux_db_class):
+    @patch("pyartcd.pipelines.update_golang.elliottutil.get_golang_container_nvrs_for_konflux_record")
+    async def test_get_existing_builders_konflux_monobranch_names(self, mock_get_golang_nvrs, mock_konflux_db_class):
         """Test Konflux builder lookup uses versioned metadata keys for the Golang monobranch."""
         mock_runtime = Mock(
             dry_run=False,
@@ -1278,6 +1279,11 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         mock_db_instance = Mock()
         mock_konflux_db_class.return_value = mock_db_instance
+        mock_build_record = Mock(
+            spec=KonfluxBuildRecord,
+            nvr="openshift-golang-builder-container-v1.26.5-202607272002.p2.g5a9ab9d.el8",
+        )
+        mock_get_golang_nvrs.return_value = {}
 
         pipeline = UpdateGolangPipeline(
             runtime=mock_runtime,
@@ -1292,8 +1298,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         )
 
         async def mock_search_builds(*_args, **_kwargs):
-            for build_record in ():
-                yield build_record
+            yield mock_build_record
 
         mock_db_instance.search_builds_by_fields = Mock(side_effect=mock_search_builds)
 
@@ -1303,6 +1308,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(builder_records, {})
+        self.assertEqual(mock_get_golang_nvrs.call_count, 2)
         self.assertEqual(
             [call.kwargs["where"]["name"] for call in mock_db_instance.search_builds_by_fields.call_args_list],
             [


### PR DESCRIPTION
## What

- resolve the Konflux builder-record name through the same group/image helper
  used by the rebase and build steps
- query versioned image keys such as
  `openshift-golang-builder-1-26.rhel8` for the Golang monobranch
- recognize Golang builder records by their stable
  `openshift-golang-builder-container` NVR component, independent of the
  metadata key layout
- retain the existing unversioned `openshift-golang-builder` lookup for legacy
  per-version branches
- handle an empty installed-Golang mapping without leaking `StopIteration`

## Why

After a successful Golang monobranch Konflux build and base-image release,
`update-golang` could not rediscover the build record it had just stored:

```text
Failed to find existing builder(s) for rhel version(s): Konflux: {8}
```

Doozer correctly stores Konflux records under the metadata `distgit_key`. On
the monobranch that key is versioned, but the post-build lookup was still
hard-coded to query the legacy unversioned key.

After correcting that query, Elliott exposed a second layout assumption: it
only treated a record as the Golang builder when `build.name` was exactly
`openshift-golang-builder`. A versioned record was treated as an ordinary child
image, producing an empty Golang-NVR mapping and:

```text
coroutine raised StopIteration
```

Using `_get_doozer_group_and_image()` aligns the database lookup with the
selected build layout. Using the NVR component identifies the builder
consistently across both layouts and remains compatible with the planned
universal monobranch behavior in #3136.

Related: #3206

## Impact

Successful monobranch builders can be rediscovered, validated against their
installed Golang RPM, and proceed to streams updates and the remaining
pipeline steps. Legacy branch lookups are unchanged.

## Verification

- focused Elliott regression: 1 passed
- all Elliott utility tests: 6 passed
- all `update-golang` tests: 92 passed
- `make format`
- `make test`: 3,084 tests passed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of existing Go builder images for each platform and Go version in Konflux.
  * Updated Go-version extraction for relevant Konflux records to rely on parsed container identifiers, improving accuracy for monobranch builds.
  * Added test coverage to validate monobranch-specific lookup behavior, including cases where no matching builder metadata is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->