### PR TITLE
build-conforma-verify: skip Slack notification on success

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_conforma_verify.py
+++ b/pyartcd/pyartcd/pipelines/build_conforma_verify.py
@@ -685,31 +685,29 @@ class BuildConformaVerifyPipeline:
             return
 
         if not any_failed:
-            message = (
-                f":white_check_mark: build-conforma-verify in {self.version} "
-                f"(assembly=`{self.assembly}`) passed (effective_time=`{self.effective_time}`)"
-            )
+            self.logger.info("All builds passed conforma verification; skipping Slack notification")
+            return
+
+        failed_parts = []
+        if image_failed:
+            failed_parts.append(f"{image_failed} image(s)")
+        if bundle_failed:
+            failed_parts.append(f"{bundle_failed} bundle(s)")
+        if fbc_failed:
+            failed_parts.append(f"{fbc_failed} FBC(s)")
+        if failed_parts:
+            detail = f"failed for: {', '.join(failed_parts)}"
         else:
-            failed_parts = []
-            if image_failed:
-                failed_parts.append(f"{image_failed} image(s)")
-            if bundle_failed:
-                failed_parts.append(f"{bundle_failed} bundle(s)")
-            if fbc_failed:
-                failed_parts.append(f"{fbc_failed} FBC(s)")
-            if failed_parts:
-                detail = f"failed for: {', '.join(failed_parts)}"
-            else:
-                detail = "failed (no violation details available)"
-            message = (
-                f":warning: build-conforma-verify in {self.version} "
-                f"(assembly=`{self.assembly}`) {detail} "
-                f"(effective_time=`{self.effective_time}`)"
-            )
+            detail = "failed (no violation details available)"
+        message = (
+            f":warning: build-conforma-verify in {self.version} "
+            f"(assembly=`{self.assembly}`) {detail} "
+            f"(effective_time=`{self.effective_time}`)"
+        )
 
         await self.slack_client.say_in_thread(message)
 
-        if any_failed and all_violations:
+        if all_violations:
             unique_rules: dict[str, str] = {}
             for violations in all_violations.values():
                 for v in violations:

--- a/pyartcd/tests/pipelines/test_build_conforma_verify.py
+++ b/pyartcd/tests/pipelines/test_build_conforma_verify.py
@@ -179,7 +179,7 @@ class TestSlackReporting(unittest.TestCase):
 
         asyncio.run(p._report_to_slack(any_failed=False, image_failed=0, bundle_failed=0, fbc_failed=0))
 
-    def test_success_message(self):
+    def test_success_skips_slack(self):
         slack = MagicMock()
         slack.say_in_thread = AsyncMock()
         p = _make_pipeline(slack_client=slack, effective_time="2026-08-05T00:00:00Z")
@@ -188,13 +188,7 @@ class TestSlackReporting(unittest.TestCase):
 
         asyncio.run(p._report_to_slack(any_failed=False, image_failed=0, bundle_failed=0, fbc_failed=0))
 
-        slack.say_in_thread.assert_called_once()
-        msg = slack.say_in_thread.call_args[0][0]
-        self.assertIn(":white_check_mark:", msg)
-        self.assertIn("4.18", msg)
-        self.assertIn("assembly=`stream`", msg)
-        self.assertIn("passed", msg)
-        self.assertIn("effective_time=`2026-08-05T00:00:00Z`", msg)
+        slack.say_in_thread.assert_not_called()
 
     def test_failure_message(self):
         slack = MagicMock()
@@ -281,7 +275,7 @@ class TestSlackReporting(unittest.TestCase):
 
         import asyncio
 
-        asyncio.run(p._report_to_slack(any_failed=False, image_failed=0, bundle_failed=0, fbc_failed=0))
+        asyncio.run(p._report_to_slack(any_failed=True, image_failed=1, bundle_failed=0, fbc_failed=0))
 
         msg = slack.say_in_thread.call_args[0][0]
         self.assertIn("effective_time=`now`", msg)


### PR DESCRIPTION
## Summary

- `_report_to_slack()` now returns early (with a console log) when all builds pass, instead of posting a `:white_check_mark:` message to `#art-release`
- Failure reporting is unchanged — warning message + violated rules thread reply still post as before
- Updated two tests: `test_success_message` → `test_success_skips_slack` (asserts no Slack call on success); `test_default_effective_time_label` rewritten to use a failure case

## Test plan

- [ ] `uv run pytest --verbose --color=yes pyartcd/tests/pipelines/test_build_conforma_verify.py` — all 22 tests pass
- [ ] Trigger a real `build-conforma-verify` run that passes and confirm no Slack message appears in `#art-release`
- [ ] Trigger a run that fails and confirm the `:warning:` message + violated rules still appear in `#art-release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Slack notifications are now sent only when build verification failures occur.
  * Failure notifications include affected build categories or indicate when violation details are unavailable.
  * Removed misleading success messages for runs without failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->