### PR TITLE
ART-21958: Rebuild and sync CI golang-builder images when their golang parent changes

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -556,6 +556,13 @@ class KonfluxRebaser:
                 if parent_metadata.should_trigger_base_image_release():
                     released_pullspec = (build.released_pullspec or "").strip()
                     if released_pullspec:
+                        self._logger.info(
+                            "member-resolve: %s NOT loaded in this run; late-resolved via latest Konflux "
+                            "build (nvr=%s) -> %s",
+                            member,
+                            build.nvr,
+                            released_pullspec,
+                        )
                         return released_pullspec, build.embargoed
                     self._logger.warning(
                         "Late-resolved parent %s: Konflux latest build has empty released_pullspec (nvr=%s); "
@@ -565,10 +572,29 @@ class KonfluxRebaser:
                     )
                     rh_pullspec = util.rh_art_images_base_pullspec(build.nvr)
                     if await self._registry_pullspec_exists(rh_pullspec):
+                        self._logger.info(
+                            "member-resolve: %s NOT loaded in this run; late-resolved via latest Konflux "
+                            "build (nvr=%s) -> %s",
+                            member,
+                            build.nvr,
+                            rh_pullspec,
+                        )
                         return rh_pullspec, build.embargoed
                     raise IOError(f"Late-resolved parent {member}: art-images-base tag unreachable at {rh_pullspec}")
+                self._logger.info(
+                    "member-resolve: %s NOT loaded in this run; late-resolved via latest Konflux build (nvr=%s) -> %s",
+                    member,
+                    build.nvr,
+                    build.image_pullspec,
+                )
                 return build.image_pullspec, build.embargoed
 
+            self._logger.info(
+                "member-resolve: %s NOT loaded in this run; --latest-parent-version not set, leaving FROM "
+                "unchanged -> %s",
+                member,
+                original_parent,
+            )
             return original_parent, False
         else:
             if not self.image_repo:
@@ -582,9 +608,23 @@ class KonfluxRebaser:
             private_fix = parent_metadata.private_fix
             if parent_metadata.should_trigger_base_image_release():
                 parent_nvr = self._rebased_member_image_nvr(parent_metadata)
-                return util.rh_art_images_base_pullspec(parent_nvr), private_fix
+                pullspec = util.rh_art_images_base_pullspec(parent_nvr)
+                self._logger.info(
+                    "member-resolve: %s loaded in this run; resolved via rebased NVR (%s) -> %s",
+                    member,
+                    parent_nvr,
+                    pullspec,
+                )
+                return pullspec, private_fix
             parent_image_repo = parent_metadata.get_konflux_image_repo(default=self.image_repo)
-            return f"{parent_image_repo}:{parent_metadata.image_name_short}-{self.uuid_tag}", private_fix
+            pullspec = f"{parent_image_repo}:{parent_metadata.image_name_short}-{self.uuid_tag}"
+            self._logger.info(
+                "member-resolve: %s loaded in this run; resolved via shared run uuid_tag (%s) -> %s",
+                member,
+                self.uuid_tag,
+                pullspec,
+            )
+            return pullspec, private_fix
 
     @start_as_current_span_async(TRACER, "rebase.resolve_stream_parent")
     async def _resolve_stream_parent(

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -556,13 +556,6 @@ class KonfluxRebaser:
                 if parent_metadata.should_trigger_base_image_release():
                     released_pullspec = (build.released_pullspec or "").strip()
                     if released_pullspec:
-                        self._logger.info(
-                            "member-resolve: %s NOT loaded in this run; late-resolved via latest Konflux "
-                            "build (nvr=%s) -> %s",
-                            member,
-                            build.nvr,
-                            released_pullspec,
-                        )
                         return released_pullspec, build.embargoed
                     self._logger.warning(
                         "Late-resolved parent %s: Konflux latest build has empty released_pullspec (nvr=%s); "
@@ -572,29 +565,10 @@ class KonfluxRebaser:
                     )
                     rh_pullspec = util.rh_art_images_base_pullspec(build.nvr)
                     if await self._registry_pullspec_exists(rh_pullspec):
-                        self._logger.info(
-                            "member-resolve: %s NOT loaded in this run; late-resolved via latest Konflux "
-                            "build (nvr=%s) -> %s",
-                            member,
-                            build.nvr,
-                            rh_pullspec,
-                        )
                         return rh_pullspec, build.embargoed
                     raise IOError(f"Late-resolved parent {member}: art-images-base tag unreachable at {rh_pullspec}")
-                self._logger.info(
-                    "member-resolve: %s NOT loaded in this run; late-resolved via latest Konflux build (nvr=%s) -> %s",
-                    member,
-                    build.nvr,
-                    build.image_pullspec,
-                )
                 return build.image_pullspec, build.embargoed
 
-            self._logger.info(
-                "member-resolve: %s NOT loaded in this run; --latest-parent-version not set, leaving FROM "
-                "unchanged -> %s",
-                member,
-                original_parent,
-            )
             return original_parent, False
         else:
             if not self.image_repo:
@@ -608,23 +582,9 @@ class KonfluxRebaser:
             private_fix = parent_metadata.private_fix
             if parent_metadata.should_trigger_base_image_release():
                 parent_nvr = self._rebased_member_image_nvr(parent_metadata)
-                pullspec = util.rh_art_images_base_pullspec(parent_nvr)
-                self._logger.info(
-                    "member-resolve: %s loaded in this run; resolved via rebased NVR (%s) -> %s",
-                    member,
-                    parent_nvr,
-                    pullspec,
-                )
-                return pullspec, private_fix
+                return util.rh_art_images_base_pullspec(parent_nvr), private_fix
             parent_image_repo = parent_metadata.get_konflux_image_repo(default=self.image_repo)
-            pullspec = f"{parent_image_repo}:{parent_metadata.image_name_short}-{self.uuid_tag}"
-            self._logger.info(
-                "member-resolve: %s loaded in this run; resolved via shared run uuid_tag (%s) -> %s",
-                member,
-                self.uuid_tag,
-                pullspec,
-            )
-            return pullspec, private_fix
+            return f"{parent_image_repo}:{parent_metadata.image_name_short}-{self.uuid_tag}", private_fix
 
     @start_as_current_span_async(TRACER, "rebase.resolve_stream_parent")
     async def _resolve_stream_parent(

--- a/doozer/doozerlib/cli/images_streams.py
+++ b/doozer/doozerlib/cli/images_streams.py
@@ -386,6 +386,8 @@ def images_streams_mirror(
             # upstream_image to all the upstream_image_mirror destinations so they all get the same version.
             if config.upstream_image_mirror is not Missing:
                 for upstream_image_mirror_dest in config.upstream_image_mirror:
+                    if live_test_mode:
+                        upstream_image_mirror_dest += '.test'
                     # Mirror to each destination only if not in only-if-missing mode OR destination doesn't exist
                     if not only_if_missing or not destinations_to_check.get(upstream_image_mirror_dest, False):
                         priv_cmd = f'oc image mirror {config.upstream_image}'

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -563,8 +563,9 @@ class ConfigScanSources:
         self.latest_image_build_records_map.update((zip(image_names, latest_image_builds)))
 
     async def scan_images(self, image_names: List[str]):
-        # Filter to only enabled images (variant-aware filtering is handled by _is_image_enabled)
-        image_names = filter(lambda name: self._is_image_enabled(self.runtime.image_map[name]), image_names)
+        # Filter to only enabled images (variant-aware filtering is handled by _is_image_enabled_for_scan,
+        # which also honors --load-disabled -- unlike _is_image_enabled alone)
+        image_names = filter(lambda name: self._is_image_enabled_for_scan(self.runtime.image_map[name]), image_names)
 
         # Do not scan images that have already been requested for rebuild
         image_names = list(filter(lambda name: name not in self.changing_image_names, image_names))

--- a/ocp-build-data-validator/tests/test_schema/test_group_schema.py
+++ b/ocp-build-data-validator/tests/test_schema/test_group_schema.py
@@ -102,3 +102,33 @@ class TestGroupSchema(unittest.TestCase):
             },
         }
         self.assertIn("'yes' is not of type 'boolean'", group_schema.validate("group.yml", invalid_data))
+
+    def test_validate_with_distinct_go_version_vars(self):
+        valid_data = {
+            "name": "openshift-4.22",
+            "vars": {"MAJOR": 4, "MINOR": 22, "GO_LATEST": "1.25", "GO_EXTRA": "1.24", "GO_PREVIOUS": "1.23"},
+        }
+        self.assertEqual("", group_schema.validate("group.yml", valid_data))
+
+    def test_validate_with_duplicate_go_version_vars(self):
+        invalid_data = {
+            "name": "openshift-4.22",
+            "vars": {"MAJOR": 4, "MINOR": 22, "GO_LATEST": "1.25", "GO_EXTRA": "1.25"},
+        }
+        result = group_schema.validate("group.yml", invalid_data)
+        self.assertIn("GO_EXTRA and GO_LATEST cannot both resolve to the same major.minor version (1.25)", result)
+
+    def test_validate_with_duplicate_go_version_vars_different_patch(self):
+        invalid_data = {
+            "name": "openshift-4.22",
+            "vars": {"MAJOR": 4, "MINOR": 22, "GO_LATEST": "1.25.1", "GO_PREVIOUS": "1.25.0"},
+        }
+        result = group_schema.validate("group.yml", invalid_data)
+        self.assertIn("GO_PREVIOUS and GO_LATEST cannot both resolve to the same major.minor version (1.25)", result)
+
+    def test_validate_with_invalid_go_version_var(self):
+        invalid_data = {
+            "name": "openshift-4.22",
+            "vars": {"MAJOR": 4, "MINOR": 22, "GO_LATEST": "not-a-version"},
+        }
+        self.assertIn("Invalid GO_LATEST value: not-a-version", group_schema.validate("group.yml", invalid_data))

--- a/ocp-build-data-validator/validator/schema/group_schema.py
+++ b/ocp-build-data-validator/validator/schema/group_schema.py
@@ -5,6 +5,7 @@ This module provides validation for group.yml files using JSON schemas.
 """
 
 import json
+import re
 import sys
 
 from artcommonlib.util import validate_bridge_release_basis_group
@@ -13,6 +14,38 @@ from jsonschema.validators import validator_for
 from schema import SchemaError
 
 from validator.support import replace_vars
+
+GO_VERSION_VARS = ("GO_LATEST", "GO_EXTRA", "GO_PREVIOUS")
+
+
+def _go_major_minor(var_name, value):
+    match = re.fullmatch(r"(\d+)\.(\d+)(?:\.\d+)?", str(value))
+    if not match:
+        raise SchemaError(f"Invalid {var_name} value: {value}")
+    return f"{match[1]}.{match[2]}"
+
+
+def _validate_go_version_vars(vars_map):
+    """
+    GO_LATEST/GO_EXTRA/GO_PREVIOUS must all resolve to distinct major.minor versions.
+    Consumers (e.g. pyartcd's update_golang pipeline) rely on this to identify a single
+    matching variant for a given golang build, rather than having to check every variant
+    that could share the same major.minor.
+    """
+    major_minors = {}
+    for var_name in GO_VERSION_VARS:
+        value = vars_map.get(var_name)
+        if value is None:
+            continue
+        major_minor = _go_major_minor(var_name, value)
+        if major_minor in major_minors:
+            return (
+                f"{var_name} and {major_minors[major_minor]} cannot both resolve to the same "
+                f"major.minor version ({major_minor})"
+            )
+        major_minors[major_minor] = var_name
+    return ''
+
 
 if sys.version_info < (3, 9):
     # importlib.resources either doesn't exist or lacks the files()
@@ -94,5 +127,12 @@ def validate(_, data):
             validate_bridge_release_basis_group(group_name, basis_group)
         except ValueError as e:
             return str(e)
+
+    try:
+        go_version_error = _validate_go_version_vars(vars_map)
+    except SchemaError as e:
+        return str(e)
+    if go_version_error:
+        return go_version_error
 
     return ''

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -53,7 +53,7 @@ class Jobs(Enum):
     BUILD_CONFORMA_VERIFY = 'aos-cd-builds/build%2Fbuild-conforma-verify'
     SCAN_OPERATOR = 'aos-cd-builds/build%2Fscan-operator'
     # TODO TEST
-    SYNC_CI_IMAGES = 'hack/bvizi/add-ci-config-to-golang-builder'
+    SYNC_CI_IMAGES = 'hack/bvizi/add-load-disabled'
     OPEN_RECONCILIATION_PRS = 'aos-cd-builds/build%2Fopen-reconciliation-prs'
     OPEN_RECONCILIATION_PRS_LAYERED = 'aos-cd-builds/build%2Fopen-reconciliation-prs-layered-products'
 

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -52,7 +52,8 @@ class Jobs(Enum):
     SCAN_PLASHET_RPMS = 'scanning/scanning%2Fplashet-rpms'
     BUILD_CONFORMA_VERIFY = 'aos-cd-builds/build%2Fbuild-conforma-verify'
     SCAN_OPERATOR = 'aos-cd-builds/build%2Fscan-operator'
-    SYNC_CI_IMAGES = 'aos-cd-builds/build%2Fsync-ci-images'
+    # TODO TEST
+    SYNC_CI_IMAGES = 'hack/bvizi/add-ci-config-to-golang-builder'
     OPEN_RECONCILIATION_PRS = 'aos-cd-builds/build%2Fopen-reconciliation-prs'
     OPEN_RECONCILIATION_PRS_LAYERED = 'aos-cd-builds/build%2Fopen-reconciliation-prs-layered-products'
 
@@ -531,10 +532,25 @@ def start_rhcos(build_version: str, new_build: bool, job_name: str = 'build', **
     )
 
 
-def start_sync_ci_images(version: str, **kwargs) -> Optional[str]:
+def start_sync_ci_images(
+    version: str,
+    assembly: str = 'stream',
+    image_list: list = None,
+    dry_run: bool = False,
+    load_disabled: bool = False,
+    live_test_mode: bool = False,
+    **kwargs,
+) -> Optional[str]:
     params = {
         'VERSION': version,
     }
+    if image_list:
+        params['IMAGE_LIST'] = ','.join(image_list)
+    params['ART_TOOLS_COMMIT'] = 'kopero2000@ci-golang-builder-from-update-golang-ART-21958'
+    params['DRY_RUN'] = dry_run
+    params['LOAD_DISABLED'] = load_disabled
+    params['LIVE_TEST_MODE'] = live_test_mode
+    params['ASSEMBLY'] = assembly
     return start_build(
         job=Jobs.SYNC_CI_IMAGES,
         params=params,

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -545,7 +545,7 @@ def start_sync_ci_images(
         'VERSION': version,
     }
     if image_list:
-        params['IMAGE_LIST'] = ','.join(image_list)
+        params['IMAGES'] = ','.join(image_list)
     params['ART_TOOLS_COMMIT'] = 'kopero2000@ci-golang-builder-from-update-golang-ART-21958'
     params['DRY_RUN'] = dry_run
     params['LOAD_DISABLED'] = load_disabled

--- a/pyartcd/pyartcd/pipelines/sync_ci_images.py
+++ b/pyartcd/pyartcd/pipelines/sync_ci_images.py
@@ -57,6 +57,8 @@ class SyncCIImagesPipeline:
         skip_waits: bool = False,
         force_run: bool = False,
         update_images_only_when_missing: bool = False,
+        load_disabled: bool = False,
+        live_test_mode: bool = False,
     ) -> None:
         """
         Initialize sync-ci-images pipeline.
@@ -84,7 +86,8 @@ class SyncCIImagesPipeline:
         self.skip_waits = skip_waits
         self.force_run = force_run
         self.update_images_only_when_missing = update_images_only_when_missing
-
+        self.load_disabled = load_disabled
+        self.live_test_mode = live_test_mode
         # Validate parameters
         self._validate_parameters()
 
@@ -512,6 +515,8 @@ class SyncCIImagesPipeline:
             f"--build-system {self.BUILD_SYSTEM} "
             f"--registry-config {auth_file}"
         )
+        if self.load_disabled:
+            doozer_opts += " --load-disabled"
         return doozer_opts
 
     @property
@@ -547,6 +552,8 @@ class SyncCIImagesPipeline:
             mirror_args += "--only-if-missing "
         if self.runtime.dry_run:
             mirror_args += "--dry-run"
+        if self.live_test_mode:
+            mirror_args += "--live-test-mode"
         await self._run_doozer_command(doozer_opts, "images:streams mirror", mirror_args.strip())
 
     async def _trigger_ci_builds(self, doozer_opts: str, auth_file: str) -> None:
@@ -669,6 +676,18 @@ class SyncCIImagesPipeline:
     default=False,
     help='Pass --only-if-missing to doozer mirror (update only missing images)',
 )
+@click.option(
+    '--load-disabled',
+    is_flag=True,
+    default=False,
+    help='Pass --load-disabled to doozer mirror',
+)
+@click.option(
+    '--live-test-mode',
+    is_flag=True,
+    default=False,
+    help='Pass --live-test-mode to doozer mirror',
+)
 @pass_runtime
 @click_coroutine
 async def sync_ci_images_cli(
@@ -682,6 +701,8 @@ async def sync_ci_images_cli(
     skip_waits: bool,
     force_run: bool,
     update_images_only_when_missing: bool,
+    load_disabled: bool,
+    live_test_mode: bool,
 ):
     """
     CLI entrypoint for sync-ci-images pipeline.
@@ -709,6 +730,8 @@ async def sync_ci_images_cli(
         skip_waits=skip_waits,
         force_run=force_run,
         update_images_only_when_missing=update_images_only_when_missing,
+        load_disabled=load_disabled,
+        live_test_mode=live_test_mode,
     )
 
     # Run with per-version lock

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -21,6 +21,7 @@ from artcommonlib.constants import (
     REGISTRY_QUAY_OCP_RELEASE_DEV,
     REGISTRY_QUAY_OPENSHIFT,
     REGISTRY_REDHAT_IO,
+    KONFLUX_DEFAULT_IMAGE_REPO,
 )
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -1227,7 +1227,11 @@ class UpdateGolangPipeline:
         cmd.append("--load-disabled")
         cmd.extend(self._get_doozer_assembly_args())
         cmd.extend(["-i", ",".join(image_keys)])
-        cmd.extend(["beta:config:konflux:scan-sources", "--yaml"])
+        # These CI images declare `scan_sources: exempt_rpms: - '*'`, so RPM changes never affect
+        # their staleness anyway. --skip-rpms avoids loading/cloning every RPM source in the whole
+        # group (mode='images' instead of 'both' in doozer), which is otherwise unconditional and
+        # unrelated to the -i image filter above.
+        cmd.extend(["beta:config:konflux:scan-sources", "--yaml", "--skip-rpms"])
         # --ci-kubeconfig is for looking at release-controller imagestreams on app.ci, which is a
         # different cluster/identity than self.kubeconfig (the Konflux SA kubeconfig).
         ci_kubeconfig = os.environ.get('KUBECONFIG')

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -1385,9 +1385,9 @@ class UpdateGolangPipeline:
             # `if self.data_path: cmd.append(f"--data-path={self.data_path}")`.
             cmd.append(f"--data-path={self._CI_TEST_DATA_PATH}")
             cmd.extend(["--group", group])
+            cmd.extend(["images:streams", "mirror", "--registry-auth", auth_file])
             for image_key in image_keys:
                 cmd.extend(["--image", image_key])
-            cmd.extend(["images:streams", "mirror", "--registry-auth", auth_file])
             if not self.is_production_assembly:
                 cmd.append("--live-test-mode")
             if self.dry_run:
@@ -1505,8 +1505,7 @@ class UpdateGolangPipeline:
             )
         else:
             _LOGGER.info(
-                "All CI golang builder/build-root images for openshift-%s already use their current parent "
-                "image;",
+                "All CI golang builder/build-root images for openshift-%s already use their current parent image;",
                 self.ocp_version,
             )
 

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -1385,6 +1385,11 @@ class UpdateGolangPipeline:
             # `if self.data_path: cmd.append(f"--data-path={self.data_path}")`.
             cmd.append(f"--data-path={self._CI_TEST_DATA_PATH}")
             cmd.extend(["--group", group])
+            # These images are `mode: disabled` in ocp-build-data (see _scan_stale_ci_images), and
+            # unlike that command this one doesn't use the global `-i` image filter (its `--image`
+            # below is a subcommand-local option), so the runtime's default enabled-only filter
+            # would otherwise drop them before `images:streams mirror` can look them up.
+            cmd.append("--load-disabled")
             cmd.extend(["images:streams", "mirror", "--registry-auth", auth_file])
             for image_key in image_keys:
                 cmd.extend(["--image", image_key])

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -1425,10 +1425,13 @@ class UpdateGolangPipeline:
         naturally covers the case where build-root itself hasn't changed but its golang-builder
         parent has. Whatever comes back stale is rebased+built together in one batch (see
         `_rebase_and_build_ci_images`) -- doozer only resolves a `from: member:` reference
-        correctly when both images are loaded in the same run. Once done, everything rebuilt is
-        synced together in a single final step. For the test assembly, `_sync_ci_images` passes
-        `--live-test-mode`, which publishes to the `.test`-suffixed CI imagestream tag instead of
-        the real one, so test-assembly runs never overwrite what production CI actually consumes.
+        correctly when both images are loaded in the same run. Once done, every image considered
+        this run (not just what was rebuilt) is synced to CI in a single final step -- re-mirroring
+        an already-current image is cheap for a handful of images, and it keeps CI in sync with the
+        latest successful build even when nothing needed rebuilding. For the test assembly,
+        `_sync_ci_images` passes `--live-test-mode`, which publishes to the `.test`-suffixed CI
+        imagestream tag instead of the real one, so test-assembly runs never overwrite what
+        production CI actually consumes.
         """
         # TODO: revert -- re-deriving allowed_major_minors from the test fork/branch below.
         # _get_allowed_go_major_minors (which produced the `allowed_major_minors` param) always
@@ -1491,30 +1494,31 @@ class UpdateGolangPipeline:
         stale_image_keys = set(await self._scan_stale_ci_images(scan_keys))
         rebuilt_image_keys = [image_key for image_key in scan_keys if image_key in stale_image_keys]
 
-        if not rebuilt_image_keys:
+        if rebuilt_image_keys:
+            await self._slack_client.say_in_thread(
+                f":construction: Rebuilding CI golang builder/build-root image(s) for "
+                f"{self.ocp_version}: {', '.join(rebuilt_image_keys)}"
+            )
+            await self._rebase_and_build_ci_images(rebuilt_image_keys)
+            await self._slack_client.say_in_thread(
+                f":white_check_mark: Rebuilt CI golang builder/build-root image(s): {', '.join(rebuilt_image_keys)}"
+            )
+        else:
             _LOGGER.info(
-                "All CI golang builder/build-root images for openshift-%s already use their current parent image",
+                "All CI golang builder/build-root images for openshift-%s already use their current parent "
+                "image;",
                 self.ocp_version,
             )
-            return
 
-        await self._slack_client.say_in_thread(
-            f":construction: Rebuilding CI golang builder/build-root image(s) for "
-            f"{self.ocp_version}: {', '.join(rebuilt_image_keys)}"
-        )
-        await self._rebase_and_build_ci_images(rebuilt_image_keys)
-        await self._slack_client.say_in_thread(
-            f":white_check_mark: Rebuilt CI golang builder/build-root image(s): {', '.join(rebuilt_image_keys)}"
-        )
-
+        # Sync every image considered this run, not just what was just rebuilt -- mirroring an
+        # already-current image is a no-op cost-wise (a handful of images at most), and it keeps CI
+        # in sync with the latest successful build even on runs where nothing needed rebuilding.
         try:
-            await self._sync_ci_images(rebuilt_image_keys)
+            await self._sync_ci_images(scan_keys)
         except Exception as e:
             raise RuntimeError(f"Failed to sync CI image(s) to CI: {e}") from e
 
-        await self._slack_client.say_in_thread(
-            f":white_check_mark: Synced CI image(s): {', '.join(rebuilt_image_keys)}"
-        )
+        await self._slack_client.say_in_thread(f":white_check_mark: Synced CI image(s): {', '.join(scan_keys)}")
 
     GOLANG_DATA_BRANCH = 'golang'
 

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -1426,6 +1426,13 @@ class UpdateGolangPipeline:
         `.test`-suffixed CI imagestream tag instead of the real one, so test-assembly runs never
         overwrite what production CI actually consumes.
         """
+        # TODO: revert -- re-deriving allowed_major_minors from the test fork/branch below.
+        # _get_allowed_go_major_minors (which produced the `allowed_major_minors` param) always
+        # reads the real upstream ocp-build-data regardless of --data-path, so without this the
+        # variant match below would use production GO_LATEST/GO_EXTRA/GO_PREVIOUS values while
+        # every doozer call in this method reads from the test fork. Restore by deleting this
+        # line so `allowed_major_minors` (the param) is used directly below.
+        allowed_major_minors = self._get_ci_allowed_go_major_minors()
         variant = next(
             (
                 self.CI_VARIANT_BY_GROUP_VAR[var_name]
@@ -1537,6 +1544,23 @@ class UpdateGolangPipeline:
         # `if self.data_gitref: group += f'@{self.data_gitref}'`.
         group += f'@{self._CI_TEST_DATA_GITREF}'
         return group
+
+    # TODO: revert -- delete this whole method once CI rebuild testing is done.
+    def _get_ci_allowed_go_major_minors(self) -> dict[str, str]:
+        """CI-scoped re-lookup of GO_LATEST/GO_EXTRA/GO_PREVIOUS against the test fork/branch, for
+        _refresh_ci_images' variant matching only -- see the TODO where this is called."""
+        branch = f"openshift-{self.ocp_version}"
+        repo, branch = self._get_ocp_build_data_repo_and_branch(
+            branch, data_path=self._CI_TEST_DATA_PATH, data_gitref=self._CI_TEST_DATA_GITREF
+        )
+        group_content = self._load_yaml_from_repo(repo, "group.yml", branch)
+        vars_content = group_content.get("vars", {})
+        return {
+            var_name: extract_major_minor(var_value, f"group.yml {var_name}")
+            for var_name in ("GO_LATEST", "GO_EXTRA", "GO_PREVIOUS")
+            for var_value in [vars_content.get(var_name)]
+            if var_value
+        }
 
     def verify_golang_builder_repo(self, el_v, go_version):
         default_branch = self.GOLANG_DATA_BRANCH

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -269,15 +269,17 @@ class UpdateGolangPipeline:
     def _get_upstream_ocp_build_data_repo(self):
         return get_github_client_for_org("openshift-eng").get_repo("openshift-eng/ocp-build-data")
 
-    def _get_ocp_build_data_repo_and_branch(self, default_branch):
+    def _get_ocp_build_data_repo_and_branch(self, default_branch, data_path=None, data_gitref=None):
         """Get the ocp-build-data repo and branch, respecting data_path/data_gitref overrides."""
-        if self.data_path:
-            match = re.search(r'github\.com[:/](.+?)(?:\.git)?$', self.data_path)
+        data_path = self.data_path if data_path is None else data_path
+        data_gitref = self.data_gitref if data_gitref is None else data_gitref
+        if data_path:
+            match = re.search(r'github\.com[:/](.+?)(?:\.git)?$', data_path)
             if match:
                 repo_name = match.group(1)
                 org = repo_name.split('/')[0]
                 repo = get_github_client_for_org(org).get_repo(repo_name)
-                branch = self.data_gitref or default_branch
+                branch = data_gitref or default_branch
                 return repo, branch
         return self._get_upstream_ocp_build_data_repo(), default_branch
 
@@ -1183,7 +1185,11 @@ class UpdateGolangPipeline:
         need to be rebuilt whenever their respective parent changes.
         """
         branch = f"openshift-{self.ocp_version}"
-        repo, branch = self._get_ocp_build_data_repo_and_branch(branch)
+        # TODO: revert -- forcing the test fork/branch below for CI rebuild testing; restore
+        # `repo, branch = self._get_ocp_build_data_repo_and_branch(branch)`.
+        repo, branch = self._get_ocp_build_data_repo_and_branch(
+            branch, data_path=self._CI_TEST_DATA_PATH, data_gitref=self._CI_TEST_DATA_GITREF
+        )
         contents = repo.get_contents("images", ref=branch)
         ci_image_keys = sorted(
             content.name[: -len(".yml")]
@@ -1204,14 +1210,15 @@ class UpdateGolangPipeline:
         references against streams.yml), it queries the parent's actual current build and flags
         the image if that build is newer than the image's own last build.
         """
-        group = f"openshift-{self.ocp_version}"
+        group = self._get_ci_group()
         cmd = [
             "doozer",
             f"--working-dir={self._doozer_working_dir}-ci-scan",
             "--build-system=konflux",
         ]
-        if self.data_path:
-            cmd.append(f"--data-path={self.data_path}")
+        # TODO: revert -- forcing the test data_path below for CI rebuild testing; restore
+        # `if self.data_path: cmd.append(f"--data-path={self.data_path}")`.
+        cmd.append(f"--data-path={self._CI_TEST_DATA_PATH}")
         cmd.extend(["--group", group])
         cmd.extend(self._get_doozer_assembly_args())
         cmd.extend(["-i", ",".join(image_keys)])
@@ -1230,30 +1237,37 @@ class UpdateGolangPipeline:
         changes = get_changes(report)
         return [image_key for image_key in changes.get('images', []) if image_key in image_keys]
 
-    async def _rebase_ci_image(self, image_key: str, version: str, release: str):
-        _LOGGER.info("Rebasing %s for Konflux...", image_key)
-        group = f"openshift-{self.ocp_version}"
+    async def _rebase_ci_images(self, image_keys: List[str], version: str, release: str):
+        _LOGGER.info("Rebasing %s for Konflux...", ", ".join(image_keys))
+        group = self._get_ci_group()
         cmd = [
             "doozer",
-            f"--working-dir={self._doozer_working_dir}-ci-{image_key}",
+            f"--working-dir={self._doozer_working_dir}-ci-rebase",
             "--build-system=konflux",
         ]
         cmd.extend(self._get_doozer_assembly_args())
-        if self.data_path:
-            cmd.append(f"--data-path={self.data_path}")
+        # TODO: revert -- forcing the test data_path below for CI rebuild testing; restore
+        # `if self.data_path: cmd.append(f"--data-path={self.data_path}")`.
+        cmd.append(f"--data-path={self._CI_TEST_DATA_PATH}")
         cmd.extend(
             [
                 "--group",
                 group,
+                # All CI images being rebuilt this run are rebased together in one doozer
+                # invocation (matching ocp4_konflux's approach), so a `from: member:` reference
+                # between them (e.g. ci-openshift-build-root-* -> ci-openshift-golang-builder-*)
+                # is resolved in-process. --latest-parent-version is kept as a fallback for a
+                # member that isn't part of this batch (e.g. only the build-root side went stale).
+                "--latest-parent-version",
                 "-i",
-                image_key,
+                ",".join(image_keys),
                 "beta:images:konflux:rebase",
                 "--version",
                 version,
                 "--release",
                 release,
                 "--message",
-                f"Bump golang parent image for {image_key}",
+                f"Bump golang parent image for {', '.join(image_keys)}",
             ]
         )
         if self.network_mode:
@@ -1262,24 +1276,26 @@ class UpdateGolangPipeline:
             cmd.append("--push")
         await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars)
 
