### PR TITLE
ART-22011: Add verify-qe-qualifier command to elliott

### DIFF
--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -76,6 +76,7 @@ from elliottlib.cli.verify_attached_operators_cli import verify_attached_operato
 from elliottlib.cli.verify_cvp_cli import verify_cvp_cli
 from elliottlib.cli.verify_image_grades_cli import verify_image_grades_cli
 from elliottlib.cli.verify_payload import verify_payload
+from elliottlib.cli.verify_qe_qualifier_cli import verify_qe_qualifier_cli
 from elliottlib.cli.verify_signatures_cli import verify_signatures_cli
 from elliottlib.exceptions import ElliottFatalError
 from elliottlib.util import pbar_header, progress_func
@@ -327,6 +328,7 @@ cli.add_command(find_bugs_second_fix_cli)
 cli.add_command(process_release_from_fbc_bugs_cli)
 cli.add_command(verify_signatures_cli)
 cli.add_command(verify_image_grades_cli)
+cli.add_command(verify_qe_qualifier_cli)
 
 # -----------------------------------------------------------------------------
 # CLI Entry point

--- a/elliott/elliottlib/cli/verify_qe_qualifier_cli.py
+++ b/elliott/elliottlib/cli/verify_qe_qualifier_cli.py
@@ -1,0 +1,201 @@
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+import aiohttp
+import click
+from artcommonlib.arch_util import go_arch_for_brew_arch
+from artcommonlib.assembly import assembly_basis
+
+from elliottlib.cli.common import cli, click_coroutine
+
+LOGGER = logging.getLogger(__name__)
+
+RELEASE_CONTROLLER_URL = "https://{go_arch}.ocp.releases.ci.openshift.org"
+
+
+@dataclass
+class QualifierCheckResult:
+    release_tag: str
+    arch: str
+    badge_earned: Optional[bool] = None
+    error: Optional[str] = None
+
+    @property
+    def passed(self) -> bool:
+        return self.badge_earned is True
+
+
+@dataclass
+class VerifyQeQualifierResult:
+    assembly: str
+    stable_results: list[QualifierCheckResult] = field(default_factory=list)
+    nightly_results: list[QualifierCheckResult] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        all_results = self.stable_results + self.nightly_results
+        return bool(all_results) and all(r.passed for r in all_results)
+
+
+async def check_qe_qualifier(release_tag: str, go_arch: str) -> QualifierCheckResult:
+    url = RELEASE_CONTROLLER_URL.format(go_arch=go_arch)
+    api_url = f"{url}/api/v1/releasetag/{release_tag}/qualifiers"
+    result = QualifierCheckResult(release_tag=release_tag, arch=go_arch)
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(api_url) as response:
+                if response.status == 404:
+                    result.error = f"Release tag {release_tag} not found on {go_arch} release controller"
+                    return result
+                response.raise_for_status()
+                data = await response.json()
+    except Exception as e:
+        result.error = f"Failed to query release controller for {release_tag} ({go_arch}): {e}"
+        return result
+
+    qe = data.get("qualifiers", {}).get("qe", {})
+    result.badge_earned = qe.get("badgeEarned", False)
+    LOGGER.info("%s (%s): QE badge %s", release_tag, go_arch, "earned" if result.badge_earned else "not earned")
+    return result
+
+
+async def verify_qe_qualifier(
+    assembly: str,
+    arches: list[str],
+    nightly_tags: dict[str, str],
+    check_stable: bool = True,
+    check_nightly: bool = True,
+) -> VerifyQeQualifierResult:
+    result = VerifyQeQualifierResult(assembly=assembly)
+
+    tasks = []
+    for arch in arches:
+        go_arch = go_arch_for_brew_arch(arch)
+        if check_stable:
+            tasks.append(("stable", check_qe_qualifier(assembly, go_arch)))
+
+        nightly_tag = nightly_tags.get(arch)
+        if check_nightly and nightly_tag:
+            tasks.append(("nightly", check_qe_qualifier(nightly_tag, go_arch)))
+
+    results = await asyncio.gather(*[t[1] for t in tasks])
+
+    for (kind, _), check in zip(tasks, results):
+        if kind == "stable":
+            result.stable_results.append(check)
+        else:
+            result.nightly_results.append(check)
+
+    return result
+
+
+def render_result(result: VerifyQeQualifierResult, output: str) -> str:
+    if output == "json":
+        data = {
+            "assembly": result.assembly,
+            "passed": result.passed,
+            "stable": [
+                {
+                    "release_tag": r.release_tag,
+                    "arch": r.arch,
+                    "badge_earned": r.badge_earned,
+                    "passed": r.passed,
+                    "error": r.error,
+                }
+                for r in result.stable_results
+            ],
+            "nightly": [
+                {
+                    "release_tag": r.release_tag,
+                    "arch": r.arch,
+                    "badge_earned": r.badge_earned,
+                    "passed": r.passed,
+                    "error": r.error,
+                }
+                for r in result.nightly_results
+            ],
+        }
+        return json.dumps(data, indent=2)
+
+    lines = [f"Assembly: {result.assembly}", ""]
+
+    if result.stable_results:
+        lines.append("Stable:")
+        for r in result.stable_results:
+            status = "PASS" if r.passed else "FAIL"
+            if r.error:
+                lines.append(f"  {r.arch}: ERROR - {r.error}")
+            else:
+                lines.append(f"  {r.arch}: {status} (tag: {r.release_tag})")
+        lines.append("")
+
+    if result.nightly_results:
+        lines.append("Nightly:")
+        for r in result.nightly_results:
+            status = "PASS" if r.passed else "FAIL"
+            if r.error:
+                lines.append(f"  {r.arch}: ERROR - {r.error}")
+            else:
+                lines.append(f"  {r.arch}: {status} (tag: {r.release_tag})")
+        lines.append("")
+
+    overall = "PASS" if result.passed else "FAIL"
+    lines.append(f"Overall: {overall}")
+    return "\n".join(lines)
+
+
+@cli.command("verify-qe-qualifier", short_help="Check release controller QE qualifier for stable and nightly builds")
+@click.option(
+    "-o", "--output", type=click.Choice(["text", "json"]), default="text", show_default=True, help="Output format."
+)
+@click.option("--stable/--no-stable", default=True, show_default=True, help="Check stable build QE qualifier.")
+@click.option("--nightly/--no-nightly", default=True, show_default=True, help="Check nightly build QE qualifier.")
+@click.pass_obj
+@click_coroutine
+async def verify_qe_qualifier_cli(runtime, output, stable, nightly):
+    """Check release controller QE qualifier for stable and nightly builds.
+
+    Checks only amd64 (x86_64) as QE qualifiers are only set on the amd64
+    release controller.
+
+    Requires --group and --assembly global options. Reads the assembly's
+    reference_releases from ocp-build-data to determine the nightly tag.
+
+    Returns exit 0 if checked builds have earned the QE badge, exit 1 otherwise.
+
+    Example:
+        elliott --data-path https://github.com/openshift-eng/ocp-build-data --group openshift-4.22 --assembly 4.22.9 verify-qe-qualifier
+        elliott ... verify-qe-qualifier --no-nightly
+        elliott ... verify-qe-qualifier --no-stable
+    """
+    if not stable and not nightly:
+        raise click.UsageError("At least one of --stable or --nightly must be enabled.")
+
+    runtime.initialize()
+
+    releases_config = runtime.get_releases_config()
+    basis = assembly_basis(releases_config, runtime.assembly)
+
+    reference_releases = basis.get("reference_releases", {})
+    if not reference_releases:
+        raise click.UsageError(f"Assembly {runtime.assembly} has no reference_releases in its basis config.")
+
+    if "x86_64" not in reference_releases:
+        raise click.UsageError(f"Assembly {runtime.assembly} has no x86_64 reference release.")
+
+    nightly_tags = {"x86_64": reference_releases["x86_64"]}
+
+    result = await verify_qe_qualifier(
+        assembly=runtime.assembly,
+        arches=["x86_64"],
+        nightly_tags=nightly_tags,
+        check_stable=stable,
+        check_nightly=nightly,
+    )
+    click.echo(render_result(result, output))
+    if not result.passed:
+        raise SystemExit(1)

