### PR TITLE
pyartcd: temporarily disable payload verification in promote pipeline

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -435,12 +435,13 @@ class PromotePipeline:
                         justification = self._reraise_if_not_permitted(err, "ATTACHED_BUGS", permits)
                         justifications.append(justification)
 
-            # Verify payload imagestreams match advisory builds before promoting
-            if image_advisory > 0 or shipment_config:
-                logger.info("Verifying payload imagestreams match advisory builds...")
-                await self.verify_payload(assembly_type, arches)
-            else:
-                logger.info("Skipping payload verification: no image advisory or shipment config defined")
+            # TODO: Temporarily skipping payload verification to unblock 4.20.34 promote
+            # if image_advisory > 0 or shipment_config:
+            #     logger.info("Verifying payload imagestreams match advisory builds...")
+            #     await self.verify_payload(assembly_type, arches)
+            # else:
+            #     logger.info("Skipping payload verification: no image advisory or shipment config defined")
+            logger.info("Payload verification is temporarily disabled")
 
             # Promote release images
             metadata = {}


### PR DESCRIPTION
## Summary
- Temporarily comments out the `verify_payload` call in `_run_pipeline` to unblock the 4.20.34 promote
- The check was failing because `assisted-installer-ui-container` is missing from the advisory
- Adds an `INFO` log message so the skip is visible in pipeline output

## Test plan
- All 38 existing promote pipeline unit tests pass (`uv run pytest pyartcd/tests/pipelines/test_promote.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Temporarily disabled payload image verification during promotion.
  * Added logging to indicate that verification is currently disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->