### PR TITLE
MCE to ART: Add multicluster-engine CPE product name mapping

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -44,7 +44,7 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 # Product name mapping for CPE labels
 CPE_PRODUCT_NAME_MAPPING = {
     'acm': 'acm',
-    'mce': 'multicluster_engine',
+    'multicluster-engine': 'multicluster_engine',
     'rhmtc': 'rhmt',
     'oadp': 'openshift_api_data_protection',
     'mta': 'migration_toolkit_applications',


### PR DESCRIPTION
The mce-2.11 group.yml uses product: multicluster-engine (with dash), but the CPE_PRODUCT_NAME_MAPPING only had 'mce' as a key. Since the mapping lookup uses the raw product value from group.yml, the dash form was falling through to the default (identity) mapping, producing cpe:/a:redhat:multicluster-engine:... instead of the registered cpe:/a:redhat:multicluster_engine:... (with underscore).

This caused LabelValidationError at stage release for all MCE 2.11 components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for recognizing the `multicluster-engine` product during rebase-related processing.
  * Improved product identification for multicluster engine builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->