### PR TITLE
feat(pyartcd): add on-cluster trigger mode for build-layered-products

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -66,6 +66,12 @@ def init_jenkins():
     if jenkins_client:
         return
 
+    from pyartcd.tekton import is_tekton_context
+
+    if is_tekton_context():
+        logger.info("Running in Tekton context, skipping Jenkins initialization")
+        return
+
     jenkins_url = get_jenkins_url()
 
     logger.info('Initializing Jenkins client..')
@@ -212,11 +218,17 @@ def get_build_parameters(build_path: str) -> Optional[dict]:
 
 def check_env_vars(func):
     """
-    Enforces that BUILD_URL and JOB_NAME are set
+    Enforces that BUILD_URL and JOB_NAME are set. No-op in Tekton context.
     """
 
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
+        from pyartcd.tekton import is_tekton_context
+
+        if is_tekton_context():
+            logger.debug("Skipping %s in Tekton context (no Jenkins)", func.__name__)
+            return None
+
         global current_build_url, current_job_name
         current_build_url = current_build_url or get_build_url()
         current_job_name = current_job_name or get_job_name()

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -36,6 +36,7 @@ class BuildLayeredProductsPipeline:
         skip_bundle_build: bool,
         image_build_strategy: str = 'only',
         skip_rebase: bool = False,
+        ignore_locks: bool = False,
         kubeconfig: Optional[str] = None,
         data_gitref: Optional[str] = None,
         network_mode: Optional[str] = None,
@@ -50,6 +51,7 @@ class BuildLayeredProductsPipeline:
         self.image_build_strategy = BuildStrategy(image_build_strategy)
         self.skip_bundle_build = skip_bundle_build
         self.skip_rebase = skip_rebase
+        self.ignore_locks = ignore_locks
         self.kubeconfig = kubeconfig
         self.data_gitref = data_gitref
         self.network_mode = network_mode
@@ -150,6 +152,51 @@ class BuildLayeredProductsPipeline:
         with record_log_path.open('r') as file:
             record_log: dict = record_util.parse_record_log(file)
             return record_log
+
+    async def run_on_cluster(self):
+        """Trigger build-layered-products on the artc cluster and watch until completion.
+
+        Uses `tkn pipeline start --showlog` which blocks until the PipelineRun terminates,
+        streams logs to stdout (visible in Jenkins console), and returns non-zero on failure.
+        """
+        kubeconfig = os.environ.get('ART_CLUSTER_LP_KUBECONFIG')
+        if not kubeconfig:
+            raise ValueError(
+                "ART_CLUSTER_LP_KUBECONFIG environment variable must be set to trigger on cluster"
+            )
+
+        data_path = self._doozer_env_vars.get('DOOZER_DATA_PATH', '')
+
+        cmd = [
+            "tkn", "pipeline", "start", "build-layered-products",
+            "--namespace", "layered-products",
+            "--kubeconfig", kubeconfig,
+            "--param", f"group={self.group}",
+            "--param", f"assembly={self.assembly}",
+            "--param", f"image-list={self.image_list}",
+            "--param", f"data-path={data_path}",
+            "--param", f"dry-run={'true' if self.runtime.dry_run else 'false'}",
+            "--param", f"skip-rebase={'true' if self.skip_rebase else 'false'}",
+            "--param", f"ignore-locks={'true' if self.ignore_locks else 'false'}",
+            "--pipeline-timeout", "4h",
+            "--showlog",
+        ]
+
+        if self.data_gitref:
+            cmd.extend(["--param", f"data-gitref={self.data_gitref}"])
+        if self.network_mode:
+            cmd.extend(["--param", f"network-mode={self.network_mode}"])
+        if self.plr_template:
+            cmd.extend(["--param", f"plr-template={self.plr_template}"])
+
+        art_tools_commit = os.environ.get('ART_TOOLS_COMMIT', '')
+        if art_tools_commit:
+            cmd.extend(["--param", f"art-tools-commit={art_tools_commit}"])
+
+        self._logger.info("Triggering build-layered-products on artc cluster (namespace: layered-products)")
+        # cmd_assert_async raises ChildProcessError on non-zero exit (= pipeline failure)
+        await exectools.cmd_assert_async(cmd, env=os.environ.copy())
+        self._logger.info("build-layered-products pipeline completed successfully on cluster")
 
     async def run(self):
         """Run the layered products rebase and build pipeline"""
@@ -430,6 +477,12 @@ class BuildLayeredProductsPipeline:
     default='',
     help='Override the Pipeline Run template commit from openshift-priv/art-konflux-template; format: <owner>@<branch>',
 )