-    async def _build_ci_image(self, image_key: str):
-        _LOGGER.info("Building %s on Konflux...", image_key)
-        group = f"openshift-{self.ocp_version}"
+    async def _build_ci_images(self, image_keys: List[str]):
+        _LOGGER.info("Building %s on Konflux...", ", ".join(image_keys))
+        group = self._get_ci_group()
         konflux_namespace = PRODUCT_NAMESPACE_MAP["ocp"]
         cmd = [
             "doozer",
-            f"--working-dir={self._doozer_working_dir}-ci-{image_key}",
+            f"--working-dir={self._doozer_working_dir}-ci-build",
             "--build-system=konflux",
         ]
         cmd.extend(self._get_doozer_assembly_args())
-        if self.data_path:
-            cmd.append(f"--data-path={self.data_path}")
+        # TODO: revert -- forcing the test data_path below for CI rebuild testing; restore
+        # `if self.data_path: cmd.append(f"--data-path={self.data_path}")`.
+        cmd.append(f"--data-path={self._CI_TEST_DATA_PATH}")
         cmd.extend(
             [
                 "--group",
                 group,
+                "--latest-parent-version",
                 "-i",
-                image_key,
+                ",".join(image_keys),
                 "beta:images:konflux:build",
                 f"--konflux-namespace={konflux_namespace}",
                 "--skip-ec-verify",
@@ -1295,24 +1311,13 @@ class UpdateGolangPipeline:
 
     async def _rebase_and_build_ci_images(self, image_keys: List[str]):
         """
-        Rebase+build each CI image directly via doozer, without touching streams.yml or creating
-        an ocp-build-data PR.
+        Rebase, then build, all given CI images together -- one doozer invocation per phase --
+        directly via doozer, without touching streams.yml or creating an ocp-build-data PR.
         """
         version = f"v{self.ocp_version}.0"
         release = default_release_suffix()
-
-        async def _rebase_and_build(image_key: str):
-            await self._rebase_ci_image(image_key, version, release)
-            await self._build_ci_image(image_key)
-
-        results = await asyncio.gather(
-            *[_rebase_and_build(image_key) for image_key in image_keys],
-            return_exceptions=True,
-        )
-        failed = [(image_key, r) for image_key, r in zip(image_keys, results) if isinstance(r, Exception)]
-        if failed:
-            summary = "\n".join(f"  ❌ {image_key}: {err}" for image_key, err in failed)
-            raise RuntimeError(f"Failed to rebuild {len(failed)}/{len(image_keys)} CI image(s):\n{summary}")
+        await self._rebase_ci_images(image_keys, version, release)
+        await self._build_ci_images(image_keys)
 
     @staticmethod
     def _get_required_env(var_name: str) -> str:
@@ -1358,7 +1363,7 @@ class UpdateGolangPipeline:
         other way to redirect it away from the production tag.
         """
         _LOGGER.info("Syncing CI image(s) to CI: %s", ", ".join(image_keys))
-        group = f"openshift-{self.ocp_version}"
+        group = self._get_ci_group()
         with self._create_ci_sync_registry_config() as auth_file:
             cmd = [
                 "doozer",
@@ -1366,8 +1371,9 @@ class UpdateGolangPipeline:
                 "--build-system=konflux",
             ]
             cmd.extend(self._get_doozer_assembly_args())
-            if self.data_path:
-                cmd.append(f"--data-path={self.data_path}")
+            # TODO: revert -- forcing the test data_path below for CI rebuild testing; restore
+            # `if self.data_path: cmd.append(f"--data-path={self.data_path}")`.
+            cmd.append(f"--data-path={self._CI_TEST_DATA_PATH}")
             cmd.extend(["--group", group])
             for image_key in image_keys:
                 cmd.extend(["--image", image_key])
@@ -1383,6 +1389,12 @@ class UpdateGolangPipeline:
         "GO_EXTRA": "extra",
         "GO_PREVIOUS": "previous",
     }
+
+    # TODO: revert -- temporary hardcoded fork/branch for testing the CI golang-builder/build-root
+    # rebuild path end-to-end. Every site tagged "TODO: revert" below forces this instead of the
+    # normal --data-path/--data-gitref values; remove them all once testing is done.
+    _CI_TEST_DATA_PATH = "https://github.com/kopero2000/ocp-build-data"
+    _CI_TEST_DATA_GITREF = "openshift-5.0-test"
 
     async def _refresh_ci_images(
         self,
@@ -1401,12 +1413,13 @@ class UpdateGolangPipeline:
         an ocp-build-data PR) any golang-builder CI image found to be stale. ci-openshift-build-root-*
         images pull their parent via a `member` reference to the golang-builder CI image (not a
         golang stream or the raw golang-builder container), so once a golang-builder image is
-        rebuilt, its corresponding build-root image is unconditionally rebuilt right after, to
-        pick up the new base image. Both rebuild steps must complete before either image is
-        mirrored to CI, so everything rebuilt this run is synced together in a single final step.
-        For the test assembly, `_sync_ci_images` passes `--live-test-mode`, which publishes to
-        the `.test`-suffixed CI imagestream tag instead of the real one, so test-assembly runs
-        never overwrite what production CI actually consumes.
+        stale, its corresponding build-root image is unconditionally rebuilt alongside it, in the
+        same rebase/build batch (see `_rebase_and_build_ci_images`) -- doozer only resolves a
+        `from: member:` reference correctly when both images are loaded in the same run. Once
+        both rebuild, everything is synced together in a single final step. For the test
+        assembly, `_sync_ci_images` passes `--live-test-mode`, which publishes to the
+        `.test`-suffixed CI imagestream tag instead of the real one, so test-assembly runs never
+        overwrite what production CI actually consumes.
         """
         variant = next(
             (
@@ -1455,30 +1468,16 @@ class UpdateGolangPipeline:
             return
 
         stale_builder_keys = [image_key for _, image_key in stale_builder_targets]
-        await self._slack_client.say_in_thread(
-            f":construction: Rebuilding CI golang builder image(s) for "
-            f"{self.ocp_version}: {', '.join(stale_builder_keys)}"
-        )
-        await self._rebase_and_build_ci_images(stale_builder_keys)
-        await self._slack_client.say_in_thread(
-            f":white_check_mark: Rebuilt CI golang builder image(s): {', '.join(stale_builder_keys)}"
-        )
 
-        # Trigger the build-root image(s) whose golang-builder parent was just rebuilt above.
+        # Build-root image(s) whose golang-builder parent is about to be rebuilt. Rebuilt in the
+        # same batch as their golang-builder parent (not a separate call) so doozer resolves the
+        # `from: member:` reference in-process.
         build_root_keys = [
             f"{CI_BUILD_ROOT_IMAGE_PREFIX}{variant}.rhel{el_v}"
             for el_v, _ in stale_builder_targets
             if f"{CI_BUILD_ROOT_IMAGE_PREFIX}{variant}.rhel{el_v}" in all_image_keys
         ]
-        if build_root_keys:
-            await self._slack_client.say_in_thread(
-                f":construction: Rebuilding CI build-root image(s) for {self.ocp_version}: {', '.join(build_root_keys)}"
-            )
-            await self._rebase_and_build_ci_images(build_root_keys)
-            await self._slack_client.say_in_thread(
-                f":white_check_mark: Rebuilt CI build-root image(s): {', '.join(build_root_keys)}"
-            )
-        else:
+        if not build_root_keys:
             _LOGGER.info(
                 "No CI build-root images found for variant %s on openshift-%s; skipping CI build-root rebuild",
                 variant,
@@ -1486,6 +1485,15 @@ class UpdateGolangPipeline:
             )
 
         rebuilt_image_keys = stale_builder_keys + build_root_keys
+        await self._slack_client.say_in_thread(
+            f":construction: Rebuilding CI golang builder/build-root image(s) for "
+            f"{self.ocp_version}: {', '.join(rebuilt_image_keys)}"
+        )
+        await self._rebase_and_build_ci_images(rebuilt_image_keys)
+        await self._slack_client.say_in_thread(
+            f":white_check_mark: Rebuilt CI golang builder/build-root image(s): {', '.join(rebuilt_image_keys)}"
+        )
+
         try:
             await self._sync_ci_images(rebuilt_image_keys)
         except Exception as e:
@@ -1513,6 +1521,17 @@ class UpdateGolangPipeline:
         if self.data_gitref:
             group += f'@{self.data_gitref}'
         return group, image_key
+
+    def _get_ci_group(self) -> str:
+        """The openshift-{version} doozer group used by the CI golang-builder/build-root
+        methods, honoring --data-gitref so a fork's non-default-named branch (e.g.
+        openshift-5.0-test) is actually checked out instead of doozer defaulting to a branch
+        literally named openshift-{version}."""
+        group = f"openshift-{self.ocp_version}"
+        # TODO: revert -- forcing the test data_gitref below for CI rebuild testing; restore
+        # `if self.data_gitref: group += f'@{self.data_gitref}'`.
+        group += f'@{self._CI_TEST_DATA_GITREF}'
+        return group
 
     def verify_golang_builder_repo(self, el_v, go_version):
         default_branch = self.GOLANG_DATA_BRANCH

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -1186,11 +1186,7 @@ class UpdateGolangPipeline:
         need to be rebuilt whenever their respective parent changes.
         """
         branch = f"openshift-{self.ocp_version}"
-        # TODO: revert -- forcing the test fork/branch below for CI rebuild testing; restore
-        # `repo, branch = self._get_ocp_build_data_repo_and_branch(branch)`.
-        repo, branch = self._get_ocp_build_data_repo_and_branch(
-            branch, data_path=self._CI_TEST_DATA_PATH, data_gitref=self._CI_TEST_DATA_GITREF
-        )
+        repo, branch = self._get_ocp_build_data_repo_and_branch(branch)
         contents = repo.get_contents("images", ref=branch)
         ci_image_keys = sorted(
             content.name[: -len(".yml")]
@@ -1217,9 +1213,8 @@ class UpdateGolangPipeline:
             f"--working-dir={self._doozer_working_dir}-ci-scan",
             "--build-system=konflux",
         ]
-        # TODO: revert -- forcing the test data_path below for CI rebuild testing; restore
-        # `if self.data_path: cmd.append(f"--data-path={self.data_path}")`.
-        cmd.append(f"--data-path={self._CI_TEST_DATA_PATH}")
+        if self.data_path:
+            cmd.append(f"--data-path={self.data_path}")
         cmd.extend(["--group", group])
         # These images are `mode: disabled` in ocp-build-data so the standing ocp4-scan job (which
         # scans the whole group without --load-disabled) leaves their lifecycle to this pipeline.
@@ -1256,9 +1251,8 @@ class UpdateGolangPipeline:
             "--build-system=konflux",
         ]
         cmd.extend(self._get_doozer_assembly_args())
-        # TODO: revert -- forcing the test data_path below for CI rebuild testing; restore
-        # `if self.data_path: cmd.append(f"--data-path={self.data_path}")`.
-        cmd.append(f"--data-path={self._CI_TEST_DATA_PATH}")
+        if self.data_path:
+            cmd.append(f"--data-path={self.data_path}")
         cmd.extend(
             [
                 "--group",
@@ -1296,9 +1290,8 @@ class UpdateGolangPipeline:
             "--build-system=konflux",
         ]
         cmd.extend(self._get_doozer_assembly_args())
-        # TODO: revert -- forcing the test data_path below for CI rebuild testing; restore
-        # `if self.data_path: cmd.append(f"--data-path={self.data_path}")`.
-        cmd.append(f"--data-path={self._CI_TEST_DATA_PATH}")
+        if self.data_path:
+            cmd.append(f"--data-path={self.data_path}")
         cmd.extend(
             [
                 "--group",
@@ -1381,9 +1374,8 @@ class UpdateGolangPipeline:
                 "--build-system=konflux",
             ]
             cmd.extend(self._get_doozer_assembly_args())
-            # TODO: revert -- forcing the test data_path below for CI rebuild testing; restore
-            # `if self.data_path: cmd.append(f"--data-path={self.data_path}")`.
-            cmd.append(f"--data-path={self._CI_TEST_DATA_PATH}")
+            if self.data_path:
+                cmd.append(f"--data-path={self.data_path}")
             cmd.extend(["--group", group])
             # These images are `mode: disabled` in ocp-build-data (see _scan_stale_ci_images), and
             # unlike that command this one doesn't use the global `-i` image filter (its `--image`
@@ -1404,12 +1396,6 @@ class UpdateGolangPipeline:
         "GO_EXTRA": "extra",
         "GO_PREVIOUS": "previous",
     }
-
-    # TODO: revert -- temporary hardcoded fork/branch for testing the CI golang-builder/build-root
-    # rebuild path end-to-end. Every site tagged "TODO: revert" below forces this instead of the
-    # normal --data-path/--data-gitref values; remove them all once testing is done.
-    _CI_TEST_DATA_PATH = "https://github.com/kopero2000/ocp-build-data"
-    _CI_TEST_DATA_GITREF = "openshift-5.0-test"
 
     async def _refresh_ci_images(
         self,
@@ -1438,13 +1424,6 @@ class UpdateGolangPipeline:
         imagestream tag instead of the real one, so test-assembly runs never overwrite what
         production CI actually consumes.
         """
-        # TODO: revert -- re-deriving allowed_major_minors from the test fork/branch below.
-        # _get_allowed_go_major_minors (which produced the `allowed_major_minors` param) always
-        # reads the real upstream ocp-build-data regardless of --data-path, so without this the
-        # variant match below would use production GO_LATEST/GO_EXTRA/GO_PREVIOUS values while
-        # every doozer call in this method reads from the test fork. Restore by deleting this
-        # line so `allowed_major_minors` (the param) is used directly below.
-        allowed_major_minors = self._get_ci_allowed_go_major_minors()
         variant = next(
             (
                 self.CI_VARIANT_BY_GROUP_VAR[var_name]
@@ -1549,27 +1528,9 @@ class UpdateGolangPipeline:
         openshift-5.0-test) is actually checked out instead of doozer defaulting to a branch
         literally named openshift-{version}."""
         group = f"openshift-{self.ocp_version}"
-        # TODO: revert -- forcing the test data_gitref below for CI rebuild testing; restore
-        # `if self.data_gitref: group += f'@{self.data_gitref}'`.
-        group += f'@{self._CI_TEST_DATA_GITREF}'
+        if self.data_gitref:
+            group += f'@{self.data_gitref}'
         return group
-
-    # TODO: revert -- delete this whole method once CI rebuild testing is done.
-    def _get_ci_allowed_go_major_minors(self) -> dict[str, str]:
-        """CI-scoped re-lookup of GO_LATEST/GO_EXTRA/GO_PREVIOUS against the test fork/branch, for
-        _refresh_ci_images' variant matching only -- see the TODO where this is called."""
-        branch = f"openshift-{self.ocp_version}"
-        repo, branch = self._get_ocp_build_data_repo_and_branch(
-            branch, data_path=self._CI_TEST_DATA_PATH, data_gitref=self._CI_TEST_DATA_GITREF
-        )
-        group_content = self._load_yaml_from_repo(repo, "group.yml", branch)
-        vars_content = group_content.get("vars", {})
-        return {
-            var_name: extract_major_minor(var_value, f"group.yml {var_name}")
-            for var_name in ("GO_LATEST", "GO_EXTRA", "GO_PREVIOUS")
-            for var_value in [vars_content.get(var_name)]
-            if var_value
-        }
 
     def verify_golang_builder_repo(self, el_v, go_version):
         default_branch = self.GOLANG_DATA_BRANCH

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -1220,6 +1220,11 @@ class UpdateGolangPipeline:
         # `if self.data_path: cmd.append(f"--data-path={self.data_path}")`.
         cmd.append(f"--data-path={self._CI_TEST_DATA_PATH}")
         cmd.extend(["--group", group])
+        # These images are `mode: disabled` in ocp-build-data so the standing ocp4-scan job (which
+        # scans the whole group without --load-disabled) leaves their lifecycle to this pipeline.
+        # scan-sources applies that same enabled-filter even to explicitly `-i`-named images, so
+        # --load-disabled is required here or this scan would always report them as not stale.
+        cmd.append("--load-disabled")
         cmd.extend(self._get_doozer_assembly_args())
         cmd.extend(["-i", ",".join(image_keys)])
         cmd.extend(["beta:config:konflux:scan-sources", "--yaml"])

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -1216,8 +1216,11 @@ class UpdateGolangPipeline:
         cmd.extend(self._get_doozer_assembly_args())
         cmd.extend(["-i", ",".join(image_keys)])
         cmd.extend(["beta:config:konflux:scan-sources", "--yaml"])
-        if self.kubeconfig:
-            cmd.append(f"--ci-kubeconfig={self.kubeconfig}")
+        # --ci-kubeconfig is for looking at release-controller imagestreams on app.ci, which is a
+        # different cluster/identity than self.kubeconfig (the Konflux SA kubeconfig).
+        ci_kubeconfig = os.environ.get('KUBECONFIG')
+        if ci_kubeconfig:
+            cmd.append(f"--ci-kubeconfig={ci_kubeconfig}")
 
         rc, out, _ = await exectools.cmd_gather_async(cmd, env=self._doozer_env_vars, stderr=None, check=False)
         if rc != 0:

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -14,11 +14,18 @@ from artcommonlib.constants import (
     BREW_HUB,
     GOLANG_BUILDER_IMAGE_NAME,
     GOLANG_NVR_LABEL,
+    KONFLUX_DEFAULT_FBC_REPO,
+    KONFLUX_DEFAULT_IMAGE_SHARE_REPO,
     PRODUCT_NAMESPACE_MAP,
+    REGISTRY_CI_OPENSHIFT,
+    REGISTRY_QUAY_OCP_RELEASE_DEV,
+    REGISTRY_QUAY_OPENSHIFT,
+    REGISTRY_REDHAT_IO,
 )
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.konflux.konflux_db import KonfluxDb
+from artcommonlib.registry_config import RegistryConfig, RegistryCredential
 from artcommonlib.release_util import isolate_assembly_in_release, isolate_el_version_in_release
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import new_roundtrip_yaml_handler
@@ -31,7 +38,7 @@ from tenacity import before_sleep_log, retry, retry_if_exception_type, stop_afte
 from pyartcd import constants, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.runtime import Runtime
-from pyartcd.util import default_release_suffix, kinit
+from pyartcd.util import default_release_suffix, get_changes, kinit
 
 _LOGGER = logging.getLogger(__name__)
 yaml = new_roundtrip_yaml_handler()
@@ -41,6 +48,8 @@ BREW_TEST_ASSEMBLY_UNSUPPORTED = (
     "Brew builds for the test assembly are not supported because Brew floating tags are updated after every "
     "successful build. Use --build-system konflux for test assembly builds."
 )
+CI_GOLANG_BUILDER_IMAGE_PREFIX = "ci-openshift-golang-builder-"
+CI_BUILD_ROOT_IMAGE_PREFIX = "ci-openshift-build-root-"
 
 
 def is_latest(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool:
@@ -230,10 +239,10 @@ class UpdateGolangPipeline:
 
         # GitHub auth is handled by get_github_client_for_org() with App auth / PAT fallback
 
-        # Initialize KonfluxDb for Konflux build system
-        if build_system in ('konflux', 'both'):
-            self.konflux_db = KonfluxDb()
-            self.konflux_db.bind(KonfluxBuildRecord)
+        # Initialize KonfluxDb. Needed for Konflux build systems, and also for the CI golang
+        # builder image reconciliation stage, which always checks/rebuilds via Konflux.
+        self.konflux_db = KonfluxDb()
+        self.konflux_db.bind(KonfluxBuildRecord)
 
     @property
     def is_production_assembly(self) -> bool:
@@ -555,6 +564,8 @@ class UpdateGolangPipeline:
                 await self.update_golang_streams(go_version, builder_pullspecs)
             else:
                 _LOGGER.info("No Konflux golang builder images found; streams.yml will not be updated.")
+
+        await self._refresh_ci_images(build_major_minor, allowed_major_minors, el_nvr_map_for_images)
 
         if self.is_production_assembly:
             await move_golang_bugs(
@@ -1162,6 +1173,324 @@ class UpdateGolangPipeline:
         """Rebase and build golang-builder image on Konflux"""
         await self._rebase_konflux(el_v, go_version, go_nvr)
         await self._build_konflux(el_v, go_version)
+
+    async def _get_ci_image_keys(self) -> List[str]:
+        """
+        List the `ci-openshift-golang-builder-*` and `ci-openshift-build-root-*` doozer image keys
+        defined for this OCP version. Golang-builder images pull their parent directly from a
+        golang stream in streams.yml (e.g. rhel-9-golang-{GO_LATEST}); build-root images pull
+        their parent via a `member` reference to the corresponding golang-builder CI image. Both
+        need to be rebuilt whenever their respective parent changes.
+        """
+        branch = f"openshift-{self.ocp_version}"
+        repo, branch = self._get_ocp_build_data_repo_and_branch(branch)
+        contents = repo.get_contents("images", ref=branch)
+        ci_image_keys = sorted(
+            content.name[: -len(".yml")]
+            for content in contents
+            if content.name.endswith(".yml")
+            and (
+                content.name.startswith(CI_GOLANG_BUILDER_IMAGE_PREFIX)
+                or content.name.startswith(CI_BUILD_ROOT_IMAGE_PREFIX)
+            )
+        )
+        return ci_image_keys
+
+    async def _scan_stale_ci_images(self, image_keys: List[str]) -> List[str]:
+        """
+        Determine which of the given CI image keys need rebuilding, by invoking doozer's
+        `beta:config:konflux:scan-sources` -- the same builder-staleness check the standing ocp4
+        scan-sources job uses. For each image's declared builder/parent (resolving `stream:`
+        references against streams.yml), it queries the parent's actual current build and flags
+        the image if that build is newer than the image's own last build.
+        """
+        group = f"openshift-{self.ocp_version}"
+        cmd = [
+            "doozer",
+            f"--working-dir={self._doozer_working_dir}-ci-scan",
+            "--build-system=konflux",
+        ]
+        if self.data_path:
+            cmd.append(f"--data-path={self.data_path}")
+        cmd.extend(["--group", group])
+        cmd.extend(self._get_doozer_assembly_args())
+        cmd.extend(["-i", ",".join(image_keys)])
+        cmd.extend(["beta:config:konflux:scan-sources", "--yaml"])
+        if self.kubeconfig:
+            cmd.append(f"--ci-kubeconfig={self.kubeconfig}")
+
+        rc, out, _ = await exectools.cmd_gather_async(cmd, env=self._doozer_env_vars, stderr=None, check=False)
+        if rc != 0:
+            raise RuntimeError(f"doozer scan-sources failed with exit code {rc} for {', '.join(image_keys)}:\n{out}")
+
+        report = yaml.load(out) or {}
+        changes = get_changes(report)
+        return [image_key for image_key in changes.get('images', []) if image_key in image_keys]
+
+    async def _rebase_ci_image(self, image_key: str, version: str, release: str):
+        _LOGGER.info("Rebasing %s for Konflux...", image_key)
+        group = f"openshift-{self.ocp_version}"
+        cmd = [
+            "doozer",
+            f"--working-dir={self._doozer_working_dir}-ci-{image_key}",
+            "--build-system=konflux",
+        ]
+        cmd.extend(self._get_doozer_assembly_args())
+        if self.data_path:
+            cmd.append(f"--data-path={self.data_path}")
+        cmd.extend(
+            [
+                "--group",
+                group,
+                "-i",
+                image_key,
+                "beta:images:konflux:rebase",
+                "--version",
+                version,
+                "--release",
+                release,
+                "--message",
+                f"Bump golang parent image for {image_key}",
+            ]
+        )
+        if self.network_mode:
+            cmd.extend(["--network-mode", self.network_mode])
+        if not self.dry_run:
+            cmd.append("--push")
+        await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars)
+
+    async def _build_ci_image(self, image_key: str):
+        _LOGGER.info("Building %s on Konflux...", image_key)
+        group = f"openshift-{self.ocp_version}"
+        konflux_namespace = PRODUCT_NAMESPACE_MAP["ocp"]
+        cmd = [
+            "doozer",
+            f"--working-dir={self._doozer_working_dir}-ci-{image_key}",
+            "--build-system=konflux",
+        ]
+        cmd.extend(self._get_doozer_assembly_args())
+        if self.data_path:
+            cmd.append(f"--data-path={self.data_path}")
+        cmd.extend(
+            [
+                "--group",
+                group,
+                "-i",
+                image_key,
+                "beta:images:konflux:build",
+                f"--konflux-namespace={konflux_namespace}",
+                "--skip-ec-verify",
+            ]
+        )
+        if self.kubeconfig:
+            cmd.extend(['--konflux-kubeconfig', self.kubeconfig])
+        if self.network_mode:
+            cmd.extend(["--network-mode", self.network_mode])
+        if self.dry_run:
+            cmd.append("--dry-run")
+        await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars, log_stdout=True)
+
+    async def _rebase_and_build_ci_images(self, image_keys: List[str]):
+        """
+        Rebase+build each CI image directly via doozer, without touching streams.yml or creating
+        an ocp-build-data PR.
+        """
+        version = f"v{self.ocp_version}.0"
+        release = default_release_suffix()
+
+        async def _rebase_and_build(image_key: str):
+            await self._rebase_ci_image(image_key, version, release)
+            await self._build_ci_image(image_key)
+
+        results = await asyncio.gather(
+            *[_rebase_and_build(image_key) for image_key in image_keys],
+            return_exceptions=True,
+        )
+        failed = [(image_key, r) for image_key, r in zip(image_keys, results) if isinstance(r, Exception)]
+        if failed:
+            summary = "\n".join(f"  ❌ {image_key}: {err}" for image_key, err in failed)
+            raise RuntimeError(f"Failed to rebuild {len(failed)}/{len(image_keys)} CI image(s):\n{summary}")
+
+    @staticmethod
+    def _get_required_env(var_name: str) -> str:
+        value = os.getenv(var_name)
+        if not value:
+            raise ValueError(f"Required environment variable {var_name} not set")
+        return value
+
+    def _create_ci_sync_registry_config(self) -> RegistryConfig:
+        """
+        Build registry credentials for pushing a newly built CI image straight to CI, using the
+        same env vars (and QCI credential setup) as the scheduled sync-ci-images job.
+        """
+        quay_auth_file = self._get_required_env('QUAY_AUTH_FILE')
+        kubeconfig = self._get_required_env('KUBECONFIG')
+        qci_user = self._get_required_env('QCI_USER')
+        qci_password = self._get_required_env('QCI_PASSWORD')
+
+        return RegistryConfig(
+            source_files=[quay_auth_file],
+            kubeconfig=kubeconfig,
+            registries=[
+                REGISTRY_CI_OPENSHIFT,
+                REGISTRY_QUAY_OCP_RELEASE_DEV,
+                KONFLUX_DEFAULT_IMAGE_REPO,
+                KONFLUX_DEFAULT_IMAGE_SHARE_REPO,
+                KONFLUX_DEFAULT_FBC_REPO,
+                REGISTRY_REDHAT_IO,
+            ],
+            credentials=[
+                RegistryCredential(REGISTRY_QUAY_OPENSHIFT, qci_user, qci_password),
+            ],
+        )
+
+    async def _sync_ci_images(self, image_keys: List[str]):
+        """
+        Mirror newly rebuilt CI image(s) straight to CI (the same `images:streams mirror` doozer
+        verb the scheduled sync-ci-images job uses), so CI does not have to wait for that job's
+        next run to pick up the rebuild. For the test assembly, `--live-test-mode` is passed so
+        doozer publishes to the `.test`-suffixed CI imagestream tag instead of the real one --
+        `images:streams mirror` resolves its destination entirely from each image's
+        ci_alignment.upstream_image config, not from anything on this command line, so there is no
+        other way to redirect it away from the production tag.
+        """
+        _LOGGER.info("Syncing CI image(s) to CI: %s", ", ".join(image_keys))
+        group = f"openshift-{self.ocp_version}"
+        with self._create_ci_sync_registry_config() as auth_file:
+            cmd = [
+                "doozer",
+                f"--working-dir={self._doozer_working_dir}-ci-sync",
+                "--build-system=konflux",
+            ]
+            cmd.extend(self._get_doozer_assembly_args())
+            if self.data_path:
+                cmd.append(f"--data-path={self.data_path}")
+            cmd.extend(["--group", group])
+            for image_key in image_keys:
+                cmd.extend(["--image", image_key])
+            cmd.extend(["images:streams", "mirror", "--registry-auth", auth_file])
+            if not self.is_production_assembly:
+                cmd.append("--live-test-mode")
+            if self.dry_run:
+                cmd.append("--dry-run")
+            await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars, log_stdout=True)
+
+    CI_VARIANT_BY_GROUP_VAR = {
+        "GO_LATEST": "latest",
+        "GO_EXTRA": "extra",
+        "GO_PREVIOUS": "previous",
+    }
+
+    async def _refresh_ci_images(
+        self,
+        build_major_minor: str,
+        allowed_major_minors: dict[str, str],
+        el_nvr_map_for_images: dict[int, str],
+    ):
+        """
+        Standing reconciliation check: make sure the ci-openshift-golang-builder-* image(s) for
+        the variant (GO_LATEST/GO_EXTRA/GO_PREVIOUS) matching this run's golang version are built
+        against their current declared parent. The ocp-build-data-validator enforces that
+        GO_LATEST/GO_EXTRA/GO_PREVIOUS never share a major.minor, so at most one variant can match
+        here. Staleness is determined via doozer's `beta:config:konflux:scan-sources` (see
+        `_scan_stale_ci_images`) -- the same builder-staleness check used by the standing ocp4
+        scan-sources job. Rebuilds (via doozer directly, without touching streams.yml or creating
+        an ocp-build-data PR) any golang-builder CI image found to be stale. ci-openshift-build-root-*
+        images pull their parent via a `member` reference to the golang-builder CI image (not a
+        golang stream or the raw golang-builder container), so once a golang-builder image is
+        rebuilt, its corresponding build-root image is unconditionally rebuilt right after, to
+        pick up the new base image. Both rebuild steps must complete before either image is
+        mirrored to CI, so everything rebuilt this run is synced together in a single final step.
+        For the test assembly, `_sync_ci_images` passes `--live-test-mode`, which publishes to
+        the `.test`-suffixed CI imagestream tag instead of the real one, so test-assembly runs
+        never overwrite what production CI actually consumes.
+        """
+        variant = next(
+            (
+                self.CI_VARIANT_BY_GROUP_VAR[var_name]
+                for var_name, major_minor in allowed_major_minors.items()
+                if major_minor == build_major_minor
+            ),
+            None,
+        )
+        if not variant:
+            _LOGGER.info(
+                "Golang %s does not match any of GO_LATEST/GO_EXTRA/GO_PREVIOUS for openshift-%s; "
+                "skipping CI golang builder/build-root reconciliation",
+                build_major_minor,
+                self.ocp_version,
+            )
+            return
+
+        all_image_keys = set(await self._get_ci_image_keys())
+        # (el_v, image_key) for every rhel version sharing this golang version that has a CI golang builder image defined
+        builder_targets = [
+            (el_v, f"{CI_GOLANG_BUILDER_IMAGE_PREFIX}{variant}.rhel{el_v}")
+            for el_v in el_nvr_map_for_images
+            if f"{CI_GOLANG_BUILDER_IMAGE_PREFIX}{variant}.rhel{el_v}" in all_image_keys
+        ]
+        if not builder_targets:
+            _LOGGER.info(
+                "No CI golang builder images found for variant %s on openshift-%s; "
+                "skipping CI golang builder/build-root reconciliation",
+                variant,
+                self.ocp_version,
+            )
+            return
+
+        builder_image_keys = [image_key for _, image_key in builder_targets]
+        stale_image_keys = set(await self._scan_stale_ci_images(builder_image_keys))
+        stale_builder_targets = [
+            (el_v, image_key) for el_v, image_key in builder_targets if image_key in stale_image_keys
+        ]
+
+        if not stale_builder_targets:
+            _LOGGER.info(
+                "All CI golang builder images for openshift-%s already use their current parent image",
+                self.ocp_version,
+            )
+            return
+
+        stale_builder_keys = [image_key for _, image_key in stale_builder_targets]
+        await self._slack_client.say_in_thread(
+            f":construction: Rebuilding CI golang builder image(s) for "
+            f"{self.ocp_version}: {', '.join(stale_builder_keys)}"
+        )
+        await self._rebase_and_build_ci_images(stale_builder_keys)
+        await self._slack_client.say_in_thread(
+            f":white_check_mark: Rebuilt CI golang builder image(s): {', '.join(stale_builder_keys)}"
+        )
+
+        # Trigger the build-root image(s) whose golang-builder parent was just rebuilt above.
+        build_root_keys = [
+            f"{CI_BUILD_ROOT_IMAGE_PREFIX}{variant}.rhel{el_v}"
+            for el_v, _ in stale_builder_targets
+            if f"{CI_BUILD_ROOT_IMAGE_PREFIX}{variant}.rhel{el_v}" in all_image_keys
+        ]
+        if build_root_keys:
+            await self._slack_client.say_in_thread(
+                f":construction: Rebuilding CI build-root image(s) for {self.ocp_version}: {', '.join(build_root_keys)}"
+            )
+            await self._rebase_and_build_ci_images(build_root_keys)
+            await self._slack_client.say_in_thread(
+                f":white_check_mark: Rebuilt CI build-root image(s): {', '.join(build_root_keys)}"
+            )
+        else:
+            _LOGGER.info(
+                "No CI build-root images found for variant %s on openshift-%s; skipping CI build-root rebuild",
+                variant,
+                self.ocp_version,
+            )
+
+        rebuilt_image_keys = stale_builder_keys + build_root_keys
+        try:
+            await self._sync_ci_images(rebuilt_image_keys)
+        except Exception as e:
+            raise RuntimeError(f"Failed to sync CI image(s) to CI: {e}") from e
+
+        await self._slack_client.say_in_thread(
+            f":white_check_mark: Synced CI image(s): {', '.join(rebuilt_image_keys)}"
+        )
 
     GOLANG_DATA_BRANCH = 'golang'
 

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -1412,23 +1412,22 @@ class UpdateGolangPipeline:
         el_nvr_map_for_images: dict[int, str],
     ):
         """
-        Standing reconciliation check: make sure the ci-openshift-golang-builder-* image(s) for
-        the variant (GO_LATEST/GO_EXTRA/GO_PREVIOUS) matching this run's golang version are built
-        against their current declared parent. The ocp-build-data-validator enforces that
-        GO_LATEST/GO_EXTRA/GO_PREVIOUS never share a major.minor, so at most one variant can match
-        here. Staleness is determined via doozer's `beta:config:konflux:scan-sources` (see
-        `_scan_stale_ci_images`) -- the same builder-staleness check used by the standing ocp4
-        scan-sources job. Rebuilds (via doozer directly, without touching streams.yml or creating
-        an ocp-build-data PR) any golang-builder CI image found to be stale. ci-openshift-build-root-*
-        images pull their parent via a `member` reference to the golang-builder CI image (not a
-        golang stream or the raw golang-builder container), so once a golang-builder image is
-        stale, its corresponding build-root image is unconditionally rebuilt alongside it, in the
-        same rebase/build batch (see `_rebase_and_build_ci_images`) -- doozer only resolves a
-        `from: member:` reference correctly when both images are loaded in the same run. Once
-        both rebuild, everything is synced together in a single final step. For the test
-        assembly, `_sync_ci_images` passes `--live-test-mode`, which publishes to the
-        `.test`-suffixed CI imagestream tag instead of the real one, so test-assembly runs never
-        overwrite what production CI actually consumes.
+        Standing reconciliation check: make sure the ci-openshift-golang-builder-* and
+        ci-openshift-build-root-* image(s) for the variant (GO_LATEST/GO_EXTRA/GO_PREVIOUS)
+        matching this run's golang version are built against their current declared parent. The
+        ocp-build-data-validator enforces that GO_LATEST/GO_EXTRA/GO_PREVIOUS never share a
+        major.minor, so at most one variant can match here. Both families are scanned together in
+        a single `_scan_stale_ci_images` call (see `beta:config:konflux:scan-sources`) -- the same
+        builder-staleness check used by the standing ocp4 scan-sources job -- so build-root's own
+        source changes are caught directly. Loading both together also means doozer's own change
+        propagation (a changing image marks its `member`-referencing descendants as changing too)
+        naturally covers the case where build-root itself hasn't changed but its golang-builder
+        parent has. Whatever comes back stale is rebased+built together in one batch (see
+        `_rebase_and_build_ci_images`) -- doozer only resolves a `from: member:` reference
+        correctly when both images are loaded in the same run. Once done, everything rebuilt is
+        synced together in a single final step. For the test assembly, `_sync_ci_images` passes
+        `--live-test-mode`, which publishes to the `.test`-suffixed CI imagestream tag instead of
+        the real one, so test-assembly runs never overwrite what production CI actually consumes.
         """
         # TODO: revert -- re-deriving allowed_major_minors from the test fork/branch below.
         # _get_allowed_go_major_minors (which produced the `allowed_major_minors` param) always
@@ -1470,37 +1469,34 @@ class UpdateGolangPipeline:
             )
             return
 
-        builder_image_keys = [image_key for _, image_key in builder_targets]
-        stale_image_keys = set(await self._scan_stale_ci_images(builder_image_keys))
-        stale_builder_targets = [
-            (el_v, image_key) for el_v, image_key in builder_targets if image_key in stale_image_keys
-        ]
-
-        if not stale_builder_targets:
-            _LOGGER.info(
-                "All CI golang builder images for openshift-%s already use their current parent image",
-                self.ocp_version,
-            )
-            return
-
-        stale_builder_keys = [image_key for _, image_key in stale_builder_targets]
-
-        # Build-root image(s) whose golang-builder parent is about to be rebuilt. Rebuilt in the
-        # same batch as their golang-builder parent (not a separate call) so doozer resolves the
-        # `from: member:` reference in-process.
-        build_root_keys = [
-            f"{CI_BUILD_ROOT_IMAGE_PREFIX}{variant}.rhel{el_v}"
-            for el_v, _ in stale_builder_targets
+        # Build-root counterpart for every el_v that has a golang-builder image, scanned alongside
+        # it regardless of the builder's own staleness -- both build-root's own source changes and
+        # "parent golang-builder changed" (via doozer's descendant-propagation once both images are
+        # loaded together) are caught by this one scan.
+        build_root_targets = [
+            (el_v, f"{CI_BUILD_ROOT_IMAGE_PREFIX}{variant}.rhel{el_v}")
+            for el_v, _ in builder_targets
             if f"{CI_BUILD_ROOT_IMAGE_PREFIX}{variant}.rhel{el_v}" in all_image_keys
         ]
-        if not build_root_keys:
+        if not build_root_targets:
             _LOGGER.info(
-                "No CI build-root images found for variant %s on openshift-%s; skipping CI build-root rebuild",
+                "No CI build-root images found for variant %s on openshift-%s; scanning golang builder image(s) only",
                 variant,
                 self.ocp_version,
             )
 
-        rebuilt_image_keys = stale_builder_keys + build_root_keys
+        scan_targets = builder_targets + build_root_targets
+        scan_keys = [image_key for _, image_key in scan_targets]
+        stale_image_keys = set(await self._scan_stale_ci_images(scan_keys))
+        rebuilt_image_keys = [image_key for image_key in scan_keys if image_key in stale_image_keys]
+
+        if not rebuilt_image_keys:
+            _LOGGER.info(
+                "All CI golang builder/build-root images for openshift-%s already use their current parent image",
+                self.ocp_version,
+            )
+            return
+
         await self._slack_client.say_in_thread(
             f":construction: Rebuilding CI golang builder/build-root image(s) for "
             f"{self.ocp_version}: {', '.join(rebuilt_image_keys)}"

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -1212,6 +1212,7 @@ class UpdateGolangPipeline:
                     "artifact_type": str(ArtifactType.IMAGE),
                     "outcome": str(KonfluxBuildOutcome.SUCCESS),
                     "engine": str(Engine.KONFLUX),
+                    "assembly": self.assembly
                 },
                 limit=1,
             ),
@@ -1226,6 +1227,7 @@ class UpdateGolangPipeline:
             f"--working-dir={self._doozer_working_dir}-ci-{image_key}",
             "--build-system=konflux",
         ]
+        cmd.extend(self._get_doozer_assembly_args())
         if self.data_path:
             cmd.append(f"--data-path={self.data_path}")
         cmd.extend(
@@ -1258,6 +1260,7 @@ class UpdateGolangPipeline:
             f"--working-dir={self._doozer_working_dir}-ci-{image_key}",
             "--build-system=konflux",
         ]
+        cmd.extend(self._get_doozer_assembly_args())
         if self.data_path:
             cmd.append(f"--data-path={self.data_path}")
         cmd.extend(
@@ -1347,6 +1350,7 @@ class UpdateGolangPipeline:
                 f"--working-dir={self._doozer_working_dir}-ci-sync",
                 "--build-system=konflux",
             ]
+            cmd.extend(self._get_doozer_assembly_args())
             if self.data_path:
                 cmd.append(f"--data-path={self.data_path}")
             cmd.extend(["--group", group])
@@ -1384,7 +1388,9 @@ class UpdateGolangPipeline:
         or the raw golang-builder container), so once a golang-builder image is rebuilt, its
         corresponding build-root image is unconditionally rebuilt right after, to pick up the new
         base image. Both rebuild steps must complete before either image is mirrored to CI, so
