### PR TITLE
ART-21088: OKD: update ARM imagestreams

### DIFF
--- a/pyartcd/pyartcd/pipelines/okd.py
+++ b/pyartcd/pyartcd/pipelines/okd.py
@@ -4,6 +4,7 @@ import logging
 import os
 import shutil
 import sys
+import tempfile
 import urllib.parse
 from pathlib import Path
 from typing import Optional
@@ -11,6 +12,7 @@ from typing import Optional
 import click
 import yaml
 from artcommonlib import exectools
+from artcommonlib.arch_util import go_arch_for_brew_arch, go_suffix_for_arch
 from artcommonlib.util import oc_image_info_for_arch_async
 from doozerlib.cli.images_okd import OKD_DEFAULT_IMAGE_REPO
 from doozerlib.state import STATE_PASS
@@ -584,33 +586,43 @@ class KonfluxOkdPipeline:
             return image_name_short[4:]
         return image_name_short
 
-    async def _get_arm64_pullspec(self, manifest_list_pullspec: str) -> Optional[str]:
+    async def _get_arch_pullspec(self, manifest_list_pullspec: str, go_arch: str) -> Optional[str]:
         """
-        Resolve the aarch64-specific pullspec from a multi-arch manifest list.
+        Resolve an architecture-specific pullspec from a multi-arch manifest list.
+
+        Uses an empty registry config to force anonymous pull, preventing existing
+        credentials (e.g. QUAY_AUTH_FILE for openshift-release-dev) from interfering
+        with access to public Konflux repos.
 
         Arg(s):
             manifest_list_pullspec (str): Multi-arch manifest list pullspec (digest-pinned).
+            go_arch (str): Go-style architecture name (e.g. 'arm64', 'amd64').
         Return Value(s):
-            str: aarch64-specific pullspec, or None if resolution fails.
+            str: Architecture-specific pullspec, or None if resolution fails.
         """
         try:
-            image_info = await oc_image_info_for_arch_async(manifest_list_pullspec, go_arch='arm64')
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.json') as f:
+                f.write('{}')
+                f.flush()
+                image_info = await oc_image_info_for_arch_async(
+                    manifest_list_pullspec, go_arch=go_arch, registry_config=f.name
+                )
             arch_digest = image_info.get('digest')
             if not arch_digest:
-                self.logger.warning('No arm64 digest found in manifest list %s', manifest_list_pullspec)
+                self.logger.warning('No %s digest found in manifest list %s', go_arch, manifest_list_pullspec)
                 return None
             # Construct arch-specific pullspec: keep registry/repo, replace digest
             base = manifest_list_pullspec.split('@')[0]
             return f'{base}@{arch_digest}'
         except Exception as e:
-            self.logger.warning('Failed to resolve arm64 pullspec from %s: %s', manifest_list_pullspec, e)
+            self.logger.warning('Failed to resolve %s pullspec from %s: %s', go_arch, manifest_list_pullspec, e)
             return None
 
     async def update_imagestreams(self):
         """
         Update static OKD imagestreams with successfully built images:
-          scos-{version}-art     - multi-arch manifest list pullspecs
-          scos-{version}-art-arm64 - aarch64-specific pullspecs
+          scos-{version}-art            - multi-arch manifest list pullspecs (x86_64)
+          scos-{version}-art-{suffix}   - arch-specific pullspecs for each non-x86 arch
         """
 
         if self.assembly != 'stream':
@@ -621,14 +633,35 @@ class KonfluxOkdPipeline:
             self.logger.warning('No images were successfully built; skipping imagestream updates')
             return
 
+        # Derive the arch-specific imagestream names
+        is_base_name = f'scos-{self.version}-art'
+        non_x86_arches = [arch for arch in OKD_ARCHES if arch != 'x86_64']
+        arch_imagestreams = {}
+        for arch in non_x86_arches:
+            suffix = go_suffix_for_arch(arch)
+            go_arch = go_arch_for_brew_arch(arch)
+            arch_namespace = f'{self.imagestream_namespace}{suffix}'
+            arch_is_name = f'{is_base_name}{suffix}'
+            arch_imagestreams[arch] = {
+                'go_arch': go_arch,
+                'namespace': arch_namespace,
+                'is_name': arch_is_name,
+            }
+
         if self.runtime.dry_run:
