### PR TITLE
ART-22862: okd: resolve amd64-specific pullspec for primary imagestream tags

### DIFF
--- a/pyartcd/pyartcd/pipelines/okd.py
+++ b/pyartcd/pyartcd/pipelines/okd.py
@@ -621,7 +621,7 @@ class KonfluxOkdPipeline:
     async def update_imagestreams(self):
         """
         Update static OKD imagestreams with successfully built images:
-          scos-{version}-art            - multi-arch manifest list pullspecs (x86_64)
+          scos-{version}-art            - amd64-specific pullspecs (x86_64)
           scos-{version}-art-{suffix}   - arch-specific pullspecs for each non-x86 arch
         """
 
@@ -708,11 +708,17 @@ class KonfluxOkdPipeline:
                 failed_tags.append(image_name)
                 continue
 
-            # Tag multi-arch manifest list into primary imagestream
+            # Resolve amd64-specific pullspec from manifest list and tag into primary imagestream
+            amd64_pullspec = await self._get_arch_pullspec(image_pullspec, go_arch_for_brew_arch('x86_64'))
+            if not amd64_pullspec:
+                self.logger.warning('Could not resolve amd64 pullspec for %s; skipping', image_name)
+                failed_tags.append(image_name)
+                continue
+
             target = f'{self.imagestream_namespace}/{is_base_name}:{payload_tag}'
             try:
-                await self._tag_image_to_stream(source_pullspec=image_pullspec, target_tag=target, env=env)
-                self.logger.info('Tagged %s into %s', image_name, target)
+                await self._tag_image_to_stream(source_pullspec=amd64_pullspec, target_tag=target, env=env)
+                self.logger.info('Tagged %s amd64 into %s', image_name, target)
                 successful_tags.append(image_name)
                 updated_imagestreams.add(f'{self.imagestream_namespace}/{is_base_name}')
             except Exception as e:

--- a/pyartcd/tests/pipelines/test_okd4.py
+++ b/pyartcd/tests/pipelines/test_okd4.py
@@ -1096,7 +1096,7 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
             self.assertEqual(mock_tag.call_count, 2)
 
     async def test_update_imagestreams_tags_arm64_imagestream(self):
-        """update_imagestreams tags aarch64-specific pullspec into origin-arm64/scos-{version}-art-arm64."""
+        """update_imagestreams tags amd64-specific pullspec into scos-art and arm64-specific into scos-art-arm64."""
 
         data_path = 'https://github.com/openshift-eng/ocp-build-data'
         pipeline = self._make_pipeline(data_path)
@@ -1113,17 +1113,22 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
         images_dir.mkdir(parents=True)
         (images_dir / 'cli.yml').write_text(yaml.dump({'name': 'openshift/ose-cli', 'for_payload': True}))
 
+        amd64_pullspec = 'quay.io/okd/cli@sha256:amd64digest'
         arm64_pullspec = 'quay.io/okd/cli@sha256:arm64digest'
+
+        def arch_pullspec_side_effect(pullspec, go_arch):
+            return amd64_pullspec if go_arch == 'amd64' else arm64_pullspec
+
         with (
             patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag,
-            patch.object(pipeline, '_get_arch_pullspec', new_callable=AsyncMock, return_value=arm64_pullspec),
+            patch.object(pipeline, '_get_arch_pullspec', new_callable=AsyncMock, side_effect=arch_pullspec_side_effect),
             patch('pyartcd.pipelines.okd.jenkins'),
         ):
             await pipeline.update_imagestreams()
 
-            # First call: multi-arch manifest into scos-4.22-art
+            # First call: amd64-specific pullspec into scos-4.22-art
             first_call = mock_tag.call_args_list[0]
-            self.assertEqual(first_call[1]['source_pullspec'], 'quay.io/okd/cli@sha256:multiarchabcdef')
+            self.assertEqual(first_call[1]['source_pullspec'], amd64_pullspec)
             self.assertEqual(first_call[1]['target_tag'], 'origin/scos-4.22-art:cli')
 
             # Second call: arm64-specific pullspec into origin-arm64/scos-4.22-art-arm64
