### PR TITLE
ART-21927: Add elliott verify-cdn-push command

### DIFF
--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -73,6 +73,7 @@ from elliottlib.cli.tarball_sources_cli import tarball_sources_cli
 from elliottlib.cli.validate_rhsa import validate_rhsa_cli
 from elliottlib.cli.verify_attached_bugs_cli import verify_attached_bugs_cli
 from elliottlib.cli.verify_attached_operators_cli import verify_attached_operators_cli
+from elliottlib.cli.verify_cdn_push_cli import verify_cdn_push_cli
 from elliottlib.cli.verify_cvp_cli import verify_cvp_cli
 from elliottlib.cli.verify_image_grades_cli import verify_image_grades_cli
 from elliottlib.cli.verify_payload import verify_payload
@@ -326,6 +327,7 @@ cli.add_command(shipment_cli)
 cli.add_command(watch_release_cli)
 cli.add_command(find_bugs_second_fix_cli)
 cli.add_command(process_release_from_fbc_bugs_cli)
+cli.add_command(verify_cdn_push_cli)
 cli.add_command(verify_signatures_cli)
 cli.add_command(verify_image_grades_cli)
 cli.add_command(verify_qe_qualifier_cli)

--- a/elliott/elliottlib/cli/verify_cdn_push_cli.py
+++ b/elliott/elliottlib/cli/verify_cdn_push_cli.py
@@ -97,10 +97,14 @@ async def check_advisory_push(api: AsyncErrataAPI, advisory_id: int, impetus: st
         if do_push and (has_failed or no_jobs):
             reason = "failed jobs" if has_failed else "no push jobs found"
             LOGGER.info("Advisory %s (%s): %s, triggering CDN stage push", advisory_id, impetus, reason)
-            await api.push_cdn_stage(advisory_id)
-            result.push_triggered = True
-            raw_jobs = await api.get_push_jobs(advisory_id)
-            result.push_jobs = parse_push_jobs(raw_jobs)
+            push_response = await api.push_cdn_stage(advisory_id)
+            if push_response is None:
+                LOGGER.warning("Advisory %s (%s): push rejected (unmet dependencies)", advisory_id, impetus)
+                result.error = "push rejected due to unmet dependencies"
+            else:
+                result.push_triggered = True
+                raw_jobs = await api.get_push_jobs(advisory_id)
+                result.push_jobs = parse_push_jobs(raw_jobs)
         else:
             for j in result.push_jobs:
                 LOGGER.info("Advisory %s (%s): target %s status %s", advisory_id, impetus, j.target, j.status)
@@ -119,7 +123,11 @@ async def check_blocking_advisories(api: AsyncErrataAPI, advisory_id: int, do_pu
         blocking_ids = erratum_data.get("blocking_advisories", [])
     except Exception as e:
         LOGGER.warning("Failed to get blocking advisories for %s: %s", advisory_id, e)
-        return []
+        return [AdvisoryPushResult(
+            advisory_id=advisory_id,
+            impetus=f"blocking-lookup-{advisory_id}",
+            error=f"failed to check blocking advisories: {e}",
+        )]
 
     results = []
     for blocking_id in blocking_ids:

--- a/elliott/elliottlib/cli/verify_cdn_push_cli.py
+++ b/elliott/elliottlib/cli/verify_cdn_push_cli.py
@@ -56,17 +56,14 @@ class AdvisoryPushResult:
 @dataclass
 class VerifyCdnPushResult:
     advisories: list[AdvisoryPushResult] = field(default_factory=list)
-    errors: list[str] = field(default_factory=list)
 
     @property
     def complete(self) -> bool:
-        if self.errors:
-            return False
         return bool(self.advisories) and all(a.complete for a in self.advisories)
 
     @property
     def failed(self) -> bool:
-        return bool(self.errors) or any(a.failed for a in self.advisories)
+        return any(a.failed for a in self.advisories)
 
 
 def parse_push_jobs(raw_jobs: list) -> list[PushJobInfo]:
@@ -189,7 +186,6 @@ def render_result(result: VerifyCdnPushResult, output: str) -> str:
                     }
                     for a in result.advisories
                 ],
