### PR TITLE
ART-21797: remove stale RPM cross-refs after advisory drop

### DIFF
--- a/elliott/elliottlib/shipment_utils.py
+++ b/elliott/elliottlib/shipment_utils.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from datetime import datetime
 from typing import Dict, Iterable, List, Tuple
 from urllib.parse import urlparse
@@ -16,6 +17,92 @@ from elliottlib.shipment_model import Issue, Issues, ReleaseNotes, ShipmentConfi
 logger = logging.getLogger(__name__)
 
 yaml = new_roundtrip_yaml_handler()
+
+
+# Single source of truth for the public errata URL.
+# verify_docs_approval.py defines the same constant; import from here once that module lands.
+PUBLIC_ERRATA_URL = "https://access.redhat.com/errata"
+
+
+def strip_advisory_cross_reference(text: str, rpm_name: str) -> str:
+    """
+    Remove the RPM advisory cross-reference block from advisory or shipment YAML text.
+
+    Strips the lead-in sentence ("See the following advisory for the RPM packages...")
+    together with the following URL paragraph from the text. Collapses any triple-newlines
+    left behind into a single blank line.
+
+    Handles two layouts:
+    - Sentence appended to a prior paragraph: "prior text. See the following...\n\nhttps://..."
+    - Sentence as its own paragraph: "prior text\n\nSee the following...\n\nhttps://..."
+
+    Arg(s):
+        text (str): freeform advisory/release-notes text to process.
+        rpm_name (str): the RPM advisory's full display name, e.g. "RHBA-2026:44227".
+    Return Value(s):
+        str: text with the cross-reference block removed.
+    """
+    escaped_url = re.escape(f"{PUBLIC_ERRATA_URL}/{rpm_name}")
+    # Strip "See the following advisory for RPM packages..." + blank line + URL line.
+    # " ?" matches the leading space when the sentence is attached to a prior sentence
+    # (" See the following...") without consuming the preceding period.
+    # "[ \t]*" before the URL handles YAML literal-block indentation (the URL line
+    # is indented when the text lives inside a YAML file rather than an ET advisory).
+    pattern = (
+        r" ?See the following advisory for (?:the )?RPM packages[^\n]*\n"
+        r"[ \t]*\n"
+        rf"[ \t]*{escaped_url}[^\n]*"
+    )
+    new_text = re.sub(pattern, "", text)
+    # Fallback: if the URL is still present (unusual format), strip just the URL paragraph.
+    if f"{PUBLIC_ERRATA_URL}/{rpm_name}" in new_text:
+        new_text = re.sub(rf"\n[ \t]*\n[ \t]*{escaped_url}[^\n]*", "", new_text)
+    # Collapse triple-newlines produced by removal.
+    new_text = re.sub(r"\n{3,}", "\n\n", new_text)
+    return new_text
+
+
+def strip_et_advisory_rpm_reference(advisory_num: int, rpm_name: str, dry_run: bool = False) -> bool:
+    """
+    Load an ET advisory, strip the RPM cross-reference from description/solution, and commit.
+
+    Soft-fails on Erratum load/commit errors (logs a warning, returns False).
+
+    Arg(s):
+        advisory_num (int): Numeric Errata Tool advisory ID.
+        rpm_name (str): the RPM advisory's full display name, e.g. "RHBA-2026:44227".
+        dry_run (bool): When True, log what would change but do not commit.
+    Return Value(s):
+        bool: True if the advisory text was (or would have been) changed.
+    """
+    try:
+        advisory = Erratum(errata_id=advisory_num)
+    except Exception as ex:
+        logger.warning("Failed to load ET advisory %s: %s", advisory_num, ex)
+        return False
+
+    updates = {}
+    for field in ("description", "solution"):
+        text = getattr(advisory, field, None)
+        if not text:
+            continue
+        new_text = strip_advisory_cross_reference(text, rpm_name)
+        if new_text != text:
+            updates[field] = new_text
+
+    if not updates:
+        return False
+    if dry_run:
+        logger.info("[DRY-RUN] Would strip RPM reference from ET advisory %s: %s", advisory_num, list(updates))
+        return True
+    try:
+        advisory.update(**updates)
+        advisory.commit()
+        logger.info("Stripped RPM reference from ET advisory %s: %s", advisory_num, list(updates))
+        return True
+    except Exception as ex:
+        logger.warning("Failed to commit ET advisory %s after stripping RPM reference: %s", advisory_num, ex)
+        return False
 
 
 def patch_et_advisory_text(

--- a/elliott/tests/test_shipment_utils.py
+++ b/elliott/tests/test_shipment_utils.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from datetime import datetime
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from artcommonlib.model import Model
 from elliottlib import shipment_utils
@@ -800,6 +800,139 @@ class TestGetFullAdvisoryIdFromShipment(unittest.TestCase):
             shipment_utils.get_full_advisory_id_from_shipment(_make_shipment_config("image", live_id=13660)),
             f"RHBA-{year}:13660",
         )
