### PR TITLE
ART-21518: Support legacy and unified Golang Konflux groups

### DIFF
--- a/elliott/elliottlib/util.py
+++ b/elliott/elliottlib/util.py
@@ -17,11 +17,11 @@ from artcommonlib import exectools
 from artcommonlib.build_visibility import get_build_system
 from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME, GOLANG_RPM_PACKAGE_NAME
 from artcommonlib.format_util import green_prefix, green_print, red_prefix
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.logutil import get_logger
 from artcommonlib.oc_image_info import oc_image_info__cached_async
-from artcommonlib.util import extract_related_images_from_fbc, is_ocp_delivery_repo
+from artcommonlib.util import extract_group_from_nvr, extract_related_images_from_fbc, is_ocp_delivery_repo
 from errata_tool import Erratum
 
 from elliottlib import brew, constants
@@ -34,6 +34,7 @@ now = datetime.datetime.now()
 YMD = '%Y-%b-%d'
 LOGGER = get_logger(__name__)
 _executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+GOLANG_MONOBRANCH_GROUP = 'golang'
 
 
 def exit_unauthenticated():
@@ -535,14 +536,52 @@ def get_golang_container_nvrs_konflux(
 
     logger.info(f'Getting build records for {len(nvrs)} nvrs from KonfluxDB')
 
-    # Need installed_packages column for golang builder image detection
+    # Need installed_packages column for golang builder image detection.
+    # Golang builder records can belong to either a legacy per-variant group
+    # (e.g. rhel-8-golang-1.26) or the unified golang group.
     all_build_objs = _executor.submit(
-        lambda: asyncio.run(konflux_db.get_build_records_by_nvrs(['{}-{}-{}'.format(*n) for n in nvrs]))
+        lambda: asyncio.run(_get_konflux_build_records_for_golang(konflux_db, nvrs))
     ).result()
 
     return get_golang_container_nvrs_for_konflux_record(
         cast(list[KonfluxBuildRecord], all_build_objs), logger, exact=exact
     )
+
+
+async def _get_konflux_build_records_for_golang(
+    konflux_db: KonfluxDb,
+    nvrs: List[Tuple[str, str, str]],
+) -> list[KonfluxBuildRecord]:
+    async def get_build_record(nvr_tuple: Tuple[str, str, str]) -> KonfluxBuildRecord:
+        nvr = '{}-{}-{}'.format(*nvr_tuple)
+        if nvr_tuple[0] != constants.GOLANG_BUILDER_CVE_COMPONENT:
+            return cast(KonfluxBuildRecord, await konflux_db.get_build_record_by_nvr(nvr))
+
+        legacy_group = extract_group_from_nvr(nvr)
+        groups = list(dict.fromkeys(group for group in (legacy_group, GOLANG_MONOBRANCH_GROUP) if group))
+        build_record = await anext(
+            konflux_db.search_builds_by_fields(
+                where={
+                    'nvr': nvr,
+                    'group': groups,
+                    'outcome': str(KonfluxBuildOutcome.SUCCESS),
+                },
+                limit=1,
+            ),
+            None,
+        )
+        if not build_record:
+            raise IOError(f"Golang builder build record not found for nvr={nvr}, groups={groups}")
+        return cast(KonfluxBuildRecord, build_record)
+
+    records = await asyncio.gather(*(get_build_record(nvr) for nvr in nvrs), return_exceptions=True)
+    errors = [
+        ('{}-{}-{}'.format(*nvr), record) for nvr, record in zip(nvrs, records) if isinstance(record, BaseException)
+    ]
+    if errors:
+        error_strings = [f"NVR {nvr}: {exc}" for nvr, exc in errors]
+        raise IOError(f"Failed to fetch NVRs from Konflux DB: {'; '.join(error_strings)}", errors)
+    return cast(list[KonfluxBuildRecord], records)
 
 
 def get_golang_container_nvrs_for_konflux_record(

--- a/elliott/tests/test_util.py
+++ b/elliott/tests/test_util.py
@@ -1,8 +1,9 @@
 import unittest
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from elliottlib import brew, util
 from elliottlib.bzutil import Bug
+from elliottlib.constants import GOLANG_BUILDER_CVE_COMPONENT
 from flexmock import flexmock
 
 
@@ -168,6 +169,67 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(result['1.23.6-2.module+el8.11.0+22775+e8b271ec'], {golang_nvr})
         for nvrs in result.values():
             self.assertNotIn(non_golang_nvr, nvrs)
+
+
+class TestKonfluxGolangBuildRecordLookup(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.builder_nvr = (
+            GOLANG_BUILDER_CVE_COMPONENT,
+            'v1.26.5',
+            '202607272002.p2.g5a9ab9d.el8',
+        )
+
+    async def test_supports_legacy_and_monobranch_groups(self):
+        for record_group in ('rhel-8-golang-1.26', 'golang'):
+            with self.subTest(record_group=record_group):
+                build_record = Mock(group=record_group)
+                konflux_db = Mock()
+
+                async def search_builds_by_fields(**_kwargs):
+                    yield build_record
+
+                konflux_db.search_builds_by_fields = Mock(side_effect=search_builds_by_fields)
+
+                records = await util._get_konflux_build_records_for_golang(konflux_db, [self.builder_nvr])
+
+                self.assertEqual(records, [build_record])
+                konflux_db.search_builds_by_fields.assert_called_once_with(
+                    where={
+                        'nvr': 'openshift-golang-builder-container-v1.26.5-202607272002.p2.g5a9ab9d.el8',
+                        'group': ['rhel-8-golang-1.26', 'golang'],
+                        'outcome': 'success',
+                    },
+                    limit=1,
+                )
+
+    async def test_errors_when_builder_is_missing_from_both_groups(self):
+        konflux_db = Mock()
+
+        async def search_builds_by_fields(**_kwargs):
+            if False:
+                yield
+
+        konflux_db.search_builds_by_fields = Mock(side_effect=search_builds_by_fields)
+
+        with self.assertRaisesRegex(
+            IOError,
+            r"groups=\['rhel-8-golang-1\.26', 'golang'\]",
+        ):
+            await util._get_konflux_build_records_for_golang(konflux_db, [self.builder_nvr])
+
+    async def test_non_builder_uses_standard_nvr_lookup(self):
+        nvr = ('ose-cli-container', 'v5.0.0', '202607272002.p2.g1234567.el9')
+        build_record = Mock()
+        konflux_db = Mock()
+        konflux_db.get_build_record_by_nvr = AsyncMock(return_value=build_record)
+
+        records = await util._get_konflux_build_records_for_golang(konflux_db, [nvr])
+
+        self.assertEqual(records, [build_record])
+        konflux_db.get_build_record_by_nvr.assert_awaited_once_with(
+            'ose-cli-container-v5.0.0-202607272002.p2.g1234567.el9'
+        )
+        konflux_db.search_builds_by_fields.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Resolve Golang builder records by exact NVR across both legacy per-variant groups and the unified `golang` group.
- Keep standard Konflux NVR lookup unchanged for non-Golang images.
- Preserve aggregated lookup errors when records are genuinely missing.

## Root cause

Golang builder NVRs encode enough information to infer legacy groups such as `rhel-8-golang-1.26`. Builders produced from the monobranch are stored under group `golang`, so Elliott's generic inferred-group lookup could not find those records during `find-bugs:golang`.

## Validation

- `elliott/tests/test_util.py` and `elliott/tests/test_find_bugs_golang_cli.py`: 21 passed, 2 subtests passed
- Ruff lint and formatting passed
- `git diff --check` passed
- Global rh-pre-commit and commit-message hooks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Golang container build record lookup across both legacy and unified build groups.
  - Added clearer error reporting when required build records cannot be found.
  - Preserved standard lookup behavior for non-builder container records.

- **Tests**
  - Added coverage for legacy and unified Golang build mappings.
  - Added validation for missing build records and standard NVR lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->