+            arch_is_names = [info['is_name'] for info in arch_imagestreams.values()]
+            all_is_names = [is_base_name] + arch_is_names
             self.logger.info(
-                '[DRY RUN] Would update imagestreams scos-%s-art and scos-%s-art-arm64 in namespace %s',
-                self.version,
-                self.version,
-                self.imagestream_namespace,
+                '[DRY RUN] Would update imagestreams %s',
+                ', '.join(
+                    f'{self.imagestream_namespace}/{n}' if n == is_base_name else f'{info["namespace"]}/{n}'
+                    for n, info in zip(
+                        [is_base_name] + arch_is_names,
+                        [{'namespace': self.imagestream_namespace}] + list(arch_imagestreams.values()),
+                    )
+                ),
             )
-            self.logger.info('[DRY RUN] Would tag %d images', len(self.built_images))
+            self.logger.info('[DRY RUN] Would tag %d images into %s', len(self.built_images), ', '.join(all_is_names))
             return
 
         # Load image metadata from ocp-build-data to get payload tag names
@@ -639,11 +672,10 @@ class KonfluxOkdPipeline:
         data_name = os.path.splitext(os.path.basename(data_url.path))[0]
         ocp_build_data_path = Path(self.runtime.doozer_working) / data_name / 'images'
 
-        is_name = f'scos-{self.version}-art'
-        is_arm64_name = f'scos-{self.version}-art-arm64'
         env = os.environ.copy()
         successful_tags = []
         failed_tags = []
+        updated_imagestreams = set()
 
         for image in self.built_images:
             # Load image metadata file
@@ -677,33 +709,40 @@ class KonfluxOkdPipeline:
                 continue
 
             # Tag multi-arch manifest list into primary imagestream
-            target = f'{self.imagestream_namespace}/{is_name}:{payload_tag}'
+            target = f'{self.imagestream_namespace}/{is_base_name}:{payload_tag}'
             try:
                 await self._tag_image_to_stream(source_pullspec=image_pullspec, target_tag=target, env=env)
                 self.logger.info('Tagged %s into %s', image_name, target)
                 successful_tags.append(image_name)
+                updated_imagestreams.add(f'{self.imagestream_namespace}/{is_base_name}')
             except Exception as e:
                 self.logger.warning('Failed to tag %s into imagestream: %s', image_name, e)
                 failed_tags.append(image_name)
                 continue
 
-            # Tag aarch64-specific pullspec into arm64 imagestream
-            arm64_pullspec = await self._get_arm64_pullspec(image_pullspec)
-            if arm64_pullspec:
-                arm64_target = f'{self.imagestream_namespace}/{is_arm64_name}:{payload_tag}'
-                try:
-                    await self._tag_image_to_stream(source_pullspec=arm64_pullspec, target_tag=arm64_target, env=env)
-                    self.logger.info('Tagged %s arm64 into %s', image_name, arm64_target)
-                except Exception as e:
-                    self.logger.warning('Failed to tag %s arm64 into imagestream: %s', image_name, e)
-            else:
-                self.logger.warning(
-                    'Skipping arm64 imagestream tag for %s: could not resolve arm64 pullspec', image_name
-                )
+            # Tag arch-specific pullspecs into per-arch imagestreams
+            for arch, info in arch_imagestreams.items():
+                arch_pullspec = await self._get_arch_pullspec(image_pullspec, info['go_arch'])
+                if arch_pullspec:
+                    arch_target = f'{info["namespace"]}/{info["is_name"]}:{payload_tag}'
+                    try:
+                        await self._tag_image_to_stream(source_pullspec=arch_pullspec, target_tag=arch_target, env=env)
+                        self.logger.info('Tagged %s %s into %s', image_name, info['go_arch'], arch_target)
+                        updated_imagestreams.add(f'{info["namespace"]}/{info["is_name"]}')
+                    except Exception as e:
+                        self.logger.warning('Failed to tag %s %s into imagestream: %s', image_name, info['go_arch'], e)
+                else:
+                    self.logger.warning(
+                        'Skipping %s imagestream tag for %s: could not resolve %s pullspec',
+                        info['go_arch'],
+                        image_name,
+                        info['go_arch'],
+                    )
 
