### PR TITLE
Skip Konflux component update when spec already matches

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -838,6 +838,36 @@ class KonfluxClient:
         """
         return await self._get__caching(API_VERSION, KIND_COMPONENT, name, strict=strict)
 
+    @staticmethod
+    def _component_matches(
+        existing: resource.ResourceInstance,
+        application: str,
+        component_name: str,
+        image_repo: Optional[str],
+        source_url: Optional[str],
+        revision: Optional[str],
+    ) -> bool:
+        """Return True if the existing component already has the desired spec values.
+
+        Only spec fields are compared. Annotations are intentionally excluded because
+        Konflux controllers (e.g. the PaC controller) may extend annotation values with
+        extra metadata after creation, causing spurious mismatches and unnecessary replaces.
+        """
+        existing_dict = existing.to_dict()
+        spec = existing_dict.get("spec", {})
+        if spec.get("application") != application:
+            return False
+        if spec.get("componentName") != component_name:
+            return False
+        if image_repo and spec.get("containerImage") != image_repo:
+            return False
+        git = spec.get("source", {}).get("git", {})
+        if source_url and git.get("url") != source_url:
+            return False
+        if revision and git.get("revision") != revision:
+            return False
+        return True
+
     async def ensure_component(
         self,
         name: str,
@@ -847,6 +877,11 @@ class KonfluxClient:
         source_url: Optional[str],
         revision: Optional[str],
     ) -> resource.ResourceInstance:
+        existing = await self.get_component(name, strict=False)
+        if existing and self._component_matches(
+            existing, application, component_name, image_repo, source_url, revision
+        ):
+            return existing
         component = self._new_component(name, application, component_name, image_repo, source_url, revision)
         return await self._create_or_replace(component)
 

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -1160,3 +1160,168 @@ class TestNewPipelinerunPrefetchMode(IsolatedAsyncioTestCase):
         task_param_names = {p["name"] for p in prefetch_task["params"]}
 
         self.assertNotIn("mode", task_param_names)
+
+
+def _make_existing_component(
+    application="test-app",
+    component_name="test-component",
+    image_repo="quay.io/test/image",
+    source_url="https://github.com/org/repo",
+    revision="main",
+    extra_annotations=None,
+):
+    """Build a mock ResourceInstance for an existing component."""
+    annotations = {}
+    if extra_annotations:
+        annotations.update(extra_annotations)
+    d = {
+        "metadata": {"name": "test-component", "annotations": annotations},
+        "spec": {
+            "application": application,
+            "componentName": component_name,
+            "containerImage": image_repo,
+            "source": {"git": {"url": source_url, "revision": revision}},
+        },
+    }
+    mock = MagicMock()
+    mock.to_dict.return_value = d
+    return mock
+
+
+class TestComponentMatches(TestCase):
+    def test_returns_true_for_matching_resource(self):
+        existing = _make_existing_component()
+        self.assertTrue(
+            KonfluxClient._component_matches(
+                existing,
+                application="test-app",
+                component_name="test-component",
+                image_repo="quay.io/test/image",
+                source_url="https://github.com/org/repo",
+                revision="main",
+            )
+        )
+
+    def test_returns_false_for_different_application(self):
+        existing = _make_existing_component(application="other-app")
+        self.assertFalse(
+            KonfluxClient._component_matches(
+                existing,
+                application="test-app",
+                component_name="test-component",
+                image_repo="quay.io/test/image",
+                source_url="https://github.com/org/repo",
+                revision="main",
+            )
+        )
+
+    def test_returns_true_even_with_extended_annotations(self):
+        # Konflux controllers may extend annotations (e.g. status with extra fields).
+        # Annotation differences must not cause a mismatch on spec-correct components.
+        existing = _make_existing_component(
+            extra_annotations={
+                "build.appstudio.openshift.io/status": '{"pac":{"state":"disabled"},"extra":"data"}',
+                "mintmaker.appstudio.redhat.com/disabled": "false",
+            }
+        )
+        self.assertTrue(
+            KonfluxClient._component_matches(
+                existing,
+                application="test-app",
+                component_name="test-component",
+                image_repo="quay.io/test/image",
+                source_url="https://github.com/org/repo",
+                revision="main",
+            )
+        )
+
+    def test_skips_optional_fields_when_none(self):
+        existing = _make_existing_component()
+        # image_repo, source_url, revision all None — should be ignored in comparison
+        self.assertTrue(
+            KonfluxClient._component_matches(
+                existing,
+                application="test-app",
+                component_name="test-component",
+                image_repo=None,
+                source_url=None,
+                revision=None,
+            )
+        )
+
+    def test_returns_false_for_different_revision(self):
+        existing = _make_existing_component(revision="old-sha")
+        self.assertFalse(
+            KonfluxClient._component_matches(
+                existing,
+                application="test-app",
+                component_name="test-component",
+                image_repo="quay.io/test/image",
+                source_url="https://github.com/org/repo",
+                revision="new-sha",
+            )
+        )
+
+
+class TestEnsureComponent(IsolatedAsyncioTestCase):
+    async def test_skips_update_when_component_matches(self):
+        client = MagicMock(spec=KonfluxClient)
+        existing = _make_existing_component()
+        client.get_component = AsyncMock(return_value=existing)
+        client._component_matches = KonfluxClient._component_matches
+        client._create_or_replace = AsyncMock()
+
+        result = await KonfluxClient.ensure_component(
+            client,
+            name="test-component",
+            application="test-app",
+            component_name="test-component",
+            image_repo="quay.io/test/image",
+            source_url="https://github.com/org/repo",
+            revision="main",
+        )
+
+        client._create_or_replace.assert_not_called()
+        self.assertIs(result, existing)
+
+    async def test_updates_when_component_differs(self):
+        client = MagicMock(spec=KonfluxClient)
+        existing = _make_existing_component(revision="old-sha")
+        client.get_component = AsyncMock(return_value=existing)
+        client._component_matches = KonfluxClient._component_matches
+        client._new_component = KonfluxClient._new_component
+        new_resource = MagicMock()
+        client._create_or_replace = AsyncMock(return_value=new_resource)
+
+        result = await KonfluxClient.ensure_component(
+            client,
+            name="test-component",
+            application="test-app",
+            component_name="test-component",
+            image_repo="quay.io/test/image",
+            source_url="https://github.com/org/repo",
+            revision="new-sha",
+        )
+
+        client._create_or_replace.assert_called_once()
+        self.assertIs(result, new_resource)
+
+    async def test_creates_when_component_not_found(self):
+        client = MagicMock(spec=KonfluxClient)
+        client.get_component = AsyncMock(return_value=None)
+        client._new_component = KonfluxClient._new_component
+        new_resource = MagicMock()
+        client._create_or_replace = AsyncMock(return_value=new_resource)
+
+        result = await KonfluxClient.ensure_component(
+            client,
+            name="test-component",
+            application="test-app",
+            component_name="test-component",
+            image_repo="quay.io/test/image",
+            source_url="https://github.com/org/repo",
+            revision="main",
+        )
+
+        client._create_or_replace.assert_called_once()
+        self.assertIs(result, new_resource)


### PR DESCRIPTION
## Summary

- `ensure_component()` previously always did a full PUT replace of the Kubernetes Component resource, even when it already had the correct values
- When multiple Jenkins jobs build different OCP versions concurrently, concurrent PUTs all hit the namespace ResourceQuota admission controller simultaneously, causing 409 Conflicts on the quota object: _\"Operation cannot be fulfilled on resourcequotas \\\"konflux\\\": the object has been modified\"_
- Add `_component_matches()` to compare desired spec fields against the existing component; if they match, return the existing resource without issuing a replace
- Annotations are excluded from the comparison because Konflux controllers (e.g. the PaC controller) may extend annotation values after creation, which would cause spurious mismatches and defeat the optimization

## Test plan

- [ ] `uv run pytest --verbose doozer/tests/backend/test_konflux_client.py` — new `TestComponentMatches` and `TestEnsureComponent` classes cover: match→skip, mismatch→replace, not-found→create, and extended-annotation tolerance
- [ ] `uv run pytest --verbose doozer/tests/backend/test_konflux_image_builder.py doozer/tests/backend/test_konflux_olm_bundler.py doozer/tests/backend/test_konflux_fbc.py` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component reconciliation by preserving existing components when their configuration already matches.
  * Automatically replaces components when application, source, image, revision, or annotation settings differ.

* **Tests**
  * Added coverage for matching, mismatched, optional, and missing component configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->