### PR TITLE
ART-14748: Support multi-RHEL MicroShift bootc shipments

### DIFF
--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -2,6 +2,7 @@ import os
 import re
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import List, Mapping, Optional, Set
 
 import aiohttp
@@ -293,11 +294,24 @@ class CreateReleaseCli:
 
     def get_object_name(self) -> str:
         timestamp = get_utc_now_formatted_str()
-        raw_prefix = f"{self.runtime.product}-{self.release_env}-{self.runtime.assembly}-{self.kind}"
+        object_kind = self._get_object_kind()
+        raw_prefix = f"{self.runtime.product}-{self.release_env}-{self.runtime.assembly}-{object_kind}"
         prefix = normalize_k8s_dns_label(raw_prefix, max_length=63 - len(timestamp) - 1)
         if not prefix:
             raise ValueError(f"Release object name prefix {raw_prefix!r} cannot be normalized to a Kubernetes name")
         return f"{prefix}-{timestamp}"
+
+    def _get_object_kind(self) -> str:
+        """
+        Return the shipment kind qualified by its RHEL version, when present.
+
+        MicroShift bootc shipments have one configuration file per RHEL version,
+        so the version must be included in Kubernetes object names to avoid
+        collisions when the releases run concurrently.
+        """
+        config_stem = Path(self.config_path).stem
+        match = re.search(rf"(?:^|\.)({re.escape(self.kind)}-el\d+)(?:\.|$)", config_stem)
+        return match.group(1) if match else self.kind
 
     async def create_snapshot(self, shipment: Shipment) -> dict:
         """

--- a/elliott/elliottlib/cli/konflux_release_cli.py
+++ b/elliott/elliottlib/cli/konflux_release_cli.py
@@ -2,7 +2,7 @@ import os
 import re
 import sys
 from dataclasses import dataclass
-from typing import List, Optional, Set
+from typing import List, Mapping, Optional, Set
 
 import aiohttp
 import click
@@ -87,7 +87,23 @@ async def _validate_snapshot_against_single_rpa(kind: str, rpa_name: str, snapsh
     )
 
 
-async def validate_snapshot_against_rpa(group: str, env: str, kind: str, snapshot_components: List[str]) -> None:
+async def validate_snapshot_against_rpa(
+    group: str,
+    env: str,
+    kind: str,
+    snapshot_components: List[str],
+    release_plans: Mapping[str, str] | None = None,
+) -> None:
+    """
+    Validate snapshot components against the configured stage and prod RPAs.
+
+    Args:
+        group: Build-data group used to determine whether RPA validation applies.
+        env: Environment being released first; the other environment is checked second.
+        kind: Shipment kind used by the legacy RPA naming fallback.
+        snapshot_components: Component names present in the shipment snapshot.
+        release_plans: Optional mapping of environment names to configured ReleasePlans.
+    """
     match = re.fullmatch(r"openshift-(\d+)\.(\d+)", group)
     if group.startswith("openshift-") and not match:
         raise ValueError(f"Unrecognized openshift group format, refusing to skip RPA validation: {group!r}")
@@ -108,7 +124,9 @@ async def validate_snapshot_against_rpa(group: str, env: str, kind: str, snapsho
 
     envs_to_check = [env] + [e for e in OCP_RPA_ENVS if e != env]
     for check_env in envs_to_check:
-        rpa_name = f"{OCP_RPA_KINDS[kind]}-{check_env}-{major}-{minor}"
+        rpa_name = (release_plans or {}).get(check_env)
+        if not rpa_name:
+            rpa_name = f"{OCP_RPA_KINDS[kind]}-{check_env}-{major}-{minor}"
         await _validate_snapshot_against_single_rpa(kind, rpa_name, snapshot_components)
 
 
@@ -234,7 +252,17 @@ class CreateReleaseCli:
         if self.runtime.group.startswith("openshift-") and config.shipment.snapshot:
             LOGGER.info("Validating snapshot components against RPA...")
             component_names = [c.name for c in config.shipment.snapshot.spec.components]
-            await validate_snapshot_against_rpa(self.runtime.group, self.release_env, self.kind, component_names)
+            release_plans = {
+                "stage": config.shipment.environments.stage.releasePlan,
+                "prod": config.shipment.environments.prod.releasePlan,
+            }
+            await validate_snapshot_against_rpa(
+                self.runtime.group,
+                self.release_env,
+                self.kind,
+                component_names,
+                release_plans=release_plans,
+            )
 
         # Create snapshot first using the spec from shipment config
         LOGGER.info("Creating snapshot from shipment config...")
@@ -538,5 +566,9 @@ async def validate_rpa_cli(runtime: Runtime, config, env, kind):
     component_names = [c.name for c in shipment_config.shipment.snapshot.spec.components]
     LOGGER.info("Validating %d components against RPA for %s/%s...", len(component_names), env, kind)
 
-    await validate_snapshot_against_rpa(runtime.group, env, kind, component_names)
+    release_plans = {
+        "stage": shipment_config.shipment.environments.stage.releasePlan,
+        "prod": shipment_config.shipment.environments.prod.releasePlan,
+    }
+    await validate_snapshot_against_rpa(runtime.group, env, kind, component_names, release_plans=release_plans)
     LOGGER.info("Validation passed: all components are present in the RPA")

--- a/elliott/elliottlib/shipment_utils.py
+++ b/elliott/elliottlib/shipment_utils.py
@@ -211,7 +211,7 @@ def get_shipment_configs_from_mr(
 
         filename = file_path.split('/')[-1]
         parts = filename.replace('.yaml', '').replace('.yml', '')
-        kind = next((k for k in kinds if k in parts), None)
+        kind = _get_shipment_config_kind(parts, kinds)
         if not kind:
             continue
 
@@ -226,6 +226,34 @@ def get_shipment_configs_from_mr(
         shipment_configs[kind] = shipment_data
 
     return shipment_configs
+
+
+def _get_shipment_config_kind(filename_stem: str, kinds: Tuple[str, ...]) -> str | None:
+    """
+    Extracts a shipment kind from a filename, preserving an optional RHEL suffix.
+
+    New multi-RHEL shipment files use names such as ``image-el9`` and
+    ``microshift-bootc-el10``. The suffix must remain part of the returned key so
+    that multiple RHEL-specific configs can coexist in one merge request.
+
+    Args:
+        filename_stem: Shipment filename without its YAML extension.
+        kinds: Base shipment kinds accepted by the caller.
+    Returns:
+        The matching base or RHEL-qualified shipment kind, if any.
+    """
+    for kind in sorted(kinds, key=len, reverse=True):
+        qualified_match = re.search(rf"(?:^|\.)({re.escape(kind)}-el\d+)(?:\.|$)", filename_stem)
+        if qualified_match:
+            return qualified_match.group(1)
+
+        base_match = re.search(rf"(?:^|\.){re.escape(kind)}(?:\.|$)", filename_stem)
+        if base_match:
+            return kind
+
+    # Preserve the historical substring matching for unusual legacy filenames such as
+    # ``rpm-extra.yaml``.
+    return next((kind for kind in kinds if kind in filename_stem), None)
 
 
 def get_shipment_config_from_mr(mr_url: str, kind: str) -> ShipmentConfig | None:

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -203,6 +203,26 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
         self.assertEqual(name, "ocp-prod-4-18-2-rc-1-image-v2-20260805200004")
         self.assertLessEqual(len(name), 63)
 
+    @patch("elliottlib.cli.konflux_release_cli.get_utc_now_formatted_str", return_value="20260909154630")
+    @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
+    def test_object_name_includes_rhel_suffix_from_shipment_filename(self, mock_konflux_client_init, _mock_timestamp):
+        mock_konflux_client_init.return_value = self.konflux_client
+        self.runtime.assembly = "rc.1"
+
+        cli = CreateReleaseCli(
+            runtime=self.runtime,
+            config_path=(
+                "shipment/ocp/openshift-5.0/openshift-5-0/stage/rc.1.microshift-bootc-el10.20260904133832.yaml"
+            ),
+            release_env="stage",
+            konflux_config=self.konflux_config,
+            image_repo_pull_secret=self.image_repo_pull_secret,
+            dry_run=self.dry_run,
+            kind="microshift-bootc",
+        )
+
+        self.assertEqual(cli.get_object_name(), "ocp-stage-rc-1-microshift-bootc-el10-20260909154630")
+
     @patch("doozerlib.backend.konflux_client.KonfluxClient.from_kubeconfig")
     async def test_release_rejects_invalid_snapshot_reference(self, mock_konflux_client_init):
         mock_konflux_client_init.return_value = self.konflux_client

--- a/elliott/tests/test_konflux_release_cli.py
+++ b/elliott/tests/test_konflux_release_cli.py
@@ -788,6 +788,29 @@ class TestCreateReleaseCli(IsolatedAsyncioTestCase):
         self.assertEqual(calls, ["ocp-art-advisory-stage-4-18", "ocp-art-advisory-prod-4-18"])
 
     @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
+    async def test_validate_rpa_uses_configured_release_plans(self, mock_fetch_rpa):
+        """Uses RHEL-specific ReleasePlans from the shipment configuration when provided."""
+        rpa_data = {"spec": {"data": {"mapping": {"components": [{"name": "comp1"}]}}}}
+        mock_fetch_rpa.return_value = rpa_data
+
+        await validate_snapshot_against_rpa(
+            "openshift-5.0",
+            "stage",
+            "microshift-bootc",
+            ["comp1"],
+            release_plans={
+                "stage": "ocp-art-advisory-stage-5-0-rhel9",
+                "prod": "ocp-art-advisory-prod-5-0-rhel9",
+            },
+        )
+
+        calls = [c.args[0] for c in mock_fetch_rpa.await_args_list]
+        self.assertEqual(
+            calls,
+            ["ocp-art-advisory-stage-5-0-rhel9", "ocp-art-advisory-prod-5-0-rhel9"],
+        )
+
+    @patch("elliottlib.cli.konflux_release_cli.fetch_rpa", new_callable=AsyncMock)
     async def test_validate_rpa_skipped_for_non_openshift(self, mock_fetch_rpa):
         await validate_snapshot_against_rpa("oadp-1.5", "prod", "image", ["comp1"])
         mock_fetch_rpa.assert_not_called()

--- a/elliott/tests/test_shipment_utils.py
+++ b/elliott/tests/test_shipment_utils.py
@@ -304,6 +304,32 @@ shipment:
         expected_kinds = {"fbc", "image", "extras", "microshift-bootc", "metadata"}
         self.assertEqual(set(result.keys()), expected_kinds)
 
+    @patch('artcommonlib.gitlab.gitlab.Gitlab')
+    @patch.dict(os.environ, {'GITLAB_TOKEN': 'test-token'})
+    def test_get_shipment_configs_preserves_rhel_qualified_kinds(self, mock_gitlab_class):
+        """RHEL-qualified shipment files remain distinct when parsed from one MR."""
+        mock_gitlab = mock_gitlab_class.return_value
+        mock_gitlab.projects.get.side_effect = [self.mock_project, self.mock_source_project]
+
+        self.mock_project.mergerequests.get.return_value = self.mock_mr
+        self.mock_mr.source_project_id = "source-project-id"
+        self.mock_mr.source_branch = "test-branch"
+
+        self.mock_diff_info.id = "diff-id"
+        self.mock_mr.diffs.list.return_value = [self.mock_diff_info]
+        self.mock_mr.diffs.get.return_value = self.mock_diff
+        self.mock_diff.diffs = [
+            {'new_path': 'microshift-bootc-el9.yaml', 'old_path': None},
+            {'new_path': 'microshift-bootc-el10.yaml', 'old_path': None},
+        ]
+
+        self.mock_file_content.decode.return_value.decode.return_value = self.sample_yaml_content
+        self.mock_source_project.files.get.return_value = self.mock_file_content
+
+        result = shipment_utils.get_shipment_configs_from_mr(self.test_mr_url)
+
+        self.assertEqual(set(result), {'microshift-bootc-el9', 'microshift-bootc-el10'})
+
 
 class TestGroupFiltering(unittest.TestCase):
     """Test cases for group-based filtering in get_shipment_configs_from_mr"""

--- a/pyartcd/pyartcd/pipelines/binary_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/binary_release_konflux.py
@@ -16,7 +16,6 @@ from artcommonlib import exectools
 from artcommonlib.build_visibility import is_nvr_embargoed
 from artcommonlib.constants import SHIPMENT_DATA_URL_TEMPLATE
 from artcommonlib.gitlab import GitLabClient
-from artcommonlib.release_util import isolate_el_version_in_release
 from artcommonlib.util import new_roundtrip_yaml_handler
 from elliottlib.shipment_model import (
     Environments,
@@ -32,6 +31,7 @@ from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.click_validators import validate_release_date
 from pyartcd.git import GitRepository
 from pyartcd.runtime import Runtime
+from pyartcd.shipment_utils import get_release_plan_names, group_nvrs_by_rhel_version
 
 yaml = new_roundtrip_yaml_handler()
 
@@ -237,14 +237,7 @@ class BinaryReleaseKonfluxPipeline:
         NVRs without a detectable .el* suffix go under the 'default' key.
         Returns an OrderedDict-like dict sorted by key for deterministic ordering.
         """
