### PR TITLE
elliott: support --build-system=konflux in verify-attached-operators

### DIFF
--- a/elliott/elliottlib/cli/verify_attached_operators_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_operators_cli.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import re
 from io import BytesIO
@@ -10,6 +11,7 @@ import requests
 import yaml
 from artcommonlib import exectools
 from artcommonlib.format_util import green_print, red_print
+from artcommonlib.konflux.konflux_build_record import KonfluxBuildOutcome, KonfluxBundleBuildRecord
 from errata_tool import Erratum
 
 from elliottlib import brew, constants, errata
@@ -17,6 +19,7 @@ from elliottlib.cli.common import cli, move_builds, pass_runtime
 from elliottlib.cli.find_builds_cli import find_builds_cli
 from elliottlib.exceptions import BrewBuildException, ElliottFatalError
 from elliottlib.runtime import Runtime
+from elliottlib.shipment_utils import get_builds_from_mr
 
 
 @cli.command("verify-attached-operators", short_help="Verify attached operator bundle references are (being) shipped")
@@ -35,7 +38,14 @@ from elliottlib.runtime import Runtime
     is_flag=True,
     help='Attach unshipped dependencies to advisory, removing them from any other advisory',
 )
-@click.argument("advisories", nargs=-1, type=click.IntRange(1), required=True)
+@click.option(
+    "--shipment-mr",
+    required=False,
+    metavar='URL',
+    help='(Konflux) URL of the shipment merge request to validate. '
+    'Defaults to the shipment URL configured for the assembly.',
+)
+@click.argument("advisories", nargs=-1, type=click.IntRange(1), required=False)
 @pass_runtime
 @click.pass_context
 def verify_attached_operators_cli(
@@ -44,6 +54,7 @@ def verify_attached_operators_cli(
     omit_shipped: bool,
     omit_attached: bool,
     gather_dependencies: bool,
+    shipment_mr: str,
     advisories: Tuple[int, ...],
 ):
     """
@@ -72,16 +83,42 @@ def verify_attached_operators_cli(
     --gather-dependencies can be specified to attach unshipped dependencies to the bundle advisory,
     removing them from any other advisory. This is intended only for operator pre-releases; during
     ordinary z-streams it may risk stealing dependencies from advisories intended to ship earlier.
+
+    KONFLUX MODE (--build-system=konflux):
+
+    In Konflux there are no advisories; the source of truth for what is shipping is the
+    shipment merge request (MR). This validates that the builds attached to the shipment MR
+    are correct: every operator and operand referenced by the MR's bundle (metadata) builds
+    must be present among the image builds (image + extras) attached to the same MR.
+
+    The MR is taken from --shipment-mr, or (if omitted) the shipment URL configured for the
+    assembly in releases.yml:
+
+        elliott -g openshift-4.19 --assembly 4.19.5 --build-system=konflux \\
+                verify-attached-operators --shipment-mr https://gitlab.../merge_requests/123
+
+    The --omit-shipped, --omit-attached, --gather-dependencies options and advisory arguments
+    are advisory-only and are not supported in Konflux mode.
     """
 
+    runtime.initialize(mode="images")
+
+    if runtime.build_system == 'konflux':
+        _verify_attached_operators_konflux(
+            runtime, advisories, omit_shipped, omit_attached, gather_dependencies, shipment_mr
+        )
+        return
+
+    if shipment_mr:
+        raise click.BadParameter("--shipment-mr is only supported with --build-system=konflux.")
+    if not advisories:
+        raise click.BadParameter("At least one advisory ID is required for Brew builds.")
     if gather_dependencies and omit_shipped:
         red_print("--gather-dependencies is incompatible with --omit-shipped")
         exit(1)  # it could cause us to attempt to attach already-shipped content
     if gather_dependencies and len(advisories) != 1:
         red_print("--gather-dependencies requires specifying exactly one metadata advisory as a destination")
         exit(1)
-
-    runtime.initialize(mode="images")
 
     problems, invalid, unshipped_builds_by_advisory = _analyze_image_builds(
         runtime, advisories, omit_shipped, omit_attached, gather_dependencies
@@ -108,6 +145,103 @@ def verify_attached_operators_cli(
             raise ElliottFatalError("Please attach builds as indicated before shipping bundles.")
 
     green_print("All operator bundles were valid and references were found.")
+
+
+def _verify_attached_operators_konflux(
+    runtime,
+    advisories: Tuple[int, ...],
+    omit_shipped: bool,
+    omit_attached: bool,
+    gather_dependencies: bool,
+    shipment_mr: str,
+):
+    """
+    Konflux equivalent of verify-attached-operators.
+
+    In Konflux there are no advisories; the source of truth for the builds being shipped is
+    the shipment MR. This validates that whatever is attached to the shipment MR is correct:
+    every operator and operand referenced by the MR's bundle (metadata) builds must be present
+    among the image (image + extras) builds attached to the same MR. This mirrors the check in
+    PrepareReleaseKonfluxPipeline.verify_attached_operators.
+    """
+    if advisories:
+        raise click.BadParameter("Konflux does not take advisory arguments; builds are read from the shipment MR.")
+    if omit_shipped or omit_attached or gather_dependencies:
+        raise click.BadParameter("Konflux does not support --omit-shipped, --omit-attached, or --gather-dependencies.")
+    if runtime.konflux_db is None:
+        raise ElliottFatalError("Cannot connect to the Konflux DB.")
+
+    mr_url = shipment_mr or (runtime.group_config.shipment.url or None)
+    if not mr_url:
+        raise click.BadParameter(
+            "No shipment MR to validate. Pass --shipment-mr, or configure shipment.url for the assembly."
+        )
+
+    missing = asyncio.run(_konflux_missing_references(runtime, mr_url))
+    if missing:
+        missing_str = "\n              ".join(missing)
+        red_print(f"""
+            Some bundle references are not part of the shipment (see notes above):
+              {missing_str}
+            Ensure all referenced operators and operands are attached to the shipment MR.
+        """)
+        raise ElliottFatalError("Please resolve the errors above before shipping bundles.")
+
+    green_print("All operator bundles were valid and references were found.")
+
+
+async def _konflux_missing_references(runtime, mr_url: str) -> List[str]:
+    """
+    Read the builds attached to the shipment MR and return a list of human-readable problems
+    for any operator/operand reference from a bundle that is not attached to the same MR.
+    """
+    builds_by_kind = get_builds_from_mr(mr_url)
+    olm_builds = builds_by_kind.get('metadata', [])
+    if not olm_builds:
+        green_print("No bundle builds attached to the shipment MR.")
+        return []
+
+    # references may be satisfied by any image or extras build attached to the shipment MR
+    image_builds = set(builds_by_kind.get('image', [])) | set(builds_by_kind.get('extras', []))
+
+    # look up each bundle's referenced operator/operands from the Konflux DB
+    runtime.konflux_db.bind(KonfluxBundleBuildRecord)
+    records = await asyncio.gather(
+        *[
+            runtime.konflux_db.get_latest_build(
+                nvr=nvr, outcome=KonfluxBuildOutcome.SUCCESS, exclude_large_columns=True
+            )
+            for nvr in olm_builds
+        ]
+    )
+
+    olm_builds_detail = {
+        record.nvr: {'operator_nvr': record.operator_nvr, 'operand_nvrs': record.operand_nvrs or []}
+        for record in records
+        if record is not None
+    }
+    green_print(f"Found {len(olm_builds_detail)} bundles")
+    return _check_konflux_bundle_references(olm_builds_detail, image_builds)
+
+
+def _check_konflux_bundle_references(olm_builds_detail: Dict[str, Dict], image_builds: Set[str]) -> List[str]:
+    """
+    Pure check: for each bundle, ensure its operator NVR and every operand NVR is present in the
+    set of image builds attached to the shipment. Returns a list of human-readable problems.
+    """
+    missing_references = []
+    for bundle_nvr, detail in olm_builds_detail.items():
+        operator_nvr = detail.get('operator_nvr')
+        if operator_nvr and operator_nvr not in image_builds:
+            missing_references.append(
+                f"Bundle {bundle_nvr} references operator {operator_nvr}, which is not attached to the shipment."
+            )
+        for operand in detail.get('operand_nvrs') or []:
+            if operand not in image_builds:
+                missing_references.append(
+                    f"Bundle {bundle_nvr} references operand {operand}, which is not attached to the shipment."
+                )
+    return missing_references
 
 
 def _analyze_image_builds(

--- a/elliott/elliottlib/cli/verify_attached_operators_cli.py
+++ b/elliott/elliottlib/cli/verify_attached_operators_cli.py
@@ -38,13 +38,6 @@ from elliottlib.shipment_utils import get_builds_from_mr
     is_flag=True,
     help='Attach unshipped dependencies to advisory, removing them from any other advisory',
 )
-@click.option(
-    "--shipment-mr",
-    required=False,
-    metavar='URL',
-    help='(Konflux) URL of the shipment merge request to validate. '
-    'Defaults to the shipment URL configured for the assembly.',
-)
 @click.argument("advisories", nargs=-1, type=click.IntRange(1), required=False)
 @pass_runtime
 @click.pass_context
@@ -54,7 +47,6 @@ def verify_attached_operators_cli(
     omit_shipped: bool,
     omit_attached: bool,
     gather_dependencies: bool,
-    shipment_mr: str,
     advisories: Tuple[int, ...],
 ):
     """
@@ -87,15 +79,13 @@ def verify_attached_operators_cli(
     KONFLUX MODE (--build-system=konflux):
 
     In Konflux there are no advisories; the source of truth for what is shipping is the
-    shipment merge request (MR). This validates that the builds attached to the shipment MR
-    are correct: every operator and operand referenced by the MR's bundle (metadata) builds
-    must be present among the image builds (image + extras) attached to the same MR.
-
-    The MR is taken from --shipment-mr, or (if omitted) the shipment URL configured for the
-    assembly in releases.yml:
+    shipment merge request (MR) configured for the assembly in releases.yml. This validates
+    that the builds attached to the shipment MR are correct: every operator and operand
+    referenced by the MR's bundle (metadata) builds must be present among the image builds
+    (image + extras) attached to the same MR.
 
         elliott -g openshift-4.19 --assembly 4.19.5 --build-system=konflux \\
-                verify-attached-operators --shipment-mr https://gitlab.../merge_requests/123
+                verify-attached-operators
 
     The --omit-shipped, --omit-attached, --gather-dependencies options and advisory arguments
     are advisory-only and are not supported in Konflux mode.
@@ -104,13 +94,9 @@ def verify_attached_operators_cli(
     runtime.initialize(mode="images")
 
     if runtime.build_system == 'konflux':
-        _verify_attached_operators_konflux(
-            runtime, advisories, omit_shipped, omit_attached, gather_dependencies, shipment_mr
-        )
+        _verify_attached_operators_konflux(runtime, advisories, omit_shipped, omit_attached, gather_dependencies)
         return
 
-    if shipment_mr:
-        raise click.BadParameter("--shipment-mr is only supported with --build-system=konflux.")
     if not advisories:
         raise click.BadParameter("At least one advisory ID is required for Brew builds.")
     if gather_dependencies and omit_shipped:
@@ -153,16 +139,15 @@ def _verify_attached_operators_konflux(
     omit_shipped: bool,
     omit_attached: bool,
     gather_dependencies: bool,
-    shipment_mr: str,
 ):
     """
     Konflux equivalent of verify-attached-operators.
 
     In Konflux there are no advisories; the source of truth for the builds being shipped is
-    the shipment MR. This validates that whatever is attached to the shipment MR is correct:
-    every operator and operand referenced by the MR's bundle (metadata) builds must be present
-    among the image (image + extras) builds attached to the same MR. This mirrors the check in
-    PrepareReleaseKonfluxPipeline.verify_attached_operators.
+    the shipment MR configured for the assembly. This validates that whatever is attached to
+    the shipment MR is correct: every operator and operand referenced by the MR's bundle
+    (metadata) builds must be present among the image (image + extras) builds attached to the
+    same MR. This mirrors the check in PrepareReleaseKonfluxPipeline.verify_attached_operators.
     """
     if advisories:
         raise click.BadParameter("Konflux does not take advisory arguments; builds are read from the shipment MR.")
@@ -171,11 +156,9 @@ def _verify_attached_operators_konflux(
     if runtime.konflux_db is None:
         raise ElliottFatalError("Cannot connect to the Konflux DB.")
 
-    mr_url = shipment_mr or (runtime.group_config.shipment.url or None)
+    mr_url = runtime.group_config.shipment.url or None
     if not mr_url:
-        raise click.BadParameter(
-            "No shipment MR to validate. Pass --shipment-mr, or configure shipment.url for the assembly."
-        )
+        raise click.BadParameter("No shipment MR to validate. Configure shipment.url for the assembly.")
 
     missing = asyncio.run(_konflux_missing_references(runtime, mr_url))
     if missing:

--- a/elliott/tests/test_verify_attached_operators.py
+++ b/elliott/tests/test_verify_attached_operators.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import unittest
@@ -182,3 +183,97 @@ class TestVerifyAttachedOperators(unittest.TestCase):
         mock_gadids.side_effect = BrewBuildException("no such build")
         vaocli._missing_references(None, bundles, set(), False, False)
         self.assertIn("failed to look up in errata-tool", out.pop())
+
+
+class TestVerifyAttachedOperatorsKonflux(unittest.TestCase):
+    def test_check_konflux_bundle_references_all_present(self):
+        olm_builds_detail = {
+            "bundle-a-1-1": {"operator_nvr": "operator-a-1-1", "operand_nvrs": ["operand-a-1-1", "operand-b-1-1"]},
+        }
+        image_builds = {"operator-a-1-1", "operand-a-1-1", "operand-b-1-1"}
+        self.assertEqual([], vaocli._check_konflux_bundle_references(olm_builds_detail, image_builds))
+
+    def test_check_konflux_bundle_references_missing_operator(self):
+        olm_builds_detail = {
+            "bundle-a-1-1": {"operator_nvr": "operator-a-1-1", "operand_nvrs": ["operand-a-1-1"]},
+        }
+        image_builds = {"operand-a-1-1"}  # operator missing
+        problems = vaocli._check_konflux_bundle_references(olm_builds_detail, image_builds)
+        self.assertEqual(1, len(problems))
+        self.assertIn("references operator operator-a-1-1", problems[0])
+        self.assertIn("not attached to the shipment", problems[0])
+
+    def test_check_konflux_bundle_references_missing_operand(self):
+        olm_builds_detail = {
+            "bundle-a-1-1": {"operator_nvr": "operator-a-1-1", "operand_nvrs": ["operand-a-1-1", "operand-b-1-1"]},
+        }
+        image_builds = {"operator-a-1-1", "operand-a-1-1"}  # operand-b missing
+        problems = vaocli._check_konflux_bundle_references(olm_builds_detail, image_builds)
+        self.assertEqual(1, len(problems))
+        self.assertIn("references operand operand-b-1-1", problems[0])
+
+    def test_check_konflux_bundle_references_handles_empty_fields(self):
+        olm_builds_detail = {
+            "bundle-a-1-1": {"operator_nvr": "", "operand_nvrs": None},
+        }
+        self.assertEqual([], vaocli._check_konflux_bundle_references(olm_builds_detail, set()))
+
+    @patch("elliottlib.cli.verify_attached_operators_cli.get_builds_from_mr")
+    def test_konflux_missing_references_reads_from_mr(self, mock_get_builds):
+
+        mock_get_builds.return_value = {
+            "metadata": ["bundle-a-1-1"],
+            "image": ["operator-a-1-1", "operand-a-1-1"],
+            "extras": ["operand-b-1-1"],
+        }
+
+        record = MagicMock(
+            nvr="bundle-a-1-1",
+            operator_nvr="operator-a-1-1",
+            operand_nvrs=["operand-a-1-1", "operand-b-1-1"],
+        )
+
+        async def fake_get_latest_build(**kwargs):
+            return record
+
+        runtime = MagicMock()
+        runtime.konflux_db.get_latest_build.side_effect = fake_get_latest_build
+
+        missing = asyncio.run(vaocli._konflux_missing_references(runtime, "https://gitlab/mr/1"))
+        self.assertEqual([], missing)
+        mock_get_builds.assert_called_once_with("https://gitlab/mr/1")
+        runtime.konflux_db.bind.assert_called_once()
+
+    @patch("elliottlib.cli.verify_attached_operators_cli.get_builds_from_mr")
+    def test_konflux_missing_references_flags_unattached_operand(self, mock_get_builds):
+
+        mock_get_builds.return_value = {
+            "metadata": ["bundle-a-1-1"],
+            "image": ["operator-a-1-1"],  # operand-b-1-1 not attached to the MR
+            "extras": [],
+        }
+
+        record = MagicMock(
+            nvr="bundle-a-1-1",
+            operator_nvr="operator-a-1-1",
+            operand_nvrs=["operand-b-1-1"],
+        )
+
+        async def fake_get_latest_build(**kwargs):
+            return record
+
+        runtime = MagicMock()
+        runtime.konflux_db.get_latest_build.side_effect = fake_get_latest_build
+
+        missing = asyncio.run(vaocli._konflux_missing_references(runtime, "https://gitlab/mr/1"))
+        self.assertEqual(1, len(missing))
+        self.assertIn("references operand operand-b-1-1", missing[0])
+
+    @patch("elliottlib.cli.verify_attached_operators_cli.get_builds_from_mr")
+    def test_konflux_missing_references_no_bundles(self, mock_get_builds):
+
+        mock_get_builds.return_value = {"image": ["operator-a-1-1"], "metadata": []}
+        runtime = MagicMock()
+        missing = asyncio.run(vaocli._konflux_missing_references(runtime, "https://gitlab/mr/1"))
+        self.assertEqual([], missing)
+        runtime.konflux_db.get_latest_build.assert_not_called()


### PR DESCRIPTION
Adds a `--build-system=konflux` branch to `verify-attached-operators` that validates the builds attached to a shipment MR, mirroring the check in `PrepareReleaseKonfluxPipeline.verify_attached_operators`.

The source of truth for what is shipping in Konflux is the shipment MR, so the command reads the builds from the MR and validates that what's attached is correct.

- Reads builds attached to the shipment MR via `get_builds_from_mr` (per-kind NVRs from the snapshot).
- Verifies every operator and operand referenced by the MR's bundle (metadata) builds is present among the image + extras builds attached to the same MR; raises on any missing reference. Bundle references come from the Konflux DB (`KonfluxBundleBuildRecord`).
- The shipment MR is resolved from the assembly's configured `shipment.url`.
- `advisories` positional arg is now optional (required only in Brew mode).
- `--omit-shipped`, `--omit-attached`, `--gather-dependencies`, and advisory args are rejected in Konflux mode.

### Example

```
elliott -g openshift-4.12 --assembly 4.12.96 --build-system=konflux verify-attached-operators
```

```
Found 10 builds for metadata
Found 180 builds for image
Found 38 builds for extras
Found 10 bundles
All operator bundles were valid and references were found.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
