### PR TITLE
ART-23300: fix(release_util): handle -rhelN suffix in split_el_suffix_in_release

### DIFF
--- a/artcommon/artcommonlib/release_util.py
+++ b/artcommon/artcommonlib/release_util.py
@@ -22,6 +22,10 @@ def split_el_suffix_in_release(release: str) -> Tuple[str, Optional[str]]:
     is None if there .el### or .scos### is not detected.
     For OKD builds, this returns the scos suffix (e.g., 'scos9').
     For OCP builds, this returns the el suffix (e.g., 'el9').
+
+    Also handles floating image tags that use a '-rhelN' suffix (e.g.,
+    'golang-builder-v1.22-rhel9'), normalising the result to the canonical
+    'el9' form so that callers behave identically for both tag styles.
     """
 
     el_suffix_match = re.match(r'(.*)[.+]((?:el|scos)\d+(?:_\d+)?)(?:.*|$)', release)
@@ -29,8 +33,18 @@ def split_el_suffix_in_release(release: str) -> Tuple[str, Optional[str]]:
         prefix = el_suffix_match.group(1)
         el_suffix = el_suffix_match.group(2)
         return prefix, el_suffix
-    else:
-        return release, None
+
+    # Fallback: floating image tags use '-rhelN' (e.g. 'golang-builder-v1.22-rhel9').
+    # Normalise to the canonical 'elN' form so downstream callers are unaffected.
+    # The leading `.*` is greedy, so when multiple `-rhelN` segments exist the
+    # rightmost match wins (e.g. 'img-rhel8-rhel9' → el9).
+    rhel_suffix_match = re.match(r'^(.*)-rhel(\d+)(.*)$', release)
+    if rhel_suffix_match:
+        prefix = rhel_suffix_match.group(1)
+        el_suffix = f'el{rhel_suffix_match.group(2)}'
+        return prefix, el_suffix
+
+    return release, None
 
 
 def isolate_assembly_in_release(release: str) -> Optional[str]:

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -200,6 +200,16 @@ class TestUtil(unittest.TestCase):
             ('202401221732.p0.g00c615b.el9_6', '202401221732.p0.g00c615b', 'el9_6'),
             ('202401221732.p0.g00c615b.el9_4', '202401221732.p0.g00c615b', 'el9_4'),
             ('1.2.3-y.p.p1.assembly.stream.el10_2', '1.2.3-y.p.p1.assembly.stream', 'el10_2'),
+            # Floating image tags with -rhelN suffix (normalised to elN)
+            ('golang-builder-v1.22-rhel9', 'golang-builder-v1.22', 'el9'),
+            ('golang-builder-v1.22-rhel8', 'golang-builder-v1.22', 'el8'),
+            ('golang-builder-v1.21-rhel10', 'golang-builder-v1.21', 'el10'),
+            # Tag with extra segments after -rhelN (greedy .* binds to last -rhelN)
+            ('some-image-v2.3-rhel9-suffix', 'some-image-v2.3', 'el9'),
+            # Multiple -rhelN segments: rightmost wins
+            ('img-rhel8-rhel9', 'img-rhel8', 'el9'),
+            # Malformed -rhel (no digits): no match, returns (release, None)
+            ('img-rhel-foo', 'img-rhel-foo', None),
         ]
 
         for t in test_cases:
@@ -224,6 +234,14 @@ class TestUtil(unittest.TestCase):
             ('202401221732.p0.g00c615b.el9_6', 9),
             ('202401221732.p0.g00c615b.el9_4', 9),
             ('1.2.3-y.p.p1.assembly.stream.el10_2', 10),
+            # Floating image tags with -rhelN suffix
+            ('golang-builder-v1.22-rhel9', 9),
+            ('golang-builder-v1.22-rhel8', 8),
+            ('golang-builder-v1.21-rhel10', 10),
+            # Multiple -rhelN segments: rightmost wins
+            ('img-rhel8-rhel9', 9),
+            # Malformed -rhel (no digits): None
+            ('img-rhel-foo', None),
         ]
 
         for t in test_cases:

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -21,7 +21,13 @@ from artcommonlib.constants import ACTIVE_OCP_VERSIONS
 from artcommonlib.exectools import limit_concurrency
 from artcommonlib.github_auth import get_github_client_for_org
 from artcommonlib.model import Missing, Model
-from artcommonlib.release_util import SoftwareLifecyclePhase, isolate_assembly_in_release
+from artcommonlib.release_util import (
+    SoftwareLifecyclePhase,
+    isolate_assembly_in_release,
+)
+from artcommonlib.release_util import (
+    isolate_el_version_in_release as _artcommon_isolate_el_version_in_release,
+)
 from artcommonlib.util import merge_objects, new_roundtrip_yaml_handler, split_git_url
 from doozerlib import util as doozerutil
 from doozerlib.constants import ART_BUILD_HISTORY_URL
@@ -37,15 +43,15 @@ logger = logging.getLogger(__name__)
 
 def isolate_el_version_in_release(release: str) -> Optional[int]:
     """
