### PR TITLE
ART-21515: detect RHEL version from image path, not just tag

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -512,12 +512,20 @@ class RpmLockfilePrototypeGenerator:
             int | None: RHEL major version (e.g. 8, 9), or None if
                 not detectable.
         """
-        if ":" not in pullspec:
-            return None
-        tag = pullspec.split("@")[0].split(":")[-1]
-        m = re.search(r"(?:rhel|ubi|centos|scos)-?(\d+)", tag)
+        # Search the full path (before digest) so image names like ubi9/ubi or
+        # rhel8/buildah are matched even when the tag is generic (e.g. "latest")
+        # or absent entirely.
+        path = pullspec.split("@", 1)[0]
+        m = re.search(r"(?:rhel|ubi|centos|scos)-?(\d+)", path)
         if m:
             return int(m.group(1))
+        # Fallback: NVR-style tags embed the version as .el8 / .el9.
+        # Guard here (not at the top) so bare paths without a tag still get
+        # the path-based match above.
+        image_ref = path.rsplit("/", 1)[-1]
+        if ":" not in image_ref:
+            return None
+        tag = image_ref.rsplit(":", 1)[-1]
         m = re.search(r"\.el(\d+)", tag)
         if m:
             return int(m.group(1))

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -997,9 +997,15 @@ class TestExtractRhelVersionFromPullspec(unittest.TestCase):
         ps = "registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25"
         self.assertEqual(RpmLockfilePrototypeGenerator._extract_rhel_version_from_pullspec(ps), 9)
 
-    def test_ubi_9_in_path_not_tag_returns_none(self):
+    def test_ubi_9_in_path_with_generic_tag(self):
+        # ubi9 in image name is enough to detect el9 even with a generic tag like "latest"
         ps = "registry.access.redhat.com/ubi9/ubi-minimal:latest"
-        self.assertIsNone(RpmLockfilePrototypeGenerator._extract_rhel_version_from_pullspec(ps))
+        self.assertEqual(RpmLockfilePrototypeGenerator._extract_rhel_version_from_pullspec(ps), 9)
+
+    def test_ubi_9_digest_only(self):
+        # digest-only with ubi9 in path: ubi9 detected from image name
+        ps = "registry.redhat.io/ubi9/ubi@sha256:d3e61197e0f96aee94872141b429f63eadb939de95a25fe6b504843f427b7a3f"
+        self.assertEqual(RpmLockfilePrototypeGenerator._extract_rhel_version_from_pullspec(ps), 9)
 
     def test_ubi_9_in_tag(self):
         ps = "registry.access.redhat.com/ubi9/ubi-minimal:ubi-9-minimal"
@@ -1019,6 +1025,11 @@ class TestExtractRhelVersionFromPullspec(unittest.TestCase):
 
     def test_no_colon_returns_none(self):
         self.assertIsNone(RpmLockfilePrototypeGenerator._extract_rhel_version_from_pullspec("builder_stage"))
+
+    def test_ubi9_bare_path_no_tag_no_digest(self):
+        # Bare path with no tag or digest: path-based match still works
+        ps = "registry.access.redhat.com/ubi9/ubi"
+        self.assertEqual(RpmLockfilePrototypeGenerator._extract_rhel_version_from_pullspec(ps), 9)
 
     def test_unrecognized_tag_returns_none(self):
         ps = "quay.io/test/builder:latest"


### PR DESCRIPTION
When a builder stage uses a generic tag like "latest" (e.g. ubi9/ubi:latest), _extract_rhel_version_from_pullspec only searched the tag and returned None, causing _has_rhel_version_mismatch to fail-open and allow el8 repos to be used against a UBI9 platform context — crashing DNF module resolution with "nothing provides module(platform:el8)" errors.

Fix: search the full image path (before digest) so image names like ubi9/ubi or rhel8/buildah are matched even when the tag is generic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of RHEL-family versions in image references, including versions specified in image paths and digest-only references.
  * Preserved fallback support for version identifiers included in image tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->