### PR TITLE
ART-21518: Fix non-latest Golang builder stream updates

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -403,6 +403,18 @@ class UpdateGolangPipeline:
         )
 
         if brew_missing or konflux_missing:
+            if not process_rpm_builds and not self.external_golang_rpms:
+                missing = []
+                if brew_missing:
+                    missing.append(f'Brew: {sorted(brew_missing)}')
+                if konflux_missing:
+                    missing.append(f'Konflux: {sorted(konflux_missing)}')
+                raise ValueError(
+                    "Cannot build missing non-GO_LATEST golang builder image(s) without "
+                    f"--external-golang-rpms ({', '.join(missing)}). "
+                    "Build them from the owning GO_LATEST release first, or enable external Golang RPMs."
+                )
+
             if not self.external_golang_rpms:
                 for el_v in el_nvr_map_for_images.keys():
                     self.verify_golang_builder_repo(el_v, go_version)
@@ -706,14 +718,18 @@ class UpdateGolangPipeline:
         """
         _LOGGER.info(f"Checking if {GOLANG_BUILDER_IMAGE_NAME} builds exist in Konflux for given golang builds")
 
-        builder_records: dict[int, KonfluxBuildRecord] = {}
         extra_patterns = {'nvr': f"{GOLANG_BUILDER_CVE_COMPONENT}-v{go_version}"}
-        build_records = await asyncio.gather(
-            *(
-                anext(
+        builder_names_by_el = {
+            el_v: (self.get_golang_image_key(el_v, go_version), GOLANG_BUILDER_IMAGE_NAME) for el_v in el_nvr_map
+        }
+
+        async def find_builder(el_v: int) -> KonfluxBuildRecord | None:
+            expected_go_nvr = el_nvr_map[el_v]
+            for builder_name in builder_names_by_el[el_v]:
+                build_record = await anext(
                     self.konflux_db.search_builds_by_fields(
                         where={
-                            "name": self._get_doozer_group_and_image(el_v, go_version)[1],
+                            "name": builder_name,
                             "el_target": f'el{el_v}',
                             "artifact_type": str(ArtifactType.IMAGE),
                             "outcome": str(KonfluxBuildOutcome.SUCCESS),
@@ -724,36 +740,37 @@ class UpdateGolangPipeline:
                     ),
                     None,
                 )
-                for el_v in el_nvr_map
-            )
-        )
-        found_records = {
-            el_v: cast(KonfluxBuildRecord, build_record)
-            for el_v, build_record in zip(el_nvr_map, build_records)
-            if build_record
-        }
-
-        for el_v, build_record in found_records.items():
-            go_nvr_map = elliottutil.get_golang_container_nvrs_for_konflux_record(
-                [build_record],
-                _LOGGER,
-                exact=True,
-            )
-            if not go_nvr_map:
-                _LOGGER.warning("Could not determine installed Golang RPM for %s", build_record.nvr)
-                continue
-            actual_go_nvr, _ = next(iter(go_nvr_map.items()))
-            expected_go_nvr = el_nvr_map[el_v]
-            if actual_go_nvr != expected_go_nvr:
-                _LOGGER.warning(
-                    f"Installed golang rpm in {build_record.nvr} is different from the expected one: {actual_go_nvr} != {expected_go_nvr}"
+                if not build_record:
+                    continue
+                build_record = cast(KonfluxBuildRecord, build_record)
+                go_nvr_map = elliottutil.get_golang_container_nvrs_for_konflux_record(
+                    [build_record],
+                    _LOGGER,
+                    exact=True,
                 )
-            else:
+                if not go_nvr_map:
+                    _LOGGER.warning("Could not determine installed Golang RPM for %s", build_record.nvr)
+                    continue
+                actual_go_nvr, _ = next(iter(go_nvr_map.items()))
+                if actual_go_nvr != expected_go_nvr:
+                    _LOGGER.warning(
+                        "Installed golang rpm in %s is different from the expected one: %s != %s",
+                        build_record.nvr,
+                        actual_go_nvr,
+                        expected_go_nvr,
+                    )
+                    continue
                 _LOGGER.info(
-                    f"Found existing builder image in Konflux: {build_record.nvr} built with {expected_go_nvr}"
+                    "Found existing builder image in Konflux: %s built with %s (record name: %s)",
+                    build_record.nvr,
+                    expected_go_nvr,
+                    builder_name,
                 )
-                builder_records[el_v] = build_record
-        return builder_records
+                return build_record
+            return None
+
+        build_records = await asyncio.gather(*(find_builder(el_v) for el_v in el_nvr_map))
+        return {el_v: build_record for el_v, build_record in zip(el_nvr_map, build_records) if build_record is not None}
 
     def _get_builder_pullspec(self, builder_nvr: str):
         """Generate the published pullspec used in streams.yml for Konflux-built builders."""

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -331,6 +331,7 @@ class UpdateGolangPipeline:
         branch, allowed_major_minors, build_major_minor = self.validate_go_version_matches_group_vars(go_version)
         if self.tag_builds:
             self.validate_tag_builds_go_latest(branch, allowed_major_minors, build_major_minor)
+        process_rpm_builds = self.major_bump or build_major_minor == allowed_major_minors["GO_LATEST"]
 
         # el10 is only supported for build roots (RPM tagging), not for golang-builder images yet
         el_nvr_map_for_images = {el_v: nvr for el_v, nvr in el_nvr_map.items() if el_v != 10}
@@ -357,7 +358,7 @@ class UpdateGolangPipeline:
             await self._slack_client.say_in_thread(
                 ":warning: Using golang RPMs from external repos. Skipping tagging and availability checks."
             )
-        else:
+        elif process_rpm_builds:
             # Process golang RPM builds (always from Brew)
             cannot_proceed = not all(
                 await asyncio.gather(*[self.process_build(el_v, nvr) for el_v, nvr in el_nvr_map.items()])
@@ -372,6 +373,16 @@ class UpdateGolangPipeline:
 
             # Build plashets for golang RPMs before building images
             await self._build_golang_plashets(go_version, el_nvr_map_for_images.keys())
+        else:
+            matching_vars = sorted(
+                var_name for var_name, major_minor in allowed_major_minors.items() if major_minor == build_major_minor
+            )
+            _LOGGER.info(
+                "Skipping RPM tagging, buildroot availability checks, and plashet builds for non-GO_LATEST "
+                "golang %s (%s). Existing builder images will be reused.",
+                build_major_minor,
+                ", ".join(matching_vars),
+            )
 
         # Check if openshift-golang-builder image builds exist for the provided compiler builds
         # Only for RHEL versions that support golang-builder images (excludes el10 for now)
@@ -783,15 +794,17 @@ class UpdateGolangPipeline:
         streams_content = branch_content["streams"]
         group_content = branch_content["group"]
 
-        go_latest_var, go_previous_var = "GO_LATEST", "GO_PREVIOUS"
+        go_latest_var, go_extra_var, go_previous_var = "GO_LATEST", "GO_EXTRA", "GO_PREVIOUS"
         go_latest = group_content['vars'].get(go_latest_var)
         if not go_latest:
             raise ValueError(
                 f"{go_latest_var} variable not found in group.yml, please make sure it is defined before running the pipeline"
             )
+        go_extra = group_content['vars'].get(go_extra_var)
         go_previous = group_content['vars'].get(go_previous_var)
         build_major_minor = extract_major_minor(go_version, "golang build version")
         latest_major_minor = extract_major_minor(go_latest, f"group.yml {go_latest_var}")
+        extra_major_minor = extract_major_minor(go_extra, f"group.yml {go_extra_var}") if go_extra else None
         previous_major_minor = extract_major_minor(go_previous, f"group.yml {go_previous_var}") if go_previous else None
         build_major_minor_tuple = tuple(map(int, build_major_minor.split(".")))
         latest_major_minor_tuple = tuple(map(int, latest_major_minor.split(".")))
@@ -800,6 +813,7 @@ class UpdateGolangPipeline:
         # but we do not need to replace/update them
         # we will just look for the literal value
         go_latest_var_template = "{" + go_latest_var + "}"
+        go_extra_var_template = "{" + go_extra_var + "}"
         go_previous_var_template = "{" + go_previous_var + "}"
 
         def latest_go_stream_name(el_v):
@@ -807,6 +821,12 @@ class UpdateGolangPipeline:
 
         def previous_go_stream_name(el_v):
             return f'rhel-{el_v}-golang-{go_previous_var_template}'
+
+        def extra_go_stream_names(el_v):
+            return (
+                f'rhel-{el_v}-golang-{go_extra_var_template}',
+                f'rhel-{el_v}-golang-{extra_major_minor}',
+            )
 
         update_streams = update_group = False
 
@@ -846,6 +866,26 @@ class UpdateGolangPipeline:
 
                 for _, info in streams_content.items():
                     if info['image'] == previous_go:
+                        info['image'] = pullspec
+                        update_streams = True
+        # This is to bump minor golang for GO_EXTRA
+        elif extra_major_minor and build_major_minor == extra_major_minor:
+            for el_v, pullspec in builder_pullspecs.items():
+                stream_names = extra_go_stream_names(el_v)
+                _LOGGER.info("Looking for golang streams %s in streams.yml", ", ".join(stream_names))
+                extra_go_stream = None
+                for stream_name in stream_names:
+                    extra_go_stream = get_stream(stream_name)
+                    if extra_go_stream:
+                        break
+                if not extra_go_stream:
+                    raise ValueError(
+                        f"Could not find a golang stream for {go_extra_var}={extra_major_minor} and RHEL {el_v}"
+                    )
+                extra_go = extra_go_stream['image']
+
+                for _, info in streams_content.items():
+                    if info['image'] == extra_go:
                         info['image'] = pullspec
                         update_streams = True
         # This is to bump major golang for GO_LATEST and update GO_PREVIOUS to current GO_LATEST

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -967,6 +967,86 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         )
         move_golang_bugs.assert_awaited_once()
 
+    @patch("pyartcd.pipelines.update_golang.kinit", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.update_golang.move_golang_bugs", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_run_go_extra_fails_before_building_when_builder_is_missing(
+        self, mock_konflux_db, move_golang_bugs, mock_kinit
+    ):
+        """Test GO_EXTRA without external RPMs never rebases a missing builder"""
+        pipeline = UpdateGolangPipeline(
+            runtime=self._make_test_runtime(),
+            ocp_version="5.0",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.11-1.el8_10"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            build_system="konflux",
+        )
+        pipeline.validate_go_version_matches_group_vars = Mock(
+            return_value=("openshift-5.0", {"GO_LATEST": "1.26", "GO_EXTRA": "1.25"}, "1.25")
+        )
+        pipeline.process_build = AsyncMock()
+        pipeline._build_golang_plashets = AsyncMock()
+        pipeline.get_existing_builders_konflux = AsyncMock(return_value={})
+        pipeline.verify_golang_builder_repo = Mock()
+        pipeline._rebase_and_build_konflux = AsyncMock()
+
+        with self.assertRaisesRegex(ValueError, "Cannot build missing non-GO_LATEST"):
+            await pipeline.run()
+
+        pipeline.process_build.assert_not_awaited()
+        pipeline._build_golang_plashets.assert_not_awaited()
+        pipeline.verify_golang_builder_repo.assert_not_called()
+        pipeline._rebase_and_build_konflux.assert_not_awaited()
+        move_golang_bugs.assert_not_awaited()
+
+    @patch("pyartcd.pipelines.update_golang.kinit", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.update_golang.move_golang_bugs", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_run_go_extra_external_rpms_builds_missing_builder(
+        self, mock_konflux_db, move_golang_bugs, mock_kinit
+    ):
+        """Test external RPMs allow a missing GO_EXTRA builder to be rebased and built"""
+        pipeline = UpdateGolangPipeline(
+            runtime=self._make_test_runtime(),
+            ocp_version="5.0",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.11-1.el8_10"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            build_system="konflux",
+            external_golang_rpms=True,
+        )
+        pipeline.validate_go_version_matches_group_vars = Mock(
+            return_value=("openshift-5.0", {"GO_LATEST": "1.26", "GO_EXTRA": "1.25"}, "1.25")
+        )
+        pipeline.process_build = AsyncMock()
+        pipeline._build_golang_plashets = AsyncMock()
+        builder_record = Mock(nvr="openshift-golang-builder-container-v1.25.11-202607281030.p2.gbbb222.el8")
+        pipeline.get_existing_builders_konflux = AsyncMock(side_effect=[{}, {8: builder_record}])
+        pipeline.verify_golang_builder_repo = Mock()
+        pipeline._rebase_and_build_konflux = AsyncMock()
+        pipeline._get_builder_pullspec = Mock(return_value="registry.example.com/golang-builder:v1.25.11-el8")
+        pipeline._ensure_builder_pullspec_available = AsyncMock()
+        pipeline.update_golang_streams = AsyncMock()
+
+        await pipeline.run()
+
+        pipeline.process_build.assert_not_awaited()
+        pipeline._build_golang_plashets.assert_not_awaited()
+        pipeline.verify_golang_builder_repo.assert_not_called()
+        pipeline._rebase_and_build_konflux.assert_awaited_once_with(
+            8,
+            "1.25.11",
+            "golang-1.25.11-1.el8_10",
+        )
+        self.assertEqual(pipeline.get_existing_builders_konflux.await_count, 2)
+        pipeline.update_golang_streams.assert_awaited_once()
+        move_golang_bugs.assert_awaited_once()
+
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_module_tag(self, mock_konflux_db):
         """Test get_module_tag method"""
@@ -1303,7 +1383,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("pyartcd.pipelines.update_golang.elliottutil.get_golang_container_nvrs_for_konflux_record")
     async def test_get_existing_builders_konflux(self, mock_get_golang_nvrs, mock_konflux_db_class):
-        """Test Konflux builder lookup returns the build record on exact RPM match"""
+        """Test Konflux builder lookup falls back to the legacy name on exact RPM match"""
         mock_runtime = Mock(
             dry_run=False,
             working_dir=Path("/tmp/working"),
@@ -1328,8 +1408,9 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         mock_build_record = Mock(spec=KonfluxBuildRecord)
         mock_build_record.nvr = "openshift-golang-builder-v1.20.12-202403212137.el8.g144a3f8"
 
-        async def mock_search_builds(*_args, **_kwargs):
-            yield mock_build_record
+        async def mock_search_builds(*_args, **kwargs):
+            if kwargs["where"]["name"] == GOLANG_BUILDER_IMAGE_NAME:
+                yield mock_build_record
 
         mock_db_instance.search_builds_by_fields = Mock(side_effect=mock_search_builds)
 
@@ -1345,14 +1426,17 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         self.assertEqual(mock_get_golang_nvrs.call_args.args[0], [mock_build_record])
         self.assertEqual(mock_get_golang_nvrs.call_args.kwargs, {"exact": True})
         self.assertEqual(
-            mock_db_instance.search_builds_by_fields.call_args.kwargs["where"]["name"],
-            GOLANG_BUILDER_IMAGE_NAME,
+            [call.kwargs["where"]["name"] for call in mock_db_instance.search_builds_by_fields.call_args_list],
+            [
+                "openshift-golang-builder-1-20.rhel8",
+                GOLANG_BUILDER_IMAGE_NAME,
+            ],
         )
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("pyartcd.pipelines.update_golang.elliottutil.get_golang_container_nvrs_for_konflux_record")
     async def test_get_existing_builders_konflux_monobranch_names(self, mock_get_golang_nvrs, mock_konflux_db_class):
-        """Test Konflux builder lookup uses versioned metadata keys for the Golang monobranch."""
+        """Test Konflux builder lookup uses the same names with the Golang monobranch enabled."""
         mock_runtime = Mock(
             dry_run=False,
             working_dir=Path("/tmp/working"),
@@ -1365,7 +1449,9 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             spec=KonfluxBuildRecord,
             nvr="openshift-golang-builder-container-v1.26.5-202607272002.p2.g5a9ab9d.el8",
         )
-        mock_get_golang_nvrs.return_value = {}
+        mock_get_golang_nvrs.return_value = {
+            "golang-1.26.5-1.el8": {("ignored-builder", "ignored-version", "ignored-release")}
+        }
 
         pipeline = UpdateGolangPipeline(
             runtime=mock_runtime,
@@ -1379,8 +1465,9 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             use_new_golang_branch=True,
         )
 
-        async def mock_search_builds(*_args, **_kwargs):
-            yield mock_build_record
+        async def mock_search_builds(*_args, **kwargs):
+            if kwargs["where"]["name"] == "openshift-golang-builder-1-26.rhel8":
+                yield mock_build_record
 
         mock_db_instance.search_builds_by_fields = Mock(side_effect=mock_search_builds)
 
@@ -1389,13 +1476,14 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             "1.26.5",
         )
 
-        self.assertEqual(builder_records, {})
-        self.assertEqual(mock_get_golang_nvrs.call_count, 2)
+        self.assertEqual(builder_records, {8: mock_build_record})
+        self.assertEqual(mock_get_golang_nvrs.call_count, 1)
         self.assertEqual(
             [call.kwargs["where"]["name"] for call in mock_db_instance.search_builds_by_fields.call_args_list],
             [
                 "openshift-golang-builder-1-26.rhel8",
                 "openshift-golang-builder-1-26.rhel9",
+                GOLANG_BUILDER_IMAGE_NAME,
             ],
         )
 

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -558,6 +558,46 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         self.assertEqual(requested_paths.count("group.yml"), 1)
         self.assertEqual(requested_paths.count("streams.yml"), 1)
 
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_update_golang_streams_updates_go_extra_literal_streams(self, mock_konflux_db):
+        """Test GO_EXTRA updates literal streams and other streams sharing the same builder"""
+        pipeline = UpdateGolangPipeline(
+            runtime=self._make_test_runtime(),
+            ocp_version="5.0",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.11-1.el8_10"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            build_system="konflux",
+        )
+        pipeline.dry_run = True
+        old_pullspec = "registry.example.com/golang-builder:v1.25.8-el8"
+        new_pullspec = "registry.example.com/golang-builder:v1.25.11-el8"
+        pipeline._branch_content = {
+            "branch": "openshift-5.0",
+            "repo": Mock(),
+            "group": {"vars": {"GO_LATEST": "1.26", "GO_EXTRA": "1.25"}},
+            "streams": {
+                "rhel-8-golang": {
+                    "aliases": ["rhel-8-golang-{GO_LATEST}"],
+                    "image": "registry.example.com/golang-builder:v1.26.5-el8",
+                },
+                "rhel-8-golang-1.25": {"image": old_pullspec},
+                "partner-rhel-8-golang-1.25": {"image": old_pullspec},
+            },
+        }
+
+        await pipeline.update_golang_streams("1.25.11", {8: new_pullspec})
+
+        streams = pipeline._branch_content["streams"]
+        self.assertEqual(streams["rhel-8-golang-1.25"]["image"], new_pullspec)
+        self.assertEqual(streams["partner-rhel-8-golang-1.25"]["image"], new_pullspec)
+        self.assertEqual(
+            streams["rhel-8-golang"]["image"],
+            "registry.example.com/golang-builder:v1.26.5-el8",
+        )
+
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_validate_go_version_matches_group_vars_accepts_matching_go_previous(
@@ -884,6 +924,48 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             any("Skipping streams.yml update for brew-only run" in message for message in slack_messages),
             slack_messages,
         )
+
+    @patch("pyartcd.pipelines.update_golang.kinit", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.update_golang.move_golang_bugs", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_run_go_extra_reuses_builder_without_processing_rpm(
+        self, mock_konflux_db, move_golang_bugs, mock_kinit
+    ):
+        """Test GO_EXTRA skips RPM buildroot processing and reuses an existing builder"""
+        pipeline = UpdateGolangPipeline(
+            runtime=self._make_test_runtime(),
+            ocp_version="5.0",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.11-1.el8_10"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            build_system="konflux",
+        )
+        pipeline.validate_go_version_matches_group_vars = Mock(
+            return_value=("openshift-5.0", {"GO_LATEST": "1.26", "GO_EXTRA": "1.25"}, "1.25")
+        )
+        pipeline.process_build = AsyncMock()
+        pipeline._build_golang_plashets = AsyncMock()
+        builder_record = Mock(nvr="openshift-golang-builder-container-v1.25.11-202607281030.p2.gbbb222.el8")
+        pipeline.get_existing_builders_konflux = AsyncMock(return_value={8: builder_record})
+        pipeline._get_builder_pullspec = Mock(return_value="registry.example.com/golang-builder:v1.25.11-el8")
+        pipeline._ensure_builder_pullspec_available = AsyncMock()
+        pipeline.update_golang_streams = AsyncMock()
+
+        await pipeline.run()
+
+        pipeline.process_build.assert_not_awaited()
+        pipeline._build_golang_plashets.assert_not_awaited()
+        pipeline.get_existing_builders_konflux.assert_awaited_once_with(
+            {8: "golang-1.25.11-1.el8_10"},
+            "1.25.11",
+        )
+        pipeline.update_golang_streams.assert_awaited_once_with(
+            "1.25.11",
+            {8: "registry.example.com/golang-builder:v1.25.11-el8"},
+        )
+        move_golang_bugs.assert_awaited_once()
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_module_tag(self, mock_konflux_db):


### PR DESCRIPTION
## Summary

- Skip RPM tagging, buildroot availability checks, and plashet builds for configured non-`GO_LATEST` lines.
- Discover Konflux builders under both versioned and legacy record names, regardless of the Golang branch-layout flag, and require an exact installed compiler NVR match.
- Reuse existing non-`GO_LATEST` builders; fail before rebase when a required builder is missing.
- Preserve missing-builder rebase/build behavior with `--external-golang-rpms`.
- Update `GO_EXTRA` streams using either templated aliases or literal versioned keys, including streams sharing the selected builder image.

## Root cause

The pipeline accepted `GO_EXTRA` but still unconditionally processed its RPMs. After that was skipped, a monobranch lookup searched only versioned Konflux record names, so legacy builders were treated as missing and the normal missing-image path rebased them.

## External RPM behavior

`--external-golang-rpms` still permits a missing builder to be rebased and built. It assumes the selected golang-builder metadata enables the external repository containing the requested RPM; after the build, the pipeline rediscovers the builder and verifies its installed Golang NVR exactly.

## Validation

- Focused update-golang tests: 96 passed
- Ruff lint and formatting passed
- `git diff --check` passed
- Global rh-pre-commit and commit-message hooks passed
