### PR TITLE
fix(doozer): retry and extend timeout on IDMS fetch in fbc:merge

### DIFF
--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -439,7 +439,7 @@ class KonfluxFbcFragmentMerger:
 
         # Render the FBC fragments
         logger.info("Rendering FBC fragments...")
-        semaphore = asyncio.BoundedSemaphore(10)  # Limit concurrency to avoid overwhelming the registry
+        semaphore = asyncio.BoundedSemaphore(5)  # Limit concurrency to avoid OOM and overwhelming the registry
 
         async def _render_fragment(fragment: str):
             async with semaphore:

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -38,7 +38,7 @@ from doozerlib.image import ImageMetadata
 from doozerlib.record_logger import RecordLogger
 from elliottlib.shipment_utils import get_shipment_config_from_mr
 from semver import VersionInfo
-from tenacity import retry, stop_after_attempt, wait_fixed
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 
 class AssemblyBundleCsvInfo(NamedTuple):
@@ -555,8 +555,17 @@ class KonfluxFbcFragmentMerger:
         if not fragments:
             raise ValueError("At least one fragment must be provided.")
 
-        async with httpx.AsyncClient(verify=truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)) as http_client:
+        async with httpx.AsyncClient(
+            verify=truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT),
+            timeout=httpx.Timeout(30.0),
+        ) as http_client:
 
+            @retry(
+                reraise=True,
+                stop=stop_after_attempt(3),
+                wait=wait_fixed(5),
+                retry=retry_if_exception_type(httpx.ConnectTimeout),
+            )
             async def _get_fragment_idms(fragment: str) -> list[dict]:
                 """
                 Fetch the ImageDigestMirrorSet for a given fragment.


### PR DESCRIPTION
## Summary

- `_merge_idms` in `konflux_fbc.py` fires concurrent GitHub raw fetches via `asyncio.gather` — one `ConnectTimeout` through the proxy kills the whole operation
- Added `timeout=httpx.Timeout(30.0)` to `AsyncClient` (default 5s is too short through proxy)
- Added `@retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(5), retry=retry_if_exception_type(httpx.ConnectTimeout))` on `_get_fragment_idms`

## Test plan

- [ ] Verify `doozer fbc:merge` succeeds in CI (transient timeout no longer fatal)
- [ ] Confirm format/lint pass (`make format-check && make lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving image mirror configuration by adding request timeouts and retries for connection timeouts.
  * Reduced concurrent fragment rendering to improve stability under load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->