### PR TITLE
ART-21878: Add elliott verify-security-alerts command

### DIFF
--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -79,6 +79,7 @@ from elliottlib.cli.verify_image_grades_cli import verify_image_grades_cli
 from elliottlib.cli.verify_kernel_tag_cli import verify_kernel_tag_cli
 from elliottlib.cli.verify_payload import verify_payload
 from elliottlib.cli.verify_qe_qualifier_cli import verify_qe_qualifier_cli
+from elliottlib.cli.verify_security_alerts_cli import verify_security_alerts_cli
 from elliottlib.cli.verify_signatures_cli import verify_signatures_cli
 from elliottlib.exceptions import ElliottFatalError
 from elliottlib.util import pbar_header, progress_func
@@ -329,6 +330,7 @@ cli.add_command(watch_release_cli)
 cli.add_command(find_bugs_second_fix_cli)
 cli.add_command(process_release_from_fbc_bugs_cli)
 cli.add_command(verify_cdn_push_cli)
+cli.add_command(verify_security_alerts_cli)
 cli.add_command(verify_signatures_cli)
 cli.add_command(verify_image_grades_cli)
 cli.add_command(verify_qe_qualifier_cli)

--- a/elliott/elliottlib/cli/verify_security_alerts_cli.py
+++ b/elliott/elliottlib/cli/verify_security_alerts_cli.py
@@ -57,6 +57,11 @@ async def check_advisory_security_alerts(api: AsyncErrataAPI, advisory_id: int, 
         advisory_data = await api.get_advisory(advisory_id)
         result.errata_type = get_errata_type(advisory_data)
 
+        if not result.errata_type:
+            result.error = "unable to determine advisory type"
+            LOGGER.error("Advisory %s (%s): %s", advisory_id, impetus, result.error)
+            return result
+
         if result.errata_type != "rhsa":
             LOGGER.info(
                 "Advisory %s (%s): type %s, skipping security alerts check",
@@ -171,7 +176,8 @@ async def verify_security_alerts_cli(runtime, output):
 
     Refreshes security alert data from ProdSec and checks for blocking
     alerts on all RHSA advisories in the assembly. Non-RHSA advisories
-    are skipped. Exits with code 1 if any blocking alert is found.
+    are skipped. Exits with code 1 if any blocking alert is found or
+    if any advisory check fails with an error.
 
     Requires --group and --assembly global options. Advisory IDs are
     resolved from the assembly config in releases.yml.

--- a/elliott/elliottlib/cli/verify_security_alerts_cli.py
+++ b/elliott/elliottlib/cli/verify_security_alerts_cli.py
@@ -1,0 +1,191 @@
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+import click
+from artcommonlib.assembly import assembly_config_struct
+
+from elliottlib.cli.common import cli, click_coroutine
+from elliottlib.errata_async import AsyncErrataAPI
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class AdvisoryAlertResult:
+    advisory_id: int
+    impetus: str
+    errata_type: str = ""
+    blocking: bool = False
+    skipped: bool = False
+    error: Optional[str] = None
+
+    @property
+    def ok(self) -> bool:
+        return not self.blocking and not self.error
+
+    @property
+    def failed(self) -> bool:
+        return self.blocking or bool(self.error)
+
+
+@dataclass
+class VerifySecurityAlertsResult:
+    advisories: list[AdvisoryAlertResult] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        if self.errors:
+            return False
+        return all(a.ok for a in self.advisories)
+
+    @property
+    def failed(self) -> bool:
+        return bool(self.errors) or any(a.failed for a in self.advisories)
+
+
+def get_errata_type(advisory_data: dict) -> str:
+    errata = advisory_data.get("errata", {})
+    return next(iter(errata.keys()), "")
+
+
+async def check_advisory_security_alerts(api: AsyncErrataAPI, advisory_id: int, impetus: str) -> AdvisoryAlertResult:
+    result = AdvisoryAlertResult(advisory_id=advisory_id, impetus=impetus)
+    try:
+        advisory_data = await api.get_advisory(advisory_id)
+        result.errata_type = get_errata_type(advisory_data)
+
+        if result.errata_type != "rhsa":
+            LOGGER.info(
+                "Advisory %s (%s): type %s, skipping security alerts check",
+                advisory_id,
+                impetus,
+                result.errata_type.upper(),
+            )
+            result.skipped = True
+            return result
+
+        response = await api.refresh_security_alerts(advisory_id)
+        alerts = response.get("alerts", {})
+        LOGGER.debug("Advisory %s (%s): security alerts response: %s", advisory_id, impetus, alerts)
+        result.blocking = bool(alerts.get("blocking", False))
+
+        if result.blocking:
+            LOGGER.error("Advisory %s (%s): has BLOCKING security alerts", advisory_id, impetus)
+        else:
+            LOGGER.info("Advisory %s (%s): no blocking security alerts", advisory_id, impetus)
+
+    except Exception as e:
+        LOGGER.error("Advisory %s (%s): error checking security alerts: %s", advisory_id, impetus, e)
+        result.error = str(e)
+
+    return result
+
+
+async def verify_security_alerts(advisories: dict[str, int]) -> VerifySecurityAlertsResult:
+    result = VerifySecurityAlertsResult()
+
+    async with AsyncErrataAPI() as api:
+        for impetus, advisory_id in advisories.items():
+            ar = await check_advisory_security_alerts(api, advisory_id, impetus)
+            result.advisories.append(ar)
+
+    return result
+
+
+def render_result(result: VerifySecurityAlertsResult, output: str) -> str:
+    if output == "json":
+        return json.dumps(
+            {
+                "ok": result.ok,
+                "failed": result.failed,
+                "advisories": [
+                    {
+                        "advisory_id": a.advisory_id,
+                        "impetus": a.impetus,
+                        "errata_type": a.errata_type,
+                        "blocking": a.blocking,
+                        "skipped": a.skipped,
+                        "error": a.error,
+                    }
+                    for a in result.advisories
+                ],
+                "errors": result.errors,
+            },
+            indent=2,
+        )
+
+    lines = ["Security alerts check", ""]
+    for a in result.advisories:
+        if a.skipped:
+            lines.append(f"  Advisory {a.advisory_id} ({a.impetus}): SKIPPED ({a.errata_type.upper()})")
+        elif a.blocking:
+            lines.append(f"  Advisory {a.advisory_id} ({a.impetus}): BLOCKING")
+        elif a.error:
+            lines.append(f"  Advisory {a.advisory_id} ({a.impetus}): ERROR")
+            lines.append(f"    {a.error}")
+        else:
+            lines.append(f"  Advisory {a.advisory_id} ({a.impetus}): OK")
+    lines.append("")
+
+    if result.errors:
+        lines.append("Errors:")
+        for err in result.errors:
+            lines.append(f"  - {err}")
+        lines.append("")
+
+    overall = "OK" if result.ok else "FAIL"
+    lines.append(f"Overall: {overall}")
+    return "\n".join(lines)
+
+
+SKIPPED_IMPETUS = ("microshift",)
+
+
+def get_advisory_ids(runtime) -> dict[str, int]:
+    releases_config = runtime.get_releases_config()
+    group_config = assembly_config_struct(releases_config, runtime.assembly, "group", {})
+    advisories = group_config.get("advisories", {})
+    result = {}
+    for impetus, ad_id in advisories.items():
+        if ad_id and impetus not in SKIPPED_IMPETUS:
+            result[impetus] = int(ad_id)
+    return result
+
+
+@cli.command("verify-security-alerts", short_help="Check RHSA advisories for blocking security alerts")
+@click.option(
+    "-o",
+    "--output",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    show_default=True,
+    help="Output format.",
+)
+@click.pass_obj
+@click_coroutine
+async def verify_security_alerts_cli(runtime, output):
+    """Check RHSA advisories for blocking security alerts.
+
+    Refreshes security alert data from ProdSec and checks for blocking
+    alerts on all RHSA advisories in the assembly. Non-RHSA advisories
+    are skipped. Exits with code 1 if any blocking alert is found.
+
+    Requires --group and --assembly global options. Advisory IDs are
+    resolved from the assembly config in releases.yml.
+
+    Example:
+        elliott --group openshift-4.18 --assembly 4.18.51 verify-security-alerts
+    """
+    runtime.initialize()
+    advisories = get_advisory_ids(runtime)
+    if not advisories:
+        raise click.UsageError("No advisory IDs found in assembly config.")
+
+    LOGGER.info("Checking security alerts for advisories: %s", advisories)
+    result = await verify_security_alerts(advisories=advisories)
+    click.echo(render_result(result, output))
+    if not result.ok:
+        raise SystemExit(1)

--- a/elliott/elliottlib/cli/verify_security_alerts_cli.py
+++ b/elliott/elliottlib/cli/verify_security_alerts_cli.py
@@ -74,7 +74,13 @@ async def check_advisory_security_alerts(api: AsyncErrataAPI, advisory_id: int, 
 
         response = await api.refresh_security_alerts(advisory_id)
         alerts = response.get("alerts", {})
-        LOGGER.debug("Advisory %s (%s): security alerts response: %s", advisory_id, impetus, alerts)
+        LOGGER.debug(
+            "Advisory %s (%s): blocking=%s, alert_count=%d",
+            advisory_id,
+            impetus,
+            alerts.get("blocking", False),
+            len(alerts.get("alerts", [])),
+        )
         result.blocking = bool(alerts.get("blocking", False))
 
         if result.blocking:
@@ -146,6 +152,7 @@ def render_result(result: VerifySecurityAlertsResult, output: str) -> str:
     return "\n".join(lines)
 
 
+# microshift advisories are managed separately and don't go through ProdSec alert flow
 SKIPPED_IMPETUS = ("microshift",)
 
 

--- a/elliott/elliottlib/cli/verify_security_alerts_cli.py
+++ b/elliott/elliottlib/cli/verify_security_alerts_cli.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from dataclasses import dataclass, field
@@ -33,17 +34,14 @@ class AdvisoryAlertResult:
 @dataclass
 class VerifySecurityAlertsResult:
     advisories: list[AdvisoryAlertResult] = field(default_factory=list)
-    errors: list[str] = field(default_factory=list)
 
     @property
     def ok(self) -> bool:
-        if self.errors:
-            return False
         return all(a.ok for a in self.advisories)
 
     @property
     def failed(self) -> bool:
-        return bool(self.errors) or any(a.failed for a in self.advisories)
+        return any(a.failed for a in self.advisories)
 
 
 def get_errata_type(advisory_data: dict) -> str:
@@ -99,9 +97,11 @@ async def verify_security_alerts(advisories: dict[str, int]) -> VerifySecurityAl
     result = VerifySecurityAlertsResult()
 
     async with AsyncErrataAPI() as api:
-        for impetus, advisory_id in advisories.items():
-            ar = await check_advisory_security_alerts(api, advisory_id, impetus)
-            result.advisories.append(ar)
+        tasks = [
+            check_advisory_security_alerts(api, advisory_id, impetus) for impetus, advisory_id in advisories.items()
+        ]
+        results = await asyncio.gather(*tasks)
+        result.advisories.extend(results)
 
     return result
 
@@ -123,7 +123,6 @@ def render_result(result: VerifySecurityAlertsResult, output: str) -> str:
                     }
                     for a in result.advisories
                 ],
-                "errors": result.errors,
             },
             indent=2,
         )
