### PR TITLE
Modify dependency audit step to include warning

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -48,5 +48,10 @@ jobs:
         run: make test
 
       - name: Run dependency audit
+        id: audit
         continue-on-error: true
         run: make audit
+
+      - name: Log audit warning
+        if: steps.audit.outcome == 'failure'
+        run: echo "::warning title=Audit Warning::Dependency audit found vulnerabilities - see audit output above"


### PR DESCRIPTION
Updated dependency audit step to show warning on vulnerabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Dependency audit failures now display a clear workflow warning while allowing the remaining checks to continue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->