### PR TITLE
fix(okd): mirror CoreOS imagestream tags for all versions

### DIFF
--- a/pyartcd/pyartcd/pipelines/okd.py
+++ b/pyartcd/pyartcd/pipelines/okd.py
@@ -678,9 +678,12 @@ class KonfluxOkdPipeline:
         - origin/scos-{version}:stream-coreos-extensions -> origin/scos-{version}-art:stream-coreos-extensions
 
         Special case:
-        - Only 4.23 needs mirroring (source: scos-5.0 / master branch).
-          All other versions have openshift/release CI configs promoting stream-coreos
-          directly to the -art namespace.
+        - 4.23 has no dedicated scos-4.23 CoreOS stream (master builds 5.0), so it
+          sources CoreOS tags from scos-5.0. Every other version mirrors from its own
+          same-version scos stream.
+
+        Mirroring for all versions makes ART the reliable producer of the CoreOS tags
+        in the -art namespace, independent of openshift/release promotion timing.
         """
 
         if self.assembly != 'stream':
@@ -691,13 +694,10 @@ class KonfluxOkdPipeline:
             self.logger.warning('No images were successfully built; skipping CoreOS imagestream mirroring')
             return
 
-        # Only 4.23 needs mirroring; all other versions are handled by openshift/release CI configs
-        if self.version != '4.23':
-            self.logger.info('Version %s: CoreOS mirroring is handled by openshift/release; skipping', self.version)
-            return
-
         tags_to_mirror = ['stream-coreos', 'stream-coreos-extensions']
-        source_version = '5.0'
+
+        # Only 4.23 is special (no own scos-4.23 stream); everything else uses its own version.
+        source_version = '5.0' if self.version == '4.23' else self.version
 
         if self.runtime.dry_run:
             self.logger.info('[DRY RUN] Would mirror CoreOS imagestream tags')

--- a/pyartcd/tests/pipelines/test_okd4.py
+++ b/pyartcd/tests/pipelines/test_okd4.py
@@ -265,13 +265,13 @@ class TestKonfluxOkdPipeline(IsolatedAsyncioTestCase):
             self.assertEqual(second_call[1]['source_pullspec'], 'custom-namespace/scos-5.0:stream-coreos-extensions')
             self.assertEqual(second_call[1]['target_tag'], 'custom-namespace/scos-4.23-art:stream-coreos-extensions')
 
-    async def test_mirror_coreos_imagestreams_skipped_for_release_managed_versions(self):
+    async def test_mirror_coreos_imagestreams_uses_same_version_source(self):
         """
-        Test that CoreOS mirroring is skipped for versions whose openshift/release CI config
-        promotes stream-coreos directly to the -art namespace.
+        Test that CoreOS mirroring uses the version's own scos stream as source for every
+        version except the 4.23 special case (which has no dedicated scos-4.23 stream).
         """
 
-        for version in ['4.21', '4.22', '5.0']:
+        for version in ['4.21', '4.22', '5.0', '5.1']:
             with self.subTest(version=version):
                 pipeline = KonfluxOkdPipeline(
                     runtime=self.mock_runtime,
@@ -296,9 +296,25 @@ class TestKonfluxOkdPipeline(IsolatedAsyncioTestCase):
                         'image_tag': 'latest',
                     }
                 ]
-                with patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag:
+                with (
+                    patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag,
+                    patch('pyartcd.pipelines.okd.jenkins'),
+                ):
                     await pipeline.mirror_coreos_imagestreams()
-                    mock_tag.assert_not_called()
+
+                    self.assertEqual(mock_tag.call_count, 2)
+
+                    first_call = mock_tag.call_args_list[0]
+                    self.assertEqual(first_call[1]['source_pullspec'], f'origin/scos-{version}:stream-coreos')
+                    self.assertEqual(first_call[1]['target_tag'], f'origin/scos-{version}-art:stream-coreos')
+
+                    second_call = mock_tag.call_args_list[1]
+                    self.assertEqual(
+                        second_call[1]['source_pullspec'], f'origin/scos-{version}:stream-coreos-extensions'
+                    )
+                    self.assertEqual(
+                        second_call[1]['target_tag'], f'origin/scos-{version}-art:stream-coreos-extensions'
+                    )
 
     async def test_mirror_coreos_imagestreams_4_23_uses_5_0_source(self):
         """


### PR DESCRIPTION
## Problem

PR #3266 changed `mirror_coreos_imagestreams()` to run **only** for 4.23 (sourcing from `scos-5.0`), relying on openshift/release CI to promote `stream-coreos` directly into the `scos-<version>-art` namespace for every other version.

That promotion ([`openshift-os-master__okd-scos.yaml`](https://github.com/openshift/release/blob/main/ci-operator/config/openshift/os/openshift-os-master__okd-scos.yaml#L50-L55) promotes `stream-coreos` to `origin/scos-5.0-art`) is **not landing the tag reliably** before ART assembles the nightly. As a result `scos-5.0-art:stream-coreos` went missing and the OKD SCOS 5.0 nightly failed at assembly:

```
operator "driver-toolkit" contained an invalid image-references file:
no input image tag named "stream-coreos"
```

Jobs also hung with `No public location to pull this image from`.

## Fix

Make ART the reliable producer of the CoreOS tags again: mirror on **every** stream build, sourcing from the version's **own** `scos` stream. Only 4.23 stays special (no dedicated `scos-4.23` stream — master builds 5.0, so it sources from `scos-5.0`).

```python
source_version = '5.0' if self.version == '4.23' else self.version
```

- **4.23** → `scos-5.0:* -> scos-4.23-art:*` (unchanged)
- **5.0** → `scos-5.0:* -> scos-5.0-art:*` (restores the missing tag automatically)
- **5.1 / 4.22 / etc** → own same-version stream

Idempotent, correct same-version content, and removes the dependency on openshift/release promotion timing. Existing guards (`assembly == 'stream'`, `built_images` non-empty, per-tag failure is non-fatal) are unchanged.

## Testing

- Replaced the now-obsolete "skipped for release-managed versions" test with `test_mirror_coreos_imagestreams_uses_same_version_source` covering 4.21/4.22/5.0/5.1.
- All 40 tests in `pyartcd/tests/pipelines/test_okd4.py` pass; ruff format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CoreOS image streams are now mirrored for every supported assembly version.
  * Versions use their matching source and target streams, with version 4.23 continuing to use the designated `scos-5.0` source.

* **Bug Fixes**
  * Removed the previous limitation that restricted CoreOS mirroring to version 4.23.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->