### PR TITLE
ART-21728: Extend scheduled Conforma verification to layered products

### DIFF
--- a/artcommon/artcommonlib/constants.py
+++ b/artcommon/artcommonlib/constants.py
@@ -124,6 +124,40 @@ PRODUCT_BASE_IMAGE_KONFLUX_RELEASE_MAP = {
     "zero-trust-workload-identity-manager": ("oap-zt-images-base-silent", "oap-images-base"),
 }
 
+# Layered-product release-time EC policies for scheduled Conforma verification.
+# Image/bundle policies use the product stage policy; FBC policies follow the
+# product's release configuration. OCP lifecycle variants are intentionally excluded.
+LAYERED_PRODUCT_CONFORMA_STAGE_POLICY_MAP = {
+    "rhacm2": (
+        "rhtap-releng-tenant/registry-art-acm-stage",
+        "rhtap-releng-tenant/fbc-art-acm-stage",
+    ),
+    "multicluster-engine": (
+        "rhtap-releng-tenant/registry-art-acm-stage",
+        "rhtap-releng-tenant/fbc-art-acm-stage",
+    ),
+    "oadp": (
+        "rhtap-releng-tenant/registry-art-oadp-stage",
+        "rhtap-releng-tenant/fbc-art-oadp-stage",
+    ),
+    "mta": (
+        "rhtap-releng-tenant/registry-art-mta-stage",
+        "rhtap-releng-tenant/fbc-stage",
+    ),
+    "rhmtc": (
+        "rhtap-releng-tenant/registry-art-mtc-stage",
+        "rhtap-releng-tenant/fbc-stage",
+    ),
+    "openshift-logging": (
+        "rhtap-releng-tenant/registry-art-logging-stage",
+        "rhtap-releng-tenant/fbc-stage",
+    ),
+    "oc-mirror": (
+        "rhtap-releng-tenant/registry-standard",
+        None,
+    ),
+}
+
 # Pre-release lifecycle (software_lifecycle.phase) — registry-ocp-art-base-ec-prod via ART-19498.
 PRODUCT_BASE_IMAGE_KONFLUX_EC_RELEASE_MAP = {
     "ocp": ("ocp-art-images-base-silent-ec", "art-images-base"),

--- a/artcommon/artcommonlib/konflux/konflux_db.py
+++ b/artcommon/artcommonlib/konflux/konflux_db.py
@@ -1355,6 +1355,7 @@ class KonfluxDb:
 
         # Extract additional filters from where if provided
         assembly = where.get('assembly') if where else None
+        group = where.get('group') if where else None
         el_target = where.get('el_target') if where else None
         artifact_type = where.get('artifact_type') if where else None
         engine = where.get('engine') if where else None
@@ -1366,6 +1367,7 @@ class KonfluxDb:
                 nvr=nvr,
                 outcome=outcome,
                 assembly=assembly,
+                group=group,
                 el_target=el_target,
                 artifact_type=artifact_type,
                 engine=engine,

--- a/artcommon/tests/test_konflux_db.py
+++ b/artcommon/tests/test_konflux_db.py
@@ -748,6 +748,28 @@ class TestKonfluxDB(IsolatedAsyncioTestCase):
             nvr=nvr, outcome=KonfluxBuildOutcome.SUCCESS, strict=True, exclude_large_columns=False
         )
 
