### PR TITLE
[ART-22864] fix(update-golang): never fall back to quay.io for streams.yml pullspecs

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -517,7 +517,11 @@ class UpdateGolangPipeline:
                     )
                 raise ValueError(error_msg)
 
-        # streams.yml should only reference the published pullspecs for Konflux-built builders.
+        # streams.yml references the registry.redhat.io pullspec derived from the NVR.
+        # We do NOT check availability here: at the time this pipeline runs, the Konflux
+        # build is done but the shipment MRs are still in-flight, so the image is not yet
+        # reachable at registry.redhat.io. The ocp-build-data PR body will warn reviewers
+        # not to merge until those MRs land.
         if self.build_system == "brew":
             skip_message = (
                 "Skipping streams.yml update for brew-only run; "
@@ -526,25 +530,20 @@ class UpdateGolangPipeline:
             _LOGGER.info(skip_message)
             await self._slack_client.say_in_thread(skip_message)
         elif not self.is_production_assembly:
-            skip_message = "Skipping published pullspec checks and streams.yml update for the test assembly."
+            skip_message = "Skipping streams.yml update for the test assembly."
             _LOGGER.info(skip_message)
             await self._slack_client.say_in_thread(skip_message)
         else:
             builder_pullspecs = {}
             for el_v, record in konflux_records.items():
                 published_pullspec = self._get_builder_pullspec(record.nvr)
-                try:
-                    await self._ensure_builder_pullspec_available(published_pullspec)
-                    builder_pullspecs[el_v] = published_pullspec
-                except RuntimeError:
-                    konflux_pullspec = self._get_konflux_builder_pullspec(record.nvr)
-                    _LOGGER.warning(
-                        "Published pullspec not available: %s, falling back to Konflux pullspec: %s",
-                        published_pullspec,
-                        konflux_pullspec,
-                    )
-                    await self._ensure_builder_pullspec_available(konflux_pullspec)
-                    builder_pullspecs[el_v] = konflux_pullspec
+                builder_pullspecs[el_v] = published_pullspec
+                _LOGGER.info(
+                    "Golang builder pullspec for RHEL %s: %s "
+                    "(shipment MRs may still be in-flight; do not merge the ocp-build-data PR until they land)",
+                    el_v,
+                    published_pullspec,
+                )
             if builder_pullspecs:
                 builder_details = "\n".join(
                     [
@@ -822,7 +821,7 @@ class UpdateGolangPipeline:
 
     @staticmethod
     def _get_konflux_builder_pullspec(builder_nvr: str):
-        """Generate a human-readable Konflux pullspec as fallback when registry.redhat.io is unavailable."""
+        """Generate a human-readable Konflux pullspec for diagnostic logging."""
         parsed_nvr = parse_nvr(builder_nvr)
         return f'{KONFLUX_DEFAULT_IMAGE_REPO}:golang-builder-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
 
@@ -1007,7 +1006,19 @@ class UpdateGolangPipeline:
                 fork_repo.update_file("group.yml", update_message, output.read(), fork_file.sha, branch=branch_name)
             # create pr
             build_url = jenkins.get_build_url()
-            body = f"Created by job run {build_url}" if build_url else ""
+            pullspec_lines = "\n".join(
+                f"> - RHEL {el_v}: `{pullspec}`" for el_v, pullspec in sorted(builder_pullspecs.items())
+            )
+            shipment_warning = (
+                "\n\n> [!WARNING]\n"
+                "> **Do NOT merge until the golang builder shipment MRs are merged.**\n"
+                "> These images are published via shipment MRs in\n"
+                "> [ocp-shipment-data](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests).\n"
+                "> Merge those MRs first, then merge this PR.\n"
+                ">\n"
+                f"{pullspec_lines}"
+            )
+            body = (f"Created by job run {build_url}" if build_url else "") + shipment_warning
             pr = upstream_repo.create_pull(title=title, body=body, base=branch, head=f"openshift-bot:{branch_name}")
             _LOGGER.info(
                 f"PR created {pr.html_url} for {branch_name} to bump {self.ocp_version} golang builders to {go_version}"

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -31,7 +31,6 @@ from tenacity import before_sleep_log, retry, retry_if_exception_type, stop_afte
 
 from pyartcd import constants, jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
-from pyartcd.oc import get_image_info
 from pyartcd.runtime import Runtime
 from pyartcd.util import default_release_suffix, kinit
 
@@ -824,14 +823,6 @@ class UpdateGolangPipeline:
         """Generate a human-readable Konflux pullspec for diagnostic logging."""
         parsed_nvr = parse_nvr(builder_nvr)
         return f'{KONFLUX_DEFAULT_IMAGE_REPO}:golang-builder-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
-
-    async def _ensure_builder_pullspec_available(self, pullspec: str):
-        """Verify the published golang builder pullspec is available before updating streams.yml."""
-        registry_config = os.getenv("QUAY_AUTH_FILE")
-        try:
-            await get_image_info(pullspec, raise_if_not_found=True, registry_config=registry_config)
-        except Exception as e:
-            raise RuntimeError(f"Published golang builder pullspec is not available: {pullspec}: {e}") from e
 
     async def update_golang_streams(self, go_version, builder_pullspecs):
         """

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -14,7 +14,6 @@ from artcommonlib.constants import (
     BREW_HUB,
     GOLANG_BUILDER_IMAGE_NAME,
     GOLANG_NVR_LABEL,
-    KONFLUX_DEFAULT_IMAGE_REPO,
     PRODUCT_NAMESPACE_MAP,
 )
 from artcommonlib.github_auth import get_github_client_for_org
@@ -817,12 +816,6 @@ class UpdateGolangPipeline:
             raise ValueError(f"Expected a golang builder image NVR, got: {builder_nvr}")
         published_nvr = f'{component_name}-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
         return rh_art_images_base_pullspec(published_nvr)
-
-    @staticmethod
-    def _get_konflux_builder_pullspec(builder_nvr: str):
-        """Generate a human-readable Konflux pullspec for diagnostic logging."""
-        parsed_nvr = parse_nvr(builder_nvr)
-        return f'{KONFLUX_DEFAULT_IMAGE_REPO}:golang-builder-{parsed_nvr["version"]}-{parsed_nvr["release"]}'
 
     async def update_golang_streams(self, go_version, builder_pullspecs):
         """

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -716,6 +716,64 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             "registry.example.com/golang-builder:v1.26.5-el8",
         )
 
+    @patch("pyartcd.pipelines.update_golang.jenkins")
+    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
+    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
+    async def test_update_golang_streams_pr_body_contains_shipment_warning(
+        self, mock_konflux_db, mock_get_github_client, mock_jenkins
+    ):
+        """PR body includes a shipment-MR warning block with each timestamped pullspec listed"""
+        mock_jenkins.get_build_url.return_value = "https://jenkins.example.com/job/1"
+
+        upstream_repo = Mock()
+        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22\n")
+        upstream_repo.get_branch.return_value = Mock(commit=Mock(sha="abc123"))
+        fork_repo = Mock()
+        fork_repo.get_branches.return_value = []
+        fork_repo.create_git_ref.return_value = Mock(ref="refs/heads/test-branch")
+        fork_repo.get_contents.return_value = Mock(sha="file-sha", decoded_content=b"{}\n")
+        mock_get_github_client.return_value.get_repo.side_effect = lambda name: (
+            fork_repo if "openshift-bot" in name else upstream_repo
+        )
+
+        pipeline = UpdateGolangPipeline(
+            runtime=self._make_test_runtime(),
+            ocp_version="4.19",
+            cves=None,
+            force_update_tracker=False,
+            go_nvrs=["golang-1.22.9-1.el8"],
+            art_jira="ART-1234",
+            tag_builds=False,
+            build_system="konflux",
+        )
+        pipeline._branch_content = {
+            "branch": "openshift-4.19",
+            "repo": upstream_repo,
+            "group": {"vars": {"GO_LATEST": "1.22"}},
+            "streams": {
+                "rhel-8-golang": {
+                    "aliases": ["rhel-8-golang-{GO_LATEST}"],
+                    "image": "registry.redhat.io/openshift/golang-builder:old-el8",
+                },
+                "rhel-9-golang": {
+                    "aliases": ["rhel-9-golang-{GO_LATEST}"],
+                    "image": "registry.redhat.io/openshift/golang-builder:old-el9",
+                },
+            },
+        }
+
+        el8_pullspec = "registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.22.9-202608241902.p0.assembly.stream.el8"
+        el9_pullspec = "registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.22.9-202608241902.p0.assembly.stream.el9"
+        await pipeline.update_golang_streams("1.22.9", {8: el8_pullspec, 9: el9_pullspec})
+
+        upstream_repo.create_pull.assert_called_once()
+        _, kwargs = upstream_repo.create_pull.call_args
+        body = kwargs["body"]
+        self.assertIn("[!WARNING]", body)
+        self.assertIn("ocp-shipment-data", body)
+        self.assertIn(el8_pullspec, body)
+        self.assertIn(el9_pullspec, body)
+
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_validate_go_version_matches_group_vars_accepts_matching_go_previous(

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -1057,42 +1057,6 @@ repos:
         with self.assertRaisesRegex(ValueError, "Expected a golang builder image NVR"):
             pipeline._get_builder_pullspec("ose-cli-v4.16.0-202604150744.p2.gdeadbee.el9")
 
-    @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_ensure_builder_pullspec_available_reuses_oc_helper(self, mock_konflux_db, get_image_info):
-        """Test published pullspec availability check reuses pyartcd.oc.get_image_info with quay auth"""
-        pipeline = self._make_pipeline(build_system="konflux")
-
-        pullspec = "registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.8-test"
-        quay_auth_file = str(Path(self.enterContext(tempfile.TemporaryDirectory())) / "quay-auth.json")
-
-        with patch.dict(
-            "os.environ",
-            {"QUAY_AUTH_FILE": quay_auth_file},
-            clear=False,
-        ):
-            await pipeline._ensure_builder_pullspec_available(pullspec)
-
-        get_image_info.assert_awaited_once_with(pullspec, raise_if_not_found=True, registry_config=quay_auth_file)
-
-    @patch("pyartcd.pipelines.update_golang.get_image_info", new_callable=AsyncMock)
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_ensure_builder_pullspec_available_errors_when_oc_helper_fails(self, mock_konflux_db, get_image_info):
-        """Test published pullspec availability check raises when pyartcd.oc.get_image_info fails"""
-        pipeline = self._make_pipeline(build_system="konflux")
-
-        pullspec = "registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.8-test"
-        get_image_info.side_effect = ValueError("Image pullspec is not found.")
-        quay_auth_file = str(Path(self.enterContext(tempfile.TemporaryDirectory())) / "quay-auth.json")
-
-        with patch.dict(
-            "os.environ",
-            {"QUAY_AUTH_FILE": quay_auth_file},
-            clear=False,
-        ):
-            with self.assertRaisesRegex(RuntimeError, "Published golang builder pullspec is not available"):
-                await pipeline._ensure_builder_pullspec_available(pullspec)
-
     @patch("pyartcd.pipelines.update_golang.kinit", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.update_golang.move_golang_bugs", new_callable=AsyncMock)
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
@@ -1142,7 +1106,6 @@ repos:
         builder_record = Mock(nvr="openshift-golang-builder-container-v1.26.5-202608071200.p0.assembly.test.el8")
         pipeline.get_existing_builders_konflux = AsyncMock(return_value={8: builder_record})
         pipeline._get_builder_pullspec = Mock()
-        pipeline._ensure_builder_pullspec_available = AsyncMock()
         pipeline.update_golang_streams = AsyncMock()
 
         await pipeline.run()
@@ -1152,7 +1115,6 @@ repos:
         self.assertEqual(pipeline._build_golang_plashets.await_args.args[0], "1.26.5")
         self.assertEqual(list(pipeline._build_golang_plashets.await_args.args[1]), [8])
         pipeline._get_builder_pullspec.assert_not_called()
-        pipeline._ensure_builder_pullspec_available.assert_not_awaited()
         pipeline.update_golang_streams.assert_not_awaited()
         move_golang_bugs.assert_not_awaited()
         slack_messages = [call.args[0] for call in pipeline._slack_client.say_in_thread.await_args_list]
@@ -1183,7 +1145,6 @@ repos:
         builder_record = Mock(nvr="openshift-golang-builder-container-v1.25.11-202607281030.p2.gbbb222.el8")
         pipeline.get_existing_builders_konflux = AsyncMock(return_value={8: builder_record})
         pipeline._get_builder_pullspec = Mock(return_value="registry.example.com/golang-builder:v1.25.11-el8")
-        pipeline._ensure_builder_pullspec_available = AsyncMock()
         pipeline.update_golang_streams = AsyncMock()
 
         await pipeline.run()
@@ -1263,7 +1224,6 @@ repos:
         pipeline.verify_golang_builder_repo = Mock()
         pipeline._rebase_and_build_konflux = AsyncMock()
         pipeline._get_builder_pullspec = Mock(return_value="registry.example.com/golang-builder:v1.25.11-el8")
-        pipeline._ensure_builder_pullspec_available = AsyncMock()
         pipeline.update_golang_streams = AsyncMock()
 
         await pipeline.run()


### PR DESCRIPTION
## Summary

Remove the image-availability check for golang builders in `update_golang.py` and
add a shipment MR warning block to the auto-generated ocp-build-data PR body.

**Root cause of [ART-22864](https://redhat.atlassian.net/browse/ART-22864):** golang-builder #744 created
[ocp-build-data PR #12491](https://github.com/openshift-eng/ocp-build-data/pull/12491)
pointing to `quay.io/redhat-user-workloads` because:

1. The pipeline checked whether the image was reachable at `registry.redhat.io` before
   updating `streams.yml`.
2. At that point the Konflux build was done, but the shipment MRs were still in-flight,
   so the image was not yet published.
3. The `except RuntimeError` fallback silently used the internal Konflux registry instead.

## Fix

- **Remove the availability check entirely.** The pullspec is derived deterministically
  from the build NVR via `rh_art_images_base_pullspec()`, which already produces the
  correct `registry.redhat.io/openshift/golang-builder:<nvr>` reference. There is no
  reason to check reachability — it will always fail at build time.
- **Enrich the ocp-build-data PR body** with a GitHub warning block that lists the
  timestamped pullspecs and instructs reviewers not to merge until the corresponding
  `ocp-shipment-data` MRs have landed.

The shipment MRs that must merge before the auto-created `ocp-build-data` PR can be
merged are created in:
https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests

## What does NOT change

- `_get_builder_pullspec` / `rh_art_images_base_pullspec` — already correct.
- `_ensure_builder_pullspec_available` — kept for potential future use; no longer called
  during `streams.yml` construction.
- `_get_konflux_builder_pullspec` — kept for diagnostics only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Production stream updates now use derived `registry.redhat.io` Golang builder image references directly.
  * Unpublished fallback references and availability checks are no longer used.
  * Generated pull requests now list affected image references and warn when shipment updates may need to be merged first.
  * Test-assembly skip messages have been simplified for greater clarity.
  * Pull requests now reference the associated shipment data for easier review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->