-                "errors": result.errors,
             },
             indent=2,
         )
@@ -205,12 +201,6 @@ def render_result(result: VerifyCdnPushResult, output: str) -> str:
         for j in a.push_jobs:
             lines.append(f"    {j.target}: {j.status} (job {j.job_id})")
     lines.append("")
-
-    if result.errors:
-        lines.append("Errors:")
-        for err in result.errors:
-            lines.append(f"  - {err}")
-        lines.append("")
 
     overall = "COMPLETE" if result.complete else ("FAIL" if result.failed else "PENDING")
     lines.append(f"Overall: {overall}")

--- a/elliott/elliottlib/cli/verify_cdn_push_cli.py
+++ b/elliott/elliottlib/cli/verify_cdn_push_cli.py
@@ -123,11 +123,13 @@ async def check_blocking_advisories(api: AsyncErrataAPI, advisory_id: int, do_pu
         blocking_ids = erratum_data.get("blocking_advisories", [])
     except Exception as e:
         LOGGER.warning("Failed to get blocking advisories for %s: %s", advisory_id, e)
-        return [AdvisoryPushResult(
-            advisory_id=advisory_id,
-            impetus=f"blocking-lookup-{advisory_id}",
-            error=f"failed to check blocking advisories: {e}",
-        )]
+        return [
+            AdvisoryPushResult(
+                advisory_id=advisory_id,
+                impetus=f"blocking-lookup-{advisory_id}",
+                error=f"failed to check blocking advisories: {e}",
+            )
+        ]
 
     results = []
     for blocking_id in blocking_ids:

--- a/elliott/elliottlib/cli/verify_cdn_push_cli.py
+++ b/elliott/elliottlib/cli/verify_cdn_push_cli.py
@@ -1,0 +1,261 @@
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+import click
+from artcommonlib.assembly import assembly_config_struct
+
+from elliottlib.cli.common import cli, click_coroutine
+from elliottlib.errata_async import AsyncErrataAPI
+
+LOGGER = logging.getLogger(__name__)
+
+PUSH_STATUS_COMPLETE = "COMPLETE"
+PUSH_STATUS_FAILED = "FAILED"
+
+CDN_PUSH_ADVISORY_TYPES = ("rpm", "rhcos")
+
+
+@dataclass
+class PushJobInfo:
+    target: str
+    job_id: int
+    status: str
+
+    @property
+    def complete(self) -> bool:
+        return self.status == PUSH_STATUS_COMPLETE
+
+    @property
+    def failed(self) -> bool:
+        return self.status == PUSH_STATUS_FAILED
+
+
+@dataclass
+class AdvisoryPushResult:
+    advisory_id: int
+    impetus: str
+    push_jobs: list[PushJobInfo] = field(default_factory=list)
+    push_triggered: bool = False
+    error: Optional[str] = None
+
+    @property
+    def complete(self) -> bool:
+        return bool(self.push_jobs) and all(j.complete for j in self.push_jobs) and not self.error
+
+    @property
+    def failed(self) -> bool:
+        return bool(self.error) or any(j.failed for j in self.push_jobs)
+
+    @property
+    def pending(self) -> bool:
+        return not self.complete and not self.failed and not self.error
+
+
+@dataclass
+class VerifyCdnPushResult:
+    advisories: list[AdvisoryPushResult] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def complete(self) -> bool:
+        if self.errors:
+            return False
+        return bool(self.advisories) and all(a.complete for a in self.advisories)
+
+    @property
+    def failed(self) -> bool:
+        return bool(self.errors) or any(a.failed for a in self.advisories)
+
+
+def parse_push_jobs(raw_jobs: list) -> list[PushJobInfo]:
+    latest_by_target: dict[str, PushJobInfo] = {}
+    for job in raw_jobs:
+        job_id = job["id"]
+        status = job["status"]
+        target = job["target"]["name"]
+        if target not in latest_by_target or job_id > latest_by_target[target].job_id:
+            latest_by_target[target] = PushJobInfo(target=target, job_id=job_id, status=status)
+    return list(latest_by_target.values())
+
+
+async def check_advisory_push(api: AsyncErrataAPI, advisory_id: int, impetus: str, do_push: bool) -> AdvisoryPushResult:
+    result = AdvisoryPushResult(advisory_id=advisory_id, impetus=impetus)
+    try:
+        raw_jobs = await api.get_push_jobs(advisory_id)
+        result.push_jobs = parse_push_jobs(raw_jobs)
+
+        all_complete = bool(result.push_jobs) and all(j.complete for j in result.push_jobs)
+        if all_complete:
+            LOGGER.info("Advisory %s (%s): all push jobs complete", advisory_id, impetus)
+            return result
+
+        has_failed = any(j.failed for j in result.push_jobs)
+        no_jobs = not result.push_jobs
+
+        if do_push and (has_failed or no_jobs):
+            reason = "failed jobs" if has_failed else "no push jobs found"
+            LOGGER.info("Advisory %s (%s): %s, triggering CDN stage push", advisory_id, impetus, reason)
+            await api.push_cdn_stage(advisory_id)
+            result.push_triggered = True
+            raw_jobs = await api.get_push_jobs(advisory_id)
+            result.push_jobs = parse_push_jobs(raw_jobs)
+        else:
+            for j in result.push_jobs:
+                LOGGER.info("Advisory %s (%s): target %s status %s", advisory_id, impetus, j.target, j.status)
+
+    except Exception as e:
+        LOGGER.error("Advisory %s (%s): error checking push status: %s", advisory_id, impetus, e)
+        result.error = str(e)
+
+    return result
+
+
+async def check_blocking_advisories(api: AsyncErrataAPI, advisory_id: int, do_push: bool) -> list[AdvisoryPushResult]:
+    try:
+        raw = await api.get_advisory(advisory_id)
+        erratum_data = next(iter(raw.get("errata", {}).values()), {})
+        blocking_ids = erratum_data.get("blocking_advisories", [])
+    except Exception as e:
+        LOGGER.warning("Failed to get blocking advisories for %s: %s", advisory_id, e)
+        return []
+
+    results = []
+    for blocking_id in blocking_ids:
+        LOGGER.info("Advisory %s has blocking advisory %s, checking it first", advisory_id, blocking_id)
+        result = await check_advisory_push(api, blocking_id, f"blocking-{blocking_id}", do_push)
+        results.append(result)
+    return results
+
+
+async def verify_cdn_push(advisories: dict[str, int], do_push: bool) -> VerifyCdnPushResult:
+    result = VerifyCdnPushResult()
+
+    async with AsyncErrataAPI() as api:
+        for impetus, advisory_id in advisories.items():
+            blocking_results = await check_blocking_advisories(api, advisory_id, do_push)
+            result.advisories.extend(blocking_results)
+
+            blocking_incomplete = any(not r.complete for r in blocking_results)
+            if blocking_incomplete:
+                LOGGER.warning(
+                    "Advisory %s (%s): blocking advisories not yet complete, skipping",
+                    advisory_id,
+                    impetus,
+                )
+                result.advisories.append(
+                    AdvisoryPushResult(
+                        advisory_id=advisory_id,
+                        impetus=impetus,
+                        error="blocking advisories not yet complete",
+                    )
+                )
+                continue
+
+            ar = await check_advisory_push(api, advisory_id, impetus, do_push)
+            result.advisories.append(ar)
+
+    return result
+
+
+def render_result(result: VerifyCdnPushResult, output: str) -> str:
+    if output == "json":
+        return json.dumps(
+            {
+                "complete": result.complete,
+                "failed": result.failed,
+                "advisories": [
+                    {
+                        "advisory_id": a.advisory_id,
+                        "impetus": a.impetus,
+                        "complete": a.complete,
+                        "failed": a.failed,
+                        "push_triggered": a.push_triggered,
+                        "error": a.error,
+                        "push_jobs": [
+                            {"target": j.target, "job_id": j.job_id, "status": j.status} for j in a.push_jobs
+                        ],
+                    }
+                    for a in result.advisories
+                ],
+                "errors": result.errors,
+            },
+            indent=2,
+        )
+
+    lines = ["CDN staging push status", ""]
+    for a in result.advisories:
+        status = "COMPLETE" if a.complete else ("FAIL" if a.failed else "PENDING")
+        lines.append(f"  Advisory {a.advisory_id} ({a.impetus}): {status}")
+        if a.push_triggered:
+            lines.append("    Push re-triggered")
+        if a.error:
+            lines.append(f"    Error: {a.error}")
+        for j in a.push_jobs:
+            lines.append(f"    {j.target}: {j.status} (job {j.job_id})")
+    lines.append("")
+
+    if result.errors:
+        lines.append("Errors:")
+        for err in result.errors:
+            lines.append(f"  - {err}")
+        lines.append("")
+
+    overall = "COMPLETE" if result.complete else ("FAIL" if result.failed else "PENDING")
+    lines.append(f"Overall: {overall}")
+    return "\n".join(lines)
+
+
+def get_advisory_ids(runtime) -> dict[str, int]:
+    releases_config = runtime.get_releases_config()
+    group_config = assembly_config_struct(releases_config, runtime.assembly, "group", {})
+    advisories = group_config.get("advisories", {})
+    result = {}
+    for impetus in CDN_PUSH_ADVISORY_TYPES:
+        ad_id = advisories.get(impetus)
+        if ad_id:
+            result[impetus] = int(ad_id)
+    return result
+
+
+@cli.command("verify-cdn-push", short_help="Verify CDN staging push jobs for advisories")
+@click.option(
+    "--push/--no-push",
+    default=True,
+    show_default=True,
+    help="Re-trigger CDN push for advisories with failed or missing push jobs.",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    show_default=True,
+    help="Output format.",
+)
+@click.pass_obj
+@click_coroutine
+async def verify_cdn_push_cli(runtime, push, output):
+    """Verify CDN staging push jobs have completed for release advisories.
+
+    Checks push job status for CDN push advisory types (rpm, rhcos) via the Errata API.
+    With --push (default), re-triggers push for advisories with failed or
+    missing push jobs. Handles advisory push dependencies automatically.
+
+    Requires --group and --assembly global options. Advisory IDs are
+    resolved from the assembly config in releases.yml.
+
+    Example:
+        elliott --group openshift-4.18 --assembly 4.18.51 verify-cdn-push
+    """
+    runtime.initialize()
+    advisories = get_advisory_ids(runtime)
+    if not advisories:
+        raise click.UsageError(f"No advisory IDs found for {CDN_PUSH_ADVISORY_TYPES} in assembly config.")
+
+    LOGGER.info("Checking CDN push status for advisories: %s", advisories)
+    result = await verify_cdn_push(advisories=advisories, do_push=push)
+    click.echo(render_result(result, output))
+    if not result.complete:
+        raise SystemExit(1)

--- a/elliott/elliottlib/cli/verify_cdn_push_cli.py
+++ b/elliott/elliottlib/cli/verify_cdn_push_cli.py
@@ -50,7 +50,7 @@ class AdvisoryPushResult:
 
     @property
     def pending(self) -> bool:
-        return not self.complete and not self.failed and not self.error
+        return not self.complete and not self.failed
 
 
 @dataclass

--- a/elliott/elliottlib/errata_async.py
+++ b/elliott/elliottlib/errata_async.py
@@ -70,6 +70,20 @@ class AsyncErrataAPI:
                 headers=response.headers,
             )
 