+
+
+class TestStripAdvisoryCrossReference(unittest.TestCase):
+    RPM = "RHBA-2026:44227"
+    URL = f"https://access.redhat.com/errata/{RPM}"
+
+    def test_strips_sentence_attached_to_paragraph(self):
+        text = (
+            "This advisory contains the container images for this release."
+            " See the following advisory for the RPM packages and full list of security fixes for this release:\n"
+            f"\n{self.URL}\n"
+            "\nThis update contains the following images:\n"
+        )
+        result = shipment_utils.strip_advisory_cross_reference(text, self.RPM)
+        self.assertNotIn(self.RPM, result)
+        self.assertIn("This advisory contains the container images for this release.", result)
+        self.assertIn("This update contains the following images:", result)
+
+    def test_strips_sentence_as_own_paragraph(self):
+        text = (
+            f"Intro paragraph.\n\nSee the following advisory for the RPM packages:\n\n{self.URL}\n\nNext paragraph.\n"
+        )
+        result = shipment_utils.strip_advisory_cross_reference(text, self.RPM)
+        self.assertNotIn(self.RPM, result)
+        self.assertIn("Intro paragraph.", result)
+        self.assertIn("Next paragraph.", result)
+
+    def test_no_triple_newlines_after_strip(self):
+        text = f"Para one.\n\nSee the following advisory for the RPM packages:\n\n{self.URL}\n\nPara two.\n"
+        result = shipment_utils.strip_advisory_cross_reference(text, self.RPM)
+        self.assertNotIn("\n\n\n", result)
+
+    def test_unchanged_when_no_reference(self):
+        text = "No advisory reference here.\n\nJust a normal paragraph.\n"
+        result = shipment_utils.strip_advisory_cross_reference(text, self.RPM)
+        self.assertEqual(result, text)
+
+    def test_unchanged_for_different_advisory(self):
+        other_url = "https://access.redhat.com/errata/RHBA-2026:99999"
+        text = f"See the following advisory for the RPM packages:\n\n{other_url}\n\nNext.\n"
+        result = shipment_utils.strip_advisory_cross_reference(text, self.RPM)
+        self.assertIn(other_url, result)
+
+    def test_fallback_strips_bare_url_paragraph(self):
+        # URL present but without the lead-in sentence (unusual format)
+        text = f"Para one.\n\n{self.URL}\n\nPara two.\n"
+        result = shipment_utils.strip_advisory_cross_reference(text, self.RPM)
+        self.assertNotIn(self.RPM, result)
+
+    def test_strips_yaml_indented_content(self):
+        # Mirrors the layout inside a YAML literal block scalar where each line
+        # has leading spaces and blank lines are bare newlines.
+        text = (
+            "      description: |\n"
+            "        Intro paragraph.\n"
+            "\n"
+            "        This advisory contains images. See the following advisory for the RPM packages for this release:\n"
+            "\n"
+            f"        {self.URL}\n"
+            "\n"
+            "        Space precludes documenting all images.\n"
+        )
+        result = shipment_utils.strip_advisory_cross_reference(text, self.RPM)
+        self.assertNotIn(self.RPM, result)
+        self.assertIn("This advisory contains images.", result)
+        self.assertIn("Space precludes documenting all images.", result)
+        # Blank line between the two remaining sentences must be preserved
+        self.assertIn("This advisory contains images.\n\n        Space precludes", result)
+
+
+class TestStripEtAdvisoryRpmReference(unittest.TestCase):
+    RPM = "RHBA-2026:44227"
+    URL = f"https://access.redhat.com/errata/{RPM}"
+
+    def _make_erratum(self, description="", solution=""):
+        m = MagicMock()
+        m.description = description
+        m.solution = solution
+        return m
+
+    @patch("elliottlib.shipment_utils.Erratum")
+    def test_strips_description_and_commits(self, mock_erratum_cls):
+        text = f"Intro. See the following advisory for the RPM packages:\n\n{self.URL}\n\nNext paragraph.\n"
+        advisory = self._make_erratum(description=text)
+        mock_erratum_cls.return_value = advisory
+
+        changed = shipment_utils.strip_et_advisory_rpm_reference(12345, self.RPM, dry_run=False)
+
+        self.assertTrue(changed)
+        advisory.update.assert_called_once()
+        advisory.commit.assert_called_once()
+        updated_description = advisory.update.call_args[1]["description"]
+        self.assertNotIn(self.RPM, updated_description)
+
+    @patch("elliottlib.shipment_utils.Erratum")
+    def test_dry_run_does_not_commit(self, mock_erratum_cls):
+        text = f"See the following advisory for the RPM packages:\n\n{self.URL}\n\nEnd.\n"
+        advisory = self._make_erratum(description=text)
+        mock_erratum_cls.return_value = advisory
+
+        changed = shipment_utils.strip_et_advisory_rpm_reference(12345, self.RPM, dry_run=True)
+
+        self.assertTrue(changed)
+        advisory.update.assert_not_called()
+        advisory.commit.assert_not_called()
+
+    @patch("elliottlib.shipment_utils.Erratum")
+    def test_returns_false_when_no_reference(self, mock_erratum_cls):
+        advisory = self._make_erratum(description="No reference here.")
+        mock_erratum_cls.return_value = advisory
+
+        changed = shipment_utils.strip_et_advisory_rpm_reference(12345, self.RPM)
+
+        self.assertFalse(changed)
+        advisory.update.assert_not_called()
+
+    @patch("elliottlib.shipment_utils.Erratum", side_effect=Exception("not found"))
+    def test_returns_false_on_erratum_load_failure(self, _):
+        changed = shipment_utils.strip_et_advisory_rpm_reference(12345, self.RPM)
+        self.assertFalse(changed)
+
+    @patch("elliottlib.shipment_utils.Erratum")
+    def test_returns_false_on_commit_failure(self, mock_erratum_cls):
+        text = f"See the following advisory for the RPM packages:\n\n{self.URL}\n\nEnd.\n"
+        advisory = self._make_erratum(description=text)
+        advisory.commit.side_effect = Exception("ET unavailable")
+        mock_erratum_cls.return_value = advisory
+
+        changed = shipment_utils.strip_et_advisory_rpm_reference(12345, self.RPM, dry_run=False)
+
+        self.assertFalse(changed)
+        advisory.update.assert_called_once()
+        advisory.commit.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -43,14 +43,19 @@ from doozerlib.cli.release_gen_payload import (
 )
 from elliottlib.errata import get_builds, get_errata_live_id
 from elliottlib.shipment_utils import (
+    PUBLIC_ERRATA_URL,
     get_full_advisory_id_from_shipment,
     get_shipment_config_from_mr,
     get_shipment_configs_from_mr,
     patch_et_advisory_text,
+    strip_advisory_cross_reference,
+    strip_et_advisory_rpm_reference,
 )
 from github import GithubException
 from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
 from ruamel.yaml.parser import ParserError
