### PR TITLE
fix: respect plr_template_commitish in task bundle staleness check

### DIFF
--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -34,7 +34,6 @@ from doozerlib import rhcos, util
 from doozerlib.build_info import KonfluxBuildRecordInspector
 from doozerlib.cli import cli, click_coroutine, pass_runtime
 from doozerlib.cli import release_gen_payload as rgp
-from doozerlib.constants import KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.image import ImageMetadata
 from doozerlib.metadata import Metadata, RebuildHint, RebuildHintCode
@@ -1506,13 +1505,21 @@ class ConfigScanSources:
     @retry(reraise=True, stop=stop_after_attempt(10), wait=wait_fixed(5))
     async def get_current_task_bundle_shas(self) -> Dict[str, str]:
         """
-        Fetch current task bundle SHAs from the art-konflux-template GitHub repository
+        Fetch current task bundle SHAs from the art-konflux-template GitHub repository.
+        Respects the konflux.plr_template_commitish group config override (format: "owner@branch").
         """
-        self.logger.info(f'Fetching task bundle template from {KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL}')
+        plr_template_commitish = self.runtime.group_config.get("konflux", {}).get("plr_template_commitish")
+        if plr_template_commitish:
+            owner, branch = plr_template_commitish.split("@")
+        else:
+            owner = "openshift-priv"
+            branch = "main"
+
+        self.logger.info(f'Fetching task bundle template from {owner}/art-konflux-template ref={branch}')
 
         def _fetch():
-            repo = get_github_client_for_org("openshift-priv").get_repo("openshift-priv/art-konflux-template")
-            content = repo.get_contents(".tekton/art-konflux-template-push.yaml", ref="main")
+            repo = get_github_client_for_org(owner).get_repo(f"{owner}/art-konflux-template")
+            content = repo.get_contents(".tekton/art-konflux-template-push.yaml", ref=branch)
             return content.decoded_content.decode('utf-8')
 
         yaml_content = await asyncio.to_thread(_fetch)

--- a/doozer/tests/cli/test_scan_sources_konflux.py
+++ b/doozer/tests/cli/test_scan_sources_konflux.py
@@ -24,15 +24,16 @@ class TestScanSourcesKonflux(IsolatedAsyncioTestCase):
         self.runtime.image_metas.return_value = []
         self.runtime.rpm_metas.return_value = []
         self.runtime.image_map = {}
+        self.runtime.group_config = {}  # Default: no group-level overrides
         self.session = MagicMock(spec=aiohttp.ClientSession)
         self.ci_kubeconfig = "/tmp/test_kubeconfig"
 
         # Mock get_github_client_for_org (returns client directly; no Github class or GITHUB_TOKEN)
         # Patch must persist for test duration since get_current_task_bundle_shas calls it at runtime
         self._github_patch = patch('doozerlib.cli.scan_sources_konflux.get_github_client_for_org')
-        mock_get_github_client = self._github_patch.start()
+        self.mock_get_github_client_fn = self._github_patch.start()
         self.mock_github_client = MagicMock()