+    async def get_push_jobs(self, advisory_id: int) -> list:
+        path = f"/api/v1/erratum/{int(advisory_id)}/push"
+        return await self._make_request(aiohttp.hdrs.METH_GET, path)
+
+    async def push_cdn_stage(self, advisory_id: int) -> Optional[Dict]:
+        path = f"/api/v1/erratum/{int(advisory_id)}/push"
+        data = [{"target": "cdn_stage"}, {"target": "cdn_docker_stage"}]
+        try:
+            return await self._make_request(aiohttp.hdrs.METH_POST, path, json=data)
+        except ClientResponseError as e:
+            if e.status == 400 and "dependencies" in str(e.message):
+                return None
+            raise
+
     async def get_advisory(self, advisory: Union[int, str]) -> Dict:
         path = f"/api/v1/erratum/{quote(str(advisory))}"
         return await self._make_request(aiohttp.hdrs.METH_GET, path)

--- a/elliott/elliottlib/errata_async.py
+++ b/elliott/elliottlib/errata_async.py
@@ -74,9 +74,11 @@ class AsyncErrataAPI:
         path = f"/api/v1/erratum/{int(advisory_id)}/push"
         return await self._make_request(aiohttp.hdrs.METH_GET, path)
 
-    async def push_cdn_stage(self, advisory_id: int) -> Optional[Dict]:
+    async def push_cdn_stage(self, advisory_id: int, targets: Optional[list] = None) -> Optional[Dict]:
         path = f"/api/v1/erratum/{int(advisory_id)}/push"
