### PR TITLE
ART-21816: Add elliott verify-image-grades command for Pyxis freshness grade check

### DIFF
--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -74,6 +74,7 @@ from elliottlib.cli.validate_rhsa import validate_rhsa_cli
 from elliottlib.cli.verify_attached_bugs_cli import verify_attached_bugs_cli
 from elliottlib.cli.verify_attached_operators_cli import verify_attached_operators_cli
 from elliottlib.cli.verify_cvp_cli import verify_cvp_cli
+from elliottlib.cli.verify_image_grades_cli import verify_image_grades_cli
 from elliottlib.cli.verify_payload import verify_payload
 from elliottlib.cli.verify_signatures_cli import verify_signatures_cli
 from elliottlib.exceptions import ElliottFatalError
@@ -325,6 +326,7 @@ cli.add_command(watch_release_cli)
 cli.add_command(find_bugs_second_fix_cli)
 cli.add_command(process_release_from_fbc_bugs_cli)
 cli.add_command(verify_signatures_cli)
+cli.add_command(verify_image_grades_cli)
 
 # -----------------------------------------------------------------------------
 # CLI Entry point

--- a/elliott/elliottlib/cli/verify_image_grades_cli.py
+++ b/elliott/elliottlib/cli/verify_image_grades_cli.py
@@ -1,0 +1,335 @@
+import asyncio
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+
+import aiohttp
+import click
+import requests
+import yaml
+from artcommonlib.assembly import assembly_config_struct
+from artcommonlib.gitlab import GitLabClient
+
+from elliottlib.cli.common import cli, click_coroutine
+
+LOGGER = logging.getLogger(__name__)
+
+PYXIS_API_URL = "https://catalog.stage.redhat.com/api/containers/v1/images"
+PYXIS_PROXY = "http://squid.corp.redhat.com:3128"
+DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+ADVISORY_ALLOWED_ORIGINS = {
+    "https://errata.devel.redhat.com",
+    "https://errata.stage.engineering.redhat.com",
+    "https://gitlab.cee.redhat.com/rhtap-release/advisories",
+    "https://gitlab.cee.redhat.com/releng/advisories",
+}
+
+
+@dataclass
+class ImageGradeResult:
+    name: str
+    pullspec: str
+    digest: str
+    grade: str = "Unknown"
+    available: bool = True
+
+    @property
+    def healthy(self) -> bool:
+        return self.grade in ("A", "B")
+
+
+@dataclass
+class VerifyImageGradesResult:
+    shipment_mr_url: str
+    shipment_version: str = ""
+    results: list[ImageGradeResult] = field(default_factory=list)
+
+    @property
+    def total_scanned(self) -> int:
+        return len(self.results)
+
+    @property
+    def passed(self) -> bool:
+        return bool(self.results) and all(r.healthy for r in self.results)
+
+    @property
+    def unhealthy_images(self) -> list[ImageGradeResult]:
+        return [r for r in self.results if not r.healthy]
+
+    @property
+    def unknown_count(self) -> int:
+        return sum(1 for r in self.results if r.grade == "Unknown")
+
+    @property
+    def unavailable_images(self) -> list[ImageGradeResult]:
+        return [r for r in self.results if not r.available]
+
+
+def extract_digest(pullspec: str) -> str:
+    if "@sha256:" in pullspec:
+        return pullspec.split("@sha256:", 1)[1]
+    return ""
+
+
+def _parse_timestamp(value: str) -> datetime:
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def get_current_grade(grades: list[dict]) -> str:
+    if not grades:
+        return "Unknown"
+
+    now = datetime.now(timezone.utc)
+    valid = []
+    for g in grades:
+        start = g.get("start_date")
+        if not start:
+            LOGGER.warning("Skipping grade entry with no start_date: %s", g)
+            continue
+        try:
+            if _parse_timestamp(start) <= now:
+                valid.append(g)
+        except (ValueError, TypeError):
+            LOGGER.warning("Skipping grade entry with unparseable start_date: %s", start)
+            continue
+
+    if not valid:
+        return "Unknown"
+
+    valid.sort(key=lambda g: _parse_timestamp(g["start_date"]), reverse=True)
+    return valid[0].get("grade", "Unknown")
+
+
+def resolve_shipment_mr_url(runtime) -> str:
+    releases_config = runtime.get_releases_config()
+    assembly_group_config = assembly_config_struct(releases_config, runtime.assembly, "group", {})
+    shipment = assembly_group_config.get("shipment", {})
+    url = shipment.get("url")
+    if not url:
+        raise RuntimeError(
+            f"No shipment URL found in assembly '{runtime.assembly}' group config. "
+            f"Ensure releases.yml has releases.{runtime.assembly}.assembly.group.shipment.url set."
+        )
+    return url
+
+
+def fetch_shipment_components(mr_url: str) -> tuple[list[tuple[str, str]], str]:
+    gl = GitLabClient.from_url(mr_url)
+    mr = gl.get_mr_from_url(mr_url)
+    source_project = gl.get_project(mr.source_project_id)
+
+    title = mr.title or ""
+    match = re.search(r"Shipment for (\d+\.\d+\.\d+(?:-\S+)?)", title, re.IGNORECASE)
+    version = match.group(1) if match else ""
+
+    diff_versions = mr.diffs.list(all=True)
+    if not diff_versions:
+        raise RuntimeError(f"No diff versions found for MR {mr_url}")
+    diff_info = diff_versions[0]
+    diff = mr.diffs.get(diff_info.id)
+
+    components: list[tuple[str, str]] = []
+    failures: list[str] = []
+    for file_diff in diff.diffs:
+        file_path = file_diff.get("new_path") or file_diff.get("old_path")
+        if not file_path or not file_path.endswith((".yaml", ".yml")):
+            continue
+        if ".fbc." in file_path.lower():
+            continue
+
+        try:
+            file_content = source_project.files.get(file_path, mr.source_branch)
+            content = file_content.decode().decode("utf-8")
+            data = yaml.safe_load(content)
+            if not isinstance(data, dict):
+                LOGGER.warning("Shipment file %s is not a YAML mapping; skipping", file_path)
+                continue
+
+            shipment = data.get("shipment") or {}
+            environments = shipment.get("environments") or {}
+            stage = environments.get("stage") or {}
+            advisory = stage.get("advisory") or {}
+            advisory_url = advisory.get("internal_url")
+            if not advisory_url:
+                LOGGER.debug("No advisory internal_url in %s, skipping", file_path)
+                continue
+
+            if not any(advisory_url.startswith(origin) for origin in ADVISORY_ALLOWED_ORIGINS):
+                parsed = urlparse(advisory_url)
+                raise RuntimeError(f"Advisory URL not allowed: {parsed.hostname}")
+
+            advisory_resp = requests.get(advisory_url, timeout=30, allow_redirects=False)
+            advisory_resp.raise_for_status()
+            advisory_data = yaml.safe_load(advisory_resp.text)
+
+            spec = (advisory_data or {}).get("spec") or {}
+            for image in spec.get("content", {}).get("images", []):
+                name = image.get("component", "")
+                pullspec = image.get("containerImage", "")
+                if pullspec:
+                    components.append((name, pullspec))
+        except Exception:
+            LOGGER.warning("Failed to process shipment file %s in MR %s", file_path, mr_url, exc_info=True)
+            failures.append(file_path)
+            continue
+
+    if failures and not components:
+        raise RuntimeError(f"Failed to read any shipment file from MR {mr_url}: {failures}")
+
+    return components, version
+
+
+async def query_freshness_grades(session: aiohttp.ClientSession, digest: str) -> tuple[list[dict], bool]:
+    """Returns (grades, available). available=False means the lookup itself failed."""
+    if not DIGEST_RE.match(digest):
+        LOGGER.warning("Rejecting malformed image digest: %s", digest)
+        return [], False
+    params = {
+        "filter": f"image_id==sha256:{digest}",
+        "page_size": "1",
+        "page": "0",
+        "include": "data.freshness_grades",
+    }
+    try:
+        async with session.get(PYXIS_API_URL, params=params, proxy=PYXIS_PROXY) as resp:
+            if resp.status != 200:
+                LOGGER.warning("Pyxis API returned status %s for digest %s", resp.status, digest)
+                return [], False
+            data = await resp.json()
+            if not data.get("data"):
+                return [], True
+            return data["data"][0].get("freshness_grades", []), True
+    except Exception:
+        LOGGER.warning("Failed to query Pyxis API for digest %s", digest, exc_info=True)
+        return [], False
+
+
+async def verify_image_grades(shipment_mr_url: str) -> VerifyImageGradesResult:
+    components, version = await asyncio.to_thread(fetch_shipment_components, shipment_mr_url)
+
+    result = VerifyImageGradesResult(
+        shipment_mr_url=shipment_mr_url,
+        shipment_version=version,
+    )
+
+    LOGGER.info("Checking freshness grades for %d shipment components", len(components))
+
+    semaphore = asyncio.Semaphore(20)
+    timeout = aiohttp.ClientTimeout(total=30)
+
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+
+        async def _check_grade(name: str, pullspec: str) -> ImageGradeResult:
+            digest = extract_digest(pullspec)
+            if not digest:
+                LOGGER.warning("No digest found in pullspec %s", pullspec)
+                return ImageGradeResult(name=name, pullspec=pullspec, digest="", available=False)
+
+            async with semaphore:
+                grades, available = await query_freshness_grades(session, digest)
+
+            grade = get_current_grade(grades)
+            LOGGER.debug("Grade for %s: %s (available=%s)", name, grade, available)
+            return ImageGradeResult(name=name, pullspec=pullspec, digest=digest, grade=grade, available=available)
+
+        results = await asyncio.gather(*(_check_grade(n, ps) for n, ps in components))
+
+    result.results = list(results)
+    return result
+
+
+def render_result(result: VerifyImageGradesResult, output: str) -> str:
+    if output == "json":
+        return json.dumps(
+            {
+                "shipment_mr_url": result.shipment_mr_url,
+                "shipment_version": result.shipment_version,
+                "total_scanned": result.total_scanned,
+                "passed": result.passed,
+                "unhealthy_count": len(result.unhealthy_images),
+                "unknown_count": result.unknown_count,
+                "unavailable_count": len(result.unavailable_images),
+                "unhealthy_images": [
+                    {"name": r.name, "pullspec": r.pullspec, "grade": r.grade} for r in result.unhealthy_images
+                ],
+                "unavailable_images": [{"name": r.name, "pullspec": r.pullspec} for r in result.unavailable_images],
+                "results": [
+                    {
+                        "name": r.name,
+                        "pullspec": r.pullspec,
+                        "digest": r.digest,
+                        "grade": r.grade,
+                        "healthy": r.healthy,
+                        "available": r.available,
+                    }
+                    for r in result.results
+                ],
+            },
+            indent=2,
+        )
+
+    lines = [
+        f"Image freshness grade check for shipment {result.shipment_version or result.shipment_mr_url}",
+        f"Shipment MR: {result.shipment_mr_url}",
+        f"Images scanned: {result.total_scanned}",
+    ]
+
+    if result.unavailable_images:
+        lines.append("")
+        lines.append("UNAVAILABLE (grade lookup failed):")
+        for r in result.unavailable_images:
+            lines.append(f"  - {r.name}: {r.pullspec}")
+
+    graded_unhealthy = [r for r in result.unhealthy_images if r.available]
+    if graded_unhealthy:
+        lines.append("")
+        lines.append("UNHEALTHY IMAGES:")
+        for r in graded_unhealthy:
+            lines.append(f"  - {r.name} (grade {r.grade}): {r.pullspec}")
+
+    lines.append("")
+    overall = "PASS" if result.passed else "FAIL"
+    healthy_count = result.total_scanned - len(result.unhealthy_images)
+    lines.append(f"Overall: {overall} ({healthy_count}/{result.total_scanned} healthy)")
+    return "\n".join(lines)
+
+
+@cli.command("verify-image-grades", short_help="Check Pyxis freshness grades for shipment images")
+@click.option(
+    "-o",
+    "--output",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    show_default=True,
+    help="Output format.",
+)
+@click.pass_obj
+@click_coroutine
+async def verify_image_grades_cli(runtime, output):
+    """Check Pyxis freshness grades for container images in a shipment MR.
+
+    Requires --group and --assembly global options. Resolves the shipment
+    MR URL from the assembly config in releases.yml.
+
+    Queries the Red Hat Catalog (Pyxis) API for each image's freshness
+    grade. Images with grade worse than B or Unknown are flagged as
+    unhealthy. Exits with code 1 if any unhealthy images are found.
+
+    Example:
+        elliott --group openshift-4.18 --assembly 4.18.51 verify-image-grades
+    """
+    runtime.initialize(config_only=True)
+    shipment_mr_url = resolve_shipment_mr_url(runtime)
+    LOGGER.info("Resolved shipment MR URL: %s", shipment_mr_url)
+    result = await verify_image_grades(shipment_mr_url=shipment_mr_url)
+    click.echo(render_result(result, output))
+    if not result.passed:
+        raise SystemExit(1)