-        everything rebuilt this run is synced together in a single final step.
+        everything rebuilt this run is synced together in a single final step -- except for the
+        test assembly, where the sync to CI is skipped since test-assembly builds must not be
+        mirrored into real CI streams.
         """
         variant = next(
             (
@@ -1487,6 +1493,10 @@ class UpdateGolangPipeline:
             )
 
         rebuilt_image_keys = stale_builder_keys + build_root_keys
+        if not self.is_production_assembly:
+            _LOGGER.info("Skipping CI image sync for the test assembly")
+            return
+
         try:
             await self._sync_ci_images(rebuilt_image_keys)
         except Exception as e:

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -52,6 +52,7 @@ BREW_TEST_ASSEMBLY_UNSUPPORTED = (
     "successful build. Use --build-system konflux for test assembly builds."
 )
 CI_GOLANG_BUILDER_IMAGE_PREFIX = "ci-openshift-golang-builder-"
+CI_BUILD_ROOT_IMAGE_PREFIX = "ci-openshift-build-root-"
 
 
 def is_latest(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool:
@@ -569,9 +570,7 @@ class UpdateGolangPipeline:
                 _LOGGER.info("No Konflux golang builder images found; streams.yml will not be updated.")
 
         if self.is_production_assembly:
-            await self._reconcile_ci_golang_builder_images(
-                go_version, build_major_minor, allowed_major_minors, el_nvr_map_for_images
-            )
+            await self._reconcile_ci_images(go_version, build_major_minor, allowed_major_minors, el_nvr_map_for_images)
 
             await move_golang_bugs(
                 ocp_version=self.ocp_version,
@@ -1181,21 +1180,27 @@ class UpdateGolangPipeline:
         await self._rebase_konflux(el_v, go_version, go_nvr)
         await self._build_konflux(el_v, go_version)
 
-    async def _get_ci_golang_builder_image_keys(self) -> List[str]:
+    async def _get_ci_image_keys(self) -> List[str]:
         """
