### PR TITLE
ART-21854: feat(rhcos): make require_consistency stream-aware for RHEL10 support

### DIFF
--- a/doozer/doozerlib/cli/inspect_stream.py
+++ b/doozer/doozerlib/cli/inspect_stream.py
@@ -59,8 +59,10 @@ async def inspect_stream(runtime: Runtime, code: AssemblyIssueCode, strict: bool
             exit(0)
 
         runtime.logger.info("Checking cross-payload consistency requirements defined in group.yml")
-        for img in requirements.keys():
-            runtime.late_resolve_image(img, add=True)
+        stream_requirements = PayloadGenerator.normalize_rhcos_consistency_config(requirements)
+        for consistency_config in stream_requirements.values():
+            for img in consistency_config.keys():
+                runtime.late_resolve_image(img, add=True)
         assembly_inspector = AssemblyInspector(runtime)
         await assembly_inspector.initialize(lookup_mode="images")
         package_rpm_finder = PackageRpmFinder(runtime)

--- a/doozer/doozerlib/cli/release_gen_payload.py
+++ b/doozer/doozerlib/cli/release_gen_payload.py
@@ -2420,12 +2420,38 @@ class PayloadGenerator:
                 )
         return inconsistencies
 
+    RHCOS_DEFAULT_STREAM = "rhel-coreos"
+
+    @staticmethod
+    def normalize_rhcos_consistency_config(
+        payload_consistency_config: Dict[str, Any],
+    ) -> Dict[str, Dict[str, List[str]]]:
+        """
+        Normalizes rhcos.require_consistency into the stream-aware nested form:
+          {stream_name: {distgit_key: [pkg_name, ...]}}
+
+        Legacy flat form {distgit_key: [pkg_name, ...]} is treated as belonging
+        entirely to the "rhel-coreos" (RHEL9) stream.
+        """
+        if not payload_consistency_config:
+            return {}
+        values = list(payload_consistency_config.values())
+        all_lists = all(isinstance(v, list) for v in values)
+        all_dicts = all(isinstance(v, dict) for v in values)
+        if not (all_lists or all_dicts):
+            raise ValueError(
+                f"Unrecognized rhcos.require_consistency format — values must be uniformly "
+                f"lists (flat) or dicts (stream-keyed), got mixed: {payload_consistency_config!r}"
+            )
+        if all_lists:
+            return {PayloadGenerator.RHCOS_DEFAULT_STREAM: dict(payload_consistency_config)}
+        return dict(payload_consistency_config)
+
     def find_rhcos_payload_rpm_inconsistencies(
         self,
         primary_rhcos_build: RHCOSBuildInspector,
         payload_bri: Dict[str, BuildRecordInspector],
-        # payload tag -> [pkg_name1, ...]
-        payload_consistency_config: Dict[str, List[str]],
+        payload_consistency_config: Dict[str, Any],
         package_rpm_finder=None,
     ) -> List[AssemblyIssue]:
         """
@@ -2441,42 +2467,51 @@ class PayloadGenerator:
         :return: Returns a list of AssemblyIssue objects describing any inconsistencies found.
         """
         issues: List[AssemblyIssue] = []
+        logger = primary_rhcos_build.runtime.logger
 
-        # index by name the RPMs installed in the RHCOS build
-        rhcos_rpm_vrs: Dict[str, str] = {}  # name -> version-release
+        stream_requirements = self.normalize_rhcos_consistency_config(payload_consistency_config)
+
+        # Build per-stream RPM index. One RHCOSBuildInspector carries both RHEL9
+        # (rhel-coreos) and RHEL10 (rhel-coreos-10) RPMs tagged by repo_name.
+        rhcos_rpm_vrs_by_stream: Dict[str, Dict[str, str]] = {}
         for rpm in primary_rhcos_build.get_os_metadata_rpm_list():
             name, _, version, release, _, repo_name = rpm
-            if repo_name in COREOS_RHEL10_STREAMS:
-                # skip el10 rhcos kernels check
-                continue
-            rhcos_rpm_vrs[name] = f"{version}-{release}"
+            stream = "rhel-coreos-10" if repo_name in COREOS_RHEL10_STREAMS else self.RHCOS_DEFAULT_STREAM
+            rhcos_rpm_vrs_by_stream.setdefault(stream, {})[name] = f"{version}-{release}"
 