@@ -140,12 +139,6 @@ def render_result(result: VerifySecurityAlertsResult, output: str) -> str:
         else:
             lines.append(f"  Advisory {a.advisory_id} ({a.impetus}): OK")
     lines.append("")
-
-    if result.errors:
-        lines.append("Errors:")
-        for err in result.errors:
-            lines.append(f"  - {err}")
-        lines.append("")
 
     overall = "OK" if result.ok else "FAIL"
     lines.append(f"Overall: {overall}")

--- a/elliott/elliottlib/errata_async.py
+++ b/elliott/elliottlib/errata_async.py
@@ -90,6 +90,10 @@ class AsyncErrataAPI:
         path = f"/api/v1/erratum/{quote(str(advisory))}"
         return await self._make_request(aiohttp.hdrs.METH_GET, path)
 
+    async def refresh_security_alerts(self, advisory_id: int) -> Dict:
+        path = f"/api/v1/erratum/{int(advisory_id)}/security_alerts/refresh"
+        return await self._make_request(aiohttp.hdrs.METH_POST, path)
+
     async def reserve_live_id(self) -> str:
         path = "/api/v1/advisory/reserve_live_id"
         result = await self._make_request(aiohttp.hdrs.METH_POST, path)

--- a/elliott/elliottlib/errata_async.py
+++ b/elliott/elliottlib/errata_async.py
@@ -91,7 +91,7 @@ class AsyncErrataAPI:
         return await self._make_request(aiohttp.hdrs.METH_GET, path)
 
     async def refresh_security_alerts(self, advisory_id: int) -> Dict:
