### PR TITLE
Add version '5.1' to ACTIVE_OCP_VERSIONS list

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -31,6 +31,7 @@ ACTIVE_OCP_VERSIONS = [
     "4.22",
     "4.23",
     "5.0",
+    "5.1",
 ]
 
 # Last standard (non-bridge) minor for each OCP major release, used when crossing


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OpenShift Container Platform version 5.1 in the list of actively supported releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->