### PR TITLE
ART-21902 Harden Konflux snapshot name handling

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -42,6 +42,9 @@ from tenacity import before_sleep_log, retry, retry_if_exception_type, stop_afte
 LOGGER = logging.getLogger(__name__)
 KONFLUX_LOGGER = logutil.get_logger(__name__)
 
+K8S_DNS_LABEL_MAX_LENGTH = 63
+K8S_DNS_LABEL_PATTERN = re.compile(r'^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$')
+
 
 def extract_version_fields(version, at_least=0):
     """
@@ -1204,6 +1207,28 @@ def validate_build_priority(build_priority):
         raise
 
 
+def normalize_k8s_dns_label(name: str, max_length: int = K8S_DNS_LABEL_MAX_LENGTH) -> str:
+    """Normalize *name* to a Kubernetes DNS label within *max_length*."""
+    if not 1 <= max_length <= K8S_DNS_LABEL_MAX_LENGTH:
+        raise ValueError(f"max_length must be between 1 and {K8S_DNS_LABEL_MAX_LENGTH}, got {max_length}")
+    if not name:
+        return ""
+
+    normalized = re.sub(r'[^a-z0-9-]', '-', name.lower())
+    normalized = re.sub(r'-+', '-', normalized).strip('-')
+    return normalized[:max_length].rstrip('-')
+
+
+def validate_k8s_dns_label(name: str, field_name: str = "Name") -> str:
+    """Return *name* when it is a Kubernetes DNS label; otherwise raise ``ValueError``."""
+    if not isinstance(name, str) or len(name) > K8S_DNS_LABEL_MAX_LENGTH or not K8S_DNS_LABEL_PATTERN.fullmatch(name):
+        raise ValueError(
+            f"{field_name} {name!r} must be at most {K8S_DNS_LABEL_MAX_LENGTH} characters and match "
+            f"{K8S_DNS_LABEL_PATTERN.pattern!r}"
+        )
+    return name
+
+
 def normalize_group_name_for_k8s(group_name: str) -> str:
     """
     Normalize a group name to comply with Kubernetes DNS label rules.
