### PR TITLE
fix: allow rebase-priv for non-OCP layered products in Konflux scan-sources

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -235,7 +235,7 @@ class ConfigScanSources:
                 else:
                     self.rebase_into_priv()
             else:
-                # Non-OCP groups (layered products like oc-mirror-2.0, oadp-1.5, etc.) always
+                # Non-OCP groups (layered products like oc-mirror-2.0, logging-6.6, etc.) always
                 # build via Konflux, so the imagestream override version check does not apply.
                 self.rebase_into_priv()
 

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -222,13 +222,21 @@ class ConfigScanSources:
     async def run(self):
         # Try to rebase into openshift-priv to reduce upstream merge -> downstream build time
         if self.rebase_priv:
-            major, minor = self.runtime.get_major_minor_fields()
-            version = f'{major}.{minor}'
-            if not uses_konflux_imagestream_override(version):
-                self.logger.warning(
-                    'ocp4-scan for Konflux is not allowed to rebase into openshfit-priv version %s', version
-                )
+            if self.runtime.group.startswith("openshift-"):
+                # For OCP groups, only rebase when the version uses the Konflux imagestream override
+                # (i.e. versions that have fully migrated to Konflux, >= 4.12). Older OCP versions
+                # should not be rebased here.
+                major, minor = self.runtime.get_major_minor_fields()
+                version = f'{major}.{minor}'
+                if not uses_konflux_imagestream_override(version):
+                    self.logger.warning(
+                        'Konflux scan-sources is not allowed to rebase into openshift-priv for version %s', version
+                    )
+                else:
+                    self.rebase_into_priv()
             else:
+                # Non-OCP groups (layered products like oc-mirror-2.0, oadp-1.5, etc.) always
+                # build via Konflux, so the imagestream override version check does not apply.
                 self.rebase_into_priv()
 
         # Skip RPM-related operations for OKD variant or when --skip-rpms is set

--- a/doozer/tests/cli/test_scan_sources_konflux.py
+++ b/doozer/tests/cli/test_scan_sources_konflux.py
@@ -138,6 +138,63 @@ class TestMinimalCrashIsolation(TestScanSourcesKonflux):
             good_meta, 'good', 'main', 'main', priv_url='https://example.com/org/good.git'
         )
 
+    def _make_scanner_for_rebase_test(self, group, rebase_priv=True, major_minor=None):
+        """Helper: create a ConfigScanSources with a group set and runtime.image_tree mocked."""
+        self.runtime.group = group
+        self.runtime.image_tree = {}
+        if major_minor:
+            self.runtime.get_major_minor_fields.return_value = major_minor
+        scanner = ConfigScanSources(
+            runtime=self.runtime,
+            ci_kubeconfig=self.ci_kubeconfig,
+            session=self.session,
+            as_yaml=False,
+            rebase_priv=rebase_priv,
+            dry_run=False,
+        )
+        scanner.all_metas = set()
+        scanner.all_image_metas = set()
+        scanner.all_rpm_metas = set()
+        return scanner
+
+    async def _run_with_rebase_mocked(self, scanner):
+        """Helper: run scanner with everything except the rebase-priv gate mocked out."""
+        with (
+            patch.object(scanner, 'rebase_into_priv') as mock_rebase,
+            patch.object(scanner, 'check_changing_rpms', new_callable=AsyncMock),
+            patch.object(scanner, 'get_current_task_bundle_shas', new_callable=AsyncMock, return_value={}),
+            patch.object(scanner, 'generate_dependency_tree', return_value={}),
+            patch.object(scanner, 'scan_images', new_callable=AsyncMock),
+            patch.object(scanner, 'detect_rhcos_status', new_callable=AsyncMock),
+            patch.object(scanner, 'generate_report'),
+        ):
+            await scanner.run()
+            return mock_rebase
+
+    async def test_run_rebase_priv_called_for_non_ocp_group(self):
+        """Non-OCP layered products should always rebase into openshift-priv, regardless of version."""
+        scanner = self._make_scanner_for_rebase_test('oc-mirror-2.0')
+        mock_rebase = await self._run_with_rebase_mocked(scanner)
+        mock_rebase.assert_called_once()
+
+    async def test_run_rebase_priv_called_for_ocp_4_20(self):
+        """OCP groups >= 4.12 should rebase into openshift-priv."""
+        scanner = self._make_scanner_for_rebase_test('openshift-4.20', major_minor=(4, 20))
+        mock_rebase = await self._run_with_rebase_mocked(scanner)
+        mock_rebase.assert_called_once()
+
+    async def test_run_rebase_priv_skipped_for_ocp_4_11(self):
+        """OCP groups < 4.12 should NOT rebase into openshift-priv."""
+        scanner = self._make_scanner_for_rebase_test('openshift-4.11', major_minor=(4, 11))
+        mock_rebase = await self._run_with_rebase_mocked(scanner)
+        mock_rebase.assert_not_called()
+
+    async def test_run_rebase_priv_called_for_oadp_group(self):
+        """OADP layered product groups should always rebase, just like oc-mirror."""
+        scanner = self._make_scanner_for_rebase_test('oadp-1.5')
+        mock_rebase = await self._run_with_rebase_mocked(scanner)
+        mock_rebase.assert_called_once()
+
 
 class TestScanTaskBundleChanges(TestScanSourcesKonflux):
     """Test the scan_task_bundle_changes method."""


### PR DESCRIPTION
## Summary

- `rebase_into_priv()` in `scan_sources_konflux.py` was gated behind `uses_konflux_imagestream_override(version)`, which checks `(major, minor) >= (4, 12)`. Layered products like `oc-mirror-2.0` have version `"2.0"`, so the check evaluated to `False` and the rebase was silently skipped — even when `--rebase-priv` was explicitly passed by the pipeline.
- The fix scopes the imagestream override version check to `openshift-*` groups only. Non-OCP groups (layered products like `oc-mirror-2.0`, `oadp-1.5`, etc.) always build via Konflux, so the check is irrelevant and `rebase_into_priv()` should always run.
- Four new unit tests verify the behaviour for both layered products and OCP groups (including the < 4.12 guard).

## Test plan

- [x] `uv run pytest --verbose doozer/tests/cli/test_scan_sources_konflux.py` — 53/53 pass
- [x] `ruff check` and `ruff format --check` — clean on changed files

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source rebasing for OpenShift versions that support Konflux imagestream overrides.
  * Added warnings when rebasing is skipped for unsupported OpenShift versions.
  * Ensured non-OpenShift groups and supported OpenShift versions continue to rebase correctly.
  * Preserved rebasing behavior for OADP groups.

* **Tests**
  * Added coverage for supported, unsupported, non-OpenShift, and OADP rebase scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->