--- a/elliott/elliottlib/cli/verify_qe_qualifier_cli.py
+++ b/elliott/elliottlib/cli/verify_qe_qualifier_cli.py
@@ -14,6 +14,7 @@ from elliottlib.cli.common import cli, click_coroutine
 LOGGER = logging.getLogger(__name__)
 
 RELEASE_CONTROLLER_URL = "https://{go_arch}.ocp.releases.ci.openshift.org"
+REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=30)
 
 
 @dataclass
@@ -46,7 +47,7 @@ async def check_qe_qualifier(release_tag: str, go_arch: str) -> QualifierCheckRe
     result = QualifierCheckResult(release_tag=release_tag, arch=go_arch)
 
     try:
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(timeout=REQUEST_TIMEOUT) as session:
             async with session.get(api_url) as response:
                 if response.status == 404:
                     result.error = f"Release tag {release_tag} not found on {go_arch} release controller"
@@ -177,17 +178,19 @@ async def verify_qe_qualifier_cli(runtime, output, stable, nightly):
 
     runtime.initialize()
 
-    releases_config = runtime.get_releases_config()
-    basis = assembly_basis(releases_config, runtime.assembly)
+    nightly_tags = {}
+    if nightly:
+        releases_config = runtime.get_releases_config()
+        basis = assembly_basis(releases_config, runtime.assembly)
 
