### PR TITLE
doozer: handle unknown FBC catalog blob schemas gracefully

### DIFF
--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -301,8 +301,11 @@ class KonfluxFbcImporter:
                     package_name = blob["name"]
                 case "olm.channel" | "olm.bundle" | "olm.deprecations":
                     package_name = blob["package"]
-            if not package_name:
-                raise IOError(f"Couldn't determine package name for unknown schema: {schema}")
+                case _:
+                    package_name = blob.get("package") or blob.get("name")
+                    if not package_name:
+                        self._logger.warning("Skipping blob with unknown schema %s (no package/name field)", schema)
+                        continue
             if package_name not in allowed_package_names:
                 continue  # filtered out; skipping
             if package_name not in filtered:
@@ -1610,11 +1613,14 @@ class KonfluxFbcRebaser:
                     package_name = blob["name"]
                 case "olm.channel" | "olm.bundle" | "olm.deprecations":
                     package_name = blob["package"]
-                case _:  # Unknown schema
-                    raise IOError(f"Found unsupported schema: {schema}")
+                case _:
+                    package_name = blob.get("package") or blob.get("name")
+                    if not package_name:
+                        self._logger.warning("Skipping blob with unsupported schema %s", schema)
+                        continue
             if not package_name:
                 raise IOError(f"Couldn't determine package name for unknown schema: {schema}")
-            blob_key = package_name if schema == "olm.deprecations" else blob["name"]
+            blob_key = package_name if schema == "olm.deprecations" else blob.get("name", f"{schema}:{package_name}")
             categorized_blobs.setdefault(package_name, {}).setdefault(schema, {})[blob_key] = blob
         return categorized_blobs
 

--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -235,15 +235,21 @@ class TestKonfluxFbcImporter(unittest.IsolatedAsyncioTestCase):
             "package": "test-package2",
             "name": "test-lifecycle",
         }
+        name_only_blob = {
+            "schema": "some.unknown.schema.v1",
+            "name": "test-package2",
+        }
         catalog_blobs = [
             {"schema": "olm.package", "name": "test-package2"},
             {"schema": "olm.channel", "name": "test-channel2", "package": "test-package2"},
             lifecycle_blob,
+            name_only_blob,
             {"schema": "olm.package", "name": "test-package3"},
         ]
         actual = self.importer._filter_catalog_blobs(catalog_blobs, {"test-package2"})
         self.assertEqual(actual.keys(), {"test-package2"})
         self.assertIn(lifecycle_blob, actual["test-package2"])
+        self.assertIn(name_only_blob, actual["test-package2"])
 
     def test_filter_catalog_blobs_unknown_schema_without_package_field(self):
         """Unknown schemas with no 'package' or 'name' field should be silently skipped."""
@@ -897,10 +903,15 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
             "package": "test-package",
             "name": "test-lifecycle",
         }
+        package_only_blob = {
+            "schema": "io.openshift.operators.lifecycles.v1alpha1",
+            "package": "test-package",
+        }
         catalog_blobs = [
             {"schema": "olm.package", "name": "test-package"},
             {"schema": "olm.channel", "name": "test-channel", "package": "test-package"},
             lifecycle_blob,
+            package_only_blob,
         ]
         actual = self.rebaser._catagorize_catalog_blobs(catalog_blobs)
         self.assertIn("test-package", actual)
@@ -908,6 +919,13 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             actual["test-package"]["io.openshift.operators.lifecycles.v1alpha1"]["test-lifecycle"],
             lifecycle_blob,
+        )
+        # package-only blob falls back to schema:package as its key
+        self.assertEqual(
+            actual["test-package"]["io.openshift.operators.lifecycles.v1alpha1"][
+                "io.openshift.operators.lifecycles.v1alpha1:test-package"
+            ],
+            package_only_blob,
         )
 
     def test_categorize_catalog_blobs_unknown_schema_without_package_field(self):
@@ -921,6 +939,7 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(actual.keys(), {"test-package"})
         self.assertNotIn("some.unknown.schema.v1", actual.get("test-package", {}))
 
+    def test_extract_version_from_bundle_name(self):
         """Test version extraction from bundle names with 'v' prefix"""
         from semver import VersionInfo
 

