### PR TITLE
Add konflux.component name overrides to fix 63-char limit for Konflux Component names

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -354,7 +354,7 @@ class KonfluxImageBuilder:
 
                     image_with_digest = f"{image_pullspec.split(':')[0]}@{image_digest}"
                     source_url = artlib_util.convert_remote_git_to_https(build_repo.url)
-                    konflux_component_name = util.konflux_image_component_name(app_name, metadata.distgit_key)
+                    konflux_component_name = metadata.get_konflux_component_name(app_name)
 
                     ec_result = await self._konflux_client.verify_enterprise_contract(
                         namespace=self._config.namespace,
@@ -768,7 +768,7 @@ class KonfluxImageBuilder:
         await self._konflux_client.ensure_application(name=app_name, display_name=app_name)
 
         # Ensure the component resource exists
-        component_name = util.konflux_image_component_name(app_name, metadata.distgit_key)
+        component_name = metadata.get_konflux_component_name(app_name)
         default_revision = f"art-{self._config.group_name}-assembly-test-dgk-{metadata.distgit_key}"
         logger.info(f"Using component: {component_name}")
         await self._konflux_client.ensure_component(

--- a/doozer/doozerlib/backend/konflux_olm_bundler.py
+++ b/doozer/doozerlib/backend/konflux_olm_bundler.py
@@ -1191,8 +1191,7 @@ class KonfluxOlmBundleBuilder:
                     is_ocp_group = self.group.startswith("openshift-")
                     if outcome is KonfluxBuildOutcome.SUCCESS and is_ocp_group and not self.skip_ec_verify:
                         app_name = util.konflux_application_name(metadata.runtime.group)
-                        bundle_name = metadata.get_olm_bundle_short_name()
-                        component_name = util.konflux_image_component_name(app_name, bundle_name)
+                        component_name = metadata.get_konflux_bundle_component_name(app_name)
                         image_with_digest = f"{image_pullspec.split(':')[0]}@{image_digest}"
                         source_url = artlib_util.convert_remote_git_to_https(bundle_build_repo.url)
 
@@ -1300,8 +1299,7 @@ class KonfluxOlmBundleBuilder:
         await konflux_client.ensure_application(name=app_name, display_name=app_name)
         logger.info(f"Konflux application {app_name} created")
         # Ensure the Component resource exists
-        bundle_name = metadata.get_olm_bundle_short_name()
-        component_name = util.konflux_image_component_name(app_name, bundle_name)
+        component_name = metadata.get_konflux_bundle_component_name(app_name)
         logger.info(f"Creating Konflux component: {component_name}")
         dest_image_repo = output_image.split(":")[0]
         await konflux_client.ensure_component(

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -863,6 +863,43 @@ class ImageMetadata(Metadata):
             return str(group_override).strip()
         return default
 
+    def get_konflux_component_name(self, app_name: str) -> str:
+        """Returns the Konflux Component resource name for regular image builds.
+
+        Checks for an override in konflux.component.name_override first. If not set,
+        falls back to the auto-generated name from util.konflux_image_component_name().
+        Raises ValueError if the resulting name exceeds the Kubernetes 63-char limit.
+        """
+        override = self.config.konflux.component.name_override
+        if override is not Missing and override:
+            return str(override)
+        name = util.konflux_image_component_name(app_name, self.distgit_key)
+        if len(name) > 63:
+            raise ValueError(
+                f"[{self.distgit_key}] Konflux component name '{name}' is {len(name)} chars, "
+                f"exceeding the 63-char limit. Set 'konflux.component.name_override' in the image config."
+            )
+        return name
+
+    def get_konflux_bundle_component_name(self, app_name: str) -> str:
+        """Returns the Konflux Component resource name for OLM bundle builds.
+
+        Checks for an override in konflux.component.bundle_name_override first. If not set,
+        falls back to the auto-generated name using the bundle short name.
+        Raises ValueError if the resulting name exceeds the Kubernetes 63-char limit.
+        """
+        override = self.config.konflux.component.bundle_name_override
+        if override is not Missing and override:
+            return str(override)
+        bundle_name = self.get_olm_bundle_short_name()
+        name = util.konflux_image_component_name(app_name, bundle_name)
+        if len(name) > 63:
+            raise ValueError(
+                f"[{self.distgit_key}] Konflux bundle component name '{name}' is {len(name)} chars, "
+                f"exceeding the 63-char limit. Set 'konflux.component.bundle_name_override' in the image config."
+            )
+        return name
+
     def _validate_upstream_builder_stream(self) -> None:
         """
         When canonical_builders_from_upstream is enabled, validate that the upstream golang builder

--- a/doozer/tests/backend/test_konflux_olm_bundler.py
+++ b/doozer/tests/backend/test_konflux_olm_bundler.py
@@ -1537,6 +1537,7 @@ class TestKonfluxOlmBundleBuilder(IsolatedAsyncioTestCase):
         metadata = MagicMock()
         metadata.distgit_key = "test-distgit-key"
         metadata.get_olm_bundle_short_name.return_value = "test-bundle"
+        metadata.get_konflux_bundle_component_name.return_value = "test-group-test-bundle"
         metadata.runtime.group = "test-group"
         bundle_build_repo = MagicMock()
         bundle_build_repo.commit_hash = "test-commit-hash"

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1242,6 +1242,69 @@ RUN echo "test"
             result = metadata.get_olm_bundle_image_name()
         self.assertEqual(result, 'rhacm2/acm-operator-bundle')
 
+    def test_get_konflux_component_name_no_override(self):
+        metadata = self._create_image_metadata('openshift/test')
+        mock_config = MagicMock()
+        mock_config.konflux.component.name_override = Missing
+        metadata.config = mock_config
+        result = metadata.get_konflux_component_name('openshift-4-18')
+        self.assertEqual(result, 'ose-4-18-my-distgit')
+
+    def test_get_konflux_component_name_with_override(self):
+        metadata = self._create_image_metadata('openshift/test')
+        mock_config = MagicMock()
+        mock_config.konflux.component.name_override = 'my-short-name'
+        metadata.config = mock_config
+        result = metadata.get_konflux_component_name('openshift-4-18')
+        self.assertEqual(result, 'my-short-name')
+
+    def test_get_konflux_component_name_exceeds_limit_raises(self):
+        metadata = self._create_image_metadata('openshift/test')
+        mock_config = MagicMock()
+        mock_config.konflux.component.name_override = Missing
+        metadata.config = mock_config
+        # Directly set distgit_key to a value that makes the generated name exceed 63 chars:
+        # 'zero-trust-1-1' (14) + '-' (1) + 'zero-trust-workload-identity-manager-op' (39) = 54 chars total
+        # But 'zero-trust-1-1' (14) + '-' (1) + 'zero-trust-workload-identity-manager-operator-x' (47) = 62 chars
+        # Use 'zero-trust-workload-identity-manager-operator-bundle' (52) -> 14+1+52 = 67 > 63
+        metadata.distgit_key = 'zero-trust-workload-identity-manager-operator-bundle'
+        with self.assertRaises(ValueError) as ctx:
+            metadata.get_konflux_component_name('zero-trust-1-1')
+        self.assertIn('63-char limit', str(ctx.exception))
+        self.assertIn('konflux.component.name_override', str(ctx.exception))
+
+    def test_get_konflux_bundle_component_name_no_override(self):
+        metadata = self._create_image_metadata('openshift/test')
+        mock_config = MagicMock()
+        mock_config.konflux.component.bundle_name_override = Missing
+        mock_config.bundle_name_override = Missing
+        metadata.config = mock_config
+        with patch.object(type(metadata), 'is_olm_operator', new_callable=lambda: property(lambda self: True)):
+            result = metadata.get_konflux_bundle_component_name('openshift-4-18')
+        self.assertEqual(result, 'ose-4-18-my-distgit-bundle')
+
+    def test_get_konflux_bundle_component_name_with_override(self):
+        metadata = self._create_image_metadata('openshift/test')
+        mock_config = MagicMock()
+        mock_config.konflux.component.bundle_name_override = 'my-short-bundle'
+        metadata.config = mock_config
+        with patch.object(type(metadata), 'is_olm_operator', new_callable=lambda: property(lambda self: True)):
+            result = metadata.get_konflux_bundle_component_name('openshift-4-18')
+        self.assertEqual(result, 'my-short-bundle')
+
+    def test_get_konflux_bundle_component_name_exceeds_limit_raises(self):
+        metadata = self._create_image_metadata('openshift/test')
+        mock_config = MagicMock()
+        mock_config.konflux.component.bundle_name_override = Missing
+        mock_config.bundle_name_override = Missing
+        metadata.config = mock_config
+        metadata.distgit_key = 'zero-trust-workload-identity-manager-operator'
+        with patch.object(type(metadata), 'is_olm_operator', new_callable=lambda: property(lambda self: True)):
+            with self.assertRaises(ValueError) as ctx:
+                metadata.get_konflux_bundle_component_name('zero-trust-1-1')
+        self.assertIn('63-char limit', str(ctx.exception))
+        self.assertIn('konflux.component.bundle_name_override', str(ctx.exception))
+
 
 class TestImageInspector(IsolatedAsyncioTestCase):
     @mock.patch("doozerlib.repos.Repo.get_repodata_threadsafe")

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -1661,6 +1661,48 @@
           "$ref": "#/properties/konflux/properties/workspace_storage"
         },
         "workspace_storage-": {},
+        "component": {
+          "description": "Overrides for Konflux Component resource names",
+          "type": "object",
+          "properties": {
+            "name_override": {
+              "description": "Override the Konflux Component resource name for regular image builds. Use when the auto-generated name exceeds the k8s 63-char limit.",
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 63,
+              "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+            },
+            "name_override?": {
+              "$ref": "#/properties/konflux/properties/component/properties/name_override"
+            },
+            "name_override!": {
+              "$ref": "#/properties/konflux/properties/component/properties/name_override"
+            },
+            "name_override-": {},
+            "bundle_name_override": {
+              "description": "Override the Konflux Component resource name for OLM bundle builds. Use when the auto-generated name exceeds the k8s 63-char limit.",
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 63,
+              "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+            },
+            "bundle_name_override?": {
+              "$ref": "#/properties/konflux/properties/component/properties/bundle_name_override"
+            },
+            "bundle_name_override!": {
+              "$ref": "#/properties/konflux/properties/component/properties/bundle_name_override"
+            },
+            "bundle_name_override-": {}
+          },
+          "additionalProperties": false
+        },
+        "component?": {
+          "$ref": "#/properties/konflux/properties/component"
+        },
+        "component!": {
+          "$ref": "#/properties/konflux/properties/component"
+        },
+        "component-": {},
         "content": {
           "$ref": "image_content.base.schema.json"
         }


### PR DESCRIPTION
## Summary

- When building OLM bundles in Konflux for non-openshift groups (e.g. `zero-trust-1.1`), the auto-generated Konflux Component name can exceed the Kubernetes 63-byte limit. The name `zero-trust-1-1-zero-trust-workload-identity-manager-operator-bundle` is 67 chars.
- The existing `bundle_name_override` field changes too many things (Dockerfile labels, delivery repo, DB records) — not a targeted fix.
- This PR adds two new fields under `konflux.component` in image metadata YAML:
  - `name_override`: overrides the Konflux Component name for regular image builds
  - `bundle_name_override`: overrides the Konflux Component name for OLM bundle builds
- Also adds a clear `ValueError` at build time when a generated name exceeds 63 chars, instead of a cryptic 422 Unprocessable Entity from the k8s API.

## Usage (in ocp-build-data image config)

```yaml
konflux:
  component:
    bundle_name_override: zt-wim-op-bundle  # must be ≤63 chars, lowercase alphanumeric + dashes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable component name overrides for image and OLM bundle builds.
  * Automatically generates compliant component names when no override is provided.
* **Bug Fixes**
  * Improved consistency of component naming during build setup and verification.
  * Added validation to prevent names exceeding Kubernetes’s 63-character limit.
  * Enforced lowercase, valid component names through configuration validation.
* **Tests**
  * Added coverage for generated names, overrides, and invalid name lengths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->