### PR TITLE
elliott: fix close_reconciliation_bugs crash on unbounded JQL when target versions are missing

### DIFF
--- a/elliott/elliottlib/cli/find_bugs_qe_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_qe_cli.py
@@ -79,7 +79,12 @@ def close_reconciliation_bugs(runtime, noop: bool, bug_tracker):
         status=statuses,
         include_labels=['art:reconciliation'],
     )
-    bugs = bug_tracker._search(query, verbose=runtime.debug)
+    if query is None:
+        # All configured target versions were filtered out (e.g. not yet defined in JIRA
+        # for a new release). _query() already logged why; nothing to search for.
+        bugs = []
+    else:
+        bugs = bug_tracker._search(query, verbose=runtime.debug)
     LOGGER.info(f"Found {len(bugs)} bugs to close: {', '.join(sorted(str(b.id) for b in bugs))}")
 
     close_comment = (

--- a/elliott/tests/test_find_bugs_qe_cli.py
+++ b/elliott/tests/test_find_bugs_qe_cli.py
@@ -128,6 +128,25 @@ class FindBugsQETestCase(unittest.TestCase):
 
         close_reconciliation_bugs(runtime, True, bug_tracker)
 
+    def test_close_reconciliation_bugs_no_valid_target_versions(self):
+        """_query returns None when all configured target versions are filtered out
+        (e.g. not yet defined in JIRA for a new release). close_reconciliation_bugs
+        must treat that as "no bugs found" instead of searching with a None query,
+        which JIRA rejects as an unbounded query."""
+        runtime = flexmock(debug=False)
+        client = flexmock()
+        bug_tracker = flexmock(type='jira', _client=client)
+        flexmock(bug_tracker).should_receive("target_release").and_return(["5.1.0", "5.1.z", "5.1"])
+        flexmock(bug_tracker).should_receive("_query").with_args(
+            status=RECONCILIATION_STATUSES,
+            include_labels=['art:reconciliation'],
+        ).and_return(None).once()
+        flexmock(bug_tracker).should_receive("_search").never()
+        flexmock(client).should_receive("transition_issue").never()
+        flexmock(bug_tracker).should_receive("add_comment").never()
+
+        close_reconciliation_bugs(runtime, False, bug_tracker)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- `close_reconciliation_bugs` (elliott `find-bugs:qe`) crashed with `JiraError HTTP 400: Unbounded JQL queries are not allowed here` whenever a group's configured target-release versions (e.g. `5.1.0`, `5.1.z`, `5.1` from `ocp-build-data/bug.yml`) don't yet exist as "Target Version" options in the OCPBUGS JIRA project (e.g. right after a new OCP release is cut).
- `BugTracker._query()` already handles this case by returning `None` when all configured target versions are filtered out, and every other caller (`search`, `blocker_search`, `cve_tracker_search`) checks for `None` and short-circuits to `[]`. `close_reconciliation_bugs` was the one caller that skipped this check and passed `None` straight into `_search()`, which sent JIRA a query with no real restriction.
- This fix adds the same `if query is None: return []`-style guard to `close_reconciliation_bugs`, matching the existing pattern used elsewhere in `bzutil.py`.

## Test plan
- [x] Added `test_close_reconciliation_bugs_no_valid_target_versions` covering the `_query() -> None` path (asserts `_search` is never called and no bugs are transitioned/commented on).
- [x] `uv run pytest elliott/tests/test_find_bugs_qe_cli.py` — all 5 tests pass.
- [x] `make lint` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation bug handling when no query is provided.
  * Prevents unnecessary searches, status changes, and comments when no bugs are identified.

* **Tests**
  * Added regression coverage for reconciliation workflows with no query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->