### PR TITLE
Resolve dnf --installroot packages with --bare in rpm-lockfile-prototype

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -58,14 +58,44 @@ _BARE_UPDATE_RE = re.compile(
     r"\b(?:microdnf|dnf|yum)\s+(?:-y\s+)?(?:update|upgrade)(?:\s+-y)?\s*(?:\\\n\s*&&\s*|&&\s*|;\s*|\n|(?=$))"
 )
 
+# Flags between the manager and ``install`` must not cross ``&&`` / ``;``
+# or a mixed RUN (normal install + --installroot) would skip the first command.
 _INSTALL_CMD_RE = re.compile(
-    r"\b(?:microdnf|dnf|yum)\s+(?:.*?\s+)?install\b(.*?)(?:&&|;|\n|$)",
+    r"\b(?:microdnf|dnf|yum)\s+(?:[^\n&;]*?\s+)?install\b(.*?)(?:&&|;|\n|$)",
     re.DOTALL,
 )
+
+_INSTALLROOT_RE = re.compile(r"--installroot(?:=|\s+)\S+")
 
 _PKG_NAME_RE = re.compile(r"^[a-zA-Z][\w.+\-]*$")
 
 _RPM_ARCHES = frozenset({"x86_64", "aarch64", "ppc64le", "s390x", "i686", "noarch", "src"})
+
+
+def _tokens_from_install_args(install_args: str) -> set[str]:
+    """
+    Parse package names from the argument tail of a dnf/yum install
+    command. Flags (``-*``), variables (``$*``), and non-package
+    tokens are skipped. Architecture qualifiers (e.g. glibc.x86_64)
+    are stripped.
+
+    Arg(s):
+        install_args (str): Text after the ``install`` verb.
+    Return Value(s):
+        set[str]: Package names.
+    """
+    packages: set[str] = set()
+    for token in install_args.split():
+        token = token.strip().rstrip("\\")
+        if token.startswith("-") or token.startswith("$"):
+            continue
+        if _PKG_NAME_RE.match(token):
+            if "." in token:
+                name, _, suffix = token.rpartition(".")
+                if suffix in _RPM_ARCHES:
+                    token = name
+            packages.add(token)
+    return packages
 
 
 def _extract_install_packages(entries: list[dict], stage_num: int) -> set[str]:
@@ -91,16 +121,39 @@ def _extract_install_packages(entries: list[dict], stage_num: int) -> set[str]:
             current_stage += 1
         elif entry["instruction"] == "RUN" and current_stage == stage_num:
             for m in _INSTALL_CMD_RE.finditer(entry["value"]):
-                for token in m.group(1).split():
-                    token = token.strip().rstrip("\\")
-                    if token.startswith("-") or token.startswith("$"):
-                        continue
-                    if _PKG_NAME_RE.match(token):
-                        if "." in token:
-                            name, _, suffix = token.rpartition(".")
-                            if suffix in _RPM_ARCHES:
-                                token = name
-                        packages.add(token)
+                packages |= _tokens_from_install_args(m.group(1))
+    return packages
+
+
+def _extract_installroot_packages(entries: list[dict], stage_num: int) -> set[str]:
+    """
+    Extract package names from dnf/yum/microdnf install commands that
+    use ``--installroot``. Those packages are installed into an empty
+    root, not into the stage image, so they must be resolved with
+    ``--bare``.
+
+    ``dnf --installroot … clean all`` has no install verb and is
+    ignored. Both ``--installroot=/path`` and ``--installroot /path``
+    forms are recognized.
+
+    Arg(s):
+        entries (list[dict]): DockerfileParser structure entries.
+        stage_num (int): 0-indexed stage number.
+    Return Value(s):
+        set[str]: Package names from --installroot install commands.
+    """
+    packages: set[str] = set()
+    current_stage = -1
+    for entry in entries:
+        if entry["instruction"] == "FROM":
+            current_stage += 1
+        elif entry["instruction"] == "RUN" and current_stage == stage_num:
+            if not _INSTALLROOT_RE.search(entry["value"]):
+                continue
+            for m in _INSTALL_CMD_RE.finditer(entry["value"]):
+                if not _INSTALLROOT_RE.search(m.group(0)):
+                    continue
+                packages |= _tokens_from_install_args(m.group(1))
     return packages
 
 
