### PR TITLE
Add rhacm2 product mapping for ACM bundle name label fix

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -90,8 +90,8 @@ GOLANG_NVR_ENV = '__doozer_golang_nvr'
 
 # Product-based mappings for Konflux tenant namespaces and kubeconfigs
 PRODUCT_NAMESPACE_MAP = {
-    "acm": "art-acm-tenant",
     "multicluster-engine": "art-acm-tenant",
+    "rhacm2": "art-acm-tenant",
     "cert-manager": "art-oap-tenant",
     "external-secrets-operator": "art-oap-tenant",
     "installer-ove-ui": "art-installer-agent-tenant",
@@ -117,8 +117,8 @@ PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP = {
     "oadp": ("oadp-images-base-silent", "oadp-images-base"),
     "logging": ("logging-images-base-silent", "logging-images-base"),
     "openshift-logging": ("logging-images-base-silent", "logging-images-base"),
-    "acm": ("acm-images-base-silent", "acm-images-base"),
     "multicluster-engine": ("acm-images-base-silent", "acm-images-base"),
+    "rhacm2": ("acm-images-base-silent", "acm-images-base"),
     "external-secrets-operator": ("oap-eso-images-base-silent", "oap-images-base"),
     "cert-manager": ("oap-cm-images-base-silent", "oap-images-base"),
     "zero-trust-workload-identity-manager": ("oap-zt-images-base-silent", "oap-images-base"),
@@ -130,8 +130,8 @@ PRODUCT_BASE_IMAGE_KONFLUX_EC_RELEASE_MAP = {
 }
 
 PRODUCT_KUBECONFIG_MAP = {
-    "acm": "ACM_KONFLUX_SA_KUBECONFIG",
     "multicluster-engine": "ACM_KONFLUX_SA_KUBECONFIG",
+    "rhacm2": "ACM_KONFLUX_SA_KUBECONFIG",
     "cert-manager": "OAP_KONFLUX_SA_KUBECONFIG",
     "external-secrets-operator": "OAP_KONFLUX_SA_KUBECONFIG",
     "installer-ove-ui": "ASSISTED_INSTALLER_SA_KUBECONFIG",

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -43,7 +43,7 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 
 # Product name mapping for CPE labels
 CPE_PRODUCT_NAME_MAPPING = {
-    'acm': 'acm',
+    'rhacm2': 'acm',
     'multicluster-engine': 'multicluster_engine',
     'rhmtc': 'rhmt',
     'oadp': 'openshift_api_data_protection',

--- a/pyartcd/tests/pipelines/test_gen_assembly_lp.py
+++ b/pyartcd/tests/pipelines/test_gen_assembly_lp.py
@@ -22,7 +22,7 @@ class TestGenAssemblyLPPipeline(unittest.TestCase):
         )
         kwargs.update(overrides)
         pipeline = GenAssemblyLPPipeline(**kwargs)
-        pipeline.product = "acm"
+        pipeline.product = "rhacm2"
         return pipeline
 
     def test_init_requires_fbc_or_basis(self):
@@ -363,7 +363,7 @@ class TestGenAssemblyLPRun(unittest.TestCase):
     @patch.object(GenAssemblyLPPipeline, '_extract_nvrs_from_fbc', new_callable=AsyncMock)
     @patch.object(GenAssemblyLPPipeline, '_load_product_from_group_config', new_callable=AsyncMock)
     def test_run_fresh_assembly(self, mock_load_product, mock_extract, mock_fbc_map, mock_pr):
-        mock_load_product.return_value = "acm"
+        mock_load_product.return_value = "rhacm2"
         mock_extract.return_value = {
             "search-v2-api-container": "search-v2-api-container-2.17.3-1",
             "console-container": "console-container-2.17.3-1",
@@ -384,7 +384,7 @@ class TestGenAssemblyLPRun(unittest.TestCase):
     @patch.object(GenAssemblyLPPipeline, '_resolve_parent_operands', new_callable=AsyncMock)
     @patch.object(GenAssemblyLPPipeline, '_load_product_from_group_config', new_callable=AsyncMock)
     def test_run_inherited_assembly(self, mock_load_product, mock_resolve, mock_pr):
-        mock_load_product.return_value = "acm"
+        mock_load_product.return_value = "rhacm2"
         mock_resolve.return_value = {
             "search-v2-api-container": "search-v2-api-container-2.17.2-1",
             "console-container": "console-container-2.17.2-1",

--- a/pyartcd/tests/pipelines/test_prepare_release_lp.py
+++ b/pyartcd/tests/pipelines/test_prepare_release_lp.py
@@ -452,7 +452,7 @@ class TestPrepareReleaseLPRun(unittest.TestCase):
     def test_run_dry_run(self, mock_product, mock_assembly, mock_bundle, mock_fbc, mock_snapshot, mock_template):
         import tempfile
 
-        mock_product.return_value = "acm"
+        mock_product.return_value = "rhacm2"
         mock_assembly.return_value = {
             'assembly': {
                 'type': 'standard',
@@ -689,7 +689,7 @@ class TestCreateShipmentMrApprovalRules(unittest.TestCase):
             assembly="2.17.3",
             create_mr=True,
         )
-        pipeline.product = "acm"
+        pipeline.product = "rhacm2"
         pipeline.shipment_data_repo = AsyncMock()
         pipeline.shipment_data_repo_push_url = "https://gitlab.example.com/user/ocp-shipment-data.git"
         pipeline.shipment_data_repo_pull_url = "https://gitlab.example.com/org/ocp-shipment-data.git"


### PR DESCRIPTION
## Summary
- Adds `rhacm2` entries to `PRODUCT_NAMESPACE_MAP`, `PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP`, and `PRODUCT_KUBECONFIG_MAP` in `artcommon/artcommonlib/constants.py`
- Adds `rhacm2: acm` to `CPE_PRODUCT_NAME_MAPPING` in `doozer/doozerlib/backend/rebaser.py` so CPE labels remain `cpe:/a:redhat:acm:...`
- Updates test fixtures from `acm` to `rhacm2` to match the new product value

## Context
The ACM `group.yml` (`product` field) is being changed from `acm` to `rhacm2` so that OLM bundle `name` labels produce `rhacm2/{bundle_short_name}` instead of `acm/{bundle_short_name}`. This fixes a Konflux `LabelValidationError` where the bundle name label did not match the expected delivery repo namespace.

Companion PR in ocp-build-data will change `product: acm` to `product: rhacm2` in the acm-2.16 group.yml.

## Test plan
- [ ] Verify `make unit` passes with the new product value
- [ ] Confirm bundle builds produce `rhacm2/...` name labels after ocp-build-data companion merges


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `rhacm2` product across namespace, image-release, kubeconfig, and CPE product mappings.
  * Assembly and release preparation workflows now recognize `rhacm2` as an ACM product.

* **Tests**
  * Updated pipeline test scenarios and expectations to validate `rhacm2` product handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->