### PR TITLE
ART-23426 Improve RHCOS Jenkins build descriptions

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4_konflux.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_konflux.py
@@ -1116,13 +1116,10 @@ class KonfluxOcpPipeline:
             child_params,
             block_until_complete=True,
         )
+        child_job_path = jenkins.Jobs.RHCOS_NODE_IMAGE_POST_BUILD.value.replace('/', '/job/').replace('%2F', '%252F')
+        child_job_url = f'{jenkins.get_jenkins_url()}/job/{child_job_path}/'
         jenkins.update_description(
-            '<br/>RHCOS %s post-build child parameters: <code>%s</code><br/>Result: %s'
-            % (
-                rhel_label,
-                json.dumps(child_params, sort_keys=True),
-                child_result,
-            )
+            '<br/>RHCOS %s post-build: <a href="%s">rhcos-node-image-post-build</a><br/>' % (rhel_label, child_job_url)
         )
         if child_result != 'SUCCESS':
             raise RuntimeError(f"RHCOS {rhel_label} post-build job did not pass (result={child_result})")

--- a/pyartcd/pyartcd/pipelines/rhcos_node_image_post_build.py
+++ b/pyartcd/pyartcd/pipelines/rhcos_node_image_post_build.py
@@ -108,6 +108,15 @@ class RhcosNodeImagePostBuildPipeline:
             )
         return description
 
+    def _update_build_description(self, description: str):
+        """Update the Jenkins description without changing the build result if it fails."""
+
+        try:
+            jenkins.init_jenkins()
+            jenkins.update_description(description)
+        except Exception:
+            self.runtime.logger.warning('Unable to update the Jenkins build description', exc_info=True)
+
     async def run(self):
         """Run integration testing and mirror the exact tested image digests."""
 
@@ -132,7 +141,7 @@ class RhcosNodeImagePostBuildPipeline:
         )
         result = client.wait_for_build('build-node-image', build_number)
         if result['result'] != 'SUCCESS':
-            jenkins.update_description(self._build_description(result))
+            self._update_build_description(self._build_description(result))
             raise RuntimeError(
                 f'RHCOS integration test failed for {self.release}: '
                 f'{result.get("url", "")} - {result.get("description", "")}'
@@ -144,7 +153,7 @@ class RhcosNodeImagePostBuildPipeline:
             tags,
         )
         await self._promote(tags)
-        jenkins.update_description(self._build_description(result, tags))
+        self._update_build_description(self._build_description(result, tags))
 
 
 @cli.command('rhcos-node-image-post-build', help='Test and promote a pair of Konflux-built RHCOS images')

--- a/pyartcd/pyartcd/pipelines/rhcos_node_image_post_build.py
+++ b/pyartcd/pyartcd/pipelines/rhcos_node_image_post_build.py
@@ -1,12 +1,14 @@
+import html
 import os
 import re
-from typing import Dict
+from typing import Dict, Optional
 
 import click
 from artcommonlib.constants import KONFLUX_DEFAULT_IMAGE_REPO, RHCOS_IMAGE_REPO
 from artcommonlib.registry_config import RegistryConfig
 from artcommonlib.util import sync_to_quay
 
+from pyartcd import jenkins
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.rhcos_jenkins_client import RhcosJenkinsClient
 from pyartcd.runtime import Runtime
@@ -87,6 +89,25 @@ class RhcosNodeImagePostBuildPipeline:
                 else:
                     os.environ['QUAY_AUTH_FILE'] = previous_auth_file
 
+    def _build_description(self, integration_test: dict, tags: Optional[Dict[str, str]] = None) -> str:
+        """Build the Jenkins description for the integration test and promotion."""
+
+        integration_url = html.escape(integration_test.get('url', ''), quote=True)
+        integration_result = html.escape(str(integration_test.get('result', 'UNKNOWN')))
+        integration_job = f'<a href="{integration_url}">build-node-image</a>' if integration_url else 'build-node-image'
+        description = (
+            f'RHCOS integration test: {integration_job} (result: {integration_result})<br/>'
+            f'Input node image: <code>{html.escape(self.node_image)}</code><br/>'
+            f'Input extensions image: <code>{html.escape(self.extensions_image)}</code><br/>'
+        )
+        if tags:
+            description += (
+                'Updated pullspecs:<br/>'
+                f'<code>{html.escape(KONFLUX_DEFAULT_IMAGE_REPO)}:{html.escape(tags["node"])}</code><br/>'
+                f'<code>{html.escape(KONFLUX_DEFAULT_IMAGE_REPO)}:{html.escape(tags["extensions"])}</code><br/>'
+            )
+        return description
+
     async def run(self):
         """Run integration testing and mirror the exact tested image digests."""
 
