### PR TITLE
[ART-21924] feat(shipment): add advisory field to shipment metadata model

### DIFF
--- a/elliott/elliottlib/shipment_model.py
+++ b/elliott/elliottlib/shipment_model.py
@@ -20,7 +20,7 @@ class Metadata(StrictBaseModel):
     group: str  # associated build-data group for component metadata
     assembly: str  # associated build-data assembly
     fbc: Optional[bool] = False  # indicates if shipment is for an FBC release
-    advisory: Optional[bool] = True  # when False, shipment-ci skips advisory URL check (registry-push-only)
+    advisory_required: Optional[bool] = True  # when False, shipment-ci skips advisory URL check (registry-push-only)
 
 
 class GitSource(StrictBaseModel):

--- a/elliott/elliottlib/shipment_model.py
+++ b/elliott/elliottlib/shipment_model.py
@@ -20,6 +20,7 @@ class Metadata(StrictBaseModel):
     group: str  # associated build-data group for component metadata
     assembly: str  # associated build-data assembly
     fbc: Optional[bool] = False  # indicates if shipment is for an FBC release
+    advisory: Optional[bool] = True  # when False, shipment-ci skips advisory URL check (registry-push-only)
 
 
 class GitSource(StrictBaseModel):

--- a/ocp-build-data-validator/validator/json_schemas/shipment.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/shipment.schema.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Schema generated on 2026-08-06 14:23 UTC from elliottlib.shipment_model",
+  "$comment": "Schema generated on 2026-08-06 15:29 UTC from elliottlib.shipment_model",
   "$defs": {
     "ComponentSource": {
       "additionalProperties": false,
@@ -213,7 +213,7 @@
           "default": false,
           "title": "Fbc"
         },
-        "advisory": {
+        "advisory_required": {
           "anyOf": [
             {
               "type": "boolean"
@@ -223,7 +223,7 @@
             }
           ],
           "default": true,
-          "title": "Advisory"
+          "title": "Advisory Required"
         }
       },
       "required": [

--- a/ocp-build-data-validator/validator/json_schemas/shipment.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/shipment.schema.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Schema generated on 2025-11-01 23:15 UTC from elliottlib.shipment_model",
+  "$comment": "Schema generated on 2026-08-06 14:23 UTC from elliottlib.shipment_model",
   "$defs": {
     "ComponentSource": {
       "additionalProperties": false,
@@ -212,6 +212,18 @@
           ],
           "default": false,
           "title": "Fbc"
+        },
+        "advisory": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": true,
+          "title": "Advisory"
         }
       },
       "required": [


### PR DESCRIPTION
Registry-push-only releases (like golang-builder via rh-push-to-registry-redhat-io) don't produce advisory artifacts. The shipment-ci generated watch job currently fails with "Both advisory_internal_url and advisory_url are empty" for these releases because there's no exit path between the FBC check and the advisory check.

This adds an `advisory` field to `Metadata` in `shipment_model.py` (default `true` for backward compat). When a shipment sets `advisory: false`, shipment-ci will skip the advisory URL extraction.

The JSON schema is regenerated to include the new field so `validate-ocp-build-data` accepts it.

Companion shipment-ci MR adds the actual check in the generated CI. Both must merge before ocp-shipment-data MR 716 can use `advisory: false`.

Jira: https://redhat.atlassian.net/browse/ART-21924


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional advisory setting to shipment metadata, enabled by default.
  * Shipments can now be marked as registry-push-only by disabling advisory mode.
* **Bug Fixes**
  * Registry-push-only shipments no longer require advisory URL validation.
* **Documentation**
  * Updated shipment validation rules to recognize the new advisory setting, including nullable values and its default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->