### PR TITLE
ART-20718: Add 24-hour cooldown for mass rebuilds

### DIFF
--- a/pyartcd/pyartcd/locks.py
+++ b/pyartcd/pyartcd/locks.py
@@ -38,6 +38,7 @@ class Lock(enum.Enum):
 class Keys(enum.Enum):
     BREW_MASS_REBUILD_QUEUE = 'appdata:brew:mass-rebuild-queue'
     KONFLUX_MASS_REBUILD_QUEUE = 'appdata:konflux:mass-rebuild-queue'
+    KONFLUX_LAST_MASS_REBUILD_START = 'appdata:konflux:last-mass-rebuild-start:{version}'
 
 
 # Use a BIG timeout value so that locks do not silently expire.

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -4,6 +4,7 @@ import logging
 import os
 import shutil
 import tempfile
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import Optional, Tuple
@@ -41,6 +42,7 @@ from pyartcd.util import (
     get_group_images,
     get_group_rpms,
     increment_fail_counter,
+    is_mass_rebuild,
     mass_rebuild_score,
     reset_fail_counter,
 )
@@ -748,7 +750,7 @@ class KonfluxOcpPipeline:
                 jenkins.update_description(f'Images: building {n_images} images.<br/>')
 
             # It's a mass rebuild if we included more than half of all active images in the group
-            if n_images > self.build_plan.active_image_count / 2:
+            if is_mass_rebuild(n_images, self.build_plan.active_image_count):
                 self.mass_rebuild = True
 
         else:  # build_plan.build_strategy == BuildStrategy.EXCEPT
@@ -893,8 +895,13 @@ class KonfluxOcpPipeline:
             version_queue_name=queue,
         )
 
+    async def _record_mass_rebuild_start(self):
+        key = locks.Keys.KONFLUX_LAST_MASS_REBUILD_START.value.format(version=self.version)
+        await redis.set_value(key, datetime.now().isoformat(), expiry=60 * 60 * 24 * 7)  # keep for 7 days
+
     async def rebase_and_build_images(self):
         if self.mass_rebuild:
+            await self._record_mass_rebuild_start()
             await self.slack_client.say(
                 f':construction: Starting image builds for {self.version} mass rebuild :construction:'
             )

--- a/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan_konflux.py
@@ -1,10 +1,11 @@
 import logging
 import os
 import sys
+from datetime import datetime, timedelta
 
 import click
 import yaml
-from artcommonlib import exectools
+from artcommonlib import exectools, redis
 
 from pyartcd import constants, jenkins, locks, util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
@@ -68,7 +69,7 @@ class Ocp4ScanPipeline:
         await self.handle_bridge_bug_mirroring()
 
         # Handle image source changes
-        self.handle_source_changes()
+        await self.handle_source_changes()
 
         # Handle RHCOS changes or inconsistencies
         await self.handle_rhcos_changes()
@@ -183,7 +184,7 @@ class Ocp4ScanPipeline:
             self.rhcos_inconsistent = True
             self.inconsistent_rhcos_rpms = e
 
-    def handle_source_changes(self):
+    async def handle_source_changes(self):
         if not self.changes:
             return
 
@@ -196,11 +197,22 @@ class Ocp4ScanPipeline:
         # Note: OCP5 uses the same ocp4-konflux job as OCP4
         match major_version:
             case 5 | 4:
-                self.trigger_ocp4()
+                await self.trigger_ocp4()
             case _:
                 raise ValueError(f'Unsupported OCP major version: {major_version}')
 
-    def trigger_ocp4(self):
+    async def _mass_rebuild_cooldown_active(self) -> bool:
+        """
+        Returns True if this group's last Konflux mass rebuild started less than 24h ago.
+        """
+
+        key = locks.Keys.KONFLUX_LAST_MASS_REBUILD_START.value.format(version=self.version)
+        last_start_str = await redis.get_value(key)
+        if not last_start_str:
+            return False
+        return datetime.now() - datetime.fromisoformat(last_start_str) < timedelta(hours=24)
+
+    async def trigger_ocp4(self):
         changed_rpm = self.changes.get('rpms', [])
 
         # Filter out okd-only images (mode: disabled, okd.mode: enabled)
@@ -213,6 +225,17 @@ class Ocp4ScanPipeline:
 
         if not changed_ocp_images and not changed_rpm:
             self.logger.info('No OCP images/RPMs to build')
