### PR TITLE
ART-23273: Use QCI pullspecs for OKD CoreOS mirroring

### DIFF
--- a/pyartcd/pyartcd/pipelines/okd.py
+++ b/pyartcd/pyartcd/pipelines/okd.py
@@ -763,8 +763,8 @@ class KonfluxOkdPipeline:
         This is a temporary solution until the RHCOS team starts mirroring to ART's imagestreams directly.
 
         Mirrors:
-        - origin/scos-{version}:stream-coreos -> origin/scos-{version}-art:stream-coreos
-        - origin/scos-{version}:stream-coreos-extensions -> origin/scos-{version}-art:stream-coreos-extensions
+        - quay-proxy.ci.openshift.org/openshift/ci:<namespace>_scos-{version}_stream-coreos -> origin/scos-{version}-art:stream-coreos
+        - quay-proxy.ci.openshift.org/openshift/ci:<namespace>_scos-{version}_stream-coreos-extensions -> origin/scos-{version}-art:stream-coreos-extensions
 
         Special case:
         - 4.23 has no dedicated scos-4.23 CoreOS stream (master builds 5.0), so it
@@ -791,21 +791,25 @@ class KonfluxOkdPipeline:
         if self.runtime.dry_run:
             self.logger.info('[DRY RUN] Would mirror CoreOS imagestream tags')
             for tag in tags_to_mirror:
-                self.logger.info(f'[DRY RUN] From: {self.imagestream_namespace}/scos-{source_version}:{tag}')
+                self.logger.info(
+                    f'[DRY RUN] From: quay-proxy.ci.openshift.org/openshift/ci:{self.imagestream_namespace}_scos-{source_version}_{tag}'
+                )
                 self.logger.info(f'[DRY RUN] To: {self.imagestream_namespace}/scos-{self.version}-art:{tag}')
             return
 
         env = os.environ.copy()
 
         for tag in tags_to_mirror:
-            source_tag = f'{self.imagestream_namespace}/scos-{source_version}:{tag}'
+            source_pullspec = (
+                f'quay-proxy.ci.openshift.org/openshift/ci:{self.imagestream_namespace}_scos-{source_version}_{tag}'
+            )
             target_tag = f'{self.imagestream_namespace}/scos-{self.version}-art:{tag}'
 
-            self.logger.info('Mirroring CoreOS imagestream from %s to %s', source_tag, target_tag)
+            self.logger.info('Mirroring CoreOS imagestream from %s to %s', source_pullspec, target_tag)
 
             try:
-                await self._tag_image_to_stream(source_pullspec=source_tag, target_tag=target_tag, env=env)
-                success_msg = f'Mirrored CoreOS tag: {source_tag} -> {target_tag}'
+                await self._tag_image_to_stream(source_pullspec=source_pullspec, target_tag=target_tag, env=env)
+                success_msg = f'Mirrored CoreOS tag: {source_pullspec} -> {target_tag}'
                 jenkins.update_description(f'{success_msg}<br>')
                 self.logger.info(success_msg)
 

--- a/pyartcd/tests/pipelines/test_okd4.py
+++ b/pyartcd/tests/pipelines/test_okd4.py
@@ -70,12 +70,18 @@ class TestKonfluxOkdPipeline(IsolatedAsyncioTestCase):
 
             # Check first call (stream-coreos) — source is scos-5.0 (master branch)
             first_call = mock_tag.call_args_list[0]
-            self.assertEqual(first_call[1]['source_pullspec'], 'origin/scos-5.0:stream-coreos')
+            self.assertEqual(
+                first_call[1]['source_pullspec'],
+                'quay-proxy.ci.openshift.org/openshift/ci:origin_scos-5.0_stream-coreos',
+            )
             self.assertEqual(first_call[1]['target_tag'], 'origin/scos-4.23-art:stream-coreos')
 
             # Check second call (stream-coreos-extensions)
             second_call = mock_tag.call_args_list[1]
-            self.assertEqual(second_call[1]['source_pullspec'], 'origin/scos-5.0:stream-coreos-extensions')
+            self.assertEqual(
+                second_call[1]['source_pullspec'],
+                'quay-proxy.ci.openshift.org/openshift/ci:origin_scos-5.0_stream-coreos-extensions',
+            )
             self.assertEqual(second_call[1]['target_tag'], 'origin/scos-4.23-art:stream-coreos-extensions')
 
             # Should update Jenkins description twice (once per successful tag)
