### PR TITLE
release-from-fbc: Fix JIRA remote link, remove broken wrapper, call python-jira directly

### DIFF
--- a/pyartcd/pyartcd/jira_client.py
+++ b/pyartcd/pyartcd/jira_client.py
@@ -41,15 +41,6 @@ class JIRAClient:
     def add_comment(self, key, comment):
         self._client.add_comment(key, comment, visibility={'type': 'group', 'value': 'Red Hat Employee'})
 
-    def add_remote_link(self, issue_key: str, link_object: dict):
-        """Add a remote web link to a JIRA issue.
-
-        Args:
-            issue_key: The JIRA issue key (e.g. "OADP-1234")
-            link_object: Dict with "title" and "url" keys
-        """
-        self._client.add_remote_link(issue_key, {"object": link_object})
-
     def assign_to_me(self, key):
         self._client.assign_issue(key, 'openshift-art-jira-bot')
 

--- a/pyartcd/pyartcd/pipelines/release_from_fbc.py
+++ b/pyartcd/pyartcd/pipelines/release_from_fbc.py
@@ -991,7 +991,7 @@ class ReleaseFromFbcPipeline:
 
         try:
             jira_client = self.runtime.new_jira_client()
-            jira_client.add_remote_link(issue_key, {"title": "Shipment MR", "url": mr_url})
+            jira_client._client.add_remote_link(issue_key, {"title": "Shipment MR", "url": mr_url})
             self.logger.info("Added shipment MR link to JIRA ticket %s", issue_key)
         except Exception as e:  # noqa: BLE001 — best-effort; JIRA failures must not block the release
             self.logger.warning("Failed to update JIRA ticket %s with MR link: %s", issue_key, e)

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -797,7 +797,7 @@ class TestReleaseJira(unittest.TestCase):
 
         pipeline._update_jira_with_mr_link("https://gitlab.example.com/org/repo/-/merge_requests/10")
 
-        mock_jira.add_remote_link.assert_called_once_with(
+        mock_jira._client.add_remote_link.assert_called_once_with(
             "OADP-5678",
             {"title": "Shipment MR", "url": "https://gitlab.example.com/org/repo/-/merge_requests/10"},
         )
@@ -809,7 +809,7 @@ class TestReleaseJira(unittest.TestCase):
 
         pipeline._update_jira_with_mr_link("https://gitlab.example.com/org/repo/-/merge_requests/10")
 
-        mock_jira.add_remote_link.assert_called_once_with(
+        mock_jira._client.add_remote_link.assert_called_once_with(
             "OADP-5678",
             {"title": "Shipment MR", "url": "https://gitlab.example.com/org/repo/-/merge_requests/10"},
         )

--- a/pyartcd/tests/test_jira_client.py
+++ b/pyartcd/tests/test_jira_client.py
@@ -34,14 +34,6 @@ class TestJIRAClient(TestCase):
             }
         )
 
-    def test_add_remote_link(self):
-        client = JIRAClient(mock.MagicMock())
-        client.add_remote_link("OADP-1234", {"title": "Shipment MR", "url": "https://gitlab.example.com/mr/1"})
-        client._client.add_remote_link.assert_called_once_with(
-            "OADP-1234",
-            {"object": {"title": "Shipment MR", "url": "https://gitlab.example.com/mr/1"}},
-        )
-
     def test_clone_issue(self):
         source_issue = mock.MagicMock(
             key="FOO-1",


### PR DESCRIPTION
## Summary

The `JIRAClient.add_remote_link()` wrapper introduced in [#2715](https://github.com/openshift-eng/art-tools/pull/2715) double-wrapped the remote link payload — `python-jira`'s `JIRA.add_remote_link()` already wraps the destination dict in an `"object"` key internally, so our wrapper produced `{"object": {"object": {...}}}` which JIRA rejects with HTTP 400.

## Fix

Remove the wrapper entirely and call `jira.JIRA.add_remote_link()` directly via `_client`, matching the proven pattern already used in doozer (`images_streams.py`) and elliott (`find_bugs_kernel_cli.py`).

## Evidence

**Failing build (double-wrap):** [build #175](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Frelease-from-fbc/175/) — HTTP 400 on remotelink endpoint

**Successful build (direct call):** [build #176](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Frelease-from-fbc/176/) — "Added shipment MR link to JIRA ticket" confirmed

## Test plan

- [x] Unit tests updated and passing
- [x] Verified on release-from-fbc build #176 that JIRA remote link was created successfully

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED