### PR TITLE
pyartcd: include target OCP version in FBC shipment file names for LPs

### DIFF
--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -39,6 +39,7 @@ from tenacity import retry, stop_after_attempt
 from pyartcd import constants
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.fbc_util import extract_fbc_labels as _extract_fbc_labels
+from pyartcd.fbc_util import extract_ocp_version_from_nvr
 from pyartcd.fbc_util import validate_fbc_related_images as _validate_fbc_related_images
 from pyartcd.git import GitRepository
 from pyartcd.runtime import Runtime
@@ -119,6 +120,9 @@ class ReleaseFromFbcPipeline:
 
         # FBC operator doozer keys - populated during validate_fbc_related_images()
         self._fbc_operator_keys: list[str] = []
+
+        # OCP version per advisory kind (e.g. 'fbc01' -> '4.19') for LP FBC shipment file naming
+        self._fbc_ocp_versions: Dict[str, str] = {}
 
         # Set default shipment_path if not provided, using same logic as elliott
         self.shipment_path_was_defaulted = not shipment_path
@@ -968,7 +972,11 @@ class ReleaseFromFbcPipeline:
         if advisory_kind.startswith('fbc'):
             # Extract counter from advisory_kind (e.g., 'fbc01' -> '01')
             counter = advisory_kind[3:]  # Remove 'fbc' prefix
-            filename = f"{self.assembly}.fbc.{timestamp}{counter}.yaml"
+            ocp_ver = self._fbc_ocp_versions.get(advisory_kind)
+            if ocp_ver:
+                filename = f"{self.assembly}.fbc.ocp{ocp_ver}.{timestamp}{counter}.yaml"
+            else:
+                filename = f"{self.assembly}.fbc.{timestamp}{counter}.yaml"
         else:
             filename = f"{self.assembly}.{advisory_kind}.{timestamp}.yaml"
 
@@ -1160,10 +1168,13 @@ class ReleaseFromFbcPipeline:
 
         # Create separate FBC shipment for each FBC build
         fbc_counter = 1
-        for _, fbc_snapshot in fbc_snapshots.items():
+        for fbc_nvr, fbc_snapshot in fbc_snapshots.items():
             if fbc_snapshot:
                 shipment_config = self.create_shipment_config('fbc', fbc_snapshot)
                 shipment_kind = f"fbc{fbc_counter:02d}"
+                ocp_ver = extract_ocp_version_from_nvr(fbc_nvr)
+                if ocp_ver:
+                    self._fbc_ocp_versions[shipment_kind] = ocp_ver
                 shipments_by_kind[shipment_kind] = shipment_config
                 fbc_counter += 1
 

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -1841,5 +1841,60 @@ class TestCreateShipmentMrImageConfigApprovers(unittest.TestCase):
         )
 
 
+class TestWriteShipmentFileOcpVersion(unittest.IsolatedAsyncioTestCase):
+    """Tests for OCP version inclusion in FBC shipment file names."""
+
+    def _make_pipeline(self):
+        runtime = MagicMock()
+        runtime.dry_run = False
+        runtime.working_dir = MagicMock()
+        runtime.working_dir.absolute.return_value = MagicMock()
+        runtime.config = {}
+
+        pipeline = ReleaseFromFbcPipeline(
+            runtime=runtime,
+            group="logging-6.5",
+            assembly="6.5.2",
+            fbc_pullspecs=["quay.io/test/fbc:latest"],
+            create_mr=False,
+        )
+        pipeline.product = "logging"
+        return pipeline
+
+    def _make_shipment_config(self):
+        config = MagicMock()
+        config.shipment.metadata.product = "logging"
+        config.shipment.metadata.group = "logging-6-5"
+        config.shipment.metadata.application = "logging-6-5"
+        config.model_dump.return_value = {}
+        return config
+
+    async def test_fbc_filename_includes_ocp_version_for_lp(self):
+        """FBC shipment filename includes ocp version when _fbc_ocp_versions is populated."""
+        pipeline = self._make_pipeline()
+        pipeline._fbc_ocp_versions = {"fbc01": "4.19"}
+        pipeline.shipment_data_repo = AsyncMock()
+        pipeline.shipment_data_repo._directory = MagicMock()
+        pipeline.shipment_data_repo._directory.__truediv__ = MagicMock(return_value=MagicMock())
+
+        result = await pipeline._write_shipment_file("fbc01", self._make_shipment_config(), "prod", "202608170101")
+
+        self.assertIn("ocp4.19", result)
+        self.assertIn("6.5.2.fbc.ocp4.19.202608170101", result)
+
+    async def test_fbc_filename_fallback_without_ocp_version(self):
+        """FBC shipment filename falls back to counter-only when no OCP version is available (OCP FBCs)."""
+        pipeline = self._make_pipeline()
+        pipeline._fbc_ocp_versions = {}
+        pipeline.shipment_data_repo = AsyncMock()
+        pipeline.shipment_data_repo._directory = MagicMock()
+        pipeline.shipment_data_repo._directory.__truediv__ = MagicMock(return_value=MagicMock())
+
+        result = await pipeline._write_shipment_file("fbc01", self._make_shipment_config(), "prod", "202608170101")
+
+        self.assertNotIn("ocp", result)
+        self.assertIn("6.5.2.fbc.202608170101", result)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- For layered product FBC shipments, the target OCP version is now embedded in the shipment filename (e.g. `6.5.2.fbc.ocp4.19.2026081716164501.yaml`) instead of the previous opaque format (`6.5.2.fbc.2026081716164501.yaml`)
- The OCP version is extracted from the FBC NVR using the existing `extract_ocp_version_from_nvr()` utility in `fbc_util.py`
- OCP-native FBCs (whose NVRs don't carry a `.ocp` suffix) fall back unchanged to the previous naming convention

## Test plan

- [ ] New unit tests in `TestWriteShipmentFileOcpVersion` cover both the LP case (OCP version in filename) and the fallback (no OCP version for OCP-native FBCs)
- [ ] `uv run pytest pyartcd/tests/pipelines/test_release_from_fbc.py` -- all 111 tests pass
- [ ] `uv run ruff check pyartcd/pyartcd/pipelines/release_from_fbc.py pyartcd/tests/pipelines/test_release_from_fbc.py` -- clean

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FBC shipment filenames now include the associated OCP version when available.
  * Existing filename formatting is preserved when no OCP version can be determined.
* **Bug Fixes**
  * Improved association of OCP versions with individual FBC advisory kinds during shipment creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->