### PR TITLE
Fix multi-arch RPM lockfile generation

### DIFF
--- a/doozer/doozerlib/lockfile_prototype/container_utils.py
+++ b/doozer/doozerlib/lockfile_prototype/container_utils.py
@@ -10,6 +10,7 @@ import logging
 import os
 
 from artcommonlib import logutil
+from artcommonlib.arch_util import go_arch_for_brew_arch
 from artcommonlib.exectools import cmd_gather_async
 from artcommonlib.util import oc_image_info_for_arch_async
 
@@ -82,12 +83,13 @@ class ContainerImageHelper:
         self.logger.debug(f"Resolved to: {resolved}")
         return resolved
 
-    async def get_installed_packages(self, image_pullspec: str) -> list[str]:
+    async def get_installed_packages(self, image_pullspec: str, arch: str) -> list[str]:
         """
         Query the list of installed RPM package names from a container image.
 
         Arg(s):
             image_pullspec (str): Fully-qualified image pullspec (digest preferred).
+            arch (str): Brew architecture to query.
         Return Value(s):
             list[str]: Sorted unique package names installed in the image.
         """
@@ -97,7 +99,7 @@ class ContainerImageHelper:
             "run",
             "--rm",
             "--platform",
-            DEFAULT_PLATFORM,
+            f"linux/{go_arch_for_brew_arch(arch)}",
             "--entrypoint",
             "rpm",
             query_pullspec,

--- a/doozer/doozerlib/lockfile_prototype/generator.py
+++ b/doozer/doozerlib/lockfile_prototype/generator.py
@@ -7,6 +7,7 @@ the upstream rpm-lockfile-prototype tool (v0.22.0+). Container image
 interactions are delegated to ContainerImageHelper.
 """
 
+import asyncio
 import logging
 import re
 import shlex
@@ -30,6 +31,7 @@ from doozerlib.lockfile_prototype.container_utils import ContainerImageHelper
 from doozerlib.lockfile_prototype.fallback import extract_generated_file_content
 from doozerlib.lockfile_prototype.lockfile_merger import merge_lockfiles
 from doozerlib.lockfile_prototype.models import (
+    ArchResult,
     ArchSpecificPackage,
     LockfileData,
     ModuleEntry,
@@ -52,6 +54,18 @@ def _is_local_rpm(token: str) -> bool:
     if "/" in token and "*" in token:
         return True
     return False
+
+
+def _package_name(package: str | ArchSpecificPackage) -> str:
+    """
+    Return the package name from a plain or architecture-scoped package spec.
+
+    Arg(s):
+        package (str | ArchSpecificPackage): Package specification.
+    Return Value(s):
+        str: Plain package name.
+    """
+    return package if isinstance(package, str) else package.name
 
 
 _BARE_UPDATE_RE = re.compile(
@@ -168,7 +182,7 @@ def build_rpms_in_yaml(
     packages: list[str],
     arch_specific_packages: dict[str, list[str]] | None = None,
     reinstall_packages: list[str] | None = None,
-    upgrade_packages: list[str] | None = None,
+    upgrade_packages: list[str | ArchSpecificPackage] | None = None,
     module_enable: list[str] | None = None,
     exclude_packages: list[str] | None = None,
     context: dict[str, bool | str] | None = None,
@@ -185,7 +199,7 @@ def build_rpms_in_yaml(
         arch_specific_packages (dict[str, list[str]] | None): Per-arch packages.
         reinstall_packages (list[str] | None): Installed packages to reinstall
             from repos (ensures they appear in the lockfile).
-        upgrade_packages (list[str] | None): Packages to upgrade.
+        upgrade_packages (list[str | ArchSpecificPackage] | None): Packages to upgrade.
         module_enable (list[str] | None): Module streams to enable
             (e.g., ["nodejs:18", "python36:3.6"]).
         exclude_packages (list[str] | None): Packages to exclude from
@@ -204,7 +218,7 @@ def build_rpms_in_yaml(
     if reinstall_packages:
         reinstall_packages = [p for p in reinstall_packages if not _is_local_rpm(p)]
     if upgrade_packages:
-        upgrade_packages = [p for p in upgrade_packages if not _is_local_rpm(p)]
+        upgrade_packages = [p for p in upgrade_packages if not _is_local_rpm(_package_name(p))]
 
     package_entries: list[str | ArchSpecificPackage] = list(packages)
     if arch_specific_packages:
@@ -483,7 +497,7 @@ class RpmLockfilePrototypeGenerator:
             upgrade_pkgs: list[str] | None = None
             if stage_num == final_stage_num and not bare_context:
                 if image_pullspec:
-                    base_pkgs = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key)
+                    base_pkgs = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key, arches)
                     if base_pkgs:
                         # Use upgrade semantics for base image packages so repos
                         # can provide newer versions. reinstallPackages pins to the
@@ -497,7 +511,7 @@ class RpmLockfilePrototypeGenerator:
                             "packages added as upgrade targets into lockfile"
                         )
                 else:
-                    base_pkgs = await self._get_base_image_packages(stage_num, None, distgit_key)
+                    base_pkgs = await self._get_base_image_packages(stage_num, None, distgit_key, arches)
                     if base_pkgs:
                         extra = [p for p in base_pkgs if p not in extra_packages]
                         if extra:
@@ -515,7 +529,9 @@ class RpmLockfilePrototypeGenerator:
                 elif stage_num != final_stage_num and not upgrade_pkgs:
                     # Final stage already populated upgrade_pkgs from base image;
                     # only query again for non-final stages with bare updates.
-                    bare_update_base = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key)
+                    bare_update_base = await self._get_base_image_packages(
+                        stage_num, image_pullspec, distgit_key, arches
+                    )
                     if bare_update_base:
                         upgrade_pkgs = list(bare_update_base)
                 if upgrade_pkgs and stage_num in stages_with_bare_updates:
@@ -545,10 +561,12 @@ class RpmLockfilePrototypeGenerator:
                 dockerfile_install_pkgs = _extract_install_packages(entries, stage_num)
                 if dockerfile_install_pkgs:
                     if upgrade_pkgs:
-                        base_pkg_set = set(upgrade_pkgs)
+                        base_pkg_set = {_package_name(package) for package in upgrade_pkgs}
                     else:
-                        stage_base_pkgs = await self._get_base_image_packages(stage_num, image_pullspec, distgit_key)
-                        base_pkg_set = set(stage_base_pkgs) if stage_base_pkgs else set()
+                        stage_base_pkgs = await self._get_base_image_packages(
+                            stage_num, image_pullspec, distgit_key, arches
+                        )
+                        base_pkg_set = {_package_name(package) for package in stage_base_pkgs}
                     pin_candidates = sorted(dockerfile_install_pkgs & base_pkg_set)
                     if pin_candidates:
                         result = await self._pin_missing_dockerfile_packages(
@@ -566,23 +584,43 @@ class RpmLockfilePrototypeGenerator:
 
         return stage_lockfiles
 
-    async def _get_base_image_packages(self, stage_num: int, image_pullspec: str | None, distgit_key: str) -> list[str]:
+    async def _get_base_image_packages(
+        self,
+        stage_num: int,
+        image_pullspec: str | None,
+        distgit_key: str,
+        arches: list[str],
+    ) -> list[str | ArchSpecificPackage]:
         """