-    Given a release field, determines whether is contains
-    a RHEL version. If it does, it returns the version value as int.
-    If it is not found, None is returned.
-    """
-    match = re.match(r'.*\.el(\d+)(?:\.+|$)', release)
-    if match:
-        return int(match.group(1))
+    Given a release field, determines whether it contains a RHEL version.
+    If it does, it returns the version value as int; otherwise None.
 
-    return None
+    Delegates to artcommonlib.release_util.isolate_el_version_in_release so
+    that both the canonical '.elN'/'+elN'/'.scosN' patterns and floating image
+    tag '-rhelN' suffixes (e.g. 'golang-builder-v1.22-rhel9') are handled in
+    one place.
+    """
+    return _artcommon_isolate_el_version_in_release(release)
 
 
 def isolate_el_version_in_branch(branch_name: str) -> Optional[int]:

--- a/pyartcd/tests/test_util.py
+++ b/pyartcd/tests/test_util.py
@@ -6,11 +6,15 @@ from pyartcd import util
 
 class TestUtil(IsolatedAsyncioTestCase):
     def test_isolate_el_version_in_release(self):
+        # Existing .elN patterns
         self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.4.9.99.el7'), 7)
         self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.4.9.el7'), 7)
         self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.art12398.el199'), 199)
         self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.art12398'), None)
         self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.4.7.e.8'), None)
+        # Floating image tags with -rhelN suffix (delegated to artcommonlib)
+        self.assertEqual(util.isolate_el_version_in_release('golang-builder-v1.22-rhel9'), 9)
+        self.assertEqual(util.isolate_el_version_in_release('golang-builder-v1.22-rhel8'), 8)
 
     def test_isolate_el_version_in_branch(self):
         self.assertEqual(util.isolate_el_version_in_branch('rhaos-4.9-rhel-7-candidate'), 7)


### PR DESCRIPTION
## Summary

`isolate_el_version_in_release()` was returning `None` for floating golang-builder tags like `golang-builder-v1.22-rhel9` because `split_el_suffix_in_release()` only matched `.elN`/`+elN`/`.scosN` suffixes, not the `-rhelN` form used by floating tags introduced in [ART-23148](https://redhat.atlassian.net/browse/ART-23148).

This caused the rebaser's upstream-to-stream matching (`rebaser.py:2409`) to silently fail the EL-version comparison and fall back to default stream resolution, losing the `# ART matched upstream parent` Dockerfile annotation.

## Problem

**Before:** `isolate_el_version_in_release("golang-builder-v1.22-rhel9")` returned `None`. The rebaser could not match floating-tag stream entries by RHEL version.

**After:** Returns `9` (or `8`, `10`, etc.). The rebaser correctly pairs upstream CI builder images to the right stream entry.

## Implementation Details

- Added a `-rhelN` fallback regex in `split_el_suffix_in_release()` (`artcommonlib/release_util.py`) that normalises matches to the canonical `elN` form. The primary `.elN`/`.scosN` branch is unchanged and always wins for real RPM NVRs.
- Delegated `pyartcd.util.isolate_el_version_in_release()` to the artcommonlib canonical implementation. The delegation is safe — `pyartcd/util.py` already imports from `artcommonlib.release_util`. This also extends pyartcd callers to handle `+elN`/`.scosN` patterns they previously missed.
- New tests cover `rhel8`/`rhel9`/`rhel10`, multiple `-rhelN` segments (rightmost wins due to greedy `.*`), and a malformed `-rhel` (no digits) case. All existing patterns pass.

Note: the `-rhelN` regex is a fallback that only fires when the primary `.elN`/`.scosN` branch does not match. Real RPM NVRs always carry a dist tag, so there is no false-positive risk for existing callers.

Fixes: [ART-23300](https://redhat.atlassian.net/browse/ART-23300)
Related: ART-23167, [ART-23148](https://redhat.atlassian.net/browse/ART-23148)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release parsing for floating image tags with `-rhelN` suffixes.
  * Normalized supported suffixes to the corresponding EL version, including tags containing multiple suffixes.
  * Added consistent handling for `.elN`, `+elN`, `.scosN`, and `-rhelN` formats.
  * Improved handling of malformed suffixes that lack a numeric version.

* **Tests**
  * Expanded coverage for valid, multiple, and malformed release suffixes across supported image tag formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->