### PR TITLE
Rename OAP product keys to match csv_namespace

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -93,7 +93,7 @@ PRODUCT_NAMESPACE_MAP = {
     "acm": "art-acm-tenant",
     "multicluster-engine": "art-acm-tenant",
     "cert-manager": "art-oap-tenant",
-    "external-secrets": "art-oap-tenant",
+    "external-secrets-operator": "art-oap-tenant",
     "installer-ove-ui": "art-installer-agent-tenant",
     "logging": "art-logging-tenant",
     "mta": "art-mta-tenant",
@@ -104,7 +104,7 @@ PRODUCT_NAMESPACE_MAP = {
     "quay": "art-quay-tenant",
     "rhmtc": "art-mtc-tenant",
     "supplemental-tools": "ocp-art-tenant",
-    "zero-trust": "art-oap-tenant",
+    "zero-trust-workload-identity-manager": "art-oap-tenant",
 }
 
 # Konflux silent base-image workflow: ReleasePlan metadata.name and Application (Snapshot/Releases spec.application).
@@ -119,9 +119,9 @@ PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP = {
     "openshift-logging": ("logging-images-base-silent", "logging-images-base"),
     "acm": ("acm-images-base-silent", "acm-images-base"),
     "multicluster-engine": ("acm-images-base-silent", "acm-images-base"),
-    "external-secrets": ("oap-eso-images-base-silent", "oap-images-base"),
+    "external-secrets-operator": ("oap-eso-images-base-silent", "oap-images-base"),
     "cert-manager": ("oap-cm-images-base-silent", "oap-images-base"),
-    "zero-trust": ("oap-zt-images-base-silent", "oap-images-base"),
+    "zero-trust-workload-identity-manager": ("oap-zt-images-base-silent", "oap-images-base"),
 }
 
 # Pre-release lifecycle (software_lifecycle.phase) — registry-ocp-art-base-ec-prod via ART-19498.
@@ -133,7 +133,7 @@ PRODUCT_KUBECONFIG_MAP = {
     "acm": "ACM_KONFLUX_SA_KUBECONFIG",
     "multicluster-engine": "ACM_KONFLUX_SA_KUBECONFIG",
     "cert-manager": "OAP_KONFLUX_SA_KUBECONFIG",
-    "external-secrets": "OAP_KONFLUX_SA_KUBECONFIG",
+    "external-secrets-operator": "OAP_KONFLUX_SA_KUBECONFIG",
     "installer-ove-ui": "ASSISTED_INSTALLER_SA_KUBECONFIG",
     "logging": "LOGGING_KONFLUX_SA_KUBECONFIG",
     "mta": "MTA_KONFLUX_SA_KUBECONFIG",
@@ -145,7 +145,7 @@ PRODUCT_KUBECONFIG_MAP = {
     "quay": "QUAY_KONFLUX_SA_KUBECONFIG",
     "rhmtc": "MTC_KONFLUX_SA_KUBECONFIG",
     "supplemental-tools": "KONFLUX_SA_KUBECONFIG",
-    "zero-trust": "OAP_KONFLUX_SA_KUBECONFIG",
+    "zero-trust-workload-identity-manager": "OAP_KONFLUX_SA_KUBECONFIG",
 }
 
 # Default namespace for Konflux operations

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -51,8 +51,8 @@ CPE_PRODUCT_NAME_MAPPING = {
     'logging': 'logging',
     'openshift-logging': 'logging',
     'cert-manager': 'cert_manager',
-    'external-secrets': 'external_secrets_operator',
-    'zero-trust': 'zero_trust_workload_identity_manager',
+    'external-secrets-operator': 'external_secrets_operator',
+    'zero-trust-workload-identity-manager': 'zero_trust_workload_identity_manager',
 }
 
 LOGGER = logging.getLogger(__name__)

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -553,10 +553,16 @@ def konflux_image_component_name(application_name: str, image_name: str) -> str:
     Konflux Component name for a container image (distgit member), given the Application slug.
 
     OpenShift forbids dots/underscores; component names must be RFC1123-ish (lowercase, length limits).
+    Names exceeding 63 characters are truncated with a short hash suffix to ensure uniqueness.
     """
     name = f"{application_name}-{image_name}".replace(".", "-").replace("_", "-")
     # 'openshift-4-18-ose-installer-terraform' -> 'ose-4-18-ose-installer-terraform'
     name = f"ose-{name[10:]}" if name.startswith("openshift-") else name
+    if len(name) > 63:
+        import hashlib
+
+        suffix = hashlib.sha256(name.encode()).hexdigest()[:8]
+        name = f"{name[:54]}-{suffix}"
     return name
 
 

--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -553,16 +553,10 @@ def konflux_image_component_name(application_name: str, image_name: str) -> str:
     Konflux Component name for a container image (distgit member), given the Application slug.
 
     OpenShift forbids dots/underscores; component names must be RFC1123-ish (lowercase, length limits).
-    Names exceeding 63 characters are truncated with a short hash suffix to ensure uniqueness.
     """
     name = f"{application_name}-{image_name}".replace(".", "-").replace("_", "-")
     # 'openshift-4-18-ose-installer-terraform' -> 'ose-4-18-ose-installer-terraform'
     name = f"ose-{name[10:]}" if name.startswith("openshift-") else name
-    if len(name) > 63:
-        import hashlib
-
-        suffix = hashlib.sha256(name.encode()).hexdigest()[:8]
-        name = f"{name[:54]}-{suffix}"
     return name
 
 


### PR DESCRIPTION
Update PRODUCT_NAMESPACE_MAP, PRODUCT_KUBECONFIG_MAP, PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP, and CPE_PRODUCT_NAME_MAPPING to use csv_namespace-aligned product keys:
- external-secrets -> external-secrets-operator
- zero-trust -> zero-trust-workload-identity-manager

The product field in group.yml is used by Doozer to derive the OLM bundle name label namespace. Aligning it with csv_namespace ensures the bundle name label matches the Pyxis registry path.



rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated product identifiers for External Secrets Operator and Zero Trust Workload Identity Manager.
  - Improved consistency across release configuration, namespace handling, kubeconfig selection, and product metadata.
  - Existing configuration values and behavior remain unchanged apart from recognizing the updated product names.
  - Ensured related release and deployment workflows continue using the correct current product names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->