### PR TITLE
[ART-21625] Add 'until' expiry field for assembly overrides

### DIFF
--- a/artcommon/artcommonlib/assembly.py
+++ b/artcommon/artcommonlib/assembly.py
@@ -1,7 +1,7 @@
 import copy
 import difflib
 import typing
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from enum import Enum
 
 from artcommonlib.model import ListModel, Missing, Model
@@ -232,6 +232,31 @@ def _merger(a, b):
     raise TypeError(f'Unexpected value type: {type(a)}: {a}')
 
 
+def _check_until_date(until_str: str, context: str) -> typing.Optional[str]:
+    """
+    Check whether an 'until' expiry date has passed.
+
+    Arg(s):
+        until_str (str): ISO 8601 date string (YYYY-MM-DD) from an 'until' field.
+        context (str): Human-readable description of the override (for error messages).
+    Return Value(s):
+        str | None: Error message if expired, None if still valid.
+    """
+    try:
+        until_date = date.fromisoformat(until_str)
+    except ValueError:
+        raise ValueError(f"Invalid 'until' date format in {context}: {until_str!r}. Expected YYYY-MM-DD.")
+    today = date.today()
+    if until_date < today:
+        days_overdue = (today - until_date).days
+        return (
+            f"Assembly override has expired: {context} had 'until: {until_str}' "
+            f"but today is {today.isoformat()} ({days_overdue} day(s) overdue). "
+            f"Remove or extend this override."
+        )
+    return None
+
+
 def assembly_permits(releases_config: Model, group_config: Model, assembly: typing.Optional[str]) -> ListModel:
     """
     :param releases_config: The content of releases.yml in Model form.
@@ -261,6 +286,12 @@ def assembly_permits(releases_config: Model, group_config: Model, assembly: typi
                 f'and permitting conflicts causes RPM advisories to claim newer versions than '
                 f'what actually shipped in RHCOS.'
             )
+        if permit.until is not Missing and permit.until:
+            msg = _check_until_date(
+                str(permit.until), f"permit(code={permit.code}, component={permit.component}) in assembly '{assembly}'"
+            )
+            if msg:
+                raise ValueError(msg)
     return defined_permits
 
 
@@ -605,3 +636,54 @@ def assembly_validate_member_distgit_keys(
                 f"Assembly '{assembly}' references {meta_type} member '{dgk}' "
                 f"which does not match any known {meta_type} definition in the group.{suggestion}"
             )
+
+
+def check_assembly_overrides_expiry(releases_config: Model, assembly: typing.Optional[str]) -> typing.List[str]:
+    """
+    Check whether any member overrides have passed their 'until' expiry date.
+    Covers members.images[].until and members.rpms[].until.
+    Permit expiry is checked separately by assembly_permits().
+
+    Arg(s):
+        releases_config (Model): The content of releases.yml in Model form.
+        assembly (str | None): The name of the assembly to check.
+    Return Value(s):
+        list[str]: Human-readable error messages for every expired override.
+                   Empty list means all overrides are still valid (or have no 'until').
+    """
+    if not assembly or not isinstance(releases_config, Model):
+        return []
+
+    errors: typing.List[str] = []
+    _check_members_expiry(releases_config, assembly, 'image', errors)
+    _check_members_expiry(releases_config, assembly, 'rpm', errors)
+    return errors
+
+
+def _check_members_expiry(
+    releases_config: Model,
+    assembly: str,
+    meta_type: str,
+    errors: typing.List[str],
+) -> None:
+    """
+    Accumulate expiry errors for members.images[] or members.rpms[].
+
+    Arg(s):
+        releases_config (Model): The content of releases.yml in Model form.
+        assembly (str): The name of the assembly to check.
+        meta_type (str): 'image' or 'rpm'.
+        errors (list[str]): List to append error messages to.
+    """
+    component_list = assembly_config_struct(releases_config, assembly, 'members', {})
+    entries = component_list[f'{meta_type}s']
+    if entries is Missing:
+        return
+    for entry in entries:
+        if entry.until is not Missing and entry.until:
+            msg = _check_until_date(
+                str(entry.until),
+                f"member {meta_type} override(distgit_key={entry.distgit_key}) in assembly '{assembly}'",
+            )
+            if msg:
+                errors.append(msg)

--- a/artcommon/tests/test_assembly.py
+++ b/artcommon/tests/test_assembly.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from unittest import TestCase
 
 import yaml
@@ -15,6 +15,7 @@ from artcommonlib.assembly import (
     assembly_rhcos_config,
     assembly_targeted_fixes_only,
     assembly_validate_member_distgit_keys,
+    check_assembly_overrides_expiry,
 )
 from artcommonlib.model import Missing, Model
 
@@ -1120,3 +1121,217 @@ releases:
         releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
         with self.assertRaises(ValueError):
             assembly_validate_member_distgit_keys(releases_config, 'loop_assembly', 'image', {'some-image'})
+
+
+class TestAssemblyOverridesExpiry(TestCase):
+    """Tests for the 'until' expiry field on assembly overrides."""
+
+    def _group_config(self):
+        return Model(dict_to_model={'software_lifecycle': {'phase': 'release'}})
+
+    def test_permit_until_not_expired(self):
+        """Permit with future 'until' date should not raise."""
+        future = (date.today() + timedelta(days=30)).isoformat()
+        releases_yml = f"""
+releases:
+  test:
+    assembly:
+      permits:
+        - code: MISMATCHED_SIBLINGS
+          component: '*'
+          until: "{future}"
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        permits = assembly_permits(releases_config, self._group_config(), "test")
+        self.assertEqual(len(permits), 1)
+
+    def test_permit_until_expired(self):
+        """Permit with past 'until' date should raise ValueError."""
+        past = (date.today() - timedelta(days=5)).isoformat()
+        releases_yml = f"""
+releases:
+  test:
+    assembly:
+      permits:
+        - code: MISMATCHED_SIBLINGS
+          component: '*'
+          until: "{past}"
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        with self.assertRaises(ValueError) as cm:
+            assembly_permits(releases_config, self._group_config(), "test")
+        self.assertIn("expired", str(cm.exception))
+        self.assertIn("MISMATCHED_SIBLINGS", str(cm.exception))
+        self.assertIn("5 day(s) overdue", str(cm.exception))
+
+    def test_permit_until_invalid_format(self):
+        """Permit with non-date 'until' should raise ValueError."""
+        releases_yml = """
+releases:
+  test:
+    assembly:
+      permits:
+        - code: MISMATCHED_SIBLINGS
+          component: '*'
+          until: "not-a-date"
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        with self.assertRaises(ValueError) as cm:
+            assembly_permits(releases_config, self._group_config(), "test")
+        self.assertIn("Invalid 'until' date format", str(cm.exception))
+
+    def test_permit_without_until_still_works(self):
+        """Permits without 'until' should work as before."""
+        releases_yml = """
+releases:
+  test:
+    assembly:
+      permits:
+        - code: MISMATCHED_SIBLINGS
+          component: '*'
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        permits = assembly_permits(releases_config, self._group_config(), "test")
+        self.assertEqual(len(permits), 1)
+
+    def test_member_image_until_expired(self):
+        """Member image override with past 'until' should be reported."""
+        past = (date.today() - timedelta(days=10)).isoformat()
+        releases_yml = f"""
+releases:
+  test:
+    assembly:
+      members:
+        images:
+          - distgit_key: ose-network-operator
+            why: "Pin for testing"
+            until: "{past}"
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        errors = check_assembly_overrides_expiry(releases_config, "test")
+        self.assertEqual(len(errors), 1)
+        self.assertIn("ose-network-operator", errors[0])
+        self.assertIn("expired", errors[0])
+
+    def test_member_rpm_until_expired(self):
+        """Member RPM override with past 'until' should be reported."""
+        past = (date.today() - timedelta(days=3)).isoformat()
+        releases_yml = f"""
+releases:
+  test:
+    assembly:
+      members:
+        rpms:
+          - distgit_key: my-rpm
+            why: "Pin NVR"
+            until: "{past}"
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        errors = check_assembly_overrides_expiry(releases_config, "test")
+        self.assertEqual(len(errors), 1)
+        self.assertIn("my-rpm", errors[0])
+
+    def test_member_until_not_expired(self):
+        """Member override with future 'until' should not be reported."""
+        future = (date.today() + timedelta(days=30)).isoformat()
+        releases_yml = f"""
+releases:
+  test:
+    assembly:
+      members:
+        images:
+          - distgit_key: ose-network-operator
+            why: "Pin for testing"
+            until: "{future}"
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        errors = check_assembly_overrides_expiry(releases_config, "test")
+        self.assertEqual(len(errors), 0)
+
+    def test_no_until_no_error(self):
+        """Overrides without 'until' should produce no errors."""
+        releases_yml = """
+releases:
+  test:
+    assembly:
+      members:
+        images:
+          - distgit_key: ose-network-operator
+            why: "Pin for testing"
+      permits:
+        - code: MISMATCHED_SIBLINGS
+          component: '*'
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        errors = check_assembly_overrides_expiry(releases_config, "test")
+        self.assertEqual(len(errors), 0)
+        permits = assembly_permits(releases_config, self._group_config(), "test")
+        self.assertEqual(len(permits), 1)
+
+    def test_inherited_member_until_expired(self):
+        """Expired 'until' on a member override in a parent assembly should be caught."""
+        past = (date.today() - timedelta(days=7)).isoformat()
+        releases_yml = f"""
+releases:
+  parent:
+    assembly:
+      members:
+        images:
+          - distgit_key: inherited-image
+            why: "Temporary pin"
+            until: "{past}"
+  child:
+    assembly:
+      basis:
+        assembly: parent
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        errors = check_assembly_overrides_expiry(releases_config, "child")
+        self.assertEqual(len(errors), 1)
+        self.assertIn("inherited-image", errors[0])
+
+    def test_none_assembly_returns_empty(self):
+        """None assembly should return empty list."""
+        releases_config = Model(dict_to_model={})
+        errors = check_assembly_overrides_expiry(releases_config, None)
+        self.assertEqual(len(errors), 0)
+
+    def test_multiple_expired_overrides(self):
+        """Multiple expired overrides should all be reported."""
+        past = (date.today() - timedelta(days=1)).isoformat()
+        releases_yml = f"""
+releases:
+  test:
+    assembly:
+      members:
+        images:
+          - distgit_key: image-a
+            why: "Pin A"
+            until: "{past}"
+          - distgit_key: image-b
+            why: "Pin B"
+            until: "{past}"
+        rpms:
+          - distgit_key: rpm-c
+            why: "Pin C"
+            until: "{past}"
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        errors = check_assembly_overrides_expiry(releases_config, "test")
+        self.assertEqual(len(errors), 3)
+
+    def test_permit_until_today_not_expired(self):
+        """Permit with 'until' set to today should not be expired (expires after today)."""
+        today = date.today().isoformat()
+        releases_yml = f"""
+releases:
+  test:
+    assembly:
+      permits:
+        - code: MISMATCHED_SIBLINGS
+          component: '*'
+          until: "{today}"
+"""
+        releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+        permits = assembly_permits(releases_config, self._group_config(), "test")
+        self.assertEqual(len(permits), 1)

--- a/doozer/doozerlib/assembly_inspector.py
+++ b/doozer/doozerlib/assembly_inspector.py
@@ -9,6 +9,7 @@ from artcommonlib.assembly import (
     assembly_permits,
     assembly_rhcos_config,
     assembly_type,
+    check_assembly_overrides_expiry,
 )
 from artcommonlib.konflux.package_rpm_finder import PackageRpmFinder
 from artcommonlib.rhcos import RhcosMissingContainerException, get_container_configs
@@ -44,6 +45,12 @@ class AssemblyInspector:
             str, Dict[str, Optional[Dict]]
         ] = {}  # Dict[tag] -> Dict[distgit_key] -> Optional[BuildDict]
         self._permits = assembly_permits(self.runtime.releases_config, self.runtime.group_config, self.runtime.assembly)
+        expiry_errors = check_assembly_overrides_expiry(self.runtime.releases_config, self.runtime.assembly)
+        if expiry_errors:
+            raise ValueError(
+                "Assembly override(s) have expired and must be cleaned up:\n"
+                + "\n".join(f"  - {e}" for e in expiry_errors)
+            )
         self._rpm_deliveries: Dict[str, List[RPMDelivery]] = {}  # Dict[package_name] => list of RpmDelivery configs
         self._release_build_record_inspectors: Dict[str, Optional[BuildRecordInspector]] = dict()
 

--- a/ocp-build-data-validator/validator/json_schemas/member_image.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/member_image.schema.json
@@ -19,6 +19,11 @@
     "metadata": {
       "description": "Image configuration",
       "$ref": "image_config.base.schema.json"
+    },
+    "until": {
+      "description": "ISO 8601 date (YYYY-MM-DD) after which this member override expires. Builds will fail if today is past this date.",
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
     }
   },
   "required": [

--- a/ocp-build-data-validator/validator/json_schemas/member_rpm.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/member_rpm.schema.json
@@ -16,6 +16,11 @@
             "description": "If true, exclude this component from the assembly.",
             "const": true
         },
+        "until": {
+            "description": "ISO 8601 date (YYYY-MM-DD) after which this member override expires. Builds will fail if today is past this date.",
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        },
         "metadata": {
             "type": "object",
             "properties": {

--- a/ocp-build-data-validator/validator/json_schemas/permits.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/permits.schema.json
@@ -13,6 +13,11 @@
         "description": "Name of the component that this permit applies to. Use '*' to permit all components.",
         "type": "string",
         "minLength": 1
+      },
+      "until": {
+        "description": "ISO 8601 date (YYYY-MM-DD) after which this permit expires. Builds will fail if today is past this date.",
+        "type": "string",
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
       }
     },
     "additionalProperties": false,

--- a/ocp-build-data-validator/validator/schema/releases_schema.py
+++ b/ocp-build-data-validator/validator/schema/releases_schema.py
@@ -1,10 +1,6 @@
 import json
 import sys
 
-from jsonschema import RefResolver, ValidationError
-from jsonschema.validators import validator_for
-from schema import SchemaError
-
 if sys.version_info < (3, 9):
     # importlib.resources either doesn't exist or lacks the files()
     # function, so use the PyPI version:
@@ -12,6 +8,12 @@ if sys.version_info < (3, 9):
 else:
     # importlib.resources has files(), so use that:
     import importlib.resources as importlib_resources
+
+from artcommonlib.assembly import assembly_permits, check_assembly_overrides_expiry
+from artcommonlib.model import Model
+from jsonschema import RefResolver, ValidationError
+from jsonschema.validators import validator_for
+from schema import SchemaError
 
 
 def _demerge(data):
@@ -57,3 +59,18 @@ def validate(_, data):
     except ValidationError:
         errors = validator.iter_errors(demerged_data)
         return '\n'.join([f"{e.json_path}: {e.message}" for e in errors])
+
+    # Check for expired 'until' dates on permits and member overrides
+    releases_model = Model(dict_to_model=data)
+    group_config_stub = Model(dict_to_model={})
+    for assembly_name in data.get('releases', {}):
+        try:
+            assembly_permits(releases_model, group_config_stub, assembly_name)
+        except ValueError as e:
+            return str(e)
+        try:
+            expiry_errors = check_assembly_overrides_expiry(releases_model, assembly_name)
+            if expiry_errors:
+                return '\n'.join(expiry_errors)
+        except ValueError as e:
+            return str(e)


### PR DESCRIPTION
## Summary

- Adds optional `until: "YYYY-MM-DD"` field to assembly permits and member (image/RPM) overrides
- When the date passes, builds fail with a clear error message forcing cleanup of stale overrides
- Enforced at runtime (`AssemblyInspector`) and at PR review time (ocp-build-data validator)
- 12 new tests covering future/past/invalid dates, inheritance, multiple overrides, edge cases

Resolves: [ART-21625](https://redhat.atlassian.net/browse/ART-21625)
Related: [ART-21624](https://redhat.atlassian.net/browse/ART-21624), [ART-5128](https://redhat.atlassian.net/browse/ART-5128)

## Usage

```yaml
# Permit that auto-expires:
permits:
  - code: MISMATCHED_SIBLINGS
    component: "*"
    until: "2026-09-01"

# Pinned image NVR that auto-expires:
members:
  images:
    - distgit_key: ose-network-operator
      why: "Pinned while upstream fix is tested"
      until: "2026-10-01"
      metadata: { ... }
```

## Test plan

- [x] All 3,278 existing tests pass (zero regressions)
- [x] 12 new tests for expiry logic
- [x] Lint and format checks pass
- [ ] Manual verification: add expired `until` to a test assembly, confirm build failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional expiration dates for assembly permits, image overrides, and RPM overrides.
  * Added support for validating inherited overrides and reporting all expired entries.
  * Expiration dates use the `YYYY-MM-DD` format.

* **Bug Fixes**
  * Expired or malformed entries are now rejected during release validation and assembly inspection.

* **Documentation**
  * Updated validation schemas to describe expiration-date support and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->