@@ -415,6 +468,11 @@ class RpmLockfilePrototypeGenerator:
         Stages without RUN commands (and no $(cat ...) extra packages)
         are skipped — they can't install RPMs. The final stage is always
         processed because it may need base image reinstall packages.
+
+        ``dnf --installroot`` packages are resolved separately with
+        ``--bare`` (empty rpmdb). They are not installs into the stage
+        image. Stages whose only RPM work is --installroot skip the
+        ``--image`` pass entirely.
         """
         stage_lockfiles: list[LockfileData] = []
         final_stage_num = total_stages - 1
@@ -425,13 +483,49 @@ class RpmLockfilePrototypeGenerator:
                     self.logger.debug(f"{distgit_key}: stage {stage_num}: no RUN commands, skipping")
                     continue
 
-            image_pullspec = await self._determine_stage_pullspec(stage_num, distgit_key)
-
             if stage_num != final_stage_num:
                 if self._has_rhel_version_mismatch(stage_num, repo_list, distgit_key):
                     continue
 
             extra_packages: list[str] = list(cat_packages.get(stage_num, []))
+            installroot_pkgs = _extract_installroot_packages(entries, stage_num)
+            normal_install_pkgs = _extract_install_packages(entries, stage_num) - installroot_pkgs
+            # --installroot is empty-root, not an install into the stage image.
+            # Skip --image when this stage has nothing else that needs the
+            # base-image rpmdb (CLO builder: make build + dnf --installroot).
+            skip_image_mode = bool(installroot_pkgs) and not (
+                normal_install_pkgs
+                or extra_packages
+                or stage_num in stages_with_bare_updates
+                or stage_num == final_stage_num
+            )
+
+            stage_results: list[LockfileData] = []
+            if installroot_pkgs:
+                self.logger.info(
+                    f"{distgit_key}: stage {stage_num}: resolving {len(installroot_pkgs)} "
+                    f"--installroot packages in bare mode: {sorted(installroot_pkgs)}"
+                )
+                installroot_result = await self._resolve_with_reconciliation(
+                    repo_list,
+                    arches,
+                    sorted(installroot_pkgs),
+                    None,
+                    distgit_key,
+                    stage_num,
+                    containerfile_path=None,
+                )
+                if installroot_result:
+                    stage_results.append(installroot_result)
+
+            if skip_image_mode:
+                if stage_results:
+                    stage_lockfiles.append(
+                        merge_lockfiles(stage_results) if len(stage_results) > 1 else stage_results[0]
+                    )
+                continue
+
+            image_pullspec = await self._determine_stage_pullspec(stage_num, distgit_key)
 
             reinstall_pkgs: list[str] | None = None
             upgrade_pkgs: list[str] | None = None
@@ -488,14 +582,16 @@ class RpmLockfilePrototypeGenerator:
                 reinstall_packages=reinstall_pkgs,
                 containerfile_path=str(dockerfile_path),
                 upgrade_packages=upgrade_pkgs,
+                exclude_packages=sorted(installroot_pkgs) if installroot_pkgs else None,
             )
 
             # Pass 2: pin Dockerfile packages that overlap with the base
             # image. These are "already installed" so neither install nor
             # upgrade captures them, but cachi2 needs them in the lockfile.
             # Runs for every image-backed stage, not just final/bare-update.
+            # --installroot names are resolved in the bare pass above.
             if image_pullspec:
-                dockerfile_install_pkgs = _extract_install_packages(entries, stage_num)
+                dockerfile_install_pkgs = _extract_install_packages(entries, stage_num) - installroot_pkgs
                 if dockerfile_install_pkgs:
                     if upgrade_pkgs:
                         base_pkg_set = set(upgrade_pkgs)
@@ -515,7 +611,9 @@ class RpmLockfilePrototypeGenerator:
                         )
 
             if result:
-                stage_lockfiles.append(result)
+                stage_results.append(result)
+            if stage_results:
+                stage_lockfiles.append(merge_lockfiles(stage_results) if len(stage_results) > 1 else stage_results[0])
 
         return stage_lockfiles
 
@@ -658,6 +756,7 @@ class RpmLockfilePrototypeGenerator:
         reinstall_packages: list[str] | None = None,
         containerfile_path: str | None = None,
         upgrade_packages: list[str] | None = None,
+        exclude_packages: list[str] | None = None,
     ) -> LockfileData | None:
         """
         Resolve a single stage, retrying after removing unavailable packages.
