### PR TITLE
ART-21880: Add verify-metadata-url command

### DIFF
--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -77,6 +77,7 @@ from elliottlib.cli.verify_cdn_push_cli import verify_cdn_push_cli
 from elliottlib.cli.verify_cvp_cli import verify_cvp_cli
 from elliottlib.cli.verify_image_grades_cli import verify_image_grades_cli
 from elliottlib.cli.verify_kernel_tag_cli import verify_kernel_tag_cli
+from elliottlib.cli.verify_metadata_url_cli import verify_metadata_url_cli
 from elliottlib.cli.verify_payload import verify_payload
 from elliottlib.cli.verify_qe_qualifier_cli import verify_qe_qualifier_cli
 from elliottlib.cli.verify_security_alerts_cli import verify_security_alerts_cli
@@ -335,6 +336,7 @@ cli.add_command(verify_signatures_cli)
 cli.add_command(verify_image_grades_cli)
 cli.add_command(verify_qe_qualifier_cli)
 cli.add_command(verify_kernel_tag_cli)
+cli.add_command(verify_metadata_url_cli)
 
 # -----------------------------------------------------------------------------
 # CLI Entry point

--- a/elliott/elliottlib/cli/verify_metadata_url_cli.py
+++ b/elliott/elliottlib/cli/verify_metadata_url_cli.py
@@ -1,0 +1,165 @@
+import json
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import aiohttp
+import click
+from artcommonlib import exectools
+
+from elliottlib.cli.common import cli, click_coroutine
+
+LOGGER = logging.getLogger(__name__)
+
+RELEASE_STREAM_API = "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream"
+
+
+@dataclass
+class VerifyMetadataUrlResult:
+    release: str
+    pullspec: str = ""
+    metadata_url: str = ""
+    accessible: bool = False
+    error: Optional[str] = None
+
+    @property
+    def passed(self) -> bool:
+        return self.accessible and not self.error
+
+    @property
+    def failed(self) -> bool:
+        return not self.accessible or bool(self.error)
+
+
+async def get_release_pullspec(release: str) -> str:
+    major = release.split(".")[0]
+    url = f"{RELEASE_STREAM_API}/{major}-stable/latest?prefix={release}"
+    LOGGER.info("Fetching pullspec from %s", url)
+    session = aiohttp.ClientSession()
+    try:
+        resp = await session.get(url, timeout=aiohttp.ClientTimeout(total=30))
+        try:
+            if not resp.ok:
+                raise RuntimeError(f"Release stream API returned {resp.status} for {url}")
+            data = await resp.json()
+            pullspec = data.get("pullSpec")
+            if not pullspec:
+                raise RuntimeError(f"No pullSpec in release stream response for {release}")
+            return pullspec
+        finally:
+            resp.release()
+    finally:
+        await session.close()
+
+
+async def extract_metadata_url(pullspec: str) -> str:
+    cmd = ["oc", "adm", "release", "info", pullspec, "-o", "json"]
+    rc, stdout, stderr = await exectools.cmd_gather_async(cmd, check=False)
+    if rc != 0:
+        raise RuntimeError(f"oc adm release info failed: {stderr.strip()}")
+    release_info = json.loads(stdout)
+    try:
+        url = release_info["metadata"]["metadata"]["url"]
+    except (KeyError, TypeError):
+        raise RuntimeError("metadata.metadata.url not found in release info")
+    if not url:
+        raise RuntimeError("metadata.metadata.url is empty")
+    return url
+
+
+async def check_url_accessible(url: str) -> bool:
+    LOGGER.info("Checking accessibility of %s", url)
+    session = aiohttp.ClientSession()
+    try:
+        resp = await session.get(url, timeout=aiohttp.ClientTimeout(total=30))
+        try:
+            LOGGER.info("HTTP %s for %s", resp.status, url)
+            return resp.ok
+        finally:
+            resp.release()
+    finally:
+        await session.close()
+
+
+async def verify_metadata_url(release: str) -> VerifyMetadataUrlResult:
+    result = VerifyMetadataUrlResult(release=release)
+    try:
+        result.pullspec = await get_release_pullspec(release)
+        LOGGER.info("Release %s pullspec: %s", release, result.pullspec)
+
+        result.metadata_url = await extract_metadata_url(result.pullspec)
+        LOGGER.info("Metadata URL: %s", result.metadata_url)
+
+        result.accessible = await check_url_accessible(result.metadata_url)
+
+    except Exception as e:
+        LOGGER.error("Error verifying metadata URL for %s: %s", release, e)
+        result.error = str(e)
+
+    return result
+
+
+def render_result(result: VerifyMetadataUrlResult, output: str) -> str:
+    if output == "json":
+        return json.dumps(
+            {
+                "passed": result.passed,
+                "failed": result.failed,
+                "release": result.release,
+                "pullspec": result.pullspec,
+                "metadata_url": result.metadata_url,
+                "accessible": result.accessible,
+                "error": result.error,
+            },
+            indent=2,
+        )
+
+    lines = ["Metadata URL check", ""]
+    lines.append(f"  Release: {result.release}")
+    if result.pullspec:
+        lines.append(f"  Pullspec: {result.pullspec}")
+    if result.metadata_url:
+        lines.append(f"  Metadata URL: {result.metadata_url}")
+        lines.append(f"  Accessible: {'yes' if result.accessible else 'no'}")
+    if result.error:
+        lines.append(f"  Error: {result.error}")
+    lines.append("")
+
+    overall = "PASS" if result.passed else "FAIL"
+    lines.append(f"Overall: {overall}")
+    return "\n".join(lines)
+
+
+@cli.command("verify-metadata-url", short_help="Check release payload metadata URL accessibility")
+@click.option(
+    "-o",
+    "--output",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    show_default=True,
+    help="Output format.",
+)
+@click.pass_obj
+@click_coroutine
+async def verify_metadata_url_cli(runtime, output):
+    """Check that the release payload metadata URL is accessible.
+
+    Fetches the release pullspec from the release stream API,
+    extracts the metadata URL via 'oc adm release info', and verifies
+    it returns HTTP 200. The metadata URL points to the customer-facing
+    errata page on access.redhat.com.
+
+    Requires --group and --assembly global options. Uses the assembly name
+    as the release version prefix for the release stream API query.
+
+    Example:
+        elliott --group openshift-4.18 --assembly 4.18.50 verify-metadata-url
+    """
+    runtime.initialize()
+    release = runtime.assembly
+
+    LOGGER.info("Verifying metadata URL for release %s", release)
+    result = await verify_metadata_url(release=release)
+    click.echo(render_result(result, output))
+    if not result.passed:
+        raise SystemExit(1)

