### PR TITLE
Fix test portability and stale product assertion

### DIFF
--- a/artcommon/tests/test_util.py
+++ b/artcommon/tests/test_util.py
@@ -717,9 +717,8 @@ class TestProductBasedResolution(unittest.TestCase):
 
     @patch.dict("os.environ", {"KONFLUX_SA_KUBECONFIG": "/path/to/kubeconfig"})
     def test_product_kubeconfig_resolution(self):
-        # Test that both oc-mirror and oc-mirror-2.0 resolve to the same KONFLUX_SA_KUBECONFIG path
+        # Test that oc-mirror resolves to the KONFLUX_SA_KUBECONFIG path
         self.assertEqual(util.resolve_konflux_kubeconfig_by_product("oc-mirror"), "/path/to/kubeconfig")
-        self.assertEqual(util.resolve_konflux_kubeconfig_by_product("oc-mirror-2.0"), "/path/to/kubeconfig")
 
         # Test that ocp also resolves to KONFLUX_SA_KUBECONFIG path
         self.assertEqual(util.resolve_konflux_kubeconfig_by_product("ocp"), "/path/to/kubeconfig")

--- a/run-tests-parallel.sh
+++ b/run-tests-parallel.sh
@@ -51,7 +51,7 @@ for pkg in "${packages[@]}"; do
     if grep -q "FAILED" "$tmpdir/$pkg.out" || grep -q "ERROR" "$tmpdir/$pkg.out"; then
         echo "❌ $pkg: FAILED"
     else
-        passed=$(awk '/ passed/{for (i = 2; i <= NF; i++) if ($i == "passed" && $(i - 1) ~ /^[0-9]+$/) print $(i - 1)}' "$tmpdir/$pkg.out" | tail -1)
+        passed=$(awk '/ passed/{for (i = 2; i <= NF; i++) { gsub(/[[:punct:]]+$/, "", $i); if ($i == "passed" && $(i - 1) ~ /^[0-9]+$/) print $(i - 1) }}' "$tmpdir/$pkg.out" | tail -1)
         passed=${passed:-0}
         echo "✅ $pkg: $passed tests passed"
     fi

--- a/run-tests-parallel.sh
+++ b/run-tests-parallel.sh
@@ -22,7 +22,7 @@ pids=()
 
 for pkg in "${packages[@]}"; do
     echo "  Starting: $pkg"
-    uv run pytest --verbose --color=yes "$pkg/tests/" > "$tmpdir/$pkg.out" 2>&1 &
+    uv run pytest --verbose --color=no "$pkg/tests/" > "$tmpdir/$pkg.out" 2>&1 &
     pids+=($!)
 done
 
@@ -51,7 +51,8 @@ for pkg in "${packages[@]}"; do
     if grep -q "FAILED" "$tmpdir/$pkg.out" || grep -q "ERROR" "$tmpdir/$pkg.out"; then
         echo "❌ $pkg: FAILED"
     else
-        passed=$(grep -oP '\d+(?= passed)' "$tmpdir/$pkg.out" | tail -1 || echo "0")
+        passed=$(awk '/ passed/{for (i = 2; i <= NF; i++) if ($i == "passed" && $(i - 1) ~ /^[0-9]+$/) print $(i - 1)}' "$tmpdir/$pkg.out" | tail -1)
+        passed=${passed:-0}
         echo "✅ $pkg: $passed tests passed"
     fi
 done


### PR DESCRIPTION
Summary:
- Remove the stale oc-mirror-2.0 kubeconfig assertion after its redundant map entry was removed.
- Make the parallel test runner portable to macOS and report numeric pass counts correctly.

Tests:
- env UV_CACHE_DIR=/tmp/art-tools-uv-cache PYLINTHOME=/tmp/art-tools-pylint make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated product configuration coverage to reflect currently supported kubeconfig resolution scenarios.
  - Improved parallel test reporting reliability by standardizing output handling across environments.
  - Test result counts are now parsed more consistently, including when no passing-test count is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->