### PR TITLE
handle situation in which there's no previous minor z-stream exists

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -402,7 +402,7 @@ def get_inflight(assembly, group, date=None):
         headers={'Accept': 'application/json'},
     )
     if response.status_code == 404:
-        logger.info(
+        LOGGER.info(
                 "No previous-minor z-stream release schedule exists for %s; "
                 "continuing without an inflight release.",
                 prev_group,)

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -401,6 +401,12 @@ def get_inflight(assembly, group, date=None):
         f'{RELEASE_SCHEDULES}/{prev_group}.z/?fields=all_ga_tasks',
         headers={'Accept': 'application/json'},
     )
+    if response.status_code == 404:
+        logger.info(
+                "No previous-minor z-stream release schedule exists for %s; "
+                "continuing without an inflight release.",
+                prev_group,)
+        return None
     response.raise_for_status()
     try:
         data = response.json()

--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -403,9 +403,9 @@ def get_inflight(assembly, group, date=None):
     )
     if response.status_code == 404:
         LOGGER.info(
-                "No previous-minor z-stream release schedule exists for %s; "
-                "continuing without an inflight release.",
-                prev_group,)
+            "No previous-minor z-stream release schedule exists for %s; continuing without an inflight release.",
+            prev_group,
+        )
         return None
     response.raise_for_status()
     try:


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

handles 404 like https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgen-assembly/1333/console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal logging formatting was cleaned up without changing application behavior.
  * No user-facing functionality or workflows were added, removed, or modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->