-    reference_releases = basis.get("reference_releases", {})
-    if not reference_releases:
-        raise click.UsageError(f"Assembly {runtime.assembly} has no reference_releases in its basis config.")
+        reference_releases = basis.get("reference_releases", {})
+        if not reference_releases:
+            raise click.UsageError(f"Assembly {runtime.assembly} has no reference_releases in its basis config.")
 
-    if "x86_64" not in reference_releases:
-        raise click.UsageError(f"Assembly {runtime.assembly} has no x86_64 reference release.")
+        if "x86_64" not in reference_releases:
+            raise click.UsageError(f"Assembly {runtime.assembly} has no x86_64 reference release.")
 
-    nightly_tags = {"x86_64": reference_releases["x86_64"]}
+        nightly_tags = {"x86_64": reference_releases["x86_64"]}
 
     result = await verify_qe_qualifier(
         assembly=runtime.assembly,

--- a/elliott/elliottlib/cli/verify_qe_qualifier_cli.py
+++ b/elliott/elliottlib/cli/verify_qe_qualifier_cli.py
@@ -41,19 +41,18 @@ class VerifyQeQualifierResult:
         return bool(all_results) and all(r.passed for r in all_results)
 
 
-async def check_qe_qualifier(release_tag: str, go_arch: str) -> QualifierCheckResult:
+async def check_qe_qualifier(release_tag: str, go_arch: str, session: aiohttp.ClientSession) -> QualifierCheckResult:
     url = RELEASE_CONTROLLER_URL.format(go_arch=go_arch)
     api_url = f"{url}/api/v1/releasetag/{release_tag}/qualifiers"
     result = QualifierCheckResult(release_tag=release_tag, arch=go_arch)
 
     try:
-        async with aiohttp.ClientSession(timeout=REQUEST_TIMEOUT) as session:
-            async with session.get(api_url) as response:
-                if response.status == 404:
-                    result.error = f"Release tag {release_tag} not found on {go_arch} release controller"
-                    return result
-                response.raise_for_status()
-                data = await response.json()
+        async with session.get(api_url) as response:
+            if response.status == 404:
+                result.error = f"Release tag {release_tag} not found on {go_arch} release controller"
+                return result
+            response.raise_for_status()
+            data = await response.json()
     except Exception as e:
         result.error = f"Failed to query release controller for {release_tag} ({go_arch}): {e}"
         return result
@@ -73,17 +72,18 @@ async def verify_qe_qualifier(
 ) -> VerifyQeQualifierResult:
     result = VerifyQeQualifierResult(assembly=assembly)
 
-    tasks = []
-    for arch in arches:
-        go_arch = go_arch_for_brew_arch(arch)
-        if check_stable:
-            tasks.append(("stable", check_qe_qualifier(assembly, go_arch)))
+    async with aiohttp.ClientSession(timeout=REQUEST_TIMEOUT) as session:
+        tasks = []
+        for arch in arches:
+            go_arch = go_arch_for_brew_arch(arch)
+            if check_stable:
+                tasks.append(("stable", check_qe_qualifier(assembly, go_arch, session)))
 
-        nightly_tag = nightly_tags.get(arch)
-        if check_nightly and nightly_tag:
-            tasks.append(("nightly", check_qe_qualifier(nightly_tag, go_arch)))
+            nightly_tag = nightly_tags.get(arch)
+            if check_nightly and nightly_tag:
+                tasks.append(("nightly", check_qe_qualifier(nightly_tag, go_arch, session)))
 
-    results = await asyncio.gather(*[t[1] for t in tasks])
+        results = await asyncio.gather(*[t[1] for t in tasks])
 
     for (kind, _), check in zip(tasks, results):
         if kind == "stable":

--- a/elliott/tests/test_verify_qe_qualifier_cli.py
+++ b/elliott/tests/test_verify_qe_qualifier_cli.py
@@ -108,6 +108,14 @@ def _mock_aiohttp_session(response_status, response_json=None, raise_for_status_
     return mock_session
 
 
+def _mock_error_session(error):
+    mock_session = AsyncMock()
+    mock_session.get = MagicMock(side_effect=error)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    return mock_session
+
+
 class TestCheckQeQualifier(IsolatedAsyncioTestCase):
     async def test_badge_earned(self):
         response_data = {
@@ -122,8 +130,7 @@ class TestCheckQeQualifier(IsolatedAsyncioTestCase):
             }
         }
         mock_session = _mock_aiohttp_session(200, response_data)
-        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
-            result = await check_qe_qualifier("4.22.9", "amd64")
+        result = await check_qe_qualifier("4.22.9", "amd64", mock_session)
         self.assertTrue(result.passed)
         self.assertTrue(result.badge_earned)
         self.assertIsNone(result.error)
@@ -141,55 +148,45 @@ class TestCheckQeQualifier(IsolatedAsyncioTestCase):
             }
         }
         mock_session = _mock_aiohttp_session(200, response_data)
