### PR TITLE
Disable bugzilla login

### DIFF
--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -1215,12 +1215,9 @@ class BugzillaBugTracker(BugTracker):
         return bug_config
 
     def login(self):
-        client = bugzilla.Bugzilla(self._server)
-        if not client.logged_in:
-            raise ValueError(
-                f"elliott requires cached login credentials for {self._server}. Login using 'bugzilla login --api-key"
-            )
-        return client
+        # Bugzilla is only used for publicly visible data. Explicitly disable
+        # cached credentials so an expired API key cannot prevent read access.
+        return bugzilla.Bugzilla(self._server, use_creds=False)
 
     def __init__(self, config):
         super().__init__(config, 'bugzilla')

--- a/elliott/tests/test_bzutil.py
+++ b/elliott/tests/test_bzutil.py
@@ -579,6 +579,15 @@ class TestJIRABugTracker(unittest.TestCase):
 
 
 class TestBugzillaBugTracker(unittest.TestCase):
+    @mock.patch("elliottlib.bzutil.bugzilla.Bugzilla")
+    def test_login_uses_anonymous_client(self, mock_bugzilla):
+        client = mock_bugzilla.return_value
+
+        tracker = BugzillaBugTracker({"server": hostname})
+
+        mock_bugzilla.assert_called_once_with(hostname, use_creds=False)
+        self.assertIs(tracker.client(), client)
+
     def test_get_config(self):
         config = {"foo": 1, "bugzilla_config": {"bar": 2}}
         vars_mock = flexmock(MAJOR="4", MINOR="9")


### PR DESCRIPTION
rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bugzilla connection handling by allowing anonymous access when cached login credentials are unavailable.
  * Prevented unnecessary login errors for unauthenticated Bugzilla clients.

* **Tests**
  * Added coverage verifying anonymous connections use the configured Bugzilla server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->