### PR TITLE
fix: update EC pipeline reference to conforma/cli

### DIFF
--- a/doozer/doozerlib/constants.py
+++ b/doozer/doozerlib/constants.py
@@ -67,9 +67,9 @@ ART_BUILD_FAILURES_URL = 'https://art-build-failures-art-build-failures.apps.art
 # Enterprise Contract (EC) verification pipeline constants
 # TODO: Expand EC verification to layered products (logging, oadp, mta, rhmtc, quay, cert-manager, etc.)
 # Currently scoped to OCP only.
-KONFLUX_EC_PIPELINE_GIT_URL = "https://github.com/konflux-ci/build-definitions"
+KONFLUX_EC_PIPELINE_GIT_URL = "https://github.com/conforma/cli"
 KONFLUX_EC_PIPELINE_REVISION = "main"
-KONFLUX_EC_PIPELINE_PATH = "pipelines/enterprise-contract.yaml"
+KONFLUX_EC_PIPELINE_PATH = "pipelines/enterprise-contract/0.1/enterprise-contract.yaml"
 # https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/tenants-config/cluster/kflux-ocp-p01/tenants/ocp-art-tenant/ecp-build-stage.yaml
 KONFLUX_DEFAULT_EC_POLICY_CONFIGURATION = "ocp-art-tenant/conforma-build-stage"
 # PreGA (PREVIEW assembly) EC policy: same as stage but allows unsigned RPMs

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -207,9 +207,9 @@ class TestNewIntegrationTestScenario(TestCase):
         self.assertEqual(resolver_ref["resolver"], "git")
         self.assertEqual(resolver_ref["resourceKind"], "pipeline")
         resolver_params = {p["name"]: p["value"] for p in resolver_ref["params"]}
-        self.assertEqual(resolver_params["url"], "https://github.com/konflux-ci/build-definitions")
+        self.assertEqual(resolver_params["url"], "https://github.com/conforma/cli")
         self.assertEqual(resolver_params["revision"], "main")
-        self.assertEqual(resolver_params["pathInRepo"], "pipelines/enterprise-contract.yaml")
+        self.assertEqual(resolver_params["pathInRepo"], "pipelines/enterprise-contract/0.1/enterprise-contract.yaml")
 
 
 class TestNewIntegrationTestScenarioPreGA(TestCase):
@@ -275,8 +275,8 @@ class TestNewEcPipelinerun(TestCase):
         pipeline_ref = manifest["spec"]["pipelineRef"]
         self.assertEqual(pipeline_ref["resolver"], "git")
         ref_params = {p["name"]: p["value"] for p in pipeline_ref["params"]}
-        self.assertEqual(ref_params["url"], "https://github.com/konflux-ci/build-definitions")
-        self.assertEqual(ref_params["pathInRepo"], "pipelines/enterprise-contract.yaml")
+        self.assertEqual(ref_params["url"], "https://github.com/conforma/cli")
+        self.assertEqual(ref_params["pathInRepo"], "pipelines/enterprise-contract/0.1/enterprise-contract.yaml")
 
         # params
         params = {p["name"]: p["value"] for p in manifest["spec"]["params"]}


### PR DESCRIPTION
## Problem

`build-conforma-verify` is failing with:

```
Pipeline ocp-art-tenant/ can't be Run; it contains Tasks that don't exist:
Couldn't retrieve Task "resolver type bundles\nname = collect-keyless-params\n":
error requesting remote resource: error getting "bundleresolver"
"ocp-art-tenant/bundles-e9ad4eb88026a7f43ca5ab131a224074":
cannot retrieve the oci image: GET https://quay.io/v2/conforma/tekton-task/manifests/sha256:13375ed6...: MANIFEST_UNKNOWN
```

The enterprise-contract pipeline at `konflux-ci/build-definitions` is deprecated and references a `quay.io/conforma/tekton-task` bundle digest that no longer exists.

## Fix

Update `KONFLUX_EC_PIPELINE_GIT_URL` / `KONFLUX_EC_PIPELINE_PATH` to point to the new canonical pipeline location in `conforma/cli`:

- **Old**: `https://github.com/konflux-ci/build-definitions` → `pipelines/enterprise-contract.yaml`
- **New**: `https://github.com/conforma/cli` → `pipelines/enterprise-contract/0.1/enterprise-contract.yaml`

The new pipeline uses a floating `quay.io/conforma/tekton-task:konflux` tag (no stale digest pin), so this failure will not recur.

Also updates the two corresponding unit test assertions in `test_konflux_client.py`.

## Testing

- `uv run pytest doozer/tests/backend/test_konflux_client.py` — 60 passed
- `ruff check` / `ruff format --check` on changed files — clean

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Enterprise Contract pipeline references to use the Conforma CLI repository and the versioned pipeline definition.
  * Updated validation to recognize the new pipeline source and path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->