-        groups: Dict[str, List[str]] = {}
-        for nvr in nvrs:
-            # The release field is the last hyphen-delimited segment of an NVR
-            release = nvr.rsplit('-', 1)[-1] if '-' in nvr else nvr
-            el_ver = isolate_el_version_in_release(release)
-            key = f"el{el_ver}" if el_ver is not None else "default"
-            groups.setdefault(key, []).append(nvr)
-        return dict(sorted(groups.items()))
+        return group_nvrs_by_rhel_version(nvrs)
 
     async def create_snapshot(self, builds: List[str]) -> Optional[Snapshot]:
         """
@@ -316,21 +309,8 @@ class BinaryReleaseKonfluxPipeline:
             fbc=False,
         )
 
-        stage_rpa = "n/a"
-        prod_rpa = "n/a"
         config_path = self.shipment_data_repo._directory / "config.yaml"
-        if config_path.exists():
-            with open(config_path, 'r') as f:
-                shipment_config = stdlib_yaml.safe_load(f) or {}
-            applications = shipment_config.get("applications", {})
-            # Try RHEL-versioned key first (e.g. 'oc-mirror-2-0-el9'), then fall back to the
-            # plain application name for products that don't split by RHEL version.
-            lookup_key = f"{application}-{rhel_suffix}" if rhel_suffix else application
-            app_env_config = (applications.get(lookup_key) or applications.get(application) or {}).get(
-                "environments", {}
-            )
-            stage_rpa = app_env_config.get("stage", {}).get("releasePlan", "n/a")
-            prod_rpa = app_env_config.get("prod", {}).get("releasePlan", "n/a")
+        stage_rpa, prod_rpa = get_release_plan_names(config_path, application, rhel_suffix)
 
         if stage_rpa == "n/a" or prod_rpa == "n/a":
             effective_key = f"{application}-{rhel_suffix}" if rhel_suffix else application

--- a/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift_bootc.py
@@ -42,7 +42,7 @@ from artcommonlib.util import (
 )
 from doozerlib.backend.konflux_client import API_VERSION, KIND_SNAPSHOT
 from doozerlib.util import isolate_git_commit_in_release
-from elliottlib.shipment_model import ShipmentConfig, Snapshot, SnapshotSpec
+from elliottlib.shipment_model import Environments, ShipmentConfig, ShipmentEnv, Snapshot, SnapshotSpec
 from github import GithubException
 
 from pyartcd import constants, jenkins
@@ -50,6 +50,7 @@ from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.git import GitRepository
 from pyartcd.plashets import convert_plashet_config_to_new_style, plashet_config_for_major_minor
 from pyartcd.runtime import Runtime
+from pyartcd.shipment_utils import get_release_plan_names, group_nvrs_by_rhel_version
 from pyartcd.util import (
     default_release_suffix,
     get_assembly_type,
@@ -871,7 +872,7 @@ class BuildMicroShiftBootcPipeline:
             await asyncio.sleep(check_interval)
 
     async def _prepare_shipment(self, builds: dict[str, KonfluxBuildRecord]):
-        """Prepare shipment for microshift-bootc (all variants combined in one shipment MR).
+        """Prepare RHEL-specific microshift-bootc shipments in one shipment MR.
 
         Args:
             builds: Mapping of image_name -> KonfluxBuildRecord for each built variant.
@@ -884,8 +885,8 @@ class BuildMicroShiftBootcPipeline:
         # Step 2: Setup shipment data repository first
         await self._setup_shipment_data_repo()
 
-        # Step 3: Check for existing shipment branch and try to load existing config
-        shipment_config = await self._load_or_init_shipment_config()
+        # Step 3: Reuse the existing shipment MR branch when one is configured.
+        await self._load_or_init_shipment_branch()
 
         # Check if there was an existing microshift_bootc_shipment URL
         assembly_shipment_config = self.assembly_group_config.get("microshift_bootc_shipment", {})
@@ -899,14 +900,11 @@ class BuildMicroShiftBootcPipeline:
         for image_name, build in builds.items():
             self._logger.info("Using bootc build for %s: %s", image_name, build.nvr)
 
-        # Step 5: Create snapshot from all bootc builds
-        image_names = list(builds.keys())
-        nvrs = [build.nvr for build in builds.values()]
-        snapshot = await self._create_snapshot(nvrs, image_names)
-        shipment_config.shipment.snapshot = snapshot
+        # Step 5: Create one snapshot and shipment config for each RHEL version.
+        shipment_configs = await self._create_shipment_configs(builds)
 
-        # Step 6: Create shipment MR
-        self.shipment_mr_url = await self._create_shipment_mr(shipment_config, env)
+        # Step 6: Create or update one shipment MR containing all RHEL-specific files.
+        self.shipment_mr_url = await self._create_shipment_mr(shipment_configs, env)
 
         if self.shipment_mr_url:
             await self.slack_client.say_in_thread(f"Shipment MR created: {self.shipment_mr_url}")
@@ -917,6 +915,37 @@ class BuildMicroShiftBootcPipeline:
                 await self._create_or_update_build_data_pr()
         else:
             await self.slack_client.say_in_thread("No changes in shipment data. MR was not created or updated.")
+
+    async def _create_shipment_configs(self, builds: dict[str, KonfluxBuildRecord]) -> dict[str, ShipmentConfig]:
+        """
+        Create one snapshot and shipment config for each RHEL version in the builds.
+
+        Args:
+            builds: Mapping of bootc image name to its Konflux build record.
+        Returns:
+            Shipment configurations keyed by the shipment filename kind.
+        """
+        builds_by_nvr = {build.nvr: (image_name, build) for image_name, build in builds.items()}
+        nvr_groups = group_nvrs_by_rhel_version([build.nvr for build in builds.values()])
+        multiple_rhel_versions = len(nvr_groups) > 1
+        shipment_configs: dict[str, ShipmentConfig] = {}
+
+        for rhel_suffix, group_nvrs in nvr_groups.items():
+            image_names = [builds_by_nvr[nvr][0] for nvr in group_nvrs]
+            snapshot = await self._create_snapshot(group_nvrs, image_names)
+            if snapshot is None:
+                raise ValueError(f"No snapshot created for RHEL group {rhel_suffix}")
+
+            shipment_config = await self._init_shipment_config(rhel_suffix if rhel_suffix != "default" else None)
+            shipment_config.shipment.snapshot = snapshot
+
+            if multiple_rhel_versions:
+                shipment_kind = f"microshift-bootc-{rhel_suffix}"
+            else:
+                shipment_kind = "microshift-bootc"
+            shipment_configs[shipment_kind] = shipment_config
+
+        return shipment_configs
 
     def _resolve_shipment_env(self) -> str:
         """Resolve the target shipment environment (stage/prod) from the assembly definition.