@@ -1149,17 +1154,23 @@ class TestUpdateImagestreamsDataPath(IsolatedAsyncioTestCase):
         images_dir.mkdir(parents=True)
         (images_dir / 'cli.yml').write_text(yaml.dump({'name': 'openshift/ose-cli', 'for_payload': True}))
 
+        amd64_pullspec = 'quay.io/okd/cli@sha256:amd64digest'
+
+        def arch_pullspec_side_effect(pullspec, go_arch):
+            # amd64 resolves, arm64 fails
+            return amd64_pullspec if go_arch == 'amd64' else None
+
         with (
             patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock) as mock_tag,
-            # arm64 resolution fails
-            patch.object(pipeline, '_get_arch_pullspec', new_callable=AsyncMock, return_value=None),
+            patch.object(pipeline, '_get_arch_pullspec', new_callable=AsyncMock, side_effect=arch_pullspec_side_effect),
             patch('pyartcd.pipelines.okd.jenkins'),
         ):
             await pipeline.update_imagestreams()
 
-            # multi-arch tag still succeeds; arm64 tag is skipped
+            # amd64 tag succeeds; arm64 tag is skipped but does not cause a failure
             self.assertEqual(mock_tag.call_count, 1)
             first_call = mock_tag.call_args_list[0]
+            self.assertEqual(first_call[1]['source_pullspec'], amd64_pullspec)
             self.assertEqual(first_call[1]['target_tag'], 'origin/scos-4.22-art:cli')
 
 
@@ -1327,10 +1338,13 @@ class TestArchSuffixedNamespace(IsolatedAsyncioTestCase):
         images_dir.mkdir(parents=True)
         (images_dir / 'cli.yml').write_text(yaml.dump({'name': 'openshift/ose-cli', 'for_payload': True}))
 
-        # arm64 resolution fails — only primary imagestream should be mentioned
+        # amd64 resolves, arm64 resolution fails — only primary imagestream should be mentioned
+        def arch_pullspec_side_effect(pullspec, go_arch):
+            return 'quay.io/okd/cli@sha256:amd64digest' if go_arch == 'amd64' else None
+
         with (
             patch.object(pipeline, '_tag_image_to_stream', new_callable=AsyncMock),
-            patch.object(pipeline, '_get_arch_pullspec', new_callable=AsyncMock, return_value=None),
+            patch.object(pipeline, '_get_arch_pullspec', new_callable=AsyncMock, side_effect=arch_pullspec_side_effect),
             patch('pyartcd.pipelines.okd.jenkins') as mock_jenkins,
         ):
             await pipeline.update_imagestreams()


### PR DESCRIPTION
## Summary

- The primary imagestream `scos-{version}-art` (watched by the amd64 Release Controller) was being tagged with multi-arch manifest list pullspecs from Konflux
- This caused the amd64 RC to produce multi-arch nightly payloads, which is outside the RC's intended per-arch operating model and was the root cause of the missing `release.openshift.io/architecture` annotation on OKD SCOS nightlies
- Fix: call `_get_arch_pullspec('amd64')` to resolve the amd64-specific digest before tagging into `origin/scos-{version}-art`, consistent with how arm64 imagestreams were already handled

Fixes: [ART-22859](https://redhat.atlassian.net/browse/ART-22859)

## Test plan

- [ ] Unit tests updated and passing (`908 passed`)
- [ ] Verify OKD SCOS amd64 nightlies are single-arch after this change (`oc image info` should show a single amd64 digest, not a manifest list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OKD image stream updates by selecting the correct amd64 image from multi-architecture manifests.
  * Prevented unresolved amd64 images from being tagged and clearly reported them as failed.
  * Preserved independent handling of non-x86 architecture images, so failures do not block primary stream updates.
  * Updated success reporting to list only image streams that were successfully updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->