### PR TITLE
fix: include rebase failures in chai-bot OKD health notifications

### DIFF
--- a/pyartcd/pyartcd/pipelines/okd_images_health.py
+++ b/pyartcd/pyartcd/pipelines/okd_images_health.py
@@ -99,9 +99,15 @@ class ImagesHealthPipeline:
             await self.notify_okd_channel()
 
         if self.ping_chai_bot:
-            multi_failure_images = self._get_multi_failure_images()
-            for version, failing_concerns in multi_failure_images.items():
-                await self.notify_chai_bot(version, failing_concerns)
+            multi_build_failures = self._get_multi_failure_images()
+            multi_rebase_failures = self._get_multi_rebase_failures()
+            all_versions = set(multi_build_failures) | set(multi_rebase_failures)
+            for version in all_versions:
+                await self.notify_chai_bot(
+                    version,
+                    multi_build_failures.get(version, []),
+                    multi_rebase_failures.get(version, {}),
+                )
 
     async def get_report(self, version: str) -> Optional[list]:
         group = OKD_GROUP_TEMPLATE.format(version)
@@ -546,29 +552,58 @@ class ImagesHealthPipeline:
 
         return multi_failures
 
-    def _build_chai_bot_prompt(self, version: str, failing_concerns: list[dict]) -> str:
+    def _get_multi_rebase_failures(self) -> dict[str, dict[str, dict]]:
         """
-        Build structured prompt for @chai-bot to fix OKD build failures.
+        Filter self.rebase_failures for images with >1 consecutive rebase failure.
+
+        Return Value(s):
+            dict[str, dict[str, dict]]: Version -> {image_name: failure_info}
+        """
+        result = {}
+        for version, failures in self.rebase_failures.items():
+            multi = {image: info for image, info in failures.items() if info.get('failure_count', 0) > 1}
+            if multi:
+                result[version] = multi
+        return result
+
+    def _build_chai_bot_prompt(
+        self, version: str, failing_concerns: list[dict], rebase_failures: dict[str, dict] | None = None
+    ) -> str:
+        """
+        Build structured prompt for @chai-bot to fix OKD build and rebase failures.
 
         Arg(s):
             version (str): OKD version (e.g., "4.21")
-            failing_concerns (list[dict]): List of concern dicts with failure info
+            failing_concerns (list[dict]): List of concern dicts with build failure info
+            rebase_failures (dict[str, dict]): Map of image_name -> failure_info for rebase failures
         Return Value(s):
             str: Formatted prompt for chai-bot
         """
         okd_group = f'okd-{version}'
-        prompt_parts = [f'Please investigate and fix OKD build failures for *{okd_group}*.\n', '*Failing Images:*']
+        prompt_parts = [f'Please investigate and fix OKD build failures for *{okd_group}*.\n']
 
-        for concern in failing_concerns:
-            image_name = concern['image_name']
-            failure_count = concern.get('latest_success_idx', 0)
-            logs_url = self.get_logs_url(concern)
-            search_url = self.get_search_url(concern)
+        if failing_concerns:
+            prompt_parts.append('*Failing Images (build failures):*')
+            for concern in failing_concerns:
+                image_name = concern['image_name']
+                failure_count = concern.get('latest_success_idx', 0)
+                logs_url = self.get_logs_url(concern)
+                search_url = self.get_search_url(concern)
 