-        List the `ci-openshift-golang-builder-*` doozer image keys defined for this OCP version.
-        These images pull their parent directly from a golang stream in streams.yml (e.g.
-        rhel-9-golang-{GO_LATEST}), so they need to be rebuilt whenever that stream changes.
+        List the `ci-openshift-golang-builder-*` and `ci-openshift-build-root-*` doozer image keys
+        defined for this OCP version. Golang-builder images pull their parent directly from a
+        golang stream in streams.yml (e.g. rhel-9-golang-{GO_LATEST}); build-root images pull
+        their parent via a `member` reference to the corresponding golang-builder CI image. Both
+        need to be rebuilt whenever their respective parent changes.
         """
         branch = f"openshift-{self.ocp_version}"
         repo, branch = self._get_ocp_build_data_repo_and_branch(branch)
         contents = repo.get_contents("images", ref=branch)
-        image_keys = sorted(
+        ci_image_keys = sorted(
             content.name[: -len(".yml")]
             for content in contents
-            if content.name.startswith(CI_GOLANG_BUILDER_IMAGE_PREFIX) and content.name.endswith(".yml")
+            if content.name.endswith(".yml")
+            and (
+                content.name.startswith(CI_GOLANG_BUILDER_IMAGE_PREFIX)
+                or content.name.startswith(CI_BUILD_ROOT_IMAGE_PREFIX)
+            )
         )
-        return image_keys
+        return ci_image_keys
 
     async def _find_latest_ci_golang_builder_build(self, image_key: str, el_v: int) -> KonfluxBuildRecord | None:
         """Look up the latest successful Konflux build record for a CI golang builder image."""
@@ -1213,7 +1218,7 @@ class UpdateGolangPipeline:
             None,
         )
 
-    async def _rebase_ci_golang_builder_image(self, image_key: str, version: str, release: str):
+    async def _rebase_ci_image(self, image_key: str, version: str, release: str):
         _LOGGER.info("Rebasing %s for Konflux...", image_key)
         group = f"openshift-{self.ocp_version}"
         cmd = [
@@ -1244,7 +1249,7 @@ class UpdateGolangPipeline:
             cmd.append("--push")
         await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars)
 
-    async def _build_ci_golang_builder_image(self, image_key: str):
+    async def _build_ci_image(self, image_key: str):
         _LOGGER.info("Building %s on Konflux...", image_key)
         group = f"openshift-{self.ocp_version}"
         konflux_namespace = PRODUCT_NAMESPACE_MAP["ocp"]
@@ -1274,9 +1279,26 @@ class UpdateGolangPipeline:
             cmd.append("--dry-run")
         await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars, log_stdout=True)
 
-    async def _rebase_and_build_ci_golang_builder_image(self, image_key: str, version: str, release: str):
-        await self._rebase_ci_golang_builder_image(image_key, version, release)
-        await self._build_ci_golang_builder_image(image_key)
+    async def _rebase_and_build_ci_images(self, image_keys: List[str]):
+        """
+        Rebase+build each CI image directly via doozer, without touching streams.yml or creating
+        an ocp-build-data PR.
+        """
+        version = f"v{self.ocp_version}.0"
+        release = default_release_suffix()
+
+        async def _rebase_and_build(image_key: str):
+            await self._rebase_ci_image(image_key, version, release)
+            await self._build_ci_image(image_key)
+
+        results = await asyncio.gather(
+            *[_rebase_and_build(image_key) for image_key in image_keys],
+            return_exceptions=True,
+        )
+        failed = [(image_key, r) for image_key, r in zip(image_keys, results) if isinstance(r, Exception)]
+        if failed:
+            summary = "\n".join(f"  ❌ {image_key}: {err}" for image_key, err in failed)
+            raise RuntimeError(f"Failed to rebuild {len(failed)}/{len(image_keys)} CI image(s):\n{summary}")
 
     @staticmethod
     def _get_required_env(var_name: str) -> str:
@@ -1287,8 +1309,8 @@ class UpdateGolangPipeline:
 
     def _create_ci_sync_registry_config(self) -> RegistryConfig:
         """
-        Build registry credentials for pushing a newly built CI golang builder image straight to
-        CI, using the same env vars (and QCI credential setup) as the scheduled sync-ci-images job.
+        Build registry credentials for pushing a newly built CI image straight to CI, using the
+        same env vars (and QCI credential setup) as the scheduled sync-ci-images job.
         """
         quay_auth_file = self._get_required_env('QUAY_AUTH_FILE')
         kubeconfig = self._get_required_env('KUBECONFIG')
@@ -1311,13 +1333,13 @@ class UpdateGolangPipeline:
             ],
         )
 
-    async def _sync_ci_golang_builder_images(self, image_keys: List[str]):
+    async def _sync_ci_images(self, image_keys: List[str]):
         """
-        Mirror newly rebuilt CI golang builder image(s) straight to CI (the same
-        `images:streams mirror` doozer verb the scheduled sync-ci-images job uses), so CI does
-        not have to wait for that job's next run to pick up the rebuild.
+        Mirror newly rebuilt CI image(s) straight to CI (the same `images:streams mirror` doozer
+        verb the scheduled sync-ci-images job uses), so CI does not have to wait for that job's
+        next run to pick up the rebuild.
         """
-        _LOGGER.info("Syncing CI golang builder image(s) to CI: %s", ", ".join(image_keys))
+        _LOGGER.info("Syncing CI image(s) to CI: %s", ", ".join(image_keys))
         group = f"openshift-{self.ocp_version}"
         with self._create_ci_sync_registry_config() as auth_file:
             cmd = [
@@ -1335,13 +1357,13 @@ class UpdateGolangPipeline:
                 cmd.append("--dry-run")
             await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars, log_stdout=True)
 
-    CI_GOLANG_BUILDER_VARIANT_BY_GROUP_VAR = {
+    CI_VARIANT_BY_GROUP_VAR = {
         "GO_LATEST": "latest",
         "GO_EXTRA": "extra",
         "GO_PREVIOUS": "previous",
     }
 
-    async def _reconcile_ci_golang_builder_images(
+    async def _reconcile_ci_images(
         self,
         go_version: str,
         build_major_minor: str,
@@ -1356,12 +1378,17 @@ class UpdateGolangPipeline:
         variant can match here. We deliberately do NOT resolve the parent via streams.yml: any
         streams.yml update from this same run is only a pending PR until a human merges it, so
         checking against streams.yml would always report "unchanged" immediately after a bump.
-        Rebuilds (via doozer directly, without touching streams.yml or creating an ocp-build-data PR)
-        any CI image found to be stale.
+        Rebuilds (via doozer directly, without touching streams.yml or creating an ocp-build-data
+        PR) any golang-builder CI image found to be stale. ci-openshift-build-root-* images pull
+        their parent via a `member` reference to the golang-builder CI image (not a golang stream
+        or the raw golang-builder container), so once a golang-builder image is rebuilt, its
+        corresponding build-root image is unconditionally rebuilt right after, to pick up the new
+        base image. Both rebuild steps must complete before either image is mirrored to CI, so
+        everything rebuilt this run is synced together in a single final step.
         """
         variant = next(
             (
-                self.CI_GOLANG_BUILDER_VARIANT_BY_GROUP_VAR[var_name]
+                self.CI_VARIANT_BY_GROUP_VAR[var_name]
                 for var_name, major_minor in allowed_major_minors.items()
                 if major_minor == build_major_minor
             ),
@@ -1370,34 +1397,34 @@ class UpdateGolangPipeline:
         if not variant:
             _LOGGER.info(
                 "Golang %s does not match any of GO_LATEST/GO_EXTRA/GO_PREVIOUS for openshift-%s; "
-                "skipping CI golang builder reconciliation",
+                "skipping CI golang builder/build-root reconciliation",
                 build_major_minor,
                 self.ocp_version,
             )
             return
 
-        all_image_keys = set(await self._get_ci_golang_builder_image_keys())
-        # (el_v, image_key) for every rhel version sharing this golang version that has a CI image defined
-        targets = [
+        all_image_keys = set(await self._get_ci_image_keys())
+        # (el_v, image_key) for every rhel version sharing this golang version that has a CI golang builder image defined
+        builder_targets = [
             (el_v, f"{CI_GOLANG_BUILDER_IMAGE_PREFIX}{variant}.rhel{el_v}")
             for el_v in el_nvr_map_for_images
             if f"{CI_GOLANG_BUILDER_IMAGE_PREFIX}{variant}.rhel{el_v}" in all_image_keys
         ]
-        if not targets:
+        if not builder_targets:
             _LOGGER.info(
                 "No CI golang builder images found for variant %s on openshift-%s; "
-                "skipping CI golang builder reconciliation",
+                "skipping CI golang builder/build-root reconciliation",
                 variant,
                 self.ocp_version,
             )
             return
 
         builder_records = await self.get_existing_builders_konflux(
-            {el_v: el_nvr_map_for_images[el_v] for el_v, _ in targets}, go_version
+            {el_v: el_nvr_map_for_images[el_v] for el_v, _ in builder_targets}, go_version
         )
 
-        stale_image_keys = []
-        for el_v, image_key in targets:
+        stale_builder_targets = []
+        for el_v, image_key in builder_targets:
             builder_record = builder_records.get(el_v)
             if not builder_record:
                 _LOGGER.warning(
@@ -1410,7 +1437,7 @@ class UpdateGolangPipeline:
             latest_ci_build = await self._find_latest_ci_golang_builder_build(image_key, el_v)
             if not latest_ci_build:
                 _LOGGER.info("%s has never been built in Konflux; will build it", image_key)
-                stale_image_keys.append(image_key)
+                stale_builder_targets.append((el_v, image_key))
             elif latest_ci_build.start_time < builder_record.start_time:
                 _LOGGER.info(
                     "%s (built %s) is older than its golang parent %s (built %s); will rebuild",
@@ -1419,46 +1446,54 @@ class UpdateGolangPipeline:
                     builder_record.nvr,
                     builder_record.start_time,
                 )
-                stale_image_keys.append(image_key)
+                stale_builder_targets.append((el_v, image_key))
 
-        if not stale_image_keys:
+        if not stale_builder_targets:
             _LOGGER.info(
                 "All CI golang builder images for openshift-%s already use the latest golang parent image",
                 self.ocp_version,
             )
             return
 
+        stale_builder_keys = [image_key for _, image_key in stale_builder_targets]
         await self._slack_client.say_in_thread(
-            f":construction: Rebuilding CI golang builder image(s) with a stale golang parent for "
-            f"{self.ocp_version}: {', '.join(stale_image_keys)}"
+            f":construction: Rebuilding CI golang builder image(s) for "
+            f"{self.ocp_version}: {', '.join(stale_builder_keys)}"
         )
-        version = f"v{self.ocp_version}.0"
-        release = default_release_suffix()
-        results = await asyncio.gather(
-            *[
-                self._rebase_and_build_ci_golang_builder_image(image_key, version, release)
-                for image_key in stale_image_keys
-            ],
-            return_exceptions=True,
+        await self._rebase_and_build_ci_images(stale_builder_keys)
+        await self._slack_client.say_in_thread(
+            f":white_check_mark: Rebuilt CI golang builder image(s): {', '.join(stale_builder_keys)}"
         )
-        failed = [(image_key, r) for image_key, r in zip(stale_image_keys, results) if isinstance(r, Exception)]
-        if failed:
-            summary = "\n".join(f"  ❌ {image_key}: {err}" for image_key, err in failed)
-            raise RuntimeError(
-                f"Failed to rebuild {len(failed)}/{len(stale_image_keys)} CI golang builder image(s):\n{summary}"
+
+        # Trigger the build-root image(s) whose golang-builder parent was just rebuilt above.
+        build_root_keys = [
+            f"{CI_BUILD_ROOT_IMAGE_PREFIX}{variant}.rhel{el_v}"
+            for el_v, _ in stale_builder_targets
+            if f"{CI_BUILD_ROOT_IMAGE_PREFIX}{variant}.rhel{el_v}" in all_image_keys
+        ]
+        if build_root_keys:
+            await self._slack_client.say_in_thread(
+                f":construction: Rebuilding CI build-root image(s) for {self.ocp_version}: {', '.join(build_root_keys)}"
+            )
+            await self._rebase_and_build_ci_images(build_root_keys)
+            await self._slack_client.say_in_thread(
+                f":white_check_mark: Rebuilt CI build-root image(s): {', '.join(build_root_keys)}"
+            )
+        else:
+            _LOGGER.info(
+                "No CI build-root images found for variant %s on openshift-%s; skipping CI build-root rebuild",
+                variant,
+                self.ocp_version,
             )
 
-        await self._slack_client.say_in_thread(
-            f":white_check_mark: Rebuilt CI golang builder image(s): {', '.join(stale_image_keys)}"
-        )
-
+        rebuilt_image_keys = stale_builder_keys + build_root_keys
         try:
-            await self._sync_ci_golang_builder_images(stale_image_keys)
+            await self._sync_ci_images(rebuilt_image_keys)
         except Exception as e:
-            raise RuntimeError(f"Failed to sync CI golang builder image(s) to CI: {e}") from e
+            raise RuntimeError(f"Failed to sync CI image(s) to CI: {e}") from e
 
         await self._slack_client.say_in_thread(
-            f":white_check_mark: Synced CI golang builder image(s) to CI: {', '.join(stale_image_keys)}"
+            f":white_check_mark: Synced CI image(s): {', '.join(rebuilt_image_keys)}"
         )
 
     GOLANG_DATA_BRANCH = 'golang'

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -14,13 +14,19 @@ from artcommonlib.constants import (
     BREW_HUB,
     GOLANG_BUILDER_IMAGE_NAME,
     GOLANG_NVR_LABEL,
+    KONFLUX_DEFAULT_FBC_REPO,
     KONFLUX_DEFAULT_IMAGE_REPO,
+    KONFLUX_DEFAULT_IMAGE_SHARE_REPO,
     PRODUCT_NAMESPACE_MAP,
+    REGISTRY_CI_OPENSHIFT,
+    REGISTRY_QUAY_OCP_RELEASE_DEV,
+    REGISTRY_QUAY_OPENSHIFT,
     REGISTRY_REDHAT_IO,
 )
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.konflux.konflux_db import KonfluxDb
+from artcommonlib.registry_config import RegistryConfig, RegistryCredential
 from artcommonlib.release_util import isolate_assembly_in_release, isolate_el_version_in_release
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import new_roundtrip_yaml_handler
@@ -45,6 +51,7 @@ BREW_TEST_ASSEMBLY_UNSUPPORTED = (
     "Brew builds for the test assembly are not supported because Brew floating tags are updated after every "
     "successful build. Use --build-system konflux for test assembly builds."
 )
+CI_GOLANG_BUILDER_IMAGE_PREFIX = "ci-openshift-golang-builder-"
 
 
 def is_latest(ocp_version: str, el_v: int, nvr: str, koji_session) -> bool:
@@ -234,10 +241,10 @@ class UpdateGolangPipeline:
 
         # GitHub auth is handled by get_github_client_for_org() with App auth / PAT fallback
 
-        # Initialize KonfluxDb for Konflux build system
-        if build_system in ('konflux', 'both'):
-            self.konflux_db = KonfluxDb()
-            self.konflux_db.bind(KonfluxBuildRecord)
+        # Initialize KonfluxDb. Needed for Konflux build systems, and also for the CI golang
+        # builder image reconciliation stage, which always checks/rebuilds via Konflux.
+        self.konflux_db = KonfluxDb()
+        self.konflux_db.bind(KonfluxBuildRecord)
 
     @property
     def is_production_assembly(self) -> bool:
@@ -562,6 +569,10 @@ class UpdateGolangPipeline:
                 _LOGGER.info("No Konflux golang builder images found; streams.yml will not be updated.")
 
         if self.is_production_assembly:
+            await self._reconcile_ci_golang_builder_images(
+                go_version, build_major_minor, allowed_major_minors, el_nvr_map_for_images
+            )
+
             await move_golang_bugs(
                 ocp_version=self.ocp_version,
                 cves=self.cves,
@@ -571,7 +582,7 @@ class UpdateGolangPipeline:
                 dry_run=self.dry_run,
             )
         else:
-            _LOGGER.info("Skipping Golang bug updates for the test assembly")
+            _LOGGER.info("Skipping Golang bug updates and CI golang builder reconciliation for the test assembly")
         await self._slack_client.say_in_thread(
             f":white_check_mark: Updating golang for {self.ocp_version} assembly {self.assembly} complete."
         )
@@ -1169,6 +1180,286 @@ class UpdateGolangPipeline:
         """Rebase and build golang-builder image on Konflux"""
         await self._rebase_konflux(el_v, go_version, go_nvr)
         await self._build_konflux(el_v, go_version)
+
+    async def _get_ci_golang_builder_image_keys(self) -> List[str]:
+        """
+        List the `ci-openshift-golang-builder-*` doozer image keys defined for this OCP version.
+        These images pull their parent directly from a golang stream in streams.yml (e.g.
+        rhel-9-golang-{GO_LATEST}), so they need to be rebuilt whenever that stream changes.
+        """
+        branch = f"openshift-{self.ocp_version}"
+        repo, branch = self._get_ocp_build_data_repo_and_branch(branch)
+        contents = repo.get_contents("images", ref=branch)
+        image_keys = sorted(
+            content.name[: -len(".yml")]
+            for content in contents
+            if content.name.startswith(CI_GOLANG_BUILDER_IMAGE_PREFIX) and content.name.endswith(".yml")
+        )
+        return image_keys
+
+    async def _find_latest_ci_golang_builder_build(self, image_key: str, el_v: int) -> KonfluxBuildRecord | None:
+        """Look up the latest successful Konflux build record for a CI golang builder image."""
+        return await anext(
+            self.konflux_db.search_builds_by_fields(
+                where={
+                    "name": image_key,
+                    "el_target": f"el{el_v}",
+                    "artifact_type": str(ArtifactType.IMAGE),
+                    "outcome": str(KonfluxBuildOutcome.SUCCESS),
+                    "engine": str(Engine.KONFLUX),
+                },
+                limit=1,
+            ),
+            None,
+        )
+
+    async def _rebase_ci_golang_builder_image(self, image_key: str, version: str, release: str):
+        _LOGGER.info("Rebasing %s for Konflux...", image_key)
+        group = f"openshift-{self.ocp_version}"
+        cmd = [
+            "doozer",
+            f"--working-dir={self._doozer_working_dir}-ci-{image_key}",
+            "--build-system=konflux",
+        ]
+        if self.data_path:
+            cmd.append(f"--data-path={self.data_path}")
+        cmd.extend(
+            [
+                "--group",
+                group,
+                "-i",
+                image_key,
+                "beta:images:konflux:rebase",
+                "--version",
+                version,
+                "--release",
+                release,
+                "--message",
+                f"Bump golang parent image for {image_key}",
+            ]
+        )
+        if self.network_mode:
+            cmd.extend(["--network-mode", self.network_mode])
+        if not self.dry_run:
+            cmd.append("--push")
+        await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars)
+
+    async def _build_ci_golang_builder_image(self, image_key: str):
+        _LOGGER.info("Building %s on Konflux...", image_key)
+        group = f"openshift-{self.ocp_version}"
+        konflux_namespace = PRODUCT_NAMESPACE_MAP["ocp"]
+        cmd = [
+            "doozer",
+            f"--working-dir={self._doozer_working_dir}-ci-{image_key}",
+            "--build-system=konflux",
+        ]
+        if self.data_path:
+            cmd.append(f"--data-path={self.data_path}")
+        cmd.extend(
+            [
+                "--group",
+                group,
+                "-i",
+                image_key,
+                "beta:images:konflux:build",
+                f"--konflux-namespace={konflux_namespace}",
+                "--skip-ec-verify",
+            ]
+        )
+        if self.kubeconfig:
+            cmd.extend(['--konflux-kubeconfig', self.kubeconfig])
+        if self.network_mode:
+            cmd.extend(["--network-mode", self.network_mode])
+        if self.dry_run:
+            cmd.append("--dry-run")
+        await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars, log_stdout=True)
+
+    async def _rebase_and_build_ci_golang_builder_image(self, image_key: str, version: str, release: str):
+        await self._rebase_ci_golang_builder_image(image_key, version, release)
+        await self._build_ci_golang_builder_image(image_key)
+
+    @staticmethod
+    def _get_required_env(var_name: str) -> str:
+        value = os.getenv(var_name)
+        if not value:
+            raise ValueError(f"Required environment variable {var_name} not set")
+        return value
+
+    def _create_ci_sync_registry_config(self) -> RegistryConfig:
+        """
+        Build registry credentials for pushing a newly built CI golang builder image straight to
+        CI, using the same env vars (and QCI credential setup) as the scheduled sync-ci-images job.
+        """
+        quay_auth_file = self._get_required_env('QUAY_AUTH_FILE')
+        kubeconfig = self._get_required_env('KUBECONFIG')
+        qci_user = self._get_required_env('QCI_USER')
+        qci_password = self._get_required_env('QCI_PASSWORD')
+
+        return RegistryConfig(
+            source_files=[quay_auth_file],
+            kubeconfig=kubeconfig,
+            registries=[
+                REGISTRY_CI_OPENSHIFT,
+                REGISTRY_QUAY_OCP_RELEASE_DEV,
+                KONFLUX_DEFAULT_IMAGE_REPO,
+                KONFLUX_DEFAULT_IMAGE_SHARE_REPO,
+                KONFLUX_DEFAULT_FBC_REPO,
+                REGISTRY_REDHAT_IO,
+            ],
+            credentials=[
+                RegistryCredential(REGISTRY_QUAY_OPENSHIFT, qci_user, qci_password),
+            ],
+        )
+
+    async def _sync_ci_golang_builder_images(self, image_keys: List[str]):
+        """
+        Mirror newly rebuilt CI golang builder image(s) straight to CI (the same
+        `images:streams mirror` doozer verb the scheduled sync-ci-images job uses), so CI does
+        not have to wait for that job's next run to pick up the rebuild.
+        """
+        _LOGGER.info("Syncing CI golang builder image(s) to CI: %s", ", ".join(image_keys))
+        group = f"openshift-{self.ocp_version}"
+        with self._create_ci_sync_registry_config() as auth_file:
+            cmd = [
+                "doozer",
+                f"--working-dir={self._doozer_working_dir}-ci-sync",
+                "--build-system=konflux",
+            ]
+            if self.data_path:
+                cmd.append(f"--data-path={self.data_path}")
+            cmd.extend(["--group", group])
+            for image_key in image_keys:
+                cmd.extend(["--image", image_key])
+            cmd.extend(["images:streams", "mirror", "--registry-auth", auth_file])
+            if self.dry_run:
+                cmd.append("--dry-run")
+            await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars, log_stdout=True)
+
+    CI_GOLANG_BUILDER_VARIANT_BY_GROUP_VAR = {
+        "GO_LATEST": "latest",
+        "GO_EXTRA": "extra",
+        "GO_PREVIOUS": "previous",
+    }
+
+    async def _reconcile_ci_golang_builder_images(
+        self,
+        go_version: str,
+        build_major_minor: str,
+        allowed_major_minors: dict[str, str],
+        el_nvr_map_for_images: dict[int, str],
+    ):
+        """
+        Standing reconciliation check: make sure the ci-openshift-golang-builder-* image(s) for
+        the variant (GO_LATEST/GO_EXTRA/GO_PREVIOUS) matching this run's golang version are built
+        against the actual latest golang-builder image in Konflux. The ocp-build-data-validator
+        enforces that GO_LATEST/GO_EXTRA/GO_PREVIOUS never share a major.minor, so at most one
+        variant can match here. We deliberately do NOT resolve the parent via streams.yml: any
+        streams.yml update from this same run is only a pending PR until a human merges it, so
+        checking against streams.yml would always report "unchanged" immediately after a bump.
+        Rebuilds (via doozer directly, without touching streams.yml or creating an ocp-build-data PR)
+        any CI image found to be stale.
+        """
+        variant = next(
+            (
+                self.CI_GOLANG_BUILDER_VARIANT_BY_GROUP_VAR[var_name]
+                for var_name, major_minor in allowed_major_minors.items()
+                if major_minor == build_major_minor
+            ),
+            None,
+        )
+        if not variant:
+            _LOGGER.info(
+                "Golang %s does not match any of GO_LATEST/GO_EXTRA/GO_PREVIOUS for openshift-%s; "
+                "skipping CI golang builder reconciliation",
+                build_major_minor,
+                self.ocp_version,
+            )
+            return
+
+        all_image_keys = set(await self._get_ci_golang_builder_image_keys())
+        # (el_v, image_key) for every rhel version sharing this golang version that has a CI image defined
+        targets = [
+            (el_v, f"{CI_GOLANG_BUILDER_IMAGE_PREFIX}{variant}.rhel{el_v}")
+            for el_v in el_nvr_map_for_images
+            if f"{CI_GOLANG_BUILDER_IMAGE_PREFIX}{variant}.rhel{el_v}" in all_image_keys
+        ]
+        if not targets:
+            _LOGGER.info(
+                "No CI golang builder images found for variant %s on openshift-%s; "
+                "skipping CI golang builder reconciliation",
+                variant,
+                self.ocp_version,
+            )
+            return
+
+        builder_records = await self.get_existing_builders_konflux(
+            {el_v: el_nvr_map_for_images[el_v] for el_v, _ in targets}, go_version
+        )
+
+        stale_image_keys = []
+        for el_v, image_key in targets:
+            builder_record = builder_records.get(el_v)
+            if not builder_record:
+                _LOGGER.warning(
+                    "No Konflux golang-builder build found for el%s go %s; cannot check %s for staleness",
+                    el_v,
+                    go_version,
+                    image_key,
+                )
+                continue
+            latest_ci_build = await self._find_latest_ci_golang_builder_build(image_key, el_v)
+            if not latest_ci_build:
+                _LOGGER.info("%s has never been built in Konflux; will build it", image_key)
+                stale_image_keys.append(image_key)
+            elif latest_ci_build.start_time < builder_record.start_time:
+                _LOGGER.info(
+                    "%s (built %s) is older than its golang parent %s (built %s); will rebuild",
+                    image_key,
+                    latest_ci_build.start_time,
+                    builder_record.nvr,
+                    builder_record.start_time,
+                )
+                stale_image_keys.append(image_key)
+
+        if not stale_image_keys:
+            _LOGGER.info(
+                "All CI golang builder images for openshift-%s already use the latest golang parent image",
+                self.ocp_version,
+            )
+            return
+
+        await self._slack_client.say_in_thread(
+            f":construction: Rebuilding CI golang builder image(s) with a stale golang parent for "
+            f"{self.ocp_version}: {', '.join(stale_image_keys)}"
+        )
+        version = f"v{self.ocp_version}.0"
+        release = default_release_suffix()
+        results = await asyncio.gather(
+            *[
+                self._rebase_and_build_ci_golang_builder_image(image_key, version, release)
+                for image_key in stale_image_keys
+            ],
+            return_exceptions=True,
+        )
+        failed = [(image_key, r) for image_key, r in zip(stale_image_keys, results) if isinstance(r, Exception)]
+        if failed:
+            summary = "\n".join(f"  ❌ {image_key}: {err}" for image_key, err in failed)
+            raise RuntimeError(
+                f"Failed to rebuild {len(failed)}/{len(stale_image_keys)} CI golang builder image(s):\n{summary}"
+            )
+
+        await self._slack_client.say_in_thread(
+            f":white_check_mark: Rebuilt CI golang builder image(s): {', '.join(stale_image_keys)}"
+        )
+
+        try:
+            await self._sync_ci_golang_builder_images(stale_image_keys)
+        except Exception as e:
+            raise RuntimeError(f"Failed to sync CI golang builder image(s) to CI: {e}") from e
+
+        await self._slack_client.say_in_thread(
+            f":white_check_mark: Synced CI golang builder image(s) to CI: {', '.join(stale_image_keys)}"
+        )
 
     GOLANG_DATA_BRANCH = 'golang'
 

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -1483,7 +1483,14 @@ class UpdateGolangPipeline:
                 f":construction: Rebuilding CI golang builder/build-root image(s) for "
                 f"{self.ocp_version}: {', '.join(rebuilt_image_keys)}"
             )
-            await self._rebase_and_build_ci_images(rebuilt_image_keys)
+
+            # await self._rebase_and_build_ci_images(rebuilt_image_keys)
+            build_result = jenkins.start_ocp4_konflux(
+                build_version=self.ocp_version,
+                assembly=self.assembly,
+                image_list=rebuilt_image_keys,
+                dry_run=self.dry_run
+            )
             await self._slack_client.say_in_thread(
                 f":white_check_mark: Rebuilt CI golang builder/build-root image(s): {', '.join(rebuilt_image_keys)}"
             )

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -15,13 +15,13 @@ from artcommonlib.constants import (
     GOLANG_BUILDER_IMAGE_NAME,
     GOLANG_NVR_LABEL,
     KONFLUX_DEFAULT_FBC_REPO,
+    KONFLUX_DEFAULT_IMAGE_REPO,
     KONFLUX_DEFAULT_IMAGE_SHARE_REPO,
     PRODUCT_NAMESPACE_MAP,
     REGISTRY_CI_OPENSHIFT,
     REGISTRY_QUAY_OCP_RELEASE_DEV,
     REGISTRY_QUAY_OPENSHIFT,
     REGISTRY_REDHAT_IO,
-    KONFLUX_DEFAULT_IMAGE_REPO,
 )
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
@@ -1489,8 +1489,12 @@ class UpdateGolangPipeline:
                 build_version=self.ocp_version,
                 assembly=self.assembly,
                 image_list=rebuilt_image_keys,
-                dry_run=self.dry_run
+                dry_run=self.dry_run,
+                block_until_complete=True,
             )
