### PR TITLE
Support stream and test assemblies in update-golang

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -21,7 +21,7 @@ from artcommonlib.constants import (
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.konflux.konflux_db import KonfluxDb
-from artcommonlib.release_util import isolate_el_version_in_release
+from artcommonlib.release_util import isolate_assembly_in_release, isolate_el_version_in_release
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import new_roundtrip_yaml_handler
 from doozerlib.cli.config_plashet import KNOWN_SIGNING_KEYS
@@ -39,6 +39,8 @@ from pyartcd.util import default_release_suffix, kinit
 _LOGGER = logging.getLogger(__name__)
 yaml = new_roundtrip_yaml_handler()
 PUBLISHED_GOLANG_BUILDER_REPO = f"{REGISTRY_REDHAT_IO}/openshift/{ART_IMAGES_BASE_APPLICATION}"
+GOLANG_ASSEMBLIES = ("stream", "test")
+DEFAULT_GOLANG_ASSEMBLY = "stream"
 
 
 def is_latest(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool:
@@ -147,7 +149,7 @@ async def move_golang_bugs(
         '--group',
         f'openshift-{ocp_version}',
         '--assembly',
-        'stream',
+        DEFAULT_GOLANG_ASSEMBLY,
         'find-bugs:golang',
         '--analyze',
         '--update-tracker',
@@ -190,6 +192,7 @@ class UpdateGolangPipeline:
         external_golang_rpms: bool = False,
         network_mode: str | None = None,
         major_bump: bool = False,
+        assembly: str = DEFAULT_GOLANG_ASSEMBLY,
     ):
         self.runtime = runtime
         self.dry_run = runtime.dry_run
@@ -209,6 +212,9 @@ class UpdateGolangPipeline:
         self.external_golang_rpms = external_golang_rpms
         self.network_mode = network_mode
         self.major_bump = major_bump
+        if assembly not in GOLANG_ASSEMBLIES:
+            raise ValueError(f"Unsupported golang assembly {assembly!r}; expected one of {GOLANG_ASSEMBLIES}")
+        self.assembly = assembly
         self._slack_client = self.runtime.new_slack_client()
         self._doozer_working_dir = self.runtime.working_dir / "doozer-working"
         self._doozer_env_vars = os.environ.copy()
@@ -225,6 +231,24 @@ class UpdateGolangPipeline:
         if build_system in ('konflux', 'both'):
             self.konflux_db = KonfluxDb()
             self.konflux_db.bind(KonfluxBuildRecord)
+
+    @property
+    def is_production_assembly(self) -> bool:
+        return self.assembly == DEFAULT_GOLANG_ASSEMBLY
+
+    def _existing_build_matches_assembly(self, release: str) -> bool:
+        """Match the selected stream-type assembly for existing-build lookup.
+
+        Legacy unqualified builds are compatible with stream only. Test builds
+        must carry an explicit ``assembly.test`` qualifier.
+        """
+        build_assembly = isolate_assembly_in_release(release)
+        if self.is_production_assembly:
+            return build_assembly in (None, DEFAULT_GOLANG_ASSEMBLY)
+        return build_assembly == self.assembly
+
+    def _get_doozer_assembly_args(self) -> list[str]:
+        return ["--assembly", self.assembly]
 
     @staticmethod
     def _load_yaml_from_repo(repo, path: str, ref: str):
@@ -279,6 +303,11 @@ class UpdateGolangPipeline:
         return branch, allowed_major_minors
 
     def validate_go_version_matches_group_vars(self, go_version: str):
+        repo, branch = self._get_ocp_build_data_repo_and_branch(self.GOLANG_DATA_BRANCH)
+        golang_group = self._load_yaml_from_repo(repo, "group.yml", branch)
+        if not golang_group.get("assemblies", {}).get("enabled", False):
+            raise ValueError(f"Assemblies are not enabled in ocp-build-data branch {branch}")
+
         branch, allowed_major_minors = self._get_allowed_go_major_minors()
         build_major_minor = extract_major_minor(go_version, "golang build version")
         if build_major_minor not in allowed_major_minors.values():
@@ -338,14 +367,18 @@ class UpdateGolangPipeline:
         self._slack_client.bind_channel(self.ocp_version)
         running_in_jenkins = os.environ.get('BUILD_ID', False)
         if running_in_jenkins:
-            title_update = f" {self.ocp_version} - {go_version} - el{list(el_nvr_map.keys())} - {self.build_system}"
+            title_update = (
+                f" {self.ocp_version} - {go_version} - el{list(el_nvr_map.keys())}"
+                f" - {self.build_system} - {self.assembly}"
+            )
             if self.dry_run:
                 title_update += ' [dry-run]'
             jenkins.init_jenkins()
             jenkins.update_title(title_update)
         external_repos_msg = " using golang RPMs from external repos" if self.external_golang_rpms else ""
         await self._slack_client.say_in_thread(
-            f":construction: Updating golang for {self.ocp_version} (building images on {self.build_system}{external_repos_msg}) :construction:"
+            f":construction: Updating golang for {self.ocp_version} "
+            f"(building {self.assembly} images on {self.build_system}{external_repos_msg}) :construction:"
         )
 
         if self.external_golang_rpms:
@@ -487,6 +520,10 @@ class UpdateGolangPipeline:
             )
             _LOGGER.info(skip_message)
             await self._slack_client.say_in_thread(skip_message)
+        elif not self.is_production_assembly:
+            skip_message = "Skipping published pullspec checks and streams.yml update for the test assembly."
+            _LOGGER.info(skip_message)
+            await self._slack_client.say_in_thread(skip_message)
         else:
             builder_pullspecs = {}
             for el_v, record in konflux_records.items():
@@ -517,15 +554,20 @@ class UpdateGolangPipeline:
             else:
                 _LOGGER.info("No Konflux golang builder images found; streams.yml will not be updated.")
 
-        await move_golang_bugs(
-            ocp_version=self.ocp_version,
-            cves=self.cves,
-            nvrs=self.go_nvrs if self.cves else None,
-            components=[GOLANG_BUILDER_CVE_COMPONENT],
-            force_update_tracker=self.force_update_tracker,
-            dry_run=self.dry_run,
+        if self.is_production_assembly:
+            await move_golang_bugs(
+                ocp_version=self.ocp_version,
+                cves=self.cves,
+                nvrs=self.go_nvrs if self.cves else None,
+                components=[GOLANG_BUILDER_CVE_COMPONENT],
+                force_update_tracker=self.force_update_tracker,
+                dry_run=self.dry_run,
+            )
+        else:
+            _LOGGER.info("Skipping Golang bug updates for the test assembly")
+        await self._slack_client.say_in_thread(
+            f":white_check_mark: Updating golang for {self.ocp_version} assembly {self.assembly} complete."
         )
-        await self._slack_client.say_in_thread(f":white_check_mark: Updating golang for {self.ocp_version} complete.")
 
     async def process_build(self, el_v, nvr):
         await self.ensure_signed(el_v, nvr)
@@ -655,7 +697,7 @@ class UpdateGolangPipeline:
             result = jenkins.start_build_plashets(
                 group=group,
                 release=default_release_suffix(),
-                assembly="stream",
+                assembly=self.assembly,
                 repos=[repo_name],
                 version=version,
                 block_until_complete=True,
@@ -669,7 +711,11 @@ class UpdateGolangPipeline:
 
     def get_existing_builders_brew(self, el_nvr_map, go_version):
         component = GOLANG_BUILDER_CVE_COMPONENT
-        _LOGGER.info(f"Checking if {component} builds exist in Brew for given golang builds")
+        _LOGGER.info(
+            "Checking if %s %s builds exist in Brew for given golang builds",
+            component,
+            self.assembly,
+        )
         package_info = self.koji_session.getPackage(component)
         if not package_info:
             raise IOError(f'Cannot find brew package info for {component}')
@@ -681,10 +727,11 @@ class UpdateGolangPipeline:
                 packageID=package_id,
                 state=BuildStates.COMPLETE.value,
                 pattern=pattern,
-                queryOpts={'limit': 1, 'order': '-creation_event_id'},
+                queryOpts={'limit': 50, 'order': '-creation_event_id'},
             )
-            if builds:
-                build = builds[0]
+            for build in builds:
+                if not self._existing_build_matches_assembly(build['release']):
+                    continue
                 # `elliottutil.get_golang_container_nvrs` uses p-flag to determine the build system.
                 # However, our existing golang-builders may not have p-flags.
                 # Here we are safe to looking at only Brew builds.
@@ -697,6 +744,7 @@ class UpdateGolangPipeline:
                 if builder_go_vr in go_nvr:
                     _LOGGER.info(f"Found existing builder image: {build['nvr']} built with {go_nvr}")
                     builder_nvrs[el_v] = build['nvr']
+                    break
         return builder_nvrs
 
     async def get_existing_builders_konflux(
@@ -707,7 +755,11 @@ class UpdateGolangPipeline:
         Similar to get_existing_builders_brew but queries KonfluxDb instead of Brew.
         Returns {el_v: KonfluxBuildRecord} so callers have access to image_pullspec.
         """
-        _LOGGER.info(f"Checking if {GOLANG_BUILDER_IMAGE_NAME} builds exist in Konflux for given golang builds")
+        _LOGGER.info(
+            "Checking if %s %s builds exist in Konflux for given golang builds",
+            GOLANG_BUILDER_IMAGE_NAME,
+            self.assembly,
+        )
 
         extra_patterns = {'nvr': f"{GOLANG_BUILDER_CVE_COMPONENT}-v{go_version}"}
         builder_names_by_el = {
@@ -717,47 +769,58 @@ class UpdateGolangPipeline:
         async def find_builder(el_v: int) -> KonfluxBuildRecord | None:
             expected_go_nvr = el_nvr_map[el_v]
             for builder_name in builder_names_by_el[el_v]:
-                build_record = await anext(
-                    self.konflux_db.search_builds_by_fields(
-                        where={
-                            "name": builder_name,
-                            "el_target": f'el{el_v}',
-                            "artifact_type": str(ArtifactType.IMAGE),
-                            "outcome": str(KonfluxBuildOutcome.SUCCESS),
-                            "engine": str(Engine.KONFLUX),
-                        },
+                # The unified golang branch records assembly-qualified builds.
+                # Stream lookup falls back to an unqualified legacy query so builds
+                # created before assemblies were enabled remain reusable.
+                assembly_candidates: list[str | None]
+                assembly_candidates = [self.assembly, None] if self.is_production_assembly else [self.assembly]
+                for assembly_filter in assembly_candidates:
+                    where = {
+                        "name": builder_name,
+                        "el_target": f'el{el_v}',
+                        "artifact_type": str(ArtifactType.IMAGE),
+                        "outcome": str(KonfluxBuildOutcome.SUCCESS),
+                        "engine": str(Engine.KONFLUX),
+                    }
+                    if assembly_filter is not None:
+                        where["assembly"] = assembly_filter
+                    build_records = self.konflux_db.search_builds_by_fields(
+                        where=where,
                         extra_patterns=extra_patterns,
-                        limit=1,
-                    ),
-                    None,
-                )
-                if not build_record:
-                    continue
-                build_record = cast(KonfluxBuildRecord, build_record)
-                go_nvr_map = elliottutil.get_golang_container_nvrs_for_konflux_record(
-                    [build_record],
-                    _LOGGER,
-                    exact=True,
-                )
-                if not go_nvr_map:
-                    _LOGGER.warning("Could not determine installed Golang RPM for %s", build_record.nvr)
-                    continue
-                actual_go_nvr, _ = next(iter(go_nvr_map.items()))
-                if actual_go_nvr != expected_go_nvr:
-                    _LOGGER.warning(
-                        "Installed golang rpm in %s is different from the expected one: %s != %s",
-                        build_record.nvr,
-                        actual_go_nvr,
-                        expected_go_nvr,
+                        limit=50 if assembly_filter is None else 1,
                     )
-                    continue
-                _LOGGER.info(
-                    "Found existing builder image in Konflux: %s built with %s (record name: %s)",
-                    build_record.nvr,
-                    expected_go_nvr,
-                    builder_name,
-                )
-                return build_record
+                    async for build_record in build_records:
+                        build_record = cast(KonfluxBuildRecord, build_record)
+                        build_release = parse_nvr(build_record.nvr)["release"]
+                        if assembly_filter is None and not self._existing_build_matches_assembly(build_release):
+                            # An unqualified query may return records from other
+                            # assemblies. Legacy compatibility is stream-only.
+                            continue
+                        go_nvr_map = elliottutil.get_golang_container_nvrs_for_konflux_record(
+                            [build_record],
+                            _LOGGER,
+                            exact=True,
+                        )
+                        if not go_nvr_map:
+                            _LOGGER.warning("Could not determine installed Golang RPM for %s", build_record.nvr)
+                            continue
+                        actual_go_nvr, _ = next(iter(go_nvr_map.items()))
+                        if actual_go_nvr != expected_go_nvr:
+                            _LOGGER.warning(
+                                "Installed golang rpm in %s is different from the expected one: %s != %s",
+                                build_record.nvr,
+                                actual_go_nvr,
+                                expected_go_nvr,
+                            )
+                            continue
+                        _LOGGER.info(
+                            "Found existing builder image in Konflux: %s built with %s (record name: %s, assembly: %s)",
+                            build_record.nvr,
+                            expected_go_nvr,
+                            builder_name,
+                            assembly_filter or "legacy stream",
+                        )
+                        return build_record
             return None
 
         build_records = await asyncio.gather(*(find_builder(el_v) for el_v in el_nvr_map))
@@ -796,6 +859,10 @@ class UpdateGolangPipeline:
         3. If it'a major version bump, also need to update key in streams.yml and vars in group.yml
         4. Create pr to update changes
         """
+        if not self.is_production_assembly:
+            _LOGGER.info("Skipping streams.yml update for the test assembly")
+            return
+
         branch_content = self._get_branch_content()
         branch = branch_content["branch"]
         upstream_repo = branch_content["repo"]
@@ -983,6 +1050,7 @@ class UpdateGolangPipeline:
             f"--working-dir={self._doozer_working_dir}-brew-{el_v}",
             "--build-system=brew",
         ]
+        cmd.extend(self._get_doozer_assembly_args())
         if self.data_path:
             cmd.append(f"--data-path={self.data_path}")
         cmd.extend(self._get_doozer_var_args())
@@ -1015,6 +1083,7 @@ class UpdateGolangPipeline:
             f"--working-dir={self._doozer_working_dir}-brew-{el_v}",
             "--build-system=brew",
         ]
+        cmd.extend(self._get_doozer_assembly_args())
         if self.data_path:
             cmd.append(f"--data-path={self.data_path}")
         cmd.extend(self._get_doozer_var_args())
@@ -1051,6 +1120,7 @@ class UpdateGolangPipeline:
             f"--working-dir={self._doozer_working_dir}-konflux-{el_v}",
             "--build-system=konflux",
         ]