--- a/doozer/tests/backend/test_konflux_fbc.py
+++ b/doozer/tests/backend/test_konflux_fbc.py
@@ -228,6 +228,33 @@ class TestKonfluxFbcImporter(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    def test_filter_catalog_blobs_unknown_schema_with_package_field(self):
+        """Unknown schemas that carry a 'package' field should be included, not raise."""
+        lifecycle_blob = {
+            "schema": "io.openshift.operators.lifecycles.v1alpha1",
+            "package": "test-package2",
+            "name": "test-lifecycle",
+        }
+        catalog_blobs = [
+            {"schema": "olm.package", "name": "test-package2"},
+            {"schema": "olm.channel", "name": "test-channel2", "package": "test-package2"},
+            lifecycle_blob,
+            {"schema": "olm.package", "name": "test-package3"},
+        ]
+        actual = self.importer._filter_catalog_blobs(catalog_blobs, {"test-package2"})
+        self.assertEqual(actual.keys(), {"test-package2"})
+        self.assertIn(lifecycle_blob, actual["test-package2"])
+
+    def test_filter_catalog_blobs_unknown_schema_without_package_field(self):
+        """Unknown schemas with no 'package' or 'name' field should be silently skipped."""
+        catalog_blobs = [
+            {"schema": "olm.package", "name": "test-package"},
+            {"schema": "some.unknown.schema.v1"},
+        ]
+        # Should not raise; the unknown blob is skipped
+        actual = self.importer._filter_catalog_blobs(catalog_blobs, {"test-package"})
+        self.assertEqual(actual.keys(), {"test-package"})
+
     @patch("doozerlib.backend.konflux_fbc.KonfluxFbcImporter._render_index_image", new_callable=AsyncMock)
     async def test_get_catalog_blobs_from_index_image(self, mock_render_index_image):
         index_image = "test-index-image"
@@ -863,7 +890,37 @@ class TestKonfluxFbcRebaser(unittest.IsolatedAsyncioTestCase):
             {"schema": "olm.bundle", "name": "test-bundle2", "package": "test-package2"},
         )
 
-    def test_extract_version_from_bundle_name(self):
+    def test_categorize_catalog_blobs_unknown_schema_with_package_field(self):
+        """Unknown schemas that carry a 'package' field should be included, not raise."""
+        lifecycle_blob = {
+            "schema": "io.openshift.operators.lifecycles.v1alpha1",
+            "package": "test-package",
+            "name": "test-lifecycle",
+        }
+        catalog_blobs = [
+            {"schema": "olm.package", "name": "test-package"},
+            {"schema": "olm.channel", "name": "test-channel", "package": "test-package"},
+            lifecycle_blob,
+        ]
+        actual = self.rebaser._catagorize_catalog_blobs(catalog_blobs)
+        self.assertIn("test-package", actual)
+        self.assertIn("io.openshift.operators.lifecycles.v1alpha1", actual["test-package"])
+        self.assertEqual(
+            actual["test-package"]["io.openshift.operators.lifecycles.v1alpha1"]["test-lifecycle"],
+            lifecycle_blob,
+        )
+
+    def test_categorize_catalog_blobs_unknown_schema_without_package_field(self):
+        """Unknown schemas with no 'package' or 'name' field should be silently skipped."""
+        catalog_blobs = [
+            {"schema": "olm.package", "name": "test-package"},
+            {"schema": "some.unknown.schema.v1"},
+        ]
+        # Should not raise; the unknown blob is skipped
+        actual = self.rebaser._catagorize_catalog_blobs(catalog_blobs)
+        self.assertEqual(actual.keys(), {"test-package"})
+        self.assertNotIn("some.unknown.schema.v1", actual.get("test-package", {}))
+
         """Test version extraction from bundle names with 'v' prefix"""
         from semver import VersionInfo
 


### PR DESCRIPTION
## Problem

The `build-fbc` job for `openshift-5.0` ([example run #46423](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-fbc/46423/console)) was failing for all 15 operators in the batch because OCP 5.0 operator index images now include blobs with a new schema: `io.openshift.operators.lifecycles.v1alpha1`.

`_filter_catalog_blobs` and `_catagorize_catalog_blobs` only recognised the four core OLM schemas (`olm.package`, `olm.channel`, `olm.bundle`, `olm.deprecations`) and raised `IOError` on anything else:

```
OSError: Couldn't determine package name for unknown schema: io.openshift.operators.lifecycles.v1alpha1
```

## Fix

Both methods now handle unknown schemas gracefully:

- Try `blob.get("package")` then `blob.get("name")` to determine the package name (the standard OLM convention).
- If neither field is present, skip the blob with a `warning` log instead of crashing.

This makes the pipeline resilient to future new schemas introduced by OLM.

## Testing

Added 4 unit tests covering:
- Unknown schema **with** a `package` field → blob is included in output
- Unknown schema **without** `package`/`name` → blob is silently skipped, no exception

Full test run: 88/88 passed, zero regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved catalog processing for entries with unknown schemas.
  * Entries are now recognized using either package or name information.
  * Invalid entries missing both fields are skipped without interrupting processing.
  * Catalog categorization is more reliable when standard name data is unavailable.

* **Tests**
  * Added coverage for importing and rebasing catalogs with unknown schemas and incomplete entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->