+            if build_result != "SUCCESS":
+                raise RuntimeError(f"CI image build for {self.ocp_version} failed with result: {build_result}")
+
             await self._slack_client.say_in_thread(
                 f":white_check_mark: Rebuilt CI golang builder/build-root image(s): {', '.join(rebuilt_image_keys)}"
             )
@@ -1503,10 +1507,18 @@ class UpdateGolangPipeline:
         # Sync every image considered this run, not just what was just rebuilt -- mirroring an
         # already-current image is a no-op cost-wise (a handful of images at most), and it keeps CI
         # in sync with the latest successful build even on runs where nothing needed rebuilding.
-        try:
-            await self._sync_ci_images(scan_keys)
-        except Exception as e:
-            raise RuntimeError(f"Failed to sync CI image(s) to CI: {e}") from e
+
+        sync_result = jenkins.start_sync_ci_images(
+            version=self.ocp_version,
+            block_until_complete=True,
+            assembly=self.assembly,
+            image_list=scan_keys,
+            dry_run=self.dry_run,
+            load_disabled=True,
+            live_test_mode=not self.is_production_assembly,
+        )
+        if sync_result != "SUCCESS":
+            raise RuntimeError(f"CI image sync for {self.ocp_version} failed with result: {sync_result}")
 
         await self._slack_client.say_in_thread(f":white_check_mark: Synced CI image(s): {', '.join(scan_keys)}")
 

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -14,19 +14,11 @@ from artcommonlib.constants import (
     BREW_HUB,
     GOLANG_BUILDER_IMAGE_NAME,
     GOLANG_NVR_LABEL,
-    KONFLUX_DEFAULT_FBC_REPO,
-    KONFLUX_DEFAULT_IMAGE_REPO,
-    KONFLUX_DEFAULT_IMAGE_SHARE_REPO,
     PRODUCT_NAMESPACE_MAP,
-    REGISTRY_CI_OPENSHIFT,
-    REGISTRY_QUAY_OCP_RELEASE_DEV,
-    REGISTRY_QUAY_OPENSHIFT,
-    REGISTRY_REDHAT_IO,
 )
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.konflux.konflux_build_record import ArtifactType, Engine, KonfluxBuildOutcome, KonfluxBuildRecord
 from artcommonlib.konflux.konflux_db import KonfluxDb
-from artcommonlib.registry_config import RegistryConfig, RegistryCredential
 from artcommonlib.release_util import isolate_assembly_in_release, isolate_el_version_in_release
 from artcommonlib.rpm_utils import parse_nvr
 from artcommonlib.util import new_roundtrip_yaml_handler
@@ -1242,155 +1234,6 @@ class UpdateGolangPipeline:
         changes = get_changes(report)
         return [image_key for image_key in changes.get('images', []) if image_key in image_keys]
 
-    async def _rebase_ci_images(self, image_keys: List[str], version: str, release: str):
-        _LOGGER.info("Rebasing %s for Konflux...", ", ".join(image_keys))
-        group = self._get_ci_group()
-        cmd = [
-            "doozer",
-            f"--working-dir={self._doozer_working_dir}-ci-rebase",
-            "--build-system=konflux",
-        ]
-        cmd.extend(self._get_doozer_assembly_args())
-        if self.data_path:
-            cmd.append(f"--data-path={self.data_path}")
-        cmd.extend(
-            [
-                "--group",
-                group,
-                # All CI images being rebuilt this run are rebased together in one doozer
-                # invocation (matching ocp4_konflux's approach), so a `from: member:` reference
-                # between them (e.g. ci-openshift-build-root-* -> ci-openshift-golang-builder-*)
-                # is resolved in-process. --latest-parent-version is kept as a fallback for a
-                # member that isn't part of this batch (e.g. only the build-root side went stale).
-                "--latest-parent-version",
-                "-i",
-                ",".join(image_keys),
-                "beta:images:konflux:rebase",
-                "--version",
-                version,
-                "--release",
-                release,
-                "--message",
-                f"Bump golang parent image for {', '.join(image_keys)}",
-            ]
-        )
-        if self.network_mode:
-            cmd.extend(["--network-mode", self.network_mode])
-        if not self.dry_run:
-            cmd.append("--push")
-        await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars)
-
-    async def _build_ci_images(self, image_keys: List[str]):
-        _LOGGER.info("Building %s on Konflux...", ", ".join(image_keys))
-        group = self._get_ci_group()
-        konflux_namespace = PRODUCT_NAMESPACE_MAP["ocp"]
-        cmd = [
-            "doozer",
-            f"--working-dir={self._doozer_working_dir}-ci-build",
-            "--build-system=konflux",
-        ]
-        cmd.extend(self._get_doozer_assembly_args())
-        if self.data_path:
-            cmd.append(f"--data-path={self.data_path}")
-        cmd.extend(
-            [
-                "--group",
-                group,
-                "--latest-parent-version",
-                "-i",
-                ",".join(image_keys),
-                "beta:images:konflux:build",
-                f"--konflux-namespace={konflux_namespace}",
-                "--skip-ec-verify",
-            ]
-        )
-        if self.kubeconfig:
-            cmd.extend(['--konflux-kubeconfig', self.kubeconfig])
-        if self.network_mode:
-            cmd.extend(["--network-mode", self.network_mode])
-        if self.dry_run:
-            cmd.append("--dry-run")
-        await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars, log_stdout=True)
-
-    async def _rebase_and_build_ci_images(self, image_keys: List[str]):
-        """
-        Rebase, then build, all given CI images together -- one doozer invocation per phase --
-        directly via doozer, without touching streams.yml or creating an ocp-build-data PR.
-        """
-        version = f"v{self.ocp_version}.0"
-        release = default_release_suffix()
-        await self._rebase_ci_images(image_keys, version, release)
-        await self._build_ci_images(image_keys)
-
-    @staticmethod
-    def _get_required_env(var_name: str) -> str:
-        value = os.getenv(var_name)
-        if not value:
-            raise ValueError(f"Required environment variable {var_name} not set")
-        return value
-
-    def _create_ci_sync_registry_config(self) -> RegistryConfig:
-        """
-        Build registry credentials for pushing a newly built CI image straight to CI, using the
-        same env vars (and QCI credential setup) as the scheduled sync-ci-images job.
-        """
-        quay_auth_file = self._get_required_env('QUAY_AUTH_FILE')
-        kubeconfig = self._get_required_env('KUBECONFIG')
-        qci_user = self._get_required_env('QCI_USER')
-        qci_password = self._get_required_env('QCI_PASSWORD')
-
-        return RegistryConfig(
-            source_files=[quay_auth_file],
-            kubeconfig=kubeconfig,
-            registries=[
-                REGISTRY_CI_OPENSHIFT,
-                REGISTRY_QUAY_OCP_RELEASE_DEV,
-                KONFLUX_DEFAULT_IMAGE_REPO,
-                KONFLUX_DEFAULT_IMAGE_SHARE_REPO,
-                KONFLUX_DEFAULT_FBC_REPO,
-                REGISTRY_REDHAT_IO,
-            ],
-            credentials=[
-                RegistryCredential(REGISTRY_QUAY_OPENSHIFT, qci_user, qci_password),
-            ],
-        )
-
-    async def _sync_ci_images(self, image_keys: List[str]):
-        """
-        Mirror newly rebuilt CI image(s) straight to CI (the same `images:streams mirror` doozer
-        verb the scheduled sync-ci-images job uses), so CI does not have to wait for that job's
-        next run to pick up the rebuild. For the test assembly, `--live-test-mode` is passed so
-        doozer publishes to the `.test`-suffixed CI imagestream tag instead of the real one --
-        `images:streams mirror` resolves its destination entirely from each image's
-        ci_alignment.upstream_image config, not from anything on this command line, so there is no
-        other way to redirect it away from the production tag.
-        """
-        _LOGGER.info("Syncing CI image(s) to CI: %s", ", ".join(image_keys))
-        group = self._get_ci_group()
-        with self._create_ci_sync_registry_config() as auth_file:
-            cmd = [
-                "doozer",
-                f"--working-dir={self._doozer_working_dir}-ci-sync",
-                "--build-system=konflux",
-            ]
-            cmd.extend(self._get_doozer_assembly_args())
-            if self.data_path:
-                cmd.append(f"--data-path={self.data_path}")
-            cmd.extend(["--group", group])
-            # These images are `mode: disabled` in ocp-build-data (see _scan_stale_ci_images), and
-            # unlike that command this one doesn't use the global `-i` image filter (its `--image`
-            # below is a subcommand-local option), so the runtime's default enabled-only filter
-            # would otherwise drop them before `images:streams mirror` can look them up.
-            cmd.append("--load-disabled")
-            cmd.extend(["images:streams", "mirror", "--registry-auth", auth_file])
-            for image_key in image_keys:
-                cmd.extend(["--image", image_key])
-            if not self.is_production_assembly:
-                cmd.append("--live-test-mode")
-            if self.dry_run:
-                cmd.append("--dry-run")
-            await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars, log_stdout=True)
-
     CI_VARIANT_BY_GROUP_VAR = {
         "GO_LATEST": "latest",
         "GO_EXTRA": "extra",
@@ -1414,15 +1257,17 @@ class UpdateGolangPipeline:
         source changes are caught directly. Loading both together also means doozer's own change
         propagation (a changing image marks its `member`-referencing descendants as changing too)
         naturally covers the case where build-root itself hasn't changed but its golang-builder
-        parent has. Whatever comes back stale is rebased+built together in one batch (see
-        `_rebase_and_build_ci_images`) -- doozer only resolves a `from: member:` reference
-        correctly when both images are loaded in the same run. Once done, every image considered
-        this run (not just what was rebuilt) is synced to CI in a single final step -- re-mirroring
-        an already-current image is cheap for a handful of images, and it keeps CI in sync with the
+        parent has. Whatever comes back stale is rebased+built together in one batch by triggering
+        the standing `ocp4-konflux` job (see `jenkins.start_ocp4_konflux`), scoped to just these
+        image(s) via `IMAGE_LIST` -- doozer only resolves a `from: member:` reference correctly
+        when both images are loaded in the same run. Once done, every image considered this run
+        (not just what was rebuilt) is synced to CI in a single final step by triggering the
+        standing `sync-ci-images` job (see `jenkins.start_sync_ci_images`) -- re-mirroring an
+        already-current image is cheap for a handful of images, and it keeps CI in sync with the
         latest successful build even when nothing needed rebuilding. For the test assembly,
-        `_sync_ci_images` passes `--live-test-mode`, which publishes to the `.test`-suffixed CI
-        imagestream tag instead of the real one, so test-assembly runs never overwrite what
-        production CI actually consumes.
+        `live_test_mode` is passed so that job publishes to the `.test`-suffixed CI imagestream
+        tag instead of the real one, so test-assembly runs never overwrite what production CI
+        actually consumes.
         """
         variant = next(
             (
@@ -1484,7 +1329,6 @@ class UpdateGolangPipeline:
                 f"{self.ocp_version}: {', '.join(rebuilt_image_keys)}"
             )
 
-            # await self._rebase_and_build_ci_images(rebuilt_image_keys)
             build_result = jenkins.start_ocp4_konflux(
                 build_version=self.ocp_version,
                 assembly=self.assembly,

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -2160,8 +2160,8 @@ repos:
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_assert_async")
-    async def test_rebase_ci_image_includes_assembly(self, mock_cmd_assert, mock_konflux_db):
-        """Test _rebase_ci_image passes --assembly for the pipeline's assembly"""
+    async def test_rebase_ci_images_includes_assembly(self, mock_cmd_assert, mock_konflux_db):
+        """Test _rebase_ci_images passes --assembly for the pipeline's assembly"""
         mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
         mock_runtime.new_slack_client.return_value = Mock()
 
@@ -2177,7 +2177,7 @@ repos:
             assembly="test",
         )
 
-        await pipeline._rebase_ci_image("ci-openshift-golang-builder-latest.rhel9", "v4.18.0", "1")
+        await pipeline._rebase_ci_images(["ci-openshift-golang-builder-latest.rhel9"], "v4.18.0", "1")
 
         cmd = mock_cmd_assert.call_args[0][0]
         self.assertIn("beta:images:konflux:rebase", cmd)
@@ -2185,8 +2185,8 @@ repos:
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_assert_async")
-    async def test_build_ci_image_includes_assembly(self, mock_cmd_assert, mock_konflux_db):
-        """Test _build_ci_image passes --assembly for the pipeline's assembly"""
+    async def test_build_ci_images_includes_assembly(self, mock_cmd_assert, mock_konflux_db):
+        """Test _build_ci_images passes --assembly for the pipeline's assembly"""
         mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
         mock_runtime.new_slack_client.return_value = Mock()
 
@@ -2201,7 +2201,7 @@ repos:
             build_system="konflux",
         )
 
-        await pipeline._build_ci_image("ci-openshift-golang-builder-latest.rhel9")
+        await pipeline._build_ci_images(["ci-openshift-golang-builder-latest.rhel9"])
 
         cmd = mock_cmd_assert.call_args[0][0]
         self.assertIn("beta:images:konflux:build", cmd)
@@ -2669,7 +2669,7 @@ class TestReconcileCiImages(IsolatedAsyncioTestCase):
         pipeline._sync_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
         self.assertTrue(
             any(
-                "Rebuilding CI golang builder image" in call.args[0]
+                "Rebuilding CI golang builder/build-root image" in call.args[0]
                 for call in pipeline._slack_client.say_in_thread.await_args_list
             )
         )
@@ -2703,7 +2703,7 @@ class TestReconcileCiImages(IsolatedAsyncioTestCase):
     async def test_reconcile_triggers_build_root_after_golang_builder_rebuild(self, mock_konflux_db):
         """
         Build-root images pull their parent via a `member` reference to the golang-builder CI
-        image, not via the golang-builder staleness scan, so once golang builder is rebuilt its
+        image, not via the golang-builder staleness scan, so once golang builder is stale its
         build-root sibling is triggered unconditionally -- no extra staleness check for build-root.
         """
         pipeline = self._make_pipeline()
@@ -2719,18 +2719,17 @@ class TestReconcileCiImages(IsolatedAsyncioTestCase):
         # Only the golang-builder image is scanned; build-root is triggered directly, without a
         # staleness check of its own.
         pipeline._scan_stale_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
-        # Golang builder and build-root are rebuilt as two separate, ordered batch calls.
-        self.assertEqual(
-            [call.args[0] for call in pipeline._rebase_and_build_ci_images.await_args_list],
-            [["ci-openshift-golang-builder-latest.rhel9"], ["ci-openshift-build-root-latest.rhel9"]],
+        # Golang builder and build-root are rebuilt together in a single batch call, so doozer
+        # resolves the `from: member:` reference between them in-process.
+        pipeline._rebase_and_build_ci_images.assert_awaited_once_with(
+            ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
         )
-        # Both families are synced together in a single call, after both rebuild steps complete.
+        # Both families are synced together in a single call, after the rebuild batch completes.
         pipeline._sync_ci_images.assert_awaited_once_with(
             ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
         )
         slack_messages = [call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list]
-        self.assertTrue(any("Rebuilding CI golang builder image" in m for m in slack_messages))
-        self.assertTrue(any("Rebuilding CI build-root image" in m for m in slack_messages))
+        self.assertTrue(any("Rebuilding CI golang builder/build-root image" in m for m in slack_messages))
         self.assertTrue(any("Synced CI image" in m for m in slack_messages))
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -2769,16 +2768,14 @@ class TestReconcileCiImages(IsolatedAsyncioTestCase):
             return_value=["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
         )
         pipeline._scan_stale_ci_images = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
-        pipeline._rebase_and_build_ci_images = AsyncMock(
-            side_effect=[None, RuntimeError("Failed to rebuild 1/1")],
-        )
+        pipeline._rebase_and_build_ci_images = AsyncMock(side_effect=RuntimeError("Failed to rebuild 1/1"))
         pipeline._sync_ci_images = AsyncMock()
 
         with self.assertRaisesRegex(RuntimeError, "Failed to rebuild"):
             await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
 
-        # Sync only happens after both rebuild stages complete, so a build-root failure means
-        # nothing gets mirrored to CI this run -- even though golang-builder itself rebuilt fine.
+        # Sync only happens after the rebuild batch completes, so a build-root failure means
+        # nothing gets mirrored to CI this run -- even though the batch call is single-shot.
         pipeline._sync_ci_images.assert_not_awaited()
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -2892,36 +2889,29 @@ class TestRebaseAndBuildCiImages(IsolatedAsyncioTestCase):
         )
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_rebases_and_builds_each_image(self, mock_konflux_db):
+    async def test_rebases_then_builds_the_batch_together(self, mock_konflux_db):
+        """
+        All given image keys are rebased in one doozer call, then built in one doozer call --
+        not per-image -- so a `from: member:` reference between them (e.g.
+        ci-openshift-build-root-* -> ci-openshift-golang-builder-*) resolves in-process.
+        """
         pipeline = self._make_pipeline()
-        pipeline._rebase_ci_image = AsyncMock()
-        pipeline._build_ci_image = AsyncMock()
+        pipeline._rebase_ci_images = AsyncMock()
+        pipeline._build_ci_images = AsyncMock()
 
-        await pipeline._rebase_and_build_ci_images(
-            ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
-        )
+        image_keys = ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
+        await pipeline._rebase_and_build_ci_images(image_keys)
 
-        self.assertEqual(
-            {call.args[0] for call in pipeline._rebase_ci_image.await_args_list},
-            {"ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"},
-        )
-        self.assertEqual(
-            {call.args[0] for call in pipeline._build_ci_image.await_args_list},
-            {"ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"},
-        )
+        self.assertEqual(pipeline._rebase_ci_images.await_args.args[0], image_keys)
+        pipeline._build_ci_images.assert_awaited_once_with(image_keys)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_raises_aggregated_error_when_some_images_fail(self, mock_konflux_db):
+    async def test_raises_when_build_fails(self, mock_konflux_db):
         pipeline = self._make_pipeline()
-        pipeline._rebase_ci_image = AsyncMock()
+        pipeline._rebase_ci_images = AsyncMock()
+        pipeline._build_ci_images = AsyncMock(side_effect=ChildProcessError("build failed"))
 
-        async def _build_side_effect(image_key):
-            if image_key == "ci-openshift-build-root-latest.rhel9":
-                raise ChildProcessError("build failed")
-
-        pipeline._build_ci_image = AsyncMock(side_effect=_build_side_effect)
-
-        with self.assertRaisesRegex(RuntimeError, r"Failed to rebuild 1/2 CI image\(s\)"):
+        with self.assertRaises(ChildProcessError):
             await pipeline._rebase_and_build_ci_images(
                 ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
             )

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import os
 import tempfile
 import unittest
@@ -1131,11 +1132,13 @@ repos:
             return_value={9: "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9"}
         )
         pipeline.update_golang_streams = AsyncMock()
+        pipeline._refresh_ci_images = AsyncMock()
 
         await pipeline.run()
 
         mock_kinit.assert_awaited_once()
         pipeline.update_golang_streams.assert_not_awaited()
+        pipeline._refresh_ci_images.assert_awaited_once()
         move_golang_bugs.assert_awaited_once()
         slack_messages = [call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list]
         self.assertTrue(
@@ -1165,6 +1168,7 @@ repos:
         pipeline.get_existing_builders_konflux = AsyncMock(return_value={8: builder_record})
         pipeline._get_builder_pullspec = Mock()
         pipeline.update_golang_streams = AsyncMock()
+        pipeline._refresh_ci_images = AsyncMock()
 
         await pipeline.run()
 
@@ -1174,6 +1178,9 @@ repos:
         self.assertEqual(list(pipeline._build_golang_plashets.await_args.args[1]), [8])
         pipeline._get_builder_pullspec.assert_not_called()
         pipeline.update_golang_streams.assert_not_awaited()
+        # CI image reconciliation still runs for the test assembly (it publishes to the
+        # .test-suffixed CI tag via --live-test-mode instead of skipping entirely).
+        pipeline._refresh_ci_images.assert_awaited_once()
         move_golang_bugs.assert_not_awaited()
         slack_messages = [call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list]
         self.assertTrue(any("test assembly" in message for message in slack_messages), slack_messages)
@@ -1204,6 +1211,7 @@ repos:
         pipeline.get_existing_builders_konflux = AsyncMock(return_value={8: builder_record})
         pipeline._get_builder_pullspec = Mock(return_value="registry.example.com/golang-builder:v1.25.11-el8")
         pipeline.update_golang_streams = AsyncMock()
+        pipeline._refresh_ci_images = AsyncMock()
 
         await pipeline.run()
 
@@ -1217,6 +1225,7 @@ repos:
             "1.25.11",
             {8: "registry.example.com/golang-builder:v1.25.11-el8"},
         )
+        pipeline._refresh_ci_images.assert_awaited_once()
         move_golang_bugs.assert_awaited_once()
 
     @patch("pyartcd.pipelines.update_golang.kinit", new_callable=AsyncMock)
@@ -1283,6 +1292,7 @@ repos:
         pipeline._rebase_and_build_konflux = AsyncMock()
         pipeline._get_builder_pullspec = Mock(return_value="registry.example.com/golang-builder:v1.25.11-el8")
         pipeline.update_golang_streams = AsyncMock()
+        pipeline._refresh_ci_images = AsyncMock()
 
         await pipeline.run()
 
