### PR TITLE
Forbid CONFLICTING_INHERITED_DEPENDENCY permits for rhcos

### DIFF
--- a/artcommon/artcommonlib/assembly.py
+++ b/artcommon/artcommonlib/assembly.py
@@ -253,6 +253,13 @@ def assembly_permits(releases_config: Model, group_config: Model, assembly: typi
             raise ValueError(f'IMPERMISSIBLE cannot be permitted in any assembly (assembly: {assembly})')
         if permit.code not in ['*', *[aic.name for aic in AssemblyIssueCode]]:
             raise ValueError(f'Undefined permit code in assembly {assembly}: {permit.code}')
+        if permit.code == AssemblyIssueCode.CONFLICTING_INHERITED_DEPENDENCY.name and permit.component == 'rhcos':
+            raise ValueError(
+                f'CONFLICTING_INHERITED_DEPENDENCY cannot be permitted for rhcos component '
+                f'(assembly: {assembly}). RHCOS content defines what is delivered to nodes, '
+                f'and permitting conflicts causes RPM advisories to claim newer versions than '
+                f'what actually shipped in RHCOS.'
+            )
     return defined_permits
 
 

--- a/artcommon/tests/test_assembly.py
+++ b/artcommon/tests/test_assembly.py
@@ -10,6 +10,7 @@ from artcommonlib.assembly import (
     assembly_group_config,
     assembly_metadata_config,
     assembly_own_issues_config,
+    assembly_permits,
     assembly_resolved,
     assembly_rhcos_config,
     assembly_targeted_fixes_only,
@@ -853,3 +854,85 @@ releases:
 
     def test_none_releases_config_returns_false(self):
         self.assertFalse(assembly_targeted_fixes_only(None, "targeted_assembly"))
+
+
+class TestAssemblyPermits(TestCase):
+    def test_rhcos_conflicting_inherited_dependency_forbidden(self):
+        """CONFLICTING_INHERITED_DEPENDENCY permits for rhcos component should be rejected."""
+        releases_yml = """
+releases:
+  test_assembly:
+    assembly:
+      basis:
+        time: "2026-01-01T00:00:00+00:00"
+      permits:
+        - code: CONFLICTING_INHERITED_DEPENDENCY
+          component: rhcos
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        group_config = Model(dict_to_model={'software_lifecycle': {'phase': 'release'}})
+
+        with self.assertRaises(ValueError) as cm:
+            assembly_permits(releases_config, group_config, "test_assembly")
+
+        self.assertIn("CONFLICTING_INHERITED_DEPENDENCY cannot be permitted for rhcos", str(cm.exception))
+        self.assertIn("RPM advisories to claim newer versions", str(cm.exception))
+
+    def test_rhcos_conflicting_inherited_dependency_wildcard_component_allowed(self):
+        """CONFLICTING_INHERITED_DEPENDENCY permits for wildcard component should be allowed."""
+        releases_yml = """
+releases:
+  test_assembly:
+    assembly:
+      basis:
+        time: "2026-01-01T00:00:00+00:00"
+      permits:
+        - code: CONFLICTING_INHERITED_DEPENDENCY
+          component: '*'
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        group_config = Model(dict_to_model={'software_lifecycle': {'phase': 'release'}})
+
+        # Should not raise
+        permits = assembly_permits(releases_config, group_config, "test_assembly")
+        self.assertEqual(len(permits), 1)
+
+    def test_rhcos_conflicting_inherited_dependency_other_component_allowed(self):
+        """CONFLICTING_INHERITED_DEPENDENCY permits for non-rhcos components should be allowed."""
+        releases_yml = """
+releases:
+  test_assembly:
+    assembly:
+      basis:
+        time: "2026-01-01T00:00:00+00:00"
+      permits:
+        - code: CONFLICTING_INHERITED_DEPENDENCY
+          component: some-image
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        group_config = Model(dict_to_model={'software_lifecycle': {'phase': 'release'}})
+
+        # Should not raise
+        permits = assembly_permits(releases_config, group_config, "test_assembly")
+        self.assertEqual(len(permits), 1)
+
+    def test_rhcos_other_issue_codes_allowed(self):
+        """Other issue codes for rhcos component should be allowed."""
+        releases_yml = """
+releases:
+  test_assembly:
+    assembly:
+      basis:
+        time: "2026-01-01T00:00:00+00:00"
+      permits:
+        - code: CONFLICTING_GROUP_RPM_INSTALLED
+          component: rhcos
+        - code: INCONSISTENT_RHCOS_RPMS
+          component: rhcos
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        group_config = Model(dict_to_model={'software_lifecycle': {'phase': 'release'}})
+
+        # Should not raise
+        permits = assembly_permits(releases_config, group_config, "test_assembly")
+        self.assertEqual(len(permits), 2)


### PR DESCRIPTION
## Summary

Prevents assembly permits from allowing `CONFLICTING_INHERITED_DEPENDENCY` for the `rhcos` component to avoid RPM advisory data inconsistencies.

## Problem

RHCOS content defines what is actually delivered to OpenShift nodes. When assembly permits allow `CONFLICTING_INHERITED_DEPENDENCY` for rhcos, it causes RPM advisories to claim newer package versions than what actually shipped in RHCOS.

This happened in [RHSA-2026:3851](https://access.redhat.com/errata/RHSA-2026:3851) where:
- Advisory claimed: `runc-1.2.9-3` and `conmon-2.1.12-12` 
- Actual RHCOS in 4.20.16/17 had: `runc-1.2.9-2` and `conmon-2.1.12-1`

**Root cause:** ART permitted newer RPMs for payload images when RHCOS lagged behind. The permit made the conflict "acceptable" which resulted in wrong NVRs appearing in the RPM advisory.

## Solution

Add validation in `assembly_permits()` to reject any permit that tries to allow `CONFLICTING_INHERITED_DEPENDENCY` for the `rhcos` component.

- ✅ Other components can still use this permit
- ✅ RHCOS can still use other permit codes  
- ❌ RHCOS + CONFLICTING_INHERITED_DEPENDENCY = validation error

## Testing

Added comprehensive test coverage in `test_assembly.py::TestAssemblyPermits`:
- Test that rhcos + CONFLICTING_INHERITED_DEPENDENCY is rejected
- Test that wildcard component is still allowed
- Test that other components are still allowed
- Test that other issue codes for rhcos are still allowed

All existing tests pass.

## References

- Jira: [ART-21882](https://redhat.atlassian.net/browse/ART-21882)
- Slack discussion: [thread](https://redhat-internal.slack.com/archives/CB95J6R4N/p1786358517931729)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid assembly permits for `rhcos` components when conflicting inherited dependencies are detected.
  * Added clear validation feedback for rejected permits.
  * Preserved permit handling for wildcard, non-`rhcos`, and other valid issue types.

* **Tests**
  * Added coverage for valid and invalid permit scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->