@@ -111,6 +132,7 @@ class RhcosNodeImagePostBuildPipeline:
         )
         result = client.wait_for_build('build-node-image', build_number)
         if result['result'] != 'SUCCESS':
+            jenkins.update_description(self._build_description(result))
             raise RuntimeError(
                 f'RHCOS integration test failed for {self.release}: '
                 f'{result.get("url", "")} - {result.get("description", "")}'
@@ -122,6 +144,7 @@ class RhcosNodeImagePostBuildPipeline:
             tags,
         )
         await self._promote(tags)
+        jenkins.update_description(self._build_description(result, tags))
 
 
 @cli.command('rhcos-node-image-post-build', help='Test and promote a pair of Konflux-built RHCOS images')

--- a/pyartcd/tests/pipelines/test_ocp4_konflux_rhcos.py
+++ b/pyartcd/tests/pipelines/test_ocp4_konflux_rhcos.py
@@ -161,6 +161,10 @@ class TestRhcosPostBuildDelegation(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(result['NODE_IMAGE'], params['NODE_IMAGE'])
         mock_update_description.assert_called_once()
+        description = mock_update_description.call_args.args[0]
+        self.assertIn('rhcos-node-image-post-build', description)
+        self.assertIn('/job/aos-cd-builds/job/build%252Frhcos-node-image-post-build/', description)
+        self.assertNotIn('EXTENSIONS_IMAGE', description)
 
     @patch('pyartcd.pipelines.ocp4_konflux.load_group_config', new_callable=AsyncMock)
     @patch('pyartcd.pipelines.ocp4_konflux.jenkins.update_description')

--- a/pyartcd/tests/pipelines/test_rhcos_node_image_post_build.py
+++ b/pyartcd/tests/pipelines/test_rhcos_node_image_post_build.py
@@ -48,12 +48,14 @@ class TestRhcosNodeImagePostBuildPipeline(unittest.IsolatedAsyncioTestCase):
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.RegistryConfig')
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.sync_to_quay', new_callable=AsyncMock)
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.load_group_config', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.rhcos_node_image_post_build.jenkins.init_jenkins')
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.jenkins.update_description')
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.RhcosJenkinsClient')
     async def test_tests_then_promotes_exact_digests_with_configured_tags(
         self,
         mock_client_type,
         mock_update_description,
+        mock_init_jenkins,
         mock_load_group_config,
         mock_sync,
         mock_registry_config,
@@ -90,6 +92,7 @@ class TestRhcosNodeImagePostBuildPipeline(unittest.IsolatedAsyncioTestCase):
             ['5.0-9.8-node-image-extensions'],
         )
         self.assertEqual(mock_sync.await_count, 2)
+        mock_init_jenkins.assert_called_once()
         mock_update_description.assert_called_once()
         description = mock_update_description.call_args.args[0]
         self.assertIn('https://jenkins.example.com/job/build-node-image/46173/', description)