-        data = [{"target": "cdn_stage"}, {"target": "cdn_docker_stage"}]
+        if targets is None:
+            targets = ["cdn_stage"]
+        data = [{"target": t} for t in targets]
         try:
             return await self._make_request(aiohttp.hdrs.METH_POST, path, json=data)
         except ClientResponseError as e:

--- a/elliott/tests/test_verify_cdn_push_cli.py
+++ b/elliott/tests/test_verify_cdn_push_cli.py
@@ -1,0 +1,304 @@
+import json
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, patch
+
+from elliottlib.cli.verify_cdn_push_cli import (
+    AdvisoryPushResult,
+    PushJobInfo,
+    VerifyCdnPushResult,
+    check_advisory_push,
+    parse_push_jobs,
+    render_result,
+    verify_cdn_push,
+)
+
+
+class TestPushJobInfo(TestCase):
+    def test_complete(self):
+        j = PushJobInfo(target="cdn_stage", job_id=100, status="COMPLETE")
+        self.assertTrue(j.complete)
+        self.assertFalse(j.failed)
+
+    def test_failed(self):
+        j = PushJobInfo(target="cdn_stage", job_id=100, status="FAILED")
+        self.assertFalse(j.complete)
+        self.assertTrue(j.failed)
+
+    def test_running(self):
+        j = PushJobInfo(target="cdn_stage", job_id=100, status="RUNNING")
+        self.assertFalse(j.complete)
+        self.assertFalse(j.failed)
+
+
+class TestAdvisoryPushResult(TestCase):
+    def test_complete(self):
+        r = AdvisoryPushResult(
+            advisory_id=12345,
+            impetus="rpm",
+            push_jobs=[
+                PushJobInfo(target="cdn_stage", job_id=1, status="COMPLETE"),
+                PushJobInfo(target="cdn_docker_stage", job_id=2, status="COMPLETE"),
+            ],
+        )
+        self.assertTrue(r.complete)
+        self.assertFalse(r.failed)
+        self.assertFalse(r.pending)
+
+    def test_failed(self):
+        r = AdvisoryPushResult(
+            advisory_id=12345,
+            impetus="rpm",
+            push_jobs=[
+                PushJobInfo(target="cdn_stage", job_id=1, status="COMPLETE"),
+                PushJobInfo(target="cdn_docker_stage", job_id=2, status="FAILED"),
+            ],
+        )
+        self.assertFalse(r.complete)
+        self.assertTrue(r.failed)
+
+    def test_pending(self):
+        r = AdvisoryPushResult(
+            advisory_id=12345,
+            impetus="rpm",
+            push_jobs=[
+                PushJobInfo(target="cdn_stage", job_id=1, status="RUNNING"),
+            ],
+        )
+        self.assertFalse(r.complete)
+        self.assertFalse(r.failed)
+        self.assertTrue(r.pending)
+
+    def test_error(self):
+        r = AdvisoryPushResult(advisory_id=12345, impetus="rpm", error="something broke")
+        self.assertFalse(r.complete)
+        self.assertTrue(r.failed)
+
+    def test_empty_jobs(self):
+        r = AdvisoryPushResult(advisory_id=12345, impetus="rpm")
+        self.assertFalse(r.complete)
+        self.assertFalse(r.failed)
+        self.assertTrue(r.pending)
+
+
+class TestVerifyCdnPushResult(TestCase):
+    def test_all_complete(self):
+        r = VerifyCdnPushResult(
+            advisories=[
+                AdvisoryPushResult(
+                    advisory_id=1,
+                    impetus="rpm",
+                    push_jobs=[PushJobInfo(target="cdn_stage", job_id=1, status="COMPLETE")],
+                ),
+                AdvisoryPushResult(
+                    advisory_id=2,
+                    impetus="rhcos",
+                    push_jobs=[PushJobInfo(target="cdn_stage", job_id=2, status="COMPLETE")],
+                ),
+            ]
+        )
+        self.assertTrue(r.complete)
+        self.assertFalse(r.failed)
+
+    def test_one_failed(self):
+        r = VerifyCdnPushResult(
+            advisories=[
+                AdvisoryPushResult(
+                    advisory_id=1,
+                    impetus="rpm",
+                    push_jobs=[PushJobInfo(target="cdn_stage", job_id=1, status="COMPLETE")],
+                ),
+                AdvisoryPushResult(
+                    advisory_id=2,
+                    impetus="rhcos",
+                    push_jobs=[PushJobInfo(target="cdn_stage", job_id=2, status="FAILED")],
+                ),
+            ]
+        )
+        self.assertFalse(r.complete)
+        self.assertTrue(r.failed)
+
+    def test_global_errors(self):
+        r = VerifyCdnPushResult(errors=["oops"])
+        self.assertFalse(r.complete)
+        self.assertTrue(r.failed)
+
+
+class TestParsePushJobs(TestCase):
+    def test_picks_latest_per_target(self):
+        raw = [
+            {"id": 1, "status": "FAILED", "target": {"name": "cdn_stage"}},
+            {"id": 5, "status": "COMPLETE", "target": {"name": "cdn_stage"}},
+            {"id": 3, "status": "RUNNING", "target": {"name": "cdn_stage"}},
+            {"id": 2, "status": "COMPLETE", "target": {"name": "cdn_docker_stage"}},
+        ]
+        jobs = parse_push_jobs(raw)
+        by_target = {j.target: j for j in jobs}
+        self.assertEqual(by_target["cdn_stage"].job_id, 5)
+        self.assertEqual(by_target["cdn_stage"].status, "COMPLETE")
+        self.assertEqual(by_target["cdn_docker_stage"].job_id, 2)
+
+    def test_empty_list(self):
+        self.assertEqual(parse_push_jobs([]), [])
+
+    def test_single_job(self):
+        raw = [{"id": 10, "status": "RUNNING", "target": {"name": "cdn_stage"}}]
+        jobs = parse_push_jobs(raw)
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(jobs[0].status, "RUNNING")
+
+
+class TestCheckAdvisoryPush(IsolatedAsyncioTestCase):
+    async def test_all_complete(self):
+        api = AsyncMock()
+        api.get_push_jobs.return_value = [
+            {"id": 1, "status": "COMPLETE", "target": {"name": "cdn_stage"}},
+            {"id": 2, "status": "COMPLETE", "target": {"name": "cdn_docker_stage"}},
+        ]
+        result = await check_advisory_push(api, 12345, "rpm", do_push=True)
+        self.assertTrue(result.complete)
+        self.assertFalse(result.push_triggered)
+        api.push_cdn_stage.assert_not_called()
+
+    async def test_failed_with_push(self):
+        api = AsyncMock()
+        api.get_push_jobs.side_effect = [
+            [{"id": 1, "status": "FAILED", "target": {"name": "cdn_stage"}}],
+            [{"id": 2, "status": "RUNNING", "target": {"name": "cdn_stage"}}],
+        ]
+        result = await check_advisory_push(api, 12345, "rpm", do_push=True)
+        self.assertTrue(result.push_triggered)
+        api.push_cdn_stage.assert_called_once_with(12345)
+
+    async def test_failed_without_push(self):
+        api = AsyncMock()
+        api.get_push_jobs.return_value = [
+            {"id": 1, "status": "FAILED", "target": {"name": "cdn_stage"}},
+        ]
+        result = await check_advisory_push(api, 12345, "rpm", do_push=False)
+        self.assertFalse(result.push_triggered)
+        api.push_cdn_stage.assert_not_called()
+
+    async def test_no_jobs_with_push(self):
+        api = AsyncMock()
+        api.get_push_jobs.side_effect = [
+            [],
+            [{"id": 1, "status": "RUNNING", "target": {"name": "cdn_stage"}}],
+        ]
+        result = await check_advisory_push(api, 12345, "rpm", do_push=True)
+        self.assertTrue(result.push_triggered)
+
+    async def test_running_no_push(self):
+        api = AsyncMock()
+        api.get_push_jobs.return_value = [
+            {"id": 1, "status": "RUNNING", "target": {"name": "cdn_stage"}},
+        ]
+        result = await check_advisory_push(api, 12345, "rpm", do_push=True)
+        self.assertFalse(result.push_triggered)
+        self.assertTrue(result.pending)
+
+    async def test_api_error(self):
+        api = AsyncMock()
+        api.get_push_jobs.side_effect = RuntimeError("connection failed")
+        result = await check_advisory_push(api, 12345, "rpm", do_push=True)
+        self.assertTrue(result.failed)
+        self.assertIn("connection failed", result.error)
+
+
+class TestVerifyCdnPush(IsolatedAsyncioTestCase):
+    @patch("elliottlib.cli.verify_cdn_push_cli.AsyncErrataAPI")
+    async def test_all_complete(self, mock_api_cls):
+        api = AsyncMock()
+        mock_api_cls.return_value.__aenter__ = AsyncMock(return_value=api)
+        mock_api_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        api.get_advisory.return_value = {"errata": {"rhba": {"blocking_advisories": []}}}
+        api.get_push_jobs.return_value = [
+            {"id": 1, "status": "COMPLETE", "target": {"name": "cdn_stage"}},
+        ]
+
+        result = await verify_cdn_push({"rpm": 111}, do_push=True)
+        self.assertTrue(result.complete)
+
+    @patch("elliottlib.cli.verify_cdn_push_cli.AsyncErrataAPI")
+    async def test_with_blocking_advisory(self, mock_api_cls):
+        api = AsyncMock()
+        mock_api_cls.return_value.__aenter__ = AsyncMock(return_value=api)
+        mock_api_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        api.get_advisory.return_value = {"errata": {"rhba": {"blocking_advisories": [999]}}}
+        api.get_push_jobs.return_value = [
+            {"id": 1, "status": "COMPLETE", "target": {"name": "cdn_stage"}},
+        ]
+
+        result = await verify_cdn_push({"rpm": 111}, do_push=True)
+        self.assertTrue(result.complete)
+        self.assertEqual(len(result.advisories), 2)
+
+    @patch("elliottlib.cli.verify_cdn_push_cli.AsyncErrataAPI")
+    async def test_blocking_incomplete_skips_main(self, mock_api_cls):
+        api = AsyncMock()
+        mock_api_cls.return_value.__aenter__ = AsyncMock(return_value=api)
+        mock_api_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        api.get_advisory.return_value = {"errata": {"rhba": {"blocking_advisories": [999]}}}
+        api.get_push_jobs.return_value = [
+            {"id": 1, "status": "RUNNING", "target": {"name": "cdn_stage"}},
+        ]
+
+        result = await verify_cdn_push({"rpm": 111}, do_push=True)
+        self.assertFalse(result.complete)
+
+
+class TestRenderResult(TestCase):
+    def test_text_complete(self):
+        r = VerifyCdnPushResult(
+            advisories=[
+                AdvisoryPushResult(
+                    advisory_id=12345,
+                    impetus="rpm",
+                    push_jobs=[PushJobInfo(target="cdn_stage", job_id=1, status="COMPLETE")],
+                ),
+            ]
+        )
+        text = render_result(r, "text")
+        self.assertIn("COMPLETE", text)
+        self.assertIn("12345", text)
+
+    def test_text_with_push_triggered(self):
+        r = VerifyCdnPushResult(
+            advisories=[
+                AdvisoryPushResult(
+                    advisory_id=12345,
+                    impetus="rpm",
+                    push_triggered=True,
+                    push_jobs=[PushJobInfo(target="cdn_stage", job_id=2, status="RUNNING")],
+                ),
+            ]
+        )
+        text = render_result(r, "text")
+        self.assertIn("re-triggered", text.lower())
+
+    def test_json_output(self):
+        r = VerifyCdnPushResult(
+            advisories=[
+                AdvisoryPushResult(
+                    advisory_id=12345,
+                    impetus="rpm",
+                    push_jobs=[PushJobInfo(target="cdn_stage", job_id=1, status="COMPLETE")],
+                ),
+            ]
+        )
+        data = json.loads(render_result(r, "json"))
+        self.assertTrue(data["complete"])
+        self.assertEqual(len(data["advisories"]), 1)
+        self.assertEqual(data["advisories"][0]["advisory_id"], 12345)
+
+    def test_text_fail(self):
+        r = VerifyCdnPushResult(
+            advisories=[
+                AdvisoryPushResult(advisory_id=12345, impetus="rpm", error="boom"),
+            ]
+        )
+        text = render_result(r, "text")
+        self.assertIn("FAIL", text)
+        self.assertIn("boom", text)