-        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
-            result = await check_qe_qualifier("4.22.9", "amd64")
+        result = await check_qe_qualifier("4.22.9", "amd64", mock_session)
         self.assertFalse(result.passed)
         self.assertFalse(result.badge_earned)
 
     async def test_no_qe_qualifier(self):
         response_data = {"qualifiers": {}}
         mock_session = _mock_aiohttp_session(200, response_data)
-        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
-            result = await check_qe_qualifier("4.22.9", "amd64")
+        result = await check_qe_qualifier("4.22.9", "amd64", mock_session)
         self.assertFalse(result.passed)
         self.assertFalse(result.badge_earned)
 
     async def test_empty_qualifiers(self):
         response_data = {}
         mock_session = _mock_aiohttp_session(200, response_data)
-        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
-            result = await check_qe_qualifier("4.22.9", "amd64")
+        result = await check_qe_qualifier("4.22.9", "amd64", mock_session)
         self.assertFalse(result.passed)
 
     async def test_404_not_found(self):
         mock_session = _mock_aiohttp_session(404)
-        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
-            result = await check_qe_qualifier("4.22.99", "amd64")
+        result = await check_qe_qualifier("4.22.99", "amd64", mock_session)
         self.assertFalse(result.passed)
         self.assertIn("not found", result.error)
 
     async def test_network_error(self):
-        mock_session = AsyncMock()
-        mock_session.get = MagicMock(side_effect=Exception("connection refused"))
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
-        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
-            result = await check_qe_qualifier("4.22.9", "amd64")
+        mock_session = _mock_error_session(Exception("connection refused"))
+        result = await check_qe_qualifier("4.22.9", "amd64", mock_session)
         self.assertFalse(result.passed)
         self.assertIn("Failed to query", result.error)
 
     async def test_http_500_error(self):
         mock_session = _mock_aiohttp_session(500, raise_for_status_error=Exception("500 Server Error"))
-        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
-            result = await check_qe_qualifier("4.22.9", "amd64")
+        result = await check_qe_qualifier("4.22.9", "amd64", mock_session)
         self.assertFalse(result.passed)
         self.assertIn("Failed to query", result.error)
 
     async def test_correct_url_construction(self):
         response_data = {"qualifiers": {"qe": {"badgeEarned": True}}}
         mock_session = _mock_aiohttp_session(200, response_data)
-        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
-            await check_qe_qualifier("4.22.9", "amd64")
+        await check_qe_qualifier("4.22.9", "amd64", mock_session)
         mock_session.get.assert_called_once_with(
             "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasetag/4.22.9/qualifiers"
         )
@@ -197,8 +194,7 @@ class TestCheckQeQualifier(IsolatedAsyncioTestCase):
     async def test_arm64_url(self):
         response_data = {"qualifiers": {"qe": {"badgeEarned": True}}}
         mock_session = _mock_aiohttp_session(200, response_data)
-        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
-            await check_qe_qualifier("4.22.9", "arm64")
+        await check_qe_qualifier("4.22.9", "arm64", mock_session)
         mock_session.get.assert_called_once_with(
             "https://arm64.ocp.releases.ci.openshift.org/api/v1/releasetag/4.22.9/qualifiers"
         )
@@ -219,7 +215,7 @@ class TestVerifyQeQualifier(IsolatedAsyncioTestCase):
         self.assertEqual(len(result.nightly_results), 1)
 
     async def test_single_arch_stable_fail(self):