+from ruamel.yaml.scalarstring import LiteralScalarString
 from semver import VersionInfo
 from tenacity import (
     RetryCallState,
@@ -81,6 +86,10 @@ from pyartcd.signatory import AsyncSignatory, SigstoreSignatory
 
 yaml = YAML(typ="safe")
 yaml.default_flow_style = False
+
+# Advisory impetuses that are legitimately empty and therefore droppable.
+# _fix_docs_after_advisory_drop dispatch must stay in sync with this set.
+_DROPPABLE_IMPETUSES: tuple[str, ...] = ("rpm", "rhcos")
 
 # YAML handler for shipment config dumping
 shipment_yaml = YAML()
@@ -322,7 +331,10 @@ class PromotePipeline:
             if assembly_type == AssemblyTypes.STANDARD:
                 # Check for empty advisories (no builds attached) and drop them
                 # before attempting to move to QE, which would fail for empty advisories.
-                await self._drop_empty_advisories(impetus_advisories)
+                await self._drop_empty_advisories(
+                    impetus_advisories,
+                    shipment_url=(group_config.get("shipment") or {}).get("url"),
+                )
 
                 # Attempt to move all advisories to QE
                 tasks_with_args = []
@@ -387,7 +399,7 @@ class PromotePipeline:
             if assembly_type in [AssemblyTypes.STANDARD, AssemblyTypes.CANDIDATE]:
                 if not full_advisory_id:
                     raise VerificationError("Could not find live ID from image advisory. Please investigate.")
-                errata_url = f"https://access.redhat.com/errata/{full_advisory_id}"  # don't quote
+                errata_url = f"{PUBLIC_ERRATA_URL}/{full_advisory_id}"  # don't quote
                 logger.info("Using errata URL: %s", errata_url)
 
             # Verify attached bugs
@@ -1400,7 +1412,7 @@ class PromotePipeline:
         async with self._elliott_lock:
             await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars, stdout=sys.stderr)
 
