### PR TITLE
ART-21872: add image-level okd.arches override support

### DIFF
--- a/doozer/doozerlib/metadata.py
+++ b/doozer/doozerlib/metadata.py
@@ -14,8 +14,9 @@ from artcommonlib import exectools
 from artcommonlib.assembly import assembly_metadata_config
 from artcommonlib.brew import BuildStates
 from artcommonlib.metadata import MetadataBase
-from artcommonlib.model import Model
+from artcommonlib.model import Missing, Model
 from artcommonlib.pushd import Dir
+from artcommonlib.variants import BuildVariant
 from defusedxml import ElementTree
 from dockerfile_parse import DockerfileParser
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
@@ -195,6 +196,8 @@ class Metadata(MetadataBase):
         """
         :return: Returns the list of architecture this image/rpm should build for. This is an intersection
         of config specific arches & globally enabled arches in group.yml
+
+        For OKD variant: if okd.arches is defined in metadata, it overrides the standard arches config.
         """
         global_arches = (
             self.runtime.get_global_konflux_arches()
@@ -202,8 +205,19 @@ class Metadata(MetadataBase):
             else self.runtime.get_global_arches()
         )
 
-        if self.config.arches:
-            ca = self.config.arches
+        # For OKD variant, check if okd.arches is configured (image-level override)
+        config_arches = None
+        if self.runtime.variant == BuildVariant.OKD:
+            if self.config.okd.arches is not Missing:
+                config_arches = self.config.okd.arches
+                self.logger.debug(f'Using OKD-specific arches override: {config_arches}')
+
+        # Fall back to standard arches config if no OKD override
+        if config_arches is None and self.config.arches:
+            config_arches = self.config.arches
+
+        if config_arches:
+            ca = config_arches
             intersection = list(set(global_arches) & set(ca))
             if len(intersection) != len(ca):
                 self.logger.info(

--- a/doozer/tests/test_metadata.py
+++ b/doozer/tests/test_metadata.py
@@ -910,3 +910,134 @@ class TestMetadata(TestCase):
 
         # Should return distgit.branch, not runtime.branch
         self.assertEqual(meta.branch(), "rhaos-5.0-rhel-9")
+
+    def test_get_arches_okd_with_image_override(self):
+        """Test that okd.arches override is used for OKD variant"""
+        data_obj = MagicMock(key="test-image", filename="test-image.yml", data={"name": "test-image"})
+        runtime = MagicMock()
+        runtime.variant = BuildVariant.OKD
+        runtime.arches = ['x86_64', 'aarch64', 's390x', 'ppc64le']  # Group-level arches
+        runtime.build_system = 'brew'
+
+        meta = Metadata("image", runtime, data_obj)
+        meta.logger = Mock()
+        meta.config = Model(
+            dict_to_model={
+                "arches": ['x86_64', 's390x'],  # Standard arches config
+                "okd": {
+                    "arches": ['x86_64', 'aarch64'],  # Image-specific OKD override
+                },
+            }
+        )
+
+        runtime.get_global_arches = Mock(return_value=['x86_64', 'aarch64', 's390x', 'ppc64le'])
+
+        # Should return intersection of okd.arches override with global arches
+        self.assertEqual(sorted(meta.get_arches()), ['aarch64', 'x86_64'])
+
+    def test_get_arches_okd_without_image_override(self):
+        """Test that standard arches config is used for OKD when no okd.arches override exists"""
+        data_obj = MagicMock(key="test-image", filename="test-image.yml", data={"name": "test-image"})
+        runtime = MagicMock()
+        runtime.variant = BuildVariant.OKD
+        runtime.arches = ['x86_64', 'aarch64', 's390x', 'ppc64le']
+        runtime.build_system = 'brew'
+
+        meta = Metadata("image", runtime, data_obj)
+        meta.logger = Mock()
+        meta.config = Model(
+            dict_to_model={
+                "arches": ['x86_64', 's390x'],  # Standard arches config
+            }
+        )
+
+        runtime.get_global_arches = Mock(return_value=['x86_64', 'aarch64', 's390x', 'ppc64le'])
+
+        # Should return intersection of standard arches with global arches
+        self.assertEqual(sorted(meta.get_arches()), ['s390x', 'x86_64'])
+
+    def test_get_arches_okd_with_missing_okd_arches(self):
+        """Test that standard arches is used when okd.arches is Missing"""
+        data_obj = MagicMock(key="test-image", filename="test-image.yml", data={"name": "test-image"})
+        runtime = MagicMock()
+        runtime.variant = BuildVariant.OKD
+        runtime.arches = ['x86_64', 'aarch64']
+        runtime.build_system = 'brew'
+
+        meta = Metadata("image", runtime, data_obj)
+        meta.logger = Mock()
+        meta.config = Model(
+            dict_to_model={
+                "arches": ['x86_64', 'aarch64'],
+            }
+        )
+
+        runtime.get_global_arches = Mock(return_value=['x86_64', 'aarch64', 's390x', 'ppc64le'])
+
+        # Should return intersection of standard arches with global arches
+        self.assertEqual(sorted(meta.get_arches()), ['aarch64', 'x86_64'])
+
+    def test_get_arches_okd_with_no_arches_config(self):
+        """Test that global arches is used when no arches config exists"""
+        data_obj = MagicMock(key="test-image", filename="test-image.yml", data={"name": "test-image"})
+        runtime = MagicMock()
+        runtime.variant = BuildVariant.OKD
+        runtime.arches = ['x86_64', 'aarch64']
+        runtime.build_system = 'brew'
+
+        meta = Metadata("image", runtime, data_obj)
+        meta.logger = Mock()
+        meta.config = Model(dict_to_model={})
+
+        runtime.get_global_arches = Mock(return_value=['x86_64', 'aarch64'])
+
+        # Should return global arches
+        self.assertEqual(sorted(meta.get_arches()), ['aarch64', 'x86_64'])
+
+    def test_get_arches_ocp_ignores_okd_arches(self):
+        """Test that OCP variant ignores okd.arches and uses standard arches config"""
+        data_obj = MagicMock(key="test-image", filename="test-image.yml", data={"name": "test-image"})
+        runtime = MagicMock()
+        runtime.variant = BuildVariant.OCP
+        runtime.arches = ['x86_64', 'aarch64', 's390x', 'ppc64le']
+        runtime.build_system = 'brew'
+
+        meta = Metadata("image", runtime, data_obj)
+        meta.logger = Mock()
+        meta.config = Model(
+            dict_to_model={
+                "arches": ['x86_64', 's390x'],  # Standard arches config
+                "okd": {
+                    "arches": ['x86_64', 'aarch64'],  # Should be ignored for OCP
+                },
+            }
+        )
+
+        runtime.get_global_arches = Mock(return_value=['x86_64', 'aarch64', 's390x', 'ppc64le'])
+
+        # Should return intersection of standard arches with global arches, ignoring okd.arches
+        self.assertEqual(sorted(meta.get_arches()), ['s390x', 'x86_64'])
+
+    def test_get_arches_okd_konflux(self):
+        """Test that OKD with Konflux uses okd.arches override with konflux global arches"""
+        data_obj = MagicMock(key="test-image", filename="test-image.yml", data={"name": "test-image"})
+        runtime = MagicMock()
+        runtime.variant = BuildVariant.OKD
+        runtime.arches = ['x86_64', 'aarch64']
+        runtime.build_system = 'konflux'
+
+        meta = Metadata("image", runtime, data_obj)
+        meta.logger = Mock()
+        meta.config = Model(
+            dict_to_model={
+                "arches": ['x86_64', 's390x'],  # Standard arches config
+                "okd": {
+                    "arches": ['x86_64', 'aarch64'],  # Image-specific OKD override
+                },
+            }
+        )
+
+        runtime.get_global_konflux_arches = Mock(return_value=['x86_64', 'aarch64'])
+
+        # Should return intersection of okd.arches with global konflux arches
+        self.assertEqual(sorted(meta.get_arches()), ['aarch64', 'x86_64'])

--- a/ocp-build-data-validator/tests/test_schema/test_image_schema.py
+++ b/ocp-build-data-validator/tests/test_schema/test_image_schema.py
@@ -385,3 +385,52 @@ class TestImageSchema(unittest.TestCase):
             'enabled_repos': ['rhel-9-appstream-rpms', 'rhel-8-server-rpms'],
         }
         self.assertIsNone(image_schema.validate('filename', valid_data, images_dir=images_dir))
