### PR TITLE
[ART-21949] feat(shipment): make metadata.assembly optional for golang builders

### DIFF
--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -262,7 +262,7 @@ class CreateReleaseCli:
         return created_release
 
     def get_object_name(self) -> str:
-        assembly_str = self.runtime.assembly.replace(".", "-")
+        assembly_str = (self.runtime.assembly or self.runtime.group).replace(".", "-")
         return f"{self.runtime.product}-{self.release_env}-{assembly_str}-{self.kind}-{get_utc_now_formatted_str()}"
 
     async def create_snapshot(self, shipment: Shipment) -> dict:
@@ -361,10 +361,11 @@ class CreateReleaseCli:
 
     def get_annotations(self) -> dict:
         annotations = {
-            "art.redhat.com/assembly": self.runtime.assembly,
             "art.redhat.com/env": self.release_env,
             "art.redhat.com/kind": self.kind,
         }
+        if self.runtime.assembly is not None:
+            annotations["art.redhat.com/assembly"] = self.runtime.assembly
         if self.job_url:
             annotations["art.redhat.com/job-url"] = self.job_url
         return annotations

--- a/elliott/elliottlib/shipment_model.py
+++ b/elliott/elliottlib/shipment_model.py
@@ -18,7 +18,7 @@ class Metadata(StrictBaseModel):
     product: str  # product associated with shipment - see group.yml `product` field
     application: str  # Konflux application to release for
     group: str  # associated build-data group for component metadata
-    assembly: str  # associated build-data assembly
+    assembly: Optional[str] = None  # associated build-data assembly; None when assemblies not enabled (e.g. golang)
     fbc: Optional[bool] = False  # indicates if shipment is for an FBC release
     advisory_required: Optional[bool] = True  # when False, shipment-ci skips advisory URL check (registry-push-only)
 

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -591,15 +591,11 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
                     ),
                 ),
                 data=Data(
-                    releaseNotes=ReleaseNotes(
-                        type="RHBA", synopsis="s", topic="t", description="d", solution="s"
-                    )
+                    releaseNotes=ReleaseNotes(type="RHBA", synopsis="s", topic="t", description="d", solution="s")
                 ),
             ),
         )
-        self.runtime.shipment_gitdata.load_yaml_file.return_value = shipment_config.model_dump(
-            exclude_none=True
-        )
+        self.runtime.shipment_gitdata.load_yaml_file.return_value = shipment_config.model_dump(exclude_none=True)
         self.konflux_client._get_api.return_value = MagicMock()
         self.konflux_client._get.return_value = MagicMock()
 

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -616,6 +616,12 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
         annotations = cli.get_annotations()
         self.assertNotIn("art.redhat.com/assembly", annotations)
 
+        # Verify the assembly validation in run() also passes (None == None).
+        # This exercises the guard at: elif meta.assembly != self.runtime.assembly
+        result = await cli.run()
+        # dry_run=True still creates resources — it just changes the log message
+        self.assertEqual(self.konflux_client._create.call_count, 2)  # snapshot + release
+
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
     @patch("elliottlib.runtime.Runtime")
     async def test_config_data_validation_error(self, mock_runtime, mock_konflux_client_init):

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -618,7 +618,7 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
 
         # Verify the assembly validation in run() also passes (None == None).
         # This exercises the guard at: elif meta.assembly != self.runtime.assembly
-        result = await cli.run()
+        await cli.run()
         # dry_run=True still creates resources — it just changes the log message
         self.assertEqual(self.konflux_client._create.call_count, 2)  # snapshot + release
 

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -508,12 +508,10 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
         mock_runtime.return_value = self.runtime
         mock_konflux_client_init.return_value = self.konflux_client
 