-        # Update Jenkins description with results
-        if successful_tags:
-            success_msg = f'Updated {is_name} and {is_arm64_name} with {len(successful_tags)} images'
+        # Update Jenkins description with results — only report imagestreams actually updated
+        if successful_tags and updated_imagestreams:
+            is_list = ', '.join(sorted(updated_imagestreams))
+            success_msg = f'Updated {is_list} with {len(successful_tags)} images'
             jenkins.update_description(f'{success_msg}<br>')
             self.logger.info(success_msg)
 

--- a/pyartcd/pyartcd/pipelines/okd.py
+++ b/pyartcd/pyartcd/pipelines/okd.py
@@ -11,6 +11,7 @@ from typing import Optional
 import click
 import yaml
 from artcommonlib import exectools
+from artcommonlib.util import oc_image_info_for_arch_async
 from doozerlib.cli.images_okd import OKD_DEFAULT_IMAGE_REPO
 from doozerlib.state import STATE_PASS
 
@@ -583,10 +584,33 @@ class KonfluxOkdPipeline:
             return image_name_short[4:]
         return image_name_short
 
+    async def _get_arm64_pullspec(self, manifest_list_pullspec: str) -> Optional[str]:
+        """
+        Resolve the aarch64-specific pullspec from a multi-arch manifest list.
+
+        Arg(s):
+            manifest_list_pullspec (str): Multi-arch manifest list pullspec (digest-pinned).
+        Return Value(s):
+            str: aarch64-specific pullspec, or None if resolution fails.
+        """
+        try:
+            image_info = await oc_image_info_for_arch_async(manifest_list_pullspec, go_arch='arm64')
+            arch_digest = image_info.get('digest')
+            if not arch_digest:
+                self.logger.warning('No arm64 digest found in manifest list %s', manifest_list_pullspec)
+                return None
+            # Construct arch-specific pullspec: keep registry/repo, replace digest
+            base = manifest_list_pullspec.split('@')[0]
+            return f'{base}@{arch_digest}'
+        except Exception as e:
+            self.logger.warning('Failed to resolve arm64 pullspec from %s: %s', manifest_list_pullspec, e)
+            return None
+
     async def update_imagestreams(self):
         """
-        Update static OKD imagestream with successfully built images:
-        scos-{version}-art - accumulates all successfully built images
+        Update static OKD imagestreams with successfully built images:
+          scos-{version}-art     - multi-arch manifest list pullspecs
+          scos-{version}-art-arm64 - aarch64-specific pullspecs
         """
 
         if self.assembly != 'stream':
@@ -598,7 +622,12 @@ class KonfluxOkdPipeline:
             return
 
         if self.runtime.dry_run:
-            self.logger.info('[DRY RUN] Would update imagestreams in namespace %s', self.imagestream_namespace)
+            self.logger.info(
+                '[DRY RUN] Would update imagestreams scos-%s-art and scos-%s-art-arm64 in namespace %s',
+                self.version,
+                self.version,
+                self.imagestream_namespace,
+            )
             self.logger.info('[DRY RUN] Would tag %d images', len(self.built_images))
             return
 
@@ -611,6 +640,7 @@ class KonfluxOkdPipeline:
         ocp_build_data_path = Path(self.runtime.doozer_working) / data_name / 'images'
 
         is_name = f'scos-{self.version}-art'
+        is_arm64_name = f'scos-{self.version}-art-arm64'
         env = os.environ.copy()
         successful_tags = []
         failed_tags = []
@@ -646,20 +676,34 @@ class KonfluxOkdPipeline:
                 failed_tags.append(image_name)
                 continue
 
-            # Tag into imagestream
+            # Tag multi-arch manifest list into primary imagestream
             target = f'{self.imagestream_namespace}/{is_name}:{payload_tag}'
             try:
                 await self._tag_image_to_stream(source_pullspec=image_pullspec, target_tag=target, env=env)
                 self.logger.info('Tagged %s into %s', image_name, target)
                 successful_tags.append(image_name)
-
             except Exception as e:
                 self.logger.warning('Failed to tag %s into imagestream: %s', image_name, e)
                 failed_tags.append(image_name)
