### PR TITLE
fix: handle invalid kubeconfig/settings files in Tekton environment

### DIFF
--- a/artcommon/artcommonlib/dotconfig.py
+++ b/artcommon/artcommonlib/dotconfig.py
@@ -92,7 +92,8 @@ class Config(object):
         self._data = defaults
         with open(self.full_path, 'r') as f:
             data = yaml.full_load(f)
-            self._data.update(data)
+            if data:
+                self._data.update(data)
             # load envvars if given and override
             for k, v in envvars.items():
                 if v in os.environ:

--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -509,6 +509,40 @@ class KonfluxClient:
                     self._logger.warning(f"Failed to delete stale Secret {secret.metadata.name}: {e}")
 
     @staticmethod
+    def _reconstruct_kubeconfig_from_flat(flat: str) -> dict:
+        """Reconstruct a kubeconfig dict from a single-line (newline-stripped) string.
+
+        ExternalSecrets can strip newlines from Vault values, producing a flat string that is
+        not valid YAML. Extract key fields via regex and build a minimal kubeconfig dict.
+        """
+        server = re.search(r'server:\s+(\S+)', flat)
+        token = re.search(r'token:\s+(\S+)', flat)
+        ca_data = re.search(r'certificate-authority-data:\s+(\S+)', flat)
+        namespace = re.search(r'namespace:\s+(\S+)', flat)
+        if not server or not token:
+            raise ValueError("Cannot reconstruct kubeconfig: missing server or token field")
+        cluster: dict = {'server': server.group(1)}
+        if ca_data:
+            cluster['certificate-authority-data'] = ca_data.group(1)
+        return {
+            'apiVersion': 'v1',
+            'kind': 'Config',
+            'clusters': [{'cluster': cluster, 'name': 'cluster'}],
+            'contexts': [
+                {
+                    'context': {
+                        'cluster': 'cluster',
+                        'namespace': namespace.group(1) if namespace else 'default',
+                        'user': 'user',
+                    },
+                    'name': 'context',
+                }
+            ],
+            'current-context': 'context',
+            'users': [{'name': 'user', 'user': {'token': token.group(1)}}],
+        }
+
+    @staticmethod
     def from_kubeconfig(
         default_namespace: str,
         config_file: Optional[str],
@@ -526,9 +560,28 @@ class KonfluxClient:
         :return: The KonfluxClient.
         """
         cfg = Configuration()
-        config.load_kube_config(
-            config_file=config_file, context=context, persist_config=False, client_configuration=cfg
-        )
+        temp_file = None
+        try:
+            actual_config_file = config_file
+            if config_file and os.path.exists(config_file):
+                with open(config_file) as f:
+                    content = f.read()
+                try:
+                    yaml.load(content)
+                except Exception:
+                    # File is not valid YAML (e.g., newlines stripped by ExternalSecrets/Vault).
+                    # Reconstruct a proper kubeconfig from the flat string.
+                    kubeconfig = KonfluxClient._reconstruct_kubeconfig_from_flat(content)
+                    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as tmp:
+                        yaml.dump(kubeconfig, tmp)
+                        temp_file = tmp.name
+                    actual_config_file = temp_file
+            config.load_kube_config(
+                config_file=actual_config_file, context=context, persist_config=False, client_configuration=cfg
+            )
+        finally:
+            if temp_file and os.path.exists(temp_file):
+                os.unlink(temp_file)
         return KonfluxClient(default_namespace=default_namespace, config=cfg, dry_run=dry_run, logger=logger or LOGGER)
 
     @alru_cache


### PR DESCRIPTION
## Summary

Two bugs causing the `release-from-fbc` Tekton pipeline to fail for the `logging` product while the same Jenkins pipeline succeeds.

### Bug 1: `DotConfig` crashes on empty/null YAML settings file (`artcommon/artcommonlib/dotconfig.py`)

`yaml.full_load()` returns `None` for an empty or `---`-only YAML file. `dict.update(None)` then raises `TypeError`, crashing `doozer config:read-group product` before it can return the product name (e.g., `openshift-logging`). Jenkins has a populated settings file; the Tekton container has an empty one.

**Fix:** Guard `self._data.update(data)` with `if data:`.

### Bug 2: Single-line kubeconfig from ExternalSecrets (`doozer/doozerlib/backend/konflux_client.py`)

The `konflux-sa-kubeconfigs` Secret in `art-logging-tenant` is managed by an ExternalSecret pulling from Vault. The Vault values have newlines stripped, producing single-line strings that are not valid YAML. `kubernetes.config.load_kube_config()` then fails with `ScannerError`.

In Jenkins, the same secret is created manually with proper multi-line YAML.

**Fix:** In `from_kubeconfig()`, validate the file as YAML first. If invalid, extract key fields (server, token, CA data, namespace) via regex and reconstruct a proper kubeconfig in a temp file. The check is a no-op in Jenkins where the file is already valid.

## Test plan

- [ ] `uv run pytest artcommon/tests/` — all pass
- [ ] Re-trigger the `release-from-fbc` Tekton PipelineRun for `logging-6.5` and confirm both issues are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where loading an empty configuration file could cause an error.
  * Empty configuration files now load successfully using default settings.
  * Improved configuration loading for malformed or compact Kubernetes configuration data.
  * Kubernetes connection details can now be recovered when configuration formatting is invalid, including server, authentication, certificate, and namespace settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->