@@ -679,6 +778,9 @@ class RpmLockfilePrototypeGenerator:
                 package extraction.
             upgrade_packages (list[str] | None): Base image packages to
                 upgrade (from bare dnf/yum update commands).
+            exclude_packages (list[str] | None): Packages to exclude
+                from Containerfile extraction (e.g. --installroot names
+                resolved separately in --bare mode).
         Return Value(s):
             LockfileData | None: Lockfile data, or None if all packages filtered out.
         """
@@ -698,7 +800,7 @@ class RpmLockfilePrototypeGenerator:
         remaining_upgrade = list(upgrade_packages) if upgrade_packages else []
         real_retries = 0
         reinstall_strip_count = 0
-        excluded_packages: set[str] = set()
+        excluded_packages: set[str] = set(exclude_packages) if exclude_packages else set()
 
         while real_retries < MAX_RESOLUTION_RETRIES:
             all_upgrade_targets = list(remaining_reinstall)
@@ -905,6 +1007,7 @@ class RpmLockfilePrototypeGenerator:
         reinstall_packages: list[str] | None = None,
         containerfile_path: str | None = None,
         upgrade_packages: list[str] | None = None,
+        exclude_packages: list[str] | None = None,
     ) -> LockfileData | None:
         """
         Resolve a stage with cross-arch version reconciliation.
@@ -926,6 +1029,8 @@ class RpmLockfilePrototypeGenerator:
                 package extraction.
             upgrade_packages (list[str] | None): Base image packages to
                 upgrade (from bare dnf/yum update commands).
+            exclude_packages (list[str] | None): Packages to exclude
+                from Containerfile extraction (e.g. --installroot names).
         Return Value(s):
             LockfileData | None: Resolved lockfile with consistent
                 versions, or None if no packages remain.
@@ -940,6 +1045,7 @@ class RpmLockfilePrototypeGenerator:
             reinstall_packages=reinstall_packages,
             containerfile_path=containerfile_path,
             upgrade_packages=upgrade_packages,
+            exclude_packages=exclude_packages,
         )
         if not first_pass:
             return None
@@ -978,6 +1084,7 @@ class RpmLockfilePrototypeGenerator:
                 reinstall_packages=pinned_reinstall,
                 containerfile_path=containerfile_path,
                 upgrade_packages=pinned_upgrade,
