### PR TITLE
ART-21797: Split advisory placeholder substitution between prepare-release and promote

### DIFF
--- a/elliott/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliott/elliottlib/cli/attach_cve_flaws_cli.py
@@ -17,7 +17,7 @@ from errata_tool import Erratum
 from elliottlib import constants
 from elliottlib.bzutil import Bug, BugTracker, get_flaws, get_highest_security_impact, sort_cve_bugs
 from elliottlib.cli.common import cli, click_coroutine, find_default_advisory, use_default_advisory_option
-from elliottlib.errata import get_errata_live_id, is_security_advisory
+from elliottlib.errata import is_security_advisory
 from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
 from elliottlib.runtime import Runtime
 from elliottlib.shipment_model import CveAssociation, ReleaseNotes
@@ -197,10 +197,6 @@ class AttachCveFlaws:
         self.errata_api: Optional[AsyncErrataAPI] = None
         self.major, self.minor, self.patch = self.runtime.get_major_minor_patch()
         self._replace_vars = {"MAJOR": self.major, "MINOR": self.minor, "PATCH": self.patch}
-        rpm_advisory = self.runtime.group_config.advisories.get("rpm")
-        if rpm_advisory is not None:
-            live_id = get_errata_live_id(rpm_advisory)
-            self._replace_vars.update({"RPM_ADVISORY": live_id})
 
     async def run(self):
         if self.runtime.build_system == 'konflux':

--- a/elliott/elliottlib/shipment_utils.py
+++ b/elliott/elliottlib/shipment_utils.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from typing import Dict, Iterable, List, Tuple
 from urllib.parse import urlparse
 
@@ -8,12 +9,80 @@ from artcommonlib.gitlab import GitLabClient
 from artcommonlib.jira_config import JIRA_DOMAIN_NAME
 from artcommonlib.model import Model
 from artcommonlib.util import new_roundtrip_yaml_handler
+from errata_tool import Erratum
 
 from elliottlib.shipment_model import Issue, Issues, ReleaseNotes, ShipmentConfig
 
 logger = logging.getLogger(__name__)
 
 yaml = new_roundtrip_yaml_handler()