@@ -1296,6 +1306,7 @@ repos:
         )
         self.assertEqual(pipeline.get_existing_builders_konflux.await_count, 2)
         pipeline.update_golang_streams.assert_awaited_once()
+        pipeline._refresh_ci_images.assert_awaited_once()
         move_golang_bugs.assert_awaited_once()
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -2149,6 +2160,112 @@ repos:
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_assert_async")
+    async def test_rebase_ci_image_includes_assembly(self, mock_cmd_assert, mock_konflux_db):
+        """Test _rebase_ci_image passes --assembly for the pipeline's assembly"""
+        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.18",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            build_system="konflux",
+            assembly="test",
+        )
+
+        await pipeline._rebase_ci_image("ci-openshift-golang-builder-latest.rhel9", "v4.18.0", "1")
+
+        cmd = mock_cmd_assert.call_args[0][0]
+        self.assertIn("beta:images:konflux:rebase", cmd)
+        self.assertEqual(cmd[cmd.index("--assembly") + 1], "test")
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("artcommonlib.exectools.cmd_assert_async")
+    async def test_build_ci_image_includes_assembly(self, mock_cmd_assert, mock_konflux_db):
+        """Test _build_ci_image passes --assembly for the pipeline's assembly"""
+        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.18",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="konflux",
+        )
+
+        await pipeline._build_ci_image("ci-openshift-golang-builder-latest.rhel9")
+
+        cmd = mock_cmd_assert.call_args[0][0]
+        self.assertIn("beta:images:konflux:build", cmd)
+        self.assertEqual(cmd[cmd.index("--assembly") + 1], "stream")
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("artcommonlib.exectools.cmd_assert_async")
+    async def test_sync_ci_images_includes_assembly(self, mock_cmd_assert, mock_konflux_db):
+        """Test _sync_ci_images passes --assembly for the pipeline's assembly"""
+        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.18",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="konflux",
+        )
+        pipeline._create_ci_sync_registry_config = Mock(return_value=contextlib.nullcontext("/tmp/auth.json"))
+
+        await pipeline._sync_ci_images(["ci-openshift-golang-builder-latest.rhel9"])
+
+        cmd = mock_cmd_assert.call_args[0][0]
+        self.assertIn("images:streams", cmd)
+        self.assertEqual(cmd[cmd.index("--assembly") + 1], "stream")
+        self.assertNotIn("--live-test-mode", cmd)
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("artcommonlib.exectools.cmd_assert_async")
+    async def test_sync_ci_images_uses_live_test_mode_for_test_assembly(self, mock_cmd_assert, mock_konflux_db):
+        """
+        For the test assembly, doozer must publish to the .test-suffixed CI imagestream tag
+        instead of the real one -- images:streams mirror resolves its destination purely from
+        each image's ci_alignment.upstream_image config, so --live-test-mode is the only way to
+        redirect it away from what production CI actually consumes.
+        """
+        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = Mock()
+
+        pipeline = UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.18",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            build_system="konflux",
+            assembly="test",
+        )
+        pipeline._create_ci_sync_registry_config = Mock(return_value=contextlib.nullcontext("/tmp/auth.json"))
+
+        await pipeline._sync_ci_images(["ci-openshift-golang-builder-latest.rhel9"])
+
+        cmd = mock_cmd_assert.call_args[0][0]
+        self.assertEqual(cmd[cmd.index("--assembly") + 1], "test")
+        self.assertIn("--live-test-mode", cmd)
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_test_assembly_dry_run_commands_for_konflux(self, mock_cmd_assert, mock_konflux_db):
         runtime = self._make_test_runtime()
         runtime.dry_run = True
@@ -2430,6 +2547,382 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
 
         mock_jenkins.start_build_plashets.assert_called_once()
         self.assertTrue(mock_jenkins.start_build_plashets.call_args.kwargs["dry_run"])
