### PR TITLE
fix(konflux-db): pass group from where clause to get_latest_build in get_build_records_by_nvrs

### DIFF
--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -1354,6 +1354,7 @@ class KonfluxDb:
                 )
 
         # Extract additional filters from where if provided
+        group = where.get('group') if where else None
         assembly = where.get('assembly') if where else None
         el_target = where.get('el_target') if where else None
         artifact_type = where.get('artifact_type') if where else None
@@ -1364,6 +1365,7 @@ class KonfluxDb:
         async def _task(nvr):
             return await self.get_latest_build(
                 nvr=nvr,
+                group=group,
                 outcome=outcome,
                 assembly=assembly,
                 el_target=el_target,

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -188,7 +188,6 @@ class UpdateGolangPipeline:
         kubeconfig: str | None = None,
         data_path: str | None = None,
         data_gitref: str | None = None,
-        skip_pr: bool = False,
         external_golang_rpms: bool = False,
         network_mode: str | None = None,
         major_bump: bool = False,
@@ -208,7 +207,6 @@ class UpdateGolangPipeline:
         self.tag_builds = tag_builds
         self.data_path = data_path
         self.data_gitref = data_gitref
-        self.skip_pr = skip_pr
         self.external_golang_rpms = external_golang_rpms
         self.network_mode = network_mode
         self.major_bump = major_bump
@@ -945,78 +943,7 @@ class UpdateGolangPipeline:
                         info['image'] = latest_go
                 group_content['vars'][go_latest_var] = build_major_minor
                 update_streams = update_group = True
-        # save changes and create pr
-        if update_streams:
-            if self.dry_run:
-                _LOGGER.info(f"[DRY RUN] Would have created PR to update {go_version} golang builders")
-                return
-            if self.skip_pr:
-                # Log NVRs and pullspecs for golang builder images
-                builder_info = []
-                for el_v, pullspec in builder_pullspecs.items():
-                    builder_info.append(f"  - RHEL {el_v}: {pullspec}")
-                builder_details = "\n".join(builder_info)
-
-                _LOGGER.info(
-                    f"Skipping PR creation (--skip-pr flag set) for {go_version} golang builders update.\n"
-                    f"Golang builder images:\n{builder_details}"
-                )
-                await self._slack_client.say_in_thread(
-                    f"Skipping PR creation (--skip-pr flag set) for {go_version} golang builders update.\n"
-                    f"Golang builder images:\n{builder_details}"
-                )
-                return
-            fork_repo = get_github_client_for_org("openshift-bot").get_repo("openshift-bot/ocp-build-data")
-            branch_name = f"update-golang-{self.ocp_version}-{go_version}"
-            title = f"{self.art_jira} - Bump {self.ocp_version} golang builders to {go_version}"
-            update_message = f"Bump {self.ocp_version} golang builders to {go_version}"
-            for fork_branch in fork_repo.get_branches():
-                if fork_branch.name == branch_name:
-                    fork_repo.get_git_ref(f"heads/{branch_name}").delete()
-            fork_branch = fork_repo.create_git_ref(
-                f"refs/heads/{branch_name}", upstream_repo.get_branch(branch).commit.sha
-            )
-            _LOGGER.info(f"Created fork branch ref {fork_branch.ref}")
-            output = io.BytesIO()
-            yaml.dump(streams_content, output)
-            output.seek(0)
-            fork_file = fork_repo.get_contents("streams.yml", ref=branch_name)
-            fork_repo.update_file("streams.yml", update_message, output.read(), fork_file.sha, branch=branch_name)
-            if update_group:
-                output = io.BytesIO()
-                yaml.dump(group_content, output)
-                output.seek(0)
-                fork_file = fork_repo.get_contents("group.yml", ref=branch_name)
-                fork_repo.update_file("group.yml", update_message, output.read(), fork_file.sha, branch=branch_name)
-            # create pr
-            build_url = jenkins.get_build_url()
-            pullspec_lines = "\n".join(
-                f"> - RHEL {el_v}: `{pullspec}`" for el_v, pullspec in sorted(builder_pullspecs.items())
-            )
-            shipment_warning = (
-                "\n\n> [!WARNING]\n"
-                "> **Do NOT merge until the golang builder shipment MRs are merged.**\n"
-                "> These images are published via shipment MRs in\n"
-                "> [ocp-shipment-data](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests).\n"
-                "> Merge those MRs first, then merge this PR.\n"
-                ">\n"
-                f"{pullspec_lines}"
-            )
-            body = (f"Created by job run {build_url}" if build_url else "") + shipment_warning
-            pr = upstream_repo.create_pull(title=title, body=body, base=branch, head=f"openshift-bot:{branch_name}")
-            _LOGGER.info(
-                f"PR created {pr.html_url} for {branch_name} to bump {self.ocp_version} golang builders to {go_version}"
-            )
-            await self._slack_client.say_in_thread(
-                f"PR created {pr.html_url} for {branch_name} to bump {self.ocp_version} golang builders to {go_version}"
-            )
-        else:
-            if self.tag_builds:
-                await self._slack_client.say_in_thread(
-                    "No pr created, please double check if it's expected because new build get tagged."
-                )
-            else:
-                _LOGGER.info(f"No update needed in {branch}")
+        _LOGGER.info("streams.yml pinned-NVR update skipped: floating tags in use")
 
     async def _rebase_brew(self, el_v, go_version, go_nvr: str):
         _LOGGER.info("Rebasing for Brew...")
@@ -1269,12 +1196,6 @@ class UpdateGolangPipeline:
 )
 @click.option('--data-gitref', required=False, default='', help='Doozer data path git [branch / tag / sha] to use')
 @click.option(
-    '--skip-pr',
-    is_flag=True,
-    default=False,
-    help='Skip PR generation for ocp-build-data updates. Defaults to False (PRs will be created).',
-)
-@click.option(
     '--external-golang-rpms',
     is_flag=True,
     default=False,
@@ -1317,7 +1238,6 @@ async def update_golang(
     kubeconfig: str,
     data_path: str,
     data_gitref: str,
-    skip_pr: bool,
     external_golang_rpms: bool,
     network_mode: str | None,
     assembly: str,
@@ -1348,7 +1268,6 @@ async def update_golang(
         kubeconfig,
         data_path,
         data_gitref,
-        skip_pr,
         external_golang_rpms,
         network_mode,
         major_bump,

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -716,64 +716,6 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             "registry.example.com/golang-builder:v1.26.5-el8",
         )
 
-    @patch("pyartcd.pipelines.update_golang.jenkins")
-    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_update_golang_streams_pr_body_contains_shipment_warning(
-        self, mock_konflux_db, mock_get_github_client, mock_jenkins
-    ):
-        """PR body includes a shipment-MR warning block with each timestamped pullspec listed"""
-        mock_jenkins.get_build_url.return_value = "https://jenkins.example.com/job/1"
-
-        upstream_repo = Mock()
-        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22\n")
-        upstream_repo.get_branch.return_value = Mock(commit=Mock(sha="abc123"))
-        fork_repo = Mock()
-        fork_repo.get_branches.return_value = []
-        fork_repo.create_git_ref.return_value = Mock(ref="refs/heads/test-branch")
-        fork_repo.get_contents.return_value = Mock(sha="file-sha", decoded_content=b"{}\n")
-        mock_get_github_client.return_value.get_repo.side_effect = lambda name: (
-            fork_repo if "openshift-bot" in name else upstream_repo
-        )
-
-        pipeline = UpdateGolangPipeline(
-            runtime=self._make_test_runtime(),
-            ocp_version="4.19",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.22.9-1.el8"],
-            art_jira="ART-1234",
-            tag_builds=False,
-            build_system="konflux",
-        )
-        pipeline._branch_content = {
-            "branch": "openshift-4.19",
-            "repo": upstream_repo,
-            "group": {"vars": {"GO_LATEST": "1.22"}},
-            "streams": {
-                "rhel-8-golang": {
-                    "aliases": ["rhel-8-golang-{GO_LATEST}"],
-                    "image": "registry.redhat.io/openshift/golang-builder:old-el8",
-                },
-                "rhel-9-golang": {
-                    "aliases": ["rhel-9-golang-{GO_LATEST}"],
-                    "image": "registry.redhat.io/openshift/golang-builder:old-el9",
-                },
-            },
-        }
-
-        el8_pullspec = "registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.22.9-202608241902.p0.assembly.stream.el8"
-        el9_pullspec = "registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.22.9-202608241902.p0.assembly.stream.el9"
-        await pipeline.update_golang_streams("1.22.9", {8: el8_pullspec, 9: el9_pullspec})
-
-        upstream_repo.create_pull.assert_called_once()
-        _, kwargs = upstream_repo.create_pull.call_args
-        body = kwargs["body"]
-        self.assertIn("[!WARNING]", body)
-        self.assertIn("ocp-shipment-data", body)
-        self.assertIn(el8_pullspec, body)
-        self.assertIn(el9_pullspec, body)
-
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_validate_go_version_matches_group_vars_accepts_matching_go_previous(


### PR DESCRIPTION
## Summary

- `get_build_records_by_nvrs` was silently ignoring the `group` key in the `where` parameter, causing `get_latest_build` to fall back to `extract_group_from_nvr()` for NVR-only lookups
- For golang builder NVRs, this extracts the old per-version group (`rhel-9-golang-1.26`) instead of the unified `golang` group used since the branch migration
- `GolangBuilderShipmentHandler._create_snapshot_via_elliott` calls `elliott snapshot new --group golang`, which passes `where={"group": "golang"}`, but the DB query was searching under `rhel-9-golang-1.26` and returning 0 results

## Fix

Extract `group` from the `where` param alongside `assembly`, `el_target`, etc., and forward it to `get_latest_build`.

## Test plan

- [ ] Verify `elliott snapshot new --group golang --nvr openshift-golang-builder-container-v1.26.5-...` finds the build record
- [ ] Confirm `base-image-release` Jenkins job with `BUILD_VERSION=golang SKIP_LEGACY_RELEASE=true` succeeds end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Build record searches now correctly apply the optional group filter when retrieving the latest build information.

* **Changes**
  * The Golang update command no longer supports the `--skip-pr` option.
  * Golang stream updates no longer create or update build-data branches, files, or pull requests.
  * Pinned-NVR updates are skipped after stream processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->