--- a/elliott/elliottlib/cli/verify_metadata_url_cli.py
+++ b/elliott/elliottlib/cli/verify_metadata_url_cli.py
@@ -84,6 +84,7 @@ def validate_metadata_url(url: str) -> None:
 
 
 async def check_url_accessible(url: str) -> bool:
+    # Redirects disabled to prevent SSRF via redirect chains
     validate_metadata_url(url)
     LOGGER.info("Checking accessibility of metadata URL")
     session = aiohttp.ClientSession()
@@ -105,6 +106,7 @@ async def verify_metadata_url(release: str) -> VerifyMetadataUrlResult:
         LOGGER.info("Release %s pullspec: %s", release, result.pullspec)
 
         result.metadata_url = await extract_metadata_url(result.pullspec)
+        validate_metadata_url(result.metadata_url)
         LOGGER.info("Metadata URL: %s", result.metadata_url)
 
         result.accessible = await check_url_accessible(result.metadata_url)

--- a/elliott/elliottlib/cli/verify_metadata_url_cli.py
+++ b/elliott/elliottlib/cli/verify_metadata_url_cli.py
@@ -2,6 +2,7 @@ import json
 import logging
 from dataclasses import dataclass
 from typing import Optional
+from urllib.parse import urlsplit
 
 import aiohttp
 import click
@@ -67,13 +68,29 @@ async def extract_metadata_url(pullspec: str) -> str:
     return url
 
 