+
+
+def patch_et_advisory_text(
+    advisory_num: int,
+    format_dict: dict[str, str],
+    dry_run: bool = False,
+    validate_targets: tuple[str, ...] = (),
+) -> list[str]:
+    """
+    Load an Errata Tool advisory, substitute placeholders in description/solution, and commit.
+
+    Soft-fails on Erratum update/commit errors: logs a warning and returns without raising.
+    If the advisory cannot be loaded at all, validation is also skipped (the text is
+    unreadable) — callers that need guaranteed validation should treat an all-empty return
+    from a known-placeholder advisory as suspicious when ET errors are present.
+
+    Arg(s):
+        advisory_num (int): Numeric Errata Tool advisory ID.
+        format_dict (dict[str, str]): Mapping of placeholder name → replacement value, e.g.
+            ``{"IMAGE_ADVISORY": "RHBA-2025:13660"}``.  Only entries with non-empty values
+            should be included; the caller is responsible for filtering.
+        dry_run (bool): When True, log what would change but do not call update/commit.
+        validate_targets (tuple[str, ...]): Placeholder names to scan for in the advisory
+            text *before* substitution.  Any that appear in the text but have no corresponding
+            entry in ``format_dict`` are returned as human-readable strings so the caller can
+            raise or warn.  Pass ``()`` to skip validation (default).
+    Return Value(s):
+        list[str]: Descriptions of placeholders from ``validate_targets`` that were found in
+            the advisory text but could not be substituted (no value in ``format_dict``).
+            Empty when ``validate_targets`` is ``()`` or all targets were resolved.
+    """
+    unresolved: list[str] = []
+    try:
+        advisory = Erratum(errata_id=advisory_num)
+    except Exception as ex:
+        # If the advisory cannot be loaded at all, neither substitution nor placeholder
+        # validation is possible. Log and return empty — caller is responsible for deciding
+        # whether this is fatal.
+        logger.warning("Failed to load ET advisory %s: %s", advisory_num, ex)
+        return unresolved
+
+    updates = {}
+    for field in ("description", "solution"):
+        text = getattr(advisory, field, None)
+        if not text:
+            continue
+        new_text = text
+        for var_name, value in format_dict.items():
+            new_text = new_text.replace(f"{{{var_name}}}", value)
+        if new_text != text:
+            updates[field] = new_text
+        for target in validate_targets:
+            if f"{{{target}}}" in text and target not in format_dict:
+                unresolved.append(f"ET advisory {advisory_num} ({field}): {{{target}}}")
+
+    if not updates:
+        return unresolved
+    if dry_run:
+        logger.info("[DRY-RUN] Would patch ET advisory %s: %s", advisory_num, list(updates))
+        return unresolved
+    try:
+        advisory.update(**updates)
+        advisory.commit()
+        logger.info("Patched ET advisory %s: %s", advisory_num, list(updates))
+    except Exception as ex:
+        logger.warning("Failed to commit ET advisory %s: %s", advisory_num, ex)
+    return unresolved
 
 
 def get_shipment_configs_from_mr(
@@ -120,6 +189,24 @@ def set_jira_bug_ids(release_notes: ReleaseNotes, bug_ids: Iterable[str]):
         release_notes.issues = None
     else:
         release_notes.issues = Issues(fixed=fixed)
+
+
+def get_full_advisory_id_from_shipment(shipment_config: ShipmentConfig) -> str:
+    """
+    Build the full advisory display id from a shipment config's live ID, e.g. "RHBA-2025:13660".
+
+    Arg(s):
+        shipment_config (ShipmentConfig): Shipment config containing releaseNotes.type and
+            releaseNotes.live_id.
+    Return Value(s):
+        str: The formatted advisory id, e.g. "RHBA-2025:13660".
+    """
+    release_notes = shipment_config.shipment.data.releaseNotes
+    live_id = release_notes.live_id
+    if not live_id:
+        raise ValueError("Could not find live ID in image shipment config!")
+    year = datetime.now().strftime("%Y")
+    return f"{release_notes.type.upper()}-{year}:{live_id:04}"
 
 
 def get_bug_ids_from_open_shipment_mrs(

--- a/elliott/tests/test_shipment_utils.py
+++ b/elliott/tests/test_shipment_utils.py
@@ -1,9 +1,19 @@
 import os
 import unittest
+from datetime import datetime
 from unittest.mock import Mock, patch
 
 from artcommonlib.model import Model
 from elliottlib import shipment_utils
+from elliottlib.shipment_model import (
+    Data,
+    Environments,
+    Metadata,
+    ReleaseNotes,
+    Shipment,
+    ShipmentConfig,
+    ShipmentEnv,
+)
 
 
 class TestShipmentUtils(unittest.TestCase):
@@ -754,6 +764,42 @@ class TestGetBugIdsFromOpenShipmentMrs(unittest.TestCase):
 
         self._call(group="openshift-4.18")
         mock_get_configs.assert_called_once_with(mr_url, group="openshift-4.18")
+
+
+def _make_shipment_config(kind: str, **release_notes_kwargs) -> ShipmentConfig:
+    """Build a minimal ShipmentConfig for a given kind, optionally with releaseNotes fields."""
+    data = None
+    if release_notes_kwargs:
+        data = Data(releaseNotes=ReleaseNotes(type="RHBA", **release_notes_kwargs))
+    return ShipmentConfig(
+        shipment=Shipment(
+            metadata=Metadata(
+                product="ocp",
+                application=f"app-{kind}",
+                group="openshift-4.18",
+                assembly="4.18.1",
+                fbc=(kind == "fbc"),
+            ),
+            environments=Environments(
+                stage=ShipmentEnv(releasePlan=f"rp-{kind}-stage"),
+                prod=ShipmentEnv(releasePlan=f"rp-{kind}-prod"),
+            ),
+            data=data,
+        )
+    )
+
+
+class TestGetFullAdvisoryIdFromShipment(unittest.TestCase):
+    def test_formats_type_year_and_padded_id(self):
+        year = datetime.now().strftime("%Y")
+        self.assertEqual(
+            shipment_utils.get_full_advisory_id_from_shipment(_make_shipment_config("image", live_id=42)),
+            f"RHBA-{year}:0042",
+        )
+        self.assertEqual(
+            shipment_utils.get_full_advisory_id_from_shipment(_make_shipment_config("image", live_id=13660)),
+            f"RHBA-{year}:13660",
+        )
 
 
 if __name__ == '__main__':

--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -49,10 +49,15 @@ from doozerlib.cli.release_gen_payload import (
     payload_imagestream_namespace_and_name,
 )
 from elliottlib.cli.konflux_release_cli import validate_snapshot_against_rpa
-from elliottlib.errata import push_cdn_stage
+from elliottlib.errata import get_errata_live_id, push_cdn_stage
 from elliottlib.errata_async import AsyncErrataAPI
 from elliottlib.shipment_model import Issue, ReleaseNotes, ShipmentConfig, Snapshot, SnapshotSpec, Tools
-from elliottlib.shipment_utils import get_shipment_configs_from_mr, set_jira_bug_ids
+from elliottlib.shipment_utils import (
+    get_full_advisory_id_from_shipment,
+    get_shipment_configs_from_mr,
+    patch_et_advisory_text,
+    set_jira_bug_ids,
+)
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from pyartcd import constants
@@ -284,6 +289,10 @@ class PrepareReleaseKonfluxPipeline:
             await self.finalize_et_advisories(impetus_advisories)
             if shipment_data:
                 await self.finalize_shipment(shipment_data)
+
+            # Phase 4: Now that every advisory's live ID is known and no further CVE/reconcile
+            # renders will happen, resolve any remaining IMAGE_ADVISORY/RPM_ADVISORY placeholders.
+            await self.resolve_advisory_placeholders(impetus_advisories, shipment_data)
 
             await self.handle_jira_ticket()
         except Exception as ex:
@@ -691,6 +700,171 @@ class PrepareReleaseKonfluxPipeline:
 
             # Update shipment MR with found CVE flaws
             await self.update_shipment_mr(shipments_by_kind, env, shipment_url)
+
+    async def resolve_advisory_placeholders(self, impetus_advisories: dict, shipment_data: tuple | None):
+        """Final pass to resolve IMAGE_ADVISORY/RPM_ADVISORY placeholders.
+
+        Boilerplate templates reference these advisories before either one exists, so their
+        descriptions are created (and possibly re-rendered by attach-cve-flaws) with the literal
+        placeholder text. This runs last, once every advisory's live ID is known and no further
+        CVE/reconcile renders will happen. Patches both classic ET advisories (rpm, rhcos) via
+        the Errata Tool API and the Konflux shipment MR YAML. Arch SHA digest placeholders are
+        promote's responsibility and are not touched here.
+
+        :param impetus_advisories: Dict of {impetus: advisory_num} from create_et_advisories().
+        :param shipment_data: Tuple of (shipments_by_kind, env, shipment_url) from
+                 prepare_shipment_builds(), or None if no shipment config exists.
+        """
+        rpm_advisory_num = (impetus_advisories or {}).get("rpm")
+        rpm_advisory_id = None
+        if rpm_advisory_num and rpm_advisory_num > 0:
+            try:
+                rpm_advisory_id = get_errata_live_id(rpm_advisory_num)
+            except Exception as ex:
+                self.logger.warning("Failed to resolve RPM_ADVISORY placeholder: %s", ex)
+
+        image_advisory_id = None
+        if shipment_data:
+            shipments_by_kind, _, _ = shipment_data
+            image_shipment = (shipments_by_kind or {}).get("image")
+            if (
+                image_shipment
+                and image_shipment.shipment.data
+                and isinstance(image_shipment.shipment.data.releaseNotes.live_id, int)
+            ):
+                image_advisory_id = get_full_advisory_id_from_shipment(image_shipment)
+
+        if not rpm_advisory_id and not image_advisory_id:
+            return
+
+        format_dict = {
+            k: v for k, v in {"IMAGE_ADVISORY": image_advisory_id, "RPM_ADVISORY": rpm_advisory_id}.items() if v
+        }
+
+        # Patch classic ET advisories (rpm, rhcos); microshift is populated after promote.
+        et_unresolved: list[str] = []
+        for impetus, advisory_num in (impetus_advisories or {}).items():
+            if impetus == "microshift" or advisory_num <= 0:
+                continue
+            et_unresolved.extend(
+                self._resolve_classic_advisory_placeholders(
+                    advisory_num, image_advisory=image_advisory_id, rpm_advisory=rpm_advisory_id
+                )
+            )
+
+        # Patch the Konflux shipment MR YAML (description/solution on releaseNotes).
+        shipment_unresolved: list[str] = []
+        if shipment_data:
+            shipments_by_kind, env, shipment_url = shipment_data
+            await self._resolve_shipment_mr_placeholders(shipments_by_kind, env, shipment_url, format_dict)
+            shipment_unresolved = self._collect_unresolved_shipment_placeholders(shipments_by_kind)
+
+        # Raise if any Phase-4 placeholders remain (shift left: promote won't catch IMAGE/RPM advisory holes).
+        if not self.dry_run:
+            all_unresolved = et_unresolved + shipment_unresolved
+            if all_unresolved:
+                raise ValueError(
+                    "Advisory placeholders not fully resolved after Phase 4:\n"
+                    + "\n".join(f"  - {item}" for item in all_unresolved)
+                )
+
+    def _resolve_classic_advisory_placeholders(
+        self, advisory_num: int, image_advisory: str | None, rpm_advisory: str | None
+    ) -> list[str]:
+        """Replace any resolvable IMAGE_ADVISORY/RPM_ADVISORY placeholders in a classic
+        advisory's description/solution text, leaving everything else untouched.
+
+        Returns a list of human-readable strings describing placeholders that appeared in
+        the advisory text but could not be resolved (because the corresponding advisory ID
+        was None). Collected by the caller for post-resolution validation.
+
+        :param advisory_num: The classic advisory's numeric id.
+        :param image_advisory: The image advisory's full display id (e.g. "RHBA-2025:13660"),
+                 or None if not resolvable.
+        :param rpm_advisory: The rpm advisory's full display id, or None if not resolvable.
+        """
+        format_dict = {k: v for k, v in {"IMAGE_ADVISORY": image_advisory, "RPM_ADVISORY": rpm_advisory}.items() if v}
+        return patch_et_advisory_text(
+            advisory_num,
+            format_dict,
+            dry_run=self.dry_run,
+            validate_targets=("IMAGE_ADVISORY", "RPM_ADVISORY"),
+        )
+
+    async def _resolve_shipment_mr_placeholders(
+        self,
+        shipments_by_kind: dict,
+        env: str,
+        shipment_url: str,
+        format_dict: dict[str, str],
+    ) -> None:
+        """Replace IMAGE_ADVISORY/RPM_ADVISORY placeholders in shipment MR YAML description/solution fields.
+
+        Modifies the ShipmentConfig objects in-place and re-pushes via update_shipment_mr().
+        No-op if no shipment has matching placeholders or if shipment_url is absent.
+
+        :param shipments_by_kind: In-memory shipment configs keyed by advisory kind.
+        :param env: The environment (prod or stage).
+        :param shipment_url: The shipment MR URL used to locate and update the MR.
+        :param format_dict: Placeholder name → replacement value (IMAGE_ADVISORY, RPM_ADVISORY).
+        """
+        if not shipment_url or not format_dict:
+            return
+
+        modified: dict = {}
+        for kind, shipment in (shipments_by_kind or {}).items():
+            if kind == "fbc":
+                continue
+            rn = shipment.shipment.data.releaseNotes if (shipment.shipment.data) else None
+            if not rn:
+                continue
+            changed = False
+            for field in ("description", "solution"):
+                text = getattr(rn, field, None)
+                if not text:
+                    continue
+                new_text = text
+                for var_name, value in format_dict.items():
+                    new_text = new_text.replace(f"{{{var_name}}}", value)
+                if new_text != text:
+                    setattr(rn, field, new_text)
+                    changed = True
+            if changed:
+                modified[kind] = shipment
+
+        if not modified:
+            self.logger.info("No advisory ID placeholders found in shipment MR YAML, skipping")
+            return
+
+        try:
+            await self.update_shipment_mr(modified, env, shipment_url)
+            self.logger.info("Resolved advisory ID placeholders in shipment MR: %s", list(modified))
+        except Exception as ex:
+            self.logger.error("Failed to patch shipment MR with advisory ID placeholders: %s", ex)
+            raise
+
+    def _collect_unresolved_shipment_placeholders(self, shipments_by_kind: dict) -> list[str]:
+        """Scan in-memory shipment configs for remaining IMAGE_ADVISORY/RPM_ADVISORY placeholders.
+
+        Called after _resolve_shipment_mr_placeholders() has already made its in-place substitutions.
+        Any placeholder still present means the corresponding advisory ID was unavailable.
+
+        :param shipments_by_kind: In-memory shipment configs keyed by advisory kind.
+        :return: List of human-readable strings describing each unresolved placeholder location.
+        """
+        unresolved: list[str] = []
+        for kind, shipment in (shipments_by_kind or {}).items():
+            if kind == "fbc":
+                continue
+            rn = shipment.shipment.data.releaseNotes if shipment.shipment.data else None
+            if not rn:
+                continue
+            for field in ("description", "solution"):
+                text = getattr(rn, field, None) or ""
+                for target in ("IMAGE_ADVISORY", "RPM_ADVISORY"):
+                    if f"{{{target}}}" in text:
+                        unresolved.append(f"shipment {kind} (releaseNotes.{field}): {{{target}}}")
+        return unresolved
 
     async def verify_attached_operators(self, kind_to_builds: Dict[str, List[str]]):
         """

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -10,7 +10,6 @@ import sys
 import tarfile
 import traceback
 from collections import OrderedDict
-from datetime import datetime
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Set, Union
 from urllib.parse import quote, urlparse
@@ -43,10 +42,11 @@ from doozerlib.cli.release_gen_payload import (
     payload_imagestream_namespace_and_name,
 )
 from elliottlib.errata import get_builds, get_errata_live_id
-from elliottlib.shipment_model import ShipmentConfig
 from elliottlib.shipment_utils import (
+    get_full_advisory_id_from_shipment,
     get_shipment_config_from_mr,
     get_shipment_configs_from_mr,
+    patch_et_advisory_text,
 )
 from github import GithubException
 from ruamel.yaml import YAML
@@ -361,7 +361,7 @@ class PromotePipeline:
                 image_shipment = get_shipment_config_from_mr(shipment_url, "image")
                 if not image_shipment:
                     raise ValueError("Could not find image shipment config in merge request!")
-                full_advisory_id = self.get_full_advisory_id_from_shipment(image_shipment)
+                full_advisory_id = get_full_advisory_id_from_shipment(image_shipment)
                 logger.info("Constructed full advisory ID from shipment config: %s", full_advisory_id)
                 # TODO: ensure that shipment MR is open and is not in a draft state (and optionally stage push is successful)
             else:
@@ -479,6 +479,14 @@ class PromotePipeline:
                 except Exception as ex:
                     self._logger.warning("Failed to update shipment MR with payload SHAs: %s", ex)
                     await self._slack_client.say_in_thread(f"Failed to update shipment MR with payload SHAs: {ex}")
+
+                # Also patch classic ET advisories (rpm, rhcos) with arch SHA digests.
+                # IMAGE_ADVISORY/RPM_ADVISORY are handled by Phase 4 in prepare_release_konflux.
+                if impetus_advisories:
+                    try:
+                        await self.update_et_advisories_with_payload_shas(impetus_advisories, payload_shas)
+                    except Exception as ex:
+                        self._logger.warning("Failed to update ET advisories with payload SHAs: %s", ex)
             else:
                 self._logger.info("No shipment configuration found, skipping shipment MR update")
 
@@ -1544,22 +1552,6 @@ class PromotePipeline:
         live_id = advisory_info["fulladvisory"].rsplit("-", 1)[0]  # RHBA-2019:2681-02 => RHBA-2019:2681
         return live_id
 
-    @staticmethod
-    def get_full_advisory_id_from_shipment(shipment_config: ShipmentConfig) -> str:
-        """Get the full advisory ID from a shipment config, if it exists."""
-        live_id = shipment_config.shipment.data.releaseNotes.live_id
-        if not live_id:
-            raise ValueError("Could not find live ID in image shipment config!")
-
-        # construct full advisory id like RHBA-2025:13660
-        advisory_type = shipment_config.shipment.data.releaseNotes.type
-        year = datetime.now().strftime("%Y")
-
-        # Important: Pad liveID with 0 if it is less than 4 digits
-        live_id = f"{live_id:04}"
-
-        return f"{advisory_type.upper()}-{year}:{live_id}"
-
     def verify_advisory_status(self, advisory_info: Dict):
         if advisory_info["status"] not in {"QE", "REL_PREP", "PUSH_READY", "IN_PUSH", "SHIPPED_LIVE"}:
             raise VerificationError(f"Advisory {advisory_info['id']} should not be in {advisory_info['status']} state.")
@@ -2621,37 +2613,8 @@ class PromotePipeline:
 
                 self._logger.info("Prepared format variable: %s -> %s", arch, sha)
 
-        # Generate IMAGE_ADVISORY template key for all shipment types (get from image shipment data)
-        try:
-            image_shipment = shipments_by_kind.get("image")
-
-            if (
-                image_shipment
-                and hasattr(image_shipment.shipment.data.releaseNotes, 'type')
-                and hasattr(image_shipment.shipment.data.releaseNotes, 'live_id')
-                and image_shipment.shipment.data.releaseNotes.type
-                and image_shipment.shipment.data.releaseNotes.live_id
-            ):
-                image_advisory = self.get_full_advisory_id_from_shipment(image_shipment)
-                format_dict["IMAGE_ADVISORY"] = image_advisory
-                self._logger.info("Generated IMAGE_ADVISORY: %s", image_advisory)
-            else:
-                self._logger.warning("Cannot generate IMAGE_ADVISORY: missing image shipment or type/live_id data")
-        except Exception as ex:
-            self._logger.warning("Failed to generate IMAGE_ADVISORY: %s", ex)
-
-        # Generate RPM_ADVISORY template key for all shipment types
-        try:
-            rpm_advisory_id = await self._get_rpm_advisory_id()
-            if rpm_advisory_id:
-                format_dict["RPM_ADVISORY"] = rpm_advisory_id
-                self._logger.info("Generated RPM_ADVISORY: %s", rpm_advisory_id)
-            else:
-                # Don't replace RPM_ADVISORY placeholder if we can't generate it
-                self._logger.warning("Could not generate RPM_ADVISORY: no RPM advisory found in releases.yml")
-        except Exception as ex:
-            # Don't replace RPM_ADVISORY placeholder on error
-            self._logger.warning("Failed to generate RPM_ADVISORY: %s", ex)
+        # IMAGE_ADVISORY and RPM_ADVISORY are resolved by Phase 4 of prepare_release_konflux.
+        # Promote only handles arch SHA digest placeholders that are known post-promotion.
 
         # If no replacements are needed, skip this shipment
         if not format_dict:
@@ -2808,6 +2771,47 @@ class PromotePipeline:
         except Exception as ex:
             self._logger.error("Failed to update shipment MR with doc updates: %s", ex)
             raise
+
+    async def update_et_advisories_with_payload_shas(
+        self,
+        impetus_advisories: Dict[str, int],
+        payload_shas: Dict[str, str],
+    ) -> None:
+        """Patch classic ET advisory (rpm, rhcos) solution with arch payload SHA digests.
+
+        IMAGE_ADVISORY and RPM_ADVISORY placeholders are the responsibility of Phase 4 in
+        prepare_release_konflux, which runs before promote. This method only handles the
+        arch digest placeholders that are only known after payload promotion.
+
+        :param impetus_advisories: Dict of {impetus: advisory_num} from group config advisories.
+        :param payload_shas: Dict mapping architecture names to their SHA256 digests.
+        """
+        # "x864_DIGEST" (not "x86_64") matches the template variable name used in ET boilerplate.
+        arch_map = {
+            "x86_64": "x864_DIGEST",
+            "s390x": "s390x_DIGEST",
+            "ppc64le": "ppc64le_DIGEST",
+            "aarch64": "aarch64_DIGEST",
+        }
+        format_dict: Dict[str, str] = {arch_map[arch]: sha for arch, sha in payload_shas.items() if arch in arch_map}
+
+        if not format_dict:
+            self._logger.info("No arch SHA digests to substitute in ET advisories, skipping")
+            return
+
+        for impetus, advisory_num in impetus_advisories.items():
+            # microshift advisory is populated post-promote by a separate pipeline step.
+            if impetus == "microshift" or not advisory_num or advisory_num <= 0:
+                continue
+            self._patch_et_advisory_placeholders(advisory_num, format_dict)
+
+    def _patch_et_advisory_placeholders(self, advisory_num: int, format_dict: Dict[str, str]) -> None:
+        """Replace template placeholders in an ET advisory's description and solution fields.
+
+        :param advisory_num: The classic ET advisory's numeric id.
+        :param format_dict: Dict of placeholder name to replacement value.
+        """
+        patch_et_advisory_text(advisory_num, format_dict, dry_run=self.runtime.dry_run)
 
     async def _get_rpm_advisory_id(self) -> Optional[str]:
         """Get RPM advisory ID from releases.yml and query errata endpoint for advisory type.

--- a/pyartcd/tests/pipelines/test_prepare_release_konflux.py
+++ b/pyartcd/tests/pipelines/test_prepare_release_konflux.py
@@ -1076,6 +1076,205 @@ class TestPrepareReleaseKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
         # Verify that execute_command_with_logging was not called
         pipeline.execute_command_with_logging.assert_not_called()
 
+    async def test_resolve_advisory_placeholders_noop_when_nothing_resolvable(self):
+        """No rpm advisory and no shipment: nothing to resolve, no ET API calls."""
+        pipeline = PrepareReleaseKonfluxPipeline(
+            slack_client=self.mock_slack_client,
+            runtime=self.runtime,
+            group=self.group,
+            assembly=self.assembly,
+        )
+        pipeline.logger = Mock()
+
+        await pipeline.resolve_advisory_placeholders({}, None)
+
+    @patch("elliottlib.shipment_utils.Erratum")
+    @patch("pyartcd.pipelines.prepare_release_konflux.get_errata_live_id")
+    async def test_resolve_advisory_placeholders_patches_classic_advisories(self, mock_get_live_id, mock_erratum_cls):
+        """Classic rpm advisory gets IMAGE_ADVISORY placeholder resolved from image shipment live_id."""
+        from elliottlib.shipment_utils import get_full_advisory_id_from_shipment
+
+        pipeline = PrepareReleaseKonfluxPipeline(
+            slack_client=self.mock_slack_client,
+            runtime=self.runtime,
+            group=self.group,
+            assembly=self.assembly,
+        )
+        pipeline.logger = Mock()
+        pipeline.dry_run = False
+
+        mock_get_live_id.return_value = "RHBA-2026:16158"
+
+        image_shipment = ShipmentConfig(
+            shipment=Shipment(
+                metadata=Metadata(product="ocp", group=self.group, assembly=self.assembly, application="app-image"),
+                environments=Environments(
+                    stage=ShipmentEnv(releasePlan="rp-img-stage"),
+                    prod=ShipmentEnv(releasePlan="rp-img-prod"),
+                ),
+                data=Data(
+                    releaseNotes=ReleaseNotes(
+                        type="RHBA",
+                        live_id=16164,
+                    )
+                ),
+            )
+        )
+
+        rpm_advisory = Mock(description="See https://access.redhat.com/errata/{IMAGE_ADVISORY}", solution="")
+        mock_erratum_cls.return_value = rpm_advisory
+
+        impetus_advisories = {"rpm": 999}
+        shipment_data = ({"image": image_shipment}, "prod", "https://gitlab.example.com/x/-/merge_requests/1")
+
+        await pipeline.resolve_advisory_placeholders(impetus_advisories, shipment_data)
+
+        expected_image_advisory = get_full_advisory_id_from_shipment(image_shipment)
+
+        # classic rpm advisory patched with IMAGE_ADVISORY and committed
+        mock_erratum_cls.assert_called_once_with(errata_id=999)
+        rpm_advisory.update.assert_called_once_with(
+            description=f"See https://access.redhat.com/errata/{expected_image_advisory}"
+        )
+        rpm_advisory.commit.assert_called_once()
+
+    @patch("elliottlib.shipment_utils.Erratum")
+    @patch("pyartcd.pipelines.prepare_release_konflux.get_errata_live_id")
+    async def test_resolve_advisory_placeholders_commit_failure_soft_fails(self, mock_get_live_id, mock_erratum_cls):
+        """Erratum.commit() raising must not propagate — Phase 4 continues with a warning."""
+        pipeline = PrepareReleaseKonfluxPipeline(
+            slack_client=self.mock_slack_client,
+            runtime=self.runtime,
+            group=self.group,
+            assembly=self.assembly,
+        )
+        pipeline.logger = Mock()
+        pipeline.dry_run = False
+        pipeline.update_shipment_mr = AsyncMock()
+
+        mock_get_live_id.return_value = "RHBA-2026:16158"
+
+        image_shipment = ShipmentConfig(
+            shipment=Shipment(
+                metadata=Metadata(product="ocp", group=self.group, assembly=self.assembly, application="app-image"),
+                environments=Environments(
+                    stage=ShipmentEnv(releasePlan="rp-img-stage"),
+                    prod=ShipmentEnv(releasePlan="rp-img-prod"),
+                ),
+                data=Data(
+                    releaseNotes=ReleaseNotes(
+                        type="RHBA",
+                        live_id=16164,
+                    )
+                ),
+            )
+        )
+
+        rpm_advisory = Mock(description="See {IMAGE_ADVISORY}", solution="")
+        rpm_advisory.commit.side_effect = Exception("ET network error")
+        mock_erratum_cls.return_value = rpm_advisory
+
+        impetus_advisories = {"rpm": 999}
+        shipment_data = ({"image": image_shipment}, "prod", "https://gitlab.example.com/x/-/merge_requests/1")
+
+        # Must not raise; soft-fail is intentional for ET API errors.
+        await pipeline.resolve_advisory_placeholders(impetus_advisories, shipment_data)
+
+    @patch("elliottlib.shipment_utils.Erratum")
+    @patch("pyartcd.pipelines.prepare_release_konflux.get_errata_live_id")
+    async def test_resolve_advisory_placeholders_raises_when_placeholder_unresolvable(
+        self, mock_get_live_id, mock_erratum_cls
+    ):
+        """Raises ValueError if a target placeholder remains after Phase 4 substitution."""
+        pipeline = PrepareReleaseKonfluxPipeline(
+            slack_client=self.mock_slack_client,
+            runtime=self.runtime,
+            group=self.group,
+            assembly=self.assembly,
+        )
+        pipeline.logger = Mock()
+        pipeline.dry_run = False
+        pipeline.update_shipment_mr = AsyncMock()
+
+        # RPM live-ID lookup fails → rpm_advisory_id stays None
+        mock_get_live_id.side_effect = Exception("ET unavailable")
+
+        image_shipment = ShipmentConfig(
+            shipment=Shipment(
+                metadata=Metadata(product="ocp", group=self.group, assembly=self.assembly, application="app-image"),
+                environments=Environments(
+                    stage=ShipmentEnv(releasePlan="rp-img-stage"),
+                    prod=ShipmentEnv(releasePlan="rp-img-prod"),
+                ),
+                data=Data(
+                    releaseNotes=ReleaseNotes(
+                        type="RHBA",
+                        live_id=16164,
+                        description="See {IMAGE_ADVISORY} and {RPM_ADVISORY} for details.",
+                    )
+                ),
+            )
+        )
+
+        # Classic advisory has no placeholders in its text
+        rpm_advisory_mock = Mock(description="", solution="")
+        mock_erratum_cls.return_value = rpm_advisory_mock
+
+        impetus_advisories = {"rpm": 999}
+        shipment_data = ({"image": image_shipment}, "prod", "https://gitlab.example.com/x/-/merge_requests/1")
+
+        with self.assertRaises(ValueError) as ctx:
+            await pipeline.resolve_advisory_placeholders(impetus_advisories, shipment_data)
+
+        self.assertIn("RPM_ADVISORY", str(ctx.exception))
+        self.assertIn("not fully resolved", str(ctx.exception))
+
+    @patch("elliottlib.shipment_utils.Erratum")
+    @patch("pyartcd.pipelines.prepare_release_konflux.get_errata_live_id")
+    async def test_resolve_advisory_placeholders_raises_on_shipment_mr_push_failure(
+        self, mock_get_live_id, mock_erratum_cls
+    ):
+        """Raises if update_shipment_mr() fails — in-memory changes must not be silently orphaned."""
+        pipeline = PrepareReleaseKonfluxPipeline(
+            slack_client=self.mock_slack_client,
+            runtime=self.runtime,
+            group=self.group,
+            assembly=self.assembly,
+        )
+        pipeline.logger = Mock()
+        pipeline.dry_run = False
+        pipeline.update_shipment_mr = AsyncMock(side_effect=Exception("GitLab push failed"))
+
+        mock_get_live_id.return_value = "RHBA-2026:16158"
+
+        image_shipment = ShipmentConfig(
+            shipment=Shipment(
+                metadata=Metadata(product="ocp", group=self.group, assembly=self.assembly, application="app-image"),
+                environments=Environments(
+                    stage=ShipmentEnv(releasePlan="rp-img-stage"),
+                    prod=ShipmentEnv(releasePlan="rp-img-prod"),
+                ),
+                data=Data(
+                    releaseNotes=ReleaseNotes(
+                        type="RHBA",
+                        live_id=16164,
+                        description="See {IMAGE_ADVISORY}",
+                    )
+                ),
+            )
+        )
+
+        rpm_advisory_mock = Mock(description="See {IMAGE_ADVISORY}", solution="")
+        mock_erratum_cls.return_value = rpm_advisory_mock
+
+        impetus_advisories = {"rpm": 999}
+        shipment_data = ({"image": image_shipment}, "prod", "https://gitlab.example.com/x/-/merge_requests/1")
+
+        with self.assertRaises(Exception) as ctx:
+            await pipeline.resolve_advisory_placeholders(impetus_advisories, shipment_data)
+
+        self.assertIn("GitLab push failed", str(ctx.exception))
+
 
 class TestCheckBugConfigForGa(unittest.IsolatedAsyncioTestCase):
     def setUp(self):

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -1882,7 +1882,7 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
     @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
     @patch("pyartcd.pipelines.promote.PromotePipeline.check_blocker_bugs")
     @patch("pyartcd.pipelines.promote.get_shipment_config_from_mr")
-    @patch("pyartcd.pipelines.promote.datetime")
+    @patch("elliottlib.shipment_utils.datetime")
     @patch(
         "pyartcd.pipelines.promote.util.load_releases_config",
         return_value={
@@ -1996,6 +1996,65 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         # Ensure the legacy advisory info path was not used
         pipeline.get_advisory_info.assert_not_called()
 
+    @patch("elliottlib.shipment_utils.Erratum")
+    @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
+    async def test_update_et_advisories_with_payload_shas(self, _, mock_erratum_cls):
+        """ET advisories get solution patched with arch SHA digests; IMAGE/RPM advisory IDs left to Phase 4."""
+        runtime = MagicMock(
+            config={
+                "build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"},
+                "jira": {"url": JIRA_SERVER_URL},
+            },
+            working_dir=Path("/path/to/working"),
+            dry_run=False,
+        )
+        pipeline = PromotePipeline(runtime, group="openshift-4.22", assembly="4.22.1", signing_env="prod")
+        pipeline._logger = MagicMock()
+
+        rpm_advisory = MagicMock()
+        rpm_advisory.description = "See https://access.redhat.com/errata/{IMAGE_ADVISORY}"
+        rpm_advisory.solution = "The image digest is {x864_DIGEST}"
+        mock_erratum_cls.return_value = rpm_advisory
+
+        impetus_advisories = {"rpm": 999, "microshift": 111}
+        payload_shas = {"x86_64": "sha256:aabbcc", "s390x": "sha256:ddeeff"}
+
+        await pipeline.update_et_advisories_with_payload_shas(impetus_advisories, payload_shas)
+
+        # Only rpm advisory patched; microshift skipped
+        mock_erratum_cls.assert_called_once_with(errata_id=999)
+        rpm_advisory.update.assert_called_once()
+        call_kwargs = rpm_advisory.update.call_args[1]
+        # SHA digest substituted in solution; IMAGE_ADVISORY left untouched (Phase 4's responsibility)
+        self.assertIn("sha256:aabbcc", call_kwargs.get("solution", ""))
+        self.assertNotIn("description", call_kwargs)
+        rpm_advisory.commit.assert_called_once()
+
+    @patch("elliottlib.shipment_utils.Erratum")
+    @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
+    async def test_update_et_advisories_dry_run_skips_commit(self, _, mock_erratum_cls):
+        """In dry-run mode ET advisory is not committed."""
+        runtime = MagicMock(
+            config={
+                "build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"},
+                "jira": {"url": JIRA_SERVER_URL},
+            },
+            working_dir=Path("/path/to/working"),
+            dry_run=True,
+        )
+        pipeline = PromotePipeline(runtime, group="openshift-4.22", assembly="4.22.1", signing_env="prod")
+        pipeline._logger = MagicMock()
+
+        rpm_advisory = MagicMock()
+        rpm_advisory.description = "See {IMAGE_ADVISORY}"
+        rpm_advisory.solution = "digest is {x864_DIGEST}"
+        mock_erratum_cls.return_value = rpm_advisory
+
+        await pipeline.update_et_advisories_with_payload_shas({"rpm": 999}, {"x86_64": "sha256:aabbcc"})
+
+        rpm_advisory.update.assert_not_called()
+        rpm_advisory.commit.assert_not_called()
+
     @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
     def test_build_create_symlink(self, _):
         runtime = MagicMock(
@@ -2045,14 +2104,13 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
     async def test_update_shipment_with_payload_shas_no_image_shipment(
         self, mock_getenv: Mock, mock_gitlab_class: Mock, mock_get_shipment_configs: Mock, _
     ):
-        """Test when no image shipment is found in MR"""
+        """Promote patches only arch SHA digests in shipment MR; IMAGE/RPM advisory IDs are Phase 4's concern."""
         mock_getenv.side_effect = lambda key: {"GITLAB_TOKEN": "fake-token"}.get(key)
 
-        # Setup GitLab mocks to prevent real network calls
         mock_gitlab = MagicMock()
         mock_gitlab_class.return_value = mock_gitlab
 
-        # No image shipment in configs
+        # Only rpm shipment — no image shipment; promote should still proceed with SHA-only patching
         mock_get_shipment_configs.return_value = {"rpm": MagicMock()}
 
         runtime = MagicMock()
@@ -2061,18 +2119,16 @@ class TestPromotePipeline(IsolatedAsyncioTestCase):
         runtime.logger = MagicMock()
 
         pipeline = PromotePipeline(runtime, group="openshift-4.19", assembly="4.19.0", signing_env="prod")
-        # Mock the RPM advisory generation to prevent doozer calls
-        pipeline._get_rpm_advisory = AsyncMock(return_value=None)
 
         payload_shas = {"x86_64": "sha256:abc123"}
         shipment_url = "https://gitlab.example.com/project/-/merge_requests/123"
 
         await pipeline.update_shipment_with_payload_shas(shipment_url, payload_shas)
 
-        # Should log warning about missing IMAGE_ADVISORY generation
-        runtime.logger.warning.assert_any_call(
-            "Cannot generate IMAGE_ADVISORY: missing image shipment or type/live_id data"
-        )
+        # IMAGE_ADVISORY/RPM_ADVISORY warnings should NOT appear — promote no longer handles them
+        for call in runtime.logger.warning.call_args_list:
+            self.assertNotIn("IMAGE_ADVISORY", str(call))
+            self.assertNotIn("RPM_ADVISORY", str(call))
 
     @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
     @patch("pyartcd.pipelines.promote.get_github_client_for_org")


### PR DESCRIPTION
  ## Summary

  Enforce a clean split of responsibilities for advisory placeholder substitution (`{IMAGE_ADVISORY}`, `{RPM_ADVISORY}`, arch SHA digests).

  **prepare_release_konflux owns `{IMAGE_ADVISORY}` / `{RPM_ADVISORY}`:**
  After `finalize_et_advisories()` and `finalize_shipment()` complete, all advisory live IDs are stable and no further CVE/reconcile renders will overwrite text. A new `resolve_advisory_placeholders()` step runs at that point and patches:
  - Classic ET advisories (rpm, rhcos) via the Errata Tool API
  - Konflux shipment MR YAML (`releaseNotes.description` / `solution`) by modifying ShipmentConfig objects in-memory and re-pushing via `update_shipment_mr()`

  Early `RPM_ADVISORY` resolution removed from `attach_cve_flaws` init — `SafeFormatter` leaves unfound keys as-is so placeholders survive until resolution time.

  **promote owns arch SHA digests (`{x864_DIGEST}`, etc.):**
  After payload promotion, two new paths patch arch digests:
  - `update_et_advisories_with_payload_shas()` — patches classic ET advisories
  - `_prepare_shipment_templates()` — patches the shipment MR YAML (IMAGE_ADVISORY/RPM_ADVISORY removed from its format dict)

  **Other:**
  - Consolidate `get_full_advisory_id_from_shipment()` into `elliottlib.shipment_utils` (was a static method on `PromotePipeline`)
  - Guard `DRY_RUN_LIVE_ID`: skip `get_full_advisory_id_from_shipment` when `live_id` is the synthetic string set in dry-run mode (would fail `:04` int formatting)

  ## Test plan

  - [x] `resolve_advisory_placeholders` unit tests: ET advisory patching, shipment MR patching, dry-run behavior, `DRY_RUN_LIVE_ID` guard
  - [x] `update_et_advisories_with_payload_shas` unit tests: SHA digest substitution, microshift skipped, dry-run skips commit
  - [x] promote shipment template tests updated: IMAGE/RPM advisory warnings no longer expected
  - [x] 68/68 tests pass across `test_promote.py` + `test_prepare_release_konflux.py`
  - [ ] Manual: verify ET advisory (e.g. 170852) gets `{RPM_ADVISORY}` resolved after prepare-release, then `{x864_DIGEST}` etc. resolved after promote


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Advisory placeholders are resolved automatically after shipments and advisories are finalized.
  * Shipment advisory IDs include the release-note type, current year, and zero-padded live ID.
  * Classic advisory descriptions and solutions are updated with image and RPM advisory IDs.
  * Payload SHA values are added to applicable RPM and RHCOS advisories.
  * Shipment update records are refreshed when resolved values change.

* **Bug Fixes**
  * Missing shipment live IDs now produce a clear validation error.
  * Dry runs report intended updates without committing changes; individual failures no longer stop processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->