-    async def _drop_empty_advisories(self, impetus_advisories: Dict[str, int]):
+    async def _drop_empty_advisories(self, impetus_advisories: Dict[str, int], shipment_url: str | None = None):
         """Check advisories that may legitimately have no builds and drop them.
 
         RPM and RHCOS advisories can end up empty in z-stream releases when
@@ -1410,10 +1422,12 @@ class PromotePipeline:
         Dropped advisories are removed from *impetus_advisories* so they
         are skipped by the QE loop and not leaked into downstream
         notifications or repository updates.
+
+        When an advisory is dropped, stale cross-references are cleaned up in
+        sibling ET advisories and the shipment MR (best-effort).
         """
         logger = self._logger
-        # Only rpm and rhcos advisories can legitimately be empty
-        droppable_impetuses = ("rpm", "rhcos")
+        droppable_impetuses = _DROPPABLE_IMPETUSES
 
         for impetus in droppable_impetuses:
             advisory = impetus_advisories.get(impetus, 0)
@@ -1424,6 +1438,26 @@ class PromotePipeline:
                 dropped = await self._check_and_drop_empty_advisory(impetus, advisory)
                 if dropped:
                     del impetus_advisories[impetus]
+                    try:
+                        await self._fix_docs_after_advisory_drop(
+                            dropped_impetus=impetus,
+                            dropped_advisory=advisory,
+                            sibling_advisory_ids=dict(impetus_advisories),
+                            shipment_url=shipment_url,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Failed to clean up cross-references after dropping %s advisory %s; continuing",
+                            impetus,
+                            advisory,
+                        )
+                        try:
+                            await self._slack_client.say_in_thread(
+                                f"Warning: failed to clean up cross-references after dropping {impetus} advisory "
+                                f"{advisory}. Manual cleanup may be required. Details in log."
+                            )
+                        except Exception:
+                            logger.exception("Failed to send Slack notification for cleanup failure")
             except Exception:
                 logger.exception("Failed to check/drop %s advisory %s; will still attempt QE move", impetus, advisory)
                 try:
