### PR TITLE
ART-21983: Sign all golang RPMs with internal key regardless of source

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -640,27 +640,24 @@ class UpdateGolangPipeline:
             await self._slack_client.say_in_thread(f"Tagged {build} with {build_tag} tag")
 
     async def ensure_signed(self, el_v, nvr):
+        if not self.is_production_assembly:
+            _LOGGER.info("Skipping signing for non-stream assembly %s", self.assembly)
+            return
+
         parsed = parse_nvr(nvr)
-        go_version = parsed['version']
         if self.is_rpm_signed(parsed):
             _LOGGER.info(f"{nvr} is already signed")
             return
 
-        if self.should_sign_golang_rpm(el_v, go_version):
-            signing_tag = f'rhaos-{self.ocp_version}-rhel-{el_v}-golang'
-            self.brew_login()
-            if self.dry_run:
-                _LOGGER.info(f"[DRY RUN] Would have tagged {nvr} into {signing_tag} for auto-signing")
-            else:
-                self.koji_session.tagBuild(signing_tag, nvr)
-                _LOGGER.info(f"Tagged {nvr} into {signing_tag} for auto-signing")
-                await self._slack_client.say_in_thread(f"Tagged {nvr} into {signing_tag} for auto-signing")
-                # Polling for the signed RPM to appear in brewroot is handled by the plashet build
+        signing_tag = f'rhaos-{self.ocp_version}-rhel-{el_v}-golang'
+        self.brew_login()
+        if self.dry_run:
+            _LOGGER.info(f"[DRY RUN] Would have tagged {nvr} into {signing_tag} for auto-signing")
         else:
-            raise ValueError(
-                f"{nvr} is not signed. RHEL-supported golang RPMs must be signed through the RHEL process. "
-                f"Wait for the RPM to be signed before running this pipeline."
-            )
+            self.koji_session.tagBuild(signing_tag, nvr)
+            _LOGGER.info(f"Tagged {nvr} into {signing_tag} for auto-signing")
+            await self._slack_client.say_in_thread(f"Tagged {nvr} into {signing_tag} for auto-signing")
+            # Polling for the signed RPM to appear in brewroot is handled by the plashet build
 
     @staticmethod
     def is_rpm_signed(parsed_nvr):
@@ -670,25 +667,6 @@ class UpdateGolangPipeline:
             if (build_path / 'data' / 'signed' / key).exists():
                 return True
         return False
-
-    def should_sign_golang_rpm(self, el_v, go_version) -> bool:
-        """Check sign_golang_rpm config for a specific golang version.
-        Reads the per-image metadata (e.g. images/openshift-golang-builder-1-22.rhel9.yml)
-        since multiple golang versions share the same group.yml in the monobranch.
-        If not set in image config, falls back to group.yml.
-        Defaults to False so that RHEL-shipped golang is never accidentally signed by us.
-        """
-        default_branch = self.GOLANG_DATA_BRANCH
-        repo, branch = self._get_ocp_build_data_repo_and_branch(default_branch)
-        image_key = self.get_golang_image_key(el_v, go_version)
-        content = repo.get_contents(f"images/{image_key}.yml", ref=branch)
-        image_config = yaml.load(content.decoded_content)
-        if image_config.get('sign_golang_rpm') is not None:
-            return image_config.get('sign_golang_rpm', False)
-        # Fall back to group.yml
-        content = repo.get_contents("group.yml", ref=branch)
-        group_config = yaml.load(content.decoded_content)
-        return group_config.get('sign_golang_rpm', False)
 
     async def _build_golang_plashets(self, go_version, el_versions):
         go_v = ".".join(go_version.split(".")[:2])

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -2208,105 +2208,6 @@ repos:
         self.assertEqual(mock_cmd_assert.call_count, 2)
 
 