@@ -257,12 +263,18 @@ class TestKonfluxOkdPipeline(IsolatedAsyncioTestCase):
 
             # Check first call uses custom namespace
             first_call = mock_tag.call_args_list[0]
-            self.assertEqual(first_call[1]['source_pullspec'], 'custom-namespace/scos-5.0:stream-coreos')
+            self.assertEqual(
+                first_call[1]['source_pullspec'],
+                'quay-proxy.ci.openshift.org/openshift/ci:custom-namespace_scos-5.0_stream-coreos',
+            )
             self.assertEqual(first_call[1]['target_tag'], 'custom-namespace/scos-4.23-art:stream-coreos')
 
             # Check second call uses custom namespace
             second_call = mock_tag.call_args_list[1]
-            self.assertEqual(second_call[1]['source_pullspec'], 'custom-namespace/scos-5.0:stream-coreos-extensions')
+            self.assertEqual(
+                second_call[1]['source_pullspec'],
+                'quay-proxy.ci.openshift.org/openshift/ci:custom-namespace_scos-5.0_stream-coreos-extensions',
+            )
             self.assertEqual(second_call[1]['target_tag'], 'custom-namespace/scos-4.23-art:stream-coreos-extensions')
 
     async def test_mirror_coreos_imagestreams_uses_same_version_source(self):
@@ -305,12 +317,16 @@ class TestKonfluxOkdPipeline(IsolatedAsyncioTestCase):
                     self.assertEqual(mock_tag.call_count, 2)
 
                     first_call = mock_tag.call_args_list[0]
-                    self.assertEqual(first_call[1]['source_pullspec'], f'origin/scos-{version}:stream-coreos')
+                    self.assertEqual(
+                        first_call[1]['source_pullspec'],
+                        f'quay-proxy.ci.openshift.org/openshift/ci:origin_scos-{version}_stream-coreos',
+                    )
                     self.assertEqual(first_call[1]['target_tag'], f'origin/scos-{version}-art:stream-coreos')
 
                     second_call = mock_tag.call_args_list[1]
                     self.assertEqual(
-                        second_call[1]['source_pullspec'], f'origin/scos-{version}:stream-coreos-extensions'
+                        second_call[1]['source_pullspec'],
+                        f'quay-proxy.ci.openshift.org/openshift/ci:origin_scos-{version}_stream-coreos-extensions',
                     )
                     self.assertEqual(
                         second_call[1]['target_tag'], f'origin/scos-{version}-art:stream-coreos-extensions'
@@ -354,11 +370,17 @@ class TestKonfluxOkdPipeline(IsolatedAsyncioTestCase):
 
             # Check that 5.0 is used as source, 4.23 as target
             first_call = mock_tag.call_args_list[0]
-            self.assertEqual(first_call[1]['source_pullspec'], 'origin/scos-5.0:stream-coreos')
+            self.assertEqual(
+                first_call[1]['source_pullspec'],
+                'quay-proxy.ci.openshift.org/openshift/ci:origin_scos-5.0_stream-coreos',
+            )
             self.assertEqual(first_call[1]['target_tag'], 'origin/scos-4.23-art:stream-coreos')
 
             second_call = mock_tag.call_args_list[1]
-            self.assertEqual(second_call[1]['source_pullspec'], 'origin/scos-5.0:stream-coreos-extensions')
+            self.assertEqual(
+                second_call[1]['source_pullspec'],
+                'quay-proxy.ci.openshift.org/openshift/ci:origin_scos-5.0_stream-coreos-extensions',
+            )
             self.assertEqual(second_call[1]['target_tag'], 'origin/scos-4.23-art:stream-coreos-extensions')
 
 


### PR DESCRIPTION
## Summary

- Use the documented QCI pullspec format for OKD CoreOS source images.
- Rename the local source variable to source_pullspec.
- Keep dry-run output and mirror tests aligned with runtime behavior.

The format is verified against the [CI documentation](https://docs.ci.openshift.org/how-tos/use-registries-in-build-farm/#how-promotion-works)

Normal OKD image mirroring already uses complete source pullspecs from build records; this applies the same pattern to CoreOS images.

## Tests

- make format-check
- make lint
- uv run pytest --verbose --color=yes pyartcd/tests/pipelines/test_okd4.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CoreOS imagestream mirroring to use registry-proxy source images instead of ART-specific tags.
  * Updated dry-run output, tagging commands, and success messages to reflect the new image sources.
  * Preserved existing version-selection behavior, including standard and extensions stream mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->