### PR TITLE
Migrate Konflux registry auth to QUAY_AUTH_FILE

### DIFF
--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -2933,7 +2933,7 @@ class KonfluxRebaser:
 
             self._logger.info(f"Resolving digest for external image {target}")
             try:
-                registry_auth = os.getenv("QUAY_AUTH_FILE")
+                registry_auth = self._runtime.registry_config or os.getenv("QUAY_AUTH_FILE")
                 image_info = await util.oc_image_info_for_arch_async(target, registry_config=registry_auth)
                 # Use listDigest for multi-arch images, if no listDigest, use digest
                 digest = image_info.get('listDigest')

--- a/doozer/doozerlib/backend/rebaser.py
+++ b/doozer/doozerlib/backend/rebaser.py
@@ -2933,7 +2933,7 @@ class KonfluxRebaser:
 
             self._logger.info(f"Resolving digest for external image {target}")
             try:
-                registry_auth = os.getenv("KONFLUX_OPERATOR_INDEX_AUTH_FILE")
+                registry_auth = os.getenv("QUAY_AUTH_FILE")
                 image_info = await util.oc_image_info_for_arch_async(target, registry_config=registry_auth)
                 # Use listDigest for multi-arch images, if no listDigest, use digest
                 digest = image_info.get('listDigest')

--- a/doozer/doozerlib/cli/fbc.py
+++ b/doozer/doozerlib/cli/fbc.py
@@ -917,7 +917,7 @@ class FbcRebaseAndBuildCli:
     metavar='PATH',
     help="The registry authentication file to use for the index image."
     " This might be needed if --reset-to-prod is used and the production index image requires authentication."
