### PR TITLE
Allow skipping Konflux SLSA validation

### DIFF
--- a/doozer/doozerlib/backend/konflux_image_builder.py
+++ b/doozer/doozerlib/backend/konflux_image_builder.py
@@ -307,7 +307,8 @@ class KonfluxImageBuilder:
                         # Validate SLSA attestation and source image signature
                         # Skip for non-OCP groups (e.g., OKD) as they may not have attestations/signatures
                         is_ocp_group = self._config.group_name.startswith("openshift-")
-                        if is_ocp_group:
+                        skip_validate_slsa = metadata.config.get("konflux", {}).get("skip_validate_slsa", False)
+                        if is_ocp_group and skip_validate_slsa is not True:
                             try:
                                 # use image_digest here to be precise, image_pullspec can collide in case of golang-builder images
                                 await self._validate_build_attestation_and_signature(
@@ -318,11 +319,16 @@ class KonfluxImageBuilder:
                                     f"Failed to get SLA attestation / source signature from konflux for image {definitive_image_pullspec}, marking build as {KonfluxBuildOutcome.BUILD_ERROR}. Error: {e}"
                                 )
                                 outcome = KonfluxBuildOutcome.BUILD_ERROR
-                        else:
+                        elif not is_ocp_group:
                             logger.info(
                                 "Skipping SLSA attestation validation for %s: non-OCP group '%s'",
                                 metadata.distgit_key,
                                 self._config.group_name,
+                            )
+                        else:
+                            logger.info(
+                                "Skipping SLSA attestation validation for %s: disabled by image metadata",
+                                metadata.distgit_key,
                             )
                     elif not self._config.dry_run:
                         # This should never happen in real builds - only expected in dry-run mode

--- a/doozer/tests/backend/test_konflux_image_builder.py
+++ b/doozer/tests/backend/test_konflux_image_builder.py
@@ -233,6 +233,59 @@ class TestKonfluxImageBuilder(unittest.IsolatedAsyncioTestCase):
 
         mock_validate.assert_awaited_once_with("quay.io/test/image@sha256:testdigest", "test-image")
 
+    async def test_build_skips_slsa_validation_when_configured(self):
+        metadata = self._metadata()
+        metadata.config.get.return_value = {"skip_validate_slsa": True}
+        dest_dir = self.builder._config.base_dir.joinpath(metadata.qualified_key)
+        dest_dir.mkdir(parents=True)
+
+        build_repo = MagicMock()
+        build_repo.local_dir = dest_dir
+        build_repo.url = "https://github.com/test/repo.git"
+        build_repo.commit_hash = "test-commit"
+
+        initial_pipelinerun = MagicMock()
+        initial_pipelinerun.name = "test-pipelinerun"
+        initial_pipelinerun.to_dict.return_value = {"metadata": {"name": "test-pipelinerun"}}
+
+        completed_pipelinerun = MagicMock()
+        completed_pipelinerun.name = "test-pipelinerun"
+        completed_pipelinerun.find_condition.return_value = {"status": "True"}
+        completed_pipelinerun.to_dict.return_value = {
+            "metadata": {"name": "test-pipelinerun"},
+            "status": {
+                "results": [
+                    {"name": "IMAGE_URL", "value": "quay.io/test/image:test-tag"},
+                    {"name": "IMAGE_DIGEST", "value": "sha256:testdigest"},
+                ]
+            },
+        }
+        self.mock_konflux_client.wait_for_pipelinerun = AsyncMock(return_value=completed_pipelinerun)
+
+        with (
+            patch(
+                "doozerlib.backend.konflux_image_builder.BuildRepo.from_local_dir",
+                new=AsyncMock(return_value=build_repo),
+            ),
+            patch.object(self.builder, "_parse_dockerfile", return_value=("test-uuid", "test-component", "1.0", "1")),
+            patch.object(self.builder, "_wait_for_parent_members", new=AsyncMock(return_value=[])),
+            patch.object(self.builder, "_start_build", new=AsyncMock(return_value=initial_pipelinerun)),
+            patch.object(self.builder, "update_konflux_db", new=AsyncMock(return_value=MagicMock(record_id="1"))),
+            patch.object(self.builder, "_validate_build_attestation_and_signature", new=AsyncMock()) as mock_validate,
+            patch.object(
+                self.builder._konflux_client,
+                "verify_enterprise_contract",
+                new=AsyncMock(return_value=MagicMock(ec_pipeline_url="", ec_failed=False)),
+            ),
+            patch(
+                "doozerlib.backend.konflux_image_builder.KonfluxBuildOutcome.extract_from_pipelinerun_succeeded_condition",
+                return_value=KonfluxBuildOutcome.SUCCESS,
+            ),
+        ):
+            await self.builder.build(metadata)
+
+        mock_validate.assert_not_awaited()
+
     async def test_build_skips_slsa_validation_for_non_ocp_groups(self):
         """Test that SLSA attestation validation is skipped for non-OCP groups like OKD."""
         # Create a builder with an OKD group name

--- a/ocp-build-data-validator/tests/test_schema/test_image_schema.py
+++ b/ocp-build-data-validator/tests/test_schema/test_image_schema.py
@@ -138,6 +138,26 @@ class TestImageSchema(unittest.TestCase):
         }
         self.assertIsNone(image_schema.validate('filename', valid_data))
 
+    def test_validate_with_valid_konflux_skip_validate_slsa(self):
+        data = {
+            'from': {},
+            'name': 'my-name',
+            'for_payload': True,
+            'delivery': {'delivery_repo_names': ['foo', 'bar']},
+            'konflux': {'skip_validate_slsa': True},
+        }
+        self.assertIsNone(image_schema.validate('filename', data))
+
+    def test_validate_with_invalid_konflux_skip_validate_slsa(self):
+        data = {
+            'from': {},
+            'name': 'my-name',
+            'for_payload': True,
+            'delivery': {'delivery_repo_names': ['foo', 'bar']},
+            'konflux': {'skip_validate_slsa': 'true'},
+        }
+        self.assertIn("'true' is not of type 'boolean'", image_schema.validate('filename', data))
+
     def test_validate_with_empty_konflux_cachi2_lockfile_rpms(self):
         """Test empty rpms array is valid"""
         valid_data = {

--- a/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
+++ b/ocp-build-data-validator/validator/json_schemas/image_config.base.schema.json
@@ -1548,6 +1548,17 @@
           "$ref": "#/properties/konflux/properties/build_attempts"
         },
         "build_attempts-": {},
+        "skip_validate_slsa": {
+          "description": "Skip SLSA attestation and source image signature validation after a successful Konflux build",
+          "type": "boolean"
+        },
+        "skip_validate_slsa!": {
+          "$ref": "#/properties/konflux/properties/skip_validate_slsa"
+        },
+        "skip_validate_slsa?": {
+          "$ref": "#/properties/konflux/properties/skip_validate_slsa"
+        },
+        "skip_validate_slsa-": {},
         "image_repo": {
           "description": "Override the default Konflux image repository for this image's builds",
           "type": "string"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an image configuration option to skip SLSA attestation and source-signature validation after successful builds.
  * The option accepts boolean values only and is validated by the image schema.
  * Build logs now distinguish between validation skipped for non-OCP groups and validation disabled by image configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->