### PR TITLE
ART-21533: Report conforma-verify results to #art-release

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_conforma_verify.py
+++ b/pyartcd/pyartcd/pipelines/build_conforma_verify.py
@@ -788,7 +788,7 @@ async def build_conforma_verify(
         if not slack_token:
             raise RuntimeError("SLACK_BOT_TOKEN is required with --report-to-slack")
         slack_client = runtime.new_slack_client(token=slack_token)
-        slack_client.bind_channel("#art-cluster-monitoring")
+        slack_client.bind_channel("#art-release")
 
     pipeline = BuildConformaVerifyPipeline(
         runtime=runtime,


### PR DESCRIPTION
Change the Slack channel for `build-conforma-verify` reports from `#art-cluster-monitoring` (testing) to `#art-release`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release notifications to appear in the `#art-release` Slack channel instead of `#art-cluster-monitoring`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->