### PR TITLE
ART-21876: Add verify-cve-trackers elliott command and verify_release step

### DIFF
--- a/elliott/elliottlib/cli/__main__.py
+++ b/elliott/elliottlib/cli/__main__.py
@@ -74,6 +74,7 @@ from elliottlib.cli.validate_rhsa import validate_rhsa_cli
 from elliottlib.cli.verify_attached_bugs_cli import verify_attached_bugs_cli
 from elliottlib.cli.verify_attached_operators_cli import verify_attached_operators_cli
 from elliottlib.cli.verify_cdn_push_cli import verify_cdn_push_cli
+from elliottlib.cli.verify_cve_trackers_cli import verify_cve_trackers_cli
 from elliottlib.cli.verify_cvp_cli import verify_cvp_cli
 from elliottlib.cli.verify_docs_approval import verify_docs_approval
 from elliottlib.cli.verify_image_grades_cli import verify_image_grades_cli
@@ -333,6 +334,7 @@ cli.add_command(watch_release_cli)
 cli.add_command(find_bugs_second_fix_cli)
 cli.add_command(process_release_from_fbc_bugs_cli)
 cli.add_command(verify_cdn_push_cli)
+cli.add_command(verify_cve_trackers_cli)
 cli.add_command(verify_security_alerts_cli)
 cli.add_command(verify_signatures_cli)
 cli.add_command(verify_image_grades_cli)