+
+    def test_validate_with_okd_arches(self):
+        """
+        Test validation of okd.arches in image metadata.
+        """
+        valid_data = {
+            'from': {},
+            'name': 'test-image',
+            'for_payload': True,
+            'delivery': {'delivery_repo_names': ['foo']},
+            'okd': {
+                'arches': ['x86_64', 'aarch64'],
+            },
+        }
+        self.assertIsNone(image_schema.validate('filename', valid_data))
+
+    def test_validate_with_invalid_okd_arches(self):
+        """
+        Test validation of invalid okd.arches (non-array type).
+        """
+        invalid_data = {
+            'from': {},
+            'name': 'test-image',
+            'for_payload': True,
+            'delivery': {'delivery_repo_names': ['foo']},
+            'okd': {
+                'arches': 'x86_64',  # Should be an array
+            },
+        }
+        error = image_schema.validate('filename', invalid_data)
+        self.assertIsNotNone(error)
+        self.assertIn("'x86_64' is not of type 'array'", error)
+
+    def test_validate_with_invalid_arch_in_okd_arches(self):
+        """
+        Test validation of invalid architecture name in okd.arches.
+        """
+        invalid_data = {
+            'from': {},
+            'name': 'test-image',
+            'for_payload': True,
+            'delivery': {'delivery_repo_names': ['foo']},
+            'okd': {
+                'arches': ['x86_64', 'invalid_arch'],
+            },
+        }
+        error = image_schema.validate('filename', invalid_data)
+        self.assertIsNotNone(error)
+        self.assertIn("'invalid_arch' is not one of", error)

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -777,7 +777,24 @@
     "odcs-": {},
     "okd": {
       "description": "If present, this config is specific to OKD content overrides.",
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "arches": {
+          "type": "array",
+          "description": "List of architectures to build for OKD variant. Overrides group-level okd.arches.",
+          "items": {
+            "$ref": "arch.schema.json"
+          }
+        },
+        "arches!": {
+          "$ref": "#/properties/okd/properties/arches"
+        },
+        "arches?": {
+          "$ref": "#/properties/okd/properties/arches"
+        },
+        "arches-": {}
+      },
+      "additionalProperties": true
     },
     "okd!": {
       "$ref": "#/properties/okd"

--- a/pyartcd/tests/pipelines/test_okd_scan.py
+++ b/pyartcd/tests/pipelines/test_okd_scan.py
@@ -223,10 +223,10 @@ class TestOkdScanPipeline(unittest.IsolatedAsyncioTestCase):
         self.assertIn('--variant=okd', cmd)
 
     @patch.dict(os.environ, {'KUBECONFIG': '/path/to/kubeconfig'})
-    @patch('pyartcd.pipelines.okd_scan.constants.OKD_ENABLED_VERSIONS', ['4.21'])
+    @patch('pyartcd.pipelines.okd_scan.util.is_okd_version_enabled', new_callable=AsyncMock, return_value=True)
     @patch('pyartcd.pipelines.okd_scan.jenkins')
     @patch('pyartcd.pipelines.okd_scan.exectools.cmd_gather_async')
-    async def test_scan_passes_okd_arches(self, mock_cmd_gather, mock_jenkins):
+    async def test_scan_passes_okd_arches(self, mock_cmd_gather, mock_jenkins, _mock_is_enabled):
         """
         Test that okd-scan passes --arches with OKD_ARCHES to doozer.
         This ensures arch-change detection uses OKD target arches, not OCP group arches.


### PR DESCRIPTION
Allow individual image metadata to override the global OKD arch configuration defined in group.yml okd.arches. This provides fine-grained control over which architectures each image builds for in the OKD variant.

Test: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fokd/1511/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OKD image configurations can specify supported architectures independently.
  * Architecture selection honors OKD-specific settings while retaining standard and global fallbacks.
  * Configuration validation accepts valid architecture lists and rejects invalid values.

* **Bug Fixes**
  * OCP configurations continue using standard architecture settings without being affected by OKD-specific options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->