### PR TITLE
Pin layered RHCOS pullspec to the repo from config

### DIFF
--- a/artcommon/artcommonlib/rhcos.py
+++ b/artcommon/artcommonlib/rhcos.py
@@ -5,7 +5,6 @@ from artcommonlib.arch_util import go_arch_for_brew_arch
 from artcommonlib.model import ListModel, Model
 from artcommonlib.oc_image_info import oc_image_info__cached
 from artcommonlib.runtime import GroupRuntime
-from artcommonlib.util import get_art_prod_image_repo_for_version
 
 # Historically the only RHCOS container was 'machine-os-content'; see
 # https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
@@ -131,13 +130,12 @@ def get_build_id_from_rhcos_pullspec(pullspec, registry_config: str = None) -> s
     return build_id
 
 
-def get_latest_layered_rhcos_build(container_conf: Model, arch: str, major: int, registry_config: str = None):
+def get_latest_layered_rhcos_build(container_conf: Model, arch: str, registry_config: str = None):
     """
     Get the latest Layered RHCOS build ID and pullspec for the specified rhcos container configuration.
 
     :param container_conf: Payload tag config Model from group.yml (exposes rhel_build_id_index, rhcos_index_tag, etc.)
     :param arch: Brew architecture (e.g., 'x86_64', 'aarch64')
-    :param major: OCP major version, used to select the art-dev repo (e.g. 5 -> ocp-v5.0-art-dev)
     :param registry_config: Optional path to registry auth config file
     :return: Tuple of (build_id, pullspec)
     """
@@ -158,8 +156,10 @@ def get_latest_layered_rhcos_build(container_conf: Model, arch: str, major: int,
         )
         digest = json.loads(rhcos_info_str)['digest']
 
-    # RHCOS images are hosted in the art-dev repository matching the OCP major version
-    # (e.g. ocp-v5.0-art-dev for OCP 5.x), consistent with the rest of the release payload.
-    art_repo = get_art_prod_image_repo_for_version(major=major, repo_type="dev")
-    pullspec = f"{art_repo}@{digest}"
+    # Pin the digest against the same repository the index tag was resolved from, so the
+    # resulting pullspec is always retrievable. RHCOS images are published only to the repo
+    # referenced in config (e.g. ocp-v4.0-art-dev); reconstructing a different repo can yield
+    # a pullspec whose manifest does not exist there.
+    repo = container_conf.rhcos_index_tag.split('@', 1)[0].rsplit(':', 1)[0]
+    pullspec = f"{repo}@{digest}"
     return build_id, pullspec

--- a/artcommon/tests/test_rhcos.py
+++ b/artcommon/tests/test_rhcos.py
@@ -7,17 +7,15 @@ from artcommonlib.model import Model
 
 
 class TestGetLatestLayeredRhcosBuild(unittest.TestCase):
-    def _container_conf(self):
+    @patch("artcommonlib.rhcos.oc_image_info__cached")
+    def test_pullspec_repo_taken_from_config(self, oc_info_mock):
         # rhel_build_id_index == rhcos_index_tag so only one image lookup is needed
