### PR TITLE
[ART-22787] use manifest-list digest approach for rpm-lockfile-prototype --image mode

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/container_utils.py
+++ b/doozer/doozerlib/lockfile_prototype/container_utils.py
@@ -2,15 +2,16 @@
 Container image utilities for RPM lockfile generation.
 
 Provides async helpers for interacting with container images via
-skopeo (tag-to-digest resolution) and podman (querying installed
-packages, reading files from images).
+oc (tag-to-digest resolution, preferring manifest-list digests) and
+podman (querying installed packages, reading files from images).
 """
 
-import json
 import logging
+import os
 
 from artcommonlib import logutil
 from artcommonlib.exectools import cmd_gather_async
+from artcommonlib.util import oc_image_info_for_arch_async
 
 from doozerlib.constants import BREW_REGISTRY_BASE_URL, REGISTRY_PROXY_BASE_URL
 from doozerlib.lockfile_prototype.constants import DEFAULT_PLATFORM, DIGEST_PREFIX, RPM_PSEUDO_PACKAGES
@@ -29,43 +30,55 @@ class ContainerImageHelper:
     def _proxy_pullspec(pullspec: str) -> str:
         return pullspec.replace(BREW_REGISTRY_BASE_URL, REGISTRY_PROXY_BASE_URL)
 
-    async def resolve_to_digest(self, pullspec: str) -> str:
+    @staticmethod
+    def _repo_from_pullspec(pullspec: str) -> str:
         """
-        If pullspec uses a tag, resolve it to a digest via skopeo inspect.
-        Returns the pullspec with @sha256:... instead of :tag.
-        If already a digest, returns as-is.
+        Return the repository portion of a pullspec, stripping tag and digest.
 
         Arg(s):
             pullspec (str): Container image pullspec.
         Return Value(s):
-            str: Pullspec with digest.
+            str: Repository (registry/namespace/name) without tag or digest.
         """
         if DIGEST_PREFIX in pullspec:
-            return pullspec
-
-        inspect_pullspec = self._proxy_pullspec(pullspec)
-        env = build_env()
-        cmd = ["skopeo", "inspect", "--no-tags", f"docker://{inspect_pullspec}"]
-        self.logger.debug(f"Resolving tag to digest: {pullspec}")
-
-        rc, stdout, stderr = await cmd_gather_async(cmd, check=False, env=env)
-
-        if rc != 0:
-            self.logger.warning(f"Failed to resolve digest for {pullspec}, using tag: {stderr[:200]}")
-            return pullspec
-
-        digest = json.loads(stdout).get("Digest", "")
-        if not digest:
-            self.logger.warning(f"No digest found for {pullspec}, using tag")
-            return pullspec
-
+            pullspec = pullspec.split(DIGEST_PREFIX, 1)[0]
         # Strip tag after the last "/" to avoid stripping port numbers
         last_slash = pullspec.rfind("/")
         if ":" in pullspec[last_slash + 1 :]:
-            repo = pullspec[: last_slash + 1] + pullspec[last_slash + 1 :].rsplit(":", 1)[0]
-        else:
-            repo = pullspec
-        resolved = f"{repo}@{digest}"
+            return pullspec[: last_slash + 1] + pullspec[last_slash + 1 :].rsplit(":", 1)[0]
+        return pullspec
+
+    async def resolve_to_digest(self, pullspec: str) -> str:
+        """
+        Resolve a pullspec to a digest-pinned pullspec.
+
+        Prefers the manifest-list digest (listDigest) so rpm-lockfile-prototype
+        --image mode can extract per-arch rpmdbs via skopeo --override-arch
+        (ART-22787). Falls back to the platform digest for single-arch images.
+        Already-digest pullspecs are re-inspected so a platform digest can be
+        upgraded to listDigest when the image is a manifest list.
+
+        Arg(s):
+            pullspec (str): Container image pullspec (tag or digest).
+        Return Value(s):
+            str: Pullspec with digest. Returns the original pullspec if inspect fails.
+        """
+        inspect_pullspec = self._proxy_pullspec(pullspec)
+        registry_config = os.environ.get("QUAY_AUTH_FILE") or os.environ.get("REGISTRY_AUTH_FILE")
+        self.logger.debug(f"Resolving to digest (prefer listDigest): {pullspec}")
+
+        try:
+            image_data = await oc_image_info_for_arch_async(inspect_pullspec, registry_config=registry_config)
+        except Exception as e:
+            self.logger.warning(f"Failed to resolve digest for {pullspec}, using original: {e}")
+            return pullspec
+
+        digest = image_data.get("listDigest") or image_data.get("digest")
+        if not digest:
+            self.logger.warning(f"No digest found for {pullspec}, using original")
+            return pullspec
+
+        resolved = f"{self._repo_from_pullspec(pullspec)}@{digest}"
         self.logger.debug(f"Resolved to: {resolved}")
         return resolved
 

--- a/doozer/tests/lockfile_prototype/test_container_utils.py
+++ b/doozer/tests/lockfile_prototype/test_container_utils.py
@@ -4,69 +4,108 @@ Tests for doozerlib.lockfile_prototype.container_utils.
 
 import asyncio
 import unittest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from doozerlib.lockfile_prototype.container_utils import ContainerImageHelper
 
 
 class TestContainerImageHelper(unittest.TestCase):
-    @patch("doozerlib.lockfile_prototype.container_utils.cmd_gather_async")
-    def test_resolve_to_digest_already_digest(self, mock_gather):
+    @patch("doozerlib.lockfile_prototype.container_utils.oc_image_info_for_arch_async", new_callable=AsyncMock)
+    def test_resolve_to_digest_already_list_digest(self, mock_oc):
         """