-        async def mock_check(tag, arch):
+        async def mock_check(tag, arch, session):
             result = QualifierCheckResult(release_tag=tag, arch=arch)
             result.badge_earned = "nightly" in tag
             return result

--- a/elliott/tests/test_verify_qe_qualifier_cli.py
+++ b/elliott/tests/test_verify_qe_qualifier_cli.py
@@ -93,11 +93,11 @@ class TestVerifyQeQualifierResult(TestCase):
         self.assertFalse(r.passed)
 
 
-def _mock_aiohttp_session(response_status, response_json=None):
+def _mock_aiohttp_session(response_status, response_json=None, raise_for_status_error=None):
     mock_response = AsyncMock()
     mock_response.status = response_status
     mock_response.json = AsyncMock(return_value=response_json)
-    mock_response.raise_for_status = MagicMock()
+    mock_response.raise_for_status = MagicMock(side_effect=raise_for_status_error)
     mock_response.__aenter__ = AsyncMock(return_value=mock_response)
     mock_response.__aexit__ = AsyncMock(return_value=False)
 
@@ -173,6 +173,13 @@ class TestCheckQeQualifier(IsolatedAsyncioTestCase):
         mock_session.get = MagicMock(side_effect=Exception("connection refused"))
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=False)
+        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
+            result = await check_qe_qualifier("4.22.9", "amd64")
+        self.assertFalse(result.passed)
+        self.assertIn("Failed to query", result.error)
+
+    async def test_http_500_error(self):
+        mock_session = _mock_aiohttp_session(500, raise_for_status_error=Exception("500 Server Error"))
         with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
             result = await check_qe_qualifier("4.22.9", "amd64")
         self.assertFalse(result.passed)
@@ -264,6 +271,21 @@ class TestVerifyQeQualifier(IsolatedAsyncioTestCase):
                 assembly="4.22.9",
                 arches=["x86_64"],
                 nightly_tags={"x86_64": "4.22.0-0.nightly-2026-08-05-104816"},
+                check_stable=True,
+                check_nightly=False,
+            )
+        self.assertTrue(result.passed)
+        self.assertEqual(len(result.stable_results), 1)
+        self.assertEqual(len(result.nightly_results), 0)
+
+    async def test_stable_only_no_nightly_tags(self):
+        response_data = {"qualifiers": {"qe": {"badgeEarned": True}}}
+        mock_session = _mock_aiohttp_session(200, response_data)
+        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
+            result = await verify_qe_qualifier(
+                assembly="4.22.9",
+                arches=["x86_64"],
+                nightly_tags={},
                 check_stable=True,
                 check_nightly=False,
             )