--- a/elliott/elliottlib/cli/verify_cve_trackers_cli.py
+++ b/elliott/elliottlib/cli/verify_cve_trackers_cli.py
@@ -1,0 +1,230 @@
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+import click
+from artcommonlib.assembly import assembly_config_struct
+from artcommonlib.jira_config import JIRA_DOMAIN_NAME
+
+from elliottlib import errata
+from elliottlib.cli.common import cli, click_coroutine
+from elliottlib.cli.find_bugs_sweep_cli import (
+    FindBugsSweep,
+    categorize_bugs_by_type,
+    get_bugs_sweep,
+    get_builds_by_advisory_kind,
+)
+from elliottlib.shipment_utils import get_shipment_configs_from_mr
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class MissedTracker:
+    bug_id: str
+    kind: str
+    source: str
+
+
+@dataclass
+class VerifyCVETrackersResult:
+    missed_trackers: list[MissedTracker] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return len(self.missed_trackers) == 0
+
+    @property
+    def failed(self) -> bool:
+        return len(self.missed_trackers) > 0
+
+
+def render_result(result: VerifyCVETrackersResult, output: str) -> str:
+    if output == "json":
+        return json.dumps(
+            {
+                "ok": result.ok,
+                "missed_trackers": [
+                    {
+                        "bug_id": t.bug_id,
+                        "kind": t.kind,
+                        "source": t.source,
+                    }
+                    for t in result.missed_trackers
+                ],
+            },
+            indent=2,
+        )
+
+    lines = ["CVE tracker bug check", ""]
+    if result.ok:
+        lines.append("  No missed CVE tracker bugs found.")
+    else:
+        lines.append(f"  Found {len(result.missed_trackers)} missed CVE tracker bug(s):")
+        for t in result.missed_trackers:
+            lines.append(f"    {t.bug_id} (kind={t.kind}, not found in {t.source})")
+    lines.append("")
+    overall = "OK" if result.ok else "FAIL"
+    lines.append(f"Overall: {overall}")
+    return "\n".join(lines)
+
+
+async def get_advisory_jira_issues(advisory_id: int) -> set[str]:
+    """Get all jira issue IDs attached to an advisory."""
+    bug_ids = errata.get_bug_ids(advisory_id)
+    return set(bug_ids.get("jira", []))
+
+
+def get_shipment_jira_issues(mr_url: str, group: str) -> set[str]:
+    """Get all jira issue IDs from shipment YAML files in a merge request."""
+    issues: set[str] = set()
+    shipment_configs = get_shipment_configs_from_mr(mr_url, group=group)
+    for config in shipment_configs.values():
+        release_notes = config.shipment.data.releaseNotes if config.shipment.data else None
+        if not release_notes or not release_notes.issues or not release_notes.issues.fixed:
+            continue
+        for issue in release_notes.issues.fixed:
+            if issue.source == JIRA_DOMAIN_NAME:
+                issues.add(issue.id)
+    return issues
+
+
+async def find_cve_tracker_bugs(runtime, permissive: bool = True) -> dict[str, list[str]]:
+    """Run find-bugs --cve-only logic and return tracker bug IDs by advisory kind."""
+    find_bugs_obj = FindBugsSweep(cve_only=True, art_managed_trackers_only=True)
+    bug_tracker = runtime.get_bug_tracker("jira")
+
+    bugs = await get_bugs_sweep(runtime, find_bugs_obj, bug_tracker, filter_attached_bugs=True)
+    major_version, minor_version = runtime.get_major_minor()
+    builds_by_advisory_kind = get_builds_by_advisory_kind(runtime)
+    bugs_by_type, _ = categorize_bugs_by_type(
+        runtime=runtime,
+        bugs=bugs,
+        builds_by_advisory_kind=builds_by_advisory_kind,
+        major_version=major_version,
+        minor_version=minor_version,
+        operator_bundle_advisory="metadata",
+        permissive=permissive,
+        exclude_trackers=False,
+    )
+
+    return {kind: [b.id for b in kind_bugs] for kind, kind_bugs in bugs_by_type.items()}
+
+
+def get_advisory_ids(runtime) -> dict[str, int]:
+    """Get advisory IDs from assembly config, similar to verify_security_alerts_cli."""
+    releases_config = runtime.get_releases_config()
+    group_config = assembly_config_struct(releases_config, runtime.assembly, "group", {})
+    advisories = group_config.get("advisories", {})
+    result = {}
+    for impetus, ad_id in advisories.items():
+        if ad_id:
+            result[impetus] = int(ad_id)
+    return result
+
+
+def get_shipment_mr_url(runtime) -> Optional[str]:
+    """Get shipment MR URL from assembly config."""
+    releases_config = runtime.get_releases_config()
+    group_config = assembly_config_struct(releases_config, runtime.assembly, "group", {})
+    shipment = group_config.get("shipment", {})
+    return shipment.get("url")
+
+
+async def verify_cve_trackers(runtime, permissive: bool = True) -> VerifyCVETrackersResult:
+    result = VerifyCVETrackersResult()
+
+    LOGGER.info("Finding CVE tracker bugs...")
+    cve_trackers_by_kind = await find_cve_tracker_bugs(runtime, permissive=permissive)
+
+    total_trackers = sum(len(bugs) for bugs in cve_trackers_by_kind.values())
+    if total_trackers == 0:
+        LOGGER.info("No CVE tracker bugs found for this assembly")
+        return result
+
+    LOGGER.info("Found %d CVE tracker bug(s) across %d kind(s)", total_trackers, len(cve_trackers_by_kind))
+    for kind, bugs in cve_trackers_by_kind.items():
+        LOGGER.info("  %s: %s", kind, bugs)
+
+    # Get advisory IDs and determine which are RHSA
+    advisories = get_advisory_ids(runtime)
+    if not advisories:
+        LOGGER.warning("No advisory IDs found in assembly config")
+
+    # Collect jira issues from RHSA advisories
+    rhsa_jira_issues: set[str] = set()
+    for impetus, advisory_id in advisories.items():
+        raw = errata.get_raw_erratum(advisory_id)
+        errata_type = next(iter(raw.get("errata", {}).keys()), "")
+        if errata_type != "rhsa":
+            LOGGER.info("Advisory %s (%s): type %s, skipping (not RHSA)", advisory_id, impetus, errata_type.upper())
+            continue
+        issues = await get_advisory_jira_issues(advisory_id)
+        LOGGER.info("Advisory %s (%s): RHSA, found %d jira issues", advisory_id, impetus, len(issues))
+        rhsa_jira_issues.update(issues)
+
+    # Cross-check CVE trackers against RHSA advisories (for rpm and rhcos kinds)
+    advisory_kinds = ("rpm", "rhcos")
+    for kind in advisory_kinds:
+        trackers = cve_trackers_by_kind.get(kind, [])
+        for tracker_id in trackers:
+            if tracker_id not in rhsa_jira_issues:
+                LOGGER.warning("CVE tracker %s (kind=%s) not found in RHSA advisories", tracker_id, kind)
+                result.missed_trackers.append(MissedTracker(bug_id=tracker_id, kind=kind, source="RHSA advisories"))
+
+    # Check shipment MR (Konflux flow) if available
+    mr_url = get_shipment_mr_url(runtime)
+    if mr_url:
+        LOGGER.info("Checking shipment MR for CVE tracker coverage: %s", mr_url)
+        shipment_jira_issues = get_shipment_jira_issues(mr_url, group=runtime.group)
+        LOGGER.info("Found %d jira issues in shipment MR", len(shipment_jira_issues))
+
+        # Cross-check all CVE trackers against shipment data
+        for kind, trackers in cve_trackers_by_kind.items():
+            for tracker_id in trackers:
+                if tracker_id not in shipment_jira_issues:
+                    LOGGER.warning("CVE tracker %s (kind=%s) not found in shipment MR", tracker_id, kind)
+                    result.missed_trackers.append(MissedTracker(bug_id=tracker_id, kind=kind, source="shipment MR"))
+    else:
+        LOGGER.info("No shipment MR URL found in assembly config, skipping shipment check")
+
+    return result
+
+
+@cli.command("verify-cve-trackers", short_help="Check that CVE tracker bugs are attached to advisories/shipment")
+@click.option(
+    "-o",
+    "--output",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    show_default=True,
+    help="Output format.",
+)
+@click.option(
+    "--permissive",
+    is_flag=True,
+    default=True,
+    show_default=True,
+    help="Ignore bugs that are determined to be invalid and continue",
+)
+@click.pass_obj
+@click_coroutine
+async def verify_cve_trackers_cli(runtime, output, permissive):
+    """Check that all CVE tracker bugs are properly attached to RHSA advisories
+    and/or shipment merge requests.
+
+    Finds CVE tracker bugs for the assembly, then cross-checks them against:
+    - RHSA advisories: rpm and rhcos tracker bugs must be in RHSA advisory jira issues
+    - Shipment MR (Konflux flow): all tracker bugs must be in shipment YAML files
+
+    Exits with code 1 if any CVE tracker bug is missing.
+
+    Example:
+        elliott --group openshift-4.18 --assembly 4.18.51 verify-cve-trackers
+    """
+    runtime.initialize(mode="both")
+    result = await verify_cve_trackers(runtime, permissive=permissive)
+    click.echo(render_result(result, output))
+    if not result.ok:
+        raise SystemExit(1)

--- a/elliott/elliottlib/cli/verify_cve_trackers_cli.py
+++ b/elliott/elliottlib/cli/verify_cve_trackers_cli.py
@@ -73,7 +73,7 @@ def render_result(result: VerifyCVETrackersResult, output: str) -> str:
 
 async def get_advisory_jira_issues(advisory_id: int) -> set[str]:
     """Get all jira issue IDs attached to an advisory."""