+ALLOWED_METADATA_HOST = "access.redhat.com"
+
+
+def validate_metadata_url(url: str) -> None:
+    parsed = urlsplit(url)
+    if parsed.scheme != "https":
+        raise ValueError(f"Metadata URL must use https, got {parsed.scheme}")
+    if parsed.hostname != ALLOWED_METADATA_HOST:
+        raise ValueError(f"Metadata URL host must be {ALLOWED_METADATA_HOST}, got {parsed.hostname}")
+    if parsed.port is not None and parsed.port != 443:
+        raise ValueError(f"Metadata URL must not specify a non-standard port, got {parsed.port}")
+    if parsed.username or parsed.password:
+        raise ValueError("Metadata URL must not contain credentials")
+
+
 async def check_url_accessible(url: str) -> bool:
-    LOGGER.info("Checking accessibility of %s", url)
+    validate_metadata_url(url)
+    LOGGER.info("Checking accessibility of metadata URL")
     session = aiohttp.ClientSession()
     try:
-        resp = await session.get(url, timeout=aiohttp.ClientTimeout(total=30))
+        resp = await session.get(url, timeout=aiohttp.ClientTimeout(total=30), allow_redirects=False)
         try:
-            LOGGER.info("HTTP %s for %s", resp.status, url)
+            LOGGER.info("HTTP %s for metadata URL", resp.status)
             return resp.ok
         finally:
             resp.release()

--- a/elliott/elliottlib/cli/verify_metadata_url_cli.py
+++ b/elliott/elliottlib/cli/verify_metadata_url_cli.py
@@ -32,9 +32,17 @@ class VerifyMetadataUrlResult:
         return not self.accessible or bool(self.error)
 
 
-async def get_release_pullspec(release: str) -> str:
+def _release_stream_name(release: str) -> str:
     major = release.split(".")[0]
-    url = f"{RELEASE_STREAM_API}/{major}-stable/latest?prefix={release}"
+    parts = release.split("-", 1)
+    if len(parts) > 1 and parts[1].startswith("ec."):
+        return f"{major}-dev-preview"
+    return f"{major}-stable"
+
+
+async def get_release_pullspec(release: str) -> str:
+    stream = _release_stream_name(release)
+    url = f"{RELEASE_STREAM_API}/{stream}/latest?prefix={release}"
     LOGGER.info("Fetching pullspec from %s", url)
     session = aiohttp.ClientSession()
     try:
@@ -106,9 +114,6 @@ async def verify_metadata_url(release: str) -> VerifyMetadataUrlResult:
         LOGGER.info("Release %s pullspec: %s", release, result.pullspec)
 
         result.metadata_url = await extract_metadata_url(result.pullspec)
-        validate_metadata_url(result.metadata_url)
-        LOGGER.info("Metadata URL: %s", result.metadata_url)
-
         result.accessible = await check_url_accessible(result.metadata_url)
 
     except Exception as e:

--- a/elliott/tests/test_verify_metadata_url_cli.py
+++ b/elliott/tests/test_verify_metadata_url_cli.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from elliottlib.cli.verify_metadata_url_cli import (
     VerifyMetadataUrlResult,
+    _release_stream_name,
     check_url_accessible,
     extract_metadata_url,
     get_release_pullspec,
@@ -47,6 +48,20 @@ class TestVerifyMetadataUrlResult(TestCase):
         )
         self.assertFalse(r.passed)
         self.assertTrue(r.failed)
+
+
+class TestReleaseStreamName(TestCase):
+    def test_stable_release(self):
+        self.assertEqual(_release_stream_name("4.18.50"), "4-stable")
+
+    def test_stable_major_5(self):
+        self.assertEqual(_release_stream_name("5.0.3"), "5-stable")
+
+    def test_ec_release(self):
+        self.assertEqual(_release_stream_name("5.0.0-ec.5"), "5-dev-preview")
+
+    def test_rc_release(self):
+        self.assertEqual(_release_stream_name("4.22.0-rc.0"), "4-stable")
 
 
 class TestGetReleasePullspec(IsolatedAsyncioTestCase):
@@ -106,6 +121,23 @@ class TestGetReleasePullspec(IsolatedAsyncioTestCase):
         mock_session.get.assert_called_once()
         call_args = mock_session.get.call_args
         self.assertIn("5-stable", str(call_args))