-        path = f"/api/v1/erratum/{int(advisory_id)}/security_alerts/refresh"
+        path = f"/api/v1/erratum/{advisory_id}/security_alerts/refresh"
         return await self._make_request(aiohttp.hdrs.METH_POST, path)
 
     async def reserve_live_id(self) -> str:

--- a/elliott/tests/test_verify_security_alerts_cli.py
+++ b/elliott/tests/test_verify_security_alerts_cli.py
@@ -92,6 +92,13 @@ class TestCheckAdvisorySecurityAlerts(IsolatedAsyncioTestCase):
         self.assertFalse(result.blocking)
         self.assertTrue(result.ok)
 
+    async def test_unknown_type(self):
+        api = AsyncMock()
+        api.get_advisory.return_value = {}
+        result = await check_advisory_security_alerts(api, 12345, "rpm")
+        self.assertTrue(result.failed)
+        self.assertIn("unable to determine", result.error)
+
     async def test_rhsa_blocking(self):
         api = AsyncMock()
         api.get_advisory.return_value = {"errata": {"rhsa": {}}}

--- a/elliott/tests/test_verify_security_alerts_cli.py
+++ b/elliott/tests/test_verify_security_alerts_cli.py
@@ -98,6 +98,7 @@ class TestCheckAdvisorySecurityAlerts(IsolatedAsyncioTestCase):
         result = await check_advisory_security_alerts(api, 12345, "rpm")
         self.assertTrue(result.failed)
         self.assertIn("unable to determine", result.error)
