### PR TITLE
ART-19530: trigger RHCOS integration test trigger in ocp4-konflux

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -77,6 +77,7 @@ REGISTRY_REDHAT_IO = "registry.redhat.io"
 REGISTRY_BREW = "brew.registry.redhat.io"
 KONFLUX_DEFAULT_IMAGE_REPO = "quay.io/redhat-user-workloads/ocp-art-tenant/art-images"
 KONFLUX_DEFAULT_IMAGE_SHARE_REPO = "quay.io/redhat-user-workloads/ocp-art-tenant/art-images-share"
+RHCOS_IMAGE_REPO = "quay.io/redhat-user-workloads/ocp-art-tenant/art-rhcos-images"
 KONFLUX_DEFAULT_FBC_REPO = "quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc"
 
 KONFLUX_DEFAULT_BUILD_PRIORITY = 5

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -778,10 +778,46 @@ async def get_konflux_data(pullspec: str, mode: str = "attestation", registry_au
 
     cmd = f"cosign download {mode} {pullspec}"
     env = os.environ.copy()
-    if registry_auth_file:
-        LOGGER.debug("Using registry auth file: %s", registry_auth_file)
+    if not registry_auth_file:
+        _, out, _ = await cmd_gather_async(cmd, env=env)
+        return out.strip()
+
+    # cosign's go-containerregistry keychain resolves credentials by hostname,
+    # while Docker auth files commonly contain path-scoped entries. Select the
+    # most-specific entry for this pullspec and expose it under the hostname.
+    # This is important when different repositories on quay.io use credentials
+    # supplied through separate Jenkins bindings (for example RHCOS images).
+    LOGGER.debug("Using registry auth file: %s", registry_auth_file)
+    with open(registry_auth_file, encoding="utf-8") as auth_file:
+        auth_data = json.load(auth_file)
+
+    auths = auth_data.get("auths", {})
+    image_ref = pullspec.split("@", 1)[0].split("//", 1)[-1]
+    last_slash = image_ref.rfind("/")
+    last_colon = image_ref.rfind(":")
+    if last_colon > last_slash:
+        image_ref = image_ref[:last_colon]
+    host, separator, _ = image_ref.partition("/")
+    matching_auth = None
+    matching_key = ""
+    for key, value in auths.items():
+        normalized_key = key.split("//", 1)[-1].rstrip("/")
+        is_image_repository = image_ref == normalized_key or image_ref.startswith(f"{normalized_key}/")
+        if normalized_key == host or (separator and is_image_repository):
+            if len(normalized_key) > len(matching_key):
+                matching_key = normalized_key
+                matching_auth = value
+
+    if matching_auth is not None:
+        auth_data.setdefault("auths", {})[host] = matching_auth
+
+    with tempfile.TemporaryDirectory(prefix="cosign-docker-config-") as docker_config_dir:
+        docker_config_file = os.path.join(docker_config_dir, "config.json")
+        with open(docker_config_file, "w", encoding="utf-8") as config_file:
+            json.dump(auth_data, config_file)
+        env["DOCKER_CONFIG"] = docker_config_dir
         env["REGISTRY_AUTH_FILE"] = registry_auth_file
-    _, out, _ = await cmd_gather_async(cmd, env=env)
+        _, out, _ = await cmd_gather_async(cmd, env=env)
 
     return out.strip()
 

--- a/artcommon/tests/test_konflux_data.py
+++ b/artcommon/tests/test_konflux_data.py
@@ -1,0 +1,45 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from artcommonlib import util
+
+
+class TestKonfluxData(unittest.IsolatedAsyncioTestCase):
+    @patch("artcommonlib.util.cmd_gather_async", new_callable=AsyncMock)
+    async def test_get_konflux_data_uses_most_specific_registry_auth(self, mock_cmd):
+        observed_auth = {}
+
+        async def run_cosign(_cmd, env):
+            config_path = Path(env["DOCKER_CONFIG"]) / "config.json"
+            with config_path.open(encoding="utf-8") as config_file:
+                observed_auth.update(json.load(config_file)["auths"])
+            return 0, "attestation", ""
+
+        mock_cmd.side_effect = run_cosign
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as auth_file:
+            json.dump(
+                {
+                    "auths": {
+                        "quay.io/openshift": {"auth": "wrong"},
+                        "quay.io/redhat-user-workloads/ocp-art-tenant/art-rhcos-images": {"auth": "rhcos"},
+                    }
+                },
+                auth_file,
+            )
+            auth_file.flush()
+
+            result = await util.get_konflux_data(
+                "quay.io/redhat-user-workloads/ocp-art-tenant/art-rhcos-images@sha256:digest",
+                registry_auth_file=auth_file.name,
+            )
+
+        self.assertEqual(result, "attestation")
+        self.assertEqual(observed_auth["quay.io"]["auth"], "rhcos")
+        self.assertEqual(mock_cmd.call_args.kwargs["env"]["REGISTRY_AUTH_FILE"], auth_file.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -576,11 +576,12 @@ class KonfluxImageBuilder:
         :param distgit_key: The distgit key for logging purposes
         :raises: Exception if validation fails
         """
-        # Get SLA attestation from konflux. The command will error out if it cannot find it.
+        # RHCOS images use a separate Quay credential from the other Konflux images.
+        # Pass that source file directly so cosign can authenticate to the RHCOS repo.
         attestation = await fetch_slsa_attestation(
             image_pullspec=image_pullspec,
             build_name=distgit_key,
-            registry_auth_file=self._config.registry_auth_file,
+            registry_auth_file=self._registry_auth_file_for_image(image_pullspec),
         )
         if not attestation:
             raise ValueError("SLSA attestation cannot be empty")
@@ -609,6 +610,15 @@ class KonfluxImageBuilder:
         except ChildProcessError:
             LOGGER.error(f'Failed to fetch signature for {source_image_pullspec}')
             raise
+
+    def _registry_auth_file_for_image(self, image_pullspec: str) -> Optional[str]:
+        """Return the registry auth file appropriate for an image pullspec."""
+        rhcos_repo = artlib_constants.RHCOS_IMAGE_REPO
+        if image_pullspec.startswith((f"{rhcos_repo}@", f"{rhcos_repo}:")):
+            rhcos_auth_file = os.getenv("RHCOS_QUAY_AUTH_FILE")
+            if rhcos_auth_file and Path(rhcos_auth_file).is_file():
+                return rhcos_auth_file
+        return self._config.registry_auth_file
 
     async def _wait_for_parent_members(self, metadata: ImageMetadata):
         # If this image is FROM another group member, we need to wait on that group member to be built

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -71,6 +71,24 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
         metadata.is_golang_builder = MagicMock(return_value=False)
         return metadata
 
+    @patch.dict("os.environ", {"RHCOS_QUAY_AUTH_FILE": "/tmp/rhcos-auth.json"}, clear=False)
+    def test_registry_auth_file_for_image_uses_rhcos_credentials_only_for_rhcos_repo(self):
+        self.builder._config.registry_auth_file = "/tmp/merged-auth.json"
+
+        with patch("pathlib.Path.is_file", return_value=True):
+            self.assertEqual(
+                self.builder._registry_auth_file_for_image(
+                    "quay.io/redhat-user-workloads/ocp-art-tenant/art-rhcos-images@sha256:digest"
+                ),
+                "/tmp/rhcos-auth.json",
+            )
+        self.assertEqual(
+            self.builder._registry_auth_file_for_image(
+                "quay.io/redhat-user-workloads/ocp-art-tenant/art-images@sha256:digest"
+            ),
+            "/tmp/merged-auth.json",
+        )
+
     async def test_get_successful_image_build_by_nvr_is_not_assembly_scoped(self):
         metadata = self._metadata()
         existing_build = MagicMock(spec=KonfluxBuildRecord)

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -140,6 +140,10 @@ class KonfluxOcpPipeline:
         self.use_mass_rebuild_locks = use_mass_rebuild_locks
         self.network_mode = network_mode
 
+        # RHCOS Jenkins client, authenticated early in run() so its token is cached
+        # before the withCredentials kubeconfig temp file can be reaped mid-build.
+        self.rhcos_jenkins_client = None
+
         # If build plan includes more than half or excludes less than half or rebuilds everything, it's a mass rebuild
         self.mass_rebuild = False
 
@@ -885,6 +889,40 @@ class KonfluxOcpPipeline:
     RHCOS_RHEL9_PAIR = {'node': 'rhcos-node-image', 'extensions': 'rhcos-node-extensions'}
     RHCOS_RHEL10_PAIR = {'node': 'rhcos-node-image-rhel10', 'extensions': 'rhcos-node-extensions-rhel10'}
 
+    def _init_rhcos_jenkins_client(self):
+        """Authenticate the RHCOS Jenkins client early and cache its bearer token.
+
+        The RHCOS Jenkins kubeconfig is provided via a Jenkins withCredentials
+        file binding ($RHCOS_JENKINS_KUBECONFIG). That temp file can be reaped by
+        idle-file cleanup during a long build, so by the time integration tests
+        are triggered (~50+ minutes after the withCredentials block opened) the
+        file may no longer exist even though the env var is still set.
+
+        To avoid depending on that temp file surviving the whole build, we build
+        the client and resolve its auth token up front, while the kubeconfig file
+        is still fresh. The client caches the token in memory, so triggering the
+        tests later never needs to read the kubeconfig again.
+
+        Best-effort: on failure the client is left as None and integration tests
+        are skipped, since these are non-fatal shadow tests for now.
+        """
+        if self.skip_rhcos_integration_tests:
+            return
+
+        from pyartcd.rhcos_jenkins_client import RhcosJenkinsClient
+
+        try:
+            client = RhcosJenkinsClient(kubeconfig_env_var='RHCOS_JENKINS_KUBECONFIG')
+            # Resolve and cache the token now, while the kubeconfig file still exists
+            client.retrieve_auth_token()
+            self.rhcos_jenkins_client = client
+            LOGGER.info("RHCOS Jenkins client authenticated; token cached for later integration tests")
+        except Exception as e:
+            LOGGER.warning(
+                "Failed to authenticate RHCOS Jenkins client at startup; integration tests will be skipped: %s", e
+            )
+            self.rhcos_jenkins_client = None
+
     async def trigger_rhcos_integration_tests(self):
         """Trigger RHCOS-owned Jenkins integration tests for rebuilt node/extensions images.
 
@@ -898,6 +936,10 @@ class KonfluxOcpPipeline:
         """
         if self.skip_rhcos_integration_tests:
             LOGGER.warning("Skipping RHCOS integration tests because --skip-rhcos-integration-tests flag is set")
+            return
+
+        if not self.rhcos_jenkins_client:
+            LOGGER.warning("RHCOS Jenkins client is not available (auth failed at startup), skipping integration tests")
             return
 
         record_log = self.parse_record_log()
@@ -1057,9 +1099,7 @@ class KonfluxOcpPipeline:
             return
 
         try:
-            from pyartcd.rhcos_jenkins_client import RhcosJenkinsClient
-
-            client = RhcosJenkinsClient(kubeconfig_env_var='RHCOS_JENKINS_KUBECONFIG')
+            client = self.rhcos_jenkins_client
             build_number = client.trigger_build(
                 'build-node-image',
                 {
@@ -1183,6 +1223,11 @@ class KonfluxOcpPipeline:
         if 'XDG_RUNTIME_DIR' in os.environ:
             LOGGER.info('Unsetting XDG_RUNTIME_DIR to prevent use of default registry auth')
             del os.environ['XDG_RUNTIME_DIR']
+
+        # Authenticate the RHCOS Jenkins client and cache its token before the long
+        # build begins; the Jenkins withCredentials kubeconfig temp file may be
+        # reaped by the time integration tests are triggered near the end of the run.
+        self._init_rhcos_jenkins_client()
 
         # Get Jenkins credentials
         quay_auth_file = os.getenv('QUAY_AUTH_FILE')

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -21,7 +21,8 @@ from artcommonlib.constants import (
     REGISTRY_QUAY_OPENSHIFT,
     REGISTRY_REDHAT_IO,
 )
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBuildRecord
+from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.registry_config import RegistryConfig, RegistryCredential
 from artcommonlib.util import (
     new_roundtrip_yaml_handler,
@@ -41,6 +42,7 @@ from pyartcd.util import (
     get_group_images,
     get_group_rpms,
     increment_fail_counter,
+    load_group_config,
     mass_rebuild_score,
     reset_fail_counter,
 )
@@ -878,17 +880,21 @@ class KonfluxOcpPipeline:
         except Exception as e:
             LOGGER.exception(f"Failed to trigger bundle build: {e}")
 
-    def trigger_rhcos_integration_tests(self):
+    # RHCOS image pairs grouped by RHEL version for integration testing.
+    # Each pair consists of a node image and its corresponding extensions image.
+    RHCOS_RHEL9_PAIR = {'node': 'rhcos-node-image', 'extensions': 'rhcos-node-extensions'}
+    RHCOS_RHEL10_PAIR = {'node': 'rhcos-node-image-rhel10', 'extensions': 'rhcos-node-extensions-rhel10'}
+
+    async def trigger_rhcos_integration_tests(self):
         """Trigger RHCOS-owned Jenkins integration tests for rebuilt node/extensions images.
 
         When any RHCOS images listed in RHCOS_ART_IMAGE_KEYS are rebuilt
-        successfully, this method will eventually trigger RHCOS-owned Jenkins
-        integration tests. If those tests pass, it will sync the ART-built
-        node/extensions images to the shadow imagestream tags.
+        successfully, this method triggers RHCOS-owned Jenkins integration tests
+        via the build-node-image job. The tests are triggered independently for
+        each RHEL version (9/10) whose images were rebuilt.
 
-        Currently raises NotImplementedError when RHCOS images were rebuilt, as the
-        integration tests are not yet available. Set --skip-rhcos-integration-tests
-        to bypass (default: True).
+        These are shadow images for now, so test failures are logged as warnings
+        but do not fail the pipeline.
         """
         if self.skip_rhcos_integration_tests:
             LOGGER.warning("Skipping RHCOS integration tests because --skip-rhcos-integration-tests flag is set")
@@ -901,21 +907,184 @@ class KonfluxOcpPipeline:
 
         try:
             records = record_log.get('image_build_konflux', [])
-            rebuilt_rhcos = [
-                record['name']
-                for record in records
-                if record.get('name') in RHCOS_ART_IMAGE_KEYS and record['status'] == '0'
+
+            # Build a lookup of rebuilt RHCOS images: {name: pullspec}
+            rebuilt_images = {}
+            for record in records:
+                name = record.get('name')
+                if name in RHCOS_ART_IMAGE_KEYS and record['status'] == '0':
+                    pullspec = record.get('image_pullspec', '')
+                    rebuilt_images[name] = pullspec
+
+            if not rebuilt_images:
+                LOGGER.info("No RHCOS images were rebuilt, skipping integration tests")
+                return
+
+            LOGGER.info("RHCOS images rebuilt successfully: %s", ', '.join(rebuilt_images.keys()))
+
+            # Build a full lookup of ALL RHCOS image records (including those not rebuilt)
+            # so we can find pullspecs for the pair partner if only one was rebuilt
+            all_rhcos_records = {}
+            for record in records:
+                name = record.get('name')
+                if name in RHCOS_ART_IMAGE_KEYS and record['status'] == '0':
+                    all_rhcos_records[name] = record.get('image_pullspec', '')
+
+            # Load group config to derive RELEASE streams from group.yml instead of hardcoding
+            group_config = await load_group_config(group=f"openshift-{self.version}", assembly="stream")
+
+            # Build release stream mapping: {rhel_label: release_stream}
+            # e.g. {'rhel9': '4.19-9.8', 'rhel10': '4.19-10.0'}
+            release_streams = {}
+            for tag in group_config.get('rhcos', {}).get('payload_tags', []):
+                rhel_ver = tag.get('rhel_version', '')
+                if rhel_ver:
+                    major = rhel_ver.split('.')[0]
+                    release_streams[f"rhel{major}"] = f"{self.version}-{rhel_ver}"
+
+            # Ensure default RHEL version from group vars is present
+            default_major = group_config['vars']['RHCOS_EL_MAJOR']
+            default_minor = group_config['vars']['RHCOS_EL_MINOR']
+            release_streams.setdefault(f"rhel{default_major}", f"{self.version}-{default_major}.{default_minor}")
+
+            LOGGER.info("RHCOS release streams from group.yml: %s", release_streams)
+
+            # Trigger tests for each RHEL version pair that has at least one rebuilt image
+            rhel_pairs = [
+                ('rhel9', self.RHCOS_RHEL9_PAIR),
+                ('rhel10', self.RHCOS_RHEL10_PAIR),
             ]
-            if rebuilt_rhcos:
-                LOGGER.info(f"RHCOS images rebuilt successfully: {', '.join(rebuilt_rhcos)}")
-                raise NotImplementedError(
-                    "RHCOS integration tests are not yet implemented. Set --skip-rhcos-integration-tests to bypass."
+
+            for rhel_label, pair in rhel_pairs:
+                await self._trigger_rhcos_pair_test(
+                    rhel_label, pair, rebuilt_images, all_rhcos_records, release_streams
                 )
-        except NotImplementedError:
-            raise
+
         except Exception as e:
-            LOGGER.exception(f"Failed to trigger RHCOS integration tests: {e}")
-            raise
+            LOGGER.exception("Failed to trigger RHCOS integration tests: %s", e)
+
+    async def _trigger_rhcos_pair_test(
+        self,
+        rhel_label: str,
+        pair: dict,
+        rebuilt_images: dict,
+        all_rhcos_records: dict,
+        release_streams: dict,
+    ):
+        """Trigger integration test for a single RHEL version's RHCOS image pair.
+
+        Args:
+            rhel_label: Human-readable label like 'rhel9' or 'rhel10'.
+            pair: Dict with 'node' and 'extensions' keys mapping to image names.
+            rebuilt_images: Dict of {image_name: pullspec} for images that were rebuilt.
+            all_rhcos_records: Dict of {image_name: pullspec} for all successful RHCOS builds.
+            release_streams: Dict mapping rhel_label to release stream (e.g. {'rhel9': '4.19-9.8'}).
+        """
+        node_name = pair['node']
+        ext_name = pair['extensions']
+
+        # Check if at least one image in this pair was rebuilt
+        if node_name not in rebuilt_images and ext_name not in rebuilt_images:
+            return
+
+        LOGGER.info("Triggering %s RHCOS integration tests", rhel_label)
+
+        # Resolve pullspecs: prefer from rebuilt, fall back to all records from same run
+        node_pullspec = rebuilt_images.get(node_name) or all_rhcos_records.get(node_name)
+        ext_pullspec = rebuilt_images.get(ext_name) or all_rhcos_records.get(ext_name)
+
+        # Fallback: look up the latest successful build from KonfluxDb for the missing partner
+        if not node_pullspec or not ext_pullspec:
+            db = KonfluxDb()
+            db.bind(KonfluxBuildRecord)
+            group = f"openshift-{self.version}"
+            if not node_pullspec:
+                LOGGER.info("Looking up latest %s build from KonfluxDb...", node_name)
+                record = await db.get_latest_build(
+                    name=node_name,
+                    group=group,
+                    outcome=KonfluxBuildOutcome.SUCCESS,
+                    assembly=self.assembly,
+                    exclude_large_columns=True,
+                )
+                if record:
+                    node_pullspec = record.image_pullspec
+                    LOGGER.info("Found latest %s pullspec from KonfluxDb: %s", node_name, node_pullspec)
+                else:
+                    LOGGER.warning("No successful %s build found in KonfluxDb for group %s", node_name, group)
+            if not ext_pullspec:
+                LOGGER.info("Looking up latest %s build from KonfluxDb...", ext_name)
+                record = await db.get_latest_build(
+                    name=ext_name,
+                    group=group,
+                    outcome=KonfluxBuildOutcome.SUCCESS,
+                    assembly=self.assembly,
+                    exclude_large_columns=True,
+                )
+                if record:
+                    ext_pullspec = record.image_pullspec
+                    LOGGER.info("Found latest %s pullspec from KonfluxDb: %s", ext_name, ext_pullspec)
+                else:
+                    LOGGER.warning("No successful %s build found in KonfluxDb for group %s", ext_name, group)
+
+        if not node_pullspec:
+            LOGGER.warning("Cannot trigger %s integration test: no pullspec found for %s", rhel_label, node_name)
+            return
+        if not ext_pullspec:
+            LOGGER.warning("Cannot trigger %s integration test: no pullspec found for %s", rhel_label, ext_name)
+            return
+
+        # Validate that pullspecs are digest-based
+        if '@sha256:' not in node_pullspec:
+            LOGGER.warning(
+                "Node image pullspec is not digest-based, skipping %s integration test: %s",
+                rhel_label,
+                node_pullspec,
+            )
+            return
+        if '@sha256:' not in ext_pullspec:
+            LOGGER.warning(
+                "Extensions image pullspec is not digest-based, skipping %s integration test: %s",
+                rhel_label,
+                ext_pullspec,
+            )
+            return
+
+        # Derive RELEASE param from group.yml (loaded by trigger_rhcos_integration_tests)
+        release_stream = release_streams.get(rhel_label)
+        if not release_stream:
+            LOGGER.warning("No release stream found in group.yml for %s, skipping integration test", rhel_label)
+            return
+
+        try:
+            from pyartcd.rhcos_jenkins_client import RhcosJenkinsClient
+
+            client = RhcosJenkinsClient(kubeconfig_env_var='RHCOS_JENKINS_KUBECONFIG')
+            build_number = client.trigger_build(
+                'build-node-image',
+                {
+                    'NODE_IMAGE': node_pullspec,
+                    'EXTENSIONS_IMAGE': ext_pullspec,
+                    'RELEASE': release_stream,
+                },
+            )
+            LOGGER.info("Waiting for %s integration test build-node-image #%d...", rhel_label, build_number)
+            result = client.wait_for_build('build-node-image', build_number)
+
+            if result['result'] == 'SUCCESS':
+                LOGGER.info("RHCOS %s integration test passed: %s #%d", rhel_label, result['url'], build_number)
+            else:
+                LOGGER.warning(
+                    "RHCOS %s integration test did not pass (result=%s): %s - %s",
+                    rhel_label,
+                    result['result'],
+                    result['url'],
+                    result.get('description', ''),
+                )
+
+        except Exception as e:
+            # Don't fail the pipeline for integration test issues - these are shadow images for now
+            LOGGER.warning("Failed to run %s RHCOS integration test: %s", rhel_label, e)
 
     def parse_record_log(self) -> Optional[dict]:
         record_log_path = Path(self.runtime.doozer_working, 'record.log')
@@ -1132,7 +1301,7 @@ class KonfluxOcpPipeline:
                 )
 
             self.trigger_bundle_build()
-            self.trigger_rhcos_integration_tests()
+            await self.trigger_rhcos_integration_tests()
 
             # Wrap problematic operations to prevent them from blocking each other or clean_up
             await run_safe(self.mirror_images, critical_failures)
@@ -1246,8 +1415,7 @@ class KonfluxOcpPipeline:
     "--skip-ec-verify", is_flag=True, default=False, help="Skip Enterprise Contract verification for built images"
 )
 @click.option(
-    "--skip-rhcos-integration-tests",
-    is_flag=True,
+    "--skip-rhcos-integration-tests/--no-skip-rhcos-integration-tests",
     default=True,
     help="Skip RHCOS integration tests (default: True, tests not yet available)",
 )

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -143,6 +143,8 @@ class KonfluxOcpPipeline:
         # RHCOS Jenkins client, authenticated early in run() so its token is cached
         # before the withCredentials kubeconfig temp file can be reaped mid-build.
         self.rhcos_jenkins_client = None
+        # Stored if _init_rhcos_jenkins_client() fails; re-raised in trigger_rhcos_integration_tests.
+        self._rhcos_init_error: Optional[Exception] = None
 
         # If build plan includes more than half or excludes less than half or rebuilds everything, it's a mass rebuild
         self.mass_rebuild = False
@@ -903,8 +905,9 @@ class KonfluxOcpPipeline:
         is still fresh. The client caches the token in memory, so triggering the
         tests later never needs to read the kubeconfig again.
 
-        Best-effort: on failure the client is left as None and integration tests
-        are skipped, since these are non-fatal shadow tests for now.
+        On failure the error is stored in self._rhcos_init_error and re-raised later
+        inside trigger_rhcos_integration_tests, which is wrapped by run_safe so the
+        pipeline exits non-zero without blocking subsequent steps.
         """
         if self.skip_rhcos_integration_tests:
             return
@@ -918,9 +921,8 @@ class KonfluxOcpPipeline:
             self.rhcos_jenkins_client = client
             LOGGER.info("RHCOS Jenkins client authenticated; token cached for later integration tests")
         except Exception as e:
-            LOGGER.warning(
-                "Failed to authenticate RHCOS Jenkins client at startup; integration tests will be skipped: %s", e
-            )
+            LOGGER.warning("Failed to authenticate RHCOS Jenkins client at startup; integration tests will fail: %s", e)
+            self._rhcos_init_error = e
             self.rhcos_jenkins_client = None
 
     async def trigger_rhcos_integration_tests(self):
@@ -931,16 +933,15 @@ class KonfluxOcpPipeline:
         via the build-node-image job. The tests are triggered independently for
         each RHEL version (9/10) whose images were rebuilt.
 
-        These are shadow images for now, so test failures are logged as warnings
-        but do not fail the pipeline.
+        Failures are propagated so the caller (run_safe) can record them in
+        critical_failures and cause the pipeline to exit non-zero.
         """
         if self.skip_rhcos_integration_tests:
             LOGGER.warning("Skipping RHCOS integration tests because --skip-rhcos-integration-tests flag is set")
             return
 
         if not self.rhcos_jenkins_client:
-            LOGGER.warning("RHCOS Jenkins client is not available (auth failed at startup), skipping integration tests")
-            return
+            raise RuntimeError(f"RHCOS Jenkins client unavailable (auth failed at startup): {self._rhcos_init_error}")
 
         record_log = self.parse_record_log()
         if not record_log:
@@ -1004,6 +1005,7 @@ class KonfluxOcpPipeline:
 
         except Exception as e:
             LOGGER.exception("Failed to trigger RHCOS integration tests: %s", e)
+            raise
 
     async def _trigger_rhcos_pair_test(
         self,
@@ -1114,17 +1116,14 @@ class KonfluxOcpPipeline:
             if result['result'] == 'SUCCESS':
                 LOGGER.info("RHCOS %s integration test passed: %s #%d", rhel_label, result['url'], build_number)
             else:
-                LOGGER.warning(
-                    "RHCOS %s integration test did not pass (result=%s): %s - %s",
-                    rhel_label,
-                    result['result'],
-                    result['url'],
-                    result.get('description', ''),
+                raise RuntimeError(
+                    f"RHCOS {rhel_label} integration test did not pass (result={result['result']}): "
+                    f"{result['url']} - {result.get('description', '')}"
                 )
 
         except Exception as e:
-            # Don't fail the pipeline for integration test issues - these are shadow images for now
-            LOGGER.warning("Failed to run %s RHCOS integration test: %s", rhel_label, e)
+            LOGGER.exception("Failed to run %s RHCOS integration test: %s", rhel_label, e)
+            raise
 
     def parse_record_log(self) -> Optional[dict]:
         record_log_path = Path(self.runtime.doozer_working, 'record.log')
@@ -1346,7 +1345,7 @@ class KonfluxOcpPipeline:
                 )
 
             self.trigger_bundle_build()
-            await self.trigger_rhcos_integration_tests()
+            await run_safe(self.trigger_rhcos_integration_tests, critical_failures)
 
             # Wrap problematic operations to prevent them from blocking each other or clean_up
             await run_safe(self.mirror_images, critical_failures)

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -1100,6 +1100,17 @@ class KonfluxOcpPipeline:
             LOGGER.warning("No release stream found in group.yml for %s, skipping integration test", rhel_label)
             return
 
+        # The RHCOS Jenkins job has no credentials for the internal Konflux build registry
+        # (art-images).  Rewrite pullspecs to art-images-share, which mirror_images already
+        # populated before this method is called.
+        _INTERNAL = "quay.io/redhat-user-workloads/ocp-art-tenant/art-images@"
+        _SHARED = "quay.io/redhat-user-workloads/ocp-art-tenant/art-images-share@"
+        if node_pullspec.startswith(_INTERNAL):
+            node_pullspec = _SHARED + node_pullspec[len(_INTERNAL):]
+        if ext_pullspec.startswith(_INTERNAL):
+            ext_pullspec = _SHARED + ext_pullspec[len(_INTERNAL):]
+        LOGGER.info("Using art-images-share pullspecs for RHCOS job: node=%s ext=%s", node_pullspec, ext_pullspec)
+
         try:
             client = self.rhcos_jenkins_client
             build_number = client.trigger_build(
@@ -1345,10 +1356,12 @@ class KonfluxOcpPipeline:
                 )
 
             self.trigger_bundle_build()
-            await run_safe(self.trigger_rhcos_integration_tests, critical_failures)
 
-            # Wrap problematic operations to prevent them from blocking each other or clean_up
+            # mirror_images must run before trigger_rhcos_integration_tests so that
+            # art-images-share pullspecs exist when we hand them to the RHCOS Jenkins job.
+            # The RHCOS job has no credentials for the internal art-images Konflux registry.
             await run_safe(self.mirror_images, critical_failures)
+            await run_safe(self.trigger_rhcos_integration_tests, critical_failures)
             await run_safe(self.mirror_streams_to_ci, critical_failures)
 
             try:

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -20,8 +20,10 @@ from artcommonlib.constants import (
     REGISTRY_QUAY_OCP_RELEASE_DEV,
     REGISTRY_QUAY_OPENSHIFT,
     REGISTRY_REDHAT_IO,
+    RHCOS_IMAGE_REPO,
 )
-from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBuildRecord
+from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.registry_config import RegistryConfig, RegistryCredential
 from artcommonlib.util import (
     new_roundtrip_yaml_handler,
@@ -41,6 +43,7 @@ from pyartcd.util import (
     get_group_images,
     get_group_rpms,
     increment_fail_counter,
+    load_group_config,
     mass_rebuild_score,
     reset_fail_counter,
 )
@@ -109,7 +112,7 @@ class KonfluxOcpPipeline:
         skip_bundle_build: bool = None,
         skip_build_sync_konflux: bool = False,
         skip_ec_verify: bool = False,
-        skip_rhcos_integration_tests: bool = True,
+        skip_rhcos_integration_tests: bool = False,
         arches: Tuple[str, ...] = None,
         plr_template: str = None,
         lock_identifier: str = None,
@@ -137,6 +140,12 @@ class KonfluxOcpPipeline:
         self.build_priority = build_priority
         self.use_mass_rebuild_locks = use_mass_rebuild_locks
         self.network_mode = network_mode
+
+        # RHCOS Jenkins client, authenticated early in run() so its token is cached
+        # before the withCredentials kubeconfig temp file can be reaped mid-build.
+        self.rhcos_jenkins_client = None
+        # Stored if _init_rhcos_jenkins_client() fails; re-raised in trigger_rhcos_integration_tests.
+        self._rhcos_init_error: Optional[Exception] = None
 
         # If build plan includes more than half or excludes less than half or rebuilds everything, it's a mass rebuild
         self.mass_rebuild = False
@@ -882,21 +891,62 @@ class KonfluxOcpPipeline:
         except Exception as e:
             LOGGER.exception(f"Failed to trigger bundle build: {e}")
 
-    def trigger_rhcos_integration_tests(self):
+    # RHCOS image pairs grouped by RHEL version for integration testing.
+    # Each pair consists of a node image and its corresponding extensions image.
+    RHCOS_RHEL9_PAIR = {'node': 'rhcos-node-image', 'extensions': 'rhcos-node-extensions'}
+    RHCOS_RHEL10_PAIR = {'node': 'rhcos-node-image-rhel10', 'extensions': 'rhcos-node-extensions-rhel10'}
+
+    def _init_rhcos_jenkins_client(self):
+        """Authenticate the RHCOS Jenkins client early and cache its bearer token.
+
+        The RHCOS Jenkins kubeconfig is provided via a Jenkins withCredentials
+        file binding ($RHCOS_JENKINS_KUBECONFIG). That temp file can be reaped by
+        idle-file cleanup during a long build, so by the time integration tests
+        are triggered (~50+ minutes after the withCredentials block opened) the
+        file may no longer exist even though the env var is still set.
+
+        To avoid depending on that temp file surviving the whole build, we build
+        the client and resolve its auth token up front, while the kubeconfig file
+        is still fresh. The client caches the token in memory, so triggering the
+        tests later never needs to read the kubeconfig again.
+
+        On failure the error is stored in self._rhcos_init_error and re-raised later
+        inside trigger_rhcos_integration_tests, which is wrapped by run_safe so the
+        pipeline exits non-zero without blocking subsequent steps.
+        """
+        if self.skip_rhcos_integration_tests:
+            return
+
+        from pyartcd.rhcos_jenkins_client import RhcosJenkinsClient
+
+        try:
+            client = RhcosJenkinsClient(kubeconfig_env_var='RHCOS_JENKINS_KUBECONFIG')
+            # Resolve and cache the token now, while the kubeconfig file still exists
+            client.retrieve_auth_token()
+            self.rhcos_jenkins_client = client
+            LOGGER.info("RHCOS Jenkins client authenticated; token cached for later integration tests")
+        except Exception as e:
+            LOGGER.warning("Failed to authenticate RHCOS Jenkins client at startup; integration tests will fail: %s", e)
+            self._rhcos_init_error = e
+            self.rhcos_jenkins_client = None
+
+    async def trigger_rhcos_integration_tests(self):
         """Trigger RHCOS-owned Jenkins integration tests for rebuilt node/extensions images.
 
         When any RHCOS images listed in RHCOS_ART_IMAGE_KEYS are rebuilt
-        successfully, this method will eventually trigger RHCOS-owned Jenkins
-        integration tests. If those tests pass, it will sync the ART-built
-        node/extensions images to the shadow imagestream tags.
+        successfully, this method triggers RHCOS-owned Jenkins integration tests
+        via the build-node-image job. The tests are triggered independently for
+        each RHEL version (9/10) whose images were rebuilt.
 
-        Currently raises NotImplementedError when RHCOS images were rebuilt, as the
-        integration tests are not yet available. Set --skip-rhcos-integration-tests
-        to bypass (default: True).
+        Failures are propagated so the caller (run_safe) can record them in
+        critical_failures and cause the pipeline to exit non-zero.
         """
         if self.skip_rhcos_integration_tests:
             LOGGER.warning("Skipping RHCOS integration tests because --skip-rhcos-integration-tests flag is set")
             return
+
+        if not self.rhcos_jenkins_client:
+            raise RuntimeError(f"RHCOS Jenkins client unavailable (auth failed at startup): {self._rhcos_init_error}")
 
         record_log = self.parse_record_log()
         if not record_log:
@@ -905,20 +955,181 @@ class KonfluxOcpPipeline:
 
         try:
             records = record_log.get('image_build_konflux', [])
-            rebuilt_rhcos = [
-                record['name']
-                for record in records
-                if record.get('name') in RHCOS_ART_IMAGE_KEYS and record['status'] == '0'
+
+            # Build a lookup of rebuilt RHCOS images: {name: pullspec}
+            rebuilt_images = {}
+            for record in records:
+                name = record.get('name')
+                if name in RHCOS_ART_IMAGE_KEYS and record['status'] == '0':
+                    pullspec = record.get('image_pullspec', '')
+                    rebuilt_images[name] = pullspec
+
+            if not rebuilt_images:
+                LOGGER.info("No RHCOS images were rebuilt, skipping integration tests")
+                return
+
+            LOGGER.info("RHCOS images rebuilt successfully: %s", ', '.join(rebuilt_images.keys()))
+
+            # Build a full lookup of ALL RHCOS image records (including those not rebuilt)
+            # so we can find pullspecs for the pair partner if only one was rebuilt
+            all_rhcos_records = {}
+            for record in records:
+                name = record.get('name')
+                if name in RHCOS_ART_IMAGE_KEYS and record['status'] == '0':
+                    all_rhcos_records[name] = record.get('image_pullspec', '')
+
+            # Load group config to derive RELEASE streams from group.yml instead of hardcoding
+            group_config = await load_group_config(group=f"openshift-{self.version}", assembly="stream")
+
+            # Build release stream mapping: {rhel_label: release_stream}
+            # e.g. {'rhel9': '4.19-9.8', 'rhel10': '4.19-10.0'}
+            release_streams = {}
+            for tag in group_config.get('rhcos', {}).get('payload_tags', []):
+                rhel_ver = tag.get('rhel_version', '')
+                if rhel_ver:
+                    major = rhel_ver.split('.')[0]
+                    release_streams[f"rhel{major}"] = f"{self.version}-{rhel_ver}"
+
+            # Ensure default RHEL version from group vars is present
+            default_major = group_config['vars']['RHCOS_EL_MAJOR']
+            default_minor = group_config['vars']['RHCOS_EL_MINOR']
+            release_streams.setdefault(f"rhel{default_major}", f"{self.version}-{default_major}.{default_minor}")
+
+            LOGGER.info("RHCOS release streams from group.yml: %s", release_streams)
+
+            # Trigger tests for each RHEL version pair that has at least one rebuilt image
+            rhel_pairs = [
+                ('rhel9', self.RHCOS_RHEL9_PAIR),
+                ('rhel10', self.RHCOS_RHEL10_PAIR),
             ]
-            if rebuilt_rhcos:
-                LOGGER.info(f"RHCOS images rebuilt successfully: {', '.join(rebuilt_rhcos)}")
-                raise NotImplementedError(
-                    "RHCOS integration tests are not yet implemented. Set --skip-rhcos-integration-tests to bypass."
+
+            for rhel_label, pair in rhel_pairs:
+                await self._trigger_rhcos_pair_test(
+                    rhel_label, pair, rebuilt_images, all_rhcos_records, release_streams
                 )
-        except NotImplementedError:
-            raise
+
         except Exception as e:
-            LOGGER.exception(f"Failed to trigger RHCOS integration tests: {e}")
+            LOGGER.exception("Failed to trigger RHCOS integration tests: %s", e)
+            raise
+
+    async def _trigger_rhcos_pair_test(
+        self,
+        rhel_label: str,
+        pair: dict,
+        rebuilt_images: dict,
+        all_rhcos_records: dict,
+        release_streams: dict,
+    ):
+        """Trigger integration test for a single RHEL version's RHCOS image pair.
+
+        Args:
+            rhel_label: Human-readable label like 'rhel9' or 'rhel10'.
+            pair: Dict with 'node' and 'extensions' keys mapping to image names.
+            rebuilt_images: Dict of {image_name: pullspec} for images that were rebuilt.
+            all_rhcos_records: Dict of {image_name: pullspec} for all successful RHCOS builds.
+            release_streams: Dict mapping rhel_label to release stream (e.g. {'rhel9': '4.19-9.8'}).
+        """
+        node_name = pair['node']
+        ext_name = pair['extensions']
+
+        # Check if at least one image in this pair was rebuilt
+        if node_name not in rebuilt_images and ext_name not in rebuilt_images:
+            return
+
+        LOGGER.info("Triggering %s RHCOS integration tests", rhel_label)
+
+        # Resolve pullspecs: prefer from rebuilt, fall back to all records from same run
+        node_pullspec = rebuilt_images.get(node_name) or all_rhcos_records.get(node_name)
+        ext_pullspec = rebuilt_images.get(ext_name) or all_rhcos_records.get(ext_name)
+
+        # Fallback: look up the latest successful build from KonfluxDb for the missing partner
+        if not node_pullspec or not ext_pullspec:
+            db = KonfluxDb()
+            db.bind(KonfluxBuildRecord)
+            group = f"openshift-{self.version}"
+            if not node_pullspec:
+                LOGGER.info("Looking up latest %s build from KonfluxDb...", node_name)
+                record = await db.get_latest_build(
+                    name=node_name,
+                    group=group,
+                    outcome=KonfluxBuildOutcome.SUCCESS,
+                    assembly=self.assembly,
+                    exclude_large_columns=True,
+                )
+                if record:
+                    node_pullspec = record.image_pullspec
+                    LOGGER.info("Found latest %s pullspec from KonfluxDb: %s", node_name, node_pullspec)
+                else:
+                    LOGGER.warning("No successful %s build found in KonfluxDb for group %s", node_name, group)
+            if not ext_pullspec:
+                LOGGER.info("Looking up latest %s build from KonfluxDb...", ext_name)
+                record = await db.get_latest_build(
+                    name=ext_name,
+                    group=group,
+                    outcome=KonfluxBuildOutcome.SUCCESS,
+                    assembly=self.assembly,
+                    exclude_large_columns=True,
+                )
+                if record:
+                    ext_pullspec = record.image_pullspec
+                    LOGGER.info("Found latest %s pullspec from KonfluxDb: %s", ext_name, ext_pullspec)
+                else:
+                    LOGGER.warning("No successful %s build found in KonfluxDb for group %s", ext_name, group)
+
+        if not node_pullspec:
+            LOGGER.warning("Cannot trigger %s integration test: no pullspec found for %s", rhel_label, node_name)
+            return
+        if not ext_pullspec:
+            LOGGER.warning("Cannot trigger %s integration test: no pullspec found for %s", rhel_label, ext_name)
+            return
+
+        # Validate that pullspecs are digest-based
+        if '@sha256:' not in node_pullspec:
+            LOGGER.warning(
+                "Node image pullspec is not digest-based, skipping %s integration test: %s",
+                rhel_label,
+                node_pullspec,
+            )
+            return
+        if '@sha256:' not in ext_pullspec:
+            LOGGER.warning(
+                "Extensions image pullspec is not digest-based, skipping %s integration test: %s",
+                rhel_label,
+                ext_pullspec,
+            )
+            return
+
+        # Derive RELEASE param from group.yml (loaded by trigger_rhcos_integration_tests)
+        release_stream = release_streams.get(rhel_label)
+        if not release_stream:
+            LOGGER.warning("No release stream found in group.yml for %s, skipping integration test", rhel_label)
+            return
+
+        LOGGER.info("Using RHCOS image pullspecs for Jenkins job: node=%s ext=%s", node_pullspec, ext_pullspec)
+
+        try:
+            client = self.rhcos_jenkins_client
+            build_number = client.trigger_build(
+                'build-node-image',
+                {
+                    'NODE_IMAGE': node_pullspec,
+                    'EXTENSIONS_IMAGE': ext_pullspec,
+                    'RELEASE': release_stream,
+                },
+            )
+            LOGGER.info("Waiting for %s integration test build-node-image #%d...", rhel_label, build_number)
+            result = client.wait_for_build('build-node-image', build_number)
+
+            if result['result'] == 'SUCCESS':
+                LOGGER.info("RHCOS %s integration test passed: %s #%d", rhel_label, result['url'], build_number)
+            else:
+                raise RuntimeError(
+                    f"RHCOS {rhel_label} integration test did not pass (result={result['result']}): "
+                    f"{result['url']} - {result.get('description', '')}"
+                )
+
+        except Exception as e:
+            LOGGER.exception("Failed to run %s RHCOS integration test: %s", rhel_label, e)
             raise
 
     def parse_record_log(self) -> Optional[dict]:
@@ -1019,17 +1230,32 @@ class KonfluxOcpPipeline:
             LOGGER.info('Unsetting XDG_RUNTIME_DIR to prevent use of default registry auth')
             del os.environ['XDG_RUNTIME_DIR']
 
+        # Authenticate the RHCOS Jenkins client and cache its token before the long
+        # build begins; the Jenkins withCredentials kubeconfig temp file may be
+        # reaped by the time integration tests are triggered near the end of the run.
+        self._init_rhcos_jenkins_client()
+
         # Get Jenkins credentials
         quay_auth_file = os.getenv('QUAY_AUTH_FILE')
+        redhat_registry_auth_file = os.getenv('KONFLUX_OPERATOR_INDEX_AUTH_FILE')
+        rhcos_quay_auth_file = os.getenv('RHCOS_QUAY_AUTH_FILE')
 
         if not quay_auth_file:
             raise ValueError(
                 "QUAY_AUTH_FILE environment variable is required but not set. "
                 "Ensure Jenkins credentials are properly bound."
             )
+        if not rhcos_quay_auth_file:
+            raise ValueError(
+                "RHCOS_QUAY_AUTH_FILE environment variable is required but not set. "
+                "Ensure Jenkins credentials are properly bound."
+            )
 
         # Build source files list
         source_files = [quay_auth_file]
+        if redhat_registry_auth_file:
+            source_files.append(redhat_registry_auth_file)
+        source_files.append(rhcos_quay_auth_file)
 
         # Build explicit credentials for QCI push (DPTP's CI registry)
         qci_user = os.environ.get('QCI_USER')
@@ -1052,6 +1278,7 @@ class KonfluxOcpPipeline:
             registries=[
                 REGISTRY_QUAY_OCP_RELEASE_DEV,  # For: ART release images
                 KONFLUX_DEFAULT_IMAGE_REPO,  # For: Konflux builds (cosign attestations)
+                RHCOS_IMAGE_REPO,  # For: ART-built RHCOS images
                 KONFLUX_DEFAULT_IMAGE_SHARE_REPO,  # For: Konflux image sharing (sync_images)
                 REGISTRY_REDHAT_IO,  # For: RHEL base images
                 REGISTRY_BREW,  # For: parent images (uses registry.redhat.io creds via alias)
@@ -1071,6 +1298,7 @@ class KonfluxOcpPipeline:
 
                 original_docker_config = os.environ.get('DOCKER_CONFIG')
                 os.environ['DOCKER_CONFIG'] = docker_config_dir
+                os.environ['QUAY_AUTH_FILE'] = global_auth_file
 
                 LOGGER.info(
                     f'Set registry auth file={global_auth_file} for pipeline operations '
@@ -1080,6 +1308,7 @@ class KonfluxOcpPipeline:
                 try:
                     await self._run_pipeline()
                 finally:
+                    os.environ['QUAY_AUTH_FILE'] = quay_auth_file
                     if original_docker_config:
                         os.environ['DOCKER_CONFIG'] = original_docker_config
                     elif 'DOCKER_CONFIG' in os.environ:
@@ -1133,10 +1362,11 @@ class KonfluxOcpPipeline:
                 )
 
             self.trigger_bundle_build()
-            self.trigger_rhcos_integration_tests()
 
-            # Wrap problematic operations to prevent them from blocking each other or clean_up
+            # Keep mirroring before the remaining stream operations. The RHCOS integration
+            # job receives the original pullspecs from the successful RHCOS image builds.
             await run_safe(self.mirror_images, critical_failures)
+            await run_safe(self.trigger_rhcos_integration_tests, critical_failures)
             await run_safe(self.mirror_streams_to_ci, critical_failures)
 
             try:
@@ -1249,8 +1479,8 @@ class KonfluxOcpPipeline:
 @click.option(
     "--skip-rhcos-integration-tests",
     is_flag=True,
-    default=True,
-    help="Skip RHCOS integration tests (default: True, tests not yet available)",
+    default=False,
+    help="Skip RHCOS integration tests",
 )
 @click.option(
     "--arch", "arches", metavar="TAG", multiple=True, help="(Optional) [MULTIPLE] Limit included arches to this list"

--- a/pyartcd/pyartcd/rhcos_jenkins_client.py
+++ b/pyartcd/pyartcd/rhcos_jenkins_client.py
@@ -1,0 +1,235 @@
+"""Shared RHCOS Jenkins client for authentication and job triggering.
+
+Extracted from pyartcd.pipelines.build_rhcos to allow reuse in other pipelines
+(e.g. ocp4-konflux integration test triggering).
+"""
+
+import base64
+import logging
+import os
+import time
+
+import openshift_client as oc
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+logger = logging.getLogger(__name__)
+
+JENKINS_BASE_URL = "https://jenkins-rhcos--prod-pipeline.apps.int.prod-stable-spoke1-dc-iad2.itup.redhat.com"
+
+
+# Lifted verbatim from
+# https://findwork.dev/blog/advanced-usage-python-requests-timeouts-retries-hooks/
+class TimeoutHTTPAdapter(HTTPAdapter):
+    def __init__(self, *args, timeout=5, **kwargs):
+        self.timeout = timeout
+        super().__init__(*args, **kwargs)
+
+    def send(self, request, **kwargs):
+        kwargs.setdefault("timeout", self.timeout)
+        return super().send(request, **kwargs)
+
+
+class RhcosJenkinsClient:
+    """Client for interacting with the RHCOS Jenkins instance.
+
+    Handles authentication via OpenShift service account tokens and provides
+    methods for triggering and monitoring Jenkins builds.
+
+    The kubeconfig_env_var parameter allows callers to specify which environment
+    variable holds the kubeconfig path. This is important because ocp4-konflux
+    already uses KUBECONFIG for app.ci via withAppCiAsArtPublish(), so we need
+    a separate env var (e.g. RHCOS_JENKINS_KUBECONFIG) for the RHCOS cluster.
+    """
+
+    def __init__(self, kubeconfig_env_var: str = 'RHCOS_JENKINS_KUBECONFIG'):
+        self.kubeconfig_env_var = kubeconfig_env_var
+        self._token = None
+        self._session = None
+
+    def _get_session(self) -> requests.Session:
+        """Create or return a requests session with retry logic."""
+        if self._session is None:
+            self._session = requests.Session()
+            retries = Retry(
+                total=5,
+                backoff_factor=1,
+                status_forcelist=[401, 403, 500, 502, 503, 504],
+                allowed_methods=["HEAD", "GET", "POST"],
+                raise_on_status=True,
+            )
+            self._session.mount("https://", TimeoutHTTPAdapter(max_retries=retries))
+        return self._session
+
+    def retrieve_auth_token(self) -> str:
+        """Retrieve the auth token from the Jenkins service account.
+
+        Uses the kubeconfig specified by self.kubeconfig_env_var to connect to
+        the RHCOS cluster and find a valid Jenkins SA token.
+
+        Falls back to the standard KUBECONFIG env var if the primary is not set.
+
+        Returns:
+            A valid Bearer token string for Jenkins API authentication.
+
+        Raises:
+            Exception: If no valid Jenkins service account token is found.
+        """
+        if self._token:
+            return self._token
+
+        kubeconfig = os.environ.get(self.kubeconfig_env_var) or os.environ.get('KUBECONFIG')
+        if not kubeconfig:
+            raise Exception(
+                f"Neither {self.kubeconfig_env_var} nor KUBECONFIG environment variable is set. "
+                "Cannot authenticate to RHCOS Jenkins cluster."
+            )
+
+        logger.info("Retrieving RHCOS Jenkins auth token using kubeconfig from %s", self.kubeconfig_env_var)
+        session = self._get_session()
+
+        with oc.api_server(oc.get_config_context()['cluster']), oc.options({'kubeconfig': kubeconfig}):
+            jenkins_uid = oc.selector('sa/jenkins').objects()[0].model.metadata.uid
+            for s in oc.selector('secrets'):
+                if (
+                    s.model.type == "kubernetes.io/service-account-token"
+                    and s.model.metadata.annotations["kubernetes.io/service-account.name"] == "jenkins"
+                    and s.model.metadata.annotations["kubernetes.io/service-account.uid"] == jenkins_uid
+                ):
+                    secret_maybe = base64.b64decode(s.model.data.token).decode('utf-8')
+                    r = session.get(
+                        f"{JENKINS_BASE_URL}/me/api/json",
+                        headers={"Authorization": f"Bearer {secret_maybe}"},
+                    )
+                    if r.status_code == 200:
+                        self._token = secret_maybe
+                        logger.info("Successfully authenticated to RHCOS Jenkins")
+                        return self._token
+
+        raise Exception("Unable to find a valid Jenkins service account token for RHCOS Jenkins")
+
+    def trigger_build(self, job: str, params: dict) -> int:
+        """Trigger a Jenkins build and wait for it to start.
+
+        Posts to buildWithParameters and polls the queue until the build
+        gets an executor and a build number is assigned.
+
+        Args:
+            job: Jenkins job name (e.g. 'build-node-image').
+            params: Build parameters to pass to the job.
+
+        Returns:
+            The build number of the started build.
+
+        Raises:
+            Exception: If the build fails to start within 300 seconds.
+        """
+        token = self.retrieve_auth_token()
+        session = self._get_session()
+        session.headers.update({"Authorization": f"Bearer {token}"})
+
+        job_url = f"{JENKINS_BASE_URL}/job/{job}/buildWithParameters"
+        logger.info("Triggering Jenkins build: %s with params %s", job, params)
+
+        response = session.post(job_url, data=params)
+        if response.status_code not in (200, 201):
+            raise Exception(f"Failed to trigger RHCOS Jenkins build: {response.status_code} {response.text}")
+
+        queue_url = response.headers.get('Location')
+        if not queue_url:
+            raise Exception("No Location header in Jenkins queue response")
+
+        logger.info("Build queued at %s, waiting for executor...", queue_url)
+        start_time = time.time()
+        while time.time() - start_time < 300:
+            queue_response = session.get(f"{queue_url}/api/json").json()
+            if 'executable' in queue_response:
+                build_number = queue_response['executable']['number']
+                logger.info("Build started: %s #%d", job, build_number)
+                return build_number
+            time.sleep(5)
+
+        raise Exception(f"Jenkins build for {job} didn't start within 300 seconds")
+
+    def wait_for_build(self, job: str, build_number: int, timeout: int = 1800) -> dict:
+        """Wait for a Jenkins build to complete and return its info.
+
+        Polls the build API until the result field is set (build is complete).
+
+        Args:
+            job: Jenkins job name.
+            build_number: The build number to wait for.
+            timeout: Maximum seconds to wait (default: 1800 = 30 minutes).
+
+        Returns:
+            A dict with build info including 'result', 'url', and 'description'.
+
+        Raises:
+            Exception: If the build does not complete within the timeout.
+        """
+        token = self.retrieve_auth_token()
+        session = self._get_session()
+        session.headers.update({"Authorization": f"Bearer {token}"})
+
+        build_url = f"{JENKINS_BASE_URL}/job/{job}/{build_number}/api/json"
+        logger.info("Waiting for build %s #%d to complete (timeout: %ds)...", job, build_number, timeout)
+
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            build_info = session.get(build_url).json()
+            if build_info.get('result') is not None:
+                logger.info("Build %s #%d completed with result: %s", job, build_number, build_info['result'])
+                return {
+                    'result': build_info['result'],
+                    'url': build_info.get('url', ''),
+                    'description': build_info.get('description', ''),
+                }
+            time.sleep(15)
+
+        raise Exception(f"Jenkins build {job} #{build_number} did not complete within {timeout} seconds")
+
+    def query_existing_builds(self, job: str, match_params: dict) -> list:
+        """Query for in-progress builds matching the given parameters.
+
+        Checks the Jenkins job for builds that are currently running and have
+        parameters matching the provided dict.
+
+        Args:
+            job: Jenkins job name.
+            match_params: Dict of parameter name->value pairs to match against.
+
+        Returns:
+            A list of dicts with 'result', 'description', and 'url' for each
+            matching in-progress build.
+        """
+        token = self.retrieve_auth_token()
+        session = self._get_session()
+        session.headers.update({"Authorization": f"Bearer {token}"})
+
+        response = session.get(
+            f"{JENKINS_BASE_URL}/job/{job}/api/json"
+            "?tree=builds[number,description,url,result,actions[parameters[name,value]]]",
+        )
+        builds_info = response.json()["builds"]
+
+        matching = []
+        for build in builds_info:
+            if build["result"] is not None:
+                continue
+            for action in build.get("actions", []):
+                if "parameters" not in action:
+                    continue
+                build_params = {p["name"]: p["value"] for p in action["parameters"]}
+                if all(build_params.get(k) == v for k, v in match_params.items()):
+                    matching.append(
+                        {
+                            "result": None,
+                            "description": build.get("description", ""),
+                            "url": build["url"],
+                        }
+                    )
+                    break
+
+        logger.info("Found %d in-progress builds for %s matching %s", len(matching), job, match_params)
+        return matching

--- a/pyartcd/pyartcd/rhcos_jenkins_client.py
+++ b/pyartcd/pyartcd/rhcos_jenkins_client.py
@@ -1,0 +1,239 @@
+"""Shared RHCOS Jenkins client for authentication and job triggering.
+
+Extracted from pyartcd.pipelines.build_rhcos to allow reuse in other pipelines
+(e.g. ocp4-konflux integration test triggering).
+"""
+
+import base64
+import logging
+import os
+import time
+
+import openshift_client as oc
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+logger = logging.getLogger(__name__)
+
+JENKINS_BASE_URL = "https://jenkins-rhcos--prod-pipeline.apps.int.prod-stable-spoke1-dc-iad2.itup.redhat.com"
+
+
+# Lifted verbatim from
+# https://findwork.dev/blog/advanced-usage-python-requests-timeouts-retries-hooks/
+class TimeoutHTTPAdapter(HTTPAdapter):
+    def __init__(self, *args, timeout=5, **kwargs):
+        self.timeout = timeout
+        super().__init__(*args, **kwargs)
+
+    def send(self, request, **kwargs):
+        kwargs.setdefault("timeout", self.timeout)
+        return super().send(request, **kwargs)
+
+
+class RhcosJenkinsClient:
+    """Client for interacting with the RHCOS Jenkins instance.
+
+    Handles authentication via OpenShift service account tokens and provides
+    methods for triggering and monitoring Jenkins builds.
+
+    The kubeconfig_env_var parameter allows callers to specify which environment
+    variable holds the kubeconfig path. This is important because ocp4-konflux
+    already uses KUBECONFIG for app.ci via withAppCiAsArtPublish(), so we need
+    a separate env var (e.g. RHCOS_JENKINS_KUBECONFIG) for the RHCOS cluster.
+    """
+
+    def __init__(self, kubeconfig_env_var: str = 'RHCOS_JENKINS_KUBECONFIG'):
+        self.kubeconfig_env_var = kubeconfig_env_var
+        self._token = None
+        self._session = None
+
+    def _get_session(self) -> requests.Session:
+        """Create or return a requests session with retry logic."""
+        if self._session is None:
+            self._session = requests.Session()
+            retries = Retry(
+                total=5,
+                backoff_factor=1,
+                status_forcelist=[401, 403, 500, 502, 503, 504],
+                allowed_methods=["HEAD", "GET", "POST"],
+                raise_on_status=True,
+            )
+            self._session.mount("https://", TimeoutHTTPAdapter(max_retries=retries))
+        return self._session
+
+    def retrieve_auth_token(self) -> str:
+        """Retrieve the auth token from the Jenkins service account.
+
+        Uses the kubeconfig specified by self.kubeconfig_env_var to connect to
+        the RHCOS cluster and find a valid Jenkins SA token.
+
+        Falls back to the standard KUBECONFIG env var if the primary is not set.
+
+        Returns:
+            A valid Bearer token string for Jenkins API authentication.
+
+        Raises:
+            Exception: If no valid Jenkins service account token is found.
+        """
+        if self._token:
+            return self._token
+
+        kubeconfig = os.environ.get(self.kubeconfig_env_var) or os.environ.get('KUBECONFIG')
+        if not kubeconfig:
+            raise Exception(
+                f"Neither {self.kubeconfig_env_var} nor KUBECONFIG environment variable is set. "
+                "Cannot authenticate to RHCOS Jenkins cluster."
+            )
+
+        logger.info("Retrieving RHCOS Jenkins auth token using kubeconfig from %s", self.kubeconfig_env_var)
+        session = self._get_session()
+
+        # Use oc.api_server(kubeconfig_path=...) rather than oc.options({'kubeconfig': ...}).
+        # The options path runs .lower() on the entire key=value string, which corrupts file
+        # paths that contain uppercase characters.  api_server() appends --kubeconfig verbatim.
+        # No api_url is passed, so no --server flag is added; the kubeconfig supplies the URL.
+        with oc.api_server(kubeconfig_path=kubeconfig):
+            jenkins_uid = oc.selector('sa/jenkins').objects()[0].model.metadata.uid
+            for s in oc.selector('secrets'):
+                if (
+                    s.model.type == "kubernetes.io/service-account-token"
+                    and s.model.metadata.annotations["kubernetes.io/service-account.name"] == "jenkins"
+                    and s.model.metadata.annotations["kubernetes.io/service-account.uid"] == jenkins_uid
+                ):
+                    secret_maybe = base64.b64decode(s.model.data.token).decode('utf-8')
+                    r = session.get(
+                        f"{JENKINS_BASE_URL}/me/api/json",
+                        headers={"Authorization": f"Bearer {secret_maybe}"},
+                    )
+                    if r.status_code == 200:
+                        self._token = secret_maybe
+                        logger.info("Successfully authenticated to RHCOS Jenkins")
+                        return self._token
+
+        raise Exception("Unable to find a valid Jenkins service account token for RHCOS Jenkins")
+
+    def trigger_build(self, job: str, params: dict) -> int:
+        """Trigger a Jenkins build and wait for it to start.
+
+        Posts to buildWithParameters and polls the queue until the build
+        gets an executor and a build number is assigned.
+
+        Args:
+            job: Jenkins job name (e.g. 'build-node-image').
+            params: Build parameters to pass to the job.
+
+        Returns:
+            The build number of the started build.
+
+        Raises:
+            Exception: If the build fails to start within 300 seconds.
+        """
+        token = self.retrieve_auth_token()
+        session = self._get_session()
+        session.headers.update({"Authorization": f"Bearer {token}"})
+
+        job_url = f"{JENKINS_BASE_URL}/job/{job}/buildWithParameters"
+        logger.info("Triggering Jenkins build: %s with params %s", job, params)
+
+        response = session.post(job_url, data=params)
+        if response.status_code not in (200, 201):
+            raise Exception(f"Failed to trigger RHCOS Jenkins build: {response.status_code} {response.text}")
+
+        queue_url = response.headers.get('Location')
+        if not queue_url:
+            raise Exception("No Location header in Jenkins queue response")
+
+        logger.info("Build queued at %s, waiting for executor...", queue_url)
+        start_time = time.time()
+        while time.time() - start_time < 300:
+            queue_response = session.get(f"{queue_url}/api/json").json()
+            if 'executable' in queue_response:
+                build_number = queue_response['executable']['number']
+                logger.info("Build started: %s #%d", job, build_number)
+                return build_number
+            time.sleep(5)
+
+        raise Exception(f"Jenkins build for {job} didn't start within 300 seconds")
+
+    def wait_for_build(self, job: str, build_number: int, timeout: int = 1800) -> dict:
+        """Wait for a Jenkins build to complete and return its info.
+
+        Polls the build API until the result field is set (build is complete).
+
+        Args:
+            job: Jenkins job name.
+            build_number: The build number to wait for.
+            timeout: Maximum seconds to wait (default: 1800 = 30 minutes).
+
+        Returns:
+            A dict with build info including 'result', 'url', and 'description'.
+
+        Raises:
+            Exception: If the build does not complete within the timeout.
+        """
+        token = self.retrieve_auth_token()
+        session = self._get_session()
+        session.headers.update({"Authorization": f"Bearer {token}"})
+
+        build_url = f"{JENKINS_BASE_URL}/job/{job}/{build_number}/api/json"
+        logger.info("Waiting for build %s #%d to complete (timeout: %ds)...", job, build_number, timeout)
+
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            build_info = session.get(build_url).json()
+            if build_info.get('result') is not None:
+                logger.info("Build %s #%d completed with result: %s", job, build_number, build_info['result'])
+                return {
+                    'result': build_info['result'],
+                    'url': build_info.get('url', ''),
+                    'description': build_info.get('description', ''),
+                }
+            time.sleep(15)
+
+        raise Exception(f"Jenkins build {job} #{build_number} did not complete within {timeout} seconds")
+
+    def query_existing_builds(self, job: str, match_params: dict) -> list:
+        """Query for in-progress builds matching the given parameters.
+
+        Checks the Jenkins job for builds that are currently running and have
+        parameters matching the provided dict.
+
+        Args:
+            job: Jenkins job name.
+            match_params: Dict of parameter name->value pairs to match against.
+
+        Returns:
+            A list of dicts with 'result', 'description', and 'url' for each
+            matching in-progress build.
+        """
+        token = self.retrieve_auth_token()
+        session = self._get_session()
+        session.headers.update({"Authorization": f"Bearer {token}"})
+
+        response = session.get(
+            f"{JENKINS_BASE_URL}/job/{job}/api/json"
+            "?tree=builds[number,description,url,result,actions[parameters[name,value]]]",
+        )
+        builds_info = response.json()["builds"]
+
+        matching = []
+        for build in builds_info:
+            if build["result"] is not None:
+                continue
+            for action in build.get("actions", []):
+                if "parameters" not in action:
+                    continue
+                build_params = {p["name"]: p["value"] for p in action["parameters"]}
+                if all(build_params.get(k) == v for k, v in match_params.items()):
+                    matching.append(
+                        {
+                            "result": None,
+                            "description": build.get("description", ""),
+                            "url": build["url"],
+                        }
+                    )
+                    break
+
+        logger.info("Found %d in-progress builds for %s matching %s", len(matching), job, match_params)
+        return matching

--- a/pyartcd/pyartcd/rhcos_jenkins_client.py
+++ b/pyartcd/pyartcd/rhcos_jenkins_client.py
@@ -89,7 +89,11 @@ class RhcosJenkinsClient:
         logger.info("Retrieving RHCOS Jenkins auth token using kubeconfig from %s", self.kubeconfig_env_var)
         session = self._get_session()
 
-        with oc.options({'kubeconfig': kubeconfig}):
+        # Use oc.api_server(kubeconfig_path=...) rather than oc.options({'kubeconfig': ...}).
+        # The options path runs .lower() on the entire key=value string, which corrupts file
+        # paths that contain uppercase characters.  api_server() appends --kubeconfig verbatim.
+        # No api_url is passed, so no --server flag is added; the kubeconfig supplies the URL.
+        with oc.api_server(kubeconfig_path=kubeconfig):
             jenkins_uid = oc.selector('sa/jenkins').objects()[0].model.metadata.uid
             for s in oc.selector('secrets'):
                 if (

--- a/pyartcd/pyartcd/rhcos_jenkins_client.py
+++ b/pyartcd/pyartcd/rhcos_jenkins_client.py
@@ -89,7 +89,7 @@ class RhcosJenkinsClient:
         logger.info("Retrieving RHCOS Jenkins auth token using kubeconfig from %s", self.kubeconfig_env_var)
         session = self._get_session()
 
-        with oc.api_server(oc.get_config_context()['cluster']), oc.options({'kubeconfig': kubeconfig}):
+        with oc.options({'kubeconfig': kubeconfig}):
             jenkins_uid = oc.selector('sa/jenkins').objects()[0].model.metadata.uid
             for s in oc.selector('secrets'):
                 if (

--- a/pyartcd/tests/pipelines/test_ocp4_konflux_rhcos.py
+++ b/pyartcd/tests/pipelines/test_ocp4_konflux_rhcos.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+import os
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from artcommonlib.constants import RHCOS_IMAGE_REPO
+from pyartcd.pipelines.ocp4_konflux import KonfluxOcpPipeline, ocp4
+
+
+def _make_pipeline(assembly='stream', version='4.21'):
+    runtime = MagicMock()
+    runtime.doozer_working = '/tmp/doozer-working'
+    runtime.new_slack_client.return_value = MagicMock()
+    with patch('pyartcd.pipelines.ocp4_konflux.util.default_release_suffix', return_value='202408190000'):
+        return KonfluxOcpPipeline(
+            runtime=runtime,
+            assembly=assembly,
+            version=version,
+            image_build_strategy='all',
+            rpm_build_strategy='none',
+            build_priority='auto',
+            data_path='https://github.com/openshift-eng/ocp-build-data',
+        )
+
+
+class TestRhcosIntegrationCli(unittest.TestCase):
+    def setUp(self):
+        self.required_args = [
+            '--image-build-strategy=none',
+            '--image-list=none',
+            '--rpm-build-strategy=none',
+            '--rpm-list=none',
+            '--assembly=stream',
+            '--version=4.21',
+        ]
+
+    def test_rhcos_integration_tests_run_by_default(self):
+        with ocp4.make_context('beta:ocp4-konflux', self.required_args) as context:
+            self.assertFalse(context.params['skip_rhcos_integration_tests'])
+
+        self.assertFalse(_make_pipeline().skip_rhcos_integration_tests)
+
+    def test_rhcos_integration_tests_can_be_skipped(self):
+        args = [*self.required_args, '--skip-rhcos-integration-tests']
+
+        with ocp4.make_context('beta:ocp4-konflux', args) as context:
+            self.assertTrue(context.params['skip_rhcos_integration_tests'])
+
+    def test_skip_rhcos_integration_tests_is_a_one_way_flag(self):
+        option = next(param for param in ocp4.params if param.name == 'skip_rhcos_integration_tests')
+
+        self.assertEqual(option.opts, ['--skip-rhcos-integration-tests'])
+        self.assertFalse(option.secondary_opts)
+
+
+class TestRegistryAuthConfiguration(unittest.IsolatedAsyncioTestCase):
+    @patch.dict(
+        os.environ,
+        {
+            'QUAY_AUTH_FILE': '/tmp/quay-auth.json',
+            'KONFLUX_OPERATOR_INDEX_AUTH_FILE': '/tmp/redhat-registry-auth.json',
+            'RHCOS_QUAY_AUTH_FILE': '/tmp/rhcos-quay-auth.json',
+            'QCI_USER': 'qci-user',
+            'QCI_PASSWORD': 'qci-password',
+        },
+        clear=True,
+    )
+    @patch('pyartcd.pipelines.ocp4_konflux.shutil.copy2')
+    @patch('pyartcd.pipelines.ocp4_konflux.tempfile.mkdtemp', return_value='/tmp/docker-config-test')
+    @patch('pyartcd.pipelines.ocp4_konflux.RegistryConfig')
+    async def test_run_merges_rhcos_registry_credentials(
+        self,
+        mock_registry_config,
+        _mock_mkdtemp,
+        _mock_copy,
+    ):
+        mock_registry_config.return_value.__enter__.return_value = '/tmp/merged-auth.json'
+        pipeline = _make_pipeline()
+        pipeline._run_pipeline = AsyncMock()
+
+        await pipeline.run()
+
+        registry_config_args = mock_registry_config.call_args.kwargs
+        self.assertEqual(
+            registry_config_args['source_files'],
+            ['/tmp/quay-auth.json', '/tmp/redhat-registry-auth.json', '/tmp/rhcos-quay-auth.json'],
+        )
+        self.assertIn(RHCOS_IMAGE_REPO, registry_config_args['registries'])
+        pipeline._run_pipeline.assert_awaited_once_with()
+        self.assertEqual(os.environ['QUAY_AUTH_FILE'], '/tmp/quay-auth.json')
+        self.assertNotIn('DOCKER_CONFIG', os.environ)
+
+
+class TestRhcosIntegrationPullspecs(unittest.IsolatedAsyncioTestCase):
+    async def test_rhcos_repo_pullspecs_are_passed_to_build_node_image(self):
+        pipeline = _make_pipeline()
+        pipeline.rhcos_jenkins_client = MagicMock()
+        pipeline.rhcos_jenkins_client.trigger_build.return_value = 123
+        pipeline.rhcos_jenkins_client.wait_for_build.return_value = {
+            'result': 'SUCCESS',
+            'url': 'https://jenkins.example.com/job/build-node-image/123/',
+        }
+        node_digest = 'a' * 64
+        extensions_digest = 'b' * 64
+
+        await pipeline._trigger_rhcos_pair_test(
+            'rhel9',
+            pipeline.RHCOS_RHEL9_PAIR,
+            {
+                'rhcos-node-image': f'{RHCOS_IMAGE_REPO}@sha256:{node_digest}',
+                'rhcos-node-extensions': f'{RHCOS_IMAGE_REPO}@sha256:{extensions_digest}',
+            },
+            {},
+            {'rhel9': '4.21-9.8'},
+        )
+
+        parameters = pipeline.rhcos_jenkins_client.trigger_build.call_args.args[1]
+        self.assertEqual(
+            parameters['NODE_IMAGE'],
+            f'{RHCOS_IMAGE_REPO}@sha256:{node_digest}',
+        )
+        self.assertEqual(
+            parameters['EXTENSIONS_IMAGE'],
+            f'{RHCOS_IMAGE_REPO}@sha256:{extensions_digest}',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
[Test run](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/dpaolell/job/ocp4-konflux/220/) triggered https://jenkins-rhcos--prod-pipeline.apps.int.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/build-node-image/9018/ on the RHCOS Jenkins instance.

Needs https://github.com/openshift-eng/aos-cd-jobs/pull/4813

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated RHCOS integration testing for rebuilt RHEL 9 and RHEL 10 image pairs.
  - Tests validate image digests, trigger Jenkins jobs, and monitor completion results.
  - Added authenticated Jenkins integration with cached credentials, retries, timeouts, and build tracking.

- **Enhancements**
  - Added CLI controls to explicitly enable or skip integration tests; tests remain skipped by default.
  - Image mirroring now occurs before integration tests are triggered.
  - Authentication, triggering, and test failures now correctly fail the pipeline instead of being silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->