### PR TITLE
Start consuming RHCOS images from v5.0-art-dev repo

### DIFF
--- a/artcommon/artcommonlib/rhcos.py
+++ b/artcommon/artcommonlib/rhcos.py
@@ -131,12 +131,13 @@ def get_build_id_from_rhcos_pullspec(pullspec, registry_config: str = None) -> s
     return build_id
 
 
-def get_latest_layered_rhcos_build(container_conf: Model, arch: str, registry_config: str = None):
+def get_latest_layered_rhcos_build(container_conf: Model, arch: str, major: int, registry_config: str = None):
     """
     Get the latest Layered RHCOS build ID and pullspec for the specified rhcos container configuration.
 
     :param container_conf: Payload tag config Model from group.yml (exposes rhel_build_id_index, rhcos_index_tag, etc.)
     :param arch: Brew architecture (e.g., 'x86_64', 'aarch64')
+    :param major: OCP major version, used to select the art-dev repo (e.g. 5 -> ocp-v5.0-art-dev)
     :param registry_config: Optional path to registry auth config file
     :return: Tuple of (build_id, pullspec)
     """
@@ -157,10 +158,8 @@ def get_latest_layered_rhcos_build(container_conf: Model, arch: str, registry_co
         )
         digest = json.loads(rhcos_info_str)['digest']
 
-    # NOTE: RHCOS images are always hosted in the OCP 4.x art-dev repository, even for OCP 5.x,
-    # until RHCOS 5.x becomes available. This is because RHCOS versioning is independent of OCP versioning.
-    # When RHCOS 5.x is released, this code will need to be updated to determine the RHCOS major version
-    # (which may differ from OCP major version) and pass it to get_art_prod_image_repo_for_version().
-    art_repo = get_art_prod_image_repo_for_version(major=4, repo_type="dev")
+    # RHCOS images are hosted in the art-dev repository matching the OCP major version
+    # (e.g. ocp-v5.0-art-dev for OCP 5.x), consistent with the rest of the release payload.
+    art_repo = get_art_prod_image_repo_for_version(major=major, repo_type="dev")
     pullspec = f"{art_repo}@{digest}"
     return build_id, pullspec

--- a/artcommon/tests/test_rhcos.py
+++ b/artcommon/tests/test_rhcos.py
@@ -1,0 +1,46 @@
+import json
+import unittest
+from unittest.mock import patch
+
+from artcommonlib import rhcos
+from artcommonlib.model import Model
+
+
+class TestGetLatestLayeredRhcosBuild(unittest.TestCase):
+    def _container_conf(self):
+        # rhel_build_id_index == rhcos_index_tag so only one image lookup is needed
+        return Model(
+            {
+                "rhel_build_id_index": "registry.example.com/rhcos-index:latest",
+                "rhcos_index_tag": "registry.example.com/rhcos-index:latest",
+            }
+        )
+
+    @patch("artcommonlib.rhcos.oc_image_info__cached")
+    def test_repo_tracks_major_version(self, oc_info_mock):
+        oc_info_mock.return_value = json.dumps(
+            {
+                "config": {"config": {"Labels": {"org.opencontainers.image.version": "5.0.0-ec"}}},
+                "digest": "sha256:abcd",
+            }
+        )
+
+        build_id, pullspec = rhcos.get_latest_layered_rhcos_build(self._container_conf(), "x86_64", major=5)
+        self.assertEqual(build_id, "5.0.0-ec")
+        self.assertEqual(pullspec, "quay.io/openshift-release-dev/ocp-v5.0-art-dev@sha256:abcd")
+
+    @patch("artcommonlib.rhcos.oc_image_info__cached")
+    def test_repo_for_major_4(self, oc_info_mock):
+        oc_info_mock.return_value = json.dumps(
+            {
+                "config": {"config": {"Labels": {"org.opencontainers.image.version": "4.19.0"}}},
+                "digest": "sha256:1234",
+            }
+        )
+
+        _, pullspec = rhcos.get_latest_layered_rhcos_build(self._container_conf(), "x86_64", major=4)
+        self.assertEqual(pullspec, "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1234")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/doozer/doozerlib/cli/release_gen_assembly_targeted.py
+++ b/doozer/doozerlib/cli/release_gen_assembly_targeted.py
@@ -387,7 +387,10 @@ class GenAssemblyTargetedCli:
 
             for arch in arches:
                 build_id, pullspec = get_latest_layered_rhcos_build(
-                    container_conf, arch, registry_config=self.runtime.registry_config
+                    container_conf,
+                    arch,
+                    int(self.runtime.group_config.vars['MAJOR']),
+                    registry_config=self.runtime.registry_config,
                 )
                 rhcos_config[container_name]["images"][arch] = pullspec
 

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -1806,7 +1806,10 @@ class ConfigScanSources:
                 for container_conf in self.runtime.group_config.rhcos.payload_tags:
                     if self.runtime.group_config.rhcos.get("layered_rhcos", False):
                         build_id, pullspec = get_latest_layered_rhcos_build(
-                            container_conf, brew_arch, registry_config=self.runtime.registry_config
+                            container_conf,
+                            brew_arch,
+                            int(self.runtime.group_config.vars['MAJOR']),
+                            registry_config=self.runtime.registry_config,
                         )
                     else:
                         build_id, pullspec = rhcos.RHCOSBuildFinder(

--- a/doozer/doozerlib/rhcos.py
+++ b/doozer/doozerlib/rhcos.py
@@ -249,7 +249,10 @@ class RHCOSBuildFinder:
         """
         if self.layered:
             build_id, pullspec = rhcos.get_latest_layered_rhcos_build(
-                container_conf, self.brew_arch, registry_config=self.registry_config
+                container_conf,
+                self.brew_arch,
+                int(self.runtime.group_config.vars['MAJOR']),
+                registry_config=self.registry_config,
             )
             return build_id, pullspec
         else:


### PR DESCRIPTION
RHCOS pipeline is now publishing images to `ocp-v5.0-art-dev`. So now we can migrate to that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Layered RHCOS builds are now resolved from the repository matching the configured OpenShift major version.
  * Corrected payload tag and container lookup behavior for OpenShift 5.x while preserving support for 4.x.

* **Tests**
  * Added coverage validating layered RHCOS build selection and pullspec generation across supported OpenShift versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->