### PR TITLE
[ART-21951] update output to quay.io

### DIFF
--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/image/build_base.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/image/build_base.yaml
@@ -20,7 +20,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: art-cd:latest
+      name: art-cd:base
   successfulBuildsHistoryLimit: 10
   failedBuildsHistoryLimit: 5
   runPolicy: Serial

--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/image/build_base.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/image/build_base.yaml
@@ -19,8 +19,8 @@ spec:
     type: Docker
   output:
     to:
-      kind: ImageStreamTag
-      name: art-cd:base
+      kind: DockerImage
+      name: quay.io/redhat-user-workloads/ocp-art-tenant/art-cd:latest
   successfulBuildsHistoryLimit: 10
   failedBuildsHistoryLimit: 5
   runPolicy: Serial

--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/image/build_base.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/image/build_base.yaml
@@ -19,8 +19,8 @@ spec:
     type: Docker
   output:
     to:
-      kind: DockerImage
-      name: quay.io/redhat-user-workloads/ocp-art-tenant/art-cd:latest
+      kind: ImageStreamTag
+      name: art-cd:latest
   successfulBuildsHistoryLimit: 10
   failedBuildsHistoryLimit: 5
   runPolicy: Serial

--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/image/build_latest.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/image/build_latest.yaml
@@ -22,6 +22,8 @@ spec:
     to:
       kind: DockerImage
       name: quay.io/redhat-user-workloads/ocp-art-tenant/art-cd:latest
+    pushSecret:
+      name: quay-push-secret
   successfulBuildsHistoryLimit: 10
   failedBuildsHistoryLimit: 5
   runPolicy: Serial

--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/image/build_latest.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/image/build_latest.yaml
@@ -20,8 +20,8 @@ spec:
     type: Docker
   output:
     to:
-      kind: ImageStreamTag
-      name: art-cd:latest
+      kind: DockerImage
+      name: quay.io/redhat-user-workloads/ocp-art-tenant/art-cd:latest
   successfulBuildsHistoryLimit: 10
   failedBuildsHistoryLimit: 5
   runPolicy: Serial

--- a/art-cluster/pipelines/config/argocd/project/art-cd/common/image/build_latest.yaml
+++ b/art-cluster/pipelines/config/argocd/project/art-cd/common/image/build_latest.yaml
@@ -23,7 +23,7 @@ spec:
       kind: DockerImage
       name: quay.io/redhat-user-workloads/ocp-art-tenant/art-cd:latest
     pushSecret:
-      name: quay-push-secret
+      name: konflux-art-cd-push-secret
   successfulBuildsHistoryLimit: 10
   failedBuildsHistoryLimit: 5
   runPolicy: Serial


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deployment**
  * Updated image builds to publish to the external Quay registry.
  * Configured image publishing to use the updated push credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->