-    " If not set, the KONFLUX_OPERATOR_INDEX_AUTH_FILE environment variable will be used if set.",
+    " If not set, the QUAY_AUTH_FILE environment variable will be used if set.",
 )
 @click.option(
     "--major-minor",
@@ -971,7 +971,7 @@ async def fbc_rebase_and_build(
         )
 
     if reset_to_prod and not prod_registry_auth:
-        prod_registry_auth = os.environ.get('KONFLUX_OPERATOR_INDEX_AUTH_FILE')
+        prod_registry_auth = os.environ.get('QUAY_AUTH_FILE')
 
     cli = FbcRebaseAndBuildCli(
         runtime=runtime,

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -961,10 +961,10 @@ class ConfigScanSources:
             builder_image_url = self.runtime.resolve_brew_image_url(builder_image_name)
 
         # Find and map the builder image NVR
-        # Use KONFLUX_OPERATOR_INDEX_AUTH_FILE for non-openshift groups (like OADP), otherwise use default
+        # Prefer QUAY_AUTH_FILE for non-openshift groups (like OADP), otherwise use default
         # Since OADP et. al. uses other streams like https://github.com/openshift-eng/ocp-build-data/blob/oadp-1.5/streams.yml#L13
         builder_auth_file = (
-            (os.getenv("KONFLUX_OPERATOR_INDEX_AUTH_FILE") or self.runtime.registry_config)
+            (os.getenv("QUAY_AUTH_FILE") or self.runtime.registry_config)
             if not self.runtime.group.startswith("openshift-")
             else self.runtime.registry_config
         )
@@ -1217,7 +1217,7 @@ class ConfigScanSources:
                 pinned_pullspecs[tag_name] = pullspec
 
         # Resolve current digests for all external images concurrently
-        registry_auth = os.getenv("KONFLUX_OPERATOR_INDEX_AUTH_FILE") or self.runtime.registry_config
+        registry_auth = os.getenv("QUAY_AUTH_FILE") or self.runtime.registry_config
 
         async def resolve_current_digest(replace_ref: str) -> Optional[str]:
             try:

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -964,7 +964,7 @@ class ConfigScanSources:
         # Prefer QUAY_AUTH_FILE for non-openshift groups (like OADP), otherwise use default
         # Since OADP et. al. uses other streams like https://github.com/openshift-eng/ocp-build-data/blob/oadp-1.5/streams.yml#L13
         builder_auth_file = (
-            (os.getenv("QUAY_AUTH_FILE") or self.runtime.registry_config)
+            (self.runtime.registry_config or os.getenv("QUAY_AUTH_FILE"))
             if not self.runtime.group.startswith("openshift-")
             else self.runtime.registry_config
         )
@@ -1217,7 +1217,7 @@ class ConfigScanSources:
                 pinned_pullspecs[tag_name] = pullspec
 
         # Resolve current digests for all external images concurrently
-        registry_auth = os.getenv("QUAY_AUTH_FILE") or self.runtime.registry_config
+        registry_auth = self.runtime.registry_config or os.getenv("QUAY_AUTH_FILE")
 
         async def resolve_current_digest(replace_ref: str) -> Optional[str]:
             try:

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -1,11 +1,12 @@
 import asyncio
+import os
 import re
 import stat
 from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import IsolatedAsyncioTestCase, TestCase
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import semver
 from artcommonlib.model import Missing, Model
@@ -1772,6 +1773,7 @@ class TestPrivateFixDetection(IsolatedAsyncioTestCase):
         finally:
             util.is_commit_in_public_upstream_async = original_func
 
+
     async def test_no_private_fix_when_pull_url_none_and_commit_is_in_public(self):
         """Test: url=openshift-priv, pull_url=None, commit IS in public -> private_fix=False.
 
@@ -1935,6 +1937,41 @@ class TestPrivateFixDetection(IsolatedAsyncioTestCase):
             child_private_fix = True
 
         self.assertTrue(child_private_fix)
+
+
+class TestRebaserExternalImageAuth(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.directory = TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.rebaser = KonfluxRebaser.__new__(KonfluxRebaser)
+        self.rebaser._runtime = MagicMock()
+        self.rebaser._logger = MagicMock()
+
+    async def _assert_registry_config(self, runtime_config, expected_config):
+        self.rebaser._runtime.registry_config = runtime_config
+        csv_file = Path(self.directory.name) / 'bundle.csv'
+        csv_file.write_text('RELATED_IMAGE_TEST')
+        with patch.dict(os.environ, {'QUAY_AUTH_FILE': '/env/auth.json'}, clear=False), patch.object(
+            self.rebaser, '_find_image_refs_path', return_value=None
+        ), patch('doozerlib.backend.rebaser.util.oc_image_info_for_arch_async', new_callable=AsyncMock) as mock_info:
+            mock_info.return_value = {'digest': 'sha256:test'}
+            await self.rebaser._replace_external_image_refs(
+                str(csv_file),
+                {},
+                Path(self.directory.name),
+                {
+                    'external-images': [
+                        {'name': 'test', 'search': 'RELATED_IMAGE_TEST', 'replace': 'registry.example/test:latest'}
+                    ]
+                },
+            )
+            mock_info.assert_awaited_once_with('registry.example/test:latest', registry_config=expected_config)
+
+    async def test_runtime_registry_config_precedes_environment(self):
+        await self._assert_registry_config('/runtime/auth.json', '/runtime/auth.json')
+
+    async def test_environment_used_when_runtime_registry_config_is_unset(self):
+        await self._assert_registry_config(None, '/env/auth.json')
 
 
 class TestPrivateFixDetectionE2E(IsolatedAsyncioTestCase):

--- a/doozer/tests/backend/test_rebaser.py
+++ b/doozer/tests/backend/test_rebaser.py
@@ -1773,7 +1773,6 @@ class TestPrivateFixDetection(IsolatedAsyncioTestCase):
         finally:
             util.is_commit_in_public_upstream_async = original_func
 
-
     async def test_no_private_fix_when_pull_url_none_and_commit_is_in_public(self):
         """Test: url=openshift-priv, pull_url=None, commit IS in public -> private_fix=False.
 
@@ -1951,9 +1950,11 @@ class TestRebaserExternalImageAuth(IsolatedAsyncioTestCase):
         self.rebaser._runtime.registry_config = runtime_config
         csv_file = Path(self.directory.name) / 'bundle.csv'
         csv_file.write_text('RELATED_IMAGE_TEST')
-        with patch.dict(os.environ, {'QUAY_AUTH_FILE': '/env/auth.json'}, clear=False), patch.object(
-            self.rebaser, '_find_image_refs_path', return_value=None
-        ), patch('doozerlib.backend.rebaser.util.oc_image_info_for_arch_async', new_callable=AsyncMock) as mock_info:
+        with (
+            patch.dict(os.environ, {'QUAY_AUTH_FILE': '/env/auth.json'}, clear=False),
+            patch.object(self.rebaser, '_find_image_refs_path', return_value=None),
+            patch('doozerlib.backend.rebaser.util.oc_image_info_for_arch_async', new_callable=AsyncMock) as mock_info,
+        ):
             mock_info.return_value = {'digest': 'sha256:test'}
             await self.rebaser._replace_external_image_refs(
                 str(csv_file),

--- a/doozer/tests/cli/test_scan_sources_konflux.py
+++ b/doozer/tests/cli/test_scan_sources_konflux.py
@@ -923,6 +923,73 @@ class TestScanExternalImageChanges(TestScanSourcesKonflux):
             await self.scanner.scan_external_image_changes(self.image_meta)
             mock_add_change.assert_not_called()
 
+        mock_oc_image_info.assert_awaited_once_with(
+            'registry.redhat.io/rhel9/postgresql-15:latest', registry_config=self.runtime.registry_config
+        )
+
+    @patch('doozerlib.cli.scan_sources_konflux.oc_image_info_for_arch_async')
+    async def test_external_image_auth_prefers_runtime_registry_config(self, mock_oc_image_info):
+        self.runtime.registry_config = '/runtime/auth.json'
+        mock_oc_image_info.return_value = {'listDigest': 'sha256:currentdigest123'}
+        art_yaml = {
+            'external-images': [
+                {'name': 'postgresql', 'search': 'RELATED_IMAGE_POSTGRESQL', 'replace': 'registry.redhat.io/rhel9/postgresql-15:latest'}
+            ]
+        }
+        image_refs = {'spec': {'tags': [{'name': 'postgresql', 'from': {'name': 'registry.redhat.io/rhel9/postgresql-15@sha256:currentdigest123'}}]}}
+        with patch.dict('os.environ', {'QUAY_AUTH_FILE': '/env/auth.json'}), patch.object(
+            self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock, return_value=art_yaml
+        ), patch.object(
+            self.scanner, '_fetch_image_references_from_rebase', new_callable=AsyncMock, return_value=image_refs
+        ):
+            await self.scanner.scan_external_image_changes(self.image_meta)
+        mock_oc_image_info.assert_awaited_once_with(
+            'registry.redhat.io/rhel9/postgresql-15:latest', registry_config='/runtime/auth.json'
+        )
+
+    @patch('doozerlib.cli.scan_sources_konflux.oc_image_info_for_arch_async')
+    async def test_external_image_auth_falls_back_to_environment(self, mock_oc_image_info):
+        self.runtime.registry_config = None
+        mock_oc_image_info.return_value = {'listDigest': 'sha256:currentdigest123'}
+        art_yaml = {
+            'external-images': [
+                {'name': 'postgresql', 'search': 'RELATED_IMAGE_POSTGRESQL', 'replace': 'registry.redhat.io/rhel9/postgresql-15:latest'}
+            ]
+        }
+        image_refs = {'spec': {'tags': [{'name': 'postgresql', 'from': {'name': 'registry.redhat.io/rhel9/postgresql-15@sha256:currentdigest123'}}]}}
+        with patch.dict('os.environ', {'QUAY_AUTH_FILE': '/env/auth.json'}), patch.object(
+            self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock, return_value=art_yaml
+        ), patch.object(
+            self.scanner, '_fetch_image_references_from_rebase', new_callable=AsyncMock, return_value=image_refs
+        ):
+            await self.scanner.scan_external_image_changes(self.image_meta)
+        mock_oc_image_info.assert_awaited_once_with(
+            'registry.redhat.io/rhel9/postgresql-15:latest', registry_config='/env/auth.json'
+        )
+
+    @patch('doozerlib.cli.scan_sources_konflux.Model')
+    @patch('doozerlib.cli.scan_sources_konflux.oc_image_info_for_arch_async', new_callable=AsyncMock)
+    async def test_builder_auth_prefers_runtime_registry_config(self, mock_oc_image_info, mock_model):
+        self.runtime.group = 'oadp-1.5'
+        self.runtime.registry_config = '/runtime/auth.json'
+        mock_model.return_value.config.config.Labels = {
+            'com.redhat.component': 'component', 'version': '1', 'release': '1'
+        }
+        await self.scanner.get_builder_build_nvr('registry.example/builder:latest')
+        mock_oc_image_info.assert_awaited_once_with('registry.example/builder:latest', registry_config='/runtime/auth.json')
+
+    @patch('doozerlib.cli.scan_sources_konflux.Model')
+    @patch('doozerlib.cli.scan_sources_konflux.oc_image_info_for_arch_async', new_callable=AsyncMock)
+    async def test_builder_auth_falls_back_to_environment(self, mock_oc_image_info, mock_model):
+        self.runtime.group = 'oadp-1.5'
+        self.runtime.registry_config = None
+        mock_model.return_value.config.config.Labels = {
+            'com.redhat.component': 'component', 'version': '1', 'release': '1'
+        }
+        with patch.dict('os.environ', {'QUAY_AUTH_FILE': '/env/auth.json'}):
+            await self.scanner.get_builder_build_nvr('registry.example/builder:latest')
+        mock_oc_image_info.assert_awaited_once_with('registry.example/builder:latest', registry_config='/env/auth.json')
+
     @patch('doozerlib.cli.scan_sources_konflux.oc_image_info_for_arch_async')
     async def test_triggers_rebuild_when_digest_changed(self, mock_oc_image_info):
         """Should trigger rebuild when external image has a new digest."""

--- a/doozer/tests/cli/test_scan_sources_konflux.py
+++ b/doozer/tests/cli/test_scan_sources_konflux.py
@@ -933,14 +933,29 @@ class TestScanExternalImageChanges(TestScanSourcesKonflux):
         mock_oc_image_info.return_value = {'listDigest': 'sha256:currentdigest123'}
         art_yaml = {
             'external-images': [
-                {'name': 'postgresql', 'search': 'RELATED_IMAGE_POSTGRESQL', 'replace': 'registry.redhat.io/rhel9/postgresql-15:latest'}
+                {
+                    'name': 'postgresql',
+                    'search': 'RELATED_IMAGE_POSTGRESQL',
+                    'replace': 'registry.redhat.io/rhel9/postgresql-15:latest',
+                }
             ]
         }
-        image_refs = {'spec': {'tags': [{'name': 'postgresql', 'from': {'name': 'registry.redhat.io/rhel9/postgresql-15@sha256:currentdigest123'}}]}}
-        with patch.dict('os.environ', {'QUAY_AUTH_FILE': '/env/auth.json'}), patch.object(
-            self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock, return_value=art_yaml
-        ), patch.object(
-            self.scanner, '_fetch_image_references_from_rebase', new_callable=AsyncMock, return_value=image_refs
+        image_refs = {
+            'spec': {
+                'tags': [
+                    {
+                        'name': 'postgresql',
+                        'from': {'name': 'registry.redhat.io/rhel9/postgresql-15@sha256:currentdigest123'},
+                    }
+                ]
+            }
+        }
+        with (
+            patch.dict('os.environ', {'QUAY_AUTH_FILE': '/env/auth.json'}),
+            patch.object(self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock, return_value=art_yaml),
+            patch.object(
+                self.scanner, '_fetch_image_references_from_rebase', new_callable=AsyncMock, return_value=image_refs
+            ),
         ):
             await self.scanner.scan_external_image_changes(self.image_meta)
         mock_oc_image_info.assert_awaited_once_with(
@@ -953,14 +968,29 @@ class TestScanExternalImageChanges(TestScanSourcesKonflux):
         mock_oc_image_info.return_value = {'listDigest': 'sha256:currentdigest123'}
         art_yaml = {
             'external-images': [
-                {'name': 'postgresql', 'search': 'RELATED_IMAGE_POSTGRESQL', 'replace': 'registry.redhat.io/rhel9/postgresql-15:latest'}
+                {
+                    'name': 'postgresql',
+                    'search': 'RELATED_IMAGE_POSTGRESQL',
+                    'replace': 'registry.redhat.io/rhel9/postgresql-15:latest',
+                }
             ]
         }
-        image_refs = {'spec': {'tags': [{'name': 'postgresql', 'from': {'name': 'registry.redhat.io/rhel9/postgresql-15@sha256:currentdigest123'}}]}}
-        with patch.dict('os.environ', {'QUAY_AUTH_FILE': '/env/auth.json'}), patch.object(
-            self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock, return_value=art_yaml
-        ), patch.object(
-            self.scanner, '_fetch_image_references_from_rebase', new_callable=AsyncMock, return_value=image_refs
+        image_refs = {
+            'spec': {
+                'tags': [
+                    {
+                        'name': 'postgresql',
+                        'from': {'name': 'registry.redhat.io/rhel9/postgresql-15@sha256:currentdigest123'},
+                    }
+                ]
+            }
+        }
+        with (
+            patch.dict('os.environ', {'QUAY_AUTH_FILE': '/env/auth.json'}),
+            patch.object(self.scanner, '_fetch_art_yaml_from_rebase', new_callable=AsyncMock, return_value=art_yaml),
+            patch.object(
+                self.scanner, '_fetch_image_references_from_rebase', new_callable=AsyncMock, return_value=image_refs
+            ),
         ):
             await self.scanner.scan_external_image_changes(self.image_meta)
         mock_oc_image_info.assert_awaited_once_with(
@@ -973,10 +1003,14 @@ class TestScanExternalImageChanges(TestScanSourcesKonflux):
         self.runtime.group = 'oadp-1.5'
         self.runtime.registry_config = '/runtime/auth.json'
         mock_model.return_value.config.config.Labels = {
-            'com.redhat.component': 'component', 'version': '1', 'release': '1'
+            'com.redhat.component': 'component',
+            'version': '1',
+            'release': '1',
         }
         await self.scanner.get_builder_build_nvr('registry.example/builder:latest')
-        mock_oc_image_info.assert_awaited_once_with('registry.example/builder:latest', registry_config='/runtime/auth.json')
+        mock_oc_image_info.assert_awaited_once_with(
+            'registry.example/builder:latest', registry_config='/runtime/auth.json'
+        )
 
     @patch('doozerlib.cli.scan_sources_konflux.Model')
     @patch('doozerlib.cli.scan_sources_konflux.oc_image_info_for_arch_async', new_callable=AsyncMock)
@@ -984,7 +1018,9 @@ class TestScanExternalImageChanges(TestScanSourcesKonflux):
         self.runtime.group = 'oadp-1.5'
         self.runtime.registry_config = None
         mock_model.return_value.config.config.Labels = {
-            'com.redhat.component': 'component', 'version': '1', 'release': '1'
+            'com.redhat.component': 'component',
+            'version': '1',
+            'release': '1',
         }
         with patch.dict('os.environ', {'QUAY_AUTH_FILE': '/env/auth.json'}):
             await self.scanner.get_builder_build_nvr('registry.example/builder:latest')

--- a/pyartcd/pyartcd/pipelines/build_fbc.py
+++ b/pyartcd/pyartcd/pipelines/build_fbc.py
@@ -105,7 +105,7 @@ class BuildFbcPipeline:
         self._logger.info('Checking if production index image exists: %s', index_image)
 
         cmd = ['skopeo', 'inspect', '--no-tags', f'docker://{index_image}']
-        auth = self.prod_registry_auth or os.environ.get('KONFLUX_OPERATOR_INDEX_AUTH_FILE')
+        auth = self.prod_registry_auth or os.environ.get('QUAY_AUTH_FILE')
         if auth:
             cmd.extend(['--authfile', auth])
 

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -185,10 +185,7 @@ class BuildMicroShiftBootcPipeline:
             KONFLUX_DEFAULT_IMAGE_REPO,
             REGISTRY_CI_OPENSHIFT,
         ]
-        redhat_registry_auth_file = os.getenv('KONFLUX_OPERATOR_INDEX_AUTH_FILE')
-        if redhat_registry_auth_file:
-            source_files.append(redhat_registry_auth_file)
-            registries.append(REGISTRY_REDHAT_IO)
+        registries.append(REGISTRY_REDHAT_IO)
 
         with RegistryConfig(
             kubeconfig=os.environ.get('KUBECONFIG'),

--- a/pyartcd/pyartcd/pipelines/fbc_import_from_index.py
+++ b/pyartcd/pyartcd/pipelines/fbc_import_from_index.py
@@ -69,9 +69,7 @@ class FbcImportPipeline:
 
         auth_file = os.environ.get('QUAY_AUTH_FILE')
         if not auth_file:
-            self._logger.warning(
-                'QUAY_AUTH_FILE is not set. This may cause issues with operator index authentication.'
-            )
+            self._logger.warning('QUAY_AUTH_FILE is not set. This may cause issues with operator index authentication.')
         else:
             cmd.extend(['--registry-auth', auth_file])
         if not self.runtime.dry_run:

--- a/pyartcd/pyartcd/pipelines/fbc_import_from_index.py
+++ b/pyartcd/pyartcd/pipelines/fbc_import_from_index.py
@@ -67,10 +67,10 @@ class FbcImportPipeline:
         if self.into_fbc_repo:
             cmd.extend(['--fbc-repo', self.into_fbc_repo])
 
-        auth_file = os.environ.get('KONFLUX_OPERATOR_INDEX_AUTH_FILE')
+        auth_file = os.environ.get('QUAY_AUTH_FILE')
         if not auth_file:
             self._logger.warning(
-                'KONFLUX_OPERATOR_INDEX_AUTH_FILE is not set. This may cause issues with operator index authentication.'
+                'QUAY_AUTH_FILE is not set. This may cause issues with operator index authentication.'
             )
         else:
             cmd.extend(['--registry-auth', auth_file])

--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -1021,7 +1021,6 @@ class KonfluxOcpPipeline:
 
         # Get Jenkins credentials
         quay_auth_file = os.getenv('QUAY_AUTH_FILE')
-        redhat_registry_auth_file = os.getenv('KONFLUX_OPERATOR_INDEX_AUTH_FILE')
 
         if not quay_auth_file:
             raise ValueError(
@@ -1031,8 +1030,6 @@ class KonfluxOcpPipeline:
 
         # Build source files list
         source_files = [quay_auth_file]
-        if redhat_registry_auth_file:
-            source_files.append(redhat_registry_auth_file)
 
         # Build explicit credentials for QCI push (DPTP's CI registry)
         qci_user = os.environ.get('QCI_USER')

--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -246,11 +246,7 @@ class PrepareReleaseKonfluxPipeline:
             )
 
         source_files = [quay_auth_file]
-        registries = [REGISTRY_QUAY_OCP_RELEASE_DEV]
-        redhat_registry_auth_file = os.getenv('KONFLUX_OPERATOR_INDEX_AUTH_FILE')
-        if redhat_registry_auth_file:
-            source_files.append(redhat_registry_auth_file)
-            registries.append(REGISTRY_REDHAT_IO)
+        registries = [REGISTRY_QUAY_OCP_RELEASE_DEV, REGISTRY_REDHAT_IO]
 
         with RegistryConfig(
             kubeconfig=os.environ.get('KUBECONFIG'),


### PR DESCRIPTION
## Summary

Konflux registry authentication was still reading `KONFLUX_OPERATOR_INDEX_AUTH_FILE` in several Doozer and PyARTCD paths. That file did not contain the credentials required to resolve images from `registry.stage.redhat.io`, causing image inspection and rebase operations to fail.

This change standardizes those paths on `QUAY_AUTH_FILE`, which now contains the required registry credentials.

Verified that aos-cd-jobs has QUAY_AUTH_FILE for all the references:
  - jobs/build/build-fbc/Jenkinsfile:160
  - jobs/build/build-microshift-bootc/Jenkinsfile:134
  - jobs/build/fbc-import-from-index/Jenkinsfile:111
  - jobs/build/ocp4-konflux/Jenkinsfile:244
  - jobs/build/ocp4-scan-konflux/Jenkinsfile:122
  - jobs/build/prepare-release-konflux/Jenkinsfile:111

## Changes

- Use `QUAY_AUTH_FILE` for:
  - External-image digest resolution during Konflux rebases and source scans.
  - FBC production-index inspection and reset-to-production flows.
  - FBC index imports.
  - MicroShift bootc, OCP, and release-preparation registry configuration.
- Preserve existing explicit authentication inputs and `runtime.registry_config` fallbacks where they apply.
- Keep `registry.redhat.io` in the registry allowlist/configuration while avoiding a second, obsolete auth-file source.
- Remove all remaining production references to `KONFLUX_OPERATOR_INDEX_AUTH_FILE`.

## Expected result

Jobs that provide the updated `QUAY_AUTH_FILE` can authenticate consistently when inspecting or resolving images from Quay and Red Hat registries, including `registry.stage.redhat.io`.

## Validation

- 97 focused Doozer tests passed.
- 71 focused PyARTCD tests passed.
- Ruff checks passed for all modified files.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Registry authentication now consistently uses `QUAY_AUTH_FILE` for image digest resolution, FBC operations, imports, and release workflows.
  - Runtime registry configuration takes precedence when resolving external and builder images.
  - Registry access reliably includes required Quay and Red Hat registry sources.
  - Updated command-line guidance and warnings to reflect the current authentication setting.
  - Removed reliance on the deprecated optional Konflux operator index credential source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->