### PR TITLE
ART-23148: remove PR creation and --skip-pr from update-golang pipeline

### DIFF
--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -828,8 +828,6 @@ class UpdateGolangPipeline:
             return
 
         branch_content = self._get_branch_content()
-        branch = branch_content["branch"]
-        upstream_repo = branch_content["repo"]
         streams_content = branch_content["streams"]
         group_content = branch_content["group"]
 
@@ -867,8 +865,6 @@ class UpdateGolangPipeline:
                 f'rhel-{el_v}-golang-{extra_major_minor}',
             )
 
-        update_streams = update_group = False
-
         # register aliases
         stream_alias_map = {}
         for stream_name, info in streams_content.items():
@@ -896,7 +892,6 @@ class UpdateGolangPipeline:
                 for _, info in streams_content.items():
                     if info['image'] == latest_go:
                         info['image'] = pullspec
-                        update_streams = True
         # This is to bump minor golang for GO_PREVIOUS
         elif previous_major_minor and build_major_minor == previous_major_minor:
             for el_v, pullspec in builder_pullspecs.items():
@@ -906,7 +901,6 @@ class UpdateGolangPipeline:
                 for _, info in streams_content.items():
                     if info['image'] == previous_go:
                         info['image'] = pullspec
-                        update_streams = True
         # This is to bump minor golang for GO_EXTRA
         elif extra_major_minor and build_major_minor == extra_major_minor:
             for el_v, pullspec in builder_pullspecs.items():
@@ -926,7 +920,6 @@ class UpdateGolangPipeline:
                 for _, info in streams_content.items():
                     if info['image'] == extra_go:
                         info['image'] = pullspec
-                        update_streams = True
         # This is to bump major golang for GO_LATEST and update GO_PREVIOUS to current GO_LATEST
         elif build_major_minor_tuple > latest_major_minor_tuple:
             for el_v, pullspec in builder_pullspecs.items():
@@ -942,7 +935,6 @@ class UpdateGolangPipeline:
                     if info['image'] == previous_go:
                         info['image'] = latest_go
                 group_content['vars'][go_latest_var] = build_major_minor
-                update_streams = update_group = True
         _LOGGER.info("streams.yml pinned-NVR update skipped: floating tags in use")
 
     async def _rebase_brew(self, el_v, go_version, go_nvr: str):

--- a/pyartcd/pyartcd/pipelines/update_golang.py
+++ b/pyartcd/pyartcd/pipelines/update_golang.py
@@ -188,7 +188,6 @@ class UpdateGolangPipeline:
         kubeconfig: str | None = None,
         data_path: str | None = None,
         data_gitref: str | None = None,
-        skip_pr: bool = False,
         external_golang_rpms: bool = False,
         network_mode: str | None = None,
         major_bump: bool = False,
@@ -208,7 +207,6 @@ class UpdateGolangPipeline:
         self.tag_builds = tag_builds
         self.data_path = data_path
         self.data_gitref = data_gitref
-        self.skip_pr = skip_pr
         self.external_golang_rpms = external_golang_rpms
         self.network_mode = network_mode
         self.major_bump = major_bump
@@ -945,78 +943,7 @@ class UpdateGolangPipeline:
                         info['image'] = latest_go
                 group_content['vars'][go_latest_var] = build_major_minor
                 update_streams = update_group = True