+
+    @patch("elliottlib.cli.verify_metadata_url_cli.aiohttp.ClientSession")
+    async def test_ec_release_uses_dev_preview(self, mock_session_cls):
+        mock_resp = AsyncMock()
+        mock_resp.ok = True
+        mock_resp.json = AsyncMock(
+            return_value={"pullSpec": "quay.io/openshift-release-dev/ocp-release:5.0.0-ec.5-x86_64"}
+        )
+        mock_resp.release = MagicMock()
+        mock_session = AsyncMock()
+        mock_session.get = AsyncMock(return_value=mock_resp)
+        mock_session_cls.return_value = mock_session
+
+        result = await get_release_pullspec("5.0.0-ec.5")
+        self.assertEqual(result, "quay.io/openshift-release-dev/ocp-release:5.0.0-ec.5-x86_64")
+        call_args = mock_session.get.call_args
+        self.assertIn("5-dev-preview", str(call_args))
 
 
 class TestExtractMetadataUrl(IsolatedAsyncioTestCase):

--- a/elliott/tests/test_verify_metadata_url_cli.py
+++ b/elliott/tests/test_verify_metadata_url_cli.py
@@ -8,6 +8,7 @@ from elliottlib.cli.verify_metadata_url_cli import (
     extract_metadata_url,
     get_release_pullspec,
     render_result,
+    validate_metadata_url,
     verify_metadata_url,
 )
 
@@ -140,6 +141,39 @@ class TestExtractMetadataUrl(IsolatedAsyncioTestCase):
         with self.assertRaises(RuntimeError) as ctx:
             await extract_metadata_url("quay.io/test:4.18")
         self.assertIn("empty", str(ctx.exception))
+
+
+class TestValidateMetadataUrl(TestCase):
+    def test_valid_url(self):
+        validate_metadata_url("https://access.redhat.com/errata/RHBA-2025:1234")
+
+    def test_valid_url_with_port_443(self):
+        validate_metadata_url("https://access.redhat.com:443/errata/RHBA-2025:1234")
+
+    def test_http_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_metadata_url("http://access.redhat.com/errata/RHBA-2025:1234")
+        self.assertIn("https", str(ctx.exception))
+
+    def test_wrong_host_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_metadata_url("https://evil.example.com/errata/RHBA-2025:1234")
+        self.assertIn("access.redhat.com", str(ctx.exception))
+
+    def test_subdomain_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_metadata_url("https://access.redhat.com.evil.example/errata/RHBA-2025:1234")
+        self.assertIn("access.redhat.com", str(ctx.exception))
+
+    def test_non_standard_port_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_metadata_url("https://access.redhat.com:8443/errata/RHBA-2025:1234")
+        self.assertIn("port", str(ctx.exception))
+
+    def test_userinfo_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_metadata_url("https://user:pass@access.redhat.com/errata/RHBA-2025:1234")
+        self.assertIn("credentials", str(ctx.exception))
 
 
 class TestCheckUrlAccessible(IsolatedAsyncioTestCase):

