### PR TITLE
Fix bundle stage release watch timeout

### DIFF
--- a/doozer/doozerlib/cli/images_konflux.py
+++ b/doozer/doozerlib/cli/images_konflux.py
@@ -4,7 +4,6 @@ import logging
 import os
 import sys
 import traceback
-from datetime import timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
 
@@ -1165,10 +1164,7 @@ class BundleStageReleaseRelatedImagesCli:
         release_url = konflux_client.resource_url(created_release)
         self._logger.info("Created Release %s for Snapshot %s (%s)", release_name, snapshot_name, release_url)
 
-        released = KubeCondition.find_condition(
-            await konflux_client.wait_for_release(release_name, overall_timeout_timedelta=timedelta(minutes=30)),
-            'Released',
-        )
+        released = KubeCondition.find_condition(await konflux_client.wait_for_release(release_name), 'Released')
         if not released or released.status != "True" or released.reason != "Succeeded":
             raise RuntimeError(
                 f"Stage release {release_name} for {operator_nvr} did not succeed "

--- a/doozer/tests/cli/test_images_konflux.py
+++ b/doozer/tests/cli/test_images_konflux.py
@@ -397,9 +397,11 @@ class TestBundleStageReleaseRelatedImagesCli(unittest.IsolatedAsyncioTestCase):
     def _mock_konflux_client(released_condition):
         client = mock.AsyncMock()
         client.resource_url = mock.Mock(return_value="https://konflux/url")
-        created = mock.Mock()
-        created.metadata.name = "fbc-ri-stage-rhacm2-2-16-operator-a-xyz"
-        client._create = mock.AsyncMock(return_value=created)
+        created_snapshot = mock.Mock()
+        created_snapshot.metadata.name = "snapshot-xyz"
+        created_release = mock.Mock()
+        created_release.metadata.name = "release-xyz"
+        client._create = mock.AsyncMock(side_effect=[created_snapshot, created_release])
         client._get = mock.AsyncMock(return_value={})
         client.wait_for_release = mock.AsyncMock(return_value={"status": {"conditions": [released_condition]}})
         return client
@@ -465,7 +467,7 @@ class TestBundleStageReleaseRelatedImagesCli(unittest.IsolatedAsyncioTestCase):
         release = client._create.call_args_list[1].args[0]
         self.assertEqual(release["spec"]["releasePlan"], "acm-advisory-stage-2-16")
         self.assertEqual(release["metadata"]["annotations"]["art.redhat.com/operator-nvr"], "operator-a-1-1")
-        client.wait_for_release.assert_awaited_once_with("fbc-ri-stage-rhacm2-2-16-operator-a-xyz")
+        client.wait_for_release.assert_awaited_once_with("release-xyz")
 
     @mock.patch("doozerlib.cli.images_konflux.KonfluxDb")
     async def test_stage_release_raises_when_release_fails(self, mock_db_class):

--- a/doozer/tests/cli/test_images_konflux.py
+++ b/doozer/tests/cli/test_images_konflux.py
@@ -465,7 +465,7 @@ class TestBundleStageReleaseRelatedImagesCli(unittest.IsolatedAsyncioTestCase):
         release = client._create.call_args_list[1].args[0]
         self.assertEqual(release["spec"]["releasePlan"], "acm-advisory-stage-2-16")
         self.assertEqual(release["metadata"]["annotations"]["art.redhat.com/operator-nvr"], "operator-a-1-1")
-        client.wait_for_release.assert_awaited_once()
+        client.wait_for_release.assert_awaited_once_with("fbc-ri-stage-rhacm2-2-16-operator-a-xyz")
 
     @mock.patch("doozerlib.cli.images_konflux.KonfluxDb")
     async def test_stage_release_raises_when_release_fails(self, mock_db_class):
@@ -475,6 +475,24 @@ class TestBundleStageReleaseRelatedImagesCli(unittest.IsolatedAsyncioTestCase):
         cli = self._make_cli(self._make_runtime(product="rhacm2", version_str="2.16.0", major=4, minor=21))
 
         with self.assertRaisesRegex(RuntimeError, "managed pipeline blew up"):
+            await cli._stage_release(
+                konflux_client=client,
+                components=[self._component("comp-a", "img-a")],
+                release_plan_name="acm-advisory-stage-2-16",
+                group="rhacm2-2.16",
+                assembly="stream",
+                operator_name="operator-a",
+                operator_nvr="operator-a-1-1",
+            )
+
+    @mock.patch("doozerlib.cli.images_konflux.KonfluxDb")
+    async def test_stage_release_raises_when_release_is_still_progressing(self, mock_db_class):
+        client = self._mock_konflux_client(
+            {"type": "Released", "status": "False", "reason": "Progressing", "message": "release is running"}
+        )
+        cli = self._make_cli(self._make_runtime(product="rhacm2", version_str="2.16.0", major=4, minor=21))
+
+        with self.assertRaisesRegex(RuntimeError, "Progressing"):
             await cli._stage_release(
                 konflux_client=client,
                 components=[self._component("comp-a", "img-a")],


### PR DESCRIPTION
## Summary

The bundle build job's related-image stage release inherited a hard-coded 30-minute watch timeout, causing Jenkins false failures when Konflux Releases remained Progressing longer than 30 minutes. This removes the workflow-specific override so the existing 5-hour Konflux Release wait applies.

A Release that ultimately fails or remains unresolved after the shared timeout still fails the affected operator/job.

## Validation

- uv run pytest doozer/tests/cli/test_images_konflux.py (15 passed)
- Ruff checks passed
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release waiting now uses the server-generated Release name, improving reliability.
  * Releases that remain in a progressing state now report an error with the underlying condition reason.

* **Behavior Changes**
  * Release operations no longer apply a fixed 30-minute timeout override, allowing the standard release-waiting behavior to take effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->