@@ -1088,35 +1117,33 @@ class BuildMicroShiftBootcPipeline:
         await self._wait_for_pr_merge(pr)
         return True
 
-    async def _load_or_init_shipment_config(self) -> ShipmentConfig:
-        """Load existing shipment config from branch or initialize new one
-
-        If a shipment MR already exists (URL in config), reuse the existing branch.
-        Otherwise, create a new branch with timestamp.
-
-        Sets self._shipment_source_branch to the resolved branch name for reuse in _create_shipment_mr.
+    async def _load_or_init_shipment_branch(self) -> None:
         """
-        # Check if shipment already exists in assembly config
+        Switches to the existing shipment branch or prepares for a new branch.
+
+        Existing shipment MRs must remain open so that a rerun can safely update
+        their source branch.
+        """
         assembly_shipment_config = self.assembly_group_config.get("microshift_bootc_shipment", {})
         existing_mr_url = assembly_shipment_config.get("url")
 
         if existing_mr_url:
-            # Get the branch name from the existing MR (validates MR state)
             self._shipment_source_branch = self._get_shipment_mr_branch(existing_mr_url)
-
-            self._logger.info('Found existing shipment MR, using branch: %s', self._shipment_source_branch)
+            self._logger.info("Found existing shipment MR, using branch: %s", self._shipment_source_branch)
             await self.shipment_data_repo.fetch_switch_branch(self._shipment_source_branch, remote="origin")
-
-            # Initialize new config - we'll load the snapshot from existing files later if needed
-            return await self._init_shipment_config()
         else:
-            # No existing MR - this is the first run, initialize new config
-            self._logger.info('No existing shipment MR found, will initialize new shipment config')
+            self._logger.info("No existing shipment MR found, will initialize a new shipment branch")
             self._shipment_source_branch = None
-            return await self._init_shipment_config()
 
-    async def _init_shipment_config(self) -> ShipmentConfig:
-        """Initialize shipment configuration using elliott shipment init"""
+    async def _init_shipment_config(self, rhel_suffix: str | None = None) -> ShipmentConfig:
+        """
+        Initialize shipment configuration and resolve its RHEL-specific ReleasePlans.
+
+        Args:
+            rhel_suffix: Optional suffix such as ``el9`` or ``el10``.
+        Returns:
+            Initialized shipment configuration with resolved stage/prod ReleasePlans.
+        """
         self._logger.info("Initializing shipment configuration for microshift-bootc...")
 
         create_cmd = self._elliott_base_command + [
@@ -1130,6 +1157,21 @@ class BuildMicroShiftBootcPipeline:
         # Convert CommentedMap to regular Python objects before creating Pydantic model
         out = Model(yaml.load(stdout)).primitive()
         shipment = ShipmentConfig(**out)
+
+        config_path = self.shipment_data_repo._directory / "config.yaml"
+        application = shipment.shipment.metadata.application
+        stage_release_plan, prod_release_plan = get_release_plan_names(config_path, application, rhel_suffix)
+        if stage_release_plan == "n/a" or prod_release_plan == "n/a":
+            effective_key = f"{application}-{rhel_suffix}" if rhel_suffix else application
+            raise ValueError(
+                f"stage/prod releasePlan is not registered for '{effective_key}' in {config_path}. "
+                "Cannot create a shipment MR with unresolved ReleasePlans."
+            )
+
+        shipment.shipment.environments = Environments(
+            stage=ShipmentEnv(releasePlan=stage_release_plan),
+            prod=ShipmentEnv(releasePlan=prod_release_plan),
+        )
 
         self._logger.info("Shipment configuration initialized")
         return shipment
@@ -1190,8 +1232,8 @@ class BuildMicroShiftBootcPipeline:
 
         self._logger.info("Shipment data repository setup completed")
 
-    async def _create_shipment_mr(self, shipment_config: ShipmentConfig, env: str = "prod") -> str | None:
-        """Create or update shipment MR with the given shipment config. Returns None if no changes.
+    async def _create_shipment_mr(self, shipments_by_kind: dict[str, ShipmentConfig], env: str = "prod") -> str | None:
+        """Create or update shipment MR with the given shipment configs. Returns None if no changes.
 
         :param env: The target environment (prod or stage) that determines the shipment file directory.
         """
@@ -1199,10 +1241,10 @@ class BuildMicroShiftBootcPipeline:
 
         target_branch = "main"
 
-        # Use the cached branch name from _load_or_init_shipment_config (if available)
+        # Use the cached branch name from _load_or_init_shipment_branch (if available)
         cached_branch = getattr(self, '_shipment_source_branch', None)
         if cached_branch:
-            # Reusing existing MR branch (already switched in _load_or_init_shipment_config)
+            # Reusing existing MR branch (already switched in _load_or_init_shipment_branch)
             source_branch = cached_branch
             self._logger.info('Reusing existing shipment branch: %s', source_branch)
         else:
@@ -1215,7 +1257,7 @@ class BuildMicroShiftBootcPipeline:
         # Update shipment data repo with shipment config
         release_name = get_release_name_for_assembly(self.group, self.releases_config, self.assembly)
         commit_message = f"Add microshift-bootc shipment configuration for {release_name}"
-        updated = await self._update_shipment_data(shipment_config, commit_message, source_branch, env)
+        updated = await self._update_shipment_data(shipments_by_kind, commit_message, source_branch, env)
         if not updated:
             self._logger.info("No changes in shipment data. MR will not be created or updated.")
             return None
@@ -1267,30 +1309,29 @@ class BuildMicroShiftBootcPipeline:
         return mr_url
 
     async def _update_shipment_data(
-        self, shipment_config: ShipmentConfig, commit_message: str, branch: str, env: str = "prod"
+        self,
+        shipments_by_kind: dict[str, ShipmentConfig],
+        commit_message: str,
+        branch: str,
+        env: str = "prod",
     ) -> bool:
