### PR TITLE
Fix binary config preservation in cachito to prefetch-input translation

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -754,6 +754,10 @@ class KonfluxImageBuilder:
                                 if "requirements_build_files" not in data:
                                     data["requirements_build_files"] = []
                                 data["requirements_build_files"] += values
+
+                        if entry == "binary":
+                            data["binary"] = values
+
                         flag = True
                     prefetch.append(data)
 

--- a/doozer/tests/backend/test_konflux_cachi2.py
+++ b/doozer/tests/backend/test_konflux_cachi2.py
@@ -464,3 +464,34 @@ class TestKonfluxCachi2(TestCase):
         }
         expected = [expected_rpm_data, {'type': 'gomod', 'path': '.'}]
         self.assertEqual(result, expected)
+
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    def test_prefetch_pip_with_binary_config(self, mock_konflux_client_init):
+        """Test that binary config is preserved when extracting pip package config"""
+        builder = KonfluxImageBuilder(MagicMock())
+        metadata = MagicMock()
+        metadata.is_cachi2_enabled.return_value = True
+        metadata.is_lockfile_generation_enabled.return_value = False
+        metadata.is_artifact_lockfile_enabled.return_value = False
+        metadata.get_konflux_network_mode.return_value = "open"
+        metadata.config.content.source.pkg_managers = ["pip"]
+        metadata.config.cachito.packages = {
+            'pip': [
+                {
+                    'path': '.',
+                    'requirements_files': ['requirements.txt', 'pip-build-constraints.txt'],
+                    'binary': {'py_version': '312'},
+                }
+            ]
+        }
+
+        result = builder._prefetch(metadata=metadata, group="test-group")
+        expected = [
+            {
+                'type': 'pip',
+                'path': '.',
+                'requirements_files': ['requirements.txt', 'pip-build-constraints.txt'],
+                'binary': {'py_version': '312'},
+            }
+        ]
+        self.assertEqual(result, expected)


### PR DESCRIPTION
Preserve binary field (e.g., py_version) when translating cachito package config to cachi2 prefetch-input. This ensures hermeto receives instruction to generate wheels for Python packages instead of downloading source distributions.

Without this fix, hermeto downloads .tar.gz files causing pip to try compiling from source, which fails with maturin cargo metadata errors in hermetic mode.

Added test: test_prefetch_pip_with_binary_config to verify binary config is correctly passed through to prefetch-input.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved binary configuration details when preparing Konflux package prefetch data.
  * Ensured pip package settings, including Python version information, remain intact during processing.

* **Tests**
  * Added coverage validating preservation of pip binary configuration and requirements files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->