-        return Model(
+        container_conf = Model(
             {
-                "rhel_build_id_index": "registry.example.com/rhcos-index:latest",
-                "rhcos_index_tag": "registry.example.com/rhcos-index:latest",
+                "rhel_build_id_index": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:5.0-9.8-node-image",
+                "rhcos_index_tag": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:5.0-9.8-node-image",
             }
         )
-
-    @patch("artcommonlib.rhcos.oc_image_info__cached")
-    def test_repo_tracks_major_version(self, oc_info_mock):
         oc_info_mock.return_value = json.dumps(
             {
                 "config": {"config": {"Labels": {"org.opencontainers.image.version": "5.0.0-ec"}}},
@@ -25,21 +23,33 @@ class TestGetLatestLayeredRhcosBuild(unittest.TestCase):
             }
         )
 
-        build_id, pullspec = rhcos.get_latest_layered_rhcos_build(self._container_conf(), "x86_64", major=5)
+        build_id, pullspec = rhcos.get_latest_layered_rhcos_build(container_conf, "x86_64")
         self.assertEqual(build_id, "5.0.0-ec")
-        self.assertEqual(pullspec, "quay.io/openshift-release-dev/ocp-v5.0-art-dev@sha256:abcd")
+        # Digest is pinned against the repo the index tag was resolved from, not a reconstructed one
+        self.assertEqual(pullspec, "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abcd")
 
     @patch("artcommonlib.rhcos.oc_image_info__cached")
-    def test_repo_for_major_4(self, oc_info_mock):
-        oc_info_mock.return_value = json.dumps(
+    def test_pullspec_repo_from_rhcos_index_tag_when_indexes_differ(self, oc_info_mock):
+        # rhel_build_id_index != rhcos_index_tag: digest (and repo) come from rhcos_index_tag
+        container_conf = Model(
             {
-                "config": {"config": {"Labels": {"org.opencontainers.image.version": "4.19.0"}}},
-                "digest": "sha256:1234",
+                "rhel_build_id_index": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:5.0-9.8-node-image",
+                "rhcos_index_tag": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:5.0-9.8-node-image-extensions",
             }
         )
+        oc_info_mock.side_effect = [
+            json.dumps(
+                {
+                    "config": {"config": {"Labels": {"org.opencontainers.image.version": "5.0.0-ec"}}},
+                    "digest": "sha256:rhel",
+                }
+            ),
+            json.dumps({"digest": "sha256:ext"}),
+        ]
 
-        _, pullspec = rhcos.get_latest_layered_rhcos_build(self._container_conf(), "x86_64", major=4)
-        self.assertEqual(pullspec, "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1234")
+        build_id, pullspec = rhcos.get_latest_layered_rhcos_build(container_conf, "x86_64")
+        self.assertEqual(build_id, "5.0.0-ec")
+        self.assertEqual(pullspec, "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ext")
 
 
 if __name__ == "__main__":

--- a/doozer/doozerlib/cli/release_gen_assembly_targeted.py
+++ b/doozer/doozerlib/cli/release_gen_assembly_targeted.py
@@ -389,7 +389,6 @@ class GenAssemblyTargetedCli:
                 build_id, pullspec = get_latest_layered_rhcos_build(
                     container_conf,
                     arch,
-                    int(self.runtime.group_config.vars['MAJOR']),
                     registry_config=self.runtime.registry_config,
                 )
                 rhcos_config[container_name]["images"][arch] = pullspec

--- a/doozer/doozerlib/cli/scan_sources_konflux.py
+++ b/doozer/doozerlib/cli/scan_sources_konflux.py
@@ -1808,7 +1808,6 @@ class ConfigScanSources:
                         build_id, pullspec = get_latest_layered_rhcos_build(
                             container_conf,
                             brew_arch,
-                            int(self.runtime.group_config.vars['MAJOR']),
                             registry_config=self.runtime.registry_config,
                         )
                     else:

--- a/doozer/doozerlib/rhcos.py
+++ b/doozer/doozerlib/rhcos.py
@@ -251,7 +251,6 @@ class RHCOSBuildFinder:
             build_id, pullspec = rhcos.get_latest_layered_rhcos_build(
                 container_conf,
                 self.brew_arch,
-                int(self.runtime.group_config.vars['MAJOR']),
                 registry_config=self.registry_config,
             )
             return build_id, pullspec


### PR DESCRIPTION
## Summary
Derive the layered RHCOS pullspec repository from the resolved index tag (config) instead of reconstructing it from the OCP major version.

## Why
The digest resolved from `rhcos_index_tag`/`rhel_build_id_index` (e.g. `ocp-v4.0-art-dev:5.0-9.8-node-image`) only exists in that repo. Reconstructing a different repo (`ocp-v5.0-art-dev`) produced a pullspec whose manifest doesn't exist, crashing `release:gen-payload` with `manifest unknown` and breaking the 5.0 build-sync-konflux pipeline. Pinning against the config repo is always retrievable and follows config automatically if it later moves to v5.0.

## Changes
- `get_latest_layered_rhcos_build`: build pullspec as `<repo-from-config-index-tag>@<digest>`; drop the `major` param.
- Revert the three callers to no longer pass `major`.
- Update unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layered RHCOS build lookups by using configured image indexes instead of deriving repositories from the OCP major version.
  * Added support for selecting the correct RHEL and RHCOS repositories, including digest-pinned results.
* **Refactor**
  * Simplified layered RHCOS lookup configuration by removing the required major-version parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->