+                continue
+
+            # Tag aarch64-specific pullspec into arm64 imagestream
+            arm64_pullspec = await self._get_arm64_pullspec(image_pullspec)
+            if arm64_pullspec:
+                arm64_target = f'{self.imagestream_namespace}/{is_arm64_name}:{payload_tag}'
+                try:
+                    await self._tag_image_to_stream(source_pullspec=arm64_pullspec, target_tag=arm64_target, env=env)
+                    self.logger.info('Tagged %s arm64 into %s', image_name, arm64_target)
+                except Exception as e:
+                    self.logger.warning('Failed to tag %s arm64 into imagestream: %s', image_name, e)
+            else:
+                self.logger.warning(
+                    'Skipping arm64 imagestream tag for %s: could not resolve arm64 pullspec', image_name
+                )
 
         # Update Jenkins description with results
         if successful_tags:
-            success_msg = f'Updated {is_name} with {len(successful_tags)} images'
+            success_msg = f'Updated {is_name} and {is_arm64_name} with {len(successful_tags)} images'
             jenkins.update_description(f'{success_msg}<br>')
             self.logger.info(success_msg)
 

--- a/pyartcd/tests/pipelines/test_okd4.py
+++ b/pyartcd/tests/pipelines/test_okd4.py
@@ -1021,7 +1021,7 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
         data_path = 'https://github.com/openshift-eng/ocp-build-data'
         pipeline = self._make_pipeline(data_path)
         pipeline.built_images = [
-            {'name': 'cli', 'nvr': 'cli-1.0', 'image_pullspec': 'quay.io/okd/cli:latest', 'image_tag': 'latest'},
+            {'name': 'cli', 'nvr': 'cli-1.0', 'image_pullspec': 'quay.io/okd/cli@sha256:abc', 'image_tag': 'latest'},
         ]
 
         # Create the expected metadata directory and file
@@ -1032,6 +1032,9 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
 
         with (
             patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock),
+            patch.object(
+                pipeline, '_get_arm64_pullspec', new_callable=AsyncMock, return_value='quay.io/okd/cli@sha256:arm64'
+            ),
             patch('pyartcd.pipelines.okd.jenkins'),
         ):
             # when / then — should not raise FileNotFoundError
@@ -1044,7 +1047,7 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
         data_path = 'https://github.com/redhat-chai-bot/openshift-eng_ocp-build-data'
         pipeline = self._make_pipeline(data_path)
         pipeline.built_images = [
-            {'name': 'cli', 'nvr': 'cli-1.0', 'image_pullspec': 'quay.io/okd/cli:latest', 'image_tag': 'latest'},
+            {'name': 'cli', 'nvr': 'cli-1.0', 'image_pullspec': 'quay.io/okd/cli@sha256:abc', 'image_tag': 'latest'},
         ]
 
         # Create the expected metadata directory using the fork's repo name
@@ -1053,15 +1056,17 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
         yaml_file = images_dir / 'cli.yml'
         yaml_file.write_text(yaml.dump({'name': 'openshift/ose-cli', 'for_payload': True}))
 
+        arm64_pullspec = 'quay.io/okd/cli@sha256:arm64digest'
         with (
             patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag,
+            patch.object(pipeline, '_get_arm64_pullspec', new_callable=AsyncMock, return_value=arm64_pullspec),
             patch('pyartcd.pipelines.okd.jenkins'),
         ):
             # when — should resolve the fork directory, not hardcoded 'ocp-build-data'
             await pipeline.update_imagestreams()
 
-            # then — the image should be tagged successfully
-            mock_tag.assert_called_once()
+            # then — tagged into both multi-arch and arm64 imagestreams
+            self.assertEqual(mock_tag.call_count, 2)
 
     async def test_update_imagestreams_data_path_with_git_suffix(self):
         """update_imagestreams strips .git suffix when deriving the data directory name."""
@@ -1070,7 +1075,7 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
         data_path = 'https://github.com/openshift-eng/ocp-build-data.git'
         pipeline = self._make_pipeline(data_path)
         pipeline.built_images = [
-            {'name': 'cli', 'nvr': 'cli-1.0', 'image_pullspec': 'quay.io/okd/cli:latest', 'image_tag': 'latest'},
+            {'name': 'cli', 'nvr': 'cli-1.0', 'image_pullspec': 'quay.io/okd/cli@sha256:abc', 'image_tag': 'latest'},
         ]
 
         # .git suffix should be stripped → directory is 'ocp-build-data'
@@ -1079,13 +1084,83 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
         yaml_file = images_dir / 'cli.yml'
         yaml_file.write_text(yaml.dump({'name': 'openshift/ose-cli', 'for_payload': True}))
 