+        api.refresh_security_alerts.assert_not_called()
 
     async def test_rhsa_blocking(self):
         api = AsyncMock()

--- a/elliott/tests/test_verify_security_alerts_cli.py
+++ b/elliott/tests/test_verify_security_alerts_cli.py
@@ -55,11 +55,6 @@ class TestVerifySecurityAlertsResult(TestCase):
         self.assertFalse(r.ok)
         self.assertTrue(r.failed)
 
-    def test_global_errors(self):
-        r = VerifySecurityAlertsResult(errors=["oops"])
-        self.assertFalse(r.ok)
-        self.assertTrue(r.failed)
-
 
 class TestGetErrataType(TestCase):
     def test_rhsa(self):

--- a/elliott/tests/test_verify_security_alerts_cli.py
+++ b/elliott/tests/test_verify_security_alerts_cli.py
@@ -1,0 +1,225 @@
+import json
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, patch
+
+from elliottlib.cli.verify_security_alerts_cli import (
+    AdvisoryAlertResult,
+    VerifySecurityAlertsResult,
+    check_advisory_security_alerts,
+    get_errata_type,
+    render_result,
+    verify_security_alerts,
+)
+
+
+class TestAdvisoryAlertResult(TestCase):
+    def test_ok(self):
+        r = AdvisoryAlertResult(advisory_id=1, impetus="rpm", errata_type="rhsa", blocking=False)
+        self.assertTrue(r.ok)
+        self.assertFalse(r.failed)
+
+    def test_blocking(self):
+        r = AdvisoryAlertResult(advisory_id=1, impetus="rpm", errata_type="rhsa", blocking=True)
+        self.assertFalse(r.ok)
+        self.assertTrue(r.failed)
+
+    def test_error(self):
+        r = AdvisoryAlertResult(advisory_id=1, impetus="rpm", error="boom")
+        self.assertFalse(r.ok)
+        self.assertTrue(r.failed)
+
+    def test_skipped_is_ok(self):
+        r = AdvisoryAlertResult(advisory_id=1, impetus="rpm", errata_type="rhba", skipped=True)
+        self.assertTrue(r.ok)
+        self.assertFalse(r.failed)
+
+
+class TestVerifySecurityAlertsResult(TestCase):
+    def test_all_ok(self):
+        r = VerifySecurityAlertsResult(
+            advisories=[
+                AdvisoryAlertResult(advisory_id=1, impetus="rpm", errata_type="rhsa"),
+                AdvisoryAlertResult(advisory_id=2, impetus="rhcos", errata_type="rhba", skipped=True),
+            ]
+        )
+        self.assertTrue(r.ok)
+        self.assertFalse(r.failed)
+
+    def test_one_blocking(self):
+        r = VerifySecurityAlertsResult(
+            advisories=[
+                AdvisoryAlertResult(advisory_id=1, impetus="rpm", errata_type="rhsa", blocking=True),
+                AdvisoryAlertResult(advisory_id=2, impetus="rhcos", errata_type="rhba", skipped=True),
+            ]
+        )
+        self.assertFalse(r.ok)
+        self.assertTrue(r.failed)
+
+    def test_global_errors(self):
+        r = VerifySecurityAlertsResult(errors=["oops"])
+        self.assertFalse(r.ok)
+        self.assertTrue(r.failed)
+
+
+class TestGetErrataType(TestCase):
+    def test_rhsa(self):
+        self.assertEqual(get_errata_type({"errata": {"rhsa": {}}}), "rhsa")
+
+    def test_rhba(self):
+        self.assertEqual(get_errata_type({"errata": {"rhba": {}}}), "rhba")
+
+    def test_empty(self):
+        self.assertEqual(get_errata_type({"errata": {}}), "")
+
+    def test_missing(self):
+        self.assertEqual(get_errata_type({}), "")
+
+
+class TestCheckAdvisorySecurityAlerts(IsolatedAsyncioTestCase):
+    async def test_rhba_skipped(self):
+        api = AsyncMock()
+        api.get_advisory.return_value = {"errata": {"rhba": {}}}
+        result = await check_advisory_security_alerts(api, 12345, "rpm")
+        self.assertTrue(result.skipped)
+        self.assertTrue(result.ok)
+        api.refresh_security_alerts.assert_not_called()
+
+    async def test_rhsa_no_blocking(self):
+        api = AsyncMock()
+        api.get_advisory.return_value = {"errata": {"rhsa": {}}}
+        api.refresh_security_alerts.return_value = {"alerts": {"blocking": False, "alerts": []}}
+        result = await check_advisory_security_alerts(api, 12345, "rpm")
+        self.assertFalse(result.blocking)
+        self.assertTrue(result.ok)
+
+    async def test_rhsa_blocking(self):
+        api = AsyncMock()
+        api.get_advisory.return_value = {"errata": {"rhsa": {}}}
+        api.refresh_security_alerts.return_value = {"alerts": {"blocking": True, "alerts": [{"id": 1}]}}
+        result = await check_advisory_security_alerts(api, 12345, "rpm")
+        self.assertTrue(result.blocking)
+        self.assertTrue(result.failed)
+
+    async def test_rhsa_empty_alerts(self):
+        api = AsyncMock()
+        api.get_advisory.return_value = {"errata": {"rhsa": {}}}
+        api.refresh_security_alerts.return_value = {"alerts": {}}
+        result = await check_advisory_security_alerts(api, 12345, "rpm")
+        self.assertFalse(result.blocking)
+        self.assertTrue(result.ok)
+
+    async def test_api_error(self):
+        api = AsyncMock()
+        api.get_advisory.side_effect = RuntimeError("connection failed")
+        result = await check_advisory_security_alerts(api, 12345, "rpm")
+        self.assertTrue(result.failed)
+        self.assertIn("connection failed", result.error)
+
+    async def test_refresh_error(self):
+        api = AsyncMock()
+        api.get_advisory.return_value = {"errata": {"rhsa": {}}}
+        api.refresh_security_alerts.side_effect = RuntimeError("refresh failed")
+        result = await check_advisory_security_alerts(api, 12345, "rpm")
+        self.assertTrue(result.failed)
+        self.assertIn("refresh failed", result.error)
+
+
+class TestVerifySecurityAlerts(IsolatedAsyncioTestCase):
+    @patch("elliottlib.cli.verify_security_alerts_cli.AsyncErrataAPI")
+    async def test_all_ok(self, mock_api_cls):
+        api = AsyncMock()
+        mock_api_cls.return_value.__aenter__ = AsyncMock(return_value=api)
+        mock_api_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        api.get_advisory.return_value = {"errata": {"rhba": {}}}
+
+        result = await verify_security_alerts({"rpm": 111, "rhcos": 222})
+        self.assertTrue(result.ok)
+        self.assertEqual(len(result.advisories), 2)
+
+    @patch("elliottlib.cli.verify_security_alerts_cli.AsyncErrataAPI")
+    async def test_rhsa_blocking(self, mock_api_cls):
+        api = AsyncMock()
+        mock_api_cls.return_value.__aenter__ = AsyncMock(return_value=api)
+        mock_api_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        api.get_advisory.return_value = {"errata": {"rhsa": {}}}
+        api.refresh_security_alerts.return_value = {"alerts": {"blocking": True, "alerts": [{"id": 1}]}}
+
+        result = await verify_security_alerts({"rpm": 111})
+        self.assertFalse(result.ok)
+        self.assertTrue(result.failed)
+
+    @patch("elliottlib.cli.verify_security_alerts_cli.AsyncErrataAPI")
+    async def test_mixed_types(self, mock_api_cls):
+        api = AsyncMock()
+        mock_api_cls.return_value.__aenter__ = AsyncMock(return_value=api)
+        mock_api_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        def get_advisory_side_effect(advisory_id):
+            if advisory_id == 111:
+                return {"errata": {"rhsa": {}}}
+            return {"errata": {"rhba": {}}}
+
+        api.get_advisory.side_effect = get_advisory_side_effect
+        api.refresh_security_alerts.return_value = {"alerts": {"blocking": False, "alerts": []}}
+
+        result = await verify_security_alerts({"rpm": 111, "rhcos": 222})
+        self.assertTrue(result.ok)
+        rhsa_result = next(a for a in result.advisories if a.impetus == "rpm")
+        rhba_result = next(a for a in result.advisories if a.impetus == "rhcos")
+        self.assertFalse(rhsa_result.skipped)
+        self.assertTrue(rhba_result.skipped)
+
+
+class TestRenderResult(TestCase):
+    def test_text_ok(self):
+        r = VerifySecurityAlertsResult(
+            advisories=[
+                AdvisoryAlertResult(advisory_id=12345, impetus="rpm", errata_type="rhsa"),
+            ]
+        )
+        text = render_result(r, "text")
+        self.assertIn("OK", text)
+        self.assertIn("12345", text)
+
+    def test_text_blocking(self):
+        r = VerifySecurityAlertsResult(
+            advisories=[
+                AdvisoryAlertResult(advisory_id=12345, impetus="rpm", errata_type="rhsa", blocking=True),
+            ]
+        )
+        text = render_result(r, "text")
+        self.assertIn("BLOCKING", text)
+        self.assertIn("FAIL", text)
+
+    def test_text_skipped(self):
+        r = VerifySecurityAlertsResult(
+            advisories=[
+                AdvisoryAlertResult(advisory_id=12345, impetus="rpm", errata_type="rhba", skipped=True),
+            ]
+        )
+        text = render_result(r, "text")
+        self.assertIn("SKIPPED", text)
+        self.assertIn("RHBA", text)
+
+    def test_json_output(self):
+        r = VerifySecurityAlertsResult(
+            advisories=[
+                AdvisoryAlertResult(advisory_id=12345, impetus="rpm", errata_type="rhsa", blocking=True),
+            ]
+        )
+        data = json.loads(render_result(r, "json"))
+        self.assertFalse(data["ok"])
+        self.assertTrue(data["failed"])
+        self.assertTrue(data["advisories"][0]["blocking"])
+
+    def test_text_error(self):
+        r = VerifySecurityAlertsResult(
+            advisories=[
+                AdvisoryAlertResult(advisory_id=12345, impetus="rpm", error="boom"),
+            ]
+        )
+        text = render_result(r, "text")
+        self.assertIn("ERROR", text)
+        self.assertIn("boom", text)


### PR DESCRIPTION
Adds a new async elliott command to check RHSA advisories for blocking security alerts via the Errata ProdSec API. Non-RHSA advisories are skipped. Microshift advisories are excluded per OAR convention.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `verify-security-alerts` command for configured advisories.
  - Refreshes security-alert information before verification.
  - Supports text and JSON reports covering blocked, skipped, and errored advisories.
  - Returns a failure status when blocking alerts or verification errors are found.

- **Bug Fixes**
  - Added clear handling for missing advisory configuration and unsupported advisory types.
  - Non-security advisories are skipped appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->