### PR TITLE
ART-21515: restore upgrade-over-reinstall for base image packages

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -387,14 +387,21 @@ class RpmLockfilePrototypeGenerator:
             extra_packages: list[str] = list(cat_packages.get(stage_num, []))
 
             reinstall_pkgs: list[str] | None = None
+            upgrade_pkgs: list[str] | None = None
             if stage_num == final_stage_num:
                 if image_pullspec:
                     base_pkgs = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key)
                     if base_pkgs:
-                        reinstall_pkgs = list(base_pkgs)
+                        # Use upgrade semantics for base image packages so repos
+                        # can provide newer versions. reinstallPackages pins to the
+                        # installed EVR and overrides DNF's upgrade intent for the
+                        # same package — e.g. python3-setuptools 53.0.0 from e4s
+                        # would silently win over 67.6.1 in the ironic plashet even
+                        # when the Containerfile explicitly installs a newer version.
+                        upgrade_pkgs = list(base_pkgs)
                         self.logger.info(
-                            f"{distgit_key}: stage {stage_num}: {len(reinstall_pkgs)} base image "
-                            "packages will be reinstalled into lockfile"
+                            f"{distgit_key}: stage {stage_num}: {len(upgrade_pkgs)} base image "
+                            "packages added as upgrade targets into lockfile"
                         )
                 else:
                     base_pkgs = await self._get_base_image_packages(stage_num, None, distgit_key)
@@ -403,7 +410,6 @@ class RpmLockfilePrototypeGenerator:
                         if extra:
                             extra_packages = extra_packages + extra
 
-            upgrade_pkgs: list[str] | None = None
             if stage_num in stages_with_bare_updates:
                 if not image_pullspec:
                     # No base image to query (stage alias) — can't determine
@@ -413,27 +419,17 @@ class RpmLockfilePrototypeGenerator:
                         f"{distgit_key}: stage {stage_num}: bare update detected but no "
                         "base image available, marking upgrades as dropped"
                     )
-                else:
-                    if reinstall_pkgs:
-                        upgrade_pkgs = list(reinstall_pkgs)
-                    else:
-                        bare_update_base = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key)
-                        if bare_update_base:
-                            upgrade_pkgs = list(bare_update_base)
-                    if upgrade_pkgs:
-                        # Reinstall pins the installed EVR which wins over an
-                        # upgrade request for the same package, silently keeping
-                        # old versions. This prevents the upgrade resolution from
-                        # failing on dep conflicts (e.g. glibc vs
-                        # glibc-minimal-langpack), which in turn prevents
-                        # upgrades_dropped from being set and the bare update
-                        # from being stripped.
-                        reinstall_pkgs = None
-                        self.logger.info(
-                            f"{distgit_key}: stage {stage_num}: {len(upgrade_pkgs)} base image "
-                            "packages added as upgrade targets for bare update "
-                            "(reinstall disabled to avoid pinning installed EVRs)"
-                        )
+                elif stage_num != final_stage_num and not upgrade_pkgs:
+                    # Final stage already populated upgrade_pkgs from base image;
+                    # only query again for non-final stages with bare updates.
+                    bare_update_base = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key)
+                    if bare_update_base:
+                        upgrade_pkgs = list(bare_update_base)
+                if upgrade_pkgs and stage_num in stages_with_bare_updates:
+                    self.logger.info(
+                        f"{distgit_key}: stage {stage_num}: {len(upgrade_pkgs)} base image "
+                        "packages added as upgrade targets for bare update"
+                    )
 
             result = await self._resolve_with_reconciliation(
                 repo_list,

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -1449,3 +1449,45 @@ class TestBareUpdateUpgradeResolution(unittest.TestCase):
             asyncio.run(generator.generate_lockfile(self._make_mock_image_meta(), dest_dir))
 
         self.assertTrue(generator.upgrades_dropped)
+
+    def test_base_image_package_uses_upgrade_not_reinstall(self):
+        """
+        Base image packages must go to upgradePackages, NOT reinstallPackages.
+
+        reinstallPackages pins to the installed EVR and overrides DNF's upgrade
+        intent — e.g. python3-setuptools 53.0.0 from e4s wins over 67.6.1 in
+        the ironic plashet, causing prepare-image.sh's >= 64.0.0 requirement to
+        fail at build time.
+
+        Regression: ART-21309 rewrite (612950052) lost the fix from ART-21515
+        (055086c65 / PR #3126) that kept base image packages out of reinstall.
+        """
+        container = MagicMock(spec=ContainerImageHelper)
+        container.resolve_to_digest = AsyncMock(side_effect=lambda p: p + "@sha256:abc123")
+        container.get_installed_packages = AsyncMock(return_value=["glibc", "python3-setuptools"])
+        container.read_file_from_image = AsyncMock(return_value="")
+
+        resolver = MagicMock(spec=RpmResolver)
+        resolver.resolve = AsyncMock(return_value=FAKE_LOCKFILE_DATA.model_copy(deep=True))
+
+        generator = RpmLockfilePrototypeGenerator(
+            repos=self._make_mock_repos(),
+            working_dir=Path(tempfile.mkdtemp()),
+            container_helper=container,
+            resolver=resolver,
+        )
+        generator.downstream_parents = ["quay.io/test/base:latest"]
+
+        with TemporaryDirectory() as tmpdir:
+            dest_dir = Path(tmpdir)
+            (dest_dir / "Dockerfile").write_text("FROM base\nRUN dnf install -y python3-setuptools gcc\n")
+            asyncio.run(generator.generate_lockfile(self._make_mock_image_meta(), dest_dir))
+
+        calls = resolver.resolve.call_args_list
+        self.assertGreaterEqual(len(calls), 1)
+        config = calls[0].args[0]
+        # Base image packages must go to upgradePackages so repos can provide
+        # newer versions. reinstallPackages pins to the installed EVR and wins
+        # over the upgrade request, silently keeping the old version.
+        self.assertNotIn("python3-setuptools", config.reinstallPackages)
+        self.assertIn("python3-setuptools", config.upgradePackages)


### PR DESCRIPTION
[ART-21309](https://redhat.atlassian.net/browse/ART-21309) rewrite (612950052) lost the fix from PR #3126 (055086c65) that kept base image packages out of reinstallPackages. Reinstalling pins to the installed EVR and overrides DNF's upgrade intent — e.g. python3-setuptools 53.0.0 from the e4s baseos repo silently wins over 67.6.1 in the ironic plashet, causing prepare-image.sh's >= 64.0.0 requirement to fail at build time.

Pass base image packages as upgradePackages instead of reinstallPackages for the final stage so repos can provide newer versions. Also collapses the duplicate bare-update branch (final stage already populates upgrade_pkgs) to avoid a redundant _get_base_image_packages call.

Adds a regression test that fails with the old reinstall behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved final-stage package updates so newer repository versions can replace packages inherited from the base image.
  * Ensured bare updates consistently use the correct package targets across build stages.

* **Tests**
  * Added regression coverage for selecting newer repository versions over installed base-image packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->