-    bug_ids = errata.get_bug_ids(advisory_id)
+    bug_ids = await asyncio.to_thread(errata.get_bug_ids, advisory_id)
     return set(bug_ids.get("jira", []))
 
 
@@ -156,7 +156,7 @@ async def verify_cve_trackers(runtime, permissive: bool = True) -> VerifyCVETrac
     # Collect jira issues from RHSA advisories
     rhsa_jira_issues: set[str] = set()
     for impetus, advisory_id in advisories.items():
-        raw = errata.get_raw_erratum(advisory_id)
+        raw = await asyncio.to_thread(errata.get_raw_erratum, advisory_id)
         errata_type = next(iter(raw.get("errata", {}).keys()), "")
         if errata_type != "rhsa":
             LOGGER.info("Advisory %s (%s): type %s, skipping (not RHSA)", advisory_id, impetus, errata_type.upper())
@@ -203,11 +203,10 @@ async def verify_cve_trackers(runtime, permissive: bool = True) -> VerifyCVETrac
     help="Output format.",
 )
 @click.option(
-    "--permissive",
-    is_flag=True,
+    "--permissive/--no-permissive",
     default=True,
     show_default=True,
-    help="Ignore bugs that are determined to be invalid and continue. Use --no-permissive to fail on invalid bugs.",
+    help="Ignore bugs that are determined to be invalid and continue.",
 )
 @click.pass_obj
 @click_coroutine

--- a/elliott/elliottlib/cli/verify_cve_trackers_cli.py
+++ b/elliott/elliottlib/cli/verify_cve_trackers_cli.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from dataclasses import dataclass, field
@@ -177,7 +178,7 @@ async def verify_cve_trackers(runtime, permissive: bool = True) -> VerifyCVETrac
     mr_url = get_shipment_mr_url(runtime)
     if mr_url:
         LOGGER.info("Checking shipment MR for CVE tracker coverage: %s", mr_url)
-        shipment_jira_issues = get_shipment_jira_issues(mr_url, group=runtime.group)
+        shipment_jira_issues = await asyncio.to_thread(get_shipment_jira_issues, mr_url, runtime.group)
         LOGGER.info("Found %d jira issues in shipment MR", len(shipment_jira_issues))
 
         # Cross-check all CVE trackers against shipment data
@@ -206,7 +207,7 @@ async def verify_cve_trackers(runtime, permissive: bool = True) -> VerifyCVETrac
     is_flag=True,
     default=True,
     show_default=True,
-    help="Ignore bugs that are determined to be invalid and continue",
+    help="Ignore bugs that are determined to be invalid and continue. Use --no-permissive to fail on invalid bugs.",
 )
 @click.pass_obj
 @click_coroutine

--- a/elliott/elliottlib/cli/verify_cve_trackers_cli.py
+++ b/elliott/elliottlib/cli/verify_cve_trackers_cli.py
@@ -157,9 +157,8 @@ async def verify_cve_trackers(runtime, permissive: bool = True) -> VerifyCVETrac
     rhsa_jira_issues: set[str] = set()
     for impetus, advisory_id in advisories.items():
         raw = await asyncio.to_thread(errata.get_raw_erratum, advisory_id)
-        errata_type = next(iter(raw.get("errata", {}).keys()), "")
-        if errata_type != "rhsa":
-            LOGGER.info("Advisory %s (%s): type %s, skipping (not RHSA)", advisory_id, impetus, errata_type.upper())
+        if "rhsa" not in raw.get("errata", {}):
+            LOGGER.info("Advisory %s (%s): not RHSA, skipping", advisory_id, impetus)
             continue
         issues = await get_advisory_jira_issues(advisory_id)
         LOGGER.info("Advisory %s (%s): RHSA, found %d jira issues", advisory_id, impetus, len(issues))
@@ -177,7 +176,7 @@ async def verify_cve_trackers(runtime, permissive: bool = True) -> VerifyCVETrac
     # Check shipment MR (Konflux flow) if available
     mr_url = get_shipment_mr_url(runtime)
     if mr_url:
-        LOGGER.info("Checking shipment MR for CVE tracker coverage: %s", mr_url)
+        LOGGER.info("Checking shipment MR for CVE tracker coverage")
         shipment_jira_issues = await asyncio.to_thread(get_shipment_jira_issues, mr_url, runtime.group)
         LOGGER.info("Found %d jira issues in shipment MR", len(shipment_jira_issues))
 