@@ -100,8 +103,11 @@ class TestRhcosNodeImagePostBuildPipeline(unittest.IsolatedAsyncioTestCase):
 
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.sync_to_quay', new_callable=AsyncMock)
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.RhcosJenkinsClient')
+    @patch('pyartcd.pipelines.rhcos_node_image_post_build.jenkins.init_jenkins')
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.jenkins.update_description')
-    async def test_failed_integration_test_does_not_promote(self, mock_update_description, mock_client_type, mock_sync):
+    async def test_failed_integration_test_does_not_promote(
+        self, mock_update_description, mock_init_jenkins, mock_client_type, mock_sync
+    ):
         mock_client = mock_client_type.return_value
         mock_client.trigger_build.return_value = 46173
         mock_client.wait_for_build.return_value = {
@@ -113,10 +119,23 @@ class TestRhcosNodeImagePostBuildPipeline(unittest.IsolatedAsyncioTestCase):
             await _make_pipeline().run()
 
         mock_sync.assert_not_awaited()
+        mock_init_jenkins.assert_called_once()
         mock_update_description.assert_called_once()
         self.assertIn(
             'https://jenkins.example.com/job/build-node-image/46173/', mock_update_description.call_args.args[0]
         )
+
+    @patch('pyartcd.pipelines.rhcos_node_image_post_build.jenkins.init_jenkins')
+    @patch('pyartcd.pipelines.rhcos_node_image_post_build.jenkins.update_description')
+    def test_description_update_failure_does_not_fail_pipeline(self, mock_update_description, mock_init_jenkins):
+        mock_update_description.side_effect = RuntimeError('description update failed')
+        pipeline = _make_pipeline()
+
+        pipeline._update_build_description('description')
+
+        mock_init_jenkins.assert_called_once()
+        mock_update_description.assert_called_once_with('description')
+        pipeline.runtime.logger.warning.assert_called_once()
 
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.RhcosJenkinsClient')
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.sync_to_quay', new_callable=AsyncMock)

--- a/pyartcd/tests/pipelines/test_rhcos_node_image_post_build.py
+++ b/pyartcd/tests/pipelines/test_rhcos_node_image_post_build.py
@@ -48,10 +48,12 @@ class TestRhcosNodeImagePostBuildPipeline(unittest.IsolatedAsyncioTestCase):
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.RegistryConfig')
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.sync_to_quay', new_callable=AsyncMock)
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.load_group_config', new_callable=AsyncMock)
+    @patch('pyartcd.pipelines.rhcos_node_image_post_build.jenkins.update_description')
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.RhcosJenkinsClient')
     async def test_tests_then_promotes_exact_digests_with_configured_tags(
         self,
         mock_client_type,
+        mock_update_description,
         mock_load_group_config,
         mock_sync,
         mock_registry_config,
@@ -88,10 +90,18 @@ class TestRhcosNodeImagePostBuildPipeline(unittest.IsolatedAsyncioTestCase):
             ['5.0-9.8-node-image-extensions'],
         )
         self.assertEqual(mock_sync.await_count, 2)
+        mock_update_description.assert_called_once()
+        description = mock_update_description.call_args.args[0]
+        self.assertIn('https://jenkins.example.com/job/build-node-image/46173/', description)
+        self.assertIn(f'{KONFLUX_DEFAULT_IMAGE_REPO}:5.0-9.8-node-image', description)
+        self.assertIn(f'{KONFLUX_DEFAULT_IMAGE_REPO}:5.0-9.8-node-image-extensions', description)
+        self.assertIn(f'{RHCOS_IMAGE_REPO}@sha256:{"a" * 64}', description)
+        self.assertIn(f'{RHCOS_IMAGE_REPO}@sha256:{"b" * 64}', description)
 
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.sync_to_quay', new_callable=AsyncMock)
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.RhcosJenkinsClient')
-    async def test_failed_integration_test_does_not_promote(self, mock_client_type, mock_sync):
+    @patch('pyartcd.pipelines.rhcos_node_image_post_build.jenkins.update_description')
+    async def test_failed_integration_test_does_not_promote(self, mock_update_description, mock_client_type, mock_sync):
         mock_client = mock_client_type.return_value
         mock_client.trigger_build.return_value = 46173
         mock_client.wait_for_build.return_value = {
@@ -103,6 +113,10 @@ class TestRhcosNodeImagePostBuildPipeline(unittest.IsolatedAsyncioTestCase):
             await _make_pipeline().run()
 
         mock_sync.assert_not_awaited()
+        mock_update_description.assert_called_once()
+        self.assertIn(
+            'https://jenkins.example.com/job/build-node-image/46173/', mock_update_description.call_args.args[0]
+        )
 
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.RhcosJenkinsClient')
     @patch('pyartcd.pipelines.rhcos_node_image_post_build.sync_to_quay', new_callable=AsyncMock)


### PR DESCRIPTION
## What

- Replace the verbose RHCOS child-parameter JSON in ocp4-konflux descriptions with a link to the post-build job.
- Add the triggered build-node-image link and promoted pullspecs to the post-build description.
- Keep the full child parameters in the build log.

## Testing

- `make lint`
- 12 targeted pyartcd tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jenkins build descriptions now link directly to triggered child jobs.
  * RHCOS post-build descriptions include integration results, source image references, promoted tags, and relevant build links.
  * Descriptions are updated for both successful promotions and integration-test failures.

* **Bug Fixes**
  * Improved formatting and safety of Jenkins build description content.
  * Failed integration tests now record the failure build while preventing promotion.
  * Jenkins description update failures are logged without causing the pipeline to fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->