### PR TITLE
ART-21903 Parse multi-assignment Dockerfile ENV instructions

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/dockerfile_parser.py
+++ b/doozer/doozerlib/lockfile_prototype/dockerfile_parser.py
@@ -22,6 +22,8 @@ from doozerlib.lockfile_prototype.shell_parser import (
     resolve_bash_expansion,
 )
 
+_ESCAPED_DOLLAR_SENTINEL = "\0"
+
 
 def _strip_quotes(value: str) -> str:
     if len(value) >= 2 and value[0] in ("\"", "'") and value[-1] == value[0]:
@@ -37,8 +39,12 @@ def _parse_env_assignments(value: str) -> list[tuple[str, str]]:
     and the legacy ``ENV key value`` form. ``shlex`` preserves spaces in
     quoted or escaped values while separating modern assignments.
     """
+    # ``shlex`` removes the backslash from ``\$``. Protect escaped dollar
+    # signs so that later environment expansion can distinguish them from
+    # variable references.
+    protected_value = value.strip().replace(r"\$", _ESCAPED_DOLLAR_SENTINEL)
     try:
-        tokens = shlex.split(value.strip())
+        tokens = shlex.split(protected_value)
     except ValueError:
         return []
 
@@ -97,7 +103,7 @@ def collect_stage_vars(entries: list[dict], inherited_vars: dict[str, str] | Non
             # become visible to subsequent instructions, not sibling entries.
             previous_variables = dict(variables)
             resolved_assignments = {
-                var_name: resolve_bash_expansion(raw_value, previous_variables)
+                var_name: resolve_bash_expansion(raw_value, previous_variables).replace(_ESCAPED_DOLLAR_SENTINEL, "$")
                 for var_name, raw_value in _parse_env_assignments(value)
             }
             variables.update(resolved_assignments)

--- a/doozer/doozerlib/lockfile_prototype/dockerfile_parser.py
+++ b/doozer/doozerlib/lockfile_prototype/dockerfile_parser.py
@@ -29,6 +29,38 @@ def _strip_quotes(value: str) -> str:
     return value
 
 
+def _parse_env_assignments(value: str) -> list[tuple[str, str]]:
+    """
+    Parse an ENV instruction into name/value assignments.
+
+    Supports both the preferred ``ENV key=value [key=value ...]`` form
+    and the legacy ``ENV key value`` form. ``shlex`` preserves spaces in
+    quoted or escaped values while separating modern assignments.
+    """
+    try:
+        tokens = shlex.split(value.strip())
+    except ValueError:
+        return []
+
+    if not tokens:
+        return []
+
+    # The legacy form assigns the entire remainder of the instruction to
+    # the first key, even when that remainder resembles more assignments.
+    if "=" not in tokens[0]:
+        if len(tokens) < 2 or not re.fullmatch(r"\w+", tokens[0]):
+            return []
+        return [(tokens[0], " ".join(tokens[1:]))]
+
+    assignments: list[tuple[str, str]] = []
+    for token in tokens:
+        var_name, separator, raw_value = token.partition("=")
+        if not separator or not re.fullmatch(r"\w+", var_name):
+            return []
+        assignments.append((var_name, raw_value))
+    return assignments
+
+
 def collect_stage_vars(entries: list[dict], inherited_vars: dict[str, str] | None = None) -> dict[str, str]:
     """
     Collect ARG and ENV variable definitions from DockerfileParser