--- a/elliott/tests/test_verify_qe_qualifier_cli.py
+++ b/elliott/tests/test_verify_qe_qualifier_cli.py
@@ -1,0 +1,346 @@
+import json
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from elliottlib.cli.verify_qe_qualifier_cli import (
+    QualifierCheckResult,
+    VerifyQeQualifierResult,
+    check_qe_qualifier,
+    render_result,
+    verify_qe_qualifier,
+)
+
+
+class TestQualifierCheckResult(TestCase):
+    def test_passed_badge_earned(self):
+        r = QualifierCheckResult(release_tag="4.22.9", arch="amd64", badge_earned=True)
+        self.assertTrue(r.passed)
+
+    def test_failed_badge_not_earned(self):
+        r = QualifierCheckResult(release_tag="4.22.9", arch="amd64", badge_earned=False)
+        self.assertFalse(r.passed)
+
+    def test_failed_badge_none(self):
+        r = QualifierCheckResult(release_tag="4.22.9", arch="amd64")
+        self.assertFalse(r.passed)
+
+    def test_failed_with_error(self):
+        r = QualifierCheckResult(release_tag="4.22.9", arch="amd64", error="not found")
+        self.assertFalse(r.passed)
+
+
+class TestVerifyQeQualifierResult(TestCase):
+    def test_passed_all_earned(self):
+        r = VerifyQeQualifierResult(
+            assembly="4.22.9",
+            stable_results=[QualifierCheckResult(release_tag="4.22.9", arch="amd64", badge_earned=True)],
+            nightly_results=[
+                QualifierCheckResult(release_tag="4.22.0-0.nightly-2026-08-05-104816", arch="amd64", badge_earned=True)
+            ],
+        )
+        self.assertTrue(r.passed)
+
+    def test_failed_stable_not_earned(self):
+        r = VerifyQeQualifierResult(
+            assembly="4.22.9",
+            stable_results=[QualifierCheckResult(release_tag="4.22.9", arch="amd64", badge_earned=False)],
+            nightly_results=[
+                QualifierCheckResult(release_tag="4.22.0-0.nightly-2026-08-05-104816", arch="amd64", badge_earned=True)
+            ],
+        )
+        self.assertFalse(r.passed)
+
+    def test_failed_nightly_not_earned(self):
+        r = VerifyQeQualifierResult(
+            assembly="4.22.9",
+            stable_results=[QualifierCheckResult(release_tag="4.22.9", arch="amd64", badge_earned=True)],
+            nightly_results=[
+                QualifierCheckResult(release_tag="4.22.0-0.nightly-2026-08-05-104816", arch="amd64", badge_earned=False)
+            ],
+        )
+        self.assertFalse(r.passed)
+
+    def test_failed_empty(self):
+        r = VerifyQeQualifierResult(assembly="4.22.9")
+        self.assertFalse(r.passed)
+
+    def test_passed_multi_arch(self):
+        r = VerifyQeQualifierResult(
+            assembly="4.22.9",
+            stable_results=[
+                QualifierCheckResult(release_tag="4.22.9", arch="amd64", badge_earned=True),
+                QualifierCheckResult(release_tag="4.22.9", arch="arm64", badge_earned=True),
+            ],
+            nightly_results=[
+                QualifierCheckResult(release_tag="4.22.0-0.nightly-2026-08-05-104816", arch="amd64", badge_earned=True),
+                QualifierCheckResult(release_tag="4.22.0-0.nightly-2026-08-05-104816", arch="arm64", badge_earned=True),
+            ],
+        )
+        self.assertTrue(r.passed)
+
+    def test_failed_one_arch_missing(self):
+        r = VerifyQeQualifierResult(
+            assembly="4.22.9",
+            stable_results=[
+                QualifierCheckResult(release_tag="4.22.9", arch="amd64", badge_earned=True),
+                QualifierCheckResult(release_tag="4.22.9", arch="arm64", badge_earned=False),
+            ],
+            nightly_results=[
+                QualifierCheckResult(release_tag="4.22.0-0.nightly-2026-08-05-104816", arch="amd64", badge_earned=True),
+                QualifierCheckResult(release_tag="4.22.0-0.nightly-2026-08-05-104816", arch="arm64", badge_earned=True),
+            ],
+        )
+        self.assertFalse(r.passed)
+
+
+def _mock_aiohttp_session(response_status, response_json=None):
+    mock_response = AsyncMock()
+    mock_response.status = response_status
+    mock_response.json = AsyncMock(return_value=response_json)
+    mock_response.raise_for_status = MagicMock()
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = AsyncMock()
+    mock_session.get = MagicMock(return_value=mock_response)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    return mock_session
+
+
+class TestCheckQeQualifier(IsolatedAsyncioTestCase):
+    async def test_badge_earned(self):
+        response_data = {
+            "qualifiers": {
+                "qe": {
+                    "aggregateState": "Success",
+                    "badgeName": "QE",
+                    "badgeEarned": True,
+                    "badgePropagated": True,
+                    "approval": True,
+                }
+            }
+        }
+        mock_session = _mock_aiohttp_session(200, response_data)
+        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
+            result = await check_qe_qualifier("4.22.9", "amd64")
+        self.assertTrue(result.passed)
+        self.assertTrue(result.badge_earned)
+        self.assertIsNone(result.error)
+
+    async def test_badge_not_earned(self):
+        response_data = {
+            "qualifiers": {
+                "qe": {
+                    "aggregateState": "Pending",
+                    "badgeName": "QE",
+                    "badgeEarned": False,
+                    "badgePropagated": False,
+                    "approval": False,
+                }
+            }
+        }
+        mock_session = _mock_aiohttp_session(200, response_data)
+        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
+            result = await check_qe_qualifier("4.22.9", "amd64")
+        self.assertFalse(result.passed)
+        self.assertFalse(result.badge_earned)
+
+    async def test_no_qe_qualifier(self):
+        response_data = {"qualifiers": {}}
+        mock_session = _mock_aiohttp_session(200, response_data)
+        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
+            result = await check_qe_qualifier("4.22.9", "amd64")
+        self.assertFalse(result.passed)
+        self.assertFalse(result.badge_earned)
+
+    async def test_empty_qualifiers(self):
+        response_data = {}
+        mock_session = _mock_aiohttp_session(200, response_data)
+        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
+            result = await check_qe_qualifier("4.22.9", "amd64")
+        self.assertFalse(result.passed)
+
+    async def test_404_not_found(self):
+        mock_session = _mock_aiohttp_session(404)
+        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
+            result = await check_qe_qualifier("4.22.99", "amd64")
+        self.assertFalse(result.passed)
+        self.assertIn("not found", result.error)
+
+    async def test_network_error(self):
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(side_effect=Exception("connection refused"))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
+            result = await check_qe_qualifier("4.22.9", "amd64")
+        self.assertFalse(result.passed)
+        self.assertIn("Failed to query", result.error)
+
+    async def test_correct_url_construction(self):
+        response_data = {"qualifiers": {"qe": {"badgeEarned": True}}}
+        mock_session = _mock_aiohttp_session(200, response_data)
+        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
+            await check_qe_qualifier("4.22.9", "amd64")
+        mock_session.get.assert_called_once_with(
+            "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasetag/4.22.9/qualifiers"
+        )
+
+    async def test_arm64_url(self):
+        response_data = {"qualifiers": {"qe": {"badgeEarned": True}}}
+        mock_session = _mock_aiohttp_session(200, response_data)
+        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
+            await check_qe_qualifier("4.22.9", "arm64")
+        mock_session.get.assert_called_once_with(
+            "https://arm64.ocp.releases.ci.openshift.org/api/v1/releasetag/4.22.9/qualifiers"
+        )
+
+
+class TestVerifyQeQualifier(IsolatedAsyncioTestCase):
+    async def test_single_arch_all_pass(self):
+        response_data = {"qualifiers": {"qe": {"badgeEarned": True}}}
+        mock_session = _mock_aiohttp_session(200, response_data)
+        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
+            result = await verify_qe_qualifier(
+                assembly="4.22.9",
+                arches=["x86_64"],
+                nightly_tags={"x86_64": "4.22.0-0.nightly-2026-08-05-104816"},
+            )
+        self.assertTrue(result.passed)
+        self.assertEqual(len(result.stable_results), 1)
+        self.assertEqual(len(result.nightly_results), 1)
+
+    async def test_single_arch_stable_fail(self):
+        async def mock_check(tag, arch):
+            result = QualifierCheckResult(release_tag=tag, arch=arch)
+            result.badge_earned = "nightly" in tag
+            return result
+
+        with patch("elliottlib.cli.verify_qe_qualifier_cli.check_qe_qualifier", side_effect=mock_check):
+            result = await verify_qe_qualifier(
+                assembly="4.22.9",
+                arches=["x86_64"],
+                nightly_tags={"x86_64": "4.22.0-0.nightly-2026-08-05-104816"},
+            )
+        self.assertFalse(result.passed)
+        self.assertFalse(result.stable_results[0].passed)
+        self.assertTrue(result.nightly_results[0].passed)
+
+    async def test_multi_arch(self):
+        response_data = {"qualifiers": {"qe": {"badgeEarned": True}}}
+        mock_session = _mock_aiohttp_session(200, response_data)
+        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
+            result = await verify_qe_qualifier(
+                assembly="4.22.9",
+                arches=["x86_64", "aarch64"],
+                nightly_tags={
+                    "x86_64": "4.22.0-0.nightly-2026-08-05-104816",
+                    "aarch64": "4.22.0-0.nightly-arm64-2026-08-05-104816",
+                },
+            )
+        self.assertTrue(result.passed)
+        self.assertEqual(len(result.stable_results), 2)
+        self.assertEqual(len(result.nightly_results), 2)
+
+    async def test_no_nightly_for_arch(self):
+        response_data = {"qualifiers": {"qe": {"badgeEarned": True}}}
+        mock_session = _mock_aiohttp_session(200, response_data)
+        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
+            result = await verify_qe_qualifier(
+                assembly="4.22.9",
+                arches=["x86_64"],
+                nightly_tags={},
+            )
+        self.assertTrue(result.passed)
+        self.assertEqual(len(result.stable_results), 1)
+        self.assertEqual(len(result.nightly_results), 0)
+
+    async def test_check_stable_only(self):
+        response_data = {"qualifiers": {"qe": {"badgeEarned": True}}}
+        mock_session = _mock_aiohttp_session(200, response_data)
+        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
+            result = await verify_qe_qualifier(
+                assembly="4.22.9",
+                arches=["x86_64"],
+                nightly_tags={"x86_64": "4.22.0-0.nightly-2026-08-05-104816"},
+                check_stable=True,
+                check_nightly=False,
+            )
+        self.assertTrue(result.passed)
+        self.assertEqual(len(result.stable_results), 1)
+        self.assertEqual(len(result.nightly_results), 0)
+
+    async def test_check_nightly_only(self):
+        response_data = {"qualifiers": {"qe": {"badgeEarned": True}}}
+        mock_session = _mock_aiohttp_session(200, response_data)
+        with patch("elliottlib.cli.verify_qe_qualifier_cli.aiohttp.ClientSession", return_value=mock_session):
+            result = await verify_qe_qualifier(
+                assembly="4.22.9",
+                arches=["x86_64"],
+                nightly_tags={"x86_64": "4.22.0-0.nightly-2026-08-05-104816"},
+                check_stable=False,
+                check_nightly=True,
+            )
+        self.assertTrue(result.passed)
+        self.assertEqual(len(result.stable_results), 0)
+        self.assertEqual(len(result.nightly_results), 1)
+
+
+class TestRenderResult(TestCase):
+    def test_text_all_pass(self):
+        result = VerifyQeQualifierResult(
+            assembly="4.22.9",
+            stable_results=[QualifierCheckResult(release_tag="4.22.9", arch="amd64", badge_earned=True)],
+            nightly_results=[
+                QualifierCheckResult(release_tag="4.22.0-0.nightly-2026-08-05-104816", arch="amd64", badge_earned=True)
+            ],
+        )
+        text = render_result(result, "text")
+        self.assertIn("Assembly: 4.22.9", text)
+        self.assertIn("Overall: PASS", text)
+        self.assertIn("Stable:", text)
+        self.assertIn("Nightly:", text)
+
+    def test_text_fail(self):
+        result = VerifyQeQualifierResult(
+            assembly="4.22.9",
+            stable_results=[QualifierCheckResult(release_tag="4.22.9", arch="amd64", badge_earned=False)],
+        )
+        text = render_result(result, "text")
+        self.assertIn("Overall: FAIL", text)
+
+    def test_text_error(self):
+        result = VerifyQeQualifierResult(
+            assembly="4.22.9",
+            stable_results=[QualifierCheckResult(release_tag="4.22.9", arch="amd64", error="release not found")],
+        )
+        text = render_result(result, "text")
+        self.assertIn("ERROR", text)
+        self.assertIn("release not found", text)
+
+    def test_json_output(self):
+        result = VerifyQeQualifierResult(
+            assembly="4.22.9",
+            stable_results=[QualifierCheckResult(release_tag="4.22.9", arch="amd64", badge_earned=True)],
+            nightly_results=[
+                QualifierCheckResult(release_tag="4.22.0-0.nightly-2026-08-05-104816", arch="amd64", badge_earned=True)
+            ],
+        )
+        text = render_result(result, "json")
+        data = json.loads(text)
+        self.assertEqual(data["assembly"], "4.22.9")
+        self.assertTrue(data["passed"])
+        self.assertEqual(len(data["stable"]), 1)
+        self.assertEqual(len(data["nightly"]), 1)
+        self.assertTrue(data["stable"][0]["badge_earned"])
+
+    def test_json_with_error(self):
+        result = VerifyQeQualifierResult(
+            assembly="4.22.9",
+            stable_results=[QualifierCheckResult(release_tag="4.22.9", arch="amd64", error="not found")],
+        )
+        text = render_result(result, "json")
+        data = json.loads(text)
+        self.assertFalse(data["passed"])
+        self.assertEqual(data["stable"][0]["error"], "not found")


### PR DESCRIPTION
## Summary
- New `elliott verify-qe-qualifier` command that checks release controller QE qualifier badge
- Checks stable (e.g. `4.22.9`) and nightly builds on amd64 release controller
- Reads `reference_releases` from assembly config in ocp-build-data for nightly tags
- Supports `--stable/--no-stable` and `--nightly/--no-nightly` flags
- Text and JSON output formats (`-o text|json`)
- Exit 0 = all checked builds have QE badge, exit 1 = not yet

## Usage
```
elliott --group openshift-4.22 --assembly 4.22.9 verify-qe-qualifier
elliott ... verify-qe-qualifier --no-nightly
elliott ... verify-qe-qualifier -o json
```

## Test plan
- [x] 29 unit tests covering all code paths (dataclasses, async API calls, render, flags)
- [x] Manually tested against live release controller for 4.16–4.22 assemblies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `verify-qe-qualifier` command to verify stable and nightly release qualifiers across architectures.
  - Reports badge status and verification errors in text or JSON format.
  - Supports selecting stable checks, nightly checks, or both.
  - Returns a failure status when any requested verification fails.

- **Tests**
  - Added comprehensive coverage for verification flows, output formats, errors, and multi-architecture checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->