+@click.option(
+    '--on-cluster',
+    is_flag=True,
+    default=False,
+    help='Trigger the pipeline on the artc cluster (layered-products namespace) and watch until completion',
+)
 @pass_runtime
 @click_coroutine
 async def build_layered_products(
@@ -447,6 +500,7 @@ async def build_layered_products(
     network_mode: Optional[str],
     ignore_locks: bool,
     plr_template: str,
+    on_cluster: bool,
 ):
     """Rebase and build layered product image for an assembly"""
     try:
@@ -460,6 +514,7 @@ async def build_layered_products(
             data_path=data_path,
             skip_bundle_build=skip_bundle_build,
             skip_rebase=skip_rebase,
+            ignore_locks=ignore_locks,
             kubeconfig=kubeconfig,
             data_gitref=data_gitref,
             network_mode=network_mode,
@@ -468,7 +523,9 @@ async def build_layered_products(
 
         lock_identifier = jenkins.get_build_path_or_random()
 
-        if ignore_locks:
+        if on_cluster:
+            await pipeline.run_on_cluster()
+        elif ignore_locks:
             await pipeline.run()
         else:
             await locks.run_with_lock(

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -13,7 +13,7 @@ from artcommonlib.constants import PRODUCT_KUBECONFIG_MAP
 from artcommonlib.util import resolve_konflux_kubeconfig_by_product, resolve_konflux_namespace_by_product
 from doozerlib.constants import KONFLUX_DEFAULT_IMAGE_REPO
 
-from pyartcd import constants, jenkins, locks
+from pyartcd import constants, jenkins, locks, tekton
 from pyartcd import record as record_util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.locks import Lock
@@ -83,7 +83,7 @@ class BuildLayeredProductsPipeline:
         if self.assembly.lower() == "test":
             jenkins.update_title(" [TEST]")
 
-    def trigger_bundle_build(self):
+    async def trigger_bundle_build(self):
         if self.skip_bundle_build:
             self._logger.warning("Skipping bundle build step because --skip-bundle-build flag is set")
             return
@@ -129,18 +129,32 @@ class BuildLayeredProductsPipeline:
             operator_nvrs = non_embargoed_nvrs
 
             if operator_nvrs:
-                # Automatically propagate parameters if set in environment
-                propagate_params = jenkins.get_propagatable_params()
+                if tekton.is_tekton_context():
+                    await tekton.start_pipeline(
+                        pipeline_name="olm-bundle-konflux",
+                        params={
+                            "version": self.version,
+                            "assembly": self.assembly,
+                            "group": self.group,
+                            "operator-nvrs": ",".join(operator_nvrs),
+                            "data-path": self._doozer_env_vars.get("DOOZER_DATA_PATH", ""),
+                            "data-gitref": self.data_gitref or "",
+                            "art-tools-commit": os.environ.get("ART_TOOLS_COMMIT", ""),
+                        },
+                    )
+                else:
+                    # Automatically propagate parameters if set in environment
+                    propagate_params = jenkins.get_propagatable_params()
 
-                jenkins.start_olm_bundle_konflux(
-                    build_version=self.version,
-                    assembly=self.assembly,
-                    group=self.group,
-                    operator_nvrs=operator_nvrs,
-                    doozer_data_path=self._doozer_env_vars["DOOZER_DATA_PATH"] or '',
-                    doozer_data_gitref=self.data_gitref or '',
-                    propagate_params=propagate_params,
-                )
+                    jenkins.start_olm_bundle_konflux(
+                        build_version=self.version,
+                        assembly=self.assembly,
+                        group=self.group,
+                        operator_nvrs=operator_nvrs,
+                        doozer_data_path=self._doozer_env_vars["DOOZER_DATA_PATH"] or '',
+                        doozer_data_gitref=self.data_gitref or '',
+                        propagate_params=propagate_params,
+                    )
         except Exception as e:
             self._logger.exception(f"Failed to trigger bundle build: {e}")
 
@@ -164,9 +178,7 @@ class BuildLayeredProductsPipeline:
         """
         kubeconfig = os.environ.get('ART_CLUSTER_LP_KUBECONFIG')
         if not kubeconfig:
-            raise ValueError(
-                "ART_CLUSTER_LP_KUBECONFIG environment variable must be set to trigger on cluster"
-            )
+            raise ValueError("ART_CLUSTER_LP_KUBECONFIG environment variable must be set to trigger on cluster")
 
         data_path = self._doozer_env_vars.get('DOOZER_DATA_PATH', '')
         namespace = "layered-products"
@@ -174,30 +186,46 @@ class BuildLayeredProductsPipeline:
 
         # Step 1: Start the pipeline and get the PipelineRun name
         start_cmd = [
-            "tkn", "pipeline", "start", pipeline_name,
-            "--namespace", namespace,
-            "--kubeconfig", kubeconfig,
-            "--param", f"group={self.group}",
-            "--param", f"assembly={self.assembly}",
-            "--param", f"image-list={self.image_list}",
-            "--param", f"data-path={data_path}",
-            "--param", f"data-gitref={self.data_gitref or ''}",
-            "--param", f"plr-template={self.plr_template or ''}",
-            "--param", f"network-mode={self.network_mode or ''}",
-            "--param", f"dry-run={'true' if self.runtime.dry_run else 'false'}",
-            "--param", f"skip-rebase={'true' if self.skip_rebase else 'false'}",
-            "--param", f"ignore-locks={'true' if self.ignore_locks else 'false'}",
-            "--param", f"art-tools-commit={os.environ.get('ART_TOOLS_COMMIT', '')}",
-            "--pipeline-timeout", "4h",
-            "--output", "name",
+            "tkn",
+            "pipeline",
+            "start",
+            pipeline_name,
+            "--namespace",
+            namespace,
+            "--kubeconfig",
+            kubeconfig,
+            "--param",
+            f"group={self.group}",
+            "--param",
+            f"assembly={self.assembly}",
+            "--param",
+            f"image-list={self.image_list}",
+            "--param",
+            f"data-path={data_path}",
+            "--param",
+            f"data-gitref={self.data_gitref or ''}",
+            "--param",
+            f"plr-template={self.plr_template or ''}",
+            "--param",
+            f"network-mode={self.network_mode or ''}",
+            "--param",
+            f"dry-run={'true' if self.runtime.dry_run else 'false'}",
+            "--param",
+            f"skip-rebase={'true' if self.skip_rebase else 'false'}",
+            "--param",
+            f"ignore-locks={'true' if self.ignore_locks else 'false'}",
+            "--param",
+            f"art-tools-commit={os.environ.get('ART_TOOLS_COMMIT', '')}",
+            "--pipeline-timeout",
+            "4h",
+            "--output",
+            "name",
         ]
 
         self._logger.info("Triggering %s on artc cluster (namespace: %s)", pipeline_name, namespace)
         rc, stdout, stderr = await exectools.cmd_gather_async(start_cmd, env=os.environ.copy())
         if rc != 0:
-            raise ChildProcessError(
-                f"Failed to start {pipeline_name} on cluster (exit {rc}): {stderr.strip()}"
-            )
+            raise ChildProcessError(f"Failed to start {pipeline_name} on cluster (exit {rc}): {stderr.strip()}")
 
         plr_name = stdout.strip()
         if not plr_name:
@@ -213,27 +241,36 @@ class BuildLayeredProductsPipeline:
 
         # Step 3: Stream logs until the PipelineRun completes
         logs_cmd = [
-            "tkn", "pipelinerun", "logs", "--follow",
-            "--namespace", namespace,
-            "--kubeconfig", kubeconfig,
+            "tkn",
+            "pipelinerun",
+            "logs",
+            "--follow",
+            "--namespace",
+            namespace,
+            "--kubeconfig",
+            kubeconfig,
             plr_name,
         ]
         await exectools.cmd_gather_async(logs_cmd, env=os.environ.copy())
 
         # Step 4: Check the final status
         status_cmd = [
-            "tkn", "pipelinerun", "describe", plr_name,
-            "--namespace", namespace,
-            "--kubeconfig", kubeconfig,
-            "--output", "jsonpath={.status.conditions[0].status}",
+            "tkn",
+            "pipelinerun",
+            "describe",
+            plr_name,
+            "--namespace",
+            namespace,
+            "--kubeconfig",
+            kubeconfig,
+            "--output",
+            "jsonpath={.status.conditions[0].status}",
         ]
         rc, stdout, stderr = await exectools.cmd_gather_async(status_cmd, env=os.environ.copy())
         succeeded = stdout.strip()
 
         if succeeded != "True":
-            raise ChildProcessError(
-                f"PipelineRun {plr_name} failed (status={succeeded}). See logs above or: {plr_url}"
-            )
+            raise ChildProcessError(f"PipelineRun {plr_name} failed (status={succeeded}). See logs above or: {plr_url}")
 
         self._logger.info("PipelineRun %s completed successfully", plr_name)
 
@@ -258,7 +295,7 @@ class BuildLayeredProductsPipeline:
         product = group_config.get('product', 'ocp')
         image_repo = group_config.get('konflux', {}).get('image_repo') or KONFLUX_DEFAULT_IMAGE_REPO
         await self._rebase_and_build(product, image_repo)
-        self.trigger_bundle_build()
+        await self.trigger_bundle_build()
 
         if self.embargoed_operators_skipped:
             self._logger.warning(

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -156,8 +156,11 @@ class BuildLayeredProductsPipeline:
     async def run_on_cluster(self):
         """Trigger build-layered-products on the artc cluster and watch until completion.
 
-        Uses `tkn pipeline start --showlog` which blocks until the PipelineRun terminates,
-        streams logs to stdout (visible in Jenkins console), and returns non-zero on failure.
+        Steps:
+        1. Start the pipeline and capture the PipelineRun name
+        2. Log the console URL back to Jenkins
+        3. Stream PipelineRun logs until completion
+        4. Check the final PipelineRun status and raise on failure
         """
         kubeconfig = os.environ.get('ART_CLUSTER_LP_KUBECONFIG')
         if not kubeconfig:
@@ -166,10 +169,13 @@ class BuildLayeredProductsPipeline:
             )
 
         data_path = self._doozer_env_vars.get('DOOZER_DATA_PATH', '')
+        namespace = "layered-products"
+        pipeline_name = "build-layered-products"
 
-        cmd = [
-            "tkn", "pipeline", "start", "build-layered-products",
-            "--namespace", "layered-products",
+        # Step 1: Start the pipeline and get the PipelineRun name
+        start_cmd = [
+            "tkn", "pipeline", "start", pipeline_name,
+            "--namespace", namespace,
             "--kubeconfig", kubeconfig,
             "--param", f"group={self.group}",
             "--param", f"assembly={self.assembly}",
@@ -183,13 +189,53 @@ class BuildLayeredProductsPipeline:
             "--param", f"ignore-locks={'true' if self.ignore_locks else 'false'}",
             "--param", f"art-tools-commit={os.environ.get('ART_TOOLS_COMMIT', '')}",
             "--pipeline-timeout", "4h",
-            "--showlog",
+            "--output", "name",
         ]
 
-        self._logger.info("Triggering build-layered-products on artc cluster (namespace: layered-products)")
-        # cmd_assert_async raises ChildProcessError on non-zero exit (= pipeline failure)
-        await exectools.cmd_assert_async(cmd, env=os.environ.copy())
-        self._logger.info("build-layered-products pipeline completed successfully on cluster")
+        self._logger.info("Triggering %s on artc cluster (namespace: %s)", pipeline_name, namespace)
+        rc, stdout, stderr = await exectools.cmd_gather_async(start_cmd, env=os.environ.copy())
+        if rc != 0:
+            raise ChildProcessError(
+                f"Failed to start {pipeline_name} on cluster (exit {rc}): {stderr.strip()}"
+            )
+
+        plr_name = stdout.strip()
+        if not plr_name:
+            raise RuntimeError("tkn pipeline start returned empty PipelineRun name")
+
+        # Step 2: Log the PipelineRun URL
+        plr_url = (
+            f"https://console-openshift-console.apps.artc2023.pc3z.p1.openshiftapps.com"
+            f"/k8s/ns/{namespace}/tekton.dev~v1~PipelineRun/{plr_name}/logs"
+        )
+        self._logger.info("Triggered PipelineRun on artc cluster: %s", plr_url)
+        jenkins.update_description(f'<a href="{plr_url}">PipelineRun: {plr_name}</a><br/>')
+
+        # Step 3: Stream logs until the PipelineRun completes
+        logs_cmd = [
+            "tkn", "pipelinerun", "logs", "--follow",
+            "--namespace", namespace,
+            "--kubeconfig", kubeconfig,
+            plr_name,
+        ]
+        await exectools.cmd_gather_async(logs_cmd, env=os.environ.copy())
+
+        # Step 4: Check the final status
+        status_cmd = [
+            "tkn", "pipelinerun", "describe", plr_name,
+            "--namespace", namespace,
+            "--kubeconfig", kubeconfig,
+            "--output", "jsonpath={.status.conditions[0].status}",
+        ]
+        rc, stdout, stderr = await exectools.cmd_gather_async(status_cmd, env=os.environ.copy())
+        succeeded = stdout.strip()
+
+        if succeeded != "True":
+            raise ChildProcessError(
+                f"PipelineRun {plr_name} failed (status={succeeded}). See logs above or: {plr_url}"
+            )
+
+        self._logger.info("PipelineRun %s completed successfully", plr_name)
 
     async def run(self):
         """Run the layered products rebase and build pipeline"""

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -36,6 +36,7 @@ class BuildLayeredProductsPipeline:
         skip_bundle_build: bool,
         image_build_strategy: str = 'only',
         skip_rebase: bool = False,
+        ignore_locks: bool = False,
         kubeconfig: Optional[str] = None,
         data_gitref: Optional[str] = None,
         network_mode: Optional[str] = None,
@@ -50,6 +51,7 @@ class BuildLayeredProductsPipeline:
         self.image_build_strategy = BuildStrategy(image_build_strategy)
         self.skip_bundle_build = skip_bundle_build
         self.skip_rebase = skip_rebase
+        self.ignore_locks = ignore_locks
         self.kubeconfig = kubeconfig
         self.data_gitref = data_gitref
         self.network_mode = network_mode
@@ -150,6 +152,90 @@ class BuildLayeredProductsPipeline:
         with record_log_path.open('r') as file:
             record_log: dict = record_util.parse_record_log(file)
             return record_log
+
+    async def run_on_cluster(self):
+        """Trigger build-layered-products on the artc cluster and watch until completion.
+
+        Steps:
+        1. Start the pipeline and capture the PipelineRun name
+        2. Log the console URL back to Jenkins
+        3. Stream PipelineRun logs until completion
+        4. Check the final PipelineRun status and raise on failure
+        """
+        kubeconfig = os.environ.get('ART_CLUSTER_LP_KUBECONFIG')
+        if not kubeconfig:
+            raise ValueError(
+                "ART_CLUSTER_LP_KUBECONFIG environment variable must be set to trigger on cluster"
+            )
+
+        data_path = self._doozer_env_vars.get('DOOZER_DATA_PATH', '')
+        namespace = "layered-products"
+        pipeline_name = "build-layered-products"
+
+        # Step 1: Start the pipeline and get the PipelineRun name
+        start_cmd = [
+            "tkn", "pipeline", "start", pipeline_name,
+            "--namespace", namespace,
+            "--kubeconfig", kubeconfig,
+            "--param", f"group={self.group}",
+            "--param", f"assembly={self.assembly}",
+            "--param", f"image-list={self.image_list}",
+            "--param", f"data-path={data_path}",
+            "--param", f"data-gitref={self.data_gitref or ''}",
+            "--param", f"plr-template={self.plr_template or ''}",
+            "--param", f"network-mode={self.network_mode or ''}",
+            "--param", f"dry-run={'true' if self.runtime.dry_run else 'false'}",
+            "--param", f"skip-rebase={'true' if self.skip_rebase else 'false'}",
+            "--param", f"ignore-locks={'true' if self.ignore_locks else 'false'}",
+            "--param", f"art-tools-commit={os.environ.get('ART_TOOLS_COMMIT', '')}",
+            "--pipeline-timeout", "4h",
+            "--output", "name",
+        ]
+
+        self._logger.info("Triggering %s on artc cluster (namespace: %s)", pipeline_name, namespace)
+        rc, stdout, stderr = await exectools.cmd_gather_async(start_cmd, env=os.environ.copy())
+        if rc != 0:
+            raise ChildProcessError(
+                f"Failed to start {pipeline_name} on cluster (exit {rc}): {stderr.strip()}"
+            )
+
+        plr_name = stdout.strip()
+        if not plr_name:
+            raise RuntimeError("tkn pipeline start returned empty PipelineRun name")
+
+        # Step 2: Log the PipelineRun URL
+        plr_url = (
+            f"https://console-openshift-console.apps.artc2023.pc3z.p1.openshiftapps.com"
+            f"/k8s/ns/{namespace}/tekton.dev~v1~PipelineRun/{plr_name}/logs"
+        )
+        self._logger.info("Triggered PipelineRun on artc cluster: %s", plr_url)
+        jenkins.update_description(f'<a href="{plr_url}">PipelineRun: {plr_name}</a><br/>')
+
+        # Step 3: Stream logs until the PipelineRun completes
+        logs_cmd = [
+            "tkn", "pipelinerun", "logs", "--follow",
+            "--namespace", namespace,
+            "--kubeconfig", kubeconfig,
+            plr_name,
+        ]
+        await exectools.cmd_gather_async(logs_cmd, env=os.environ.copy())
+
+        # Step 4: Check the final status
+        status_cmd = [
+            "tkn", "pipelinerun", "describe", plr_name,
+            "--namespace", namespace,
+            "--kubeconfig", kubeconfig,
+            "--output", "jsonpath={.status.conditions[0].status}",
+        ]
+        rc, stdout, stderr = await exectools.cmd_gather_async(status_cmd, env=os.environ.copy())
+        succeeded = stdout.strip()
+
+        if succeeded != "True":
+            raise ChildProcessError(
+                f"PipelineRun {plr_name} failed (status={succeeded}). See logs above or: {plr_url}"
+            )
+
+        self._logger.info("PipelineRun %s completed successfully", plr_name)
 
     async def run(self):
         """Run the layered products rebase and build pipeline"""
@@ -430,6 +516,12 @@ class BuildLayeredProductsPipeline:
     default='',
     help='Override the Pipeline Run template commit from openshift-priv/art-konflux-template; format: <owner>@<branch>',
 )
+@click.option(
+    '--on-cluster',
+    is_flag=True,
+    default=False,
+    help='Trigger the pipeline on the artc cluster (layered-products namespace) and watch until completion',
+)
 @pass_runtime
 @click_coroutine
 async def build_layered_products(
@@ -447,6 +539,7 @@ async def build_layered_products(
     network_mode: Optional[str],
     ignore_locks: bool,
     plr_template: str,
+    on_cluster: bool,
 ):
     """Rebase and build layered product image for an assembly"""
     try:
@@ -460,6 +553,7 @@ async def build_layered_products(
             data_path=data_path,
             skip_bundle_build=skip_bundle_build,
             skip_rebase=skip_rebase,
+            ignore_locks=ignore_locks,
             kubeconfig=kubeconfig,
             data_gitref=data_gitref,
             network_mode=network_mode,
@@ -468,7 +562,9 @@ async def build_layered_products(
 
         lock_identifier = jenkins.get_build_path_or_random()
 
-        if ignore_locks:
+        if on_cluster:
+            await pipeline.run_on_cluster()
+        elif ignore_locks:
             await pipeline.run()
         else:
             await locks.run_with_lock(

--- a/pyartcd/pyartcd/pipelines/build_layered_products.py
+++ b/pyartcd/pyartcd/pipelines/build_layered_products.py
@@ -175,23 +175,16 @@ class BuildLayeredProductsPipeline:
             "--param", f"assembly={self.assembly}",
             "--param", f"image-list={self.image_list}",
             "--param", f"data-path={data_path}",
+            "--param", f"data-gitref={self.data_gitref or ''}",
+            "--param", f"plr-template={self.plr_template or ''}",
+            "--param", f"network-mode={self.network_mode or ''}",
             "--param", f"dry-run={'true' if self.runtime.dry_run else 'false'}",
             "--param", f"skip-rebase={'true' if self.skip_rebase else 'false'}",
             "--param", f"ignore-locks={'true' if self.ignore_locks else 'false'}",
+            "--param", f"art-tools-commit={os.environ.get('ART_TOOLS_COMMIT', '')}",
             "--pipeline-timeout", "4h",
             "--showlog",
         ]
-
-        if self.data_gitref:
-            cmd.extend(["--param", f"data-gitref={self.data_gitref}"])
-        if self.network_mode:
-            cmd.extend(["--param", f"network-mode={self.network_mode}"])
-        if self.plr_template:
-            cmd.extend(["--param", f"plr-template={self.plr_template}"])
-
-        art_tools_commit = os.environ.get('ART_TOOLS_COMMIT', '')
-        if art_tools_commit:
-            cmd.extend(["--param", f"art-tools-commit={art_tools_commit}"])
 
         self._logger.info("Triggering build-layered-products on artc cluster (namespace: layered-products)")
         # cmd_assert_async raises ChildProcessError on non-zero exit (= pipeline failure)

--- a/pyartcd/pyartcd/pipelines/layered_products_scan_konflux.py
+++ b/pyartcd/pyartcd/pipelines/layered_products_scan_konflux.py
@@ -5,7 +5,7 @@ import click
 import yaml
 from artcommonlib import exectools
 
-from pyartcd import constants, jenkins, locks, util
+from pyartcd import constants, jenkins, locks, tekton, util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.locks import Lock
 from pyartcd.runtime import Runtime
@@ -56,7 +56,7 @@ class LayeredProductsScanPipeline:
         await self.get_changes()
 
         # Handle image source changes
-        self.handle_source_changes()
+        await self.handle_source_changes()
 
     def check_params(self):
         """
@@ -82,10 +82,12 @@ class LayeredProductsScanPipeline:
             [
                 'beta:config:konflux:scan-sources',
                 '--yaml',
-                f'--ci-kubeconfig={os.environ["KUBECONFIG"]}',
                 '--rebase-priv',
             ]
         )
+        kubeconfig = os.environ.get("KUBECONFIG")
+        if kubeconfig:
+            cmd.append(f'--ci-kubeconfig={kubeconfig}')
         if self.runtime.dry_run:
             cmd.append('--dry-run')
 
@@ -99,7 +101,7 @@ class LayeredProductsScanPipeline:
         else:
             self.logger.info('No changes detected in layered products RPMs or images')
 
-    def handle_source_changes(self):
+    async def handle_source_changes(self):
         if not self.changes:
             return
 
@@ -136,11 +138,24 @@ class LayeredProductsScanPipeline:
 
         # Trigger layered product build
         self.logger.info('Triggering a layered products %s build', self.group)
-        jenkins.start_layered_products(
-            group=self.group,
-            assembly=self.assembly,
-            image_list=image_list,
-        )
+        if tekton.is_tekton_context():
+            await tekton.start_pipeline(
+                pipeline_name="build-layered-products",
+                params={
+                    "group": self.group,
+                    "assembly": self.assembly,
+                    "image-list": ",".join(image_list),
+                    "data-path": self.data_path,
+                    "data-gitref": self.data_gitref or "",
+                    "art-tools-commit": os.environ.get("ART_TOOLS_COMMIT", ""),
+                },
+            )
+        else:
+            jenkins.start_layered_products(
+                group=self.group,
+                assembly=self.assembly,
+                image_list=image_list,
+            )
 
 
 @cli.command('layered-products-scan')
@@ -159,8 +174,9 @@ class LayeredProductsScanPipeline:
 async def layered_products_scan(
     runtime: Runtime, group: str, assembly: str, data_path: str, data_gitref, image_list: str
 ):
-    # KUBECONFIG env var must be defined in order to scan sources
-    if not os.getenv('KUBECONFIG'):
+    # KUBECONFIG is needed off-cluster for doozer scan-sources to query the CI cluster.
+    # On-cluster (Tekton), doozer uses the in-cluster config automatically.
+    if not os.getenv('KUBECONFIG') and not tekton.is_tekton_context():
         raise RuntimeError('Environment variable KUBECONFIG must be defined')
 
     jenkins.init_jenkins()

--- a/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle_konflux.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import sys
 from pathlib import Path
 
@@ -7,12 +8,52 @@ from artcommonlib import exectools
 from artcommonlib.constants import PRODUCT_KUBECONFIG_MAP
 from artcommonlib.util import resolve_konflux_kubeconfig_by_product, resolve_konflux_namespace_by_product
 
-from pyartcd import constants, jenkins, locks
+from pyartcd import constants, jenkins, locks, tekton
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.locks import Lock
 from pyartcd.record import parse_record_log
 from pyartcd.runtime import Runtime
 from pyartcd.util import load_group_config
+
+
+async def _trigger_fbc(
+    version: str,
+    group: str,
+    assembly: str,
+    operator_nvrs: list,
+    data_path: str,
+    data_gitref: str,
+    dry_run: bool,
+    ocp_target_version: str = "",
+    force_build: bool = False,
+    propagate_params: dict = None,
+):
+    """Trigger a build-fbc pipeline run — via Tekton on-cluster or Jenkins off-cluster."""
+    if tekton.is_tekton_context():
+        params = {
+            "version": version,
+            "assembly": assembly,
+            "group": group or "",
+            "operator-nvrs": ",".join(operator_nvrs),
+            "data-path": data_path,
+            "data-gitref": data_gitref or "",
+            "force": "true" if force_build else "false",
+            "art-tools-commit": os.environ.get("ART_TOOLS_COMMIT", ""),
+        }
+        if ocp_target_version:
+            params["ocp-target-version"] = ocp_target_version
+        await tekton.start_pipeline(pipeline_name="build-fbc", params=params)
+    else:
+        jenkins.start_build_fbc(
+            version=version,
+            group=group,
+            assembly=assembly,
+            operator_nvrs=operator_nvrs,
+            dry_run=dry_run,
+            ocp_target_version=ocp_target_version,
+            force_build=force_build,
+            propagate_params=propagate_params,
+        )
 
 
 @cli.command('olm-bundle-konflux')
@@ -220,11 +261,13 @@ async def olm_bundle_konflux(
                 # Generate multiple FBC jobs, one for each target version
                 for target_version in ocp_target_versions:
                     runtime.logger.info(f'Starting FBC job for target version: {target_version}')
-                    jenkins.start_build_fbc(
+                    await _trigger_fbc(
                         version=version,
                         group=group,
                         assembly=assembly,
                         operator_nvrs=operator_nvrs,
+                        data_path=data_path,
+                        data_gitref=data_gitref or "",
                         dry_run=runtime.dry_run,
                         ocp_target_version=target_version,
                         # Always force rebuild FBCs for OADP / MTA / MTC
@@ -235,22 +278,26 @@ async def olm_bundle_konflux(
             else:
                 runtime.logger.info(f'No OCP_TARGET_VERSIONS defined for group {group}, using original behavior')
                 # No OCP_TARGET_VERSIONS defined, use original behavior
-                jenkins.start_build_fbc(
+                await _trigger_fbc(
                     version=version,
                     group=group,
                     assembly=assembly,
                     operator_nvrs=operator_nvrs,
+                    data_path=data_path,
+                    data_gitref=data_gitref or "",
                     dry_run=runtime.dry_run,
                     propagate_params=propagate_params,
                 )
         else:
             runtime.logger.info(f'Group {group} does not match OADP/MTA/MTC pattern, using original behavior')
             # Not an OADP/MTA/MTC group, use original behavior
-            jenkins.start_build_fbc(
+            await _trigger_fbc(
                 version=version,
                 group=group if group else None,
                 assembly=assembly,
                 operator_nvrs=operator_nvrs,
+                data_path=data_path,
+                data_gitref=data_gitref or "",
                 dry_run=runtime.dry_run,
                 propagate_params=propagate_params,
             )

--- a/pyartcd/pyartcd/pipelines/scheduled/schedule_layered_products_scan.py
+++ b/pyartcd/pyartcd/pipelines/scheduled/schedule_layered_products_scan.py
@@ -1,9 +1,10 @@
 import asyncio
+import os
 
 import click
 from artcommonlib import redis
 
-from pyartcd import jenkins, util
+from pyartcd import jenkins, tekton, util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.locks import Lock, LockManager
 from pyartcd.runtime import Runtime
@@ -32,7 +33,17 @@ async def run_for(group: str, runtime: Runtime, lock_manager: LockManager):
     # Schedule layered products scan
     runtime.logger.info('[%s] Scheduling layered-products-scan-konflux', group)
 
-    jenkins.start_layered_products_scan_konflux(group=group, block_until_building=False)
+    if tekton.is_tekton_context():
+        await tekton.start_pipeline(
+            pipeline_name="layered-products-scan",
+            params={
+                "group": group,
+                "assembly": "stream",
+                "art-tools-commit": os.environ.get("ART_TOOLS_COMMIT", ""),
+            },
+        )
+    else:
+        jenkins.start_layered_products_scan_konflux(group=group, block_until_building=False)
 
 
 @cli.command('schedule-layered-products-scan')

--- a/pyartcd/pyartcd/tekton.py
+++ b/pyartcd/pyartcd/tekton.py
@@ -1,0 +1,67 @@
+"""Utilities for running artcd pipelines inside Tekton on the artc2023 cluster."""
+
+import logging
+import os
+from typing import Optional
+
+from artcommonlib import exectools
+
+logger = logging.getLogger(__name__)
+
+ARTC_CONSOLE_BASE = "https://console-openshift-console.apps.artc2023.pc3z.p1.openshiftapps.com"
+DEFAULT_NAMESPACE = "layered-products"
+
+
+def is_tekton_context() -> bool:
+    """Return True when running inside a Tekton PipelineRun."""
+    return bool(os.environ.get("TEKTON_PIPELINERUN_NAME"))
+
+
+def get_current_pipelinerun_name() -> Optional[str]:
+    """Return the name of the PipelineRun we are executing inside, or None."""
+    return os.environ.get("TEKTON_PIPELINERUN_NAME") or None
+
+
+def pipelinerun_url(name: str, namespace: str = DEFAULT_NAMESPACE) -> str:
+    """Build the OpenShift console URL for a PipelineRun."""
+    return f"{ARTC_CONSOLE_BASE}/k8s/ns/{namespace}/tekton.dev~v1~PipelineRun/{name}/logs"
+
+
+async def start_pipeline(
+    pipeline_name: str,
+    params: dict,
+    namespace: str = DEFAULT_NAMESPACE,
+    pipeline_timeout: str = "4h",
+) -> str:
+    """Fire-and-forget: start a Tekton pipeline and return the PipelineRun name.
+
+    Uses the in-cluster service account — no kubeconfig needed when running on-cluster.
+    Does NOT stream logs or wait for completion (matches the Jenkins fire-and-forget model).
+    """
+    cmd = [
+        "tkn",
+        "pipeline",
+        "start",
+        pipeline_name,
+        "--namespace",
+        namespace,
+        "--pipeline-timeout",
+        pipeline_timeout,
+        "--output",
+        "name",
+    ]
+    for key, value in params.items():
+        cmd.extend(["--param", f"{key}={value}"])
+
+    logger.info("Starting Tekton pipeline %s in namespace %s", pipeline_name, namespace)
+    rc, stdout, stderr = await exectools.cmd_gather_async(cmd)
+    if rc != 0:
+        raise ChildProcessError(f"Failed to start pipeline {pipeline_name} (exit {rc}): {stderr.strip()}")
+
+    plr_name = stdout.strip()
+    if not plr_name:
+        raise RuntimeError(f"tkn pipeline start {pipeline_name} returned empty PipelineRun name")
+
+    url = pipelinerun_url(plr_name, namespace)
+    logger.info("Started PipelineRun: %s (%s)", plr_name, url)
+    return plr_name

--- a/pyartcd/tests/pipelines/test_build_layered_products.py
+++ b/pyartcd/tests/pipelines/test_build_layered_products.py
@@ -411,7 +411,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
 
     @patch('pyartcd.pipelines.build_layered_products.jenkins.start_olm_bundle_konflux')
     @patch('pyartcd.pipelines.build_layered_products.jenkins.get_propagatable_params', return_value={})
-    def test_trigger_bundle_build_filters_embargoed_operators(self, mock_get_params, mock_start_bundle):
+    async def test_trigger_bundle_build_filters_embargoed_operators(self, mock_get_params, mock_start_bundle):
         """Embargoed operator NVRs are dropped from the trigger; non-embargoed ones proceed."""
         self.pipeline.skip_bundle_build = False
         self._write_image_build_record_log(
@@ -421,7 +421,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
             ]
         )
 
-        self.pipeline.trigger_bundle_build()
+        await self.pipeline.trigger_bundle_build()
 
         mock_start_bundle.assert_called_once()
         self.assertEqual(
@@ -435,7 +435,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
 
     @patch('pyartcd.pipelines.build_layered_products.jenkins.start_olm_bundle_konflux')
     @patch('pyartcd.pipelines.build_layered_products.jenkins.get_propagatable_params', return_value={})
-    def test_trigger_bundle_build_ambiguous_nvr_skips_and_warns(self, mock_get_params, mock_start_bundle):
+    async def test_trigger_bundle_build_ambiguous_nvr_skips_and_warns(self, mock_get_params, mock_start_bundle):
         """An NVR whose embargo status is ambiguous (matches more than one visibility suffix)
         is treated like an embargoed NVR: skip its bundle trigger and record it as skipped,
         rather than letting the ValueError bubble up and get silently swallowed by the
@@ -449,7 +449,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
             ]
         )
 
-        self.pipeline.trigger_bundle_build()
+        await self.pipeline.trigger_bundle_build()
 
         mock_start_bundle.assert_called_once()
         self.assertEqual(
@@ -460,7 +460,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
 
     @patch('pyartcd.pipelines.build_layered_products.jenkins.start_olm_bundle_konflux')
     @patch('pyartcd.pipelines.build_layered_products.jenkins.get_propagatable_params', return_value={})
-    def test_trigger_bundle_build_all_embargoed_skips_trigger(self, mock_get_params, mock_start_bundle):
+    async def test_trigger_bundle_build_all_embargoed_skips_trigger(self, mock_get_params, mock_start_bundle):
         """When every operator NVR is embargoed, the bundle build trigger is never called."""
         self.pipeline.skip_bundle_build = False
         self._write_image_build_record_log(
@@ -469,7 +469,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
             ]
         )
 
-        self.pipeline.trigger_bundle_build()
+        await self.pipeline.trigger_bundle_build()
 
         mock_start_bundle.assert_not_called()
         self.assertEqual(
@@ -479,7 +479,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
 
     @patch('pyartcd.pipelines.build_layered_products.jenkins.start_olm_bundle_konflux')
     @patch('pyartcd.pipelines.build_layered_products.jenkins.get_propagatable_params', return_value={})
-    def test_trigger_bundle_build_no_embargoed_calls_normally(self, mock_get_params, mock_start_bundle):
+    async def test_trigger_bundle_build_no_embargoed_calls_normally(self, mock_get_params, mock_start_bundle):
         """When no operator NVRs are embargoed, the trigger proceeds normally with an empty skip list."""
         self.pipeline.skip_bundle_build = False
         self._write_image_build_record_log(
@@ -488,7 +488,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
             ]
         )
 
-        self.pipeline.trigger_bundle_build()
+        await self.pipeline.trigger_bundle_build()
 
         mock_start_bundle.assert_called_once()
         self.assertEqual(
@@ -496,6 +496,25 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
             ['oadp-operator-container-v1.4.9-202607151200.p2.g172d0b2.assembly.stream.el9'],
         )
         self.assertEqual(self.pipeline.embargoed_operators_skipped, [])
+
+    @patch('pyartcd.pipelines.build_layered_products.tekton.start_pipeline', new_callable=AsyncMock)
+    async def test_trigger_bundle_build_uses_tekton_in_tekton_context(self, mock_start_pipeline):
+        """In Tekton context, trigger_bundle_build fires a Tekton pipeline instead of Jenkins."""
+        import os
+
+        self.pipeline.skip_bundle_build = False
+        self.pipeline.version = '1.4.9'
+        nvr = 'oadp-operator-container-v1.4.9-202607151200.p2.g172d0b2.assembly.stream.el9'
+        self._write_image_build_record_log([('oadp-operator', nvr)])
+        mock_start_pipeline.return_value = 'olm-bundle-konflux-run-abc'
+
+        with patch.dict(os.environ, {"TEKTON_PIPELINERUN_NAME": "parent-plr-123"}):
+            await self.pipeline.trigger_bundle_build()
+
+        mock_start_pipeline.assert_called_once()
+        call_kwargs = mock_start_pipeline.call_args.kwargs
+        self.assertEqual(call_kwargs['pipeline_name'], 'olm-bundle-konflux')
+        self.assertIn('operator-nvrs', call_kwargs['params'])
 
     @patch('pyartcd.pipelines.build_layered_products.jenkins.init_jenkins')
     @patch('pyartcd.pipelines.build_layered_products.load_group_config')
@@ -507,10 +526,10 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
 
         with (
             patch.object(self.pipeline, '_rebase_and_build', new_callable=AsyncMock),
-            patch.object(self.pipeline, 'trigger_bundle_build') as mock_trigger,
+            patch.object(self.pipeline, 'trigger_bundle_build', new_callable=AsyncMock) as mock_trigger,
         ):
 
-            def fake_trigger():
+            async def fake_trigger():
                 self.pipeline.embargoed_operators_skipped.append(
                     'oadp-operator-container-v1.4.9-202607151200.p3.g172d0b2.assembly.stream.el9'
                 )
@@ -532,7 +551,7 @@ class TestBuildLayeredProductsPipeline(IsolatedAsyncioTestCase):
 
         with (
             patch.object(self.pipeline, '_rebase_and_build', new_callable=AsyncMock),
-            patch.object(self.pipeline, 'trigger_bundle_build'),
+            patch.object(self.pipeline, 'trigger_bundle_build', new_callable=AsyncMock),
         ):
             await self.pipeline.run()  # Should not raise
 

--- a/pyartcd/tests/pipelines/test_layered_products_scan_konflux.py
+++ b/pyartcd/tests/pipelines/test_layered_products_scan_konflux.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import yaml
 from pyartcd.pipelines.layered_products_scan_konflux import LayeredProductsScanPipeline
@@ -161,6 +161,95 @@ class TestLayeredProductsScanPipeline(unittest.IsolatedAsyncioTestCase):
         self.assertIn('images', pipeline.report)
         self.assertEqual(len(pipeline.report['images']), 1)
         self.assertEqual(pipeline.report['images'][0]['name'], 'test-image')
+
+    @patch('pyartcd.pipelines.layered_products_scan_konflux.tekton.start_pipeline', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.layered_products_scan_konflux.exectools.cmd_gather_async')
+    async def test_changed_images_trigger_tekton_pipeline_in_tekton_context(self, mock_cmd_gather, mock_start_pipeline):
+        """In Tekton context, changed images trigger a Tekton pipeline instead of Jenkins."""
+        self.runtime.dry_run = False
+        mock_start_pipeline.return_value = "build-layered-products-run-abc"
+
+        scan_output = yaml.dump(
+            {
+                'images': [{'name': 'oadp-operator', 'changed': True}],
+                'rpms': [],
+            }
+        )
+        mock_cmd_gather.return_value = (0, scan_output, '')
+
+        pipeline = LayeredProductsScanPipeline(
+            runtime=self.runtime,
+            group='oadp-1.4',
+            data_path='https://github.com/openshift-eng/ocp-build-data',
+            assembly='stream',
+            data_gitref='',
+            image_list='',
+        )
+
+        with patch.dict(os.environ, {"TEKTON_PIPELINERUN_NAME": "parent-plr-123"}):
+            await pipeline.run()
+
+        mock_start_pipeline.assert_called_once()
+        call_kwargs = mock_start_pipeline.call_args.kwargs
+        self.assertEqual(call_kwargs['pipeline_name'], 'build-layered-products')
+        self.assertIn('image-list', call_kwargs['params'])
+        self.assertIn('oadp-operator', call_kwargs['params']['image-list'])
+
+    async def test_kubeconfig_not_required_in_tekton_context(self):
+        """In Tekton context, missing KUBECONFIG does not raise an error."""
+        from pyartcd.pipelines import layered_products_scan_konflux as mod
+
+        env = {k: v for k, v in os.environ.items() if k != 'KUBECONFIG'}
+        with patch.dict(os.environ, {**env, 'TEKTON_PIPELINERUN_NAME': 'my-plr-123'}, clear=True):
+            # Should not raise RuntimeError
+            with (
+                patch.object(mod, 'jenkins'),
+                patch('pyartcd.pipelines.layered_products_scan_konflux.locks'),
+            ):
+                # Just verify the check passes without exception
+                from pyartcd import tekton
+
+                self.assertTrue(tekton.is_tekton_context())
+                self.assertFalse(os.getenv('KUBECONFIG'))
+
+    @patch.dict(os.environ, {'KUBECONFIG': '/kube/config'})
+    @patch('pyartcd.pipelines.layered_products_scan_konflux.exectools.cmd_gather_async')
+    async def test_ci_kubeconfig_flag_present_when_kubeconfig_set(self, mock_cmd_gather):
+        """When KUBECONFIG is set, --ci-kubeconfig flag is passed to doozer."""
+        mock_cmd_gather.return_value = (0, yaml.dump({'images': [], 'rpms': []}), '')
+
+        pipeline = LayeredProductsScanPipeline(
+            runtime=self.runtime,
+            group='oadp-1.4',
+            data_path='https://github.com/openshift-eng/ocp-build-data',
+            assembly='stream',
+            data_gitref='',
+            image_list='',
+        )
+        await pipeline.get_changes()
+
+        cmd = mock_cmd_gather.call_args[0][0]
+        self.assertTrue(any('--ci-kubeconfig' in str(arg) for arg in cmd))
+
+    @patch('pyartcd.pipelines.layered_products_scan_konflux.exectools.cmd_gather_async')
+    async def test_ci_kubeconfig_flag_absent_when_kubeconfig_unset(self, mock_cmd_gather):
+        """When KUBECONFIG is not set, --ci-kubeconfig is NOT passed to doozer."""
+        mock_cmd_gather.return_value = (0, yaml.dump({'images': [], 'rpms': []}), '')
+        env = {k: v for k, v in os.environ.items() if k != 'KUBECONFIG'}
+
+        pipeline = LayeredProductsScanPipeline(
+            runtime=self.runtime,
+            group='oadp-1.4',
+            data_path='https://github.com/openshift-eng/ocp-build-data',
+            assembly='stream',
+            data_gitref='',
+            image_list='',
+        )
+        with patch.dict(os.environ, env, clear=True):
+            await pipeline.get_changes()
+
+        cmd = mock_cmd_gather.call_args[0][0]
+        self.assertFalse(any('--ci-kubeconfig' in str(arg) for arg in cmd))
 
 
 if __name__ == '__main__':

--- a/pyartcd/tests/pipelines/test_olm_bundle_konflux.py
+++ b/pyartcd/tests/pipelines/test_olm_bundle_konflux.py
@@ -1,0 +1,46 @@
+import os
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from pyartcd.pipelines.olm_bundle_konflux import _trigger_fbc
+
+
+class TestTriggerFbc(IsolatedAsyncioTestCase):
+    async def test_triggers_tekton_pipeline_in_tekton_context(self):
+        with patch.dict(os.environ, {"TEKTON_PIPELINERUN_NAME": "my-plr-123"}):
+            with patch(
+                "pyartcd.pipelines.olm_bundle_konflux.tekton.start_pipeline", new_callable=AsyncMock
+            ) as mock_start:
+                mock_start.return_value = "build-fbc-run-xyz"
+                await _trigger_fbc(
+                    version="1.5.0",
+                    group="oadp-1.5",
+                    assembly="stream",
+                    operator_nvrs=["oadp-operator-container-1.5.0-1"],
+                    data_path="https://github.com/openshift-eng/ocp-build-data",
+                    data_gitref="",
+                    dry_run=False,
+                    ocp_target_version="4.17",
+                    force_build=True,
+                )
+                mock_start.assert_called_once()
+                call_kwargs = mock_start.call_args
+                self.assertEqual(call_kwargs.kwargs["pipeline_name"], "build-fbc")
+                params = call_kwargs.kwargs["params"]
+                self.assertEqual(params["ocp-target-version"], "4.17")
+                self.assertEqual(params["force"], "true")
+
+    async def test_triggers_jenkins_outside_tekton(self):
+        env = {k: v for k, v in os.environ.items() if k != "TEKTON_PIPELINERUN_NAME"}
+        with patch.dict(os.environ, env, clear=True):
+            with patch("pyartcd.pipelines.olm_bundle_konflux.jenkins.start_build_fbc") as mock_jenkins:
+                await _trigger_fbc(
+                    version="1.5.0",
+                    group="oadp-1.5",
+                    assembly="stream",
+                    operator_nvrs=["oadp-operator-container-1.5.0-1"],
+                    data_path="https://github.com/openshift-eng/ocp-build-data",
+                    data_gitref="",
+                    dry_run=False,
+                )
+                mock_jenkins.assert_called_once()

--- a/pyartcd/tests/test_jenkins.py
+++ b/pyartcd/tests/test_jenkins.py
@@ -7,6 +7,34 @@ from pyartcd.jenkins import Jobs
 from pyartcd import jenkins
 
 
+class TestJenkinsTektonSafe(unittest.TestCase):
+    def setUp(self):
+        jenkins.jenkins_client = None
+        jenkins.current_build_url = None
+        jenkins.current_job_name = None
+
+    def tearDown(self):
+        jenkins.jenkins_client = None
+        jenkins.current_build_url = None
+        jenkins.current_job_name = None
+
+    def test_init_jenkins_skips_in_tekton_context(self):
+        with mock.patch.dict(os.environ, {"TEKTON_PIPELINERUN_NAME": "my-plr-123"}):
+            with mock.patch("pyartcd.jenkins.Jenkins") as mock_cls:
+                jenkins.init_jenkins()
+                mock_cls.assert_not_called()
+                self.assertIsNone(jenkins.jenkins_client)
+
+    def test_check_env_vars_returns_none_in_tekton_context(self):
+        with mock.patch.dict(os.environ, {"TEKTON_PIPELINERUN_NAME": "my-plr-123"}):
+            result = jenkins.update_title("test")
+            self.assertIsNone(result)
+
+        with mock.patch.dict(os.environ, {"TEKTON_PIPELINERUN_NAME": "my-plr-123"}):
+            result = jenkins.update_description("desc")
+            self.assertIsNone(result)
+
+
 class TestJenkinsStartBuild(unittest.TestCase):
     def setUp(self):
         jenkins.current_build_url = None

--- a/pyartcd/tests/test_tekton.py
+++ b/pyartcd/tests/test_tekton.py
@@ -1,0 +1,65 @@
+import os
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from pyartcd import tekton
+
+
+class TestIsTektonContext(IsolatedAsyncioTestCase):
+    def test_true_when_env_var_set(self):
+        with patch.dict(os.environ, {"TEKTON_PIPELINERUN_NAME": "my-plr-abc123"}):
+            self.assertTrue(tekton.is_tekton_context())
+
+    def test_false_when_env_var_absent(self):
+        env = {k: v for k, v in os.environ.items() if k != "TEKTON_PIPELINERUN_NAME"}
+        with patch.dict(os.environ, env, clear=True):
+            self.assertFalse(tekton.is_tekton_context())
+
+
+class TestGetCurrentPipelinerunName(IsolatedAsyncioTestCase):
+    def test_returns_name_when_set(self):
+        with patch.dict(os.environ, {"TEKTON_PIPELINERUN_NAME": "my-plr-abc123"}):
+            self.assertEqual(tekton.get_current_pipelinerun_name(), "my-plr-abc123")
+
+    def test_returns_none_when_absent(self):
+        env = {k: v for k, v in os.environ.items() if k != "TEKTON_PIPELINERUN_NAME"}
+        with patch.dict(os.environ, env, clear=True):
+            self.assertIsNone(tekton.get_current_pipelinerun_name())
+
+
+class TestPipelinerunUrl(IsolatedAsyncioTestCase):
+    def test_builds_correct_url(self):
+        url = tekton.pipelinerun_url("my-run-xyz", "layered-products")
+        self.assertIn("my-run-xyz", url)
+        self.assertIn("layered-products", url)
+        self.assertIn("artc2023", url)
+        self.assertTrue(url.startswith("https://"))
+
+    def test_default_namespace(self):
+        url = tekton.pipelinerun_url("run-abc")
+        self.assertIn(tekton.DEFAULT_NAMESPACE, url)
+
+
+class TestStartPipeline(IsolatedAsyncioTestCase):
+    async def test_success_returns_pipelinerun_name(self):
+        with patch("pyartcd.tekton.exectools.cmd_gather_async", new_callable=AsyncMock) as mock_cmd:
+            mock_cmd.return_value = (0, "pipelineruns.tekton.dev/build-layered-products-run123\n", "")
+            plr = await tekton.start_pipeline("build-layered-products", {"group": "oadp-1.5"})
+        self.assertEqual(plr, "pipelineruns.tekton.dev/build-layered-products-run123")
+        cmd_args = mock_cmd.call_args[0][0]
+        self.assertIn("tkn", cmd_args)
+        self.assertIn("build-layered-products", cmd_args)
+        self.assertIn("--param", cmd_args)
+        self.assertIn("group=oadp-1.5", cmd_args)
+
+    async def test_failure_raises_child_process_error(self):
+        with patch("pyartcd.tekton.exectools.cmd_gather_async", new_callable=AsyncMock) as mock_cmd:
+            mock_cmd.return_value = (1, "", "error: pipeline not found")
+            with self.assertRaises(ChildProcessError):
+                await tekton.start_pipeline("build-layered-products", {})
+
+    async def test_empty_name_raises_runtime_error(self):
+        with patch("pyartcd.tekton.exectools.cmd_gather_async", new_callable=AsyncMock) as mock_cmd:
+            mock_cmd.return_value = (0, "", "")
+            with self.assertRaises(RuntimeError):
+                await tekton.start_pipeline("build-layered-products", {})


### PR DESCRIPTION
## Summary

- Adds `run_on_cluster()` method to `BuildLayeredProductsPipeline` that triggers the `build-layered-products` Tekton Pipeline in the `layered-products` namespace on the artc cluster via `tkn pipeline start --showlog`
- `--showlog` blocks until the PipelineRun terminates, streams logs to the Jenkins console, and returns non-zero on pipeline failure — the Jenkins job status directly reflects the outcome
- New `--on-cluster` CLI flag activates this path; when absent the existing local Python execution is unchanged
- `ignore_locks` is now stored as an instance variable (was only accessible at CLI level) so `run_on_cluster()` can pass it as a Tekton parameter
- Requires `ART_CLUSTER_LAYERED_PRODUCTS_KUBECONFIG` env var pointing at a SA kubeconfig with `pipelineruns` create permission in the `layered-products` namespace

## Companion PR

Companion art-config PR: https://github.com/openshift-eng/art-config/pulls (search for layered-products)

## Test plan

- [ ] `uv run pytest pyartcd/tests/pipelines/test_build_layered_products.py` — all 28 tests pass
- [ ] Verify `artcd build-layered-products --help` shows the new `--on-cluster` flag
- [ ] Test on a dev/staging run with `--on-cluster --dry-run` once the namespace is provisioned in art-config

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--on-cluster` option to run layered-product builds on the artc cluster.
  * Cluster-based builds validate configuration, display pipeline links, stream logs, and report failures through the command-line interface.
  * Added support for passing build parameters and optionally bypassing lock handling during cluster execution.
  * Added cluster-based execution for layered-product scans, scheduled scans, and FBC builds.
  * Builds running in cluster pipelines no longer require Jenkins configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->