### PR TITLE
ART-20930: feat(doozer): add GolangBuilderShipmentHandler

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -57,6 +57,7 @@ BUNDLES_TABLE_ID = 'bundles'
 FBCS_TABLE_ID = 'fbcs'
 TASKRUN_TABLE_ID = 'taskruns'
 
+REDHAT_GITLAB_URL = "https://gitlab.cee.redhat.com"
 SHIPMENT_DATA_URL_TEMPLATE = "https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data"
 SHIPMENT_CONFIG_KINDS = ("image", "extras", "metadata", "fbc", "microshift-bootc")
 

--- a/doozer/doozerlib/backend/golang_builder_shipment.py
+++ b/doozer/doozerlib/backend/golang_builder_shipment.py
@@ -54,8 +54,8 @@ def format_shipment_mr_title(golang_group: str) -> str:
 
 
 GOLANG_BUILDER_SHIPMENT_RELEASE_PLAN_MAP = {
-    "stage": "ocp-art-golang-builder-ec-rhel9",
-    "prod": "ocp-art-golang-builder-prod-rhel9",
+    "stage": "ocp-art-golang-builder-ec",
+    "prod": "ocp-art-golang-builder-prod",
 }
 
 

--- a/doozer/doozerlib/backend/golang_builder_shipment.py
+++ b/doozer/doozerlib/backend/golang_builder_shipment.py
@@ -44,6 +44,8 @@ from pyartcd.git import GitRepository
 yaml = new_roundtrip_yaml_handler()
 
 _PRODUCT = "ocp"
+_ELLIOTT_GOLANG_GROUP = "golang"
+_DEFAULT_ENV = "prod"
 
 
 def format_shipment_mr_title(golang_group: str) -> str:
@@ -83,11 +85,6 @@ def basic_auth_url(url: str, token: str) -> str:
     return urlunparse(parsed._replace(netloc=netloc))
 
 
-def resolve_env_from_runtime(runtime) -> str:
-    """Return the shipment target env for MR placement (always prod)."""
-    return "prod"
-
-
 class GolangBuilderShipmentHandler:
     """Creates a shipment MR in ocp-shipment-data for golang builder images."""
 
@@ -98,11 +95,9 @@ class GolangBuilderShipmentHandler:
         shipment_data_repo_pull_url: Optional[str] = None,
         shipment_data_repo_push_url: Optional[str] = None,
         art_jira: str = "",
-        ocp_version: Optional[str] = None,
     ):
         self.runtime = runtime
         self.art_jira = art_jira
-        self.ocp_version = ocp_version
         self.logger = getattr(runtime, "logger", None) or logging.getLogger(__name__)
         self.gitlab_url = gitlab_url
         # Follow the established pyartcd pattern: use a known subdir of the runtime
@@ -116,29 +111,19 @@ class GolangBuilderShipmentHandler:
         self.shipment_data_repo = GitRepository(self._shipment_data_repo_dir, False)
         self._gitlab_token: Optional[str] = None
 
-    @staticmethod
-    def resolve_release_plan(env: str) -> str:
-        """Map shipment env to the correct ReleasePlan name."""
-        plan = GOLANG_BUILDER_SHIPMENT_RELEASE_PLAN_MAP.get(env)
-        if not plan:
-            raise ValueError(
-                f"Unknown env '{env}'. Must be one of: {list(GOLANG_BUILDER_SHIPMENT_RELEASE_PLAN_MAP.keys())}"
-            )
-        return plan
-
     async def create_shipment(
         self,
         nvr: str,
         container_image: str,
         rebase_repo_url: str,
         rebase_commitish: str,
+        env: Optional[str] = None,
     ) -> Optional[str]:
         """Create shipment MR for one golang builder build (non-fatal inline path)."""
         try:
             golang_group = derive_golang_group([nvr])