+            return
+
+        active_ocp_image_count = sum(1 for image in self.report.get('images', []) if not image.get('okd_only'))
+        is_mass_rebuild = util.is_mass_rebuild(len(changed_ocp_images), active_ocp_image_count)
+        if is_mass_rebuild and await self._mass_rebuild_cooldown_active():
+            self.logger.info(
+                'Mass rebuild detected for %s but 24h cooldown has not elapsed; skipping ocp4-konflux trigger',
+                self.version,
+            )
+            jenkins.update_title(' [MASS REBUILD SKIPPED][COOLDOWN]')
+            jenkins.update_description('Mass rebuild detected but skipped: 24h cooldown has not elapsed.<br/>')
             return
 
         # Update Jenkins title and description

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -997,6 +997,14 @@ async def get_microshift_builds(group, assembly, env):
     return [n for n in nvrs if isolate_assembly_in_release(n) == assembly]
 
 
+def is_mass_rebuild(included_count: int, active_count: int) -> bool:
+    """
+    Building more than half of a group's active images counts as a mass rebuild.
+    """
+
+    return active_count > 0 and included_count > active_count / 2
+
+
 def mass_rebuild_score(version: str, okd: bool = False) -> int:
     """
     For the ocp_version (e.g. `4.16`) return an integer score value

--- a/pyartcd/tests/pipelines/test_ocp4_konflux.py
+++ b/pyartcd/tests/pipelines/test_ocp4_konflux.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import unittest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pyartcd.pipelines.ocp4_konflux import KonfluxOcpPipeline
+from pyartcd.runtime import Runtime
+
+
+class TestRecordMassRebuildStart(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.runtime = MagicMock(spec=Runtime)
+        self.runtime.doozer_working = '/tmp/doozer_working'
+        self.runtime.new_slack_client.return_value = AsyncMock()
+        self.pipeline = KonfluxOcpPipeline(
+            runtime=self.runtime,
+            assembly='stream',
+            data_path='https://github.com/openshift-eng/ocp-build-data',
+            image_build_strategy='none',
+            image_list='',
+            rpm_build_strategy='none',
+            rpm_list='',
+            version='4.21',
+            build_priority='auto',
+        )
+
+    @patch('pyartcd.pipelines.ocp4_konflux.redis.set_value')
+    async def test_records_timestamp_for_group(self, mock_set_value):
+        await self.pipeline._record_mass_rebuild_start()
+
+        mock_set_value.assert_called_once()
+        key, value = mock_set_value.call_args.args
+        self.assertEqual(key, 'appdata:konflux:last-mass-rebuild-start:4.21')
+        datetime.fromisoformat(value)  # should not raise
+        self.assertEqual(mock_set_value.call_args.kwargs.get('expiry'), 60 * 60 * 24 * 7)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
+++ b/pyartcd/tests/pipelines/test_ocp4_scan_konflux.py
@@ -2,8 +2,9 @@
 
 import os
 import unittest
+from datetime import datetime, timedelta
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import yaml
 from pyartcd.pipelines.ocp4_scan_konflux import Ocp4ScanPipeline
@@ -69,7 +70,7 @@ class TestOcp4ScanKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
         pipeline.get_changes = AsyncMock(side_effect=fake_get_changes)
         pipeline.get_rhcos_inconsistencies = AsyncMock()
         pipeline.handle_bridge_bug_mirroring = AsyncMock()
-        pipeline.handle_source_changes = Mock()
+        pipeline.handle_source_changes = AsyncMock()
         pipeline.handle_rhcos_changes = AsyncMock()
 
         with self.assertRaises(SystemExit) as ctx:
@@ -96,7 +97,7 @@ class TestOcp4ScanKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
         pipeline.get_changes = AsyncMock(side_effect=fake_get_changes)
         pipeline.get_rhcos_inconsistencies = AsyncMock()
         pipeline.handle_bridge_bug_mirroring = AsyncMock()
-        pipeline.handle_source_changes = Mock()
+        pipeline.handle_source_changes = AsyncMock()
         pipeline.handle_rhcos_changes = AsyncMock()
 
         with self.assertRaises(RuntimeError) as ctx:
@@ -124,7 +125,7 @@ class TestOcp4ScanKonfluxPipeline(unittest.IsolatedAsyncioTestCase):
         pipeline.get_changes = AsyncMock(side_effect=fake_get_changes)
         pipeline.get_rhcos_inconsistencies = AsyncMock()
         pipeline.handle_bridge_bug_mirroring = AsyncMock()
-        pipeline.handle_source_changes = Mock()
+        pipeline.handle_source_changes = AsyncMock()
         pipeline.handle_rhcos_changes = AsyncMock()
 
         with self.assertRaises(RuntimeError) as ctx:
@@ -158,7 +159,7 @@ class TestBridgeBugMirroring(unittest.IsolatedAsyncioTestCase):
         self.pipeline.get_changes = AsyncMock()
         self.pipeline.get_rhcos_inconsistencies = AsyncMock()
         self.pipeline.handle_bridge_bug_mirroring = AsyncMock()
-        self.pipeline.handle_source_changes = MagicMock()
+        self.pipeline.handle_source_changes = AsyncMock()
         self.pipeline.handle_rhcos_changes = AsyncMock()
 
         await self.pipeline.run()
@@ -211,6 +212,115 @@ class TestBridgeBugMirroring(unittest.IsolatedAsyncioTestCase):
 
         slack_client.bind_channel.assert_called_once_with("openshift-4.23")
         slack_client.say.assert_awaited_once_with("Bridge bug mirroring failed for 4.23. Please investigate")
+
+
+class TestTriggerOcp4MassRebuildCooldown(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.runtime = MagicMock(spec=Runtime)
+        self.runtime.dry_run = False
+        self.runtime.working_dir = MagicMock()
+        self.runtime.working_dir.__truediv__ = lambda self, x: MagicMock()
+        self.pipeline = Ocp4ScanPipeline(
+            runtime=self.runtime,
+            version='4.21',
+            data_path='https://github.com/openshift-eng/ocp-build-data',
+            assembly='stream',
+            data_gitref='',
+            image_list='',
+            skip_rpms=False,
+        )
+        # 3 of 4 active images changed -> mass rebuild
+        self.pipeline.report = {
+            'images': [
+                {'name': 'img1', 'changed': True},
+                {'name': 'img2', 'changed': True},
+                {'name': 'img3', 'changed': True},
+                {'name': 'img4', 'changed': False},
+            ]
+        }
+        self.pipeline.changes = {}
+
+    @patch('pyartcd.pipelines.ocp4_scan_konflux.jenkins')
+    @patch('pyartcd.pipelines.ocp4_scan_konflux.redis.get_value')
+    async def test_skips_trigger_when_mass_rebuild_cooldown_active(self, mock_get_value, mock_jenkins):
+        mock_get_value.return_value = datetime.now().isoformat()
+
+        await self.pipeline.trigger_ocp4()
+
+        mock_jenkins.start_ocp4_konflux.assert_not_called()
+        mock_jenkins.update_title.assert_called_with(' [MASS REBUILD SKIPPED][COOLDOWN]')
+
+    @patch('pyartcd.pipelines.ocp4_scan_konflux.jenkins')
+    @patch('pyartcd.pipelines.ocp4_scan_konflux.redis.get_value')
+    async def test_triggers_when_mass_rebuild_cooldown_expired(self, mock_get_value, mock_jenkins):
+        mock_get_value.return_value = (datetime.now() - timedelta(hours=25)).isoformat()
+
+        await self.pipeline.trigger_ocp4()
+
+        mock_jenkins.start_ocp4_konflux.assert_called_once()
+
+    @patch('pyartcd.pipelines.ocp4_scan_konflux.jenkins')
+    @patch('pyartcd.pipelines.ocp4_scan_konflux.redis.get_value')
+    async def test_triggers_when_no_prior_mass_rebuild_recorded(self, mock_get_value, mock_jenkins):
+        mock_get_value.return_value = None
+
+        await self.pipeline.trigger_ocp4()
+
+        mock_jenkins.start_ocp4_konflux.assert_called_once()
+
+    @patch('pyartcd.pipelines.ocp4_scan_konflux.jenkins')
+    @patch('pyartcd.pipelines.ocp4_scan_konflux.redis.get_value')
+    async def test_cooldown_not_checked_when_not_mass_rebuild(self, mock_get_value, mock_jenkins):
+        # Only 1 of 4 active images changed -> not a mass rebuild
+        self.pipeline.report = {
+            'images': [
+                {'name': 'img1', 'changed': True},
+                {'name': 'img2', 'changed': False},
+                {'name': 'img3', 'changed': False},
+                {'name': 'img4', 'changed': False},
+            ]
+        }
+        mock_get_value.return_value = datetime.now().isoformat()
+
+        await self.pipeline.trigger_ocp4()
+
+        mock_get_value.assert_not_called()
+        mock_jenkins.start_ocp4_konflux.assert_called_once()
+
+
+class TestMassRebuildCooldownCheck(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.runtime = MagicMock(spec=Runtime)
+        self.runtime.working_dir = MagicMock()
+        self.runtime.working_dir.__truediv__ = lambda self, x: MagicMock()
+        self.pipeline = Ocp4ScanPipeline(
+            runtime=self.runtime,
+            version='4.21',
+            data_path='https://github.com/openshift-eng/ocp-build-data',
+            assembly='stream',
+            data_gitref='',
+            image_list='',
+            skip_rpms=False,
+        )
+
+    @patch('pyartcd.pipelines.ocp4_scan_konflux.redis.get_value')
+    async def test_no_record_means_no_cooldown(self, mock_get_value):
+        mock_get_value.return_value = None
+
+        self.assertFalse(await self.pipeline._mass_rebuild_cooldown_active())
+        mock_get_value.assert_called_once_with('appdata:konflux:last-mass-rebuild-start:4.21')
+
+    @patch('pyartcd.pipelines.ocp4_scan_konflux.redis.get_value')
+    async def test_recent_record_means_cooldown_active(self, mock_get_value):
+        mock_get_value.return_value = datetime.now().isoformat()
+
+        self.assertTrue(await self.pipeline._mass_rebuild_cooldown_active())
+
+    @patch('pyartcd.pipelines.ocp4_scan_konflux.redis.get_value')
+    async def test_old_record_means_cooldown_expired(self, mock_get_value):
+        mock_get_value.return_value = (datetime.now() - timedelta(hours=25)).isoformat()
+
+        self.assertFalse(await self.pipeline._mass_rebuild_cooldown_active())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Replaces the previous global 24-hour mass-rebuild cooldown with a **per-group** cooldown for Konflux mass rebuilds, checked *before* the `ocp4-konflux` Jenkins job is even triggered.

## Why

The initial approach hooked the cooldown into the `KONFLUX_MASS_REBUILD` lock's enqueue path using a single global Redis key. That meant one OCP version's mass rebuild would block every other version's mass rebuild for 24h, and the check only ran after the Jenkins job had already started (it would sit retrying for up to 24h, tying up an executor).

## Changes

- **`pyartcd/locks.py`**: added a per-group key template, `KONFLUX_LAST_MASS_REBUILD_START` (`appdata:konflux:last-mass-rebuild-start:{version}`). No changes to the existing lock/queue serializer logic.
- **`pyartcd/util.py`**: added a shared `is_mass_rebuild(included_count, active_count)` helper (building more than half of a group's active images) used by both pipelines below, so the definition can't drift.
- **`ocp4-konflux`** (writer): whenever it actually begins a mass rebuild (`self.mass_rebuild` is `True`, in `rebase_and_build_images()`), it records a per-group timestamp in Redis (regardless of whether it was triggered manually or via scan).
- **`ocp4-scan-konflux`** (reader/gate): before triggering `ocp4-konflux`, it estimates whether the changed images would constitute a mass rebuild for that group (using the same `is_mass_rebuild` formula against its own scan-sources report). If so, it checks that group's Redis record — if less than 24h have passed since the last mass rebuild started, it skips triggering `ocp4-konflux` entirely for this scan cycle (title/description are updated to say so). Non-mass-rebuild changes are unaffected and never consult the cooldown.

## Behavior

- Each OCP/OKD group has its own independent 24h cooldown; a mass rebuild on one version no longer blocks another.
- A would-be mass rebuild during cooldown is never started at all (no Jenkins job, no waiting/retrying).
- Ordinary (non-mass) scan-triggered builds are triggered exactly as before.

## Testing

- `make lint` passes.
- `uv run pytest pyartcd/tests/` — full pyartcd unit suite passes (846 tests).
- Added/updated unit tests covering the cooldown check, the skip-on-cooldown trigger path, and the Redis record write.

## Related

- Jira: [ART-20718](https://redhat.atlassian.net/browse/ART-20718)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards to prevent Brew and Konflux mass rebuilds from starting more than once within a 24-hour period.
  * Mass rebuild start times are now recorded to support cooldown enforcement and reliable scheduling.
  * Repeated mass-rebuild triggers during the cooldown are skipped, with build status updated accordingly.
  * Normal, non-mass-rebuild processing continues without the cooldown restriction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->