+                exclude_packages=exclude_packages,
             )
         except RuntimeError as e:
             raise RuntimeError(

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -14,6 +14,8 @@ from doozerlib.lockfile_prototype.container_utils import ContainerImageHelper
 from doozerlib.lockfile_prototype.generator import (
     RpmLockfilePrototypeGenerator,
     _detect_stages_with_bare_updates,
+    _extract_install_packages,
+    _extract_installroot_packages,
     _is_local_rpm,
     build_rpms_in_yaml,
 )
@@ -1491,3 +1493,282 @@ class TestBareUpdateUpgradeResolution(unittest.TestCase):
         # over the upgrade request, silently keeping the old version.
         self.assertNotIn("python3-setuptools", config.reinstallPackages)
         self.assertIn("python3-setuptools", config.upgradePackages)
+
+
+def _lockfile_with_packages(names: list[str]) -> LockfileData:
+    return LockfileData(
+        lockfileVersion=1,
+        lockfileVendor="redhat",
+        arches=[
+            ArchResult(
+                arch="x86_64",
+                packages=[
+                    PackageEntry(
+                        url=f"https://example.com/{n}-1.0-1.el9.x86_64.rpm",
+                        repoid="rhel-9-baseos-rpms",
+                        name=n,
+                        evr="1.0-1.el9",
+                    )
+                    for n in names
+                ],
+                source=[],
+                module_metadata=[],
+            )
+        ],
+    )
+
+
+class TestExtractInstallrootPackages(unittest.TestCase):
+    """
+    Tests for _extract_installroot_packages vs normal dnf install.
+    """
+
+    def _entries_from_dockerfile(self, content: str) -> list[dict]:
+        from dockerfile_parse import DockerfileParser
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            df_path = Path(tmpdir) / "Dockerfile"
+            df_path.write_text(content)
+            return DockerfileParser(str(df_path)).structure
+
+    def test_equals_form(self):
+        entries = self._entries_from_dockerfile(
+            "FROM base\nRUN dnf --installroot=/mnt/rootfs install -y rsync xz tar gzip python3-pyyaml\n"
+        )
+        self.assertEqual(
+            _extract_installroot_packages(entries, 0),
+            {"rsync", "xz", "tar", "gzip", "python3-pyyaml"},
+        )
+
+    def test_space_form(self):
+        entries = self._entries_from_dockerfile("FROM base\nRUN dnf --installroot /mnt/rootfs install -y rsync xz\n")
+        self.assertEqual(_extract_installroot_packages(entries, 0), {"rsync", "xz"})
+        self.assertNotIn("/mnt/rootfs", _extract_installroot_packages(entries, 0))
+
+    def test_clean_all_ignored(self):
+        entries = self._entries_from_dockerfile(
+            "FROM base\n"
+            "RUN dnf --installroot=/mnt/rootfs install -y rsync xz \\\n"
+            "      && dnf --installroot=/mnt/rootfs clean all\n"
+        )
+        self.assertEqual(_extract_installroot_packages(entries, 0), {"rsync", "xz"})
+
+    def test_normal_install_not_treated_as_installroot(self):
+        entries = self._entries_from_dockerfile("FROM base\nRUN dnf install -y nfs-utils jq\n")
+        self.assertEqual(_extract_installroot_packages(entries, 0), set())
+        self.assertEqual(_extract_install_packages(entries, 0), {"nfs-utils", "jq"})
+
+    def test_mixed_run_only_installroot_match(self):
+        entries = self._entries_from_dockerfile(
+            "FROM base\nRUN dnf install -y gcc && dnf --installroot=/mnt/rootfs install -y rsync\n"
+        )
+        self.assertEqual(_extract_installroot_packages(entries, 0), {"rsync"})
+        self.assertEqual(_extract_install_packages(entries, 0), {"gcc", "rsync"})
+        self.assertEqual(
+            _extract_install_packages(entries, 0) - _extract_installroot_packages(entries, 0),
+            {"gcc"},
+        )
+
+    def test_clean_all_only_ignored(self):
+        entries = self._entries_from_dockerfile("FROM base\nRUN dnf --installroot=/mnt/rootfs clean all\n")
+        self.assertEqual(_extract_installroot_packages(entries, 0), set())
+
+
+class TestInstallrootBareResolve(unittest.TestCase):
+    """
+    Tests for --installroot packages resolved with --bare in generate_lockfile.
+    """
+
+    def _make_mock_repos(self) -> MagicMock:
+        repos = MagicMock()
+        baseos = MagicMock()
+        baseos.name = "rhel-9-baseos-rpms"
+        baseos.baseurl.return_value = "https://example.com/baseos/x86_64/os/"
+        baseos.content_set.return_value = "rhel-9-for-x86_64-baseos-rpms"
+        baseos.cs_optional = False
+        baseos._data.conf = {}
+        repo_map = {"rhel-9-baseos-rpms": baseos}
+        repos.__getitem__ = lambda self_repos, key: repo_map[key]
+        return repos
+
+    def _make_mock_image_meta(self) -> MagicMock:
+        meta = MagicMock()
+        meta.distgit_key = "cluster-logging-operator"
+        meta.get_arches.return_value = ["x86_64"]
+        meta.get_enabled_repos.return_value = {"rhel-9-baseos-rpms"}
+        meta.is_lockfile_generation_enabled.return_value = True
+        meta.is_cross_arch_enabled.return_value = False
+        return meta
+
+    def test_clo_like_skips_image_mode_for_installroot_only_stage(self):
+        """
+        Stage 0 only uses dnf --installroot: resolve those names with
+        --bare (no golang-builder pull). Final stage still uses --image.
+        """
+        installroot_names = ["gzip", "python3-pyyaml", "rsync", "tar", "xz"]
+
+        async def mock_resolve(config, image_pullspec=None, containerfile_path=None, stage_num=None):
+            if image_pullspec is None:
+                names = [p if isinstance(p, str) else p.name for p in config.packages]
+                return _lockfile_with_packages(names)
+            return FAKE_LOCKFILE_DATA.model_copy(deep=True)
+
+        container = MagicMock(spec=ContainerImageHelper)
+        container.resolve_to_digest = AsyncMock(side_effect=lambda p: p + "@sha256:abc123")
+        container.get_installed_packages = AsyncMock(return_value=[])
+        container.read_file_from_image = AsyncMock(return_value="")
+
+        resolver = MagicMock(spec=RpmResolver)
+        resolver.resolve = AsyncMock(side_effect=mock_resolve)
+
+        generator = RpmLockfilePrototypeGenerator(
+            repos=self._make_mock_repos(),
+            working_dir=Path(tempfile.mkdtemp()),
+            container_helper=container,
+            resolver=resolver,
+        )
+        generator.downstream_parents = [
+            "quay.io/test/golang-builder:latest",
+            "quay.io/test/ubi-micro:latest",
+        ]
+
+        with TemporaryDirectory() as tmpdir:
+            dest_dir = Path(tmpdir)
+            (dest_dir / "Dockerfile").write_text(
+                "FROM golang-builder AS builder\n"
+                "RUN make build\n"
+                "RUN dnf --installroot=/mnt/rootfs install -y rsync xz tar gzip python3-pyyaml "
+                "&& dnf --installroot=/mnt/rootfs clean all\n"
+                "\n"
+                "FROM ubi-micro\n"
+                "COPY --from=builder /mnt/rootfs /\n"
+            )
+            asyncio.run(generator.generate_lockfile(self._make_mock_image_meta(), dest_dir))
+
+            lockfile_path = dest_dir / "rpms.lock.yaml"
+            self.assertTrue(lockfile_path.exists())
+            dumped = yaml.safe_load(lockfile_path.read_text())
+
+        digest_args = [c.args[0] for c in container.resolve_to_digest.call_args_list]
+        self.assertFalse(any("golang-builder" in p for p in digest_args))
+
+        bare_calls = [c for c in resolver.resolve.call_args_list if c.kwargs.get("image_pullspec") is None]
+        self.assertEqual(len(bare_calls), 1)
+        self.assertIsNone(bare_calls[0].kwargs.get("containerfile_path"))
+        self.assertEqual(sorted(bare_calls[0].args[0].packages), installroot_names)
+
+        image_calls = [c for c in resolver.resolve.call_args_list if c.kwargs.get("image_pullspec")]
+        self.assertTrue(image_calls)
+        self.assertFalse(any("golang-builder" in (c.kwargs.get("image_pullspec") or "") for c in image_calls))
+
+        locked_names = {pkg["name"] for arch in dumped["arches"] for pkg in arch.get("packages", [])}
+        for name in installroot_names:
+            self.assertIn(name, locked_names)
+
+    def test_normal_install_still_uses_image_mode(self):
+        """
+        A stage with only dnf install (no --installroot) must keep --image
+        and must not add a --bare resolve call.
+        """
+        container = MagicMock(spec=ContainerImageHelper)
+        container.resolve_to_digest = AsyncMock(side_effect=lambda p: p + "@sha256:abc123")
+        container.get_installed_packages = AsyncMock(return_value=[])
+        container.read_file_from_image = AsyncMock(return_value="")
+
+        resolver = MagicMock(spec=RpmResolver)
+        resolver.resolve = AsyncMock(return_value=FAKE_LOCKFILE_DATA.model_copy(deep=True))
+
+        generator = RpmLockfilePrototypeGenerator(
+            repos=self._make_mock_repos(),
+            working_dir=Path(tempfile.mkdtemp()),
+            container_helper=container,
+            resolver=resolver,
+        )
+        generator.downstream_parents = ["quay.io/test/base:latest"]
+
+        with TemporaryDirectory() as tmpdir:
+            dest_dir = Path(tmpdir)
+            (dest_dir / "Dockerfile").write_text("FROM base\nRUN dnf install -y nfs-utils\n")
+            asyncio.run(generator.generate_lockfile(self._make_mock_image_meta(), dest_dir))
+
+        bare_calls = [c for c in resolver.resolve.call_args_list if c.kwargs.get("image_pullspec") is None]
+        self.assertEqual(bare_calls, [])
+        image_calls = [c for c in resolver.resolve.call_args_list if c.kwargs.get("image_pullspec")]
+        self.assertTrue(image_calls)
+        self.assertTrue(any(c.kwargs.get("containerfile_path") for c in image_calls))
+
+    def test_mixed_stage_bare_and_image_merged(self):
+        """
+        A stage with both a normal dnf install and --installroot: --bare
+        for installroot names, --image with those names excluded from
+        pin, results merged.
+        """
+
+        async def mock_resolve(config, image_pullspec=None, containerfile_path=None, stage_num=None):
+            if image_pullspec is None:
+                names = [p if isinstance(p, str) else p.name for p in config.packages]
+                return _lockfile_with_packages(names)
+            if config.reinstallPackages:
+                return _lockfile_with_packages(list(config.reinstallPackages))
+            return FAKE_LOCKFILE_DATA.model_copy(deep=True)
+
+        container = MagicMock(spec=ContainerImageHelper)
+        container.resolve_to_digest = AsyncMock(side_effect=lambda p: p + "@sha256:abc123")
+        container.get_installed_packages = AsyncMock(return_value=["gcc", "rsync", "xz", "glibc"])
+        container.read_file_from_image = AsyncMock(return_value="")
+
+        resolver = MagicMock(spec=RpmResolver)
+        resolver.resolve = AsyncMock(side_effect=mock_resolve)
+
+        generator = RpmLockfilePrototypeGenerator(
+            repos=self._make_mock_repos(),
+            working_dir=Path(tempfile.mkdtemp()),
+            container_helper=container,
+            resolver=resolver,
+        )
+        generator.downstream_parents = [
+            "quay.io/test/builder:latest",
+            "quay.io/test/base:latest",
+        ]
+
+        with TemporaryDirectory() as tmpdir:
+            dest_dir = Path(tmpdir)
+            (dest_dir / "Dockerfile").write_text(
+                "FROM builder AS build\n"
+                "RUN dnf install -y gcc\n"
+                "RUN dnf --installroot=/mnt/rootfs install -y rsync xz\n"
+                "\n"
+                "FROM base\n"
+                "COPY --from=build /app /app\n"
+            )
+            asyncio.run(generator.generate_lockfile(self._make_mock_image_meta(), dest_dir))
+
+            dumped = yaml.safe_load((dest_dir / "rpms.lock.yaml").read_text())
+
+        bare_calls = [c for c in resolver.resolve.call_args_list if c.kwargs.get("image_pullspec") is None]
+        self.assertEqual(len(bare_calls), 1)
+        self.assertEqual(sorted(bare_calls[0].args[0].packages), ["rsync", "xz"])
+        self.assertIsNone(bare_calls[0].kwargs.get("containerfile_path"))
+
+        stage0_image = [
+            c
+            for c in resolver.resolve.call_args_list
+            if c.kwargs.get("containerfile_path") and "builder" in (c.kwargs.get("image_pullspec") or "")
+        ]
+        self.assertTrue(stage0_image)
+        self.assertEqual(sorted(stage0_image[0].args[0].excludePackages), ["rsync", "xz"])
+
+        pin_calls = [
+            c for c in resolver.resolve.call_args_list if c.kwargs.get("image_pullspec") and c.args[0].reinstallPackages
+        ]
+        self.assertTrue(pin_calls)
+        for call in pin_calls:
+            self.assertNotIn("rsync", call.args[0].reinstallPackages)
+            self.assertNotIn("xz", call.args[0].reinstallPackages)
+            self.assertNotIn("rsync", call.args[0].packages)
+            self.assertNotIn("xz", call.args[0].packages)
+
+        locked_names = {pkg["name"] for arch in dumped["arches"] for pkg in arch.get("packages", [])}
+        self.assertIn("rsync", locked_names)
+        self.assertIn("xz", locked_names)
+        self.assertIn("gcc", locked_names)


### PR DESCRIPTION
## Summary
- `dnf --installroot` installs into an empty root, not the stage image. Resolving those names with `--image` (e.g. golang-builder) saw them as already installed, produced an empty RPM lockfile, and broke hermetic Konflux (no yum repos).
- Split resolve: installroot package names go through `--bare`; stages whose only RPM work is `--installroot` skip the `--image`/pin path entirely (CLO builder). Mixed stages keep `--image` and exclude those names from pin.
- Normal `dnf install` into the stage image is unchanged.

## Failed job
Konflux pipeline run `logging-6-7-cluster-logging-operator-lwx4l` (`art-logging-tenant` / `logging-6-7`). Hermetic `dnf --installroot` failed with no yum repos after an empty RPM lockfile.

## Test plan
- [x] `uv run pytest --verbose --color=yes doozer/tests/lockfile_prototype/test_generator.py` (89 passed)
- [ ] Re-run `build/layered-products` for logging-6.7 `cluster-logging-operator` with `ART_TOOLS_COMMIT` pointing at this branch
- [ ] Confirm no pin-pass `rsync` warnings; `rpms.lock.yaml` contains `rsync`/`xz`/deps; Hermeto RPM prefetch downloads; hermetic `dnf --installroot` sees a yum repo