-            env = resolve_env_from_runtime(self.runtime)
-            release_plan = self.resolve_release_plan(env)
-            ocp_version = self.ocp_version or golang_group
+            env = env or _DEFAULT_ENV
+            release_plan = GOLANG_BUILDER_SHIPMENT_RELEASE_PLAN_MAP[env]
 
             self.logger.info(
                 "Starting golang builder shipment: nvr=%s golang_group=%s env=%s release_plan=%s",
@@ -152,7 +137,6 @@ class GolangBuilderShipmentHandler:
 
             snapshot = self._build_inline_snapshot(
                 nvr=nvr,
-                golang_group=golang_group,
                 container_image=container_image,
                 rebase_repo_url=rebase_repo_url,
                 rebase_commitish=rebase_commitish,
@@ -161,7 +145,6 @@ class GolangBuilderShipmentHandler:
                 snapshot=snapshot,
                 nvrs=[nvr],
                 golang_group=golang_group,
-                ocp_version=ocp_version,
             )
             mr_url = await self._create_shipment_mr(
                 shipment_config,
@@ -169,7 +152,6 @@ class GolangBuilderShipmentHandler:
                 env=env,
                 release_plan=release_plan,
                 nvrs=[nvr],
-                ocp_version=ocp_version,
             )
             self.logger.info("Golang builder shipment MR created: %s", mr_url)
             return mr_url
@@ -185,13 +167,11 @@ class GolangBuilderShipmentHandler:
         """Create shipment MR from NVR list (CLI path; may use elliott for snapshot)."""
         nvrs = sorted(nvrs)
         golang_group = derive_golang_group(nvrs)
-        env = env or resolve_env_from_runtime(self.runtime)
-        release_plan = self.resolve_release_plan(env)
-        ocp_version = self.ocp_version or golang_group
+        env = env or _DEFAULT_ENV
+        release_plan = GOLANG_BUILDER_SHIPMENT_RELEASE_PLAN_MAP[env]
 
         self.logger.info(
-            "Starting golang-builder-shipment: ocp_version=%s golang_group=%s env=%s release_plan=%s nvrs=%s",
-            ocp_version,
+            "Starting golang-builder-shipment: golang_group=%s env=%s release_plan=%s nvrs=%s",
             golang_group,
             env,
             release_plan,
@@ -200,12 +180,11 @@ class GolangBuilderShipmentHandler:
 
         await self._setup_repos()
 
-        snapshot = await self._create_snapshot_via_elliott(nvrs, golang_group)
+        snapshot = await self._create_snapshot_via_elliott(nvrs)
         shipment_config = self._build_shipment_config(
             snapshot=snapshot,
             nvrs=nvrs,
             golang_group=golang_group,
-            ocp_version=ocp_version,
         )
         mr_url = await self._create_shipment_mr(
             shipment_config,
@@ -213,7 +192,6 @@ class GolangBuilderShipmentHandler:
             env=env,
             release_plan=release_plan,
             nvrs=nvrs,
-            ocp_version=ocp_version,
         )
         self.logger.info("Shipment MR created: %s", mr_url)
         return mr_url
@@ -249,7 +227,6 @@ class GolangBuilderShipmentHandler:
     @staticmethod
     def _build_inline_snapshot(
         nvr: str,
-        golang_group: str,
         container_image: str,
         rebase_repo_url: str,
         rebase_commitish: str,
@@ -271,7 +248,6 @@ class GolangBuilderShipmentHandler:
         snapshot: Snapshot,
         nvrs: List[str],
         golang_group: str,
-        ocp_version: str,
     ) -> ShipmentConfig:
         # group must match the ocp-build-data branch name that elliott resolves.
         # For golang builders this is "golang", not the version-specific group
@@ -286,22 +262,18 @@ class GolangBuilderShipmentHandler:
         )
 
         environments = Environments(
-            stage=ShipmentEnv(releasePlan=self.resolve_release_plan("stage")),
-            prod=ShipmentEnv(releasePlan=self.resolve_release_plan("prod")),
+            stage=ShipmentEnv(releasePlan=GOLANG_BUILDER_SHIPMENT_RELEASE_PLAN_MAP["stage"]),
+            prod=ShipmentEnv(releasePlan=GOLANG_BUILDER_SHIPMENT_RELEASE_PLAN_MAP["prod"]),
         )
 
         release_notes = ReleaseNotes(
             type="RHBA",
-            synopsis=f"Golang builder image update for OpenShift {ocp_version}",
+            synopsis=f"Golang builder image update ({golang_group})",
             topic=(
-                f"An update for the golang builder images is now available for "
-                f"Red Hat OpenShift Container Platform {ocp_version}."
+                f"An update for the golang builder images ({golang_group}) is now available for "
+                f"Red Hat OpenShift Container Platform."
             ),
-            description=(
-                f"This update provides rebuilt golang builder images for "
-                f"Red Hat OpenShift Container Platform {ocp_version}.\n\n"
-                f"Golang group: {golang_group}"
-            ),
+            description=(f"This update provides rebuilt golang builder images for {golang_group}."),
             solution="The golang builder images are available from registry.redhat.io/openshift/golang-builder.",
         )
         if self.art_jira:
@@ -318,7 +290,7 @@ class GolangBuilderShipmentHandler:
         self.logger.info("Built ShipmentConfig with %d NVRs", len(nvrs))
         return config
 
-    async def _create_snapshot_via_elliott(self, nvrs: List[str], golang_group: str) -> Snapshot:
+    async def _create_snapshot_via_elliott(self, nvrs: List[str]) -> Snapshot:
         """Create a Snapshot from NVRs using ``elliott snapshot new --builds-file``."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
             for nvr in nvrs:
@@ -329,7 +301,7 @@ class GolangBuilderShipmentHandler:
             cmd = [
                 "elliott",
                 "--group",
-                golang_group,
+                _ELLIOTT_GOLANG_GROUP,
                 "--assembly",
                 "stream",
                 "snapshot",
@@ -371,7 +343,6 @@ class GolangBuilderShipmentHandler:
         env: str,
         release_plan: str,
         nvrs: List[str],
-        ocp_version: str,
     ) -> str:
         """Write the shipment YAML and open a draft MR in ocp-shipment-data."""
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
@@ -405,8 +376,7 @@ class GolangBuilderShipmentHandler:
             raise RuntimeError("Failed to push shipment data to remote")
 
         mr_title = format_shipment_mr_title(golang_group)
-        mr_description = f"Golang builder shipment for OCP {ocp_version}\n\n"
-        mr_description += f"Group: {golang_group}\n"
+        mr_description = f"Golang builder shipment for {golang_group}\n\n"
         mr_description += f"Environment: {env}\n"
         mr_description += f"ReleasePlan: {release_plan}\n"
         mr_description += f"NVRs: {len(nvrs)}\n"

--- a/doozer/doozerlib/backend/golang_builder_shipment.py
+++ b/doozer/doozerlib/backend/golang_builder_shipment.py
@@ -1,0 +1,451 @@
+"""
+Create shipment MRs in ocp-shipment-data for golang builder releases.
+
+:class:`GolangBuilderShipmentHandler` builds ShipmentConfig YAML and opens draft MRs in
+ocp-shipment-data. Inline builds use a single-component Snapshot; the CLI path may use
+``elliott snapshot new`` for multi-NVR snapshots.
+"""
+
+import logging
+import os
+import re
+import shutil
+import tempfile
+from datetime import datetime, timezone
+from io import StringIO
+from pathlib import Path
+from typing import List, Optional
+from urllib.parse import urlparse, urlunparse
+
+import gitlab as python_gitlab
+from artcommonlib import exectools
+from artcommonlib.constants import REDHAT_GITLAB_URL, SHIPMENT_DATA_URL_TEMPLATE
+from artcommonlib.release_util import isolate_el_version_in_release
+from artcommonlib.rpm_utils import parse_nvr
+from artcommonlib.util import new_roundtrip_yaml_handler
+from doozerlib.constants import ART_IMAGES_BASE_APPLICATION
+from doozerlib.util import konflux_golang_builder_component_name
+from elliottlib.shipment_model import (
+    ComponentSource,
+    Data,
+    Environments,
+    GitSource,
+    Metadata,
+    ReleaseNotes,
+    Shipment,
+    ShipmentConfig,
+    ShipmentEnv,
+    Snapshot,
+    SnapshotComponent,
+    SnapshotSpec,
+)
+from pyartcd.git import GitRepository
+
+yaml = new_roundtrip_yaml_handler()
+
+_PRODUCT = "ocp"
+
+
+def format_shipment_mr_title(golang_group: str) -> str:
+    """Match ocp-shipment-data convention: ``Shipment for 4.21.28 (ship date: …)``."""
+    return f"Shipment for {golang_group}"
+
+
+GOLANG_BUILDER_SHIPMENT_RELEASE_PLAN_MAP = {
+    "stage": "ocp-art-golang-builder-ec-rhel9",
+    "prod": "ocp-art-golang-builder-prod-rhel9",
+}
+
+
+def derive_golang_group(nvrs: List[str]) -> str:
+    """Derive the ocp-build-data golang group from NVR patterns."""
+    for nvr in nvrs:
+        m = re.search(r"v(\d+)\.(\d+)\.\d+.*\.el(\d+)", nvr)
+        if m:
+            return f"rhel-{m.group(3)}-golang-{m.group(1)}.{m.group(2)}"
+
+        parsed = parse_nvr(nvr)
+        if parsed["name"] == "golang":
+            major_minor = ".".join(parsed["version"].split(".")[:2])
+            el_v = isolate_el_version_in_release(parsed["release"])
+            if el_v is not None:
+                return f"rhel-{el_v}-golang-{major_minor}"
+
+    raise ValueError(f"Cannot derive golang group from NVRs: {nvrs}")
+
+
+def basic_auth_url(url: str, token: str) -> str:
+    """Inject token into a GitLab URL for push authentication."""
+    parsed = urlparse(url)
+    netloc = f"oauth2:{token}@{parsed.hostname}"
+    if parsed.port:
+        netloc += f":{parsed.port}"
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+def resolve_env_from_runtime(runtime) -> str:
+    """Return the shipment target env for MR placement (always prod)."""
+    return "prod"
+
+
+class GolangBuilderShipmentHandler:
+    """Creates a shipment MR in ocp-shipment-data for golang builder images."""
+
+    def __init__(
+        self,
+        runtime,
+        gitlab_url: str = REDHAT_GITLAB_URL,
+        shipment_data_repo_pull_url: Optional[str] = None,
+        shipment_data_repo_push_url: Optional[str] = None,
+        art_jira: str = "",
+        ocp_version: Optional[str] = None,
+    ):
+        self.runtime = runtime
+        self.art_jira = art_jira
+        self.ocp_version = ocp_version
+        self.logger = getattr(runtime, "logger", None) or logging.getLogger(__name__)
+        self.gitlab_url = gitlab_url
+        # Follow the established pyartcd pattern: use a known subdir of the runtime
+        # working directory. The runtime manages that dir's lifecycle (atexit cleanup
+        # when auto-created, or preserved when user-specified for debugging).
+        self._shipment_data_repo_dir = Path(runtime.working_dir) / "golang-shipment-data"
+
+        self.shipment_data_repo_pull_url = shipment_data_repo_pull_url or SHIPMENT_DATA_URL_TEMPLATE
+        self.shipment_data_repo_push_url = shipment_data_repo_push_url or SHIPMENT_DATA_URL_TEMPLATE
+        # pyartcd.git is co-installed with doozer in rh-art-tools
+        self.shipment_data_repo = GitRepository(self._shipment_data_repo_dir, False)
+        self._gitlab_token: Optional[str] = None
+
+    @staticmethod
+    def resolve_release_plan(env: str) -> str:
+        """Map shipment env to the correct ReleasePlan name."""
+        plan = GOLANG_BUILDER_SHIPMENT_RELEASE_PLAN_MAP.get(env)
+        if not plan:
+            raise ValueError(
+                f"Unknown env '{env}'. Must be one of: {list(GOLANG_BUILDER_SHIPMENT_RELEASE_PLAN_MAP.keys())}"
+            )
+        return plan
+
+    async def create_shipment(
+        self,
+        nvr: str,
+        container_image: str,
+        rebase_repo_url: str,
+        rebase_commitish: str,
+    ) -> Optional[str]:
+        """Create shipment MR for one golang builder build (non-fatal inline path)."""
+        try:
+            golang_group = derive_golang_group([nvr])
+            env = resolve_env_from_runtime(self.runtime)
+            release_plan = self.resolve_release_plan(env)
+            ocp_version = self.ocp_version or golang_group
+
+            self.logger.info(
+                "Starting golang builder shipment: nvr=%s golang_group=%s env=%s release_plan=%s",
+                nvr,
+                golang_group,
+                env,
+                release_plan,
+            )
+
+            await self._setup_repos()
+
+            snapshot = self._build_inline_snapshot(
+                nvr=nvr,
+                golang_group=golang_group,
+                container_image=container_image,
+                rebase_repo_url=rebase_repo_url,
+                rebase_commitish=rebase_commitish,
+            )
+            shipment_config = self._build_shipment_config(
+                snapshot=snapshot,
+                nvrs=[nvr],
+                golang_group=golang_group,
+                ocp_version=ocp_version,
+            )
+            mr_url = await self._create_shipment_mr(
+                shipment_config,
+                golang_group=golang_group,
+                env=env,
+                release_plan=release_plan,
+                nvrs=[nvr],
+                ocp_version=ocp_version,
+            )
+            self.logger.info("Golang builder shipment MR created: %s", mr_url)
+            return mr_url
+        except Exception:
+            self.logger.exception("Golang builder shipment failed for %s", nvr)
+            return None
+
+    async def create_shipment_from_nvrs(
+        self,
+        nvrs: List[str],
+        env: Optional[str] = None,
+    ) -> Optional[str]:
+        """Create shipment MR from NVR list (CLI path; may use elliott for snapshot)."""
+        nvrs = sorted(nvrs)
+        golang_group = derive_golang_group(nvrs)
+        env = env or resolve_env_from_runtime(self.runtime)
+        release_plan = self.resolve_release_plan(env)
+        ocp_version = self.ocp_version or golang_group
+
+        self.logger.info(
+            "Starting golang-builder-shipment: ocp_version=%s golang_group=%s env=%s release_plan=%s nvrs=%s",
+            ocp_version,
+            golang_group,
+            env,
+            release_plan,
+            nvrs,
+        )
+
+        await self._setup_repos()
+
+        snapshot = await self._create_snapshot_via_elliott(nvrs, golang_group)
+        shipment_config = self._build_shipment_config(
+            snapshot=snapshot,
+            nvrs=nvrs,
+            golang_group=golang_group,
+            ocp_version=ocp_version,
+        )
+        mr_url = await self._create_shipment_mr(
+            shipment_config,
+            golang_group=golang_group,
+            env=env,
+            release_plan=release_plan,
+            nvrs=nvrs,
+            ocp_version=ocp_version,
+        )
+        self.logger.info("Shipment MR created: %s", mr_url)
+        return mr_url
+
+    async def _setup_repos(self) -> None:
+        self._gitlab_token = os.getenv("GITLAB_TOKEN")
+        if not self._gitlab_token:
+            raise ValueError("GITLAB_TOKEN environment variable is required")
+
+        if self._shipment_data_repo_dir.exists():
+            shutil.rmtree(self._shipment_data_repo_dir, ignore_errors=True)
+
+        await self.shipment_data_repo.setup(
+            remote_url=basic_auth_url(self.shipment_data_repo_push_url, self._gitlab_token),
+            upstream_remote_url=self.shipment_data_repo_pull_url,
+        )
+        await self.shipment_data_repo.fetch_switch_branch("main")
+
+    @staticmethod
+    def _apply_rpa_component_names(snapshot: Snapshot, nvrs: List[str]) -> None:
+        """Rewrite snapshot component names to RPA mapping names (same as BaseImageHandler)."""
+        components = snapshot.spec.components
+        if len(components) != len(nvrs):
+            raise ValueError(f"Cannot map {len(nvrs)} NVR(s) to {len(components)} snapshot component(s)")
+        if len(nvrs) == 1:
+            components[0].name = konflux_golang_builder_component_name(nvrs[0])
+            return
+        sorted_nvrs = sorted(nvrs, key=konflux_golang_builder_component_name)
+        sorted_components = sorted(components, key=lambda c: c.name)
+        for component, nvr in zip(sorted_components, sorted_nvrs):
+            component.name = konflux_golang_builder_component_name(nvr)
+
+    @staticmethod
+    def _build_inline_snapshot(
+        nvr: str,
+        golang_group: str,
+        container_image: str,
+        rebase_repo_url: str,
+        rebase_commitish: str,
+    ) -> Snapshot:
+        component = SnapshotComponent(
+            name=konflux_golang_builder_component_name(nvr),
+            containerImage=container_image,
+            source=ComponentSource(
+                git=GitSource(url=rebase_repo_url, revision=rebase_commitish),
+            ),
+        )
+        return Snapshot(
+            spec=SnapshotSpec(application=ART_IMAGES_BASE_APPLICATION, components=[component]),
+            nvrs=[nvr],
+        )
+
+    def _build_shipment_config(
+        self,
+        snapshot: Snapshot,
+        nvrs: List[str],
+        golang_group: str,
+        ocp_version: str,
+    ) -> ShipmentConfig:
+        # group must match the ocp-build-data branch name that elliott resolves.
+        # For golang builders this is "golang", not the version-specific group
+        # (e.g. "rhel-9-golang-1.25"). Version specificity lives in the snapshot
+        # component names (e.g. "golang-builder-v1.25-rhel9") must match RPA mapping.
+        metadata = Metadata(
+            product=_PRODUCT,
+            application=snapshot.spec.application,
+            group="golang",
+            assembly="stream",
+            advisory_required=False,
+        )
+
+        environments = Environments(
+            stage=ShipmentEnv(releasePlan=self.resolve_release_plan("stage")),
+            prod=ShipmentEnv(releasePlan=self.resolve_release_plan("prod")),
+        )
+
+        release_notes = ReleaseNotes(
+            type="RHBA",
+            synopsis=f"Golang builder image update for OpenShift {ocp_version}",
+            topic=(
+                f"An update for the golang builder images is now available for "
+                f"Red Hat OpenShift Container Platform {ocp_version}."
+            ),
+            description=(
+                f"This update provides rebuilt golang builder images for "
+                f"Red Hat OpenShift Container Platform {ocp_version}.\n\n"
+                f"Golang group: {golang_group}"
+            ),
+            solution="The golang builder images are available from registry.redhat.io/openshift/golang-builder.",
+        )
+        if self.art_jira:
+            release_notes.references = [f"https://redhat.atlassian.net/browse/{self.art_jira}"]
+
+        shipment = Shipment(
+            metadata=metadata,
+            environments=environments,
+            snapshot=snapshot,
+            data=Data(releaseNotes=release_notes),
+        )
+
+        config = ShipmentConfig(shipment=shipment)
+        self.logger.info("Built ShipmentConfig with %d NVRs", len(nvrs))
+        return config
+
+    async def _create_snapshot_via_elliott(self, nvrs: List[str], golang_group: str) -> Snapshot:
+        """Create a Snapshot from NVRs using ``elliott snapshot new --builds-file``."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            for nvr in nvrs:
+                f.write(nvr + "\n")
+            builds_file = f.name
+
+        try:
+            cmd = [
+                "elliott",
+                "--group",
+                golang_group,
+                "--assembly",
+                "stream",
+                "snapshot",
+                "new",
+                f"--builds-file={builds_file}",
+            ]
+            quay_auth_file = os.getenv("QUAY_AUTH_FILE")
+            if quay_auth_file:
+                cmd.append(f"--pull-secret={quay_auth_file}")
+
+            rc, stdout, stderr = await exectools.cmd_gather_async(cmd, check=False)
+            if rc != 0:
+                raise RuntimeError(f"elliott snapshot new failed (rc={rc}): {stderr or stdout}")
+            if stdout:
+                self.logger.info("elliott snapshot new output:\n%s", stdout)
+        finally:
+            os.unlink(builds_file)
+
+        snapshot_obj = yaml.load(stdout)
+        if not snapshot_obj or not isinstance(snapshot_obj, dict):
+            raise ValueError(f"elliott snapshot new returned invalid output: {stdout!r}")
+
+        spec = snapshot_obj.get("spec")
+        if not spec:
+            raise ValueError(f"elliott snapshot new output missing 'spec': {snapshot_obj}")
+
+        snapshot = Snapshot(
+            spec=SnapshotSpec(**spec),
+            nvrs=nvrs,
+        )
+        snapshot.spec.application = ART_IMAGES_BASE_APPLICATION
+        self._apply_rpa_component_names(snapshot, nvrs)
+        return snapshot
+
+    async def _create_shipment_mr(
+        self,
+        shipment_config: ShipmentConfig,
+        golang_group: str,
+        env: str,
+        release_plan: str,
+        nvrs: List[str],
+        ocp_version: str,
+    ) -> str:
+        """Write the shipment YAML and open a draft MR in ocp-shipment-data."""
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+        source_branch = f"golang-builder-shipment-{golang_group}-{timestamp}"
+
+        await self.shipment_data_repo.create_branch(source_branch)
+
+        application = shipment_config.shipment.metadata.application
+        relative_target_dir = Path("shipment") / _PRODUCT / "golang" / application / env
+        target_dir = self.shipment_data_repo._directory / relative_target_dir
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        filename = f"stream.image.{timestamp}.yaml"
+        filepath = relative_target_dir / filename
+        shipment_dump = shipment_config.model_dump(exclude_unset=True, exclude_none=True)
+        out = StringIO()
+        yaml.dump(shipment_dump, out)
+        await self.shipment_data_repo.write_file(filepath, out.getvalue())
+        await self.shipment_data_repo.add_all()
+        await self.shipment_data_repo.log_diff()
+
+        commit_message = f"Add golang builder shipment for {golang_group}"
+        if self.art_jira:
+            commit_message += f"\n\nRef: {self.art_jira}"
+        job_url = os.getenv("BUILD_URL", "")
+        if job_url:
+            commit_message += f"\n{job_url}"
+
+        pushed = await self.shipment_data_repo.commit_push(commit_message, safe=True)
+        if not pushed:
+            raise RuntimeError("Failed to push shipment data to remote")
+
+        mr_title = format_shipment_mr_title(golang_group)
+        mr_description = f"Golang builder shipment for OCP {ocp_version}\n\n"
+        mr_description += f"Group: {golang_group}\n"
+        mr_description += f"Environment: {env}\n"
+        mr_description += f"ReleasePlan: {release_plan}\n"
+        mr_description += f"NVRs: {len(nvrs)}\n"
+        if self.art_jira:
+            mr_description += f"\nRef: https://redhat.atlassian.net/browse/{self.art_jira}"
+        if job_url:
+            mr_description += f"\nCreated by: {job_url}"
+
+        gl = python_gitlab.Gitlab(self.gitlab_url, private_token=self._gitlab_token)
+
+        def _get_project(url):
+            parsed = urlparse(url)
+            project_path = parsed.path.strip("/").removesuffix(".git")
+            return gl.projects.get(project_path)
+
+        source_project = _get_project(self.shipment_data_repo_push_url)
+        target_project = _get_project(self.shipment_data_repo_pull_url)
+
+        mr = source_project.mergerequests.create(
+            {
+                "source_branch": source_branch,
+                "target_project_id": target_project.id,
+                "target_branch": "main",
+                "title": mr_title,
+                "description": mr_description,
+                "remove_source_branch": True,
+            }
+        )
+        self.logger.info("Created Draft MR: %s", mr.web_url)
+
+        # The project has default approval rules (ART + ERT + Docs).
+        # Golang builder shipments only require ART sign-off — strip the rest.
+        try:
+            target_mr = target_project.mergerequests.get(mr.iid)
+            for rule in target_mr.approval_rules.list():
+                if rule.name != "ART":
+                    self.logger.info("Removing approval rule '%s' (not needed for golang builder shipment)", rule.name)
+                    rule.delete()
+        except Exception as e:
+            self.logger.warning("Could not clean up approval rules: %s", e)
+
+        return mr.web_url

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -32,6 +32,7 @@ from dockerfile_parse import DockerfileParser
 from doozerlib import constants, util
 from doozerlib.backend.base_image_handler import BaseImageHandler, BaseImageReleaseResult, BaseImageSnapshotInput
 from doozerlib.backend.build_repo import BuildRepo
+from doozerlib.backend.golang_builder_shipment import GolangBuilderShipmentHandler
 from doozerlib.backend.konflux_client import ImageBuildParams, KonfluxClient
 from doozerlib.backend.pipelinerun_utils import PipelineRunInfo
 from doozerlib.backend.rebaser import KonfluxRebaser
@@ -430,6 +431,28 @@ class KonfluxImageBuilder:
                         outcome = (
                             KonfluxBuildOutcome.SUCCESS if release_succeeded else KonfluxBuildOutcome.RELEASE_ERROR
                         )
+
+                    if (
+                        outcome is KonfluxBuildOutcome.SUCCESS
+                        and metadata.should_create_golang_builder_shipment()
+                        and image_pullspec
+                        and image_digest
+                    ):
+                        try:
+                            shipment_handler = GolangBuilderShipmentHandler(
+                                metadata.runtime,
+                            )
+                            mr_url = await shipment_handler.create_shipment(
+                                nvr=nvr,
+                                container_image=definitive_image_pullspec,
+                                rebase_repo_url=build_repo.https_url,
+                                rebase_commitish=build_repo.commit_hash,
+                            )
+                            if mr_url:
+                                logger.info("Golang builder shipment MR: %s", mr_url)
+                                record["shipment_mr"] = mr_url
+                        except Exception:
+                            logger.exception("Golang builder shipment MR creation failed (non-fatal)")
 
                     build_record = await self.update_konflux_db(
                         metadata,
@@ -1425,6 +1448,13 @@ class KonfluxImageBuilder:
             :class:`BaseImageReleaseResult` when snapshot→release completes; ``None`` on failure or exception.
         """
         logger = self._logger.getChild(f"[{metadata.distgit_key}]")
+
+        if metadata.is_golang_builder():
+            logger.warning(
+                "Golang builder images use the shipment MR path for release; "
+                "_trigger_base_image_release() must not be called for them"
+            )
+            return None
 
         logger.info(f"Triggering base image snapshot-release for {nvr}")
 

--- a/doozer/doozerlib/cli/__main__.py
+++ b/doozer/doozerlib/cli/__main__.py
@@ -33,6 +33,7 @@ from doozerlib.cli.config_tag_rpms import config_tag_rpms
 from doozerlib.cli.detect_embargo import detect_embargo
 from doozerlib.cli.fbc import fbc_import, fbc_rebase_and_build
 from doozerlib.cli.get_nightlies import get_nightlies
+from doozerlib.cli.golang_builder_shipment import golang_builder_shipment
 from doozerlib.cli.images import (
     distgit_config_template,
     images_build_image,

--- a/doozer/doozerlib/cli/golang_builder_shipment.py
+++ b/doozer/doozerlib/cli/golang_builder_shipment.py
@@ -1,0 +1,48 @@
+"""
+doozer golang-builder-shipment — create a shipment MR in ocp-shipment-data for a golang builder image.
+
+Invocation::
+
+    doozer --group rhel-9-golang-1.25 golang-builder-shipment \\
+        openshift-golang-builder-container-v1.25.11-....el9
+"""
+
+import logging
+from typing import Optional, Tuple
+
+import click
+
+from doozerlib.backend.golang_builder_shipment import GolangBuilderShipmentHandler
+from doozerlib.cli import cli, click_coroutine, pass_runtime
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@cli.command("golang-builder-shipment", short_help="Create shipment MR in ocp-shipment-data for a golang builder image")
+@click.option("--ocp-version", required=False, default=None, help="OCP version label (e.g. 4.22)")
+@click.option("--art-jira", default="", help="Related ART Jira ticket (e.g. ART-20930)")
+@click.option("--shipment-data-repo-url", default=None, help="Override ocp-shipment-data repo URL")
+@click.argument("nvrs", nargs=-1, required=True)
+@pass_runtime
+@click_coroutine
+async def golang_builder_shipment(
+    runtime,
+    ocp_version: Optional[str],
+    art_jira: str,
+    shipment_data_repo_url: Optional[str],
+    nvrs: Tuple[str, ...],
+):
+    """Create a shipment MR in ocp-shipment-data for golang builder images.
+
+    Pass one or more Konflux image NVRs as arguments. The golang group is derived
+    from the NVRs automatically.
+    """
+    handler = GolangBuilderShipmentHandler(
+        runtime=runtime,
+        art_jira=art_jira,
+        ocp_version=ocp_version,
+        shipment_data_repo_pull_url=shipment_data_repo_url,
+        shipment_data_repo_push_url=shipment_data_repo_url,
+    )
+    mr_url = await handler.create_shipment_from_nvrs(list(nvrs))
+    click.echo(f"Shipment MR: {mr_url}")

--- a/doozer/doozerlib/cli/golang_builder_shipment.py
+++ b/doozer/doozerlib/cli/golang_builder_shipment.py
@@ -3,7 +3,7 @@ doozer golang-builder-shipment — create a shipment MR in ocp-shipment-data for
 
 Invocation::
 
-    doozer --group rhel-9-golang-1.25 golang-builder-shipment \\
+    doozer --group golang golang-builder-shipment \\
         openshift-golang-builder-container-v1.25.11-....el9
 """
 
@@ -19,7 +19,6 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @cli.command("golang-builder-shipment", short_help="Create shipment MR in ocp-shipment-data for a golang builder image")
-@click.option("--ocp-version", required=False, default=None, help="OCP version label (e.g. 4.22)")
 @click.option("--art-jira", default="", help="Related ART Jira ticket (e.g. ART-20930)")
 @click.option("--shipment-data-repo-url", default=None, help="Override ocp-shipment-data repo URL")
 @click.argument("nvrs", nargs=-1, required=True)
@@ -27,7 +26,6 @@ _LOGGER = logging.getLogger(__name__)
 @click_coroutine
 async def golang_builder_shipment(
     runtime,
-    ocp_version: Optional[str],
     art_jira: str,
     shipment_data_repo_url: Optional[str],
     nvrs: Tuple[str, ...],
@@ -35,12 +33,11 @@ async def golang_builder_shipment(
     """Create a shipment MR in ocp-shipment-data for golang builder images.
 
     Pass one or more Konflux image NVRs as arguments. The golang group is derived
-    from the NVRs automatically.
+    from the NVRs automatically. Always use --group golang.
     """
     handler = GolangBuilderShipmentHandler(
         runtime=runtime,
         art_jira=art_jira,
-        ocp_version=ocp_version,
         shipment_data_repo_pull_url=shipment_data_repo_url,
         shipment_data_repo_push_url=shipment_data_repo_url,
     )

--- a/doozer/doozerlib/image.py
+++ b/doozer/doozerlib/image.py
@@ -1464,7 +1464,7 @@ class ImageMetadata(Metadata):
         0. Variant must be OCP (not OKD); OKD never uses RH base-image snapshot→release
         1. Assembly must not be ``test`` (unconditional block, not bypassed by force)
         2. Image metadata ``base_image_release.force`` set to true enables workflow (OCP only)
-        3. Image must be ``base_only`` or a golang builder
+        3. Image must be ``base_only`` (golang builders are excluded — they use the shipment MR path)
         4. Base image release enabled override:
            - Image metadata configuration (``self.config.base_image_release.enabled``)
            - Group configuration (``self.runtime.group_config.base_image_release.enabled``)
@@ -1485,7 +1485,7 @@ class ImageMetadata(Metadata):
             self.logger.info("Base image release force enabled from metadata config True")
             return True
 
-        if not (self.is_base_image() or self.is_golang_builder()):
+        if not self.is_base_image():
             return False
 
         source = None
@@ -1503,6 +1503,44 @@ class ImageMetadata(Metadata):
 
         self.logger.info(f"Base image release enabled set from {source} {base_image_release_enabled}")
         return base_image_release_enabled
+
+    def should_create_golang_builder_shipment(self) -> bool:
+        """
+        Whether to create an ocp-shipment-data MR after a successful golang builder build.
+
+        Gates (in order):
+        0. Variant must be OCP — OKD never uses RH registry releases
+        1. Assembly must not be ``test``
+        2. Image must be a golang builder
+        3. Respects ``base_image_release.enabled`` at image or group level (defaults True)
+
+        Returns:
+            bool: True if a golang builder shipment MR should be created, False otherwise.
+        """
+        if self.runtime.variant is BuildVariant.OKD:
+            return False
+
+        if self.runtime.assembly == "test":
+            self.logger.info("Skipping golang builder shipment for test assembly")
+            return False
+
+        if not self.is_golang_builder():
+            return False
+
+        enabled = True
+        source = None
+        config_override = self.config.base_image_release.enabled
+        if config_override not in [Missing, None]:
+            enabled = bool(config_override)
+            source = "metadata config"
+        else:
+            group_override = self.runtime.group_config.base_image_release.enabled
+            if group_override not in [Missing, None]:
+                enabled = bool(group_override)
+                source = "group config"
+
+        self.logger.info(f"Golang builder shipment enabled set from {source} {enabled}")
+        return enabled
 
     def get_required_artifacts(self) -> list:
         """

--- a/doozer/tests/backend/test_base_image_handler.py
+++ b/doozer/tests/backend/test_base_image_handler.py
@@ -135,9 +135,11 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_kubeconfig_by_product")
-    async def test_snapshot_release_golang_builder_success(
+    async def test_snapshot_release_golang_builder_returns_none(
         self, mock_kubeconfig, mock_namespace, mock_konflux_client_init
     ):
+        # Golang builders are excluded from the base-image release workflow via
+        # should_trigger_base_image_release(). They use the shipment MR path instead.
         from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
 
         mock_namespace.return_value = "ocp-art-tenant"
@@ -155,9 +157,8 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         golang_metadata = ImageMetadata(self.runtime, golang_data)
         golang_metadata.distgit_key = "golang-builder"
 
-        golang_nvr = "golang-builder-container-v1.0.0-1.el9"
         inp = BaseImageSnapshotInput(
-            nvr=golang_nvr,
+            nvr="golang-builder-container-v1.0.0-1.el9",
             distgit_key="golang-builder",
             container_image="quay.io/test/golang-builder:latest",
             rebase_repo_url="https://example.com/golang-builder.git",
@@ -168,21 +169,8 @@ class TestBaseImageHandler(IsolatedAsyncioTestCase):
         handler = BaseImageHandler(self.runtime, dry_run=True)
         self.runtime.image_map = {"golang-builder": golang_metadata}
 
-        with patch.object(handler, "_snapshot_from_component", new=AsyncMock(return_value="golang-snapshot")):
-            with patch.object(
-                handler,
-                "_create_release_from_snapshot",
-                new=AsyncMock(return_value=("golang-release", "https://konflux.example/releases/golang-release")),
-            ):
-                with patch.object(handler, "_wait_for_release_completion", return_value=True):
-                    result = await handler.snapshot_release(inp)
-
-        self.assertIsNotNone(result)
-        self.assertIsInstance(result, BaseImageReleaseResult)
-        self.assertEqual(result.release_name, "golang-release")
-        self.assertEqual(result.snapshot_name, "golang-snapshot")
-        self.assertEqual(result.release_pipeline, "https://konflux.example/releases/golang-release")
-        self.assertEqual(result.released_pullspec, rh_art_images_base_pullspec(golang_nvr))
+        result = await handler.snapshot_release(inp)
+        self.assertIsNone(result)
 
     @patch("doozerlib.backend.base_image_handler.KonfluxClient.from_kubeconfig")
     @patch("doozerlib.backend.base_image_handler.resolve_konflux_namespace_by_product")

--- a/doozer/tests/backend/test_golang_builder_shipment.py
+++ b/doozer/tests/backend/test_golang_builder_shipment.py
@@ -5,12 +5,10 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from artcommonlib.model import Model
 from doozerlib.backend.golang_builder_shipment import (
-    GOLANG_BUILDER_SHIPMENT_RELEASE_PLAN_MAP,
     GolangBuilderShipmentHandler,
     basic_auth_url,
     derive_golang_group,
     format_shipment_mr_title,
-    resolve_env_from_runtime,
 )
 from doozerlib.constants import ART_IMAGES_BASE_APPLICATION
 
@@ -23,45 +21,6 @@ class TestFormatShipmentMrTitle(unittest.TestCase):
             format_shipment_mr_title("rhel-9-golang-1.25"),
             "Shipment for rhel-9-golang-1.25",
         )
-
-
-class TestResolveReleasePlan(unittest.TestCase):
-    def test_prod_returns_prod_plan(self):
-        plan = GolangBuilderShipmentHandler.resolve_release_plan("prod")
-        self.assertEqual(plan, "ocp-art-golang-builder-prod-rhel9")
-
-    def test_stage_returns_ec_plan(self):
-        plan = GolangBuilderShipmentHandler.resolve_release_plan("stage")
-        self.assertEqual(plan, "ocp-art-golang-builder-ec-rhel9")
-
-    def test_unknown_env_raises(self):
-        with self.assertRaises(ValueError):
-            GolangBuilderShipmentHandler.resolve_release_plan("staging")
-
-    def test_removed_ec_key_raises(self):
-        with self.assertRaises(ValueError):
-            GolangBuilderShipmentHandler.resolve_release_plan("ec")
-
-    def test_map_keys_are_complete(self):
-        self.assertIn("stage", GOLANG_BUILDER_SHIPMENT_RELEASE_PLAN_MAP)
-        self.assertIn("prod", GOLANG_BUILDER_SHIPMENT_RELEASE_PLAN_MAP)
-
-
-class TestResolveEnvFromRuntime(unittest.TestCase):
-    def test_pre_release_returns_prod(self):
-        runtime = Mock()
-        runtime.group_config = Model({"software_lifecycle": {"phase": "pre-release"}})
-        self.assertEqual(resolve_env_from_runtime(runtime), "prod")
-
-    def test_release_returns_prod(self):
-        runtime = Mock()
-        runtime.group_config = Model({"software_lifecycle": {"phase": "release"}})
-        self.assertEqual(resolve_env_from_runtime(runtime), "prod")
-
-    def test_missing_lifecycle_returns_prod(self):
-        runtime = Mock()
-        runtime.group_config = Model({})
-        self.assertEqual(resolve_env_from_runtime(runtime), "prod")
 
 
 class TestBasicAuthUrl(unittest.TestCase):
@@ -81,7 +40,6 @@ class TestBuildShipmentConfig(unittest.TestCase):
         runtime.working_dir = "/tmp"
         handler = GolangBuilderShipmentHandler(
             runtime=runtime,
-            ocp_version="4.22",
             art_jira="ART-20930",
         )
         return handler
@@ -110,7 +68,6 @@ spec:
         nvrs = ["golang-builder-container-v1.25-202606220000.el9"]
         snapshot = handler._build_inline_snapshot(
             nvr=nvrs[0],
-            golang_group="rhel-9-golang-1.25",
             container_image="quay.io/test@sha256:abc123",
             rebase_repo_url="https://github.com/openshift-priv/builder",
             rebase_commitish="abc123",
@@ -119,7 +76,6 @@ spec:
             snapshot=snapshot,
             nvrs=nvrs,
             golang_group="rhel-9-golang-1.25",
-            ocp_version="4.22",
         )
 
         self.assertEqual(config.shipment.metadata.product, "ocp")
@@ -163,7 +119,6 @@ spec:
         nvrs = ["golang-builder-container-v1.26-202606220000.el9"]
         snapshot = handler._build_inline_snapshot(
             nvr=nvrs[0],
-            golang_group="rhel-9-golang-1.26",
             container_image="quay.io/test@sha256:def456",
             rebase_repo_url="https://github.com/openshift-priv/builder",
             rebase_commitish="def456",
@@ -172,7 +127,6 @@ spec:
             snapshot=snapshot,
             nvrs=nvrs,
             golang_group="rhel-9-golang-1.26",
-            ocp_version="4.22",
         )
 
         self.assertEqual(
@@ -193,7 +147,6 @@ class TestCreateShipmentMR(IsolatedAsyncioTestCase):
         runtime.working_dir = "/tmp"
         handler = GolangBuilderShipmentHandler(
             runtime=runtime,
-            ocp_version="4.22",
             art_jira="ART-20930",
         )
         handler.shipment_data_repo = AsyncMock()
@@ -226,7 +179,6 @@ class TestCreateShipmentMR(IsolatedAsyncioTestCase):
                 env="prod",
                 release_plan="ocp-art-golang-builder-prod-rhel9",
                 nvrs=["some-nvr"],
-                ocp_version="4.22",
             )
 
         self.assertEqual(result, mock_mr.web_url)
@@ -272,7 +224,7 @@ spec:
         runtime.group_config = Model({})
         runtime.working_dir = "/tmp"
         handler = GolangBuilderShipmentHandler(runtime=runtime)
-        await handler._create_snapshot_via_elliott([SAMPLE_GOLANG_NVR], "rhel-9-golang-1.25")
+        await handler._create_snapshot_via_elliott([SAMPLE_GOLANG_NVR])
         cmd_args = mock_cmd.call_args[0][0]
         self.assertTrue(any("--pull-secret=" in str(a) for a in cmd_args))
 
@@ -301,9 +253,9 @@ spec:
         runtime.logger = Mock()
         runtime.group_config = Model({})
         runtime.working_dir = "/tmp"
-        handler = GolangBuilderShipmentHandler(runtime=runtime, art_jira="ART-20930", ocp_version="4.22")
+        handler = GolangBuilderShipmentHandler(runtime=runtime, art_jira="ART-20930")
         nvr = "openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.el9"
-        snapshot = await handler._create_snapshot_via_elliott([nvr], "rhel-9-golang-1.25")
+        snapshot = await handler._create_snapshot_via_elliott([nvr])
 
         self.assertEqual(snapshot.spec.application, ART_IMAGES_BASE_APPLICATION)
         self.assertEqual(snapshot.spec.components[0].name, "golang-builder-v1.25-rhel9")
@@ -324,7 +276,7 @@ class TestCreateSnapshotErrors(IsolatedAsyncioTestCase):
         mock_cmd.return_value = (1, "", "elliott error: NVR not found")
         handler = self._make_handler()
         with self.assertRaises(RuntimeError) as ctx:
-            await handler._create_snapshot_via_elliott([SAMPLE_GOLANG_NVR], "rhel-9-golang-1.25")
+            await handler._create_snapshot_via_elliott([SAMPLE_GOLANG_NVR])
         self.assertIn("elliott snapshot new failed", str(ctx.exception))
 
     @patch("doozerlib.backend.golang_builder_shipment.exectools.cmd_gather_async")
@@ -334,7 +286,7 @@ class TestCreateSnapshotErrors(IsolatedAsyncioTestCase):
         mock_cmd.return_value = (0, "", "")
         handler = self._make_handler()
         with self.assertRaises(ValueError) as ctx:
-            await handler._create_snapshot_via_elliott([SAMPLE_GOLANG_NVR], "rhel-9-golang-1.25")
+            await handler._create_snapshot_via_elliott([SAMPLE_GOLANG_NVR])
         self.assertIn("invalid output", str(ctx.exception))
 
     @patch("doozerlib.backend.golang_builder_shipment.exectools.cmd_gather_async")
@@ -344,7 +296,7 @@ class TestCreateSnapshotErrors(IsolatedAsyncioTestCase):
         mock_cmd.return_value = (0, "apiVersion: v1\nkind: Snapshot\n", "")
         handler = self._make_handler()
         with self.assertRaises(ValueError) as ctx:
-            await handler._create_snapshot_via_elliott([SAMPLE_GOLANG_NVR], "rhel-9-golang-1.25")
+            await handler._create_snapshot_via_elliott([SAMPLE_GOLANG_NVR])
         self.assertIn("missing 'spec'", str(ctx.exception))
 
 
@@ -356,7 +308,6 @@ class TestCommitPushFailure(IsolatedAsyncioTestCase):
         runtime.working_dir = "/tmp"
         handler = GolangBuilderShipmentHandler(
             runtime=runtime,
-            ocp_version="4.22",
             art_jira="ART-20930",
         )
         handler.shipment_data_repo = AsyncMock()
@@ -375,20 +326,18 @@ class TestCommitPushFailure(IsolatedAsyncioTestCase):
                     env="prod",
                     release_plan="ocp-art-golang-builder-prod-rhel9",
                     nvrs=["some-nvr"],
-                    ocp_version="4.22",
                 )
         self.assertIn("Failed to push", str(ctx.exception))
 
 
 class TestCreateShipmentFromNvrs(IsolatedAsyncioTestCase):
     @patch("doozerlib.backend.golang_builder_shipment.derive_golang_group", return_value="rhel-9-golang-1.25")
-    @patch("doozerlib.backend.golang_builder_shipment.resolve_env_from_runtime", return_value="prod")
-    async def test_create_shipment_from_nvrs_wires_steps(self, mock_env, mock_derive):
+    async def test_create_shipment_from_nvrs_wires_steps(self, mock_derive):
         runtime = Mock()
         runtime.logger = Mock()
         runtime.group_config = Model({})
         runtime.working_dir = "/tmp"
-        handler = GolangBuilderShipmentHandler(runtime=runtime, ocp_version="4.22")
+        handler = GolangBuilderShipmentHandler(runtime=runtime)
         handler._setup_repos = AsyncMock()
         handler._create_snapshot_via_elliott = AsyncMock(return_value=Mock(spec=["spec"]))
         handler._create_snapshot_via_elliott.return_value.spec.application = ART_IMAGES_BASE_APPLICATION
@@ -411,7 +360,7 @@ class TestCreateShipmentInline(IsolatedAsyncioTestCase):
         runtime.logger = Mock()
         runtime.group_config = Model({})
         runtime.working_dir = "/tmp"
-        handler = GolangBuilderShipmentHandler(runtime=runtime, ocp_version="4.22")
+        handler = GolangBuilderShipmentHandler(runtime=runtime)
         handler._setup_repos = AsyncMock(side_effect=RuntimeError("boom"))
 
         result = await handler.create_shipment(
@@ -433,7 +382,6 @@ class TestBuildInlineSnapshot(unittest.TestCase):
         nvr = "openshift-golang-builder-container-v1.25.9-202605121249.p2.gdf787b0.el9"
         snapshot = handler._build_inline_snapshot(
             nvr=nvr,
-            golang_group="rhel-9-golang-1.25",
             container_image="quay.io/test@sha256:abc",
             rebase_repo_url="https://example.com/repo.git",
             rebase_commitish="abc123",
@@ -501,7 +449,6 @@ class TestShipmentFilePath(IsolatedAsyncioTestCase):
         runtime.working_dir = "/tmp"
         handler = GolangBuilderShipmentHandler(
             runtime=runtime,
-            ocp_version="4.22",
             art_jira="ART-20930",
         )
 
@@ -548,7 +495,6 @@ class TestShipmentFilePath(IsolatedAsyncioTestCase):
                     env="prod",
                     release_plan="ocp-art-golang-builder-prod-rhel9",
                     nvrs=["some-nvr"],
-                    ocp_version="4.22",
                 )
 
         self.assertEqual(len(recorded_paths), 1)

--- a/doozer/tests/backend/test_golang_builder_shipment.py
+++ b/doozer/tests/backend/test_golang_builder_shipment.py
@@ -84,11 +84,11 @@ spec:
         self.assertFalse(config.shipment.metadata.advisory_required)
         self.assertEqual(
             config.shipment.environments.stage.releasePlan,
-            "ocp-art-golang-builder-ec-rhel9",
+            "ocp-art-golang-builder-ec",
         )
         self.assertEqual(
             config.shipment.environments.prod.releasePlan,
-            "ocp-art-golang-builder-prod-rhel9",
+            "ocp-art-golang-builder-prod",
         )
         self.assertIn(
             "https://redhat.atlassian.net/browse/ART-20930",
@@ -131,11 +131,11 @@ spec:
 
         self.assertEqual(
             config.shipment.environments.stage.releasePlan,
-            "ocp-art-golang-builder-ec-rhel9",
+            "ocp-art-golang-builder-ec",
         )
         self.assertEqual(
             config.shipment.environments.prod.releasePlan,
-            "ocp-art-golang-builder-prod-rhel9",
+            "ocp-art-golang-builder-prod",
         )
 
 
@@ -177,7 +177,7 @@ class TestCreateShipmentMR(IsolatedAsyncioTestCase):
                 config,
                 golang_group="rhel-9-golang-1.25",
                 env="prod",
-                release_plan="ocp-art-golang-builder-prod-rhel9",
+                release_plan="ocp-art-golang-builder-prod",
                 nvrs=["some-nvr"],
             )
 
@@ -324,7 +324,7 @@ class TestCommitPushFailure(IsolatedAsyncioTestCase):
                     config,
                     golang_group="rhel-9-golang-1.25",
                     env="prod",
-                    release_plan="ocp-art-golang-builder-prod-rhel9",
+                    release_plan="ocp-art-golang-builder-prod",
                     nvrs=["some-nvr"],
                 )
         self.assertIn("Failed to push", str(ctx.exception))
@@ -493,7 +493,7 @@ class TestShipmentFilePath(IsolatedAsyncioTestCase):
                     config,
                     golang_group="rhel-9-golang-1.25",
                     env="prod",
-                    release_plan="ocp-art-golang-builder-prod-rhel9",
+                    release_plan="ocp-art-golang-builder-prod",
                     nvrs=["some-nvr"],
                 )
 

--- a/doozer/tests/backend/test_golang_builder_shipment.py
+++ b/doozer/tests/backend/test_golang_builder_shipment.py
@@ -1,0 +1,567 @@
+import unittest
+from pathlib import Path
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+from artcommonlib.model import Model
+from doozerlib.backend.golang_builder_shipment import (
+    GOLANG_BUILDER_SHIPMENT_RELEASE_PLAN_MAP,
+    GolangBuilderShipmentHandler,
+    basic_auth_url,
+    derive_golang_group,
+    format_shipment_mr_title,
+    resolve_env_from_runtime,
+)
+from doozerlib.constants import ART_IMAGES_BASE_APPLICATION
+
+SAMPLE_GOLANG_NVR = "openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.el9"
+
+
+class TestFormatShipmentMrTitle(unittest.TestCase):
+    def test_title_matches_shipment_convention(self):
+        self.assertEqual(
+            format_shipment_mr_title("rhel-9-golang-1.25"),
+            "Shipment for rhel-9-golang-1.25",
+        )
+
+
+class TestResolveReleasePlan(unittest.TestCase):
+    def test_prod_returns_prod_plan(self):
+        plan = GolangBuilderShipmentHandler.resolve_release_plan("prod")
+        self.assertEqual(plan, "ocp-art-golang-builder-prod-rhel9")
+
+    def test_stage_returns_ec_plan(self):
+        plan = GolangBuilderShipmentHandler.resolve_release_plan("stage")
+        self.assertEqual(plan, "ocp-art-golang-builder-ec-rhel9")
+
+    def test_unknown_env_raises(self):
+        with self.assertRaises(ValueError):
+            GolangBuilderShipmentHandler.resolve_release_plan("staging")
+
+    def test_removed_ec_key_raises(self):
+        with self.assertRaises(ValueError):
+            GolangBuilderShipmentHandler.resolve_release_plan("ec")
+
+    def test_map_keys_are_complete(self):
+        self.assertIn("stage", GOLANG_BUILDER_SHIPMENT_RELEASE_PLAN_MAP)
+        self.assertIn("prod", GOLANG_BUILDER_SHIPMENT_RELEASE_PLAN_MAP)
+
+
+class TestResolveEnvFromRuntime(unittest.TestCase):
+    def test_pre_release_returns_prod(self):
+        runtime = Mock()
+        runtime.group_config = Model({"software_lifecycle": {"phase": "pre-release"}})
+        self.assertEqual(resolve_env_from_runtime(runtime), "prod")
+
+    def test_release_returns_prod(self):
+        runtime = Mock()
+        runtime.group_config = Model({"software_lifecycle": {"phase": "release"}})
+        self.assertEqual(resolve_env_from_runtime(runtime), "prod")
+
+    def test_missing_lifecycle_returns_prod(self):
+        runtime = Mock()
+        runtime.group_config = Model({})
+        self.assertEqual(resolve_env_from_runtime(runtime), "prod")
+
+
+class TestBasicAuthUrl(unittest.TestCase):
+    def test_injects_token(self):
+        url = "https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data.git"
+        result = basic_auth_url(url, "mytoken")
+        self.assertIn("oauth2:mytoken@", result)
+        self.assertIn("gitlab.cee.redhat.com", result)
+        self.assertTrue(result.startswith("https://"))
+
+
+class TestBuildShipmentConfig(unittest.TestCase):
+    def _make_handler(self, env="prod"):
+        runtime = Mock()
+        runtime.logger = Mock()
+        runtime.group_config = Model({})
+        runtime.working_dir = "/tmp"
+        handler = GolangBuilderShipmentHandler(
+            runtime=runtime,
+            ocp_version="4.22",
+            art_jira="ART-20930",
+        )
+        return handler
+
+    @patch("doozerlib.backend.golang_builder_shipment.exectools.cmd_gather_async")
+    @patch("doozerlib.backend.golang_builder_shipment.os.unlink")
+    @patch.dict("os.environ", {}, clear=False)
+    def test_build_shipment_config_prod(self, mock_unlink, mock_cmd):
+        mock_cmd.return_value = (
+            0,
+            """
+spec:
+  application: art-images-base
+  components:
+    - name: golang-builder-v1.25-rhel9
+      containerImage: quay.io/redhat-user-workloads/ocp-art-tenant/art-images@sha256:abc123
+      source:
+        git:
+          url: https://github.com/openshift-priv/builder
+          revision: abc123
+""",
+            "",
+        )
+
+        handler = self._make_handler()
+        nvrs = ["golang-builder-container-v1.25-202606220000.el9"]
+        snapshot = handler._build_inline_snapshot(
+            nvr=nvrs[0],
+            golang_group="rhel-9-golang-1.25",
+            container_image="quay.io/test@sha256:abc123",
+            rebase_repo_url="https://github.com/openshift-priv/builder",
+            rebase_commitish="abc123",
+        )
+        config = handler._build_shipment_config(
+            snapshot=snapshot,
+            nvrs=nvrs,
+            golang_group="rhel-9-golang-1.25",
+            ocp_version="4.22",
+        )
+
+        self.assertEqual(config.shipment.metadata.product, "ocp")
+        self.assertEqual(config.shipment.metadata.application, ART_IMAGES_BASE_APPLICATION)
+        self.assertEqual(config.shipment.metadata.group, "golang")
+        self.assertFalse(config.shipment.metadata.advisory_required)
+        self.assertEqual(
+            config.shipment.environments.stage.releasePlan,
+            "ocp-art-golang-builder-ec-rhel9",
+        )
+        self.assertEqual(
+            config.shipment.environments.prod.releasePlan,
+            "ocp-art-golang-builder-prod-rhel9",
+        )
+        self.assertIn(
+            "https://redhat.atlassian.net/browse/ART-20930",
+            config.shipment.data.releaseNotes.references,
+        )
+
+    @patch("doozerlib.backend.golang_builder_shipment.exectools.cmd_gather_async")
+    @patch("doozerlib.backend.golang_builder_shipment.os.unlink")
+    @patch.dict("os.environ", {}, clear=False)
+    def test_build_shipment_config_uses_split_release_plans(self, mock_unlink, mock_cmd):
+        mock_cmd.return_value = (
+            0,
+            """
+spec:
+  application: art-images-base
+  components:
+    - name: golang-builder-v1.26-rhel9
+      containerImage: quay.io/test@sha256:def456
+      source:
+        git:
+          url: https://github.com/openshift-priv/builder
+          revision: def456
+""",
+            "",
+        )
+
+        handler = self._make_handler()
+        nvrs = ["golang-builder-container-v1.26-202606220000.el9"]
+        snapshot = handler._build_inline_snapshot(
+            nvr=nvrs[0],
+            golang_group="rhel-9-golang-1.26",
+            container_image="quay.io/test@sha256:def456",
+            rebase_repo_url="https://github.com/openshift-priv/builder",
+            rebase_commitish="def456",
+        )
+        config = handler._build_shipment_config(
+            snapshot=snapshot,
+            nvrs=nvrs,
+            golang_group="rhel-9-golang-1.26",
+            ocp_version="4.22",
+        )
+
+        self.assertEqual(
+            config.shipment.environments.stage.releasePlan,
+            "ocp-art-golang-builder-ec-rhel9",
+        )
+        self.assertEqual(
+            config.shipment.environments.prod.releasePlan,
+            "ocp-art-golang-builder-prod-rhel9",
+        )
+
+
+class TestCreateShipmentMR(IsolatedAsyncioTestCase):
+    def _make_handler(self):
+        runtime = Mock()
+        runtime.logger = Mock()
+        runtime.group_config = Model({})
+        runtime.working_dir = "/tmp"
+        handler = GolangBuilderShipmentHandler(
+            runtime=runtime,
+            ocp_version="4.22",
+            art_jira="ART-20930",
+        )
+        handler.shipment_data_repo = AsyncMock()
+        handler.shipment_data_repo._directory = Path("/tmp/test-working/shipment-data-push")
+        handler.shipment_data_repo.commit_push = AsyncMock(return_value=True)
+        return handler
+
+    def _make_config_mock(self):
+        config = Mock()
+        config.shipment.metadata.application = "art-images-base"
+        config.model_dump.return_value = {"shipment": {}}
+        return config
+
+    @patch("doozerlib.backend.golang_builder_shipment.python_gitlab")
+    async def test_creates_mr_with_correct_title(self, mock_gitlab):
+        handler = self._make_handler()
+        handler._gitlab_token = "test-token"
+        config = self._make_config_mock()
+
+        mock_project = MagicMock()
+        mock_mr = MagicMock()
+        mock_mr.web_url = "https://gitlab.cee.redhat.com/test/-/merge_requests/1"
+        mock_project.mergerequests.create.return_value = mock_mr
+        mock_gitlab.Gitlab.return_value.projects.get.return_value = mock_project
+
+        with patch("pathlib.Path.mkdir"):
+            result = await handler._create_shipment_mr(
+                config,
+                golang_group="rhel-9-golang-1.25",
+                env="prod",
+                release_plan="ocp-art-golang-builder-prod-rhel9",
+                nvrs=["some-nvr"],
+                ocp_version="4.22",
+            )
+
+        self.assertEqual(result, mock_mr.web_url)
+        create_args = mock_project.mergerequests.create.call_args[0][0]
+        self.assertEqual(create_args["title"], "Shipment for rhel-9-golang-1.25")
+        self.assertEqual(create_args["target_branch"], "main")
+
+
+class TestSetupReposNoToken(IsolatedAsyncioTestCase):
+    @patch.dict("os.environ", {}, clear=True)
+    async def test_missing_gitlab_token_raises(self):
+        runtime = Mock()
+        runtime.logger = Mock()
+        runtime.group_config = Model({})
+        runtime.working_dir = "/tmp"
+        handler = GolangBuilderShipmentHandler(runtime=runtime)
+        with self.assertRaises(ValueError):
+            await handler._setup_repos()
+
+
+class TestSnapshotWithQuayAuth(IsolatedAsyncioTestCase):
+    @patch("doozerlib.backend.golang_builder_shipment.exectools.cmd_gather_async")
+    @patch("doozerlib.backend.golang_builder_shipment.os.unlink")
+    @patch.dict("os.environ", {"QUAY_AUTH_FILE": "/tmp/quay-auth.json"})
+    async def test_pull_secret_flag_added(self, mock_unlink, mock_cmd):
+        mock_cmd.return_value = (
+            0,
+            """
+spec:
+  application: art-images-base
+  components:
+    - name: golang-builder-v1.25-rhel9
+      containerImage: quay.io/test@sha256:abc
+      source:
+        git:
+          url: https://github.com/openshift-priv/builder
+          revision: abc123
+""",
+            "",
+        )
+        runtime = Mock()
+        runtime.logger = Mock()
+        runtime.group_config = Model({})
+        runtime.working_dir = "/tmp"
+        handler = GolangBuilderShipmentHandler(runtime=runtime)
+        await handler._create_snapshot_via_elliott([SAMPLE_GOLANG_NVR], "rhel-9-golang-1.25")
+        cmd_args = mock_cmd.call_args[0][0]
+        self.assertTrue(any("--pull-secret=" in str(a) for a in cmd_args))
+
+
+class TestApplicationOverride(IsolatedAsyncioTestCase):
+    @patch("doozerlib.backend.golang_builder_shipment.exectools.cmd_gather_async")
+    @patch("doozerlib.backend.golang_builder_shipment.os.unlink")
+    @patch.dict("os.environ", {}, clear=False)
+    async def test_elliott_app_overridden_to_art_images_base(self, mock_unlink, mock_cmd):
+        mock_cmd.return_value = (
+            0,
+            """
+spec:
+  application: rhel-9-golang-1-25
+  components:
+    - name: golang-builder-v1.25-rhel9
+      containerImage: quay.io/test@sha256:abc
+      source:
+        git:
+          url: https://github.com/openshift-priv/builder
+          revision: abc123
+""",
+            "",
+        )
+        runtime = Mock()
+        runtime.logger = Mock()
+        runtime.group_config = Model({})
+        runtime.working_dir = "/tmp"
+        handler = GolangBuilderShipmentHandler(runtime=runtime, art_jira="ART-20930", ocp_version="4.22")
+        nvr = "openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.el9"
+        snapshot = await handler._create_snapshot_via_elliott([nvr], "rhel-9-golang-1.25")
+
+        self.assertEqual(snapshot.spec.application, ART_IMAGES_BASE_APPLICATION)
+        self.assertEqual(snapshot.spec.components[0].name, "golang-builder-v1.25-rhel9")
+
+
+class TestCreateSnapshotErrors(IsolatedAsyncioTestCase):
+    def _make_handler(self):
+        runtime = Mock()
+        runtime.logger = Mock()
+        runtime.group_config = Model({})
+        runtime.working_dir = "/tmp"
+        return GolangBuilderShipmentHandler(runtime=runtime)
+
+    @patch("doozerlib.backend.golang_builder_shipment.exectools.cmd_gather_async")
+    @patch("doozerlib.backend.golang_builder_shipment.os.unlink")
+    @patch.dict("os.environ", {}, clear=False)
+    async def test_elliott_nonzero_rc_raises(self, mock_unlink, mock_cmd):
+        mock_cmd.return_value = (1, "", "elliott error: NVR not found")
+        handler = self._make_handler()
+        with self.assertRaises(RuntimeError) as ctx:
+            await handler._create_snapshot_via_elliott([SAMPLE_GOLANG_NVR], "rhel-9-golang-1.25")
+        self.assertIn("elliott snapshot new failed", str(ctx.exception))
+
+    @patch("doozerlib.backend.golang_builder_shipment.exectools.cmd_gather_async")
+    @patch("doozerlib.backend.golang_builder_shipment.os.unlink")
+    @patch.dict("os.environ", {}, clear=False)
+    async def test_empty_stdout_raises(self, mock_unlink, mock_cmd):
+        mock_cmd.return_value = (0, "", "")
+        handler = self._make_handler()
+        with self.assertRaises(ValueError) as ctx:
+            await handler._create_snapshot_via_elliott([SAMPLE_GOLANG_NVR], "rhel-9-golang-1.25")
+        self.assertIn("invalid output", str(ctx.exception))
+
+    @patch("doozerlib.backend.golang_builder_shipment.exectools.cmd_gather_async")
+    @patch("doozerlib.backend.golang_builder_shipment.os.unlink")
+    @patch.dict("os.environ", {}, clear=False)
+    async def test_missing_spec_raises(self, mock_unlink, mock_cmd):
+        mock_cmd.return_value = (0, "apiVersion: v1\nkind: Snapshot\n", "")
+        handler = self._make_handler()
+        with self.assertRaises(ValueError) as ctx:
+            await handler._create_snapshot_via_elliott([SAMPLE_GOLANG_NVR], "rhel-9-golang-1.25")
+        self.assertIn("missing 'spec'", str(ctx.exception))
+
+
+class TestCommitPushFailure(IsolatedAsyncioTestCase):
+    async def test_push_failure_raises(self):
+        runtime = Mock()
+        runtime.logger = Mock()
+        runtime.group_config = Model({})
+        runtime.working_dir = "/tmp"
+        handler = GolangBuilderShipmentHandler(
+            runtime=runtime,
+            ocp_version="4.22",
+            art_jira="ART-20930",
+        )
+        handler.shipment_data_repo = AsyncMock()
+        handler.shipment_data_repo._directory = Path("/tmp/test-working/shipment-data-push")
+        handler.shipment_data_repo.commit_push = AsyncMock(return_value=False)
+
+        config = Mock()
+        config.shipment.metadata.application = "art-images-base"
+        config.model_dump.return_value = {"shipment": {}}
+
+        with patch("pathlib.Path.mkdir"):
+            with self.assertRaises(RuntimeError) as ctx:
+                await handler._create_shipment_mr(
+                    config,
+                    golang_group="rhel-9-golang-1.25",
+                    env="prod",
+                    release_plan="ocp-art-golang-builder-prod-rhel9",
+                    nvrs=["some-nvr"],
+                    ocp_version="4.22",
+                )
+        self.assertIn("Failed to push", str(ctx.exception))
+
+
+class TestCreateShipmentFromNvrs(IsolatedAsyncioTestCase):
+    @patch("doozerlib.backend.golang_builder_shipment.derive_golang_group", return_value="rhel-9-golang-1.25")
+    @patch("doozerlib.backend.golang_builder_shipment.resolve_env_from_runtime", return_value="prod")
+    async def test_create_shipment_from_nvrs_wires_steps(self, mock_env, mock_derive):
+        runtime = Mock()
+        runtime.logger = Mock()
+        runtime.group_config = Model({})
+        runtime.working_dir = "/tmp"
+        handler = GolangBuilderShipmentHandler(runtime=runtime, ocp_version="4.22")
+        handler._setup_repos = AsyncMock()
+        handler._create_snapshot_via_elliott = AsyncMock(return_value=Mock(spec=["spec"]))
+        handler._create_snapshot_via_elliott.return_value.spec.application = ART_IMAGES_BASE_APPLICATION
+        handler._build_shipment_config = Mock(return_value=Mock())
+        handler._create_shipment_mr = AsyncMock(return_value="https://gitlab.example.com/-/merge_requests/1")
+
+        result = await handler.create_shipment_from_nvrs(
+            ["openshift-golang-builder-container-v1.25.8-202604081607.p0.g2aa6a05.el9"],
+        )
+
+        self.assertEqual(result, "https://gitlab.example.com/-/merge_requests/1")
+        handler._setup_repos.assert_called_once()
+        handler._create_snapshot_via_elliott.assert_called_once()
+        handler._create_shipment_mr.assert_called_once()
+
+
+class TestCreateShipmentInline(IsolatedAsyncioTestCase):
+    async def test_create_shipment_returns_none_on_failure(self):
+        runtime = Mock()
+        runtime.logger = Mock()
+        runtime.group_config = Model({})
+        runtime.working_dir = "/tmp"
+        handler = GolangBuilderShipmentHandler(runtime=runtime, ocp_version="4.22")
+        handler._setup_repos = AsyncMock(side_effect=RuntimeError("boom"))
+
+        result = await handler.create_shipment(
+            nvr="openshift-golang-builder-container-v1.25.9-202605121249.p2.gdf787b0.el9",
+            container_image="quay.io/test@sha256:abc",
+            rebase_repo_url="https://example.com/repo.git",
+            rebase_commitish="abc123",
+        )
+        self.assertIsNone(result)
+
+
+class TestBuildInlineSnapshot(unittest.TestCase):
+    def test_inline_snapshot_uses_component_name_and_application(self):
+        runtime = Mock()
+        runtime.logger = Mock()
+        runtime.group_config = Model({})
+        runtime.working_dir = "/tmp"
+        handler = GolangBuilderShipmentHandler(runtime=runtime)
+        nvr = "openshift-golang-builder-container-v1.25.9-202605121249.p2.gdf787b0.el9"
+        snapshot = handler._build_inline_snapshot(
+            nvr=nvr,
+            golang_group="rhel-9-golang-1.25",
+            container_image="quay.io/test@sha256:abc",
+            rebase_repo_url="https://example.com/repo.git",
+            rebase_commitish="abc123",
+        )
+        self.assertEqual(snapshot.spec.application, ART_IMAGES_BASE_APPLICATION)
+        self.assertEqual(snapshot.nvrs, [nvr])
+        self.assertEqual(snapshot.spec.components[0].containerImage, "quay.io/test@sha256:abc")
+        self.assertEqual(snapshot.spec.components[0].name, "golang-builder-v1.25-rhel9")
+
+
+class TestApplyRpaComponentNames(unittest.TestCase):
+    def test_renames_konflux_cr_name_from_elliott(self):
+        from elliottlib.shipment_model import ComponentSource, GitSource, Snapshot, SnapshotComponent, SnapshotSpec
+
+        nvr = "openshift-golang-builder-container-v1.25.11-202607210212.p2.g6245b3b.el9"
+        snapshot = Snapshot(
+            spec=SnapshotSpec(
+                application=ART_IMAGES_BASE_APPLICATION,
+                components=[
+                    SnapshotComponent(
+                        name="rhel-9-golang-1-25-openshift-golang-builder",
+                        containerImage="quay.io/test@sha256:abc",
+                        source=ComponentSource(
+                            git=GitSource(
+                                url="https://github.com/openshift-eng/ocp-build-data",
+                                revision="abc123",
+                            ),
+                        ),
+                    )
+                ],
+            ),
+            nvrs=[nvr],
+        )
+        GolangBuilderShipmentHandler._apply_rpa_component_names(snapshot, [nvr])
+        self.assertEqual(snapshot.spec.components[0].name, "golang-builder-v1.25-rhel9")
+
+
+class TestDeriveGolangGroup(unittest.TestCase):
+    def test_from_rpm_nvr(self):
+        self.assertEqual(derive_golang_group(["golang-1.25.9-1.el9"]), "rhel-9-golang-1.25")
+
+    def test_from_konflux_image_nvr(self):
+        nvr = "openshift-golang-builder-container-v1.25.9-202605121249.p2.gdf787b0.el9"
+        self.assertEqual(derive_golang_group([nvr]), "rhel-9-golang-1.25")
+
+    def test_unknown_nvr_raises(self):
+        with self.assertRaises(ValueError):
+            derive_golang_group(["not-a-golang-nvr-1.0-1.noarch"])
+
+
+class TestShipmentFilePath(IsolatedAsyncioTestCase):
+    """Verify that _create_shipment_mr writes the YAML under the expected path.
+
+    The real production path is:
+        shipment/<product>/golang/<application>/<env>/<filename>
+
+    Note: the directory segment is the literal string ``"golang"``, not the
+    version-specific golang_group (e.g. ``"rhel-9-golang-1.25"``).
+    """
+
+    async def test_write_file_uses_golang_literal_segment(self):
+        runtime = Mock()
+        runtime.logger = Mock()
+        runtime.group_config = Model({})
+        runtime.working_dir = "/tmp"
+        handler = GolangBuilderShipmentHandler(
+            runtime=runtime,
+            ocp_version="4.22",
+            art_jira="ART-20930",
+        )
+
+        recorded_paths = []
+
+        async def capture_write(path, content):
+            recorded_paths.append(Path(path))
+
+        handler.shipment_data_repo = AsyncMock()
+        handler.shipment_data_repo._directory = Path("/tmp/fake-repo")
+        handler.shipment_data_repo.create_branch = AsyncMock()
+        handler.shipment_data_repo.write_file = capture_write
+        handler.shipment_data_repo.add_all = AsyncMock()
+        handler.shipment_data_repo.log_diff = AsyncMock()
+        handler.shipment_data_repo.commit_push = AsyncMock(return_value=True)
+        handler._gitlab_token = "fake-token"
+
+        from unittest.mock import patch as _patch
+
+        mock_mr = Mock()
+        mock_mr.web_url = "https://gitlab.example.com/-/merge_requests/42"
+        mock_mr.iid = 42
+
+        mock_project = Mock()
+        mock_project.mergerequests = Mock()
+        mock_project.mergerequests.create = Mock(return_value=mock_mr)
+        mock_mr_obj = Mock()
+        mock_mr_obj.approval_rules = Mock()
+        mock_mr_obj.approval_rules.list = Mock(return_value=[])
+        mock_project.mergerequests.get = Mock(return_value=mock_mr_obj)
+
+        config = Mock()
+        config.shipment = Mock()
+        config.shipment.metadata = Mock()
+        config.shipment.metadata.application = "art-images-base"
+        config.model_dump.return_value = {"shipment": {}}
+
+        with _patch("doozerlib.backend.golang_builder_shipment.python_gitlab") as mock_gl_mod:
+            mock_gl_mod.Gitlab.return_value.projects.get.return_value = mock_project
+            with _patch("pathlib.Path.mkdir"):
+                await handler._create_shipment_mr(
+                    config,
+                    golang_group="rhel-9-golang-1.25",
+                    env="prod",
+                    release_plan="ocp-art-golang-builder-prod-rhel9",
+                    nvrs=["some-nvr"],
+                    ocp_version="4.22",
+                )
+
+        self.assertEqual(len(recorded_paths), 1)
+        path = recorded_paths[0]
+        parts = path.parts
+        # Expected: shipment/ocp/golang/art-images-base/prod/<filename>
+        self.assertEqual(parts[0], "shipment")
+        self.assertEqual(parts[1], "ocp")
+        self.assertEqual(parts[2], "golang")  # literal "golang", not golang_group
+        self.assertEqual(parts[3], "art-images-base")
+        self.assertEqual(parts[4], "prod")
+        self.assertTrue(parts[5].endswith(".yaml"), f"Expected .yaml filename, got {parts[5]}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -1159,8 +1159,8 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(inp.container_image, pullspec)
         self.assertFalse(inp.is_golang_builder)
 
-    async def test_trigger_base_image_release_golang_calls_is_golang_builder(self):
-        """Inline release passes through metadata.is_golang_builder() (openshift/golang-builder vs hyphen)."""
+    async def test_trigger_base_image_release_rejects_golang_builder(self):
+        """_trigger_base_image_release() returns None immediately for golang builders (defense-in-depth)."""
         from doozerlib.backend import base_image_handler
 
         metadata = self._metadata()
@@ -1170,25 +1170,15 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         build_repo.commit_hash = "abc123"
         pullspec = "quay.io/test/img@sha256:deadbeef"
 
-        release_result = base_image_handler.BaseImageReleaseResult(
-            release_name="test-release",
-            snapshot_name="test-snapshot",
-            nvr="test-nvr",
-            release_pipeline="https://example.com/pipeline",
-            released_pullspec="example.com/openshift/foo:test-nvr",
-        )
-
         with patch.object(
             base_image_handler.BaseImageHandler,
             "snapshot_release",
-            new=AsyncMock(return_value=release_result),
+            new=AsyncMock(),
         ) as mock_snap:
             result = await self.builder._trigger_base_image_release(metadata, "test-nvr", pullspec, build_repo)
 
-        self.assertIs(result, release_result)
-        metadata.is_golang_builder.assert_called_once()
-        inp = mock_snap.await_args[0][0]
-        self.assertTrue(inp.is_golang_builder)
+        self.assertIsNone(result)
+        mock_snap.assert_not_awaited()
 
     async def test_trigger_base_image_release_returns_none_when_handler_returns_none(self):
         """When handler returns None, _trigger_base_image_release returns None."""
@@ -1210,6 +1200,138 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(result)
         mock_snap.assert_awaited_once()
+
+    async def test_golang_builder_build_uses_shipment_gate(self):
+        """Successful golang builder build: no base-image release, shipment gate fires create_shipment."""
+        metadata = self._metadata()
+        metadata.should_trigger_base_image_release = MagicMock(return_value=False)
+        metadata.should_create_golang_builder_shipment = MagicMock(return_value=True)
+        dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        build_repo = MagicMock()
+        build_repo.local_dir = dest_dir
+        build_repo.url = "https://github.com/test/repo.git"
+        build_repo.https_url = "https://github.com/test/repo.git"
+        build_repo.commit_hash = "abc123"
+
+        initial_pipelinerun = MagicMock()
+        initial_pipelinerun.name = "test-pipelinerun"
+        initial_pipelinerun.to_dict.return_value = {"metadata": {"name": "test-pipelinerun"}}
+
+        completed_pipelinerun = MagicMock()
+        completed_pipelinerun.name = "test-pipelinerun"
+        completed_pipelinerun.find_condition.return_value = {"status": "True"}
+        completed_pipelinerun.to_dict.return_value = {
+            "metadata": {"name": "test-pipelinerun"},
+            "status": {
+                "results": [
+                    {"name": "IMAGE_URL", "value": "quay.io/test/golang-builder:latest"},
+                    {"name": "IMAGE_DIGEST", "value": "sha256:abc123"},
+                ]
+            },
+        }
+        self.mock_konflux_client.wait_for_pipelinerun = AsyncMock(return_value=completed_pipelinerun)
+
+        mock_mr_url = "https://gitlab.example.com/mr/1"
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=build_repo),
+            ),
+            patch.object(self.builder, "_parse_dockerfile", return_value=("test-uuid", "test-component", "1.0", "1")),
+            patch.object(self.builder, "_wait_for_parent_members", new=AsyncMock(return_value=[])),
+            patch.object(self.builder, "_start_build", new=AsyncMock(return_value=initial_pipelinerun)),
+            patch.object(self.builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))),
+            patch.object(self.builder, "_trigger_base_image_release", new=AsyncMock()) as mock_trigger_release,
+            patch.object(self.builder, "_validate_build_attestation_and_signature", new=AsyncMock()),
+            patch.object(
+                self.builder._konflux_client,
+                "verify_enterprise_contract",
+                new=AsyncMock(return_value=MagicMock(ec_pipeline_url="", ec_failed=False)),
+            ),
+            patch(
+                "doozerlib.backend.konflux_image_builder.KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition",
+                return_value=KonfluxBuildOutcome.SUCCESS,
+            ),
+            patch(
+                "doozerlib.backend.konflux_image_builder.GolangBuilderShipmentHandler",
+            ) as mock_shipment_cls,
+        ):
+            mock_shipment_handler = AsyncMock()
+            mock_shipment_handler.create_shipment = AsyncMock(return_value=mock_mr_url)
+            mock_shipment_cls.return_value = mock_shipment_handler
+
+            await self.builder.build(metadata)
+
+        mock_trigger_release.assert_not_awaited()
+        mock_shipment_handler.create_shipment.assert_awaited_once()
+        call_kwargs = mock_shipment_handler.create_shipment.await_args
+        self.assertIsNotNone(call_kwargs.kwargs.get("nvr"))
+
+    async def test_golang_builder_build_skips_shipment_on_gate_false(self):
+        """When should_create_golang_builder_shipment() returns False, create_shipment() is not called."""
+        metadata = self._metadata()
+        metadata.should_trigger_base_image_release = MagicMock(return_value=False)
+        metadata.should_create_golang_builder_shipment = MagicMock(return_value=False)
+        dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        build_repo = MagicMock()
+        build_repo.local_dir = dest_dir
+        build_repo.url = "https://github.com/test/repo.git"
+        build_repo.commit_hash = "test-commit"
+
+        initial_pipelinerun = MagicMock()
+        initial_pipelinerun.name = "test-pipelinerun"
+        initial_pipelinerun.to_dict.return_value = {"metadata": {"name": "test-pipelinerun"}}
+
+        completed_pipelinerun = MagicMock()
+        completed_pipelinerun.name = "test-pipelinerun"
+        completed_pipelinerun.find_condition.return_value = {"status": "True"}
+        completed_pipelinerun.to_dict.return_value = {
+            "metadata": {"name": "test-pipelinerun"},
+            "status": {
+                "results": [
+                    {"name": "IMAGE_URL", "value": "quay.io/test/golang-builder:latest"},
+                    {"name": "IMAGE_DIGEST", "value": "sha256:abc123"},
+                ]
+            },
+        }
+        self.mock_konflux_client.wait_for_pipelinerun = AsyncMock(return_value=completed_pipelinerun)
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=build_repo),
+            ),
+            patch.object(self.builder, "_parse_dockerfile", return_value=("test-uuid", "test-component", "1.0", "1")),
+            patch.object(self.builder, "_wait_for_parent_members", new=AsyncMock(return_value=[])),
+            patch.object(self.builder, "_start_build", new=AsyncMock(return_value=initial_pipelinerun)),
+            patch.object(self.builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))),
+            patch.object(self.builder, "_trigger_base_image_release", new=AsyncMock()),
+            patch.object(self.builder, "_validate_build_attestation_and_signature", new=AsyncMock()),
+            patch.object(
+                self.builder._konflux_client,
+                "verify_enterprise_contract",
+                new=AsyncMock(return_value=MagicMock(ec_pipeline_url="", ec_failed=False)),
+            ),
+            patch(
+                "doozerlib.backend.konflux_image_builder.KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition",
+                return_value=KonfluxBuildOutcome.SUCCESS,
+            ),
+            patch(
+                "doozerlib.backend.konflux_image_builder.GolangBuilderShipmentHandler",
+            ) as mock_shipment_cls,
+        ):
+            mock_shipment_handler = AsyncMock()
+            mock_shipment_handler.create_shipment = AsyncMock(return_value=None)
+            mock_shipment_cls.return_value = mock_shipment_handler
+
+            await self.builder.build(metadata)
+
+        mock_shipment_cls.assert_not_called()
 
     async def test_build_parent_failure_captures_message_in_record(self):
         """When parent images fail, the record message should capture the actual error, not 'Unknown failure'."""

--- a/doozer/tests/cli/test_golang_builder_shipment.py
+++ b/doozer/tests/cli/test_golang_builder_shipment.py
@@ -1,0 +1,50 @@
+"""Tests for doozer golang-builder-shipment CLI command."""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from click.testing import CliRunner
+
+
+class TestGolangBuilderShipmentCli(unittest.IsolatedAsyncioTestCase):
+    def _make_runtime(self, dry_run=False):
+        runtime = MagicMock()
+        runtime.dry_run = dry_run
+        return runtime
+
+    @patch("doozerlib.cli.golang_builder_shipment.GolangBuilderShipmentHandler")
+    def test_cli_invokes_handler(self, mock_handler_cls):
+        mock_handler = mock_handler_cls.return_value
+        mock_handler.create_shipment_from_nvrs = AsyncMock(return_value="https://gitlab.example.com/mr/1")
+
+        runner = CliRunner()
+        from doozerlib.cli import cli
+
+        result = runner.invoke(
+            cli,
+            [
+                "--group",
+                "rhel-9-golang-1.25",
+                "golang-builder-shipment",
+                "openshift-golang-builder-container-v1.25.9-1.el9",
+            ],
+            obj=MagicMock(dry_run=False),
+            catch_exceptions=False,
+        )
+        self.assertIn("https://gitlab.example.com/mr/1", result.output)
+        mock_handler.create_shipment_from_nvrs.assert_called_once()
+
+    def test_cli_requires_nvrs(self):
+        runner = CliRunner()
+        from doozerlib.cli import cli
+
+        result = runner.invoke(
+            cli,
+            ["--group", "rhel-9-golang-1.25", "golang-builder-shipment"],
+            obj=MagicMock(dry_run=False),
+        )
+        self.assertNotEqual(result.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/doozer/tests/cli/test_golang_builder_shipment.py
+++ b/doozer/tests/cli/test_golang_builder_shipment.py
@@ -24,7 +24,7 @@ class TestGolangBuilderShipmentCli(unittest.IsolatedAsyncioTestCase):
             cli,
             [
                 "--group",
-                "rhel-9-golang-1.25",
+                "golang",
                 "golang-builder-shipment",
                 "openshift-golang-builder-container-v1.25.9-1.el9",
             ],
@@ -40,7 +40,7 @@ class TestGolangBuilderShipmentCli(unittest.IsolatedAsyncioTestCase):
 
         result = runner.invoke(
             cli,
-            ["--group", "rhel-9-golang-1.25", "golang-builder-shipment"],
+            ["--group", "golang", "golang-builder-shipment"],
             obj=MagicMock(dry_run=False),
         )
         self.assertNotEqual(result.exit_code, 0)

--- a/doozer/tests/test_image.py
+++ b/doozer/tests/test_image.py
@@ -1908,11 +1908,11 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         base_metadata = ImageMetadata(runtime, base_data)
         self.assertTrue(base_metadata.should_trigger_base_image_release())
 
-        # Test golang builder - should trigger workflow
+        # Golang builders do NOT use the base-image release path — they go through the shipment MR
         golang_builder = Model({'name': GOLANG_BUILDER_IMAGE_NAME})
         golang_data = Model({'key': 'golang-builder', 'data': golang_builder, 'filename': 'golang-builder.yaml'})
         golang_metadata = ImageMetadata(runtime, golang_data)
-        self.assertTrue(golang_metadata.should_trigger_base_image_release())
+        self.assertFalse(golang_metadata.should_trigger_base_image_release())
 
         # Test assembly: base/golang do not use the base-image release path
         test_assembly_runtime = MagicMock()
@@ -1924,7 +1924,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         self.assertFalse(ImageMetadata(test_assembly_runtime, base_data).should_trigger_base_image_release())
         self.assertFalse(ImageMetadata(test_assembly_runtime, golang_data).should_trigger_base_image_release())
 
-        # Named (non-test) assembly still uses the base-image release path
+        # Named (non-test) assembly: base images still use base-image release; golang builders still don't
         named_runtime = MagicMock()
         named_runtime.logger = logging.getLogger('test_runtime')
         named_runtime.variant = BuildVariant.OCP
@@ -1932,7 +1932,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         named_runtime.product = 'ocp'
         named_runtime.group_config = Model({})
         self.assertTrue(ImageMetadata(named_runtime, base_data).should_trigger_base_image_release())
-        self.assertTrue(ImageMetadata(named_runtime, golang_data).should_trigger_base_image_release())
+        self.assertFalse(ImageMetadata(named_runtime, golang_data).should_trigger_base_image_release())
 
         # Test regular image - should NOT trigger workflow
         regular_image = Model({'name': 'test-regular'})
@@ -2010,7 +2010,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         both_metadata = ImageMetadata(runtime_both, both_data)
         self.assertTrue(both_metadata.should_trigger_base_image_release())
 
-        # Layered product: same base/golang trigger rules as OCP when variant and assembly allow
+        # Layered product: base images trigger; golang builders still use the shipment MR path
         layered_runtime = MagicMock()
         layered_runtime.logger = logging.getLogger('test_runtime')
         layered_runtime.variant = BuildVariant.OCP
@@ -2018,7 +2018,7 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
         layered_runtime.product = 'rhmtc'
         layered_runtime.group_config = Model({})
         self.assertTrue(ImageMetadata(layered_runtime, base_data).should_trigger_base_image_release())
-        self.assertTrue(ImageMetadata(layered_runtime, golang_data).should_trigger_base_image_release())
+        self.assertFalse(ImageMetadata(layered_runtime, golang_data).should_trigger_base_image_release())
 
         # OKD: base image would trigger on OCP but never on OKD (no RH registry release)
         okd_runtime = MagicMock()
@@ -2053,6 +2053,83 @@ class TestImageMetadataAsyncMethods(IsolatedAsyncioTestCase):
             Model({'key': 'test-assembly-forced', 'data': test_assembly_forced, 'filename': 'taf.yaml'}),
         )
         self.assertFalse(test_assembly_forced_metadata.should_trigger_base_image_release())
+
+    def test_should_create_golang_builder_shipment(self):
+        from artcommonlib.constants import GOLANG_BUILDER_IMAGE_NAME
+        from artcommonlib.model import Model
+
+        runtime = MagicMock()
+        runtime.logger = logging.getLogger('test_runtime')
+        runtime.variant = BuildVariant.OCP
+        runtime.assembly = 'stream'
+        runtime.product = 'ocp'
+        runtime.group_config = Model({})
+
+        golang_builder = Model({'name': GOLANG_BUILDER_IMAGE_NAME})
+        golang_data = Model({'key': 'golang-builder', 'data': golang_builder, 'filename': 'golang-builder.yaml'})
+        golang_metadata = ImageMetadata(runtime, golang_data)
+
+        # Golang builder on OCP stream assembly → should create shipment
+        self.assertTrue(golang_metadata.should_create_golang_builder_shipment())
+
+        # Non-golang image → False
+        regular = Model({'name': 'test-regular'})
+        regular_data = Model({'key': 'test-regular', 'data': regular, 'filename': 'test-regular.yaml'})
+        self.assertFalse(ImageMetadata(runtime, regular_data).should_create_golang_builder_shipment())
+
+        # OKD variant → False
+        okd_runtime = MagicMock()
+        okd_runtime.logger = logging.getLogger('test_runtime')
+        okd_runtime.variant = BuildVariant.OKD
+        okd_runtime.assembly = 'stream'
+        okd_runtime.product = 'ocp'
+        okd_runtime.group_config = Model({})
+        self.assertFalse(ImageMetadata(okd_runtime, golang_data).should_create_golang_builder_shipment())
+
+        # Test assembly → False
+        test_runtime = MagicMock()
+        test_runtime.logger = logging.getLogger('test_runtime')
+        test_runtime.variant = BuildVariant.OCP
+        test_runtime.assembly = 'test'
+        test_runtime.product = 'ocp'
+        test_runtime.group_config = Model({})
+        self.assertFalse(ImageMetadata(test_runtime, golang_data).should_create_golang_builder_shipment())
+
+        # Named (non-test) assembly → True
+        named_runtime = MagicMock()
+        named_runtime.logger = logging.getLogger('test_runtime')
+        named_runtime.variant = BuildVariant.OCP
+        named_runtime.assembly = '4.17.1'
+        named_runtime.product = 'ocp'
+        named_runtime.group_config = Model({})
+        self.assertTrue(ImageMetadata(named_runtime, golang_data).should_create_golang_builder_shipment())
+
+        # base_image_release.enabled: false in image config → False
+        golang_disabled = Model({'name': GOLANG_BUILDER_IMAGE_NAME, 'base_image_release': Model({'enabled': False})})
+        golang_disabled_data = Model({'key': 'go-off', 'data': golang_disabled, 'filename': 'go-off.yaml'})
+        self.assertFalse(ImageMetadata(runtime, golang_disabled_data).should_create_golang_builder_shipment())
+
+        # base_image_release.enabled: false in group config → False
+        group_off_runtime = MagicMock()
+        group_off_runtime.logger = logging.getLogger('test_runtime')
+        group_off_runtime.variant = BuildVariant.OCP
+        group_off_runtime.assembly = 'stream'
+        group_off_runtime.product = 'ocp'
+        group_off_runtime.group_config = Model({'base_image_release': Model({'enabled': False})})
+        self.assertFalse(ImageMetadata(group_off_runtime, golang_data).should_create_golang_builder_shipment())
+
+        # Image-level enabled: true overrides group-level false
+        group_off_image_on_runtime = MagicMock()
+        group_off_image_on_runtime.logger = logging.getLogger('test_runtime')
+        group_off_image_on_runtime.variant = BuildVariant.OCP
+        group_off_image_on_runtime.assembly = 'stream'
+        group_off_image_on_runtime.product = 'ocp'
+        group_off_image_on_runtime.group_config = Model({'base_image_release': Model({'enabled': False})})
+        golang_enabled = Model({'name': GOLANG_BUILDER_IMAGE_NAME, 'base_image_release': Model({'enabled': True})})
+        golang_enabled_data = Model({'key': 'go-on', 'data': golang_enabled, 'filename': 'go-on.yaml'})
+        self.assertTrue(
+            ImageMetadata(group_off_image_on_runtime, golang_enabled_data).should_create_golang_builder_shipment()
+        )
 
 
 class TestExtractGolangVersionFromPullspec(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds the golang builder shipment pipeline to doozer. After a successful Konflux build,
golang builder images now get a shipment MR created in ocp-shipment-data automatically,
without going through the generic base-image release path.

## Problem

**Before:** After a golang builder Konflux build, `_trigger_base_image_release()` was called,
which pushed the image to the base-image registry. Then the shipment MR stage step would
push it again — a double-release. There was also no gating to skip this for test assemblies
or OKD variants.

**After:** `should_create_golang_builder_shipment()` gates the shipment MR path with proper
checks (OKD, test assembly, `base_image_release.enabled`). Golang builders are explicitly
rejected from `_trigger_base_image_release()` so only one release path runs.

## Implementation Details

### Key changes
- `image.py`: adds `should_create_golang_builder_shipment()` and updates
  `should_trigger_base_image_release()` to exclude golang builders
- `konflux_image_builder.py`: adds defensive guard in `_trigger_base_image_release()`;
  switches shipment block to use the new gate method
- `constants.py`: adds `REDHAT_GITLAB_URL`
- `doozer/doozerlib/backend/golang_builder_shipment.py` — `GolangBuilderShipmentHandler`
- `doozer/doozerlib/cli/golang_builder_shipment.py` — `doozer golang-builder-shipment` CLI

Jira: [ART-20930](https://redhat.atlassian.net/browse/ART-20930)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command to create shipment merge requests for Golang builder images from specified NVRs.
  * Eligible image builds can now automatically generate shipment merge requests.
  * Added validation for release plans, environments, snapshots, and shipment metadata.

* **Bug Fixes**
  * Golang builder images no longer trigger base-image release workflows.
  * Shipment creation is skipped for unsupported variants, test assemblies, or disabled configurations.

* **Tests**
  * Added coverage for shipment creation, CLI behavior, validation, and release gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->