-        """Update shipment data repo with the given shipment config file
+        """Update shipment data repo with the given shipment config files.
 
-        :param env: The target environment (prod or stage) that determines the shipment file directory.
+        Args:
+            shipments_by_kind: Shipment configurations keyed by filename kind.
+            commit_message: Git commit message for the shipment update.
+            branch: Shipment branch name containing the timestamp.
+            env: Target environment directory, either ``prod`` or ``stage``.
         """
         # Extract timestamp from branch name (last segment after splitting by "-")
         # Branch format: prepare-microshift-bootc-shipment-{assembly}-{timestamp}
         timestamp = branch.split("-")[-1]
-        filename = f"{self.assembly}.microshift-bootc.{timestamp}.yaml"
-        product = shipment_config.shipment.metadata.product
-        group = shipment_config.shipment.metadata.group
-        application = shipment_config.shipment.metadata.application
 
-        relative_target_dir = Path("shipment") / product / group / application / env
-        target_dir = self.shipment_data_repo._directory / relative_target_dir
-        target_dir.mkdir(parents=True, exist_ok=True)
-        filepath = relative_target_dir / filename
+        if len(shipments_by_kind) > 1:
+            await self._remove_legacy_combined_shipment_file(shipments_by_kind, timestamp, env)
 
-        self._logger.info("Updating shipment file: %s", filename)
-        shipment_dump = shipment_config.model_dump(exclude_unset=True, exclude_none=True)
-        out = StringIO()
-        yaml.dump(shipment_dump, out)
-        await self.shipment_data_repo.write_file(filepath, out.getvalue())
+        for shipment_kind, shipment_config in shipments_by_kind.items():
+            await self._write_shipment_file(shipment_kind, shipment_config, timestamp, env)
 
         await self.shipment_data_repo.add_all()
         await self.shipment_data_repo.log_diff()
@@ -1300,6 +1341,71 @@ class BuildMicroShiftBootcPipeline:
             commit_message += f"\n{job_url}"
 
         return await self.shipment_data_repo.commit_push(commit_message, safe=True)
+
+    async def _write_shipment_file(
+        self,
+        shipment_kind: str,
+        shipment_config: ShipmentConfig,
+        timestamp: str,
+        env: str,
+    ) -> Path:
+        """
+        Writes one shipment config file to the shipment-data repository.
+
+        Args:
+            shipment_kind: Kind used in the shipment filename.
+            shipment_config: Shipment configuration to serialize.
+            timestamp: Timestamp shared by all files in the shipment MR.
+            env: Target environment directory, either ``prod`` or ``stage``.
+        Returns:
+            Relative path of the written shipment file.
+        """
+        product = shipment_config.shipment.metadata.product
+        group = shipment_config.shipment.metadata.group
+        application = shipment_config.shipment.metadata.application
+        relative_target_dir = Path("shipment") / product / group / application / env
+        target_dir = self.shipment_data_repo._directory / relative_target_dir
+        target_dir.mkdir(parents=True, exist_ok=True)
+        filename = f"{self.assembly}.{shipment_kind}.{timestamp}.yaml"
+        filepath = relative_target_dir / filename
+
+        self._logger.info("Updating shipment file: %s", filename)
+        shipment_dump = shipment_config.model_dump(exclude_unset=True, exclude_none=True)
+        out = StringIO()
+        yaml.dump(shipment_dump, out)
+        await self.shipment_data_repo.write_file(filepath, out.getvalue())
+        return filepath
+
+    async def _remove_legacy_combined_shipment_file(
+        self,
+        shipments_by_kind: dict[str, ShipmentConfig],
+        timestamp: str,
+        env: str,
+    ) -> None:
+        """
+        Removes the old combined shipment file when migrating to RHEL-specific files.
+
+        Args:
+            shipments_by_kind: New shipment configurations used to locate the target directory.
+            timestamp: Timestamp encoded in the existing shipment branch.
+            env: Target environment directory, either ``prod`` or ``stage``.
+        """
+        shipment_config = next(iter(shipments_by_kind.values()))
+        product = shipment_config.shipment.metadata.product
+        group = shipment_config.shipment.metadata.group
+        application = shipment_config.shipment.metadata.application
+        legacy_relative_path = (
+            Path("shipment")
+            / product
+            / group
+            / application
+            / env
+            / f"{self.assembly}.microshift-bootc.{timestamp}.yaml"
+        )
+        legacy_path = self.shipment_data_repo._directory / legacy_relative_path
+        if legacy_path.exists():
+            self._logger.info("Removing legacy combined shipment file: %s", legacy_relative_path)
+            legacy_path.unlink()
 
     @cached_property
     def _gitlab(self) -> GitLabClient:

--- a/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release_konflux.py
@@ -676,7 +676,17 @@ class PrepareReleaseKonfluxPipeline:
         for kind, shipment in shipments_by_kind.items():
             if shipment.shipment.snapshot and shipment.shipment.snapshot.spec.components:
                 component_names = [c.name for c in shipment.shipment.snapshot.spec.components]
-                await validate_snapshot_against_rpa(self.group, env, kind, component_names)
+                release_plans = {
+                    "stage": shipment.shipment.environments.stage.releasePlan,
+                    "prod": shipment.shipment.environments.prod.releasePlan,
+                }
+                await validate_snapshot_against_rpa(
+                    self.group,
+                    env,
+                    kind,
+                    component_names,
+                    release_plans=release_plans,
+                )
 
         # Update shipment MR with found builds
         await self.update_shipment_mr(shipments_by_kind, env, shipment_url)

--- a/pyartcd/pyartcd/shipment_utils.py
+++ b/pyartcd/pyartcd/shipment_utils.py
@@ -1,0 +1,87 @@
+"""
+Shared helpers for Konflux shipment pipelines.
+
+The helpers in this module keep RHEL-version handling consistent between
+standalone binary releases and MicroShift bootc shipments.
+"""
+
+from pathlib import Path
+
+import yaml as stdlib_yaml
+from artcommonlib.release_util import isolate_el_version_in_release
+
+
+def group_nvrs_by_rhel_version(nvrs: list[str]) -> dict[str, list[str]]:
+    """
+    Groups NVRs by their RHEL version suffix.
+
+    Args:
+        nvrs: Build NVRs whose final release segment may contain an ``elN`` suffix.
+    Returns:
+        Dictionary keyed by ``elN`` or ``default``, sorted by key for deterministic output.
+    """
+    groups: dict[str, list[str]] = {}
+    for nvr in nvrs:
+        # The release field is the last hyphen-delimited segment of an NVR.
+        release = nvr.rsplit("-", 1)[-1] if "-" in nvr else nvr
+        el_version = isolate_el_version_in_release(release)
+        key = f"el{el_version}" if el_version is not None else "default"
+        groups.setdefault(key, []).append(nvr)
+
+    return dict(
+        sorted(
+            groups.items(),
+            key=lambda item: -1 if item[0] == "default" else int(item[0].removeprefix("el")),
+        )
+    )
+
+
+def get_release_plan_names(
+    config_path: Path,
+    application: str,
+    rhel_suffix: str | None = None,
+) -> tuple[str, str]:
+    """
+    Loads stage and production ReleasePlan names from shipment config.yaml.
+
+    When a RHEL suffix is provided, the RHEL-specific application key is tried
+    first and the plain application key is used as a backwards-compatible fallback.
+
+    Args:
+        config_path: Path to the shipment-data config.yaml file.
+        application: Base Konflux application name.
+        rhel_suffix: Optional suffix such as ``el9`` or ``el10``.
+    Returns:
+        Tuple containing the stage and production ReleasePlan names. Missing
+        values retain the existing ``n/a`` behavior.
+    """
+    stage_release_plan = "n/a"
+    prod_release_plan = "n/a"
+
+    if not config_path.exists():
+        return stage_release_plan, prod_release_plan
+
+    with config_path.open("r") as config_file:
+        shipment_config = stdlib_yaml.safe_load(config_file) or {}
+
+    applications = shipment_config.get("applications", {})
+    lookup_keys = [application]
+    if rhel_suffix:
+        rhel_number = rhel_suffix.removeprefix("el").removeprefix("rhel")
+        lookup_keys = [
+            f"{application}-rhel{rhel_number}",
+            f"{application}-{rhel_suffix}",
+            application,
+        ]
+
+    application_config = {}
+    for lookup_key in lookup_keys:
+        application_config = applications.get(lookup_key, {})
+        if application_config:
+            break
+
+    application_config = application_config.get("environments", {})
+    stage_release_plan = application_config.get("stage", {}).get("releasePlan", "n/a")
+    prod_release_plan = application_config.get("prod", {}).get("releasePlan", "n/a")
+
+    return stage_release_plan, prod_release_plan

--- a/pyartcd/tests/pipelines/test_build_microshift_bootc.py
+++ b/pyartcd/tests/pipelines/test_build_microshift_bootc.py
@@ -82,7 +82,7 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
         source_branch = f"prepare-microshift-bootc-shipment-{self.assembly}-{existing_timestamp}"
 
         # when
-        await pipeline._update_shipment_data(mock_shipment_config, "Test commit", source_branch)
+        await pipeline._update_shipment_data({"microshift-bootc": mock_shipment_config}, "Test commit", source_branch)
 
         # then
         pipeline.shipment_data_repo.write_file.assert_called_once()
@@ -126,7 +126,9 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
         source_branch = f"prepare-microshift-bootc-shipment-{self.assembly}-{timestamp}"
 
         # when
-        await pipeline._update_shipment_data(mock_shipment_config, "Test commit", source_branch, "stage")
+        await pipeline._update_shipment_data(
+            {"microshift-bootc": mock_shipment_config}, "Test commit", source_branch, "stage"
+        )
 
         # then
         pipeline.shipment_data_repo.write_file.assert_called_once()
@@ -235,7 +237,7 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
 
         # when
         with patch('pyartcd.pipelines.build_microshift_bootc.get_release_name_for_assembly', return_value="4.21.0"):
-            _ = await pipeline._create_shipment_mr(mock_shipment_config)
+            _ = await pipeline._create_shipment_mr({"microshift-bootc": mock_shipment_config})
 
         # then
         pipeline.shipment_data_repo.write_file.assert_called_once()
@@ -297,7 +299,7 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
 
         # when
         with patch('pyartcd.pipelines.build_microshift_bootc.get_release_name_for_assembly', return_value="4.18.1"):
-            _ = await pipeline._create_shipment_mr(mock_shipment_config)
+            _ = await pipeline._create_shipment_mr({"microshift-bootc": mock_shipment_config})
 
         # then
         # Verify a new branch with timestamp was created
@@ -319,6 +321,27 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
         self.assertEqual(timestamp_from_branch, timestamp_part)
         self.assertEqual(len(timestamp_part), 14)
         self.assertTrue(timestamp_part.isdigit())
+
+    async def test_load_or_init_shipment_branch_reuses_open_mr_branch(self):
+        """Reuses the source branch from the configured open shipment MR."""
+        pipeline = self._make_pipeline(group="openshift-5.0", assembly="rc.1")
+        existing_mr_url = "https://gitlab.example.com/shipment-data/-/merge_requests/806"
+        existing_branch = "prepare-microshift-bootc-shipment-rc.1-20260904133832"
+        pipeline.releases_config = Model(
+            {"releases": {"rc.1": {"assembly": {"group": {"microshift_bootc_shipment": {"url": existing_mr_url}}}}}}
+        )
+        pipeline.shipment_data_repo = Mock()
+        pipeline.shipment_data_repo.fetch_switch_branch = AsyncMock()
+
+        mock_mr = Mock(source_branch=existing_branch, state="opened")
+        mock_gitlab = Mock()
+        mock_gitlab.get_mr_from_url.return_value = mock_mr
+        pipeline._gitlab = mock_gitlab
+
+        await pipeline._load_or_init_shipment_branch()
+
+        self.assertEqual(pipeline._shipment_source_branch, existing_branch)
+        pipeline.shipment_data_repo.fetch_switch_branch.assert_awaited_once_with(existing_branch, remote="origin")
 
     @patch("pyartcd.pipelines.build_microshift_bootc.get_microshift_builds")
     async def test_get_microshift_rpm_commit_extracts_commit(self, mock_get_builds):
@@ -641,6 +664,76 @@ class TestBuildMicroShiftBootcPipeline(IsolatedAsyncioTestCase):
         self.assertEqual(images[1]["distgit_key"], "microshift-bootc-rhel10")
         self.assertEqual(
             images[1]["metadata"]["is"]["nvr"], "microshift-bootc-rhel10-container-v4.22-202606081229.el10"
+        )
+
+    @patch.object(BuildMicroShiftBootcPipeline, "_init_shipment_config", new_callable=AsyncMock)
+    @patch.object(BuildMicroShiftBootcPipeline, "_create_snapshot", new_callable=AsyncMock)
+    async def test_create_shipment_configs_groups_builds_by_rhel_version(
+        self, mock_create_snapshot, mock_init_shipment_config
+    ):
+        """Creates one shipment config and snapshot for each RHEL version."""
+        pipeline = self._make_pipeline(group="openshift-5.0", assembly="rc.1")
+        snapshot_el9 = Mock()
+        snapshot_el10 = Mock()
+        mock_create_snapshot.side_effect = [snapshot_el9, snapshot_el10]
+
+        config_el9 = Mock()
+        config_el10 = Mock()
+        mock_init_shipment_config.side_effect = [config_el9, config_el10]
+        builds = {
+            "microshift-bootc": Mock(nvr="microshift-bootc-container-v5.0-1.el9"),
+            "microshift-bootc-rhel10": Mock(nvr="microshift-bootc-rhel10-container-v5.0-1.el10"),
+        }
+
+        shipment_configs = await pipeline._create_shipment_configs(builds)
+
+        self.assertEqual(list(shipment_configs), ["microshift-bootc-el9", "microshift-bootc-el10"])
+        self.assertIs(shipment_configs["microshift-bootc-el9"], config_el9)
+        self.assertIs(shipment_configs["microshift-bootc-el10"], config_el10)
+        mock_init_shipment_config.assert_any_await("el9")
+        mock_init_shipment_config.assert_any_await("el10")
+        self.assertEqual(mock_create_snapshot.await_count, 2)
+
+    async def test_update_shipment_data_writes_multiple_files_and_removes_legacy_file(self):
+        """Writes RHEL-specific files and removes the old combined shipment file."""
+        pipeline = self._make_pipeline(group="openshift-5.0", assembly="rc.1")
+        pipeline.shipment_data_repo = Mock()
+        pipeline.shipment_data_repo._directory = Path(tempfile.mkdtemp())
+        pipeline.shipment_data_repo.write_file = AsyncMock()
+        pipeline.shipment_data_repo.add_all = AsyncMock()
+        pipeline.shipment_data_repo.log_diff = AsyncMock()
+        pipeline.shipment_data_repo.commit_push = AsyncMock(return_value=True)
+
+        legacy_dir = pipeline.shipment_data_repo._directory / "shipment/ocp/openshift-5.0/openshift-5-0/stage"
+        legacy_dir.mkdir(parents=True)
+        legacy_file = legacy_dir / "rc.1.microshift-bootc.20260904133832.yaml"
+        legacy_file.write_text("legacy")
+
+        configs = {}
+        for kind in ("microshift-bootc-el9", "microshift-bootc-el10"):
+            config = Mock()
+            config.shipment.metadata.product = "ocp"
+            config.shipment.metadata.group = "openshift-5.0"
+            config.shipment.metadata.application = "openshift-5-0"
+            config.model_dump.return_value = {"shipment": {}}
+            configs[kind] = config
+
+        updated = await pipeline._update_shipment_data(
+            configs,
+            "Update shipment",
+            "prepare-microshift-bootc-shipment-rc.1-20260904133832",
+            "stage",
+        )
+
+        self.assertTrue(updated)
+        self.assertFalse(legacy_file.exists())
+        written_paths = [call.args[0] for call in pipeline.shipment_data_repo.write_file.call_args_list]
+        self.assertEqual(
+            {path.name for path in written_paths},
+            {
+                "rc.1.microshift-bootc-el9.20260904133832.yaml",
+                "rc.1.microshift-bootc-el10.20260904133832.yaml",
+            },
         )
 
     def test_pin_image_nvr_updates_existing_entry(self):

--- a/pyartcd/tests/test_shipment_utils.py
+++ b/pyartcd/tests/test_shipment_utils.py
@@ -1,0 +1,73 @@
+"""
+Tests for shared Konflux shipment helpers.
+"""
+
+from pathlib import Path
+
+from pyartcd.shipment_utils import get_release_plan_names, group_nvrs_by_rhel_version
+
+
+def test_group_nvrs_by_rhel_version_sorts_rhel_groups() -> None:
+    """Groups NVRs by their RHEL suffix in deterministic order."""
+    nvrs = [
+        "microshift-bootc-rhel10-container-v5.0-1.el10",
+        "microshift-bootc-container-v5.0-1.el9",
+    ]
+
+    assert group_nvrs_by_rhel_version(nvrs) == {
+        "el10": ["microshift-bootc-rhel10-container-v5.0-1.el10"],
+        "el9": ["microshift-bootc-container-v5.0-1.el9"],
+    }
+
+
+def test_group_nvrs_by_rhel_version_uses_default_without_suffix() -> None:
+    """Places NVRs without a detectable RHEL suffix in the default group."""
+    assert group_nvrs_by_rhel_version(["microshift-bootc-container-v5.0-1"]) == {
+        "default": ["microshift-bootc-container-v5.0-1"]
+    }
+
+
+def test_get_release_plan_names_prefers_rhel_specific_application(tmp_path: Path) -> None:
+    """Uses the RHEL-specific application entry when it exists."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "applications:\n"
+        "  openshift-5-0:\n"
+        "    environments:\n"
+        "      stage:\n"
+        "        releasePlan: old-stage\n"
+        "      prod:\n"
+        "        releasePlan: old-prod\n"
+        "  openshift-5-0-rhel10:\n"
+        "    environments:\n"
+        "      stage:\n"
+        "        releasePlan: rhel10-stage\n"
+        "      prod:\n"
+        "        releasePlan: rhel10-prod\n"
+    )
+
+    assert get_release_plan_names(config_path, "openshift-5-0", "el10") == (
+        "rhel10-stage",
+        "rhel10-prod",
+    )
+
+
+def test_get_release_plan_names_falls_back_to_plain_application(tmp_path: Path) -> None:
+    """Falls back to the plain application entry for older shipment data."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "applications:\n"
+        "  openshift-4-22:\n"
+        "    environments:\n"
+        "      stage:\n"
+        "        releasePlan: stage\n"
+        "      prod:\n"
+        "        releasePlan: prod\n"
+    )
+
+    assert get_release_plan_names(config_path, "openshift-4-22", "el9") == ("stage", "prod")
+
+
+def test_get_release_plan_names_returns_na_for_missing_config(tmp_path: Path) -> None:
+    """Returns the existing n/a defaults when no application is configured."""
+    assert get_release_plan_names(tmp_path / "missing.yaml", "openshift-5-0", "el9") == ("n/a", "n/a")


### PR DESCRIPTION
  ## What does this PR do?

  Updates ART tools to support MicroShift bootc shipments containing both RHEL 9 and RHEL 10 builds.

  ## Why is this needed?

  MicroShift bootc produces separate RHEL 9 and RHEL 10 images. Each version requires its own snapshot and RHEL-specific ReleasePlans.

  Additionally, RPA validation was deriving legacy unsuffixed names such as:

  - `ocp-art-advisory-stage-5-0`
  - `ocp-art-advisory-prod-5-0`

  Those RPAs were replaced by RHEL-specific RPAs.

  ## Changes

  - Add shared helpers for:
    - Grouping NVRs by RHEL version.
    - Resolving RHEL-specific ReleasePlans.
  - Update `build-microshift-bootc` to:
    - Create separate snapshots for RHEL 9 and RHEL 10.
    - Generate separate shipment files in one shipment MR.
    - Reuse the branch of an existing open shipment MR.
    - Remove the legacy combined shipment file.
  - Update shipment MR parsing to preserve RHEL-qualified shipment kinds.
  - Update RPA validation to use the ReleasePlans declared in the shipment configuration.
  - Preserve legacy derived RPA-name behavior for callers without configured ReleasePlans.
  - Add regression coverage for multi-RHEL shipment generation and RPA validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Process shipment configurations separately for each RHEL version.
  * Generate version-specific shipment files, snapshots, ReleasePlans, and release names, allowing multiple versions to coexist without collisions.
  * Group builds by RHEL version and reuse existing shipment merge request branches.
  * Support RHEL-specific release-plan mappings with fallback to shared configuration values.
  * Validate releases using configured stage and production ReleasePlans.

* **Bug Fixes**
  * Preserve distinct RHEL-qualified shipment configuration names.
  * Remove legacy combined shipment files when version-specific configurations are generated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->