### PR TITLE
Add bundle_name_override config field to allow custom OLM bundle short names

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -90,7 +90,7 @@ GOLANG_NVR_ENV = '__doozer_golang_nvr'
 # Product-based mappings for Konflux tenant namespaces and kubeconfigs
 PRODUCT_NAMESPACE_MAP = {
     "acm": "art-acm-tenant",
-    "mce": "art-acm-tenant",
+    "multicluster-engine": "art-acm-tenant",
     "cert-manager": "art-oap-tenant",
     "external-secrets": "art-oap-tenant",
     "installer-ove-ui": "art-installer-agent-tenant",
@@ -117,7 +117,7 @@ PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP = {
     "logging": ("logging-images-base-silent", "logging-images-base"),
     "openshift-logging": ("logging-images-base-silent", "logging-images-base"),
     "acm": ("acm-images-base-silent", "acm-images-base"),
-    "mce": ("acm-images-base-silent", "acm-images-base"),
+    "multicluster-engine": ("acm-images-base-silent", "acm-images-base"),
 }
 
 # Pre-release lifecycle (software_lifecycle.phase) — registry-ocp-art-base-ec-prod via ART-19498.
@@ -127,7 +127,7 @@ PRODUCT_BASE_IMAGE_KONFLUX_EC_RELEASE_MAP = {
 
 PRODUCT_KUBECONFIG_MAP = {
     "acm": "ACM_KONFLUX_SA_KUBECONFIG",
-    "mce": "ACM_KONFLUX_SA_KUBECONFIG",
+    "multicluster-engine": "ACM_KONFLUX_SA_KUBECONFIG",
     "cert-manager": "OAP_KONFLUX_SA_KUBECONFIG",
     "external-secrets": "OAP_KONFLUX_SA_KUBECONFIG",
     "installer-ove-ui": "ASSISTED_INSTALLER_SA_KUBECONFIG",

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -861,6 +861,7 @@ class KonfluxFbcRebaser:
         self,
         shipment,
         operator_name: str,
+        bundle_name_override: Optional[str] = None,
     ):
         """
         Find a component matching the operator name in a shipment snapshot.
@@ -868,6 +869,9 @@ class KonfluxFbcRebaser:
         Args:
             shipment: The shipment config object
             operator_name: The operator distgit key to search for
+            bundle_name_override: If the operator's bundle short name was overridden
+                (config.bundle_name_override), this is that overridden name. Tried
+                before the default "{operator_name}-bundle" pattern.
 
         Returns:
             The matching component if found, None otherwise
@@ -876,9 +880,14 @@ class KonfluxFbcRebaser:
             return None
 
         # Bundle components typically follow pattern: {operator_name}-bundle
-        expected_names = (
-            f"{operator_name}-bundle",
-            operator_name,
+        expected_names = tuple(
+            name
+            for name in (
+                bundle_name_override,
+                f"{operator_name}-bundle",
+                operator_name,
+            )
+            if name
         )
         for expected_name in expected_names:
             component = next(
@@ -999,7 +1008,12 @@ class KonfluxFbcRebaser:
             self._logger.info("Fetching metadata shipment config from %s", shipment_url)
             metadata_shipment = get_shipment_config_from_mr(shipment_url, "metadata")
             operator_name = metadata.distgit_key
-            bundle_component = self._find_component_in_shipment(metadata_shipment, operator_name)
+            bundle_name_override = metadata.config.bundle_name_override
+            bundle_component = self._find_component_in_shipment(
+                metadata_shipment,
+                operator_name,
+                bundle_name_override=str(bundle_name_override) if bundle_name_override else None,
+            )
             if not bundle_component:
                 self._logger.info("Bundle component for %s not found in assembly %s", operator_name, assembly)
                 return None

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -573,7 +573,8 @@ class FbcRebaseAndBuildCli:
         :param strict: Whether to fail if bundle build is not found
         :return: Bundle build record.
         """
-        bundle_name = f"{operator_build.name}-bundle"
+        operator_meta = self.runtime.image_map.get(operator_build.name)
+        bundle_name = operator_meta.get_olm_bundle_short_name() if operator_meta else f"{operator_build.name}-bundle"
         LOGGER.info("Fetching bundle build for %s from Konflux DB...", operator_build.nvr)
         where = {
             "name": bundle_name,

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -538,7 +538,8 @@ class KonfluxBundleCli:
         :param operator_build: Operator build record.
         :return: Bundle build record.
         """
-        bundle_name = f"{operator_build.name}-bundle"
+        operator_meta = self.runtime.image_map.get(operator_build.name)
+        bundle_name = operator_meta.get_olm_bundle_short_name() if operator_meta else f"{operator_build.name}-bundle"
         LOGGER.info("Fetching bundle build for %s from Konflux DB...", operator_build.nvr)
         where = {
             "name": bundle_name,

--- a/doozer/doozerlib/cli/olm_bundle.py
+++ b/doozer/doozerlib/cli/olm_bundle.py
@@ -26,9 +26,9 @@ LOGGER = logutil.get_logger(__name__)
 @cli.command('olm-bundle:list-olm-operators', short_help='List all images that are OLM operators')
 @click.option(
     '--output-format',
-    type=click.Choice(['component', 'distgit-key'], case_sensitive=False),
+    type=click.Choice(['component', 'distgit-key', 'bundle-name'], case_sensitive=False),
     default='component',
-    help='Output format: component name (default) or distgit key',
+    help='Output format: component name (default), distgit key, or bundle short name',
 )
 @pass_runtime
 def list_olm_operators(runtime: Runtime, output_format: str):
@@ -37,10 +37,13 @@ def list_olm_operators(runtime: Runtime, output_format: str):
 
     By default, outputs component names (e.g., ose-ptp-operator-container).
     Use --output-format=distgit-key to output distgit keys (e.g., ptp-operator).
+    Use --output-format=bundle-name to output tab-separated "{distgit_key}\t{bundle_short_name}"
+    pairs, which honors any `bundle_name_override` config (e.g., "ptp-operator\tptp-operator-bundle").
 
     Examples:
     $ doozer --group openshift-4.5 olm-bundle:list-olm-operators
     $ doozer --group openshift-4.5 olm-bundle:list-olm-operators --output-format=distgit-key
+    $ doozer --group openshift-4.5 olm-bundle:list-olm-operators --output-format=bundle-name
     """
     runtime.initialize(clone_distgits=False, clone_source=False, prevent_cloning=True)
 
@@ -48,6 +51,8 @@ def list_olm_operators(runtime: Runtime, output_format: str):
         if image.enabled and image.config['update-csv'] is not Missing:
             if output_format == 'distgit-key':
                 print(image.distgit_key)
+            elif output_format == 'bundle-name':
+                print(f"{image.distgit_key}\t{image.get_olm_bundle_short_name()}")
             else:
                 print(image.get_component_name())
 

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -197,11 +197,17 @@ class ImageMetadata(Metadata):
     def get_olm_bundle_short_name(self):
         """Returns the short name of the OLM bundle for this OLM operator.
 
+        If the top-level `bundle_name_override` config field is set, it is used
+        instead of the default `{distgit_key}-bundle` derivation.
+
         :return: The short name of the OLM bundle for this OLM operator.
         :raises IOError: If the image is not an OLM operator.
         """
         if not self.is_olm_operator:
             raise IOError(f"[{self.distgit_key}] No update-csv config found in the image's metadata")
+        override = self.config.bundle_name_override
+        if override is not Missing and override:
+            return str(override)
         return f"{self.distgit_key}-bundle"
 
     def get_olm_bundle_image_name(self):

--- a/doozer/doozerlib/olm/bundle.py
+++ b/doozer/doozerlib/olm/bundle.py
@@ -548,6 +548,12 @@ class OLMBundle(object):
 
     @property
     def bundle_name(self):
+        try:
+            config = self.runtime.image_map[self.operator_name].config
+        except (AttributeError, KeyError):
+            config = None
+        if config is not None and 'bundle_name_override' in config and config['bundle_name_override']:
+            return config['bundle_name_override']
         return '{}-bundle'.format(self.operator_name)
 
     @property

--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -2570,6 +2570,36 @@ class TestKonfluxFbcRebaserAssemblyMethods(unittest.IsolatedAsyncioTestCase):
         result = self.rebaser._find_component_in_shipment(shipment, "nfd-operator")
         self.assertIsNone(result)
 
+    def test_find_component_in_shipment_uses_bundle_name_override(self):
+        """A bundle_name_override should be tried before the default '{name}-bundle' pattern."""
+        shipment = MagicMock()
+
+        default_component = MagicMock()
+        default_component.name = "nfd-operator-bundle"
+        overridden_component = MagicMock()
+        overridden_component.name = "custom-bundle-name"
+
+        shipment.shipment.snapshot.spec.components = [default_component, overridden_component]
+
+        result = self.rebaser._find_component_in_shipment(
+            shipment, "nfd-operator", bundle_name_override="custom-bundle-name"
+        )
+        self.assertEqual(result, overridden_component)
+
+    def test_find_component_in_shipment_falls_back_when_override_not_found(self):
+        """If the overridden bundle name isn't in the shipment, fall back to the default pattern."""
+        shipment = MagicMock()
+
+        default_component = MagicMock()
+        default_component.name = "nfd-operator-bundle"
+
+        shipment.shipment.snapshot.spec.components = [default_component]
+
+        result = self.rebaser._find_component_in_shipment(
+            shipment, "nfd-operator", bundle_name_override="custom-bundle-name"
+        )
+        self.assertEqual(result, default_component)
+
     @patch("doozerlib.backend.konflux_fbc._fetch_csv_from_git", new_callable=AsyncMock)
     async def test_extract_csv_info_from_bundle_success(self, mock_fetch_csv):
         """Test extracting CSV info from a bundle component."""

--- a/doozer/tests/cli/test_fbc.py
+++ b/doozer/tests/cli/test_fbc.py
@@ -67,6 +67,9 @@ class TestFbcRebaseAndBuildCli(unittest.IsolatedAsyncioTestCase):
         self.runtime.konflux_db = mock.AsyncMock()
         self.runtime.konflux_db.bind = mock.Mock()  # Mock the bind method
         self.runtime.record_logger = mock.Mock()
+        # Default to an empty map so get_bundle_build_for() falls back to the default
+        # "{name}-bundle" naming for tests that don't care about metadata lookups.
+        self.runtime.image_map = {}
 
         # Mock KonfluxDb class to return mock instances
         self.mock_db_for_bundles = mock.AsyncMock()
@@ -276,8 +279,18 @@ class TestFbcRebaseAndBuildCli(unittest.IsolatedAsyncioTestCase):
         self.runtime.konflux_db.get_build_records_by_nvrs.return_value = [operator_build1, operator_build2]
         self.runtime.images = ["test-operator-1", "test-operator-2"]
         self.runtime.image_map = {
-            "test-operator-1": mock.Mock(is_olm_operator=True, distgit_key="test-operator-1", name="test-operator-1"),
-            "test-operator-2": mock.Mock(is_olm_operator=True, distgit_key="test-operator-2", name="test-operator-2"),
+            "test-operator-1": mock.Mock(
+                is_olm_operator=True,
+                distgit_key="test-operator-1",
+                name="test-operator-1",
+                **{"get_olm_bundle_short_name.return_value": "test-operator-1-bundle"},
+            ),
+            "test-operator-2": mock.Mock(
+                is_olm_operator=True,
+                distgit_key="test-operator-2",
+                name="test-operator-2",
+                **{"get_olm_bundle_short_name.return_value": "test-operator-2-bundle"},
+            ),
         }
 
         async def mock_bundle_search(*args, **kwargs):
@@ -365,6 +378,29 @@ class TestFbcRebaseAndBuildCli(unittest.IsolatedAsyncioTestCase):
         result = await self.fbc_cli.get_bundle_build_for(operator_build, strict=False)
 
         self.assertIsNone(result)
+
+    async def test_get_bundle_build_for_uses_bundle_name_override(self):
+        """The lookup should use the operator's overridden bundle short name, not '{name}-bundle'."""
+        operator_build = self._create_mock_operator_build("test-operator", "test-operator-1.0.0-1")
+        bundle_build = self._create_mock_bundle_build(
+            "custom-bundle-name", "custom-bundle-name-1.0.0-1", "test-operator-1.0.0-1"
+        )
+        self.runtime.image_map = {
+            "test-operator": mock.Mock(**{"get_olm_bundle_short_name.return_value": "custom-bundle-name"}),
+        }
+
+        seen_where = {}
+
+        async def mock_bundle_search(*args, **kwargs):
+            seen_where.update(kwargs.get('where', {}))
+            yield bundle_build
+
+        self.mock_db_for_bundles.search_builds_by_fields = mock_bundle_search
+
+        result = await self.fbc_cli.get_bundle_build_for(operator_build)
+
+        self.assertEqual(result, bundle_build)
+        self.assertEqual(seen_where.get('name'), 'custom-bundle-name')
 
     @mock.patch("doozerlib.cli.fbc.KonfluxFbcRebaser.get_fbc_name")
     async def test_check_existing_fbc_build_found(self, mock_get_fbc_name):

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1208,6 +1208,40 @@ RUN echo "test"
             with self.assertRaises(IOError):
                 metadata.get_olm_bundle_delivery_repo_name()
 
+    def test_get_olm_bundle_short_name_no_override(self):
+        metadata = self._create_image_metadata('openshift/test')
+        mock_config = MagicMock()
+        mock_config.bundle_name_override = Missing
+        metadata.config = mock_config
+        with patch.object(type(metadata), 'is_olm_operator', new_callable=lambda: property(lambda self: True)):
+            result = metadata.get_olm_bundle_short_name()
+        self.assertEqual(result, 'my-distgit-bundle')
+
+    def test_get_olm_bundle_short_name_with_override(self):
+        metadata = self._create_image_metadata('openshift/test')
+        mock_config = MagicMock()
+        mock_config.bundle_name_override = 'acm-operator-bundle'
+        metadata.config = mock_config
+        with patch.object(type(metadata), 'is_olm_operator', new_callable=lambda: property(lambda self: True)):
+            result = metadata.get_olm_bundle_short_name()
+        self.assertEqual(result, 'acm-operator-bundle')
+
+    def test_get_olm_bundle_short_name_not_olm_operator_raises(self):
+        metadata = self._create_image_metadata('openshift/test')
+        with patch.object(type(metadata), 'is_olm_operator', new_callable=lambda: property(lambda self: False)):
+            with self.assertRaises(IOError):
+                metadata.get_olm_bundle_short_name()
+
+    def test_get_olm_bundle_image_name_with_override(self):
+        metadata = self._create_image_metadata('openshift/test')
+        mock_config = MagicMock()
+        mock_config.bundle_name_override = 'acm-operator-bundle'
+        metadata.config = mock_config
+        metadata.runtime.group_config.product = 'rhacm2'
+        with patch.object(type(metadata), 'is_olm_operator', new_callable=lambda: property(lambda self: True)):
+            result = metadata.get_olm_bundle_image_name()
+        self.assertEqual(result, 'rhacm2/acm-operator-bundle')
+
 
 class TestImageInspector(IsolatedAsyncioTestCase):
     @mock.patch("doozerlib.repos.Repo.get_repodata_threadsafe")

--- a/doozer/tests/test_olm_bundle.py
+++ b/doozer/tests/test_olm_bundle.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 
+from artcommonlib.model import Missing, Model
 from doozerlib.olm.bundle import OLMBundle
 from flexmock import flexmock
 
@@ -35,3 +36,33 @@ class TestOLMBundle(unittest.TestCase):
             )
         )
         self.assertEqual(olm.bundle_image_name, 'openshift/ose-foo-operator-bundle')
+
+    def _make_olm_bundle_with_runtime(self, name, config):
+        runtime = MagicMock()
+        image_meta = MagicMock()
+        image_meta.config = config
+        runtime.image_map = {name: image_meta}
+        return OLMBundle(
+            runtime=runtime,
+            operator_nvr_or_dict={
+                'nvr': f'{name}-1.0.0-1',
+                'source': f'https://pkgs.devel.redhat.com/git/containers/{name}'
+                '#d37b219bb1227aed06e32a995f74595f845bb981',
+            },
+            brew_session=MagicMock(),
+        )
+
+    def test_bundle_name_no_override(self):
+        name = 'foo-operator'
+        olm = self._make_olm_bundle_with_runtime(name, Model({}))
+        self.assertEqual(olm.bundle_name, 'foo-operator-bundle')
+
+    def test_bundle_name_with_override(self):
+        name = 'foo-operator'
+        olm = self._make_olm_bundle_with_runtime(name, Model({'bundle_name_override': 'custom-bundle-name'}))
+        self.assertEqual(olm.bundle_name, 'custom-bundle-name')
+
+    def test_bundle_name_override_missing_falls_back(self):
+        name = 'foo-operator'
+        olm = self._make_olm_bundle_with_runtime(name, Model({'bundle_name_override': Missing}))
+        self.assertEqual(olm.bundle_name, 'foo-operator-bundle')

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -694,6 +694,18 @@
       "$ref": "#/properties/name"
     },
     "name-": {},