-        Get installed package names from the base image for conflict
-        detection. Tries a live podman query first; falls back to parent
-        lockfile data if the image is unreachable.
+        Get installed package names from the base image for upgrade targets
+        and conflict detection. Tries live podman queries for every target
+        architecture first; falls back to parent lockfile data if the image
+        is unreachable.
 
         Arg(s):
             stage_num (int): Dockerfile stage number.
             image_pullspec (str | None): Base image pullspec (None = bare mode).
             distgit_key (str): Image identifier for logging.
         Return Value(s):
-            list[str]: Package names, or empty if unavailable.
+            list[str | ArchSpecificPackage]: Package names or scoped package
+                specifications, or empty if unavailable.
         """
         if image_pullspec:
-            pkgs = await self._container.get_installed_packages(image_pullspec)
-            if pkgs:
-                return pkgs
+            packages_by_arch = await asyncio.gather(
+                *(self._container.get_installed_packages(image_pullspec, arch) for arch in arches)
+            )
+            scoped_packages = [
+                ArchSpecificPackage(name=package, arches={"only": arch})
+                for arch, packages in zip(arches, packages_by_arch)
+                for package in packages
+            ]
+            empty_arches = [arch for arch, packages in zip(arches, packages_by_arch) if not packages]
+            if empty_arches:
+                self.logger.warning(
+                    f"{distgit_key}: stage {stage_num}: no installed package data for architectures: {empty_arches}"
+                )
+            if scoped_packages:
+                return scoped_packages
         if stage_num in self.fallback_installed:
             self.logger.info(
                 f"{distgit_key}: stage {stage_num}: using parent lockfile data "
@@ -704,7 +742,7 @@ class RpmLockfilePrototypeGenerator:
         stage_num: int,
         reinstall_packages: list[str] | None = None,
         containerfile_path: str | None = None,
-        upgrade_packages: list[str] | None = None,
+        upgrade_packages: list[str | ArchSpecificPackage] | None = None,
         bare_context: bool = False,
     ) -> LockfileData | None:
         """