--- a/elliott/tests/test_verify_cdn_push_cli.py
+++ b/elliott/tests/test_verify_cdn_push_cli.py
@@ -117,11 +117,6 @@ class TestVerifyCdnPushResult(TestCase):
         self.assertFalse(r.complete)
         self.assertTrue(r.failed)
 
-    def test_global_errors(self):
-        r = VerifyCdnPushResult(errors=["oops"])
-        self.assertFalse(r.complete)
-        self.assertTrue(r.failed)
-
 
 class TestParsePushJobs(TestCase):
     def test_picks_latest_per_target(self):

--- a/elliott/tests/test_verify_cdn_push_cli.py
+++ b/elliott/tests/test_verify_cdn_push_cli.py
@@ -203,6 +203,15 @@ class TestCheckAdvisoryPush(IsolatedAsyncioTestCase):
         self.assertTrue(result.failed)
         self.assertIn("connection failed", result.error)
 
+    async def test_push_rejected_dependencies(self):
+        api = AsyncMock()
+        api.get_push_jobs.return_value = []
+        api.push_cdn_stage.return_value = None
+        result = await check_advisory_push(api, 12345, "rpm", do_push=True)
+        self.assertFalse(result.push_triggered)
+        self.assertTrue(result.failed)
+        self.assertIn("unmet dependencies", result.error)
+
 
 class TestVerifyCdnPush(IsolatedAsyncioTestCase):
     @patch("elliottlib.cli.verify_cdn_push_cli.AsyncErrataAPI")