+        cmd.extend(self._get_doozer_assembly_args())
         if self.data_path:
             cmd.append(f"--data-path={self.data_path}")
         cmd.extend(self._get_doozer_var_args())
@@ -1087,6 +1157,7 @@ class UpdateGolangPipeline:
             f"--working-dir={self._doozer_working_dir}-konflux-{el_v}",
             "--build-system=konflux",
         ]
+        cmd.extend(self._get_doozer_assembly_args())
         if self.data_path:
             cmd.append(f"--data-path={self.data_path}")
         cmd.extend(self._get_doozer_var_args())
@@ -1154,7 +1225,11 @@ class UpdateGolangPipeline:
         err = False
         for arch, template_url in group_config['repos'][golang_repo]['conf']['baseurl'].items():
             expected_suffix = f'{content_repo_url_suffix}/{arch}/os/'
-            actual_url = template_url.format(MAJOR=ocp_major, MINOR=ocp_minor)
+            actual_url = template_url.format(
+                MAJOR=ocp_major,
+                MINOR=ocp_minor,
+                runtime_assembly=self.assembly,
+            )
             if not actual_url.endswith(expected_suffix):
                 err = True
                 _LOGGER.error(f"{expected_suffix} not found in URL {actual_url}")
@@ -1167,7 +1242,7 @@ class UpdateGolangPipeline:
         _LOGGER.info(f"Builder branch {branch} has the expected content set urls")
 
     def get_content_repo_url_suffix(self, el_v):