+
+
+class TestReconcileCiImages(IsolatedAsyncioTestCase):
+    """Test the CI golang builder / build-root image reconciliation stage"""
+
+    def _make_pipeline(self, dry_run=False, assembly=DEFAULT_GOLANG_ASSEMBLY):
+        mock_slack = Mock()
+        mock_slack.say_in_thread = AsyncMock()
+        mock_runtime = Mock(dry_run=dry_run, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = mock_slack
+        return UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.18",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=(assembly == DEFAULT_GOLANG_ASSEMBLY),
+            build_system="konflux",
+            assembly=assembly,
+        )
+
+    @staticmethod
+    def _content(name):
+        content = Mock()
+        content.name = name
+        return content
+
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_get_ci_image_keys_filters_by_prefix(self, mock_konflux_db, mock_get_github_client):
+        pipeline = self._make_pipeline()
+        upstream_repo = Mock()
+        upstream_repo.get_contents.return_value = [
+            self._content("ci-openshift-golang-builder-latest.rhel9.yml"),
+            self._content("ci-openshift-golang-builder-extra.rhel8.yml"),
+            self._content("ci-openshift-build-root-latest.rhel9.yml"),
+            self._content("openshift-enterprise-ansible-operator.yml"),
+        ]
+        mock_get_github_client.return_value.get_repo.return_value = upstream_repo
+
+        image_keys = await pipeline._get_ci_image_keys()
+
+        self.assertEqual(
+            image_keys,
+            [
+                "ci-openshift-build-root-latest.rhel9",
+                "ci-openshift-golang-builder-extra.rhel8",
+                "ci-openshift-golang-builder-latest.rhel9",
+            ],
+        )
+        upstream_repo.get_contents.assert_called_once_with("images", ref="openshift-4.18")
+
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_get_ci_image_keys_returns_empty_when_none_found(self, mock_konflux_db, mock_get_github_client):
+        pipeline = self._make_pipeline()
+        upstream_repo = Mock()
+        upstream_repo.get_contents.return_value = [self._content("openshift-enterprise-ansible-operator.yml")]
+        mock_get_github_client.return_value.get_repo.return_value = upstream_repo
+
+        image_keys = await pipeline._get_ci_image_keys()
+
+        self.assertEqual(image_keys, [])
+
+    # Common args for _refresh_ci_images: a GO_LATEST bump on rhel9.
+    RECONCILE_ARGS = ("1.22", {"GO_LATEST": "1.22"}, {9: "golang-1.22.9-1.el9"})
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_noops_when_variant_unmatched(self, mock_konflux_db):
+        """No GO_LATEST/GO_EXTRA/GO_PREVIOUS var matches this build; nothing to check."""
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_image_keys = AsyncMock()
+        pipeline._rebase_and_build_ci_images = AsyncMock()
+
+        await pipeline._refresh_ci_images("1.23", {"GO_LATEST": "1.22"}, {9: "golang"})
+
+        pipeline._get_ci_image_keys.assert_not_awaited()
+        pipeline._rebase_and_build_ci_images.assert_not_awaited()
+        pipeline._slack_client.say_in_thread.assert_not_awaited()
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_noops_when_no_matching_images_found(self, mock_konflux_db):
+        """GO_LATEST matches, but no ci-openshift-golang-builder-latest.rhel* image exists."""
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_image_keys = AsyncMock(return_value=[])
+        pipeline._scan_stale_ci_images = AsyncMock()
+        pipeline._rebase_and_build_ci_images = AsyncMock()
+
+        await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
+
+        pipeline._scan_stale_ci_images.assert_not_awaited()
+        pipeline._rebase_and_build_ci_images.assert_not_awaited()
+        pipeline._slack_client.say_in_thread.assert_not_awaited()
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_noops_when_ci_image_already_current(self, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._scan_stale_ci_images = AsyncMock(return_value=[])
+        pipeline._rebase_and_build_ci_images = AsyncMock()
+
+        await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
+
+        pipeline._scan_stale_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._rebase_and_build_ci_images.assert_not_awaited()
+        pipeline._slack_client.say_in_thread.assert_not_awaited()
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_rebuilds_stale_image(self, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._scan_stale_ci_images = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._rebase_and_build_ci_images = AsyncMock()
+        pipeline._sync_ci_images = AsyncMock()
+
+        await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
+
+        pipeline._rebase_and_build_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._sync_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+        self.assertTrue(
+            any(
+                "Rebuilding CI golang builder image" in call.args[0]
+                for call in pipeline._slack_client.say_in_thread.await_args_list
+            )
+        )
+        self.assertTrue(
+            any("Synced CI image" in call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list)
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_raises_when_scan_fails(self, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._scan_stale_ci_images = AsyncMock(side_effect=RuntimeError("doozer scan-sources failed"))
+        pipeline._rebase_and_build_ci_images = AsyncMock()
+
+        with self.assertRaisesRegex(RuntimeError, "scan-sources failed"):
+            await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
+
+        pipeline._rebase_and_build_ci_images.assert_not_awaited()
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_raises_when_rebuild_fails(self, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._scan_stale_ci_images = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._rebase_and_build_ci_images = AsyncMock(side_effect=RuntimeError("Failed to rebuild 1/1"))
+
+        with self.assertRaisesRegex(RuntimeError, "Failed to rebuild"):
+            await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_triggers_build_root_after_golang_builder_rebuild(self, mock_konflux_db):
+        """
+        Build-root images pull their parent via a `member` reference to the golang-builder CI
+        image, not via the golang-builder staleness scan, so once golang builder is rebuilt its
+        build-root sibling is triggered unconditionally -- no extra staleness check for build-root.
+        """
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_image_keys = AsyncMock(
+            return_value=["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
+        )
+        pipeline._scan_stale_ci_images = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._rebase_and_build_ci_images = AsyncMock()
+        pipeline._sync_ci_images = AsyncMock()
+
+        await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
+
+        # Only the golang-builder image is scanned; build-root is triggered directly, without a
+        # staleness check of its own.
+        pipeline._scan_stale_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+        # Golang builder and build-root are rebuilt as two separate, ordered batch calls.
+        self.assertEqual(
+            [call.args[0] for call in pipeline._rebase_and_build_ci_images.await_args_list],
+            [["ci-openshift-golang-builder-latest.rhel9"], ["ci-openshift-build-root-latest.rhel9"]],
+        )
+        # Both families are synced together in a single call, after both rebuild steps complete.
+        pipeline._sync_ci_images.assert_awaited_once_with(
+            ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
+        )
+        slack_messages = [call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list]
+        self.assertTrue(any("Rebuilding CI golang builder image" in m for m in slack_messages))
+        self.assertTrue(any("Rebuilding CI build-root image" in m for m in slack_messages))
+        self.assertTrue(any("Synced CI image" in m for m in slack_messages))
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_skips_build_root_when_golang_builder_already_fresh(self, mock_konflux_db):
+        """If golang builder wasn't rebuilt, its build-root sibling is left untouched."""
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_image_keys = AsyncMock(
+            return_value=["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
+        )
+        pipeline._scan_stale_ci_images = AsyncMock(return_value=[])
+        pipeline._rebase_and_build_ci_images = AsyncMock()
+
+        await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
+
+        pipeline._rebase_and_build_ci_images.assert_not_awaited()
+        pipeline._slack_client.say_in_thread.assert_not_awaited()
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_skips_build_root_when_none_defined_for_variant(self, mock_konflux_db):
+        """Golang builder rebuilds fine even when no matching build-root image is defined."""
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._scan_stale_ci_images = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._rebase_and_build_ci_images = AsyncMock()
+        pipeline._sync_ci_images = AsyncMock()
+
+        await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
+
+        pipeline._rebase_and_build_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._sync_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_raises_when_build_root_rebuild_fails(self, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_image_keys = AsyncMock(
+            return_value=["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
+        )
+        pipeline._scan_stale_ci_images = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._rebase_and_build_ci_images = AsyncMock(
+            side_effect=[None, RuntimeError("Failed to rebuild 1/1")],
+        )
+        pipeline._sync_ci_images = AsyncMock()
+
+        with self.assertRaisesRegex(RuntimeError, "Failed to rebuild"):
+            await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
+
+        # Sync only happens after both rebuild stages complete, so a build-root failure means
+        # nothing gets mirrored to CI this run -- even though golang-builder itself rebuilt fine.
+        pipeline._sync_ci_images.assert_not_awaited()
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_syncs_for_test_assembly(self, mock_konflux_db):
+        """
+        Test-assembly builds get rebuilt and synced too -- _sync_ci_images itself is responsible
+        for redirecting the publish to the .test-suffixed CI tag via --live-test-mode, so
+        _refresh_ci_images doesn't need to skip the call for the test assembly.
+        """
+        pipeline = self._make_pipeline(assembly="test")
+        pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._scan_stale_ci_images = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._rebase_and_build_ci_images = AsyncMock()
+        pipeline._sync_ci_images = AsyncMock()
+
+        await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
+
+        pipeline._rebase_and_build_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._sync_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+        self.assertTrue(
+            any("Synced CI image" in call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list)
+        )
+
+
+class TestScanStaleCiImages(IsolatedAsyncioTestCase):
+    """Test the doozer scan-sources wrapper used to detect stale CI images"""
+
+    def _make_pipeline(self, kubeconfig=None):
+        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = Mock()
+        return UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.18",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+            build_system="konflux",
+            kubeconfig=kubeconfig,
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("artcommonlib.exectools.cmd_gather_async")
+    async def test_builds_command_and_returns_changed_images(self, mock_cmd_gather, mock_konflux_db):
+        pipeline = self._make_pipeline(kubeconfig="/tmp/kubeconfig")
+        report = (
+            "images:\n"
+            "- name: ci-openshift-golang-builder-latest.rhel9\n"
+            "  changed: true\n"
+            "- name: ci-openshift-golang-builder-extra.rhel8\n"
+            "  changed: false\n"
+        )
+        mock_cmd_gather.return_value = (0, report, "")
+
+        stale = await pipeline._scan_stale_ci_images(
+            ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-golang-builder-extra.rhel8"]
+        )
+
+        self.assertEqual(stale, ["ci-openshift-golang-builder-latest.rhel9"])
+        cmd = mock_cmd_gather.call_args.args[0]
+        self.assertIn("beta:config:konflux:scan-sources", cmd)
+        self.assertIn("--yaml", cmd)
+        self.assertEqual(cmd[cmd.index("--assembly") + 1], "stream")
+        self.assertEqual(
+            cmd[cmd.index("-i") + 1],
+            "ci-openshift-golang-builder-latest.rhel9,ci-openshift-golang-builder-extra.rhel8",
+        )
+        self.assertIn("--ci-kubeconfig=/tmp/kubeconfig", cmd)
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("artcommonlib.exectools.cmd_gather_async")
+    async def test_omits_ci_kubeconfig_when_not_set(self, mock_cmd_gather, mock_konflux_db):
+        pipeline = self._make_pipeline(kubeconfig=None)
+        # Force this regardless of ambient env vars other tests in this process may have leaked
+        # (KONFLUX_SA_KUBECONFIG is a fallback the pipeline reads at construction time).
+        pipeline.kubeconfig = None
+        mock_cmd_gather.return_value = (0, "images: []\n", "")
+
+        await pipeline._scan_stale_ci_images(["ci-openshift-golang-builder-latest.rhel9"])
+
+        cmd = mock_cmd_gather.call_args.args[0]
+        self.assertFalse(any(arg.startswith("--ci-kubeconfig") for arg in cmd))
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    @patch("artcommonlib.exectools.cmd_gather_async")
+    async def test_raises_when_doozer_command_fails(self, mock_cmd_gather, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        mock_cmd_gather.return_value = (1, "", "boom")
+
+        with self.assertRaisesRegex(RuntimeError, "doozer scan-sources failed"):
+            await pipeline._scan_stale_ci_images(["ci-openshift-golang-builder-latest.rhel9"])
+
+
+class TestRebaseAndBuildCiImages(IsolatedAsyncioTestCase):
+    """Test the low-level rebase+build batch helper used by CI image reconciliation"""
+
+    def _make_pipeline(self):
+        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = Mock()
+        return UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.18",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_rebases_and_builds_each_image(self, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        pipeline._rebase_ci_image = AsyncMock()
+        pipeline._build_ci_image = AsyncMock()
+
+        await pipeline._rebase_and_build_ci_images(
+            ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
+        )
+
+        self.assertEqual(
+            {call.args[0] for call in pipeline._rebase_ci_image.await_args_list},
+            {"ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"},
+        )
+        self.assertEqual(
+            {call.args[0] for call in pipeline._build_ci_image.await_args_list},
+            {"ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"},
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_raises_aggregated_error_when_some_images_fail(self, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        pipeline._rebase_ci_image = AsyncMock()
+
+        async def _build_side_effect(image_key):
+            if image_key == "ci-openshift-build-root-latest.rhel9":
+                raise ChildProcessError("build failed")
+
+        pipeline._build_ci_image = AsyncMock(side_effect=_build_side_effect)
+
+        with self.assertRaisesRegex(RuntimeError, r"Failed to rebuild 1/2 CI image\(s\)"):
+            await pipeline._rebase_and_build_ci_images(
+                ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
+            )
 
 
 class TestMonobranchDispatch(IsolatedAsyncioTestCase):

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -2824,7 +2824,9 @@ class TestScanStaleCiImages(IsolatedAsyncioTestCase):
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_gather_async")
     async def test_builds_command_and_returns_changed_images(self, mock_cmd_gather, mock_konflux_db):
-        pipeline = self._make_pipeline(kubeconfig="/tmp/kubeconfig")
+        # --ci-kubeconfig must come from the app.ci KUBECONFIG env var, not self.kubeconfig
+        # (which holds the Konflux SA kubeconfig and lacks RBAC on app.ci imagestreams).
+        pipeline = self._make_pipeline(kubeconfig="/tmp/konflux-kubeconfig")
         report = (
             "images:\n"
             "- name: ci-openshift-golang-builder-latest.rhel9\n"
@@ -2834,9 +2836,10 @@ class TestScanStaleCiImages(IsolatedAsyncioTestCase):
         )
         mock_cmd_gather.return_value = (0, report, "")
 
-        stale = await pipeline._scan_stale_ci_images(
-            ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-golang-builder-extra.rhel8"]
-        )
+        with patch.dict(os.environ, {"KUBECONFIG": "/tmp/ci-kubeconfig"}):
+            stale = await pipeline._scan_stale_ci_images(
+                ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-golang-builder-extra.rhel8"]
+            )
 
         self.assertEqual(stale, ["ci-openshift-golang-builder-latest.rhel9"])
         cmd = mock_cmd_gather.call_args.args[0]
@@ -2847,18 +2850,17 @@ class TestScanStaleCiImages(IsolatedAsyncioTestCase):
             cmd[cmd.index("-i") + 1],
             "ci-openshift-golang-builder-latest.rhel9,ci-openshift-golang-builder-extra.rhel8",
         )
-        self.assertIn("--ci-kubeconfig=/tmp/kubeconfig", cmd)
+        self.assertIn("--ci-kubeconfig=/tmp/ci-kubeconfig", cmd)
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_gather_async")
     async def test_omits_ci_kubeconfig_when_not_set(self, mock_cmd_gather, mock_konflux_db):
         pipeline = self._make_pipeline(kubeconfig=None)
-        # Force this regardless of ambient env vars other tests in this process may have leaked
-        # (KONFLUX_SA_KUBECONFIG is a fallback the pipeline reads at construction time).
-        pipeline.kubeconfig = None
         mock_cmd_gather.return_value = (0, "images: []\n", "")
 
-        await pipeline._scan_stale_ci_images(["ci-openshift-golang-builder-latest.rhel9"])
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("KUBECONFIG", None)
+            await pipeline._scan_stale_ci_images(["ci-openshift-golang-builder-latest.rhel9"])
 
         cmd = mock_cmd_gather.call_args.args[0]
         self.assertFalse(any(arg.startswith("--ci-kubeconfig") for arg in cmd))

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1109,11 +1109,13 @@ repos:
             return_value={9: "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9"}
         )
         pipeline.update_golang_streams = AsyncMock()
+        pipeline._reconcile_ci_golang_builder_images = AsyncMock()
 
         await pipeline.run()
 
         mock_kinit.assert_awaited_once()
         pipeline.update_golang_streams.assert_not_awaited()
+        pipeline._reconcile_ci_golang_builder_images.assert_awaited_once()
         move_golang_bugs.assert_awaited_once()
         slack_messages = [call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list]
         self.assertTrue(
@@ -1185,6 +1187,7 @@ repos:
         pipeline._get_builder_pullspec = Mock(return_value="registry.example.com/golang-builder:v1.25.11-el8")
         pipeline._ensure_builder_pullspec_available = AsyncMock()
         pipeline.update_golang_streams = AsyncMock()
+        pipeline._reconcile_ci_golang_builder_images = AsyncMock()
 
         await pipeline.run()
 
@@ -1198,6 +1201,7 @@ repos:
             "1.25.11",
             {8: "registry.example.com/golang-builder:v1.25.11-el8"},
         )
+        pipeline._reconcile_ci_golang_builder_images.assert_awaited_once()
         move_golang_bugs.assert_awaited_once()
 
     @patch("pyartcd.pipelines.update_golang.kinit", new_callable=AsyncMock)
@@ -1265,6 +1269,7 @@ repos:
         pipeline._get_builder_pullspec = Mock(return_value="registry.example.com/golang-builder:v1.25.11-el8")
         pipeline._ensure_builder_pullspec_available = AsyncMock()
         pipeline.update_golang_streams = AsyncMock()
+        pipeline._reconcile_ci_golang_builder_images = AsyncMock()
 
         await pipeline.run()
 
@@ -1278,6 +1283,7 @@ repos:
         )
         self.assertEqual(pipeline.get_existing_builders_konflux.await_count, 2)
         pipeline.update_golang_streams.assert_awaited_once()
+        pipeline._reconcile_ci_golang_builder_images.assert_awaited_once()
         move_golang_bugs.assert_awaited_once()
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -2412,6 +2418,201 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
 
         mock_jenkins.start_build_plashets.assert_called_once()
         self.assertTrue(mock_jenkins.start_build_plashets.call_args.kwargs["dry_run"])
+
+
+class TestReconcileCiGolangBuilderImages(IsolatedAsyncioTestCase):
+    """Test the CI golang builder image reconciliation stage"""
+
+    def _make_pipeline(self, dry_run=False):
+        mock_slack = Mock()
+        mock_slack.say_in_thread = AsyncMock()
+        mock_runtime = Mock(dry_run=dry_run, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = mock_slack
+        return UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.18",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+        )
+
+    @staticmethod
+    def _content(name):
+        content = Mock()
+        content.name = name
+        return content
+
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_get_ci_golang_builder_image_keys_filters_by_prefix(self, mock_konflux_db, mock_get_github_client):
+        pipeline = self._make_pipeline()
+        upstream_repo = Mock()
+        upstream_repo.get_contents.return_value = [
+            self._content("ci-openshift-golang-builder-latest.rhel9.yml"),
+            self._content("ci-openshift-golang-builder-extra.rhel8.yml"),
+            self._content("ci-openshift-build-root-latest.rhel9.yml"),
+            self._content("openshift-enterprise-ansible-operator.yml"),
+        ]
+        mock_get_github_client.return_value.get_repo.return_value = upstream_repo
+
+        image_keys = await pipeline._get_ci_golang_builder_image_keys()
+
+        self.assertEqual(
+            image_keys,
+            ["ci-openshift-golang-builder-extra.rhel8", "ci-openshift-golang-builder-latest.rhel9"],
+        )
+        upstream_repo.get_contents.assert_called_once_with("images", ref="openshift-4.18")
+
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_get_ci_golang_builder_image_keys_returns_empty_when_none_found(
+        self, mock_konflux_db, mock_get_github_client
+    ):
+        pipeline = self._make_pipeline()
+        upstream_repo = Mock()
+        upstream_repo.get_contents.return_value = [self._content("openshift-enterprise-ansible-operator.yml")]
+        mock_get_github_client.return_value.get_repo.return_value = upstream_repo
+
+        image_keys = await pipeline._get_ci_golang_builder_image_keys()
+
+        self.assertEqual(image_keys, [])
+
+    @staticmethod
+    def _build_record(nvr, start_time):
+        return Mock(nvr=nvr, start_time=start_time)
+
+    # Common args for _reconcile_ci_golang_builder_images: a GO_LATEST bump on rhel9.
+    RECONCILE_ARGS = ("1.22.9", "1.22", {"GO_LATEST": "1.22"}, {9: "golang-1.22.9-1.el9"})
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_noops_when_variant_unmatched(self, mock_konflux_db):
+        """No GO_LATEST/GO_EXTRA/GO_PREVIOUS var matches this build; nothing to check."""
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_golang_builder_image_keys = AsyncMock()
+        pipeline._rebase_and_build_ci_golang_builder_image = AsyncMock()
+
+        await pipeline._reconcile_ci_golang_builder_images("1.23.1", "1.23", {"GO_LATEST": "1.22"}, {9: "golang"})
+
+        pipeline._get_ci_golang_builder_image_keys.assert_not_awaited()
+        pipeline._rebase_and_build_ci_golang_builder_image.assert_not_awaited()
+        pipeline._slack_client.say_in_thread.assert_not_awaited()
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_noops_when_no_matching_images_found(self, mock_konflux_db):
+        """GO_LATEST matches, but no ci-openshift-golang-builder-latest.rhel* image exists."""
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_golang_builder_image_keys = AsyncMock(return_value=[])
+        pipeline.get_existing_builders_konflux = AsyncMock()
+        pipeline._rebase_and_build_ci_golang_builder_image = AsyncMock()
+
+        await pipeline._reconcile_ci_golang_builder_images(*self.RECONCILE_ARGS)
+
+        pipeline.get_existing_builders_konflux.assert_not_awaited()
+        pipeline._rebase_and_build_ci_golang_builder_image.assert_not_awaited()
+        pipeline._slack_client.say_in_thread.assert_not_awaited()
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_noops_when_ci_image_already_newer_than_builder(self, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_golang_builder_image_keys = AsyncMock(
+            return_value=["ci-openshift-golang-builder-latest.rhel9"]
+        )
+        builder_record = self._build_record("openshift-golang-builder-container-v1.22.9-1.el9", 100)
+        pipeline.get_existing_builders_konflux = AsyncMock(return_value={9: builder_record})
+        pipeline._find_latest_ci_golang_builder_build = AsyncMock(
+            return_value=self._build_record("ci-openshift-golang-builder-latest-container-v4.18.0-1", 200)
+        )
+        pipeline._rebase_and_build_ci_golang_builder_image = AsyncMock()
+
+        await pipeline._reconcile_ci_golang_builder_images(*self.RECONCILE_ARGS)
+
+        pipeline._rebase_and_build_ci_golang_builder_image.assert_not_awaited()
+        pipeline._slack_client.say_in_thread.assert_not_awaited()
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_rebuilds_image_older_than_builder(self, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_golang_builder_image_keys = AsyncMock(
+            return_value=["ci-openshift-golang-builder-latest.rhel9"]
+        )
+        builder_record = self._build_record("openshift-golang-builder-container-v1.22.9-1.el9", 200)
+        pipeline.get_existing_builders_konflux = AsyncMock(return_value={9: builder_record})
+        pipeline._find_latest_ci_golang_builder_build = AsyncMock(
+            return_value=self._build_record("ci-openshift-golang-builder-latest-container-v4.18.0-1", 100)
+        )
+        pipeline._rebase_and_build_ci_golang_builder_image = AsyncMock()
+        pipeline._sync_ci_golang_builder_images = AsyncMock()
+
+        await pipeline._reconcile_ci_golang_builder_images(*self.RECONCILE_ARGS)
+
+        pipeline.get_existing_builders_konflux.assert_awaited_once_with({9: "golang-1.22.9-1.el9"}, "1.22.9")
+        pipeline._rebase_and_build_ci_golang_builder_image.assert_awaited_once_with(
+            "ci-openshift-golang-builder-latest.rhel9", "v4.18.0", unittest.mock.ANY
+        )
+        pipeline._sync_ci_golang_builder_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+        self.assertTrue(
+            any(
+                "Rebuilding CI golang builder image" in call.args[0]
+                for call in pipeline._slack_client.say_in_thread.await_args_list
+            )
+        )
+        self.assertTrue(
+            any(
+                "Synced CI golang builder image" in call.args[0]
+                for call in pipeline._slack_client.say_in_thread.await_args_list
+            )
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_rebuilds_image_never_built(self, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_golang_builder_image_keys = AsyncMock(
+            return_value=["ci-openshift-golang-builder-latest.rhel9"]
+        )
+        builder_record = self._build_record("openshift-golang-builder-container-v1.22.9-1.el9", 200)
+        pipeline.get_existing_builders_konflux = AsyncMock(return_value={9: builder_record})
+        pipeline._find_latest_ci_golang_builder_build = AsyncMock(return_value=None)
+        pipeline._rebase_and_build_ci_golang_builder_image = AsyncMock()
+        pipeline._sync_ci_golang_builder_images = AsyncMock()
+
+        await pipeline._reconcile_ci_golang_builder_images(*self.RECONCILE_ARGS)
+
+        pipeline._rebase_and_build_ci_golang_builder_image.assert_awaited_once_with(
+            "ci-openshift-golang-builder-latest.rhel9", "v4.18.0", unittest.mock.ANY
+        )
+        pipeline._sync_ci_golang_builder_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_skips_when_no_builder_record_found(self, mock_konflux_db):
+        """If there's no Konflux build of the golang-builder itself, we can't compare -- skip that image."""
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_golang_builder_image_keys = AsyncMock(
+            return_value=["ci-openshift-golang-builder-latest.rhel9"]
+        )
+        pipeline.get_existing_builders_konflux = AsyncMock(return_value={})
+        pipeline._find_latest_ci_golang_builder_build = AsyncMock()
+        pipeline._rebase_and_build_ci_golang_builder_image = AsyncMock()
+
+        await pipeline._reconcile_ci_golang_builder_images(*self.RECONCILE_ARGS)
+
+        pipeline._find_latest_ci_golang_builder_build.assert_not_awaited()
+        pipeline._rebase_and_build_ci_golang_builder_image.assert_not_awaited()
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_raises_when_rebuild_fails(self, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_golang_builder_image_keys = AsyncMock(
+            return_value=["ci-openshift-golang-builder-latest.rhel9"]
+        )
+        builder_record = self._build_record("openshift-golang-builder-container-v1.22.9-1.el9", 200)
+        pipeline.get_existing_builders_konflux = AsyncMock(return_value={9: builder_record})
+        pipeline._find_latest_ci_golang_builder_build = AsyncMock(return_value=None)
+        pipeline._rebase_and_build_ci_golang_builder_image = AsyncMock(side_effect=ChildProcessError("build failed"))
+
+        with self.assertRaisesRegex(RuntimeError, "Failed to rebuild"):
+            await pipeline._reconcile_ci_golang_builder_images(*self.RECONCILE_ARGS)
 
 
 class TestMonobranchDispatch(IsolatedAsyncioTestCase):

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1109,13 +1109,13 @@ repos:
             return_value={9: "openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9"}
         )
         pipeline.update_golang_streams = AsyncMock()
-        pipeline._reconcile_ci_golang_builder_images = AsyncMock()
+        pipeline._reconcile_ci_images = AsyncMock()
 
         await pipeline.run()
 
         mock_kinit.assert_awaited_once()
         pipeline.update_golang_streams.assert_not_awaited()
-        pipeline._reconcile_ci_golang_builder_images.assert_awaited_once()
+        pipeline._reconcile_ci_images.assert_awaited_once()
         move_golang_bugs.assert_awaited_once()
         slack_messages = [call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list]
         self.assertTrue(
@@ -1187,7 +1187,7 @@ repos:
         pipeline._get_builder_pullspec = Mock(return_value="registry.example.com/golang-builder:v1.25.11-el8")
         pipeline._ensure_builder_pullspec_available = AsyncMock()
         pipeline.update_golang_streams = AsyncMock()
-        pipeline._reconcile_ci_golang_builder_images = AsyncMock()
+        pipeline._reconcile_ci_images = AsyncMock()
 
         await pipeline.run()
 
@@ -1201,7 +1201,7 @@ repos:
             "1.25.11",
             {8: "registry.example.com/golang-builder:v1.25.11-el8"},
         )
-        pipeline._reconcile_ci_golang_builder_images.assert_awaited_once()
+        pipeline._reconcile_ci_images.assert_awaited_once()
         move_golang_bugs.assert_awaited_once()
 
     @patch("pyartcd.pipelines.update_golang.kinit", new_callable=AsyncMock)
@@ -1269,7 +1269,7 @@ repos:
         pipeline._get_builder_pullspec = Mock(return_value="registry.example.com/golang-builder:v1.25.11-el8")
         pipeline._ensure_builder_pullspec_available = AsyncMock()
         pipeline.update_golang_streams = AsyncMock()
-        pipeline._reconcile_ci_golang_builder_images = AsyncMock()
+        pipeline._reconcile_ci_images = AsyncMock()
 
         await pipeline.run()
 
@@ -1283,7 +1283,7 @@ repos:
         )
         self.assertEqual(pipeline.get_existing_builders_konflux.await_count, 2)
         pipeline.update_golang_streams.assert_awaited_once()
-        pipeline._reconcile_ci_golang_builder_images.assert_awaited_once()
+        pipeline._reconcile_ci_images.assert_awaited_once()
         move_golang_bugs.assert_awaited_once()
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -2420,8 +2420,8 @@ class TestBuildGolangPlashets(IsolatedAsyncioTestCase):
         self.assertTrue(mock_jenkins.start_build_plashets.call_args.kwargs["dry_run"])
 
 
-class TestReconcileCiGolangBuilderImages(IsolatedAsyncioTestCase):
-    """Test the CI golang builder image reconciliation stage"""
+class TestReconcileCiImages(IsolatedAsyncioTestCase):
+    """Test the CI golang builder / build-root image reconciliation stage"""
 
     def _make_pipeline(self, dry_run=False):
         mock_slack = Mock()
@@ -2446,7 +2446,7 @@ class TestReconcileCiGolangBuilderImages(IsolatedAsyncioTestCase):
 
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_get_ci_golang_builder_image_keys_filters_by_prefix(self, mock_konflux_db, mock_get_github_client):
+    async def test_get_ci_image_keys_filters_by_prefix(self, mock_konflux_db, mock_get_github_client):
         pipeline = self._make_pipeline()
         upstream_repo = Mock()
         upstream_repo.get_contents.return_value = [
@@ -2457,25 +2457,27 @@ class TestReconcileCiGolangBuilderImages(IsolatedAsyncioTestCase):
         ]
         mock_get_github_client.return_value.get_repo.return_value = upstream_repo
 
-        image_keys = await pipeline._get_ci_golang_builder_image_keys()
+        image_keys = await pipeline._get_ci_image_keys()
 
         self.assertEqual(
             image_keys,
-            ["ci-openshift-golang-builder-extra.rhel8", "ci-openshift-golang-builder-latest.rhel9"],
+            [
+                "ci-openshift-build-root-latest.rhel9",
+                "ci-openshift-golang-builder-extra.rhel8",
+                "ci-openshift-golang-builder-latest.rhel9",
+            ],
         )
         upstream_repo.get_contents.assert_called_once_with("images", ref="openshift-4.18")
 
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_get_ci_golang_builder_image_keys_returns_empty_when_none_found(
-        self, mock_konflux_db, mock_get_github_client
-    ):
+    async def test_get_ci_image_keys_returns_empty_when_none_found(self, mock_konflux_db, mock_get_github_client):
         pipeline = self._make_pipeline()
         upstream_repo = Mock()
         upstream_repo.get_contents.return_value = [self._content("openshift-enterprise-ansible-operator.yml")]
         mock_get_github_client.return_value.get_repo.return_value = upstream_repo
 
-        image_keys = await pipeline._get_ci_golang_builder_image_keys()
+        image_keys = await pipeline._get_ci_image_keys()
 
         self.assertEqual(image_keys, [])
 
@@ -2483,75 +2485,69 @@ class TestReconcileCiGolangBuilderImages(IsolatedAsyncioTestCase):
     def _build_record(nvr, start_time):
         return Mock(nvr=nvr, start_time=start_time)
 
-    # Common args for _reconcile_ci_golang_builder_images: a GO_LATEST bump on rhel9.
+    # Common args for _reconcile_ci_images: a GO_LATEST bump on rhel9.
     RECONCILE_ARGS = ("1.22.9", "1.22", {"GO_LATEST": "1.22"}, {9: "golang-1.22.9-1.el9"})
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     async def test_reconcile_noops_when_variant_unmatched(self, mock_konflux_db):
         """No GO_LATEST/GO_EXTRA/GO_PREVIOUS var matches this build; nothing to check."""
         pipeline = self._make_pipeline()
-        pipeline._get_ci_golang_builder_image_keys = AsyncMock()
-        pipeline._rebase_and_build_ci_golang_builder_image = AsyncMock()
+        pipeline._get_ci_image_keys = AsyncMock()
+        pipeline._rebase_and_build_ci_images = AsyncMock()
 
-        await pipeline._reconcile_ci_golang_builder_images("1.23.1", "1.23", {"GO_LATEST": "1.22"}, {9: "golang"})
+        await pipeline._reconcile_ci_images("1.23.1", "1.23", {"GO_LATEST": "1.22"}, {9: "golang"})
 
-        pipeline._get_ci_golang_builder_image_keys.assert_not_awaited()
-        pipeline._rebase_and_build_ci_golang_builder_image.assert_not_awaited()
+        pipeline._get_ci_image_keys.assert_not_awaited()
+        pipeline._rebase_and_build_ci_images.assert_not_awaited()
         pipeline._slack_client.say_in_thread.assert_not_awaited()
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     async def test_reconcile_noops_when_no_matching_images_found(self, mock_konflux_db):
         """GO_LATEST matches, but no ci-openshift-golang-builder-latest.rhel* image exists."""
         pipeline = self._make_pipeline()
-        pipeline._get_ci_golang_builder_image_keys = AsyncMock(return_value=[])
+        pipeline._get_ci_image_keys = AsyncMock(return_value=[])
         pipeline.get_existing_builders_konflux = AsyncMock()
-        pipeline._rebase_and_build_ci_golang_builder_image = AsyncMock()
+        pipeline._rebase_and_build_ci_images = AsyncMock()
 
-        await pipeline._reconcile_ci_golang_builder_images(*self.RECONCILE_ARGS)
+        await pipeline._reconcile_ci_images(*self.RECONCILE_ARGS)
 
         pipeline.get_existing_builders_konflux.assert_not_awaited()
-        pipeline._rebase_and_build_ci_golang_builder_image.assert_not_awaited()
+        pipeline._rebase_and_build_ci_images.assert_not_awaited()
         pipeline._slack_client.say_in_thread.assert_not_awaited()
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     async def test_reconcile_noops_when_ci_image_already_newer_than_builder(self, mock_konflux_db):
         pipeline = self._make_pipeline()
-        pipeline._get_ci_golang_builder_image_keys = AsyncMock(
-            return_value=["ci-openshift-golang-builder-latest.rhel9"]
-        )
+        pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
         builder_record = self._build_record("openshift-golang-builder-container-v1.22.9-1.el9", 100)
         pipeline.get_existing_builders_konflux = AsyncMock(return_value={9: builder_record})
-        pipeline._find_latest_ci_golang_builder_build = AsyncMock(
+        pipeline._find_latest_ci_build = AsyncMock(
             return_value=self._build_record("ci-openshift-golang-builder-latest-container-v4.18.0-1", 200)
         )
-        pipeline._rebase_and_build_ci_golang_builder_image = AsyncMock()
+        pipeline._rebase_and_build_ci_images = AsyncMock()
 
-        await pipeline._reconcile_ci_golang_builder_images(*self.RECONCILE_ARGS)
+        await pipeline._reconcile_ci_images(*self.RECONCILE_ARGS)
 
-        pipeline._rebase_and_build_ci_golang_builder_image.assert_not_awaited()
+        pipeline._rebase_and_build_ci_images.assert_not_awaited()
         pipeline._slack_client.say_in_thread.assert_not_awaited()
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     async def test_reconcile_rebuilds_image_older_than_builder(self, mock_konflux_db):
         pipeline = self._make_pipeline()
-        pipeline._get_ci_golang_builder_image_keys = AsyncMock(
-            return_value=["ci-openshift-golang-builder-latest.rhel9"]
-        )
+        pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
         builder_record = self._build_record("openshift-golang-builder-container-v1.22.9-1.el9", 200)
         pipeline.get_existing_builders_konflux = AsyncMock(return_value={9: builder_record})
-        pipeline._find_latest_ci_golang_builder_build = AsyncMock(
+        pipeline._find_latest_ci_build = AsyncMock(
             return_value=self._build_record("ci-openshift-golang-builder-latest-container-v4.18.0-1", 100)
         )
-        pipeline._rebase_and_build_ci_golang_builder_image = AsyncMock()
-        pipeline._sync_ci_golang_builder_images = AsyncMock()
+        pipeline._rebase_and_build_ci_images = AsyncMock()
+        pipeline._sync_ci_images = AsyncMock()
 
-        await pipeline._reconcile_ci_golang_builder_images(*self.RECONCILE_ARGS)
+        await pipeline._reconcile_ci_images(*self.RECONCILE_ARGS)
 
         pipeline.get_existing_builders_konflux.assert_awaited_once_with({9: "golang-1.22.9-1.el9"}, "1.22.9")
-        pipeline._rebase_and_build_ci_golang_builder_image.assert_awaited_once_with(
-            "ci-openshift-golang-builder-latest.rhel9", "v4.18.0", unittest.mock.ANY
-        )
-        pipeline._sync_ci_golang_builder_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._rebase_and_build_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._sync_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
         self.assertTrue(
             any(
                 "Rebuilding CI golang builder image" in call.args[0]
@@ -2559,60 +2555,193 @@ class TestReconcileCiGolangBuilderImages(IsolatedAsyncioTestCase):
             )
         )
         self.assertTrue(
-            any(
-                "Synced CI golang builder image" in call.args[0]
-                for call in pipeline._slack_client.say_in_thread.await_args_list
-            )
+            any("Synced CI image" in call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list)
         )
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     async def test_reconcile_rebuilds_image_never_built(self, mock_konflux_db):
         pipeline = self._make_pipeline()
-        pipeline._get_ci_golang_builder_image_keys = AsyncMock(
-            return_value=["ci-openshift-golang-builder-latest.rhel9"]
-        )
+        pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
         builder_record = self._build_record("openshift-golang-builder-container-v1.22.9-1.el9", 200)
         pipeline.get_existing_builders_konflux = AsyncMock(return_value={9: builder_record})
-        pipeline._find_latest_ci_golang_builder_build = AsyncMock(return_value=None)
-        pipeline._rebase_and_build_ci_golang_builder_image = AsyncMock()
-        pipeline._sync_ci_golang_builder_images = AsyncMock()
+        pipeline._find_latest_ci_build = AsyncMock(return_value=None)
+        pipeline._rebase_and_build_ci_images = AsyncMock()
+        pipeline._sync_ci_images = AsyncMock()
 
-        await pipeline._reconcile_ci_golang_builder_images(*self.RECONCILE_ARGS)
+        await pipeline._reconcile_ci_images(*self.RECONCILE_ARGS)
 
-        pipeline._rebase_and_build_ci_golang_builder_image.assert_awaited_once_with(
-            "ci-openshift-golang-builder-latest.rhel9", "v4.18.0", unittest.mock.ANY
-        )
-        pipeline._sync_ci_golang_builder_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._rebase_and_build_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._sync_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     async def test_reconcile_skips_when_no_builder_record_found(self, mock_konflux_db):
         """If there's no Konflux build of the golang-builder itself, we can't compare -- skip that image."""
         pipeline = self._make_pipeline()
-        pipeline._get_ci_golang_builder_image_keys = AsyncMock(
-            return_value=["ci-openshift-golang-builder-latest.rhel9"]
-        )
+        pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
         pipeline.get_existing_builders_konflux = AsyncMock(return_value={})
-        pipeline._find_latest_ci_golang_builder_build = AsyncMock()
-        pipeline._rebase_and_build_ci_golang_builder_image = AsyncMock()
+        pipeline._find_latest_ci_build = AsyncMock()
+        pipeline._rebase_and_build_ci_images = AsyncMock()
 
-        await pipeline._reconcile_ci_golang_builder_images(*self.RECONCILE_ARGS)
+        await pipeline._reconcile_ci_images(*self.RECONCILE_ARGS)
 
-        pipeline._find_latest_ci_golang_builder_build.assert_not_awaited()
-        pipeline._rebase_and_build_ci_golang_builder_image.assert_not_awaited()
+        pipeline._find_latest_ci_build.assert_not_awaited()
+        pipeline._rebase_and_build_ci_images.assert_not_awaited()
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     async def test_reconcile_raises_when_rebuild_fails(self, mock_konflux_db):
         pipeline = self._make_pipeline()
-        pipeline._get_ci_golang_builder_image_keys = AsyncMock(
-            return_value=["ci-openshift-golang-builder-latest.rhel9"]
+        pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
+        builder_record = self._build_record("openshift-golang-builder-container-v1.22.9-1.el9", 200)
+        pipeline.get_existing_builders_konflux = AsyncMock(return_value={9: builder_record})
+        pipeline._find_latest_ci_build = AsyncMock(return_value=None)
+        pipeline._rebase_and_build_ci_images = AsyncMock(side_effect=RuntimeError("Failed to rebuild 1/1"))
+
+        with self.assertRaisesRegex(RuntimeError, "Failed to rebuild"):
+            await pipeline._reconcile_ci_images(*self.RECONCILE_ARGS)
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_triggers_build_root_after_golang_builder_rebuild(self, mock_konflux_db):
+        """
+        Build-root images pull their parent via a `member` reference to the golang-builder CI
+        image, not via Konflux staleness comparison, so once golang builder is rebuilt its
+        build-root sibling is triggered unconditionally -- no extra Konflux lookup for build-root.
+        """
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_image_keys = AsyncMock(
+            return_value=["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
         )
         builder_record = self._build_record("openshift-golang-builder-container-v1.22.9-1.el9", 200)
         pipeline.get_existing_builders_konflux = AsyncMock(return_value={9: builder_record})
-        pipeline._find_latest_ci_golang_builder_build = AsyncMock(return_value=None)
-        pipeline._rebase_and_build_ci_golang_builder_image = AsyncMock(side_effect=ChildProcessError("build failed"))
+        pipeline._find_latest_ci_build = AsyncMock(return_value=None)
+        pipeline._rebase_and_build_ci_images = AsyncMock()
+        pipeline._sync_ci_images = AsyncMock()
+
+        await pipeline._reconcile_ci_images(*self.RECONCILE_ARGS)
+
+        # _find_latest_ci_build is only used to check golang-builder staleness; build-root is
+        # triggered directly, without a Konflux lookup of its own.
+        pipeline._find_latest_ci_build.assert_awaited_once_with("ci-openshift-golang-builder-latest.rhel9", 9)
+        # Golang builder and build-root are rebuilt as two separate, ordered batch calls.
+        self.assertEqual(
+            [call.args[0] for call in pipeline._rebase_and_build_ci_images.await_args_list],
+            [["ci-openshift-golang-builder-latest.rhel9"], ["ci-openshift-build-root-latest.rhel9"]],
+        )
+        # Both families are synced together in a single call, after both rebuild steps complete.
+        pipeline._sync_ci_images.assert_awaited_once_with(
+            ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
+        )
+        slack_messages = [call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list]
+        self.assertTrue(any("Rebuilding CI golang builder image" in m for m in slack_messages))
+        self.assertTrue(any("Rebuilding CI build-root image" in m for m in slack_messages))
+        self.assertTrue(any("Synced CI image" in m for m in slack_messages))
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_skips_build_root_when_golang_builder_already_fresh(self, mock_konflux_db):
+        """If golang builder wasn't rebuilt, its build-root sibling is left untouched."""
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_image_keys = AsyncMock(
+            return_value=["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
+        )
+        builder_record = self._build_record("openshift-golang-builder-container-v1.22.9-1.el9", 100)
+        pipeline.get_existing_builders_konflux = AsyncMock(return_value={9: builder_record})
+        pipeline._find_latest_ci_build = AsyncMock(
+            return_value=self._build_record("ci-openshift-golang-builder-latest-container-v4.18.0-1", 200)
+        )
+        pipeline._rebase_and_build_ci_images = AsyncMock()
+
+        await pipeline._reconcile_ci_images(*self.RECONCILE_ARGS)
+
+        pipeline._rebase_and_build_ci_images.assert_not_awaited()
+        pipeline._slack_client.say_in_thread.assert_not_awaited()
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_skips_build_root_when_none_defined_for_variant(self, mock_konflux_db):
+        """Golang builder rebuilds fine even when no matching build-root image is defined."""
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
+        builder_record = self._build_record("openshift-golang-builder-container-v1.22.9-1.el9", 200)
+        pipeline.get_existing_builders_konflux = AsyncMock(return_value={9: builder_record})
+        pipeline._find_latest_ci_build = AsyncMock(return_value=None)
+        pipeline._rebase_and_build_ci_images = AsyncMock()
+        pipeline._sync_ci_images = AsyncMock()
+
+        await pipeline._reconcile_ci_images(*self.RECONCILE_ARGS)
+
+        pipeline._rebase_and_build_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+        pipeline._sync_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_reconcile_raises_when_build_root_rebuild_fails(self, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        pipeline._get_ci_image_keys = AsyncMock(
+            return_value=["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
+        )
+        builder_record = self._build_record("openshift-golang-builder-container-v1.22.9-1.el9", 200)
+        pipeline.get_existing_builders_konflux = AsyncMock(return_value={9: builder_record})
+        pipeline._find_latest_ci_build = AsyncMock(return_value=None)
+        pipeline._rebase_and_build_ci_images = AsyncMock(
+            side_effect=[None, RuntimeError("Failed to rebuild 1/1")],
+        )
+        pipeline._sync_ci_images = AsyncMock()
 
         with self.assertRaisesRegex(RuntimeError, "Failed to rebuild"):
-            await pipeline._reconcile_ci_golang_builder_images(*self.RECONCILE_ARGS)
+            await pipeline._reconcile_ci_images(*self.RECONCILE_ARGS)
+
+        # Sync only happens after both rebuild stages complete, so a build-root failure means
+        # nothing gets mirrored to CI this run -- even though golang-builder itself rebuilt fine.
+        pipeline._sync_ci_images.assert_not_awaited()
+
+
+class TestRebaseAndBuildCiImages(IsolatedAsyncioTestCase):
+    """Test the low-level rebase+build batch helper used by CI image reconciliation"""
+
+    def _make_pipeline(self):
+        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
+        mock_runtime.new_slack_client.return_value = Mock()
+        return UpdateGolangPipeline(
+            runtime=mock_runtime,
+            ocp_version="4.18",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el9"],
+            art_jira="ART-1234",
+            tag_builds=True,
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_rebases_and_builds_each_image(self, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        pipeline._rebase_ci_image = AsyncMock()
+        pipeline._build_ci_image = AsyncMock()
+
+        await pipeline._rebase_and_build_ci_images(
+            ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
+        )
+
+        self.assertEqual(
+            {call.args[0] for call in pipeline._rebase_ci_image.await_args_list},
+            {"ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"},
+        )
+        self.assertEqual(
+            {call.args[0] for call in pipeline._build_ci_image.await_args_list},
+            {"ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"},
+        )
+
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_raises_aggregated_error_when_some_images_fail(self, mock_konflux_db):
+        pipeline = self._make_pipeline()
+        pipeline._rebase_ci_image = AsyncMock()
+
+        async def _build_side_effect(image_key):
+            if image_key == "ci-openshift-build-root-latest.rhel9":
+                raise ChildProcessError("build failed")
+
+        pipeline._build_ci_image = AsyncMock(side_effect=_build_side_effect)
+
+        with self.assertRaisesRegex(RuntimeError, r"Failed to rebuild 1/2 CI image\(s\)"):
+            await pipeline._rebase_and_build_ci_images(
+                ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
+            )
 
 
 class TestMonobranchDispatch(IsolatedAsyncioTestCase):

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import os
 import tempfile
 import unittest
@@ -2160,112 +2159,6 @@ repos:
 
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     @patch("artcommonlib.exectools.cmd_assert_async")
-    async def test_rebase_ci_images_includes_assembly(self, mock_cmd_assert, mock_konflux_db):
-        """Test _rebase_ci_images passes --assembly for the pipeline's assembly"""
-        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
-        mock_runtime.new_slack_client.return_value = Mock()
-
-        pipeline = UpdateGolangPipeline(
-            runtime=mock_runtime,
-            ocp_version="4.18",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.22.9-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=False,
-            build_system="konflux",
-            assembly="test",
-        )
-
-        await pipeline._rebase_ci_images(["ci-openshift-golang-builder-latest.rhel9"], "v4.18.0", "1")
-
-        cmd = mock_cmd_assert.call_args[0][0]
-        self.assertIn("beta:images:konflux:rebase", cmd)
-        self.assertEqual(cmd[cmd.index("--assembly") + 1], "test")
-
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    @patch("artcommonlib.exectools.cmd_assert_async")
-    async def test_build_ci_images_includes_assembly(self, mock_cmd_assert, mock_konflux_db):
-        """Test _build_ci_images passes --assembly for the pipeline's assembly"""
-        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
-        mock_runtime.new_slack_client.return_value = Mock()
-
-        pipeline = UpdateGolangPipeline(
-            runtime=mock_runtime,
-            ocp_version="4.18",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.22.9-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-            build_system="konflux",
-        )
-
-        await pipeline._build_ci_images(["ci-openshift-golang-builder-latest.rhel9"])
-
-        cmd = mock_cmd_assert.call_args[0][0]
-        self.assertIn("beta:images:konflux:build", cmd)
-        self.assertEqual(cmd[cmd.index("--assembly") + 1], "stream")
-
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    @patch("artcommonlib.exectools.cmd_assert_async")
-    async def test_sync_ci_images_includes_assembly(self, mock_cmd_assert, mock_konflux_db):
-        """Test _sync_ci_images passes --assembly for the pipeline's assembly"""
-        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
-        mock_runtime.new_slack_client.return_value = Mock()
-
-        pipeline = UpdateGolangPipeline(
-            runtime=mock_runtime,
-            ocp_version="4.18",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.22.9-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-            build_system="konflux",
-        )
-        pipeline._create_ci_sync_registry_config = Mock(return_value=contextlib.nullcontext("/tmp/auth.json"))
-
-        await pipeline._sync_ci_images(["ci-openshift-golang-builder-latest.rhel9"])
-
-        cmd = mock_cmd_assert.call_args[0][0]
-        self.assertIn("images:streams", cmd)
-        self.assertEqual(cmd[cmd.index("--assembly") + 1], "stream")
-        self.assertNotIn("--live-test-mode", cmd)
-
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    @patch("artcommonlib.exectools.cmd_assert_async")
-    async def test_sync_ci_images_uses_live_test_mode_for_test_assembly(self, mock_cmd_assert, mock_konflux_db):
-        """
-        For the test assembly, doozer must publish to the .test-suffixed CI imagestream tag
-        instead of the real one -- images:streams mirror resolves its destination purely from
-        each image's ci_alignment.upstream_image config, so --live-test-mode is the only way to
-        redirect it away from what production CI actually consumes.
-        """
-        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
-        mock_runtime.new_slack_client.return_value = Mock()
-
-        pipeline = UpdateGolangPipeline(
-            runtime=mock_runtime,
-            ocp_version="4.18",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.22.9-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=False,
-            build_system="konflux",
-            assembly="test",
-        )
-        pipeline._create_ci_sync_registry_config = Mock(return_value=contextlib.nullcontext("/tmp/auth.json"))
-
-        await pipeline._sync_ci_images(["ci-openshift-golang-builder-latest.rhel9"])
-
-        cmd = mock_cmd_assert.call_args[0][0]
-        self.assertEqual(cmd[cmd.index("--assembly") + 1], "test")
-        self.assertIn("--live-test-mode", cmd)
-
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    @patch("artcommonlib.exectools.cmd_assert_async")
     async def test_test_assembly_dry_run_commands_for_konflux(self, mock_cmd_assert, mock_konflux_db):
         runtime = self._make_test_runtime()
         runtime.dry_run = True
@@ -2615,58 +2508,94 @@ class TestReconcileCiImages(IsolatedAsyncioTestCase):
     # Common args for _refresh_ci_images: a GO_LATEST bump on rhel9.
     RECONCILE_ARGS = ("1.22", {"GO_LATEST": "1.22"}, {9: "golang-1.22.9-1.el9"})
 
+    @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_reconcile_noops_when_variant_unmatched(self, mock_konflux_db):
+    async def test_reconcile_noops_when_variant_unmatched(self, mock_konflux_db, mock_jenkins):
         """No GO_LATEST/GO_EXTRA/GO_PREVIOUS var matches this build; nothing to check."""
         pipeline = self._make_pipeline()
         pipeline._get_ci_image_keys = AsyncMock()
-        pipeline._rebase_and_build_ci_images = AsyncMock()
 
         await pipeline._refresh_ci_images("1.23", {"GO_LATEST": "1.22"}, {9: "golang"})
 
         pipeline._get_ci_image_keys.assert_not_awaited()
-        pipeline._rebase_and_build_ci_images.assert_not_awaited()
+        mock_jenkins.start_ocp4_konflux.assert_not_called()
+        mock_jenkins.start_sync_ci_images.assert_not_called()
         pipeline._slack_client.say_in_thread.assert_not_awaited()
 
+    @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_reconcile_noops_when_no_matching_images_found(self, mock_konflux_db):
+    async def test_reconcile_noops_when_no_matching_images_found(self, mock_konflux_db, mock_jenkins):
         """GO_LATEST matches, but no ci-openshift-golang-builder-latest.rhel* image exists."""
         pipeline = self._make_pipeline()
         pipeline._get_ci_image_keys = AsyncMock(return_value=[])
         pipeline._scan_stale_ci_images = AsyncMock()
-        pipeline._rebase_and_build_ci_images = AsyncMock()
 
         await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
 
         pipeline._scan_stale_ci_images.assert_not_awaited()
-        pipeline._rebase_and_build_ci_images.assert_not_awaited()
+        mock_jenkins.start_ocp4_konflux.assert_not_called()
+        mock_jenkins.start_sync_ci_images.assert_not_called()
         pipeline._slack_client.say_in_thread.assert_not_awaited()
 
+    @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_reconcile_noops_when_ci_image_already_current(self, mock_konflux_db):
+    async def test_reconcile_syncs_but_does_not_rebuild_when_ci_image_already_current(
+        self, mock_konflux_db, mock_jenkins
+    ):
+        """
+        No image was stale, so the ocp4-konflux build is never triggered -- but the sync-ci-images
+        job still runs unconditionally, to keep CI in sync with the latest successful build even
+        when nothing needed rebuilding this run.
+        """
         pipeline = self._make_pipeline()
         pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
         pipeline._scan_stale_ci_images = AsyncMock(return_value=[])
-        pipeline._rebase_and_build_ci_images = AsyncMock()
+        mock_jenkins.start_sync_ci_images.return_value = "SUCCESS"
 
         await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
 
         pipeline._scan_stale_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
-        pipeline._rebase_and_build_ci_images.assert_not_awaited()
-        pipeline._slack_client.say_in_thread.assert_not_awaited()
+        mock_jenkins.start_ocp4_konflux.assert_not_called()
+        mock_jenkins.start_sync_ci_images.assert_called_once_with(
+            version=pipeline.ocp_version,
+            block_until_complete=True,
+            assembly=pipeline.assembly,
+            image_list=["ci-openshift-golang-builder-latest.rhel9"],
+            dry_run=pipeline.dry_run,
+            load_disabled=True,
+            live_test_mode=False,
+        )
+        slack_messages = [call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list]
+        self.assertFalse(any("Rebuilding CI golang builder/build-root image" in m for m in slack_messages))
+        self.assertTrue(any("Synced CI image" in m for m in slack_messages))
 
+    @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_reconcile_rebuilds_stale_image(self, mock_konflux_db):
+    async def test_reconcile_rebuilds_stale_image(self, mock_konflux_db, mock_jenkins):
         pipeline = self._make_pipeline()
         pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
         pipeline._scan_stale_ci_images = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
-        pipeline._rebase_and_build_ci_images = AsyncMock()
-        pipeline._sync_ci_images = AsyncMock()
+        mock_jenkins.start_ocp4_konflux.return_value = "SUCCESS"
+        mock_jenkins.start_sync_ci_images.return_value = "SUCCESS"
 
         await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
 
-        pipeline._rebase_and_build_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
-        pipeline._sync_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+        mock_jenkins.start_ocp4_konflux.assert_called_once_with(
+            build_version=pipeline.ocp_version,
+            assembly=pipeline.assembly,
+            image_list=["ci-openshift-golang-builder-latest.rhel9"],
+            dry_run=pipeline.dry_run,
+            block_until_complete=True,
+        )
+        mock_jenkins.start_sync_ci_images.assert_called_once_with(
+            version=pipeline.ocp_version,
+            block_until_complete=True,
+            assembly=pipeline.assembly,
+            image_list=["ci-openshift-golang-builder-latest.rhel9"],
+            dry_run=pipeline.dry_run,
+            load_disabled=True,
+            live_test_mode=False,
+        )
         self.assertTrue(
             any(
                 "Rebuilding CI golang builder/build-root image" in call.args[0]
@@ -2677,124 +2606,178 @@ class TestReconcileCiImages(IsolatedAsyncioTestCase):
             any("Synced CI image" in call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list)
         )
 
+    @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_reconcile_raises_when_scan_fails(self, mock_konflux_db):
+    async def test_reconcile_raises_when_scan_fails(self, mock_konflux_db, mock_jenkins):
         pipeline = self._make_pipeline()
         pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
         pipeline._scan_stale_ci_images = AsyncMock(side_effect=RuntimeError("doozer scan-sources failed"))
-        pipeline._rebase_and_build_ci_images = AsyncMock()
 
         with self.assertRaisesRegex(RuntimeError, "scan-sources failed"):
             await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
 
-        pipeline._rebase_and_build_ci_images.assert_not_awaited()
+        mock_jenkins.start_ocp4_konflux.assert_not_called()
+        mock_jenkins.start_sync_ci_images.assert_not_called()
 
+    @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_reconcile_raises_when_rebuild_fails(self, mock_konflux_db):
+    async def test_reconcile_raises_when_rebuild_fails(self, mock_konflux_db, mock_jenkins):
         pipeline = self._make_pipeline()
         pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
         pipeline._scan_stale_ci_images = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
-        pipeline._rebase_and_build_ci_images = AsyncMock(side_effect=RuntimeError("Failed to rebuild 1/1"))
+        mock_jenkins.start_ocp4_konflux.return_value = "FAILURE"
 
-        with self.assertRaisesRegex(RuntimeError, "Failed to rebuild"):
+        with self.assertRaisesRegex(RuntimeError, "CI image build .* failed with result: FAILURE"):
             await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
 
+        # Sync only happens after the build step completes, so a build failure means nothing
+        # gets mirrored to CI this run.
+        mock_jenkins.start_sync_ci_images.assert_not_called()
+
+    @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_reconcile_triggers_build_root_after_golang_builder_rebuild(self, mock_konflux_db):
+    async def test_reconcile_triggers_build_root_after_golang_builder_rebuild(self, mock_konflux_db, mock_jenkins):
         """
         Build-root images pull their parent via a `member` reference to the golang-builder CI
-        image, not via the golang-builder staleness scan, so once golang builder is stale its
-        build-root sibling is triggered unconditionally -- no extra staleness check for build-root.
+        image. Both are scanned together in one `_scan_stale_ci_images` call, so doozer's own
+        change propagation (a changing image marks its `member`-referencing descendants as
+        changing too) reports build-root as stale right alongside its golang-builder parent.
         """
         pipeline = self._make_pipeline()
         pipeline._get_ci_image_keys = AsyncMock(
             return_value=["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
         )
-        pipeline._scan_stale_ci_images = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
-        pipeline._rebase_and_build_ci_images = AsyncMock()
-        pipeline._sync_ci_images = AsyncMock()
+        pipeline._scan_stale_ci_images = AsyncMock(
+            return_value=["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
+        )
+        mock_jenkins.start_ocp4_konflux.return_value = "SUCCESS"
+        mock_jenkins.start_sync_ci_images.return_value = "SUCCESS"
 
         await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
 
-        # Only the golang-builder image is scanned; build-root is triggered directly, without a
-        # staleness check of its own.
-        pipeline._scan_stale_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
-        # Golang builder and build-root are rebuilt together in a single batch call, so doozer
-        # resolves the `from: member:` reference between them in-process.
-        pipeline._rebase_and_build_ci_images.assert_awaited_once_with(
+        # Both families are scanned together in a single call.
+        pipeline._scan_stale_ci_images.assert_awaited_once_with(
             ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
         )
+        # Golang builder and build-root are rebuilt together in a single batch call, so doozer
+        # resolves the `from: member:` reference between them in-process.
+        mock_jenkins.start_ocp4_konflux.assert_called_once_with(
+            build_version=pipeline.ocp_version,
+            assembly=pipeline.assembly,
+            image_list=["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"],
+            dry_run=pipeline.dry_run,
+            block_until_complete=True,
+        )
         # Both families are synced together in a single call, after the rebuild batch completes.
-        pipeline._sync_ci_images.assert_awaited_once_with(
-            ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
+        mock_jenkins.start_sync_ci_images.assert_called_once_with(
+            version=pipeline.ocp_version,
+            block_until_complete=True,
+            assembly=pipeline.assembly,
+            image_list=["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"],
+            dry_run=pipeline.dry_run,
+            load_disabled=True,
+            live_test_mode=False,
         )
         slack_messages = [call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list]
         self.assertTrue(any("Rebuilding CI golang builder/build-root image" in m for m in slack_messages))
         self.assertTrue(any("Synced CI image" in m for m in slack_messages))
 
+    @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_reconcile_skips_build_root_when_golang_builder_already_fresh(self, mock_konflux_db):
+    async def test_reconcile_skips_build_root_when_golang_builder_already_fresh(self, mock_konflux_db, mock_jenkins):
         """If golang builder wasn't rebuilt, its build-root sibling is left untouched."""
         pipeline = self._make_pipeline()
         pipeline._get_ci_image_keys = AsyncMock(
             return_value=["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
         )
         pipeline._scan_stale_ci_images = AsyncMock(return_value=[])
-        pipeline._rebase_and_build_ci_images = AsyncMock()
+        mock_jenkins.start_sync_ci_images.return_value = "SUCCESS"
 
         await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
 
-        pipeline._rebase_and_build_ci_images.assert_not_awaited()
-        pipeline._slack_client.say_in_thread.assert_not_awaited()
+        mock_jenkins.start_ocp4_konflux.assert_not_called()
+        slack_messages = [call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list]
+        self.assertFalse(any("Rebuilding CI golang builder/build-root image" in m for m in slack_messages))
 
+    @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_reconcile_skips_build_root_when_none_defined_for_variant(self, mock_konflux_db):
+    async def test_reconcile_skips_build_root_when_none_defined_for_variant(self, mock_konflux_db, mock_jenkins):
         """Golang builder rebuilds fine even when no matching build-root image is defined."""
         pipeline = self._make_pipeline()
         pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
         pipeline._scan_stale_ci_images = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
-        pipeline._rebase_and_build_ci_images = AsyncMock()
-        pipeline._sync_ci_images = AsyncMock()
+        mock_jenkins.start_ocp4_konflux.return_value = "SUCCESS"
+        mock_jenkins.start_sync_ci_images.return_value = "SUCCESS"
 
         await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
 
-        pipeline._rebase_and_build_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
-        pipeline._sync_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+        mock_jenkins.start_ocp4_konflux.assert_called_once_with(
+            build_version=pipeline.ocp_version,
+            assembly=pipeline.assembly,
+            image_list=["ci-openshift-golang-builder-latest.rhel9"],
+            dry_run=pipeline.dry_run,
+            block_until_complete=True,
+        )
+        mock_jenkins.start_sync_ci_images.assert_called_once_with(
+            version=pipeline.ocp_version,
+            block_until_complete=True,
+            assembly=pipeline.assembly,
+            image_list=["ci-openshift-golang-builder-latest.rhel9"],
+            dry_run=pipeline.dry_run,
+            load_disabled=True,
+            live_test_mode=False,
+        )
 
+    @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_reconcile_raises_when_build_root_rebuild_fails(self, mock_konflux_db):
+    async def test_reconcile_raises_when_build_root_rebuild_fails(self, mock_konflux_db, mock_jenkins):
         pipeline = self._make_pipeline()
         pipeline._get_ci_image_keys = AsyncMock(
             return_value=["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
         )
         pipeline._scan_stale_ci_images = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
-        pipeline._rebase_and_build_ci_images = AsyncMock(side_effect=RuntimeError("Failed to rebuild 1/1"))
-        pipeline._sync_ci_images = AsyncMock()
+        mock_jenkins.start_ocp4_konflux.return_value = "FAILURE"
 
-        with self.assertRaisesRegex(RuntimeError, "Failed to rebuild"):
+        with self.assertRaisesRegex(RuntimeError, "CI image build .* failed with result: FAILURE"):
             await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
 
         # Sync only happens after the rebuild batch completes, so a build-root failure means
         # nothing gets mirrored to CI this run -- even though the batch call is single-shot.
-        pipeline._sync_ci_images.assert_not_awaited()
+        mock_jenkins.start_sync_ci_images.assert_not_called()
 
+    @patch("pyartcd.pipelines.update_golang.jenkins")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_reconcile_syncs_for_test_assembly(self, mock_konflux_db):
+    async def test_reconcile_syncs_for_test_assembly(self, mock_konflux_db, mock_jenkins):
         """
-        Test-assembly builds get rebuilt and synced too -- _sync_ci_images itself is responsible
-        for redirecting the publish to the .test-suffixed CI tag via --live-test-mode, so
-        _refresh_ci_images doesn't need to skip the call for the test assembly.
+        Test-assembly builds get rebuilt and synced too -- start_sync_ci_images itself is
+        responsible for redirecting the publish to the .test-suffixed CI tag via
+        `live_test_mode`, so _refresh_ci_images doesn't need to skip the call for the test
+        assembly.
         """
         pipeline = self._make_pipeline(assembly="test")
         pipeline._get_ci_image_keys = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
         pipeline._scan_stale_ci_images = AsyncMock(return_value=["ci-openshift-golang-builder-latest.rhel9"])
-        pipeline._rebase_and_build_ci_images = AsyncMock()
-        pipeline._sync_ci_images = AsyncMock()
+        mock_jenkins.start_ocp4_konflux.return_value = "SUCCESS"
+        mock_jenkins.start_sync_ci_images.return_value = "SUCCESS"
 
         await pipeline._refresh_ci_images(*self.RECONCILE_ARGS)
 
-        pipeline._rebase_and_build_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
-        pipeline._sync_ci_images.assert_awaited_once_with(["ci-openshift-golang-builder-latest.rhel9"])
+        mock_jenkins.start_ocp4_konflux.assert_called_once_with(
+            build_version=pipeline.ocp_version,
+            assembly=pipeline.assembly,
+            image_list=["ci-openshift-golang-builder-latest.rhel9"],
+            dry_run=pipeline.dry_run,
+            block_until_complete=True,
+        )
+        mock_jenkins.start_sync_ci_images.assert_called_once_with(
+            version=pipeline.ocp_version,
+            block_until_complete=True,
+            assembly=pipeline.assembly,
+            image_list=["ci-openshift-golang-builder-latest.rhel9"],
+            dry_run=pipeline.dry_run,
+            load_disabled=True,
+            live_test_mode=True,
+        )
         self.assertTrue(
             any("Synced CI image" in call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list)
         )
@@ -2870,51 +2853,6 @@ class TestScanStaleCiImages(IsolatedAsyncioTestCase):
 
         with self.assertRaisesRegex(RuntimeError, "doozer scan-sources failed"):
             await pipeline._scan_stale_ci_images(["ci-openshift-golang-builder-latest.rhel9"])
-
-
-class TestRebaseAndBuildCiImages(IsolatedAsyncioTestCase):
-    """Test the low-level rebase+build batch helper used by CI image reconciliation"""
-
-    def _make_pipeline(self):
-        mock_runtime = Mock(dry_run=False, working_dir=Path("/tmp/working"))
-        mock_runtime.new_slack_client.return_value = Mock()
-        return UpdateGolangPipeline(
-            runtime=mock_runtime,
-            ocp_version="4.18",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.22.9-1.el9"],
-            art_jira="ART-1234",
-            tag_builds=True,
-        )
-
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_rebases_then_builds_the_batch_together(self, mock_konflux_db):
-        """
-        All given image keys are rebased in one doozer call, then built in one doozer call --
-        not per-image -- so a `from: member:` reference between them (e.g.
-        ci-openshift-build-root-* -> ci-openshift-golang-builder-*) resolves in-process.
-        """
-        pipeline = self._make_pipeline()
-        pipeline._rebase_ci_images = AsyncMock()
-        pipeline._build_ci_images = AsyncMock()
-
-        image_keys = ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
-        await pipeline._rebase_and_build_ci_images(image_keys)
-
-        self.assertEqual(pipeline._rebase_ci_images.await_args.args[0], image_keys)
-        pipeline._build_ci_images.assert_awaited_once_with(image_keys)
-
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_raises_when_build_fails(self, mock_konflux_db):
-        pipeline = self._make_pipeline()
-        pipeline._rebase_ci_images = AsyncMock()
-        pipeline._build_ci_images = AsyncMock(side_effect=ChildProcessError("build failed"))
-
-        with self.assertRaises(ChildProcessError):
-            await pipeline._rebase_and_build_ci_images(
-                ["ci-openshift-golang-builder-latest.rhel9", "ci-openshift-build-root-latest.rhel9"]
-            )
 
 
 class TestMonobranchDispatch(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- Add a standing reconciliation check in `update-golang` (`_reconcile_ci_golang_builder_images`) that detects when a `ci-openshift-golang-builder-*` CI image is stale relative to its golang parent's latest Konflux build, and rebuilds it directly (bypassing streams.yml/PRs) via `beta:images:konflux:rebase`/`build`.
- After a successful rebuild, immediately mirror the new image to CI (`_sync_ci_golang_builder_images`, using the same `images:streams mirror` mechanism and credential env vars as the scheduled sync-ci-images job) instead of waiting for that job's next run to pick it up.
- Add an ocp-build-data-validator check requiring `GO_LATEST`/`GO_EXTRA`/`GO_PREVIOUS` group.yml vars to resolve to distinct major.minor versions, so the reconciliation logic can assume at most one matching variant per golang build instead of checking every variant that could share a version.

## Test plan
- [x] `uv run pytest pyartcd/tests/pipelines/test_update_golang.py` (116 passed)
- [x] `uv run pytest ocp-build-data-validator/tests/test_schema/test_group_schema.py` (13 passed)
- [x] `make lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for Go version variables, including format checks and duplicate major/minor version detection.
  * Added automatic reconciliation of stale CI Go builder and build-root images.
  * Test assemblies now synchronize rebuilt CI images using test-specific image tags.
  * Added shipment warnings and per-platform pullspec details to build-data updates.

* **Bug Fixes**
  * Prevented invalid or conflicting Go version configurations from passing validation.

* **Tests**
  * Added coverage for Go version validation, image staleness detection, rebuilding, synchronization, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->