### PR TITLE
fix(konflux_client): remove deprecated sbom-syft-generate and push step overrides

### DIFF
--- a/doozer/doozerlib/backend/konflux_client.py
+++ b/doozer/doozerlib/backend/konflux_client.py
@@ -1459,27 +1459,14 @@ class KonfluxClient:
         if has_build_images_task:
             ephemeral_storage = (build_params.build_step_resources or {}).get("ephemeral-storage")
 
-            sbom_syft_resources: dict = {
-                "requests": {"memory": "5Gi"},
-                "limits": {"memory": "10Gi"},
-            }
-            if ephemeral_storage:
-                sbom_syft_resources["requests"]["ephemeral-storage"] = "1Gi"
-                sbom_syft_resources["limits"]["ephemeral-storage"] = "1Gi"
-
-            build_images_step_specs: list[dict] = [
-                {
-                    "name": "sbom-syft-generate",
-                    "computeResources": sbom_syft_resources,
-                },
-            ]
+            build_images_step_specs: list[dict] = []
 
             if ephemeral_storage:
                 post_build_resources: dict = {
                     "requests": {"ephemeral-storage": "1Gi"},
                     "limits": {"ephemeral-storage": "1Gi"},
                 }
-                for step_name in ("push", "prepare-sboms", "upload-sbom"):
+                for step_name in ("prepare-sboms", "upload-sbom"):
                     build_images_step_specs.append({"name": step_name, "computeResources": post_build_resources})
 
             if build_params.build_step_resources:
@@ -1493,12 +1480,13 @@ class KonfluxClient:
                     }
                 )
 
-            task_run_specs += [
-                {
-                    "pipelineTaskName": "build-images",
-                    "stepSpecs": build_images_step_specs,
-                }
-            ]
+            if build_images_step_specs:
+                task_run_specs += [
+                    {
+                        "pipelineTaskName": "build-images",
+                        "stepSpecs": build_images_step_specs,
+                    }
+                ]
         if has_prefetch_task:
             task_run_specs += [
                 {

--- a/doozer/tests/backend/test_konflux_client.py
+++ b/doozer/tests/backend/test_konflux_client.py
@@ -899,9 +899,8 @@ class TestNewPipelinerunBuildStepResources(IsolatedAsyncioTestCase):
         )
 
         task_run_specs = result["spec"]["taskRunSpecs"]
-        build_images_spec = next(s for s in task_run_specs if s["pipelineTaskName"] == "build-images")
-        step_names = {s["name"] for s in build_images_spec["stepSpecs"]}
-        self.assertNotIn("build", step_names)
+        build_images_spec = next((s for s in task_run_specs if s["pipelineTaskName"] == "build-images"), None)
+        self.assertIsNone(build_images_spec, "Expected no build-images stepSpecs when build_step_resources is None")
 
 
 class TestNewPipelinerunWorkspaceStorage(IsolatedAsyncioTestCase):
@@ -964,13 +963,15 @@ class TestNewPipelinerunEphemeralStorage(IsolatedAsyncioTestCase):
         step_specs = {s["name"]: s for s in build_images_spec["stepSpecs"]}
 
         self.assertEqual(step_specs["build"]["computeResources"]["requests"]["ephemeral-storage"], "250Gi")
-        for step_name in ("push", "sbom-syft-generate", "prepare-sboms", "upload-sbom"):
+        for step_name in ("prepare-sboms", "upload-sbom"):
             self.assertIn(step_name, step_specs, f"Missing stepSpec for {step_name}")
             self.assertEqual(
                 step_specs[step_name]["computeResources"]["requests"]["ephemeral-storage"],
                 "1Gi",
                 f"Wrong ephemeral-storage for {step_name}",
             )
+        self.assertNotIn("sbom-syft-generate", step_specs)
+        self.assertNotIn("push", step_specs)
 
     @patch("doozerlib.backend.konflux_client.KonfluxClient._get_pipelinerun_template")
     async def test_no_ephemeral_storage_no_post_build_steps(self, mock_get_template):
@@ -986,6 +987,7 @@ class TestNewPipelinerunEphemeralStorage(IsolatedAsyncioTestCase):
         build_images_spec = next(s for s in task_run_specs if s["pipelineTaskName"] == "build-images")
         step_names = {s["name"] for s in build_images_spec["stepSpecs"]}
         self.assertIn("build", step_names)
+        self.assertNotIn("sbom-syft-generate", step_names)
         self.assertNotIn("push", step_names)
         self.assertNotIn("prepare-sboms", step_names)
         self.assertNotIn("upload-sbom", step_names)


### PR DESCRIPTION
## Summary

- `buildah` v0.11.0 (included in [art-konflux-template#174](https://github.com/openshift-priv/art-konflux-template/pull/174)) removed the `sbom-syft-generate` and `push` steps — SBOM generation and image push now happen inside the `build` step
- PipelineRuns that carry `stepSpecs` overriding these non-existent steps fail with `[User error] invalid StepOverride: No Step named sbom-syft-generate`
- Remove both step overrides from `_new_pipelinerun_for_image_build`
- Guard the `build-images` taskRunSpec so it is only added when there are actual overrides to apply (avoids emitting an empty `stepSpecs` list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image build resource configuration by applying ephemeral-storage settings only to the relevant SBOM preparation and upload steps.
  * Prevented unnecessary resource settings from being applied to SBOM generation and image push steps.
  * Omitted build step specifications when no build resources are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->