### PR TITLE
ART-17451: stage-release bundle related images from bundle build job

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -129,6 +129,31 @@ PRODUCT_BASE_IMAGE_KONFLUX_EC_RELEASE_MAP = {
     "ocp": ("ocp-art-images-base-silent-ec", "art-images-base"),
 }
 
+# Per-version ReleasePlan name lookup for FBC related-image advisory-stage release workflow.
+# Keys are (product_major, product_minor) tuples — these are PRODUCT versions, NOT OCP versions.
+# Exact plan names sourced from konflux-release-data ReleasePlan resources per product tenant.
+# Must stay aligned with konflux-release-data. See ART-17452.
+PRODUCT_FBC_STAGE_RELEASE_PLAN_MAP: dict[str, dict[tuple[int, int], str]] = {
+    "cert-manager": {
+        (1, 19): "cm-advisory-stage-1-19",
+    },
+    "external-secrets-operator": {
+        (1, 1): "eso-advisory-stage-1-1",
+    },
+    "multicluster-engine": {
+        (2, 11): "mce-advisory-stage-2-11",
+        (5, 0): "mce-advisory-stage-5-0",
+    },
+    "rhacm2": {
+        (2, 16): "acm-advisory-stage-2-16",
+        (5, 0): "acm-advisory-stage-5-0",
+    },
+    "zero-trust-workload-identity-manager": {
+        (1, 0): "zt-advisory-stage-1-0",
+        (1, 1): "zt-advisory-stage-1-1",
+    },
+}
+
 PRODUCT_KUBECONFIG_MAP = {
     "multicluster-engine": "ACM_KONFLUX_SA_KUBECONFIG",
     "rhacm2": "ACM_KONFLUX_SA_KUBECONFIG",

--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -135,10 +135,10 @@ PRODUCT_BASE_IMAGE_KONFLUX_EC_RELEASE_MAP = {
 # Must stay aligned with konflux-release-data. See ART-17452.
 PRODUCT_FBC_STAGE_RELEASE_PLAN_MAP: dict[str, dict[tuple[int, int], str]] = {
     "cert-manager": {
-        (1, 19): "cm-advisory-stage-1-19",
+        (1, 19): "cm-stage-auto-1-19",
     },
     "external-secrets-operator": {
-        (1, 1): "eso-advisory-stage-1-1",
+        (1, 1): "eso-stage-auto-1-1",
     },
     "multicluster-engine": {
         (2, 11): "mce-advisory-stage-2-11",
@@ -149,8 +149,8 @@ PRODUCT_FBC_STAGE_RELEASE_PLAN_MAP: dict[str, dict[tuple[int, int], str]] = {
         (5, 0): "acm-advisory-stage-5-0",
     },
     "zero-trust-workload-identity-manager": {
-        (1, 0): "zt-advisory-stage-1-0",
-        (1, 1): "zt-advisory-stage-1-1",
+        (1, 0): "zt-stage-auto-1-0",
+        (1, 1): "zt-stage-auto-1-1",
     },
 }
 

--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -1329,6 +1329,7 @@ class KonfluxDb:
         where: typing.Optional[typing.Dict[str, typing.Any]] = None,
         strict: bool = True,
         exclude_large_columns: bool = False,
+        group: typing.Optional[str] = None,
     ) -> list[KonfluxRecord | None]:
         """Get build records by NVRs.
 
@@ -1342,6 +1343,9 @@ class KonfluxDb:
         :param exclude_large_columns: If True, exclude installed_rpms and installed_packages columns from
                                       BigQuery queries to reduce query cost and latency.
                                       Defaults to False for backwards compatibility.
+        :param group: Optional group name for cache optimization (e.g. 'openshift-4.18', 'acm-2.16').
+                      When provided, the cache is loaded for this group, avoiding fallback to
+                      builder_base_image and improving lookup performance.
         :return: The build records.
         """
         nvrs = list(nvrs)
@@ -1364,6 +1368,7 @@ class KonfluxDb:
         async def _task(nvr):
             return await self.get_latest_build(
                 nvr=nvr,
+                group=group,
                 outcome=outcome,
                 assembly=assembly,
                 el_target=el_target,

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -23,6 +23,7 @@ from artcommonlib.constants import (
     OCP5_BRIDGE_MINOR_BASE,
     PRODUCT_BASE_IMAGE_KONFLUX_EC_RELEASE_MAP,
     PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP,
+    PRODUCT_FBC_STAGE_RELEASE_PLAN_MAP,
     PRODUCT_KUBECONFIG_MAP,
     PRODUCT_NAMESPACE_MAP,
     RELEASE_SCHEDULES,
@@ -1366,6 +1367,28 @@ def resolve_konflux_base_image_release_targets(
         f"Using OCP defaults: releasePlan={default_plan!r}, application={default_app!r}"
     )
     return default_plan, default_app
+
+
+def resolve_konflux_fbc_stage_release_plan(product: str, major: int, minor: int) -> Optional[str]:
+    """
+    Resolve the Konflux ReleasePlan name for FBC related-image advisory-stage release.
+
+    ReleasePlan names are per product version (e.g. ``acm-advisory-stage-2-16`` for ACM 2.16).
+    ``major`` and ``minor`` are the **product** version — NOT the OCP version.
+    Must stay aligned with konflux-release-data ReleasePlan resources (see ART-17452).
+
+    Args:
+        product: Runtime product key (e.g. rhacm2, multicluster-engine, logging).
+        major: Product major version (e.g. 2 for ACM 2.16, 6 for logging 6.5).
+        minor: Product minor version (e.g. 16 for ACM 2.16, 5 for logging 6.5).
+
+    Returns:
+        ReleasePlan resource metadata.name, or None if the product/version has no configured plan.
+    """
+    version_map = PRODUCT_FBC_STAGE_RELEASE_PLAN_MAP.get(product)
+    if not version_map:
+        return None
+    return version_map.get((major, minor))
 
 
 async def run_safe(func: Callable[[], Any], failures_list: Optional[List[Tuple[str, Exception]]] = None) -> Any:

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -14,6 +14,7 @@ from artcommonlib.util import (
     isolate_major_minor_in_group,
     normalize_group_name_for_k8s,
     normalize_k8s_dns_label,
+    resolve_konflux_fbc_stage_release_plan,
     validate_k8s_dns_label,
 )
 
@@ -1262,3 +1263,17 @@ class TestGetInflight(unittest.TestCase):
         result = get_inflight('rc.4', 'openshift-4.22', date='2026-05-25')
 
         self.assertEqual(result, '4.21.16')
+
+
+class TestResolveKonfluxFbcStageReleasePlan(unittest.TestCase):
+    def test_layered_product_version_returns_exact_name(self):
+        # ACM 2.16 — product version, not OCP version
+        self.assertEqual(resolve_konflux_fbc_stage_release_plan("rhacm2", 2, 16), "acm-advisory-stage-2-16")
+
+    def test_ocp_version_passed_as_product_version_returns_none(self):
+        # Passing OCP version (4.18) instead of product version yields None — no such plan
+        self.assertIsNone(resolve_konflux_fbc_stage_release_plan("rhacm2", 4, 18))
+
+    def test_unknown_product_returns_none(self):
+        self.assertIsNone(resolve_konflux_fbc_stage_release_plan("quay", 4, 18))
+        self.assertIsNone(resolve_konflux_fbc_stage_release_plan("", 4, 18))

--- a/doozer/doozerlib/backend/konflux_fbc.py
+++ b/doozer/doozerlib/backend/konflux_fbc.py
@@ -49,6 +49,22 @@ class AssemblyBundleCsvInfo(NamedTuple):
     bundle_blob: Optional[Dict]  # The olm.bundle blob to add to the catalog
 
 
+async def get_referenced_images(
+    konflux_db: "KonfluxDb", bundle_build: "KonfluxBundleBuildRecord"
+) -> "List[KonfluxBuildRecord]":
+    """Get operator + operand build records referenced by a bundle build.
+
+    Filters out "external" NVRs (images we consume but don't build, e.g. postgresql).
+    """
+    assert bundle_build.operator_nvr, "operator_nvr is empty; doozer bug?"
+    nvrs = {bundle_build.operator_nvr}
+    if bundle_build.operand_nvrs:
+        nvrs |= set(bundle_build.operand_nvrs)
+    nvrs = {nvr for nvr in nvrs if nvr != "external"}
+    assert konflux_db.record_cls is KonfluxBuildRecord, "konflux_db is not bound to KonfluxBuildRecord. Doozer bug?"
+    return await konflux_db.get_build_records_by_nvrs(list(nvrs), exclude_large_columns=True, group=bundle_build.group)
+
+
 LOGGER = logging.getLogger(__name__)
 yaml = opm.yaml
 
@@ -1126,15 +1142,7 @@ class KonfluxFbcRebaser:
         return nvr
 
     async def _get_referenced_images(self, konflux_db: KonfluxDb, bundle_build: KonfluxBundleBuildRecord):
-        assert bundle_build.operator_nvr, "operator_nvr is empty; doozer bug?"
-        nvrs = {bundle_build.operator_nvr}
-        if bundle_build.operand_nvrs:
-            nvrs |= set(bundle_build.operand_nvrs)
-        # Filter out "external" image NVRs - these are external images we consume but do not necessarly build (i.e postgresql, etc)
-        nvrs = {nvr for nvr in nvrs if nvr != "external"}
-        assert konflux_db.record_cls is KonfluxBuildRecord, "konflux_db is not bound to KonfluxBuildRecord. Doozer bug?"
-        ref_builds = await konflux_db.get_build_records_by_nvrs(list(nvrs), exclude_large_columns=True)
-        return ref_builds
+        return await get_referenced_images(konflux_db, bundle_build)
 
     async def _rebase_dir(
         self,
@@ -1191,7 +1199,7 @@ class KonfluxFbcRebaser:
         konflux_db: KonfluxDb = metadata.runtime.konflux_db
         konflux_db.bind(KonfluxBuildRecord)
         ref_builds = await self._get_referenced_images(konflux_db, bundle_build)
-        ref_builds.append(bundle_build)  # Include the bundle build itself
+        ref_builds.append(bundle_build)  # Include the bundle build itself (for IDMS only)
         ref_pullspecs = {
             b.image_pullspec.replace(constants.REGISTRY_PROXY_BASE_URL, constants.BREW_REGISTRY_BASE_URL)
             for b in ref_builds

--- a/doozer/doozerlib/cli/__main__.py
+++ b/doozer/doozerlib/cli/__main__.py
@@ -52,7 +52,11 @@ from doozerlib.cli.images import (
     query_rpm_version,
 )
 from doozerlib.cli.images_health import images_health
-from doozerlib.cli.images_konflux import images_konflux_build, images_konflux_rebase
+from doozerlib.cli.images_konflux import (
+    bundle_stage_release_related_images,
+    images_konflux_build,
+    images_konflux_rebase,
+)
 from doozerlib.cli.images_okd import images_okd
 from doozerlib.cli.images_streams import images_streams, images_streams_gen_buildconfigs, images_streams_mirror
 from doozerlib.cli.inspect_stream import inspect_stream

--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -1,8 +1,10 @@
 import asyncio
 import json
 import logging
+import os
 import sys
 import traceback
+from datetime import timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
 
@@ -15,11 +17,25 @@ from artcommonlib.konflux.konflux_build_record import (
 )
 from artcommonlib.konflux.konflux_db import KonfluxDb
 from artcommonlib.telemetry import start_as_current_span_async
-from artcommonlib.util import validate_build_priority
+from artcommonlib.util import (
+    KubeCondition,
+    normalize_k8s_dns_label,
+    resolve_konflux_fbc_stage_release_plan,
+    validate_build_priority,
+)
 from artcommonlib.variants import BuildVariant
+from kubernetes.dynamic import exceptions as k8s_exceptions
 from opentelemetry import trace
 
-from doozerlib import constants
+from doozerlib import constants, util
+from doozerlib.backend.konflux_client import (
+    API_VERSION,
+    KIND_RELEASE,
+    KIND_RELEASE_PLAN,
+    KIND_SNAPSHOT,
+    KonfluxClient,
+)
+from doozerlib.backend.konflux_fbc import get_referenced_images
 from doozerlib.backend.konflux_image_builder import KonfluxImageBuilder, KonfluxImageBuilderConfig
 from doozerlib.backend.konflux_olm_bundler import KonfluxOlmBundleBuilder, KonfluxOlmBundleRebaser
 from doozerlib.backend.rebaser import KonfluxRebaser
@@ -829,3 +845,398 @@ async def images_konflux_bundle(
         output=output,
     )
     await cli.run()
+
+
+class BundleStageReleaseRelatedImagesCli:
+    """Stage-release operator + operand images (bundle related images) via a Konflux advisory-stage ReleasePlan.
+
+    Runs at the end of the bundle build job, before FBC builds are triggered. Each operator gets its own
+    Snapshot/Release, created one after another, so a failure is contained to the operator that caused it.
+    The release plan is resolved from the product version in group config (MAJOR.MINOR),
+    not from the OCP version.
+    """
+
+    def __init__(
+        self,
+        runtime: Runtime,
+        operator_nvrs: Tuple[str, ...],
+        stage_release_plan: Optional[str],
+        konflux_kubeconfig: Optional[str],
+        konflux_context: Optional[str],
+        konflux_namespace: str,
+        dry_run: bool,
+    ):
+        self.runtime = runtime
+        self.operator_nvrs = operator_nvrs
+        self.stage_release_plan = stage_release_plan
+        self.konflux_kubeconfig = konflux_kubeconfig
+        self.konflux_context = konflux_context
+        self.konflux_namespace = konflux_namespace
+        self.dry_run = dry_run
+        self._logger = LOGGER.getChild("BundleStageReleaseRelatedImagesCli")
+        self._db_for_bundles = KonfluxDb()
+        self._db_for_bundles.bind(KonfluxBundleBuildRecord)
+
+    async def run(self):
+        runtime = self.runtime
+        runtime.initialize(config_only=True)
+        assembly = runtime.assembly
+
+        if assembly != "stream":
+            self._logger.info("Assembly is '%s' (not 'stream'); skipping stage release of related images", assembly)
+            return
+
+        assert runtime.konflux_db is not None, "konflux_db is not initialized. Doozer bug?"
+        runtime.konflux_db.bind(KonfluxBuildRecord)
+
+        # Use product version (not OCP version) to resolve the release plan.
+        # Layered products (e.g. ACM) set `version: 2.16.0` in group.yml; MAJOR/MINOR there are the OCP
+        # version used for the brew branch — do NOT use them for product version resolution.
+        # OCP groups (e.g. openshift-5.0) have no `version:` field; MAJOR/MINOR ARE the product version.
+        # MissingModel.__bool__ is False, so `if version_str:` is the correct guard for the missing case.
+        assert runtime.group_config is not None, "group_config is not initialized. Doozer bug?"
+        version_str = runtime.group_config.version
+        if version_str:
+            parts = str(version_str).split(".")
+            product_major, product_minor = int(parts[0]), int(parts[1])
+        else:
+            product_major = int(runtime.group_config.vars.MAJOR)
+            product_minor = int(runtime.group_config.vars.MINOR)
+
+        # Resolve release plan once (same for all operators in this group)
+        release_plan = self.stage_release_plan
+        if not release_plan:
+            release_plan = resolve_konflux_fbc_stage_release_plan(runtime.product, product_major, product_minor)
+        if not release_plan:
+            self._logger.info(
+                "No stage release plan configured for product '%s' (%d.%d); skipping stage release",
+                runtime.product,
+                product_major,
+                product_minor,
+            )
+            return
+
+        # Look up operator build records. strict=False so a single missing NVR is reported against that
+        # operator only, instead of raising and taking down every other operator's stage release.
+        records = await runtime.konflux_db.get_build_records_by_nvrs(
+            list(self.operator_nvrs), strict=False, exclude_large_columns=True, group=runtime.group
+        )
+        resolved: List[Tuple[str, KonfluxBuildRecord]] = []
+        failed_nvrs: List[str] = []
+        for nvr, record in zip(self.operator_nvrs, records):
+            if record is None:
+                self._logger.error("No build record found for operator NVR %s", nvr)
+                self._add_record(nvr, operator=None, error=f"No build record found for operator NVR {nvr}")
+                failed_nvrs.append(nvr)
+            else:
+                resolved.append((nvr, record))
+
+        if not resolved:
+            raise DoozerFatalError(f"No build records found for operator NVRs: {self.operator_nvrs}")
+
+        # NOTE: this second initialize() is not skipped only because the config_only call above
+        # returns before Runtime sets self.initialized. If that ever changes, the
+        # `if self.initialized: return` guard would swallow this call and leave image_map empty.
+        runtime.images = [r.name for _, r in resolved]
+        runtime.initialize(mode='images', clone_distgits=False)
+
+        konflux_client = KonfluxClient.from_kubeconfig(
+            default_namespace=self.konflux_namespace,
+            config_file=self.konflux_kubeconfig,
+            context=self.konflux_context,
+            dry_run=self.dry_run,
+        )
+
+        # One Snapshot/Release per operator: an operator whose stage release fails must not prevent the
+        # other operators in this job from being released and moving on to their FBC builds.
+        # Operators of the same product routinely share operands, so a shared operand ends up in more than
+        # one Snapshot. That duplication is deliberate — it is what keeps operators independent — and it is
+        # also why these run serially: two Releases pushing the same image concurrently is asking for trouble.
+        for nvr, record in resolved:
+            try:
+                release_url = await self._stage_release_operator(
+                    konflux_client=konflux_client,
+                    record=record,
+                    release_plan_name=release_plan,
+                    assembly=assembly,
+                )
+            except Exception as e:  # noqa: BLE001 - failures are contained to this operator
+                self._logger.error(
+                    "Stage release failed for operator %s (%s): %s\n%s",
+                    record.name,
+                    nvr,
+                    e,
+                    ''.join(traceback.TracebackException.from_exception(e).format()),
+                )
+                self._add_record(nvr, operator=record.name, error=str(e))
+                failed_nvrs.append(nvr)
+            else:
+                self._add_record(nvr, operator=record.name, release_url=release_url)
+
+        if failed_nvrs:
+            raise DoozerFatalError(f"Stage release of related images failed for: {', '.join(failed_nvrs)}")
+        self._logger.info("Stage release of related images completed for %d operator(s)", len(resolved))
+
+    def _add_record(
+        self,
+        operator_nvr: str,
+        operator: Optional[str],
+        release_url: str = "",
+        error: str = "",
+    ):
+        """Record this operator's stage release outcome in record.log for the calling pipeline.
+
+        pyartcd reads these to drop failed operators from the FBC trigger list while letting the rest through.
+        """
+        if not self.runtime.record_logger:
+            return
+        # '|' is the record field separator; keep an error message from inventing fields
+        message = error.replace("|", "/")[:500]
+        self.runtime.record_logger.add_record(
+            "stage_release_related_images",
+            status=1 if error else 0,
+            operator_nvr=operator_nvr,
+            operator=operator or "",
+            release_url=release_url,
+            message=message,
+        )
+
+    async def _stage_release_operator(
+        self,
+        konflux_client: KonfluxClient,
+        record: KonfluxBuildRecord,
+        release_plan_name: str,
+        assembly: str,
+    ) -> str:
+        """Stage-release one operator's related images (itself + its operands). Returns the release URL."""
+        runtime = self.runtime
+        operator_name = record.name
+        operator_meta = runtime.image_map.get(operator_name)
+        if not operator_meta:
+            raise DoozerFatalError(f"No image metadata for operator '{operator_name}'; cannot resolve bundle name")
+
+        where = {
+            "name": operator_meta.get_olm_bundle_short_name(),
+            "group": runtime.group,
+            "operator_nvr": record.nvr,
+            "outcome": str(KonfluxBuildOutcome.SUCCESS),
+        }
+        bundle_build = await anext(self._db_for_bundles.search_builds_by_fields(where=where, limit=1), None)
+        if not bundle_build:
+            raise DoozerFatalError(f"Bundle build not found for operator {operator_name} ({record.nvr})")
+
+        # Dedup by component name within this operator: an operator can list itself among its operands.
+        components: Dict[str, dict] = {}
+        for build in await get_referenced_images(runtime.konflux_db, bundle_build):
+            name = build.get_konflux_component_name()
+            if name in components:
+                continue
+            components[name] = {
+                "name": name,
+                "source": {"git": {"url": build.rebase_repo_url, "revision": build.rebase_commitish}},
+                "containerImage": build.image_pullspec,
+            }
+
+        if not components:
+            self._logger.info(
+                "No related image builds found for operator %s (%s); nothing to stage-release",
+                operator_name,
+                record.nvr,
+            )
+            return ""
+
+        self._logger.info(
+            "Stage-releasing %d related image(s) for operator %s (%s) via ReleasePlan '%s'...",
+            len(components),
+            operator_name,
+            record.nvr,
+            release_plan_name,
+        )
+        release_url = await self._stage_release(
+            konflux_client=konflux_client,
+            components=sorted(components.values(), key=lambda c: c["name"]),
+            release_plan_name=release_plan_name,
+            group=runtime.group,
+            assembly=assembly,
+            operator_name=operator_name,
+            operator_nvr=record.nvr,
+        )
+        self._logger.info("Stage release succeeded for operator %s (%s): %s", operator_name, record.nvr, release_url)
+        return release_url
+
+    async def _stage_release(
+        self,
+        konflux_client: KonfluxClient,
+        components: List[dict],
+        release_plan_name: str,
+        group: str,
+        assembly: str,
+        operator_name: str,
+        operator_nvr: str,
+    ) -> str:
+        """Create one Snapshot + Release for one operator's related images and wait for it.
+
+        Returns the release URL.
+        """
+        application_name = util.konflux_application_name(group)
+        # Snapshot names are generated server-side: two operators truncated to the same 63-char DNS label
+        # would otherwise collide.
+        # 63-char DNS label budget: "fbc-ri-stage-" (13) + group + "-" + operator + "-" + 5 chars the
+        # apiserver appends for generateName.
+        group_safe = normalize_k8s_dns_label(group, max_length=20)
+        operator_safe = normalize_k8s_dns_label(operator_name, max_length=max(1, 43 - len(group_safe)))
+        generate_name = f"fbc-ri-stage-{group_safe}-{operator_safe}-"
+
+        if self.dry_run:
+            self._logger.info(
+                "[DRY-RUN] Would create Snapshot '%s*' with %d component(s) and Release via '%s'",
+                generate_name,
+                len(components),
+                release_plan_name,
+            )
+            return "https://dry-run.invalid"
+
+        # Create Snapshot
+        snapshot_obj = {
+            "apiVersion": API_VERSION,
+            "kind": KIND_SNAPSHOT,
+            "metadata": {
+                "generateName": generate_name,
+                "namespace": self.konflux_namespace,
+                "labels": {
+                    "test.appstudio.openshift.io/type": "override",
+                    "appstudio.openshift.io/application": application_name,
+                },
+            },
+            "spec": {"application": application_name, "components": components},
+        }
+        result_snapshot = await konflux_client._create(snapshot_obj)
+        snapshot_name = result_snapshot.metadata.name
+        snapshot_url = konflux_client.resource_url(result_snapshot)
+        self._logger.info("Created Snapshot %s (%s)", snapshot_name, snapshot_url)
+
+        # Wait for Snapshot to be readable
+        timeout_s, poll_s, elapsed = 60, 10, 0
+        while elapsed < timeout_s:
+            try:
+                await konflux_client._get(API_VERSION, KIND_SNAPSHOT, snapshot_name)
+                break
+            except k8s_exceptions.NotFoundError:
+                await asyncio.sleep(poll_s)
+                elapsed += poll_s
+        else:
+            raise RuntimeError(f"Snapshot {snapshot_name} not available after 1 minute")
+
+        # Verify ReleasePlan exists before creating Release
+        try:
+            await konflux_client._get(API_VERSION, KIND_RELEASE_PLAN, release_plan_name)
+        except k8s_exceptions.NotFoundError:
+            raise RuntimeError(
+                f"ReleasePlan '{release_plan_name}' not found in namespace '{self.konflux_namespace}'. "
+                "Ensure ART-17452 has landed and the ReleasePlan name is correct."
+            ) from None
+
+        # Create Release
+        release_annotations = {
+            "art.redhat.com/kind": "bundle-ri-stage-release",
+            "art.redhat.com/group": group,
+            "art.redhat.com/assembly": assembly,
+            "art.redhat.com/distgit-key": operator_name,
+            "art.redhat.com/operator-nvr": operator_nvr,
+        }
+        if job_url := os.getenv("BUILD_URL"):
+            release_annotations["art.redhat.com/job-url"] = job_url
+
+        release_obj = {
+            "apiVersion": API_VERSION,
+            "kind": KIND_RELEASE,
+            "metadata": {
+                "generateName": generate_name,
+                "namespace": self.konflux_namespace,
+                "labels": {"appstudio.openshift.io/application": application_name},
+                "annotations": release_annotations,
+            },
+            "spec": {"releasePlan": release_plan_name, "snapshot": snapshot_name},
+        }
+        created_release = await konflux_client._create(release_obj)
+        release_name = created_release.metadata.name
+        release_url = konflux_client.resource_url(created_release)
+        self._logger.info("Created Release %s for Snapshot %s (%s)", release_name, snapshot_name, release_url)
+
+        released = KubeCondition.find_condition(
+            await konflux_client.wait_for_release(release_name, overall_timeout_timedelta=timedelta(minutes=30)),
+            'Released',
+        )
+        if not released or released.status != "True" or released.reason != "Succeeded":
+            raise RuntimeError(
+                f"Stage release {release_name} for {operator_nvr} did not succeed "
+                f"({released.reason if released else 'no Released condition'}): "
+                f"{released.message if released else 'timed out'}. See {release_url}"
+            )
+        self._logger.info("Stage release %s succeeded", release_name)
+        return release_url
+
+
+@cli.command(
+    "beta:bundle:stage-release-related-images",
+    short_help="Stage-release bundle related images (operator + operands) before FBC builds are triggered.",
+)
+@click.option(
+    '--konflux-kubeconfig', metavar='PATH', help='Path to the kubeconfig file to use for Konflux cluster connections.'
+)
+@click.option(
+    '--konflux-context',
+    metavar='CONTEXT',
+    help='The name of the kubeconfig context to use for Konflux cluster connections.',
+)
+@click.option(
+    '--konflux-namespace',
+    metavar='NAMESPACE',
+    default=KONFLUX_DEFAULT_NAMESPACE,
+    help='The namespace to use for Konflux cluster connections.',
+)
+@click.option(
+    "--stage-release-plan",
+    metavar="NAME",
+    default=None,
+    help="Override the auto-resolved Konflux ReleasePlan name.",
+)
+@click.option(
+    '--dry-run', default=False, is_flag=True, help='Do not create Snapshots/Releases, only print what would be done.'
+)
+@click.argument('operator_nvrs', nargs=-1, required=True)
+@pass_runtime
+@click_coroutine
+async def bundle_stage_release_related_images(
+    runtime: Runtime,
+    konflux_kubeconfig: Optional[str],
+    konflux_context: Optional[str],
+    konflux_namespace: str,
+    stage_release_plan: Optional[str],
+    dry_run: bool,
+    operator_nvrs: Tuple[str, ...],
+):
+    """Stage-release operator and operand images to the advisory before FBC builds.
+
+    Takes operator NVRs and, for each one in turn, looks up its bundle build, extracts the referenced
+    images (operator + operands), and releases them through a Konflux advisory-stage ReleasePlan as its
+    own Snapshot/Release. One operator's failure does not stop the others: every outcome is written to
+    record.log as a `stage_release_related_images` entry, and the command exits non-zero if any operator
+    failed so the caller can drop just those operators.
+
+    Only runs for the 'stream' assembly. If no release plan is configured for the product, the command
+    exits successfully without doing anything.
+    """
+    if not konflux_kubeconfig:
+        konflux_kubeconfig = os.environ.get('KONFLUX_SA_KUBECONFIG')
+
+    stage_cli = BundleStageReleaseRelatedImagesCli(
+        runtime=runtime,
+        operator_nvrs=operator_nvrs,
+        stage_release_plan=stage_release_plan,
+        konflux_kubeconfig=konflux_kubeconfig,
+        konflux_context=konflux_context,
+        konflux_namespace=konflux_namespace,
+        dry_run=dry_run,
+    )
+    await stage_cli.run()

--- a/doozer/tests/cli/test_images_konflux.py
+++ b/doozer/tests/cli/test_images_konflux.py
@@ -8,7 +8,7 @@ from artcommonlib.konflux.konflux_build_record import (
     KonfluxBundleBuildRecord,
 )
 from artcommonlib.model import Model
-from doozerlib.cli.images_konflux import KonfluxBundleCli, KonfluxRebaseCli
+from doozerlib.cli.images_konflux import BundleStageReleaseRelatedImagesCli, KonfluxBundleCli, KonfluxRebaseCli
 from doozerlib.exceptions import DoozerFatalError, ParentRebaseFailedError
 from doozerlib.runtime import Runtime
 from doozerlib.source_resolver import SourceResolver
@@ -330,3 +330,256 @@ class TestKonfluxRebaseCli(unittest.IsolatedAsyncioTestCase):
         )
         self.assertNotIn("failed-images", rebase_state)
         self.assertNotIn("skipped-due-to-parent-rebase-failure", rebase_state)
+
+
+class TestBundleStageReleaseRelatedImagesCli(unittest.IsolatedAsyncioTestCase):
+    """Cover product major/minor resolution and the per-operator stage release loop.
+
+    Layered products (e.g. ACM) set `version: 2.16.0` in group.yml while using MAJOR/MINOR for
+    the OCP brew-branch version (e.g. 4.21).  OCP groups have no `version:` field and their
+    MAJOR/MINOR vars ARE the product version.  The code must prefer group_config.version when
+    present and fall back to vars.MAJOR/MINOR only when it is absent (MissingModel is falsy).
+
+    Each operator is stage-released on its own so that one failure cannot stop the others from
+    reaching their FBC builds; every outcome is written to record.log for the calling pipeline.
+    """
+
+    def _make_runtime(self, *, product: str, version_str: str = "", major: int = 0, minor: int = 0):
+        runtime = mock.Mock(spec=Runtime)
+        runtime.assembly = "stream"
+        runtime.product = product
+        runtime.konflux_db = mock.Mock()
+        runtime.konflux_db.bind = mock.Mock()
+        runtime.group = "rhacm2-2.16"
+        runtime.record_logger = mock.Mock()
+        gc_data = {"vars": {"MAJOR": major, "MINOR": minor}}
+        if version_str:
+            gc_data["version"] = version_str
+        runtime.group_config = Model(gc_data)
+        return runtime
+
+    def _make_cli(self, runtime, operator_nvrs=("some-operator-nvr",)):
+        return BundleStageReleaseRelatedImagesCli(
+            runtime=runtime,
+            operator_nvrs=operator_nvrs,
+            stage_release_plan=None,
+            konflux_kubeconfig="/path/to/kubeconfig",
+            konflux_context=None,
+            konflux_namespace="test-namespace",
+            dry_run=False,
+        )
+
+    @mock.patch("doozerlib.cli.images_konflux.KonfluxDb")
+    @mock.patch("doozerlib.cli.images_konflux.resolve_konflux_fbc_stage_release_plan")
+    async def test_layered_product_uses_group_config_version(self, mock_resolve, mock_db_class):
+        """ACM: group_config.version='2.16.0' must be used, not vars.MAJOR=4 / MINOR=21."""
+        mock_db_class.return_value = mock.Mock()
+        mock_resolve.return_value = None  # no plan → early return after the resolve call
+
+        runtime = self._make_runtime(product="rhacm2", version_str="2.16.0", major=4, minor=21)
+        await self._make_cli(runtime).run()
+
+        mock_resolve.assert_called_once_with("rhacm2", 2, 16)
+
+    @mock.patch("doozerlib.cli.images_konflux.KonfluxDb")
+    @mock.patch("doozerlib.cli.images_konflux.resolve_konflux_fbc_stage_release_plan")
+    async def test_ocp_group_uses_vars_major_minor(self, mock_resolve, mock_db_class):
+        """OCP: no version: field in group config; vars.MAJOR/MINOR are the product version."""
+        mock_db_class.return_value = mock.Mock()
+        mock_resolve.return_value = None
+
+        runtime = self._make_runtime(product="ocp", major=5, minor=0)
+        await self._make_cli(runtime).run()
+
+        mock_resolve.assert_called_once_with("ocp", 5, 0)
+
+    @staticmethod
+    def _mock_konflux_client(released_condition):
+        client = mock.AsyncMock()
+        client.resource_url = mock.Mock(return_value="https://konflux/url")
+        created = mock.Mock()
+        created.metadata.name = "fbc-ri-stage-rhacm2-2-16-operator-a-xyz"
+        client._create = mock.AsyncMock(return_value=created)
+        client._get = mock.AsyncMock(return_value={})
+        client.wait_for_release = mock.AsyncMock(return_value={"status": {"conditions": [released_condition]}})
+        return client
+
+    @staticmethod
+    def _component(name, pullspec):
+        return {
+            "name": name,
+            "source": {"git": {"url": "https://git/repo", "revision": "deadbeef"}},
+            "containerImage": pullspec,
+        }
+
+    @staticmethod
+    def _operator_record(name):
+        record = mock.Mock()
+        record.name = name
+        record.nvr = f"{name}-1-1"
+        return record
+
+    @staticmethod
+    def _ref(component_name):
+        build = mock.Mock()
+        build.get_konflux_component_name.return_value = component_name
+        build.rebase_repo_url = "https://git/repo"
+        build.rebase_commitish = "deadbeef"
+        build.image_pullspec = f"img-{component_name}"
+        return build
+
+    def _prepare_run(self, runtime, operator_names, records=None):
+        """Wire up a runtime so run() reaches the per-operator stage release loop."""
+        operators = records if records is not None else [self._operator_record(n) for n in operator_names]
+        runtime.konflux_db.get_build_records_by_nvrs = mock.AsyncMock(return_value=operators)
+        meta = mock.Mock()
+        meta.get_olm_bundle_short_name.return_value = "some-bundle"
+        runtime.image_map = {name: meta for name in operator_names}
+        return operators
+
+    @mock.patch("doozerlib.cli.images_konflux.KonfluxDb")
+    async def test_stage_release_creates_snapshot_and_release_for_one_operator(self, mock_db_class):
+        """A single operator's related images go into one Snapshot and one Release."""
+        client = self._mock_konflux_client({"type": "Released", "status": "True", "reason": "Succeeded"})
+        cli = self._make_cli(self._make_runtime(product="rhacm2", version_str="2.16.0", major=4, minor=21))
+
+        components = [self._component("comp-a", "img-a"), self._component("comp-b", "img-b")]
+        url = await cli._stage_release(
+            konflux_client=client,
+            components=components,
+            release_plan_name="acm-advisory-stage-2-16",
+            group="rhacm2-2.16",
+            assembly="stream",
+            operator_name="operator-a",
+            operator_nvr="operator-a-1-1",
+        )
+
+        self.assertEqual(url, "https://konflux/url")
+        self.assertEqual([c.args[0]["kind"] for c in client._create.call_args_list], ["Snapshot", "Release"])
+        snapshot = client._create.call_args_list[0].args[0]
+        self.assertEqual([c["name"] for c in snapshot["spec"]["components"]], ["comp-a", "comp-b"])
+        # Names are generated server-side so two operators cannot collide on a truncated label
+        self.assertNotIn("name", snapshot["metadata"])
+        self.assertTrue(snapshot["metadata"]["generateName"].startswith("fbc-ri-stage-rhacm2-2-16-operator-a-"))
+        release = client._create.call_args_list[1].args[0]
+        self.assertEqual(release["spec"]["releasePlan"], "acm-advisory-stage-2-16")
+        self.assertEqual(release["metadata"]["annotations"]["art.redhat.com/operator-nvr"], "operator-a-1-1")
+        client.wait_for_release.assert_awaited_once()
+
+    @mock.patch("doozerlib.cli.images_konflux.KonfluxDb")
+    async def test_stage_release_raises_when_release_fails(self, mock_db_class):
+        client = self._mock_konflux_client(
+            {"type": "Released", "status": "False", "reason": "Failed", "message": "managed pipeline blew up"}
+        )
+        cli = self._make_cli(self._make_runtime(product="rhacm2", version_str="2.16.0", major=4, minor=21))
+
+        with self.assertRaisesRegex(RuntimeError, "managed pipeline blew up"):
+            await cli._stage_release(
+                konflux_client=client,
+                components=[self._component("comp-a", "img-a")],
+                release_plan_name="acm-advisory-stage-2-16",
+                group="rhacm2-2.16",
+                assembly="stream",
+                operator_name="operator-a",
+                operator_nvr="operator-a-1-1",
+            )
+
+    @mock.patch("doozerlib.cli.images_konflux.get_referenced_images")
+    @mock.patch("doozerlib.cli.images_konflux.KonfluxClient")
+    @mock.patch("doozerlib.cli.images_konflux.KonfluxDb")
+    @mock.patch("doozerlib.cli.images_konflux.resolve_konflux_fbc_stage_release_plan")
+    async def test_run_creates_one_release_per_operator(
+        self, mock_resolve, mock_db_class, mock_client_cls, mock_get_refs
+    ):
+        """Two operators sharing an operand get one Release each; the shared operand is in both."""
+        mock_resolve.return_value = "acm-advisory-stage-2-16"
+        runtime = self._make_runtime(product="rhacm2", version_str="2.16.0", major=4, minor=21)
+        self._prepare_run(runtime, ["operator-a", "operator-b"])
+
+        mock_get_refs.side_effect = [
+            [self._ref("comp-a"), self._ref("comp-shared")],
+            [self._ref("comp-b"), self._ref("comp-shared")],
+        ]
+
+        async def _bundle_builds(*args, **kwargs):
+            yield mock.Mock()
+
+        cli = self._make_cli(runtime, operator_nvrs=("operator-a-1-1", "operator-b-1-1"))
+        cli._db_for_bundles.search_builds_by_fields = _bundle_builds
+        cli._stage_release = mock.AsyncMock(return_value="https://konflux/url")
+
+        await cli.run()
+
+        self.assertEqual(cli._stage_release.await_count, 2)
+        first, second = cli._stage_release.await_args_list
+        self.assertEqual([c["name"] for c in first.kwargs["components"]], ["comp-a", "comp-shared"])
+        self.assertEqual(first.kwargs["operator_nvr"], "operator-a-1-1")
+        self.assertEqual([c["name"] for c in second.kwargs["components"]], ["comp-b", "comp-shared"])
+        self.assertEqual(second.kwargs["operator_nvr"], "operator-b-1-1")
+
+        statuses = [call.kwargs["status"] for call in runtime.record_logger.add_record.call_args_list]
+        self.assertEqual(statuses, [0, 0])
+
+    @mock.patch("doozerlib.cli.images_konflux.get_referenced_images")
+    @mock.patch("doozerlib.cli.images_konflux.KonfluxClient")
+    @mock.patch("doozerlib.cli.images_konflux.KonfluxDb")
+    @mock.patch("doozerlib.cli.images_konflux.resolve_konflux_fbc_stage_release_plan")
+    async def test_run_continues_after_operator_failure(
+        self, mock_resolve, mock_db_class, mock_client_cls, mock_get_refs
+    ):
+        """A failing operator is recorded and skipped; the next operator is still released."""
+        mock_resolve.return_value = "acm-advisory-stage-2-16"
+        runtime = self._make_runtime(product="rhacm2", version_str="2.16.0", major=4, minor=21)
+        self._prepare_run(runtime, ["operator-a", "operator-b"])
+
+        mock_get_refs.side_effect = [[self._ref("comp-a")], [self._ref("comp-b")]]
+
+        async def _bundle_builds(*args, **kwargs):
+            yield mock.Mock()
+
+        cli = self._make_cli(runtime, operator_nvrs=("operator-a-1-1", "operator-b-1-1"))
+        cli._db_for_bundles.search_builds_by_fields = _bundle_builds
+        cli._stage_release = mock.AsyncMock(side_effect=[RuntimeError("release blew up"), "https://konflux/url"])
+
+        with self.assertRaisesRegex(DoozerFatalError, "operator-a-1-1"):
+            await cli.run()
+
+        self.assertEqual(cli._stage_release.await_count, 2)
+        records = [call.kwargs for call in runtime.record_logger.add_record.call_args_list]
+        self.assertEqual(
+            [(r["operator_nvr"], r["status"]) for r in records], [("operator-a-1-1", 1), ("operator-b-1-1", 0)]
+        )
+        self.assertIn("release blew up", records[0]["message"])
+
+    @mock.patch("doozerlib.cli.images_konflux.get_referenced_images")
+    @mock.patch("doozerlib.cli.images_konflux.KonfluxClient")
+    @mock.patch("doozerlib.cli.images_konflux.KonfluxDb")
+    @mock.patch("doozerlib.cli.images_konflux.resolve_konflux_fbc_stage_release_plan")
+    async def test_run_records_operator_with_missing_build_record(
+        self, mock_resolve, mock_db_class, mock_client_cls, mock_get_refs
+    ):
+        """An NVR with no build record fails only itself; the others are still stage-released."""
+        mock_resolve.return_value = "acm-advisory-stage-2-16"
+        runtime = self._make_runtime(product="rhacm2", version_str="2.16.0", major=4, minor=21)
+        self._prepare_run(runtime, ["operator-b"], records=[None, self._operator_record("operator-b")])
+
+        mock_get_refs.side_effect = [[self._ref("comp-b")]]
+
+        async def _bundle_builds(*args, **kwargs):
+            yield mock.Mock()
+
+        cli = self._make_cli(runtime, operator_nvrs=("operator-a-1-1", "operator-b-1-1"))
+        cli._db_for_bundles.search_builds_by_fields = _bundle_builds
+        cli._stage_release = mock.AsyncMock(return_value="https://konflux/url")
+
+        with self.assertRaisesRegex(DoozerFatalError, "operator-a-1-1"):
+            await cli.run()
+
+        # strict=False keeps a missing NVR from taking down the whole command
+        self.assertFalse(runtime.konflux_db.get_build_records_by_nvrs.await_args.kwargs["strict"])
+        cli._stage_release.assert_awaited_once()
+        self.assertEqual(cli._stage_release.await_args.kwargs["operator_nvr"], "operator-b-1-1")
+        records = [call.kwargs for call in runtime.record_logger.add_record.call_args_list]
+        self.assertEqual(
+            [(r["operator_nvr"], r["status"]) for r in records], [("operator-a-1-1", 1), ("operator-b-1-1", 0)]
+        )

--- a/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
@@ -15,6 +15,67 @@ from pyartcd.runtime import Runtime
 from pyartcd.util import load_group_config
 
 
+async def _stage_release_related_images(
+    runtime: Runtime,
+    doozer_base_cmd: list,
+    namespace: str,
+    final_kubeconfig: str,
+    operator_nvrs: list,
+) -> list:
+    """Run doozer beta:bundle:stage-release-related-images for the given operator NVRs.
+
+    Called once per bundle job, before triggering FBC builds, so images are released to the advisory
+    here rather than once per FBC build (which could be many for layered products). Doozer stage-releases
+    each operator separately, so one operator's failure leaves the rest untouched.
+
+    :return: the operator NVRs whose stage release failed. An empty list means everything succeeded.
+    """
+    cmd = doozer_base_cmd + [
+        'beta:bundle:stage-release-related-images',
+        '--konflux-namespace',
+        namespace,
+        '--konflux-kubeconfig',
+        final_kubeconfig,
+    ]
+    if runtime.dry_run:
+        cmd.append('--dry-run')
+    cmd.append('--')
+    cmd.extend(operator_nvrs)
+
+    runtime.logger.info('Stage-releasing bundle related images')
+    try:
+        await exectools.cmd_assert_async(cmd)
+        return []
+    except ChildProcessError as e:
+        failed_nvrs = _parse_failed_stage_releases(runtime)
+        if not failed_nvrs:
+            # Doozer failed without attributing the failure to any operator (bad kubeconfig, crash before
+            # the first operator, ...). That is a job-wide failure, not a partial one.
+            runtime.logger.error(f'Stage release of related images failed with no per-operator results: {e}')
+            raise
+        runtime.logger.error(f'Stage release of related images failed for: {", ".join(failed_nvrs)}')
+        return failed_nvrs
+
+
+def _parse_failed_stage_releases(runtime: Runtime) -> list:
+    """Collect operator NVRs whose stage_release_related_images record.log entry reports a failure."""
+    record_log_path = Path(runtime.doozer_working, 'record.log')
+    if not record_log_path.exists():
+        runtime.logger.error('record.log not found - cannot determine stage release results')
+        return []
+    with record_log_path.open() as file:
+        record_log = parse_record_log(file)
+    failed_nvrs = []
+    for record in record_log.get('stage_release_related_images', []):
+        if record.get('status') == '0':
+            continue
+        nvr = record.get('operator_nvr')
+        if nvr:
+            failed_nvrs.append(nvr)
+            runtime.logger.error(f'Stage release failed for {nvr}: {record.get("message", "")}')
+    return failed_nvrs
+
+
 @cli.command('olm-bundle-konflux')
 @click.option('--version', required=True, help='OCP version')
 @click.option('--assembly', required=True, help='Assembly name')
@@ -82,8 +143,8 @@ async def olm_bundle_konflux(
     if not group:
         group = f"openshift-{version}"
 
-    # Create Doozer invocation
-    cmd = [
+    # Shared doozer invocation prefix, reused by the stage-release call below
+    doozer_base_cmd = [
         'doozer',
         '--build-system=konflux',
         f'--assembly={assembly}',
@@ -91,6 +152,9 @@ async def olm_bundle_konflux(
         f'--group={group}@{data_gitref}' if data_gitref else f'--group={group}',
         f'--data-path={data_path}',
     ]
+
+    # Create Doozer invocation
+    cmd = doozer_base_cmd.copy()
     if only:
         cmd.append(f'--images={only}')
     if exclude:
@@ -153,6 +217,10 @@ async def olm_bundle_konflux(
         runtime.logger.warning(f'Doozer command failed: {e}')
         runtime.logger.info('Checking record.log for partial success...')
 
+    # Explicitly-requested operator NVRs. Only used if record.log turns up empty, which means
+    # every requested bundle already existed and doozer skipped it.
+    fallback_nvrs = [n.strip() for n in nvrs.split(',') if n.strip()] if nvrs else []
+
     # Parse doozer record.log to determine actual build results
     # This runs regardless of whether doozer succeeded or failed
     operator_nvrs = []
@@ -184,10 +252,18 @@ async def olm_bundle_konflux(
 
     total_bundles = len(successful_bundles) + len(operators_with_failed_bundles)
     if total_bundles == 0:
-        runtime.logger.error('No bundle builds were attempted')
         if doozer_error:
+            runtime.logger.error('No bundle builds were attempted')
             raise doozer_error
-        raise RuntimeError('No bundle builds found in record.log')
+        if not fallback_nvrs:
+            raise RuntimeError('No bundle builds found in record.log and no input NVRs provided')
+        # Doozer succeeded but wrote no record.log — all bundles already existed and were skipped.
+        # Use fallback_nvrs to still trigger stage-release and FBC builds.
+        runtime.logger.info(
+            'No new bundles were built (all already exist); proceeding with %d pre-existing operator(s)',
+            len(fallback_nvrs),
+        )
+        operator_nvrs = fallback_nvrs
 
     if operators_with_failed_bundles and not successful_bundles:
         # All builds failed - re-raise the error or raise a new one
@@ -196,12 +272,36 @@ async def olm_bundle_konflux(
             raise doozer_error
         raise RuntimeError(f'All {len(operators_with_failed_bundles)} bundle build(s) failed')
 
+    # Operators whose related-image stage release failed; they are excluded from FBC and mark the job UNSTABLE
+    failed_stage_nvrs = []
+
     # Trigger FBC builds for successful bundles only
     if operator_nvrs:
         runtime.logger.info(f'Found operator NVRs: {operator_nvrs}')
 
         # Automatically propagate parameters if set in environment
         propagate_params = jenkins.get_propagatable_params()
+
+        # Stage-release related images before triggering any FBC builds.
+        # The release plan is resolved per product version (not OCP version), so a single call covers all target versions.
+        failed_stage_nvrs = await _stage_release_related_images(
+            runtime=runtime,
+            doozer_base_cmd=doozer_base_cmd,
+            namespace=namespace,
+            final_kubeconfig=final_kubeconfig,
+            operator_nvrs=operator_nvrs,
+        )
+        if failed_stage_nvrs:
+            # Don't build FBC for an operator whose images never made it to the advisory; the rest carry on.
+            operator_nvrs = [nvr for nvr in operator_nvrs if nvr not in failed_stage_nvrs]
+            if not operator_nvrs:
+                raise RuntimeError(
+                    f'Stage release of related images failed for every operator: {", ".join(failed_stage_nvrs)}'
+                )
+            runtime.logger.warning(
+                f'Skipping FBC builds for {len(failed_stage_nvrs)} operator(s) whose stage release failed; '
+                f'continuing with: {operator_nvrs}'
+            )
 
         # Check if this is a non-openshift group and if OCP_TARGET_VERSIONS is configured
         if group and not group.startswith("openshift-"):
@@ -255,15 +355,22 @@ async def olm_bundle_konflux(
                 propagate_params=propagate_params,
             )
 
-    if operators_with_failed_bundles and successful_bundles:
+    if operators_with_failed_bundles or failed_stage_nvrs:
         # Partial failure - exit with code 2 to mark Jenkins job as UNSTABLE
         runtime.logger.warning(
-            'Job completed with partial success - some bundle builds failed but FBC triggered for successful bundles'
+            'Job completed with partial success - FBC triggered only for the operators that fully succeeded'
         )
-        runtime.logger.warning(
-            f'{len(successful_bundles)} bundle(s) built successfully: {", ".join(successful_bundles)}'
-        )
-        runtime.logger.warning(f'{len(operators_with_failed_bundles)} bundle(s) failed - see errors above')
+        if successful_bundles:
+            runtime.logger.warning(
+                f'{len(successful_bundles)} bundle(s) built successfully: {", ".join(successful_bundles)}'
+            )
+        if operators_with_failed_bundles:
+            runtime.logger.warning(f'{len(operators_with_failed_bundles)} bundle(s) failed - see errors above')
+        if failed_stage_nvrs:
+            runtime.logger.warning(
+                f'{len(failed_stage_nvrs)} operator(s) failed to stage-release their related images: '
+                f'{", ".join(failed_stage_nvrs)}'
+            )
         sys.exit(2)
 
     # If we get here, all builds succeeded - job will be marked as SUCCESS

--- a/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
@@ -117,8 +117,7 @@ def _parse_failed_stage_releases(runtime: Runtime) -> list:
     '--force', is_flag=True, help='Rebuild bundle containers, even if they already exist for given operator NVRs'
 )
 @click.option(
-    '--force-release', is_flag=True,
-    help='Stage-release related images even if bundle containers were not rebuilt'
+    '--force-release', is_flag=True, help='Stage-release related images even if bundle containers were not rebuilt'
 )
 @click.option("--kubeconfig", required=False, help="Path to kubeconfig file to use for Konflux cluster connections")
 @click.option(
@@ -310,8 +309,7 @@ async def olm_bundle_konflux(
                 )
         else:
             runtime.logger.info(
-                'Skipping stage release of related images — no new bundles were built '
-                '(use --force-release to override)'
+                'Skipping stage release of related images — no new bundles were built (use --force-release to override)'
             )
 
         # Check if this is a non-openshift group and if OCP_TARGET_VERSIONS is configured

--- a/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
@@ -116,6 +116,10 @@ def _parse_failed_stage_releases(runtime: Runtime) -> list:
 @click.option(
     '--force', is_flag=True, help='Rebuild bundle containers, even if they already exist for given operator NVRs'
 )
+@click.option(
+    '--force-release', is_flag=True,
+    help='Stage-release related images even if bundle containers were not rebuilt'
+)
 @click.option("--kubeconfig", required=False, help="Path to kubeconfig file to use for Konflux cluster connections")
 @click.option(
     '--plr-template',
@@ -135,6 +139,7 @@ async def olm_bundle_konflux(
     only: bool,
     exclude: str,
     force: bool,
+    force_release: bool,
     kubeconfig: str,
     plr_template: str,
     group: str,
@@ -251,6 +256,7 @@ async def olm_bundle_konflux(
             raise doozer_error
 
     total_bundles = len(successful_bundles) + len(operators_with_failed_bundles)
+    bundles_were_built = total_bundles > 0
     if total_bundles == 0:
         if doozer_error:
             runtime.logger.error('No bundle builds were attempted')
@@ -258,7 +264,7 @@ async def olm_bundle_konflux(
         if not fallback_nvrs:
             raise RuntimeError('No bundle builds found in record.log and no input NVRs provided')
         # Doozer succeeded but wrote no record.log — all bundles already existed and were skipped.
-        # Use fallback_nvrs to still trigger stage-release and FBC builds.
+        # Use fallback_nvrs to still trigger FBC builds.
         runtime.logger.info(
             'No new bundles were built (all already exist); proceeding with %d pre-existing operator(s)',
             len(fallback_nvrs),
@@ -283,24 +289,29 @@ async def olm_bundle_konflux(
         propagate_params = jenkins.get_propagatable_params()
 
         # Stage-release related images before triggering any FBC builds.
-        # The release plan is resolved per product version (not OCP version), so a single call covers all target versions.
-        failed_stage_nvrs = await _stage_release_related_images(
-            runtime=runtime,
-            doozer_base_cmd=doozer_base_cmd,
-            namespace=namespace,
-            final_kubeconfig=final_kubeconfig,
-            operator_nvrs=operator_nvrs,
-        )
-        if failed_stage_nvrs:
-            # Don't build FBC for an operator whose images never made it to the advisory; the rest carry on.
-            operator_nvrs = [nvr for nvr in operator_nvrs if nvr not in failed_stage_nvrs]
-            if not operator_nvrs:
-                raise RuntimeError(
-                    f'Stage release of related images failed for every operator: {", ".join(failed_stage_nvrs)}'
+        # Skip when bundles were not rebuilt — related images were already released in the original build.
+        if bundles_were_built or force_release:
+            failed_stage_nvrs = await _stage_release_related_images(
+                runtime=runtime,
+                doozer_base_cmd=doozer_base_cmd,
+                namespace=namespace,
+                final_kubeconfig=final_kubeconfig,
+                operator_nvrs=operator_nvrs,
+            )
+            if failed_stage_nvrs:
+                operator_nvrs = [nvr for nvr in operator_nvrs if nvr not in failed_stage_nvrs]
+                if not operator_nvrs:
+                    raise RuntimeError(
+                        f'Stage release of related images failed for every operator: {", ".join(failed_stage_nvrs)}'
+                    )
+                runtime.logger.warning(
+                    f'Skipping FBC builds for {len(failed_stage_nvrs)} operator(s) whose stage release failed; '
+                    f'continuing with: {operator_nvrs}'
                 )
-            runtime.logger.warning(
-                f'Skipping FBC builds for {len(failed_stage_nvrs)} operator(s) whose stage release failed; '
-                f'continuing with: {operator_nvrs}'
+        else:
+            runtime.logger.info(
+                'Skipping stage release of related images — no new bundles were built '
+                '(use --force-release to override)'
             )
 
         # Check if this is a non-openshift group and if OCP_TARGET_VERSIONS is configured

--- a/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
@@ -5,7 +5,11 @@ from pathlib import Path
 import click
 from artcommonlib import exectools
 from artcommonlib.constants import PRODUCT_KUBECONFIG_MAP
-from artcommonlib.util import resolve_konflux_kubeconfig_by_product, resolve_konflux_namespace_by_product
+from artcommonlib.util import (
+    resolve_konflux_fbc_stage_release_plan,
+    resolve_konflux_kubeconfig_by_product,
+    resolve_konflux_namespace_by_product,
+)
 
 from pyartcd import constants, jenkins, locks
 from pyartcd.cli import cli, click_coroutine, pass_runtime
@@ -173,6 +177,16 @@ async def olm_bundle_konflux(
     )
     product = group_config.get('product', 'ocp')
 
+    version_str = group_config.get('version')
+    if version_str:
+        parts = str(version_str).split(".")
+        product_major, product_minor = int(parts[0]), int(parts[1])
+    else:
+        vars_section = group_config.get('vars', {})
+        product_major = int(vars_section.get('MAJOR', 0))
+        product_minor = int(vars_section.get('MINOR', 0))
+    has_stage_release_plan = bool(resolve_konflux_fbc_stage_release_plan(product, product_major, product_minor))
+
     # Set namespace based on product
     namespace = resolve_konflux_namespace_by_product(product)
     cmd.extend(['--konflux-namespace', namespace])
@@ -288,8 +302,16 @@ async def olm_bundle_konflux(
         propagate_params = jenkins.get_propagatable_params()
 
         # Stage-release related images before triggering any FBC builds.
-        # Skip when bundles were not rebuilt — related images were already released in the original build.
-        if bundles_were_built or force_release:
+        # Skip when no release plan is configured for this product/version.
+        # When a plan exists, skip only if bundles were not rebuilt (unless --force-release is set).
+        if not has_stage_release_plan:
+            runtime.logger.info(
+                "No stage release plan configured for product '%s' (%d.%d); skipping stage release",
+                product,
+                product_major,
+                product_minor,
+            )
+        elif bundles_were_built or force_release:
             failed_stage_nvrs = await _stage_release_related_images(
                 runtime=runtime,
                 doozer_base_cmd=doozer_base_cmd,

--- a/pyartcd/tests/pipelines/test_olm_bundle_konflux.py
+++ b/pyartcd/tests/pipelines/test_olm_bundle_konflux.py
@@ -76,5 +76,94 @@ class TestStageReleaseRelatedImages(unittest.IsolatedAsyncioTestCase):
         self.assertIn('--dry-run', cmd_assert_async.await_args.args[0])
 
 
+class TestOlmBundleKonfluxStageReleaseGating(unittest.IsolatedAsyncioTestCase):
+    """Stage release should only run when bundles were actually built, unless --force-release is set."""
+
+    def setUp(self):
+        self._working_dir = TemporaryDirectory()
+        self.addCleanup(self._working_dir.cleanup)
+        self.runtime = mock.MagicMock(dry_run=False, doozer_working=self._working_dir.name)
+
+    def _write_bundle_record(self, status='0', operator_nvr='op-1-1', bundle_nvr='op-bundle-1-1'):
+        line = f"build_olm_bundle_konflux|status={status}|operator_nvr={operator_nvr}|bundle_nvr={bundle_nvr}|"
+        Path(self._working_dir.name, 'record.log').write_text(line + "\n")
+
+    def _get_original_func(self):
+        from pyartcd.pipelines.olm_bundle_konflux import olm_bundle_konflux
+        # Unwrap pass_runtime -> click_coroutine -> original async function
+        return olm_bundle_konflux.callback.__wrapped__.__wrapped__
+
+    async def _run_pipeline(self, mock_stage_release, mock_load_group_config, mock_locks, mock_jenkins,
+                            nvrs='operator-container-4.18.0-1', force_release=False):
+        mock_locks.run_with_lock = mock.AsyncMock()
+        mock_load_group_config.return_value = {'product': 'ocp'}
+        mock_jenkins.get_build_path_or_random.return_value = 'test'
+        mock_jenkins.get_propagatable_params.return_value = {}
+
+        await self._get_original_func()(
+            runtime=self.runtime,
+            version='4.18',
+            assembly='stream',
+            data_path='https://github.com/openshift-eng/ocp-build-data',
+            data_gitref='',
+            nvrs=nvrs,
+            only=None,
+            exclude=None,
+            force=False,
+            force_release=force_release,
+            kubeconfig='/fake/kubeconfig',
+            plr_template='',
+            group='openshift-4.18',
+        )
+
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.jenkins")
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.locks")
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.exectools.cmd_assert_async", new_callable=mock.AsyncMock)
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.load_group_config", new_callable=mock.AsyncMock)
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux._stage_release_related_images", new_callable=mock.AsyncMock)
+    async def test_stage_release_skipped_when_bundles_not_rebuilt(
+        self, mock_stage_release, mock_load_group_config, mock_cmd_assert, mock_locks, mock_jenkins,
+    ):
+        """When all bundles are skipped (already exist), stage release should not run."""
+        await self._run_pipeline(mock_stage_release, mock_load_group_config, mock_locks, mock_jenkins)
+
+        mock_stage_release.assert_not_called()
+        mock_jenkins.start_build_fbc.assert_called_once()
+
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.jenkins")
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.locks")
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.exectools.cmd_assert_async", new_callable=mock.AsyncMock)
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.load_group_config", new_callable=mock.AsyncMock)
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux._stage_release_related_images", new_callable=mock.AsyncMock)
+    async def test_stage_release_runs_when_force_release_set(
+        self, mock_stage_release, mock_load_group_config, mock_cmd_assert, mock_locks, mock_jenkins,
+    ):
+        """When --force-release is set, stage release runs even for skipped bundles."""
+        mock_stage_release.return_value = []
+        await self._run_pipeline(
+            mock_stage_release, mock_load_group_config, mock_locks, mock_jenkins, force_release=True
+        )
+
+        mock_stage_release.assert_called_once()
+
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.jenkins")
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.locks")
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.exectools.cmd_assert_async", new_callable=mock.AsyncMock)
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.load_group_config", new_callable=mock.AsyncMock)
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux._stage_release_related_images", new_callable=mock.AsyncMock)
+    async def test_stage_release_runs_when_bundles_actually_built(
+        self, mock_stage_release, mock_load_group_config, mock_cmd_assert, mock_locks, mock_jenkins,
+    ):
+        """When bundles are actually built (record.log has entries), stage release runs."""
+        mock_stage_release.return_value = []
+        self._write_bundle_record(status='0', operator_nvr='op-1-1', bundle_nvr='op-bundle-1-1')
+
+        await self._run_pipeline(
+            mock_stage_release, mock_load_group_config, mock_locks, mock_jenkins, nvrs=''
+        )
+
+        mock_stage_release.assert_called_once()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/pyartcd/tests/pipelines/test_olm_bundle_konflux.py
+++ b/pyartcd/tests/pipelines/test_olm_bundle_konflux.py
@@ -90,11 +90,19 @@ class TestOlmBundleKonfluxStageReleaseGating(unittest.IsolatedAsyncioTestCase):
 
     def _get_original_func(self):
         from pyartcd.pipelines.olm_bundle_konflux import olm_bundle_konflux
+
         # Unwrap pass_runtime -> click_coroutine -> original async function
         return olm_bundle_konflux.callback.__wrapped__.__wrapped__
 
-    async def _run_pipeline(self, mock_stage_release, mock_load_group_config, mock_locks, mock_jenkins,
-                            nvrs='operator-container-4.18.0-1', force_release=False):
+    async def _run_pipeline(
+        self,
+        mock_stage_release,
+        mock_load_group_config,
+        mock_locks,
+        mock_jenkins,
+        nvrs='operator-container-4.18.0-1',
+        force_release=False,
+    ):
         mock_locks.run_with_lock = mock.AsyncMock()
         mock_load_group_config.return_value = {'product': 'ocp'}
         mock_jenkins.get_build_path_or_random.return_value = 'test'
@@ -122,7 +130,12 @@ class TestOlmBundleKonfluxStageReleaseGating(unittest.IsolatedAsyncioTestCase):
     @mock.patch("pyartcd.pipelines.olm_bundle_konflux.load_group_config", new_callable=mock.AsyncMock)
     @mock.patch("pyartcd.pipelines.olm_bundle_konflux._stage_release_related_images", new_callable=mock.AsyncMock)
     async def test_stage_release_skipped_when_bundles_not_rebuilt(
-        self, mock_stage_release, mock_load_group_config, mock_cmd_assert, mock_locks, mock_jenkins,
+        self,
+        mock_stage_release,
+        mock_load_group_config,
+        mock_cmd_assert,
+        mock_locks,
+        mock_jenkins,
     ):
         """When all bundles are skipped (already exist), stage release should not run."""
         await self._run_pipeline(mock_stage_release, mock_load_group_config, mock_locks, mock_jenkins)
@@ -136,7 +149,12 @@ class TestOlmBundleKonfluxStageReleaseGating(unittest.IsolatedAsyncioTestCase):
     @mock.patch("pyartcd.pipelines.olm_bundle_konflux.load_group_config", new_callable=mock.AsyncMock)
     @mock.patch("pyartcd.pipelines.olm_bundle_konflux._stage_release_related_images", new_callable=mock.AsyncMock)
     async def test_stage_release_runs_when_force_release_set(
-        self, mock_stage_release, mock_load_group_config, mock_cmd_assert, mock_locks, mock_jenkins,
+        self,
+        mock_stage_release,
+        mock_load_group_config,
+        mock_cmd_assert,
+        mock_locks,
+        mock_jenkins,
     ):
         """When --force-release is set, stage release runs even for skipped bundles."""
         mock_stage_release.return_value = []
@@ -152,15 +170,18 @@ class TestOlmBundleKonfluxStageReleaseGating(unittest.IsolatedAsyncioTestCase):
     @mock.patch("pyartcd.pipelines.olm_bundle_konflux.load_group_config", new_callable=mock.AsyncMock)
     @mock.patch("pyartcd.pipelines.olm_bundle_konflux._stage_release_related_images", new_callable=mock.AsyncMock)
     async def test_stage_release_runs_when_bundles_actually_built(
-        self, mock_stage_release, mock_load_group_config, mock_cmd_assert, mock_locks, mock_jenkins,
+        self,
+        mock_stage_release,
+        mock_load_group_config,
+        mock_cmd_assert,
+        mock_locks,
+        mock_jenkins,
     ):
         """When bundles are actually built (record.log has entries), stage release runs."""
         mock_stage_release.return_value = []
         self._write_bundle_record(status='0', operator_nvr='op-1-1', bundle_nvr='op-bundle-1-1')
 
-        await self._run_pipeline(
-            mock_stage_release, mock_load_group_config, mock_locks, mock_jenkins, nvrs=''
-        )
+        await self._run_pipeline(mock_stage_release, mock_load_group_config, mock_locks, mock_jenkins, nvrs='')
 
         mock_stage_release.assert_called_once()
 

--- a/pyartcd/tests/pipelines/test_olm_bundle_konflux.py
+++ b/pyartcd/tests/pipelines/test_olm_bundle_konflux.py
@@ -102,9 +102,14 @@ class TestOlmBundleKonfluxStageReleaseGating(unittest.IsolatedAsyncioTestCase):
         mock_jenkins,
         nvrs='operator-container-4.18.0-1',
         force_release=False,
+        product='rhacm2',
+        group_config_extra=None,
     ):
         mock_locks.run_with_lock = mock.AsyncMock()
-        mock_load_group_config.return_value = {'product': 'ocp'}
+        group_cfg = {'product': product, 'vars': {'MAJOR': '2', 'MINOR': '16'}}
+        if group_config_extra:
+            group_cfg.update(group_config_extra)
+        mock_load_group_config.return_value = group_cfg
         mock_jenkins.get_build_path_or_random.return_value = 'test'
         mock_jenkins.get_propagatable_params.return_value = {}
 
@@ -184,6 +189,37 @@ class TestOlmBundleKonfluxStageReleaseGating(unittest.IsolatedAsyncioTestCase):
         await self._run_pipeline(mock_stage_release, mock_load_group_config, mock_locks, mock_jenkins, nvrs='')
 
         mock_stage_release.assert_called_once()
+
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.jenkins")
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.locks")
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.exectools.cmd_assert_async", new_callable=mock.AsyncMock)
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.load_group_config", new_callable=mock.AsyncMock)
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux._stage_release_related_images", new_callable=mock.AsyncMock)
+    async def test_stage_release_skipped_when_no_plan_configured(
+        self,
+        mock_stage_release,
+        mock_load_group_config,
+        mock_cmd_assert,
+        mock_locks,
+        mock_jenkins,
+    ):
+        """Products with no configured stage release plan skip stage release even with --force-release and built bundles."""
+        mock_stage_release.return_value = []
+        self._write_bundle_record(status='0', operator_nvr='op-1-1', bundle_nvr='op-bundle-1-1')
+
+        await self._run_pipeline(
+            mock_stage_release,
+            mock_load_group_config,
+            mock_locks,
+            mock_jenkins,
+            nvrs='',
+            force_release=True,
+            product='ocp',
+            group_config_extra={'vars': {'MAJOR': '5', 'MINOR': '1'}},
+        )
+
+        mock_stage_release.assert_not_called()
+        mock_jenkins.start_build_fbc.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/pyartcd/tests/pipelines/test_olm_bundle_konflux.py
+++ b/pyartcd/tests/pipelines/test_olm_bundle_konflux.py
@@ -1,0 +1,80 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from pyartcd.pipelines.olm_bundle_konflux import _stage_release_related_images
+
+
+class TestStageReleaseRelatedImages(unittest.IsolatedAsyncioTestCase):
+    """A stage release failure must be attributed to individual operators, not the whole job.
+
+    pyartcd drops only the failed operators from the FBC trigger list, so it needs the per-operator
+    `stage_release_related_images` records doozer writes to record.log.
+    """
+
+    def setUp(self):
+        self._working_dir = TemporaryDirectory()
+        self.addCleanup(self._working_dir.cleanup)
+        self.runtime = mock.MagicMock(dry_run=False, doozer_working=self._working_dir.name)
+
+    def _write_record_log(self, *records):
+        lines = []
+        for record in records:
+            fields = "|".join(f"{k}={v}" for k, v in record.items())
+            lines.append(f"stage_release_related_images|{fields}|")
+        Path(self._working_dir.name, 'record.log').write_text("\n".join(lines) + "\n")
+
+    async def _run(self):
+        return await _stage_release_related_images(
+            runtime=self.runtime,
+            doozer_base_cmd=['doozer', '--group=rhacm2-2.16'],
+            namespace='ns',
+            final_kubeconfig='/path/to/kubeconfig',
+            operator_nvrs=['operator-a-1-1', 'operator-b-1-1'],
+        )
+
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.exectools.cmd_assert_async")
+    async def test_returns_empty_list_on_success(self, cmd_assert_async: mock.AsyncMock):
+        self.assertEqual(await self._run(), [])
+        cmd = cmd_assert_async.await_args.args[0]
+        self.assertEqual(cmd[-2:], ['operator-a-1-1', 'operator-b-1-1'])
+        self.assertIn('beta:bundle:stage-release-related-images', cmd)
+
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.exectools.cmd_assert_async")
+    async def test_returns_failed_operator_nvrs(self, cmd_assert_async: mock.AsyncMock):
+        cmd_assert_async.side_effect = ChildProcessError('doozer failed')
+        self._write_record_log(
+            {'status': '1', 'operator_nvr': 'operator-a-1-1', 'operator': 'operator-a', 'message': 'boom'},
+            {'status': '0', 'operator_nvr': 'operator-b-1-1', 'operator': 'operator-b', 'message': ''},
+        )
+
+        self.assertEqual(await self._run(), ['operator-a-1-1'])
+
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.exectools.cmd_assert_async")
+    async def test_reraises_when_no_per_operator_results(self, cmd_assert_async: mock.AsyncMock):
+        """A crash before any operator ran (bad kubeconfig, etc.) is a job-wide failure."""
+        cmd_assert_async.side_effect = ChildProcessError('doozer failed')
+
+        with self.assertRaises(ChildProcessError):
+            await self._run()
+
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.exectools.cmd_assert_async")
+    async def test_reraises_when_all_records_succeeded(self, cmd_assert_async: mock.AsyncMock):
+        cmd_assert_async.side_effect = ChildProcessError('doozer failed')
+        self._write_record_log(
+            {'status': '0', 'operator_nvr': 'operator-a-1-1', 'operator': 'operator-a', 'message': ''},
+        )
+
+        with self.assertRaises(ChildProcessError):
+            await self._run()
+
+    @mock.patch("pyartcd.pipelines.olm_bundle_konflux.exectools.cmd_assert_async")
+    async def test_passes_dry_run_through(self, cmd_assert_async: mock.AsyncMock):
+        self.runtime.dry_run = True
+        await self._run()
+        self.assertIn('--dry-run', cmd_assert_async.await_args.args[0])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
e## Summary

- Adds stage-release of operator + operand images (bundle related images) to the **bundle build job**, running once before any FBC builds are triggered.
- Adds `PRODUCT_FBC_STAGE_RELEASE_PLAN_MAP` and `resolve_konflux_fbc_stage_release_plan()` for per-version ReleasePlan resolution per product.
- New doozer command `beta:bundle:stage-release-related-images`: given operator NVRs, looks up their bundle builds, extracts referenced images (operator + operands), and releases them via a Konflux advisory-stage ReleasePlan. No-ops for non-stream assemblies and products with no configured plan.
- Operators are processed **serially** — one Snapshot+Release pair per operator, in sequence. A failure on one operator is recorded but does not stop the remaining operators; a `DoozerFatalError` is raised at the end if any failed.
- Pipeline (`olm_bundle_konflux`) calls the command once before triggering FBC jobs — a single call covers all OCP target versions since the release plan is resolved from the product version, not the OCP version.
- Falls back to input NVRs when all bundles already existed (no new builds in record.log), so stage-release still fires.
- Refactors `_get_referenced_images` in `konflux_fbc.py` into a public module-level function `get_referenced_images()` so it can be reused by the new CLI command.
- Adds optional `group` parameter to `get_build_records_by_nvrs()` in `konflux_db.py` and threads it through to `get_latest_build()` for cache optimization.

## Why the bundle job

Placing stage-release here means images are released to the advisory exactly once per bundle build, regardless of how many FBC jobs fan out from it (layered products can target multiple OCP versions). Doing it per FBC build would create duplicate Snapshots/Releases for the same images.

## Coordination

ReleasePlan names in `PRODUCT_FBC_STAGE_RELEASE_PLAN_MAP` must stay aligned with `konflux-release-data` ReleasePlan resources. See [ART-17452](https://redhat.atlassian.net/browse/ART-17452).

## Test coverage

- `artcommon/tests/test_util.py` — 3 unit tests for `resolve_konflux_fbc_stage_release_plan()` (known product+version, wrong version, unknown product)
- `doozer/tests/cli/test_images_konflux.py` — 7 async tests for `BundleStageReleaseRelatedImagesCli` (version resolution, Snapshot/Release creation, release failure propagation, per-operator isolation, missing build records)
- `pyartcd/tests/pipelines/test_olm_bundle_konflux.py` — new file, 5 async tests for `_stage_release_related_images()` (success, partial failure, job-wide crash, all-succeeded-but-exit-nonzero, dry-run flag passthrough)

## Test plan

- ACM -> https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Folm_bundle_konflux/31622/console -> in list -> release triggered https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/art-acm-tenant/applications/acm-2-16/releases/fbc-ri-stage-acm-2-16-multiclusterhub-operator-5jx8n

- ACM -> in list -> pre-existing build -> no force-release -> https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Folm_bundle_konflux/31669/console -> skipped 

```
22:02:10  2026-08-21 02:02:10,567 pyartcd      INFO Skipping stage release of related images — no new bundles were built (use --force-release to override)
```

- Same as above, but with force-release -> https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Folm_bundle_konflux/31670/console --> ok

- OCP -> https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Folm_bundle_konflux/31673/console-> not in list
```
    INFO No stage release plan configured for product 'ocp' (5.1); skipping stage release
```