--- a/elliott/tests/test_verify_metadata_url_cli.py
+++ b/elliott/tests/test_verify_metadata_url_cli.py
@@ -1,0 +1,279 @@
+import json
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from elliottlib.cli.verify_metadata_url_cli import (
+    VerifyMetadataUrlResult,
+    check_url_accessible,
+    extract_metadata_url,
+    get_release_pullspec,
+    render_result,
+    verify_metadata_url,
+)
+
+
+class TestVerifyMetadataUrlResult(TestCase):
+    def test_passed(self):
+        r = VerifyMetadataUrlResult(
+            release="4.18",
+            pullspec="quay.io/openshift-release-dev/ocp-release:4.18.51-x86_64",
+            metadata_url="https://access.redhat.com/errata/RHBA-2025:1234",
+            accessible=True,
+        )
+        self.assertTrue(r.passed)
+        self.assertFalse(r.failed)
+
+    def test_not_accessible(self):
+        r = VerifyMetadataUrlResult(
+            release="4.18",
+            pullspec="quay.io/test:4.18",
+            metadata_url="https://access.redhat.com/errata/RHBA-2025:1234",
+            accessible=False,
+        )
+        self.assertFalse(r.passed)
+        self.assertTrue(r.failed)
+
+    def test_error(self):
+        r = VerifyMetadataUrlResult(release="4.18", error="connection failed")
+        self.assertFalse(r.passed)
+        self.assertTrue(r.failed)
+
+    def test_error_overrides_accessible(self):
+        r = VerifyMetadataUrlResult(
+            release="4.18",
+            accessible=True,
+            error="some warning",
+        )
+        self.assertFalse(r.passed)
+        self.assertTrue(r.failed)
+
+
+class TestGetReleasePullspec(IsolatedAsyncioTestCase):
+    @patch("elliottlib.cli.verify_metadata_url_cli.aiohttp.ClientSession")
+    async def test_success(self, mock_session_cls):
+        mock_resp = AsyncMock()
+        mock_resp.ok = True
+        mock_resp.json = AsyncMock(
+            return_value={"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.51-x86_64"}
+        )
+        mock_resp.release = MagicMock()
+        mock_session = AsyncMock()
+        mock_session.get = AsyncMock(return_value=mock_resp)
+        mock_session_cls.return_value = mock_session
+
+        result = await get_release_pullspec("4.18")
+        self.assertEqual(result, "quay.io/openshift-release-dev/ocp-release:4.18.51-x86_64")
+
+    @patch("elliottlib.cli.verify_metadata_url_cli.aiohttp.ClientSession")
+    async def test_api_error(self, mock_session_cls):
+        mock_resp = AsyncMock()
+        mock_resp.ok = False
+        mock_resp.status = 404
+        mock_resp.release = MagicMock()
+        mock_session = AsyncMock()
+        mock_session.get = AsyncMock(return_value=mock_resp)
+        mock_session_cls.return_value = mock_session
+
+        with self.assertRaises(RuntimeError):
+            await get_release_pullspec("4.99")
+
+    @patch("elliottlib.cli.verify_metadata_url_cli.aiohttp.ClientSession")
+    async def test_no_pullspec_in_response(self, mock_session_cls):
+        mock_resp = AsyncMock()
+        mock_resp.ok = True
+        mock_resp.json = AsyncMock(return_value={"name": "4.18.51"})
+        mock_resp.release = MagicMock()
+        mock_session = AsyncMock()
+        mock_session.get = AsyncMock(return_value=mock_resp)
+        mock_session_cls.return_value = mock_session
+
+        with self.assertRaises(RuntimeError):
+            await get_release_pullspec("4.18")
+
+    @patch("elliottlib.cli.verify_metadata_url_cli.aiohttp.ClientSession")
+    async def test_major_version_5(self, mock_session_cls):
+        mock_resp = AsyncMock()
+        mock_resp.ok = True
+        mock_resp.json = AsyncMock(return_value={"pullSpec": "quay.io/openshift-release-dev/ocp-release:5.0.3-x86_64"})
+        mock_resp.release = MagicMock()
+        mock_session = AsyncMock()
+        mock_session.get = AsyncMock(return_value=mock_resp)
+        mock_session_cls.return_value = mock_session
+
+        result = await get_release_pullspec("5.0")
+        self.assertEqual(result, "quay.io/openshift-release-dev/ocp-release:5.0.3-x86_64")
+        mock_session.get.assert_called_once()
+        call_args = mock_session.get.call_args
+        self.assertIn("5-stable", str(call_args))
+
+
+class TestExtractMetadataUrl(IsolatedAsyncioTestCase):
+    @patch("elliottlib.cli.verify_metadata_url_cli.exectools.cmd_gather_async")
+    async def test_success(self, mock_cmd):
+        release_info = {"metadata": {"metadata": {"url": "https://access.redhat.com/errata/RHBA-2025:1234"}}}
+        mock_cmd.return_value = (0, json.dumps(release_info), "")
+
+        result = await extract_metadata_url("quay.io/test:4.18")
+        self.assertEqual(result, "https://access.redhat.com/errata/RHBA-2025:1234")
+
+    @patch("elliottlib.cli.verify_metadata_url_cli.exectools.cmd_gather_async")
+    async def test_oc_command_fails(self, mock_cmd):
+        mock_cmd.return_value = (1, "", "error: unauthorized")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            await extract_metadata_url("quay.io/test:4.18")
+        self.assertIn("oc adm release info failed", str(ctx.exception))
+
+    @patch("elliottlib.cli.verify_metadata_url_cli.exectools.cmd_gather_async")
+    async def test_missing_metadata_key(self, mock_cmd):
+        mock_cmd.return_value = (0, json.dumps({"metadata": {}}), "")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            await extract_metadata_url("quay.io/test:4.18")
+        self.assertIn("not found", str(ctx.exception))
+
+    @patch("elliottlib.cli.verify_metadata_url_cli.exectools.cmd_gather_async")
+    async def test_empty_url(self, mock_cmd):
+        release_info = {"metadata": {"metadata": {"url": ""}}}
+        mock_cmd.return_value = (0, json.dumps(release_info), "")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            await extract_metadata_url("quay.io/test:4.18")
+        self.assertIn("empty", str(ctx.exception))
+
+
+class TestCheckUrlAccessible(IsolatedAsyncioTestCase):
+    @patch("elliottlib.cli.verify_metadata_url_cli.aiohttp.ClientSession")
+    async def test_accessible(self, mock_session_cls):
+        mock_resp = AsyncMock()
+        mock_resp.ok = True
+        mock_resp.status = 200
+        mock_resp.release = MagicMock()
+        mock_session = AsyncMock()
+        mock_session.get = AsyncMock(return_value=mock_resp)
+        mock_session_cls.return_value = mock_session
+
+        result = await check_url_accessible("https://access.redhat.com/errata/RHBA-2025:1234")
+        self.assertTrue(result)
+
+    @patch("elliottlib.cli.verify_metadata_url_cli.aiohttp.ClientSession")
+    async def test_not_accessible(self, mock_session_cls):
+        mock_resp = AsyncMock()
+        mock_resp.ok = False
+        mock_resp.status = 404
+        mock_resp.release = MagicMock()
+        mock_session = AsyncMock()
+        mock_session.get = AsyncMock(return_value=mock_resp)
+        mock_session_cls.return_value = mock_session
+
+        result = await check_url_accessible("https://access.redhat.com/errata/RHBA-2025:9999")
+        self.assertFalse(result)
+
+
+class TestVerifyMetadataUrl(IsolatedAsyncioTestCase):
+    @patch("elliottlib.cli.verify_metadata_url_cli.check_url_accessible")
+    @patch("elliottlib.cli.verify_metadata_url_cli.extract_metadata_url")
+    @patch("elliottlib.cli.verify_metadata_url_cli.get_release_pullspec")
+    async def test_all_pass(self, mock_pullspec, mock_extract, mock_check):
+        mock_pullspec.return_value = "quay.io/test:4.18.51"
+        mock_extract.return_value = "https://access.redhat.com/errata/RHBA-2025:1234"
+        mock_check.return_value = True
+
+        result = await verify_metadata_url("4.18")
+        self.assertTrue(result.passed)
+        self.assertEqual(result.pullspec, "quay.io/test:4.18.51")
+        self.assertEqual(result.metadata_url, "https://access.redhat.com/errata/RHBA-2025:1234")
+
+    @patch("elliottlib.cli.verify_metadata_url_cli.check_url_accessible")
+    @patch("elliottlib.cli.verify_metadata_url_cli.extract_metadata_url")
+    @patch("elliottlib.cli.verify_metadata_url_cli.get_release_pullspec")
+    async def test_url_not_accessible(self, mock_pullspec, mock_extract, mock_check):
+        mock_pullspec.return_value = "quay.io/test:4.18.51"
+        mock_extract.return_value = "https://access.redhat.com/errata/RHBA-2025:1234"
+        mock_check.return_value = False
+
+        result = await verify_metadata_url("4.18")
+        self.assertFalse(result.passed)
+        self.assertTrue(result.failed)
+        self.assertFalse(result.accessible)
+
+    @patch("elliottlib.cli.verify_metadata_url_cli.get_release_pullspec")
+    async def test_pullspec_error(self, mock_pullspec):
+        mock_pullspec.side_effect = RuntimeError("API unreachable")
+
+        result = await verify_metadata_url("4.18")
+        self.assertFalse(result.passed)
+        self.assertIn("API unreachable", result.error)
+
+    @patch("elliottlib.cli.verify_metadata_url_cli.extract_metadata_url")
+    @patch("elliottlib.cli.verify_metadata_url_cli.get_release_pullspec")
+    async def test_oc_error(self, mock_pullspec, mock_extract):
+        mock_pullspec.return_value = "quay.io/test:4.18.51"
+        mock_extract.side_effect = RuntimeError("oc adm release info failed")
+
+        result = await verify_metadata_url("4.18")
+        self.assertFalse(result.passed)
+        self.assertIn("oc adm release info failed", result.error)
+
+    @patch("elliottlib.cli.verify_metadata_url_cli.check_url_accessible")
+    @patch("elliottlib.cli.verify_metadata_url_cli.extract_metadata_url")
+    @patch("elliottlib.cli.verify_metadata_url_cli.get_release_pullspec")
+    async def test_http_check_error(self, mock_pullspec, mock_extract, mock_check):
+        mock_pullspec.return_value = "quay.io/test:4.18.51"
+        mock_extract.return_value = "https://access.redhat.com/errata/RHBA-2025:1234"
+        mock_check.side_effect = Exception("connection timeout")
+
+        result = await verify_metadata_url("4.18")
+        self.assertFalse(result.passed)
+        self.assertIn("connection timeout", result.error)
+
+
+class TestRenderResult(TestCase):
+    def test_text_pass(self):
+        r = VerifyMetadataUrlResult(
+            release="4.18",
+            pullspec="quay.io/test:4.18.51",
+            metadata_url="https://access.redhat.com/errata/RHBA-2025:1234",
+            accessible=True,
+        )
+        text = render_result(r, "text")
+        self.assertIn("PASS", text)
+        self.assertIn("4.18", text)
+        self.assertIn("access.redhat.com", text)
+
+    def test_text_fail(self):
+        r = VerifyMetadataUrlResult(
+            release="4.18",
+            pullspec="quay.io/test:4.18.51",
+            metadata_url="https://access.redhat.com/errata/RHBA-2025:1234",
+            accessible=False,
+        )
+        text = render_result(r, "text")
+        self.assertIn("FAIL", text)
+        self.assertIn("no", text)
+
+    def test_text_error(self):
+        r = VerifyMetadataUrlResult(release="4.18", error="API unreachable")
+        text = render_result(r, "text")
+        self.assertIn("FAIL", text)
+        self.assertIn("API unreachable", text)
+
+    def test_json_pass(self):
+        r = VerifyMetadataUrlResult(
+            release="4.18",
+            pullspec="quay.io/test:4.18.51",
+            metadata_url="https://access.redhat.com/errata/RHBA-2025:1234",
+            accessible=True,
+        )
+        data = json.loads(render_result(r, "json"))
+        self.assertTrue(data["passed"])
+        self.assertFalse(data["failed"])
+        self.assertEqual(data["release"], "4.18")
+        self.assertEqual(data["metadata_url"], "https://access.redhat.com/errata/RHBA-2025:1234")
+
+    def test_json_fail(self):
+        r = VerifyMetadataUrlResult(release="4.18", error="boom")
+        data = json.loads(render_result(r, "json"))
+        self.assertFalse(data["passed"])
+        self.assertTrue(data["failed"])
+        self.assertEqual(data["error"], "boom")


### PR DESCRIPTION
## Summary
- New `elliott verify-metadata-url` command that verifies the release payload metadata URL (errata page on access.redhat.com) is accessible
- Three-step check: release stream API → `oc adm release info` → HTTP GET
- Ports OAR `is_payload_metadata_url_accessible()` from `release-tests/oar/core/util.py`
- 24 unit tests covering all code paths

## Usage
```
elliott --group openshift-4.18 --assembly 4.18.50 verify-metadata-url
elliott --group openshift-4.18 --assembly 4.18.50 verify-metadata-url -o json
```

## Test plan
- [x] 24 unit tests passing
- [x] Manually verified on 4.22.9 — PASS
- [x] Compared with OAR implementation — same logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a CLI command to verify release metadata URLs.
  - Retrieves release information, validates the metadata URL, and checks HTTPS accessibility without following redirects.
  - Supports text and JSON output formats.
  - Reports verification failures clearly and returns a failure status when checks do not pass.

- **Tests**
  - Added coverage for successful checks, failures, missing data, exceptions, validation, accessibility checks, and output rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->