+        arm64_pullspec = 'quay.io/okd/cli@sha256:arm64digest'
         with (
             patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag,
+            patch.object(pipeline, '_get_arm64_pullspec', new_callable=AsyncMock, return_value=arm64_pullspec),
             patch('pyartcd.pipelines.okd.jenkins'),
         ):
             # when / then — should not raise
             await pipeline.update_imagestreams()
-            mock_tag.assert_called_once()
+            # tagged into both multi-arch and arm64 imagestreams
+            self.assertEqual(mock_tag.call_count, 2)
+
+    async def test_update_imagestreams_tags_arm64_imagestream(self):
+        """update_imagestreams tags aarch64-specific pullspec into scos-{version}-art-arm64."""
+
+        data_path = 'https://github.com/openshift-eng/ocp-build-data'
+        pipeline = self._make_pipeline(data_path)
+        pipeline.built_images = [
+            {
+                'name': 'cli',
+                'nvr': 'cli-1.0',
+                'image_pullspec': 'quay.io/okd/cli@sha256:multiarchabcdef',
+                'image_tag': 'latest',
+            },
+        ]
+
+        images_dir = Path(self.mock_runtime.doozer_working) / 'ocp-build-data' / 'images'
+        images_dir.mkdir(parents=True)
+        (images_dir / 'cli.yml').write_text(yaml.dump({'name': 'openshift/ose-cli', 'for_payload': True}))
+
+        arm64_pullspec = 'quay.io/okd/cli@sha256:arm64digest'
+        with (
+            patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag,
+            patch.object(pipeline, '_get_arm64_pullspec', new_callable=AsyncMock, return_value=arm64_pullspec),
+            patch('pyartcd.pipelines.okd.jenkins'),
+        ):
+            await pipeline.update_imagestreams()
+
+            # First call: multi-arch manifest into scos-4.22-art
+            first_call = mock_tag.call_args_list[0]
+            self.assertEqual(first_call[1]['source_pullspec'], 'quay.io/okd/cli@sha256:multiarchabcdef')
+            self.assertEqual(first_call[1]['target_tag'], 'origin/scos-4.22-art:cli')
+
+            # Second call: arm64-specific pullspec into scos-4.22-art-arm64
+            second_call = mock_tag.call_args_list[1]
+            self.assertEqual(second_call[1]['source_pullspec'], arm64_pullspec)
+            self.assertEqual(second_call[1]['target_tag'], 'origin/scos-4.22-art-arm64:cli')
+
+    async def test_update_imagestreams_arm64_failure_does_not_block_other_images(self):
+        """Failure to resolve arm64 pullspec logs a warning but does not fail the pipeline."""
+
+        data_path = 'https://github.com/openshift-eng/ocp-build-data'
+        pipeline = self._make_pipeline(data_path)
+        pipeline.built_images = [
+            {
+                'name': 'cli',
+                'nvr': 'cli-1.0',
+                'image_pullspec': 'quay.io/okd/cli@sha256:abc',
+                'image_tag': 'latest',
+            },
+        ]
+
+        images_dir = Path(self.mock_runtime.doozer_working) / 'ocp-build-data' / 'images'
+        images_dir.mkdir(parents=True)
+        (images_dir / 'cli.yml').write_text(yaml.dump({'name': 'openshift/ose-cli', 'for_payload': True}))
+
+        with (
+            patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag,
+            # arm64 resolution fails
+            patch.object(pipeline, '_get_arm64_pullspec', new_callable=AsyncMock, return_value=None),
+            patch('pyartcd.pipelines.okd.jenkins'),
+        ):
+            await pipeline.update_imagestreams()
+
+            # multi-arch tag still succeeds; arm64 tag is skipped
+            self.assertEqual(mock_tag.call_count, 1)
+            first_call = mock_tag.call_args_list[0]
+            self.assertEqual(first_call[1]['target_tag'], 'origin/scos-4.22-art:cli')
 
 
 class TestRebaseFailCounters(IsolatedAsyncioTestCase):

--- a/pyartcd/tests/pipelines/test_okd4.py
+++ b/pyartcd/tests/pipelines/test_okd4.py
@@ -1033,7 +1033,7 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
         with (
             patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock),
             patch.object(
-                pipeline, '_get_arm64_pullspec', new_callable=AsyncMock, return_value='quay.io/okd/cli@sha256:arm64'
+                pipeline, '_get_arch_pullspec', new_callable=AsyncMock, return_value='quay.io/okd/cli@sha256:arm64'
             ),
             patch('pyartcd.pipelines.okd.jenkins'),
         ):
