### PR TITLE
Revert "Skip oc-mirror binary sync for OCP 5.0+"

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1044,9 +1044,9 @@ class PromotePipeline:
         )
 
         # Starting from 4.14, oc-mirror will be synced for all arches. See ART-6820 and ART-6863
-        # oc-mirror was introduced in 4.10, so skip for <= 4.9. Not applicable for 5.0+.
+        # oc-mirror was introduced in 4.10, so skip for <= 4.9.
         major, minor = isolate_major_minor_in_group(self.group)
-        if major < 5 and ((major, minor) >= (4, 14) or ((major, minor) >= (4, 10) and build_arch == 'x86_64')):
+        if (major, minor) >= (4, 14) or ((major, minor) >= (4, 10) and build_arch == 'x86_64'):
             # oc image  extract requires an empty destination directory. So do this before extracting tools.
             # oc adm release extract --tools does not require an empty directory.
             image_stat, oc_mirror_pullspec = get_release_image_pullspec(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release publishing so `oc-mirror` is correctly extracted and bundled for 5.x and later releases.
  * Preserved the existing behavior of excluding `oc-mirror` from releases in the 4.9 and earlier series.
  * This ensures newer release payloads include the tooling needed for mirroring workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->