@@ -1220,30 +1245,10 @@ def normalize_group_name_for_k8s(group_name: str) -> str:
     Returns:
         Normalized group name (e.g., "test-group-1-5")
     """
-    if not group_name:
-        return ""
-
-    # Convert to lowercase
-    normalized = group_name.lower()
-
-    # Replace dots and any non-alphanumeric characters (except '-') with '-'
-    normalized = re.sub(r'[^a-z0-9\-]', '-', normalized)
-
-    # Collapse consecutive '-' into a single '-'
-    normalized = re.sub(r'-+', '-', normalized)
-
-    # Trim leading/trailing non-alphanumeric characters (including '-')
-    normalized = re.sub(r'^[^a-z0-9]+|[^a-z0-9]+$', '', normalized)
-
     # Truncate to 63 characters if needed (leave room for timestamp suffix)
     # Reserve space for timestamp format like "-20251031141128-1" (18 chars)
     max_group_length = 63 - 18 - 1  # -1 for the connecting dash
-    if len(normalized) > max_group_length:
-        normalized = normalized[:max_group_length]
-        # Ensure we don't end with a dash after truncation
-        normalized = normalized.rstrip('-')
-
-    return normalized
+    return normalize_k8s_dns_label(group_name, max_length=max_group_length)
 
 
 def resolve_konflux_kubeconfig_by_product(product: str, provided_kubeconfig: Optional[str] = None) -> Optional[str]:

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -13,6 +13,8 @@ from artcommonlib.util import (
     get_inflight,
     isolate_major_minor_in_group,
     normalize_group_name_for_k8s,
+    normalize_k8s_dns_label,
+    validate_k8s_dns_label,
 )
 
 
@@ -430,6 +432,27 @@ class TestSoftwareLifecyclePhase(unittest.TestCase):
         actual = release_util.isolate_timestamp_in_release("")
         expected = None
         self.assertEqual(actual, expected)
+
+
+class TestK8sDnsLabels(unittest.TestCase):
+    def test_normalize(self):
+        self.assertEqual(normalize_k8s_dns_label("Golang.Builder__v1.23"), "golang-builder-v1-23")
+
+    def test_normalize_with_length_budget(self):
+        self.assertEqual(normalize_k8s_dns_label("component-name", max_length=10), "component")
+
+    def test_normalize_rejects_invalid_length_budget(self):
+        for max_length in (0, 64):
+            with self.subTest(max_length=max_length), self.assertRaises(ValueError):
+                normalize_k8s_dns_label("component", max_length=max_length)
+
+    def test_validate(self):
+        self.assertEqual(validate_k8s_dns_label("golang-builder-v1-23"), "golang-builder-v1-23")
+
+    def test_validate_rejects_invalid_names(self):
+        for name in ("", "v1.23", "Uppercase", "under_score", "-leading", "trailing-", "a" * 64):
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                validate_k8s_dns_label(name, "Snapshot name")
 
 
 class TestNormalizeGroupNameForK8s(unittest.TestCase):

--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -7,7 +7,6 @@ CLI lives in ``doozerlib.cli.images`` (see ``images:release-to-base-repo``).
 
 import asyncio
 import os
-import re
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -16,9 +15,11 @@ from artcommonlib.model import Missing
 from artcommonlib.util import (
     get_utc_now_formatted_str,
     normalize_group_name_for_k8s,
+    normalize_k8s_dns_label,
     resolve_konflux_base_image_release_targets,
     resolve_konflux_kubeconfig_by_product,
     resolve_konflux_namespace_by_product,
+    validate_k8s_dns_label,
 )
 from doozerlib import util as doozer_util
 from doozerlib.backend.konflux_client import API_VERSION, KIND_RELEASE, KIND_RELEASE_PLAN, KIND_SNAPSHOT, KonfluxClient
@@ -30,13 +31,6 @@ def _truncate_for_k8s_name(name: str, max_len: int) -> str:
     if len(name) <= max_len:
         return name
     return name[:max_len].rstrip('-')
-
-
-def _normalize_for_k8s_name(name: str) -> str:
-    """Normalize *name* to the lowercase DNS-label syntax used by Kubernetes resource names."""
-    normalized = re.sub(r'[^a-z0-9-]', '-', name.lower())
-    normalized = re.sub(r'-+', '-', normalized)
-    return normalized.strip('-')
 
 
 def _software_lifecycle_phase(runtime) -> Optional[str]:
@@ -249,13 +243,15 @@ class BaseImageHandler:
                 raise ValueError(f"Group name '{self.runtime.group}' produces invalid normalized name for Kubernetes")
 
             timestamp = get_utc_now_formatted_str()
-            component_safe = _normalize_for_k8s_name(component["name"])
+            component_safe = normalize_k8s_dns_label(
+                component["name"], max_length=63 - len(group_safe) - len(timestamp) - 2
+            )
             if not component_safe:
                 raise ValueError(
                     f"Component name '{component['name']}' produces invalid normalized name for Kubernetes"
                 )
-            comp_name = _truncate_for_k8s_name(component_safe, 63 - len(group_safe) - len(timestamp) - 2)
-            snapshot_name = f"{group_safe}-{comp_name}-{timestamp}"
+            snapshot_name = f"{group_safe}-{component_safe}-{timestamp}"
+            validate_k8s_dns_label(snapshot_name, "Generated snapshot name")
 
             if self.dry_run:
                 self.logger.info(f"[DRY-RUN] Would create snapshot {snapshot_name}")
@@ -312,6 +308,8 @@ class BaseImageHandler:
             ``(release_name, release_console_url)`` or ``None`` on failure.
         """
         try:
+            validate_k8s_dns_label(snapshot_name, "Release snapshot reference")
+
             if not self.dry_run:
                 self.logger.info(f"Verifying release plan {self.base_image_release_plan} exists")
                 try:

--- a/doozer/doozerlib/backend/base_image_handler.py
+++ b/doozer/doozerlib/backend/base_image_handler.py
@@ -7,6 +7,7 @@ CLI lives in ``doozerlib.cli.images`` (see ``images:release-to-base-repo``).
 
 import asyncio
 import os
+import re
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -29,6 +30,13 @@ def _truncate_for_k8s_name(name: str, max_len: int) -> str:
     if len(name) <= max_len:
         return name
     return name[:max_len].rstrip('-')