-        # check that each member consistency condition is met
-        primary_rhcos_build.runtime.logger.debug(f"Running payload consistency checks against {primary_rhcos_build}")
-        for payload_tag, consistent_pkgs in payload_consistency_config.items():
-            bbii = payload_bri.get(payload_tag)
-            if not bbii:
-                issues.append(
-                    AssemblyIssue(
-                        f"RHCOS consistency configuration specifies a payload tag '{payload_tag}' that does not exist",
-                        payload_tag,
-                        AssemblyIssueCode.IMPERMISSIBLE,
-                    )
+        logger.debug(f"Running payload consistency checks against {primary_rhcos_build}")
+        for stream_name, consistency_config in stream_requirements.items():
+            rhcos_rpm_vrs = rhcos_rpm_vrs_by_stream.get(stream_name)
+            if rhcos_rpm_vrs is None:
+                logger.debug(
+                    f"RHCOS build {primary_rhcos_build} has no '{stream_name}' RPM metadata; "
+                    f"skipping consistency checks for {list(consistency_config.keys())}"
                 )
                 continue
 
-            # check that each specified package in the member is consistent with the RHCOS build
-            for pkg in consistent_pkgs:
-                issues.append(
-                    self.validate_pkg_consistency_req(
-                        payload_tag,
-                        pkg,
-                        bbii,
-                        rhcos_rpm_vrs,
-                        str(primary_rhcos_build),
-                        package_rpm_finder or self.package_rpm_finder,
+            for distgit_key, consistent_pkgs in consistency_config.items():
+                bbii = payload_bri.get(distgit_key)
+                if not bbii:
+                    issues.append(
+                        AssemblyIssue(
+                            f"RHCOS consistency configuration specifies a payload component "
+                            f"'{distgit_key}' that does not exist",
+                            distgit_key,
+                            AssemblyIssueCode.IMPERMISSIBLE,
+                        )
                     )
-                )
+                    continue
+                for pkg in consistent_pkgs:
+                    issues.append(
+                        self.validate_pkg_consistency_req(
+                            distgit_key,
+                            pkg,
+                            bbii,
+                            rhcos_rpm_vrs,
+                            str(primary_rhcos_build),
+                            package_rpm_finder or self.package_rpm_finder,
+                        )
+                    )
 
         return [issue for issue in issues if issue]
 

--- a/doozer/tests/cli/test_gen_payload.py
+++ b/doozer/tests/cli/test_gen_payload.py
@@ -69,6 +69,191 @@ class TestGenPayloadCli(IsolatedAsyncioTestCase):
         self.assertEqual([], issues)
         self.assertEqual(2, len(rhcos_entries))
 
+    def test_normalize_rhcos_consistency_config_flat(self):
+        """Flat {distgit_key: [pkg]} format is wrapped under the rhel-coreos stream key."""
+        flat = {"driver-toolkit": ["kernel"]}
+        result = rgp_cli.PayloadGenerator.normalize_rhcos_consistency_config(flat)
+        self.assertEqual({"rhel-coreos": {"driver-toolkit": ["kernel"]}}, result)
+
+    def test_normalize_rhcos_consistency_config_nested(self):
+        """Stream-keyed nested format passes through unchanged."""
+        nested = {
+            "rhel-coreos": {"driver-toolkit": ["kernel"]},
+            "rhel-coreos-10": {"driver-toolkit-rhel10": ["kernel"]},
+        }
+        result = rgp_cli.PayloadGenerator.normalize_rhcos_consistency_config(nested)
+        self.assertEqual(nested, result)
+
+    def test_normalize_rhcos_consistency_config_empty(self):
+        """Empty or None input returns an empty dict."""
+        self.assertEqual({}, rgp_cli.PayloadGenerator.normalize_rhcos_consistency_config({}))
+        self.assertEqual({}, rgp_cli.PayloadGenerator.normalize_rhcos_consistency_config(None))
+
+    def test_normalize_rhcos_consistency_config_mixed_raises(self):
+        """Mixed list and dict values raise ValueError."""
+        mixed = {"driver-toolkit": ["kernel"], "rhel-coreos-10": {"driver-toolkit-rhel10": ["kernel"]}}
+        with self.assertRaises(ValueError):
+            rgp_cli.PayloadGenerator.normalize_rhcos_consistency_config(mixed)
+
+    @patch.object(rgp_cli.PayloadGenerator, "validate_pkg_consistency_req", return_value=None)
+    def test_find_rhcos_payload_rpm_inconsistencies_legacy_flat_still_works(self, validate_mock):
+        """Flat require_consistency config is treated as rhel-coreos stream; RHEL9 RPMs are used."""
+        rhcos_build = MagicMock()
+        rhcos_build.runtime.logger = MagicMock()
+        rhcos_build.get_os_metadata_rpm_list.return_value = [
+            ("kernel-core", 0, "5.14.0", "427.116.1.el9_4", "x86_64", "rhel-coreos"),
+            ("kernel", 0, "5.14.0", "427.116.1.el9_4", "x86_64", "rhel-coreos"),
+        ]
+        payload_bri = {"driver-toolkit": MagicMock()}
+        pg = rgp_cli.PayloadGenerator(runtime=MagicMock())
+        flat_config = {"driver-toolkit": ["kernel"]}
+
+        issues = pg.find_rhcos_payload_rpm_inconsistencies(
+            rhcos_build,
+            payload_bri,
+            flat_config,
+        )
+
+        self.assertEqual([], issues)
+        validate_mock.assert_called_once()
+        _, _, _, rhcos_rpm_vrs, _, _ = validate_mock.call_args[0]
+        self.assertEqual(
+            {"kernel-core": "5.14.0-427.116.1.el9_4", "kernel": "5.14.0-427.116.1.el9_4"},
+            rhcos_rpm_vrs,
+        )
+
+    def test_find_rhcos_payload_rpm_inconsistencies_rhel10_stream_checked(self):
+        """RHEL10 stream config uses the rhel-coreos-10 RPM dict, not the RHEL9 one."""
+        rhcos_build = MagicMock()
+        rhcos_build.runtime.logger = MagicMock()
+        rhcos_build.get_os_metadata_rpm_list.return_value = [
+            ("kernel-core", 0, "5.14.0", "427.116.1.el9_4", "x86_64", "rhel-coreos"),
+            ("kernel-core", 0, "6.12.0", "100.el10", "x86_64", "rhel-coreos-10"),
+        ]
+        payload_bri = {"driver-toolkit-rhel10": MagicMock()}
+        pg = rgp_cli.PayloadGenerator(runtime=MagicMock())
+        nested_config = {
+            "rhel-coreos-10": {"driver-toolkit-rhel10": ["kernel"]},
+        }
+        mismatch_issue = AssemblyIssue(
+            "RHCOS and 'driver-toolkit-rhel10' should use the same build of package 'kernel'",
+            "driver-toolkit-rhel10",
+            AssemblyIssueCode.FAILED_CONSISTENCY_REQUIREMENT,
+        )
+
+        with patch.object(
+            rgp_cli.PayloadGenerator,
+            "validate_pkg_consistency_req",
+            return_value=mismatch_issue,
+        ) as validate_mock:
+            issues = pg.find_rhcos_payload_rpm_inconsistencies(
+                rhcos_build,
+                payload_bri,
+                nested_config,
+            )
+
+        self.assertEqual(1, len(issues))
+        self.assertEqual(AssemblyIssueCode.FAILED_CONSISTENCY_REQUIREMENT, issues[0].code)
+        validate_mock.assert_called_once()
+        _, _, _, rhcos_rpm_vrs, _, _ = validate_mock.call_args[0]
+        self.assertEqual({"kernel-core": "6.12.0-100.el10"}, rhcos_rpm_vrs)
+
+    @patch.object(rgp_cli.PayloadGenerator, "validate_pkg_consistency_req")
+    def test_find_rhcos_payload_rpm_inconsistencies_missing_stream_no_issue(self, validate_mock):
+        """When the RHCOS build has no RHEL10 RPMs, rhel-coreos-10 checks are skipped silently."""
+        rhcos_build = MagicMock()
+        rhcos_build.runtime.logger = MagicMock()
+        rhcos_build.get_os_metadata_rpm_list.return_value = [
+            ("kernel-core", 0, "5.14.0", "427.116.1.el9_4", "x86_64", "rhel-coreos"),
+        ]
+        payload_bri = {"driver-toolkit-rhel10": MagicMock()}
+        pg = rgp_cli.PayloadGenerator(runtime=MagicMock())
+        nested_config = {
+            "rhel-coreos-10": {"driver-toolkit-rhel10": ["kernel"]},
+        }
+
+        issues = pg.find_rhcos_payload_rpm_inconsistencies(
+            rhcos_build,
+            payload_bri,
+            nested_config,
+        )
+
+        self.assertEqual([], issues)
+        validate_mock.assert_not_called()
+
+    @patch.object(rgp_cli.PayloadGenerator, "validate_pkg_consistency_req", return_value=None)
+    def test_find_rhcos_payload_rpm_inconsistencies_pre_ocp5_flat_config_no_issues(self, validate_mock):
+        """Pre-5.0 branch: flat require_consistency, RHEL9-only RHCOS RPMs, versions match."""
+        rhcos_build = MagicMock()
+        rhcos_build.runtime.logger = MagicMock()
+        rhcos_build.get_os_metadata_rpm_list.return_value = [
+            ("kernel", 0, "5.14.0", "427.116.1.el9_4", "x86_64", "rhel-coreos"),
+            ("kernel-core", 0, "5.14.0", "427.116.1.el9_4", "x86_64", "rhel-coreos"),
+        ]
+        payload_bri = {"driver-toolkit": MagicMock()}
+        pg = rgp_cli.PayloadGenerator(runtime=MagicMock())
+
+        issues = pg.find_rhcos_payload_rpm_inconsistencies(
+            rhcos_build,
+            payload_bri,
+            {"driver-toolkit": ["kernel"]},
+        )
+
+        self.assertEqual([], issues)
+        validate_mock.assert_called_once()
+        # RHEL9-only RPMs must be used — no RHEL10 dict constructed
+        _, _, _, rhcos_rpm_vrs, _, _ = validate_mock.call_args[0]
+        self.assertIn("kernel", rhcos_rpm_vrs)
+        self.assertEqual("5.14.0-427.116.1.el9_4", rhcos_rpm_vrs["kernel"])
+
+    @patch.object(
+        rgp_cli.PayloadGenerator,
+        "validate_pkg_consistency_req",
+        return_value=AssemblyIssue(
+            "RHCOS and 'driver-toolkit' should use the same build of package 'kernel'",
+            "driver-toolkit",
+            AssemblyIssueCode.FAILED_CONSISTENCY_REQUIREMENT,
+        ),
+    )
+    def test_find_rhcos_payload_rpm_inconsistencies_pre_ocp5_flat_config_mismatch(self, validate_mock):
+        """Pre-5.0 branch: flat require_consistency, RHEL9-only RHCOS RPMs, version mismatch raises issue."""
+        rhcos_build = MagicMock()
+        rhcos_build.runtime.logger = MagicMock()
+        rhcos_build.get_os_metadata_rpm_list.return_value = [
+            ("kernel", 0, "5.14.0", "427.116.1.el9_4", "x86_64", "rhel-coreos"),
+        ]
+        payload_bri = {"driver-toolkit": MagicMock()}
+        pg = rgp_cli.PayloadGenerator(runtime=MagicMock())
+
+        issues = pg.find_rhcos_payload_rpm_inconsistencies(
+            rhcos_build,
+            payload_bri,
+            {"driver-toolkit": ["kernel"]},
+        )
+
+        self.assertEqual(1, len(issues))
+        self.assertEqual(AssemblyIssueCode.FAILED_CONSISTENCY_REQUIREMENT, issues[0].code)
+
+    def test_find_rhcos_payload_rpm_inconsistencies_unknown_distgit_key(self):
+        """A distgit key not in the payload raises an IMPERMISSIBLE AssemblyIssue."""
+        rhcos_build = MagicMock()
+        rhcos_build.runtime.logger = MagicMock()
+        rhcos_build.get_os_metadata_rpm_list.return_value = [
+            ("kernel-core", 0, "5.14.0", "427.116.1.el9_4", "x86_64", "rhel-coreos"),
+        ]
+        pg = rgp_cli.PayloadGenerator(runtime=MagicMock())
+        flat_config = {"missing-image": ["kernel"]}
+
+        issues = pg.find_rhcos_payload_rpm_inconsistencies(
+            rhcos_build,
+            {},
+            flat_config,
+        )
+
+        self.assertEqual(1, len(issues))
+        self.assertEqual(AssemblyIssueCode.IMPERMISSIBLE, issues[0].code)
+        self.assertEqual("missing-image", issues[0].component)
+
     # test parameter validation
     def test_parameter_validation(self):
         # test when assembly is not valid


### PR DESCRIPTION
## Summary

OCP5 is a dual-RHEL release: nodes run both RHEL9 and RHEL10 CoreOS variants. `driver-toolkit-rhel10` must ship the exact same kernel version as `rhcos-rhel10`, just as `driver-toolkit` must match `rhcos` (RHEL9). There was no enforcement of this for the RHEL10 pair.

## Problem

**Before:** `find_rhcos_payload_rpm_inconsistencies` built a single RHEL9-only RPM dict by unconditionally dropping every RHEL10 RPM (tagged `rhel-coreos-10`/`rhel-coreos-10-extensions` via `COREOS_RHEL10_STREAMS`). A kernel drift between `driver-toolkit-rhel10` and `rhcos-rhel10` would ship silently into OCP5 nightlies — no `AssemblyIssue` raised, nothing blocks promotion.

**After:** The function builds a per-stream RPM index (`rhel-coreos` → RHEL9, `rhel-coreos-10` → RHEL10) and runs the consistency check independently for each stream. A mismatch between `driver-toolkit-rhel10` and `rhcos-rhel10` kernel now raises a `FAILED_CONSISTENCY_REQUIREMENT` `AssemblyIssue` and blocks the payload.

## Implementation Details

### `release_gen_payload.py`
- Add `normalize_rhcos_consistency_config()` static method to `PayloadGenerator`: normalizes `group.yml`'s `rhcos.require_consistency` from either the legacy flat format or the new stream-keyed nested format into `{stream_name: {distgit_key: [pkg, ...]}}`.
- Rewrite `find_rhcos_payload_rpm_inconsistencies` to build `rhcos_rpm_vrs_by_stream` (one dict per RHCOS stream) instead of a single filtered dict, then iterate per stream. If a stream has no RPM metadata in the build (e.g. pre-5.0 branches), the check is skipped gracefully with a debug log — no false positives.

### `inspect_stream.py`
- Fix the `late_resolve_image` loop to iterate inner distgit keys (not outer stream names), ensuring correct image resolution for both flat and nested `require_consistency` formats.

### Backwards compatibility
The legacy flat format (`driver-toolkit: [kernel]`) is normalized at runtime to `{rhel-coreos: {driver-toolkit: [kernel]}}`. All existing `group.yml` configs on pre-5.0 branches continue to work unchanged.

### Config change (separate PRs against ocp-build-data)
`openshift-5.0`/`openshift-5.1` `group.yml` will be updated to the new nested format once this lands:

```yaml
rhcos:
  require_consistency:
    rhel-coreos:
      driver-toolkit:
      - kernel
      ose-ovn-kubernetes:
      - libreswan
    rhel-coreos-10:
      driver-toolkit-rhel10:
      - kernel
```

## Testing

Trigger `build-sync-konflux` on Jenkins with both fork branches — no merge required:

| Parameter | Value |
|---|---|
| `BUILD_VERSION` | `5.0` |
| `ASSEMBLY` | `test` |
| `ART_TOOLS_COMMIT` | `lgarciaaco@[ART-21854](https://redhat.atlassian.net/browse/ART-21854)-dtk-rhel10-consistency` |
| `DOOZER_DATA_PATH` | `https://github.com/lgarciaaco/ocp-build-data` |
| `DOOZER_DATA_GITREF` | `ART-21854-dtk-rhel10-5.0` |
| `IMAGES` | `driver-toolkit-rhel10` |
| `PUBLISH` | `false` |
| `DRY_RUN` | `false` |

`build-sync-konflux` calls `setup_venv()` which clones and installs the `ART_TOOLS_COMMIT` fork branch. `DOOZER_DATA_PATH`/`DOOZER_DATA_GITREF` point doozer at the ocp-build-data fork branch that has the new nested `require_consistency` config.

Look in the Jenkins log for `Running payload consistency checks against <rhcos-build>` — a clean run confirms the RHEL9 check is unaffected; a `FAILED_CONSISTENCY_REQUIREMENT` issue naming `driver-toolkit-rhel10`/`kernel` confirms the new RHEL10 check is live.

Fixes: [ART-21854](https://redhat.atlassian.net/browse/ART-21854)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stream-aware RHCOS payload consistency validation for RHEL 9 and RHEL 10.
  * Supports both modern nested configuration and legacy flat configuration formats.
  * Reports configured RPM components that are missing from the payload.
* **Bug Fixes**
  * Improved consistency checks by using the appropriate metadata for the requested stream.
  * Avoids incorrect failures when stream metadata is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->