+    @patch("artcommonlib.konflux.konflux_db.KonfluxDb.get_latest_build")
+    async def test_get_build_records_by_nvrs_preserves_group_filter(self, get_latest_build_mock: MagicMock):
+        get_latest_build_mock.return_value = KonfluxBuildRecord(nvr="test-1.0-1")
+
+        records = await self.db.get_build_records_by_nvrs(
+            ["test-1.0-1"], where={"group": "oadp-1.5", "engine": "konflux"}
+        )
+
+        self.assertEqual(len(records), 1)
+        get_latest_build_mock.assert_awaited_once_with(
+            nvr="test-1.0-1",
+            outcome=KonfluxBuildOutcome.SUCCESS,
+            assembly=None,
+            group="oadp-1.5",
+            el_target=None,
+            artifact_type=None,
+            engine="konflux",
+            embargoed=None,
+            strict=True,
+            exclude_large_columns=False,
+        )
+
     def test_get_latest_build_with_string_enums(self):
         """Test that string enum parameters can be converted to enums for cache comparisons"""
         # This tests the critical fix: elliott CLI passes enum parameters as strings (e.g., 'konflux', 'success'),

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -905,10 +905,10 @@ def start_scan_operator(version: str, **kwargs) -> Optional[str]:
 
 
 def start_build_conforma_verify(
-    build_version: str,
+    group: str,
     assembly: str = 'stream',
     ec_policy: str = '',
-    fbc_ec_policy: str = '',
+    fbc_ec_policy: Optional[str] = '',
     effective_time: str = '',
     include_bundles: bool = False,
     include_fbcs: bool = False,
@@ -918,7 +918,7 @@ def start_build_conforma_verify(
     **kwargs,
 ) -> Optional[str]:
     params = {
-        'BUILD_VERSION': build_version,
+        'GROUP': group,
         'ASSEMBLY': assembly,
         'EC_POLICY': ec_policy,
         'EC_POLICY_FBC': fbc_ec_policy,

--- a/pyartcd/pyartcd/pipelines/build_conforma_verify.py
+++ b/pyartcd/pyartcd/pipelines/build_conforma_verify.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 
 import click
 from artcommonlib import exectools, logutil
-from artcommonlib.constants import KONFLUX_DEFAULT_NAMESPACE
+from artcommonlib.constants import KONFLUX_DEFAULT_NAMESPACE, PRODUCT_KUBECONFIG_MAP, PRODUCT_NAMESPACE_MAP
 from artcommonlib.konflux.konflux_build_record import (
     Engine,
     KonfluxBuildOutcome,
@@ -28,7 +28,7 @@ from doozerlib.constants import (
     KONFLUX_EC_PIPELINE_REVISION,
 )
 
-from pyartcd import constants
+from pyartcd import constants, util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.runtime import Runtime
 from pyartcd.slack import SlackClient
@@ -42,7 +42,7 @@ class BuildConformaVerifyPipeline:
     def __init__(
         self,
         runtime: Runtime,
-        version: str,
+        group: str,
         assembly: str,
         builds: Optional[List[str]],
         data_path: Optional[str] = None,
@@ -57,7 +57,9 @@ class BuildConformaVerifyPipeline:
         slack_client: Optional[SlackClient] = None,
     ):
         self.runtime = runtime
-        self.version = version
+        self.group = group
+        self.namespace = KONFLUX_DEFAULT_NAMESPACE
+        self.kubeconfig_env_var = 'KONFLUX_SA_KUBECONFIG'
         self.assembly = assembly
         self.builds = builds or []
         self.data_path = data_path or constants.OCP_BUILD_DATA_URL
@@ -75,8 +77,6 @@ class BuildConformaVerifyPipeline:
 
         self.working_dir = self.runtime.working_dir / "conforma_verify"
         self.working_dir.mkdir(parents=True, exist_ok=True)
-
-        self.group = f"openshift-{version}"
 
     @property
     def _elliott_base_command(self) -> list[str]:
@@ -107,7 +107,26 @@ class BuildConformaVerifyPipeline:
             f'--data-path={self.data_path}',
         ]
 
+    async def _resolve_layered_product_settings(self):
+        """Load group config to resolve the Konflux namespace and kubeconfig for this group."""
+        group_config = await util.load_group_config(
+            group=self.group,
+            assembly=self.assembly,
+            doozer_data_path=self.data_path,
+            doozer_data_gitref=self.data_gitref,
+        )
+        product = group_config.get('product')
+        if not product:
+            raise ValueError(f"No product configured for layered-product group '{self.group}'")
+        if product not in PRODUCT_NAMESPACE_MAP or product not in PRODUCT_KUBECONFIG_MAP:
+            raise ValueError(f"Unsupported layered-product group '{self.group}' product '{product}'")
+
+        self.namespace = PRODUCT_NAMESPACE_MAP[product]
+        self.kubeconfig_env_var = PRODUCT_KUBECONFIG_MAP[product]
+
     async def run(self):
+        if not self.group.startswith('openshift-'):
+            await self._resolve_layered_product_settings()
         any_failed = False
         image_failed = 0
         bundle_failed = 0
@@ -354,9 +373,13 @@ class BuildConformaVerifyPipeline:
 
         Returns (passed, violations_by_component).
         """
-        kubeconfig = os.getenv("KONFLUX_SA_KUBECONFIG")
+        kubeconfig = os.getenv(self.kubeconfig_env_var)
+        if not kubeconfig:
+            raise ValueError(
+                f"Kubeconfig environment variable {self.kubeconfig_env_var} is not set for group '{self.group}'"
+            )
         konflux_client = KonfluxClient.from_kubeconfig(
-            default_namespace=KONFLUX_DEFAULT_NAMESPACE,
+            default_namespace=self.namespace,
             config_file=kubeconfig,
             context=None,
             dry_run=self.dry_run,
@@ -436,7 +459,7 @@ class BuildConformaVerifyPipeline:
                 "kind": "PipelineRun",
                 "metadata": {
                     "generateName": generate_name,
-                    "namespace": KONFLUX_DEFAULT_NAMESPACE,
+                    "namespace": self.namespace,
                     "labels": labels,
                     "annotations": {
                         "test.appstudio.openshift.io/kind": "enterprise-contract",
@@ -479,7 +502,7 @@ class BuildConformaVerifyPipeline:
 
         async def _wait_for_batch(batch_idx: int, batch: list[dict], plr_name: str) -> dict:
             try:
-                plr_info = await konflux_client.wait_for_pipelinerun(plr_name, namespace=KONFLUX_DEFAULT_NAMESPACE)
+                plr_info = await konflux_client.wait_for_pipelinerun(plr_name, namespace=self.namespace)
                 plr_url = KonfluxClient.resource_url(plr_info.to_dict())
                 condition = plr_info.find_condition("Succeeded")
                 outcome = KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition(condition)
@@ -559,7 +582,7 @@ class BuildConformaVerifyPipeline:
             if "verify" not in pod_name:
                 continue
 
-            namespace = pod_info.namespace or KONFLUX_DEFAULT_NAMESPACE
+            namespace = pod_info.namespace or self.namespace
             for step_name in ("step-report", "step-detailed-report"):
                 try:
                     log = konflux_client.corev1_client.read_namespaced_pod_log(
@@ -700,7 +723,7 @@ class BuildConformaVerifyPipeline:
         else:
             detail = "failed (no violation details available)"
         message = (
-            f":warning: build-conforma-verify in {self.version} "
+            f":warning: build-conforma-verify in {self.group} "
             f"(assembly=`{self.assembly}`) {detail} "
             f"(effective_time=`{self.effective_time}`)"
         )
@@ -719,8 +742,8 @@ class BuildConformaVerifyPipeline:
             await self.slack_client.say_in_thread("\n".join(lines))
 
 
-@cli.command("build-conforma-verify", short_help="Run Conforma (EC) verification on OCP builds")
-@click.option("--version", required=True, help="OCP version (e.g. 4.18)")
+@cli.command("build-conforma-verify", short_help="Run Conforma (EC) verification on image builds")
+@click.option("--group", required=True, help="Group name (e.g. openshift-4.18, logging-6.2)")
 @click.option("--assembly", required=True, default="stream", help="Assembly name")
 @click.option("--data-path", default=None, help="ocp-build-data repo URL or path")
 @click.option("--data-gitref", default=None, help="ocp-build-data git ref")
@@ -764,7 +787,7 @@ class BuildConformaVerifyPipeline:
 @click_coroutine
 async def build_conforma_verify(
     runtime: Runtime,
-    version: str,
+    group: str,
     assembly: str,
     data_path: Optional[str],
     data_gitref: Optional[str],
@@ -790,7 +813,7 @@ async def build_conforma_verify(
 
     pipeline = BuildConformaVerifyPipeline(
         runtime=runtime,
-        version=version,
+        group=group,
         assembly=assembly,
         builds=builds_list,
         data_path=data_path,

--- a/pyartcd/pyartcd/pipelines/scheduled/schedule_build_conforma_verify.py
+++ b/pyartcd/pyartcd/pipelines/scheduled/schedule_build_conforma_verify.py
@@ -2,6 +2,7 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 
 import click
+from artcommonlib.constants import LAYERED_PRODUCT_CONFORMA_STAGE_POLICY_MAP
 from artcommonlib.release_util import SoftwareLifecyclePhase
 from doozerlib.constants import (
     KONFLUX_RELEASE_EC_POLICY_CONFIGURATION,
@@ -16,29 +17,35 @@ from pyartcd.runtime import Runtime
 EFFECTIVE_TIME_OFFSET_DAYS = 21
 
 
-async def run_for(version: str, runtime: Runtime, serial: bool = False):
+async def run_for(group: str, runtime: Runtime, serial: bool = False):
     # Skip if frozen
     if not await util.is_build_permitted(
-        version, doozer_working=str(runtime.working_dir / "doozer_working-" / version)
+        group=group, doozer_working=str(runtime.working_dir / "doozer_working-" / group)
     ):
-        runtime.logger.info('[%s] Not permitted, skipping', version)
+        runtime.logger.info('[%s] Not permitted, skipping', group)
         return
 
-    # Load group config to determine GA vs pre-GA
-    group = f'openshift-{version}'
     group_config = await util.load_group_config(group=group, assembly='stream')
-    phase_name = group_config.get('software_lifecycle', {}).get('phase', '')
 
-    try:
-        phase = SoftwareLifecyclePhase.from_name(phase_name) if phase_name else None
-    except ValueError:
-        phase = None
+    if group.startswith('openshift-'):
+        # OCP group: select EC policy based on software lifecycle phase
+        phase_name = group_config.get('software_lifecycle', {}).get('phase', '')
+        try:
+            phase = SoftwareLifecyclePhase.from_name(phase_name) if phase_name else None
+        except ValueError:
+            phase = None
 
-    if phase == SoftwareLifecyclePhase.PRE_RELEASE:
-        ec_policy = KONFLUX_RELEASE_PREGA_EC_POLICY_CONFIGURATION
+        if phase == SoftwareLifecyclePhase.PRE_RELEASE:
+            ec_policy = KONFLUX_RELEASE_PREGA_EC_POLICY_CONFIGURATION
+        else:
+            ec_policy = KONFLUX_RELEASE_EC_POLICY_CONFIGURATION
+        fbc_ec_policy = KONFLUX_RELEASE_FBC_EC_POLICY_CONFIGURATION
     else:
-        ec_policy = KONFLUX_RELEASE_EC_POLICY_CONFIGURATION
-    fbc_ec_policy = KONFLUX_RELEASE_FBC_EC_POLICY_CONFIGURATION
+        product = group_config.get('product')
+        if product not in LAYERED_PRODUCT_CONFORMA_STAGE_POLICY_MAP:
+            raise ValueError(f"Unsupported layered-product group '{group}' product '{product}'")
+        ec_policy, fbc_ec_policy = LAYERED_PRODUCT_CONFORMA_STAGE_POLICY_MAP[product]
+        phase_name = 'n/a'
 
     effective_time = (datetime.now(timezone.utc) + timedelta(days=EFFECTIVE_TIME_OFFSET_DAYS)).strftime(
         '%Y-%m-%dT%H:%M:%SZ'
@@ -46,7 +53,7 @@ async def run_for(version: str, runtime: Runtime, serial: bool = False):
 
     runtime.logger.info(
         '[%s] Scheduling build-conforma-verify (phase=%s, ec_policy=%s, fbc_ec_policy=%s, effective_time=%s)',
-        version,
+        group,
         phase_name,
         ec_policy,
         fbc_ec_policy,
@@ -55,55 +62,55 @@ async def run_for(version: str, runtime: Runtime, serial: bool = False):
 
     if serial:
         result = jenkins.start_build_conforma_verify(
-            build_version=version,
+            group=group,
             assembly='stream',
             ec_policy=ec_policy,
             fbc_ec_policy=fbc_ec_policy,
             effective_time=effective_time,
             include_corresponding_bundles=True,
-            include_corresponding_fbcs=True,
+            include_corresponding_fbcs=fbc_ec_policy is not None,
             report_to_slack=True,
             block_until_building=True,
             block_until_complete=True,
         )
-        runtime.logger.info('[%s] Conforma verify completed with result: %s', version, result)
+        runtime.logger.info('[%s] Conforma verify completed with result: %s', group, result)
     else:
         jenkins.start_build_conforma_verify(
-            build_version=version,
+            group=group,
             assembly='stream',
             ec_policy=ec_policy,
             fbc_ec_policy=fbc_ec_policy,
             effective_time=effective_time,
             include_corresponding_bundles=True,
-            include_corresponding_fbcs=True,
+            include_corresponding_fbcs=fbc_ec_policy is not None,
             report_to_slack=True,
             block_until_building=False,
         )
 
 
 @cli.command('schedule-build-conforma-verify')
-@click.option('--version', '-v', required=True, help='OCP version to verify', multiple=True)
+@click.option('--group', '-g', required=True, help='Group to verify (e.g. openshift-4.18, logging-6.7)', multiple=True)
 @click.option('--serial', is_flag=True, default=False, help='Run verifications sequentially, waiting for each')
 @pass_runtime
 @click_coroutine
-async def schedule_build_conforma_verify(runtime: Runtime, version: tuple, serial: bool):
+async def schedule_build_conforma_verify(runtime: Runtime, group: tuple, serial: bool):
     jenkins.init_jenkins()
-    failed_versions: list[str] = []
+    failed_groups: list[str] = []
 
     if serial:
-        runtime.logger.info('Running conforma verify serially for versions: %s', ', '.join(version))
-        for v in version:
+        runtime.logger.info('Running conforma verify serially for groups: %s', ', '.join(group))
+        for g in group:
             try:
-                await run_for(v, runtime, serial=True)
+                await run_for(g, runtime, serial=True)
             except Exception:
-                runtime.logger.warning('[%s] Failed to spawn conforma verify job', v, exc_info=True)
-                failed_versions.append(v)
+                runtime.logger.warning('[%s] Failed to spawn conforma verify job', g, exc_info=True)
+                failed_groups.append(g)
     else:
-        results = await asyncio.gather(*[run_for(v, runtime) for v in version], return_exceptions=True)
-        for v, result in zip(version, results):
+        results = await asyncio.gather(*[run_for(g, runtime) for g in group], return_exceptions=True)
+        for g, result in zip(group, results):
             if isinstance(result, Exception):
-                runtime.logger.warning('[%s] Failed to spawn conforma verify job: %s', v, result)
-                failed_versions.append(v)
+                runtime.logger.warning('[%s] Failed to spawn conforma verify job: %s', g, result)
+                failed_groups.append(g)
 
-    if failed_versions:
-        raise RuntimeError(f"Failed to spawn conforma verify for: {', '.join(failed_versions)}")
+    if failed_groups:
+        raise RuntimeError(f"Failed to spawn conforma verify for: {', '.join(failed_groups)}")

--- a/pyartcd/tests/pipelines/test_build_conforma_verify.py
+++ b/pyartcd/tests/pipelines/test_build_conforma_verify.py
@@ -1,5 +1,7 @@
+import asyncio
+import os
 import unittest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from pyartcd.pipelines.build_conforma_verify import BuildConformaVerifyPipeline
 
@@ -108,7 +110,7 @@ def _make_pipeline(**kwargs):
     runtime.working_dir.__truediv__ = MagicMock(return_value=MagicMock())
     defaults = {
         "runtime": runtime,
-        "version": "4.18",
+        "group": "openshift-4.18",
         "assembly": "stream",
         "builds": None,
     }
@@ -140,9 +142,72 @@ class TestPipelineInit(unittest.TestCase):
         self.assertTrue(p.include_corresponding_fbcs)
         self.assertIs(p.slack_client, slack)
 
-    def test_group_set_from_version(self):
-        p = _make_pipeline(version="4.19")
+    def test_group_set_directly(self):
+        p = _make_pipeline(group="openshift-4.19")
         self.assertEqual(p.group, "openshift-4.19")
+
+    def test_group_set_layered(self):
+        p = _make_pipeline(group="logging-6.7")
+        self.assertEqual(p.group, "logging-6.7")
+
+    def test_group_is_not_rewritten(self):
+        p = _make_pipeline(group="oadp-1.5")
+        self.assertEqual(p.group, "oadp-1.5")
+
+
+class TestProductSettings(unittest.TestCase):
+    def test_lp_settings_use_product_and_selected_data(self):
+        p = _make_pipeline(
+            group="oadp-1.5",
+            data_path="https://example.test/ocp-build-data",
+            data_gitref="feature-branch",
+        )
+
+        with patch(
+            "pyartcd.pipelines.build_conforma_verify.util.load_group_config",
+            new=AsyncMock(return_value={"product": "oadp"}),
+        ) as load_group_config:
+            asyncio.run(p._resolve_layered_product_settings())
+
+        load_group_config.assert_awaited_once_with(
+            group="oadp-1.5",
+            assembly="stream",
+            doozer_data_path="https://example.test/ocp-build-data",
+            doozer_data_gitref="feature-branch",
+        )
+        self.assertEqual(p.namespace, "art-oadp-tenant")
+        self.assertEqual(p.kubeconfig_env_var, "OADP_KONFLUX_SA_KUBECONFIG")
+
+    def test_unknown_product_raises(self):
+        p = _make_pipeline(group="unknown-1.0")
+        with patch(
+            "pyartcd.pipelines.build_conforma_verify.util.load_group_config",
+            new=AsyncMock(return_value={"product": "unknown"}),
+        ):
+            with self.assertRaisesRegex(ValueError, "unknown-1.0.*unknown"):
+                asyncio.run(p._resolve_layered_product_settings())
+
+    def test_missing_lp_kubeconfig_raises_before_client_creation(self):
+        p = _make_pipeline(group="oadp-1.5")
+        p.namespace = "art-oadp-tenant"
+        p.kubeconfig_env_var = "OADP_KONFLUX_SA_KUBECONFIG"
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("pyartcd.pipelines.build_conforma_verify.KonfluxClient.from_kubeconfig") as from_kubeconfig,
+        ):
+            with self.assertRaisesRegex(ValueError, "OADP_KONFLUX_SA_KUBECONFIG.*oadp-1.5"):
+                asyncio.run(p._verify_records([], build_type="image"))
+        from_kubeconfig.assert_not_called()
+
+    def test_missing_ocp_kubeconfig_raises_before_client_creation(self):
+        p = _make_pipeline(group="openshift-4.22")
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("pyartcd.pipelines.build_conforma_verify.KonfluxClient.from_kubeconfig") as from_kubeconfig,
+        ):
+            with self.assertRaisesRegex(ValueError, "KONFLUX_SA_KUBECONFIG.*openshift-4.22"):
+                asyncio.run(p._verify_records([], build_type="image"))
+        from_kubeconfig.assert_not_called()
 
 
 class TestPolicySelection(unittest.TestCase):
@@ -193,7 +258,7 @@ class TestSlackReporting(unittest.TestCase):
     def test_failure_message(self):
         slack = MagicMock()
         slack.say_in_thread = AsyncMock()
-        p = _make_pipeline(slack_client=slack, effective_time="2026-08-05T00:00:00Z")
+        p = _make_pipeline(group="oadp-1.5", slack_client=slack, effective_time="2026-08-05T00:00:00Z")
 
         import asyncio
 
@@ -201,6 +266,7 @@ class TestSlackReporting(unittest.TestCase):
 
         msg = slack.say_in_thread.call_args_list[0][0][0]
         self.assertIn(":warning:", msg)
+        self.assertIn("oadp-1.5", msg)
         self.assertIn("assembly=`stream`", msg)
         self.assertIn("3 image(s)", msg)
         self.assertIn("1 bundle(s)", msg)

--- a/pyartcd/tests/pipelines/test_schedule_build_conforma_verify.py
+++ b/pyartcd/tests/pipelines/test_schedule_build_conforma_verify.py
@@ -1,0 +1,113 @@
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from doozerlib.constants import (
+    KONFLUX_RELEASE_EC_POLICY_CONFIGURATION,
+    KONFLUX_RELEASE_FBC_EC_POLICY_CONFIGURATION,
+    KONFLUX_RELEASE_PREGA_EC_POLICY_CONFIGURATION,
+)
+from pyartcd.pipelines.scheduled import schedule_build_conforma_verify as scheduler
+
+
+def _runtime():
+    runtime = MagicMock()
+    runtime.working_dir = MagicMock()
+    runtime.logger = MagicMock()
+    return runtime
+
+
+class TestRunFor(unittest.IsolatedAsyncioTestCase):
+    async def _run(self, group, group_config, serial=False):
+        runtime = _runtime()
+        with (
+            patch.object(scheduler.util, "is_build_permitted", new=AsyncMock(return_value=True)) as permitted,
+            patch.object(scheduler.util, "load_group_config", new=AsyncMock(return_value=group_config)) as load_config,
+            patch.object(scheduler.jenkins, "start_build_conforma_verify") as start_build,
+        ):
+            await scheduler.run_for(group, runtime, serial=serial)
+        return permitted, load_config, start_build
+
+    async def test_ocp_pre_release_uses_prega_policies(self):
+        _, load_config, start_build = await self._run(
+            "openshift-4.23",
+            {"product": "openshift-logging", "software_lifecycle": {"phase": "pre-release"}},
+        )
+
+        load_config.assert_awaited_once_with(group="openshift-4.23", assembly="stream")
+        self.assertEqual(start_build.call_args.kwargs["group"], "openshift-4.23")
+        self.assertEqual(start_build.call_args.kwargs["ec_policy"], KONFLUX_RELEASE_PREGA_EC_POLICY_CONFIGURATION)
+        self.assertEqual(start_build.call_args.kwargs["fbc_ec_policy"], KONFLUX_RELEASE_FBC_EC_POLICY_CONFIGURATION)
+
+    async def test_ocp_non_pre_release_uses_ga_policies(self):
+        _, _, start_build = await self._run(
+            "openshift-4.22",
+            {"product": "ocp", "software_lifecycle": {"phase": "release"}},
+        )
+
+        self.assertEqual(start_build.call_args.kwargs["ec_policy"], KONFLUX_RELEASE_EC_POLICY_CONFIGURATION)
+        self.assertEqual(start_build.call_args.kwargs["fbc_ec_policy"], KONFLUX_RELEASE_FBC_EC_POLICY_CONFIGURATION)
+
+    async def test_oadp_uses_product_policies_and_full_group(self):
+        with patch.object(scheduler, "datetime") as datetime_mock:
+            datetime_mock.now.return_value = datetime(2026, 8, 31, tzinfo=timezone.utc)
+            _, _, start_build = await self._run("oadp-1.5", {"product": "oadp"}, serial=True)
+
+        self.assertEqual(
+            start_build.call_args.kwargs,
+            {
+                "group": "oadp-1.5",
+                "assembly": "stream",
+                "ec_policy": "rhtap-releng-tenant/registry-art-oadp-stage",
+                "fbc_ec_policy": "rhtap-releng-tenant/fbc-art-oadp-stage",
+                "effective_time": "2026-09-21T00:00:00Z",
+                "include_corresponding_bundles": True,
+                "include_corresponding_fbcs": True,
+                "report_to_slack": True,
+                "block_until_building": True,
+                "block_until_complete": True,
+            },
+        )
+
+    async def test_mta_uses_generic_fbc_stage_policy(self):
+        _, _, start_build = await self._run("mta-8.2", {"product": "mta"})
+
+        self.assertEqual(start_build.call_args.kwargs["ec_policy"], "rhtap-releng-tenant/registry-art-mta-stage")
+        self.assertEqual(start_build.call_args.kwargs["fbc_ec_policy"], "rhtap-releng-tenant/fbc-stage")
+
+    async def test_logging_uses_stage_fbc_policy(self):
+        _, _, start_build = await self._run("logging-6.2", {"product": "openshift-logging"})
+
+        self.assertEqual(start_build.call_args.kwargs["ec_policy"], "rhtap-releng-tenant/registry-art-logging-stage")
+        self.assertEqual(start_build.call_args.kwargs["fbc_ec_policy"], "rhtap-releng-tenant/fbc-stage")
+
+    async def test_oc_mirror_uses_registry_standard_and_no_fbc_policy(self):
+        _, _, start_build = await self._run("oc-mirror-2.0", {"product": "oc-mirror"})
+
+        self.assertEqual(start_build.call_args.kwargs["ec_policy"], "rhtap-releng-tenant/registry-standard")
+        self.assertIsNone(start_build.call_args.kwargs["fbc_ec_policy"])
+        self.assertFalse(start_build.call_args.kwargs["include_corresponding_fbcs"])
+
+    async def test_unknown_lp_product_raises(self):
+        runtime = _runtime()
+        with (
+            patch.object(scheduler.util, "is_build_permitted", new=AsyncMock(return_value=True)),
+            patch.object(scheduler.util, "load_group_config", new=AsyncMock(return_value={"product": "unknown"})),
+            patch.object(scheduler.jenkins, "start_build_conforma_verify") as start_build,
+        ):
+            with self.assertRaisesRegex(ValueError, "unknown-1.0.*unknown"):
+                await scheduler.run_for("unknown-1.0", runtime)
+        start_build.assert_not_called()
+
+    async def test_freeze_skips_without_loading_config_or_starting_jenkins(self):
+        runtime = _runtime()
+        with (
+            patch.object(scheduler.util, "is_build_permitted", new=AsyncMock(return_value=False)) as permitted,
+            patch.object(scheduler.util, "load_group_config", new=AsyncMock()) as load_config,
+            patch.object(scheduler.jenkins, "start_build_conforma_verify") as start_build,
+        ):
+            await scheduler.run_for("oadp-1.5", runtime)
+
+        permitted.assert_awaited_once()
+        load_config.assert_not_awaited()
+        start_build.assert_not_called()

--- a/pyartcd/tests/test_jenkins.py
+++ b/pyartcd/tests/test_jenkins.py
@@ -114,3 +114,12 @@ class TestJenkinsStartBuild(unittest.TestCase):
             'job/aos-cd-builds/job/build%252Focp4/46870'
         )
         self.assertEqual(jenkins.get_build_id_from_url(build_url), 46870)
+
+    @mock.patch("pyartcd.jenkins.start_build")
+    def test_start_build_conforma_verify_uses_group_parameter(self, start_build_mock):
+        jenkins.start_build_conforma_verify(group="oadp-1.5")
+
+        params = start_build_mock.call_args.kwargs["params"]
+        self.assertEqual(start_build_mock.call_args.kwargs["job"], Jobs.BUILD_CONFORMA_VERIFY)
+        self.assertEqual(params["GROUP"], "oadp-1.5")
+        self.assertNotIn("BUILD_VERSION", params)


### PR DESCRIPTION
## Summary
Extend scheduled `build-conforma-verify` runs from OCP groups to configured layered-product groups while preserving existing OCP lifecycle behavior.

## Changes
- Select layered-product image and FBC policies from an explicit product-keyed map.
- Resolve product-specific Konflux namespaces and kubeconfigs, failing clearly when configuration or credentials are missing.
- Preserve group filters during NVR lookups.
- Retain OCP GA/pre-GA policy selection and skip successful Slack notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conforma verification now supports layered-product groups with product-specific policies and environment selection.
  * Scheduling accepts direct group names, including OpenShift lifecycle policies and layered-product validation.
  * Verification commands use a group option instead of an OCP version.
  * FBC policies can be optional, with group-specific reporting and configuration.

* **Bug Fixes**
  * Preserved group and engine filters when retrieving the latest build records.

* **Tests**
  * Added coverage for policy selection, validation errors, freeze behavior, and group-based execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->