@@ -1482,6 +1516,173 @@ class PromotePipeline:
         """
         builds = await to_thread(get_builds, advisory)
         return any(pv_data.get("builds") for pv_data in builds.values()) if builds else False
+
+    async def _fix_docs_after_advisory_drop(
+        self,
+        dropped_impetus: str,
+        dropped_advisory: int,
+        sibling_advisory_ids: dict[str, int],
+        shipment_url: str | None,
+    ) -> None:
+        """
+        Clean up stale cross-references after an advisory is dropped.
+
+        When an RPM advisory is dropped, surviving ET advisories (image, rhcos) and
+        the shipment MR YAML still reference it.  This method strips those references
+        so that verify-docs-approval passes without manual intervention.
+
+        When the RHCOS advisory is dropped nothing references it, so this is a no-op.
+
+        :param dropped_impetus: Advisory impetus that was dropped; must be a member of
+            ``_DROPPABLE_IMPETUSES`` ("rpm" or "rhcos").  Extend that constant and this
+            dispatch together when new droppable impetuses are introduced.
+        :param dropped_advisory: Numeric advisory ID of the dropped advisory.
+        :param sibling_advisory_ids: Remaining {impetus: advisory_num} after the drop.
+        :param shipment_url: Shipment MR URL, or None if using classic ET advisories only.
+        """
+        if dropped_impetus == "rhcos":
+            self._logger.info("RHCOS advisory %s dropped; no cross-references to clean up.", dropped_advisory)
+            return
+        if dropped_impetus == "rpm":
+            await self._fix_docs_after_rpm_drop(dropped_advisory, sibling_advisory_ids, shipment_url)
+            return
+        self._logger.info(
+            "%s advisory %s dropped; cross-reference cleanup not implemented for this impetus.",
+            dropped_impetus,
+            dropped_advisory,
+        )
+
+    async def _fix_docs_after_rpm_drop(
+        self,
+        rpm_advisory: int,
+        sibling_advisory_ids: dict[str, int],
+        shipment_url: str | None,
+    ) -> None:
+        """
+        Strip RPM advisory cross-references from sibling ET advisories and the shipment MR.
+
+        Fetches the RPM advisory's display name (e.g. "RHBA-2026:44227"), then:
+        - For each surviving sibling ET advisory (image, rhcos): strips the lead-in
+          sentence and URL from description/solution and commits.
+        - If a shipment MR URL is present: strips the URL from each YAML file's
+          description/solution fields and commits to the MR source branch.
+
+        :param rpm_advisory: Numeric advisory ID of the dropped RPM advisory.
+        :param sibling_advisory_ids: Remaining {impetus: advisory_num} after the drop.
+        :param shipment_url: Shipment MR URL, or None if using classic ET advisories only.
+        """
+        logger = self._logger
+        dry_run = self.runtime.dry_run
+
+        # Resolve the RPM advisory's display name so we know what text to strip.
+        try:
+            rpm_name = await to_thread(get_errata_live_id, rpm_advisory)
+        except Exception as ex:
+            logger.warning(
+                "Could not resolve display name for RPM advisory %s; skipping cross-reference cleanup: %s",
+                rpm_advisory,
+                ex,
+            )
+            return
+
+        logger.info("Stripping cross-references to dropped RPM advisory %s from sibling advisories.", rpm_name)
+
+        # Strip from sibling ET advisories (image, rhcos).
+        et_impetuses = ("image", "rhcos")
+        for impetus in et_impetuses:
+            advisory_num = sibling_advisory_ids.get(impetus, 0)
+            if not advisory_num or advisory_num <= 0:
+                continue
+            changed = await to_thread(strip_et_advisory_rpm_reference, advisory_num, rpm_name, dry_run)
+            if changed:
+                logger.info("Stripped RPM reference from %s advisory %s.", impetus, advisory_num)
+            else:
+                logger.info("No RPM cross-reference found in %s advisory %s; nothing to strip.", impetus, advisory_num)
+
+        # Strip from shipment MR YAML (image and extras files).
+        if not shipment_url:
+            return
+
+        parsed_url = urlparse(shipment_url)
+        target_project_path = parsed_url.path.strip("/").split("/-/merge_requests")[0]
+        mr_id = parsed_url.path.split("/")[-1]
+
+        gl = GitLabClient.from_url(shipment_url, dry_run=dry_run)
+        project = gl.get_project(target_project_path)
+        mr = project.mergerequests.get(mr_id)
+        source_project = gl.get_project(mr.source_project_id)
+
+        diff_versions = mr.diffs.list(all=True)
+        if not diff_versions:
+            logger.info("Shipment MR %s has no diff versions; nothing to strip.", shipment_url)
+            return
+        diff = mr.diffs.get(diff_versions[0].id)
+
+        # file_path -> (file_obj, new_content); file_obj kept to avoid a second fetch on write.
+        files_to_update: dict[str, tuple] = {}
+        for file_diff in diff.diffs:
+            file_path = file_diff.get("new_path") or file_diff.get("old_path")
+            if not file_path or not file_path.endswith((".yaml", ".yml")):
+                continue
+            path_parts = file_path.split("/")
+            if len(path_parts) < 4 or path_parts[0] != "shipment" or path_parts[2] != self.group:
+                continue
+            filename = file_path.split("/")[-1].replace(".yaml", "").replace(".yml", "")
+            if not any(kind in filename for kind in ("image", "extras")):
+                continue
+
+            file_obj = source_project.files.get(file_path, mr.source_branch)
+            original_str = file_obj.decode().decode("utf-8")
+
+            # Parse and modify only releaseNotes.description / .solution so
+            # the rest of the YAML (including blank lines inside other block
+            # scalars) is never touched.
+            try:
+                doc = shipment_yaml.load(original_str)
+                release_notes = doc["shipment"]["data"]["releaseNotes"]
+            except YAMLError as ex:
+                logger.warning("Shipment file %s: could not parse YAML; skipping: %s", file_path, ex)
+                continue
+            except (KeyError, TypeError):
+                logger.info("Shipment file %s: no releaseNotes section; skipping.", file_path)
+                continue
+
+            field_changed = False
+            for field in ("description", "solution"):
+                value = release_notes.get(field)
+                if not value:
+                    continue
+                stripped = strip_advisory_cross_reference(str(value), rpm_name)
+                if stripped == str(value):
+                    continue
+                release_notes[field] = (
+                    LiteralScalarString(stripped) if isinstance(value, LiteralScalarString) else stripped
+                )
+                field_changed = True
+
+            if not field_changed:
+                logger.info("Shipment file %s: no RPM cross-reference found; nothing to strip.", file_path)
+                continue
+
+            stream = io.StringIO()
+            shipment_yaml.dump(doc, stream)
+            files_to_update[file_path] = (file_obj, stream.getvalue())
+            logger.info("Shipment file %s: stripped RPM reference to %s.", file_path, rpm_name)
+
+        if not files_to_update:
+            return
+
+        if dry_run:
+            logger.info("[DRY-RUN] Would update shipment MR files: %s", list(files_to_update))
+            return
+
+        for file_path, (file_obj, content) in files_to_update.items():
+            file_obj.content = content
+            file_obj.save(
+                branch=mr.source_branch,
+                commit_message=f"Remove stale RPM advisory cross-reference ({rpm_name}) after advisory drop",
+            )
+            logger.info("Updated %s in shipment MR branch %s.", file_path, mr.source_branch)
 
     async def check_blocker_bugs(self):
         # Note: --assembly option should always be "stream". We are checking blocker bugs for this release branch regardless of the sweep cutoff timestamp.

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -2547,3 +2547,214 @@ class TestDropEmptyAdvisories(IsolatedAsyncioTestCase):
         self.assertEqual(advisories["rpm"], 100)
         self.assertEqual(advisories["rhcos"], 200)
         self.assertEqual(advisories["image"], 300)
+
+
+class TestFixDocsAfterAdvisoryDrop(IsolatedAsyncioTestCase):
+    """Tests for PromotePipeline._fix_docs_after_advisory_drop and _fix_docs_after_rpm_drop."""
+
+    def _make_pipeline(self, dry_run=False):
+        runtime = MagicMock(
+            config={
+                "build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"},
+                "jira": {"url": JIRA_SERVER_URL},
+            },
+            dry_run=dry_run,
+            logger=MagicMock(),
+            new_slack_client=MagicMock(return_value=AsyncMock()),
+        )
+        runtime.working_dir = Path(tempfile.mkdtemp())
+        return PromotePipeline(runtime, group="openshift-4.10", assembly="4.10.99", signing_env="prod")
+
+    @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
+    async def test_rhcos_drop_is_noop(self, _):
+        pipeline = self._make_pipeline()
+        pipeline._fix_docs_after_rpm_drop = AsyncMock()
+
+        await pipeline._fix_docs_after_advisory_drop(
+            dropped_impetus="rhcos",
+            dropped_advisory=67890,
+            sibling_advisory_ids={"image": 100},
+            shipment_url=None,
+        )
+
+        pipeline._fix_docs_after_rpm_drop.assert_not_called()
+
+    @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
+    async def test_rpm_drop_delegates_to_rpm_helper(self, _):
+        pipeline = self._make_pipeline()
+        pipeline._fix_docs_after_rpm_drop = AsyncMock()
+
+        await pipeline._fix_docs_after_advisory_drop(
+            dropped_impetus="rpm",
+            dropped_advisory=12345,
+            sibling_advisory_ids={"image": 200, "rhcos": 400},
+            shipment_url="https://gitlab.example.com/group/project/-/merge_requests/42",
+        )
+
+        pipeline._fix_docs_after_rpm_drop.assert_awaited_once_with(
+            12345,
+            {"image": 200, "rhcos": 400},
+            "https://gitlab.example.com/group/project/-/merge_requests/42",
+        )
+
+    @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
+    @patch("pyartcd.pipelines.promote.strip_et_advisory_rpm_reference", return_value=True)
+    @patch("pyartcd.pipelines.promote.get_errata_live_id", return_value="RHBA-2026:44227")
+    async def test_rpm_drop_strips_et_advisories(self, mock_live_id, mock_strip, _):
+        pipeline = self._make_pipeline()
+
+        await pipeline._fix_docs_after_rpm_drop(
+            rpm_advisory=12345,
+            sibling_advisory_ids={"image": 200, "rhcos": 400},
+            shipment_url=None,
+        )
+
+        mock_live_id.assert_called_once_with(12345)
+        # Should strip from image and rhcos
+        self.assertEqual(mock_strip.call_count, 2)
+        calls = {c.args[0] for c in mock_strip.call_args_list}
+        self.assertEqual(calls, {200, 400})
+
+    @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
+    @patch("pyartcd.pipelines.promote.strip_et_advisory_rpm_reference", return_value=False)
+    @patch("pyartcd.pipelines.promote.get_errata_live_id", return_value="RHBA-2026:44227")
+    async def test_rpm_drop_skips_absent_sibling(self, mock_live_id, mock_strip, _):
+        """If rhcos advisory is absent (0 or missing), don't attempt to strip it."""
+        pipeline = self._make_pipeline()
+
+        await pipeline._fix_docs_after_rpm_drop(
+            rpm_advisory=12345,
+            sibling_advisory_ids={"image": 200},
+            shipment_url=None,
+        )
+
+        # Only image should be stripped (rhcos absent)
+        self.assertEqual(mock_strip.call_count, 1)
+        self.assertEqual(mock_strip.call_args.args[0], 200)
+
+    @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
+    @patch("pyartcd.pipelines.promote.get_errata_live_id", side_effect=Exception("ET unreachable"))
+    async def test_rpm_drop_aborts_on_name_resolution_failure(self, mock_live_id, _):
+        """If we can't resolve the RPM advisory name, log and return (no strip attempts)."""
+        pipeline = self._make_pipeline()
+
+        # Should not raise
+        await pipeline._fix_docs_after_rpm_drop(
+            rpm_advisory=12345,
+            sibling_advisory_ids={"image": 200},
+            shipment_url=None,
+        )
+
+        mock_live_id.assert_called_once_with(12345)
+
+    @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
+    @patch("pyartcd.pipelines.promote.strip_advisory_cross_reference", return_value="stripped content")
+    @patch("pyartcd.pipelines.promote.strip_et_advisory_rpm_reference", return_value=False)
+    @patch("pyartcd.pipelines.promote.get_errata_live_id", return_value="RHBA-2026:44227")
+    async def test_rpm_drop_updates_shipment_mr_yaml(self, mock_live_id, mock_strip_et, mock_strip_ref, _):
+        pipeline = self._make_pipeline()
+
+        # Minimal valid shipment YAML with a releaseNotes.description containing the RPM URL.
+        # strip_advisory_cross_reference is mocked, so the description content just needs to be non-empty.
+        shipment_yaml_bytes = (
+            b"shipment:\n"
+            b"  data:\n"
+            b"    releaseNotes:\n"
+            b"      description: |\n"
+            b"        Advisory text. See the following advisory for the RPM packages:\n"
+            b"\n"
+            b"        https://access.redhat.com/errata/RHBA-2026:44227\n"
+        )
+
+        mock_file = MagicMock()
+        mock_file.decode.return_value = shipment_yaml_bytes
+        mock_file.save = MagicMock()
+
+        mock_source_project = MagicMock()
+        mock_source_project.files.get.return_value = mock_file
+
+        mock_mr = MagicMock()
+        mock_mr.source_branch = "shipment-branch"
+        mock_mr.source_project_id = 99
+
+        mock_diff_entry = MagicMock()
+        mock_diff_entry.diffs = [
+            {"new_path": "shipment/openshift/openshift-4.10/image.yaml"},
+            {"new_path": "shipment/openshift/openshift-4.10/extras.yaml"},
+        ]
+        mock_diff_info = MagicMock()
+        mock_mr.diffs.list.return_value = [mock_diff_info]
+        mock_mr.diffs.get.return_value = mock_diff_entry
+
+        mock_project = MagicMock()
+        mock_project.mergerequests.get.return_value = mock_mr
+
+        mock_gl = MagicMock()
+        mock_gl.get_project.side_effect = [mock_project, mock_source_project]
+
+        with patch("pyartcd.pipelines.promote.GitLabClient") as mock_gl_cls:
+            mock_gl_cls.from_url.return_value = mock_gl
+
+            await pipeline._fix_docs_after_rpm_drop(
+                rpm_advisory=12345,
+                sibling_advisory_ids={"image": 200},
+                shipment_url="https://gitlab.example.com/group/project/-/merge_requests/42",
+            )
+
+        # strip_advisory_cross_reference called once per file (for the description field)
+        self.assertEqual(mock_strip_ref.call_count, 2)
+        # Both files saved to MR branch
+        self.assertEqual(mock_file.save.call_count, 2)
+
+    @patch("pyartcd.jira_client.JIRAClient.from_url", return_value=None)
+    @patch("pyartcd.pipelines.promote.strip_advisory_cross_reference", return_value="stripped content")
+    @patch("pyartcd.pipelines.promote.strip_et_advisory_rpm_reference", return_value=False)
+    @patch("pyartcd.pipelines.promote.get_errata_live_id", return_value="RHBA-2026:44227")
+    async def test_rpm_drop_dry_run_does_not_save_shipment_mr(self, mock_live_id, mock_strip_et, mock_strip_ref, _):
+        pipeline = self._make_pipeline(dry_run=True)
+
+        shipment_yaml_bytes = (
+            b"shipment:\n"
+            b"  data:\n"
+            b"    releaseNotes:\n"
+            b"      description: |\n"
+            b"        Advisory text. See the following advisory for the RPM packages:\n"
+            b"\n"
+            b"        https://access.redhat.com/errata/RHBA-2026:44227\n"
+        )
+
+        mock_file = MagicMock()
+        mock_file.decode.return_value = shipment_yaml_bytes
+        mock_file.save = MagicMock()
+
+        mock_source_project = MagicMock()
+        mock_source_project.files.get.return_value = mock_file
+
+        mock_mr = MagicMock()
+        mock_mr.source_branch = "shipment-branch"
+        mock_mr.source_project_id = 99
+
+        mock_diff_entry = MagicMock()
+        mock_diff_entry.diffs = [
+            {"new_path": "shipment/openshift/openshift-4.10/image.yaml"},
+        ]
+        mock_diff_info = MagicMock()
+        mock_mr.diffs.list.return_value = [mock_diff_info]
+        mock_mr.diffs.get.return_value = mock_diff_entry
+
+        mock_project = MagicMock()
+        mock_project.mergerequests.get.return_value = mock_mr
+
+        mock_gl = MagicMock()
+        mock_gl.get_project.side_effect = [mock_project, mock_source_project]
+
+        with patch("pyartcd.pipelines.promote.GitLabClient") as mock_gl_cls:
+            mock_gl_cls.from_url.return_value = mock_gl
+
+            await pipeline._fix_docs_after_rpm_drop(
+                rpm_advisory=12345,
+                sibling_advisory_ids={"image": 200},
+                shipment_url="https://gitlab.example.com/group/project/-/merge_requests/42",
+            )
+
+        mock_file.save.assert_not_called()