-        # save changes and create pr
-        if update_streams:
-            if self.dry_run:
-                _LOGGER.info(f"[DRY RUN] Would have created PR to update {go_version} golang builders")
-                return
-            if self.skip_pr:
-                # Log NVRs and pullspecs for golang builder images
-                builder_info = []
-                for el_v, pullspec in builder_pullspecs.items():
-                    builder_info.append(f"  - RHEL {el_v}: {pullspec}")
-                builder_details = "\n".join(builder_info)
-
-                _LOGGER.info(
-                    f"Skipping PR creation (--skip-pr flag set) for {go_version} golang builders update.\n"
-                    f"Golang builder images:\n{builder_details}"
-                )
-                await self._slack_client.say_in_thread(
-                    f"Skipping PR creation (--skip-pr flag set) for {go_version} golang builders update.\n"
-                    f"Golang builder images:\n{builder_details}"
-                )
-                return
-            fork_repo = get_github_client_for_org("openshift-bot").get_repo("openshift-bot/ocp-build-data")
-            branch_name = f"update-golang-{self.ocp_version}-{go_version}"
-            title = f"{self.art_jira} - Bump {self.ocp_version} golang builders to {go_version}"
-            update_message = f"Bump {self.ocp_version} golang builders to {go_version}"
-            for fork_branch in fork_repo.get_branches():
-                if fork_branch.name == branch_name:
-                    fork_repo.get_git_ref(f"heads/{branch_name}").delete()
-            fork_branch = fork_repo.create_git_ref(
-                f"refs/heads/{branch_name}", upstream_repo.get_branch(branch).commit.sha
-            )
-            _LOGGER.info(f"Created fork branch ref {fork_branch.ref}")
-            output = io.BytesIO()
-            yaml.dump(streams_content, output)
-            output.seek(0)
-            fork_file = fork_repo.get_contents("streams.yml", ref=branch_name)
-            fork_repo.update_file("streams.yml", update_message, output.read(), fork_file.sha, branch=branch_name)
-            if update_group:
-                output = io.BytesIO()
-                yaml.dump(group_content, output)
-                output.seek(0)
-                fork_file = fork_repo.get_contents("group.yml", ref=branch_name)
-                fork_repo.update_file("group.yml", update_message, output.read(), fork_file.sha, branch=branch_name)
-            # create pr
-            build_url = jenkins.get_build_url()
-            pullspec_lines = "\n".join(
-                f"> - RHEL {el_v}: `{pullspec}`" for el_v, pullspec in sorted(builder_pullspecs.items())
-            )
-            shipment_warning = (
-                "\n\n> [!WARNING]\n"
-                "> **Do NOT merge until the golang builder shipment MRs are merged.**\n"
-                "> These images are published via shipment MRs in\n"
-                "> [ocp-shipment-data](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests).\n"
-                "> Merge those MRs first, then merge this PR.\n"
-                ">\n"
-                f"{pullspec_lines}"
-            )
-            body = (f"Created by job run {build_url}" if build_url else "") + shipment_warning
-            pr = upstream_repo.create_pull(title=title, body=body, base=branch, head=f"openshift-bot:{branch_name}")
-            _LOGGER.info(
-                f"PR created {pr.html_url} for {branch_name} to bump {self.ocp_version} golang builders to {go_version}"
-            )
-            await self._slack_client.say_in_thread(
-                f"PR created {pr.html_url} for {branch_name} to bump {self.ocp_version} golang builders to {go_version}"
-            )
-        else:
-            if self.tag_builds:
-                await self._slack_client.say_in_thread(
-                    "No pr created, please double check if it's expected because new build get tagged."
-                )
-            else:
-                _LOGGER.info(f"No update needed in {branch}")
+        _LOGGER.info("streams.yml pinned-NVR update skipped: floating tags in use")
 
     async def _rebase_brew(self, el_v, go_version, go_nvr: str):
         _LOGGER.info("Rebasing for Brew...")