-            prompt_parts.append(
-                f'- `{image_name}`: {failure_count} consecutive failures '
-                f'({self.url_text(search_url, "history")} | {self.url_text(logs_url, "latest logs")})'
-            )
+                prompt_parts.append(
+                    f'- `{image_name}`: {failure_count} consecutive failures '
+                    f'({self.url_text(search_url, "history")} | {self.url_text(logs_url, "latest logs")})'
+                )
+
+        if rebase_failures:
+            prompt_parts.append('\n*Failing Images (rebase failures):*')
+            for image_name, failure_info in sorted(rebase_failures.items()):
+                failure_count = failure_info.get('failure_count', 0)
+                jenkins_url = failure_info.get('jenkins_url', '')
+                line = f'- `{image_name}`: {failure_count} consecutive rebase failures'
+                if jenkins_url:
+                    line += f' ({self.url_text(jenkins_url, "last failure job")})'
+                prompt_parts.append(line)
 
         prompt_parts.extend(
             [
@@ -604,25 +639,29 @@ class ImagesHealthPipeline:
 
         return '\n'.join(prompt_parts)
 
-    async def notify_chai_bot(self, version: str, failing_concerns: list[dict]):
+    async def notify_chai_bot(
+        self, version: str, failing_concerns: list[dict], rebase_failures: dict[str, dict] | None = None
+    ):
         """
         Post prompt to chai-bot channel requesting automated fix attempts.
 
         Arg(s):
             version (str): OKD version (e.g., "4.21")
-            failing_concerns (list[dict]): List of concerns with >1 consecutive failure
+            failing_concerns (list[dict]): List of build failure concerns with >1 consecutive failure
+            rebase_failures (dict[str, dict]): Map of image_name -> failure_info for rebase failures with >1 failure
         """
-        if not failing_concerns:
+        if not failing_concerns and not rebase_failures:
             return
 
-        prompt = self._build_chai_bot_prompt(version, failing_concerns)
+        prompt = self._build_chai_bot_prompt(version, failing_concerns, rebase_failures or {})
         self.slack_client.bind_channel('#team-art-chai-bot')
 
         message = f'<@U0AKNPBBVT7> {prompt}'
         await self.slack_client.say(message, unfurl_links=False, unfurl_media=False)
         self.runtime.logger.info(
-            'Notified chai-bot in #team-art-chai-bot for %d failing images in okd-%s',
+            'Notified chai-bot in #team-art-chai-bot for %d build failure(s) and %d rebase failure(s) in okd-%s',
             len(failing_concerns),
+            len(rebase_failures) if rebase_failures else 0,
             version,
         )
 

--- a/pyartcd/tests/pipelines/test_okd_images_health.py
+++ b/pyartcd/tests/pipelines/test_okd_images_health.py
@@ -155,3 +155,123 @@ class TestGetReport(IsolatedAsyncioTestCase):
         self.assertEqual(pipeline.versions, [])
         pipeline.get_report.assert_not_called()
         pipeline.notify_okd_channel.assert_not_called()
+
+
+class TestGetMultiRebaseFailures(IsolatedAsyncioTestCase):
+    def _make_pipeline(self):
+        runtime = MagicMock()
+        runtime.working_dir = MagicMock()
+        runtime.logger = MagicMock()
+        runtime.new_slack_client.return_value = MagicMock()
+        return ImagesHealthPipeline(
+            runtime=runtime,
+            versions="4.21",
+            send_to_release_channel=False,
+            send_to_okd_channel=False,
+            ping_chai_bot=True,
+            data_path=DATA_PATH,
+            data_gitref="",
+            image_list="",
+            assembly="stream",
+        )
+
+    def test_filters_single_failures(self):
+        """Images with only 1 rebase failure are excluded."""
+        pipeline = self._make_pipeline()
+        pipeline.rebase_failures = {
+            '4.21': {
+                'ironic': {'failure_count': 1, 'jenkins_url': ''},
+                'ovn-kubernetes': {'failure_count': 3, 'jenkins_url': 'http://jenkins/job/1'},
+            }
+        }
+        result = pipeline._get_multi_rebase_failures()
+        self.assertIn('4.21', result)
+        self.assertNotIn('ironic', result['4.21'])
+        self.assertIn('ovn-kubernetes', result['4.21'])
+
+    def test_excludes_versions_with_no_multi_failures(self):
+        """Versions where all images have <=1 failure are excluded from result."""
+        pipeline = self._make_pipeline()
+        pipeline.rebase_failures = {
+            '4.21': {'ironic': {'failure_count': 1, 'jenkins_url': ''}},
+        }
+        result = pipeline._get_multi_rebase_failures()
+        self.assertNotIn('4.21', result)
+
+    def test_empty_rebase_failures(self):
+        pipeline = self._make_pipeline()
+        pipeline.rebase_failures = {}
+        self.assertEqual(pipeline._get_multi_rebase_failures(), {})
+
+
+class TestNotifyChaiBot(IsolatedAsyncioTestCase):
+    def _make_pipeline(self):
+        runtime = MagicMock()
+        runtime.working_dir = MagicMock()
+        runtime.logger = MagicMock()
+        runtime.new_slack_client.return_value = MagicMock()
+        return ImagesHealthPipeline(
+            runtime=runtime,
+            versions="4.21",
+            send_to_release_channel=False,
+            send_to_okd_channel=False,
+            ping_chai_bot=True,
+            data_path=DATA_PATH,
+            data_gitref="",
+            image_list="",
+            assembly="stream",
+        )
+
+    async def test_skips_when_no_failures_of_either_kind(self):
+        pipeline = self._make_pipeline()
+        pipeline.slack_client.say = AsyncMock()
+        await pipeline.notify_chai_bot('4.21', [], {})
+        pipeline.slack_client.say.assert_not_called()
+
+    async def test_notifies_for_rebase_only(self):
+        """Rebase failures alone trigger chai-bot notification."""
+        pipeline = self._make_pipeline()
+        pipeline.slack_client.say = AsyncMock(return_value={'ts': '123'})
+        pipeline.slack_client.bind_channel = MagicMock()
+        rebase_failures = {
+            'ironic': {'failure_count': 3, 'jenkins_url': 'http://jenkins/job/1'},
+        }
+        await pipeline.notify_chai_bot('4.21', [], rebase_failures)
+        pipeline.slack_client.say.assert_called_once()
+        msg = pipeline.slack_client.say.call_args[0][0]
+        self.assertIn('ironic', msg)
+        self.assertIn('rebase failures', msg)
+
+    async def test_prompt_includes_both_build_and_rebase_sections(self):
+        """When both failure types present, prompt contains both sections."""
+        pipeline = self._make_pipeline()
+        pipeline.slack_client.say = AsyncMock(return_value={'ts': '123'})
+        pipeline.slack_client.bind_channel = MagicMock()
+        concern = _make_concern('console', 'openshift-4.21', 'LATEST_ATTEMPT_FAILED', latest_success_idx=3)
+        rebase_failures = {'ironic': {'failure_count': 3, 'jenkins_url': ''}}
+        await pipeline.notify_chai_bot('4.21', [concern], rebase_failures)
+        msg = pipeline.slack_client.say.call_args[0][0]
+        self.assertIn('build failures', msg)
+        self.assertIn('rebase failures', msg)
+        self.assertIn('console', msg)
+        self.assertIn('ironic', msg)
+
+    @patch("pyartcd.pipelines.okd_images_health.util.is_okd_version_enabled", new_callable=AsyncMock, return_value=True)
+    async def test_run_calls_chai_bot_for_rebase_only_version(self, _mock_enabled):
+        """run() calls notify_chai_bot when only rebase failures exist (no build failures)."""
+        pipeline = self._make_pipeline()
+        pipeline.get_report = AsyncMock()
+        pipeline.get_rebase_failures = AsyncMock()
+        pipeline.notify_chai_bot = AsyncMock()
+        pipeline.rebase_failures = {
+            '4.21': {'ironic': {'failure_count': 3, 'jenkins_url': ''}},
+        }
+        pipeline.report = []
+
+        await pipeline.run()
+
+        pipeline.notify_chai_bot.assert_awaited_once()
+        call_args = pipeline.notify_chai_bot.call_args
+        self.assertEqual(call_args[0][0], '4.21')
+        self.assertEqual(call_args[0][1], [])
+        self.assertIn('ironic', call_args[0][2])


### PR DESCRIPTION
## Summary

- `_get_multi_rebase_failures()` fetches images from `self.rebase_failures` with `failure_count > 1` (same threshold as build failures)
- `run()` unions build-failure and rebase-failure version sets, passes both to `notify_chai_bot` per version
- `_build_chai_bot_prompt()` emits separate *build failures* and *rebase failures* sections in the prompt
- `notify_chai_bot()` only skips if **both** lists are empty

**Root cause:** `_get_multi_failure_images()` only iterated `self.report` (build failures from BigQuery). `self.rebase_failures` was populated and sent to release/okd channels but never reached the chai-bot ping path — so images like `ironic` with 3 consecutive rebase failures were silently excluded.

## Test plan

- [ ] 13 new/existing unit tests pass (`pytest pyartcd/tests/pipelines/test_okd_images_health.py`)
- [ ] `ruff` lint clean
- [ ] `test_run_calls_chai_bot_for_rebase_only_version`: confirms chai-bot is pinged when only rebase failures exist and no build failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chai Bot notifications now report repeated image build and rebase failures separately.
  * Rebase failure notifications include relevant Jenkins links.
  * Notifications can be sent for rebase-only failures.

* **Bug Fixes**
  * Single rebase failures are filtered out to reduce unnecessary alerts.
  * Notifications are skipped only when no build or rebase failures exist.
  * Improved handling of failure data across health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->