-class TestShouldSignGolangRpm(unittest.TestCase):
-    """Test the should_sign_golang_rpm method"""
-
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
-    def test_monobranch_image_override_takes_precedence(self, mock_get_github_client, mock_konflux_db):
-        """Image config sign_golang_rpm=true overrides group.yml default"""
-        mock_repo = Mock()
-        mock_repo.get_contents.return_value = Mock(decoded_content=b"sign_golang_rpm: true\n")
-        mock_get_github_client.return_value.get_repo.return_value = mock_repo
-
-        pipeline = UpdateGolangPipeline(
-            runtime=Mock(dry_run=False, working_dir=Path("/tmp/working")),
-            ocp_version="4.18",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.22.9-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-        )
-
-        result = pipeline.should_sign_golang_rpm(9, "1.22.9")
-
-        self.assertTrue(result)
-        mock_repo.get_contents.assert_called_once_with("images/openshift-golang-builder-1-22.rhel9.yml", ref="golang")
-
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
-    def test_monobranch_falls_back_to_group_yml(self, mock_get_github_client, mock_konflux_db):
-        """When image config has no sign_golang_rpm, falls back to group.yml"""
-        mock_repo = Mock()
-        image_content = Mock(decoded_content=b"name: openshift-golang-builder\n")
-        group_content = Mock(decoded_content=b"sign_golang_rpm: true\n")
-        mock_repo.get_contents.side_effect = [image_content, group_content]
-        mock_get_github_client.return_value.get_repo.return_value = mock_repo
-
-        pipeline = UpdateGolangPipeline(
-            runtime=Mock(dry_run=False, working_dir=Path("/tmp/working")),
-            ocp_version="4.18",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.22.9-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-        )
-
-        result = pipeline.should_sign_golang_rpm(9, "1.22.9")
-
-        self.assertTrue(result)
-        self.assertEqual(mock_repo.get_contents.call_count, 2)
-        mock_repo.get_contents.assert_any_call("images/openshift-golang-builder-1-22.rhel9.yml", ref="golang")
-        mock_repo.get_contents.assert_any_call("group.yml", ref="golang")
-
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
-    def test_monobranch_defaults_false_when_neither_set(self, mock_get_github_client, mock_konflux_db):
-        """When neither image config nor group.yml has sign_golang_rpm, defaults to False"""
-        mock_repo = Mock()
-        image_content = Mock(decoded_content=b"name: openshift-golang-builder\n")
-        group_content = Mock(decoded_content=b"name: golang\n")
-        mock_repo.get_contents.side_effect = [image_content, group_content]
-        mock_get_github_client.return_value.get_repo.return_value = mock_repo
-
-        pipeline = UpdateGolangPipeline(
-            runtime=Mock(dry_run=False, working_dir=Path("/tmp/working")),
-            ocp_version="4.22",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.25.3-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-        )
-
-        result = pipeline.should_sign_golang_rpm(9, "1.25.3")
-
-        self.assertFalse(result)
-
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
-    def test_returns_false_when_explicitly_false(self, mock_get_github_client, mock_konflux_db):
-        mock_repo = Mock()
-        mock_repo.get_contents.return_value = Mock(decoded_content=b"sign_golang_rpm: false\n")
-        mock_get_github_client.return_value.get_repo.return_value = mock_repo
-
-        pipeline = UpdateGolangPipeline(
-            runtime=Mock(dry_run=False, working_dir=Path("/tmp/working")),
-            ocp_version="4.22",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.25.3-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-        )
-
-        result = pipeline.should_sign_golang_rpm(9, "1.25.3")
-
-        self.assertFalse(result)
-
-
 class TestEnsureSigned(IsolatedAsyncioTestCase):
     """Test the ensure_signed method"""
 
@@ -2322,11 +2223,11 @@ class TestEnsureSigned(IsolatedAsyncioTestCase):
             tag_builds=True,
         )
         pipeline.is_rpm_signed = Mock(return_value=True)
-        pipeline.should_sign_golang_rpm = Mock()
+        pipeline.koji_session = Mock(logged_in=True)
 
         await pipeline.ensure_signed(9, "golang-1.22.9-1.el9")
 