-        # initialize a regular shipment without a required field i.e. metadata.assembly
-        # so that the shipment schema validation fails
+        # initialize a shipment without a required field (product) to verify schema validation
         shipment_config = {
             "shipment": {
                 "metadata": {
-                    "product": "ocp",
                     "application": "openshift-4-18",
                     "group": "openshift-4.18",
                     "fbc": True,
@@ -551,9 +549,76 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
             await cli.run()
 
         self.assertIn(
-            "1 validation error for ShipmentConfig\nshipment.metadata.assembly\n  Field required",
+            "1 validation error for ShipmentConfig\nshipment.metadata.product\n  Field required",
             str(context.exception),
         )
+
+    @patch("elliottlib.cli.konflux_release_cli.get_utc_now_formatted_str", return_value="timestamp")
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    @patch("elliottlib.runtime.Runtime")
+    async def test_none_assembly_passes_for_golang(self, mock_runtime, mock_konflux_client_init, _):
+        """When assemblies are not enabled (e.g. golang), both meta.assembly and
+        runtime.assembly are None. Validation should pass."""
+        self.runtime.assembly = None
+        self.runtime.group = "golang"
+        mock_runtime.return_value = self.runtime
+        mock_konflux_client_init.return_value = self.konflux_client
+
+        shipment_config = ShipmentConfig(
+            shipment=Shipment(
+                metadata=Metadata(
+                    product="ocp",
+                    application="art-images-base",
+                    group="golang",
+                ),
+                environments=Environments(
+                    stage=ShipmentEnv(releasePlan="test-stage-rp"),
+                    prod=ShipmentEnv(releasePlan="test-prod-rp"),
+                ),
+                snapshot=Snapshot(
+                    nvrs=["golang-builder-v1.25-rhel9-container-v1.25.0-1"],
+                    spec=SnapshotSpec(
+                        application="art-images-base",
+                        components=[
+                            SnapshotComponent(
+                                name="golang-builder-v1.25-rhel9",
+                                source=ComponentSource(
+                                    git=GitSource(url="https://github.com/test.git", revision="abc")
+                                ),
+                                containerImage="quay.io/test:latest",
+                            ),
+                        ],
+                    ),
+                ),
+                data=Data(
+                    releaseNotes=ReleaseNotes(
+                        type="RHBA", synopsis="s", topic="t", description="d", solution="s"
+                    )
+                ),
+            ),
+        )
+        self.runtime.shipment_gitdata.load_yaml_file.return_value = shipment_config.model_dump(
+            exclude_none=True
+        )
+        self.konflux_client._get_api.return_value = MagicMock()
+        self.konflux_client._get.return_value = MagicMock()
+
+        cli = CreateReleaseCli(
+            runtime=self.runtime,
+            config_path=self.config_path,
+            release_env=self.release_env,
+            konflux_config=self.konflux_config,
+            image_repo_pull_secret={},
+            dry_run=True,
+            kind="image",
+        )
+
+        object_name = cli.get_object_name()
+        self.assertIn("golang", object_name)
+        self.assertNotIn("None", object_name)
+
+        annotations = cli.get_annotations()
+        self.assertNotIn("art.redhat.com/assembly", annotations)
 
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
     @patch("elliottlib.runtime.Runtime")

--- a/ocp-build-data-validator/validator/json_schemas/shipment.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/shipment.schema.json
@@ -198,8 +198,16 @@
           "type": "string"
         },
         "assembly": {
-          "title": "Assembly",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assembly"
         },
         "fbc": {
           "anyOf": [
@@ -229,8 +237,7 @@
       "required": [
         "product",
         "application",
-        "group",
-        "assembly"
+        "group"
       ],
       "title": "Metadata",
       "type": "object"


### PR DESCRIPTION
**Jira:** [ART-21949](https://redhat.atlassian.net/browse/ART-21949)

## Summary

Golang builders have no assemblies (`ocp-build-data` `golang` branch has no `assemblies.enabled`), so `runtime.assembly` is `None`. Two failures block golang shipment [MR 716](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/716):

- **create-stage**: `ValueError: shipment.metadata.assembly=stream != runtime.assembly=None`
- **validate-job**: `'assembly' is a required property` (when assembly removed from YAML)

This PR makes `assembly` optional (default `None`) so golang shipments can omit it. The existing `!=` check passes naturally when both sides are `None`.

### Changes

- **`shipment_model.py`**: `assembly: str` → `assembly: Optional[str] = None`
- **`shipment.schema.json`**: removed from `required`, added `null` type
- **`konflux_release_cli.py`**: `get_object_name()` falls back to group name when assembly is `None`; `get_annotations()` omits assembly key when `None`
- **`test_konflux_release_cli.py`**: updated validation test (missing `product` instead of `assembly`), added `test_none_assembly_passes_for_golang`

### Test plan

- [x] `pytest elliott/tests/test_konflux_release_cli.py` — 16/16 pass
- [ ] Companion shipment-ci MR for path validation and `--assembly` flag handling
- [ ] Retest MR 716 after both merges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shipments can now be processed without an assembly value.
  * Release names fall back to the runtime group when no assembly is provided, avoiding incomplete names.
  * Assembly annotations are omitted when no assembly is available.
  * Validation now accepts missing or null assembly values while continuing to report other required-field errors.
  * Golang shipments without an assembly now validate and generate correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->