-        return f'/pub/RHOCP/plashets/{self.ocp_version}/stream/golang-el{el_v}/latest'
+        return f'/pub/RHOCP/plashets/{self.ocp_version}/{self.assembly}/golang-el{el_v}/latest'
 
     def get_module_tag(self, nvr, el_v) -> str:
         tags = [t['name'] for t in self.koji_session.listTags(build=nvr)]
@@ -1232,6 +1307,13 @@ class UpdateGolangPipeline:
     help='Override network mode for Konflux builds. Takes precedence over image and group config settings.',
 )
 @click.option(
+    '--assembly',
+    type=click.Choice(GOLANG_ASSEMBLIES, case_sensitive=False),
+    default=DEFAULT_GOLANG_ASSEMBLY,
+    show_default=True,
+    help='Stream-type assembly to use for golang builder operations.',
+)
+@click.option(
     '--major-bump',
     is_flag=True,
     default=False,
@@ -1258,6 +1340,7 @@ async def update_golang(
     skip_pr: bool,
     external_golang_rpms: bool,
     network_mode: str | None,
+    assembly: str,
     major_bump: bool,
 ):
     if not runtime.dry_run and not confirm:
@@ -1268,7 +1351,6 @@ async def update_golang(
         raise ValueError('CVEs must be provided with --force-update-tracker')
     if network_mode and build_system == 'brew':
         raise click.BadParameter('--network-mode only applies when --build-system is "konflux" or "both".')
-
     pipeline = UpdateGolangPipeline(
         runtime,
         ocp_version,
@@ -1287,5 +1369,6 @@ async def update_golang(
         external_golang_rpms,
         network_mode,
         major_bump,
+        assembly,
     )
     await pipeline.run()

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -794,7 +794,7 @@ class UpdateGolangPipeline:
                     build_records = self.konflux_db.search_builds_by_fields(
                         where=where,
                         extra_patterns=extra_patterns,
-                        limit=50 if assembly_filter is None else 1,
+                        limit=50,
                     )
                     async for build_record in build_records:
                         build_record = cast(KonfluxBuildRecord, build_record)
@@ -1243,7 +1243,9 @@ class UpdateGolangPipeline:
 
         if err:
             raise ValueError(
-                f"Content repo URLs for {golang_repo} in {branch} do not look correct. Wrong MAJOR/MINOR vars?"
+                f"Content repo URLs for {golang_repo} in {branch} do not look correct. "
+                f"Check MAJOR/MINOR vars and the {{runtime_assembly}} segment "
+                f"(expected assembly: {self.assembly})."
             )
 
         _LOGGER.info(f"Builder branch {branch} has the expected content set urls")

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -41,6 +41,10 @@ yaml = new_roundtrip_yaml_handler()
 PUBLISHED_GOLANG_BUILDER_REPO = f"{REGISTRY_REDHAT_IO}/openshift/{ART_IMAGES_BASE_APPLICATION}"
 GOLANG_ASSEMBLIES = ("stream", "test")
 DEFAULT_GOLANG_ASSEMBLY = "stream"
+BREW_TEST_ASSEMBLY_UNSUPPORTED = (
+    "Brew builds for the test assembly are not supported because Brew floating tags are updated after every "
+    "successful build. Use --build-system konflux for test assembly builds."
+)
 
 
 def is_latest(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool:
@@ -214,6 +218,9 @@ class UpdateGolangPipeline:
         self.major_bump = major_bump
         if assembly not in GOLANG_ASSEMBLIES:
             raise ValueError(f"Unsupported golang assembly {assembly!r}; expected one of {GOLANG_ASSEMBLIES}")
+        if assembly == "test" and build_system in ("brew", "both"):
+            _LOGGER.error(BREW_TEST_ASSEMBLY_UNSUPPORTED)
+            raise ValueError(BREW_TEST_ASSEMBLY_UNSUPPORTED)
         self.assembly = assembly
         self._slack_client = self.runtime.new_slack_client()
         self._doozer_working_dir = self.runtime.working_dir / "doozer-working"
@@ -1278,7 +1285,7 @@ class UpdateGolangPipeline:
     '--build-system',
     type=click.Choice(['brew', 'konflux', 'both'], case_sensitive=False),
     default='brew',
-    help='Build system to use for golang-builder images (brew, konflux, or both). Defaults to brew for backward compatibility.',
+    help='Build system to use for golang-builder images (brew, konflux, or both). Test assemblies require Konflux. Defaults to brew for backward compatibility.',
 )
 @click.option("--kubeconfig", required=False, help="Path to kubeconfig file to use for Konflux cluster connections")
 @click.option(
@@ -1351,6 +1358,9 @@ async def update_golang(
         raise ValueError('CVEs must be provided with --force-update-tracker')
     if network_mode and build_system == 'brew':
         raise click.BadParameter('--network-mode only applies when --build-system is "konflux" or "both".')
+    if assembly == "test" and build_system in ("brew", "both"):
+        _LOGGER.error(BREW_TEST_ASSEMBLY_UNSUPPORTED)
+        raise click.BadParameter(BREW_TEST_ASSEMBLY_UNSUPPORTED, param_hint='--build-system')
     pipeline = UpdateGolangPipeline(
         runtime,
         ocp_version,

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -530,7 +530,9 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         mock_runtime.new_slack_client.return_value = Mock()
 
         upstream_repo = Mock()
-        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22\n")
+        upstream_repo.get_contents.return_value = Mock(
+            decoded_content=b"assemblies:\n  enabled: true\nvars:\n  GO_LATEST: 1.22\n"
+        )
         mock_get_github_client.return_value.get_repo.return_value = upstream_repo
 
         pipeline = UpdateGolangPipeline(
@@ -547,7 +549,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         pipeline.validate_tag_builds_go_latest(branch, allowed_major_minors, build_major_minor)
 
         requested_paths = [call.args[0] for call in upstream_repo.get_contents.call_args_list]
-        self.assertEqual(sorted(requested_paths), ["group.yml", "streams.yml"])
+        self.assertEqual(sorted(requested_paths), ["group.yml", "group.yml", "streams.yml"])
 
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -562,7 +564,9 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         mock_runtime.new_slack_client.return_value = Mock()
 
         upstream_repo = Mock()
-        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_EXTRA: 1.23\n")
+        upstream_repo.get_contents.return_value = Mock(
+            decoded_content=b"assemblies:\n  enabled: true\nvars:\n  GO_LATEST: 1.22\n  GO_EXTRA: 1.23\n"
+        )
         mock_get_github_client.return_value.get_repo.return_value = upstream_repo
 
         pipeline = UpdateGolangPipeline(
@@ -590,7 +594,9 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         mock_runtime.new_slack_client.return_value = Mock()
 
         upstream_repo = Mock()
-        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.20\n")
+        upstream_repo.get_contents.return_value = Mock(
+            decoded_content=b"assemblies:\n  enabled: true\nvars:\n  GO_LATEST: 1.20\n"
+        )
         mock_get_github_client.return_value.get_repo.return_value = upstream_repo
 
         pipeline = UpdateGolangPipeline(
@@ -606,7 +612,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         pipeline.validate_go_version_matches_group_vars("1.20.12")
 
         requested_paths = [call.args[0] for call in upstream_repo.get_contents.call_args_list]
-        self.assertEqual(sorted(requested_paths), ["group.yml", "streams.yml"])
+        self.assertEqual(sorted(requested_paths), ["group.yml", "group.yml", "streams.yml"])
 
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -624,6 +630,8 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         def get_contents(path, ref):
             if path == "group.yml":
+                if ref == "golang":
+                    return Mock(decoded_content=b"assemblies:\n  enabled: true\n")
                 return Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22\n")
             if path == "streams.yml":
                 return Mock(decoded_content=b"{}\n")
@@ -646,7 +654,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         await pipeline.update_golang_streams("1.22.9", {})
 
         requested_paths = [call.args[0] for call in upstream_repo.get_contents.call_args_list]
-        self.assertEqual(requested_paths.count("group.yml"), 1)
+        self.assertEqual(requested_paths.count("group.yml"), 2)
         self.assertEqual(requested_paths.count("streams.yml"), 1)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -722,7 +730,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         upstream_repo = Mock()
         upstream_repo.get_contents.return_value = Mock(
-            decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_PREVIOUS: 1.21\n"
+            decoded_content=b"assemblies:\n  enabled: true\nvars:\n  GO_LATEST: 1.22\n  GO_PREVIOUS: 1.21\n"
         )
         mock_get_github_client.return_value.get_repo.return_value = upstream_repo
 
@@ -752,7 +760,9 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         upstream_repo = Mock()
         upstream_repo.get_contents.return_value = Mock(
-            decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_EXTRA: 1.23\n  GO_PREVIOUS: 1.21\n"
+            decoded_content=(
+                b"assemblies:\n  enabled: true\nvars:\n  GO_LATEST: 1.22\n  GO_EXTRA: 1.23\n  GO_PREVIOUS: 1.21\n"
+            )
         )
         mock_get_github_client.return_value.get_repo.return_value = upstream_repo
 
@@ -786,7 +796,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         upstream_repo = Mock()
         upstream_repo.get_contents.return_value = Mock(
-            decoded_content=b"vars:\n  GO_LATEST: 1.22\n  GO_PREVIOUS: 1.21\n"
+            decoded_content=b"assemblies:\n  enabled: true\nvars:\n  GO_LATEST: 1.22\n  GO_PREVIOUS: 1.21\n"
         )
         mock_get_github_client.return_value.get_repo.return_value = upstream_repo
 
@@ -982,6 +992,34 @@ repos:
         pipeline.verify_golang_builder_repo(8, "1.26.5")
 
         repo.get_contents.assert_called_once_with("group.yml", ref="golang")
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_verify_golang_builder_repo_error_mentions_assembly_template(self, mock_konflux_db):
+        pipeline = UpdateGolangPipeline(
+            runtime=self._make_test_runtime(),
+            ocp_version="5.0",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.26.5-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            build_system="konflux",
+            assembly="test",
+        )
+        repo = Mock()
+        repo.get_contents.return_value = Mock(
+            decoded_content=b"""
+repos:
+  rhel-8-golang-rpms:
+    conf:
+      baseurl:
+        x86_64: https://example.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/golang-el8/latest/x86_64/os/
+"""
+        )
+        pipeline._get_ocp_build_data_repo_and_branch = Mock(return_value=(repo, "golang"))
+
+        with self.assertRaisesRegex(ValueError, r"\{runtime_assembly\}.*test"):
+            pipeline.verify_golang_builder_repo(8, "1.26.5")
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_builder_pullspec(self, mock_konflux_db):
@@ -1664,6 +1702,7 @@ repos:
             [call.kwargs["where"]["name"] for call in mock_db_instance.search_builds_by_fields.call_args_list],
             [
                 "openshift-golang-builder-1-20.rhel8",
+                "openshift-golang-builder-1-20.rhel8",
                 GOLANG_BUILDER_IMAGE_NAME,
             ],
         )
@@ -1770,18 +1809,25 @@ repos:
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("pyartcd.pipelines.update_golang.elliottutil.get_golang_container_nvrs_for_konflux_record")
-    async def test_get_existing_builders_konflux_test_requires_exact_assembly(
+    async def test_get_existing_builders_konflux_test_scans_older_matching_builds(
         self, mock_get_golang_nvrs, mock_konflux_db_class
     ):
         mock_db_instance = Mock()
         mock_konflux_db_class.return_value = mock_db_instance
-        test_record = Mock(
+        newest_record = Mock(
+            spec=KonfluxBuildRecord,
+            nvr="openshift-golang-builder-container-v1.26.5-202608081200.p0.assembly.test.el8",
+        )
+        matching_record = Mock(
             spec=KonfluxBuildRecord,
             nvr="openshift-golang-builder-container-v1.26.5-202608071200.p0.assembly.test.el8",
         )
-        mock_get_golang_nvrs.return_value = {
-            "golang-1.26.5-1.el8": {("ignored-builder", "ignored-version", "ignored-release")}
-        }
+
+        def mock_installed_golang_nvrs(records, *_args, **_kwargs):
+            installed_nvr = "golang-1.26.6-1.el8" if records[0] is newest_record else "golang-1.26.5-1.el8"
+            return {installed_nvr: {("ignored-builder", "ignored-version", "ignored-release")}}
+
+        mock_get_golang_nvrs.side_effect = mock_installed_golang_nvrs
         pipeline = UpdateGolangPipeline(
             runtime=self._make_test_runtime(),
             ocp_version="5.0",
@@ -1796,14 +1842,20 @@ repos:
 
         async def mock_search_builds(*_args, **kwargs):
             self.assertEqual(kwargs["where"]["assembly"], "test")
-            yield test_record
+            for record in [newest_record, matching_record][: kwargs["limit"]]:
+                yield record
 
         mock_db_instance.search_builds_by_fields = Mock(side_effect=mock_search_builds)
 
         records = await pipeline.get_existing_builders_konflux({8: "golang-1.26.5-1.el8"}, "1.26.5")
 
-        self.assertEqual(records, {8: test_record})
-        mock_get_golang_nvrs.assert_called_once_with([test_record], ANY, exact=True)
+        self.assertEqual(records, {8: matching_record})
+        self.assertEqual(mock_get_golang_nvrs.call_count, 2)
+        self.assertEqual(
+            [call.args[0][0] for call in mock_get_golang_nvrs.call_args_list],
+            [newest_record, matching_record],
+        )
+        self.assertEqual(mock_db_instance.search_builds_by_fields.call_args.kwargs["limit"], 50)
         self.assertEqual(mock_db_instance.search_builds_by_fields.call_count, 1)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -1946,12 +1998,10 @@ repos:
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_build_brew_dry_run(self, mock_cmd_assert, mock_konflux_db):
+        runtime = self._make_test_runtime()
+        runtime.dry_run = True
         pipeline = UpdateGolangPipeline(
-            runtime=Mock(
-                dry_run=True,
-                working_dir=Path("/tmp/working"),
-                new_slack_client=Mock(return_value=Mock()),
-            ),
+            runtime=runtime,
             ocp_version="4.16",
             cves=None,
             force_update_tracker=False,
@@ -2082,12 +2132,10 @@ repos:
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_test_assembly_dry_run_commands_for_konflux(self, mock_cmd_assert, mock_konflux_db):
+        runtime = self._make_test_runtime()
+        runtime.dry_run = True
         pipeline = UpdateGolangPipeline(
-            runtime=Mock(
-                dry_run=True,
-                working_dir=Path("/tmp/working"),
-                new_slack_client=Mock(return_value=Mock()),
-            ),
+            runtime=runtime,
             ocp_version="4.16",
             cves=None,
             force_update_tracker=False,

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -4,13 +4,15 @@ import tempfile
 import unittest
 from pathlib import Path
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import click
 import koji
 from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
 from artcommonlib.konflux.konflux_build_record import KonfluxBuildRecord
 from pyartcd.pipelines.update_golang import (
+    DEFAULT_GOLANG_ASSEMBLY,
+    GOLANG_ASSEMBLIES,
     UpdateGolangPipeline,
     extract_and_validate_golang_nvrs,
     get_latest_nvr_in_tag,
@@ -18,6 +20,7 @@ from pyartcd.pipelines.update_golang import (
     is_latest,
     is_latest_and_available,
     move_golang_bugs,
+    update_golang,
 )
 from tenacity import wait_none
 
@@ -316,6 +319,14 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             build_system=build_system,
         )
 
+    def test_cli_only_offers_stream_type_assemblies(self):
+        assembly_param = next(param for param in update_golang.params if param.name == "assembly")
+
+        self.assertEqual(assembly_param.default, DEFAULT_GOLANG_ASSEMBLY)
+        self.assertEqual(tuple(assembly_param.type.choices), GOLANG_ASSEMBLIES)
+        with self.assertRaises(click.BadParameter):
+            assembly_param.type.convert("art-1234", assembly_param, None)
+
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_init_brew_build_system(self, mock_konflux_db):
         """Test initialization with Brew build system"""
@@ -419,6 +430,47 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         self.assertEqual(pipeline.data_gitref, "my-branch")
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_existing_build_lookup_treats_legacy_builds_as_stream(self, mock_konflux_db):
+        pipeline = self._make_pipeline(build_system="brew")
+
+        self.assertTrue(pipeline._existing_build_matches_assembly("202608071200.p0.el9"))
+        self.assertTrue(pipeline._existing_build_matches_assembly("202608071200.p0.assembly.stream.el9"))
+        self.assertFalse(pipeline._existing_build_matches_assembly("202608071200.p0.assembly.test.el9"))
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_existing_test_build_lookup_requires_explicit_test_assembly(self, mock_konflux_db):
+        pipeline = UpdateGolangPipeline(
+            runtime=self._make_test_runtime(),
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.8-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            build_system="brew",
+            assembly="test",
+        )
+
+        self.assertFalse(pipeline._existing_build_matches_assembly("202608071200.p0.el9"))
+        self.assertFalse(pipeline._existing_build_matches_assembly("202608071200.p0.assembly.stream.el9"))
+        self.assertTrue(pipeline._existing_build_matches_assembly("202608071200.p0.assembly.test.el9"))
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_rejects_non_stream_type_assembly(self, mock_konflux_db):
+        with self.assertRaisesRegex(ValueError, "Unsupported golang assembly"):
+            UpdateGolangPipeline(
+                runtime=self._make_test_runtime(),
+                ocp_version="4.16",
+                cves=None,
+                force_update_tracker=False,
+                go_nvrs=["golang-1.25.8-1.el9"],
+                art_jira="ART-1234",
+                tag_builds=False,
+                build_system="brew",
+                assembly="art-1234",
+            )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_doozer_var_args(self, mock_konflux_db):
         """Test _get_doozer_var_args returns --var args"""
         pipeline = self._make_pipeline()
@@ -426,6 +478,28 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         pipeline.ocp_version = "5.0"
         self.assertEqual(pipeline._get_doozer_var_args(), ['--var', 'MAJOR=5', '--var', 'MINOR=0'])
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_monobranch_validation_requires_assemblies_enabled(self, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        repo = Mock()
+        repo.get_contents.return_value = Mock(decoded_content=b"assemblies:\n  enabled: false\n")
+        pipeline._get_ocp_build_data_repo_and_branch = Mock(return_value=(repo, "golang"))
+
+        with self.assertRaisesRegex(ValueError, "Assemblies are not enabled.*golang"):
+            pipeline.validate_go_version_matches_group_vars("1.25.8")
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_monobranch_validation_accepts_assemblies_enabled(self, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        repo = Mock()
+        repo.get_contents.return_value = Mock(decoded_content=b"assemblies:\n  enabled: true\n")
+        pipeline._get_ocp_build_data_repo_and_branch = Mock(return_value=(repo, "golang"))
+        pipeline._get_allowed_go_major_minors = Mock(return_value=("openshift-4.16", {"GO_LATEST": "1.25"}))
+
+        result = pipeline.validate_go_version_matches_group_vars("1.25.8")
+
+        self.assertEqual(result, ("openshift-4.16", {"GO_LATEST": "1.25"}, "1.25"))
 
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -556,6 +630,25 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         requested_paths = [call.args[0] for call in upstream_repo.get_contents.call_args_list]
         self.assertEqual(requested_paths.count("group.yml"), 1)
         self.assertEqual(requested_paths.count("streams.yml"), 1)
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_update_golang_streams_is_stream_only(self, mock_konflux_db):
+        pipeline = UpdateGolangPipeline(
+            runtime=self._make_test_runtime(),
+            ocp_version="5.0",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.26.5-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            build_system="konflux",
+            assembly="test",
+        )
+        pipeline._get_branch_content = Mock()
+
+        await pipeline.update_golang_streams("1.26.5", {8: "registry.example.com/builder:test"})
+
+        pipeline._get_branch_content.assert_not_called()
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     async def test_update_golang_streams_updates_go_extra_literal_streams(self, mock_konflux_db):
@@ -825,6 +918,52 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         self.assertEqual(suffix, "/pub/RHOCP/plashets/4.16/stream/golang-el8/latest")
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_get_content_repo_url_suffix_uses_test_assembly(self, mock_konflux_db):
+        pipeline = UpdateGolangPipeline(
+            runtime=self._make_test_runtime(),
+            ocp_version="5.0",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.26.5-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            assembly="test",
+        )
+
+        self.assertEqual(
+            pipeline.get_content_repo_url_suffix(8),
+            "/pub/RHOCP/plashets/5.0/test/golang-el8/latest",
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    def test_verify_golang_builder_repo_formats_test_assembly(self, mock_konflux_db):
+        pipeline = UpdateGolangPipeline(
+            runtime=self._make_test_runtime(),
+            ocp_version="5.0",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.26.5-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            assembly="test",
+        )
+        repo = Mock()
+        repo.get_contents.return_value = Mock(
+            decoded_content=b"""
+repos:
+  rhel-8-golang-rpms:
+    conf:
+      baseurl:
+        x86_64: https://example.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/{runtime_assembly}/golang-el8/latest/x86_64/os/
+"""
+        )
+        pipeline._get_ocp_build_data_repo_and_branch = Mock(return_value=(repo, "golang"))
+
+        pipeline.verify_golang_builder_repo(8, "1.26.5")
+
+        repo.get_contents.assert_called_once_with("group.yml", ref="golang")
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_builder_pullspec(self, mock_konflux_db):
         """Test stream-update pullspec uses the published registry.redhat.io form"""
         pipeline = self._make_pipeline(build_system="brew")
@@ -923,6 +1062,43 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             any("Skipping streams.yml update for brew-only run" in message for message in slack_messages),
             slack_messages,
         )
+
+    @patch("pyartcd.pipelines.update_golang.kinit", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.update_golang.move_golang_bugs", new_callable=AsyncMock)
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_run_test_assembly_skips_production_operations(self, mock_konflux_db, move_golang_bugs, mock_kinit):
+        pipeline = UpdateGolangPipeline(
+            runtime=self._make_test_runtime(),
+            ocp_version="5.0",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.26.5-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            build_system="konflux",
+            assembly="test",
+        )
+        pipeline.validate_go_version_matches_group_vars = Mock(return_value=("golang", {"GO_LATEST": "1.26"}, "1.26"))
+        pipeline.process_build = AsyncMock(return_value=True)
+        pipeline._build_golang_plashets = AsyncMock()
+        builder_record = Mock(nvr="openshift-golang-builder-container-v1.26.5-202608071200.p0.assembly.test.el8")
+        pipeline.get_existing_builders_konflux = AsyncMock(return_value={8: builder_record})
+        pipeline._get_builder_pullspec = Mock()
+        pipeline._ensure_builder_pullspec_available = AsyncMock()
+        pipeline.update_golang_streams = AsyncMock()
+
+        await pipeline.run()
+
+        mock_kinit.assert_awaited_once()
+        pipeline._build_golang_plashets.assert_awaited_once()
+        self.assertEqual(pipeline._build_golang_plashets.await_args.args[0], "1.26.5")
+        self.assertEqual(list(pipeline._build_golang_plashets.await_args.args[1]), [8])
+        pipeline._get_builder_pullspec.assert_not_called()
+        pipeline._ensure_builder_pullspec_available.assert_not_awaited()
+        pipeline.update_golang_streams.assert_not_awaited()
+        move_golang_bugs.assert_not_awaited()
+        slack_messages = [call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list]
+        self.assertTrue(any("test assembly" in message for message in slack_messages), slack_messages)
 
     @patch("pyartcd.pipelines.update_golang.kinit", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.update_golang.move_golang_bugs", new_callable=AsyncMock)
@@ -1380,6 +1556,92 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         self.assertEqual(builder_nvrs, {8: "openshift-golang-builder-container-v1.20.12-202403212137.el8.g144a3f8"})
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("elliottlib.util.get_golang_container_nvrs_brew")
+    def test_get_existing_builders_brew_ignores_non_stream_assembly(self, mock_get_golang_nvrs, mock_konflux_db):
+        pipeline = UpdateGolangPipeline(
+            runtime=self._make_test_runtime(),
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.20.12-2.el8"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            build_system="brew",
+        )
+        pipeline.koji_session = Mock()
+        pipeline.koji_session.getPackage.return_value = {"id": 12345}
+        stream_nvr = "openshift-golang-builder-container-v1.20.12-2.assembly.stream.el8"
+        named_nvr = "openshift-golang-builder-container-v1.20.12-1.assembly.art-1234.el8"
+        pipeline.koji_session.listBuilds.return_value = [
+            {
+                "name": "openshift-golang-builder-container",
+                "version": "v1.20.12",
+                "release": "1.assembly.art-1234.el8",
+                "nvr": named_nvr,
+            },
+            {
+                "name": "openshift-golang-builder-container",
+                "version": "v1.20.12",
+                "release": "2.assembly.stream.el8",
+                "nvr": stream_nvr,
+            },
+        ]
+        mock_get_golang_nvrs.return_value = {
+            "1.20.12-2.el8": [("openshift-golang-builder-container", "v1.20.12", "2.assembly.stream.el8")]
+        }
+
+        builder_nvrs = pipeline.get_existing_builders_brew({8: "golang-1.20.12-2.el8"}, "1.20.12")
+
+        self.assertEqual(builder_nvrs, {8: stream_nvr})
+        self.assertEqual(mock_get_golang_nvrs.call_count, 1)
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("elliottlib.util.get_golang_container_nvrs_brew")
+    def test_get_existing_builders_brew_test_requires_exact_assembly(self, mock_get_golang_nvrs, mock_konflux_db):
+        pipeline = UpdateGolangPipeline(
+            runtime=self._make_test_runtime(),
+            ocp_version="5.0",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.26.5-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            build_system="brew",
+            assembly="test",
+        )
+        pipeline.koji_session = Mock()
+        pipeline.koji_session.getPackage.return_value = {"id": 12345}
+        test_nvr = "openshift-golang-builder-container-v1.26.5-4.assembly.test.el8"
+        pipeline.koji_session.listBuilds.return_value = [
+            {
+                "name": "openshift-golang-builder-container",
+                "version": "v1.26.5",
+                "release": "3.assembly.stream.el8",
+                "nvr": "openshift-golang-builder-container-v1.26.5-3.assembly.stream.el8",
+            },
+            {
+                "name": "openshift-golang-builder-container",
+                "version": "v1.26.5",
+                "release": "2.el8",
+                "nvr": "openshift-golang-builder-container-v1.26.5-2.el8",
+            },
+            {
+                "name": "openshift-golang-builder-container",
+                "version": "v1.26.5",
+                "release": "4.assembly.test.el8",
+                "nvr": test_nvr,
+            },
+        ]
+        mock_get_golang_nvrs.return_value = {
+            "1.26.5-1.el8": [("openshift-golang-builder-container", "v1.26.5", "4.assembly.test.el8")]
+        }
+
+        builder_nvrs = pipeline.get_existing_builders_brew({8: "golang-1.26.5-1.el8"}, "1.26.5")
+
+        self.assertEqual(builder_nvrs, {8: test_nvr})
+        mock_get_golang_nvrs.assert_called_once()
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("pyartcd.pipelines.update_golang.elliottutil.get_golang_container_nvrs_for_konflux_record")
     async def test_get_existing_builders_konflux(self, mock_get_golang_nvrs, mock_konflux_db_class):
         """Test Konflux builder lookup falls back to the legacy name on exact RPM match"""
@@ -1481,9 +1743,94 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             [
                 "openshift-golang-builder-1-26.rhel8",
                 "openshift-golang-builder-1-26.rhel9",
+                "openshift-golang-builder-1-26.rhel9",
+                GOLANG_BUILDER_IMAGE_NAME,
                 GOLANG_BUILDER_IMAGE_NAME,
             ],
         )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("pyartcd.pipelines.update_golang.elliottutil.get_golang_container_nvrs_for_konflux_record")
+    async def test_get_existing_builders_konflux_stream_falls_back_to_legacy_assembly(
+        self, mock_get_golang_nvrs, mock_konflux_db_class
+    ):
+        mock_db_instance = Mock()
+        mock_konflux_db_class.return_value = mock_db_instance
+        legacy_record = Mock(
+            spec=KonfluxBuildRecord,
+            nvr="openshift-golang-builder-container-v1.26.5-202607272002.p2.g5a9ab9d.el8",
+        )
+        test_record = Mock(
+            spec=KonfluxBuildRecord,
+            nvr="openshift-golang-builder-container-v1.26.5-202607272003.p2.assembly.test.el8",
+        )
+        mock_get_golang_nvrs.return_value = {
+            "golang-1.26.5-1.el8": {("ignored-builder", "ignored-version", "ignored-release")}
+        }
+        pipeline = UpdateGolangPipeline(
+            runtime=self._make_test_runtime(),
+            ocp_version="5.0",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.26.5-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            build_system="konflux",
+        )
+
+        async def mock_search_builds(*_args, **kwargs):
+            if "assembly" not in kwargs["where"]:
+                yield test_record
+                yield legacy_record
+
+        mock_db_instance.search_builds_by_fields = Mock(side_effect=mock_search_builds)
+
+        records = await pipeline.get_existing_builders_konflux({8: "golang-1.26.5-1.el8"}, "1.26.5")
+
+        self.assertEqual(records, {8: legacy_record})
+        mock_get_golang_nvrs.assert_called_once_with([legacy_record], ANY, exact=True)
+        self.assertEqual(
+            [call.kwargs["where"].get("assembly") for call in mock_db_instance.search_builds_by_fields.call_args_list],
+            ["stream", None],
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("pyartcd.pipelines.update_golang.elliottutil.get_golang_container_nvrs_for_konflux_record")
+    async def test_get_existing_builders_konflux_test_requires_exact_assembly(
+        self, mock_get_golang_nvrs, mock_konflux_db_class
+    ):
+        mock_db_instance = Mock()
+        mock_konflux_db_class.return_value = mock_db_instance
+        test_record = Mock(
+            spec=KonfluxBuildRecord,
+            nvr="openshift-golang-builder-container-v1.26.5-202608071200.p0.assembly.test.el8",
+        )
+        mock_get_golang_nvrs.return_value = {
+            "golang-1.26.5-1.el8": {("ignored-builder", "ignored-version", "ignored-release")}
+        }
+        pipeline = UpdateGolangPipeline(
+            runtime=self._make_test_runtime(),
+            ocp_version="5.0",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.26.5-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            build_system="konflux",
+            assembly="test",
+        )
+
+        async def mock_search_builds(*_args, **kwargs):
+            self.assertEqual(kwargs["where"]["assembly"], "test")
+            yield test_record
+
+        mock_db_instance.search_builds_by_fields = Mock(side_effect=mock_search_builds)
+
+        records = await pipeline.get_existing_builders_konflux({8: "golang-1.26.5-1.el8"}, "1.26.5")
+
+        self.assertEqual(records, {8: test_record})
+        mock_get_golang_nvrs.assert_called_once_with([test_record], ANY, exact=True)
+        self.assertEqual(mock_db_instance.search_builds_by_fields.call_count, 1)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("pyartcd.pipelines.update_golang.elliottutil.get_golang_container_nvrs_for_konflux_record")
@@ -1551,6 +1898,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
         mock_cmd_assert.assert_called_once()
         cmd = mock_cmd_assert.call_args[0][0]
         self.assertIn("doozer", cmd)
+        self.assertEqual(cmd[cmd.index("--assembly") + 1], "stream")
         self.assertIn("--var", cmd)
         self.assertIn("MAJOR=4", cmd)
         self.assertIn("MINOR=16", cmd)
@@ -1615,10 +1963,33 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         cmd = mock_cmd_assert.call_args[0][0]
         self.assertIn("images:build", cmd)
+        self.assertEqual(cmd[cmd.index("--assembly") + 1], "stream")
         self.assertIn("--repo-type", cmd)
         self.assertIn("unsigned", cmd)
         self.assertIn("--push-to-defaults", cmd)
         self.assertIn("--scratch", cmd)
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("artcommonlib.exectools.cmd_assert_async")
+    async def test_build_brew_dry_run(self, mock_cmd_assert, mock_konflux_db):
+        pipeline = UpdateGolangPipeline(
+            runtime=Mock(
+                dry_run=True,
+                working_dir=Path("/tmp/working"),
+                new_slack_client=Mock(return_value=Mock()),
+            ),
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.20.12-2.el8"],
+            art_jira="ART-1234",
+            tag_builds=True,
+        )
+
+        await pipeline._build_brew(8, "1.20.12")
+
+        cmd = mock_cmd_assert.call_args.args[0]
+        self.assertIn("--dry-run", cmd)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_assert_async")
@@ -1639,12 +2010,14 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             art_jira="ART-1234",
             tag_builds=True,
             build_system="konflux",
+            assembly="test",
         )
 
         await pipeline._rebase_konflux(8, "1.20.12", "golang-1.20.12-2.el8")
 
         cmd = mock_cmd_assert.call_args[0][0]
         self.assertIn("beta:images:konflux:rebase", cmd)
+        self.assertEqual(cmd[cmd.index("--assembly") + 1], "test")
         self.assertIn("--extra-label", cmd)
         self.assertIn("io.openshift.build.golang-nvr=golang-1.20.12-2.el8", cmd)
 
@@ -1702,6 +2075,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         cmd = mock_cmd_assert.call_args[0][0]
         self.assertIn("beta:images:konflux:build", cmd)
+        self.assertEqual(cmd[cmd.index("--assembly") + 1], "stream")
         self.assertIn("--konflux-kubeconfig", cmd)
         self.assertIn("/custom/kubeconfig", cmd)
 
@@ -1730,6 +2104,41 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
 
         cmd = mock_cmd_assert.call_args[0][0]
         self.assertIn("--dry-run", cmd)
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("artcommonlib.exectools.cmd_assert_async")
+    async def test_test_assembly_dry_run_commands_for_brew_and_konflux(self, mock_cmd_assert, mock_konflux_db):
+        pipeline = UpdateGolangPipeline(
+            runtime=Mock(
+                dry_run=True,
+                working_dir=Path("/tmp/working"),
+                new_slack_client=Mock(return_value=Mock()),
+            ),
+            ocp_version="4.16",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.20.12-2.el8"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="both",
+            assembly="test",
+        )
+
+        await pipeline._rebase_brew(8, "1.20.12", "golang-1.20.12-2.el8")
+        await pipeline._build_brew(8, "1.20.12")
+        await pipeline._rebase_konflux(8, "1.20.12", "golang-1.20.12-2.el8")
+        await pipeline._build_konflux(8, "1.20.12")
+
+        brew_rebase, brew_build, konflux_rebase, konflux_build = [
+            call.args[0] for call in mock_cmd_assert.call_args_list
+        ]
+        for cmd in (brew_rebase, brew_build, konflux_rebase, konflux_build):
+            self.assertEqual(cmd[cmd.index("--assembly") + 1], "test")
+        for cmd in (brew_rebase, konflux_rebase):
+            self.assertNotIn("--push", cmd)
+            self.assertNotIn("--dry-run", cmd)
+        for cmd in (brew_build, konflux_build):
+            self.assertIn("--dry-run", cmd)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_assert_async")
@@ -1995,7 +2404,7 @@ class TestIsRpmSigned(unittest.TestCase):
 class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
     """Test the _build_golang_plashets method"""
 
-    def _make_pipeline(self, dry_run=False):
+    def _make_pipeline(self, dry_run=False, assembly=DEFAULT_GOLANG_ASSEMBLY):
         mock_slack = Mock()
         mock_slack.say_in_thread = AsyncMock()
         mock_runtime = Mock(dry_run=dry_run, working_dir=Path("/tmp/working"))
@@ -2008,6 +2417,7 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.22.9-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
+            assembly=assembly,
         )
 
     @patch("pyartcd.pipelines.update_golang.jenkins")
@@ -2023,9 +2433,22 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
         self.assertEqual(calls[0].kwargs["group"], "golang")
         self.assertEqual(calls[0].kwargs["repos"], ["rhel-8-golang-rpms"])
         self.assertEqual(calls[0].kwargs["version"], "4.18")
+        self.assertEqual(calls[0].kwargs["assembly"], "stream")
         self.assertEqual(calls[1].kwargs["group"], "golang")
         self.assertEqual(calls[1].kwargs["repos"], ["rhel-9-golang-rpms"])
         self.assertEqual(calls[1].kwargs["version"], "4.18")
+        self.assertEqual(calls[1].kwargs["assembly"], "stream")
+
+    @patch("pyartcd.pipelines.update_golang.jenkins")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_test_assembly_triggers_test_plashet(self, mock_konflux_db, mock_jenkins):
+        pipeline = self._make_pipeline(assembly="test")
+        mock_jenkins.start_build_plashets.return_value = "SUCCESS"
+
+        await pipeline._build_golang_plashets("1.22.9", [9])
+
+        mock_jenkins.start_build_plashets.assert_called_once()
+        self.assertEqual(mock_jenkins.start_build_plashets.call_args.kwargs["assembly"], "test")
 
     @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -447,7 +447,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.25.8-1.el9"],
             art_jira="ART-1234",
             tag_builds=False,
-            build_system="brew",
+            build_system="konflux",
             assembly="test",
         )
 
@@ -469,6 +469,24 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
                 build_system="brew",
                 assembly="art-1234",
             )
+
+    def test_test_assembly_rejects_brew_build_systems(self):
+        for build_system in ("brew", "both"):
+            with self.subTest(build_system=build_system):
+                with self.assertLogs("pyartcd.pipelines.update_golang", level="ERROR") as logs:
+                    with self.assertRaisesRegex(ValueError, "Brew floating tags are updated"):
+                        UpdateGolangPipeline(
+                            runtime=self._make_test_runtime(),
+                            ocp_version="5.0",
+                            cves=None,
+                            force_update_tracker=False,
+                            go_nvrs=["golang-1.26.5-1.el8"],
+                            art_jira="ART-1234",
+                            tag_builds=False,
+                            build_system=build_system,
+                            assembly="test",
+                        )
+                self.assertTrue(any("successful build" in message for message in logs.output), logs.output)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_get_doozer_var_args(self, mock_konflux_db):
@@ -927,6 +945,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.26.5-1.el8"],
             art_jira="ART-1234",
             tag_builds=False,
+            build_system="konflux",
             assembly="test",
         )
 
@@ -945,6 +964,7 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.26.5-1.el8"],
             art_jira="ART-1234",
             tag_builds=False,
+            build_system="konflux",
             assembly="test",
         )
         repo = Mock()
@@ -1596,52 +1616,6 @@ repos:
         self.assertEqual(mock_get_golang_nvrs.call_count, 1)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    @patch("elliottlib.util.get_golang_container_nvrs_brew")
-    def test_get_existing_builders_brew_test_requires_exact_assembly(self, mock_get_golang_nvrs, mock_konflux_db):
-        pipeline = UpdateGolangPipeline(
-            runtime=self._make_test_runtime(),
-            ocp_version="5.0",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.26.5-1.el8"],
-            art_jira="ART-1234",
-            tag_builds=False,
-            build_system="brew",
-            assembly="test",
-        )
-        pipeline.koji_session = Mock()
-        pipeline.koji_session.getPackage.return_value = {"id": 12345}
-        test_nvr = "openshift-golang-builder-container-v1.26.5-4.assembly.test.el8"
-        pipeline.koji_session.listBuilds.return_value = [
-            {
-                "name": "openshift-golang-builder-container",
-                "version": "v1.26.5",
-                "release": "3.assembly.stream.el8",
-                "nvr": "openshift-golang-builder-container-v1.26.5-3.assembly.stream.el8",
-            },
-            {
-                "name": "openshift-golang-builder-container",
-                "version": "v1.26.5",
-                "release": "2.el8",
-                "nvr": "openshift-golang-builder-container-v1.26.5-2.el8",
-            },
-            {
-                "name": "openshift-golang-builder-container",
-                "version": "v1.26.5",
-                "release": "4.assembly.test.el8",
-                "nvr": test_nvr,
-            },
-        ]
-        mock_get_golang_nvrs.return_value = {
-            "1.26.5-1.el8": [("openshift-golang-builder-container", "v1.26.5", "4.assembly.test.el8")]
-        }
-
-        builder_nvrs = pipeline.get_existing_builders_brew({8: "golang-1.26.5-1.el8"}, "1.26.5")
-
-        self.assertEqual(builder_nvrs, {8: test_nvr})
-        mock_get_golang_nvrs.assert_called_once()
-
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("pyartcd.pipelines.update_golang.elliottutil.get_golang_container_nvrs_for_konflux_record")
     async def test_get_existing_builders_konflux(self, mock_get_golang_nvrs, mock_konflux_db_class):
         """Test Konflux builder lookup falls back to the legacy name on exact RPM match"""
@@ -2107,7 +2081,7 @@ repos:
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_assert_async")
-    async def test_test_assembly_dry_run_commands_for_brew_and_konflux(self, mock_cmd_assert, mock_konflux_db):
+    async def test_test_assembly_dry_run_commands_for_konflux(self, mock_cmd_assert, mock_konflux_db):
         pipeline = UpdateGolangPipeline(
             runtime=Mock(
                 dry_run=True,
@@ -2120,25 +2094,19 @@ repos:
             go_nvrs=["golang-1.20.12-2.el8"],
             art_jira="ART-1234",
             tag_builds=True,
-            build_system="both",
+            build_system="konflux",
             assembly="test",
         )
 
-        await pipeline._rebase_brew(8, "1.20.12", "golang-1.20.12-2.el8")
-        await pipeline._build_brew(8, "1.20.12")
         await pipeline._rebase_konflux(8, "1.20.12", "golang-1.20.12-2.el8")
         await pipeline._build_konflux(8, "1.20.12")
 
-        brew_rebase, brew_build, konflux_rebase, konflux_build = [
-            call.args[0] for call in mock_cmd_assert.call_args_list
-        ]
-        for cmd in (brew_rebase, brew_build, konflux_rebase, konflux_build):
+        konflux_rebase, konflux_build = [call.args[0] for call in mock_cmd_assert.call_args_list]
+        for cmd in (konflux_rebase, konflux_build):
             self.assertEqual(cmd[cmd.index("--assembly") + 1], "test")
-        for cmd in (brew_rebase, konflux_rebase):
-            self.assertNotIn("--push", cmd)
-            self.assertNotIn("--dry-run", cmd)
-        for cmd in (brew_build, konflux_build):
-            self.assertIn("--dry-run", cmd)
+        self.assertNotIn("--push", konflux_rebase)
+        self.assertNotIn("--dry-run", konflux_rebase)
+        self.assertIn("--dry-run", konflux_build)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_assert_async")
@@ -2417,6 +2385,7 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
             go_nvrs=["golang-1.22.9-1.el9"],
             art_jira="ART-1234",
             tag_builds=True,
+            build_system="konflux",
             assembly=assembly,
         )
 


### PR DESCRIPTION
## Summary

- add an assembly option to update-golang, defaulting new runs to stream and accepting stream or test
- propagate the assembly through Golang image rebase, build, plashet creation, repository lookup, and notifications
- preserve legacy unqualified-build lookup for existing stream builds while requiring assembly-qualified new builds
- make test builds Konflux-only; reject brew and both because successful Brew builds update floating tags
- keep release-facing operations on stream only: test skips published pullspec checks, streams.yml updates and PRs, and bug updates
- reject named/non-stream-type assemblies in this pipeline

## Behavior

stream is the default for all new pipeline runs. test provides isolated Konflux test rebases and builds. Brew test-assembly builds are rejected before pipeline work because Brew floating tags are updated after every successful build. Existing builds without an assembly suffix remain discoverable as stream builds for backward compatibility; the pipeline does not offer a new unqualified-build mode.

## Validation

- 126 focused update-golang and rebuild-golang-rpms tests passed, including Brew and both rejection subtests
- Ruff check and formatting passed
- Doozer base-image release assembly test passed
- live Konflux no-push rebases succeeded for stream and test, producing assembly-qualified NVRs
- Brew stream and Konflux stream/test build command paths were exercised with --dry-run; execution reached the external services, where local credentials/network access blocked submission
- git diff --check

## Dependency

Requires openshift-eng/ocp-build-data#12202.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for selecting `stream` or `test` assemblies when updating Golang.
  - Assembly selection is reflected in builds, repository locations, commands, and related update operations.
  - Improved compatibility when locating existing Golang builds.

- **Bug Fixes**
  - Added validation for supported assembly configurations and unified-branch requirements.
  - Test assemblies now require the appropriate branch and platform configuration.
  - Test assemblies skip production-only publishing, stream, and bug-tracking updates.
  - Improved cached-content and dry-run behavior across assemblies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->