### PR TITLE
ART-21810: Add binary-release-konflux pipeline for standalone CDN binary products

### DIFF
--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -4,6 +4,7 @@ from pyartcd.cli import cli
 from pyartcd.pipelines import (
     advisory_drop,
     art_notify,
+    binary_release_konflux,
     brew_scan_osh,
     build_conforma_verify,
     build_fbc,
@@ -63,6 +64,7 @@ from pyartcd.pipelines.scheduled import (
 __all__ = [
     "advisory_drop",
     "art_notify",
+    "binary_release_konflux",
     "brew_scan_osh",
     "build_conforma_verify",
     "build_fbc",

--- a/pyartcd/pyartcd/pipelines/__init__.py
+++ b/pyartcd/pyartcd/pipelines/__init__.py
@@ -5,6 +5,7 @@ Pipeline modules for pyartcd.
 from . import (
     advisory_drop,
     art_notify,
+    binary_release_konflux,
     brew_scan_osh,
     build_fbc,
     build_layered_products,
@@ -53,6 +54,7 @@ from . import (
 __all__ = [
     'advisory_drop',
     'art_notify',
+    'binary_release_konflux',
     'brew_scan_osh',
     'build_fbc',
     'build_merged_fbc',

--- a/pyartcd/pyartcd/pipelines/binary_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/binary_release_konflux.py
@@ -1,0 +1,582 @@
+import asyncio
+import logging
+import os
+import shutil
+import tempfile
+from datetime import datetime, timezone
+from functools import cached_property
+from io import StringIO
+from pathlib import Path
+from typing import List, Optional
+from urllib.parse import urlparse
+
+import click
+import yaml as stdlib_yaml
+from artcommonlib import exectools
+from artcommonlib.build_visibility import is_nvr_embargoed
+from artcommonlib.constants import SHIPMENT_DATA_URL_TEMPLATE
+from artcommonlib.gitlab import GitLabClient
+from artcommonlib.util import new_roundtrip_yaml_handler
+from elliottlib.shipment_model import (
+    Environments,
+    Metadata,
+    Shipment,
+    ShipmentConfig,
+    ShipmentEnv,
+    Snapshot,
+    SnapshotSpec,
+)
+
+from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.click_validators import validate_release_date
+from pyartcd.git import GitRepository
+from pyartcd.runtime import Runtime
+
+yaml = new_roundtrip_yaml_handler()
+
+
+class BinaryReleaseKonfluxPipeline:
+    """
+    Pipeline for shipping standalone CDN binary products (e.g. oc-mirror) built via Konflux.
+
+    Unlike PrepareReleaseKonfluxPipeline (OCP payload) or ReleaseFromFbcPipeline (layered
+    products/FBC), this pipeline is for products released directly to the Customer Portal
+    Content Gateway via the `push-artifacts-to-cdn` Konflux pipeline. It takes a set of
+    already-built NVR(s), resolves them to a Konflux snapshot, and opens a shipment MR
+    referencing the product's CDN stage/prod ReleasePlans (defined in konflux-release-data
+    and ocp-shipment-data's config.yaml).
+
+    No release notes/advisory data is generated here: CDN ReleasePlanAdmissions carry their
+    own static release notes (product_id, synopsis, etc.) in konflux-release-data.
+    """
+
+    def __init__(
+        self,
+        runtime: Runtime,
+        group: str,
+        assembly: str,
+        nvrs: List[str],
+        create_mr: bool = False,
+        shipment_data_repo_url: Optional[str] = None,
+        target_release_date: Optional[str] = None,
+    ) -> None:
+        self.logger = logging.getLogger(__name__)
+        self.runtime = runtime
+        self.group = group
+        self.assembly = assembly
+        self.nvrs = nvrs
+        self.create_mr = create_mr
+        self.dry_run = self.runtime.dry_run
+        self.target_release_date = target_release_date
+
+        # Setup working directories
+        self.working_dir = self.runtime.working_dir.absolute()
+        self.elliott_working_dir = self.working_dir / "elliott-working"
+        self.doozer_working_dir = self.working_dir / "doozer-working"
+        self._shipment_data_repo_dir = self.working_dir / "shipment-data-push"
+
+        # Shipment repository configuration
+        self.gitlab_url = self.runtime.config.get("gitlab_url", "https://gitlab.cee.redhat.com")
+        self.gitlab_token = None
+        self.shipment_mr_url = None
+        self.job_url = None
+
+        # Product configuration - initialized to None, will be loaded from group config in run()
+        self.product = None
+
+        shipment_data_repo_pull_url = shipment_data_repo_url or SHIPMENT_DATA_URL_TEMPLATE
+        shipment_data_repo_push_url = shipment_data_repo_url or SHIPMENT_DATA_URL_TEMPLATE
+        self.shipment_data_repo_pull_url = shipment_data_repo_pull_url
+        self.shipment_data_repo_push_url = shipment_data_repo_push_url
+        # GitRepository expects a local filesystem path, not a URL
+        self.shipment_data_repo = GitRepository(self._shipment_data_repo_dir, self.dry_run)
+
+        # Base elliott command template
+        self._elliott_base_command = [
+            'elliott',
+            f'--group={group}',
+            f'--assembly={assembly}',
+            '--build-system=konflux',
+            f'--working-dir={self.elliott_working_dir}',
+        ]
+
+    @staticmethod
+    def basic_auth_url(url: str, token: str) -> str:
+        """
+        Create a basic auth URL with the given token.
+        """
+        parsed_url = urlparse(url)
+        scheme = parsed_url.scheme or "https"
+        netloc = parsed_url.netloc
+        path = parsed_url.path
+        params = parsed_url.params
+        query = parsed_url.query
+        fragment = parsed_url.fragment
+
+        url_parts = [path]
+        if params:
+            url_parts.append(f";{params}")
+        if query:
+            url_parts.append(f"?{query}")
+        if fragment:
+            url_parts.append(f"#{fragment}")
+
+        rest_of_url = "".join(url_parts)
+        return f'{scheme}://oauth2:{token}@{netloc}{rest_of_url}'
+
+    @cached_property
+    def _gitlab(self) -> GitLabClient:
+        """
+        Get authenticated GitLab instance.
+        """
+        return GitLabClient(self.gitlab_url, self.gitlab_token, self.dry_run)
+
+    def _get_gitlab_project(self, url: str):
+        """
+        Get GitLab project from URL.
+        """
+        parsed_url = urlparse(url)
+        project_path = parsed_url.path.strip('/').removesuffix('.git')
+        return self._gitlab.get_project(project_path)
+
+    def check_env_vars(self):
+        """
+        Check required environment variables for MR creation.
+        """
+        if not self.create_mr:
+            return
+
+        gitlab_token = os.getenv("GITLAB_TOKEN")
+        if not gitlab_token:
+            raise ValueError("GITLAB_TOKEN environment variable is required to create a merge request")
+        self.gitlab_token = gitlab_token
+
+        self.job_url = os.getenv('BUILD_URL')
+
+    def setup_working_dir(self):
+        """
+        Setup working directories, cleaning up any existing ones.
+        """
+        self.working_dir.mkdir(parents=True, exist_ok=True)
+        if self.elliott_working_dir.exists():
+            shutil.rmtree(self.elliott_working_dir, ignore_errors=True)
+        if self.doozer_working_dir.exists():
+            shutil.rmtree(self.doozer_working_dir, ignore_errors=True)
+        if self.create_mr and self._shipment_data_repo_dir.exists():
+            shutil.rmtree(self._shipment_data_repo_dir, ignore_errors=True)
+
+    async def setup_shipment_repo(self):
+        """
+        Setup shipment data repository for MR creation.
+        """
+        if not self.create_mr:
+            return
+
+        await self.shipment_data_repo.setup(
+            remote_url=self.basic_auth_url(self.shipment_data_repo_push_url, self.gitlab_token),
+            upstream_remote_url=self.shipment_data_repo_pull_url,
+        )
+        await self.shipment_data_repo.fetch_switch_branch("main")
+
+    async def _load_product_from_group_config(self) -> str:
+        """
+        Load the product field from group configuration using doozer command.
+        Falls back to extracting from group name if not found.
+        """
+        try:
+            doozer_cmd = ['doozer', f'--group={self.group}', 'config:read-group', 'product']
+
+            _, product_output, _ = await exectools.cmd_gather_async(doozer_cmd)
+            product = product_output.strip()
+
+            if product and product != 'None' and product != 'null':
+                self.logger.info(f"Loaded product from group config: {product}")
+                return product
+            else:
+                self.logger.debug("No product field found in group config, falling back to group name extraction")
+
+        except Exception as e:
+            self.logger.warning(f"Failed to load product from group config: {e}")
+
+        # Fallback: extract product from group name (e.g., "oc-mirror-2.0" -> "oc-mirror")
+        product = self.group.rsplit('-', 1)[0]
+        self.logger.info(f"Using product extracted from group name: {product}")
+        return product
+
+    async def _load_mr_approvers_from_group_config(self) -> dict[str, list[str]]:
+        """
+        Load the mr_approvers field from group configuration using doozer command.
+        Returns a dict mapping approval group names to lists of GitLab usernames.
+        Returns empty dict if not configured.
+        """
+        try:
+            cmd = [
+                'doozer',
+                f'--group={self.group}',
+                f'--working-dir={self.doozer_working_dir}',
+                'config:read-group',
+                'mr_approvers',
+            ]
+            _, output, _ = await exectools.cmd_gather_async(cmd)
+            output = output.strip()
+            if output and output not in ('None', 'null'):
+                parsed = stdlib_yaml.safe_load(output)
+                if not isinstance(parsed, dict):
+                    self.logger.warning("mr_approvers is not a dict (got %s), ignoring", type(parsed).__name__)
+                    return {}
+                return parsed
+        except Exception as e:
+            self.logger.warning(f"Failed to load mr_approvers from group config: {e}")
+        return {}
+
+    async def create_snapshot(self, builds: List[str]) -> Optional[Snapshot]:
+        """
+        Create a snapshot from a list of build NVRs using elliott.
+        """
+        if not builds:
+            self.logger.debug("No builds provided, skipping snapshot creation")
+            return None
+
+        self.logger.info(f"Creating Konflux snapshot for {len(builds)} builds...")
+
+        with tempfile.NamedTemporaryFile(delete=False, mode='w') as temp_file:
+            for nvr in builds:
+                temp_file.write(nvr + '\n')
+            temp_file.flush()
+            temp_file_path = temp_file.name
+
+        snapshot_cmd = self._elliott_base_command + [
+            "snapshot",
+            "new",
+            f"--builds-file={temp_file_path}",
+        ]
+
+        quay_auth_file = os.getenv("QUAY_AUTH_FILE")
+        if quay_auth_file:
+            snapshot_cmd.append(f"--pull-secret={quay_auth_file}")
+
+        try:
+            self.logger.info(f"Running elliott snapshot command: {' '.join(snapshot_cmd)}")
+            stdout, _ = exectools.cmd_assert(snapshot_cmd)
+        except Exception as e:
+            self.logger.exception(f"Failed to create snapshot: {e}")
+            raise
+        finally:
+            os.unlink(temp_file_path)
+
+        try:
+            new_snapshot_obj = yaml.load(stdout)
+            self.logger.info("✓ Successfully created Konflux snapshot")
+            return Snapshot(spec=SnapshotSpec(**new_snapshot_obj.get("spec")), nvrs=sorted(builds))
+        except Exception as e:
+            self.logger.exception(f"Failed to parse elliott snapshot output: {e}")
+            self.logger.debug(f"Raw output was: {stdout}")
+            raise
+
+    def create_shipment_config(self, snapshot: Snapshot) -> ShipmentConfig:
+        """
+        Create a shipment configuration (kind "image") for the given snapshot, reading
+        the stage/prod releasePlan names for the snapshot's application from config.yaml
+        in the shipment data repo.
+        """
+        if self.product is None:
+            raise RuntimeError(
+                "Product is not initialized. Please call run() first to load the product from group "
+                "configuration, or ensure self.product is set before calling create_shipment_config()."
+            )
+
+        application = snapshot.spec.application
+        self.logger.info(f"Creating shipment config for application '{application}'...")
+
+        metadata = Metadata(
+            product=self.product,
+            application=application,
+            group=self.group,
+            assembly=self.assembly,
+            fbc=False,
+        )
+
+        stage_rpa = "n/a"
+        prod_rpa = "n/a"
+        try:
+            config_path = self.shipment_data_repo._directory / "config.yaml"
+            if config_path.exists():
+                with open(config_path, 'r') as f:
+                    shipment_config = stdlib_yaml.safe_load(f) or {}
+                app_env_config = shipment_config.get("applications", {}).get(application, {}).get("environments", {})
+                stage_rpa = app_env_config.get("stage", {}).get("releasePlan", "n/a")
+                prod_rpa = app_env_config.get("prod", {}).get("releasePlan", "n/a")
+        except Exception as e:
+            self.logger.warning(f"Failed to read shipment config, using defaults: {e}")
+
+        if stage_rpa == "n/a" or prod_rpa == "n/a":
+            self.logger.warning(
+                f"Could not resolve stage/prod releasePlan for application '{application}' from config.yaml. "
+                "Please ensure it is registered there before merging the resulting MR."
+            )
+
+        environments = Environments(stage=ShipmentEnv(releasePlan=stage_rpa), prod=ShipmentEnv(releasePlan=prod_rpa))
+
+        # CDN ReleasePlanAdmissions carry their own static release notes (product_id, synopsis,
+        # etc. in konflux-release-data), so no data.releaseNotes is generated here.
+        shipment = Shipment(metadata=metadata, environments=environments, snapshot=snapshot, data=None)
+
+        return ShipmentConfig(shipment=shipment)
+
+    async def create_shipment_mr(self, shipment_config: ShipmentConfig) -> str:
+        """
+        Create a new shipment MR with the given shipment config file.
+        """
+        if not self.create_mr:
+            return ""
+
+        self.logger.info("Creating shipment MR...")
+
+        timestamp = datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
+        source_branch = f"binary-release-{self.assembly}-{timestamp}"
+        target_branch = "main"
+
+        await self.shipment_data_repo.create_branch(source_branch)
+
+        commit_message = f"Add shipment configuration for {self.product} {self.assembly}"
+        updated = await self.update_shipment_data(shipment_config, "prod", commit_message, timestamp)
+        if not updated:
+            raise ValueError("Failed to update shipment data repo. Please investigate.")
+
+        source_project = self._get_gitlab_project(self.shipment_data_repo_push_url)
+        target_project = self._get_gitlab_project(self.shipment_data_repo_pull_url)
+
+        if self.target_release_date:
+            mr_title = f"Draft: Shipment for {self.product} {self.assembly} (ship date: {self.target_release_date})"
+        else:
+            mr_title = f"Draft: Shipment for {self.product} {self.assembly}"
+        mr_description = f"Created by job: {self.job_url}\n\n" if self.job_url else ""
+        mr_description += f"Shipment file created for {self.assembly} using binary-release-konflux command"
+
+        if self.dry_run:
+            self.logger.info("[DRY-RUN] Would have created MR with title: %s", mr_title)
+            mr_url = f"{self.gitlab_url}/placeholder/placeholder/-/merge_requests/placeholder"
+        else:
+            mr = source_project.mergerequests.create(
+                {
+                    'source_branch': source_branch,
+                    'target_project_id': target_project.id,
+                    'target_branch': target_branch,
+                    'title': mr_title,
+                    'description': mr_description,
+                    'remove_source_branch': True,
+                }
+            )
+            mr_url = mr.web_url
+            self.logger.info("Created Merge Request: %s", mr_url)
+
+        approvers_config = await self._load_mr_approvers_from_group_config()
+        if approvers_config:
+            if self.dry_run:
+                self.logger.info("[DRY-RUN] Would set MR approval rules: %s", approvers_config)
+            else:
+                try:
+                    await self._gitlab.set_mr_approval_rules(mr_url, approvers_config)
+                except Exception as e:
+                    self.logger.warning(f"Failed to set MR approval rules: {e}")
+
+        self.shipment_mr_url = mr_url
+        return mr_url
+
+    async def set_shipment_mr_ready(self):
+        """
+        Mark the shipment MR as ready by removing the Draft prefix from the title.
+        """
+        mr = await self._gitlab.set_mr_ready(self.shipment_mr_url)
+
+        if mr and not self.dry_run:
+            self.logger.info("Waiting for 30 seconds to ensure MR is updated...")
+            await asyncio.sleep(30)
+
+            try:
+                pipeline_url = await self._gitlab.trigger_ci_pipeline(mr)
+                if pipeline_url:
+                    self.logger.info(f"CI pipeline triggered: {pipeline_url}")
+                else:
+                    self.logger.warning(f"Failed to trigger CI pipeline for MR branch {mr.source_branch}")
+            except Exception as e:
+                self.logger.warning(f"Failed to trigger CI MR pipeline for branch {mr.source_branch}: {e}")
+
+    async def update_shipment_data(
+        self, shipment_config: ShipmentConfig, env: str, commit_message: str, timestamp: str
+    ) -> bool:
+        """
+        Update shipment data repo with the given shipment config file.
+        """
+        if not self.create_mr:
+            return False
+
+        filepath = await self._write_shipment_file(shipment_config, env, timestamp)
+        self.logger.info("Updating shipment file: %s", filepath)
+
+        await self.shipment_data_repo.add_all()
+        await self.shipment_data_repo.log_diff()
+        return await self.shipment_data_repo.commit_push(commit_message, safe=True)
+
+    async def _write_shipment_file(self, shipment_config: ShipmentConfig, env: str, timestamp: str) -> str:
+        """
+        Write the shipment file to disk under the standard shipment path convention:
+        shipment/{product}/{group}/{application}/{env}/{assembly}.image.{timestamp}.yaml
+        """
+        filename = f"{self.assembly}.image.{timestamp}.yaml"
+
+        product = shipment_config.shipment.metadata.product
+        group = shipment_config.shipment.metadata.group
+        application = shipment_config.shipment.metadata.application
+        relative_target_dir = Path("shipment") / product / group / application / env
+        target_dir = self.shipment_data_repo._directory / relative_target_dir
+        target_dir.mkdir(parents=True, exist_ok=True)
+        filepath = relative_target_dir / filename
+
+        shipment_dump = shipment_config.model_dump(exclude_unset=True, exclude_none=True)
+        out = StringIO()
+        yaml.dump(shipment_dump, out)
+        await self.shipment_data_repo.write_file(filepath, out.getvalue())
+
+        return str(filepath)
+
+    async def write_shipment_file_locally(self, shipment_config: ShipmentConfig, env: str, timestamp: str):
+        """
+        Write the shipment file to the local repository without creating an MR.
+        """
+        filepath = await self._write_shipment_file(shipment_config, env, timestamp)
+        self.logger.info(f"Created shipment file: {filepath}")
+
+    async def run(self) -> None:
+        """
+        Execute the binary release workflow: resolve NVR(s) to a Konflux snapshot, build a
+        shipment config referencing the product's CDN releasePlans, and optionally open a
+        shipment MR.
+        """
+        self.logger.info(f"Starting binary release workflow for {self.group} {self.assembly}")
+        self.logger.info(f"Processing {len(self.nvrs)} NVR(s): {self.nvrs}")
+
+        self.check_env_vars()
+        self.setup_working_dir()
+        if self.create_mr:
+            await self.setup_shipment_repo()
+
+        self.product = await self._load_product_from_group_config()
+        self.logger.info(f"Loaded product '{self.product}' - continuing workflow for {self.product} {self.assembly}")
+
+        # Refuse to release embargoed (private-fix) NVRs to a public CDN.
+        try:
+            embargoed_nvrs = [nvr for nvr in self.nvrs if is_nvr_embargoed(nvr)]
+        except ValueError as e:
+            raise RuntimeError(f"Refusing to create a release: unable to determine embargo status: {e}") from e
+        if embargoed_nvrs:
+            raise RuntimeError(
+                f"Refusing to create a release referencing embargoed (private-fix) NVR(s): {embargoed_nvrs}"
+            )
+
+        snapshot = await self.create_snapshot(self.nvrs)
+        if not snapshot:
+            raise RuntimeError("No snapshot could be created from the provided NVR(s)")
+
+        shipment_config = self.create_shipment_config(snapshot)
+
+        timestamp = datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
+        if not self.create_mr:
+            await self.write_shipment_file_locally(shipment_config, "prod", timestamp)
+        else:
+            try:
+                mr_url = await self.create_shipment_mr(shipment_config)
+                if mr_url:
+                    self.logger.info(f"Created shipment MR: {mr_url}")
+                    await self.set_shipment_mr_ready()
+            except Exception as e:
+                self.logger.exception(f"Failed to create MR: {e}")
+                if not self.dry_run:
+                    self.logger.info("Continuing with local files only")
+
+        completion_msg = f"Binary release workflow completed for {self.product} {self.assembly}."
+        if self.shipment_mr_url:
+            completion_msg += f" MR: {self.shipment_mr_url}"
+        self.logger.info(completion_msg)
+
+
+@cli.command("binary-release-konflux")
+@click.option(
+    "-g",
+    "--group",
+    metavar='NAME',
+    required=True,
+    help="The ocp-build-data group to operate on, e.g. oc-mirror-2.0",
+)
+@click.option(
+    "--assembly",
+    metavar="ASSEMBLY_NAME",
+    required=True,
+    help="The assembly to operate on, e.g. stream",
+)
+@click.option(
+    "--nvrs",
+    metavar="NVRS",
+    required=True,
+    help="Comma-separated list of build NVR(s) to release, "
+    "e.g. oc-mirror-container-2.0-202607291654.p2.g90b54b1.assembly.stream.el9",
+)
+@click.option(
+    "--create-mr",
+    is_flag=True,
+    help="Create a merge request in the shipment data repository (requires GITLAB_TOKEN environment variable)",
+)
+@click.option(
+    '--shipment-data-repo-url',
+    help='Shipment data repository URL for MR creation. If not provided, will use default based on configuration.',
+)
+@click.option(
+    '--target-release-date',
+    default=None,
+    callback=validate_release_date,
+    help='Target ship date for the release (e.g., 2026-Mar-31 or 2026-03-31). '
+    'When provided, the date is included in the shipment MR title.',
+)
+@pass_runtime
+@click_coroutine
+async def binary_release_konflux(
+    runtime: Runtime,
+    group: str,
+    assembly: str,
+    nvrs: str,
+    create_mr: bool,
+    shipment_data_repo_url: Optional[str],
+    target_release_date: Optional[str],
+):
+    """
+    Create a shipment for a standalone CDN binary product built via Konflux.
+
+    This command resolves the given build NVR(s) into a Konflux snapshot and creates a
+    shipment file referencing the product's CDN stage/prod ReleasePlans (as configured in
+    ocp-shipment-data's config.yaml). Unlike release-from-fbc or prepare-release-konflux,
+    no advisory/release-notes data is generated - the CDN ReleasePlanAdmission already
+    carries static release notes.
+
+    \b
+    # oc-mirror 2.0 binary release:
+    $ artcd binary-release-konflux \\
+        --group oc-mirror-2.0 \\
+        --assembly stream \\
+        --nvrs oc-mirror-container-2.0-202607291654.p2.g90b54b1.assembly.stream.el9 \\
+        --create-mr
+    """
+    nvrs_list = [nvr.strip() for nvr in nvrs.split(',') if nvr.strip()]
+    if not nvrs_list:
+        raise click.ClickException("--nvrs must contain at least one valid NVR")
+
+    pipeline = BinaryReleaseKonfluxPipeline(
+        runtime=runtime,
+        group=group,
+        assembly=assembly,
+        nvrs=nvrs_list,
+        create_mr=create_mr,
+        shipment_data_repo_url=shipment_data_repo_url,
+        target_release_date=target_release_date,
+    )
+
+    await pipeline.run()

--- a/pyartcd/pyartcd/pipelines/binary_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/binary_release_konflux.py
@@ -257,7 +257,7 @@ class BinaryReleaseKonfluxPipeline:
 
         try:
             self.logger.info(f"Running elliott snapshot command: {' '.join(snapshot_cmd)}")
-            stdout, _ = exectools.cmd_assert(snapshot_cmd)
+            _, stdout, _ = await exectools.cmd_gather_async(snapshot_cmd)
         except Exception as e:
             self.logger.exception(f"Failed to create snapshot: {e}")
             raise
@@ -298,18 +298,20 @@ class BinaryReleaseKonfluxPipeline:
 
         stage_rpa = "n/a"
         prod_rpa = "n/a"
-        try:
-            config_path = self.shipment_data_repo._directory / "config.yaml"
-            if config_path.exists():
-                with open(config_path, 'r') as f:
-                    shipment_config = stdlib_yaml.safe_load(f) or {}
-                app_env_config = shipment_config.get("applications", {}).get(application, {}).get("environments", {})
-                stage_rpa = app_env_config.get("stage", {}).get("releasePlan", "n/a")
-                prod_rpa = app_env_config.get("prod", {}).get("releasePlan", "n/a")
-        except Exception as e:
-            self.logger.warning(f"Failed to read shipment config, using defaults: {e}")
+        config_path = self.shipment_data_repo._directory / "config.yaml"
+        if config_path.exists():
+            with open(config_path, 'r') as f:
+                shipment_config = stdlib_yaml.safe_load(f) or {}
+            app_env_config = shipment_config.get("applications", {}).get(application, {}).get("environments", {})
+            stage_rpa = app_env_config.get("stage", {}).get("releasePlan", "n/a")
+            prod_rpa = app_env_config.get("prod", {}).get("releasePlan", "n/a")
 
         if stage_rpa == "n/a" or prod_rpa == "n/a":
+            if self.create_mr:
+                raise ValueError(
+                    f"stage/prod releasePlan is not registered for application '{application}' in {config_path}. "
+                    "Cannot create a shipment MR with unresolved ReleasePlans."
+                )
             self.logger.warning(
                 f"Could not resolve stage/prod releasePlan for application '{application}' from config.yaml. "
                 "Please ensure it is registered there before merging the resulting MR."
@@ -484,15 +486,10 @@ class BinaryReleaseKonfluxPipeline:
         if not self.create_mr:
             await self.write_shipment_file_locally(shipment_config, "prod", timestamp)
         else:
-            try:
-                mr_url = await self.create_shipment_mr(shipment_config)
-                if mr_url:
-                    self.logger.info(f"Created shipment MR: {mr_url}")
-                    await self.set_shipment_mr_ready()
-            except Exception as e:
-                self.logger.exception(f"Failed to create MR: {e}")
-                if not self.dry_run:
-                    self.logger.info("Continuing with local files only")
+            mr_url = await self.create_shipment_mr(shipment_config)
+            if mr_url:
+                self.logger.info(f"Created shipment MR: {mr_url}")
+                await self.set_shipment_mr_ready()
 
         completion_msg = f"Binary release workflow completed for {self.product} {self.assembly}."
         if self.shipment_mr_url:

--- a/pyartcd/tests/pipelines/test_binary_release_konflux.py
+++ b/pyartcd/tests/pipelines/test_binary_release_konflux.py
@@ -1,0 +1,365 @@
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import click
+from elliottlib.shipment_model import ComponentSource, GitSource, Snapshot, SnapshotComponent, SnapshotSpec
+from pyartcd.pipelines.binary_release_konflux import BinaryReleaseKonfluxPipeline
+
+
+def _make_snapshot(app="oc-mirror-2-0"):
+    return Snapshot(
+        spec=SnapshotSpec(
+            application=app,
+            components=[
+                SnapshotComponent(
+                    name="oc-mirror-2-0-oc-mirror",
+                    containerImage="quay.io/test/image@sha256:abc",
+                    source=ComponentSource(git=GitSource(url="https://github.com/test/repo", revision="abc123")),
+                )
+            ],
+        ),
+        nvrs=["oc-mirror-container-2.0-202607291654.p2.g90b54b1.assembly.stream.el9"],
+    )
+
+
+class TestBinaryReleaseKonfluxPipeline(unittest.TestCase):
+    def _make_pipeline(self, nvrs=None, create_mr=False, dry_run=False):
+        runtime = MagicMock()
+        runtime.dry_run = dry_run
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        runtime.config = {}
+
+        pipeline = BinaryReleaseKonfluxPipeline(
+            runtime=runtime,
+            group="oc-mirror-2.0",
+            assembly="stream",
+            nvrs=nvrs or ["oc-mirror-container-2.0-202607291654.p2.g90b54b1.assembly.stream.el9"],
+            create_mr=create_mr,
+        )
+        pipeline.product = "oc-mirror"
+        return pipeline
+
+    def test_nvrs_stored(self):
+        pipeline = self._make_pipeline(nvrs=["foo-container-1.0-1.el9"])
+        self.assertEqual(pipeline.nvrs, ["foo-container-1.0-1.el9"])
+
+    def test_target_release_date_defaults_to_none(self):
+        pipeline = self._make_pipeline()
+        self.assertIsNone(pipeline.target_release_date)
+
+    def test_create_shipment_config_raises_without_product(self):
+        """create_shipment_config should raise if self.product was never set (run() not called)."""
+        pipeline = self._make_pipeline()
+        pipeline.product = None
+        snapshot = _make_snapshot()
+
+        with self.assertRaises(RuntimeError):
+            pipeline.create_shipment_config(snapshot)
+
+    def test_create_shipment_config_never_has_release_notes(self):
+        """CDN RPAs carry their own static release notes, so shipment.data must always be None."""
+        pipeline = self._make_pipeline()
+        snapshot = _make_snapshot()
+
+        config = pipeline.create_shipment_config(snapshot)
+
+        self.assertIsNone(config.shipment.data)
+
+    def test_create_shipment_config_metadata_fields(self):
+        pipeline = self._make_pipeline()
+        snapshot = _make_snapshot()
+
+        config = pipeline.create_shipment_config(snapshot)
+
+        self.assertEqual(config.shipment.metadata.product, "oc-mirror")
+        self.assertEqual(config.shipment.metadata.application, "oc-mirror-2-0")
+        self.assertEqual(config.shipment.metadata.group, "oc-mirror-2.0")
+        self.assertEqual(config.shipment.metadata.assembly, "stream")
+        self.assertFalse(config.shipment.metadata.fbc)
+
+    def test_create_shipment_config_reads_release_plans_from_config_yaml(self):
+        """Should read stage/prod releasePlan for the snapshot's application from config.yaml
+        in the shipment data repo checkout."""
+        pipeline = self._make_pipeline()
+        snapshot = _make_snapshot()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pipeline.shipment_data_repo._directory = Path(tmpdir)
+            config_path = Path(tmpdir) / "config.yaml"
+            config_path.write_text(
+                "applications:\n"
+                "  oc-mirror-2-0:\n"
+                "    environments:\n"
+                "      stage:\n"
+                "        releasePlan: oc-mirror-cdn-stage\n"
+                "      prod:\n"
+                "        releasePlan: oc-mirror-cdn-prod\n"
+            )
+
+            config = pipeline.create_shipment_config(snapshot)
+
+        self.assertEqual(config.shipment.environments.stage.releasePlan, "oc-mirror-cdn-stage")
+        self.assertEqual(config.shipment.environments.prod.releasePlan, "oc-mirror-cdn-prod")
+
+    def test_create_shipment_config_missing_config_defaults_to_na(self):
+        """When config.yaml doesn't exist (or has no entry for the app), fall back to 'n/a'."""
+        pipeline = self._make_pipeline()
+        snapshot = _make_snapshot()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pipeline.shipment_data_repo._directory = Path(tmpdir)
+
+            config = pipeline.create_shipment_config(snapshot)
+
+        self.assertEqual(config.shipment.environments.stage.releasePlan, "n/a")
+        self.assertEqual(config.shipment.environments.prod.releasePlan, "n/a")
+
+    def test_create_shipment_config_uses_snapshot_application(self):
+        """metadata.application is derived directly from the snapshot's application."""
+        pipeline = self._make_pipeline()
+        snapshot = _make_snapshot(app="some-other-app")
+
+        config = pipeline.create_shipment_config(snapshot)
+
+        self.assertEqual(config.shipment.metadata.application, "some-other-app")
+        self.assertEqual(config.shipment.snapshot.spec.application, "some-other-app")
+
+
+class TestLoadProductFromGroupConfig(unittest.TestCase):
+    def _make_pipeline(self):
+        runtime = MagicMock()
+        runtime.dry_run = False
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        runtime.config = {}
+
+        return BinaryReleaseKonfluxPipeline(
+            runtime=runtime,
+            group="oc-mirror-2.0",
+            assembly="stream",
+            nvrs=["oc-mirror-container-2.0-1-1.el9"],
+        )
+
+    @patch("pyartcd.pipelines.binary_release_konflux.exectools.cmd_gather_async")
+    def test_loads_product_from_doozer(self, mock_cmd_gather_async):
+        pipeline = self._make_pipeline()
+        mock_cmd_gather_async.return_value = (0, "oc-mirror\n", "")
+
+        result = asyncio.run(pipeline._load_product_from_group_config())
+
+        self.assertEqual(result, "oc-mirror")
+
+    @patch("pyartcd.pipelines.binary_release_konflux.exectools.cmd_gather_async")
+    def test_falls_back_to_group_name_when_doozer_fails(self, mock_cmd_gather_async):
+        pipeline = self._make_pipeline()
+        mock_cmd_gather_async.side_effect = Exception("doozer boom")
+
+        result = asyncio.run(pipeline._load_product_from_group_config())
+
+        self.assertEqual(result, "oc-mirror")
+
+    @patch("pyartcd.pipelines.binary_release_konflux.exectools.cmd_gather_async")
+    def test_falls_back_to_group_name_when_doozer_returns_none(self, mock_cmd_gather_async):
+        pipeline = self._make_pipeline()
+        mock_cmd_gather_async.return_value = (0, "None\n", "")
+
+        result = asyncio.run(pipeline._load_product_from_group_config())
+
+        self.assertEqual(result, "oc-mirror")
+
+
+class TestCreateSnapshot(unittest.TestCase):
+    def _make_pipeline(self):
+        runtime = MagicMock()
+        runtime.dry_run = False
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        runtime.config = {}
+
+        return BinaryReleaseKonfluxPipeline(
+            runtime=runtime,
+            group="oc-mirror-2.0",
+            assembly="stream",
+            nvrs=["oc-mirror-container-2.0-1-1.el9"],
+        )
+
+    def test_no_builds_returns_none(self):
+        pipeline = self._make_pipeline()
+        result = asyncio.run(pipeline.create_snapshot([]))
+        self.assertIsNone(result)
+
+    @patch("pyartcd.pipelines.binary_release_konflux.exectools.cmd_assert")
+    def test_creates_snapshot_from_elliott_output(self, mock_cmd_assert):
+        pipeline = self._make_pipeline()
+        yaml_output = (
+            "spec:\n"
+            "  application: oc-mirror-2-0\n"
+            "  components:\n"
+            "  - name: oc-mirror-2-0-oc-mirror\n"
+            "    containerImage: quay.io/test/image@sha256:abc\n"
+            "    source:\n"
+            "      git:\n"
+            "        url: https://github.com/test/repo\n"
+            "        revision: abc123\n"
+        )
+        mock_cmd_assert.return_value = (yaml_output, "")
+
+        builds = ["oc-mirror-container-2.0-202607291654.p2.g90b54b1.assembly.stream.el9"]
+        result = asyncio.run(pipeline.create_snapshot(builds))
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.spec.application, "oc-mirror-2-0")
+        self.assertEqual(result.nvrs, builds)
+
+        call_args = mock_cmd_assert.call_args[0][0]
+        self.assertIn("snapshot", call_args)
+        self.assertIn("new", call_args)
+
+
+class TestEmbargoedNvrDefensiveCheck(unittest.TestCase):
+    """run() must refuse to release if any provided NVR is embargoed (private-fix)."""
+
+    def _make_pipeline(self, nvrs):
+        runtime = MagicMock()
+        runtime.dry_run = False
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        runtime.config = {}
+
+        pipeline = BinaryReleaseKonfluxPipeline(
+            runtime=runtime,
+            group="oc-mirror-2.0",
+            assembly="stream",
+            nvrs=nvrs,
+        )
+        pipeline.check_env_vars = MagicMock()
+        pipeline.setup_working_dir = MagicMock()
+        pipeline._load_product_from_group_config = AsyncMock(return_value="oc-mirror")
+        return pipeline
+
+    def test_embargoed_nvr_raises(self):
+        embargoed_nvr = "oc-mirror-container-2.0-202607291654.p3.g90b54b1.assembly.stream.el9"
+        pipeline = self._make_pipeline([embargoed_nvr])
+
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(pipeline.run())
+        self.assertIn("embargoed", str(ctx.exception))
+        self.assertIn(embargoed_nvr, str(ctx.exception))
+
+    def test_non_embargoed_nvr_does_not_raise_embargo_error(self):
+        nvr = "oc-mirror-container-2.0-202607291654.p2.g90b54b1.assembly.stream.el9"
+        pipeline = self._make_pipeline([nvr])
+        pipeline.create_snapshot = AsyncMock(return_value=_make_snapshot())
+        pipeline.create_shipment_config = MagicMock(return_value=MagicMock())
+        pipeline.write_shipment_file_locally = AsyncMock()
+
+        asyncio.run(pipeline.run())
+
+    def test_run_raises_if_no_snapshot_created(self):
+        nvr = "oc-mirror-container-2.0-202607291654.p2.g90b54b1.assembly.stream.el9"
+        pipeline = self._make_pipeline([nvr])
+        pipeline.create_snapshot = AsyncMock(return_value=None)
+
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(pipeline.run())
+        self.assertIn("No snapshot", str(ctx.exception))
+
+
+class TestSetShipmentMrReady(unittest.TestCase):
+    """Tests for BinaryReleaseKonfluxPipeline.set_shipment_mr_ready()."""
+
+    def _make_pipeline(self, dry_run=False):
+        runtime = MagicMock()
+        runtime.dry_run = dry_run
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        runtime.config = {}
+
+        pipeline = BinaryReleaseKonfluxPipeline(
+            runtime=runtime,
+            group="oc-mirror-2.0",
+            assembly="stream",
+            nvrs=["oc-mirror-container-2.0-1-1.el9"],
+            create_mr=True,
+        )
+        pipeline.product = "oc-mirror"
+        pipeline.shipment_mr_url = "https://gitlab.cee.redhat.com/test/repo/-/merge_requests/42"
+        return pipeline
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    def test_set_shipment_mr_ready_happy_path(self, mock_sleep):
+        pipeline = self._make_pipeline(dry_run=False)
+
+        mock_mr = MagicMock()
+        mock_gitlab = MagicMock()
+        mock_gitlab.set_mr_ready = AsyncMock(return_value=mock_mr)
+        mock_gitlab.trigger_ci_pipeline = AsyncMock(return_value="https://gitlab.cee.redhat.com/pipeline/123")
+        pipeline.__dict__["_gitlab"] = mock_gitlab
+
+        asyncio.run(pipeline.set_shipment_mr_ready())
+
+        mock_gitlab.set_mr_ready.assert_awaited_once_with(pipeline.shipment_mr_url)
+        mock_sleep.assert_awaited_once_with(30)
+        mock_gitlab.trigger_ci_pipeline.assert_awaited_once_with(mock_mr)
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    def test_set_shipment_mr_ready_dry_run(self, mock_sleep):
+        pipeline = self._make_pipeline(dry_run=True)
+
+        mock_mr = MagicMock()
+        mock_gitlab = MagicMock()
+        mock_gitlab.set_mr_ready = AsyncMock(return_value=mock_mr)
+        mock_gitlab.trigger_ci_pipeline = AsyncMock()
+        pipeline.__dict__["_gitlab"] = mock_gitlab
+
+        asyncio.run(pipeline.set_shipment_mr_ready())
+
+        mock_gitlab.set_mr_ready.assert_awaited_once_with(pipeline.shipment_mr_url)
+        mock_sleep.assert_not_awaited()
+        mock_gitlab.trigger_ci_pipeline.assert_not_awaited()
+
+
+class TestCliValidation(unittest.TestCase):
+    """Test CLI argument validation via CliRunner against the real Click command."""
+
+    def _invoke(self, extra_args):
+        from click.testing import CliRunner
+        from pyartcd.pipelines.binary_release_konflux import binary_release_konflux
+        from pyartcd.runtime import Runtime
+
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
+        mock_runtime = MagicMock(spec=Runtime)
+        mock_runtime.dry_run = False
+        mock_runtime.working_dir = MagicMock()
+        mock_runtime.working_dir.absolute.return_value = MagicMock()
+        mock_runtime.config = {}
+
+        runner = CliRunner()
+        base_args = ["--group", "oc-mirror-2.0", "--assembly", "stream"]
+        return runner.invoke(binary_release_konflux, base_args + extra_args, obj=mock_runtime, standalone_mode=False)
+
+    def test_empty_nvrs_raises_error(self):
+        result = self._invoke(["--nvrs", "  ,  ,"])
+        self.assertIsInstance(result.exception, click.ClickException)
+        self.assertIn("at least one valid NVR", str(result.exception))
+
+    @patch("pyartcd.pipelines.binary_release_konflux.BinaryReleaseKonfluxPipeline")
+    def test_valid_nvrs_does_not_raise(self, mock_pipeline_cls):
+        mock_pipeline_cls.return_value.run = AsyncMock()
+        result = self._invoke(["--nvrs", "oc-mirror-container-2.0-1-1.el9"])
+        self.assertNotIsInstance(result.exception, click.ClickException)
+
+    @patch("pyartcd.pipelines.binary_release_konflux.BinaryReleaseKonfluxPipeline")
+    def test_invalid_target_release_date_raises(self, mock_pipeline_cls):
+        mock_pipeline_cls.return_value.run = AsyncMock()
+        result = self._invoke(["--nvrs", "oc-mirror-container-2.0-1-1.el9", "--target-release-date", "not-a-date"])
+        self.assertIsInstance(result.exception, click.exceptions.BadParameter)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pyartcd/tests/pipelines/test_binary_release_konflux.py
+++ b/pyartcd/tests/pipelines/test_binary_release_konflux.py
@@ -118,6 +118,18 @@ class TestBinaryReleaseKonfluxPipeline(unittest.TestCase):
         self.assertEqual(config.shipment.environments.stage.releasePlan, "n/a")
         self.assertEqual(config.shipment.environments.prod.releasePlan, "n/a")
 
+    def test_create_shipment_config_raises_when_create_mr_and_no_release_plan(self):
+        """When create_mr=True and releasePlan can't be resolved, raise ValueError."""
+        pipeline = self._make_pipeline()
+        pipeline.create_mr = True
+        snapshot = _make_snapshot()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pipeline.shipment_data_repo._directory = Path(tmpdir)
+
+            with self.assertRaises(ValueError):
+                pipeline.create_shipment_config(snapshot)
+
     def test_create_shipment_config_uses_snapshot_application(self):
         """metadata.application is derived directly from the snapshot's application."""
         pipeline = self._make_pipeline()
@@ -192,8 +204,8 @@ class TestCreateSnapshot(unittest.TestCase):
         result = asyncio.run(pipeline.create_snapshot([]))
         self.assertIsNone(result)
 
-    @patch("pyartcd.pipelines.binary_release_konflux.exectools.cmd_assert")
-    def test_creates_snapshot_from_elliott_output(self, mock_cmd_assert):
+    @patch("pyartcd.pipelines.binary_release_konflux.exectools.cmd_gather_async")
+    def test_creates_snapshot_from_elliott_output(self, mock_cmd_gather_async):
         pipeline = self._make_pipeline()
         yaml_output = (
             "spec:\n"
@@ -206,7 +218,7 @@ class TestCreateSnapshot(unittest.TestCase):
             "        url: https://github.com/test/repo\n"
             "        revision: abc123\n"
         )
-        mock_cmd_assert.return_value = (yaml_output, "")
+        mock_cmd_gather_async.return_value = (0, yaml_output, "")
 
         builds = ["oc-mirror-container-2.0-202607291654.p2.g90b54b1.assembly.stream.el9"]
         result = asyncio.run(pipeline.create_snapshot(builds))
@@ -215,7 +227,7 @@ class TestCreateSnapshot(unittest.TestCase):
         self.assertEqual(result.spec.application, "oc-mirror-2-0")
         self.assertEqual(result.nvrs, builds)
 
-        call_args = mock_cmd_assert.call_args[0][0]
+        call_args = mock_cmd_gather_async.call_args[0][0]
         self.assertIn("snapshot", call_args)
         self.assertIn("new", call_args)
 


### PR DESCRIPTION
## Summary
- Adds a new `artcd binary-release-konflux` command/pipeline that resolves build NVR(s) to a Konflux snapshot and opens a shipment MR referencing a product's CDN stage/prod ReleasePlans (e.g. `oc-mirror-2.0`).
- No advisory/release-notes data is generated - the CDN `ReleasePlanAdmission` already carries its own static release notes.
- Registers the `binary-release-konflux` command in `pyartcd/pipelines/__init__.py` and `pyartcd/__main__.py`.

Companion changes:
- `ocp-shipment-data`: adds the `oc-mirror-2-0` application entry to `config.yaml`.
- `aos-cd-jobs`: adds the `binary-release-konflux` Jenkins job.

## Test plan
- [x] Added unit tests in `pyartcd/tests/pipelines/test_binary_release_konflux.py` (21 tests)
- [x] `pytest pyartcd/tests/` passes (737 passed, 12 skipped)
- [x] `ruff check` / `ruff format --check` pass
- [x] Verified `artcd binary-release-konflux --help` output


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workflow for releasing Konflux-built standalone CDN binaries.
  * Added the `binary-release-konflux` command with options for release group, assembly, NVRs, merge request creation, repository, and target date.
  * Supports dry runs, shipment file generation, and automated merge request preparation.
  * Added validation for release settings, embargoed builds, snapshots, and shipment plans.

* **Tests**
  * Added comprehensive coverage for the new release workflow and command validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->