--- a/elliott/tests/test_verify_cve_trackers_cli.py
+++ b/elliott/tests/test_verify_cve_trackers_cli.py
@@ -1,0 +1,227 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from elliottlib.cli.verify_cve_trackers_cli import (
+    MissedTracker,
+    VerifyCVETrackersResult,
+    get_advisory_jira_issues,
+    get_shipment_jira_issues,
+    render_result,
+    verify_cve_trackers,
+)
+
+
+class TestVerifyCVETrackersResult(unittest.TestCase):
+    def test_ok_when_no_missed(self):
+        result = VerifyCVETrackersResult()
+        self.assertTrue(result.ok)
+        self.assertFalse(result.failed)
+
+    def test_failed_when_missed(self):
+        result = VerifyCVETrackersResult(missed_trackers=[MissedTracker("OCPBUGS-1", "rpm", "RHSA advisories")])
+        self.assertFalse(result.ok)
+        self.assertTrue(result.failed)
+
+
+class TestRenderResult(unittest.TestCase):
+    def test_render_text_ok(self):
+        result = VerifyCVETrackersResult()
+        text = render_result(result, "text")
+        self.assertIn("No missed CVE tracker bugs found", text)
+        self.assertIn("Overall: OK", text)
+
+    def test_render_text_fail(self):
+        result = VerifyCVETrackersResult(
+            missed_trackers=[
+                MissedTracker("OCPBUGS-123", "rpm", "RHSA advisories"),
+                MissedTracker("OCPBUGS-456", "rhcos", "shipment MR"),
+            ]
+        )
+        text = render_result(result, "text")
+        self.assertIn("2 missed CVE tracker bug(s)", text)
+        self.assertIn("OCPBUGS-123", text)
+        self.assertIn("OCPBUGS-456", text)
+        self.assertIn("Overall: FAIL", text)
+
+    def test_render_json_ok(self):
+        result = VerifyCVETrackersResult()
+        import json
+
+        data = json.loads(render_result(result, "json"))
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["missed_trackers"], [])
+
+    def test_render_json_fail(self):
+        result = VerifyCVETrackersResult(missed_trackers=[MissedTracker("OCPBUGS-1", "rpm", "RHSA advisories")])
+        import json
+
+        data = json.loads(render_result(result, "json"))
+        self.assertFalse(data["ok"])
+        self.assertEqual(len(data["missed_trackers"]), 1)
+        self.assertEqual(data["missed_trackers"][0]["bug_id"], "OCPBUGS-1")
+
+
+class TestGetAdvisoryJiraIssues(unittest.IsolatedAsyncioTestCase):
+    @patch("elliottlib.cli.verify_cve_trackers_cli.errata")
+    async def test_get_advisory_jira_issues(self, mock_errata):
+        mock_errata.get_bug_ids.return_value = {"jira": ["OCPBUGS-1", "OCPBUGS-2"], "bugzilla": []}
+        issues = await get_advisory_jira_issues(12345)
+        self.assertEqual(issues, {"OCPBUGS-1", "OCPBUGS-2"})
+        mock_errata.get_bug_ids.assert_called_once_with(12345)
+
+
+class TestGetShipmentJiraIssues(unittest.TestCase):
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_shipment_configs_from_mr")
+    def test_get_shipment_jira_issues(self, mock_get_configs):
+        mock_issue1 = MagicMock()
+        mock_issue1.source = "redhat.atlassian.net"
+        mock_issue1.id = "OCPBUGS-10"
+
+        mock_issue2 = MagicMock()
+        mock_issue2.source = "redhat.atlassian.net"
+        mock_issue2.id = "OCPBUGS-20"
+
+        mock_config = MagicMock()
+        mock_config.shipment.data.releaseNotes.issues.fixed = [mock_issue1, mock_issue2]
+
+        mock_get_configs.return_value = {"image": mock_config}
+
+        issues = get_shipment_jira_issues("https://gitlab.example.com/mr/1", "openshift-4.18")
+        self.assertEqual(issues, {"OCPBUGS-10", "OCPBUGS-20"})
+
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_shipment_configs_from_mr")
+    def test_get_shipment_jira_issues_empty(self, mock_get_configs):
+        mock_config = MagicMock()
+        mock_config.shipment.data = None
+
+        mock_get_configs.return_value = {"image": mock_config}
+
+        issues = get_shipment_jira_issues("https://gitlab.example.com/mr/1", "openshift-4.18")
+        self.assertEqual(issues, set())
+
+
+class TestVerifyCVETrackers(unittest.IsolatedAsyncioTestCase):
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_shipment_mr_url")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_advisory_ids")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.errata")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.find_cve_tracker_bugs", new_callable=AsyncMock)
+    async def test_no_trackers(self, mock_find, mock_errata, mock_get_ads, mock_get_mr):
+        mock_find.return_value = {}
+        runtime = MagicMock()
+        result = await verify_cve_trackers(runtime)
+        self.assertTrue(result.ok)
+
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_shipment_mr_url")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_advisory_ids")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.errata")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.find_cve_tracker_bugs", new_callable=AsyncMock)
+    async def test_trackers_found_in_rhsa(self, mock_find, mock_errata, mock_get_ads, mock_get_mr):
+        mock_find.return_value = {"rpm": ["OCPBUGS-1"], "rhcos": ["OCPBUGS-2"]}
+        mock_get_ads.return_value = {"rpm": 111, "image": 222}
+        mock_get_mr.return_value = None
+
+        mock_errata.get_raw_erratum.side_effect = lambda ad_id: {
+            111: {"errata": {"rhsa": {}}},
+            222: {"errata": {"rhba": {}}},
+        }[ad_id]
+        mock_errata.get_bug_ids.side_effect = lambda ad_id: {
+            111: {"jira": ["OCPBUGS-1", "OCPBUGS-2", "OCPBUGS-3"], "bugzilla": []},
+        }[ad_id]
+
+        runtime = MagicMock()
+        result = await verify_cve_trackers(runtime)
+        self.assertTrue(result.ok)
+
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_shipment_mr_url")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_advisory_ids")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.errata")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.find_cve_tracker_bugs", new_callable=AsyncMock)
+    async def test_trackers_missing_from_rhsa(self, mock_find, mock_errata, mock_get_ads, mock_get_mr):
+        mock_find.return_value = {"rpm": ["OCPBUGS-1", "OCPBUGS-99"]}
+        mock_get_ads.return_value = {"rpm": 111}
+        mock_get_mr.return_value = None
+
+        mock_errata.get_raw_erratum.return_value = {"errata": {"rhsa": {}}}
+        mock_errata.get_bug_ids.return_value = {"jira": ["OCPBUGS-1"], "bugzilla": []}
+
+        runtime = MagicMock()
+        result = await verify_cve_trackers(runtime)
+        self.assertFalse(result.ok)
+        self.assertEqual(len(result.missed_trackers), 1)
+        self.assertEqual(result.missed_trackers[0].bug_id, "OCPBUGS-99")
+        self.assertEqual(result.missed_trackers[0].source, "RHSA advisories")
+
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_shipment_jira_issues")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_shipment_mr_url")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_advisory_ids")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.errata")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.find_cve_tracker_bugs", new_callable=AsyncMock)
+    async def test_trackers_missing_from_shipment(
+        self, mock_find, mock_errata, mock_get_ads, mock_get_mr, mock_get_shipment_issues
+    ):
+        mock_find.return_value = {"image": ["OCPBUGS-50"]}
+        mock_get_ads.return_value = {}
+        mock_get_mr.return_value = "https://gitlab.cee.redhat.com/mr/1"
+        mock_get_shipment_issues.return_value = set()
+
+        runtime = MagicMock()
+        runtime.group = "openshift-4.18"
+        result = await verify_cve_trackers(runtime)
+        self.assertFalse(result.ok)
+        missed_shipment = [t for t in result.missed_trackers if t.source == "shipment MR"]
+        self.assertEqual(len(missed_shipment), 1)
+        self.assertEqual(missed_shipment[0].bug_id, "OCPBUGS-50")
+
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_shipment_jira_issues")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_shipment_mr_url")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_advisory_ids")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.errata")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.find_cve_tracker_bugs", new_callable=AsyncMock)
+    async def test_trackers_found_in_shipment(
+        self, mock_find, mock_errata, mock_get_ads, mock_get_mr, mock_get_shipment_issues
+    ):
+        mock_find.return_value = {"image": ["OCPBUGS-50"]}
+        mock_get_ads.return_value = {}
+        mock_get_mr.return_value = "https://gitlab.cee.redhat.com/mr/1"
+        mock_get_shipment_issues.return_value = {"OCPBUGS-50", "OCPBUGS-60"}
+
+        runtime = MagicMock()
+        runtime.group = "openshift-4.18"
+        result = await verify_cve_trackers(runtime)
+        self.assertTrue(result.ok)
+
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_shipment_mr_url")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_advisory_ids")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.errata")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.find_cve_tracker_bugs", new_callable=AsyncMock)
+    async def test_advisory_error_propagates(self, mock_find, mock_errata, mock_get_ads, mock_get_mr):
+        mock_find.return_value = {"rpm": ["OCPBUGS-1"]}
+        mock_get_ads.return_value = {"rpm": 111}
+        mock_get_mr.return_value = None
+        mock_errata.get_raw_erratum.side_effect = RuntimeError("Errata API unavailable")
+
+        runtime = MagicMock()
+        with self.assertRaises(RuntimeError):
+            await verify_cve_trackers(runtime)
+
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_shipment_jira_issues")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_shipment_mr_url")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.get_advisory_ids")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.errata")
+    @patch("elliottlib.cli.verify_cve_trackers_cli.find_cve_tracker_bugs", new_callable=AsyncMock)
+    async def test_shipment_error_propagates(
+        self, mock_find, mock_errata, mock_get_ads, mock_get_mr, mock_get_shipment_issues
+    ):
+        mock_find.return_value = {"image": ["OCPBUGS-50"]}
+        mock_get_ads.return_value = {}
+        mock_get_mr.return_value = "https://gitlab.cee.redhat.com/mr/1"
+        mock_get_shipment_issues.side_effect = RuntimeError("GitLab API unavailable")
+
+        runtime = MagicMock()
+        runtime.group = "openshift-4.18"
+        with self.assertRaises(RuntimeError):
+            await verify_cve_trackers(runtime)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -52,6 +52,7 @@ from pyartcd.pipelines import (
     tag_rpms,
     tarball_sources,
     update_golang,
+    verify_release,
 )
 from pyartcd.pipelines.scheduled import (
     schedule_build_conforma_verify,
@@ -116,6 +117,7 @@ __all__ = [
     "tag_rpms",
     "tarball_sources",
     "update_golang",
+    "verify_release",
     "schedule_build_conforma_verify",
     "schedule_build_sync_multi",
     "schedule_layered_products_scan",

--- a/pyartcd/pyartcd/pipelines/__init__.py
+++ b/pyartcd/pyartcd/pipelines/__init__.py
@@ -50,6 +50,7 @@ from . import (
     tag_rpms,
     tarball_sources,
     update_golang,
+    verify_release,
 )
 
 __all__ = [
@@ -100,4 +101,5 @@ __all__ = [
     'tag_rpms',
     'tarball_sources',
     'update_golang',
+    'verify_release',
 ]

--- a/pyartcd/pyartcd/pipelines/verify_release.py
+++ b/pyartcd/pyartcd/pipelines/verify_release.py
@@ -69,7 +69,10 @@ def render_result(result: VerifyReleaseResult, output: str, version: str, assemb
 
     lines = [f"Verify release {assembly}", ""]
     for s in result.steps:
-        lines.append(f"  {s.name}: {s.status.value}")
+        line = f"  {s.name}: {s.status.value}"
+        if s.message:
+            line += f" — {s.message}"
+        lines.append(line)
     lines.append("")
     overall = "PASS" if result.passed else "FAIL"
     lines.append(f"Overall: {overall}")
@@ -215,7 +218,19 @@ class VerifyReleasePipeline:
     "--skip",
     "skip_steps",
     multiple=True,
-    help="Steps to skip (cdn-push, signatures, image-grades, payload, qe-qualifier, security-alerts, kernel-tag, cve-trackers)",
+    type=click.Choice(
+        [
+            "cdn-push",
+            "signatures",
+            "image-grades",
+            "payload",
+            "qe-qualifier",
+            "security-alerts",
+            "kernel-tag",
+            "cve-trackers",
+        ]
+    ),
+    help="Steps to skip.",
 )
 @click.option(
     "-o",

--- a/pyartcd/pyartcd/pipelines/verify_release.py
+++ b/pyartcd/pyartcd/pipelines/verify_release.py
@@ -1,0 +1,247 @@
+import asyncio
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+import click
+from artcommonlib import exectools
+
+from pyartcd import constants
+from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.runtime import Runtime
+
+LOGGER = logging.getLogger(__name__)
+
+
+class StepStatus(Enum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+    SKIP = "SKIP"
+
+
+@dataclass
+class StepResult:
+    name: str
+    status: StepStatus
+    message: str = ""
+
+
+@dataclass
+class VerifyReleaseResult:
+    steps: list[StepResult] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return all(s.status in (StepStatus.PASS, StepStatus.SKIP) for s in self.steps)
+
+    def summary(self) -> str:
+        lines = []
+        for s in self.steps:
+            line = f"{s.name}: {s.status.value}"
+            if s.message:
+                line += f" — {s.message}"
+            lines.append(line)
+        return "\n".join(lines)
+
+
+def render_result(result: VerifyReleaseResult, output: str, version: str, assembly: str) -> str:
+    if output == "json":
+        return json.dumps(
+            {
+                "version": version,
+                "assembly": assembly,
+                "passed": result.passed,
+                "steps": [
+                    {
+                        "name": s.name,
+                        "status": s.status.value,
+                        "message": s.message,
+                    }
+                    for s in result.steps
+                ],
+            },
+            indent=2,
+        )
+
+    lines = [f"Verify release {assembly}", ""]
+    for s in result.steps:
+        lines.append(f"  {s.name}: {s.status.value}")
+    lines.append("")
+    overall = "PASS" if result.passed else "FAIL"
+    lines.append(f"Overall: {overall}")
+    return "\n".join(lines)
+
+
+class VerifyReleasePipeline:
+    def __init__(
+        self,
+        runtime: Runtime,
+        version: str,
+        assembly: str,
+        skip_steps: Optional[list[str]] = None,
+    ):
+        self.runtime = runtime
+        self.version = version
+        self.assembly = assembly
+        self.group = f"openshift-{version}"
+        self.data_path = constants.OCP_BUILD_DATA_URL
+        self.skip_steps = set(skip_steps or [])
+
+        self.working_dir = self.runtime.working_dir / "verify_release"
+        self.working_dir.mkdir(parents=True, exist_ok=True)
+
+        self._elliott_env = os.environ.copy()
+        self._elliott_env["ELLIOTT_WORKING_DIR"] = str(self.working_dir / "elliott-working")
+
+    @property
+    def _elliott_base(self) -> list[str]:
+        return [
+            "elliott",
+            f"--group={self.group}",
+            f"--assembly={self.assembly}",
+            f"--data-path={self.data_path}",
+            f"--working-dir={self.working_dir / 'elliott-working'}",
+        ]
+
+    async def run(self) -> VerifyReleaseResult:
+        result = VerifyReleaseResult()
+
+        # All steps can run in parallel
+        steps = [
+            ("cdn-push", self._verify_cdn_push),
+            ("signatures", self._verify_signatures),
+            ("image-grades", self._verify_image_grades),
+            ("payload", self._verify_payload),
+            ("qe-qualifier", self._verify_qe_qualifier),
+            ("security-alerts", self._verify_security_alerts),
+            ("kernel-tag", self._verify_kernel_tag),
+            ("cve-trackers", self._verify_cve_trackers),
+        ]
+
+        # Build task list (skip user-requested skips)
+        tasks = []
+        for step_name, step_fn in steps:
+            if step_name in self.skip_steps:
+                result.steps.append(StepResult(step_name, StepStatus.SKIP, "skipped by user"))
+                click.echo(f"[verify-release: {step_name}] SKIP (skipped by user)", err=True)
+            else:
+                tasks.append(self._safe_run_step(step_name, step_fn))
+
+        # Run all tasks in parallel
+        if tasks:
+            click.echo(f"[verify-release] Running {len(tasks)} steps in parallel", err=True)
+            step_results = await asyncio.gather(*tasks)
+
+            # Process results (individual steps already logged their status)
+            for step_result in step_results:
+                result.steps.append(step_result)
+
+        return result
+
+    async def _safe_run_step(self, step_name: str, step_fn):
+        """Wrap step execution to catch all exceptions and return FAIL instead."""
+        try:
+            return await step_fn()
+        except Exception as e:
+            click.echo(f"[verify-release: {step_name}] ✗ FAIL: {e}", err=True)
+            return StepResult(step_name, StepStatus.FAIL, str(e))
+
+    async def _run_elliott_cmd(self, step_name: str, cmd: list[str]) -> StepResult:
+        """Run elliott command with live output streaming."""
+        click.echo(f"[verify-release: {step_name}] Starting...", err=True)
+
+        # Use step-specific working directory to avoid race conditions in parallel execution
+        step_working_dir = self.working_dir / f"elliott-working-{step_name}"
+        step_env = self._elliott_env.copy()
+        step_env["ELLIOTT_WORKING_DIR"] = str(step_working_dir)
+
+        # Replace --working-dir argument in command
+        cmd_with_step_dir = []
+        for i, arg in enumerate(cmd):
+            if arg.startswith("--working-dir="):
+                cmd_with_step_dir.append(f"--working-dir={step_working_dir}")
+            else:
+                cmd_with_step_dir.append(arg)
+
+        try:
+            await exectools.cmd_assert_async(cmd_with_step_dir, env=step_env)
+            click.echo(f"[verify-release: {step_name}] ✓ PASS", err=True)
+            return StepResult(step_name, StepStatus.PASS)
+        except Exception as e:
+            click.echo(f"[verify-release: {step_name}] ✗ FAIL", err=True)
+            return StepResult(step_name, StepStatus.FAIL, str(e))
+
+    async def _verify_cdn_push(self) -> StepResult:
+        cmd = self._elliott_base + ["verify-cdn-push", "--no-push"]
+        return await self._run_elliott_cmd("cdn-push", cmd)
+
+    async def _verify_signatures(self) -> StepResult:
+        cmd = self._elliott_base + ["verify-signatures"]
+        return await self._run_elliott_cmd("signatures", cmd)
+
+    async def _verify_image_grades(self) -> StepResult:
+        cmd = self._elliott_base + ["verify-image-grades"]
+        return await self._run_elliott_cmd("image-grades", cmd)
+
+    async def _verify_payload(self) -> StepResult:
+        imagestream = f"ocp/{self.version}-art-assembly-{self.assembly}"
+        cmd = self._elliott_base + ["verify-payload", imagestream]
+        return await self._run_elliott_cmd("payload", cmd)
+
+    async def _verify_qe_qualifier(self) -> StepResult:
+        cmd = self._elliott_base + ["verify-qe-qualifier"]
+        return await self._run_elliott_cmd("qe-qualifier", cmd)
+
+    async def _verify_security_alerts(self) -> StepResult:
+        cmd = self._elliott_base + ["verify-security-alerts"]
+        return await self._run_elliott_cmd("security-alerts", cmd)
+
+    async def _verify_kernel_tag(self) -> StepResult:
+        cmd = self._elliott_base + ["verify-kernel-tag"]
+        return await self._run_elliott_cmd("kernel-tag", cmd)
+
+    async def _verify_cve_trackers(self) -> StepResult:
+        cmd = self._elliott_base + ["verify-cve-trackers"]
+        return await self._run_elliott_cmd("cve-trackers", cmd)
+
+
+@cli.command("verify-release", short_help="Run post-release verification checks")
+@click.option("--version", required=True, help="OCP version (e.g. 4.19)")
+@click.option("--assembly", required=True, help="Assembly name (e.g. 4.19.42)")
+@click.option(
+    "--skip",
+    "skip_steps",
+    multiple=True,
+    help="Steps to skip (cdn-push, signatures, image-grades, payload, qe-qualifier, security-alerts, kernel-tag, cve-trackers)",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    show_default=True,
+    help="Output format.",
+)
+@pass_runtime
+@click_coroutine
+async def verify_release_cli(
+    runtime: Runtime,
+    version: str,
+    assembly: str,
+    skip_steps: tuple[str, ...],
+    output: str,
+):
+    pipeline = VerifyReleasePipeline(
+        runtime=runtime,
+        version=version,
+        assembly=assembly,
+        skip_steps=list(skip_steps),
+    )
+    result = await pipeline.run()
+    click.echo(render_result(result, output, version, assembly))
+    if not result.passed:
+        sys.exit(1)

--- a/pyartcd/pyartcd/pipelines/verify_release.py
+++ b/pyartcd/pyartcd/pipelines/verify_release.py
@@ -95,7 +95,6 @@ class VerifyReleasePipeline:
         self.working_dir.mkdir(parents=True, exist_ok=True)
 
         self._elliott_env = os.environ.copy()
-        self._elliott_env["ELLIOTT_WORKING_DIR"] = str(self.working_dir / "elliott-working")
 
     @property
     def _elliott_base(self) -> list[str]:

--- a/pyartcd/tests/pipelines/test_verify_release.py
+++ b/pyartcd/tests/pipelines/test_verify_release.py
@@ -1,0 +1,136 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pyartcd.pipelines.verify_release import (
+    StepResult,
+    StepStatus,
+    VerifyReleasePipeline,
+    VerifyReleaseResult,
+)
+
+
+class TestVerifyReleaseResult(unittest.TestCase):
+    def test_passed_all_pass(self):
+        result = VerifyReleaseResult(
+            steps=[
+                StepResult("cdn-push", StepStatus.PASS),
+                StepResult("signatures", StepStatus.PASS),
+            ]
+        )
+        self.assertTrue(result.passed)
+
+    def test_passed_with_skip(self):
+        result = VerifyReleaseResult(
+            steps=[
+                StepResult("cdn-push", StepStatus.SKIP, "skipped by user"),
+                StepResult("signatures", StepStatus.PASS),
+            ]
+        )
+        self.assertTrue(result.passed)
+
+    def test_failed_on_fail(self):
+        result = VerifyReleaseResult(
+            steps=[
+                StepResult("cdn-push", StepStatus.PASS),
+                StepResult("signatures", StepStatus.FAIL, "signature check failed"),
+            ]
+        )
+        self.assertFalse(result.passed)
+
+    def test_summary(self):
+        result = VerifyReleaseResult(
+            steps=[
+                StepResult("cdn-push", StepStatus.PASS),
+                StepResult("signatures", StepStatus.FAIL, "signature check failed"),
+                StepResult("payload", StepStatus.SKIP, "skipped by user"),
+            ]
+        )
+        summary = result.summary()
+        self.assertIn("cdn-push: PASS", summary)
+        self.assertIn("signatures: FAIL — signature check failed", summary)
+        self.assertIn("payload: SKIP — skipped by user", summary)
+
+
+class TestVerifyReleasePipeline(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.runtime = MagicMock()
+        self.runtime.dry_run = False
+        self.runtime.working_dir = MagicMock()
+        self.runtime.working_dir.__truediv__ = MagicMock(return_value=MagicMock(mkdir=MagicMock()))
+
+    @patch("pyartcd.pipelines.verify_release.exectools.cmd_assert_async", new_callable=AsyncMock)
+    async def test_run_all_steps_pass(self, mock_assert):
+        mock_assert.return_value = 0
+
+        pipeline = VerifyReleasePipeline(
+            runtime=self.runtime,
+            version="4.19",
+            assembly="4.19.42",
+        )
+
+        result = await pipeline.run()
+
+        self.assertTrue(result.passed)
+        self.assertEqual(len(result.steps), 8)
+        for step in result.steps:
+            self.assertEqual(step.status, StepStatus.PASS)
+
+    @patch("pyartcd.pipelines.verify_release.exectools.cmd_assert_async", new_callable=AsyncMock)
+    async def test_run_with_skip_steps(self, mock_assert):
+        mock_assert.return_value = 0
+
+        pipeline = VerifyReleasePipeline(
+            runtime=self.runtime,
+            version="4.19",
+            assembly="4.19.42",
+            skip_steps=["cdn-push", "kernel-tag"],
+        )
+
+        result = await pipeline.run()
+
+        self.assertTrue(result.passed)
+        skipped_steps = [s for s in result.steps if s.status == StepStatus.SKIP]
+        self.assertEqual(len(skipped_steps), 2)
+        self.assertIn("cdn-push", [s.name for s in skipped_steps])
+        self.assertIn("kernel-tag", [s.name for s in skipped_steps])
+
+    @patch("pyartcd.pipelines.verify_release.exectools.cmd_assert_async", new_callable=AsyncMock)
+    async def test_run_step_failure(self, mock_assert):
+        def mock_side_effect(cmd, **kwargs):
+            if "verify-signatures" in cmd:
+                raise ChildProcessError(f"Process {cmd!r} exited with code 1.")
+            return 0
+
+        mock_assert.side_effect = mock_side_effect
+
+        pipeline = VerifyReleasePipeline(
+            runtime=self.runtime,
+            version="4.19",
+            assembly="4.19.42",
+        )
+
+        result = await pipeline.run()
+
+        self.assertFalse(result.passed)
+        sig_step = [s for s in result.steps if s.name == "signatures"][0]
+        self.assertEqual(sig_step.status, StepStatus.FAIL)
+        self.assertIn("exited with code 1", sig_step.message)
+
+    @patch("pyartcd.pipelines.verify_release.exectools.cmd_assert_async", new_callable=AsyncMock)
+    async def test_cdn_push_read_only(self, mock_assert):
+        mock_assert.return_value = 0
+
+        pipeline = VerifyReleasePipeline(
+            runtime=self.runtime,
+            version="4.19",
+            assembly="4.19.42",
+        )
+
+        await pipeline.run()
+
+        cdn_push_calls = [call for call in mock_assert.call_args_list if "verify-cdn-push" in str(call)]
+        self.assertTrue(any("--no-push" in str(call) for call in cdn_push_calls))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyartcd/tests/pipelines/test_verify_release.py
+++ b/pyartcd/tests/pipelines/test_verify_release.py
@@ -71,7 +71,17 @@ class TestVerifyReleasePipeline(unittest.IsolatedAsyncioTestCase):
         result = await pipeline.run()
 
         self.assertTrue(result.passed)
-        self.assertEqual(len(result.steps), 8)
+        expected_steps = {
+            "cdn-push",
+            "signatures",
+            "image-grades",
+            "payload",
+            "qe-qualifier",
+            "security-alerts",
+            "kernel-tag",
+            "cve-trackers",
+        }
+        self.assertEqual({s.name for s in result.steps}, expected_steps)
         for step in result.steps:
             self.assertEqual(step.status, StepStatus.PASS)
 


### PR DESCRIPTION
## Summary

- Add new `elliott verify-cve-trackers` command that cross-checks CVE tracker bugs against RHSA advisories and shipment MR data, matching the OAR `check_cve_tracker_bug` behavior
- Add `cve-trackers` step to `artcd verify-release` pipeline
- 16 unit tests for the new command

## How it works

1. Finds CVE tracker bugs via `find-bugs --cve-only` logic (with `filter_attached_bugs=True` — bugs already on other advisories/MRs are excluded)
2. Collects jira issues from RHSA advisories in the assembly
3. Cross-checks `rpm` and `rhcos` tracker bugs against RHSA advisory jira issues
4. If a shipment MR URL exists in assembly config (Konflux flow), cross-checks all tracker bugs against shipment YAML files
5. Reports any tracker bug not found in either source as missed; exits non-zero on failure

## Test plan

- [x] Unit tests pass (16/16)
- [x] Manual test on 4.22.11 — found 15 CVE trackers, all present in shipment MR (31 jira issues), RHSA advisories (rpm: 9, rhcos: 5) verified
- [x] Manual test on 4.14.72 — passed
- [x] `make format` clean

Jira: https://redhat.atlassian.net/browse/ART-20332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `verify-cve-trackers` command to validate CVE tracker coverage against advisories and shipment release notes.
  * Added text and JSON reporting, permissive validation, and failure status for missing trackers.
  * Added a `verify-release` pipeline with eight concurrent post-release checks, selectable skips, streamed status updates, and isolated execution.
  * Added text and JSON output with pass, fail, and skipped results.

* **Tests**
  * Added comprehensive coverage for tracker validation and release verification scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->