+
+
+def _normalize_for_k8s_name(name: str) -> str:
+    """Normalize *name* to the lowercase DNS-label syntax used by Kubernetes resource names."""
+    normalized = re.sub(r'[^a-z0-9-]', '-', name.lower())
+    normalized = re.sub(r'-+', '-', normalized)
+    return normalized.strip('-')
 
 
 def _software_lifecycle_phase(runtime) -> Optional[str]:
@@ -241,7 +249,12 @@ class BaseImageHandler:
                 raise ValueError(f"Group name '{self.runtime.group}' produces invalid normalized name for Kubernetes")
 
             timestamp = get_utc_now_formatted_str()
-            comp_name = _truncate_for_k8s_name(component["name"], 63 - len(group_safe) - len(timestamp) - 2)
+            component_safe = _normalize_for_k8s_name(component["name"])
+            if not component_safe:
+                raise ValueError(
+                    f"Component name '{component['name']}' produces invalid normalized name for Kubernetes"
+                )
+            comp_name = _truncate_for_k8s_name(component_safe, 63 - len(group_safe) - len(timestamp) - 2)
             snapshot_name = f"{group_safe}-{comp_name}-{timestamp}"
 
             if self.dry_run:

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -429,6 +429,24 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_release_rejects_invalid_snapshot_reference(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+        konflux_client = AsyncMock()
+        mock_konflux_client_init.return_value = konflux_client
+
+        handler = BaseImageHandler(self.runtime, dry_run=False)
+        result = await handler._create_release_from_snapshot("snapshot.v1", self.default_input)
+
+        self.assertIsNone(result)
+        konflux_client._get.assert_not_awaited()
+        konflux_client._create.assert_not_awaited()
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
     async def test_create_release_from_snapshot_rhmtc_uses_product_plan_and_application(
         self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
     ):

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -342,6 +342,26 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
+    async def test_snapshot_name_normalizes_golang_component(
+        self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
+    ):
+        mock_namespace.return_value = "ocp-art-tenant"
+        mock_kubeconfig.return_value = "/path/to/kubeconfig"
+        mock_konflux_client_init.return_value = AsyncMock()
+        self.runtime.group = "golang"
+
+        handler = BaseImageHandler(self.runtime, dry_run=True)
+        component = {"name": "golang-builder-v1.23-rhel9", "containerImage": "quay.io/test:latest"}
+
+        with patch("doozerlib.backend.base_image_handler.get_utc_now_formatted_str", return_value="20260805200004"):
+            name = await handler._snapshot_from_component(component)
+
+        self.assertEqual(name, "golang-golang-builder-v1-23-rhel9-20260805200004")
+        self.assertRegex(name, r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+
+    @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
+    @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
     async def test_snapshot_name_within_63_char_limit(self, mock_kubeconfig, mock_namespace, mock_konflux_client_init):
         mock_namespace.return_value = "ocp-art-tenant"
         mock_kubeconfig.return_value = "/path/to/kubeconfig"

--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -11,8 +11,10 @@ from artcommonlib.constants import OCP_RPA_BASE_URL, OCP_RPA_ENVS, OCP_RPA_KINDS
 from artcommonlib.util import (
     get_utc_now_formatted_str,
     new_roundtrip_yaml_handler,
+    normalize_k8s_dns_label,
     resolve_konflux_kubeconfig_by_product,
     resolve_konflux_namespace_by_product,
+    validate_k8s_dns_label,
 )
 from doozerlib.backend.konflux_client import (
     API_VERSION,
@@ -262,8 +264,12 @@ class CreateReleaseCli:
         return created_release
 
     def get_object_name(self) -> str:
-        assembly_str = self.runtime.assembly.replace(".", "-")
-        return f"{self.runtime.product}-{self.release_env}-{assembly_str}-{self.kind}-{get_utc_now_formatted_str()}"
+        timestamp = get_utc_now_formatted_str()
+        raw_prefix = f"{self.runtime.product}-{self.release_env}-{self.runtime.assembly}-{self.kind}"
+        prefix = normalize_k8s_dns_label(raw_prefix, max_length=63 - len(timestamp) - 1)
+        if not prefix:
+            raise ValueError(f"Release object name prefix {raw_prefix!r} cannot be normalized to a Kubernetes name")
+        return f"{prefix}-{timestamp}"
 
     async def create_snapshot(self, shipment: Shipment) -> dict:
         """
@@ -320,7 +326,7 @@ class CreateReleaseCli:
 
     async def new_release(self, release_config: ReleaseConfig) -> dict:
         release_plan = release_config.release_plan
-        snapshot = release_config.snapshot
+        snapshot = validate_k8s_dns_label(release_config.snapshot, "Release snapshot reference")
 
         # make sure releasePlan exists
         LOGGER.info(f"Fetching release plan {release_plan} ...")

--- a/elliott/elliottlib/cli/snapshot_cli.py
+++ b/elliott/elliottlib/cli/snapshot_cli.py
@@ -22,6 +22,7 @@ from artcommonlib.util import (
     normalize_group_name_for_k8s,
     resolve_konflux_kubeconfig_by_product,
     resolve_konflux_namespace_by_product,
+    validate_k8s_dns_label,
 )
 from doozerlib.backend.konflux_client import API_VERSION, KIND_SNAPSHOT, KonfluxClient
 from doozerlib.backend.konflux_olm_bundler import KonfluxOlmBundleBuilder
@@ -198,7 +199,7 @@ class CreateSnapshotCli:
 
     async def new_snapshots(self, build_records: List[KonfluxRecord]) -> list[dict]:
         if self.custom_name:
-            snapshot_name = self.custom_name
+            snapshot_name = validate_k8s_dns_label(self.custom_name, "Custom snapshot name")
         else:
             group_name_safe = normalize_group_name_for_k8s(self.runtime.group)
             if not group_name_safe:
@@ -269,10 +270,12 @@ class CreateSnapshotCli:
         snapshot_objs: list[dict] = []
         for index, (application_name, components) in enumerate(sorted(app_components.items()), start=1):
             components = sorted(components, key=lambda c: c['name'])
+            resource_name = snapshot_name if self.custom_name else f"{snapshot_name}-{index}"
+            validate_k8s_dns_label(resource_name, "Snapshot name")
 
             # Prepare metadata with labels and optional annotations
             metadata = {
-                "name": snapshot_name if self.custom_name else f"{snapshot_name}-{index}",
+                "name": resource_name,
                 "namespace": self.konflux_config['namespace'],
                 "labels": {
                     "test.appstudio.openshift.io/type": "override",

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from artcommonlib.model import Model
 from doozerlib.backend.konflux_client import API_VERSION, KIND_APPLICATION, KIND_RELEASE, KIND_RELEASE_PLAN
-from elliottlib.cli.konflux_release_cli import CreateReleaseCli, validate_snapshot_against_rpa
+from elliottlib.cli.konflux_release_cli import CreateReleaseCli, ReleaseConfig, validate_snapshot_against_rpa
 from elliottlib.cli.konflux_release_watch_cli import WatchReleaseCli
 from elliottlib.shipment_model import (
     ComponentSource,
@@ -182,6 +182,49 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
         # Patch verify_connection and resource_url to be regular Mocks, not AsyncMock
         self.konflux_client.verify_connection = MagicMock(return_value=True)
         self.konflux_client.resource_url = MagicMock()
+
+    @patch("elliottlib.cli.konflux_release_cli.get_utc_now_formatted_str", return_value="20260805200004")
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    def test_object_name_is_normalized_and_preserves_timestamp(self, mock_konflux_client_init, _mock_timestamp):
+        mock_konflux_client_init.return_value = self.konflux_client
+        self.runtime.assembly = "4.18.2_RC+1"
+
+        cli = CreateReleaseCli(
+            runtime=self.runtime,
+            config_path=self.config_path,
+            release_env=self.release_env,
+            konflux_config=self.konflux_config,
+            image_repo_pull_secret=self.image_repo_pull_secret,
+            dry_run=self.dry_run,
+            kind="image.v2",
+        )
+
+        name = cli.get_object_name()
+        self.assertEqual(name, "ocp-prod-4-18-2-rc-1-image-v2-20260805200004")
+        self.assertLessEqual(len(name), 63)
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    async def test_release_rejects_invalid_snapshot_reference(self, mock_konflux_client_init):
+        mock_konflux_client_init.return_value = self.konflux_client
+        cli = CreateReleaseCli(
+            runtime=self.runtime,
+            config_path=self.config_path,
+            release_env=self.release_env,
+            konflux_config=self.konflux_config,
+            image_repo_pull_secret=self.image_repo_pull_secret,
+            dry_run=self.dry_run,
+            kind="image",
+        )
+        release_config = ReleaseConfig(
+            snapshot="snapshot.v1",
+            release_plan="test-release-plan",
+            application="test-application",
+            release_name="test-release",
+        )
+
+        with self.assertRaisesRegex(ValueError, "Release snapshot reference"):
+            await cli.new_release(release_config)
+        self.konflux_client._get.assert_not_awaited()
 
     @patch("elliottlib.cli.konflux_release_cli.validate_snapshot_against_rpa", new_callable=AsyncMock)
     @patch("elliottlib.cli.konflux_release_cli.get_utc_now_formatted_str", return_value="timestamp")

--- a/elliott/tests/test_snapshot_cli.py
+++ b/elliott/tests/test_snapshot_cli.py
@@ -326,6 +326,24 @@ class TestSnapshotNaming(IsolatedAsyncioTestCase):
         self.image_repo_pull_secret = "/path/to/pull-secret"
         self.dry_run = False
 
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    async def test_custom_snapshot_name_must_be_dns_label(self, mock_konflux_client_init):
+        mock_konflux_client = AsyncMock()
+        mock_konflux_client.verify_connection = Mock(return_value=True)
+        mock_konflux_client_init.return_value = mock_konflux_client
+
+        cli = CreateSnapshotCli(
+            runtime=self.runtime,
+            konflux_config=self.konflux_config,
+            image_repo_pull_secret=self.image_repo_pull_secret,
+            builds=["test-component-v1.0.0-1"],
+            dry_run=self.dry_run,
+            custom_name="snapshot.v1",
+        )
+
+        with self.assertRaisesRegex(ValueError, "Custom snapshot name"):
+            await cli.new_snapshots([])
+
     @patch("elliottlib.cli.snapshot_cli.get_utc_now_formatted_str", return_value="20251031141128")
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
     async def test_openshift_group_snapshot_name(self, mock_konflux_client_init, _mock_timestamp):


### PR DESCRIPTION
## Summary

- add shared Kubernetes DNS-label normalization and validation helpers
- normalize every automatically generated Snapshot name while preserving timestamp suffixes and length limits
- reject invalid user-supplied Snapshot names and Release snapshot references before calling Konflux
- retain original Konflux Component names and identities

## Root cause

Golang builder components include a dotted major/minor version, for example `golang-builder-v1.23-rhel9`. The snapshot-release workflow concatenated that raw component name into the Snapshot resource name:

```text
golang-golang-builder-v1.23-rhel9-20260805200004
```

Although the Snapshot could be created, the Konflux Release API validates `spec.snapshot` as a Kubernetes DNS label and rejected the dot.

## Impact

The base-image workflow now replaces invalid characters with dashes, collapses repeated dashes, and trims invalid boundaries:

```text
golang-golang-builder-v1-23-rhel9-20260805200004
```

Snapshot names remain within the 63-character limit and match `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` before being referenced by a Release.

The same contract now protects the other direct creation paths:

- Elliott `snapshot new --name` rejects invalid custom names instead of creating Snapshots that cannot be released.
- Elliott shipment release names normalize all dynamic segments and preserve the timestamp when truncating.
- Doozer and Elliott both validate `Release.spec.snapshot` locally before an API request.

## Validation

- `82 passed, 9 subtests passed` in `artcommon/tests/test_util.py`
- `17 passed` in `doozer/tests/backend/test_base_image_handler.py`
- `41 passed` across the affected Elliott Snapshot and Release tests
- targeted Ruff lint and format checks for all eight changed files
- global `rh-pre-commit`
- global `rh-pre-commit.commit-msg`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot and release names are now normalized to valid Kubernetes DNS labels.
  * Names are lowercased, sanitized, trimmed, and limited to supported lengths.
  * Snapshot and release creation now rejects invalid names or snapshot references before making requests.
  * Custom and generated snapshot names are validated consistently.

* **Tests**
  * Added coverage for normalized, timestamped names, length limits, invalid names, and invalid snapshot references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->