+    "bundle_name_override": {
+      "description": "Override the default OLM bundle short name (normally '{distgit_key}-bundle'). Affects the Dockerfile name label, Konflux component name, and DB record name.",
+      "type": "string",
+      "minLength": 1
+    },
+    "bundle_name_override!": {
+      "$ref": "#/properties/bundle_name_override"
+    },
+    "bundle_name_override?": {
+      "$ref": "#/properties/bundle_name_override"
+    },
+    "bundle_name_override-": {},
     "odcs": {
       "description": "Configuration for an alternative, unused method for making rpms available to builds",
       "type": "object",

--- a/pyartcd/pyartcd/pipelines/build_conforma_verify.py
+++ b/pyartcd/pyartcd/pipelines/build_conforma_verify.py
@@ -260,10 +260,20 @@ class BuildConformaVerifyPipeline:
                 records_by_name[record.name] = record
         return list(records_by_name.values())
 
-    async def _find_operator_names(self) -> set[str]:
-        cmd = self._doozer_base_command + ['olm-bundle:list-olm-operators', '--output-format', 'distgit-key']
+    async def _find_operator_bundle_names(self) -> dict[str, str]:
+        """Returns a mapping of operator distgit_key -> bundle short name.
+
+        Uses doozer's "bundle-name" output format, which honors any per-image
+        `bundle_name_override` config rather than assuming '{operator_name}-bundle'.
+        """
+        cmd = self._doozer_base_command + ['olm-bundle:list-olm-operators', '--output-format', 'bundle-name']
         _, out, _ = await exectools.cmd_gather_async(cmd, stderr=None)
-        return set(out.strip().split('\n')) if out.strip() else set()
+        bundle_names_by_operator: dict[str, str] = {}
+        for line in out.strip().split('\n') if out.strip() else []:
+            distgit_key, _, bundle_name = line.partition('\t')
+            if distgit_key and bundle_name:
+                bundle_names_by_operator[distgit_key] = bundle_name
+        return bundle_names_by_operator
 
     async def _find_corresponding_builds(
         self, nvr_record_map: dict[str, KonfluxRecord], lookup_fbcs: bool = True
@@ -272,26 +282,30 @@ class BuildConformaVerifyPipeline:
 
         Returns (bundle_records, fbc_records). Set lookup_fbcs=False to skip FBC queries.
         """
-        operator_names = await self._find_operator_names()
-        if not operator_names:
+        bundle_names_by_operator = await self._find_operator_bundle_names()
+        if not bundle_names_by_operator:
             self.logger.warning("No operator names found")
             return [], []
 
-        self.logger.info("Found %d operator names, cross-referencing with image NVRs...", len(operator_names))
+        self.logger.info("Found %d operator names, cross-referencing with image NVRs...", len(bundle_names_by_operator))
 
         bundle_db = KonfluxDb()
         bundle_db.bind(KonfluxBundleBuildRecord)
 
         operator_nvrs = []
         for nvr, record in nvr_record_map.items():
-            if record.name in operator_names:
+            if record.name in bundle_names_by_operator:
                 operator_nvrs.append((record.name, nvr))
 
         self.logger.info("Found %d operator image builds to look up", len(operator_nvrs))
 
         bundle_records: list[KonfluxRecord] = []
+        # Bundle nvr -> operator distgit_key, so the FBC lookup below doesn't need to
+        # reverse-derive the operator name from the bundle name (which breaks under
+        # bundle_name_override).
+        operator_name_by_bundle_nvr: dict[str, str] = {}
         for operator_name, nvr in operator_nvrs:
-            bundle_name = f'{operator_name}-bundle'
+            bundle_name = bundle_names_by_operator[operator_name]
             bundle = await bundle_db.get_latest_build(
                 name=bundle_name,
                 group=self.group,
@@ -302,6 +316,7 @@ class BuildConformaVerifyPipeline:
             if bundle:
                 self.logger.info("  Found bundle for %s: %s", nvr, bundle.nvr)
                 bundle_records.append(bundle)
+                operator_name_by_bundle_nvr[bundle.nvr] = operator_name
             else:
                 self.logger.warning("  No bundle found for operator %s (%s)", operator_name, nvr)
 
@@ -310,7 +325,7 @@ class BuildConformaVerifyPipeline:
             fbc_db = KonfluxDb()
             fbc_db.bind(KonfluxFbcBuildRecord)
             for bundle in bundle_records:
-                operator_name = bundle.name.removesuffix('-bundle')
+                operator_name = operator_name_by_bundle_nvr[bundle.nvr]
                 fbc_name = f'{operator_name}-fbc'
                 async for fbc in fbc_db.search_builds_by_fields(
                     where={

--- a/pyartcd/pyartcd/pipelines/scan_operator.py
+++ b/pyartcd/pyartcd/pipelines/scan_operator.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import List, Optional, Set
+from typing import Dict, List, Optional, Set
 
 import click
 from artcommonlib import exectools, redis
@@ -55,6 +55,10 @@ class ScanOperatorPipeline:
         # Track operators needing builds
         self.operators_without_bundles = []
         self.operators_without_fbcs = []
+
+        # Populated by load_operator_names(): distgit_key -> bundle short name
+        # (honors any per-image `bundle_name_override` config)
+        self.bundle_names_by_operator: Dict[str, str] = {}
 
         # Build doozer base command for metadata loading
         group_param = f'{self.group}'
@@ -131,14 +135,23 @@ class ScanOperatorPipeline:
         """Load operator image names from ocp-build-data using doozer.
 
         Returns distgit keys (metadata names) like 'dpu-operator', not component names.
+
+        As a side effect, populates `self.bundle_names_by_operator` with each
+        operator's bundle short name (honoring any `bundle_name_override` config),
+        for use by `get_bundle_name()`.
         """
-        # Use doozer to list operator distgit keys)
-        cmd = self.doozer_base_command + ['olm-bundle:list-olm-operators', '--output-format', 'distgit-key']
+        # Use doozer to list operator distgit keys along with their bundle short names
+        # (tab-separated "{distgit_key}\t{bundle_short_name}" pairs).
+        cmd = self.doozer_base_command + ['olm-bundle:list-olm-operators', '--output-format', 'bundle-name']
 
         _, out, _ = await exectools.cmd_gather_async(cmd, stderr=None)
-        operator_names = set(out.strip().split('\n')) if out.strip() else set()
+        self.bundle_names_by_operator = {}
+        for line in out.strip().split('\n') if out.strip() else []:
+            distgit_key, _, bundle_name = line.partition('\t')
+            if distgit_key and bundle_name:
+                self.bundle_names_by_operator[distgit_key] = bundle_name
 
-        return operator_names
+        return set(self.bundle_names_by_operator.keys())
 
     async def get_latest_operator_builds(self, operator_names: Set[str]) -> List[KonfluxBuildRecord]:
         """Get the latest successful build for each operator."""
@@ -301,9 +314,12 @@ class ScanOperatorPipeline:
 
     def get_bundle_name(self, operator_name: str) -> str:
         """Get bundle name from operator name.
-        Bundle names append -bundle suffix (e.g., 'dpu-operator-bundle').
+
+        Uses the bundle short name resolved by `load_operator_names()`, which honors
+        any `bundle_name_override` config. Falls back to the default '{operator_name}-bundle'
+        pattern if the operator wasn't found in that mapping (e.g., in tests).
         """
-        return f'{operator_name}-bundle'
+        return self.bundle_names_by_operator.get(operator_name, f'{operator_name}-bundle')
 
     def get_fbc_name(self, operator_name: str) -> str:
         """Get FBC name from operator name.


### PR DESCRIPTION
## Summary

Adds a top-level `bundle_name_override` field to `ocp-build-data` image config, allowing an operator's OLM bundle short name to differ from the default `{distgit_key}-bundle` derivation. This is useful when an operator's bundle needs a name that doesn't follow the standard convention (e.g. to match an existing delivery/component name).

- Added `bundle_name_override` (+ assembly override variants `!`, `?`, `-`) to the `image_config.base.schema.json` schema.
- `ImageMetadata.get_olm_bundle_short_name()` now returns the override when set, falling back to `{distgit_key}-bundle` otherwise.
- Updated all downstream consumers to go through this method instead of re-deriving the name themselves:
  - Legacy `OLMBundle.bundle_name` (Brew path)
  - `doozer/doozerlib/cli/fbc.py` and `cli/images_konflux.py` bundle build lookups
  - `KonfluxFbcRebaser._find_component_in_shipment` (tries the override before the default `{name}-bundle` pattern)
- Extended the `doozer olm-bundle:list-olm-operators` CLI with a new `--output-format=bundle-name` mode (emits `{distgit_key}\t{bundle_short_name}` pairs) so pyartcd pipelines (which shell out to doozer rather than importing it) can resolve the correct bundle name without duplicating the derivation logic.
- Updated `pyartcd/pipelines/scan_operator.py` and `build_conforma_verify.py` to use that mapping instead of hardcoding `{name}-bundle`, and to track operator name via the query result rather than reverse-deriving it from the bundle name with `removesuffix('-bundle')` (which breaks under an override).

Alongside https://github.com/openshift-eng/ocp-build-data/pull/12079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring custom OLM bundle names through image metadata.
  * Bundle discovery, component matching, and build verification now honor custom names while retaining fallback naming.
  * Added a `bundle-name` output format to the OLM operator listing command.
  * Bundle names are derived from operator metadata when available.

* **Bug Fixes**
  * Improved matching for operators with non-standard bundle names.
  * Corrected the product key name for Multicluster Engine.

* **Documentation**
  * Documented bundle-name configuration and validation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->