@@ -60,10 +92,15 @@ def collect_stage_vars(entries: list[dict], inherited_vars: dict[str, str] | Non
                     variables[var_name] = resolve_bash_expansion(_strip_quotes(default_value.strip()), variables)
 
         elif instruction == "ENV":
-            env_match = re.match(r"^(\w+)(?:=|\s+)(.*)", value.strip())
-            if env_match:
-                var_name = env_match.group(1)
-                variables[var_name] = resolve_bash_expansion(_strip_quotes(env_match.group(2).strip()), variables)
+            # Docker resolves every value in an ENV instruction against the
+            # environment as it existed before that instruction. New values
+            # become visible to subsequent instructions, not sibling entries.
+            previous_variables = dict(variables)
+            resolved_assignments = {
+                var_name: resolve_bash_expansion(raw_value, previous_variables)
+                for var_name, raw_value in _parse_env_assignments(value)
+            }
+            variables.update(resolved_assignments)
 
     return variables
 

--- a/doozer/tests/lockfile_prototype/test_dockerfile_parser.py
+++ b/doozer/tests/lockfile_prototype/test_dockerfile_parser.py
@@ -53,6 +53,42 @@ class TestCollectStageVars(unittest.TestCase):
         result = collect_stage_vars(entries)
         self.assertEqual(result, {"LANG": "en_US.UTF-8"})
 
+    def test_env_with_multiple_assignments(self):
+        entries = [
+            _make_entry(
+                "ENV",
+                '__doozer=update __doozer_golang_nvr=golang-1.23.10-16.el8 SUMMARY="Golang builder image"',
+            )
+        ]
+        result = collect_stage_vars(entries)
+        self.assertEqual(
+            result,
+            {
+                "__doozer": "update",
+                "__doozer_golang_nvr": "golang-1.23.10-16.el8",
+                "SUMMARY": "Golang builder image",
+            },
+        )
+
+    def test_env_with_escaped_space(self):
+        entries = [_make_entry("ENV", r"GREETING=hello\ world LANG=en_US.UTF-8")]
+        result = collect_stage_vars(entries)
+        self.assertEqual(result, {"GREETING": "hello world", "LANG": "en_US.UTF-8"})
+
+    def test_env_legacy_value_resembling_assignments(self):
+        entries = [_make_entry("ENV", "ONE TWO= THREE=world")]
+        result = collect_stage_vars(entries)
+        self.assertEqual(result, {"ONE": "TWO= THREE=world"})
+
+    def test_env_same_instruction_uses_previous_values(self):
+        entries = [
+            _make_entry("ENV", "abc=hello"),
+            _make_entry("ENV", "abc=bye def=$abc"),
+            _make_entry("ENV", "ghi=$abc"),
+        ]
+        result = collect_stage_vars(entries)
+        self.assertEqual(result, {"abc": "bye", "def": "hello", "ghi": "bye"})
+
     def test_env_references_arg(self):
         entries = [
             _make_entry("ARG", "GCC_VERSION=12"),
@@ -536,6 +572,18 @@ class TestAnalyzeDockerfileStages(unittest.TestCase):
             path = self._write_dockerfile(tmpdir, content)
             stages, _ = analyze_dockerfile_stages(path)
             self.assertEqual(stages[0].packages, ["httpd"])
+
+    def test_multi_env_exact_golang_nvr_resolution(self):
+        with TemporaryDirectory() as tmpdir:
+            content = (
+                "FROM base\n"
+                'ENV SUMMARY="Golang builder image" VERSION="1.23"\n'
+                "ENV __doozer=update __doozer_golang_nvr=golang-1.23.10-16.el8\n"
+                'RUN dnf install -y "$__doozer_golang_nvr"\n'
+            )
+            path = self._write_dockerfile(tmpdir, content)
+            stages, _ = analyze_dockerfile_stages(path)
+            self.assertEqual(stages[0].packages, ["golang-1.23.10-16.el8"])
 
     def test_no_update_no_install(self):
         with TemporaryDirectory() as tmpdir:

--- a/doozer/tests/lockfile_prototype/test_dockerfile_parser.py
+++ b/doozer/tests/lockfile_prototype/test_dockerfile_parser.py
@@ -75,6 +75,22 @@ class TestCollectStageVars(unittest.TestCase):
         result = collect_stage_vars(entries)
         self.assertEqual(result, {"GREETING": "hello world", "LANG": "en_US.UTF-8"})
 
+    def test_env_with_escaped_variable_references(self):
+        entries = [
+            _make_entry("ENV", "VERSION=1.26"),
+            _make_entry("ENV", r"PACKAGE=\$VERSION BRACED=\${VERSION} EXPANDED=$VERSION"),
+        ]
+        result = collect_stage_vars(entries)
+        self.assertEqual(
+            result,
+            {
+                "VERSION": "1.26",
+                "PACKAGE": "$VERSION",
+                "BRACED": "${VERSION}",
+                "EXPANDED": "1.26",
+            },
+        )
+
     def test_env_legacy_value_resembling_assignments(self):
         entries = [_make_entry("ENV", "ONE TWO= THREE=world")]
         result = collect_stage_vars(entries)


### PR DESCRIPTION
## Summary

- parse every assignment in modern multi-value Dockerfile `ENV` instructions
- retain support for the legacy `ENV key value` form
- preserve Docker's same-instruction expansion semantics
- add unit and integration coverage for exact Golang NVR package extraction

## Root cause

The RPM lockfile Dockerfile parser only captured the first variable in an instruction such as:

```dockerfile
ENV __doozer=update __doozer_golang_nvr=golang-1.23.10-16.el8
```

As a result, `__doozer_golang_nvr` and other later assignments were unavailable while analyzing package-install commands.

## Impact

Lockfile generation can now resolve the exact Golang NVR injected by Doozer without requiring each generated variable to be placed in a separate `ENV` instruction. Quoted and escaped spaces are handled, and values assigned together are resolved against the environment preceding the instruction, matching Docker behavior.

This PR intentionally does not change how unresolved variables are handled.

## Validation

- `55 passed` in `doozer/tests/lockfile_prototype/test_dockerfile_parser.py`
- targeted Ruff lint and format checks
- global `rh-pre-commit`
- global `rh-pre-commit.commit-msg`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Dockerfile `ENV` parsing for multiple assignments, legacy syntax, quoted values, and escaped spaces.
  * Corrected variable expansion so assignments in the same instruction resolve consistently.
  * Added validation to reject malformed environment assignment syntax.

* **Tests**
  * Expanded coverage for environment parsing and variable expansion.
  * Added end-to-end validation of package resolution using multiple environment assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->