@@ -1059,7 +1059,7 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
         arm64_pullspec = 'quay.io/okd/cli@sha256:arm64digest'
         with (
             patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag,
-            patch.object(pipeline, '_get_arm64_pullspec', new_callable=AsyncMock, return_value=arm64_pullspec),
+            patch.object(pipeline, '_get_arch_pullspec', new_callable=AsyncMock, return_value=arm64_pullspec),
             patch('pyartcd.pipelines.okd.jenkins'),
         ):
             # when — should resolve the fork directory, not hardcoded 'ocp-build-data'
@@ -1087,7 +1087,7 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
         arm64_pullspec = 'quay.io/okd/cli@sha256:arm64digest'
         with (
             patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag,
-            patch.object(pipeline, '_get_arm64_pullspec', new_callable=AsyncMock, return_value=arm64_pullspec),
+            patch.object(pipeline, '_get_arch_pullspec', new_callable=AsyncMock, return_value=arm64_pullspec),
             patch('pyartcd.pipelines.okd.jenkins'),
         ):
             # when / then — should not raise
@@ -1096,7 +1096,7 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
             self.assertEqual(mock_tag.call_count, 2)
 
     async def test_update_imagestreams_tags_arm64_imagestream(self):
-        """update_imagestreams tags aarch64-specific pullspec into scos-{version}-art-arm64."""
+        """update_imagestreams tags aarch64-specific pullspec into origin-arm64/scos-{version}-art-arm64."""
 
         data_path = 'https://github.com/openshift-eng/ocp-build-data'
         pipeline = self._make_pipeline(data_path)
@@ -1116,7 +1116,7 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
         arm64_pullspec = 'quay.io/okd/cli@sha256:arm64digest'
         with (
             patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag,
-            patch.object(pipeline, '_get_arm64_pullspec', new_callable=AsyncMock, return_value=arm64_pullspec),
+            patch.object(pipeline, '_get_arch_pullspec', new_callable=AsyncMock, return_value=arm64_pullspec),
             patch('pyartcd.pipelines.okd.jenkins'),
         ):
             await pipeline.update_imagestreams()
@@ -1126,10 +1126,10 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
             self.assertEqual(first_call[1]['source_pullspec'], 'quay.io/okd/cli@sha256:multiarchabcdef')
             self.assertEqual(first_call[1]['target_tag'], 'origin/scos-4.22-art:cli')
 
-            # Second call: arm64-specific pullspec into scos-4.22-art-arm64
+            # Second call: arm64-specific pullspec into origin-arm64/scos-4.22-art-arm64
             second_call = mock_tag.call_args_list[1]
             self.assertEqual(second_call[1]['source_pullspec'], arm64_pullspec)
-            self.assertEqual(second_call[1]['target_tag'], 'origin/scos-4.22-art-arm64:cli')
+            self.assertEqual(second_call[1]['target_tag'], 'origin-arm64/scos-4.22-art-arm64:cli')
 
     async def test_update_imagestreams_arm64_failure_does_not_block_other_images(self):
         """Failure to resolve arm64 pullspec logs a warning but does not fail the pipeline."""
@@ -1152,7 +1152,7 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
         with (
             patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag,
             # arm64 resolution fails
-            patch.object(pipeline, '_get_arm64_pullspec', new_callable=AsyncMock, return_value=None),
+            patch.object(pipeline, '_get_arch_pullspec', new_callable=AsyncMock, return_value=None),
             patch('pyartcd.pipelines.okd.jenkins'),
         ):
             await pipeline.update_imagestreams()
@@ -1161,6 +1161,188 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
             self.assertEqual(mock_tag.call_count, 1)
             first_call = mock_tag.call_args_list[0]
             self.assertEqual(first_call[1]['target_tag'], 'origin/scos-4.22-art:cli')