-        Pullspecs with @sha256: should be returned unchanged.
+        Pullspecs already pinned to the list digest should stay unchanged.
         """
+        mock_oc.return_value = {
+            "listDigest": "sha256:abc123",
+            "digest": "sha256:platform456",
+        }
         helper = ContainerImageHelper()
         result = asyncio.run(helper.resolve_to_digest("quay.io/test/img@sha256:abc123"))
         self.assertEqual(result, "quay.io/test/img@sha256:abc123")
-        mock_gather.assert_not_called()
+        mock_oc.assert_awaited_once()
 
-    @patch("doozerlib.lockfile_prototype.container_utils.cmd_gather_async")
-    def test_resolve_to_digest_tag(self, mock_gather):
+    @patch("doozerlib.lockfile_prototype.container_utils.oc_image_info_for_arch_async", new_callable=AsyncMock)
+    def test_resolve_to_digest_upgrades_platform_digest_to_list_digest(self, mock_oc):
         """
-        Tag-based pullspecs should be resolved via skopeo.
+        A platform-instance digest should be upgraded to listDigest when available.
         """
-        import json
+        mock_oc.return_value = {
+            "listDigest": "sha256:listaaa",
+            "digest": "sha256:platformbbb",
+        }
+        helper = ContainerImageHelper()
+        result = asyncio.run(helper.resolve_to_digest("quay.io/test/img@sha256:platformbbb"))
+        self.assertEqual(result, "quay.io/test/img@sha256:listaaa")
 
-        async def mock_skopeo(cmd, **kwargs):
-            return (0, json.dumps({"Digest": "sha256:def456"}), "")
+    @patch("doozerlib.lockfile_prototype.container_utils.oc_image_info_for_arch_async", new_callable=AsyncMock)
+    def test_resolve_to_digest_tag_prefers_list_digest(self, mock_oc):
+        """
+        Multi-arch tag pullspecs should pin listDigest, not the platform digest.
+        """
+        mock_oc.return_value = {
+            "listDigest": "sha256:listdigest",
+            "digest": "sha256:platformdigest",
+        }
+        helper = ContainerImageHelper()
+        result = asyncio.run(helper.resolve_to_digest("quay.io/test/img:latest"))
+        self.assertEqual(result, "quay.io/test/img@sha256:listdigest")
 
-        mock_gather.side_effect = mock_skopeo
+    @patch("doozerlib.lockfile_prototype.container_utils.oc_image_info_for_arch_async", new_callable=AsyncMock)
+    def test_resolve_to_digest_single_arch_falls_back_to_digest(self, mock_oc):
+        """
+        Single-arch images with no listDigest should pin the platform digest.
+        """
+        mock_oc.return_value = {"digest": "sha256:def456"}
         helper = ContainerImageHelper()
         result = asyncio.run(helper.resolve_to_digest("quay.io/test/img:latest"))
         self.assertEqual(result, "quay.io/test/img@sha256:def456")
 
-    @patch("doozerlib.lockfile_prototype.container_utils.cmd_gather_async")
-    def test_resolve_to_digest_brew_registry_uses_proxy(self, mock_gather):
+    @patch("doozerlib.lockfile_prototype.container_utils.oc_image_info_for_arch_async", new_callable=AsyncMock)
+    def test_resolve_to_digest_brew_registry_uses_proxy(self, mock_oc):
         """
         brew.registry.redhat.io pullspecs should be inspected via the registry proxy,
         but the returned pullspec should keep the original brew.registry domain.
         """
-        import json
-
-        async def mock_skopeo(cmd, **kwargs):
-            assert "registry-proxy.engineering.redhat.com" in cmd[-1], (
-                f"Expected proxy URL in skopeo command, got {cmd}"
-            )
-            return (0, json.dumps({"Digest": "sha256:abc123"}), "")
-
-        mock_gather.side_effect = mock_skopeo
+        mock_oc.return_value = {
+            "listDigest": "sha256:abc123",
+            "digest": "sha256:platform",
+        }
         helper = ContainerImageHelper()
         result = asyncio.run(helper.resolve_to_digest("brew.registry.redhat.io/rh-osbs/ubi8:8.6-754"))
         self.assertEqual(result, "brew.registry.redhat.io/rh-osbs/ubi8@sha256:abc123")
+        inspect_pullspec = mock_oc.await_args.args[0]
+        self.assertIn("registry-proxy.engineering.redhat.com", inspect_pullspec)
 
-    @patch("doozerlib.lockfile_prototype.container_utils.cmd_gather_async")
-    def test_resolve_to_digest_skopeo_fails(self, mock_gather):
+    @patch("doozerlib.lockfile_prototype.container_utils.oc_image_info_for_arch_async", new_callable=AsyncMock)
+    def test_resolve_to_digest_inspect_fails(self, mock_oc):
         """
