### PR TITLE
fix(okd): stop overwriting scos-5.0-art stream-coreos with 4.22 image

### DIFF
--- a/pyartcd/pyartcd/pipelines/okd.py
+++ b/pyartcd/pyartcd/pipelines/okd.py
@@ -677,9 +677,10 @@ class KonfluxOkdPipeline:
         - origin/scos-{version}:stream-coreos -> origin/scos-{version}-art:stream-coreos
         - origin/scos-{version}:stream-coreos-extensions -> origin/scos-{version}-art:stream-coreos-extensions
 
-        Special cases:
-        - 4.21 and 4.22: Skip mirroring (handled by https://github.com/openshift/release/pull/74529/)
-        - 4.23 and 5.0: Use 4.22 as the source
+        Special case:
+        - Only 4.23 needs mirroring (source: scos-5.0 / master branch).
+          All other versions have openshift/release CI configs promoting stream-coreos
+          directly to the -art namespace.
         """
 
         if self.assembly != 'stream':
@@ -690,15 +691,13 @@ class KonfluxOkdPipeline:
             self.logger.warning('No images were successfully built; skipping CoreOS imagestream mirroring')
             return
 
-        # Skip mirroring for 4.21 and 4.22 as it's handled by openshift/release PR #74529
-        if self.version in ['4.21', '4.22']:
+        # Only 4.23 needs mirroring; all other versions are handled by openshift/release CI configs
+        if self.version != '4.23':
             self.logger.info('Version %s: CoreOS mirroring is handled by openshift/release; skipping', self.version)
             return
 
         tags_to_mirror = ['stream-coreos', 'stream-coreos-extensions']
-
-        # For OKD 4.23 and 5.0, use 4.22 as the source
-        source_version = '4.22' if self.version in ['4.23', '5.0'] else self.version
+        source_version = '5.0'
 
         if self.runtime.dry_run:
             self.logger.info('[DRY RUN] Would mirror CoreOS imagestream tags')

--- a/pyartcd/tests/pipelines/test_okd4.py
+++ b/pyartcd/tests/pipelines/test_okd4.py
@@ -45,7 +45,7 @@ class TestKonfluxOkdPipeline(IsolatedAsyncioTestCase):
             assembly='stream',
             data_path='https://github.com/openshift-eng/ocp-build-data',
             data_gitref='',
-            version='4.20',
+            version='4.23',
             ignore_locks=False,
             plr_template='',
             lock_identifier='test-lock',
@@ -68,15 +68,15 @@ class TestKonfluxOkdPipeline(IsolatedAsyncioTestCase):
             # Should be called twice - once for stream-coreos, once for stream-coreos-extensions
             self.assertEqual(mock_tag.call_count, 2)
 
-            # Check first call (stream-coreos)
+            # Check first call (stream-coreos) — source is scos-5.0 (master branch)
             first_call = mock_tag.call_args_list[0]
-            self.assertEqual(first_call[1]['source_pullspec'], 'origin/scos-4.20:stream-coreos')
-            self.assertEqual(first_call[1]['target_tag'], 'origin/scos-4.20-art:stream-coreos')
+            self.assertEqual(first_call[1]['source_pullspec'], 'origin/scos-5.0:stream-coreos')
+            self.assertEqual(first_call[1]['target_tag'], 'origin/scos-4.23-art:stream-coreos')
 
             # Check second call (stream-coreos-extensions)
             second_call = mock_tag.call_args_list[1]
-            self.assertEqual(second_call[1]['source_pullspec'], 'origin/scos-4.20:stream-coreos-extensions')
-            self.assertEqual(second_call[1]['target_tag'], 'origin/scos-4.20-art:stream-coreos-extensions')
+            self.assertEqual(second_call[1]['source_pullspec'], 'origin/scos-5.0:stream-coreos-extensions')
+            self.assertEqual(second_call[1]['target_tag'], 'origin/scos-4.23-art:stream-coreos-extensions')
 
             # Should update Jenkins description twice (once per successful tag)
             self.assertEqual(mock_jenkins.update_description.call_count, 2)
@@ -153,7 +153,7 @@ class TestKonfluxOkdPipeline(IsolatedAsyncioTestCase):
             assembly='stream',
             data_path='https://github.com/openshift-eng/ocp-build-data',
             data_gitref='',
-            version='4.20',
+            version='4.23',
             ignore_locks=False,
             plr_template='',
             lock_identifier='test-lock',
@@ -185,7 +185,7 @@ class TestKonfluxOkdPipeline(IsolatedAsyncioTestCase):
             assembly='stream',
             data_path='https://github.com/openshift-eng/ocp-build-data',
             data_gitref='',
-            version='4.20',
+            version='4.23',
             ignore_locks=False,
             plr_template='',
             lock_identifier='test-lock',
@@ -232,7 +232,7 @@ class TestKonfluxOkdPipeline(IsolatedAsyncioTestCase):
             assembly='stream',
             data_path='https://github.com/openshift-eng/ocp-build-data',
             data_gitref='',
-            version='4.20',
+            version='4.23',
             ignore_locks=False,
             plr_template='',
             lock_identifier='test-lock',
@@ -257,73 +257,52 @@ class TestKonfluxOkdPipeline(IsolatedAsyncioTestCase):
 
             # Check first call uses custom namespace
             first_call = mock_tag.call_args_list[0]
-            self.assertEqual(first_call[1]['source_pullspec'], 'custom-namespace/scos-4.20:stream-coreos')
-            self.assertEqual(first_call[1]['target_tag'], 'custom-namespace/scos-4.20-art:stream-coreos')
+            self.assertEqual(first_call[1]['source_pullspec'], 'custom-namespace/scos-5.0:stream-coreos')
+            self.assertEqual(first_call[1]['target_tag'], 'custom-namespace/scos-4.23-art:stream-coreos')
 
             # Check second call uses custom namespace
             second_call = mock_tag.call_args_list[1]
-            self.assertEqual(second_call[1]['source_pullspec'], 'custom-namespace/scos-4.20:stream-coreos-extensions')
-            self.assertEqual(second_call[1]['target_tag'], 'custom-namespace/scos-4.20-art:stream-coreos-extensions')
+            self.assertEqual(second_call[1]['source_pullspec'], 'custom-namespace/scos-5.0:stream-coreos-extensions')
+            self.assertEqual(second_call[1]['target_tag'], 'custom-namespace/scos-4.23-art:stream-coreos-extensions')
 
-    async def test_mirror_coreos_imagestreams_skipped_for_4_21(self):
+    async def test_mirror_coreos_imagestreams_skipped_for_release_managed_versions(self):
         """
-        Test that CoreOS mirroring is skipped for version 4.21 (handled by openshift/release).
-        """
-
-        # given
-        pipeline = KonfluxOkdPipeline(
-            runtime=self.mock_runtime,
-            image_build_strategy='all',
-            image_list=None,
-            assembly='stream',
-            data_path='https://github.com/openshift-eng/ocp-build-data',
-            data_gitref='',
-            version='4.21',
-            ignore_locks=False,
-            plr_template='',
-            lock_identifier='test-lock',
-            build_priority='10',
-            imagestream_namespace='origin',
-        )
-
-        with patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag:
-            # when
-            await pipeline.mirror_coreos_imagestreams()
-
-            # then
-            mock_tag.assert_not_called()
-
-    async def test_mirror_coreos_imagestreams_skipped_for_4_22(self):
-        """
-        Test that CoreOS mirroring is skipped for version 4.22 (handled by openshift/release).
+        Test that CoreOS mirroring is skipped for versions whose openshift/release CI config
+        promotes stream-coreos directly to the -art namespace.
         """
 
-        # given
-        pipeline = KonfluxOkdPipeline(
-            runtime=self.mock_runtime,
-            image_build_strategy='all',
-            image_list=None,
-            assembly='stream',
-            data_path='https://github.com/openshift-eng/ocp-build-data',
-            data_gitref='',
-            version='4.22',
-            ignore_locks=False,
-            plr_template='',
-            lock_identifier='test-lock',
-            build_priority='10',
-            imagestream_namespace='origin',
-        )
+        for version in ['4.21', '4.22', '5.0']:
+            with self.subTest(version=version):
+                pipeline = KonfluxOkdPipeline(
+                    runtime=self.mock_runtime,
+                    image_build_strategy='all',
+                    image_list=None,
+                    assembly='stream',
+                    data_path='https://github.com/openshift-eng/ocp-build-data',
+                    data_gitref='',
+                    version=version,
+                    ignore_locks=False,
+                    plr_template='',
+                    lock_identifier='test-lock',
+                    build_priority='10',
+                    imagestream_namespace='origin',
+                )
 
-        with patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag:
-            # when
-            await pipeline.mirror_coreos_imagestreams()
+                pipeline.built_images = [
+                    {
+                        'name': 'test-image',
+                        'nvr': 'test-1.0',
+                        'image_pullspec': 'quay.io/test:latest',
+                        'image_tag': 'latest',
+                    }
+                ]
+                with patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag:
+                    await pipeline.mirror_coreos_imagestreams()
+                    mock_tag.assert_not_called()
 
-            # then
-            mock_tag.assert_not_called()
-
-    async def test_mirror_coreos_imagestreams_4_23_uses_4_22_source(self):
+    async def test_mirror_coreos_imagestreams_4_23_uses_5_0_source(self):
         """
-        Test that CoreOS mirroring for version 4.23 uses 4.22 as the source.
+        Test that CoreOS mirroring for version 4.23 uses 5.0 as the source.
         """
 
         # given
@@ -357,59 +336,14 @@ class TestKonfluxOkdPipeline(IsolatedAsyncioTestCase):
             # Should be called twice
             self.assertEqual(mock_tag.call_count, 2)
 
-            # Check that 4.22 is used as source, 4.23 as target
+            # Check that 5.0 is used as source, 4.23 as target
             first_call = mock_tag.call_args_list[0]
-            self.assertEqual(first_call[1]['source_pullspec'], 'origin/scos-4.22:stream-coreos')
+            self.assertEqual(first_call[1]['source_pullspec'], 'origin/scos-5.0:stream-coreos')
             self.assertEqual(first_call[1]['target_tag'], 'origin/scos-4.23-art:stream-coreos')
 
             second_call = mock_tag.call_args_list[1]
-            self.assertEqual(second_call[1]['source_pullspec'], 'origin/scos-4.22:stream-coreos-extensions')
+            self.assertEqual(second_call[1]['source_pullspec'], 'origin/scos-5.0:stream-coreos-extensions')
             self.assertEqual(second_call[1]['target_tag'], 'origin/scos-4.23-art:stream-coreos-extensions')
-
-    async def test_mirror_coreos_imagestreams_5_0_uses_4_22_source(self):
-        """
-        Test that CoreOS mirroring for version 5.0 uses 4.22 as the source.
-        """
-
-        # given
-        pipeline = KonfluxOkdPipeline(
-            runtime=self.mock_runtime,
-            image_build_strategy='all',
-            image_list=None,
-            assembly='stream',
-            data_path='https://github.com/openshift-eng/ocp-build-data',
-            data_gitref='',
-            version='5.0',
-            ignore_locks=False,
-            plr_template='',
-            lock_identifier='test-lock',
-            build_priority='10',
-            imagestream_namespace='origin',
-        )
-        # Simulate successful image builds
-        pipeline.built_images = [
-            {'name': 'test-image', 'nvr': 'test-1.0', 'image_pullspec': 'quay.io/test:latest', 'image_tag': 'latest'}
-        ]
-
-        with (
-            patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag,
-            patch('pyartcd.pipelines.okd.jenkins'),
-        ):
-            # when
-            await pipeline.mirror_coreos_imagestreams()
-
-            # then
-            # Should be called twice
-            self.assertEqual(mock_tag.call_count, 2)
-
-            # Check that 4.22 is used as source, 5.0 as target
-            first_call = mock_tag.call_args_list[0]
-            self.assertEqual(first_call[1]['source_pullspec'], 'origin/scos-4.22:stream-coreos')
-            self.assertEqual(first_call[1]['target_tag'], 'origin/scos-5.0-art:stream-coreos')
-
-            second_call = mock_tag.call_args_list[1]
-            self.assertEqual(second_call[1]['source_pullspec'], 'origin/scos-4.22:stream-coreos-extensions')
-            self.assertEqual(second_call[1]['target_tag'], 'origin/scos-5.0-art:stream-coreos-extensions')
 
 
 class TestGetPayloadTagName(IsolatedAsyncioTestCase):


### PR DESCRIPTION
see https://github.com/openshift/release/blob/main/ci-operator/config/openshift/os/openshift-os-master__okd-scos.yaml#L54-L55

[thread](https://redhat-internal.slack.com/archives/CB95J6R4N/p1786427518087249)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CoreOS image mirroring to run only for version 4.23.
  * Version 4.23 now mirrors both CoreOS image tags from version 5.0.
  * Versions 4.21, 4.22, 5.0, and other versions no longer perform this mirroring.
  * Preserved support for custom namespaces, dry runs, and successful or failed mirroring outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->