### PR TITLE
Revert "Disable bugzilla login"

### DIFF
--- a/elliott/elliottlib/bzutil.py
+++ b/elliott/elliottlib/bzutil.py
@@ -1215,9 +1215,12 @@ class BugzillaBugTracker(BugTracker):
         return bug_config
 
     def login(self):
-        # Bugzilla is only used for publicly visible data. Explicitly disable
-        # cached credentials so an expired API key cannot prevent read access.
-        return bugzilla.Bugzilla(self._server, use_creds=False)
+        client = bugzilla.Bugzilla(self._server)
+        if not client.logged_in:
+            raise ValueError(
+                f"elliott requires cached login credentials for {self._server}. Login using 'bugzilla login --api-key"
+            )
+        return client
 
     def __init__(self, config):
         super().__init__(config, 'bugzilla')

--- a/elliott/tests/test_bzutil.py
+++ b/elliott/tests/test_bzutil.py
@@ -579,15 +579,6 @@ class TestJIRABugTracker(unittest.TestCase):
 
 
 class TestBugzillaBugTracker(unittest.TestCase):
-    @mock.patch("elliottlib.bzutil.bugzilla.Bugzilla")
-    def test_login_uses_anonymous_client(self, mock_bugzilla):
-        client = mock_bugzilla.return_value
-
-        tracker = BugzillaBugTracker({"server": hostname})
-
-        mock_bugzilla.assert_called_once_with(hostname, use_creds=False)
-        self.assertIs(tracker.client(), client)
-
     def test_get_config(self):
         config = {"foo": 1, "bugzilla_config": {"bar": 2}}
         vars_mock = flexmock(MAJOR="4", MINOR="9")


### PR DESCRIPTION
Reverts openshift-eng/art-tools#3217

Now that we have refreshed our token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bugzilla access now requires cached credentials and authenticates users before proceeding.
  * Clearer errors are provided when credentials are unavailable, instead of allowing anonymous access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->