### PR TITLE
Fix merged shipment grade checks

### DIFF
--- a/elliott/elliottlib/cli/verify_image_grades_cli.py
+++ b/elliott/elliottlib/cli/verify_image_grades_cli.py
@@ -126,7 +126,12 @@ def resolve_shipment_mr_url(runtime) -> str:
 def fetch_shipment_components(mr_url: str) -> tuple[list[tuple[str, str]], str]:
     gl = GitLabClient.from_url(mr_url)
     mr = gl.get_mr_from_url(mr_url)
-    source_project = gl.get_project(mr.source_project_id)
+    if mr.state == "merged" and mr.merge_commit_sha:
+        project = gl.get_project(mr.target_project_id)
+        file_ref = mr.merge_commit_sha
+    else:
+        project = gl.get_project(mr.source_project_id)
+        file_ref = mr.source_branch
 
     title = mr.title or ""
     match = re.search(r"Shipment for (\d+\.\d+\.\d+(?:-\S+)?)", title, re.IGNORECASE)
@@ -148,7 +153,7 @@ def fetch_shipment_components(mr_url: str) -> tuple[list[tuple[str, str]], str]:
             continue
 
         try:
-            file_content = source_project.files.get(file_path, mr.source_branch)
+            file_content = project.files.get(file_path, file_ref)
             content = file_content.decode().decode("utf-8")
             data = yaml.safe_load(content)
             if not isinstance(data, dict):

--- a/elliott/tests/test_verify_image_grades_cli.py
+++ b/elliott/tests/test_verify_image_grades_cli.py
@@ -239,6 +239,7 @@ shipment:
 
         mock_mr = MagicMock()
         mock_mr.title = "Shipment for 4.18.51"
+        mock_mr.state = "opened"
         mock_mr.source_branch = "shipment-4.18.51"
         mock_mr.source_project_id = 123
         mock_mr.diffs.list.return_value = [MagicMock(id=1)]
@@ -278,9 +279,53 @@ shipment:
         self.assertEqual(len(components), 2)
         self.assertEqual(components[0][0], "ose-cli")
         self.assertIn("sha256:abc", components[0][1])
+        mock_gl.get_project.assert_called_once_with(123)
+        mock_project.files.get.assert_called_once_with("shipments/4.18/4.18.51.yaml", "shipment-4.18.51")
         mock_requests.get.assert_called_once_with(
             "https://errata.devel.redhat.com/advisory/12345", timeout=30, allow_redirects=False
         )
+
+    @patch("elliottlib.cli.verify_image_grades_cli.requests")
+    @patch("elliottlib.cli.verify_image_grades_cli.GitLabClient")
+    def test_reads_merged_mr_from_merge_commit(self, mock_gl_cls, mock_requests):
+        shipment_yaml = """
+shipment:
+  environments:
+    stage:
+      advisory:
+        internal_url: "https://errata.devel.redhat.com/advisory/12345"
+"""
+        mock_file = MagicMock()
+        mock_file.decode.return_value = shipment_yaml.encode("utf-8")
+        mock_project = MagicMock()
+        mock_project.files.get.return_value = mock_file
+
+        mock_diff = MagicMock()
+        mock_diff.diffs = [{"new_path": "shipments/4.18/4.18.51.yaml"}]
+
+        mock_mr = MagicMock()
+        mock_mr.title = "Shipment for 4.18.51"
+        mock_mr.state = "merged"
+        mock_mr.merge_commit_sha = "merge-sha"
+        mock_mr.target_project_id = 456
+        mock_mr.source_project_id = 123
+        mock_mr.source_branch = "deleted-branch"
+        mock_mr.diffs.list.return_value = [MagicMock(id=1)]
+        mock_mr.diffs.get.return_value = mock_diff
+
+        mock_gl = MagicMock()
+        mock_gl.get_mr_from_url.return_value = mock_mr
+        mock_gl.get_project.return_value = mock_project
+        mock_gl_cls.from_url.return_value = mock_gl
+
+        mock_resp = MagicMock()
+        mock_resp.text = yaml.dump({"spec": {"content": {"images": []}}})
+        mock_requests.get.return_value = mock_resp
+
+        fetch_shipment_components("https://gitlab.example.com/mr/1")
+
+        mock_gl.get_project.assert_called_once_with(456)
+        mock_project.files.get.assert_called_once_with("shipments/4.18/4.18.51.yaml", "merge-sha")
 
     @patch("elliottlib.cli.verify_image_grades_cli.requests")
     @patch("elliottlib.cli.verify_image_grades_cli.GitLabClient")


### PR DESCRIPTION
Read merged shipment files from the target project at the merge commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Image grade verification now retrieves shipment files from the correct project and revision when a shipment merge request has been merged.
  - Verification continues to use the source project and branch for merge requests that remain open.
  - Improved handling of shipment component data helps prevent verification failures caused by referencing outdated or unavailable source branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->