### PR TITLE
[ART-21950] update golang version to 1.26 for base image because payl…

### DIFF
--- a/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
+++ b/art-cluster/pipelines/data/project/art-cd/image/Containerfile.base
@@ -1,4 +1,5 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.22
+
 
 # Set metadata
 LABEL name="openshift-art/artcd-base" \


### PR DESCRIPTION
…oad-check requires that version

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

```
STEP 27/30: RUN git clone https://github.com/openshift/check-payload check-payload &&      cd check-payload      && make      && cp check-payload /usr/local/bin     && cd ..     && rm -rf check-payload # We only need the binary
Cloning into 'check-payload'...
CGO_ENABLED=0 go build -ldflags="-X main.Commit=$(git describe --tags --abbrev=8 --dirty --always --long)"
--> 01c92e3aa1ac
STEP 28/30: COPY artcommon/configs/krb5-redhat.conf /etc/krb5.conf
--> c6ce6aee63b1
STEP 29/30: RUN useradd -m -d /home/dev -u 1000 dev
useradd: warning: the home directory /home/dev already exists.
useradd: Not copying any file from skel directory into it.
--> 678df1a23a16
STEP 30/30: USER 1000
COMMIT art-cd:base-test
--> 8c8f6c33753c
Successfully tagged localhost/art-cd:base-test
8c8f6c33753c7c9ea3506530b19b4d3eeac12f91bf2a5c2a3a5bcc9525aaa45e
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to use Go 1.26 and OpenShift 4.22.
  * Includes the latest supported base image improvements for future builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->