@@ -725,7 +763,7 @@ class RpmLockfilePrototypeGenerator:
                 to reinstall from repos into the lockfile.
             containerfile_path (str | None): Dockerfile path for upstream
                 package extraction.
-            upgrade_packages (list[str] | None): Base image packages to
+            upgrade_packages (list[str | ArchSpecificPackage] | None): Base image packages to
                 upgrade (from bare dnf/yum update commands).
             bare_context (bool): Whether to emit a bare resolution context.
         Return Value(s):
@@ -752,8 +790,10 @@ class RpmLockfilePrototypeGenerator:
         while real_retries < MAX_RESOLUTION_RETRIES:
             all_upgrade_targets = list(remaining_reinstall)
             if remaining_upgrade:
-                existing = set(all_upgrade_targets)
-                all_upgrade_targets.extend(p for p in remaining_upgrade if p not in existing)
+                existing = {_package_name(package) for package in all_upgrade_targets}
+                all_upgrade_targets.extend(
+                    package for package in remaining_upgrade if _package_name(package) not in existing
+                )
             effective_upgrade = all_upgrade_targets if (image_pullspec and all_upgrade_targets) else None
             in_yaml = build_rpms_in_yaml(
                 repo_list,
@@ -793,7 +833,8 @@ class RpmLockfilePrototypeGenerator:
                         continue
                 # Drop all bare-update upgrade packages on any miss
                 # (all-or-nothing: partial upgrades cause EVR conflicts).
-                upgrade_hit = missing & set(remaining_upgrade) if remaining_upgrade else set()
+                upgrade_names = {_package_name(package) for package in remaining_upgrade}
+                upgrade_hit = missing & upgrade_names if remaining_upgrade else set()
                 if upgrade_hit:
                     self.logger.info(
                         f"{distgit_key}: stage {stage_num}: dropping all "
@@ -851,14 +892,28 @@ class RpmLockfilePrototypeGenerator:
 
     def _assemble_lockfile(self, stage_lockfiles: list[LockfileData], image_meta: ImageMetadata) -> LockfileData:
         """
-        Merge stage lockfiles, filter empty arches, apply cross-arch merge.
+        Merge stage lockfiles, retain configured arches, and apply cross-arch merge.
         """
         if len(stage_lockfiles) == 1:
             final = stage_lockfiles[0]
         else:
             final = merge_lockfiles(stage_lockfiles)
 
-        final.arches = [arch_entry for arch_entry in final.arches if arch_entry.packages or arch_entry.source]
+        configured_arches = image_meta.get_arches()
+        arches_by_name = {arch_entry.arch: arch_entry for arch_entry in final.arches}
+        empty_arches: list[str] = []
+        final.arches = []
+        for arch in configured_arches:
+            arch_entry = arches_by_name.pop(arch, ArchResult(arch=arch))
+            if not arch_entry.packages and not arch_entry.source:
+                empty_arches.append(arch)
+            final.arches.append(arch_entry)
+        final.arches.extend(arches_by_name.values())
+
+        if empty_arches:
+            self.logger.warning(
+                f"{image_meta.distgit_key}: lockfile resolution produced no packages for architectures: {empty_arches}"
+            )
 
         if image_meta.is_cross_arch_enabled():
             self._apply_cross_arch_merge(final)
@@ -954,7 +1009,7 @@ class RpmLockfilePrototypeGenerator:
         stage_num: int,
         reinstall_packages: list[str] | None = None,
         containerfile_path: str | None = None,
-        upgrade_packages: list[str] | None = None,
+        upgrade_packages: list[str | ArchSpecificPackage] | None = None,
         bare_context: bool = False,
     ) -> LockfileData | None:
         """
@@ -975,7 +1030,7 @@ class RpmLockfilePrototypeGenerator:
                 reinstall from repos into the lockfile.
             containerfile_path (str | None): Dockerfile path for upstream
                 package extraction.
-            upgrade_packages (list[str] | None): Base image packages to
+            upgrade_packages (list[str | ArchSpecificPackage] | None): Base image packages to
                 upgrade (from bare dnf/yum update commands).
             bare_context (bool): Whether to emit a bare resolution context.
         Return Value(s):
@@ -1017,7 +1072,9 @@ class RpmLockfilePrototypeGenerator:
             [p for p in reinstall_packages if p not in mismatched_names] if reinstall_packages else reinstall_packages
         )
         pinned_upgrade = (
-            [p for p in upgrade_packages if p not in mismatched_names] if upgrade_packages else upgrade_packages
+            [p for p in upgrade_packages if _package_name(p) not in mismatched_names]
+            if upgrade_packages
+            else upgrade_packages
         )
 
         try:

--- a/doozer/doozerlib/lockfile_prototype/models.py
+++ b/doozer/doozerlib/lockfile_prototype/models.py
@@ -44,7 +44,7 @@ class RpmsInConfig(BaseModel):
     context: dict[str, bool | str] | None = None
     packages: list[str | ArchSpecificPackage] = Field(default_factory=list)
     reinstallPackages: list[str] = Field(default_factory=list)
-    upgradePackages: list[str] = Field(default_factory=list)
+    upgradePackages: list[str | ArchSpecificPackage] = Field(default_factory=list)
     moduleEnable: list[str] = Field(default_factory=list)
     excludePackages: list[str] = Field(default_factory=list)
     packagesFromContainerfile: dict | str | None = None

--- a/doozer/tests/lockfile_prototype/test_container_utils.py
+++ b/doozer/tests/lockfile_prototype/test_container_utils.py
@@ -118,8 +118,25 @@ class TestContainerImageHelper(unittest.TestCase):
 
         mock_gather.side_effect = mock_podman
         helper = ContainerImageHelper()
-        result = asyncio.run(helper.get_installed_packages("quay.io/test/img@sha256:abc"))
+        result = asyncio.run(helper.get_installed_packages("quay.io/test/img@sha256:abc", "x86_64"))
         self.assertEqual(result, ["bash", "coreutils", "glibc"])
+
+    @patch("doozerlib.lockfile_prototype.container_utils.cmd_gather_async")
+    def test_get_installed_packages_uses_requested_architecture(self, mock_gather):
+        """
+        Should query the image using the platform matching the requested RPM architecture.
+        """
+
+        async def mock_podman(cmd, **kwargs):
+            return (0, "bash\n", "")
+
+        mock_gather.side_effect = mock_podman
+        helper = ContainerImageHelper()
+        asyncio.run(helper.get_installed_packages("quay.io/test/img@sha256:abc", "aarch64"))
+
+        command = mock_gather.call_args.args[0]
+        platform_index = command.index("--platform")
+        self.assertEqual(command[platform_index + 1], "linux/arm64")
 
     @patch("doozerlib.lockfile_prototype.container_utils.cmd_gather_async")
     def test_get_installed_packages_fails(self, mock_gather):
@@ -129,7 +146,7 @@ class TestContainerImageHelper(unittest.TestCase):
         mock_gather.side_effect = ChildProcessError("Process failed")
         helper = ContainerImageHelper()
         with self.assertRaises(ChildProcessError):
-            asyncio.run(helper.get_installed_packages("quay.io/test/img@sha256:abc"))
+            asyncio.run(helper.get_installed_packages("quay.io/test/img@sha256:abc", "x86_64"))
 
     @patch("doozerlib.lockfile_prototype.container_utils.cmd_gather_async")
     def test_read_file_from_image(self, mock_gather):

--- a/doozer/tests/lockfile_prototype/test_generator.py
+++ b/doozer/tests/lockfile_prototype/test_generator.py
@@ -20,6 +20,7 @@ from doozerlib.lockfile_prototype.generator import (
 )
 from doozerlib.lockfile_prototype.models import (
     ArchResult,
+    ArchSpecificPackage,
     LockfileData,
     PackageEntry,
     RepoEntry,
@@ -65,6 +66,29 @@ class TestBuildRpmsInYaml(unittest.TestCase):
         self.assertEqual(len(arch_entries), 1)
         self.assertEqual(arch_entries[0].name, "librtas")
         self.assertEqual(arch_entries[0].arches["only"], "ppc64le")
+
+    def test_arch_specific_upgrade_packages(self):
+        repos = [
+            RepoEntry(
+                repoid="rhel-9-baseos-rpms",
+                baseurl="https://example.com/baseos/$basearch/os/",
+            ),
+        ]
+        result = build_rpms_in_yaml(
+            repos=repos,
+            arches=["x86_64", "ppc64le"],
+            packages=[],
+            upgrade_packages=[ArchSpecificPackage(name="kernel", arches={"only": "ppc64le"})],
+        )
+
+        self.assertEqual(
+            result.upgradePackages,
+            [ArchSpecificPackage(name="kernel", arches={"only": "ppc64le"})],
+        )
+        self.assertEqual(
+            result.model_dump()["upgradePackages"],
+            [{"name": "kernel", "arches": {"only": "ppc64le"}}],
+        )
 
     def test_multiple_repos(self):
         repos = [
@@ -238,6 +262,67 @@ class TestRpmLockfilePrototypeGenerator(unittest.TestCase):
             container_helper=self._make_mock_container(),
             resolver=self._make_mock_resolver(),
         )
+
+    def test_base_image_packages_are_scoped_to_each_architecture(self):
+        container = self._make_mock_container()
+
+        async def get_installed_packages(image_pullspec: str, arch: str) -> list[str]:
+            return {
+                "x86_64": ["glibc", "x86-only"],
+                "ppc64le": ["glibc", "ppc-only"],
+            }[arch]
+
+        container.get_installed_packages = AsyncMock(side_effect=get_installed_packages)
+        generator = RpmLockfilePrototypeGenerator(
+            repos=self._make_mock_repos(),
+            working_dir=Path(tempfile.mkdtemp()),
+            container_helper=container,
+            resolver=self._make_mock_resolver(),
+        )
+
+        result = asyncio.run(
+            generator._get_base_image_packages(
+                0,
+                "quay.io/test/base@sha256:abc123",
+                "test-image",
+                ["x86_64", "ppc64le"],
+            )
+        )
+
+        self.assertEqual(
+            [(package.name, package.arches) for package in result],
+            [
+                ("glibc", {"only": "x86_64"}),
+                ("x86-only", {"only": "x86_64"}),
+                ("glibc", {"only": "ppc64le"}),
+                ("ppc-only", {"only": "ppc64le"}),
+            ],
+        )
+
+    def test_assemble_lockfile_retains_configured_empty_architectures(self):
+        meta = self._make_mock_image_meta()
+        meta.is_cross_arch_enabled.return_value = False
+        generator = self._make_generator()
+        lockfile = LockfileData(
+            arches=[
+                ArchResult(
+                    arch="x86_64",
+                    packages=[
+                        PackageEntry(
+                            url="https://example.com/glibc.rpm",
+                            repoid="baseos",
+                            name="glibc",
+                            evr="1.0-1",
+                        )
+                    ],
+                )
+            ]
+        )
+
+        result = generator._assemble_lockfile([lockfile], meta)
+
+        self.assertEqual([entry.arch for entry in result.arches], ["x86_64", "ppc64le"])
+        self.assertEqual(result.arches[1].packages, [])
 
     def test_generate_lockfile_writes_result(self):
         meta = self._make_mock_image_meta()
@@ -1447,8 +1532,11 @@ class TestBareUpdateUpgradeResolution(unittest.TestCase):
         calls = resolver.resolve.call_args_list
         self.assertGreaterEqual(len(calls), 1)
         first_config = calls[0].args[0]
-        self.assertIn("glibc", first_config.upgradePackages)
-        self.assertIn("openssl", first_config.upgradePackages)
+        upgrade_names = [
+            package if isinstance(package, str) else package.name for package in first_config.upgradePackages
+        ]
+        self.assertIn("glibc", upgrade_names)
+        self.assertIn("openssl", upgrade_names)
 
     def test_upgrade_packages_dropped_on_failure(self):
         """
@@ -1533,7 +1621,8 @@ class TestBareUpdateUpgradeResolution(unittest.TestCase):
         calls = resolver.resolve.call_args_list
         self.assertGreaterEqual(len(calls), 1)
         config = calls[0].args[0]
-        self.assertIn("glibc", config.upgradePackages)
+        upgrade_names = [package if isinstance(package, str) else package.name for package in config.upgradePackages]
+        self.assertIn("glibc", upgrade_names)
         self.assertEqual(config.reinstallPackages, [])
 
     def test_bare_update_stage_alias_drops_upgrades(self):
@@ -1608,4 +1697,5 @@ class TestBareUpdateUpgradeResolution(unittest.TestCase):
         # newer versions. reinstallPackages pins to the installed EVR and wins
         # over the upgrade request, silently keeping the old version.
         self.assertNotIn("python3-setuptools", config.reinstallPackages)
-        self.assertIn("python3-setuptools", config.upgradePackages)
+        upgrade_names = [package if isinstance(package, str) else package.name for package in config.upgradePackages]
+        self.assertIn("python3-setuptools", upgrade_names)


### PR DESCRIPTION
rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added architecture-aware package resolution for multi-architecture container images.
  * Package specifications can now be scoped to specific CPU architectures.
  * Upgrade and pinning workflows preserve architecture-specific package selections.
  * Lockfiles retain all configured architectures, including architectures without resolved packages.

* **Bug Fixes**
  * Improved platform selection when discovering installed packages, including ARM64 images.
  * Added clearer warnings when no packages are resolved for a configured architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->