### PR TITLE
Allow Golang builder component name transitions

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -207,9 +207,12 @@ class KonfluxImageBuilder:
                 target_nvr_dict["version"] = _normalize_version(target_nvr_dict["version"])
                 latest_nvr_dict["version"] = _normalize_version(latest_nvr_dict["version"])
 
-                # Skip package name comparison for test assemblies
+                # Test assemblies and Golang builders can intentionally change component names.
+                # Golang builder metadata moved from versioned component names such as
+                # openshift-golang-builder-1-26-container to the shared
+                # openshift-golang-builder-container component.
                 # compare_nvr returns: 1 if target > latest, 0 if equal, -1 if target < latest
-                ignore_name = metadata.runtime.assembly == "test"
+                ignore_name = metadata.runtime.assembly == "test" or metadata.is_golang_builder()
                 if compare_nvr(target_nvr_dict, latest_nvr_dict, ignore_name=ignore_name) <= 0:
                     raise ValueError(
                         f"Target NVR {nvr} is not greater than the latest successful build {latest_build.nvr}. "

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -134,6 +134,50 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         metadata.get_latest_build.assert_not_awaited()
         start_build.assert_not_awaited()
 
+    async def test_build_ignores_component_name_for_stream_golang_builder(self):
+        metadata = self._metadata()
+        metadata.runtime.assembly = "stream"
+        metadata.is_golang_builder.return_value = True
+        metadata.get_latest_build.return_value = MagicMock(
+            nvr=("openshift-golang-builder-1-26-container-v1.26.5-202608101200.p0.assembly.stream.el8")
+        )
+        dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        class NvrCheckComplete(Exception):
+            pass
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=MagicMock()),
+            ),
+            patch.object(
+                self.builder,
+                "_parse_dockerfile",
+                return_value=(
+                    "test-uuid",
+                    "openshift-golang-builder-container",
+                    "v1.26.5",
+                    "202608111200.p0.assembly.stream.el8",
+                ),
+            ),
+            patch.object(
+                self.builder,
+                "_get_successful_image_build_by_nvr",
+                new=AsyncMock(return_value=None),
+            ),
+            patch.object(
+                self.builder,
+                "_wait_for_parent_members",
+                new=AsyncMock(side_effect=NvrCheckComplete),
+            ),
+        ):
+            with self.assertRaises(NvrCheckComplete):
+                await self.builder.build(metadata)
+
+        metadata.is_golang_builder.assert_called_once_with()
+
     async def test_build_uses_definitive_pullspec_for_attestation_validation(self):
         metadata = self._metadata()
         dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)


### PR DESCRIPTION
## What changed

- Ignore package-name differences in the Konflux NVR ordering check for Golang builder metadata.
- Add a regression test covering a stream build moving from a versioned component name to the shared Golang builder component.

## Why

The unified Golang branch now sets `distgit.component` to `openshift-golang-builder-container`. Existing successful Konflux records for the same logical image can still use a versioned component such as `openshift-golang-builder-1-26-container`.

The build ordering guard rejected that intentional transition before comparing version and release, producing:

```text
ValueError: Package names doesn't match: openshift-golang-builder-container, openshift-golang-builder-1-26-container
```

The exact-NVR lookup remains in place to prevent duplicate builds, and version/release ordering is still enforced.

## Impact

Stream Golang builder builds can cross the intentional component-name transition. Name checking remains unchanged for unrelated stream images.

## Validation

- `ruff check` on the changed implementation and test files
- `ruff format --check` on the changed implementation and test files
- `pytest doozer/tests/backend/test_konflux_image_builder.py` (`52 passed`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build validation for test assemblies and Golang builders by allowing intentional component-name changes while still checking version and release details.
  * Prevented valid builds from being incorrectly rejected during latest-build comparisons.

* **Tests**
  * Added regression coverage for stream-based Golang builder builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->