### PR TITLE
Remove ART from MR approval rules

### DIFF
--- a/artcommon/artcommonlib/gitlab.py
+++ b/artcommon/artcommonlib/gitlab.py
@@ -164,8 +164,7 @@ class GitLabClient:
     async def set_mr_approval_rules(self, mr_url: str, approvers_config: dict[str, list[str]]):
         """
         Configure MR-level approval rules based on group.yml mr_approvers config.
-        Keeps the "ART" rule, removes all other inherited rules, and creates new
-        rules from approvers_config.
+        Removes all inherited rules and creates new rules from approvers_config.
 
         Arg(s):
             mr_url: Full URL to the merge request
@@ -188,9 +187,8 @@ class GitLabClient:
         existing_rules = mr.approval_rules.list()
 
         for rule in existing_rules:
-            if rule.name != "ART":
-                logger.info(f"Deleting approval rule '{rule.name}' (id={rule.id})")
-                rule.delete()
+            logger.info(f"Deleting approval rule '{rule.name}' (id={rule.id})")
+            rule.delete()
 
         for name, usernames in approvers_config.items():
             user_ids = self._resolve_user_ids(usernames)

--- a/pyartcd/tests/pipelines/test_release_from_fbc.py
+++ b/pyartcd/tests/pipelines/test_release_from_fbc.py
@@ -418,7 +418,7 @@ class TestSetMrApprovalRules(unittest.TestCase):
 
         client.get_mr_from_url.assert_not_called()
 
-    def test_deletes_non_art_and_creates_new(self):
+    def test_deletes_all_existing_rules_and_creates_new(self):
         client = self._make_client(dry_run=False)
 
         mock_mr = MagicMock()
@@ -445,7 +445,7 @@ class TestSetMrApprovalRules(unittest.TestCase):
             )
         )
 
-        art_rule.delete.assert_not_called()
+        art_rule.delete.assert_called_once()
         ert_rule.delete.assert_called_once()
         docs_rule.delete.assert_called_once()
         mock_mr.approval_rules.create.assert_called_once_with(


### PR DESCRIPTION
Summary:
- Remove inherited ART approval rules when reconciling shipment MR approval groups.
- Update the focused test to verify all existing rules are deleted.

Tests:
- uv run pytest -q pyartcd/tests/pipelines/test_release_from_fbc.py (125 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitLab merge request approval rules are now fully reset before configured rules are created, including previously retained rules.
  * Updated validation to reflect the corrected approval-rule behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->