-        mock_get_github_client.return_value = self.mock_github_client
+        self.mock_get_github_client_fn.return_value = self.mock_github_client
         self.scanner = ConfigScanSources(
             runtime=self.runtime,
             ci_kubeconfig=self.ci_kubeconfig,
@@ -559,6 +560,65 @@ class TestGetCurrentTaskBundleShas(TestScanSourcesKonflux):
 
         expected = {"task-nested-task": "nested123", "task-cleanup": "cleanup456"}
         self.assertEqual(result, expected)
+
+    async def test_get_current_task_bundle_shas_with_plr_template_commitish(self):
+        """Test fetching task bundle SHAs from a custom owner/branch via plr_template_commitish."""
+        yaml_content = yaml.dump(self.sample_yaml)
+        mock_content = MagicMock()
+        mock_content.decoded_content = yaml_content.encode('utf-8')
+        self.mock_github_client.get_repo.return_value.get_contents.return_value = mock_content
+
+        self.scanner.runtime.group_config = {"konflux": {"plr_template_commitish": "custom-owner@feature-branch"}}
+
+        result = await self.scanner.get_current_task_bundle_shas()
+
+        expected = {
+            "task-init": "abc123def456",
+            "task-git-clone-oci-ta": "def456ghi789",
+            "task-buildah-remote-oci-ta": "ghi789jkl012",
+        }
+        self.assertEqual(result, expected)
+        self.mock_get_github_client_fn.assert_called_with("custom-owner")
+        self.mock_github_client.get_repo.assert_called_with("custom-owner/art-konflux-template")
+        self.mock_github_client.get_repo.return_value.get_contents.assert_called_with(
+            ".tekton/art-konflux-template-push.yaml", ref="feature-branch"
+        )
+
+    async def test_get_current_task_bundle_shas_without_plr_template_commitish(self):
+        """Test that default owner/branch is used when plr_template_commitish is not set."""
+        yaml_content = yaml.dump(self.sample_yaml)
+        mock_content = MagicMock()
+        mock_content.decoded_content = yaml_content.encode('utf-8')
+        self.mock_github_client.get_repo.return_value.get_contents.return_value = mock_content
+
+        self.scanner.runtime.group_config = {}
+
+        result = await self.scanner.get_current_task_bundle_shas()
+
+        self.assertEqual(len(result), 3)
+        self.mock_get_github_client_fn.assert_called_with("openshift-priv")
+        self.mock_github_client.get_repo.assert_called_with("openshift-priv/art-konflux-template")
+        self.mock_github_client.get_repo.return_value.get_contents.assert_called_with(
+            ".tekton/art-konflux-template-push.yaml", ref="main"
+        )
+
+    async def test_get_current_task_bundle_shas_konflux_config_without_commitish(self):
+        """Test default behavior when konflux config exists but no plr_template_commitish."""
+        yaml_content = yaml.dump(self.sample_yaml)
+        mock_content = MagicMock()
+        mock_content.decoded_content = yaml_content.encode('utf-8')
+        self.mock_github_client.get_repo.return_value.get_contents.return_value = mock_content
+
+        self.scanner.runtime.group_config = {"konflux": {"some_other_key": "value"}}
+
+        result = await self.scanner.get_current_task_bundle_shas()
+
+        self.assertEqual(len(result), 3)
+        self.mock_get_github_client_fn.assert_called_with("openshift-priv")
+        self.mock_github_client.get_repo.assert_called_with("openshift-priv/art-konflux-template")
+        self.mock_github_client.get_repo.return_value.get_contents.assert_called_with(
+            ".tekton/art-konflux-template-push.yaml", ref="main"
+        )
 
 
 class TestTaskBundleIntegration(TestScanSourcesKonflux):


### PR DESCRIPTION
## Summary

- `get_current_task_bundle_shas()` in `scan_sources_konflux.py` was hardcoded to always fetch the PLR template from `openshift-priv/art-konflux-template@main`
- The build system (`konflux_image_builder.py`) already respects the `konflux.plr_template_commitish` field in `group.yml` (format: `owner@branch`) to use a different template source
- This mismatch caused false positive/negative rebuild triggers when `plr_template_commitish` was set — the scan compared task bundle SHAs against the wrong template

## Changes

- `get_current_task_bundle_shas()` now reads `konflux.plr_template_commitish` from `group_config` and fetches from the specified `owner@branch` (defaults to `openshift-priv@main` when unset)
- Removed unused `KONFLUX_DEFAULT_IMAGE_BUILD_PLR_TEMPLATE_URL` import
- Added `self.runtime.group_config = {}` to test base setUp to prevent MagicMock leakage
- Added 3 new tests covering the override path, default path, and partial-config case

## Test plan

- [x] All 56 existing + new tests pass: `uv run pytest doozer/tests/cli/test_scan_sources_konflux.py`

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/56100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Task-bundle retrieval now supports a configurable template repository owner and branch.
  * Added reliable defaults when the template configuration is missing or incomplete.

* **Tests**
  * Added coverage for custom template references.
  * Added coverage confirming default behavior for absent or partial configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->