### PR DESCRIPTION
When the RPM advisory is dropped (DROPPED_NO_SHIP) during promote, the surviving image and rhcos ET advisories still reference it in their description/solution text, and so does the shipment MR YAML. This leaves verify-docs-approval failing unless someone cleans up manually.

Add automatic cleanup triggered right after `drop_advisory()`:
- `strip_advisory_cross_reference()` — pure text helper that removes the "See the following advisory for the RPM packages..." lead-in sentence and the URL paragraph from any freeform text.
- `strip_et_advisory_rpm_reference()` — loads an ET advisory, applies the strip to description/solution, and commits (dry-run aware; returns False on commit failure rather than misleading True).
- `PromotePipeline._fix_docs_after_advisory_drop()` — dispatcher; rpm impetus triggers cleanup, rhcos is a confirmed no-op (nothing references the rhcos advisory).
- `PromotePipeline._fix_docs_after_rpm_drop()` — strips from sibling ET advisories (image, rhcos) and from image/extras shipment MR YAML files via GitLabClient.from_url(); best-effort (failures are logged and Slack-notified but do not block the release).
- `_drop_empty_advisories()` now accepts shipment_url and calls the fix after each successful drop.
- `_DROPPABLE_IMPETUSES` module constant keeps _drop_empty_advisories and the dispatch table in sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed outdated RPM advisory references from related advisories and shipment documentation when advisories are dropped.
  * Updated changed advisory descriptions and solutions while preserving formatting.
  * Improved handling of missing references and cleanup failures with safe warnings.
* **New Features**
  * Added preview mode for reviewing cleanup changes before applying them.
  * Standardized links to publicly accessible errata information.
  * Added automatic cleanup for empty shipment advisories and related documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->