### PR TITLE
Treat equivalent upstream trees as public

### DIFF
--- a/doozer/doozerlib/util.py
+++ b/doozer/doozerlib/util.py
@@ -80,13 +80,18 @@ def dict_get(dct, path, default=DICT_EMPTY):
 
 def is_commit_in_public_upstream(revision: str, public_upstream_branch: str, source_dir: Union[str, Path]):
     """
-    Determine if the public upstream branch includes the specified commit.
+    Determine if the public upstream branch includes the specified commit or its exact source tree.
+
+    Commit ancestry is the fast path. If the commit is not reachable from the public branch, fall back to
+    checking whether an identical root tree is reachable. This handles public branches whose history was
+    rewritten or which received the same change through a squash/cherry-pick under a different commit SHA.
 
     :param revision: Git commit hash or reference
     :param public_upstream_branch: Git branch of the public upstream source
     :param source_dir: Path to the local Git repository
     """
-    cmd = [
+    public_ref = "public_upstream/" + public_upstream_branch
+    ancestry_cmd = [
         "git",
         "-C",
         str(source_dir),
@@ -94,25 +99,53 @@ def is_commit_in_public_upstream(revision: str, public_upstream_branch: str, sou
         "--is-ancestor",
         "--",
         revision,
-        "public_upstream/" + public_upstream_branch,
+        public_ref,
     ]
     # The command exits with status 0 if true, or with status 1 if not. Errors are signaled by a non-zero status that is not 1.
     # https://git-scm.com/docs/git-merge-base#Documentation/git-merge-base.txt---is-ancestor
-    rc, out, err = exectools.cmd_gather(cmd)
+    rc, out, err = exectools.cmd_gather(ancestry_cmd)
     if rc == 0:
         return True
-    if rc == 1:
-        return False
-    raise IOError(
-        f"Couldn't determine if the commit {revision} is in the public upstream source repo. `git merge-base` exited with {rc}, stdout={out}, stderr={err}"
-    )
+    if rc != 1:
+        raise IOError(
+            f"Couldn't determine if the commit {revision} is in the public upstream source repo. "
+            f"`git merge-base` exited with {rc}, stdout={out}, stderr={err}"
+        )
+
+    tree_cmd = ["git", "-C", str(source_dir), "rev-parse", "--verify", f"{revision}^{{tree}}"]
+    rc, out, err = exectools.cmd_gather(tree_cmd)
+    if rc:
+        raise IOError(
+            f"Couldn't determine the source tree for commit {revision}. "
+            f"`git rev-parse` exited with {rc}, stdout={out}, stderr={err}"
+        )
+    revision_tree = out.strip()
+
+    public_trees_cmd = ["git", "-C", str(source_dir), "log", "--format=%T", public_ref]
+    rc, out, err = exectools.cmd_gather(public_trees_cmd)
+    if rc:
+        raise IOError(
+            f"Couldn't inspect source trees in public upstream branch {public_upstream_branch}. "
+            f"`git log` exited with {rc}, stdout={out}, stderr={err}"
+        )
+
+    if revision_tree in {line.strip() for line in out.splitlines()}:
+        logger.info(
+            "Commit %s is not reachable from %s, but its source tree %s is; treating it as public",
+            revision,
+            public_ref,
+            revision_tree,
+        )
+        return True
+    return False
 
 
 async def is_commit_in_public_upstream_async(revision: str, public_upstream_branch: str, source_dir: Union[str, Path]):
     """
     Same as is_commit_in_public_upstream, but for async execution.
     """
-    cmd = [
+    public_ref = "public_upstream/" + public_upstream_branch
+    ancestry_cmd = [
         "git",
         "-C",
         str(source_dir),
@@ -120,18 +153,45 @@ async def is_commit_in_public_upstream_async(revision: str, public_upstream_bran
         "--is-ancestor",
         "--",
         revision,
-        "public_upstream/" + public_upstream_branch,
+        public_ref,
     ]
     # The command exits with status 0 if true, or with status 1 if not. Errors are signaled by a non-zero status that is not 1.
     # https://git-scm.com/docs/git-merge-base#Documentation/git-merge-base.txt---is-ancestor
-    rc, out, err = await exectools.cmd_gather_async(cmd, check=False)
+    rc, out, err = await exectools.cmd_gather_async(ancestry_cmd, check=False)
     if rc == 0:
         return True
-    if rc == 1:
-        return False
-    raise IOError(
-        f"Couldn't determine if the commit {revision} is in the public upstream source repo. `git merge-base` exited with {rc}, stdout={out}, stderr={err}"
-    )
+    if rc != 1:
+        raise IOError(
+            f"Couldn't determine if the commit {revision} is in the public upstream source repo. "
+            f"`git merge-base` exited with {rc}, stdout={out}, stderr={err}"
+        )
+
+    tree_cmd = ["git", "-C", str(source_dir), "rev-parse", "--verify", f"{revision}^{{tree}}"]
+    rc, out, err = await exectools.cmd_gather_async(tree_cmd, check=False)
+    if rc:
+        raise IOError(
+            f"Couldn't determine the source tree for commit {revision}. "
+            f"`git rev-parse` exited with {rc}, stdout={out}, stderr={err}"
+        )
+    revision_tree = out.strip()
+
+    public_trees_cmd = ["git", "-C", str(source_dir), "log", "--format=%T", public_ref]
+    rc, out, err = await exectools.cmd_gather_async(public_trees_cmd, check=False)
+    if rc:
+        raise IOError(
+            f"Couldn't inspect source trees in public upstream branch {public_upstream_branch}. "
+            f"`git log` exited with {rc}, stdout={out}, stderr={err}"
+        )
+
+    if revision_tree in {line.strip() for line in out.splitlines()}:
+        logger.info(
+            "Commit %s is not reachable from %s, but its source tree %s is; treating it as public",
+            revision,
+            public_ref,
+            revision_tree,
+        )
+        return True
+    return False
 
 
 def is_in_directory(path: os.PathLike, directory: os.PathLike):

--- a/doozer/tests/test_util.py
+++ b/doozer/tests/test_util.py
@@ -1,5 +1,6 @@
 import logging
 import pathlib
+import subprocess
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
@@ -581,6 +582,42 @@ class TestGetKonfluxBuildPriority(unittest.TestCase):
         self.assertGreaterEqual(int(util.get_konflux_build_priority(metadata, "openshift-4.19")), 1)
 
 
+class TestIsCommitInPublicUpstream(unittest.TestCase):
+    @patch("doozerlib.util.exectools.cmd_gather")
+    def test_returns_true_when_commit_is_ancestor(self, mock_gather):
+        mock_gather.return_value = (0, "", "")
+        result = util.is_commit_in_public_upstream("abc123", "release-4.13", "/some/dir")
+        self.assertTrue(result)
+        mock_gather.assert_called_once_with(unittest.mock.ANY)
+
+    @patch("doozerlib.util.exectools.cmd_gather")
+    def test_returns_true_when_tree_is_in_public_history(self, mock_gather):
+        mock_gather.side_effect = [
+            (1, "", ""),
+            (0, "tree123\n", ""),
+            (0, "newer-tree\ntree123\nolder-tree\n", ""),
+        ]
+        result = util.is_commit_in_public_upstream("abc123", "release-4.13", "/some/dir")
+        self.assertTrue(result)
+        self.assertEqual(mock_gather.call_count, 3)
+
+    @patch("doozerlib.util.exectools.cmd_gather")
+    def test_returns_false_when_tree_is_not_in_public_history(self, mock_gather):
+        mock_gather.side_effect = [
+            (1, "", ""),
+            (0, "private-tree\n", ""),
+            (0, "public-tree\n", ""),
+        ]
+        result = util.is_commit_in_public_upstream("abc123", "release-4.13", "/some/dir")
+        self.assertFalse(result)
+
+    @patch("doozerlib.util.exectools.cmd_gather")
+    def test_raises_on_ancestry_check_error(self, mock_gather):
+        mock_gather.return_value = (128, "", "fatal: not a git repo")
+        with self.assertRaises(IOError):
+            util.is_commit_in_public_upstream("abc123", "release-4.13", "/some/dir")
+
+
 class TestIsCommitInPublicUpstreamAsync(unittest.IsolatedAsyncioTestCase):
     @patch("doozerlib.util.exectools.cmd_gather_async")
     async def test_returns_true_on_exit_0(self, mock_gather):
@@ -590,18 +627,118 @@ class TestIsCommitInPublicUpstreamAsync(unittest.IsolatedAsyncioTestCase):
         mock_gather.assert_called_once_with(unittest.mock.ANY, check=False)
 
     @patch("doozerlib.util.exectools.cmd_gather_async")
-    async def test_returns_false_on_exit_1(self, mock_gather):
-        # exit code 1 means "not an ancestor" — must NOT raise ChildProcessError
-        mock_gather.return_value = (1, "", "")
+    async def test_returns_false_when_tree_is_not_in_public_history(self, mock_gather):
+        mock_gather.side_effect = [
+            (1, "", ""),
+            (0, "private-tree\n", ""),
+            (0, "public-tree\n", ""),
+        ]
         result = await util.is_commit_in_public_upstream_async("abc123", "release-4.13", "/some/dir")
         self.assertFalse(result)
-        mock_gather.assert_called_once_with(unittest.mock.ANY, check=False)
+        self.assertEqual(mock_gather.call_count, 3)
+
+    @patch("doozerlib.util.exectools.cmd_gather_async")
+    async def test_returns_true_when_tree_is_in_public_history(self, mock_gather):
+        mock_gather.side_effect = [
+            (1, "", ""),
+            (0, "tree123\n", ""),
+            (0, "newer-tree\ntree123\nolder-tree\n", ""),
+        ]
+        result = await util.is_commit_in_public_upstream_async("abc123", "release-4.13", "/some/dir")
+        self.assertTrue(result)
+        self.assertEqual(mock_gather.call_count, 3)
 
     @patch("doozerlib.util.exectools.cmd_gather_async")
     async def test_raises_on_other_exit_codes(self, mock_gather):
         mock_gather.return_value = (128, "", "fatal: not a git repo")
         with self.assertRaises(IOError):
             await util.is_commit_in_public_upstream_async("abc123", "release-4.13", "/some/dir")
+
+    @patch("doozerlib.util.exectools.cmd_gather_async")
+    async def test_raises_when_tree_cannot_be_resolved(self, mock_gather):
+        mock_gather.side_effect = [(1, "", ""), (128, "", "fatal: bad revision")]
+        with self.assertRaises(IOError):
+            await util.is_commit_in_public_upstream_async("abc123", "release-4.13", "/some/dir")
+
+    @patch("doozerlib.util.exectools.cmd_gather_async")
+    async def test_raises_when_public_history_cannot_be_read(self, mock_gather):
+        mock_gather.side_effect = [
+            (1, "", ""),
+            (0, "tree123\n", ""),
+            (128, "", "fatal: bad public ref"),
+        ]
+        with self.assertRaises(IOError):
+            await util.is_commit_in_public_upstream_async("abc123", "release-4.13", "/some/dir")
+
+
+class TestIsCommitInPublicUpstreamGit(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo_dir = pathlib.Path(self.temp_dir.name)
+        self._git("init")
+        self._git("config", "user.name", "Doozer Test")
+        self._git("config", "user.email", "doozer-test@example.com")
+
+        self._commit_file("source.txt", "base\n", "base")
+        base_commit = self._git("rev-parse", "HEAD")
+
+        self._git("checkout", "-b", "public-lineage")
+        self._commit_file("source.txt", "public content\n", "public change")
+        self.public_equivalent_commit = self._git("rev-parse", "HEAD")
+        self._commit_file("public.txt", "public v1\n", "public advancement")
+        public_v1_commit = self._git("rev-parse", "HEAD")
+
+        self._git("checkout", "--detach", base_commit)
+        self._commit_file("source.txt", "public content\n", "equivalent private change")
+        self.private_equivalent_commit = self._git("rev-parse", "HEAD")
+
+        self._git("checkout", "--detach", self.private_equivalent_commit)
+        self._git("merge", "--no-ff", "-m", "reconcile public", public_v1_commit)
+        self.reconciliation_commit = self._git("rev-parse", "HEAD")
+
+        self._git("checkout", "--detach", self.private_equivalent_commit)
+        self._commit_file("private.txt", "private content\n", "private change")
+        self.private_commit = self._git("rev-parse", "HEAD")
+
+        self._git("checkout", "public-lineage")
+        self._commit_file("public.txt", "public v2\n", "newer public advancement")
+        public_head = self._git("rev-parse", "HEAD")
+        self._git("update-ref", "refs/remotes/public_upstream/main", public_head)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _git(self, *args: str) -> str:
+        result = subprocess.run(
+            ["git", "-C", str(self.repo_dir), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    def _commit_file(self, filename: str, contents: str, message: str):
+        self.repo_dir.joinpath(filename).write_text(contents)
+        self._git("add", filename)
+        self._git("commit", "-m", message)
+
+    async def test_public_ancestry_is_public(self):
+        self.assertTrue(
+            await util.is_commit_in_public_upstream_async(self.public_equivalent_commit, "main", self.repo_dir)
+        )
+
+    async def test_equivalent_sibling_tree_is_public(self):
+        self.assertTrue(
+            await util.is_commit_in_public_upstream_async(self.private_equivalent_commit, "main", self.repo_dir)
+        )
+
+    async def test_reconciliation_tree_matching_older_public_commit_is_public(self):
+        self.assertTrue(
+            await util.is_commit_in_public_upstream_async(self.reconciliation_commit, "main", self.repo_dir)
+        )
+
+    async def test_private_tree_is_private(self):
+        self.assertFalse(await util.is_commit_in_public_upstream_async(self.private_commit, "main", self.repo_dir))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Doozer currently decides whether a source revision contains private fixes using commit ancestry alone. This produces a false positive when public history is rewritten or an equivalent change is cherry-picked under a different SHA.

For `stolostron-kube-rbac-proxy` `backplane-2.11`, source reconciliation created private merge commit [986c9a2](https://github.com/openshift-priv/stolostron-kube-rbac-proxy/commit/986c9a2d743d91170e3c587c32183d5f0cfdbf00) after the public branch lineage changed. The divergence originated when public commit [f2a15bb](https://github.com/stolostron/kube-rbac-proxy/commit/f2a15bb01536e4ae933c5066da5a19c9ab50b8b6) was replaced in the branch lineage by equivalent commit [62b0102](https://github.com/stolostron/kube-rbac-proxy/commit/62b0102cfbd08c592e2b76a5931e15c425a26bb3).

The reconciliation commit is not an ancestor of the public branch, but its complete source tree is identical to public commit [0217ce4](https://github.com/stolostron/kube-rbac-proxy/commit/0217ce4eff4cd6982b705eab6b13950340fa58c6). Doozer therefore incorrectly treated it as a private fix and produced an embargoed `.p3` build.

## Fix

Keep the existing ancestry check as the fast path. When ancestry fails, compare the revision root tree with every tree reachable from the configured public branch. An exact match is treated as public; a genuinely different tree remains private. Git inspection errors still fail closed.

The change applies to both synchronous and asynchronous callers and includes mock and real-Git regression tests for rewritten, cherry-picked, reconciliation, and genuinely private histories.

## Testing

- `uv run ruff check doozer/doozerlib/util.py doozer/tests/test_util.py`
- `uv run ruff format --check doozer/doozerlib/util.py doozer/tests/test_util.py`
- `uv run pytest doozer/tests/test_util.py doozer/tests/backend/test_rebaser.py doozer/tests/cli/test_scan_sources_konflux.py -q`

Result: 206 passed, 53 subtests passed.