-        If skopeo fails, return the original pullspec.
+        If inspect fails, return the original pullspec (bare-mode fallback).
         """
-
-        async def mock_fail(cmd, **kwargs):
-            return (1, "", "connection refused")
-
-        mock_gather.side_effect = mock_fail
+        mock_oc.side_effect = ChildProcessError("connection refused")
         helper = ContainerImageHelper()
         result = asyncio.run(helper.resolve_to_digest("quay.io/test/img:latest"))
         self.assertEqual(result, "quay.io/test/img:latest")
+
+    @patch("doozerlib.lockfile_prototype.container_utils.oc_image_info_for_arch_async", new_callable=AsyncMock)
+    def test_resolve_to_digest_no_digest_fields(self, mock_oc):
+        """
+        If inspect succeeds but returns no digest fields, keep the original pullspec.
+        """
+        mock_oc.return_value = {}
+        helper = ContainerImageHelper()
+        result = asyncio.run(helper.resolve_to_digest("quay.io/test/img:latest"))
+        self.assertEqual(result, "quay.io/test/img:latest")
+
+    def test_repo_from_pullspec_strips_tag_and_digest(self):
+        self.assertEqual(ContainerImageHelper._repo_from_pullspec("quay.io/test/img:latest"), "quay.io/test/img")
+        self.assertEqual(
+            ContainerImageHelper._repo_from_pullspec("quay.io/test/img@sha256:abc"),
+            "quay.io/test/img",
+        )
+        self.assertEqual(
+            ContainerImageHelper._repo_from_pullspec("registry.example.com:5000/ns/img:tag"),
+            "registry.example.com:5000/ns/img",
+        )
 
     @patch("doozerlib.lockfile_prototype.container_utils.cmd_gather_async")
     def test_get_installed_packages(self, mock_gather):


### PR DESCRIPTION
Use manifest-list digest approach so rpm-lockfile-prototype --image mode can extract per-arch rpmdbs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added container image tooling, including `yq`, `jq`, and registry utilities.
  * Improved container image digest resolution across manifest lists and single-architecture images.
  * Added support for registry authentication files and registry proxy handling.

* **Bug Fixes**
  * Preserved valid image references when digest resolution fails or digest data is unavailable.
  * Improved parsing of image repositories that include registry ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->