+
+
+class TestGetArchPullspec(IsolatedAsyncioTestCase):
+    """Tests for _get_arch_pullspec: registry_config fix and generic arch support."""
+
+    def setUp(self):
+        self.mock_runtime = MagicMock()
+        self.mock_runtime.dry_run = False
+        self.mock_runtime.doozer_working = '/tmp/doozer_working'
+
+        mock_slack_client = MagicMock()
+        mock_slack_client.say = AsyncMock()
+        mock_slack_client.bind_channel = MagicMock()
+        self.mock_runtime.new_slack_client = MagicMock(return_value=mock_slack_client)
+
+        self.pipeline = KonfluxOkdPipeline(
+            runtime=self.mock_runtime,
+            image_build_strategy='all',
+            image_list=None,
+            assembly='stream',
+            data_path='https://github.com/openshift-eng/ocp-build-data',
+            data_gitref='',
+            version='4.22',
+            ignore_locks=False,
+            plr_template='',
+            lock_identifier='test-lock',
+            build_priority='10',
+            imagestream_namespace='origin',
+        )
+
+    @patch('pyartcd.pipelines.okd.oc_image_info_for_arch_async', new_callable=AsyncMock)
+    async def test_get_arch_pullspec_passes_registry_config(self, mock_oc_info):
+        """_get_arch_pullspec passes registry_config pointing to a temp file with empty JSON."""
+        mock_oc_info.return_value = {'digest': 'sha256:arm64digest'}
+
+        result = await self.pipeline._get_arch_pullspec('quay.io/okd/cli@sha256:manifest', 'arm64')
+
+        self.assertEqual(result, 'quay.io/okd/cli@sha256:arm64digest')
+        mock_oc_info.assert_called_once()
+        call_kwargs = mock_oc_info.call_args[1]
+        self.assertIn('registry_config', call_kwargs)
+        # The temp file may be cleaned up, but registry_config was passed (non-None)
+        self.assertIsNotNone(call_kwargs['registry_config'])
+
+    @patch('pyartcd.pipelines.okd.oc_image_info_for_arch_async', new_callable=AsyncMock)
+    async def test_get_arch_pullspec_passes_go_arch(self, mock_oc_info):
+        """_get_arch_pullspec forwards the go_arch parameter correctly."""
+        mock_oc_info.return_value = {'digest': 'sha256:s390xdigest'}
+
+        result = await self.pipeline._get_arch_pullspec('quay.io/okd/cli@sha256:manifest', 's390x')
+
+        self.assertEqual(result, 'quay.io/okd/cli@sha256:s390xdigest')
+        call_kwargs = mock_oc_info.call_args
+        self.assertEqual(call_kwargs[0][0], 'quay.io/okd/cli@sha256:manifest')
+        self.assertEqual(call_kwargs[1]['go_arch'], 's390x')
+
+    @patch('pyartcd.pipelines.okd.oc_image_info_for_arch_async', new_callable=AsyncMock)
+    async def test_get_arch_pullspec_returns_none_on_no_digest(self, mock_oc_info):
+        """_get_arch_pullspec returns None when no digest is found."""
+        mock_oc_info.return_value = {}
+
+        result = await self.pipeline._get_arch_pullspec('quay.io/okd/cli@sha256:manifest', 'arm64')
+
+        self.assertIsNone(result)
+
+    @patch('pyartcd.pipelines.okd.oc_image_info_for_arch_async', new_callable=AsyncMock)
+    async def test_get_arch_pullspec_returns_none_on_exception(self, mock_oc_info):
+        """_get_arch_pullspec returns None and logs warning on failure."""
+        mock_oc_info.side_effect = Exception('oc failed')
+
+        result = await self.pipeline._get_arch_pullspec('quay.io/okd/cli@sha256:manifest', 'arm64')
+
+        self.assertIsNone(result)
+
+
+class TestArchSuffixedNamespace(IsolatedAsyncioTestCase):
+    """Tests for arch-suffixed namespace derivation in update_imagestreams."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.mock_runtime = MagicMock()
+        self.mock_runtime.dry_run = False
+        self.mock_runtime.doozer_working = str(Path(self.tmpdir) / 'doozer_working')
+        Path(self.mock_runtime.doozer_working).mkdir(parents=True)
+
+        mock_slack_client = MagicMock()
+        mock_slack_client.say = AsyncMock()
+        mock_slack_client.bind_channel = MagicMock()
+        self.mock_runtime.new_slack_client = MagicMock(return_value=mock_slack_client)
+
+    async def test_arm64_imagestream_uses_arch_suffixed_namespace(self):
+        """Verify that arm64 imagestream uses origin-arm64 namespace (not origin)."""
+
+        pipeline = KonfluxOkdPipeline(
+            runtime=self.mock_runtime,
+            image_build_strategy='all',
+            image_list=None,
+            assembly='stream',
+            data_path='https://github.com/openshift-eng/ocp-build-data',
+            data_gitref='',
+            version='5.0',
+            ignore_locks=False,
+            plr_template='',
+            lock_identifier='test-lock',
+            build_priority='10',
+            imagestream_namespace='origin',
+        )
+        pipeline.built_images = [
+            {
+                'name': 'cli',
+                'nvr': 'cli-1.0',
+                'image_pullspec': 'quay.io/okd/cli@sha256:multiarch',
+                'image_tag': 'latest',
+            },
+        ]
+
+        images_dir = Path(self.mock_runtime.doozer_working) / 'ocp-build-data' / 'images'
+        images_dir.mkdir(parents=True)
+        (images_dir / 'cli.yml').write_text(yaml.dump({'name': 'openshift/ose-cli', 'for_payload': True}))
+
+        arm64_pullspec = 'quay.io/okd/cli@sha256:arm64digest'
+        with (
+            patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag,
+            patch.object(pipeline, '_get_arch_pullspec', new_callable=AsyncMock, return_value=arm64_pullspec),
+            patch('pyartcd.pipelines.okd.jenkins'),
+        ):
+            await pipeline.update_imagestreams()
+
+            # multi-arch into origin/scos-5.0-art
+            first_call = mock_tag.call_args_list[0]
+            self.assertEqual(first_call[1]['target_tag'], 'origin/scos-5.0-art:cli')
+
+            # arm64 into origin-arm64/scos-5.0-art-arm64 (arch-suffixed namespace!)
+            second_call = mock_tag.call_args_list[1]
+            self.assertEqual(second_call[1]['target_tag'], 'origin-arm64/scos-5.0-art-arm64:cli')
+
+    async def test_log_message_only_reports_updated_imagestreams(self):
+        """Verify the log message only mentions imagestreams that were actually updated."""
+
+        pipeline = KonfluxOkdPipeline(
+            runtime=self.mock_runtime,
+            image_build_strategy='all',
+            image_list=None,
+            assembly='stream',
+            data_path='https://github.com/openshift-eng/ocp-build-data',
+            data_gitref='',
+            version='4.22',
+            ignore_locks=False,
+            plr_template='',
+            lock_identifier='test-lock',
+            build_priority='10',
+            imagestream_namespace='origin',
+        )
+        pipeline.built_images = [
+            {
+                'name': 'cli',
+                'nvr': 'cli-1.0',
+                'image_pullspec': 'quay.io/okd/cli@sha256:multiarch',
+                'image_tag': 'latest',
+            },
+        ]
+
+        images_dir = Path(self.mock_runtime.doozer_working) / 'ocp-build-data' / 'images'
+        images_dir.mkdir(parents=True)
+        (images_dir / 'cli.yml').write_text(yaml.dump({'name': 'openshift/ose-cli', 'for_payload': True}))
+
+        # arm64 resolution fails — only primary imagestream should be mentioned
+        with (
+            patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock),
+            patch.object(pipeline, '_get_arch_pullspec', new_callable=AsyncMock, return_value=None),
+            patch('pyartcd.pipelines.okd.jenkins') as mock_jenkins,
+        ):
+            await pipeline.update_imagestreams()
+
+            # Jenkins description should only mention the primary imagestream
+            desc_calls = mock_jenkins.update_description.call_args_list
+            success_calls = [c for c in desc_calls if 'Updated' in str(c)]
+            self.assertEqual(len(success_calls), 1)
+            success_msg = success_calls[0][0][0]
+            self.assertIn('origin/scos-4.22-art', success_msg)
+            # Should NOT mention the arm64 imagestream since it wasn't updated
+            self.assertNotIn('arm64', success_msg)
 
 
 class TestRebaseFailCounters(IsolatedAsyncioTestCase):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OKD image updates now support separate multi-architecture and ARM64 image streams.
  - When available, ARM64 image tags are added to the corresponding architecture-specific stream.

- **Bug Fixes**
  - ARM64 image resolution or tagging issues now generate warnings without blocking primary multi-architecture image updates or pipeline completion.
  - Completion messages report only the image streams that were successfully updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->