### PR TITLE
Fix deriving OCP registry namespace for FBC related images

### DIFF
--- a/artcommon/artcommonlib/util.py
+++ b/artcommon/artcommonlib/util.py
@@ -986,6 +986,13 @@ def _extract_images_from_catalog_json(catalog_path: str) -> list[str]:
     return images
 
 
+def get_registry_namespace_pattern(product: str) -> str:
+    """Return the registry.redhat.io namespace pattern used for a product's published images."""
+    if product in ("ocp", "openshift"):
+        return r"openshift\d+"
+    return re.escape(product)
+
+
 async def extract_related_images_from_fbc(fbc_pullspec: str, product: str) -> list[str]:
     """
     Extract related image pullspecs from FBC image using ORAS workflow.
@@ -1106,13 +1113,7 @@ async def extract_related_images_from_fbc(fbc_pullspec: str, product: str) -> li
                 "Product parameter is required to determine the registry namespace for image transformation"
             )
 
-        # Map product names to registry namespaces
-        # OCP uses 'openshift4' namespace in registry.redhat.io
-        product_to_namespace = {
-            'ocp': 'openshift4',
-            'openshift': 'openshift4',
-        }
-        registry_namespace = product_to_namespace.get(product, product)
+        registry_namespace = get_registry_namespace_pattern(product)
         LOGGER.info(f"Using registry namespace '{registry_namespace}' for product '{product}'")
 
         registry_transform_pattern = rf'registry\.redhat\.io/{registry_namespace}/[^@]*'
@@ -1128,7 +1129,7 @@ async def extract_related_images_from_fbc(fbc_pullspec: str, product: str) -> li
 
             for img_url in raw_images:
                 # Check if the URL matches the registry namespace pattern
-                if f'registry.redhat.io/{registry_namespace}/' in img_url:
+                if re.search(rf'registry\.redhat\.io/{registry_namespace}/', img_url):
                     # Apply the transformation to quay.io/redhat-user-workloads/ocp-art-tenant/art-images
                     transformed_url = re.sub(
                         registry_transform_pattern,
@@ -1158,7 +1159,7 @@ async def extract_related_images_from_fbc(fbc_pullspec: str, product: str) -> li
                 found_images = _extract_images_from_catalog_json(catalog_json_path)
 
                 for img_url in found_images:
-                    if f'registry.redhat.io/{registry_namespace}/' in img_url:
+                    if re.search(rf'registry\.redhat\.io/{registry_namespace}/', img_url):
                         transformed_url = re.sub(
                             registry_transform_pattern,
                             KONFLUX_DEFAULT_IMAGE_REPO,

--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -11,6 +11,7 @@ from artcommonlib.util import (
     deep_merge,
     extract_related_images_from_fbc,
     get_inflight,
+    get_registry_namespace_pattern,
     isolate_major_minor_in_group,
     normalize_group_name_for_k8s,
     normalize_k8s_dns_label,
@@ -802,6 +803,35 @@ class TestExtractRelatedImagesFromFBC(unittest.TestCase):
                     indent=4,
                 ),
             ]
+        )
+
+    def test_get_registry_namespace_pattern(self):
+        self.assertEqual(get_registry_namespace_pattern("ocp"), r"openshift\d+")
+        self.assertEqual(get_registry_namespace_pattern("oadp"), "oadp")
+
+    @patch('artcommonlib.util.cmd_gather_async', new_callable=AsyncMock)
+    @patch('builtins.open', new_callable=MagicMock)
+    @patch('os.path.exists')
+    @patch('os.listdir')
+    def test_transforms_ocp5_related_images(self, mock_listdir, mock_exists, mock_open, mock_cmd):
+        mock_cmd.side_effect = [
+            (0, self._create_discover_response(include_related_images=True), ''),
+            (0, 'Pulled artifact successfully', ''),
+        ]
+        mock_listdir.return_value = ['related-images.json']
+        mock_exists.side_effect = lambda path: 'related-images.json' in path
+
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.read.return_value = json.dumps(
+            ['registry.redhat.io/openshift5/ose-operator@sha256:111']
+        )
+        mock_open.return_value = mock_file
+
+        result = asyncio.run(extract_related_images_from_fbc(self.fbc_pullspec, self.product))
+
+        self.assertEqual(
+            result,
+            ['quay.io/redhat-user-workloads/ocp-art-tenant/art-images@sha256:111'],
         )
 
     def _create_discover_response(self, include_related_images=True, include_rendered_catalog=False):


### PR DESCRIPTION
## Summary
- recognize all `registry.redhat.io/openshift<major>/...` namespaces when extracting OCP FBC related images
- keep layered-product namespaces exact and product-based