@@ -247,6 +256,18 @@ class TestVerifyCdnPush(IsolatedAsyncioTestCase):
 
         result = await verify_cdn_push({"rpm": 111}, do_push=True)
         self.assertFalse(result.complete)
+
+    @patch("elliottlib.cli.verify_cdn_push_cli.AsyncErrataAPI")
+    async def test_blocking_lookup_failure(self, mock_api_cls):
+        api = AsyncMock()
+        mock_api_cls.return_value.__aenter__ = AsyncMock(return_value=api)
+        mock_api_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        api.get_advisory.side_effect = RuntimeError("connection failed")
+
+        result = await verify_cdn_push({"rpm": 111}, do_push=True)
+        self.assertFalse(result.complete)
+        self.assertTrue(result.failed)
 
 
 class TestRenderResult(TestCase):


### PR DESCRIPTION
Adds a new async elliott command to verify CDN staging push job status for rpm and rhcos advisories, with optional re-trigger for failed/missing push jobs. Handles blocking advisory dependencies.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CDN push verification command for advisory push jobs and blocking advisories.
  * Supports text or JSON output and optional retries for missing or failed pushes.
  * Reports completion or failure status with a non-success exit code when pushes remain incomplete.

* **Bug Fixes**
  * Handles dependency-related CDN staging errors without interrupting verification.

* **Tests**
  * Added comprehensive coverage for verification, retries, failures, blocking advisories, and output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->