-        pipeline.should_sign_golang_rpm.assert_not_called()
+        pipeline.koji_session.tagBuild.assert_not_called()
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     async def test_unsigned_sustaining_tags_for_signing(self, mock_konflux_db):
@@ -2345,7 +2246,6 @@ class TestEnsureSigned(IsolatedAsyncioTestCase):
             tag_builds=True,
         )
         pipeline.is_rpm_signed = Mock(return_value=False)
-        pipeline.should_sign_golang_rpm = Mock(return_value=True)
         pipeline.koji_session = Mock(logged_in=True)
 
         await pipeline.ensure_signed(9, "golang-1.22.9-1.el9")
@@ -2369,7 +2269,6 @@ class TestEnsureSigned(IsolatedAsyncioTestCase):
             tag_builds=True,
         )
         pipeline.is_rpm_signed = Mock(return_value=False)
-        pipeline.should_sign_golang_rpm = Mock(return_value=True)
         pipeline.koji_session = Mock(logged_in=True)
 
         await pipeline.ensure_signed(9, "golang-1.22.9-1.el9")
@@ -2377,9 +2276,14 @@ class TestEnsureSigned(IsolatedAsyncioTestCase):
         pipeline.koji_session.tagBuild.assert_not_called()
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_unsigned_rhel_golang_raises(self, mock_konflux_db):
+    async def test_unsigned_rhel_golang_tags_for_signing(self, mock_konflux_db):
+        mock_slack = Mock()
+        mock_slack.say_in_thread = AsyncMock()
+        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = mock_slack
+
         pipeline = UpdateGolangPipeline(
-            runtime=Mock(dry_run=False, working_dir=Path("/tmp/working")),
+            runtime=mock_runtime,
             ocp_version="4.22",
             cves=None,
             force_update_tracker=False,
@@ -2388,10 +2292,32 @@ class TestEnsureSigned(IsolatedAsyncioTestCase):
             tag_builds=True,
         )
         pipeline.is_rpm_signed = Mock(return_value=False)
-        pipeline.should_sign_golang_rpm = Mock(return_value=False)
+        pipeline.koji_session = Mock(logged_in=True)
 
-        with self.assertRaisesRegex(ValueError, "not signed.*RHEL"):
-            await pipeline.ensure_signed(9, "golang-1.25.3-1.el9")
+        await pipeline.ensure_signed(9, "golang-1.25.3-1.el9")
+
+        pipeline.koji_session.tagBuild.assert_called_once_with("rhaos-4.22-rhel-9-golang", "golang-1.25.3-1.el9")
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_non_stream_assembly_skips_signing(self, mock_konflux_db):
+        pipeline = UpdateGolangPipeline(
+            runtime=Mock(dry_run=False, working_dir=Path("/tmp/working")),
+            ocp_version="4.22",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.25.3-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            build_system="konflux",
+            assembly="test",
+        )
+        pipeline.is_rpm_signed = Mock()
+        pipeline.koji_session = Mock(logged_in=True)
+
+        await pipeline.ensure_signed(9, "golang-1.25.3-1.el9")
+
+        pipeline.is_rpm_signed.assert_not_called()
+        pipeline.koji_session.tagBuild.assert_not_called()
 
 
 class TestIsRpmSigned(unittest.TestCase):


### PR DESCRIPTION
Brew stores signatures separately from RPM content, so signing an RPM with an internal key does not prevent errata tool from later signing it with the gold key (confirmed in [Slack thread](https://redhat-internal.slack.com/archives/C03CFJBGRTK/p1786370638970439)).

It is therefore safe to sign RHEL-shipped golang RPMs the same way we sign OCP-sustaining-built ones, simplifying the logic.

## Changes
- Removes `should_sign_golang_rpm()` method and the `sign_golang_rpm` config option check from `ensure_signed()`
- `ensure_signed()` now always tags the RPM into the signing tag if not already signed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unsigned Golang RPMs from stream assemblies are now consistently tagged for automatic signing.
  * Eligible sustaining and RHEL Golang builds are included in the signing workflow.
  * Non-stream assemblies skip signing-related checks and tagging.
  * Already-signed RPMs remain unchanged and are not retagged.
  * Dry-run operations no longer apply signing tags.
  * RPMs are no longer blocked by per-version signing configuration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->