--- a/elliott/elliottlib/cli/verify_image_grades_cli.py
+++ b/elliott/elliottlib/cli/verify_image_grades_cli.py
@@ -20,11 +20,13 @@ LOGGER = logging.getLogger(__name__)
 PYXIS_API_URL = "https://catalog.stage.redhat.com/api/containers/v1/images"
 PYXIS_PROXY = "http://squid.corp.redhat.com:3128"
 DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
-ADVISORY_ALLOWED_ORIGINS = {
-    "https://errata.devel.redhat.com",
-    "https://errata.stage.engineering.redhat.com",
-    "https://gitlab.cee.redhat.com/rhtap-release/advisories",
-    "https://gitlab.cee.redhat.com/releng/advisories",
+ADVISORY_ALLOWED_NETLOCS = {
+    urlparse(o).netloc
+    for o in (
+        "https://errata.devel.redhat.com",
+        "https://errata.stage.engineering.redhat.com",
+        "https://gitlab.cee.redhat.com",
+    )
 }
 
 
@@ -162,9 +164,9 @@ def fetch_shipment_components(mr_url: str) -> tuple[list[tuple[str, str]], str]:
                 LOGGER.debug("No advisory internal_url in %s, skipping", file_path)
                 continue
 
-            if not any(advisory_url.startswith(origin) for origin in ADVISORY_ALLOWED_ORIGINS):
-                parsed = urlparse(advisory_url)
-                raise RuntimeError(f"Advisory URL not allowed: {parsed.hostname}")
+            parsed = urlparse(advisory_url)
+            if parsed.netloc not in ADVISORY_ALLOWED_NETLOCS:
+                raise RuntimeError(f"Advisory URL not allowed: {parsed.netloc}")
 
             advisory_resp = requests.get(advisory_url, timeout=30, allow_redirects=False)
             advisory_resp.raise_for_status()

--- a/elliott/elliottlib/cli/verify_image_grades_cli.py
+++ b/elliott/elliottlib/cli/verify_image_grades_cli.py
@@ -326,7 +326,7 @@ async def verify_image_grades_cli(runtime, output):
     Example:
         elliott --group openshift-4.18 --assembly 4.18.51 verify-image-grades
     """
-    runtime.initialize(config_only=True)
+    runtime.initialize()
     shipment_mr_url = resolve_shipment_mr_url(runtime)
     LOGGER.info("Resolved shipment MR URL: %s", shipment_mr_url)
     result = await verify_image_grades(shipment_mr_url=shipment_mr_url)

--- a/elliott/tests/test_verify_image_grades_cli.py
+++ b/elliott/tests/test_verify_image_grades_cli.py
@@ -1,0 +1,599 @@
+import json
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import yaml
+from aiohttp import ClientSession
+from elliottlib.cli.verify_image_grades_cli import (
+    ImageGradeResult,
+    VerifyImageGradesResult,
+    _parse_timestamp,
+    extract_digest,
+    fetch_shipment_components,
+    get_current_grade,
+    query_freshness_grades,
+    render_result,
+    resolve_shipment_mr_url,
+    verify_image_grades,
+)
+
+
+class TestExtractDigest(unittest.TestCase):
+    def test_sha256_digest(self):
+        ps = "registry.redhat.io/openshift4/ose-cli@sha256:abc123def456"
+        self.assertEqual(extract_digest(ps), "abc123def456")
+
+    def test_no_digest(self):
+        self.assertEqual(extract_digest("registry.redhat.io/openshift4/ose-cli:v4.18"), "")
+
+    def test_empty(self):
+        self.assertEqual(extract_digest(""), "")
+
+
+class TestGetCurrentGrade(unittest.TestCase):
+    def test_empty_grades(self):
+        self.assertEqual(get_current_grade([]), "Unknown")
+
+    def test_single_valid_grade(self):
+        past = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        self.assertEqual(get_current_grade([{"start_date": past, "grade": "A"}]), "A")
+
+    def test_future_grade_ignored(self):
+        future = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+        self.assertEqual(get_current_grade([{"start_date": future, "grade": "A"}]), "Unknown")
+
+    def test_most_recent_grade_wins(self):
+        old = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+        recent = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
+        grades = [
+            {"start_date": old, "grade": "A"},
+            {"start_date": recent, "grade": "C"},
+        ]
+        self.assertEqual(get_current_grade(grades), "C")
+
+    def test_missing_start_date_skipped(self):
+        valid = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        grades = [
+            {"grade": "F"},
+            {"start_date": valid, "grade": "B"},
+        ]
+        self.assertEqual(get_current_grade(grades), "B")
+
+    def test_missing_grade_field(self):
+        past = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        self.assertEqual(get_current_grade([{"start_date": past}]), "Unknown")
+
+    def test_z_suffix_timestamp(self):
+        self.assertEqual(get_current_grade([{"start_date": "2024-01-01T00:00:00Z", "grade": "A"}]), "A")
+
+    def test_naive_timestamp(self):
+        self.assertEqual(get_current_grade([{"start_date": "2024-01-01T00:00:00", "grade": "B"}]), "B")
+
+
+class TestParseTimestamp(unittest.TestCase):
+    def test_z_suffix(self):
+        dt = _parse_timestamp("2024-01-01T00:00:00Z")
+        self.assertEqual(dt.tzinfo, timezone.utc)
+
+    def test_naive_gets_utc(self):
+        dt = _parse_timestamp("2024-06-15T12:30:00")
+        self.assertEqual(dt.tzinfo, timezone.utc)
+
+    def test_offset_preserved(self):
+        dt = _parse_timestamp("2024-01-01T00:00:00+05:00")
+        self.assertEqual(dt.utcoffset().total_seconds(), 5 * 3600)
+
+
+class TestImageGradeResult(unittest.TestCase):
+    def test_healthy_grades(self):
+        for grade in ("A", "B"):
+            r = ImageGradeResult(name="test", pullspec="ps", digest="d", grade=grade)
+            self.assertTrue(r.healthy, f"Grade {grade} should be healthy")
+
+    def test_unhealthy_grades(self):
+        for grade in ("C", "D", "E", "F", "Unknown"):
+            r = ImageGradeResult(name="test", pullspec="ps", digest="d", grade=grade)
+            self.assertFalse(r.healthy, f"Grade {grade} should be unhealthy")
+
+
+class TestVerifyImageGradesResult(unittest.TestCase):
+    def _make_result(self, grades):
+        return VerifyImageGradesResult(
+            shipment_mr_url="https://gitlab.example.com/mr/1",
+            shipment_version="4.18.51",
+            results=[
+                ImageGradeResult(name=f"img-{i}", pullspec=f"ps-{i}", digest=f"d-{i}", grade=g)
+                for i, g in enumerate(grades)
+            ],
+        )
+
+    def test_all_healthy(self):
+        r = self._make_result(["A", "B", "A"])
+        self.assertTrue(r.passed)
+        self.assertEqual(len(r.unhealthy_images), 0)
+        self.assertEqual(r.total_scanned, 3)
+
+    def test_some_unhealthy(self):
+        r = self._make_result(["A", "C", "Unknown"])
+        self.assertFalse(r.passed)
+        self.assertEqual(len(r.unhealthy_images), 2)
+        self.assertEqual(r.unknown_count, 1)
+
+    def test_empty(self):
+        r = self._make_result([])
+        self.assertFalse(r.passed)
+        self.assertEqual(r.total_scanned, 0)
+
+
+class TestResolveShipmentMrUrl(unittest.TestCase):
+    def test_resolves_url(self):
+        mock_runtime = MagicMock()
+        mock_runtime.assembly = "4.18.51"
+        mock_runtime.get_releases_config.return_value = MagicMock()
+
+        with patch("elliottlib.cli.verify_image_grades_cli.assembly_config_struct") as mock_acs:
+            mock_acs.return_value = {"shipment": {"url": "https://gitlab.example.com/mr/1"}}
+            url = resolve_shipment_mr_url(mock_runtime)
+
+        self.assertEqual(url, "https://gitlab.example.com/mr/1")
+        mock_acs.assert_called_once_with(
+            mock_runtime.get_releases_config.return_value,
+            "4.18.51",
+            "group",
+            {},
+        )
+
+    def test_raises_when_no_url(self):
+        mock_runtime = MagicMock()
+        mock_runtime.assembly = "4.18.51"
+        mock_runtime.get_releases_config.return_value = MagicMock()
+
+        with patch("elliottlib.cli.verify_image_grades_cli.assembly_config_struct") as mock_acs:
+            mock_acs.return_value = {}
+            with self.assertRaises(RuntimeError) as ctx:
+                resolve_shipment_mr_url(mock_runtime)
+            self.assertIn("4.18.51", str(ctx.exception))
+
+    def test_raises_when_shipment_without_url(self):
+        mock_runtime = MagicMock()
+        mock_runtime.assembly = "4.18.51"
+        mock_runtime.get_releases_config.return_value = MagicMock()
+
+        with patch("elliottlib.cli.verify_image_grades_cli.assembly_config_struct") as mock_acs:
+            mock_acs.return_value = {"shipment": {}}
+            with self.assertRaises(RuntimeError):
+                resolve_shipment_mr_url(mock_runtime)
+
+
+class TestQueryFreshnessGrades(unittest.IsolatedAsyncioTestCase):
+    async def test_successful_query(self):
+        grades = [{"start_date": "2026-01-01T00:00:00+00:00", "grade": "A"}]
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"data": [{"freshness_grades": grades}]})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock(spec=ClientSession)
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        result, available = await query_freshness_grades(mock_session, "a" * 64)
+        self.assertEqual(result, grades)
+        self.assertTrue(available)
+
+    async def test_empty_data(self):
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"data": []})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock(spec=ClientSession)
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        result, available = await query_freshness_grades(mock_session, "a" * 64)
+        self.assertEqual(result, [])
+        self.assertTrue(available)
+
+    async def test_api_error(self):
+        mock_resp = AsyncMock()
+        mock_resp.status = 500
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock(spec=ClientSession)
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        result, available = await query_freshness_grades(mock_session, "a" * 64)
+        self.assertEqual(result, [])
+        self.assertFalse(available)
+
+    async def test_malformed_digest_rejected(self):
+        mock_session = AsyncMock(spec=ClientSession)
+        result, available = await query_freshness_grades(mock_session, "not-a-valid-digest!")
+        self.assertEqual(result, [])
+        self.assertFalse(available)
+        mock_session.get.assert_not_called()
+
+
+class TestFetchShipmentComponents(unittest.TestCase):
+    @patch("elliottlib.cli.verify_image_grades_cli.requests")
+    @patch("elliottlib.cli.verify_image_grades_cli.GitLabClient")
+    def test_parses_components_from_advisory(self, mock_gl_cls, mock_requests):
+        shipment_yaml = """
+shipment:
+  environments:
+    stage:
+      advisory:
+        internal_url: "https://errata.devel.redhat.com/advisory/12345"
+"""
+        mock_file = MagicMock()
+        mock_file.decode.return_value = shipment_yaml.encode("utf-8")
+
+        mock_project = MagicMock()
+        mock_project.files.get.return_value = mock_file
+
+        mock_diff = MagicMock()
+        mock_diff.diffs = [{"new_path": "shipments/4.18/4.18.51.yaml"}]
+
+        mock_mr = MagicMock()
+        mock_mr.title = "Shipment for 4.18.51"
+        mock_mr.source_branch = "shipment-4.18.51"
+        mock_mr.source_project_id = 123
+        mock_mr.diffs.list.return_value = [MagicMock(id=1)]
+        mock_mr.diffs.get.return_value = mock_diff
+
+        mock_gl = MagicMock()
+        mock_gl.get_mr_from_url.return_value = mock_mr
+        mock_gl.get_project.return_value = mock_project
+        mock_gl_cls.from_url.return_value = mock_gl
+
+        advisory_content = {
+            "spec": {
+                "content": {
+                    "images": [
+                        {
+                            "component": "ose-cli",
+                            "containerImage": "registry.redhat.io/openshift4/ose-cli@sha256:abc",
+                            "architecture": "amd64",
+                        },
+                        {
+                            "component": "ose-installer",
+                            "containerImage": "registry.redhat.io/openshift4/ose-installer@sha256:def",
+                            "architecture": "amd64",
+                        },
+                    ]
+                }
+            }
+        }
+        mock_resp = MagicMock()
+        mock_resp.text = yaml.dump(advisory_content)
+        mock_resp.raise_for_status = MagicMock()
+        mock_requests.get.return_value = mock_resp
+
+        components, version = fetch_shipment_components("https://gitlab.example.com/mr/1")
+
+        self.assertEqual(version, "4.18.51")
+        self.assertEqual(len(components), 2)
+        self.assertEqual(components[0][0], "ose-cli")
+        self.assertIn("sha256:abc", components[0][1])
+        mock_requests.get.assert_called_once_with(
+            "https://errata.devel.redhat.com/advisory/12345", timeout=30, allow_redirects=False
+        )
+
+    @patch("elliottlib.cli.verify_image_grades_cli.requests")
+    @patch("elliottlib.cli.verify_image_grades_cli.GitLabClient")
+    def test_skips_fbc_files(self, mock_gl_cls, mock_requests):
+        mock_diff = MagicMock()
+        mock_diff.diffs = [{"new_path": "shipments/4.18/4.18.51.fbc.yaml"}]
+
+        mock_mr = MagicMock()
+        mock_mr.title = "Shipment for 4.18.51"
+        mock_mr.source_branch = "shipment-4.18.51"
+        mock_mr.source_project_id = 123
+        mock_mr.diffs.list.return_value = [MagicMock(id=1)]
+        mock_mr.diffs.get.return_value = mock_diff
+
+        mock_gl = MagicMock()
+        mock_gl.get_mr_from_url.return_value = mock_mr
+        mock_gl.get_project.return_value = MagicMock()
+        mock_gl_cls.from_url.return_value = mock_gl
+
+        components, _ = fetch_shipment_components("https://gitlab.example.com/mr/1")
+
+        self.assertEqual(len(components), 0)
+        mock_requests.get.assert_not_called()
+
+    @patch("elliottlib.cli.verify_image_grades_cli.requests")
+    @patch("elliottlib.cli.verify_image_grades_cli.GitLabClient")
+    def test_skips_files_without_advisory_url(self, mock_gl_cls, mock_requests):
+        shipment_yaml = """
+shipment:
+  snapshot:
+    spec:
+      components:
+        - name: something
+          containerImage: "quay.io/something@sha256:abc"
+"""
+        mock_file = MagicMock()
+        mock_file.decode.return_value = shipment_yaml.encode("utf-8")
+
+        mock_project = MagicMock()
+        mock_project.files.get.return_value = mock_file
+
+        mock_diff = MagicMock()
+        mock_diff.diffs = [{"new_path": "shipments/4.18/4.18.51.yaml"}]
+
+        mock_mr = MagicMock()
+        mock_mr.title = "Shipment for 4.18.51"
+        mock_mr.source_branch = "shipment-4.18.51"
+        mock_mr.source_project_id = 123
+        mock_mr.diffs.list.return_value = [MagicMock(id=1)]
+        mock_mr.diffs.get.return_value = mock_diff
+
+        mock_gl = MagicMock()
+        mock_gl.get_mr_from_url.return_value = mock_mr
+        mock_gl.get_project.return_value = mock_project
+        mock_gl_cls.from_url.return_value = mock_gl
+
+        components, _ = fetch_shipment_components("https://gitlab.example.com/mr/1")
+
+        self.assertEqual(len(components), 0)
+        mock_requests.get.assert_not_called()
+
+    @patch("elliottlib.cli.verify_image_grades_cli.requests")
+    @patch("elliottlib.cli.verify_image_grades_cli.GitLabClient")
+    def test_raises_when_all_files_fail(self, mock_gl_cls, mock_requests):
+        mock_file = MagicMock()
+        mock_file.decode.side_effect = RuntimeError("decode error")
+
+        mock_project = MagicMock()
+        mock_project.files.get.return_value = mock_file
+
+        mock_diff = MagicMock()
+        mock_diff.diffs = [{"new_path": "shipments/4.18/4.18.51.yaml"}]
+
+        mock_mr = MagicMock()
+        mock_mr.title = "Shipment for 4.18.51"
+        mock_mr.source_branch = "shipment-4.18.51"
+        mock_mr.source_project_id = 123
+        mock_mr.diffs.list.return_value = [MagicMock(id=1)]
+        mock_mr.diffs.get.return_value = mock_diff
+
+        mock_gl = MagicMock()
+        mock_gl.get_mr_from_url.return_value = mock_mr
+        mock_gl.get_project.return_value = mock_project
+        mock_gl_cls.from_url.return_value = mock_gl
+
+        with self.assertRaises(RuntimeError) as ctx:
+            fetch_shipment_components("https://gitlab.example.com/mr/1")
+        self.assertIn("Failed to read any shipment file", str(ctx.exception))
+
+    @patch("elliottlib.cli.verify_image_grades_cli.requests")
+    @patch("elliottlib.cli.verify_image_grades_cli.GitLabClient")
+    def test_accepts_gitlab_advisory_url(self, mock_gl_cls, mock_requests):
+        shipment_yaml = """
+shipment:
+  environments:
+    stage:
+      advisory:
+        internal_url: "https://gitlab.cee.redhat.com/rhtap-release/advisories/-/raw/main/data/advisories/ocp/2026/12345/advisory.yaml"
+"""
+        mock_file = MagicMock()
+        mock_file.decode.return_value = shipment_yaml.encode("utf-8")
+
+        mock_project = MagicMock()
+        mock_project.files.get.return_value = mock_file
+
+        mock_diff = MagicMock()
+        mock_diff.diffs = [{"new_path": "shipments/4.18/4.18.51.yaml"}]
+
+        mock_mr = MagicMock()
+        mock_mr.title = "Shipment for 4.18.51"
+        mock_mr.source_branch = "shipment-4.18.51"
+        mock_mr.source_project_id = 123
+        mock_mr.diffs.list.return_value = [MagicMock(id=1)]
+        mock_mr.diffs.get.return_value = mock_diff
+
+        mock_gl = MagicMock()
+        mock_gl.get_mr_from_url.return_value = mock_mr
+        mock_gl.get_project.return_value = mock_project
+        mock_gl_cls.from_url.return_value = mock_gl
+
+        advisory_content = {
+            "spec": {
+                "content": {
+                    "images": [
+                        {"component": "ose-cli", "containerImage": "registry.redhat.io/openshift4/ose-cli@sha256:abc"},
+                    ]
+                }
+            }
+        }
+        mock_resp = MagicMock()
+        mock_resp.text = yaml.dump(advisory_content)
+        mock_resp.raise_for_status = MagicMock()
+        mock_requests.get.return_value = mock_resp
+
+        components, _ = fetch_shipment_components("https://gitlab.example.com/mr/1")
+        self.assertEqual(len(components), 1)
+        self.assertEqual(components[0][0], "ose-cli")
+
+    @patch("elliottlib.cli.verify_image_grades_cli.requests")
+    @patch("elliottlib.cli.verify_image_grades_cli.GitLabClient")
+    def test_rejects_disallowed_advisory_host(self, mock_gl_cls, mock_requests):
+        shipment_yaml = """
+shipment:
+  environments:
+    stage:
+      advisory:
+        internal_url: "https://evil.example.com/advisory/12345"
+"""
+        mock_file = MagicMock()
+        mock_file.decode.return_value = shipment_yaml.encode("utf-8")
+
+        mock_project = MagicMock()
+        mock_project.files.get.return_value = mock_file
+
+        mock_diff = MagicMock()
+        mock_diff.diffs = [{"new_path": "shipments/4.18/4.18.51.yaml"}]
+
+        mock_mr = MagicMock()
+        mock_mr.title = "Shipment for 4.18.51"
+        mock_mr.source_branch = "shipment-4.18.51"
+        mock_mr.source_project_id = 123
+        mock_mr.diffs.list.return_value = [MagicMock(id=1)]
+        mock_mr.diffs.get.return_value = mock_diff
+
+        mock_gl = MagicMock()
+        mock_gl.get_mr_from_url.return_value = mock_mr
+        mock_gl.get_project.return_value = mock_project
+        mock_gl_cls.from_url.return_value = mock_gl
+
+        with self.assertRaises(RuntimeError) as ctx:
+            fetch_shipment_components("https://gitlab.example.com/mr/1")
+        self.assertIn("Failed to read any shipment file", str(ctx.exception))
+        mock_requests.get.assert_not_called()
+
+
+class TestVerifyImageGrades(unittest.IsolatedAsyncioTestCase):
+    @patch("elliottlib.cli.verify_image_grades_cli.fetch_shipment_components")
+    @patch("elliottlib.cli.verify_image_grades_cli.query_freshness_grades")
+    async def test_all_healthy(self, mock_query, mock_fetch):
+        mock_fetch.return_value = (
+            [
+                ("ose-cli", "registry.redhat.io/openshift4/ose-cli@sha256:aaa"),
+                ("ose-installer", "registry.redhat.io/openshift4/ose-installer@sha256:bbb"),
+            ],
+            "4.18.51",
+        )
+        past = "2026-01-01T00:00:00+00:00"
+        mock_query.return_value = ([{"start_date": past, "grade": "A"}], True)
+
+        result = await verify_image_grades("https://gitlab.example.com/mr/1")
+
+        self.assertTrue(result.passed)
+        self.assertEqual(result.total_scanned, 2)
+        self.assertEqual(len(result.unhealthy_images), 0)
+        self.assertEqual(len(result.unavailable_images), 0)
+
+    @patch("elliottlib.cli.verify_image_grades_cli.fetch_shipment_components")
+    @patch("elliottlib.cli.verify_image_grades_cli.query_freshness_grades")
+    async def test_unhealthy_detected(self, mock_query, mock_fetch):
+        mock_fetch.return_value = (
+            [("ose-cli", "registry.redhat.io/openshift4/ose-cli@sha256:aaa")],
+            "4.18.51",
+        )
+        past = "2026-01-01T00:00:00+00:00"
+        mock_query.return_value = ([{"start_date": past, "grade": "D"}], True)
+
+        result = await verify_image_grades("https://gitlab.example.com/mr/1")
+
+        self.assertFalse(result.passed)
+        self.assertEqual(len(result.unhealthy_images), 1)
+        self.assertEqual(result.unhealthy_images[0].grade, "D")
+        self.assertTrue(result.unhealthy_images[0].available)
+
+    @patch("elliottlib.cli.verify_image_grades_cli.fetch_shipment_components")
+    @patch("elliottlib.cli.verify_image_grades_cli.query_freshness_grades")
+    async def test_unavailable_tracked(self, mock_query, mock_fetch):
+        mock_fetch.return_value = (
+            [("ose-cli", "registry.redhat.io/openshift4/ose-cli@sha256:aaa")],
+            "4.18.51",
+        )
+        mock_query.return_value = ([], False)
+
+        result = await verify_image_grades("https://gitlab.example.com/mr/1")
+
+        self.assertFalse(result.passed)
+        self.assertEqual(len(result.unavailable_images), 1)
+        self.assertFalse(result.results[0].available)
+
+    @patch("elliottlib.cli.verify_image_grades_cli.fetch_shipment_components")
+    @patch("elliottlib.cli.verify_image_grades_cli.query_freshness_grades")
+    async def test_no_digest_in_pullspec(self, mock_query, mock_fetch):
+        mock_fetch.return_value = (
+            [("ose-cli", "registry.redhat.io/openshift4/ose-cli:v4.18")],
+            "4.18.51",
+        )
+
+        result = await verify_image_grades("https://gitlab.example.com/mr/1")
+
+        self.assertEqual(result.results[0].grade, "Unknown")
+        self.assertFalse(result.results[0].healthy)
+        self.assertFalse(result.results[0].available)
+        mock_query.assert_not_called()
+
+
+class TestRenderResult(unittest.TestCase):
+    def _make_result(self, passed=True):
+        grades = ["A", "B"] if passed else ["A", "D", "Unknown"]
+        return VerifyImageGradesResult(
+            shipment_mr_url="https://gitlab.example.com/mr/1",
+            shipment_version="4.18.51",
+            results=[
+                ImageGradeResult(name=f"img-{i}", pullspec=f"ps-{i}", digest=f"d-{i}", grade=g)
+                for i, g in enumerate(grades)
+            ],
+        )
+
+    def test_text_pass(self):
+        text = render_result(self._make_result(passed=True), "text")
+        self.assertIn("PASS", text)
+        self.assertIn("4.18.51", text)
+        self.assertNotIn("UNHEALTHY", text)
+
+    def test_text_fail(self):
+        text = render_result(self._make_result(passed=False), "text")
+        self.assertIn("FAIL", text)
+        self.assertIn("UNHEALTHY IMAGES", text)
+        self.assertIn("grade D", text)
+
+    def test_json_output(self):
+        out = render_result(self._make_result(passed=True), "json")
+        data = json.loads(out)
+        self.assertTrue(data["passed"])
+        self.assertEqual(data["total_scanned"], 2)
+        self.assertEqual(len(data["unhealthy_images"]), 0)
+        self.assertEqual(len(data["results"]), 2)
+
+    def test_json_unhealthy(self):
+        out = render_result(self._make_result(passed=False), "json")
+        data = json.loads(out)
+        self.assertFalse(data["passed"])
+        self.assertEqual(data["unhealthy_count"], 2)
+        self.assertEqual(data["unknown_count"], 1)
+
+    def test_text_unavailable_separate_from_unhealthy(self):
+        result = VerifyImageGradesResult(
+            shipment_mr_url="https://gitlab.example.com/mr/1",
+            shipment_version="4.18.51",
+            results=[
+                ImageGradeResult(name="ok", pullspec="ps-ok", digest="d-ok", grade="A"),
+                ImageGradeResult(name="bad", pullspec="ps-bad", digest="d-bad", grade="D"),
+                ImageGradeResult(name="down", pullspec="ps-down", digest="d-down", grade="Unknown", available=False),
+            ],
+        )
+        text = render_result(result, "text")
+        self.assertIn("UNAVAILABLE (grade lookup failed):", text)
+        self.assertIn("down", text)
+        self.assertIn("UNHEALTHY IMAGES:", text)
+        self.assertIn("bad", text)
+
+    def test_json_unavailable(self):
+        result = VerifyImageGradesResult(
+            shipment_mr_url="https://gitlab.example.com/mr/1",
+            shipment_version="4.18.51",
+            results=[
+                ImageGradeResult(name="down", pullspec="ps-down", digest="", grade="Unknown", available=False),
+            ],
+        )
+        out = render_result(result, "json")
+        data = json.loads(out)
+        self.assertEqual(data["unavailable_count"], 1)
+        self.assertEqual(len(data["unavailable_images"]), 1)
+        self.assertFalse(data["results"][0]["available"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Queries the Red Hat Catalog (Pyxis) API for container image freshness grades from a shipment MR. Flags images with grade worse than B or Unknown as unhealthy.

Uses standard --group + --assembly global options with config_only initialization. Resolves shipment MR URL from assembly config in releases.yml via assembly_config_struct().

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `verify-image-grades` command to assess shipment container image freshness.
  * Supports text and JSON output with healthy, unhealthy, and unknown results.
  * Returns a failing status when any image is unhealthy.
  * Reports warnings for missing data, invalid dates, unavailable grades, service errors, and malformed shipment files.

* **Tests**
  * Added comprehensive coverage for verification, error handling, result aggregation, and output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->