@@ -1269,12 +1196,6 @@ class UpdateGolangPipeline:
 )
 @click.option('--data-gitref', required=False, default='', help='Doozer data path git [branch / tag / sha] to use')
 @click.option(
-    '--skip-pr',
-    is_flag=True,
-    default=False,
-    help='Skip PR generation for ocp-build-data updates. Defaults to False (PRs will be created).',
-)
-@click.option(
     '--external-golang-rpms',
     is_flag=True,
     default=False,
@@ -1317,7 +1238,6 @@ async def update_golang(
     kubeconfig: str,
     data_path: str,
     data_gitref: str,
-    skip_pr: bool,
     external_golang_rpms: bool,
     network_mode: str | None,
     assembly: str,
@@ -1348,7 +1268,6 @@ async def update_golang(
         kubeconfig,
         data_path,
         data_gitref,
-        skip_pr,
         external_golang_rpms,
         network_mode,
         major_bump,

--- a/pyartcd/tests/pipelines/test_update_golang.py
+++ b/pyartcd/tests/pipelines/test_update_golang.py
@@ -716,64 +716,6 @@ class TestUpdateGolangPipeline(IsolatedAsyncioTestCase):
             "registry.example.com/golang-builder:v1.26.5-el8",
         )
 
-    @patch("pyartcd.pipelines.update_golang.jenkins")
-    @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
-    @patch("pyartcd.pipelines.update_golang.KonfluxDb")
-    async def test_update_golang_streams_pr_body_contains_shipment_warning(
-        self, mock_konflux_db, mock_get_github_client, mock_jenkins
-    ):
-        """PR body includes a shipment-MR warning block with each timestamped pullspec listed"""
-        mock_jenkins.get_build_url.return_value = "https://jenkins.example.com/job/1"
-
-        upstream_repo = Mock()
-        upstream_repo.get_contents.return_value = Mock(decoded_content=b"vars:\n  GO_LATEST: 1.22\n")
-        upstream_repo.get_branch.return_value = Mock(commit=Mock(sha="abc123"))
-        fork_repo = Mock()
-        fork_repo.get_branches.return_value = []
-        fork_repo.create_git_ref.return_value = Mock(ref="refs/heads/test-branch")
-        fork_repo.get_contents.return_value = Mock(sha="file-sha", decoded_content=b"{}\n")
-        mock_get_github_client.return_value.get_repo.side_effect = lambda name: (
-            fork_repo if "openshift-bot" in name else upstream_repo
-        )
-
-        pipeline = UpdateGolangPipeline(
-            runtime=self._make_test_runtime(),
-            ocp_version="4.19",
-            cves=None,
-            force_update_tracker=False,
-            go_nvrs=["golang-1.22.9-1.el8"],
-            art_jira="ART-1234",
-            tag_builds=False,
-            build_system="konflux",
-        )
-        pipeline._branch_content = {
-            "branch": "openshift-4.19",
-            "repo": upstream_repo,
-            "group": {"vars": {"GO_LATEST": "1.22"}},
-            "streams": {
-                "rhel-8-golang": {
-                    "aliases": ["rhel-8-golang-{GO_LATEST}"],
-                    "image": "registry.redhat.io/openshift/golang-builder:old-el8",
-                },
-                "rhel-9-golang": {
-                    "aliases": ["rhel-9-golang-{GO_LATEST}"],
-                    "image": "registry.redhat.io/openshift/golang-builder:old-el9",
-                },
-            },
-        }
-
-        el8_pullspec = "registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.22.9-202608241902.p0.assembly.stream.el8"
-        el9_pullspec = "registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.22.9-202608241902.p0.assembly.stream.el9"
-        await pipeline.update_golang_streams("1.22.9", {8: el8_pullspec, 9: el9_pullspec})
-
-        upstream_repo.create_pull.assert_called_once()
-        _, kwargs = upstream_repo.create_pull.call_args
-        body = kwargs["body"]
-        self.assertIn("[!WARNING]", body)
-        self.assertIn("ocp-shipment-data", body)
-        self.assertIn(el8_pullspec, body)
-        self.assertIn(el9_pullspec, body)
-
     @patch("pyartcd.pipelines.update_golang.get_github_client_for_org")
     @patch("pyartcd.pipelines.update_golang.KonfluxDb")
     def test_validate_go_version_matches_group_vars_accepts_matching_go_previous(


### PR DESCRIPTION
## Summary

The golang-builder pipeline now uses floating tags (`golang-builder-vX.Y-rhelN`) in
`ocp-build-data/streams.yml` instead of pinned NVR pullspecs. Since floating tags always
resolve to the latest build, `streams.yml` no longer needs a PR bump after every golang
builder rebuild. The entire ocp-build-data branch/fork/PR creation block is dead code.

## Changes

**`pyartcd/pyartcd/pipelines/update_golang.py`**

Removes from `update_golang_streams`:
- The `if update_streams:` block that created fork branches, updated `streams.yml`/`group.yml`,
  and opened a PR via `openshift-bot`
- The `--skip-pr` short-circuit path with its Slack notification
- The "No PR created" fallback Slack message

Removes from the click command and `UpdateGolangPipeline` constructor:
- `--skip-pr` CLI option
- `skip_pr` parameter and `self.skip_pr` attribute

**`pyartcd/tests/pipelines/test_update_golang.py`**

Removes `test_update_golang_streams_pr_body_contains_shipment_warning`, which was the
only test covering the now-deleted PR-creation code path.

## Related

- [ART-23148](https://redhat.atlassian.net/browse/ART-23148): Migrate ocp-build-data golang streams to floating tags
- Companion PR in aos-cd-jobs removes the `SKIP_PR` Jenkinsfile parameter that called `--skip-pr`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Removed the `--skip-pr` option from the `update-golang` command.
  * Golang stream updates now apply stream and group data changes without creating pull requests.
  * Pinned-NVR updates are skipped after stream processing because floating tags are used.
  * Simplified update behavior provides a more consistent and predictable Golang stream update process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->