### PR TITLE
Accept Obsolete/Done as terminal bridge-mirror resolutions

### DIFF
--- a/elliott/elliottlib/cli/find_bugs_bridge_cli.py
+++ b/elliott/elliottlib/cli/find_bugs_bridge_cli.py
@@ -19,7 +19,11 @@ from elliottlib.cli.common import click_coroutine
 LOGGER = logging.getLogger(__name__)
 
 BRIDGE_LABEL = "art:bridge-bug"
-WONT_FIX_RESOLUTIONS = {"won't do"}
+# Resolutions that reviewers use to signal a closed mirror needs no further bridge action:
+# "Won't Do" (don't ship in the bridge), "Obsolete"/"Done" (fix already present in the bridge
+# release, so the mirror is unnecessary). Any of these is a valid terminal state; a mirror closed
+# with a resolution outside this set is treated as an anomaly requiring manual investigation.
+TERMINAL_RESOLUTIONS = {"won't do", "obsolete", "done"}
 REQUIRED_LINK_TYPES = {"depends_on", "blocked_by", "clones"}
 
 
@@ -322,13 +326,16 @@ class FindBugsBridgeCli:
             return False
         existing = self.existing_mirrors_by_source.get(source_bug.id, [])
         if existing:
-            if any(self._is_closed_wont_fix(mirror) for mirror in existing):
-                LOGGER.info("Skipping %s because an existing mirror is closed as Won't Do", source_bug.id)
+            if any(self._is_closed_terminal(mirror) for mirror in existing):
+                LOGGER.info(
+                    "Skipping %s because an existing mirror is closed with a terminal resolution", source_bug.id
+                )
                 return False
             if all(mirror.status.lower() == "closed" for mirror in existing):
                 self._record_invalid_bug(
                     source_bug.id,
-                    "Existing bridge mirror is closed without Won't Do; manual investigation required",
+                    "Existing bridge mirror is closed with an unexpected resolution "
+                    f"(not one of {sorted(TERMINAL_RESOLUTIONS)}); manual investigation required",
                 )
                 return False
             mirror = existing[0]
@@ -414,7 +421,8 @@ class FindBugsBridgeCli:
             "engineer decides otherwise.\n\n"
             f"How to disposition it for {self.major_minor}:\n"
             f"- You do not need to directly manage this issue's state unless you want to remove it from {self.major_minor} advisories.\n"
-            f"- If the issue should not appear in {self.major_minor} advisories, close this mirror with \"Won't Do\".\n"
+            f"- If the issue should not appear in {self.major_minor} advisories, or the fix is already present in "
+            f"{self.major_minor}, close this mirror with \"Won't Do\", \"Obsolete\", or \"Done\".\n"
             "- Otherwise, leave it open and ART automation will continue to manage its presence.\n\n"
             "Original description:\n"
             "----\n"
@@ -611,17 +619,21 @@ class FindBugsBridgeCli:
                 LOGGER.error("Invalid bridge bug case for %s: %s", source_bug_id, message)
 
     @staticmethod
-    def _is_closed_wont_fix(mirror_bug: JIRABug) -> bool:
-        """Return whether a mirror is closed with a Won't Do resolution.
+    def _is_closed_terminal(mirror_bug: JIRABug) -> bool:
+        """Return whether a mirror is closed with a terminal resolution.
+
+        A terminal resolution (see `TERMINAL_RESOLUTIONS`) means a reviewer has
+        deliberately dispositioned the mirror and no further bridge action is
+        required, so the source bug can be skipped cleanly.
 
         Args:
             mirror_bug: Bridge mirror issue to inspect.
 
         Returns:
-            bool: `True` when the mirror is closed with a Won't Do
-            resolution, otherwise `False`.
+            bool: `True` when the mirror is closed with a terminal resolution,
+            otherwise `False`.
         """
         if mirror_bug.status.lower() != "closed":
             return False
         resolution = (mirror_bug.resolution or "").replace("’", "'").lower()
-        return resolution in WONT_FIX_RESOLUTIONS
+        return resolution in TERMINAL_RESOLUTIONS

--- a/elliott/tests/test_find_bugs_bridge_cli.py
+++ b/elliott/tests/test_find_bugs_bridge_cli.py
@@ -138,7 +138,30 @@ class TestFindBugsBridgeCli(IsolatedAsyncioTestCase):
         self.cli.target_tracker.create_issue_link.assert_any_call("Cloners", "OCPBUGS-999", "OCPBUGS-123")
         self.assertEqual(self.cli.target_tracker.create_issue_link.call_count, 3)
 
-    async def test_sync_mirror_skips_existing_wont_fix(self):
+    async def test_sync_mirror_skips_existing_terminal_resolution(self):
+        # Reviewers close mirrors with any of these to signal no further bridge action is needed.
+        for resolution in ("Won't Do", "Obsolete", "Done"):
+            with self.subTest(resolution=resolution):
+                self.cli.target_tracker.reset_mock()
+                self.cli.invalid_bugs = {}
+
+                source_bug = MagicMock()
+                source_bug.id = "OCPBUGS-123"
+
+                image_meta = MagicMock()
+
+                existing_mirror = MagicMock()
+                existing_mirror.status = "Closed"
+                existing_mirror.resolution = resolution
+                self.cli.existing_mirrors_by_source = {"OCPBUGS-123": [existing_mirror]}
+
+                result = await self.cli._sync_mirror(source_bug, image_meta)
+
+                self.assertFalse(result)
+                self.cli.target_tracker.create_issue.assert_not_called()
+                self.assertEqual(self.cli.invalid_bugs, {})
+
+    async def test_sync_mirror_flags_closed_with_unexpected_resolution(self):
         source_bug = MagicMock()
         source_bug.id = "OCPBUGS-123"
 
@@ -146,13 +169,14 @@ class TestFindBugsBridgeCli(IsolatedAsyncioTestCase):
 
         existing_mirror = MagicMock()
         existing_mirror.status = "Closed"
-        existing_mirror.resolution = "Won't Do"
+        existing_mirror.resolution = "Duplicate"
         self.cli.existing_mirrors_by_source = {"OCPBUGS-123": [existing_mirror]}
 
         result = await self.cli._sync_mirror(source_bug, image_meta)
 
         self.assertFalse(result)
         self.cli.target_tracker.create_issue.assert_not_called()
+        self.assertIn("OCPBUGS-123", self.cli.invalid_bugs)
 
     async def test_sync_mirror_skips_update_when_unchanged(self):
         source_bug = MagicMock()


### PR DESCRIPTION
`find-bugs:bridge-mirror` only treated **Won't Do** as a valid terminal resolution for a closed mirror. Reviewers also close mirrors with **Obsolete**/**Done** (fix already in the bridge release), which caused those bugs to be wrongly flagged "closed without Won't Do; manual investigation required".

Broaden the accepted terminal set to `{won't do, obsolete, done}` so such mirrors are skipped cleanly. Bugs closed with any other resolution are still flagged. Updates the mirror description text to tell reviewers those resolutions are accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closed mirrored issues marked “Won’t Do,” “Obsolete,” or “Done” are now correctly skipped.
  * Closed mirrors with other resolutions, such as “Duplicate,” continue to be flagged for investigation.
  * Review guidance now lists all recognized terminal resolutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->