### PR TITLE
fix(rebaser): pass check=False to cmd_gather_async in is_commit_in_public_upstream_async

### DIFF
--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -115,7 +115,7 @@ async def is_commit_in_public_upstream_async(revision: str, public_upstream_bran
     ]
     # The command exits with status 0 if true, or with status 1 if not. Errors are signaled by a non-zero status that is not 1.
     # https://git-scm.com/docs/git-merge-base#Documentation/git-merge-base.txt---is-ancestor
-    rc, out, err = await exectools.cmd_gather_async(cmd)
+    rc, out, err = await exectools.cmd_gather_async(cmd, check=False)
     if rc == 0:
         return True
     if rc == 1:

--- a/doozer/tests/test_util.py
+++ b/doozer/tests/test_util.py
@@ -581,5 +581,28 @@ class TestGetKonfluxBuildPriority(unittest.TestCase):
         self.assertGreaterEqual(int(util.get_konflux_build_priority(metadata, "openshift-4.19")), 1)
 
 
+class TestIsCommitInPublicUpstreamAsync(unittest.IsolatedAsyncioTestCase):
+    @patch("doozerlib.util.exectools.cmd_gather_async")
+    async def test_returns_true_on_exit_0(self, mock_gather):
+        mock_gather.return_value = (0, "", "")
+        result = await util.is_commit_in_public_upstream_async("abc123", "release-4.13", "/some/dir")
+        self.assertTrue(result)
+        mock_gather.assert_called_once_with(unittest.mock.ANY, check=False)
+
+    @patch("doozerlib.util.exectools.cmd_gather_async")
+    async def test_returns_false_on_exit_1(self, mock_gather):
+        # exit code 1 means "not an ancestor" — must NOT raise ChildProcessError
+        mock_gather.return_value = (1, "", "")
+        result = await util.is_commit_in_public_upstream_async("abc123", "release-4.13", "/some/dir")
+        self.assertFalse(result)
+        mock_gather.assert_called_once_with(unittest.mock.ANY, check=False)
+
+    @patch("doozerlib.util.exectools.cmd_gather_async")
+    async def test_raises_on_other_exit_codes(self, mock_gather):
+        mock_gather.return_value = (128, "", "fatal: not a git repo")
+        with self.assertRaises(IOError):
+            await util.is_commit_in_public_upstream_async("abc123", "release-4.13", "/some/dir")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
git merge-base --is-ancestor exits with code 1 to mean "not an ancestor" (not an error), but cmd_gather_async raises ChildProcessError on any non-zero exit when check=True (the default). 

This caused rebase to fail for any image whose commit is not yet in the public upstream branch, e.g. openshift-enterprise-console on release-4.13.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of public-upstream commit checks when commands return nonzero status codes.
  * Preserved accurate results for successful checks, non-ancestor commits, and unexpected command errors.

* **Tests**
  * Added coverage for asynchronous commit-check outcomes and subprocess error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->